### PR TITLE
Updated MUI imports for core-components

### DIFF
--- a/.changeset/moody-waves-wait.md
+++ b/.changeset/moody-waves-wait.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Updated MUI imports for core-components to not be top level

--- a/packages/core-components/.eslintrc.js
+++ b/packages/core-components/.eslintrc.js
@@ -1,6 +1,7 @@
 module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
   rules: {
     'jest/expect-expect': 0,
+    '@backstage/no-top-level-material-ui-4-imports': 'error',
   },
   restrictedImports: [
     {

--- a/packages/core-components/src/components/AlertDisplay/AlertDisplay.tsx
+++ b/packages/core-components/src/components/AlertDisplay/AlertDisplay.tsx
@@ -19,7 +19,7 @@ import IconButton from '@material-ui/core/IconButton';
 import Snackbar from '@material-ui/core/Snackbar';
 import Typography from '@material-ui/core/Typography';
 import CloseIcon from '@material-ui/icons/Close';
-import { Alert } from '@material-ui/lab';
+import Alert from '@material-ui/lab/Alert';
 import React, { useEffect, useState } from 'react';
 import { coreComponentsTranslationRef } from '../../translation';
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updated MUI imports for core-components by adding the `@backstage/no-top-level-material-ui-4-imports` rule and running `yarn lint --fix`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
