### PR TITLE
Added OAS spec location in software-catalog API docs

### DIFF
--- a/docs/features/software-catalog/api.md
+++ b/docs/features/software-catalog/api.md
@@ -5,7 +5,8 @@ description: The Software Catalog API
 ---
 
 The software catalog backend has a JSON based REST API, which can be leveraged
-by external systems. This page describes its shape and features.
+by external systems. This page describes its shape and features. The OpenAPI spec
+for this API can be found [here](https://github.com/backstage/backstage/blob/master/plugins/catalog-backend/src/schema/openapi.yaml).
 
 ## Overview
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

* for easier API consumption, pointed to location of OpenAPI spec for software-catalog
* documentation change only

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
