### PR TITLE
cli: allow bumping to dist-tag versions in versions:bump command

### DIFF
--- a/.changeset/hot-coats-remain.md
+++ b/.changeset/hot-coats-remain.md
@@ -1,0 +1,7 @@
+---
+'@backstage/cli': patch
+---
+
+Add support for bumping packages to versions specified by dist-tags in the
+`versions:bump` command. This is primarily useful for bumping sets of
+non-@backstage packages, which naturally don't appear in the version manifest.

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -382,7 +382,7 @@ export function registerCommands(program: Command) {
     )
     .option(
       '--release <version|next|main>',
-      'Bump to a specific Backstage release line or version',
+      'Bump to a specific Backstage release line or version, or to a specific npm dist-tag',
       'main',
     )
     .option('--skip-install', 'Skips yarn install step')


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This change makes it possible to use the `versions:bump` command with collections of third-party plugins that publish release lines using dist-tags. Without this change, the cli assumes the existence of a release manifest for the packages in backstage/backstage, which obviously doesn't exist.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
