### PR TITLE
Allow multiple edges with different type (catalog graph)

### DIFF
--- a/.changeset/tame-jokes-bow.md
+++ b/.changeset/tame-jokes-bow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-graph': patch
+---
+
+Allow multiple edges with different type (e.g. `ownedBy` and `applicationOwnerBy`) to have the same source and target node.

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/DefaultRenderLabel.tsx
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/DefaultRenderLabel.tsx
@@ -38,7 +38,7 @@ export function DefaultRenderLabel({
   return (
     <text className={classes.text} textAnchor="middle">
       {relations.map((r, i) => (
-        <tspan key={r} className={classNames(i > 0 && classes.secondary)}>
+        <tspan key={r} className={classNames(i % 2 !== 0 && classes.secondary)}>
           {i > 0 && <tspan> / </tspan>}
           {r}
         </tspan>

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/useEntityRelationNodesAndEdges.test.ts
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/useEntityRelationNodesAndEdges.test.ts
@@ -372,12 +372,6 @@ describe('useEntityRelationNodesAndEdges', () => {
         to: 'b:d/c1',
       },
       {
-        from: 'b:d/c',
-        label: 'visible',
-        relations: [RELATION_HAS_PART, RELATION_PART_OF],
-        to: 'b:d/c1',
-      },
-      {
         from: 'b:d/c1',
         label: 'visible',
         relations: [RELATION_OWNER_OF, RELATION_OWNED_BY],
@@ -388,24 +382,6 @@ describe('useEntityRelationNodesAndEdges', () => {
         label: 'visible',
         relations: [RELATION_HAS_PART, RELATION_PART_OF],
         to: 'b:d/c2',
-      },
-      {
-        from: 'b:d/c1',
-        label: 'visible',
-        relations: [RELATION_HAS_PART, RELATION_PART_OF],
-        to: 'b:d/c2',
-      },
-      {
-        from: 'b:d/c',
-        label: 'visible',
-        relations: [RELATION_OWNER_OF, RELATION_OWNED_BY],
-        to: 'k:d/a1',
-      },
-      {
-        from: 'b:d/c1',
-        label: 'visible',
-        relations: [RELATION_OWNER_OF, RELATION_OWNED_BY],
-        to: 'k:d/a1',
       },
     ]);
   });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I'm currently implementing a new plugin, which is highly requested from end users in our firm.
Additionally, I saw some issues here, which go into the same direction like #17996 or #18751 

Here the first draft of my plugin code https://github.com/dweber019/backstage-plugins/tree/feat/relations/plugins/relations-backend

It works like intended and fits nicely our firms needs.

One thing I noticed, was that the catalog graph it not implemented with multiple edges in mind when the edges have the same source/from and target/to nodes but different relation types like (e.g. ownerBy, ledBy, applicationOwnerBy...).

What did I change.
1. The section in `if (unidirectional) {` will just add missing edges, if unidirectional is set to true, as with the implementation of this visitor pattern, we only visit nodes once and therefor are only picking up a relation once.
2. the `const finalEdges = edges.reduce((previousEdges` will merge relation types for edges so only edge remains per source and target. This change even seams to improve rendering performance when I tested this with a graph > 200 nodes.

Here some screenshots after the modification

![Screen Shot 2024-03-11 at 22 50 53 PM](https://github.com/backstage/backstage/assets/1021324/7d9d5918-dc43-4f07-b434-27d8899d946b)
![Screen Shot 2024-03-11 at 22 51 14 PM](https://github.com/backstage/backstage/assets/1021324/ab3e0dce-d0f9-4905-b9e3-c468b6f52dbc)
![Screen Shot 2024-03-11 at 22 51 26 PM](https://github.com/backstage/backstage/assets/1021324/5017da82-d329-4f01-89a6-d69de688a00d)
![Screen Shot 2024-03-11 at 22 51 39 PM](https://github.com/backstage/backstage/assets/1021324/c21f7817-3cf3-4348-8862-eedeca66efab)
![Screen Shot 2024-03-11 at 22 52 11 PM](https://github.com/backstage/backstage/assets/1021324/5d3443e7-79e0-4d0b-8f63-0c382f9b7363)

Would highly appreciate if we can bring this feature to the graph and grateful for any input on optimising my changes. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
