### PR TITLE
Fix absolute path resolution

### DIFF
--- a/.changeset/thirty-insects-yell.md
+++ b/.changeset/thirty-insects-yell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+Fixed absolute path resolution for Github.

--- a/.changeset/thirty-insects-yell.md
+++ b/.changeset/thirty-insects-yell.md
@@ -2,4 +2,4 @@
 '@backstage/integration': patch
 ---
 
-Fixed absolute path resolution for Github.
+Fixed an issue with absolute path resolution.

--- a/packages/integration/src/github/GithubIntegration.test.ts
+++ b/packages/integration/src/github/GithubIntegration.test.ts
@@ -67,6 +67,27 @@ describe('GithubIntegration', () => {
         base: 'https://github.com/backstage/backstage/blob/master/test/README.md',
       }),
     ).toBe('https://github.com/backstage/backstage/tree/master/test/');
+
+    expect(
+      integration.resolveUrl({
+        url: '/package.json',
+        base: 'https://github.com/backstage/backstage/tree/master/packages/cli/',
+      }),
+    ).toBe('https://github.com/backstage/backstage/tree/master/package.json');
+
+    expect(
+      integration.resolveUrl({
+        url: '/package.json',
+        base: 'https://github.com/backstage/backstage/tree/master/packages/cli',
+      }),
+    ).toBe('https://github.com/backstage/backstage/tree/master/package.json');
+
+    expect(
+      integration.resolveUrl({
+        url: '/package.json',
+        base: 'https://github.com/backstage/backstage/tree/master',
+      }),
+    ).toBe('https://github.com/backstage/backstage/tree/master/package.json');
   });
 
   it('resolve edit URL', () => {

--- a/packages/integration/src/helpers.ts
+++ b/packages/integration/src/helpers.ts
@@ -89,7 +89,12 @@ export function defaultScmResolveUrl(options: {
     updated = new URL(href);
 
     const repoRootPath = trimEnd(
-      updated.pathname.substring(0, updated.pathname.length - filepath.length),
+      updated.pathname.substring(
+        0,
+        filepath.length
+          ? updated.pathname.length - filepath.length - 1
+          : updated.pathname.length,
+      ),
       '/',
     );
     updated.pathname = `${repoRootPath}${url}`;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The logic for constructing the `repoRootPath` was incorrectly leaving the last character of the preceding directory when trimming the 'filepath' from the 'base' URL. This was due to an off-by-one error where the length of `filepath` did not account for the leading slash. The additional `-1` subtraction ensures that both the `filepath` and its leading slash are completely removed, resulting in the correct repository root path.

Previously, if given a `base` of `https://github.com/backstage/backstage/tree/master/packages/cli/` and an absolute path of `/package.json` the URL would resolve to `https://github.com/backstage/backstage/tree/master/p/package.json`. WIth this change it correctly resolves to `https://github.com/backstage/backstage/tree/master/package.json`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
