### PR TITLE
chore: rename SignalService to SignalsService

### DIFF
--- a/.changeset/neat-penguins-fix.md
+++ b/.changeset/neat-penguins-fix.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-signals-node': patch
+---
+
+Renamed `SignalService` to `SignalsService` and `signalService` to `signalServiceRef`
+to follow the naming scheme of services and their references

--- a/.changeset/tasty-ants-know.md
+++ b/.changeset/tasty-ants-know.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-notifications-backend': patch
+'@backstage/plugin-signals-backend': patch
+---
+
+Changed to use the refactored signal service naming

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -74,7 +74,7 @@ import { DefaultEventsService } from '@backstage/plugin-events-node';
 import { PrometheusExporter } from '@opentelemetry/exporter-prometheus';
 import { MeterProvider } from '@opentelemetry/sdk-metrics';
 import { metrics } from '@opentelemetry/api';
-import { DefaultSignalService } from '@backstage/plugin-signals-node';
+import { DefaultSignalsService } from '@backstage/plugin-signals-node';
 
 // Expose opentelemetry metrics using a Prometheus exporter on
 // http://localhost:9464/metrics . See prometheus.yml in packages/backend for
@@ -105,7 +105,7 @@ function makeCreateEnv(config: Config) {
     root.child({ type: 'plugin' }),
     eventsService,
   );
-  const signalService = DefaultSignalService.create({
+  const signalsService = DefaultSignalsService.create({
     events: eventsService,
   });
 
@@ -130,7 +130,7 @@ function makeCreateEnv(config: Config) {
       permissions,
       scheduler,
       identity,
-      signalService,
+      signals: signalsService,
     };
   };
 }

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -27,7 +27,7 @@ import { PluginTaskScheduler } from '@backstage/backend-tasks';
 import { IdentityApi } from '@backstage/plugin-auth-node';
 import { PermissionEvaluator } from '@backstage/plugin-permission-common';
 import { EventBroker, EventsService } from '@backstage/plugin-events-node';
-import { SignalService } from '@backstage/plugin-signals-node';
+import { SignalsService } from '@backstage/plugin-signals-node';
 
 export type PluginEnvironment = {
   logger: Logger;
@@ -45,5 +45,5 @@ export type PluginEnvironment = {
    */
   eventBroker: EventBroker;
   events: EventsService;
-  signalService: SignalService;
+  signals: SignalsService;
 };

--- a/plugins/notifications-backend/src/plugin.ts
+++ b/plugins/notifications-backend/src/plugin.ts
@@ -19,7 +19,7 @@ import {
   createBackendPlugin,
 } from '@backstage/backend-plugin-api';
 import { createRouter } from './service/router';
-import { signalService } from '@backstage/plugin-signals-node';
+import { signalsServiceRef } from '@backstage/plugin-signals-node';
 import {
   NotificationProcessor,
   notificationsProcessingExtensionPoint,
@@ -66,7 +66,7 @@ export const notificationsPlugin = createBackendPlugin({
         logger: coreServices.logger,
         database: coreServices.database,
         discovery: coreServices.discovery,
-        signals: signalService,
+        signals: signalsServiceRef,
       },
       async init({
         auth,
@@ -86,7 +86,7 @@ export const notificationsPlugin = createBackendPlugin({
             logger,
             database,
             discovery,
-            signalService: signals,
+            signals,
             processors: processingExtensions.processors,
           }),
         );

--- a/plugins/notifications-backend/src/service/router.test.ts
+++ b/plugins/notifications-backend/src/service/router.test.ts
@@ -23,7 +23,7 @@ import request from 'supertest';
 
 import { createRouter } from './router';
 import { ConfigReader } from '@backstage/config';
-import { SignalService } from '@backstage/plugin-signals-node';
+import { SignalsService } from '@backstage/plugin-signals-node';
 import { mockServices } from '@backstage/backend-test-utils';
 
 function createDatabase(): PluginDatabaseManager {
@@ -42,7 +42,7 @@ function createDatabase(): PluginDatabaseManager {
 describe('createRouter', () => {
   let app: express.Express;
 
-  const signalService: jest.Mocked<SignalService> = {
+  const signalService: jest.Mocked<SignalsService> = {
     publish: jest.fn(),
   };
 
@@ -56,7 +56,7 @@ describe('createRouter', () => {
       logger: getVoidLogger(),
       database: createDatabase(),
       discovery,
-      signalService,
+      signals: signalService,
       userInfo,
       httpAuth,
       auth,

--- a/plugins/notifications-backend/src/service/router.ts
+++ b/plugins/notifications-backend/src/service/router.ts
@@ -38,7 +38,7 @@ import {
   LoggerService,
   UserInfoService,
 } from '@backstage/backend-plugin-api';
-import { SignalService } from '@backstage/plugin-signals-node';
+import { SignalsService } from '@backstage/plugin-signals-node';
 import {
   NewNotificationSignal,
   Notification,
@@ -53,7 +53,7 @@ export interface RouterOptions {
   auth: AuthService;
   httpAuth: HttpAuthService;
   userInfo: UserInfoService;
-  signalService?: SignalService;
+  signals?: SignalsService;
   catalog?: CatalogApi;
   processors?: NotificationProcessor[];
 }
@@ -71,7 +71,7 @@ export async function createRouter(
     discovery,
     catalog,
     processors,
-    signalService,
+    signals,
   } = options;
 
   const catalogClient =
@@ -245,8 +245,8 @@ export async function createRouter(
     if (read === true) {
       await store.markRead({ user, ids });
 
-      if (signalService) {
-        await signalService.publish<NotificationReadSignal>({
+      if (signals) {
+        await signals.publish<NotificationReadSignal>({
           recipients: [user],
           message: { action: 'notification_read', notification_ids: ids },
           channel: 'notifications',
@@ -255,8 +255,8 @@ export async function createRouter(
     } else if (read === false) {
       await store.markUnread({ user: user, ids });
 
-      if (signalService) {
-        await signalService.publish<NotificationReadSignal>({
+      if (signals) {
+        await signals.publish<NotificationReadSignal>({
           recipients: [user],
           message: { action: 'notification_unread', notification_ids: ids },
           channel: 'notifications',
@@ -343,8 +343,8 @@ export async function createRouter(
       processorSendNotification(ret);
       notifications.push(ret);
 
-      if (signalService) {
-        await signalService.publish<NewNotificationSignal>({
+      if (signals) {
+        await signals.publish<NewNotificationSignal>({
           recipients: user,
           message: {
             action: 'new_notification',

--- a/plugins/notifications-backend/src/service/standaloneServer.ts
+++ b/plugins/notifications-backend/src/service/standaloneServer.ts
@@ -32,7 +32,7 @@ import {
   CatalogRequestOptions,
   GetEntitiesByRefsRequest,
 } from '@backstage/catalog-client';
-import { DefaultSignalService } from '@backstage/plugin-signals-node';
+import { DefaultSignalsService } from '@backstage/plugin-signals-node';
 import {
   EventParams,
   EventsService,
@@ -112,7 +112,7 @@ export async function startStandaloneServer(
     },
   };
 
-  const signalService = DefaultSignalService.create({ events });
+  const signalService = DefaultSignalsService.create({ events });
   // TODO: Move to use services instead this hack
   const { auth, httpAuth, userInfo } = createLegacyAuthAdapters<
     any,
@@ -128,7 +128,7 @@ export async function startStandaloneServer(
     database: dbMock,
     catalog: catalogApi,
     discovery,
-    signalService,
+    signals: signalService,
     auth,
     httpAuth,
     userInfo,

--- a/plugins/signals-backend/README.md
+++ b/plugins/signals-backend/README.md
@@ -6,7 +6,7 @@ Signals plugin allows backend plugins to publish messages to frontend plugins.
 
 ## Getting started
 
-First install the `@backstage/plugin-signals-node` plugin to get the `SignalService` set up.
+First install the `@backstage/plugin-signals-node` plugin to get the `SignalsService` set up.
 
 Next, add Signals router to your backend in `packages/backend/src/plugins/signals.ts`:
 

--- a/plugins/signals-backend/src/service/standaloneServer.ts
+++ b/plugins/signals-backend/src/service/standaloneServer.ts
@@ -21,7 +21,7 @@ import {
 import { Server } from 'http';
 import { Logger } from 'winston';
 import { createRouter } from './router';
-import { DefaultSignalService } from '@backstage/plugin-signals-node';
+import { DefaultSignalsService } from '@backstage/plugin-signals-node';
 import { DefaultIdentityClient } from '@backstage/plugin-auth-node';
 import {
   EventParams,
@@ -63,7 +63,7 @@ export async function startStandaloneServer(
     },
   };
 
-  const signals = DefaultSignalService.create({
+  const signals = DefaultSignalsService.create({
     events,
   });
 

--- a/plugins/signals-node/api-report.md
+++ b/plugins/signals-node/api-report.md
@@ -7,10 +7,13 @@ import { EventsService } from '@backstage/plugin-events-node';
 import { JsonObject } from '@backstage/types';
 import { ServiceRef } from '@backstage/backend-plugin-api';
 
+// @public @deprecated (undocumented)
+export const DefaultSignalService: typeof DefaultSignalsService;
+
 // @public (undocumented)
-export class DefaultSignalService implements SignalService {
+export class DefaultSignalsService implements SignalsService {
   // (undocumented)
-  static create(options: SignalServiceOptions): DefaultSignalService;
+  static create(options: SignalsServiceOptions): DefaultSignalsService;
   publish<TMessage extends JsonObject = JsonObject>(
     signal: SignalPayload<TMessage>,
   ): Promise<void>;
@@ -23,20 +26,26 @@ export type SignalPayload<TMessage extends JsonObject = JsonObject> = {
   message: TMessage;
 };
 
+// @public @deprecated (undocumented)
+export interface SignalService extends SignalsService {}
+
+// @public @deprecated (undocumented)
+export const signalService: ServiceRef<SignalsService, 'plugin'>;
+
 // @public (undocumented)
-export interface SignalService {
+export interface SignalsService {
   publish<TMessage extends JsonObject = JsonObject>(
     signal: SignalPayload<TMessage>,
   ): Promise<void>;
 }
 
 // @public (undocumented)
-export const signalService: ServiceRef<SignalService, 'plugin'>;
-
-// @public (undocumented)
-export type SignalServiceOptions = {
+export type SignalsServiceOptions = {
   events: EventsService;
 };
+
+// @public (undocumented)
+export const signalsServiceRef: ServiceRef<SignalsService, 'plugin'>;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/signals-node/src/DefaultSignalsService.test.ts
+++ b/plugins/signals-node/src/DefaultSignalsService.test.ts
@@ -13,15 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { DefaultSignalService } from './DefaultSignalService';
+import { DefaultSignalsService } from './DefaultSignalsService';
 
-describe('DefaultSignalService', () => {
+describe('DefaultSignalsService', () => {
   const mockEvents = {
     publish: jest.fn(),
     subscribe: jest.fn(),
   };
 
-  const service = DefaultSignalService.create({ events: mockEvents });
+  const service = DefaultSignalsService.create({ events: mockEvents });
 
   it('should publish signal', () => {
     const signal = {

--- a/plugins/signals-node/src/DefaultSignalsService.ts
+++ b/plugins/signals-node/src/DefaultSignalsService.ts
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 import { EventsService } from '@backstage/plugin-events-node';
-import { SignalPayload, SignalServiceOptions } from './types';
-import { SignalService } from './SignalService';
+import { SignalPayload, SignalsServiceOptions } from './types';
+import { SignalsService } from './SignalsService';
 import { JsonObject } from '@backstage/types';
 
 /** @public */
-export class DefaultSignalService implements SignalService {
+export class DefaultSignalsService implements SignalsService {
   private events: EventsService;
 
-  static create(options: SignalServiceOptions) {
-    return new DefaultSignalService(options);
+  static create(options: SignalsServiceOptions) {
+    return new DefaultSignalsService(options);
   }
 
-  private constructor(options: SignalServiceOptions) {
+  private constructor(options: SignalsServiceOptions) {
     ({ events: this.events } = options);
   }
 
@@ -43,3 +43,9 @@ export class DefaultSignalService implements SignalService {
     });
   }
 }
+
+/**
+ * @public
+ * @deprecated Use `DefaultSignalsService` instead
+ */
+export const DefaultSignalService = DefaultSignalsService;

--- a/plugins/signals-node/src/SignalsService.ts
+++ b/plugins/signals-node/src/SignalsService.ts
@@ -17,7 +17,7 @@ import { SignalPayload } from './types';
 import { JsonObject } from '@backstage/types';
 
 /** @public */
-export interface SignalService {
+export interface SignalsService {
   /**
    * Publishes a signal to user refs to specific topic
    * @param signal - Signal to publish
@@ -26,3 +26,9 @@ export interface SignalService {
     signal: SignalPayload<TMessage>,
   ): Promise<void>;
 }
+
+/**
+ * @public
+ * @deprecated Use `SignalsService` instead
+ */
+export interface SignalService extends SignalsService {}

--- a/plugins/signals-node/src/index.ts
+++ b/plugins/signals-node/src/index.ts
@@ -15,6 +15,6 @@
  */
 
 export * from './lib';
-export * from './DefaultSignalService';
-export * from './SignalService';
+export * from './DefaultSignalsService';
+export * from './SignalsService';
 export * from './types';

--- a/plugins/signals-node/src/lib.ts
+++ b/plugins/signals-node/src/lib.ts
@@ -17,12 +17,12 @@ import {
   createServiceFactory,
   createServiceRef,
 } from '@backstage/backend-plugin-api';
-import { DefaultSignalService } from './DefaultSignalService';
-import { SignalService } from './SignalService';
+import { DefaultSignalsService } from './DefaultSignalsService';
+import { SignalsService } from './SignalsService';
 import { eventsServiceRef } from '@backstage/plugin-events-node';
 
 /** @public */
-export const signalService = createServiceRef<SignalService>({
+export const signalsServiceRef = createServiceRef<SignalsService>({
   id: 'signals.service',
   scope: 'plugin',
   defaultFactory: async service =>
@@ -32,7 +32,13 @@ export const signalService = createServiceRef<SignalService>({
         events: eventsServiceRef,
       },
       factory({ events }) {
-        return DefaultSignalService.create({ events });
+        return DefaultSignalsService.create({ events });
       },
     }),
 });
+
+/**
+ * @public
+ * @deprecated Use `signalsServiceRef` instead
+ */
+export const signalService = signalsServiceRef;

--- a/plugins/signals-node/src/types.ts
+++ b/plugins/signals-node/src/types.ts
@@ -19,7 +19,7 @@ import { JsonObject } from '@backstage/types';
 /**
  * @public
  */
-export type SignalServiceOptions = {
+export type SignalsServiceOptions = {
   events: EventsService;
 };
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

To follow the naming scheme of service the `SignalService` is now called `SignalsService`. For backwards compatibility with the initial release, also old naming is available but it is marked as deprecated and will be removed later.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
