### PR TITLE
Add minify option to buildBackend and command

### DIFF
--- a/.changeset/calm-trainers-hear.md
+++ b/.changeset/calm-trainers-hear.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Extend option to minify generated code to the `backend` package.

--- a/docs/local-dev/cli-commands.md
+++ b/docs/local-dev/cli-commands.md
@@ -128,7 +128,7 @@ Build a package for production deployment or publishing
 
 Options:
   --role <name>              Run the command with an explicit package role
-  --minify                   Minify the generated code. Does not apply to app or backend packages.
+  --minify                   Minify the generated code. Does not apply to app package (app is minified by default).
   --skip-build-dependencies  Skip the automatic building of local dependencies. Applies to backend packages only.
   --stats                    If bundle stats are available, write them to the output directory. Applies to app packages only.
   --config <path>            Config files to load instead of app-config.yaml. Applies to app packages only. (default: [])

--- a/packages/cli/src/commands/build/buildBackend.ts
+++ b/packages/cli/src/commands/build/buildBackend.ts
@@ -29,17 +29,19 @@ interface BuildBackendOptions {
   targetDir: string;
   skipBuildDependencies: boolean;
   configPaths?: string[];
+  minify?: boolean;
 }
 
 export async function buildBackend(options: BuildBackendOptions) {
-  const { targetDir, skipBuildDependencies, configPaths } = options;
+  const { targetDir, skipBuildDependencies, configPaths, minify } = options;
   const pkg = await fs.readJson(resolvePath(targetDir, 'package.json'));
 
   // We build the target package without generating type declarations.
   await buildPackage({
-    targetDir: options.targetDir,
+    targetDir,
     packageJson: pkg,
     outputs: new Set([Output.cjs]),
+    minify,
   });
 
   const tmpDir = await fs.mkdtemp(resolvePath(os.tmpdir(), 'backstage-bundle'));
@@ -51,6 +53,7 @@ export async function buildBackend(options: BuildBackendOptions) {
       buildExcludes: [pkg.name],
       parallelism: getEnvironmentParallelism(),
       skeleton: SKELETON_FILE,
+      minify,
     });
 
     // We built the target backend package using the regular build process, but the result of

--- a/packages/cli/src/commands/build/command.ts
+++ b/packages/cli/src/commands/build/command.ts
@@ -45,6 +45,7 @@ export async function command(opts: OptionValues): Promise<void> {
       targetDir: paths.targetDir,
       configPaths,
       skipBuildDependencies: Boolean(opts.skipBuildDependencies),
+      minify: Boolean(opts.minify),
     });
   }
 

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -128,7 +128,7 @@ export function registerScriptCommand(program: Command) {
     .option('--role <name>', 'Run the command with an explicit package role')
     .option(
       '--minify',
-      'Minify the generated code. Does not apply to app or backend packages.',
+      'Minify the generated code. Does not apply to app package (app is minified by default).',
     )
     .option(
       '--skip-build-dependencies',

--- a/packages/cli/src/commands/repo/build.ts
+++ b/packages/cli/src/commands/repo/build.ts
@@ -179,6 +179,7 @@ export async function command(opts: OptionValues, cmd: Command): Promise<void> {
         await buildBackend({
           targetDir: pkg.dir,
           skipBuildDependencies: true,
+          minify: buildOptions.minify,
         });
       },
     });

--- a/packages/cli/src/lib/packager/createDistWorkspace.ts
+++ b/packages/cli/src/lib/packager/createDistWorkspace.ts
@@ -102,6 +102,11 @@ type Options = {
    * command performance.
    */
   alwaysYarnPack?: boolean;
+
+  /**
+   * If set to true, the generated code will be minified.
+   */
+  minify?: boolean;
 };
 
 function prefixLogFunc(prefix: string, out: 'stdout' | 'stderr') {
@@ -204,8 +209,7 @@ export async function createDistWorkspace(
           packageJson: pkg.packageJson,
           outputs: outputs,
           logPrefix: `${chalk.cyan(relativePath(paths.targetRoot, pkg.dir))}: `,
-          // No need to detect these for the backend builds, we assume no minification or types
-          minify: false,
+          minify: options.minify,
         });
       }
     }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes https://github.com/backstage/backstage/issues/23492

Extends the option to minify generated code to the `backend` package.

#### :heavy_check_mark: Checklist


- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
