### PR TITLE
[Kubernetes Backend Plugin] Added new CatalogRelationServiceLocator

### DIFF
--- a/.changeset/eleven-adults-add.md
+++ b/.changeset/eleven-adults-add.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': minor
+---
+
+New `CatalogRelationServiceLocator` added

--- a/.changeset/eleven-adults-add.md
+++ b/.changeset/eleven-adults-add.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-kubernetes-backend': minor
+'@backstage/plugin-kubernetes-backend': patch
 ---
 
 Added a new service locator `CatalogRelationServiceLocator` that only returns clusters an entity lists in `relations.dependsOn`.

--- a/.changeset/eleven-adults-add.md
+++ b/.changeset/eleven-adults-add.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-kubernetes-backend': minor
 ---
 
-New `CatalogRelationServiceLocator` added
+Added a new service locator `CatalogRelationServiceLocator` that only returns clusters an entity lists in `relations.dependsOn`.

--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -59,6 +59,8 @@ Valid values are:
 
 - `singleTenant` - This configuration assumes that current component run on one cluster in provided clusters.
 
+- `singleTenant` - This configuration assumes that the current component runs only on all clusters it is dependant on.
+
 ### `clusterLocatorMethods`
 
 This is an array used to determine where to retrieve cluster configuration from.

--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -59,7 +59,7 @@ Valid values are:
 
 - `singleTenant` - This configuration assumes that current component run on one cluster in provided clusters.
 
-- `singleTenant` - This configuration assumes that the current component runs only on all clusters it is dependant on.
+- `catalogRelation` - This configuration assumes that the current component runs only on all clusters it is dependant on.
 
 ### `clusterLocatorMethods`
 

--- a/plugins/kubernetes-backend/api-report.md
+++ b/plugins/kubernetes-backend/api-report.md
@@ -163,6 +163,10 @@ export class KubernetesBuilder {
     [key: string]: AuthenticationStrategy_2;
   };
   // (undocumented)
+  protected buildCatalogRelationServiceLocator(
+    clusterSupplier: KubernetesClustersSupplier_2,
+  ): KubernetesServiceLocator_2;
+  // (undocumented)
   protected buildClusterSupplier(
     refreshInterval: Duration,
   ): KubernetesClustersSupplier_2;
@@ -397,7 +401,11 @@ export class ServiceAccountStrategy implements AuthenticationStrategy_2 {
 }
 
 // @public (undocumented)
-export type ServiceLocatorMethod = 'multiTenant' | 'singleTenant' | 'http';
+export type ServiceLocatorMethod =
+  | 'multiTenant'
+  | 'singleTenant'
+  | 'catalogRelation'
+  | 'http';
 
 // @public @deprecated (undocumented)
 export type ServiceLocatorRequestContext =

--- a/plugins/kubernetes-backend/src/service-locator/CatalogRelationServiceLocator.test.ts
+++ b/plugins/kubernetes-backend/src/service-locator/CatalogRelationServiceLocator.test.ts
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Entity } from '@backstage/catalog-model';
+import { ServiceLocatorRequestContext } from '@backstage/plugin-kubernetes-node';
+import { CatalogRelationServiceLocator } from './CatalogRelationServiceLocator';
+
+describe('CatalogRelationServiceLocator', () => {
+  let serviceLocator: CatalogRelationServiceLocator;
+
+  beforeEach(() => {
+    // Mock the KubernetesClustersSupplier dependency
+    const clusterSupplier = {
+      getClusters: jest.fn().mockResolvedValue([
+        {
+          name: 'cluster1',
+          url: 'http://localhost:8080',
+          authMetadata: {},
+        },
+        {
+          name: 'cluster2',
+          url: 'http://localhost:8081',
+          authMetadata: {},
+        },
+      ]),
+    };
+
+    serviceLocator = new CatalogRelationServiceLocator(clusterSupplier);
+  });
+
+  it('empty entity returns empty cluster details', async () => {
+    const result = await serviceLocator.getClustersByEntity(
+      {} as Entity,
+      {} as ServiceLocatorRequestContext,
+    );
+
+    expect(result).toStrictEqual({ clusters: [] });
+  });
+
+  it('empty clusters returns empty cluster details', async () => {
+    const crsl = new CatalogRelationServiceLocator({
+      getClusters: async () => [],
+    });
+
+    const testEntity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      relations: [
+        { type: 'dependsOn', targetRef: 'resource:default/cluster1' },
+        { type: 'dependsOn', targetRef: 'resource:default/cluster2' },
+        { type: 'ownedBy', targetRef: 'group:default/group1' },
+      ],
+      metadata: {
+        namespace: 'default',
+        name: 'testEntity',
+      },
+    };
+
+    const result = await crsl.getClustersByEntity(
+      testEntity,
+      {} as ServiceLocatorRequestContext,
+    );
+
+    expect(result).toStrictEqual({ clusters: [] });
+  });
+
+  it('should return all referenced clusters when entity depends on multiple clusters', async () => {
+    const testEntity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      relations: [
+        { type: 'dependsOn', targetRef: 'resource:default/cluster1' },
+        { type: 'dependsOn', targetRef: 'resource:default/cluster2' },
+        { type: 'ownedBy', targetRef: 'group:default/group1' },
+      ],
+      metadata: {
+        namespace: 'default',
+        name: 'testEntity',
+      },
+    };
+
+    const result = await serviceLocator.getClustersByEntity(
+      testEntity,
+      {} as ServiceLocatorRequestContext,
+    );
+
+    expect(result).toEqual({
+      clusters: [
+        {
+          name: 'cluster1',
+          url: 'http://localhost:8080',
+          authMetadata: {},
+        },
+        {
+          name: 'cluster2',
+          url: 'http://localhost:8081',
+          authMetadata: {},
+        },
+      ],
+    });
+  });
+
+  it('should return one cluster when entity has one dependant cluster', async () => {
+    const testEntity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      relations: [
+        { type: 'dependsOn', targetRef: 'resource:default/cluster1' },
+        { type: 'ownedBy', targetRef: 'group:default/group1' },
+      ],
+      metadata: {
+        namespace: 'default',
+        name: 'testEntity',
+      },
+    };
+
+    const result = await serviceLocator.getClustersByEntity(
+      testEntity,
+      {} as ServiceLocatorRequestContext,
+    );
+
+    expect(result).toEqual({
+      clusters: [
+        {
+          name: 'cluster1',
+          url: 'http://localhost:8080',
+          authMetadata: {},
+        },
+      ],
+    });
+  });
+
+  it('should return an empty array when entity does not have dependsOn relation with resource target', async () => {
+    const testEntity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      relations: [
+        { type: 'dependsOn', targetRef: 'resource:default/database1' },
+        { type: 'dependsOn', targetRef: 'resource:default/database2' },
+        { type: 'ownedBy', targetRef: 'group:default/group1' },
+      ],
+      metadata: {
+        namespace: 'default',
+        name: 'testEntity',
+      },
+    };
+
+    const result = await serviceLocator.getClustersByEntity(
+      testEntity,
+      {} as ServiceLocatorRequestContext,
+    );
+
+    expect(result).toEqual({
+      clusters: [],
+    });
+  });
+});

--- a/plugins/kubernetes-backend/src/service-locator/CatalogRelationServiceLocator.ts
+++ b/plugins/kubernetes-backend/src/service-locator/CatalogRelationServiceLocator.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Entity } from '@backstage/catalog-model';
+import {
+  ClusterDetails,
+  KubernetesClustersSupplier,
+  KubernetesServiceLocator,
+  ServiceLocatorRequestContext,
+} from '@backstage/plugin-kubernetes-node';
+
+// This locator assumes that service is located on the clusters it depends on
+// Therefore it will return the clusters based on the relations it has or none otherwise
+export class CatalogRelationServiceLocator implements KubernetesServiceLocator {
+  private readonly clusterSupplier: KubernetesClustersSupplier;
+
+  constructor(clusterSupplier: KubernetesClustersSupplier) {
+    this.clusterSupplier = clusterSupplier;
+  }
+
+  // As this implementation always returns all clusters serviceId is ignored here
+  getClustersByEntity(
+    _entity: Entity,
+    _requestContext: ServiceLocatorRequestContext,
+  ): Promise<{ clusters: ClusterDetails[] }> {
+    if (
+      _entity.relations &&
+      _entity.relations.some(
+        r => r.type === 'dependsOn' && r.targetRef.includes('resource:'),
+      )
+    ) {
+      return this.clusterSupplier.getClusters().then(clusters => {
+        return {
+          clusters: clusters.filter(c =>
+            _entity.relations!.some(
+              rel =>
+                rel.type === 'dependsOn' &&
+                rel.targetRef ===
+                  `resource:${_entity.metadata.namespace ?? 'default'}/${
+                    c.name
+                  }`,
+            ),
+          ),
+        };
+      });
+    }
+    return Promise.resolve({ clusters: [] });
+  }
+}

--- a/plugins/kubernetes-backend/src/service-locator/CatalogRelationServiceLocator.ts
+++ b/plugins/kubernetes-backend/src/service-locator/CatalogRelationServiceLocator.ts
@@ -44,18 +44,23 @@ export class CatalogRelationServiceLocator implements KubernetesServiceLocator {
       return this.clusterSupplier.getClusters().then(clusters => {
         return {
           clusters: clusters.filter(c =>
-            entity.relations!.some(
-              rel =>
-                rel.type === 'dependsOn' &&
-                rel.targetRef ===
-                  `resource:${entity.metadata.namespace ?? 'default'}/${
-                    c.name
-                  }`,
-            ),
+            this.doesEntityDependOnCluster(entity, c),
           ),
         };
       });
     }
     return Promise.resolve({ clusters: [] });
+  }
+
+  protected doesEntityDependOnCluster(
+    entity: Entity,
+    cluster: ClusterDetails,
+  ): boolean {
+    return entity.relations!.some(
+      rel =>
+        rel.type === 'dependsOn' &&
+        rel.targetRef ===
+          `resource:${entity.metadata.namespace ?? 'default'}/${cluster.name}`,
+    );
   }
 }

--- a/plugins/kubernetes-backend/src/service-locator/CatalogRelationServiceLocator.ts
+++ b/plugins/kubernetes-backend/src/service-locator/CatalogRelationServiceLocator.ts
@@ -32,23 +32,23 @@ export class CatalogRelationServiceLocator implements KubernetesServiceLocator {
 
   // As this implementation always returns all clusters serviceId is ignored here
   getClustersByEntity(
-    _entity: Entity,
+    entity: Entity,
     _requestContext: ServiceLocatorRequestContext,
   ): Promise<{ clusters: ClusterDetails[] }> {
     if (
-      _entity.relations &&
-      _entity.relations.some(
+      entity.relations &&
+      entity.relations.some(
         r => r.type === 'dependsOn' && r.targetRef.includes('resource:'),
       )
     ) {
       return this.clusterSupplier.getClusters().then(clusters => {
         return {
           clusters: clusters.filter(c =>
-            _entity.relations!.some(
+            entity.relations!.some(
               rel =>
                 rel.type === 'dependsOn' &&
                 rel.targetRef ===
-                  `resource:${_entity.metadata.namespace ?? 'default'}/${
+                  `resource:${entity.metadata.namespace ?? 'default'}/${
                     c.name
                   }`,
             ),

--- a/plugins/kubernetes-backend/src/types/types.ts
+++ b/plugins/kubernetes-backend/src/types/types.ts
@@ -14,16 +14,20 @@
  * limitations under the License.
  */
 
-import { Logger } from 'winston';
-import type { KubernetesRequestBody } from '@backstage/plugin-kubernetes-common';
 import { Config } from '@backstage/config';
+import type { KubernetesRequestBody } from '@backstage/plugin-kubernetes-common';
 import * as k8sTypes from '@backstage/plugin-kubernetes-node';
+import { Logger } from 'winston';
 
 /**
  *
  * @public
  */
-export type ServiceLocatorMethod = 'multiTenant' | 'singleTenant' | 'http'; // TODO implement http
+export type ServiceLocatorMethod =
+  | 'multiTenant'
+  | 'singleTenant'
+  | 'catalogRelation'
+  | 'http'; // TODO implement http
 
 /**
  *


### PR DESCRIPTION
## Hey, I just made a Pull Request!

As described in #23491 a service locator that only displays the clusters a component depends on would benefit certain organisations.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
