### PR TITLE
[cli] Limit pack concurrency to 10 in build-workspace command

### DIFF
--- a/.changeset/cli-pack-so-exhausting.md
+++ b/.changeset/cli-pack-so-exhausting.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Fixed a bug that could cause the `build-workspace` command to fail when invoked with `--alwaysYarnPack` enabled in environments with limited resources.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -112,6 +112,7 @@
     "node-libs-browser": "^2.2.1",
     "npm-packlist": "^5.0.0",
     "ora": "^5.3.0",
+    "p-limit": "^3.1.0",
     "p-queue": "^6.6.2",
     "postcss": "^8.1.0",
     "process": "^0.11.10",

--- a/packages/cli/src/lib/packager/createDistWorkspace.ts
+++ b/packages/cli/src/lib/packager/createDistWorkspace.ts
@@ -21,6 +21,7 @@ import {
   resolve as resolvePath,
   relative as relativePath,
 } from 'path';
+import pLimit from 'p-limit';
 import { tmpdir } from 'os';
 import tar, { CreateOptions, FileOptions } from 'tar';
 import partition from 'lodash/partition';
@@ -352,9 +353,11 @@ async function moveToDistWorkspace(
   }
 
   // Repacking in parallel is much faster and safe for all packages outside of the Backstage repo
+  // Limit concurrency to 10 to avoid resource exhaustion on larger monorepos.
+  const limit = pLimit(10);
   await Promise.all(
-    safePackages.map(async (target, index) =>
-      pack(target, `temp-package-${index}.tgz`),
+    safePackages.map((target, index) =>
+      limit(() => pack(target, `temp-package-${index}.tgz`)),
     ),
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3691,6 +3691,7 @@ __metadata:
     nodemon: ^3.0.1
     npm-packlist: ^5.0.0
     ora: ^5.3.0
+    p-limit: ^3.1.0
     p-queue: ^6.6.2
     postcss: ^8.1.0
     process: ^0.11.10


### PR DESCRIPTION
## What / Why

Noticed in a larger monorepo on resource constrained CI runners that running `backstage-cli build-workspace` with `--alwaysYarnPack` would sporadically result in the following error:

```
Postpack script failed (exit code 129...)`
```

I believe it's because the old pack script does a decent amount of work; running it in parallel across _all_ given packages could lead to resource exhaustion issues.  Putting in a limit of any kind should help alleviate this.

I recognize this could make the performance of this flag worse overall, but we're already pretty up-front about this in the help text for the flag:

```
Force workspace output to be a result of running `yarn pack` on each package (warning: very slow)
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
