### PR TITLE
[WIP] Move TODO plugin to community-plugins repository

### DIFF
--- a/plugins/todo-backend/README.md
+++ b/plugins/todo-backend/README.md
@@ -1,3 +1,5 @@
+> Deprecated smth.smth.
+
 # @backstage/plugin-todo-backend
 
 Backend for the `@backstage/plugin-todo` plugin. Assists in scanning for and listing `// TODO` comments in source code repositories.

--- a/plugins/todo-backend/package.json
+++ b/plugins/todo-backend/package.json
@@ -3,7 +3,8 @@
   "version": "0.3.12-next.2",
   "description": "A Backstage backend plugin that lets you browse TODO comments in your source code",
   "backstage": {
-    "role": "backend-plugin"
+    "role": "backend-plugin",
+    "moved": "@backstage-community/plugin-todo-backend"
   },
   "publishConfig": {
     "access": "public",
@@ -53,5 +54,6 @@
     "@backstage/repo-tools": "workspace:^",
     "@types/supertest": "^2.0.8",
     "supertest": "^6.1.3"
-  }
+  },
+  "deprecated": true
 }

--- a/plugins/todo/README.md
+++ b/plugins/todo/README.md
@@ -1,3 +1,5 @@
+> This plugin is deprecated & moved to `@backstage-community/todo`
+
 # @backstage/plugin-todo
 
 This plugin lists `// TODO` comments in source code. It currently exports a single component extension for use on entity pages.

--- a/plugins/todo/package.json
+++ b/plugins/todo/package.json
@@ -3,7 +3,8 @@
   "version": "0.2.35-next.2",
   "description": "A Backstage plugin that lets you browse TODO comments in your source code",
   "backstage": {
-    "role": "frontend-plugin"
+    "role": "frontend-plugin",
+    "moved": "@backstage-community/todo"
   },
   "publishConfig": {
     "access": "public",
@@ -54,5 +55,6 @@
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-router-dom": "6.0.0-beta.0 || ^6.3.0"
-  }
+  },
+  "deprecated": true
 }


### PR DESCRIPTION
Moving TODO plugin to community https://github.com/backstage/community-plugins/pull/43

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
