### PR TITLE
add ability to specify author name and email for bitbucket commits

### DIFF
--- a/.changeset/fair-fishes-marry.md
+++ b/.changeset/fair-fishes-marry.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-backend-module-bitbucket-server': patch
 ---
 
-Added an option to specify a commit author by adding gitAuthorName and gitAuthorEmail options to the `publish:bitbucketServer:pull-request` action
+Added an option to specify a commit author by adding `gitAuthorName` and `gitAuthorEmail` options to the `publish:bitbucketServer:pull-request` action

--- a/.changeset/fair-fishes-marry.md
+++ b/.changeset/fair-fishes-marry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-bitbucket-server': patch
+---
+
+Added an option to specify a commit author by adding gitAuthorName and gitAuthorEmail options to the `publish:bitbucketServer:pull-request` action

--- a/plugins/scaffolder-backend-module-bitbucket-server/api-report.md
+++ b/plugins/scaffolder-backend-module-bitbucket-server/api-report.md
@@ -45,6 +45,8 @@ export function createPublishBitbucketServerPullRequestAction(options: {
     targetBranch?: string | undefined;
     sourceBranch: string;
     token?: string | undefined;
+    gitAuthorName?: string | undefined;
+    gitAuthorEmail?: string | undefined;
   },
   JsonObject
 >;

--- a/plugins/scaffolder-backend-module-bitbucket-server/src/actions/bitbucketServerPullRequest.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-server/src/actions/bitbucketServerPullRequest.ts
@@ -220,6 +220,8 @@ export function createPublishBitbucketServerPullRequestAction(options: {
     targetBranch?: string;
     sourceBranch: string;
     token?: string;
+    gitAuthorName?: string;
+    gitAuthorEmail?: string;
   }>({
     id: 'publish:bitbucketServer:pull-request',
     schema: {
@@ -257,6 +259,16 @@ export function createPublishBitbucketServerPullRequestAction(options: {
             description:
               'The token to use for authorization to BitBucket Server',
           },
+          gitAuthorName: {
+            title: 'Author Name',
+            type: 'string',
+            description: `Sets the author name for the commit. The default value is 'Scaffolder'`,
+          },
+          gitAuthorEmail: {
+            title: 'Author Email',
+            type: 'string',
+            description: `Sets the author email for the commit.`,
+          },
         },
       },
       output: {
@@ -276,6 +288,8 @@ export function createPublishBitbucketServerPullRequestAction(options: {
         description,
         targetBranch = 'master',
         sourceBranch,
+        gitAuthorName,
+        gitAuthorEmail,
       } = ctx.input;
 
       const { project, repo, host } = parseRepoUrl(repoUrl, integrations);
@@ -354,8 +368,12 @@ export function createPublishBitbucketServerPullRequestAction(options: {
             };
 
         const gitAuthorInfo = {
-          name: config.getOptionalString('scaffolder.defaultAuthor.name'),
-          email: config.getOptionalString('scaffolder.defaultAuthor.email'),
+          name:
+            gitAuthorName ||
+            config.getOptionalString('scaffolder.defaultAuthor.name'),
+          email:
+            gitAuthorEmail ||
+            config.getOptionalString('scaffolder.defaultAuthor.email'),
         };
 
         const tempDir = await ctx.createTemporaryDirectory();


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Our bitbucket instance requires that committers must match the current logged in bitbucket user, so commits using a default user will be rejected by our pre commit hooks. This allows a git author name and email to be provided for commits made with the `publish:bitbucketServer:pull-request` scaffolder action so that the committer/author can be made to match the logged in user.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
