### PR TITLE
Resolved issue where`PaginatedCatalogTable` wasn't passing options

### DIFF
--- a/.changeset/fresh-worms-build.md
+++ b/.changeset/fresh-worms-build.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Resolved an issue where the `PaginatedCatalogTable` was not propagating table options to its child table.

--- a/plugins/catalog/src/components/CatalogTable/PaginatedCatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/PaginatedCatalogTable.tsx
@@ -41,12 +41,13 @@ export function PaginatedCatalogTable(props: PaginatedCatalogTableProps) {
       columns={columns}
       data={data}
       options={{
+        ...options,
+        // These settings are configured to force server side pagination
         paginationPosition: 'both',
         pageSizeOptions: [],
         showFirstLastPageButtons: false,
         pageSize: Number.MAX_SAFE_INTEGER,
         emptyRowsWhenPaging: false,
-        ...options,
       }}
       onSearchChange={(searchText: string) =>
         updateFilters({

--- a/plugins/catalog/src/components/CatalogTable/PaginatedCatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/PaginatedCatalogTable.tsx
@@ -32,7 +32,7 @@ type PaginatedCatalogTableProps = {
  * @internal
  */
 export function PaginatedCatalogTable(props: PaginatedCatalogTableProps) {
-  const { columns, data, next, prev, title, isLoading } = props;
+  const { columns, data, next, prev, title, isLoading, options } = props;
   const { updateFilters } = useEntityList();
 
   return (
@@ -46,6 +46,7 @@ export function PaginatedCatalogTable(props: PaginatedCatalogTableProps) {
         showFirstLastPageButtons: false,
         pageSize: Number.MAX_SAFE_INTEGER,
         emptyRowsWhenPaging: false,
+        ...options,
       }}
       onSearchChange={(searchText: string) =>
         updateFilters({


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Resolved an issue where the `PaginatedCatalogTable` was not propagating table options to its child table.

Before: 

`PaginatedCatalogTable` has the props passed to it properly
![image](https://github.com/backstage/backstage/assets/130386160/30fb92fd-fa40-4d83-be1b-71c4a7dddf37)

But it does not pass them down to its child table
![image](https://github.com/backstage/backstage/assets/130386160/d51481fa-8fb4-4ae1-ba5c-cb333877ec10)

#### :heavy_check_mark: Checklist

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [-] Added or updated documentation
- [-] Tests for new functionality and regression tests for bug fixes
- [-] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
