### PR TITLE
Added Material UI 4 import rule to plugins/circleci

### DIFF
--- a/.changeset/fuzzy-weeks-press.md
+++ b/.changeset/fuzzy-weeks-press.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-circleci': patch
+---
+
+Added an optional ESLint rule - no-top-level-material-ui-4-imports -in circleci plugin which has an auto fix function to migrate the imports and used it to migrate the Material UI imports for plugins/circleci.

--- a/plugins/circleci/.eslintrc.js
+++ b/plugins/circleci/.eslintrc.js
@@ -1,1 +1,6 @@
-module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
+    rules: {
+      '@backstage/no-top-level-material-ui-4-imports': 'error',
+    },
+  });
+  

--- a/plugins/circleci/src/components/BuildWithStepsPage/BuildWithStepsPage.tsx
+++ b/plugins/circleci/src/components/BuildWithStepsPage/BuildWithStepsPage.tsx
@@ -17,7 +17,9 @@
 import React, { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { BuildWithSteps, BuildStepAction } from '../../api';
-import { Grid, Box, Typography } from '@material-ui/core';
+import Grid from '@material-ui/core/Grid';
+import Box from '@material-ui/core/Box';
+import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import { ActionOutput } from './lib/ActionOutput/ActionOutput';
 import LaunchIcon from '@material-ui/icons/Launch';

--- a/plugins/circleci/src/components/BuildWithStepsPage/lib/ActionOutput/ActionOutput.tsx
+++ b/plugins/circleci/src/components/BuildWithStepsPage/lib/ActionOutput/ActionOutput.tsx
@@ -15,12 +15,10 @@
  */
 
 import { LogViewer } from '@backstage/core-components';
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Typography,
-} from '@material-ui/core';
+import Accordion from '@material-ui/core/Accordion';
+import AccordionDetails from '@material-ui/core/AccordionDetails';
+import AccordionSummary from '@material-ui/core/AccordionSummary';
+import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import { BuildStepAction } from 'circleci-api';

--- a/plugins/circleci/src/components/BuildsPage/BuildsPage.tsx
+++ b/plugins/circleci/src/components/BuildsPage/BuildsPage.tsx
@@ -15,7 +15,7 @@
  */
 import React from 'react';
 import { Builds } from './lib/Builds';
-import { Grid } from '@material-ui/core';
+import Grid from '@material-ui/core/Grid';
 
 export const BuildsPage = () => (
   <Grid container spacing={3} direction="column">

--- a/plugins/circleci/src/components/BuildsPage/lib/CITable/CITable.tsx
+++ b/plugins/circleci/src/components/BuildsPage/lib/CITable/CITable.tsx
@@ -15,14 +15,12 @@
  */
 
 import React from 'react';
-import {
-  Avatar,
-  Typography,
-  Box,
-  IconButton,
-  makeStyles,
-  Tooltip,
-} from '@material-ui/core';
+import Avatar from '@material-ui/core/Avatar';
+import Typography from '@material-ui/core/Typography';
+import Box from '@material-ui/core/Box';
+import IconButton from '@material-ui/core/IconButton';
+import Tooltip from '@material-ui/core/Tooltip';
+import { makeStyles } from '@material-ui/core/styles';
 import RetryIcon from '@material-ui/icons/Replay';
 import GitHubIcon from '@material-ui/icons/GitHub';
 import LaunchIcon from '@material-ui/icons/Launch';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added an optional ESLint rule - no-top-level-material-ui-4-imports -in circleci plugin which has an auto fix function to migrate the imports and used it to migrate the Material UI imports for plugins/circleci.

issue: #23467

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
