### PR TITLE
Added Material UI 4 import rule to plugins/fossa

### DIFF
--- a/.changeset/young-months-learn.md
+++ b/.changeset/young-months-learn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-fossa': patch
+---
+
+Adjusted MUI imports for better tree shaking

--- a/plugins/fossa/.eslintrc.js
+++ b/plugins/fossa/.eslintrc.js
@@ -1,1 +1,5 @@
-module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
+    rules: {
+        '@backstage/no-top-level-material-ui-4-imports': 'error',
+    },
+});

--- a/plugins/fossa/dev/index.tsx
+++ b/plugins/fossa/dev/index.tsx
@@ -21,7 +21,7 @@ import {
   catalogApiRef,
   EntityProvider,
 } from '@backstage/plugin-catalog-react';
-import { Grid } from '@material-ui/core';
+import Grid from '@material-ui/core/Grid';
 import React from 'react';
 import { EntityFossaCard, fossaPlugin } from '../src';
 import { FindingSummary, FossaApi, fossaApiRef } from '../src/api';

--- a/plugins/fossa/src/components/FossaCard/FossaCard.tsx
+++ b/plugins/fossa/src/components/FossaCard/FossaCard.tsx
@@ -18,7 +18,8 @@ import {
   useEntity,
   MissingAnnotationEmptyState,
 } from '@backstage/plugin-catalog-react';
-import { Grid, Tooltip } from '@material-ui/core';
+import Grid from '@material-ui/core/Grid';
+import Tooltip from '@material-ui/core/Tooltip';
 import { makeStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import { DateTime } from 'luxon';

--- a/plugins/fossa/src/components/FossaPage/FossaPage.tsx
+++ b/plugins/fossa/src/components/FossaPage/FossaPage.tsx
@@ -26,9 +26,9 @@ import {
   humanizeEntityRef,
   getEntityRelations,
 } from '@backstage/plugin-catalog-react';
-import { Tooltip } from '@material-ui/core';
+import Tooltip from '@material-ui/core/Tooltip';
 import Typography from '@material-ui/core/Typography';
-import { Skeleton } from '@material-ui/lab';
+import Skeleton from '@material-ui/lab/Skeleton';
 import { DateTime } from 'luxon';
 import * as React from 'react';
 import { useMemo, useState } from 'react';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added an optional ESLint rule - no-top-level-material-ui-4-imports -in fossa  plugin which has an auto fix function to migrate the imports and used it to migrate the Material UI imports for plugins/fossa.

issue: #23467

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
