### PR TITLE
chore(test): Reduce lax regexp security warnings

### DIFF
--- a/plugins/auth-backend/src/providers/router.test.ts
+++ b/plugins/auth-backend/src/providers/router.test.ts
@@ -23,7 +23,7 @@ describe('Auth origin filtering', () => {
       baseUrl: 'http://example.com/extra-path',
     },
     auth: {
-      experimentalExtraAllowedOrigins: ['https://test-*.example.net'],
+      experimentalExtraAllowedOrigins: ['https://test-*\.example\.net'],
     },
   });
 

--- a/plugins/auth-backend/src/providers/router.test.ts
+++ b/plugins/auth-backend/src/providers/router.test.ts
@@ -28,27 +28,27 @@ describe('Auth origin filtering', () => {
   });
 
   it('Will explode, invalid origin', () => {
-    const origin = 'https://test.example.net';
+    const origin = 'https://test\.example\.net';
     expect(createOriginFilter(config)(origin)).toBeFalsy();
   });
 
   it('Will explode, invalid origin domain', () => {
-    const origin = 'https://test-1234.examplee.net';
+    const origin = 'https://test-1234\.examplee\.net';
     expect(createOriginFilter(config)(origin)).toBeFalsy();
   });
 
   it("Won't explode, uses app origin", () => {
-    const origin = 'http://example.com';
+    const origin = 'http://example\.com';
     expect(createOriginFilter(config)(origin)).toBeTruthy();
   });
 
   it("Won't explode, valid origin with numbers", () => {
-    const origin = 'https://test-1234.example.net';
+    const origin = 'https://test-1234\.example\.net';
     expect(createOriginFilter(config)(origin)).toBeTruthy();
   });
 
   it("Won't explode, valid origin with chars and numbers", () => {
-    const origin = 'https://test-test1234.example.net';
+    const origin = 'https://test-test1234\.example\.net';
     expect(createOriginFilter(config)(origin)).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

When the auth provider router was extracted via https://github.com/backstage/backstage/pull/23023, the test suite introduced mild security warnings about lax regular expressions.

This is just a quick fix to escape the relevant tests, but brings to bear that theoretically the expressions which come in from the config may not be escaped, and thus could theoretically be abused. I wonder if that means we should a) help make clear that the config router should be a regular expression fully escaped (specifically, the warning was about not escaping for example `.com` to be `\.com`), and/or prevent regexes and require a strict string match? likely not the latter, but haven't given it enough thought.

This should close four code-scanning results, including https://github.com/backstage/backstage/security/code-scanning/905 (maintainer link).

No change set since it's a test only change.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
