### PR TITLE
Add ESLint Rule to TechDocs Plugin

### DIFF
--- a/.changeset/smooth-fireants-notice.md
+++ b/.changeset/smooth-fireants-notice.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Added ESLint rule `no-top-level-material-ui-4-imports` to aid with the migration to Material UI v5.

--- a/plugins/techdocs/.eslintrc.js
+++ b/plugins/techdocs/.eslintrc.js
@@ -1,1 +1,5 @@
-module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
+  rules: {
+    '@backstage/no-top-level-material-ui-4-imports': 'error',
+  },
+});

--- a/plugins/techdocs/api-report.md
+++ b/plugins/techdocs/api-report.md
@@ -9,7 +9,7 @@ import { ApiRef } from '@backstage/core-plugin-api';
 import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { CompoundEntityRef } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
-import { CSSProperties } from '@material-ui/styles';
+import { CSSProperties } from '@material-ui/styles/withStyles';
 import { DiscoveryApi } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
 import { FetchApi } from '@backstage/core-plugin-api';
@@ -29,7 +29,7 @@ import { TechDocsApi as TechDocsApi_2 } from '@backstage/plugin-techdocs-react';
 import { TechDocsEntityMetadata as TechDocsEntityMetadata_2 } from '@backstage/plugin-techdocs-react';
 import { TechDocsMetadata as TechDocsMetadata_2 } from '@backstage/plugin-techdocs-react';
 import { TechDocsStorageApi as TechDocsStorageApi_2 } from '@backstage/plugin-techdocs-react';
-import { ToolbarProps } from '@material-ui/core';
+import { ToolbarProps } from '@material-ui/core/Toolbar';
 import { UserListFilterKind } from '@backstage/plugin-catalog-react';
 
 // @public

--- a/plugins/techdocs/src/home/components/Grids/DocsCardGrid.tsx
+++ b/plugins/techdocs/src/home/components/Grids/DocsCardGrid.tsx
@@ -23,7 +23,10 @@ import {
   ItemCardGrid,
   ItemCardHeader,
 } from '@backstage/core-components';
-import { Card, CardActions, CardContent, CardMedia } from '@material-ui/core';
+import Card from '@material-ui/core/Card';
+import CardActions from '@material-ui/core/CardActions';
+import CardContent from '@material-ui/core/CardContent';
+import CardMedia from '@material-ui/core/CardMedia';
 import React from 'react';
 
 /**

--- a/plugins/techdocs/src/home/components/Grids/EntityListDocsGrid.tsx
+++ b/plugins/techdocs/src/home/components/Grids/EntityListDocsGrid.tsx
@@ -28,7 +28,7 @@ import {
   useEntityList,
   useEntityOwnership,
 } from '@backstage/plugin-catalog-react';
-import { Typography } from '@material-ui/core';
+import Typography from '@material-ui/core/Typography';
 import React from 'react';
 
 /**

--- a/plugins/techdocs/src/home/components/Tables/actions.tsx
+++ b/plugins/techdocs/src/home/components/Tables/actions.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import ShareIcon from '@material-ui/icons/Share';
 import { DocsTableRow } from './types';
-import { withStyles } from '@material-ui/styles';
+import { withStyles } from '@material-ui/core/styles';
 import Star from '@material-ui/icons/Star';
 import StarBorder from '@material-ui/icons/StarBorder';
 

--- a/plugins/techdocs/src/home/components/TechDocsCustomHome.tsx
+++ b/plugins/techdocs/src/home/components/TechDocsCustomHome.tsx
@@ -16,8 +16,8 @@
 
 import React, { useState } from 'react';
 import useAsync from 'react-use/lib/useAsync';
-import { makeStyles } from '@material-ui/core';
-import { CSSProperties } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/core/styles';
+import CSSProperties from '@material-ui/styles/CSSProperties';
 import {
   CATALOG_FILTER_EXISTS,
   catalogApiRef,

--- a/plugins/techdocs/src/home/components/TechDocsCustomHome.tsx
+++ b/plugins/techdocs/src/home/components/TechDocsCustomHome.tsx
@@ -17,7 +17,7 @@
 import React, { useState } from 'react';
 import useAsync from 'react-use/lib/useAsync';
 import { makeStyles } from '@material-ui/core/styles';
-import CSSProperties from '@material-ui/styles/CSSProperties';
+import { CSSProperties } from '@material-ui/styles/withStyles';
 import {
   CATALOG_FILTER_EXISTS,
   catalogApiRef,

--- a/plugins/techdocs/src/reader/components/TechDocsBuildLogs.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsBuildLogs.tsx
@@ -15,16 +15,12 @@
  */
 
 import { LogViewer } from '@backstage/core-components';
-import {
-  Button,
-  createStyles,
-  Drawer,
-  Grid,
-  IconButton,
-  makeStyles,
-  Theme,
-  Typography,
-} from '@material-ui/core';
+import Button from '@material-ui/core/Button';
+import Drawer from '@material-ui/core/Drawer';
+import Grid from '@material-ui/core/Grid';
+import IconButton from '@material-ui/core/IconButton';
+import Typography from '@material-ui/core/Typography';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import Close from '@material-ui/icons/Close';
 import React, { useState } from 'react';
 

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPage/TechDocsAuthProvider.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPage/TechDocsAuthProvider.tsx
@@ -19,7 +19,7 @@ import { ErrorPanel } from '@backstage/core-components';
 import { techdocsApiRef } from '@backstage/plugin-techdocs-react';
 import { useApi, useApp } from '@backstage/core-plugin-api';
 import useAsyncRetry from 'react-use/lib/useAsyncRetry';
-import { Button } from '@material-ui/core';
+import Button from '@material-ui/core/Button';
 
 type TechDocsRefreshCookieMessage = MessageEvent<{
   action: string;

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPage/context.test.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPage/context.test.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import { renderHook, waitFor } from '@testing-library/react';
 
-import ThemeProvider from '@material-ui/core/ThemeProvider';
+import { ThemeProvider } from '@material-ui/core/styles';
 
 import { lightTheme } from '@backstage/theme';
 import { TestApiProvider } from '@backstage/test-utils';

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPage/context.test.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPage/context.test.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import { renderHook, waitFor } from '@testing-library/react';
 
-import { ThemeProvider } from '@material-ui/core';
+import ThemeProvider from '@material-ui/core/ThemeProvider';
 
 import { lightTheme } from '@backstage/theme';
 import { TestApiProvider } from '@backstage/test-utils';

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/TechDocsReaderPageContent.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/TechDocsReaderPageContent.tsx
@@ -16,7 +16,8 @@
 
 import React, { useCallback, useEffect } from 'react';
 
-import { makeStyles, Grid } from '@material-ui/core';
+import Grid from '@material-ui/core/Grid';
+import { makeStyles } from '@material-ui/core/styles';
 
 import {
   TechDocsShadowDom,

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/TechDocsReaderPageContentAddons.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/TechDocsReaderPageContentAddons.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-import { Portal } from '@material-ui/core';
+import Portal from '@material-ui/core/Portal';
 import {
   useTechDocsAddons,
   TechDocsAddonLocations as locations,

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx
@@ -16,7 +16,8 @@
 
 import { useCallback, useEffect, useState } from 'react';
 
-import { useTheme, useMediaQuery } from '@material-ui/core';
+import useMediaQuery from '@material-ui/core/useMediaQuery';
+import { useTheme } from '@material-ui/core/styles';
 
 import { CompoundEntityRef } from '@backstage/catalog-model';
 import { useAnalytics, useApi } from '@backstage/core-plugin-api';

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageHeader/TechDocsReaderPageHeader.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageHeader/TechDocsReaderPageHeader.tsx
@@ -17,8 +17,8 @@
 import React, { PropsWithChildren, useEffect } from 'react';
 import Helmet from 'react-helmet';
 
-import { Grid } from '@material-ui/core';
-import { Skeleton } from '@material-ui/lab';
+import Grid from '@material-ui/core/Grid';
+import Skeleton from '@material-ui/lab/Skeleton';
 import { useTheme } from '@material-ui/core/styles';
 import CodeIcon from '@material-ui/icons/Code';
 

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageSubheader/TechDocsReaderPageSubheader.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageSubheader/TechDocsReaderPageSubheader.tsx
@@ -16,15 +16,7 @@
 
 import React, { MouseEvent, useState, useCallback } from 'react';
 
-import {
-  Box,
-  makeStyles,
-  Toolbar,
-  ToolbarProps,
-  Menu,
-  Tooltip,
-  IconButton,
-} from '@material-ui/core';
+import Box, { ToolbarProps } from '@material-ui/core/Box';
 import SettingsIcon from '@material-ui/icons/Settings';
 
 import {

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageSubheader/TechDocsReaderPageSubheader.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageSubheader/TechDocsReaderPageSubheader.tsx
@@ -16,7 +16,13 @@
 
 import React, { MouseEvent, useState, useCallback } from 'react';
 
-import Box, { ToolbarProps } from '@material-ui/core/Box';
+import { makeStyles } from '@material-ui/core/styles';
+import IconButton from '@material-ui/core/IconButton';
+import Toolbar from '@material-ui/core/Toolbar';
+import { ToolbarProps } from '@material-ui/core/Toolbar';
+import Tooltip from '@material-ui/core/Tooltip';
+import Menu from '@material-ui/core/Menu';
+import Box from '@material-ui/core/Box';
 import SettingsIcon from '@material-ui/icons/Settings';
 
 import {

--- a/plugins/techdocs/src/reader/components/TechDocsStateIndicator.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsStateIndicator.tsx
@@ -15,8 +15,10 @@
  */
 
 import React from 'react';
-import { CircularProgress, Button, makeStyles } from '@material-ui/core';
-import { Alert } from '@material-ui/lab';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import Button from '@material-ui/core/Button';
+import { makeStyles } from '@material-ui/core/styles';
+import Alert from '@material-ui/lab/Alert';
 
 import { TechDocsBuildLogs } from './TechDocsBuildLogs';
 import { TechDocsNotFound } from './TechDocsNotFound';

--- a/plugins/techdocs/src/reader/transformers/copyToClipboard.tsx
+++ b/plugins/techdocs/src/reader/transformers/copyToClipboard.tsx
@@ -16,13 +16,10 @@
 
 import React, { useState, useCallback } from 'react';
 import { renderReactElement } from './renderReactElement';
-import {
-  withStyles,
-  Theme,
-  ThemeProvider,
-  SvgIcon,
-  Tooltip,
-} from '@material-ui/core';
+import ThemeProvider from '@material-ui/core/ThemeProvider';
+import SvgIcon from '@material-ui/core/SvgIcon';
+import Tooltip from '@material-ui/core/Tooltip';
+import { withStyles, Theme } from '@material-ui/core/styles';
 import IconButton from '@material-ui/core/IconButton';
 import type { Transformer } from './transformer';
 import useCopyToClipboard from 'react-use/lib/useCopyToClipboard';

--- a/plugins/techdocs/src/reader/transformers/copyToClipboard.tsx
+++ b/plugins/techdocs/src/reader/transformers/copyToClipboard.tsx
@@ -16,7 +16,7 @@
 
 import React, { useState, useCallback } from 'react';
 import { renderReactElement } from './renderReactElement';
-import ThemeProvider from '@material-ui/core/ThemeProvider';
+import { ThemeProvider } from '@material-ui/core/styles';
 import SvgIcon from '@material-ui/core/SvgIcon';
 import Tooltip from '@material-ui/core/Tooltip';
 import { withStyles, Theme } from '@material-ui/core/styles';

--- a/plugins/techdocs/src/reader/transformers/styles/rules/types.ts
+++ b/plugins/techdocs/src/reader/transformers/styles/rules/types.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Theme } from '@material-ui/core';
+import { Theme } from '@material-ui/core/styles';
 
 /**
  * A Backstage sidebar object that contains properties such as its pin state.

--- a/plugins/techdocs/src/reader/transformers/styles/rules/variables.ts
+++ b/plugins/techdocs/src/reader/transformers/styles/rules/variables.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import alpha from '@material-ui/core/alpha';
-import lighten from '@material-ui/core/lighten';
+import { alpha, lighten } from '@material-ui/core/styles';
 import { RuleOptions } from './types';
 
 export default ({ theme }: RuleOptions) => `

--- a/plugins/techdocs/src/reader/transformers/styles/rules/variables.ts
+++ b/plugins/techdocs/src/reader/transformers/styles/rules/variables.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { alpha, lighten } from '@material-ui/core';
+import alpha from '@material-ui/core/alpha';
+import lighten from '@material-ui/core/lighten';
 import { RuleOptions } from './types';
 
 export default ({ theme }: RuleOptions) => `

--- a/plugins/techdocs/src/reader/transformers/styles/transformer.ts
+++ b/plugins/techdocs/src/reader/transformers/styles/transformer.ts
@@ -15,7 +15,7 @@
  */
 
 import { useCallback, useMemo } from 'react';
-import { useTheme } from '@material-ui/core';
+import { useTheme } from '@material-ui/core/styles';
 import { useSidebarPinState } from '@backstage/core-components';
 import { Transformer } from '../transformer';
 import { rules } from './rules';

--- a/plugins/techdocs/src/search/components/TechDocsSearchResultListItem.tsx
+++ b/plugins/techdocs/src/search/components/TechDocsSearchResultListItem.tsx
@@ -15,7 +15,9 @@
  */
 
 import React, { PropsWithChildren, ReactNode } from 'react';
-import { ListItemIcon, ListItemText, makeStyles } from '@material-ui/core';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
+import { makeStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import { Link } from '@backstage/core-components';
 import { ResultHighlight } from '@backstage/plugin-search-common';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds the `no-top-level-material-ui-4-import` ESLint rule to the TechDocs plugin to aid with the 
migration to Material UI v5.

#23467

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
