### PR TITLE
backend-app-api: fix feature detection trying to load frontend packages

### DIFF
--- a/.changeset/two-hornets-allow.md
+++ b/.changeset/two-hornets-allow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+The experimental feature discovery service exported at the `/alpha` sub-path will no longer attempt to load packages that are not Backstage backend packages.

--- a/packages/backend-app-api/src/alpha/featureDiscoveryServiceFactory.ts
+++ b/packages/backend-app-api/src/alpha/featureDiscoveryServiceFactory.ts
@@ -29,6 +29,13 @@ import { resolve as resolvePath, dirname } from 'path';
 import fs from 'fs-extra';
 import { BackstagePackageJson } from '@backstage/cli-node';
 
+const DETECTED_PACKAGE_ROLES = [
+  'node-library',
+  'backend',
+  'backend-plugin',
+  'backend-plugin-module',
+];
+
 /** @internal */
 async function findClosestPackageDir(
   searchDir: string,
@@ -106,8 +113,11 @@ class PackageDiscoveryService implements FeatureDiscoveryService {
       const depPkg = require(require.resolve(`${name}/package.json`, {
         paths: [packageDir],
       })) as BackstagePackageJson;
-      if (!depPkg?.backstage || depPkg?.backstage?.role === 'cli') {
-        continue; // Not a backstage package, ignore
+      if (
+        !depPkg?.backstage?.role ||
+        !DETECTED_PACKAGE_ROLES.includes(depPkg.backstage.role)
+      ) {
+        continue; // Not a backstage backend package, ignore
       }
 
       const exportedModulePaths = [


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Bit more restrictive check for what type of packages to load, avoiding a crash where the backend tries to load the `app` package.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
