### PR TITLE
Add ESLint Rule to Badges Plugin

### DIFF
--- a/.changeset/lemon-mails-report.md
+++ b/.changeset/lemon-mails-report.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-badges': patch
+---
+
+Added ESLint rule `no-top-level-material-ui-4-imports` to aid with the migration to Material UI v5.

--- a/plugins/badges/.eslintrc.js
+++ b/plugins/badges/.eslintrc.js
@@ -1,1 +1,5 @@
-module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
+  rules: {
+    '@backstage/no-top-level-material-ui-4-imports': 'error',
+  },
+});

--- a/plugins/badges/src/components/EntityBadgesDialog.tsx
+++ b/plugins/badges/src/components/EntityBadgesDialog.tsx
@@ -15,17 +15,15 @@
  */
 
 import { useAsyncEntity } from '@backstage/plugin-catalog-react';
-import {
-  Box,
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogContentText,
-  DialogTitle,
-  useMediaQuery,
-  useTheme,
-} from '@material-ui/core';
+import Box from '@material-ui/core/Box';
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import useMediaQuery from '@material-ui/core/useMediaQuery';
+import { useTheme } from '@material-ui/core/styles';
 import React from 'react';
 import useAsync from 'react-use/lib/useAsync';
 import { badgesApiRef } from '../api';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added the `no-top-level-material-ui-4-import` ESLint rule to the Badges plugin to aid with the migration to Material UI v5.

#23467

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
