### PR TITLE
Add ESLint Rule to Bitrise Plugin

### DIFF
--- a/.changeset/curly-socks-enjoy.md
+++ b/.changeset/curly-socks-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-bitrise': patch
+---
+
+Added the `no-top-level-material-ui-4-import` ESLint rule to the Bitrise plugin to aid with the migration to Material UI v5.

--- a/plugins/bitrise/.eslintrc.js
+++ b/plugins/bitrise/.eslintrc.js
@@ -1,1 +1,5 @@
-module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
+  rules: {
+    '@backstage/no-top-level-material-ui-4-imports': 'error',
+  },
+});

--- a/plugins/bitrise/src/components/BitriseArtifactsComponent/BitriseArtifactsComponent.tsx
+++ b/plugins/bitrise/src/components/BitriseArtifactsComponent/BitriseArtifactsComponent.tsx
@@ -16,15 +16,13 @@
 
 import React from 'react';
 import { BitriseBuildResult } from '../../api/bitriseApi.model';
-import { Alert } from '@material-ui/lab';
+import Alert from '@material-ui/lab/Alert';
 import { BitriseDownloadArtifactComponent } from '../BitriseDownloadArtifactComponent';
 import { useBitriseArtifacts } from '../useBitriseArtifacts';
-import {
-  List,
-  ListItem,
-  ListItemSecondaryAction,
-  ListItemText,
-} from '@material-ui/core';
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
+import ListItemText from '@material-ui/core/ListItemText';
 import { Progress } from '@backstage/core-components';
 
 type BitriseArtifactsComponentComponentProps = {

--- a/plugins/bitrise/src/components/BitriseBuildDetailsDialog/BitriseBuildDetailsDialog.tsx
+++ b/plugins/bitrise/src/components/BitriseBuildDetailsDialog/BitriseBuildDetailsDialog.tsx
@@ -17,14 +17,12 @@
 import React, { useState } from 'react';
 import { BitriseBuildResult } from '../../api/bitriseApi.model';
 import { BitriseArtifactsComponent } from '../BitriseArtifactsComponent';
-import {
-  Chip,
-  Dialog,
-  DialogContent,
-  DialogTitle,
-  IconButton,
-  makeStyles,
-} from '@material-ui/core';
+import Chip from '@material-ui/core/Chip';
+import Dialog from '@material-ui/core/Dialog';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import IconButton from '@material-ui/core/IconButton';
+import { makeStyles } from '@material-ui/core/styles';
 import CloudDownload from '@material-ui/icons/CloudDownload';
 import CloseIcon from '@material-ui/icons/Close';
 

--- a/plugins/bitrise/src/components/BitriseBuildsTableComponent/BitriseBuildsTableComponent.tsx
+++ b/plugins/bitrise/src/components/BitriseBuildsTableComponent/BitriseBuildsTableComponent.tsx
@@ -15,8 +15,8 @@
  */
 
 import React, { useState } from 'react';
-import { Alert } from '@material-ui/lab';
-import { Button } from '@material-ui/core';
+import Alert from '@material-ui/lab/Alert';
+import Button from '@material-ui/core/Button';
 import GitHubIcon from '@material-ui/icons/GitHub';
 import { useBitriseBuilds } from '../../hooks/useBitriseBuilds';
 import {

--- a/plugins/bitrise/src/components/BitriseDownloadArtifactComponent/BitriseDownloadArtifactComponent.tsx
+++ b/plugins/bitrise/src/components/BitriseDownloadArtifactComponent/BitriseDownloadArtifactComponent.tsx
@@ -16,10 +16,12 @@
 
 import React from 'react';
 import CloudDownload from '@material-ui/icons/CloudDownload';
-import { CircularProgress, IconButton, Tooltip } from '@material-ui/core';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import IconButton from '@material-ui/core/IconButton';
+import Tooltip from '@material-ui/core/Tooltip';
 import LinkIcon from '@material-ui/icons/Link';
 import { useBitriseArtifactDetails } from '../useBitriseArtifactDetails';
-import { Alert } from '@material-ui/lab';
+import Alert from '@material-ui/lab/Alert';
 
 type BitriseDownloadArtifactComponentProps = {
   appSlug: string;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds the `no-top-level-material-ui-4-import` ESLint rule to the Bitrise plugin to aid with the migration to Material UI v5.

#23467

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
