### PR TITLE
Add ESLint Rule to Catalog Unprocessed Entities Plugin

### DIFF
--- a/.changeset/modern-snails-ring.md
+++ b/.changeset/modern-snails-ring.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-unprocessed-entities': patch
+---
+
+Added the `no-top-level-material-ui-4-imports` ESLint rule to aid with the migration to Material UI v5

--- a/plugins/catalog-unprocessed-entities/.eslintrc.js
+++ b/plugins/catalog-unprocessed-entities/.eslintrc.js
@@ -1,1 +1,5 @@
-module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
+  rules: {
+    '@backstage/no-top-level-material-ui-4-imports': 'error',
+  },
+});

--- a/plugins/catalog-unprocessed-entities/src/components/FailedEntities.tsx
+++ b/plugins/catalog-unprocessed-entities/src/components/FailedEntities.tsx
@@ -23,7 +23,9 @@ import {
   TableColumn,
 } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
-import { Box, Theme, Typography, makeStyles } from '@material-ui/core';
+import Box from '@material-ui/core/Box';
+import Typography from '@material-ui/core/Typography';
+import { Theme, makeStyles } from '@material-ui/core/styles';
 
 import { UnprocessedEntity } from '../types';
 import { EntityDialog } from './EntityDialog';

--- a/plugins/catalog-unprocessed-entities/src/components/PendingEntities.tsx
+++ b/plugins/catalog-unprocessed-entities/src/components/PendingEntities.tsx
@@ -21,7 +21,8 @@ import {
   TableColumn,
   Table,
 } from '@backstage/core-components';
-import { Theme, Typography, makeStyles } from '@material-ui/core';
+import Typography from '@material-ui/core/Typography';
+import { Theme, makeStyles } from '@material-ui/core/styles';
 
 import { UnprocessedEntity } from '../types';
 

--- a/plugins/catalog-unprocessed-entities/src/components/UnprocessedEntities.tsx
+++ b/plugins/catalog-unprocessed-entities/src/components/UnprocessedEntities.tsx
@@ -16,8 +16,11 @@
 import React, { useState } from 'react';
 
 import { Page, Header, Content } from '@backstage/core-components';
-import { Tab, makeStyles } from '@material-ui/core';
-import { TabContext, TabList, TabPanel } from '@material-ui/lab';
+import Tab from '@material-ui/core/Tab';
+import { makeStyles } from '@material-ui/core/styles';
+import TabContext from '@material-ui/lab/TabContext';
+import TabList from '@material-ui/lab/TabList';
+import TabPanel from '@material-ui/lab/TabPanel';
 
 import { FailedEntities } from './FailedEntities';
 import { PendingEntities } from './PendingEntities';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds the `no-top-level-material-ui-4-import` ESLint rule to the Catalog Unprocessed Entities plugin to aid with the migration to Material UI v5.

#23467

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
