### PR TITLE
Add ESLint Rule to Scaffolder Plugin

### DIFF
--- a/.changeset/thin-cats-speak.md
+++ b/.changeset/thin-cats-speak.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Added the `no-top-level-material-ui-4-imports` ESLint rule to aid with the migration to Material UI v5

--- a/plugins/scaffolder/.eslintrc.js
+++ b/plugins/scaffolder/.eslintrc.js
@@ -1,1 +1,5 @@
-module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
+  rules: {
+    '@backstage/no-top-level-material-ui-4-imports': 'error',
+  },
+});

--- a/plugins/scaffolder/src/components/ActionsPage/ActionsPage.tsx
+++ b/plugins/scaffolder/src/components/ActionsPage/ActionsPage.tsx
@@ -19,23 +19,21 @@ import {
   ActionExample,
   scaffolderApiRef,
 } from '@backstage/plugin-scaffolder-react';
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Box,
-  Collapse,
-  Grid,
-  makeStyles,
-  Paper,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Typography,
-} from '@material-ui/core';
+import Accordion from '@material-ui/core/Accordion';
+import AccordionDetails from '@material-ui/core/AccordionDetails';
+import AccordionSummary from '@material-ui/core/AccordionSummary';
+import Box from '@material-ui/core/Box';
+import Collapse from '@material-ui/core/Collapse';
+import Grid from '@material-ui/core/Grid';
+import Paper from '@material-ui/core/Paper';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableContainer from '@material-ui/core/TableContainer';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
 import { JSONSchema7, JSONSchema7Definition } from 'json-schema';
 import classNames from 'classnames';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';

--- a/plugins/scaffolder/src/components/ListTasksPage/OwnerListPicker.tsx
+++ b/plugins/scaffolder/src/components/ListTasksPage/OwnerListPicker.tsx
@@ -14,15 +14,13 @@
  * limitations under the License.
  */
 import { IconComponent } from '@backstage/core-plugin-api';
-import {
-  Card,
-  List,
-  ListItemIcon,
-  ListItemText,
-  makeStyles,
-  MenuItem,
-  Typography,
-} from '@material-ui/core';
+import Card from '@material-ui/core/Card';
+import List from '@material-ui/core/List';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
+import MenuItem from '@material-ui/core/MenuItem';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
 import SettingsIcon from '@material-ui/icons/Settings';
 import React, { Fragment } from 'react';
 

--- a/plugins/scaffolder/src/components/OngoingTask/ContextMenu.tsx
+++ b/plugins/scaffolder/src/components/OngoingTask/ContextMenu.tsx
@@ -14,17 +14,13 @@
  * limitations under the License.
  */
 
-import {
-  IconButton,
-  ListItemIcon,
-  ListItemText,
-  makeStyles,
-  MenuItem,
-  MenuList,
-  Popover,
-  Theme,
-  useTheme,
-} from '@material-ui/core';
+import IconButton from '@material-ui/core/IconButton';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
+import MenuItem from '@material-ui/core/MenuItem';
+import MenuList from '@material-ui/core/MenuList';
+import Popover from '@material-ui/core/Popover';
+import { makeStyles, Theme, useTheme } from '@material-ui/core/styles';
 import { useAsync } from '@react-hookz/web';
 import Cancel from '@material-ui/icons/Cancel';
 import Retry from '@material-ui/icons/Repeat';

--- a/plugins/scaffolder/src/components/OngoingTask/OngoingTask.tsx
+++ b/plugins/scaffolder/src/components/OngoingTask/OngoingTask.tsx
@@ -16,7 +16,10 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Content, ErrorPanel, Header, Page } from '@backstage/core-components';
 import { useNavigate, useParams } from 'react-router-dom';
-import { Box, Button, makeStyles, Paper } from '@material-ui/core';
+import Box from '@material-ui/core/Box';
+import Button from '@material-ui/core/Button';
+import Paper from '@material-ui/core/Paper';
+import { makeStyles } from '@material-ui/core/styles';
 import {
   ScaffolderTaskOutput,
   scaffolderApiRef,

--- a/plugins/scaffolder/src/components/TemplateTypePicker/TemplateTypePicker.tsx
+++ b/plugins/scaffolder/src/components/TemplateTypePicker/TemplateTypePicker.tsx
@@ -17,17 +17,15 @@
 import React from 'react';
 import capitalize from 'lodash/capitalize';
 import { Progress } from '@backstage/core-components';
-import {
-  Box,
-  Checkbox,
-  FormControlLabel,
-  TextField,
-  Typography,
-} from '@material-ui/core';
+import Box from '@material-ui/core/Box';
+import Checkbox from '@material-ui/core/Checkbox';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import TextField from '@material-ui/core/TextField';
+import Typography from '@material-ui/core/Typography';
 import CheckBoxIcon from '@material-ui/icons/CheckBox';
 import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
-import { Autocomplete } from '@material-ui/lab';
+import Autocomplete from '@material-ui/lab/Autocomplete';
 import { useEntityTypeFilter } from '@backstage/plugin-catalog-react';
 import { alertApiRef, useApi } from '@backstage/core-plugin-api';
 

--- a/plugins/scaffolder/src/components/fields/EntityNamePicker/EntityNamePicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityNamePicker/EntityNamePicker.tsx
@@ -15,7 +15,7 @@
  */
 import React from 'react';
 import { EntityNamePickerProps } from './schema';
-import { TextField } from '@material-ui/core';
+import TextField from '@material-ui/core/TextField';
 
 export { EntityNamePickerSchema } from './schema';
 

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
@@ -27,7 +27,7 @@ import {
   catalogApiRef,
   humanizeEntityRef,
 } from '@backstage/plugin-catalog-react';
-import { TextField } from '@material-ui/core';
+import TextField from '@material-ui/core/TextField';
 import FormControl from '@material-ui/core/FormControl';
 import Autocomplete, {
   AutocompleteChangeReason,

--- a/plugins/scaffolder/src/components/fields/EntityTagsPicker/EntityTagsPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityTagsPicker/EntityTagsPicker.tsx
@@ -20,8 +20,9 @@ import { GetEntityFacetsRequest } from '@backstage/catalog-client';
 import { makeValidator } from '@backstage/catalog-model';
 import { useApi } from '@backstage/core-plugin-api';
 import { catalogApiRef } from '@backstage/plugin-catalog-react';
-import { FormControl, TextField } from '@material-ui/core';
-import { Autocomplete } from '@material-ui/lab';
+import FormControl from '@material-ui/core/FormControl';
+import TextField from '@material-ui/core/TextField';
+import Autocomplete from '@material-ui/lab/Autocomplete';
 import { EntityTagsPickerProps } from './schema';
 
 export { EntityTagsPickerSchema } from './schema';

--- a/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.tsx
@@ -27,7 +27,7 @@ import {
   catalogApiRef,
   humanizeEntityRef,
 } from '@backstage/plugin-catalog-react';
-import { TextField } from '@material-ui/core';
+import TextField from '@material-ui/core/TextField';
 import FormControl from '@material-ui/core/FormControl';
 import Autocomplete, {
   AutocompleteChangeReason,

--- a/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.tsx
@@ -20,9 +20,10 @@ import {
   identityApiRef,
   useApi,
 } from '@backstage/core-plugin-api';
-import { TextField, FormControl } from '@material-ui/core';
+import TextField from '@material-ui/core/TextField';
+import FormControl from '@material-ui/core/FormControl';
 import { MyGroupsPickerProps, MyGroupsPickerSchema } from './schema';
-import { Autocomplete } from '@material-ui/lab';
+import Autocomplete from '@material-ui/lab/Autocomplete';
 import { catalogApiRef } from '@backstage/plugin-catalog-react';
 import { NotFoundError } from '@backstage/errors';
 import useAsync from 'react-use/lib/useAsync';

--- a/plugins/scaffolder/src/components/fields/OwnedEntityPicker/OwnedEntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/OwnedEntityPicker/OwnedEntityPicker.tsx
@@ -15,7 +15,7 @@
  */
 import { RELATION_OWNED_BY } from '@backstage/catalog-model';
 import { identityApiRef, useApi } from '@backstage/core-plugin-api';
-import { TextField } from '@material-ui/core';
+import TextField from '@material-ui/core/TextField';
 import Autocomplete from '@material-ui/lab/Autocomplete';
 import React from 'react';
 import useAsync from 'react-use/lib/useAsync';

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
@@ -32,7 +32,9 @@ import { RepoUrlPickerProps } from './schema';
 import { RepoUrlPickerState } from './types';
 import useDebounce from 'react-use/lib/useDebounce';
 import { useTemplateSecrets } from '@backstage/plugin-scaffolder-react';
-import { Box, Divider, Typography } from '@material-ui/core';
+import Box from '@material-ui/core/Box';
+import Divider from '@material-ui/core/Divider';
+import Typography from '@material-ui/core/Typography';
 
 export { RepoUrlPickerSchema } from './schema';
 

--- a/plugins/scaffolder/src/components/fields/SecretInput/SecretInput.tsx
+++ b/plugins/scaffolder/src/components/fields/SecretInput/SecretInput.tsx
@@ -17,7 +17,8 @@ import React from 'react';
 import { useTemplateSecrets } from '@backstage/plugin-scaffolder-react';
 import { ScaffolderRJSFFieldProps } from '@backstage/plugin-scaffolder-react';
 import { ScaffolderField } from '@backstage/plugin-scaffolder-react/alpha';
-import { Input, InputLabel } from '@material-ui/core';
+import Input from '@material-ui/core/Input';
+import InputLabel from '@material-ui/core/InputLabel';
 
 export const SecretInput = (props: ScaffolderRJSFFieldProps) => {
   const { setSecrets, secrets } = useTemplateSecrets();

--- a/plugins/scaffolder/src/next/TemplateEditorPage/CustomFieldExplorer.tsx
+++ b/plugins/scaffolder/src/next/TemplateEditorPage/CustomFieldExplorer.tsx
@@ -15,18 +15,16 @@
  */
 import { StreamLanguage } from '@codemirror/language';
 import { yaml as yamlSupport } from '@codemirror/legacy-modes/mode/yaml';
-import {
-  Button,
-  Card,
-  CardContent,
-  CardHeader,
-  FormControl,
-  IconButton,
-  InputLabel,
-  makeStyles,
-  MenuItem,
-  Select,
-} from '@material-ui/core';
+import Button from '@material-ui/core/Button';
+import Card from '@material-ui/core/Card';
+import CardContent from '@material-ui/core/CardContent';
+import CardHeader from '@material-ui/core/CardHeader';
+import FormControl from '@material-ui/core/FormControl';
+import IconButton from '@material-ui/core/IconButton';
+import InputLabel from '@material-ui/core/InputLabel';
+import MenuItem from '@material-ui/core/MenuItem';
+import Select from '@material-ui/core/Select';
+import { makeStyles } from '@material-ui/core/styles';
 import CloseIcon from '@material-ui/icons/Close';
 import CodeMirror from '@uiw/react-codemirror';
 import React, { useCallback, useMemo, useState } from 'react';

--- a/plugins/scaffolder/src/next/TemplateEditorPage/DryRunResults/IconLink.tsx
+++ b/plugins/scaffolder/src/next/TemplateEditorPage/DryRunResults/IconLink.tsx
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 import React from 'react';
-import { Grid, LinkProps, makeStyles, Typography } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
+import Grid from '@material-ui/core/Grid';
+import { LinkProps } from '@material-ui/core/Link';
 import LanguageIcon from '@material-ui/icons/Language';
 
 import { IconComponent } from '@backstage/core-plugin-api';

--- a/plugins/scaffolder/src/next/TemplateEditorPage/DryRunResults/TaskPageLinks.tsx
+++ b/plugins/scaffolder/src/next/TemplateEditorPage/DryRunResults/TaskPageLinks.tsx
@@ -16,7 +16,7 @@
 
 import { parseEntityRef } from '@backstage/catalog-model';
 import { entityRouteRef } from '@backstage/plugin-catalog-react';
-import { Box } from '@material-ui/core';
+import Box from '@material-ui/core/Box';
 import LanguageIcon from '@material-ui/icons/Language';
 import React from 'react';
 import { ScaffolderTaskOutput } from '@backstage/plugin-scaffolder-react';

--- a/plugins/scaffolder/src/next/TemplateEditorPage/DryRunResults/TaskStatusStepper.tsx
+++ b/plugins/scaffolder/src/next/TemplateEditorPage/DryRunResults/TaskStatusStepper.tsx
@@ -14,19 +14,15 @@
  * limitations under the License.
  */
 import React, { useState } from 'react';
+import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
 import { memo } from 'react';
 import Step from '@material-ui/core/Step';
 import StepLabel from '@material-ui/core/StepLabel';
 import Stepper from '@material-ui/core/Stepper';
 import { ScaffolderTaskStatus } from '@backstage/plugin-scaffolder-react';
-import {
-  StepButton,
-  StepIconProps,
-  Theme,
-  createStyles,
-  makeStyles,
-  CircularProgress,
-} from '@material-ui/core';
+import StepButton from '@material-ui/core/StepButton';
+import { StepIconProps } from '@material-ui/core/StepIcon';
+import CircularProgress from '@material-ui/core/CircularProgress';
 import Cancel from '@material-ui/icons/Cancel';
 import Check from '@material-ui/icons/Check';
 import FiberManualRecordIcon from '@material-ui/icons/FiberManualRecord';

--- a/plugins/scaffolder/src/next/TemplateEditorPage/TemplateEditor.tsx
+++ b/plugins/scaffolder/src/next/TemplateEditorPage/TemplateEditor.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { makeStyles } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
 import React, { useState } from 'react';
 import type { LayoutOptions } from '@backstage/plugin-scaffolder-react';
 import { FieldExtensionOptions } from '@backstage/plugin-scaffolder-react';

--- a/plugins/scaffolder/src/next/TemplateEditorPage/TemplateEditorBrowser.tsx
+++ b/plugins/scaffolder/src/next/TemplateEditorPage/TemplateEditorBrowser.tsx
@@ -13,7 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Divider, IconButton, makeStyles, Tooltip } from '@material-ui/core';
+import Divider from '@material-ui/core/Divider';
+import IconButton from '@material-ui/core/IconButton';
+import Tooltip from '@material-ui/core/Tooltip';
+import { makeStyles } from '@material-ui/core/styles';
 import CloseIcon from '@material-ui/icons/Close';
 import RefreshIcon from '@material-ui/icons/Refresh';
 import SaveIcon from '@material-ui/icons/Save';

--- a/plugins/scaffolder/src/next/TemplateEditorPage/TemplateEditorTextArea.tsx
+++ b/plugins/scaffolder/src/next/TemplateEditorPage/TemplateEditorTextArea.tsx
@@ -17,7 +17,10 @@
 import { StreamLanguage } from '@codemirror/language';
 import { yaml as yamlSupport } from '@codemirror/legacy-modes/mode/yaml';
 import { showPanel } from '@codemirror/view';
-import { IconButton, makeStyles, Paper, Tooltip } from '@material-ui/core';
+import IconButton from '@material-ui/core/IconButton';
+import Paper from '@material-ui/core/Paper';
+import Tooltip from '@material-ui/core/Tooltip';
+import { makeStyles } from '@material-ui/core/styles';
 import RefreshIcon from '@material-ui/icons/Refresh';
 import SaveIcon from '@material-ui/icons/Save';
 import { useKeyboardEvent } from '@react-hookz/web';

--- a/plugins/scaffolder/src/next/TemplateEditorPage/TemplateFormPreviewer.tsx
+++ b/plugins/scaffolder/src/next/TemplateEditorPage/TemplateFormPreviewer.tsx
@@ -19,15 +19,13 @@ import {
   catalogApiRef,
   humanizeEntityRef,
 } from '@backstage/plugin-catalog-react';
-import {
-  FormControl,
-  IconButton,
-  InputLabel,
-  LinearProgress,
-  makeStyles,
-  MenuItem,
-  Select,
-} from '@material-ui/core';
+import FormControl from '@material-ui/core/FormControl';
+import IconButton from '@material-ui/core/IconButton';
+import InputLabel from '@material-ui/core/InputLabel';
+import LinearProgress from '@material-ui/core/LinearProgress';
+import MenuItem from '@material-ui/core/MenuItem';
+import Select from '@material-ui/core/Select';
+import { makeStyles } from '@material-ui/core/styles';
 import CloseIcon from '@material-ui/icons/Close';
 import React, { useCallback, useState } from 'react';
 import useAsync from 'react-use/lib/useAsync';

--- a/plugins/scaffolder/src/next/TemplateListPage/RegisterExistingButton.tsx
+++ b/plugins/scaffolder/src/next/TemplateListPage/RegisterExistingButton.tsx
@@ -22,7 +22,7 @@ import { Link as RouterLink, LinkProps } from 'react-router-dom';
 import AddCircleOutline from '@material-ui/icons/AddCircleOutline';
 import { catalogEntityCreatePermission } from '@backstage/plugin-catalog-common/alpha';
 import { usePermission } from '@backstage/plugin-permission-react';
-import { Theme } from '@material-ui/core';
+import { Theme } from '@material-ui/core/styles';
 
 /**
  * Properties for {@link RegisterExistingButton}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds the `no-top-level-material-ui-4-import` ESLint rule to the Scaffolder plugin to aid with the migration to Material UI v5.

#23467

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
