### PR TITLE
Add ESLint Rule to Code-Climate Plugin

### DIFF
--- a/.changeset/small-wasps-perform.md
+++ b/.changeset/small-wasps-perform.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-code-climate': patch
+---
+
+Added ESLint rule `no-top-level-material-ui-4-imports` in the Code-Climate plugin to migrate the Material UI imports.

--- a/plugins/code-climate/.eslintrc.js
+++ b/plugins/code-climate/.eslintrc.js
@@ -1,1 +1,5 @@
-module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
+    rules: {
+      '@backstage/no-top-level-material-ui-4-imports': 'error',
+    },
+});

--- a/plugins/code-climate/dev/index.tsx
+++ b/plugins/code-climate/dev/index.tsx
@@ -17,7 +17,7 @@
 import { Entity } from '@backstage/catalog-model';
 // eslint-disable-next-line @backstage/no-undeclared-imports
 import { createDevApp, EntityGridItem } from '@backstage/dev-utils';
-import { Grid } from '@material-ui/core';
+import Grid from '@material-ui/core/Grid';
 import React from 'react';
 import {
   EntityCodeClimateCard,

--- a/plugins/code-climate/src/components/CodeClimateTable/CodeClimateTable.tsx
+++ b/plugins/code-climate/src/components/CodeClimateTable/CodeClimateTable.tsx
@@ -17,7 +17,9 @@
 import React from 'react';
 import { CodeClimateData } from '../../api';
 import { Link } from '@backstage/core-components';
-import { Box, makeStyles, Theme, Typography } from '@material-ui/core';
+import Box from '@material-ui/core/Box';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles, Theme } from '@material-ui/core/styles';
 
 const letterStyle = (theme: Theme) => ({
   color: theme.palette.common.white,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds the no-top-level-material-ui-4-import ESLint rule to the Code-Climate plugin to aid with the migration to Material UI v5.

Issue: #23467

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
