### PR TITLE
Add ESLint Rule to Code-Coverage Plugin

### DIFF
--- a/.changeset/yellow-panthers-refuse.md
+++ b/.changeset/yellow-panthers-refuse.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-code-coverage': patch
+---
+
+Added ESLint rule `no-top-level-material-ui-4-imports` in the Code-Coverage plugin to migrate the Material UI imports.

--- a/plugins/code-coverage/.eslintrc.js
+++ b/plugins/code-coverage/.eslintrc.js
@@ -1,1 +1,5 @@
-module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
+    rules: {
+        '@backstage/no-top-level-material-ui-4-imports': 'error',
+    },
+});

--- a/plugins/code-coverage/src/components/CoverageHistoryChart/CoverageHistoryChart.tsx
+++ b/plugins/code-coverage/src/components/CoverageHistoryChart/CoverageHistoryChart.tsx
@@ -15,19 +15,17 @@
  */
 
 import { useEntity } from '@backstage/plugin-catalog-react';
-import {
-  Box,
-  Card,
-  CardContent,
-  CardHeader,
-  makeStyles,
-  Typography,
-} from '@material-ui/core';
+import Box from '@material-ui/core/Box';
+import Card from '@material-ui/core/Card';
+import CardContent from '@material-ui/core/CardContent';
+import CardHeader from '@material-ui/core/CardHeader';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
 import TrendingDownIcon from '@material-ui/icons/TrendingDown';
 import TrendingFlatIcon from '@material-ui/icons/TrendingFlat';
 import TrendingUpIcon from '@material-ui/icons/TrendingUp';
-import { Alert } from '@material-ui/lab';
-import { ClassNameMap } from '@material-ui/styles';
+import Alert from '@material-ui/lab/Alert';
+import ClassNameMap from '@material-ui/styles/ClassNameMap';
 import React from 'react';
 import useAsync from 'react-use/lib/useAsync';
 import {

--- a/plugins/code-coverage/src/components/CoverageHistoryChart/CoverageHistoryChart.tsx
+++ b/plugins/code-coverage/src/components/CoverageHistoryChart/CoverageHistoryChart.tsx
@@ -25,7 +25,7 @@ import TrendingDownIcon from '@material-ui/icons/TrendingDown';
 import TrendingFlatIcon from '@material-ui/icons/TrendingFlat';
 import TrendingUpIcon from '@material-ui/icons/TrendingUp';
 import Alert from '@material-ui/lab/Alert';
-import { ClassNameMap } from '@material-ui/styles';
+import { ClassNameMap } from '@material-ui/styles/withStyles';
 import React from 'react';
 import useAsync from 'react-use/lib/useAsync';
 import {

--- a/plugins/code-coverage/src/components/CoverageHistoryChart/CoverageHistoryChart.tsx
+++ b/plugins/code-coverage/src/components/CoverageHistoryChart/CoverageHistoryChart.tsx
@@ -25,7 +25,7 @@ import TrendingDownIcon from '@material-ui/icons/TrendingDown';
 import TrendingFlatIcon from '@material-ui/icons/TrendingFlat';
 import TrendingUpIcon from '@material-ui/icons/TrendingUp';
 import Alert from '@material-ui/lab/Alert';
-import ClassNameMap from '@material-ui/styles/ClassNameMap';
+import { ClassNameMap } from '@material-ui/styles';
 import React from 'react';
 import useAsync from 'react-use/lib/useAsync';
 import {

--- a/plugins/code-coverage/src/components/FileExplorer/CodeRow.tsx
+++ b/plugins/code-coverage/src/components/FileExplorer/CodeRow.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-import { makeStyles } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles(theme => ({
   lineNumberCell: {

--- a/plugins/code-coverage/src/components/FileExplorer/FileContent.tsx
+++ b/plugins/code-coverage/src/components/FileExplorer/FileContent.tsx
@@ -15,8 +15,9 @@
  */
 
 import { useEntity } from '@backstage/plugin-catalog-react';
-import { makeStyles, Paper } from '@material-ui/core';
-import { Alert } from '@material-ui/lab';
+import Paper from '@material-ui/core/Paper';
+import { makeStyles } from '@material-ui/core/styles';
+import Alert from '@material-ui/lab/Alert';
 import React from 'react';
 import useAsync from 'react-use/lib/useAsync';
 import { codeCoverageApiRef } from '../../api';

--- a/plugins/code-coverage/src/components/FileExplorer/FileExplorer.tsx
+++ b/plugins/code-coverage/src/components/FileExplorer/FileExplorer.tsx
@@ -15,10 +15,12 @@
  */
 
 import { humanizeEntityRef, useEntity } from '@backstage/plugin-catalog-react';
-import { Box, Modal, makeStyles } from '@material-ui/core';
+import Box from '@material-ui/core/Box';
+import Modal from '@material-ui/core/Modal';
+import { makeStyles } from '@material-ui/core/styles';
 import FolderIcon from '@material-ui/icons/Folder';
 import FileOutlinedIcon from '@material-ui/icons/InsertDriveFileOutlined';
-import { Alert } from '@material-ui/lab';
+import Alert from '@material-ui/lab/Alert';
 import React, { Fragment, useEffect, useState } from 'react';
 import useAsync from 'react-use/lib/useAsync';
 import { codeCoverageApiRef } from '../../api';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds the no-top-level-material-ui-4-import ESLint rule to the Code-Coverage plugin to aid with the migration to Material UI v5.

issue: #23467 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
