### PR TITLE
Add ESLint Rule to Codescene Plugin

### DIFF
--- a/.changeset/nine-dryers-drive.md
+++ b/.changeset/nine-dryers-drive.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-codescene': patch
+---
+
+Added ESLint rule `no-top-level-material-ui-4-imports` in the Codescene plugin to migrate the Material UI imports.

--- a/plugins/codescene/.eslintrc.js
+++ b/plugins/codescene/.eslintrc.js
@@ -1,1 +1,5 @@
-module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
+    rules: {
+        '@backstage/no-top-level-material-ui-4-imports': 'error',
+    },
+});

--- a/plugins/codescene/src/components/CodeHealthKpisCard/CodeHealthKpisCard.tsx
+++ b/plugins/codescene/src/components/CodeHealthKpisCard/CodeHealthKpisCard.tsx
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 import { EmptyState, InfoCard } from '@backstage/core-components';
-import { Button, Grid, makeStyles, Typography } from '@material-ui/core';
+import Button from '@material-ui/core/Button';
+import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
 import React, { PropsWithChildren } from 'react';
 import { Analysis } from '../../api/types';
 import { Gauge } from '../Gauge/Gauge';

--- a/plugins/codescene/src/components/CodeSceneEntityFileSummary/CodeSceneEntityFileSummary.tsx
+++ b/plugins/codescene/src/components/CodeSceneEntityFileSummary/CodeSceneEntityFileSummary.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { Content, EmptyState, InfoCard } from '@backstage/core-components';
-import { Grid } from '@material-ui/core';
+import Grid from '@material-ui/core/Grid';
 import Alert from '@material-ui/lab/Alert';
 import React from 'react';
 import {

--- a/plugins/codescene/src/components/CodeSceneEntityKPICard/CodeSceneEntityKPICard.tsx
+++ b/plugins/codescene/src/components/CodeSceneEntityKPICard/CodeSceneEntityKPICard.tsx
@@ -29,7 +29,8 @@ import {
 } from '../../utils/commonUtil';
 import { DateTime } from 'luxon';
 import { MissingAnnotationEmptyState } from '@backstage/plugin-catalog-react';
-import { Grid, Typography } from '@material-ui/core';
+import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
 
 export const CodeSceneEntityKPICard = () => {
   const { entity } = useEntity();

--- a/plugins/codescene/src/components/CodeScenePageComponent/CodeScenePageComponent.tsx
+++ b/plugins/codescene/src/components/CodeScenePageComponent/CodeScenePageComponent.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import React from 'react';
-import { Grid } from '@material-ui/core';
+import Grid from '@material-ui/core/Grid';
 import {
   Header,
   Page,

--- a/plugins/codescene/src/components/CodeSceneProjectDetailsPage/CodeSceneProjectDetailsPage.tsx
+++ b/plugins/codescene/src/components/CodeSceneProjectDetailsPage/CodeSceneProjectDetailsPage.tsx
@@ -25,7 +25,8 @@ import {
   TableColumn,
 } from '@backstage/core-components';
 import { configApiRef, useApi, useApp } from '@backstage/core-plugin-api';
-import { Grid, Typography } from '@material-ui/core';
+import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
 import Alert from '@material-ui/lab/Alert';
 import React from 'react';
 import { useParams } from 'react-router-dom';

--- a/plugins/codescene/src/components/ProjectsComponent/ProjectsComponent.tsx
+++ b/plugins/codescene/src/components/ProjectsComponent/ProjectsComponent.tsx
@@ -27,16 +27,14 @@ import { Link as RouterLink } from 'react-router-dom';
 import { rootRouteRef } from '../../routes';
 import { codesceneApiRef } from '../../api/api';
 import { Project, Analysis } from '../../api/types';
-import {
-  Grid,
-  Card,
-  CardActionArea,
-  Input,
-  makeStyles,
-  CardContent,
-  Chip,
-  CardActions,
-} from '@material-ui/core';
+import Grid from '@material-ui/core/Grid';
+import Card from '@material-ui/core/Card';
+import CardActionArea from '@material-ui/core/CardActionArea';
+import Input from '@material-ui/core/Input';
+import CardContent from '@material-ui/core/CardContent';
+import Chip from '@material-ui/core/Chip';
+import CardActions from '@material-ui/core/CardActions';
+import { makeStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles(() => ({
   overflowXScroll: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added ESLint rule `no-top-level-material-ui-4-imports` in the Codescene plugin to migrate the Material UI imports.

issue: #23467 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
