### PR TITLE
[Auth] Create unauthorized requests rate limiting

### DIFF
--- a/.changeset/new-spoons-stare.md
+++ b/.changeset/new-spoons-stare.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': minor
+---
+
+Adds an initial rate-limiting implementation so that any incoming requests that have a 'none' principal are rate-limited automatically.

--- a/.changeset/new-spoons-stare.md
+++ b/.changeset/new-spoons-stare.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/backend-app-api': minor
+'@backstage/backend-app-api': patch
 ---
 
-Adds an initial rate-limiting implementation so that any incoming requests that have a 'none' principal are rate-limited automatically.
+Adds an initial rate-limiting implementation so that any incoming requests that have a `'none'` principal are rate-limited automatically.

--- a/packages/backend-app-api/config.d.ts
+++ b/packages/backend-app-api/config.d.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { HumanDuration } from '@backstage/types';
+
 export interface Config {
   backend?: {
     auth?: {
@@ -32,6 +34,16 @@ export interface Config {
        * unless you configure credentials for service calls.
        */
       dangerouslyDisableDefaultAuthPolicy?: boolean;
+      rateLimit?: {
+        /**
+         * Limit each IP to max requests per window
+         */
+        max?: number;
+        /**
+         * The duration for which the rate limit is enforced
+         */
+        window?: HumanDuration;
+      };
     };
   };
 

--- a/packages/backend-app-api/config.d.ts
+++ b/packages/backend-app-api/config.d.ts
@@ -34,16 +34,20 @@ export interface Config {
        * unless you configure credentials for service calls.
        */
       dangerouslyDisableDefaultAuthPolicy?: boolean;
-      rateLimit?: {
-        /**
-         * Limit each IP to max requests per window
-         */
-        max?: number;
-        /**
-         * The duration for which the rate limit is enforced
-         */
-        window?: HumanDuration;
-      };
+      rateLimit?:
+        | false
+        | {
+            /**
+             * Limit each IP to max requests per window
+             */
+            max?: number;
+            /**
+             * The duration for which the rate limit is enforced
+             */
+            window?: HumanDuration;
+
+            disable?: true;
+          };
     };
   };
 

--- a/packages/backend-app-api/config.d.ts
+++ b/packages/backend-app-api/config.d.ts
@@ -34,21 +34,24 @@ export interface Config {
        * unless you configure credentials for service calls.
        */
       dangerouslyDisableDefaultAuthPolicy?: boolean;
-      rateLimit?:
-        | false
-        | {
-            /**
-             * Limit each IP to max requests per window
-             */
-            max?: number;
-            /**
-             * The duration for which the rate limit is enforced
-             */
-            window?: HumanDuration;
-
-            disable?: true;
-          };
     };
+    /** @visibility frontend */
+    rateLimit?:
+      | false
+      | {
+          /**
+           * Limit each IP to max requests per window, defaults to 60 requests.
+           */
+          max?: number;
+          /**
+           * The duration for which the rate limit is enforced, defaults to 1 minute.
+           */
+          window?: HumanDuration;
+          /**
+           * Disable the rate limit verification.
+           */
+          disable?: true;
+        };
   };
 
   /** Discovery options. */

--- a/packages/backend-app-api/package.json
+++ b/packages/backend-app-api/package.json
@@ -64,6 +64,7 @@
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
+    "express-rate-limit": "^7.2.0",
     "fs-extra": "^11.2.0",
     "helmet": "^6.0.0",
     "jose": "^5.0.0",

--- a/packages/backend-app-api/src/services/implementations/httpRouter/createCredentialsBarrier.test.ts
+++ b/packages/backend-app-api/src/services/implementations/httpRouter/createCredentialsBarrier.test.ts
@@ -188,8 +188,8 @@ it('do not limit authenticated requests', async () => {
   const max = 2;
   const configMock = {
     backend: {
-      auth: {
-        rateLimit: {
+      rateLimit: {
+        unauthorized: {
           max, // 2 requests per window
           window: { minutes: 2 }, // rate limit window expiration time,
         },
@@ -237,8 +237,8 @@ it('limit the number of unauthenticated requests', async () => {
 
   const configMock = {
     backend: {
-      auth: {
-        rateLimit: {
+      rateLimit: {
+        unauthorized: {
           max: 2, // 2 requests per window
           window: { minutes: 2 }, // rate limit window expiration time,
         },
@@ -279,25 +279,25 @@ it('limit the number of unauthenticated requests', async () => {
   expect(cacheMock.get).toHaveBeenCalledTimes(4);
   expect(cacheMock.set).toHaveBeenNthCalledWith(
     1,
-    `rl_${randomIp}`, // rl is the default prefix for the rate limit store
+    `unauthorized_rate_limit_${randomIp}`, // unauthorized_rate_limit_ is the default prefix for the rate limit store
     { resetTime, totalHits: 1 },
     { ttl: twoMinutesInMilliseconds },
   );
   expect(cacheMock.set).toHaveBeenNthCalledWith(
     2,
-    `rl_${randomIp}`,
+    `unauthorized_rate_limit_${randomIp}`,
     { resetTime, totalHits: 2 },
     { ttl: twoMinutesInMilliseconds },
   );
   expect(cacheMock.set).toHaveBeenNthCalledWith(
     3,
-    `rl_${randomIp}`,
+    `unauthorized_rate_limit_${randomIp}`,
     { resetTime, totalHits: 3 },
     { ttl: twoMinutesInMilliseconds },
   );
   expect(cacheMock.set).toHaveBeenNthCalledWith(
     4,
-    `rl_${randomIp}`,
+    `unauthorized_rate_limit_${randomIp}`,
     { resetTime, totalHits: 1 },
     { ttl: twoMinutesInMilliseconds },
   );
@@ -320,8 +320,8 @@ it('skip limiting requests when the rate limit is disabled', async () => {
     cache: cacheMock,
     config: {
       backend: {
-        auth: {
-          rateLimit: {
+        rateLimit: {
+          unauthorized: {
             max,
             window: { minutes: 2 },
             disabled: true,
@@ -333,7 +333,6 @@ it('skip limiting requests when the rate limit is disabled', async () => {
 
   barrier1.addAuthPolicy({ allow: 'unauthenticated', path: '/public' });
 
-  // exceed the rate limit for authenticated requests
   for (let i = 0; i < max + 1; i += 1) {
     await request(app1)
       .get('/public')
@@ -349,8 +348,8 @@ it('skip limiting requests when the rate limit is disabled', async () => {
     cache: cacheMock,
     config: {
       backend: {
-        auth: {
-          rateLimit: false,
+        rateLimit: {
+          unauthorized: false,
         },
       },
     },
@@ -358,7 +357,6 @@ it('skip limiting requests when the rate limit is disabled', async () => {
 
   barrier2.addAuthPolicy({ allow: 'unauthenticated', path: '/public' });
 
-  // exceed the rate limit for authenticated requests
   await request(app2).get('/public').send().expect(200);
 
   jest.useRealTimers();

--- a/packages/backend-app-api/src/services/implementations/httpRouter/createCredentialsBarrier.ts
+++ b/packages/backend-app-api/src/services/implementations/httpRouter/createCredentialsBarrier.ts
@@ -65,17 +65,17 @@ export function createCredentialsBarrier(options: {
   const unauthenticatedPredicates = new Array<(path: string) => boolean>();
   const cookiePredicates = new Array<(path: string) => boolean>();
 
-  // Default rate limit is 100 requests per 15 minutes
+  // Default rate limit is 60 requests per 1 minute
   const max = config?.has('backend.auth.rateLimit.max')
     ? config.getNumber('backend.auth.rateLimit.max')
-    : 100;
+    : 60;
 
   const duration = config?.has('backend.auth.rateLimit.window')
     ? readDurationFromConfig(config.getConfig('backend.auth.rateLimit.window'))
     : undefined;
 
-  // Default rate limit window is 15 minutes
-  const windowMs = duration ? durationToMilliseconds(duration) : 15 * 60 * 1000;
+  // Default rate limit window is 1 minute
+  const windowMs = duration ? durationToMilliseconds(duration) : 1 * 60 * 1000;
 
   const limiter = rateLimit({
     windowMs,

--- a/packages/backend-app-api/src/services/implementations/httpRouter/createCredentialsBarrier.ts
+++ b/packages/backend-app-api/src/services/implementations/httpRouter/createCredentialsBarrier.ts
@@ -65,18 +65,19 @@ export function createCredentialsBarrier(options: {
   const unauthenticatedPredicates = new Array<(path: string) => boolean>();
   const cookiePredicates = new Array<(path: string) => boolean>();
 
-  const rateLimitConfig = config.getOptional('backend.auth.rateLimit');
+  const rateLimitConfig = config.getOptional('backend.rateLimit.unauthorized');
 
   const disabled =
     rateLimitConfig === false ||
     (typeof rateLimitConfig === 'object' &&
-      config?.getOptionalBoolean('backend.auth.rateLimit.disabled') === true);
+      config?.getOptionalBoolean('backend.rateLimit.unauthorized.disabled') ===
+        true);
 
   const duration =
     typeof rateLimitConfig === 'object' &&
-    config?.has('backend.auth.rateLimit.window')
+    config?.has('backend.rateLimit.unauthorized.window')
       ? readDurationFromConfig(
-          config.getConfig('backend.auth.rateLimit.window'),
+          config.getConfig('backend.rateLimit.unauthorized.window'),
         )
       : undefined;
 
@@ -84,8 +85,8 @@ export function createCredentialsBarrier(options: {
 
   const max =
     typeof rateLimitConfig === 'object' &&
-    config?.has('backend.auth.rateLimit.max')
-      ? config.getNumber('backend.auth.rateLimit.max')
+    config?.has('backend.rateLimit.unauthorized.max')
+      ? config.getNumber('backend.rateLimit.unauthorized.max')
       : 60;
 
   // Default rate limit is 60 requests per 1 minute

--- a/packages/backend-app-api/src/services/implementations/httpRouter/httpRouterServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/httpRouter/httpRouterServiceFactory.ts
@@ -39,20 +39,32 @@ export const httpRouterServiceFactory = createServiceFactory(
   (options?: HttpRouterFactoryOptions) => ({
     service: coreServices.httpRouter,
     deps: {
+      cache: coreServices.cache,
       plugin: coreServices.pluginMetadata,
       config: coreServices.rootConfig,
       lifecycle: coreServices.lifecycle,
       rootHttpRouter: coreServices.rootHttpRouter,
       httpAuth: coreServices.httpAuth,
     },
-    async factory({ httpAuth, config, plugin, rootHttpRouter, lifecycle }) {
+    async factory({
+      httpAuth,
+      config,
+      cache,
+      plugin,
+      rootHttpRouter,
+      lifecycle,
+    }) {
       const getPath = options?.getPath ?? (id => `/api/${id}`);
       const path = getPath(plugin.getId());
 
       const router = PromiseRouter();
       rootHttpRouter.use(path, router);
 
-      const credentialsBarrier = createCredentialsBarrier({ httpAuth, config });
+      const credentialsBarrier = createCredentialsBarrier({
+        httpAuth,
+        config,
+        cache,
+      });
 
       router.use(createLifecycleMiddleware({ lifecycle }));
       router.use(credentialsBarrier.middleware);

--- a/packages/backend-app-api/src/services/implementations/httpRouter/rateLimitStore.test.ts
+++ b/packages/backend-app-api/src/services/implementations/httpRouter/rateLimitStore.test.ts
@@ -34,7 +34,7 @@ describe('RateLimitStore', () => {
   });
 
   it('should initialize with default options', () => {
-    expect(rateLimitStore.windowMs).toBe(15 * 60 * 1000);
+    expect(rateLimitStore.windowMs).toBe(1 * 60 * 1000);
   });
 
   it('should initialize with custom options', () => {

--- a/packages/backend-app-api/src/services/implementations/httpRouter/rateLimitStore.test.ts
+++ b/packages/backend-app-api/src/services/implementations/httpRouter/rateLimitStore.test.ts
@@ -18,19 +18,22 @@ import { ServiceMock, mockServices } from '@backstage/backend-test-utils';
 import { RateLimitStore } from './rateLimitStore';
 import { CacheService } from '@backstage/backend-plugin-api';
 
-jest.setSystemTime(Date.parse('2024-03-15T08:39:11.869Z'));
-
 describe('RateLimitStore', () => {
   let cacheServiceMock: ServiceMock<CacheService>;
   let rateLimitStore: RateLimitStore;
 
   beforeEach(() => {
+    jest.useFakeTimers({ now: Date.parse('2024-03-15T08:39:11.869Z') });
     jest.clearAllMocks();
     cacheServiceMock = mockServices.cache.mock();
     rateLimitStore = RateLimitStore.fromOptions({
       prefix: 'rl_',
       cache: cacheServiceMock,
     });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   it('should initialize with default options', () => {

--- a/packages/backend-app-api/src/services/implementations/httpRouter/rateLimitStore.test.ts
+++ b/packages/backend-app-api/src/services/implementations/httpRouter/rateLimitStore.test.ts
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ServiceMock, mockServices } from '@backstage/backend-test-utils';
+import { RateLimitStore } from './rateLimitStore';
+import { CacheService } from '@backstage/backend-plugin-api';
+
+jest.setSystemTime(Date.parse('2024-03-15T08:39:11.869Z'));
+
+describe('RateLimitStore', () => {
+  let cacheServiceMock: ServiceMock<CacheService>;
+  let rateLimitStore: RateLimitStore;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    cacheServiceMock = mockServices.cache.mock();
+    rateLimitStore = RateLimitStore.fromOptions({
+      prefix: 'rl_',
+      cache: cacheServiceMock,
+    });
+  });
+
+  it('should initialize with default options', () => {
+    expect(rateLimitStore.windowMs).toBe(15 * 60 * 1000);
+  });
+
+  it('should initialize with custom options', () => {
+    rateLimitStore.init({ windowMs: 10 * 60 * 1000 });
+    expect(rateLimitStore.windowMs).toBe(10 * 60 * 1000);
+  });
+
+  it('should get rate limit info for existing key', async () => {
+    const key = 'existingKey';
+    const existingValue = {
+      totalHits: 5,
+      resetTime: new Date(),
+    };
+
+    cacheServiceMock.get.mockResolvedValue({
+      totalHits: existingValue.totalHits,
+      resetTime: existingValue.resetTime.getTime(),
+    });
+
+    const returnedValue = await rateLimitStore.get(key);
+
+    expect(returnedValue).toEqual(existingValue);
+    expect(cacheServiceMock.get).toHaveBeenCalledWith(
+      rateLimitStore.prefixKey(key),
+    );
+  });
+
+  it('should get default rate limit info for non-existing key', async () => {
+    const key = 'nonExistingKey';
+    const defaultValue = {
+      totalHits: 0,
+      resetTime: new Date(Date.now() + rateLimitStore.windowMs),
+    };
+
+    cacheServiceMock.get.mockResolvedValue(undefined);
+
+    const returnedValue = await rateLimitStore.get(key);
+
+    expect(returnedValue).toEqual(defaultValue);
+    expect(cacheServiceMock.get).toHaveBeenCalledWith(
+      rateLimitStore.prefixKey(key),
+    );
+  });
+
+  it('should increment rate limit for existing key', async () => {
+    const key = 'exisitingKey';
+    const existingValue = {
+      totalHits: 5,
+      resetTime: new Date(),
+    };
+
+    cacheServiceMock.get.mockResolvedValue({
+      totalHits: existingValue.totalHits,
+      resetTime: existingValue.resetTime.getTime(),
+    });
+
+    const incrementedValue = await rateLimitStore.increment(key);
+
+    expect(incrementedValue.totalHits).toBe(existingValue.totalHits + 1);
+    expect(incrementedValue.resetTime).toEqual(existingValue.resetTime);
+    expect(cacheServiceMock.set).toHaveBeenCalledWith(
+      rateLimitStore.prefixKey(key),
+      {
+        totalHits: existingValue.totalHits + 1,
+        resetTime: existingValue.resetTime.getTime(),
+      },
+      { ttl: rateLimitStore.windowMs },
+    );
+  });
+
+  it('should increment rate limit for non-existing key', async () => {
+    const key = 'nonExistingKey';
+
+    cacheServiceMock.get.mockResolvedValue(undefined);
+
+    const incrementedValue = await rateLimitStore.increment(key);
+
+    expect(incrementedValue.totalHits).toBe(1);
+    expect(incrementedValue.resetTime).toBeInstanceOf(Date);
+    expect(cacheServiceMock.set).toHaveBeenCalledWith(
+      rateLimitStore.prefixKey(key),
+      {
+        totalHits: incrementedValue.totalHits,
+        resetTime: incrementedValue.resetTime?.getTime(),
+      },
+      { ttl: rateLimitStore.windowMs },
+    );
+  });
+
+  it('should decrement rate limit for existing key', async () => {
+    const key = 'exisitingKey';
+    const existingValue = {
+      totalHits: 5,
+      resetTime: new Date(),
+    };
+
+    cacheServiceMock.get.mockResolvedValue({
+      totalHits: existingValue.totalHits,
+      resetTime: existingValue.resetTime.getTime(),
+    });
+
+    await rateLimitStore.decrement(key);
+
+    expect(cacheServiceMock.set).toHaveBeenCalledWith(
+      rateLimitStore.prefixKey(key),
+      {
+        totalHits: existingValue.totalHits - 1,
+        resetTime: existingValue.resetTime.getTime(),
+      },
+      { ttl: rateLimitStore.windowMs },
+    );
+  });
+
+  it('should not decrement rate limit below zero', async () => {
+    const key = 'testKey';
+    const existingValue = {
+      totalHits: 0,
+      resetTime: new Date(),
+    };
+
+    cacheServiceMock.get.mockResolvedValue({
+      totalHits: existingValue.totalHits,
+      resetTime: existingValue.resetTime.getTime(),
+    });
+
+    await rateLimitStore.decrement(key);
+
+    expect(cacheServiceMock.set).toHaveBeenCalledWith(
+      rateLimitStore.prefixKey(key),
+      {
+        totalHits: 0,
+        resetTime: existingValue.resetTime.getTime(),
+      },
+      { ttl: rateLimitStore.windowMs },
+    );
+  });
+
+  it('should reset rate limit for existing key', async () => {
+    const key = 'exitingKey';
+
+    await rateLimitStore.resetKey(key);
+
+    expect(cacheServiceMock.delete).toHaveBeenCalledWith(
+      rateLimitStore.prefixKey(key),
+    );
+  });
+});

--- a/packages/backend-app-api/src/services/implementations/httpRouter/rateLimitStore.ts
+++ b/packages/backend-app-api/src/services/implementations/httpRouter/rateLimitStore.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CacheService } from '@backstage/backend-plugin-api';
+import type {
+  Store,
+  Options,
+  IncrementResponse,
+  ClientRateLimitInfo,
+} from 'express-rate-limit';
+
+type CacheStoreOptions = {
+  /**
+   * Optional field to differentiate hit countswhen multiple rate-limits are in use
+   */
+  prefix?: string;
+  /**
+   * The cache service to use for storing the hit counts.
+   */
+  cache: CacheService;
+};
+
+type CacheStoreValue = {
+  totalHits: number;
+  resetTime: number;
+};
+
+/**
+ * A `Store` that stores the hit count for each client.
+ */
+export class RateLimitStore implements Store {
+  /**
+   * The duration of time before which all hit counts are reset (in milliseconds).
+   * default: 15 minutes
+   */
+  windowMs: number = 15 * 60 * 1000;
+  prefix: string;
+  #cache: CacheService;
+
+  private constructor(options: CacheStoreOptions) {
+    this.prefix = options.prefix ?? 'rl_';
+    this.#cache = options.cache;
+  }
+
+  static fromOptions(options: CacheStoreOptions): RateLimitStore {
+    return new RateLimitStore(options);
+  }
+
+  #getDefaultValue() {
+    return { totalHits: 0, resetTime: Date.now() + this.windowMs };
+  }
+
+  init(options: Partial<Options>): void {
+    if (options.windowMs) {
+      this.windowMs = options.windowMs;
+    }
+  }
+
+  prefixKey(key: string): string {
+    return `${this.prefix}${key}`;
+  }
+
+  async get(key: string): Promise<ClientRateLimitInfo | undefined> {
+    const value =
+      (await this.#cache.get<CacheStoreValue>(this.prefixKey(key))) ??
+      this.#getDefaultValue();
+    return {
+      totalHits: value.totalHits,
+      resetTime: new Date(value.resetTime),
+    };
+  }
+
+  async increment(key: string): Promise<IncrementResponse> {
+    const value =
+      (await this.#cache.get<CacheStoreValue>(this.prefixKey(key))) ??
+      this.#getDefaultValue();
+    const totalHits = value.totalHits + 1;
+    const resetTime = value.resetTime;
+    await this.#cache.set(
+      this.prefixKey(key),
+      { totalHits, resetTime },
+      { ttl: this.windowMs },
+    );
+    return {
+      totalHits,
+      resetTime: new Date(resetTime),
+    };
+  }
+
+  async decrement(key: string): Promise<void> {
+    const value =
+      (await this.#cache.get<CacheStoreValue>(this.prefixKey(key))) ??
+      this.#getDefaultValue();
+    const totalHits = value.totalHits > 0 ? value.totalHits - 1 : 0;
+    const resetTime = value.resetTime;
+    await this.#cache.set(
+      this.prefixKey(key),
+      { totalHits, resetTime },
+      { ttl: this.windowMs },
+    );
+  }
+
+  async resetKey(key: string): Promise<void> {
+    await this.#cache.delete(this.prefixKey(key));
+  }
+}

--- a/packages/backend-app-api/src/services/implementations/httpRouter/rateLimitStore.ts
+++ b/packages/backend-app-api/src/services/implementations/httpRouter/rateLimitStore.ts
@@ -51,7 +51,7 @@ export class RateLimitStore implements Store {
   #cache: CacheService;
 
   private constructor(options: CacheStoreOptions) {
-    this.prefix = options.prefix ?? 'rl_';
+    this.prefix = options.prefix ?? 'unauthorized_rate_limit_';
     this.#cache = options.cache;
   }
 

--- a/packages/backend-app-api/src/services/implementations/httpRouter/rateLimitStore.ts
+++ b/packages/backend-app-api/src/services/implementations/httpRouter/rateLimitStore.ts
@@ -44,9 +44,9 @@ type CacheStoreValue = {
 export class RateLimitStore implements Store {
   /**
    * The duration of time before which all hit counts are reset (in milliseconds).
-   * default: 15 minutes
+   * default: 60 requests per minute
    */
-  windowMs: number = 15 * 60 * 1000;
+  windowMs: number = 1 * 60 * 1000;
   prefix: string;
   #cache: CacheService;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3248,6 +3248,7 @@ __metadata:
     cors: ^2.8.5
     express: ^4.17.1
     express-promise-router: ^4.1.0
+    express-rate-limit: ^7.2.0
     fs-extra: ^11.2.0
     helmet: ^6.0.0
     http-errors: ^2.0.0
@@ -28041,6 +28042,15 @@ __metadata:
     "@types/express":
       optional: true
   checksum: e69ee7eb2c70470d5be71d34cd9275c26aae157c1ef16a21ecf53141e512fd4a6b5a68db89b30f745df941518505d00ec0a5e13f0becbd53ad63ffce3ed885f3
+  languageName: node
+  linkType: hard
+
+"express-rate-limit@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "express-rate-limit@npm:7.2.0"
+  peerDependencies:
+    express: 4 || 5 || ^5.0.0-beta.1
+  checksum: 6adc3e06d430e91cf8ef8da23107466ffd9193b5680b03bc12702894cab0adcbb980634602b839b3a1444620f2379707098af3a4dcc38c909e89214abaf6c1bf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This pull request adds an initial rate-limiting implementation so that any incoming requests that have a 'none' principal are rate-limited automatically.

> [!NOTE]
> Documentation will be added in a separate pull request.

#### Example

Setting the rate limit configuration:
```yaml
backend:
  auth:
    dangerouslyDisableDefaultAuthPolicy: false
  rateLimit:
      unauthorized: 
        max: 2
        window: { minutes: 2 }
```

Exceeding the max of 2 requests in 2 minutes of window:

https://github.com/backstage/backstage/assets/6290749/d4b68b29-f495-4e39-b429-c9828969cdf9

Trying again after 2 minutes:

https://github.com/backstage/backstage/assets/6290749/28804c5f-3607-4e4e-9eee-f2b6715b489e

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
