### PR TITLE
fix: Guest Provider sign-in without a user in the Catalog

### DIFF
--- a/.changeset/metal-toes-mate.md
+++ b/.changeset/metal-toes-mate.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-guest-provider': patch
+---
+
+Fix issue for issuing a token when `guest` user does not exist in catalog

--- a/plugins/auth-backend-module-guest-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-guest-provider/src/resolvers.ts
@@ -46,7 +46,7 @@ export const signInAsGuestUser: (config: Config) => SignInResolver<{}> =
       'ownershipEntityRefs',
     ) ?? [userRef];
     try {
-      return ctx.signInWithCatalogUser({ entityRef: userRef });
+      return await ctx.signInWithCatalogUser({ entityRef: userRef });
     } catch (err) {
       // We can't guarantee that a guest user exists in the catalog, so we issue a token directly,
       return ctx.issueToken({


### PR DESCRIPTION
Need to settle the promise, so that we actually hit the catch block, otherwise just the rejected promise is surfaced to the client.
