### PR TITLE
[NO-TICKET] OneLogin auth provider refresh method fixing scope as start method

### DIFF
--- a/.changeset/hip-bears-breathe.md
+++ b/.changeset/hip-bears-breathe.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+OneLogin auth provider
+Refresh method fixed scope matching start method

--- a/plugins/auth-backend/src/providers/onelogin/provider.ts
+++ b/plugins/auth-backend/src/providers/onelogin/provider.ts
@@ -120,7 +120,7 @@ export class OneLoginProvider implements OAuthHandlers {
       await executeRefreshTokenStrategy(
         this._strategy,
         req.refreshToken,
-        req.scope,
+        'openid',
       );
 
     const fullProfile = await executeFetchUserProfileStrategy(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes issue described [here](https://github.com/backstage/backstage/issues/21776)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
