### PR TITLE
Added 'onlyFailed' prop to ScorecardsCard

### DIFF
--- a/.changeset/twelve-doors-speak.md
+++ b/.changeset/twelve-doors-speak.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-tech-insights': minor
+'@backstage/plugin-tech-insights': patch
 ---
 
 Added `onlyFailed` prop to `ScorecardsCard`, and `isFailed` to each check type.

--- a/.changeset/twelve-doors-speak.md
+++ b/.changeset/twelve-doors-speak.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-tech-insights': minor
+---
+
+Added 'onlyFailed' prop to ScorecardsCard, and 'isFailed' to each check type.

--- a/.changeset/twelve-doors-speak.md
+++ b/.changeset/twelve-doors-speak.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-tech-insights': minor
 ---
 
-Added 'onlyFailed' prop to ScorecardsCard, and 'isFailed' to each check type.
+Added `onlyFailed` prop to `ScorecardsCard`, and `isFailed` to each check type.

--- a/plugins/tech-insights/api-report.md
+++ b/plugins/tech-insights/api-report.md
@@ -39,6 +39,7 @@ export type CheckResultRenderer = {
   type: string;
   component: (check: CheckResult) => React_2.ReactElement;
   description?: (check: CheckResult) => string | React_2.ReactElement;
+  isFailed?: (check: CheckResult) => boolean;
 };
 
 // @public (undocumented)
@@ -46,6 +47,7 @@ export const EntityTechInsightsScorecardCard: (props: {
   title: string;
   description?: string | undefined;
   checksId?: string[] | undefined;
+  onlyFailed?: boolean | undefined;
 }) => JSX_2.Element;
 
 // @public (undocumented)
@@ -73,6 +75,7 @@ export const ScorecardInfo: (props: {
   checkResults: CheckResult[];
   title: string;
   description?: string | undefined;
+  noWarning?: boolean | undefined;
 }) => JSX_2.Element;
 
 // @public (undocumented)

--- a/plugins/tech-insights/src/components/BooleanCheck/BooleanCheck.tsx
+++ b/plugins/tech-insights/src/components/BooleanCheck/BooleanCheck.tsx
@@ -29,3 +29,9 @@ export const BooleanCheck = (props: { checkResult: CheckResult }) => {
     <ErrorOutlineIcon color="error" />
   );
 };
+
+/**
+ * @public
+ */
+export const isBooleanCheckFailed = (checkResult: CheckResult) =>
+  !checkResult.result;

--- a/plugins/tech-insights/src/components/BooleanCheck/index.ts
+++ b/plugins/tech-insights/src/components/BooleanCheck/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { BooleanCheck } from './BooleanCheck';
+export { BooleanCheck, isBooleanCheckFailed } from './BooleanCheck';

--- a/plugins/tech-insights/src/components/CheckResultRenderer.tsx
+++ b/plugins/tech-insights/src/components/CheckResultRenderer.tsx
@@ -16,7 +16,7 @@
 
 import { CheckResult } from '@backstage/plugin-tech-insights-common';
 import React from 'react';
-import { BooleanCheck } from './BooleanCheck';
+import { BooleanCheck, isBooleanCheckFailed } from './BooleanCheck';
 
 /**
  * Defines a react component that is responsible for rendering a result of a given type.
@@ -27,6 +27,7 @@ export type CheckResultRenderer = {
   type: string;
   component: (check: CheckResult) => React.ReactElement;
   description?: (check: CheckResult) => string | React.ReactElement;
+  isFailed?: (check: CheckResult) => boolean;
 };
 
 /**
@@ -39,4 +40,5 @@ export const jsonRulesEngineCheckResultRenderer: CheckResultRenderer = {
   component: (checkResult: CheckResult) => (
     <BooleanCheck checkResult={checkResult} />
   ),
+  isFailed: isBooleanCheckFailed,
 };

--- a/plugins/tech-insights/src/components/ScorecardsCard/ScorecardsCard.tsx
+++ b/plugins/tech-insights/src/components/ScorecardsCard/ScorecardsCard.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import useAsync from 'react-use/lib/useAsync';
 import { ErrorPanel, Progress } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
@@ -27,8 +27,9 @@ export const ScorecardsCard = (props: {
   title: string;
   description?: string;
   checksId?: string[];
+  onlyFailed?: boolean;
 }) => {
-  const { title, description, checksId } = props;
+  const { title, description, checksId, onlyFailed } = props;
   const api = useApi(techInsightsApiRef);
   const { entity } = useEntity();
   const { value, loading, error } = useAsync(
@@ -36,17 +37,34 @@ export const ScorecardsCard = (props: {
     [api, entity, JSON.stringify(checksId)],
   );
 
+  const checkResultRenderers = useMemo(() => {
+    if (!onlyFailed || !value) return {};
+
+    const types = [...new Set(value.map(({ check }) => check.type))];
+    const renderers = api.getCheckResultRenderers(types);
+    return Object.fromEntries(
+      renderers.map(renderer => [renderer.type, renderer]),
+    );
+  }, [api, value, onlyFailed]);
+
   if (loading) {
     return <Progress />;
   } else if (error) {
     return <ErrorPanel error={error} />;
   }
 
+  const filteredValue = !onlyFailed
+    ? value || []
+    : (value || []).filter(val =>
+        checkResultRenderers[val.check.type]?.isFailed?.(val),
+      );
+
   return (
     <ScorecardInfo
       title={title}
       description={description}
-      checkResults={value || []}
+      checkResults={filteredValue}
+      noWarning={onlyFailed}
     />
   );
 };

--- a/plugins/tech-insights/src/components/ScorecardsInfo/ScorecardInfo.tsx
+++ b/plugins/tech-insights/src/components/ScorecardsInfo/ScorecardInfo.tsx
@@ -52,11 +52,22 @@ export const ScorecardInfo = (props: {
   checkResults: CheckResult[];
   title: string;
   description?: string;
+  noWarning?: boolean;
 }) => {
-  const { checkResults, title, description } = props;
+  const { checkResults, title, description, noWarning } = props;
   const classes = useStyles();
 
   if (!checkResults.length) {
+    if (noWarning) {
+      return infoCard(
+        title,
+        description,
+        classes.subheader,
+        <Alert severity="info">
+          All checks passed, or no checks have been performed yet
+        </Alert>,
+      );
+    }
     return infoCard(
       title,
       description,


### PR DESCRIPTION
## Improve the usability of ScorecardsCard

This PR adds a prop to the `ScorecardsCard` component, called `onlyFailed`. Before this PR, you can only show either all checks (which can be many, causing a very large/tall card), or specify an exact set of checks to display. With this PR, you can choose to show all kinds of checks, but only those that fail. This is sometimes more valuable. When using `onlyFailed`, if no checks fail, instead of a warning message, an information message is displayed.

For this, the `ScorecardInfo` component now has a prop `noWarning` which turns warnings into informations. This will be default when using `onlyFailed` in the `ScorecardsCard`:

**Before**
<img width="696" alt="Skärmavbild 2024-03-14 kl  14 50 03" src="https://github.com/backstage/backstage/assets/5362579/42f70cf0-2282-447d-9859-376b9368fe80">

**After**
<img width="692" alt="Skärmavbild 2024-03-15 kl  09 23 14" src="https://github.com/backstage/backstage/assets/5362579/91aa3960-2921-4867-b94f-2777258bcc2a">

Additionally, the `CheckResultRenderer` type has a property `isFailed` that can be used to identify failing checks. Tech Insights by default only provides a `BooleanCheck`, but implementors can create their own. With this property, they can provide means to identify failed vs passed checks, e.g. for gauges, numbers etc. This PR includes an `isFailed` implementation for the built-in `BooleanCheck`.

### Usage

You provide this prop when using `ScorecardsCard`, most likely in the `EntityPage.tsx`:

```tsx
<EntityTechInsightsScorecardCard title="Scorecard" onlyFailed />
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
