### PR TITLE
add vite to the dev deps of the cli to make it build standalone

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -168,10 +168,14 @@
     "@types/tar": "^6.1.1",
     "@types/terser-webpack-plugin": "^5.0.4",
     "@types/yarnpkg__lockfile": "^1.1.4",
+    "@vitejs/plugin-react": "^4.0.4",
     "del": "^7.0.0",
     "msw": "^1.0.0",
     "nodemon": "^3.0.1",
-    "ts-node": "^10.0.0"
+    "ts-node": "^10.0.0",
+    "vite": "^4.4.9",
+    "vite-plugin-html": "^3.2.0",
+    "vite-plugin-node-polyfills": "^0.21.0"
   },
   "peerDependencies": {
     "@vitejs/plugin-react": "^4.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3642,6 +3642,7 @@ __metadata:
     "@types/yarnpkg__lockfile": ^1.1.4
     "@typescript-eslint/eslint-plugin": ^6.12.0
     "@typescript-eslint/parser": ^6.7.2
+    "@vitejs/plugin-react": ^4.0.4
     "@yarnpkg/lockfile": ^1.1.0
     "@yarnpkg/parsers": ^3.0.0-rc.4
     bfj: ^8.0.0
@@ -3713,6 +3714,9 @@ __metadata:
     ts-node: ^10.0.0
     tsx: ^4.0.0
     util: ^0.12.3
+    vite: ^4.4.9
+    vite-plugin-html: ^3.2.0
+    vite-plugin-node-polyfills: ^0.21.0
     webpack: ^5.70.0
     webpack-dev-server: ^4.7.3
     webpack-node-externals: ^3.0.0


### PR DESCRIPTION
It used to be that builds worked "accidentally" only because the app package did pull in vite too. Then it got hoisted to the root by yarn because it saw the peer dep. But if you remove them from the app, the CLI code starts getting type errors.

After this change, the repo still builds fine if you remove them from the app.

Skipping changeset since it only affects `devDependencies`