### PR TITLE
Add optional limit parameter for getAllTeams method, default 100

### DIFF
--- a/.changeset/brown-beers-share.md
+++ b/.changeset/brown-beers-share.md
@@ -3,4 +3,4 @@
 '@backstage/plugin-azure-devops': patch
 ---
 
-getAllTeams accepts optional topTeams parameter which can be used to return more than the default top 100 teams from Azure Devops API
+`getAllTeams` now accepts an optional `topTeams` parameter which can be used to return more than the default top 100 teams from the Azure DevOps API

--- a/.changeset/brown-beers-share.md
+++ b/.changeset/brown-beers-share.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-azure-devops-backend': patch
+'@backstage/plugin-azure-devops': patch
+---
+
+getAllTeams accepts optional topTeams parameter which can be used to return more than the default top 100 teams from Azure Devops API

--- a/.changeset/brown-beers-share.md
+++ b/.changeset/brown-beers-share.md
@@ -3,4 +3,4 @@
 '@backstage/plugin-azure-devops': patch
 ---
 
-`getAllTeams` now accepts an optional `teamsLimit` parameter which can be used to return more than the default limit of 100 teams from the Azure DevOps API
+`getAllTeams` now accepts an optional `limit` parameter which can be used to return more than the default limit of 100 teams from the Azure DevOps API

--- a/.changeset/brown-beers-share.md
+++ b/.changeset/brown-beers-share.md
@@ -1,6 +1,9 @@
 ---
 '@backstage/plugin-azure-devops-backend': patch
 '@backstage/plugin-azure-devops': patch
+'@backstage/plugin-azure-common': patch
 ---
 
 `getAllTeams` now accepts an optional `limit` parameter which can be used to return more than the default limit of 100 teams from the Azure DevOps API
+
+`pullRequestOptions` have been equipped with `teamsLimit` so that the property can be used with `getAllTeams`

--- a/.changeset/brown-beers-share.md
+++ b/.changeset/brown-beers-share.md
@@ -3,4 +3,4 @@
 '@backstage/plugin-azure-devops': patch
 ---
 
-`getAllTeams` now accepts an optional `topTeams` parameter which can be used to return more than the default top 100 teams from the Azure DevOps API
+`getAllTeams` now accepts an optional `teamsLimit` parameter which can be used to return more than the default limit of 100 teams from the Azure DevOps API

--- a/plugins/azure-devops-backend/api-report.md
+++ b/plugins/azure-devops-backend/api-report.md
@@ -56,7 +56,7 @@ export class AzureDevOpsApi {
     },
   ): AzureDevOpsApi;
   // (undocumented)
-  getAllTeams(limit?: number): Promise<Team[]>;
+  getAllTeams(options?: { limit?: number }): Promise<Team[]>;
   // (undocumented)
   getBuildDefinitions(
     projectName: string,

--- a/plugins/azure-devops-backend/api-report.md
+++ b/plugins/azure-devops-backend/api-report.md
@@ -56,7 +56,7 @@ export class AzureDevOpsApi {
     },
   ): AzureDevOpsApi;
   // (undocumented)
-  getAllTeams(teamsLimit?: number): Promise<Team[]>;
+  getAllTeams(limit?: number): Promise<Team[]>;
   // (undocumented)
   getBuildDefinitions(
     projectName: string,

--- a/plugins/azure-devops-backend/api-report.md
+++ b/plugins/azure-devops-backend/api-report.md
@@ -56,7 +56,7 @@ export class AzureDevOpsApi {
     },
   ): AzureDevOpsApi;
   // (undocumented)
-  getAllTeams(topTeams?: number): Promise<Team[]>;
+  getAllTeams(teamsLimit?: number): Promise<Team[]>;
   // (undocumented)
   getBuildDefinitions(
     projectName: string,

--- a/plugins/azure-devops-backend/api-report.md
+++ b/plugins/azure-devops-backend/api-report.md
@@ -56,7 +56,7 @@ export class AzureDevOpsApi {
     },
   ): AzureDevOpsApi;
   // (undocumented)
-  getAllTeams(): Promise<Team[]>;
+  getAllTeams(topTeams?: number): Promise<Team[]>;
   // (undocumented)
   getBuildDefinitions(
     projectName: string,

--- a/plugins/azure-devops-backend/src/api/AzureDevOpsApi.ts
+++ b/plugins/azure-devops-backend/src/api/AzureDevOpsApi.ts
@@ -405,7 +405,7 @@ export class AzureDevOpsApi {
 
     const webApiTeams: WebApiTeam[] = await client.getAllTeams(
       undefined,
-      limit,
+      options?.limit,
       undefined,
       undefined,
     );

--- a/plugins/azure-devops-backend/src/api/AzureDevOpsApi.ts
+++ b/plugins/azure-devops-backend/src/api/AzureDevOpsApi.ts
@@ -397,7 +397,7 @@ export class AzureDevOpsApi {
       .filter((policy): policy is Policy => Boolean(policy));
   }
 
-  public async getAllTeams(topTeams?: number): Promise<Team[]> {
+  public async getAllTeams(teamsLimit?: number): Promise<Team[]> {
     this.logger?.debug('Getting all teams.');
 
     const webApi = await this.getWebApi();
@@ -405,7 +405,7 @@ export class AzureDevOpsApi {
 
     const webApiTeams: WebApiTeam[] = await client.getAllTeams(
       undefined,
-      topTeams,
+      teamsLimit,
       undefined,
       undefined,
     );

--- a/plugins/azure-devops-backend/src/api/AzureDevOpsApi.ts
+++ b/plugins/azure-devops-backend/src/api/AzureDevOpsApi.ts
@@ -397,7 +397,7 @@ export class AzureDevOpsApi {
       .filter((policy): policy is Policy => Boolean(policy));
   }
 
-  public async getAllTeams(options?: { limit?: number }): Promise<Team[]> {
+  public async getAllTeams(options?: { limit?: number }): Promise<Team[]> {
     this.logger?.debug('Getting all teams.');
 
     const webApi = await this.getWebApi();

--- a/plugins/azure-devops-backend/src/api/AzureDevOpsApi.ts
+++ b/plugins/azure-devops-backend/src/api/AzureDevOpsApi.ts
@@ -397,7 +397,7 @@ export class AzureDevOpsApi {
       .filter((policy): policy is Policy => Boolean(policy));
   }
 
-  public async getAllTeams(limit?: number): Promise<Team[]> {
+  public async getAllTeams(options?: { limit?: number }): Promise<Team[]> {
     this.logger?.debug('Getting all teams.');
 
     const webApi = await this.getWebApi();

--- a/plugins/azure-devops-backend/src/api/AzureDevOpsApi.ts
+++ b/plugins/azure-devops-backend/src/api/AzureDevOpsApi.ts
@@ -397,12 +397,18 @@ export class AzureDevOpsApi {
       .filter((policy): policy is Policy => Boolean(policy));
   }
 
-  public async getAllTeams(): Promise<Team[]> {
+  public async getAllTeams(topTeams?: number): Promise<Team[]> {
     this.logger?.debug('Getting all teams.');
 
     const webApi = await this.getWebApi();
     const client = await webApi.getCoreApi();
-    const webApiTeams: WebApiTeam[] = await client.getAllTeams();
+
+    const webApiTeams: WebApiTeam[] = await client.getAllTeams(
+      undefined,
+      topTeams,
+      undefined,
+      undefined,
+    );
 
     const teams: Team[] = webApiTeams.map(team => ({
       id: team.id,

--- a/plugins/azure-devops-backend/src/api/AzureDevOpsApi.ts
+++ b/plugins/azure-devops-backend/src/api/AzureDevOpsApi.ts
@@ -397,7 +397,7 @@ export class AzureDevOpsApi {
       .filter((policy): policy is Policy => Boolean(policy));
   }
 
-  public async getAllTeams(teamsLimit?: number): Promise<Team[]> {
+  public async getAllTeams(limit?: number): Promise<Team[]> {
     this.logger?.debug('Getting all teams.');
 
     const webApi = await this.getWebApi();
@@ -405,7 +405,7 @@ export class AzureDevOpsApi {
 
     const webApiTeams: WebApiTeam[] = await client.getAllTeams(
       undefined,
-      teamsLimit,
+      limit,
       undefined,
       undefined,
     );

--- a/plugins/azure-devops-backend/src/api/PullRequestsDashboardProvider.ts
+++ b/plugins/azure-devops-backend/src/api/PullRequestsDashboardProvider.ts
@@ -25,7 +25,7 @@ import { AzureDevOpsApi } from './AzureDevOpsApi';
 import { Logger } from 'winston';
 import limiterFactory from 'p-limit';
 
-export const DEFAULT_TOP_TEAMS = 100;
+export const DEFAULT_TEAMS_LIMIT = 100;
 
 export class PullRequestsDashboardProvider {
   private teams = new Map<string, Team>();
@@ -45,10 +45,10 @@ export class PullRequestsDashboardProvider {
     return provider;
   }
 
-  public async readTeams(topTeams?: number): Promise<void> {
+  public async readTeams(teamsLimit?: number): Promise<void> {
     this.logger.info('Reading teams.');
 
-    let teams = await this.azureDevOpsApi.getAllTeams(topTeams);
+    let teams = await this.azureDevOpsApi.getAllTeams(teamsLimit);
 
     // This is used to filter out the default Azure Devops project teams.
     teams = teams.filter(team =>
@@ -108,12 +108,12 @@ export class PullRequestsDashboardProvider {
   public async getDashboardPullRequests(
     projectName: string,
     options: PullRequestOptions,
-    topTeams?: number,
+    teamsLimit?: number,
   ): Promise<DashboardPullRequest[]> {
     const dashboardPullRequests =
       await this.azureDevOpsApi.getDashboardPullRequests(projectName, options);
 
-    await this.getAllTeams(topTeams); // Make sure team members are loaded
+    await this.getAllTeams(teamsLimit); // Make sure team members are loaded
 
     return dashboardPullRequests.map(pr => {
       if (pr.createdBy?.id) {
@@ -137,9 +137,9 @@ export class PullRequestsDashboardProvider {
     );
   }
 
-  public async getAllTeams(topTeams?: number): Promise<Team[]> {
+  public async getAllTeams(teamsLimit?: number): Promise<Team[]> {
     if (!this.teams.size) {
-      const maxTeams = topTeams ?? DEFAULT_TOP_TEAMS;
+      const maxTeams = teamsLimit ?? DEFAULT_TEAMS_LIMIT;
       await this.readTeams(maxTeams);
     }
 

--- a/plugins/azure-devops-backend/src/api/PullRequestsDashboardProvider.ts
+++ b/plugins/azure-devops-backend/src/api/PullRequestsDashboardProvider.ts
@@ -25,7 +25,7 @@ import { AzureDevOpsApi } from './AzureDevOpsApi';
 import { Logger } from 'winston';
 import limiterFactory from 'p-limit';
 
-const DEFAULT_TOP_TEAMS = 100;
+export const DEFAULT_TOP_TEAMS = 100;
 
 export class PullRequestsDashboardProvider {
   private teams = new Map<string, Team>();
@@ -108,11 +108,12 @@ export class PullRequestsDashboardProvider {
   public async getDashboardPullRequests(
     projectName: string,
     options: PullRequestOptions,
+    topTeams?: number,
   ): Promise<DashboardPullRequest[]> {
     const dashboardPullRequests =
       await this.azureDevOpsApi.getDashboardPullRequests(projectName, options);
 
-    await this.getAllTeams(); // Make sure team members are loaded
+    await this.getAllTeams(topTeams); // Make sure team members are loaded
 
     return dashboardPullRequests.map(pr => {
       if (pr.createdBy?.id) {

--- a/plugins/azure-devops-backend/src/api/PullRequestsDashboardProvider.ts
+++ b/plugins/azure-devops-backend/src/api/PullRequestsDashboardProvider.ts
@@ -45,10 +45,10 @@ export class PullRequestsDashboardProvider {
     return provider;
   }
 
-  public async readTeams(teamsLimit?: number): Promise<void> {
+  public async readTeams(limit?: number): Promise<void> {
     this.logger.info('Reading teams.');
 
-    let teams = await this.azureDevOpsApi.getAllTeams(teamsLimit);
+    let teams = await this.azureDevOpsApi.getAllTeams(limit);
 
     // This is used to filter out the default Azure Devops project teams.
     teams = teams.filter(team =>
@@ -137,9 +137,9 @@ export class PullRequestsDashboardProvider {
     );
   }
 
-  public async getAllTeams(teamsLimit?: number): Promise<Team[]> {
+  public async getAllTeams(limit?: number): Promise<Team[]> {
     if (!this.teams.size) {
-      const maxTeams = teamsLimit ?? DEFAULT_TEAMS_LIMIT;
+      const maxTeams = limit ?? DEFAULT_TEAMS_LIMIT;
       await this.readTeams(maxTeams);
     }
 

--- a/plugins/azure-devops-backend/src/api/PullRequestsDashboardProvider.ts
+++ b/plugins/azure-devops-backend/src/api/PullRequestsDashboardProvider.ts
@@ -25,6 +25,8 @@ import { AzureDevOpsApi } from './AzureDevOpsApi';
 import { Logger } from 'winston';
 import limiterFactory from 'p-limit';
 
+const DEFAULT_TOP_TEAMS = 100;
+
 export class PullRequestsDashboardProvider {
   private teams = new Map<string, Team>();
 
@@ -43,10 +45,10 @@ export class PullRequestsDashboardProvider {
     return provider;
   }
 
-  public async readTeams(): Promise<void> {
+  public async readTeams(topTeams?: number): Promise<void> {
     this.logger.info('Reading teams.');
 
-    let teams = await this.azureDevOpsApi.getAllTeams();
+    let teams = await this.azureDevOpsApi.getAllTeams(topTeams);
 
     // This is used to filter out the default Azure Devops project teams.
     teams = teams.filter(team =>
@@ -134,9 +136,10 @@ export class PullRequestsDashboardProvider {
     );
   }
 
-  public async getAllTeams(): Promise<Team[]> {
+  public async getAllTeams(topTeams?: number): Promise<Team[]> {
     if (!this.teams.size) {
-      await this.readTeams();
+      const maxTeams = topTeams ?? DEFAULT_TOP_TEAMS;
+      await this.readTeams(maxTeams);
     }
 
     return Array.from(this.teams.values());

--- a/plugins/azure-devops-backend/src/api/PullRequestsDashboardProvider.ts
+++ b/plugins/azure-devops-backend/src/api/PullRequestsDashboardProvider.ts
@@ -48,7 +48,7 @@ export class PullRequestsDashboardProvider {
   public async readTeams(limit?: number): Promise<void> {
     this.logger.info('Reading teams.');
 
-    let teams = await this.azureDevOpsApi.getAllTeams(limit);
+    let teams = await this.azureDevOpsApi.getAllTeams({ limit });
 
     // This is used to filter out the default Azure Devops project teams.
     teams = teams.filter(team =>

--- a/plugins/azure-devops-backend/src/api/PullRequestsDashboardProvider.ts
+++ b/plugins/azure-devops-backend/src/api/PullRequestsDashboardProvider.ts
@@ -108,12 +108,11 @@ export class PullRequestsDashboardProvider {
   public async getDashboardPullRequests(
     projectName: string,
     options: PullRequestOptions,
-    teamsLimit?: number,
   ): Promise<DashboardPullRequest[]> {
     const dashboardPullRequests =
       await this.azureDevOpsApi.getDashboardPullRequests(projectName, options);
 
-    await this.getAllTeams(teamsLimit); // Make sure team members are loaded
+    await this.getAllTeams({ limit: options.teamsLimit }); // Make sure team members are loaded
 
     return dashboardPullRequests.map(pr => {
       if (pr.createdBy?.id) {
@@ -129,7 +128,7 @@ export class PullRequestsDashboardProvider {
   }
 
   public async getUserTeamIds(email: string): Promise<string[]> {
-    await this.getAllTeams(); // Make sure team members are loaded
+    await this.getAllTeams({}); // Make sure team members are loaded
     return (
       Array.from(this.teamMembers.values()).find(
         teamMember => teamMember.uniqueName === email,
@@ -137,9 +136,9 @@ export class PullRequestsDashboardProvider {
     );
   }
 
-  public async getAllTeams(limit?: number): Promise<Team[]> {
+  public async getAllTeams(options: { limit?: number }): Promise<Team[]> {
     if (!this.teams.size) {
-      const maxTeams = limit ?? DEFAULT_TEAMS_LIMIT;
+      const maxTeams = options?.limit ?? DEFAULT_TEAMS_LIMIT;
       await this.readTeams(maxTeams);
     }
 

--- a/plugins/azure-devops-backend/src/service/router.test.ts
+++ b/plugins/azure-devops-backend/src/service/router.test.ts
@@ -348,7 +348,74 @@ describe('createRouter', () => {
       expect(azureDevOpsApi.getPullRequests).toHaveBeenCalledWith(
         'myProject',
         'myRepo',
-        { status: 1, top: 50 },
+        { status: 1, top: 50, teamsLimit: 100 },
+        undefined,
+        undefined,
+      );
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual(pullRequests);
+    });
+    it('fetches a list of pull requests when using teamsLimit', async () => {
+      const firstPullRequest: PullRequest = {
+        pullRequestId: 7181,
+        repoName: 'super-feature-repo',
+        title: 'My Awesome New Feature',
+        createdBy: 'Jane Doe',
+        creationDate: '2020-09-12T06:10:23.932Z',
+        sourceRefName: 'refs/heads/topic/super-awesome-feature',
+        targetRefName: 'refs/heads/main',
+        status: PullRequestStatus.Active,
+        isDraft: false,
+        link: 'https://host.com/myOrg/_git/super-feature-repo/pullrequest/7181',
+      };
+
+      const secondPullRequest: PullRequest = {
+        pullRequestId: 7182,
+        repoName: 'super-feature-repo',
+        title: 'Refactoring My Awesome New Feature',
+        createdBy: 'Jane Doe',
+        creationDate: '2020-09-12T06:10:23.932Z',
+        sourceRefName: 'refs/heads/topic/refactor-super-awesome-feature',
+        targetRefName: 'refs/heads/main',
+        status: PullRequestStatus.Active,
+        isDraft: false,
+        link: 'https://host.com/myOrg/_git/super-feature-repo/pullrequest/7182',
+      };
+
+      const thirdPullRequest: PullRequest = {
+        pullRequestId: 7183,
+        repoName: 'super-feature-repo',
+        title: 'Bug Fix for My Awesome New Feature',
+        createdBy: 'Jane Doe',
+        creationDate: '2020-09-12T06:10:23.932Z',
+        sourceRefName: 'refs/heads/topic/fix-super-awesome-feature',
+        targetRefName: 'refs/heads/main',
+        status: PullRequestStatus.Active,
+        isDraft: false,
+        link: 'https://host.com/myOrg/_git/super-feature-repo/pullrequest/7183',
+      };
+
+      const pullRequests: PullRequest[] = [
+        firstPullRequest,
+        secondPullRequest,
+        thirdPullRequest,
+      ];
+
+      mockedAuthorize.mockImplementationOnce(async () => [
+        { result: AuthorizeResult.ALLOW },
+      ]);
+
+      azureDevOpsApi.getPullRequests.mockResolvedValueOnce(pullRequests);
+
+      const response = await request(app)
+        .get('/pull-requests/myProject/myRepo')
+        .query({ entityRef: 'component:default/mycomponent' })
+        .query({ top: '50', status: 1, teamsLimit: 50 });
+
+      expect(azureDevOpsApi.getPullRequests).toHaveBeenCalledWith(
+        'myProject',
+        'myRepo',
+        { status: 1, top: 50, teamsLimit: 50 },
         undefined,
         undefined,
       );

--- a/plugins/azure-devops-backend/src/service/router.ts
+++ b/plugins/azure-devops-backend/src/service/router.ts
@@ -178,6 +178,9 @@ export async function createRouter(
     const { projectName, repoName } = req.params;
 
     const top = req.query.top ? Number(req.query.top) : DEFAULT_TOP;
+    const teamsLimit = req.query.teamsLimit
+      ? Number(req.query.teamsLimit)
+      : DEFAULT_TEAMS_LIMIT;
     const host = req.query.host?.toString();
     const org = req.query.org?.toString();
     const status = req.query.status
@@ -187,6 +190,7 @@ export async function createRouter(
     const pullRequestOptions: PullRequestOptions = {
       top: top,
       status: status,
+      teamsLimit: teamsLimit,
     };
 
     const entityRef = req.query.entityRef;

--- a/plugins/azure-devops-backend/src/service/router.ts
+++ b/plugins/azure-devops-backend/src/service/router.ts
@@ -266,9 +266,9 @@ export async function createRouter(
     res.status(200).json(pullRequests);
   });
 
-  router.get('/all-teams', async (_req, res) => {
-    const topTeams = _req.query.topTeams
-      ? Number(_req.query.topTeams)
+  router.get('/all-teams', async (req, res) => {
+    const topTeams = req.query.topTeams
+      ? Number(req.query.topTeams)
       : undefined;
     const allTeams = await pullRequestsDashboardProvider.getAllTeams(topTeams);
     res.status(200).json(allTeams);

--- a/plugins/azure-devops-backend/src/service/router.ts
+++ b/plugins/azure-devops-backend/src/service/router.ts
@@ -241,6 +241,7 @@ export async function createRouter(
     const pullRequestOptions: PullRequestOptions = {
       top: top,
       status: status,
+      teamsLimit: teamsLimit,
     };
 
     const token = getBearerTokenFromAuthorizationHeader(
@@ -267,7 +268,6 @@ export async function createRouter(
       await pullRequestsDashboardProvider.getDashboardPullRequests(
         projectName,
         pullRequestOptions,
-        teamsLimit,
       );
 
     res.status(200).json(pullRequests);
@@ -275,7 +275,7 @@ export async function createRouter(
 
   router.get('/all-teams', async (req, res) => {
     const limit = req.query.limit ? Number(req.query.limit) : undefined;
-    const allTeams = await pullRequestsDashboardProvider.getAllTeams(limit);
+    const allTeams = await pullRequestsDashboardProvider.getAllTeams({ limit });
     res.status(200).json(allTeams);
   });
 

--- a/plugins/azure-devops-backend/src/service/router.ts
+++ b/plugins/azure-devops-backend/src/service/router.ts
@@ -267,7 +267,10 @@ export async function createRouter(
   });
 
   router.get('/all-teams', async (_req, res) => {
-    const allTeams = await pullRequestsDashboardProvider.getAllTeams();
+    const topTeams = _req.query.topTeams
+      ? Number(_req.query.topTeams)
+      : undefined;
+    const allTeams = await pullRequestsDashboardProvider.getAllTeams(topTeams);
     res.status(200).json(allTeams);
   });
 

--- a/plugins/azure-devops-backend/src/service/router.ts
+++ b/plugins/azure-devops-backend/src/service/router.ts
@@ -23,7 +23,10 @@ import {
 import { AzureDevOpsApi } from '../api';
 import { Config } from '@backstage/config';
 import { Logger } from 'winston';
-import { PullRequestsDashboardProvider } from '../api/PullRequestsDashboardProvider';
+import {
+  PullRequestsDashboardProvider,
+  DEFAULT_TOP_TEAMS,
+} from '../api/PullRequestsDashboardProvider';
 import Router from 'express-promise-router';
 import { errorHandler, UrlReader } from '@backstage/backend-common';
 import express from 'express';
@@ -227,6 +230,9 @@ export async function createRouter(
     const { projectName } = req.params;
 
     const top = req.query.top ? Number(req.query.top) : DEFAULT_TOP;
+    const topTeams = req.query.topTeams
+      ? Number(req.query.topTeams)
+      : DEFAULT_TOP_TEAMS;
 
     const status = req.query.status
       ? Number(req.query.status)
@@ -261,6 +267,7 @@ export async function createRouter(
       await pullRequestsDashboardProvider.getDashboardPullRequests(
         projectName,
         pullRequestOptions,
+        topTeams,
       );
 
     res.status(200).json(pullRequests);

--- a/plugins/azure-devops-backend/src/service/router.ts
+++ b/plugins/azure-devops-backend/src/service/router.ts
@@ -25,7 +25,7 @@ import { Config } from '@backstage/config';
 import { Logger } from 'winston';
 import {
   PullRequestsDashboardProvider,
-  DEFAULT_TOP_TEAMS,
+  DEFAULT_TEAMS_LIMIT,
 } from '../api/PullRequestsDashboardProvider';
 import Router from 'express-promise-router';
 import { errorHandler, UrlReader } from '@backstage/backend-common';
@@ -230,9 +230,9 @@ export async function createRouter(
     const { projectName } = req.params;
 
     const top = req.query.top ? Number(req.query.top) : DEFAULT_TOP;
-    const topTeams = req.query.topTeams
-      ? Number(req.query.topTeams)
-      : DEFAULT_TOP_TEAMS;
+    const teamsLimit = req.query.teamsLimit
+      ? Number(req.query.teamsLimit)
+      : DEFAULT_TEAMS_LIMIT;
 
     const status = req.query.status
       ? Number(req.query.status)
@@ -267,17 +267,19 @@ export async function createRouter(
       await pullRequestsDashboardProvider.getDashboardPullRequests(
         projectName,
         pullRequestOptions,
-        topTeams,
+        teamsLimit,
       );
 
     res.status(200).json(pullRequests);
   });
 
   router.get('/all-teams', async (req, res) => {
-    const topTeams = req.query.topTeams
-      ? Number(req.query.topTeams)
+    const teamsLimit = req.query.teamsLimit
+      ? Number(req.query.teamsLimit)
       : undefined;
-    const allTeams = await pullRequestsDashboardProvider.getAllTeams(topTeams);
+    const allTeams = await pullRequestsDashboardProvider.getAllTeams(
+      teamsLimit,
+    );
     res.status(200).json(allTeams);
   });
 

--- a/plugins/azure-devops-backend/src/service/router.ts
+++ b/plugins/azure-devops-backend/src/service/router.ts
@@ -274,12 +274,8 @@ export async function createRouter(
   });
 
   router.get('/all-teams', async (req, res) => {
-    const teamsLimit = req.query.teamsLimit
-      ? Number(req.query.teamsLimit)
-      : undefined;
-    const allTeams = await pullRequestsDashboardProvider.getAllTeams(
-      teamsLimit,
-    );
+    const limit = req.query.limit ? Number(req.query.limit) : undefined;
+    const allTeams = await pullRequestsDashboardProvider.getAllTeams(limit);
     res.status(200).json(allTeams);
   });
 

--- a/plugins/azure-devops-common/api-report.md
+++ b/plugins/azure-devops-common/api-report.md
@@ -215,6 +215,7 @@ export type PullRequest = {
 export type PullRequestOptions = {
   top: number;
   status: PullRequestStatus;
+  teamsLimit?: number;
 };
 
 // @public (undocumented)

--- a/plugins/azure-devops-common/src/types.ts
+++ b/plugins/azure-devops-common/src/types.ts
@@ -142,6 +142,7 @@ export type PullRequest = {
 export type PullRequestOptions = {
   top: number;
   status: PullRequestStatus;
+  teamsLimit?: number;
 };
 
 /** @public */

--- a/plugins/azure-devops/api-report.md
+++ b/plugins/azure-devops/api-report.md
@@ -65,7 +65,7 @@ export type AssignedToUserFilter = BaseFilter &
 // @public (undocumented)
 export interface AzureDevOpsApi {
   // (undocumented)
-  getAllTeams(topTeams?: number): Promise<Team[]>;
+  getAllTeams(teamsLimit?: number): Promise<Team[]>;
   // (undocumented)
   getBuildRuns(
     projectName: string,
@@ -81,7 +81,7 @@ export interface AzureDevOpsApi {
   // (undocumented)
   getDashboardPullRequests(
     projectName: string,
-    topTeams?: number,
+    teamsLimit?: number,
   ): Promise<DashboardPullRequest[]>;
   // (undocumented)
   getGitTags(
@@ -127,7 +127,7 @@ export const azureDevOpsApiRef: ApiRef<AzureDevOpsApi>;
 export class AzureDevOpsClient implements AzureDevOpsApi {
   constructor(options: { discoveryApi: DiscoveryApi; fetchApi: FetchApi });
   // (undocumented)
-  getAllTeams(topTeams?: number): Promise<Team[]>;
+  getAllTeams(teamsLimit?: number): Promise<Team[]>;
   // (undocumented)
   getBuildRuns(
     projectName: string,
@@ -143,7 +143,7 @@ export class AzureDevOpsClient implements AzureDevOpsApi {
   // (undocumented)
   getDashboardPullRequests(
     projectName: string,
-    topTeams?: number,
+    teamsLimit?: number,
   ): Promise<DashboardPullRequest[]>;
   // (undocumented)
   getGitTags(
@@ -195,7 +195,7 @@ export const AzurePullRequestsPage: (props: {
   projectName?: string | undefined;
   pollingInterval?: number | undefined;
   defaultColumnConfigs?: PullRequestColumnConfig[] | undefined;
-  topTeams?: number | undefined;
+  teamsLimit?: number | undefined;
 }) => JSX_2.Element;
 
 // @public (undocumented)

--- a/plugins/azure-devops/api-report.md
+++ b/plugins/azure-devops/api-report.md
@@ -65,7 +65,7 @@ export type AssignedToUserFilter = BaseFilter &
 // @public (undocumented)
 export interface AzureDevOpsApi {
   // (undocumented)
-  getAllTeams(teamsLimit?: number): Promise<Team[]>;
+  getAllTeams(limit?: number): Promise<Team[]>;
   // (undocumented)
   getBuildRuns(
     projectName: string,
@@ -127,7 +127,7 @@ export const azureDevOpsApiRef: ApiRef<AzureDevOpsApi>;
 export class AzureDevOpsClient implements AzureDevOpsApi {
   constructor(options: { discoveryApi: DiscoveryApi; fetchApi: FetchApi });
   // (undocumented)
-  getAllTeams(teamsLimit?: number): Promise<Team[]>;
+  getAllTeams(limit?: number): Promise<Team[]>;
   // (undocumented)
   getBuildRuns(
     projectName: string,

--- a/plugins/azure-devops/api-report.md
+++ b/plugins/azure-devops/api-report.md
@@ -65,7 +65,7 @@ export type AssignedToUserFilter = BaseFilter &
 // @public (undocumented)
 export interface AzureDevOpsApi {
   // (undocumented)
-  getAllTeams(): Promise<Team[]>;
+  getAllTeams(topTeams?: number): Promise<Team[]>;
   // (undocumented)
   getBuildRuns(
     projectName: string,
@@ -81,6 +81,7 @@ export interface AzureDevOpsApi {
   // (undocumented)
   getDashboardPullRequests(
     projectName: string,
+    topTeams?: number,
   ): Promise<DashboardPullRequest[]>;
   // (undocumented)
   getGitTags(
@@ -126,7 +127,7 @@ export const azureDevOpsApiRef: ApiRef<AzureDevOpsApi>;
 export class AzureDevOpsClient implements AzureDevOpsApi {
   constructor(options: { discoveryApi: DiscoveryApi; fetchApi: FetchApi });
   // (undocumented)
-  getAllTeams(): Promise<Team[]>;
+  getAllTeams(topTeams?: number): Promise<Team[]>;
   // (undocumented)
   getBuildRuns(
     projectName: string,
@@ -142,6 +143,7 @@ export class AzureDevOpsClient implements AzureDevOpsApi {
   // (undocumented)
   getDashboardPullRequests(
     projectName: string,
+    topTeams?: number,
   ): Promise<DashboardPullRequest[]>;
   // (undocumented)
   getGitTags(
@@ -193,6 +195,7 @@ export const AzurePullRequestsPage: (props: {
   projectName?: string | undefined;
   pollingInterval?: number | undefined;
   defaultColumnConfigs?: PullRequestColumnConfig[] | undefined;
+  topTeams?: number | undefined;
 }) => JSX_2.Element;
 
 // @public (undocumented)

--- a/plugins/azure-devops/src/api/AzureDevOpsApi.ts
+++ b/plugins/azure-devops/src/api/AzureDevOpsApi.ts
@@ -64,10 +64,10 @@ export interface AzureDevOpsApi {
 
   getDashboardPullRequests(
     projectName: string,
-    topTeams?: number,
+    teamsLimit?: number,
   ): Promise<DashboardPullRequest[]>;
 
-  getAllTeams(topTeams?: number): Promise<Team[]>;
+  getAllTeams(teamsLimit?: number): Promise<Team[]>;
 
   getUserTeamIds(userId: string): Promise<string[]>;
 

--- a/plugins/azure-devops/src/api/AzureDevOpsApi.ts
+++ b/plugins/azure-devops/src/api/AzureDevOpsApi.ts
@@ -64,6 +64,7 @@ export interface AzureDevOpsApi {
 
   getDashboardPullRequests(
     projectName: string,
+    topTeams?: number,
   ): Promise<DashboardPullRequest[]>;
 
   getAllTeams(topTeams?: number): Promise<Team[]>;

--- a/plugins/azure-devops/src/api/AzureDevOpsApi.ts
+++ b/plugins/azure-devops/src/api/AzureDevOpsApi.ts
@@ -67,7 +67,7 @@ export interface AzureDevOpsApi {
     teamsLimit?: number,
   ): Promise<DashboardPullRequest[]>;
 
-  getAllTeams(teamsLimit?: number): Promise<Team[]>;
+  getAllTeams(limit?: number): Promise<Team[]>;
 
   getUserTeamIds(userId: string): Promise<string[]>;
 

--- a/plugins/azure-devops/src/api/AzureDevOpsApi.ts
+++ b/plugins/azure-devops/src/api/AzureDevOpsApi.ts
@@ -66,7 +66,7 @@ export interface AzureDevOpsApi {
     projectName: string,
   ): Promise<DashboardPullRequest[]>;
 
-  getAllTeams(): Promise<Team[]>;
+  getAllTeams(topTeams?: number): Promise<Team[]>;
 
   getUserTeamIds(userId: string): Promise<string[]>;
 

--- a/plugins/azure-devops/src/api/AzureDevOpsClient.ts
+++ b/plugins/azure-devops/src/api/AzureDevOpsClient.ts
@@ -124,10 +124,15 @@ export class AzureDevOpsClient implements AzureDevOpsApi {
 
   public getDashboardPullRequests(
     projectName: string,
+    topTeams?: number,
   ): Promise<DashboardPullRequest[]> {
-    return this.get<DashboardPullRequest[]>(
-      `dashboard-pull-requests/${projectName}?top=100`,
-    );
+    const queryString = new URLSearchParams();
+    queryString.append('top', '100');
+    if (topTeams) {
+      queryString.append('topTeams', topTeams.toString());
+    }
+    const urlSegment = `dashboard-pull-requests/${projectName}?${queryString}`;
+    return this.get<DashboardPullRequest[]>(urlSegment);
   }
 
   public getAllTeams(topTeams?: number): Promise<Team[]> {

--- a/plugins/azure-devops/src/api/AzureDevOpsClient.ts
+++ b/plugins/azure-devops/src/api/AzureDevOpsClient.ts
@@ -124,21 +124,21 @@ export class AzureDevOpsClient implements AzureDevOpsApi {
 
   public getDashboardPullRequests(
     projectName: string,
-    topTeams?: number,
+    teamsLimit?: number,
   ): Promise<DashboardPullRequest[]> {
     const queryString = new URLSearchParams();
     queryString.append('top', '100');
-    if (topTeams) {
-      queryString.append('topTeams', topTeams.toString());
+    if (teamsLimit) {
+      queryString.append('teamsLimit', teamsLimit.toString());
     }
     const urlSegment = `dashboard-pull-requests/${projectName}?${queryString}`;
     return this.get<DashboardPullRequest[]>(urlSegment);
   }
 
-  public getAllTeams(topTeams?: number): Promise<Team[]> {
+  public getAllTeams(teamsLimit?: number): Promise<Team[]> {
     const queryString = new URLSearchParams();
-    if (topTeams) {
-      queryString.append('topTeams', topTeams.toString());
+    if (teamsLimit) {
+      queryString.append('teamsLimit', teamsLimit.toString());
     }
     let urlSegment = 'all-teams';
     if (queryString.toString()) {

--- a/plugins/azure-devops/src/api/AzureDevOpsClient.ts
+++ b/plugins/azure-devops/src/api/AzureDevOpsClient.ts
@@ -107,6 +107,9 @@ export class AzureDevOpsClient implements AzureDevOpsApi {
     if (options?.status) {
       queryString.append('status', options.status.toString());
     }
+    if (options?.teamsLimit) {
+      queryString.append('teamsLimit', options.teamsLimit.toString());
+    }
     if (host) {
       queryString.append('host', host);
     }

--- a/plugins/azure-devops/src/api/AzureDevOpsClient.ts
+++ b/plugins/azure-devops/src/api/AzureDevOpsClient.ts
@@ -130,8 +130,16 @@ export class AzureDevOpsClient implements AzureDevOpsApi {
     );
   }
 
-  public getAllTeams(): Promise<Team[]> {
-    return this.get<Team[]>('all-teams');
+  public getAllTeams(topTeams?: number): Promise<Team[]> {
+    const queryString = new URLSearchParams();
+    if (topTeams) {
+      queryString.append('topTeams', topTeams.toString());
+    }
+    let urlSegment = 'all-teams';
+    if (queryString.toString()) {
+      urlSegment += `?${queryString}`;
+    }
+    return this.get<Team[]>(urlSegment);
   }
 
   public getUserTeamIds(userId: string): Promise<string[]> {

--- a/plugins/azure-devops/src/api/AzureDevOpsClient.ts
+++ b/plugins/azure-devops/src/api/AzureDevOpsClient.ts
@@ -135,10 +135,10 @@ export class AzureDevOpsClient implements AzureDevOpsApi {
     return this.get<DashboardPullRequest[]>(urlSegment);
   }
 
-  public getAllTeams(teamsLimit?: number): Promise<Team[]> {
+  public getAllTeams(limit?: number): Promise<Team[]> {
     const queryString = new URLSearchParams();
-    if (teamsLimit) {
-      queryString.append('teamsLimit', teamsLimit.toString());
+    if (limit) {
+      queryString.append('limit', limit.toString());
     }
     let urlSegment = 'all-teams';
     if (queryString.toString()) {

--- a/plugins/azure-devops/src/components/PullRequestsPage/PullRequestsPage.tsx
+++ b/plugins/azure-devops/src/components/PullRequestsPage/PullRequestsPage.tsx
@@ -70,17 +70,17 @@ type PullRequestsPageProps = {
   projectName?: string;
   pollingInterval?: number;
   defaultColumnConfigs?: PullRequestColumnConfig[];
-  topTeams?: number;
+  teamsLimit?: number;
 };
 
 export const PullRequestsPage = (props: PullRequestsPageProps) => {
-  const { projectName, pollingInterval, defaultColumnConfigs, topTeams } =
+  const { projectName, pollingInterval, defaultColumnConfigs, teamsLimit } =
     props;
 
   const { pullRequests, loading, error } = useDashboardPullRequests(
     projectName,
     pollingInterval,
-    topTeams,
+    teamsLimit,
   );
 
   const [columnConfigs] = useState(

--- a/plugins/azure-devops/src/components/PullRequestsPage/PullRequestsPage.tsx
+++ b/plugins/azure-devops/src/components/PullRequestsPage/PullRequestsPage.tsx
@@ -70,14 +70,17 @@ type PullRequestsPageProps = {
   projectName?: string;
   pollingInterval?: number;
   defaultColumnConfigs?: PullRequestColumnConfig[];
+  topTeams?: number;
 };
 
 export const PullRequestsPage = (props: PullRequestsPageProps) => {
-  const { projectName, pollingInterval, defaultColumnConfigs } = props;
+  const { projectName, pollingInterval, defaultColumnConfigs, topTeams } =
+    props;
 
   const { pullRequests, loading, error } = useDashboardPullRequests(
     projectName,
     pollingInterval,
+    topTeams,
   );
 
   const [columnConfigs] = useState(

--- a/plugins/azure-devops/src/hooks/useDashboardPullRequests.ts
+++ b/plugins/azure-devops/src/hooks/useDashboardPullRequests.ts
@@ -27,7 +27,7 @@ const POLLING_INTERVAL = 10000;
 export function useDashboardPullRequests(
   project?: string,
   pollingInterval: number = POLLING_INTERVAL,
-  topTeams?: number,
+  teamsLimit?: number,
 ): {
   pullRequests?: DashboardPullRequest[];
   loading: boolean;
@@ -44,7 +44,7 @@ export function useDashboardPullRequests(
     }
 
     try {
-      return await api.getDashboardPullRequests(project, topTeams);
+      return await api.getDashboardPullRequests(project, teamsLimit);
     } catch (error) {
       if (error instanceof Error) {
         errorApi.post(error);
@@ -52,7 +52,7 @@ export function useDashboardPullRequests(
 
       return Promise.reject(error);
     }
-  }, [project, api, topTeams, errorApi]);
+  }, [project, api, teamsLimit, errorApi]);
 
   const {
     value: pullRequests,

--- a/plugins/azure-devops/src/hooks/useDashboardPullRequests.ts
+++ b/plugins/azure-devops/src/hooks/useDashboardPullRequests.ts
@@ -27,6 +27,7 @@ const POLLING_INTERVAL = 10000;
 export function useDashboardPullRequests(
   project?: string,
   pollingInterval: number = POLLING_INTERVAL,
+  topTeams?: number,
 ): {
   pullRequests?: DashboardPullRequest[];
   loading: boolean;
@@ -43,7 +44,7 @@ export function useDashboardPullRequests(
     }
 
     try {
-      return await api.getDashboardPullRequests(project);
+      return await api.getDashboardPullRequests(project, topTeams);
     } catch (error) {
       if (error instanceof Error) {
         errorApi.post(error);
@@ -51,7 +52,7 @@ export function useDashboardPullRequests(
 
       return Promise.reject(error);
     }
-  }, [project, api, errorApi]);
+  }, [project, api, topTeams, errorApi]);
 
   const {
     value: pullRequests,

--- a/plugins/azure-devops/src/hooks/usePullRequests.ts
+++ b/plugins/azure-devops/src/hooks/usePullRequests.ts
@@ -31,16 +31,19 @@ export function usePullRequests(
   entity: Entity,
   defaultLimit?: number,
   requestedStatus?: PullRequestStatus,
+  defaultTeamsLimit?: number,
 ): {
   items?: PullRequest[];
   loading: boolean;
   error?: Error;
 } {
   const top = defaultLimit ?? AZURE_DEVOPS_DEFAULT_TOP;
+  const teamsLimit = defaultTeamsLimit ?? undefined;
   const status = requestedStatus ?? PullRequestStatus.Active;
   const options: PullRequestOptions = {
     top,
     status,
+    teamsLimit,
   };
 
   const api = useApi(azureDevOpsApiRef);


### PR DESCRIPTION
Since 100 is the default in azure-devops-node-api

fix #23533 

## Hey, I just made a Pull Request!

When reading teams from azure devops, the default limit is 100. This change will add an argument to change that limit.

The azure devops pull request dashboard provider has been outfitted to be able to use it in the future.
I've set a constant to show that the default is 100 to make it more obvious and to make it deterministic in case microsoft changes this behaviour through `azure-devops-node-api`.

I didn't want to mess with the pull request dashboard provider logic for caching the existing teams since it doesn't affect my needs. But this change could potentially lead to this value being populated with an incorrect number of teams.

❓I am looking for feedback on the behaviour you would want on getAllTeams() in PullRequestsDashboardProvider. I noticed during testing that if the number of teams in Azure Devops grows after it first being stored then those new teams will never show up unless you restart backstage.

I originally needed to change getAllTeams() in AzureDevOpsApi to facilitate that another plugin that we are using would be able to pull more than 100 teams as part of our group entity provider ("azure devops teams provider").


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
