### PR TITLE
P-Limit Deadlock Solved #23633

### DIFF
--- a/plugins/vault-backend/CHANGELOG.md
+++ b/plugins/vault-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/plugin-vault-backend
 
+## 0.4.7-next.3
+
+### Patch Changes
+
+- 594a994: Removed deadlock https://github.com/backstage/backstage/issues/23633
+
 ## 0.4.7-next.2
 
 ### Patch Changes

--- a/plugins/vault-backend/src/service/vaultApi.ts
+++ b/plugins/vault-backend/src/service/vaultApi.ts
@@ -146,13 +146,12 @@ export class VaultClient implements VaultApi {
     await Promise.all(
       result.data.keys.map(async secret => {
         if (secret.endsWith('/')) {
-          secrets.push(
-            ...(await this.limit(() =>
-              this.listSecrets(`${secretPath}/${secret.slice(0, -1)}`, {
-                secretEngine: mount,
-              }),
-            )),
-          );
+            secrets.push(
+                ...(await this.listSecrets(`${secretPath}/${secret.slice(0, -1)}`, {
+                        secretEngine: mount,
+                    },
+                )),
+            );
         } else {
           const vaultUrl =
             this.vaultConfig.publicUrl || this.vaultConfig.baseUrl;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Removed the additional `limit` call inside the `listSecrets` function to avoid Deadlocks.
Issue: https://github.com/backstage/backstage/issues/23633

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
