### PR TITLE
P-Limit Deadlock Solved

### DIFF
--- a/.changeset/angry-stingrays-cover.md
+++ b/.changeset/angry-stingrays-cover.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-vault-backend': patch
+---
+
+Removed lock inside recursion to avoid deadlocks

--- a/plugins/vault-backend/src/service/vaultApi.ts
+++ b/plugins/vault-backend/src/service/vaultApi.ts
@@ -147,11 +147,9 @@ export class VaultClient implements VaultApi {
       result.data.keys.map(async secret => {
         if (secret.endsWith('/')) {
           secrets.push(
-            ...(await this.limit(() =>
-              this.listSecrets(`${secretPath}/${secret.slice(0, -1)}`, {
-                secretEngine: mount,
-              }),
-            )),
+            ...(await this.listSecrets(`${secretPath}/${secret.slice(0, -1)}`, {
+              secretEngine: mount,
+            })),
           );
         } else {
           const vaultUrl =


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Removed the additional `limit` call inside the `listSecrets` function to avoid Deadlocks.
Issue: https://github.com/backstage/backstage/issues/23633

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
