### PR TITLE
fix: ajv warning for stricttypes

### DIFF
--- a/.changeset/popular-guests-tickle.md
+++ b/.changeset/popular-guests-tickle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-tech-insights-backend-module-jsonfc': patch
+---
+
+Fixes an invalid line in the schema that was causing AJV to complain.

--- a/plugins/tech-insights-backend-module-jsonfc/config.json
+++ b/plugins/tech-insights-backend-module-jsonfc/config.json
@@ -109,7 +109,7 @@
       ]
     },
     "rule": {
-      "type": "string",
+      "type": "object",
       "required": ["conditions"],
       "properties": {
         "conditions": {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Right now, the config schema validation sometimes prints out,
```
strict mode: missing type "object" for keyword "required" at "#" (strictTypes)
strict mode: missing type "object" for keyword "properties" at "#" (strictTypes)
strict mode: missing type "object" for keyword "required" at "#" (strictTypes)
strict mode: missing type "object" for keyword "properties" at "#" (strictTypes)
```

This is easily ignored and has no effect on execution of your program as AJV will correct this after complaining. I'm working on a CLI that requires more log sensitivity and took a go at solving this log. With this change, there are no more AJV logs.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
