### PR TITLE
Add ESLint Rule to TechInsights Plugin

### DIFF
--- a/.changeset/spotty-ducks-deny.md
+++ b/.changeset/spotty-ducks-deny.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-tech-insights': patch
+---
+
+Added ESLint rule `no-top-level-material-ui-4-imports` in the `tech-insights` plugin to migrate the Material UI imports.

--- a/plugins/tech-insights/.eslintrc.js
+++ b/plugins/tech-insights/.eslintrc.js
@@ -1,1 +1,5 @@
-module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
+    rules: {
+      '@backstage/no-top-level-material-ui-4-imports': 'error',
+    },
+});

--- a/plugins/tech-insights/src/components/ScorecardsContent/ScorecardContent.tsx
+++ b/plugins/tech-insights/src/components/ScorecardsContent/ScorecardContent.tsx
@@ -21,7 +21,7 @@ import { useApi } from '@backstage/core-plugin-api';
 import { ScorecardInfo } from '../ScorecardsInfo';
 import Alert from '@material-ui/lab/Alert';
 import { techInsightsApiRef } from '../../api/TechInsightsApi';
-import { makeStyles } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { getCompoundEntityRef } from '@backstage/catalog-model';
 

--- a/plugins/tech-insights/src/components/ScorecardsInfo/ScorecardInfo.tsx
+++ b/plugins/tech-insights/src/components/ScorecardsInfo/ScorecardInfo.tsx
@@ -15,10 +15,12 @@
  */
 
 import React from 'react';
-import { makeStyles, Grid, Typography } from '@material-ui/core';
+import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
 import { InfoCard } from '@backstage/core-components';
 import { CheckResult } from '@backstage/plugin-tech-insights-common';
-import { Alert } from '@material-ui/lab';
+import Alert from '@material-ui/lab/Alert';
 import { ScorecardsList } from '../ScorecardsList';
 
 const useStyles = makeStyles(theme => ({

--- a/plugins/tech-insights/src/components/ScorecardsList/ScorecardsList.tsx
+++ b/plugins/tech-insights/src/components/ScorecardsList/ScorecardsList.tsx
@@ -16,10 +16,13 @@
 
 import React from 'react';
 import { useApi } from '@backstage/core-plugin-api';
-import { makeStyles, List, ListItem, ListItemText } from '@material-ui/core';
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemText from '@material-ui/core/ListItemText';
+import { makeStyles } from '@material-ui/core/styles';
 import { techInsightsApiRef } from '../../api';
 import { CheckResult } from '@backstage/plugin-tech-insights-common';
-import { Alert } from '@material-ui/lab';
+import Alert from '@material-ui/lab/Alert';
 import { MarkdownContent } from '@backstage/core-components';
 
 const useStyles = makeStyles(theme => ({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds the no-top-level-material-ui-4-import ESLint rule to the TechInsights plugin to aid with the migration to Material UI v5.

Issue: #23467 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
