### PR TITLE
Add ESLint Rule to Stackstorm Plugin

### DIFF
--- a/.changeset/plenty-singers-call.md
+++ b/.changeset/plenty-singers-call.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-stackstorm': patch
+---
+
+Added ESLint rule `no-top-level-material-ui-4-imports` in the `stackstorm` plugin to migrate the Material UI imports.

--- a/plugins/stackstorm/.eslintrc.js
+++ b/plugins/stackstorm/.eslintrc.js
@@ -1,1 +1,5 @@
-module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
+    rules: {
+      '@backstage/no-top-level-material-ui-4-imports': 'error',
+    },
+});

--- a/plugins/stackstorm/src/components/ActionsList/ActionsList.tsx
+++ b/plugins/stackstorm/src/components/ActionsList/ActionsList.tsx
@@ -17,14 +17,12 @@ import React, { useState } from 'react';
 import useAsync from 'react-use/lib/useAsync';
 import { Link, Progress, ResponseErrorPanel } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
-import {
-  List,
-  ListItemText,
-  Collapse,
-  ListItem,
-  ListItemSecondaryAction,
-  ListItemIcon,
-} from '@material-ui/core';
+import List from '@material-ui/core/List';
+import ListItemText from '@material-ui/core/ListItemText';
+import Collapse from '@material-ui/core/Collapse';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
 import { makeStyles } from '@material-ui/core/styles';
 import ExpandMore from '@material-ui/icons/ExpandMore';
 import ExpandLess from '@material-ui/icons/ExpandLess';

--- a/plugins/stackstorm/src/components/ExecutionsTable/ExecutionPanel.tsx
+++ b/plugins/stackstorm/src/components/ExecutionsTable/ExecutionPanel.tsx
@@ -22,19 +22,16 @@ import {
 import { useApi } from '@backstage/core-plugin-api';
 import { Execution, stackstormApiRef } from '../../api';
 import useAsync from 'react-use/lib/useAsync';
-import {
-  Button,
-  Card,
-  CardActions,
-  CardContent,
-  makeStyles,
-  Table,
-  TableBody,
-  TableCell,
-  TableRow,
-  Typography,
-  withStyles,
-} from '@material-ui/core';
+import Button from '@material-ui/core/Button';
+import Card from '@material-ui/core/Card';
+import CardActions from '@material-ui/core/CardActions';
+import CardContent from '@material-ui/core/CardContent';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableRow from '@material-ui/core/TableRow';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles, withStyles } from '@material-ui/core/styles';
 import { Status } from './Status';
 
 const useStyles = makeStyles(theme => ({

--- a/plugins/stackstorm/src/components/StackstormHome/StackstormHome.tsx
+++ b/plugins/stackstorm/src/components/StackstormHome/StackstormHome.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import React, { Fragment } from 'react';
-import { IconButton } from '@material-ui/core';
+import IconButton from '@material-ui/core/IconButton';
 import {
   Header,
   Page,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds the no-top-level-material-ui-4-import ESLint rule to the Stackstorm plugin to aid with the migration to Material UI v5.

Issue: #23467 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
