### PR TITLE
feat(events,github): add support for EventsService, events at new backend

### DIFF
--- a/.changeset/nervous-mangos-peel.md
+++ b/.changeset/nervous-mangos-peel.md
@@ -1,0 +1,24 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+Support EventsService and events with the new backend system (through EventsService).
+
+_New/Current Backend System:_
+
+The events support for the provider will be enabled always, making it ready to consume events from its subscribed topics.
+In order to receive events and make use of this feature, you still need to set up receiving events from the event source as before.
+
+_Legacy Backend System:_
+
+You can pass the `EventsService` instance to the factory method as one of its options:
+
+```diff
+  // packages/backend/src/plugins/catalog.ts
+  const githubProvider = GithubEntityProvider.fromConfig(env.config, {
++   events: env.events,
+    logger: env.logger,
+    scheduler: env.scheduler,
+  });
+- env.eventBroker.subscribe(githubProvider);
+```

--- a/docs/integrations/github/discovery.md
+++ b/docs/integrations/github/discovery.md
@@ -51,6 +51,26 @@ export default async function createPlugin(
 
 ## Installation with Events Support
 
+_For the legacy backend system, please read the sub-section below._
+
+The catalog module for GitHub comes with events support enabled.
+This will make it subscribe to its relevant topics (`github.push`)
+and expects these events to be published via the `EventsService`.
+
+Additionally, you should install the
+[event router by `events-backend-module-github`](https://github.com/backstage/backstage/tree/master/plugins/events-backend-module-github/README.md)
+which will route received events from the generic topic `github` to more specific ones
+based on the event type (e.g., `github.push`).
+
+In order to receive Webhook events by GitHub, you have to decide how you want them
+to be ingested into Backstage and published to its `EventsService`.
+You can decide between the following options (extensible):
+
+- [via HTTP endpoint](https://github.com/backstage/backstage/tree/master/plugins/events-backend/README.md)
+- [via an AWS SQS queue](https://github.com/backstage/backstage/tree/master/plugins/events-backend-module-aws-sqs/README.md)
+
+### Legacy Backend System
+
 Please follow the installation instructions at
 
 - <https://github.com/backstage/backstage/tree/master/plugins/events-backend/README.md>
@@ -78,10 +98,10 @@ export default async function createPlugin(
   builder.addProcessor(new ScaffolderEntitiesProcessor());
   /* highlight-add-start */
   const githubProvider = GithubEntityProvider.fromConfig(env.config, {
+    events: env.events,
     logger: env.logger,
     scheduler: env.scheduler,
   });
-  env.eventBroker.subscribe(githubProvider);
   builder.addEntityProvider(githubProvider);
   /* highlight-add-end */
   const { processingEngine, router } = await builder.build();

--- a/plugins/catalog-backend-module-github/api-report.md
+++ b/plugins/catalog-backend-module-github/api-report.md
@@ -13,6 +13,7 @@ import { EntityProvider } from '@backstage/plugin-catalog-node';
 import { EntityProviderConnection } from '@backstage/plugin-catalog-node';
 import { EventBroker } from '@backstage/plugin-events-node';
 import { EventParams } from '@backstage/plugin-events-node';
+import { EventsService } from '@backstage/plugin-events-node';
 import { EventSubscriber } from '@backstage/plugin-events-node';
 import { GithubCredentialsProvider } from '@backstage/integration';
 import { GithubIntegrationConfig } from '@backstage/integration';
@@ -88,6 +89,7 @@ export class GithubEntityProvider implements EntityProvider, EventSubscriber {
   static fromConfig(
     config: Config,
     options: {
+      events?: EventsService;
       logger: Logger;
       schedule?: TaskRunner;
       scheduler?: PluginTaskScheduler;

--- a/plugins/catalog-backend-module-github/src/module/githubCatalogModule.ts
+++ b/plugins/catalog-backend-module-github/src/module/githubCatalogModule.ts
@@ -23,6 +23,7 @@ import {
   catalogAnalysisExtensionPoint,
   catalogProcessingExtensionPoint,
 } from '@backstage/plugin-catalog-node/alpha';
+import { eventsServiceRef } from '@backstage/plugin-events-node';
 import { GithubEntityProvider } from '../providers/GithubEntityProvider';
 import { GithubLocationAnalyzer } from '../analyzers/GithubLocationAnalyzer';
 
@@ -37,17 +38,19 @@ export const githubCatalogModule = createBackendModule({
   register(env) {
     env.registerInit({
       deps: {
-        catalog: catalogProcessingExtensionPoint,
         analyzers: catalogAnalysisExtensionPoint,
         auth: coreServices.auth,
-        discovery: coreServices.discovery,
+        catalog: catalogProcessingExtensionPoint,
         config: coreServices.rootConfig,
+        discovery: coreServices.discovery,
+        events: eventsServiceRef,
         logger: coreServices.logger,
         scheduler: coreServices.scheduler,
       },
       async init({
         catalog,
         config,
+        events,
         logger,
         scheduler,
         analyzers,
@@ -64,6 +67,7 @@ export const githubCatalogModule = createBackendModule({
 
         catalog.addEntityProvider(
           GithubEntityProvider.fromConfig(config, {
+            events,
             logger: loggerToWinstonLogger(logger),
             scheduler,
           }),


### PR DESCRIPTION
Adds optional support for the EventsService passed as argument to the factory method.

For the new backend, the EventsService is used as dependency and passed on. Events support will be active always.

The support for the deprecated EventBroker and its interfaces was kept for easier migration and will be removed as a separate follow-up change that could go into a following release.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
