### PR TITLE
cli: add flag to enable experimental webpack lazy compilation

### DIFF
--- a/.changeset/curvy-flies-own.md
+++ b/.changeset/curvy-flies-own.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Added a `EXPERIMENTAL_LAZY_COMPILATION` flag, which enables the experimental Webpack lazy compilation option in frontend builds.

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,16 +1,38 @@
 {
   "name": "example-app",
   "version": "0.2.93-next.2",
-  "private": true,
   "backstage": {
     "role": "frontend"
   },
-  "bundled": true,
+  "private": true,
   "homepage": "https://backstage.io",
   "repository": {
     "type": "git",
     "url": "https://github.com/backstage/backstage",
     "directory": "packages/app"
+  },
+  "license": "Apache-2.0",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "backstage-cli package build",
+    "clean": "backstage-cli package clean",
+    "lint": "backstage-cli package lint",
+    "start": "cross-env EXPERIMENTAL_LAZY_COMPILATION=1 backstage-cli package start",
+    "test": "backstage-cli package test"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
   },
   "dependencies": {
     "@backstage/app-defaults": "workspace:^",
@@ -121,27 +143,5 @@
     "@types/zen-observable": "^0.8.0",
     "cross-env": "^7.0.0"
   },
-  "scripts": {
-    "start": "backstage-cli package start",
-    "build": "backstage-cli package build",
-    "clean": "backstage-cli package clean",
-    "test": "backstage-cli package test",
-    "lint": "backstage-cli package lint"
-  },
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
-  },
-  "files": [
-    "dist"
-  ],
-  "license": "Apache-2.0"
+  "bundled": true
 }

--- a/packages/cli/src/lib/bundler/config.ts
+++ b/packages/cli/src/lib/bundler/config.ts
@@ -224,6 +224,9 @@ export async function createConfig(
           }
         : {}),
     },
+    experiments: {
+      lazyCompilation: yn(process.env.EXPERIMENTAL_LAZY_COMPILATION),
+    },
     plugins,
     ...(withCache
       ? {


### PR DESCRIPTION
Another flag for the CLI 😁, this time to enable https://webpack.js.org/configuration/experiments/#experimentslazycompilation, speeds up startup quite a bit. Also enabling it by default for the app in this repo
