### PR TITLE
Wrong link on technical FAQ

### DIFF
--- a/docs/faq/technical.md
+++ b/docs/faq/technical.md
@@ -115,7 +115,7 @@ where you write documentation using the same workflow as you write your code.
 This makes it easier to create, find, and update documentation.
 [TechDocs is now open source.](https://backstage.io/docs/features/techdocs/)
 (See also:
-"[Will Spotify's internal plugins be open sourced, too?](#will-spotifys-internal-plugins-be-open-sourced-too)"
+"[Will Spotify's internal plugins be open sourced, too?](https://backstage.io/docs/faq/product#will-spotifys-internal-plugins-be-open-sourced-too)"
 above)
 
 ### Are you planning to have plugins baked into the repo? Or should they be developed in separate repos?


### PR DESCRIPTION
## Hey, I just made a Pull Request!

A small section was probably split off of the technical FAQ and into the product FAQ (#will-spotifys-internal-plugins-be-open-sourced-too), and the link to it was broken. That's it.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] Added or updated documentationgin))
