### PR TITLE
Add ESLint Rule to SonarQube Plugin

### DIFF
--- a/.changeset/few-rules-accept.md
+++ b/.changeset/few-rules-accept.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-sonarqube': patch
+---
+
+Added ESLint rule `no-top-level-material-ui-4-imports` in the `sonarqube` plugin to migrate the Material UI imports.

--- a/plugins/sonarqube/.eslintrc.js
+++ b/plugins/sonarqube/.eslintrc.js
@@ -1,1 +1,5 @@
-module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
+    rules: {
+      '@backstage/no-top-level-material-ui-4-imports': 'error',
+    },
+});

--- a/plugins/sonarqube/dev/index.tsx
+++ b/plugins/sonarqube/dev/index.tsx
@@ -16,7 +16,7 @@
 
 import { Entity } from '@backstage/catalog-model';
 import { createDevApp, EntityGridItem } from '@backstage/dev-utils';
-import { Grid } from '@material-ui/core';
+import Grid from '@material-ui/core/Grid';
 import React from 'react';
 import { EntitySonarQubeCard, sonarQubePlugin } from '../src';
 import { Content, Header, Page } from '@backstage/core-components';

--- a/plugins/sonarqube/src/components/SonarQubeCard/Percentage.tsx
+++ b/plugins/sonarqube/src/components/SonarQubeCard/Percentage.tsx
@@ -15,7 +15,7 @@
  */
 
 import { makeStyles } from '@material-ui/core/styles';
-import { useTheme } from '@material-ui/core';
+import { useTheme } from '@material-ui/core/styles';
 import { Circle } from 'rc-progress';
 import React from 'react';
 

--- a/plugins/sonarqube/src/components/SonarQubeCard/Rating.tsx
+++ b/plugins/sonarqube/src/components/SonarQubeCard/Rating.tsx
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { Avatar } from '@material-ui/core';
+import Avatar from '@material-ui/core/Avatar';
 import { lighten, makeStyles } from '@material-ui/core/styles';
-import { CSSProperties } from '@material-ui/styles';
+import { CSSProperties } from '@material-ui/styles/withStyles';
 import React, { useMemo } from 'react';
 
 const useStyles = makeStyles(theme => {

--- a/plugins/sonarqube/src/components/SonarQubeCard/RatingCard.tsx
+++ b/plugins/sonarqube/src/components/SonarQubeCard/RatingCard.tsx
@@ -15,7 +15,8 @@
  */
 
 import { Link } from '@backstage/core-components';
-import { Grid, Typography } from '@material-ui/core';
+import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import React, { ReactNode } from 'react';
 

--- a/plugins/sonarqube/src/components/SonarQubeCard/SonarQubeCard.tsx
+++ b/plugins/sonarqube/src/components/SonarQubeCard/SonarQubeCard.tsx
@@ -23,7 +23,8 @@ import {
   useProjectInfo,
 } from '@backstage/plugin-sonarqube-react';
 import { SONARQUBE_PROJECT_KEY_ANNOTATION } from '@backstage/plugin-sonarqube-react';
-import { Chip, Grid } from '@material-ui/core';
+import Chip from '@material-ui/core/Chip';
+import Grid from '@material-ui/core/Grid';
 import { makeStyles } from '@material-ui/core/styles';
 import BugReport from '@material-ui/icons/BugReport';
 import Lock from '@material-ui/icons/Lock';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds the no-top-level-material-ui-4-import ESLint rule to the SonarQube plugin to aid with the migration to Material UI v5.

issue: #23467 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
