### PR TITLE
Add ESLint Rule to Signals Plugin

### DIFF
--- a/.changeset/unlucky-drinks-glow.md
+++ b/.changeset/unlucky-drinks-glow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-signals': patch
+---
+
+Added ESLint rule `no-top-level-material-ui-4-imports` in the `signals` plugin to migrate the Material UI imports.

--- a/plugins/signals/.eslintrc.js
+++ b/plugins/signals/.eslintrc.js
@@ -1,1 +1,5 @@
-module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
+    rules: {
+      '@backstage/no-top-level-material-ui-4-imports': 'error',
+    },
+});

--- a/plugins/signals/dev/index.tsx
+++ b/plugins/signals/dev/index.tsx
@@ -17,7 +17,7 @@ import React from 'react';
 import { createDevApp } from '@backstage/dev-utils';
 import { signalsPlugin } from '../src/plugin';
 import { Content, Header, Page } from '@backstage/core-components';
-import { Typography } from '@material-ui/core';
+import Typography from '@material-ui/core/Typography';
 
 createDevApp()
   .registerPlugin(signalsPlugin)


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds the no-top-level-material-ui-4-import ESLint rule to the Signals plugin to aid with the migration to Material UI v5.

Issue: #23467 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
