### PR TITLE
Add ESLint Rule to Shortcuts Plugin

### DIFF
--- a/.changeset/chatty-bikes-greet.md
+++ b/.changeset/chatty-bikes-greet.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-shortcuts': patch
+---
+
+Added ESLint rule `no-top-level-material-ui-4-imports` in the `shortcuts` plugin to migrate the Material UI imports.

--- a/plugins/shortcuts/.eslintrc.js
+++ b/plugins/shortcuts/.eslintrc.js
@@ -1,1 +1,5 @@
-module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
+    rules: {
+      '@backstage/no-top-level-material-ui-4-imports': 'error',
+    },
+});

--- a/plugins/shortcuts/src/AddShortcut.tsx
+++ b/plugins/shortcuts/src/AddShortcut.tsx
@@ -17,13 +17,11 @@
 import React, { useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { SubmitHandler } from 'react-hook-form';
-import {
-  Button,
-  Card,
-  CardHeader,
-  makeStyles,
-  Popover,
-} from '@material-ui/core';
+import Button from '@material-ui/core/Button';
+import Card from '@material-ui/core/Card';
+import CardHeader from '@material-ui/core/CardHeader';
+import Popover from '@material-ui/core/Popover';
+import { makeStyles } from '@material-ui/core/styles';
 import { ShortcutForm } from './ShortcutForm';
 import { FormValues, Shortcut } from './types';
 import { ShortcutApi } from './api';

--- a/plugins/shortcuts/src/EditShortcut.tsx
+++ b/plugins/shortcuts/src/EditShortcut.tsx
@@ -16,13 +16,11 @@
 
 import React from 'react';
 import { SubmitHandler } from 'react-hook-form';
-import {
-  Button,
-  Card,
-  CardHeader,
-  makeStyles,
-  Popover,
-} from '@material-ui/core';
+import Button from '@material-ui/core/Button';
+import Card from '@material-ui/core/Card';
+import CardHeader from '@material-ui/core/CardHeader';
+import Popover from '@material-ui/core/Popover';
+import { makeStyles } from '@material-ui/core/styles';
 import { ShortcutForm } from './ShortcutForm';
 import { FormValues, Shortcut } from './types';
 import DeleteIcon from '@material-ui/icons/Delete';

--- a/plugins/shortcuts/src/ShortcutForm.tsx
+++ b/plugins/shortcuts/src/ShortcutForm.tsx
@@ -17,13 +17,11 @@
 import React, { useEffect, useRef } from 'react';
 import useObservable from 'react-use/lib/useObservable';
 import { useForm, SubmitHandler, Controller } from 'react-hook-form';
-import {
-  Button,
-  CardActions,
-  CardContent,
-  makeStyles,
-  TextField,
-} from '@material-ui/core';
+import Button from '@material-ui/core/Button';
+import CardActions from '@material-ui/core/CardActions';
+import CardContent from '@material-ui/core/CardContent';
+import TextField from '@material-ui/core/TextField';
+import { makeStyles } from '@material-ui/core/styles';
 import { FormValues } from './types';
 import { shortcutsApiRef } from './api';
 import { useApi } from '@backstage/core-plugin-api';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds the no-top-level-material-ui-4-import ESLint rule to the Shortcuts plugin to aid with the migration to Material UI v5.

Issue: #23467 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
