### PR TITLE
Hide `EntityAutocompletePicker` only if there are zero available options

### DIFF
--- a/.changeset/moody-rice-jump.md
+++ b/.changeset/moody-rice-jump.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Change behavior in EntityAutoCompletePicker to only hide filter if there are no available options. Previously the filter was hidden if there were <= 1 available options.

--- a/plugins/catalog-react/src/components/EntityAutocompletePicker/EntityAutocompletePicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityAutocompletePicker/EntityAutocompletePicker.test.tsx
@@ -88,6 +88,56 @@ describe('<EntityAutocompletePicker/>', () => {
     });
   });
 
+  it('hides filter if there are no available options', async () => {
+    const mockCatalogApiNoOptions: Partial<jest.Mocked<CatalogApi>> = {
+      getEntityFacets: jest.fn().mockResolvedValue({
+        facets: {
+          'spec.options': [],
+        },
+      }),
+    };
+    render(
+      <TestApiProvider apis={[[catalogApiRef, mockCatalogApiNoOptions]]}>
+        <MockEntityListContextProvider value={{}}>
+          <EntityAutocompletePicker<EntityFilters>
+            label="Options"
+            path="spec.options"
+            name="options"
+            Filter={EntityOptionFilter}
+          />
+        </MockEntityListContextProvider>
+      </TestApiProvider>,
+    );
+    await waitFor(() => {
+      expect(screen.queryByText('Options')).not.toBeInTheDocument();
+    });
+  });
+
+  it('renders filter if there is one available option', async () => {
+    const mockCatalogApiOneOption: Partial<jest.Mocked<CatalogApi>> = {
+      getEntityFacets: jest.fn().mockResolvedValue({
+        facets: {
+          'spec.options': [{ value: 'option1', count: 1 }],
+        },
+      }),
+    };
+    render(
+      <TestApiProvider apis={[[catalogApiRef, mockCatalogApiOneOption]]}>
+        <MockEntityListContextProvider value={{}}>
+          <EntityAutocompletePicker<EntityFilters>
+            label="Options"
+            path="spec.options"
+            name="options"
+            Filter={EntityOptionFilter}
+          />
+        </MockEntityListContextProvider>
+      </TestApiProvider>,
+    );
+    await waitFor(() => {
+      expect(screen.queryByText('Options')).toBeInTheDocument();
+    });
+  });
+
   it('renders unique options in alphabetical order', async () => {
     render(
       <TestApiProvider apis={[[catalogApiRef, mockCatalogApi]]}>

--- a/plugins/catalog-react/src/components/EntityAutocompletePicker/EntityAutocompletePicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityAutocompletePicker/EntityAutocompletePicker.test.tsx
@@ -30,7 +30,7 @@ interface EntityFilters extends DefaultEntityFilters {
   options?: EntityOptionFilter;
 }
 
-const options = ['option1', 'option2', 'option3', 'option4'];
+const defaultOptions = ['option1', 'option2', 'option3', 'option4'];
 
 class EntityOptionFilter implements EntityFilter {
   constructor(readonly values: string[]) {}
@@ -46,20 +46,25 @@ class EntityOptionFilter implements EntityFilter {
   }
 }
 
-describe('<EntityAutocompletePicker/>', () => {
-  const mockCatalogApi: Partial<jest.Mocked<CatalogApi>> = {
+const makeMockCatalogApi = (
+  opts: string[] = defaultOptions,
+): Partial<jest.Mocked<CatalogApi>> => {
+  return {
     getEntityFacets: jest.fn().mockResolvedValue({
       facets: {
-        'spec.options': options.map((value, idx) => ({ value, count: idx })),
+        'spec.options': opts.map((value, idx) => ({ value, count: idx })),
       },
     }),
   };
+};
 
+describe('<EntityAutocompletePicker/>', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   it('renders all options', async () => {
+    const mockCatalogApi = makeMockCatalogApi();
     render(
       <TestApiProvider apis={[[catalogApiRef, mockCatalogApi]]}>
         <MockEntityListContextProvider value={{}}>
@@ -83,21 +88,15 @@ describe('<EntityAutocompletePicker/>', () => {
     });
 
     fireEvent.click(screen.getByTestId('options-picker-expand'));
-    options.forEach(option => {
+    defaultOptions.forEach(option => {
       expect(screen.getByText(option)).toBeInTheDocument();
     });
   });
 
   it('hides filter if there are no available options', async () => {
-    const mockCatalogApiNoOptions: Partial<jest.Mocked<CatalogApi>> = {
-      getEntityFacets: jest.fn().mockResolvedValue({
-        facets: {
-          'spec.options': [],
-        },
-      }),
-    };
+    const mockCatalogApi = makeMockCatalogApi([]);
     render(
-      <TestApiProvider apis={[[catalogApiRef, mockCatalogApiNoOptions]]}>
+      <TestApiProvider apis={[[catalogApiRef, mockCatalogApi]]}>
         <MockEntityListContextProvider value={{}}>
           <EntityAutocompletePicker<EntityFilters>
             label="Options"
@@ -114,15 +113,9 @@ describe('<EntityAutocompletePicker/>', () => {
   });
 
   it('renders filter if there is one available option', async () => {
-    const mockCatalogApiOneOption: Partial<jest.Mocked<CatalogApi>> = {
-      getEntityFacets: jest.fn().mockResolvedValue({
-        facets: {
-          'spec.options': [{ value: 'option1', count: 1 }],
-        },
-      }),
-    };
+    const mockCatalogApi = makeMockCatalogApi(['option1']);
     render(
-      <TestApiProvider apis={[[catalogApiRef, mockCatalogApiOneOption]]}>
+      <TestApiProvider apis={[[catalogApiRef, mockCatalogApi]]}>
         <MockEntityListContextProvider value={{}}>
           <EntityAutocompletePicker<EntityFilters>
             label="Options"
@@ -139,6 +132,7 @@ describe('<EntityAutocompletePicker/>', () => {
   });
 
   it('renders unique options in alphabetical order', async () => {
+    const mockCatalogApi = makeMockCatalogApi();
     render(
       <TestApiProvider apis={[[catalogApiRef, mockCatalogApi]]}>
         <MockEntityListContextProvider value={{}}>
@@ -166,6 +160,7 @@ describe('<EntityAutocompletePicker/>', () => {
   });
 
   it('renders options with counts', async () => {
+    const mockCatalogApi = makeMockCatalogApi();
     render(
       <TestApiProvider apis={[[catalogApiRef, mockCatalogApi]]}>
         <MockEntityListContextProvider value={{}}>
@@ -194,6 +189,7 @@ describe('<EntityAutocompletePicker/>', () => {
   });
 
   it('respects the query parameter filter value', async () => {
+    const mockCatalogApi = makeMockCatalogApi();
     const updateFilters = jest.fn();
     const queryParameters = { options: ['option3'] };
     render(
@@ -222,6 +218,7 @@ describe('<EntityAutocompletePicker/>', () => {
   });
 
   it('adds options to filters', async () => {
+    const mockCatalogApi = makeMockCatalogApi();
     const updateFilters = jest.fn();
     render(
       <TestApiProvider apis={[[catalogApiRef, mockCatalogApi]]}>
@@ -251,6 +248,7 @@ describe('<EntityAutocompletePicker/>', () => {
   });
 
   it('removes options from filters', async () => {
+    const mockCatalogApi = makeMockCatalogApi();
     const updateFilters = jest.fn();
     render(
       <TestApiProvider apis={[[catalogApiRef, mockCatalogApi]]}>
@@ -284,6 +282,7 @@ describe('<EntityAutocompletePicker/>', () => {
   });
 
   it('responds to external queryParameters changes', async () => {
+    const mockCatalogApi = makeMockCatalogApi();
     const updateFilters = jest.fn();
     const rendered = render(
       <TestApiProvider apis={[[catalogApiRef, mockCatalogApi]]}>
@@ -330,6 +329,7 @@ describe('<EntityAutocompletePicker/>', () => {
   });
 
   it('filters available values by kind as default', async () => {
+    const mockCatalogApi = makeMockCatalogApi();
     render(
       <TestApiProvider apis={[[catalogApiRef, mockCatalogApi]]}>
         <MockEntityListContextProvider
@@ -361,6 +361,7 @@ describe('<EntityAutocompletePicker/>', () => {
   });
 
   it('can be supplied with filters for available values', async () => {
+    const mockCatalogApi = makeMockCatalogApi();
     render(
       <TestApiProvider apis={[[catalogApiRef, mockCatalogApi]]}>
         <MockEntityListContextProvider

--- a/plugins/catalog-react/src/components/EntityAutocompletePicker/EntityAutocompletePicker.tsx
+++ b/plugins/catalog-react/src/components/EntityAutocompletePicker/EntityAutocompletePicker.tsx
@@ -144,9 +144,6 @@ export function EntityAutocompletePicker<
     return null;
   }
 
-  // Hide if there are no options; nothing to pick from
-  if (availableOptions.length === 0) return null;
-
   return (
     <Box className={classes.root} pb={1} pt={1}>
       <Typography className={classes.label} variant="button" component="label">

--- a/plugins/catalog-react/src/components/EntityAutocompletePicker/EntityAutocompletePicker.tsx
+++ b/plugins/catalog-react/src/components/EntityAutocompletePicker/EntityAutocompletePicker.tsx
@@ -144,8 +144,8 @@ export function EntityAutocompletePicker<
     return null;
   }
 
-  // Hide if there are 1 or fewer options; nothing to pick from
-  if (availableOptions.length <= 1) return null;
+  // Hide if there are no options; nothing to pick from
+  if (availableOptions.length === 0) return null;
 
   return (
     <Box className={classes.root} pb={1} pt={1}>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I noticed some odd behavior in the `EntityAutocompletePicker`. If there is one available option, the picker will be hidden. This can make sense in *some* cases, but in others be quite confusing.

Let's say I have a new catalog and have just begun using tags on my entities. Right now I only use one tag, "critical", to distinguish entities in a critical path. 5 of my 20 components have `tags: ['critical']`. _The tag picker won't render on the catalog page._ As a user I expect that I can filter by my one "critical" tag.

It seems like `EntityAutocompletePicker` evolved from the `EntityNamespacePicker` (see: https://github.com/davidan01/backstage/commit/9b3ab37e1e9b75a9b68e82c92e6c7456ea1dce32), which would explain this: `metadata.namespace` is a required field; if there's only one available option, that means that there's "nothing to pick from" (every entity has the same value, `default`).

On string fields like namespace, one option would be to have `/api/catalog/entity-facets?facet=metadata.namespace` return the number of entities where the value is unset. Then the picker could distinguish between these two cases: 

```json
{
    "facets": {
        "metadata.namespace": [
            {
                "value": "default",
                "count": 2325
            },
            {
                "value": null,
                "count": 0
            },
        ]
    }
}
```

```json
{
    "facets": {
        "metadata.labels.language": [
            {
                "value": "typescript",
                "count": 8
            },
            {
                "value": null,
                "count": 4
            },
        ]
    }
}
```

This would be a *bit* trickier with tags though, as the facets endpoint returns counts of individual tags, vs. the entire tag list on an entity.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
