### PR TITLE
feat: Moving away from spotify/web-scripts

### DIFF
--- a/.changeset/olive-radios-fly.md
+++ b/.changeset/olive-radios-fly.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+remove @spotify/prettier-config

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "trailingComma": "all",
+  "arrowParens": "avoid",
+  "singleQuote": true
+}

--- a/microsite/package.json
+++ b/microsite/package.json
@@ -17,7 +17,6 @@
     "version": "docusaurus-version",
     "write-translations": "docusaurus-write-translations"
   },
-  "prettier": "@spotify/prettier-config",
   "dependencies": {
     "@docusaurus/core": "^3.1.1",
     "@docusaurus/plugin-client-redirects": "^3.1.1",
@@ -35,7 +34,6 @@
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.1.1",
-    "@spotify/prettier-config": "^15.0.0",
     "@tsconfig/docusaurus": "^2.0.0",
     "@types/luxon": "^3.0.0",
     "@types/webpack-env": "^1.18.0",

--- a/microsite/yarn.lock
+++ b/microsite/yarn.lock
@@ -2524,15 +2524,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@spotify/prettier-config@npm:^15.0.0":
-  version: 15.0.0
-  resolution: "@spotify/prettier-config@npm:15.0.0"
-  peerDependencies:
-    prettier: 2.x
-  checksum: aa5ec5739427f9acdb9d62ae6c04f04a344898567239f7ee45c75c6205ebdffbc61747ea8de6e83baf0bc3785359967de4b7097a8723c4b4063ff57dc5cb6c44
-  languageName: node
-  linkType: hard
-
 "@svgr/babel-plugin-add-jsx-attribute@npm:^6.5.1":
   version: 6.5.1
   resolution: "@svgr/babel-plugin-add-jsx-attribute@npm:6.5.1"
@@ -3847,7 +3838,6 @@ __metadata:
     "@docusaurus/module-type-aliases": ^3.1.1
     "@docusaurus/plugin-client-redirects": ^3.1.1
     "@docusaurus/preset-classic": ^3.1.1
-    "@spotify/prettier-config": ^15.0.0
     "@swc/core": ^1.3.46
     "@tsconfig/docusaurus": ^2.0.0
     "@types/luxon": ^3.0.0

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
       "node ./scripts/verify-lockfile-duplicates --fix"
     ]
   },
-  "prettier": "@spotify/prettier-config",
   "resolutions": {
     "@material-ui/pickers@^3.2.10": "patch:@material-ui/pickers@npm%3A3.3.11#./.yarn/patches/@material-ui-pickers-npm-3.3.11-1c8f68ea20.patch",
     "@material-ui/pickers@^3.3.10": "patch:@material-ui/pickers@npm%3A3.3.11#./.yarn/patches/@material-ui-pickers-npm-3.3.11-1c8f68ea20.patch",
@@ -105,7 +104,6 @@
     "@octokit/rest": "^19.0.3",
     "@playwright/test": "^1.32.3",
     "@spotify/eslint-plugin": "^15.0.0",
-    "@spotify/prettier-config": "^15.0.0",
     "@techdocs/cli": "workspace:*",
     "@types/node": "^18.17.8",
     "@types/webpack": "^5.28.0",

--- a/packages/create-app/templates/default-app/.prettierrc.json
+++ b/packages/create-app/templates/default-app/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "trailingComma": "all",
+  "arrowParens": "avoid",
+  "singleQuote": true
+}

--- a/packages/create-app/templates/default-app/package.json.hbs
+++ b/packages/create-app/templates/default-app/package.json.hbs
@@ -34,7 +34,6 @@
     "@backstage/cli": "^{{version '@backstage/cli'}}",
     "@backstage/e2e-test-utils": "^{{version '@backstage/e2e-test-utils'}}",
     "@playwright/test": "^1.32.3",
-    "@spotify/prettier-config": "^12.0.0",
     "concurrently": "^8.0.0",
     "lerna": "^7.3.0",
     "node-gyp": "^9.0.0",
@@ -45,7 +44,6 @@
     "@types/react": "^18",
     "@types/react-dom": "^18"
   },
-  "prettier": "@spotify/prettier-config",
   "lint-staged": {
     "*.{js,jsx,ts,tsx,mjs,cjs}": [
       "eslint --fix",

--- a/packages/techdocs-cli-embedded-app/package.json
+++ b/packages/techdocs-cli-embedded-app/package.json
@@ -1,16 +1,34 @@
 {
   "name": "techdocs-cli-embedded-app",
-  "version": "0.2.95",
-  "private": true,
+  "version": "0.2.95-next.0",
   "backstage": {
     "role": "frontend"
   },
-  "bundled": true,
+  "private": true,
   "homepage": "https://backstage.io",
   "repository": {
     "type": "git",
     "url": "https://github.com/backstage/backstage",
     "directory": "packages/techdocs-cli-embedded-app"
+  },
+  "scripts": {
+    "build": "backstage-cli package build --config ./app-config.yaml",
+    "clean": "backstage-cli package clean",
+    "lint": "backstage-cli package lint",
+    "start": "backstage-cli package start --config ./app-config.yaml",
+    "test": "backstage-cli package test"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
   },
   "dependencies": {
     "@backstage/app-defaults": "workspace:^",
@@ -44,24 +62,5 @@
     "@types/react-dom": "*",
     "cross-env": "^7.0.0"
   },
-  "scripts": {
-    "start": "backstage-cli package start --config ./app-config.yaml",
-    "build": "backstage-cli package build --config ./app-config.yaml",
-    "clean": "backstage-cli package clean",
-    "test": "backstage-cli package test",
-    "lint": "backstage-cli package lint"
-  },
-  "prettier": "@spotify/prettier-config",
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
-  }
+  "bundled": true
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16705,15 +16705,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@spotify/prettier-config@npm:^15.0.0":
-  version: 15.0.0
-  resolution: "@spotify/prettier-config@npm:15.0.0"
-  peerDependencies:
-    prettier: 2.x
-  checksum: aa5ec5739427f9acdb9d62ae6c04f04a344898567239f7ee45c75c6205ebdffbc61747ea8de6e83baf0bc3785359967de4b7097a8723c4b4063ff57dc5cb6c44
-  languageName: node
-  linkType: hard
-
 "@stoplight/better-ajv-errors@npm:1.0.3":
   version: 1.0.3
   resolution: "@stoplight/better-ajv-errors@npm:1.0.3"
@@ -41011,7 +41002,6 @@ __metadata:
     "@octokit/rest": ^19.0.3
     "@playwright/test": ^1.32.3
     "@spotify/eslint-plugin": ^15.0.0
-    "@spotify/prettier-config": ^15.0.0
     "@techdocs/cli": "workspace:*"
     "@types/node": ^18.17.8
     "@types/webpack": ^5.28.0


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

The PR contains change to remove "@spotify/prettier-config" package and add a new `prettierrc.json` to adopt changes related to prettier.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

closes #23277
