### PR TITLE
Add ESLint Rule to PuppetDB Plugin

### DIFF
--- a/.changeset/stupid-seas-travel.md
+++ b/.changeset/stupid-seas-travel.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-puppetdb': patch
+---
+
+Added ESLint rule `no-top-level-material-ui-4-imports` in the `puppetdb` plugin to migrate the Material UI imports.

--- a/plugins/puppetdb/.eslintrc.js
+++ b/plugins/puppetdb/.eslintrc.js
@@ -1,1 +1,5 @@
-module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
+    rules: {
+      '@backstage/no-top-level-material-ui-4-imports': 'error',
+    },
+});

--- a/plugins/puppetdb/src/components/ReportDetailsPage/ReportDetailsPage.tsx
+++ b/plugins/puppetdb/src/components/ReportDetailsPage/ReportDetailsPage.tsx
@@ -20,14 +20,12 @@ import { makeStyles } from '@material-ui/core/styles';
 import { useRouteRef } from '@backstage/core-plugin-api';
 import { puppetDbRouteRef } from '../../routes';
 import React, { useState } from 'react';
-import {
-  Card,
-  CardContent,
-  Tab,
-  Box,
-  Typography,
-  Tabs,
-} from '@material-ui/core';
+import Card from '@material-ui/core/Card';
+import CardContent from '@material-ui/core/CardContent';
+import Tab from '@material-ui/core/Tab';
+import Box from '@material-ui/core/Box';
+import Typography from '@material-ui/core/Typography';
+import Tabs from '@material-ui/core/Tabs';
 import { ReportDetailsEventsTable } from './ReportDetailsEventsTable';
 import { ReportDetailsLogsTable } from './ReportDetailsLogsTable';
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds the no-top-level-material-ui-4-import ESLint rule to the PuppetDB plugin to aid with the migration to Material UI v5.

Issue: #23467 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
