### PR TITLE
Add ESLint Rule to Github-Deployments Plugin

### DIFF
--- a/.changeset/slimy-panthers-yawn.md
+++ b/.changeset/slimy-panthers-yawn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-github-deployments': minor
+---
+
+Added ESLint rule `no-top-level-material-ui-4-imports` in the `github-deployments` plugin to migrate the Material UI imports.

--- a/.changeset/slimy-panthers-yawn.md
+++ b/.changeset/slimy-panthers-yawn.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-github-deployments': minor
+'@backstage/plugin-github-deployments': patch
 ---
 
 Added ESLint rule `no-top-level-material-ui-4-imports` in the `github-deployments` plugin to migrate the Material UI imports.

--- a/plugins/github-deployments/.eslintrc.js
+++ b/plugins/github-deployments/.eslintrc.js
@@ -1,1 +1,5 @@
-module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
+    rules: {
+      '@backstage/no-top-level-material-ui-4-imports': 'error',
+    },
+});

--- a/plugins/github-deployments/src/components/GithubDeploymentsCard.test.tsx
+++ b/plugins/github-deployments/src/components/GithubDeploymentsCard.test.tsx
@@ -41,7 +41,7 @@ import { graphql } from 'msw';
 import { ScmIntegrations } from '@backstage/integration';
 import { Entity } from '@backstage/catalog-model';
 import { GithubDeploymentsTable } from './GithubDeploymentsTable';
-import { Box } from '@material-ui/core';
+import Box from '@material-ui/core/Box';
 
 import { ApiProvider, ConfigReader } from '@backstage/core-app-api';
 import {

--- a/plugins/github-deployments/src/components/GithubDeploymentsTable/GithubDeploymentsTable.tsx
+++ b/plugins/github-deployments/src/components/GithubDeploymentsTable/GithubDeploymentsTable.tsx
@@ -15,7 +15,8 @@
  */
 import React from 'react';
 import { GithubDeployment } from '../../api';
-import { Typography, makeStyles } from '@material-ui/core';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
 import SyncIcon from '@material-ui/icons/Sync';
 import { columnFactories } from './columns';
 import { defaultDeploymentColumns } from './presets';

--- a/plugins/github-deployments/src/components/GithubDeploymentsTable/columns.tsx
+++ b/plugins/github-deployments/src/components/GithubDeploymentsTable/columns.tsx
@@ -17,7 +17,8 @@
 import React from 'react';
 import { GithubDeployment } from '../../api';
 import { DateTime } from 'luxon';
-import { Box, Typography } from '@material-ui/core';
+import Box from '@material-ui/core/Box';
+import Typography from '@material-ui/core/Typography';
 import {
   StatusPending,
   StatusRunning,


### PR DESCRIPTION
Adds the no-top-level-material-ui-4-import ESLint rule to the Github-Deployments plugin to aid with the migration to Material UI v5.

Issue: https://github.com/backstage/backstage/issues/23467