### PR TITLE
Add ESLint Rule to Opencost Plugin

### DIFF
--- a/.changeset/modern-cats-fly.md
+++ b/.changeset/modern-cats-fly.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-opencost': patch
+---
+
+Added ESLint rule `no-top-level-material-ui-4-imports` in the `opencost` plugin to migrate the Material UI imports.

--- a/plugins/opencost/.eslintrc.js
+++ b/plugins/opencost/.eslintrc.js
@@ -1,1 +1,5 @@
-module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
+    rules: {
+      '@backstage/no-top-level-material-ui-4-imports': 'error',
+    },
+});

--- a/plugins/opencost/src/components/AllocationChart/RangeChart.jsx
+++ b/plugins/opencost/src/components/AllocationChart/RangeChart.jsx
@@ -23,7 +23,7 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from 'recharts';
-import { makeStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import { reverse } from 'lodash';
 import { primary, greyscale, browns } from '../../constants/colors';
 import { toCurrency } from '../../util';

--- a/plugins/opencost/src/components/AllocationReport.jsx
+++ b/plugins/opencost/src/components/AllocationReport.jsx
@@ -20,7 +20,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { get, round } from 'lodash';
-import { makeStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';

--- a/plugins/opencost/src/components/Controls/Edit.jsx
+++ b/plugins/opencost/src/components/Controls/Edit.jsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { makeStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import FormControl from '@material-ui/core/FormControl';
 import InputLabel from '@material-ui/core/InputLabel';
 import MenuItem from '@material-ui/core/MenuItem';

--- a/plugins/opencost/src/components/OpenCostPage/OpenCostPage.tsx
+++ b/plugins/opencost/src/components/OpenCostPage/OpenCostPage.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import React from 'react';
-import { Grid } from '@material-ui/core';
+import Grid from '@material-ui/core/Grid';
 import { Header, Page, Content } from '@backstage/core-components';
 import { OpenCostReport } from '../OpenCostReport';
 import logo from '../../images/pig.png';

--- a/plugins/opencost/src/components/OpenCostReport/OpenCostReport.tsx
+++ b/plugins/opencost/src/components/OpenCostReport/OpenCostReport.tsx
@@ -23,7 +23,7 @@ import RefreshIcon from '@material-ui/icons/Refresh';
 import Typography from '@material-ui/core/Typography';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { find, get, sortBy, toArray } from 'lodash';
-import { makeStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import AllocationReport from '../AllocationReport';
 import AllocationService from '../../services/allocation';
 import Controls from '../Controls';

--- a/plugins/opencost/src/components/Page.jsx
+++ b/plugins/opencost/src/components/Page.jsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { makeStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import React from 'react';
 
 const useStyles = makeStyles({

--- a/plugins/opencost/src/components/SelectWindow.jsx
+++ b/plugins/opencost/src/components/SelectWindow.jsx
@@ -15,11 +15,9 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import { makeStyles } from '@material-ui/styles';
-import {
-  MuiPickersUtilsProvider,
-  KeyboardDatePicker,
-} from '@material-ui/pickers';
+import { makeStyles } from '@material-ui/core/styles';
+import MuiPickersUtilsProvider from '@material-ui/pickers/MuiPickersUtilsProvider';
+import KeyboardDatePicker from '@material-ui/pickers/KeyboardDatePicker';
 import Button from '@material-ui/core/Button';
 import LuxonUtils from '@date-io/luxon';
 import FormControl from '@material-ui/core/FormControl';

--- a/plugins/opencost/src/components/Subtitle.jsx
+++ b/plugins/opencost/src/components/Subtitle.jsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-import { makeStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import { upperFirst } from 'lodash';
 import Breadcrumbs from '@material-ui/core/Breadcrumbs';
 import NavigateNextIcon from '@material-ui/icons/NavigateNext';

--- a/plugins/opencost/src/components/Warnings.jsx
+++ b/plugins/opencost/src/components/Warnings.jsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-import { makeStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemIcon from '@material-ui/core/ListItemIcon';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds the no-top-level-material-ui-4-import ESLint rule to the Opencost plugin to aid with the migration to Material UI v5.

Issue: #23467

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
