### PR TITLE
Add ESLint Rule to Gcp-projects Plugin

### DIFF
--- a/.changeset/healthy-weeks-lay.md
+++ b/.changeset/healthy-weeks-lay.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-gcp-projects': minor
+---
+
+Added ESLint rule `no-top-level-material-ui-4-imports` in the `gcp-projects` plugin to migrate the Material UI imports.

--- a/.changeset/healthy-weeks-lay.md
+++ b/.changeset/healthy-weeks-lay.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-gcp-projects':  patch
+'@backstage/plugin-gcp-projects': patch
 ---
 
 Added ESLint rule `no-top-level-material-ui-4-imports` in the `gcp-projects` plugin to migrate the Material UI imports.

--- a/.changeset/healthy-weeks-lay.md
+++ b/.changeset/healthy-weeks-lay.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-gcp-projects': minor
+'@backstage/plugin-gcp-projects':  patch
 ---
 
 Added ESLint rule `no-top-level-material-ui-4-imports` in the `gcp-projects` plugin to migrate the Material UI imports.

--- a/plugins/gcp-projects/.eslintrc.js
+++ b/plugins/gcp-projects/.eslintrc.js
@@ -1,1 +1,5 @@
-module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
+    rules: {
+      '@backstage/no-top-level-material-ui-4-imports': 'error',
+    },
+  });

--- a/plugins/gcp-projects/src/components/NewProjectPage/NewProjectPage.tsx
+++ b/plugins/gcp-projects/src/components/NewProjectPage/NewProjectPage.tsx
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-import { Button, Grid, TextField } from '@material-ui/core';
+import Button from '@material-ui/core/Button';
+import Grid from '@material-ui/core/Grid';
+import TextField from '@material-ui/core/TextField';
 import React, { useState } from 'react';
 import {
   Content,

--- a/plugins/gcp-projects/src/components/ProjectDetailsPage/ProjectDetailsPage.tsx
+++ b/plugins/gcp-projects/src/components/ProjectDetailsPage/ProjectDetailsPage.tsx
@@ -13,18 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-  Button,
-  ButtonGroup,
-  LinearProgress,
-  makeStyles,
-  Paper,
-  Table,
-  TableBody,
-  TableCell,
-  TableRow,
-  Typography,
-} from '@material-ui/core';
+import Button from '@material-ui/core/Button';
+import ButtonGroup from '@material-ui/core/ButtonGroup';
+import LinearProgress from '@material-ui/core/LinearProgress';
+import Paper from '@material-ui/core/Paper';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableRow from '@material-ui/core/TableRow';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
 import React from 'react';
 import { useAsync, useMountEffect } from '@react-hookz/web';
 import { gcpApiRef } from '../../api';

--- a/plugins/gcp-projects/src/components/ProjectListPage/ProjectListPage.tsx
+++ b/plugins/gcp-projects/src/components/ProjectListPage/ProjectListPage.tsx
@@ -15,7 +15,10 @@
  */
 
 //  NEEDS WORK
-import { Button, LinearProgress, Tooltip, Typography } from '@material-ui/core';
+import Button from '@material-ui/core/Button';
+import LinearProgress from '@material-ui/core/LinearProgress';
+import Tooltip from '@material-ui/core/Tooltip';
+import Typography from '@material-ui/core/Typography';
 import React from 'react';
 
 import { useAsync, useMountEffect } from '@react-hookz/web';


### PR DESCRIPTION
Adds the no-top-level-material-ui-4-import ESLint rule to the Gcp-projects plugin to aid with the migration to Material UI v5.

Issue: https://github.com/backstage/backstage/issues/23467