### PR TITLE
Add ESLint Rule to OctopusDeploy Plugin

### DIFF
--- a/.changeset/rare-kiwis-appear.md
+++ b/.changeset/rare-kiwis-appear.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-octopus-deploy': patch
+---
+
+Added ESLint rule `no-top-level-material-ui-4-imports` in the `octopus-deploy` plugin to migrate the Material UI imports.

--- a/plugins/octopus-deploy/.eslintrc.js
+++ b/plugins/octopus-deploy/.eslintrc.js
@@ -1,1 +1,5 @@
-module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
+    rules: {
+      '@backstage/no-top-level-material-ui-4-imports': 'error',
+    },
+});

--- a/plugins/octopus-deploy/src/components/OctopusDeployIcon/OctopusDeployIcon.tsx
+++ b/plugins/octopus-deploy/src/components/OctopusDeployIcon/OctopusDeployIcon.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { SvgIcon, SvgIconProps } from '@material-ui/core';
+import SvgIcon, { SvgIconProps } from '@material-ui/core/SvgIcon';
 
 import React from 'react';
 

--- a/plugins/octopus-deploy/src/components/ReleaseTable/ReleaseTable.tsx
+++ b/plugins/octopus-deploy/src/components/ReleaseTable/ReleaseTable.tsx
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Box, Typography } from '@material-ui/core';
+import Box from '@material-ui/core/Box';
+import Typography from '@material-ui/core/Typography';
 import {
   OctopusEnvironment,
   OctopusProject,

--- a/plugins/octopus-deploy/src/components/ScaffolderDropdown/ProjectGroupDropdown.tsx
+++ b/plugins/octopus-deploy/src/components/ScaffolderDropdown/ProjectGroupDropdown.tsx
@@ -15,7 +15,8 @@
  */
 
 import React from 'react';
-import { InputLabel, Input } from '@material-ui/core';
+import InputLabel from '@material-ui/core/InputLabel';
+import Input from '@material-ui/core/Input';
 import { Select, SelectItem } from '@backstage/core-components';
 import { useProjectGroups } from '../../hooks/useProjectGroups';
 import { ScaffolderField } from '@backstage/plugin-scaffolder-react/alpha';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds the no-top-level-material-ui-4-import ESLint rule to the OctopusDeploy plugin to aid with the migration to Material UI v5.

Issue: #23467

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
