### PR TITLE
Add ESLint Rule to github-issues Plugin

### DIFF
--- a/.changeset/breezy-socks-mix.md
+++ b/.changeset/breezy-socks-mix.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-github-issues': minor
+---
+
+Added ESLint rule `no-top-level-material-ui-4-imports` in the `github-issues` plugin to migrate the Material UI imports.

--- a/plugins/github-issues/.eslintrc.js
+++ b/plugins/github-issues/.eslintrc.js
@@ -1,1 +1,5 @@
-module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
+    rules: {
+      '@backstage/no-top-level-material-ui-4-imports': 'error',
+    },
+  });

--- a/plugins/github-issues/.eslintrc.js
+++ b/plugins/github-issues/.eslintrc.js
@@ -1,6 +1,5 @@
 module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
-    rules: {
-      '@backstage/no-top-level-material-ui-4-imports': 'error',
-    },
-  });
-  
+  rules: {
+    '@backstage/no-top-level-material-ui-4-imports': 'error',
+  },
+});

--- a/plugins/github-issues/.eslintrc.js
+++ b/plugins/github-issues/.eslintrc.js
@@ -3,3 +3,4 @@ module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
       '@backstage/no-top-level-material-ui-4-imports': 'error',
     },
   });
+  

--- a/plugins/github-issues/src/components/GithubIssues/GithubIssues.tsx
+++ b/plugins/github-issues/src/components/GithubIssues/GithubIssues.tsx
@@ -15,7 +15,9 @@
  */
 
 import React from 'react';
-import { Box, IconButton, Typography } from '@material-ui/core';
+import Box from '@material-ui/core/Box';
+import IconButton from '@material-ui/core/IconButton';
+import Typography from '@material-ui/core/Typography';
 import { InfoCard, Progress } from '@backstage/core-components';
 import RefreshIcon from '@material-ui/icons/Refresh';
 import { useEntityGithubRepositories } from '../../hooks/useEntityGithubRepositories';

--- a/plugins/github-issues/src/components/GithubIssues/IssueCard/Assignees.tsx
+++ b/plugins/github-issues/src/components/GithubIssues/IssueCard/Assignees.tsx
@@ -15,7 +15,10 @@
  */
 
 import React from 'react';
-import { Typography, Box, Avatar, makeStyles } from '@material-ui/core';
+import Typography from '@material-ui/core/Typography';
+import Box from '@material-ui/core/Box';
+import Avatar from '@material-ui/core/Avatar';
+import { makeStyles } from '@material-ui/core/styles';
 
 type AssigneesProps = {
   name?: string;

--- a/plugins/github-issues/src/components/GithubIssues/IssueCard/CommentsCount.tsx
+++ b/plugins/github-issues/src/components/GithubIssues/IssueCard/CommentsCount.tsx
@@ -16,7 +16,8 @@
 
 import React from 'react';
 import { ChatIcon } from '@backstage/core-components';
-import { Box, Badge } from '@material-ui/core';
+import Box from '@material-ui/core/Box';
+import Badge from '@material-ui/core/Badge';
 
 type CommentsCountProps = {
   commentsCount: number;

--- a/plugins/github-issues/src/components/GithubIssues/IssueCard/IssueCard.tsx
+++ b/plugins/github-issues/src/components/GithubIssues/IssueCard/IssueCard.tsx
@@ -15,7 +15,10 @@
  */
 
 import { Link } from '@backstage/core-components';
-import { Box, CardActionArea, Paper, Typography } from '@material-ui/core';
+import Box from '@material-ui/core/Box';
+import CardActionArea from '@material-ui/core/CardActionArea';
+import Paper from '@material-ui/core/Paper';
+import Typography from '@material-ui/core/Typography';
 import Divider from '@material-ui/core/Divider';
 import { DateTime } from 'luxon';
 import React from 'react';

--- a/plugins/github-issues/src/components/GithubIssues/IssuesList/Filters/Filters.tsx
+++ b/plugins/github-issues/src/components/GithubIssues/IssuesList/Filters/Filters.tsx
@@ -16,7 +16,9 @@
 
 import React from 'react';
 import { Select, SelectedItems, SelectItem } from '@backstage/core-components';
-import { makeStyles, Box, Typography } from '@material-ui/core';
+import Box from '@material-ui/core/Box';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
 
 type RepositoryFiltersProps = {
   items: Array<SelectItem>;

--- a/plugins/github-issues/src/components/GithubIssues/IssuesList/IssuesList.tsx
+++ b/plugins/github-issues/src/components/GithubIssues/IssuesList/IssuesList.tsx
@@ -15,8 +15,8 @@
  */
 
 import React from 'react';
-import { Box } from '@material-ui/core';
-import { Pagination } from '@material-ui/lab';
+import Box from '@material-ui/core/Box';
+import Pagination from '@material-ui/lab/Pagination';
 import { IssueCard } from '../IssueCard';
 import { IssuesByRepo } from '../../../api';
 import { RepositoryFilters } from './Filters';


### PR DESCRIPTION
Adds the no-top-level-material-ui-4-import ESLint rule to the github-issues plugin to aid with the migration to Material UI v5.

Issue: https://github.com/backstage/backstage/issues/23467