### PR TITLE
Added ESLint Rule to ilert Plugin

### DIFF
--- a/.changeset/tasty-sheep-yell.md
+++ b/.changeset/tasty-sheep-yell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-ilert': patch
+---
+
+Added an optional ESLint rule - no-top-level-material-ui-4-imports -in ilert plugin which has an auto fix function to migrate the imports and used it to migrate the Material UI imports for plugins/ilert.

--- a/plugins/ilert/.eslintrc.js
+++ b/plugins/ilert/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
   rules: {
     quotes: ['error', 'single'],
+    '@backstage/no-top-level-material-ui-4-imports': 'error',
   },
 });

--- a/plugins/ilert/src/components/Alert/AlertActionsMenu.tsx
+++ b/plugins/ilert/src/components/Alert/AlertActionsMenu.tsx
@@ -13,7 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { IconButton, Menu, MenuItem, Typography } from '@material-ui/core';
+import IconButton from '@material-ui/core/IconButton';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+import Typography from '@material-ui/core/Typography';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
 import React from 'react';
 import { ilertApiRef } from '../../api';

--- a/plugins/ilert/src/components/Alert/AlertAssignModal.tsx
+++ b/plugins/ilert/src/components/Alert/AlertAssignModal.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { alertApiRef, useApi } from '@backstage/core-plugin-api';
-import { Typography } from '@material-ui/core';
+import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
 import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';

--- a/plugins/ilert/src/components/Alert/AlertNewModal.tsx
+++ b/plugins/ilert/src/components/Alert/AlertNewModal.tsx
@@ -19,7 +19,7 @@ import {
   identityApiRef,
   useApi,
 } from '@backstage/core-plugin-api';
-import { Typography } from '@material-ui/core';
+import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
 import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';

--- a/plugins/ilert/src/components/AlertsPage/StatusChip.tsx
+++ b/plugins/ilert/src/components/AlertsPage/StatusChip.tsx
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Chip, withStyles } from '@material-ui/core';
+import Chip from '@material-ui/core/Chip';
+import { withStyles } from '@material-ui/core/styles';
 import React from 'react';
 import { ACCEPTED, Alert, PENDING, RESOLVED } from '../../types';
 

--- a/plugins/ilert/src/components/Errors/MissingAuthorizationHeaderError.tsx
+++ b/plugins/ilert/src/components/Errors/MissingAuthorizationHeaderError.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import React from 'react';
-import { Button } from '@material-ui/core';
+import Button from '@material-ui/core/Button';
 import { EmptyState } from '@backstage/core-components';
 
 export const MissingAuthorizationHeaderError = () => (

--- a/plugins/ilert/src/components/Service/ServiceActionsMenu.tsx
+++ b/plugins/ilert/src/components/Service/ServiceActionsMenu.tsx
@@ -13,7 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { IconButton, Menu, MenuItem, Typography } from '@material-ui/core';
+import IconButton from '@material-ui/core/IconButton';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+import Typography from '@material-ui/core/Typography';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
 import React from 'react';
 import { ilertApiRef } from '../../api';

--- a/plugins/ilert/src/components/ServicesPage/StatusChip.tsx
+++ b/plugins/ilert/src/components/ServicesPage/StatusChip.tsx
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Chip, withStyles } from '@material-ui/core';
+import Chip from '@material-ui/core/Chip';
+import { withStyles } from '@material-ui/core/styles';
 import React from 'react';
 import {
   DEGRADED,

--- a/plugins/ilert/src/components/Shift/ShiftOverrideModal.tsx
+++ b/plugins/ilert/src/components/Shift/ShiftOverrideModal.tsx
@@ -23,11 +23,12 @@ import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import Autocomplete from '@material-ui/lab/Autocomplete';
-import { Typography } from '@material-ui/core';
+import Typography from '@material-ui/core/Typography';
 import { ilertApiRef } from '../../api';
 import { useShiftOverride } from '../../hooks/useShiftOverride';
 import { Shift } from '../../types';
-import { DateTimePicker, MuiPickersUtilsProvider } from '@material-ui/pickers';
+import DateTimePicker from '@material-ui/pickers/DateTimePicker';
+import MuiPickersUtilsProvider from '@material-ui/pickers/MuiPickersUtilsProvider';
 import LuxonUtils from '@date-io/luxon';
 import { alertApiRef, useApi } from '@backstage/core-plugin-api';
 

--- a/plugins/ilert/src/components/StatusPage/StatusPageActionsMenu.tsx
+++ b/plugins/ilert/src/components/StatusPage/StatusPageActionsMenu.tsx
@@ -13,7 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { IconButton, Menu, MenuItem, Typography } from '@material-ui/core';
+import IconButton from '@material-ui/core/IconButton';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+import Typography from '@material-ui/core/Typography';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
 import React from 'react';
 import { ilertApiRef } from '../../api';

--- a/plugins/ilert/src/components/StatusPagePage/StatusChip.tsx
+++ b/plugins/ilert/src/components/StatusPagePage/StatusChip.tsx
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Chip, withStyles } from '@material-ui/core';
+import Chip from '@material-ui/core/Chip';
+import { withStyles } from '@material-ui/core/styles';
 import React from 'react';
 import {
   DEGRADED,

--- a/plugins/ilert/src/components/StatusPagePage/VisibilityChip.tsx
+++ b/plugins/ilert/src/components/StatusPagePage/VisibilityChip.tsx
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Chip, withStyles } from '@material-ui/core';
+import Chip from '@material-ui/core/Chip';
+import { withStyles } from '@material-ui/core/styles';
 import React from 'react';
 import { PRIVATE, PUBLIC, StatusPage } from '../../types';
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Added an optional ESLint rule - no-top-level-material-ui-4-imports -in ilert plugin which has an auto fix function to migrate the imports and used it to migrate the Material UI imports for plugins/ilert.

Issue for reference: https://github.com/backstage/backstage/issues/23467

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
