### PR TITLE
Add ESLint Rule to KubernetesCluster Plugin

### DIFF
--- a/.changeset/purple-seals-rest.md
+++ b/.changeset/purple-seals-rest.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-cluster': patch
+---
+
+Added ESLint rule `no-top-level-material-ui-4-imports` in the `kubernetes-cluster` plugin to migrate the Material UI imports.

--- a/plugins/kubernetes-cluster/.eslintrc.js
+++ b/plugins/kubernetes-cluster/.eslintrc.js
@@ -1,1 +1,5 @@
-module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
+    rules: {
+      '@backstage/no-top-level-material-ui-4-imports': 'error',
+    },
+});

--- a/plugins/kubernetes-cluster/src/components/ApiResources/ApiResources.tsx
+++ b/plugins/kubernetes-cluster/src/components/ApiResources/ApiResources.tsx
@@ -19,7 +19,7 @@ import { useEntity } from '@backstage/plugin-catalog-react';
 import { Table, TableColumn } from '@backstage/core-components';
 import { IAPIGroup } from '@kubernetes-models/apimachinery/apis/meta/v1';
 import { useKubernetesClusterError } from '../KubernetesClusterErrorContext/KubernetesClusterErrorContext';
-import { makeStyles } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles(theme => ({
   empty: {

--- a/plugins/kubernetes-cluster/src/components/ClusterOverview/ClusterOverview.tsx
+++ b/plugins/kubernetes-cluster/src/components/ClusterOverview/ClusterOverview.tsx
@@ -17,8 +17,8 @@ import React, { useCallback, useEffect } from 'react';
 import { InfoCard, StructuredMetadataTable } from '@backstage/core-components';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { useCluster } from './useCluster';
-import { Skeleton } from '@material-ui/lab';
-import { Theme, createStyles, makeStyles } from '@material-ui/core';
+import Skeleton from '@material-ui/lab/Skeleton';
+import { Theme, createStyles, makeStyles } from '@material-ui/core/styles';
 import { useKubernetesClusterError } from '../KubernetesClusterErrorContext/KubernetesClusterErrorContext';
 
 const useStyles = makeStyles((_theme: Theme) =>

--- a/plugins/kubernetes-cluster/src/components/KubernetesClusterContent/KubernetesClusterContent.tsx
+++ b/plugins/kubernetes-cluster/src/components/KubernetesClusterContent/KubernetesClusterContent.tsx
@@ -15,7 +15,8 @@
  */
 import React from 'react';
 import { ApiResources } from '../ApiResources/ApiResources';
-import { Grid, Typography } from '@material-ui/core';
+import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
 import { Nodes } from '../Nodes/Nodes';
 import { ClusterOverview } from '../ClusterOverview';
 import {

--- a/plugins/kubernetes-cluster/src/components/Nodes/Nodes.tsx
+++ b/plugins/kubernetes-cluster/src/components/Nodes/Nodes.tsx
@@ -22,7 +22,9 @@ import {
   TableColumn,
 } from '@backstage/core-components';
 import { INode } from 'kubernetes-models/v1';
-import { Grid, Typography, makeStyles } from '@material-ui/core';
+import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
 import { useKubernetesClusterError } from '../KubernetesClusterErrorContext/KubernetesClusterErrorContext';
 import { KubernetesDrawer } from '@backstage/plugin-kubernetes-react';
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds the no-top-level-material-ui-4-import ESLint rule to the KubernetesCluster plugin to aid with the migration to Material UI v5.

Issue: #23467

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
