### PR TITLE
Added ESLint rule  in the  app-visualizer plugin to migrate the Material UI imports.

### DIFF
--- a/plugins/app-visualizer/.eslintrc.js
+++ b/plugins/app-visualizer/.eslintrc.js
@@ -1,1 +1,5 @@
-module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
+    rules: {
+      '@backstage/no-top-level-material-ui-4-imports': 'error',
+    },
+  });


### PR DESCRIPTION
Adds the no-top-level-material-ui-4-import ESLint rule to the app-visualizer plugin to aid with the migration to Material UI v5.

Issue: https://github.com/backstage/backstage/issues/23467