### PR TITLE
Add ESlint Rule to entity-validation plugin

### DIFF
--- a/.changeset/thirty-goats-switch.md
+++ b/.changeset/thirty-goats-switch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-entity-validation': patch
+---
+
+Added ESLint rule `no-top-level-material-ui-4-imports` in the `entity-validation` plugin to migrate the Material UI imports.

--- a/plugins/entity-validation/.eslintrc.js
+++ b/plugins/entity-validation/.eslintrc.js
@@ -1,1 +1,5 @@
-module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
+    rules: {
+      '@backstage/no-top-level-material-ui-4-imports': 'error',
+    },
+  });

--- a/plugins/entity-validation/src/components/EntityTextArea/EntityTextArea.tsx
+++ b/plugins/entity-validation/src/components/EntityTextArea/EntityTextArea.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 import React, { useMemo, useState } from 'react';
-import { Box, makeStyles } from '@material-ui/core';
+import Box from '@material-ui/core/Box';
+import { makeStyles } from '@material-ui/core/styles';
 import CodeMirror from '@uiw/react-codemirror';
 import { showPanel } from '@codemirror/view';
 import { StreamLanguage } from '@codemirror/language';

--- a/plugins/entity-validation/src/components/EntityValidationOutput/EntityResult.tsx
+++ b/plugins/entity-validation/src/components/EntityValidationOutput/EntityResult.tsx
@@ -16,16 +16,14 @@
 import React, { useState } from 'react';
 import { ValidateEntityResponse } from '@backstage/catalog-client';
 import { useApp } from '@backstage/core-plugin-api';
-import {
-  Collapse,
-  IconButton,
-  ListItem,
-  ListItemIcon,
-  ListItemSecondaryAction,
-  ListItemText,
-  makeStyles,
-  Paper,
-} from '@material-ui/core';
+import Collapse from '@material-ui/core/Collapse';
+import IconButton from '@material-ui/core/IconButton';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
+import ListItemText from '@material-ui/core/ListItemText';
+import Paper from '@material-ui/core/Paper';
+import { makeStyles } from '@material-ui/core/styles';
 import { humanizeEntityRef } from '@backstage/plugin-catalog-react';
 import ExpandLessIcon from '@material-ui/icons/ExpandLess';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';

--- a/plugins/entity-validation/src/components/EntityValidationOutput/EntityValidationOutput.tsx
+++ b/plugins/entity-validation/src/components/EntityValidationOutput/EntityValidationOutput.tsx
@@ -19,7 +19,9 @@ import {
   catalogApiRef,
   humanizeEntityRef,
 } from '@backstage/plugin-catalog-react';
-import { List, makeStyles, Typography } from '@material-ui/core';
+import List from '@material-ui/core/List';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
 import useAsync from 'react-use/esm/useAsync';
 import { InfoCard, Progress } from '@backstage/core-components';
 import Alert from '@material-ui/lab/Alert';

--- a/plugins/entity-validation/src/components/EntityValidationPage/EntityValidationPage.tsx
+++ b/plugins/entity-validation/src/components/EntityValidationPage/EntityValidationPage.tsx
@@ -17,7 +17,9 @@
 import React, { useState } from 'react';
 import { Content, Header, Page } from '@backstage/core-components';
 import { EntityTextArea } from '../EntityTextArea';
-import { Button, Grid, TextField } from '@material-ui/core';
+import Button from '@material-ui/core/Button';
+import Grid from '@material-ui/core/Grid';
+import TextField from '@material-ui/core/TextField';
 import { CatalogProcessorResult } from '../../types';
 import { parseEntityYaml } from '../../utils';
 import { EntityValidationOutput } from '../EntityValidationOutput';


### PR DESCRIPTION
Adds the no-top-level-material-ui-4-import ESLint rule to the entity-validation plugin to aid with the migration to Material UI v5.

Issue: https://github.com/backstage/backstage/issues/23467