### PR TITLE
Add ESLint Rule to firehydrant Plugin

### DIFF
--- a/.changeset/nasty-radios-cheat.md
+++ b/.changeset/nasty-radios-cheat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-firehydrant': patch
+---
+
+Added ESLint rule `no-top-level-material-ui-4-imports` in the `firehydrant` plugin to migrate the Material UI imports.

--- a/plugins/firehydrant/.eslintrc.js
+++ b/plugins/firehydrant/.eslintrc.js
@@ -1,1 +1,5 @@
-module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
+    rules: {
+      '@backstage/no-top-level-material-ui-4-imports': 'error',
+    },
+  });

--- a/plugins/firehydrant/src/components/ServiceDetailsCard/ServiceDetailsCard.tsx
+++ b/plugins/firehydrant/src/components/ServiceDetailsCard/ServiceDetailsCard.tsx
@@ -17,7 +17,7 @@ import React, { useEffect, useState } from 'react';
 import { DateTime } from 'luxon';
 import { ServiceAnalytics } from '../ServiceAnalytics/ServiceAnalytics';
 import Box from '@material-ui/core/Box';
-import MaterialButton from '@material-ui/core/MaterialButton';
+import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import ExitToAppIcon from '@material-ui/icons/ExitToApp';

--- a/plugins/firehydrant/src/components/ServiceDetailsCard/ServiceDetailsCard.tsx
+++ b/plugins/firehydrant/src/components/ServiceDetailsCard/ServiceDetailsCard.tsx
@@ -208,7 +208,7 @@ export const ServiceDetailsCard = () => {
             <h2>{headerText}</h2>
           </Box>
           <Box>
-            <MaterialButton
+            <Button
               className={classes.buttonLink}
               color="default"
               href={serviceIncidentsLink}
@@ -217,7 +217,7 @@ export const ServiceDetailsCard = () => {
               variant="outlined"
             >
               View service incidents
-            </MaterialButton>
+            </Button>
           </Box>
         </Box>
       )}
@@ -241,7 +241,7 @@ export const ServiceDetailsCard = () => {
       <Box paddingLeft="16px" marginTop="10px">
         <Typography variant="subtitle1">View in FireHydrant </Typography>
         <Box className={classes.buttonContainer} marginTop="10px">
-          <MaterialButton
+          <Button
             component={Link}
             target="_blank"
             rel="noopener"
@@ -256,8 +256,8 @@ export const ServiceDetailsCard = () => {
                 <Typography component="span">Declare an incident</Typography>
               </Box>
             </Box>
-          </MaterialButton>
-          <MaterialButton
+          </Button>
+          <Button
             component={Link}
             target="_blank"
             rel="noopener"
@@ -272,9 +272,9 @@ export const ServiceDetailsCard = () => {
                 <Typography component="span">View all incidents</Typography>
               </Box>
             </Box>
-          </MaterialButton>
+          </Button>
           {showServiceDetails && (
-            <MaterialButton
+            <Button
               component={Link}
               target="_blank"
               rel="noopener"
@@ -289,7 +289,7 @@ export const ServiceDetailsCard = () => {
                   <Typography component="span">View Service Details</Typography>
                 </Box>
               </Box>
-            </MaterialButton>
+            </Button>
           )}
         </Box>
       </Box>

--- a/plugins/firehydrant/src/components/ServiceDetailsCard/ServiceDetailsCard.tsx
+++ b/plugins/firehydrant/src/components/ServiceDetailsCard/ServiceDetailsCard.tsx
@@ -16,12 +16,10 @@
 import React, { useEffect, useState } from 'react';
 import { DateTime } from 'luxon';
 import { ServiceAnalytics } from '../ServiceAnalytics/ServiceAnalytics';
-import {
-  Box,
-  Button as MaterialButton,
-  Typography,
-  makeStyles,
-} from '@material-ui/core';
+import Box from '@material-ui/core/Box';
+import MaterialButton from '@material-ui/core/MaterialButton';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
 import ExitToAppIcon from '@material-ui/icons/ExitToApp';
 import NotesIcon from '@material-ui/icons/Notes';
 import WhatshotIcon from '@material-ui/icons/Whatshot';


### PR DESCRIPTION
Adds the no-top-level-material-ui-4-import ESLint rule to the firehydrant plugin to aid with the migration to Material UI v5.

Issue: https://github.com/backstage/backstage/issues/23467