### PR TITLE
Add ESLint Rule to graphql-voyager Plugin

### DIFF
--- a/.changeset/new-bulldogs-smoke.md
+++ b/.changeset/new-bulldogs-smoke.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-graphql-voyager': patch
+---
+
+Added ESLint rule `no-top-level-material-ui-4-imports` in the `graphql-voyager` plugin to migrate the Material UI imports.

--- a/plugins/graphql-voyager/.eslintrc.js
+++ b/plugins/graphql-voyager/.eslintrc.js
@@ -1,1 +1,5 @@
-module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
+    rules: {
+      '@backstage/no-top-level-material-ui-4-imports': 'error',
+    },
+  });

--- a/plugins/graphql-voyager/src/components/GraphQLVoyagerBrowser/GraphQLVoyagerBrowser.tsx
+++ b/plugins/graphql-voyager/src/components/GraphQLVoyagerBrowser/GraphQLVoyagerBrowser.tsx
@@ -19,7 +19,10 @@ import {
   introspectionQuery,
 } from '../../lib/api/types';
 import { useState } from 'react';
-import { makeStyles, Tab, Tabs, Typography } from '@material-ui/core';
+import Tab from '@material-ui/core/Tab';
+import Tabs from '@material-ui/core/Tabs';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
 import React, { Suspense } from 'react';
 import { Content, ErrorPanel, Progress } from '@backstage/core-components';
 import { Voyager } from 'graphql-voyager';


### PR DESCRIPTION
Adds the no-top-level-material-ui-4-import ESLint rule to the graphql-voyager plugin to aid with the migration to Material UI v5.

Issue: https://github.com/backstage/backstage/issues/23467