### PR TITLE
fix: persist selected value in MyGroupsPicker.tsx

### DIFF
--- a/.changeset/hot-years-sell.md
+++ b/.changeset/hot-years-sell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Use default value for `MyGroupsPicker` if provided

--- a/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.test.tsx
@@ -274,4 +274,51 @@ describe('<MyGroupsPicker />', () => {
       expect(onChange).toHaveBeenCalledWith('group:default/group1');
     });
   });
+
+  it('should use the pre-existed formdata value if set with the form', async () => {
+    const userGroups = [
+      {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Group',
+        metadata: { name: 'group1', title: 'My First Group' },
+        spec: { members: ['Bob'] },
+      },
+      {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Group',
+        metadata: { name: 'group2', title: 'My Second Group' },
+        spec: { members: ['Bob'] },
+      },
+    ];
+
+    catalogApi.getEntities.mockResolvedValue({ items: userGroups });
+
+    const props = {
+      onChange,
+      schema,
+      required,
+      formData: 'group:default/group1',
+    } as unknown as FieldProps<string>;
+
+    const { getByRole } = render(
+      <TestApiProvider
+        apis={[
+          [identityApiRef, mockIdentityApi],
+          [catalogApiRef, catalogApi],
+          [errorApiRef, mockErrorApi],
+        ]}
+      >
+        <MyGroupsPicker {...props} />
+      </TestApiProvider>,
+    );
+
+    await waitFor(() =>
+      expect(catalogApi.getEntities).toHaveBeenCalledTimes(1),
+    );
+
+    const inputField = getByRole('combobox');
+    const inputFieldValue = inputField?.querySelector('input')?.value;
+
+    expect(inputFieldValue).toEqual(userGroups[0].metadata.title);
+  });
 });

--- a/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.tsx
@@ -37,6 +37,7 @@ export const MyGroupsPicker = (props: MyGroupsPickerProps) => {
     required,
     rawErrors,
     onChange,
+    formData,
   } = props;
 
   const identityApi = useApi(identityApiRef);
@@ -48,10 +49,6 @@ export const MyGroupsPicker = (props: MyGroupsPickerProps) => {
       ref: string;
     }[]
   >([]);
-  const [selectedGroup, setSelectedGroup] = useState<null | {
-    label: string;
-    ref: string;
-  }>(null);
 
   useAsync(async () => {
     const { userEntityRef } = await identityApi.getBackstageIdentity();
@@ -82,9 +79,10 @@ export const MyGroupsPicker = (props: MyGroupsPickerProps) => {
     _: React.ChangeEvent<{}>,
     value: { label: string; ref: string } | null,
   ) => {
-    setSelectedGroup(value);
     onChange(value?.ref ?? '');
   };
+
+  const selectedEntity = groups?.find(e => e.ref === formData) || null;
 
   return (
     <FormControl
@@ -95,7 +93,7 @@ export const MyGroupsPicker = (props: MyGroupsPickerProps) => {
       <Autocomplete
         id="OwnershipEntityRefPicker-dropdown"
         options={groups || []}
-        value={selectedGroup}
+        value={selectedEntity}
         onChange={updateChange}
         getOptionLabel={group => group.label}
         renderInput={params => (


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Apply same rule from OwnerPicker.tsx to MyGroupPicker.tsx so the value of the select get persisted. 

current behaviour:
- the selected value will be removed if a user navigate forward then backward

new behaviour:
- the selected value will remain after navigating forward and then backward

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
