### PR TITLE
Add ESLint Rule to MicrosoftCalendar Plugin

### DIFF
--- a/.changeset/grumpy-poems-grab.md
+++ b/.changeset/grumpy-poems-grab.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-microsoft-calendar': patch
+---
+
+Added ESLint rule `no-top-level-material-ui-4-imports` in the `microsoft-calender` plugin to migrate the Material UI imports.

--- a/plugins/microsoft-calendar/.eslintrc.js
+++ b/plugins/microsoft-calendar/.eslintrc.js
@@ -1,1 +1,5 @@
-module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
+    rules: {
+      '@backstage/no-top-level-material-ui-4-imports': 'error',
+    },
+});

--- a/plugins/microsoft-calendar/dev/index.tsx
+++ b/plugins/microsoft-calendar/dev/index.tsx
@@ -20,7 +20,7 @@ import { microsoftCalendarApiRef } from '../src';
 import responseMock from './mock.json';
 import { microsoftAuthApiRef } from '@backstage/core-plugin-api';
 import { Content, Page } from '@backstage/core-components';
-import { Grid } from '@material-ui/core';
+import Grid from '@material-ui/core/Grid';
 
 createDevApp()
   .registerPlugin(microsoftCalendarPlugin)

--- a/plugins/microsoft-calendar/src/components/AttendeeChip.tsx
+++ b/plugins/microsoft-calendar/src/components/AttendeeChip.tsx
@@ -15,7 +15,9 @@
  */
 
 import React from 'react';
-import { Badge, Chip, makeStyles } from '@material-ui/core';
+import Badge from '@material-ui/core/Badge';
+import Chip from '@material-ui/core/Chip';
+import { makeStyles } from '@material-ui/core/styles';
 import CancelIcon from '@material-ui/icons/Cancel';
 import CheckIcon from '@material-ui/icons/CheckCircle';
 import { Attendee, ResponseStatusMap } from '../api';

--- a/plugins/microsoft-calendar/src/components/CalendarCard.tsx
+++ b/plugins/microsoft-calendar/src/components/CalendarCard.tsx
@@ -20,7 +20,9 @@ import React, { useState } from 'react';
 
 import { InfoCard, Progress } from '@backstage/core-components';
 
-import { Box, IconButton, Typography } from '@material-ui/core';
+import Box from '@material-ui/core/Box';
+import IconButton from '@material-ui/core/IconButton';
+import Typography from '@material-ui/core/Typography';
 import PrevIcon from '@material-ui/icons/NavigateBefore';
 import NextIcon from '@material-ui/icons/NavigateNext';
 

--- a/plugins/microsoft-calendar/src/components/CalendarEvent.tsx
+++ b/plugins/microsoft-calendar/src/components/CalendarEvent.tsx
@@ -23,14 +23,12 @@ import React, { useState } from 'react';
 
 import { Link } from '@backstage/core-components';
 
-import {
-  Box,
-  Paper,
-  Popover,
-  Tooltip,
-  Typography,
-  makeStyles,
-} from '@material-ui/core';
+import Box from '@material-ui/core/Box';
+import Paper from '@material-ui/core/Paper';
+import Popover from '@material-ui/core/Popover';
+import Tooltip from '@material-ui/core/Tooltip';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
 
 import webcamIcon from '../icons/webcam.svg';
 import { CalendarEventPopoverContent } from './CalendarEventPopoverContent';

--- a/plugins/microsoft-calendar/src/components/CalendarEventPopoverContent.tsx
+++ b/plugins/microsoft-calendar/src/components/CalendarEventPopoverContent.tsx
@@ -18,14 +18,12 @@ import React from 'react';
 import DOMPurify from 'dompurify';
 
 import { Link } from '@backstage/core-components';
-import {
-  Box,
-  Divider,
-  IconButton,
-  Tooltip,
-  Typography,
-  makeStyles,
-} from '@material-ui/core';
+import Box from '@material-ui/core/Box';
+import Divider from '@material-ui/core/Divider';
+import IconButton from '@material-ui/core/IconButton';
+import Tooltip from '@material-ui/core/Tooltip';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
 import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
 
 import { AttendeeChip } from './AttendeeChip';

--- a/plugins/microsoft-calendar/src/components/CalendarSelect.tsx
+++ b/plugins/microsoft-calendar/src/components/CalendarSelect.tsx
@@ -16,16 +16,14 @@
 import { sortBy } from 'lodash';
 import React from 'react';
 
-import {
-  Checkbox,
-  FormControl,
-  Input,
-  ListItemText,
-  MenuItem,
-  Select,
-  Typography,
-  makeStyles,
-} from '@material-ui/core';
+import Checkbox from '@material-ui/core/Checkbox';
+import FormControl from '@material-ui/core/FormControl';
+import Input from '@material-ui/core/Input';
+import ListItemText from '@material-ui/core/ListItemText';
+import MenuItem from '@material-ui/core/MenuItem';
+import Select from '@material-ui/core/Select';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
 import { MicrosoftCalendar } from '../api';
 
 const useStyles = makeStyles(

--- a/plugins/microsoft-calendar/src/components/SignInContent.tsx
+++ b/plugins/microsoft-calendar/src/components/SignInContent.tsx
@@ -15,7 +15,9 @@
  */
 
 import React from 'react';
-import { Box, Button, styled } from '@material-ui/core';
+import Box from '@material-ui/core/Box';
+import Button from '@material-ui/core/Button';
+import { styled } from '@material-ui/core/styles';
 import { CalendarEvent } from './CalendarEvent';
 import mockEvents from './eventMock.json';
 import { MicrosoftCalendarEvent } from '../api';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds the no-top-level-material-ui-4-import ESLint rule to the MicrosoftCalendar plugin to aid with the migration to Material UI v5.

Issue: #23467

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
