### PR TITLE
Allow GaugeCard to handle multi-line titles better

### DIFF
--- a/.changeset/selfish-walls-visit.md
+++ b/.changeset/selfish-walls-visit.md
@@ -2,4 +2,5 @@
 '@backstage/core-components': patch
 ---
 
-Add a fullHeightFixedContent variant of the GaugeCard, and a small size version. Fixed content will vertically align the gauge in the cards, even when the card titles span across multiple lines.
+Add `alignGauge` prop to the `GaugeCard`, and a small size version. When `alignGauge` is `'bottom'` the gauge will vertically align the gauge in the cards, even when the card titles span across multiple lines.
+Add `alignContent` prop to the `InfoCard`, defaulting to `'normal'` with the option of `'bottom'` which vertically aligns the content to the bottom of the card.

--- a/.changeset/selfish-walls-visit.md
+++ b/.changeset/selfish-walls-visit.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Add a fullHeightFixedContent variant of the GaugeCard, and a small size version. Fixed content will vertically align the gauge in the cards, even when the card titles span across multiple lines.

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -610,11 +610,7 @@ export type InfoCardClassKey =
   | 'headerContent';
 
 // @public (undocumented)
-export type InfoCardVariants =
-  | 'flex'
-  | 'fullHeight'
-  | 'fullHeightFixedContent'
-  | 'gridItem';
+export type InfoCardVariants = 'flex' | 'fullHeight' | 'gridItem';
 
 // Warning: (ae-forgotten-export) The symbol "ItemCardProps" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "ItemCard" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -448,6 +448,7 @@ export type GaugeProps = {
   inverse?: boolean;
   unit?: string;
   max?: number;
+  size?: 'normal' | 'small';
   description?: ReactNode;
   getColor?: GaugePropsGetColor;
 };
@@ -609,7 +610,11 @@ export type InfoCardClassKey =
   | 'headerContent';
 
 // @public (undocumented)
-export type InfoCardVariants = 'flex' | 'fullHeight' | 'gridItem';
+export type InfoCardVariants =
+  | 'flex'
+  | 'fullHeight'
+  | 'fullHeightFixedContent'
+  | 'gridItem';
 
 // Warning: (ae-forgotten-export) The symbol "ItemCardProps" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "ItemCard" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/packages/core-components/src/components/ProgressBars/Gauge.tsx
+++ b/packages/core-components/src/components/ProgressBars/Gauge.tsx
@@ -19,6 +19,7 @@ import { makeStyles, useTheme } from '@material-ui/core/styles';
 import { Circle } from 'rc-progress';
 import React, { ReactNode, useEffect, useState } from 'react';
 import Box from '@material-ui/core/Box';
+import classNames from 'classnames';
 
 /** @public */
 export type GaugeClassKey =
@@ -42,6 +43,9 @@ const useStyles = makeStyles(
       fontSize: theme.typography.pxToRem(45),
       fontWeight: theme.typography.fontWeightBold,
       color: theme.palette.textContrast,
+    },
+    overlaySmall: {
+      fontSize: theme.typography.pxToRem(25),
     },
     description: {
       fontSize: '100%',
@@ -68,6 +72,7 @@ export type GaugeProps = {
   inverse?: boolean;
   unit?: string;
   max?: number;
+  size?: 'normal' | 'small';
   description?: ReactNode;
   getColor?: GaugePropsGetColor;
 };
@@ -121,7 +126,7 @@ export const getProgressColor: GaugePropsGetColor = ({
 
 export function Gauge(props: GaugeProps) {
   const [hoverRef, setHoverRef] = useState<HTMLDivElement | null>(null);
-  const { getColor = getProgressColor } = props;
+  const { getColor = getProgressColor, size = 'normal' } = props;
   const classes = useStyles(props);
   const { palette } = useTheme();
   const { value, fractional, inverse, unit, max, description } = {
@@ -165,7 +170,12 @@ export function Gauge(props: GaugeProps) {
       {description && isHovering ? (
         <Box className={classes.description}>{description}</Box>
       ) : (
-        <Box className={classes.overlay}>
+        <Box
+          className={classNames(
+            classes.overlay,
+            size === 'small' ? classes.overlaySmall : undefined,
+          )}
+        >
           {isNaN(value) ? 'N/A' : `${asActual}${unit}`}
         </Box>
       )}

--- a/packages/core-components/src/components/ProgressBars/Gauge.tsx
+++ b/packages/core-components/src/components/ProgressBars/Gauge.tsx
@@ -171,10 +171,9 @@ export function Gauge(props: GaugeProps) {
         <Box className={classes.description}>{description}</Box>
       ) : (
         <Box
-          className={classNames(
-            classes.overlay,
-            size === 'small' ? classes.overlaySmall : undefined,
-          )}
+          className={classNames(classes.overlay, {
+            [classes.overlaySmall]: size === 'small',
+          })}
         >
           {isNaN(value) ? 'N/A' : `${asActual}${unit}`}
         </Box>

--- a/packages/core-components/src/components/ProgressBars/GaugeCard.stories.tsx
+++ b/packages/core-components/src/components/ProgressBars/GaugeCard.stories.tsx
@@ -175,6 +175,82 @@ export const InfoMessage = () => (
   </Wrapper>
 );
 
+export const AlignedBottom = () => (
+  <Wrapper>
+    <Grid item>
+      <GaugeCard
+        variant="fullHeightFixedContent"
+        title="Progress"
+        subheader="With a subheader"
+        progress={0.3}
+      />
+    </Grid>
+    <Grid item>
+      <GaugeCard
+        variant="fullHeightFixedContent"
+        title="Progress"
+        subheader="With a subheader"
+        progress={0.57}
+      />
+    </Grid>
+    <Grid item>
+      <GaugeCard
+        variant="fullHeightFixedContent"
+        title="Progress with longer title"
+        subheader="With a subheader"
+        progress={0.89}
+      />
+    </Grid>
+    <Grid item>
+      <GaugeCard
+        variant="fullHeightFixedContent"
+        title="Progress"
+        subheader="With a subheader"
+        inverse
+        progress={0.2}
+      />
+    </Grid>
+  </Wrapper>
+);
+
+export const Small = () => (
+  <Wrapper>
+    <Grid item>
+      <GaugeCard
+        variant="fullHeightFixedContent"
+        size="small"
+        title="Progress"
+        progress={0.3}
+      />
+    </Grid>
+    <Grid item>
+      <GaugeCard
+        variant="fullHeightFixedContent"
+        size="small"
+        title="Progress"
+        progress={0.57}
+      />
+    </Grid>
+    <Grid item>
+      <GaugeCard
+        variant="fullHeightFixedContent"
+        size="small"
+        title="Progress, longer title"
+        progress={0.89}
+      />
+    </Grid>
+    <Grid item>
+      <GaugeCard
+        variant="fullHeightFixedContent"
+        size="small"
+        title="Progress"
+        inverse
+        progress={0.2}
+      />
+    </Grid>
+  </Wrapper>
+);
+
 export const HoverMessage = () => (
   <Wrapper>
     <Grid item>

--- a/packages/core-components/src/components/ProgressBars/GaugeCard.stories.tsx
+++ b/packages/core-components/src/components/ProgressBars/GaugeCard.stories.tsx
@@ -179,7 +179,8 @@ export const AlignedBottom = () => (
   <Wrapper>
     <Grid item>
       <GaugeCard
-        variant="fullHeightFixedContent"
+        variant="fullHeight"
+        alignGauge="bottom"
         title="Progress"
         subheader="With a subheader"
         progress={0.3}
@@ -187,7 +188,8 @@ export const AlignedBottom = () => (
     </Grid>
     <Grid item>
       <GaugeCard
-        variant="fullHeightFixedContent"
+        variant="fullHeight"
+        alignGauge="bottom"
         title="Progress"
         subheader="With a subheader"
         progress={0.57}
@@ -195,7 +197,8 @@ export const AlignedBottom = () => (
     </Grid>
     <Grid item>
       <GaugeCard
-        variant="fullHeightFixedContent"
+        variant="fullHeight"
+        alignGauge="bottom"
         title="Progress with longer title"
         subheader="With a subheader"
         progress={0.89}
@@ -203,7 +206,8 @@ export const AlignedBottom = () => (
     </Grid>
     <Grid item>
       <GaugeCard
-        variant="fullHeightFixedContent"
+        variant="fullHeight"
+        alignGauge="bottom"
         title="Progress"
         subheader="With a subheader"
         inverse
@@ -217,7 +221,8 @@ export const Small = () => (
   <Wrapper>
     <Grid item>
       <GaugeCard
-        variant="fullHeightFixedContent"
+        variant="fullHeight"
+        alignGauge="bottom"
         size="small"
         title="Progress"
         progress={0.3}
@@ -225,7 +230,8 @@ export const Small = () => (
     </Grid>
     <Grid item>
       <GaugeCard
-        variant="fullHeightFixedContent"
+        variant="fullHeight"
+        alignGauge="bottom"
         size="small"
         title="Progress"
         progress={0.57}
@@ -233,7 +239,8 @@ export const Small = () => (
     </Grid>
     <Grid item>
       <GaugeCard
-        variant="fullHeightFixedContent"
+        variant="fullHeight"
+        alignGauge="bottom"
         size="small"
         title="Progress, longer title"
         progress={0.89}
@@ -241,7 +248,8 @@ export const Small = () => (
     </Grid>
     <Grid item>
       <GaugeCard
-        variant="fullHeightFixedContent"
+        variant="fullHeight"
+        alignGauge="bottom"
         size="small"
         title="Progress"
         inverse

--- a/packages/core-components/src/components/ProgressBars/GaugeCard.stories.tsx
+++ b/packages/core-components/src/components/ProgressBars/GaugeCard.stories.tsx
@@ -234,6 +234,7 @@ export const Small = () => (
         alignGauge="bottom"
         size="small"
         title="Progress"
+        subheader="With a subheader"
         progress={0.57}
       />
     </Grid>

--- a/packages/core-components/src/components/ProgressBars/GaugeCard.tsx
+++ b/packages/core-components/src/components/ProgressBars/GaugeCard.tsx
@@ -27,6 +27,7 @@ type Props = {
   variant?: InfoCardVariants;
   /** Progress in % specified as decimal, e.g. "0.23" */
   progress: number;
+  size?: 'normal' | 'small';
   description?: ReactNode;
   icon?: ReactNode;
   inverse?: boolean;
@@ -42,6 +43,10 @@ const useStyles = makeStyles(
     root: {
       height: '100%',
       width: 250,
+    },
+    rootSmall: {
+      height: '100%',
+      width: 160,
     },
   },
   { name: 'BackstageGaugeCard' },
@@ -64,6 +69,7 @@ export function GaugeCard(props: Props) {
     description,
     icon,
     variant,
+    size = 'normal',
     getColor,
   } = props;
 
@@ -75,15 +81,22 @@ export function GaugeCard(props: Props) {
   };
 
   return (
-    <Box className={classes.root}>
+    <Box className={size === 'small' ? classes.rootSmall : classes.root}>
       <InfoCard
         title={title}
         subheader={subheader}
         deepLink={deepLink}
         variant={variant}
         icon={icon}
+        titleTypographyProps={
+          size === 'small'
+            ? {
+                variant: 'h6',
+              }
+            : undefined
+        }
       >
-        <Gauge {...gaugeProps} />
+        <Gauge {...gaugeProps} size={size} />
       </InfoCard>
     </Box>
   );

--- a/packages/core-components/src/components/ProgressBars/GaugeCard.tsx
+++ b/packages/core-components/src/components/ProgressBars/GaugeCard.tsx
@@ -91,13 +91,12 @@ export function GaugeCard(props: Props) {
         variant={variant}
         alignContent={alignGauge}
         icon={icon}
-        titleTypographyProps={
-          size === 'small'
-            ? {
-                variant: 'h6',
-              }
-            : undefined
-        }
+        titleTypographyProps={{
+          ...(size === 'small' ? { variant: 'subtitle2' } : undefined),
+        }}
+        subheaderTypographyProps={{
+          ...(size === 'small' ? { variant: 'body2' } : undefined),
+        }}
       >
         <Gauge {...gaugeProps} size={size} />
       </InfoCard>

--- a/packages/core-components/src/components/ProgressBars/GaugeCard.tsx
+++ b/packages/core-components/src/components/ProgressBars/GaugeCard.tsx
@@ -27,6 +27,7 @@ type Props = {
   variant?: InfoCardVariants;
   /** Progress in % specified as decimal, e.g. "0.23" */
   progress: number;
+  alignGauge?: 'normal' | 'bottom';
   size?: 'normal' | 'small';
   description?: ReactNode;
   icon?: ReactNode;
@@ -69,6 +70,7 @@ export function GaugeCard(props: Props) {
     description,
     icon,
     variant,
+    alignGauge = 'normal',
     size = 'normal',
     getColor,
   } = props;
@@ -87,6 +89,7 @@ export function GaugeCard(props: Props) {
         subheader={subheader}
         deepLink={deepLink}
         variant={variant}
+        alignContent={alignGauge}
         icon={icon}
         titleTypographyProps={
           size === 'small'

--- a/packages/core-components/src/layout/InfoCard/InfoCard.tsx
+++ b/packages/core-components/src/layout/InfoCard/InfoCard.tsx
@@ -43,12 +43,12 @@ const useStyles = makeStyles(
         paddingBottom: 0,
       },
     },
+    contentAlignBottom: {
+      display: 'flex',
+      alignItems: 'self-end',
+    },
     header: {
       padding: theme.spacing(2, 2, 2, 2.5),
-    },
-    headerFixedContent: {
-      flexGrow: 1,
-      alignItems: 'flex-start',
     },
     headerTitle: {
       fontWeight: theme.typography.fontWeightBold,
@@ -91,11 +91,6 @@ const VARIANT_STYLES = {
       flexDirection: 'column',
       height: '100%',
     },
-    fullHeightFixedContent: {
-      display: 'flex',
-      flexDirection: 'column',
-      height: '100%',
-    },
     gridItem: {
       display: 'flex',
       flexDirection: 'column',
@@ -111,9 +106,6 @@ const VARIANT_STYLES = {
     fullHeight: {
       flex: 1,
     },
-    fullHeightFixedContent: {
-      flex: '0 1 0%',
-    },
     gridItem: {
       flex: 1,
     },
@@ -121,11 +113,7 @@ const VARIANT_STYLES = {
 };
 
 /** @public */
-export type InfoCardVariants =
-  | 'flex'
-  | 'fullHeight'
-  | 'fullHeightFixedContent'
-  | 'gridItem';
+export type InfoCardVariants = 'flex' | 'fullHeight' | 'gridItem';
 
 /**
  * InfoCard is used to display a paper-styled block on the screen, similar to a panel.
@@ -154,6 +142,7 @@ export type Props = {
   slackChannel?: string;
   errorBoundaryProps?: ErrorBoundaryProps;
   variant?: InfoCardVariants;
+  alignContent?: 'normal' | 'bottom';
   children?: ReactNode;
   headerStyle?: object;
   headerProps?: CardHeaderProps;
@@ -183,6 +172,7 @@ export function InfoCard(props: Props): JSX.Element {
     slackChannel,
     errorBoundaryProps,
     variant,
+    alignContent = 'normal',
     children,
     headerStyle,
     headerProps,
@@ -244,12 +234,7 @@ export function InfoCard(props: Props): JSX.Element {
         {title && (
           <CardHeader
             classes={{
-              root: classNames(
-                classes.header,
-                variant === 'fullHeightFixedContent'
-                  ? classes.headerFixedContent
-                  : undefined,
-              ),
+              root: classNames(classes.header),
               title: classes.headerTitle,
               subheader: classes.headerSubheader,
               avatar: classes.headerAvatar,
@@ -271,6 +256,7 @@ export function InfoCard(props: Props): JSX.Element {
         <CardContent
           className={classNames(cardClassName, {
             [classes.noPadding]: noPadding,
+            [classes.contentAlignBottom]: alignContent === 'bottom',
           })}
           style={calculatedCardStyle}
         >

--- a/packages/core-components/src/layout/InfoCard/InfoCard.tsx
+++ b/packages/core-components/src/layout/InfoCard/InfoCard.tsx
@@ -46,6 +46,10 @@ const useStyles = makeStyles(
     header: {
       padding: theme.spacing(2, 2, 2, 2.5),
     },
+    headerFixedContent: {
+      flexGrow: 1,
+      alignItems: 'flex-start',
+    },
     headerTitle: {
       fontWeight: theme.typography.fontWeightBold,
     },
@@ -87,6 +91,11 @@ const VARIANT_STYLES = {
       flexDirection: 'column',
       height: '100%',
     },
+    fullHeightFixedContent: {
+      display: 'flex',
+      flexDirection: 'column',
+      height: '100%',
+    },
     gridItem: {
       display: 'flex',
       flexDirection: 'column',
@@ -102,6 +111,9 @@ const VARIANT_STYLES = {
     fullHeight: {
       flex: 1,
     },
+    fullHeightFixedContent: {
+      flex: '0 1 0%',
+    },
     gridItem: {
       flex: 1,
     },
@@ -109,7 +121,11 @@ const VARIANT_STYLES = {
 };
 
 /** @public */
-export type InfoCardVariants = 'flex' | 'fullHeight' | 'gridItem';
+export type InfoCardVariants =
+  | 'flex'
+  | 'fullHeight'
+  | 'fullHeightFixedContent'
+  | 'gridItem';
 
 /**
  * InfoCard is used to display a paper-styled block on the screen, similar to a panel.
@@ -228,7 +244,12 @@ export function InfoCard(props: Props): JSX.Element {
         {title && (
           <CardHeader
             classes={{
-              root: classes.header,
+              root: classNames(
+                classes.header,
+                variant === 'fullHeightFixedContent'
+                  ? classes.headerFixedContent
+                  : undefined,
+              ),
               title: classes.headerTitle,
               subheader: classes.headerSubheader,
               avatar: classes.headerAvatar,

--- a/packages/core-components/src/layout/InfoCard/InfoCard.tsx
+++ b/packages/core-components/src/layout/InfoCard/InfoCard.tsx
@@ -217,10 +217,7 @@ export function InfoCard(props: Props): JSX.Element {
     }
 
     return (
-      <div
-        className={classes.headerSubheader}
-        data-testid="info-card-subheader"
-      >
+      <div data-testid="info-card-subheader">
         {subheader && <div className={classes.subheader}>{subheader}</div>}
         {icon}
       </div>

--- a/packages/core-components/src/layout/InfoCard/InfoCard.tsx
+++ b/packages/core-components/src/layout/InfoCard/InfoCard.tsx
@@ -155,6 +155,7 @@ export type Props = {
   className?: string;
   noPadding?: boolean;
   titleTypographyProps?: object;
+  subheaderTypographyProps?: object;
 };
 
 /**
@@ -185,6 +186,7 @@ export function InfoCard(props: Props): JSX.Element {
     className,
     noPadding,
     titleTypographyProps,
+    subheaderTypographyProps,
   } = props;
   const classes = useStyles();
   /**
@@ -246,6 +248,7 @@ export function InfoCard(props: Props): JSX.Element {
             action={action}
             style={{ ...headerStyle }}
             titleTypographyProps={titleTypographyProps}
+            subheaderTypographyProps={subheaderTypographyProps}
             {...headerProps}
           />
         )}


### PR DESCRIPTION
## GaugeCard with different sizes of headers, handled better

The PR adds apart from the `fullHeight` a variant `fullHeightFixedContent` which allows the header to grow, instead of the content. This makes the gauges in several side-by-side cards to have the same vertical alignment of the actual gauge.

Also added is a small version of the GaugeCard, useful when showing many of them.

### fullHeight

<img width="1062" alt="Skärmavbild 2024-03-21 kl  15 25 36" src="https://github.com/backstage/backstage/assets/5362579/119288f7-e2fc-4e53-a4c6-e801625e9625">

### fullHeightFixedContent

<img width="1065" alt="Skärmavbild 2024-03-22 kl  08 59 51" src="https://github.com/backstage/backstage/assets/5362579/0882c5d1-791a-4590-a9d9-aed1cb3448ff">

### small

<img width="700" alt="Skärmavbild 2024-03-22 kl  08 42 51" src="https://github.com/backstage/backstage/assets/5362579/4cd6dce1-51ee-423c-beb3-ac75b5afdfd1">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
