### PR TITLE
chore: added missing commas to queryEntities

### DIFF
--- a/.changeset/mighty-cooks-lie.md
+++ b/.changeset/mighty-cooks-lie.md
@@ -2,4 +2,4 @@
 '@backstage/catalog-client': patch
 ---
 
-Added missing commas to the example of queryEntities
+Added missing commas to the example of `queryEntities`

--- a/.changeset/mighty-cooks-lie.md
+++ b/.changeset/mighty-cooks-lie.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-client': patch
+---
+
+Added missing commas to the example of queryEntities

--- a/packages/catalog-client/src/types/api.ts
+++ b/packages/catalog-client/src/types/api.ts
@@ -498,8 +498,8 @@ export interface CatalogApi {
    *   limit: 20,
    *   fullTextFilter: {
    *     term: 'A',
-   *   }
-   *   orderFields: { field: 'metadata.name' order: 'asc' },
+   *   },
+   *   orderFields: { field: 'metadata.name', order: 'asc' },
    * });
    * ```
    *


### PR DESCRIPTION
noticed this little _bug_ in the example for `queryEntities`. 

Not sure if changeset is needed, but added nevertheless