### PR TITLE
fix permissions being overwritten by the unprocessed entities module

### DIFF
--- a/.changeset/angry-chairs-brake.md
+++ b/.changeset/angry-chairs-brake.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-catalog-backend': minor
+'@backstage/plugin-catalog-node': minor
+---
+
+Added the ability to inject custom permissions from modules, on `CatalogBuilder` and `CatalogPermissionExtensionPoint`

--- a/.changeset/empty-spiders-pay.md
+++ b/.changeset/empty-spiders-pay.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-unprocessed': patch
+---
+
+Internal update that injects custom permissions into the catalog using its extension point

--- a/.changeset/famous-rats-kick.md
+++ b/.changeset/famous-rats-kick.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-permission-backend': patch
+---
+
+Properly forward causes of errors from upstream backends in the `PermissionIntegrationClient`

--- a/plugins/catalog-backend-module-unprocessed/package.json
+++ b/plugins/catalog-backend-module-unprocessed/package.json
@@ -40,6 +40,7 @@
     "@backstage/catalog-model": "workspace:^",
     "@backstage/errors": "workspace:^",
     "@backstage/plugin-auth-node": "workspace:^",
+    "@backstage/plugin-catalog-node": "workspace:^",
     "@backstage/plugin-catalog-unprocessed-entities-common": "workspace:^",
     "@backstage/plugin-permission-common": "workspace:^",
     "@backstage/plugin-permission-node": "workspace:^",

--- a/plugins/catalog-backend-module-unprocessed/package.json
+++ b/plugins/catalog-backend-module-unprocessed/package.json
@@ -43,7 +43,6 @@
     "@backstage/plugin-catalog-node": "workspace:^",
     "@backstage/plugin-catalog-unprocessed-entities-common": "workspace:^",
     "@backstage/plugin-permission-common": "workspace:^",
-    "@backstage/plugin-permission-node": "workspace:^",
     "express-promise-router": "^4.1.1",
     "knex": "^3.0.0"
   }

--- a/plugins/catalog-backend-module-unprocessed/src/UnprocessedEntitiesModule.ts
+++ b/plugins/catalog-backend-module-unprocessed/src/UnprocessedEntitiesModule.ts
@@ -34,7 +34,6 @@ import {
   AuthorizeResult,
   BasicPermission,
 } from '@backstage/plugin-permission-common';
-import { createPermissionIntegrationRouter } from '@backstage/plugin-permission-node';
 import { unprocessedEntitiesDeletePermission } from '@backstage/plugin-catalog-unprocessed-entities-common';
 import { NotAllowedError } from '@backstage/errors';
 import { createLegacyAuthAdapters } from '@backstage/backend-common';
@@ -145,10 +144,6 @@ export class UnprocessedEntitiesModule {
   }
 
   registerRoutes() {
-    const permissionIntegrationRouter = createPermissionIntegrationRouter({
-      permissions: [unprocessedEntitiesDeletePermission],
-    });
-
     const isRequestAuthorized = async (
       req: Request,
       permission: BasicPermission,
@@ -161,8 +156,6 @@ export class UnprocessedEntitiesModule {
 
       return decision.result !== AuthorizeResult.DENY;
     };
-
-    this.router.use(permissionIntegrationRouter);
 
     this.moduleRouter
       .get('/entities/unprocessed/failed', async (req, res) => {

--- a/plugins/catalog-backend-module-unprocessed/src/module.ts
+++ b/plugins/catalog-backend-module-unprocessed/src/module.ts
@@ -19,6 +19,8 @@ import {
   createBackendModule,
 } from '@backstage/backend-plugin-api';
 import { UnprocessedEntitiesModule } from './UnprocessedEntitiesModule';
+import { catalogPermissionExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
+import { unprocessedEntitiesDeletePermission } from '@backstage/plugin-catalog-unprocessed-entities-common';
 
 /**
  * Catalog Module for Unprocessed Entities
@@ -37,6 +39,7 @@ export const catalogModuleUnprocessedEntities = createBackendModule({
         httpAuth: coreServices.httpAuth,
         discovery: coreServices.discovery,
         permissions: coreServices.permissions,
+        catalogPermissions: catalogPermissionExtensionPoint,
       },
       async init({
         database,
@@ -45,6 +48,7 @@ export const catalogModuleUnprocessedEntities = createBackendModule({
         permissions,
         httpAuth,
         discovery,
+        catalogPermissions,
       }) {
         const module = UnprocessedEntitiesModule.create({
           database: await database.getClient(),
@@ -53,6 +57,8 @@ export const catalogModuleUnprocessedEntities = createBackendModule({
           discovery,
           httpAuth,
         });
+
+        catalogPermissions.addPermissions(unprocessedEntitiesDeletePermission);
 
         module.registerRoutes();
 

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -148,6 +148,7 @@ export class CatalogBuilder {
       CatalogPermissionRuleInput | Array<CatalogPermissionRuleInput>
     >
   ): this;
+  addPermissions(...permissions: Array<Permission | Array<Permission>>): this;
   addProcessor(
     ...processors: Array<CatalogProcessor_2 | Array<CatalogProcessor_2>>
   ): CatalogBuilder;

--- a/plugins/catalog-backend/src/service/CatalogPlugin.ts
+++ b/plugins/catalog-backend/src/service/CatalogPlugin.ts
@@ -38,6 +38,7 @@ import {
 } from '@backstage/plugin-catalog-node';
 import { loggerToWinstonLogger } from '@backstage/backend-common';
 import { merge } from 'lodash';
+import { Permission } from '@backstage/plugin-permission-common';
 
 class CatalogProcessingExtensionPointImpl
   implements CatalogProcessingExtensionPoint
@@ -113,7 +114,12 @@ class CatalogAnalysisExtensionPointImpl
 class CatalogPermissionExtensionPointImpl
   implements CatalogPermissionExtensionPoint
 {
+  #permissions = new Array<Permission>();
   #permissionRules = new Array<CatalogPermissionRuleInput>();
+
+  addPermissions(...permission: Array<Permission | Array<Permission>>): void {
+    this.#permissions.push(...permission.flat());
+  }
 
   addPermissionRules(
     ...rules: Array<
@@ -121,6 +127,10 @@ class CatalogPermissionExtensionPointImpl
     >
   ): void {
     this.#permissionRules.push(...rules.flat());
+  }
+
+  get permissions() {
+    return this.#permissions;
   }
 
   get permissionRules() {
@@ -239,6 +249,7 @@ export const catalogPlugin = createBackendPlugin({
           ([key, resolver]) => builder.setPlaceholderResolver(key, resolver),
         );
         builder.addLocationAnalyzers(...analysisExtensions.locationAnalyzers);
+        builder.addPermissions(...permissionExtensions.permissions);
         builder.addPermissionRules(...permissionExtensions.permissionRules);
         builder.setFieldFormatValidators(modelExtensions.fieldValidators);
 

--- a/plugins/catalog-node/api-report-alpha.md
+++ b/plugins/catalog-node/api-report-alpha.md
@@ -10,6 +10,7 @@ import { EntitiesSearchFilter } from '@backstage/plugin-catalog-node';
 import { Entity } from '@backstage/catalog-model';
 import { EntityProvider } from '@backstage/plugin-catalog-node';
 import { ExtensionPoint } from '@backstage/backend-plugin-api';
+import { Permission } from '@backstage/plugin-permission-common';
 import { PermissionRule } from '@backstage/plugin-permission-node';
 import { PermissionRuleParams } from '@backstage/plugin-permission-common';
 import { PlaceholderResolver } from '@backstage/plugin-catalog-node';
@@ -43,6 +44,8 @@ export interface CatalogPermissionExtensionPoint {
       CatalogPermissionRuleInput | Array<CatalogPermissionRuleInput>
     >
   ): void;
+  // (undocumented)
+  addPermissions(...permissions: Array<Permission | Array<Permission>>): void;
 }
 
 // @alpha (undocumented)

--- a/plugins/catalog-node/src/extensions.ts
+++ b/plugins/catalog-node/src/extensions.ts
@@ -24,7 +24,10 @@ import {
   PlaceholderResolver,
   ScmLocationAnalyzer,
 } from '@backstage/plugin-catalog-node';
-import { PermissionRuleParams } from '@backstage/plugin-permission-common';
+import {
+  Permission,
+  PermissionRuleParams,
+} from '@backstage/plugin-permission-common';
 import { PermissionRule } from '@backstage/plugin-permission-node';
 
 /**
@@ -104,6 +107,7 @@ export type CatalogPermissionRuleInput<
  * @alpha
  */
 export interface CatalogPermissionExtensionPoint {
+  addPermissions(...permissions: Array<Permission | Array<Permission>>): void;
   addPermissionRules(
     ...rules: Array<
       CatalogPermissionRuleInput | Array<CatalogPermissionRuleInput>

--- a/plugins/permission-backend/src/service/PermissionIntegrationClient.ts
+++ b/plugins/permission-backend/src/service/PermissionIntegrationClient.ts
@@ -29,6 +29,7 @@ import {
   BackstageCredentials,
   DiscoveryService,
 } from '@backstage/backend-plugin-api';
+import { ResponseError } from '@backstage/errors';
 
 const responseSchema = z.object({
   items: z.array(
@@ -90,9 +91,7 @@ export class PermissionIntegrationClient {
     });
 
     if (!response.ok) {
-      throw new Error(
-        `Unexpected response from plugin upstream when applying conditions. Expected 200 but got ${response.status} - ${response.statusText}`,
-      );
+      throw await ResponseError.fromResponse(response);
     }
 
     const result = responseSchema.parse(await response.json());

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
@@ -162,7 +162,6 @@ const applyConditions = <TResourceType extends string, TResource>(
 };
 
 /**
-
  * Takes some permission conditions and returns a definitive authorization result
  * on the resource to which they apply.
  *

--- a/yarn.lock
+++ b/yarn.lock
@@ -5634,7 +5634,6 @@ __metadata:
     "@backstage/plugin-catalog-node": "workspace:^"
     "@backstage/plugin-catalog-unprocessed-entities-common": "workspace:^"
     "@backstage/plugin-permission-common": "workspace:^"
-    "@backstage/plugin-permission-node": "workspace:^"
     "@types/express": ^4.17.6
     express-promise-router: ^4.1.1
     knex: ^3.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -5631,6 +5631,7 @@ __metadata:
     "@backstage/cli": "workspace:^"
     "@backstage/errors": "workspace:^"
     "@backstage/plugin-auth-node": "workspace:^"
+    "@backstage/plugin-catalog-node": "workspace:^"
     "@backstage/plugin-catalog-unprocessed-entities-common": "workspace:^"
     "@backstage/plugin-permission-common": "workspace:^"
     "@backstage/plugin-permission-node": "workspace:^"


### PR DESCRIPTION
Fixes an issue where `@backstage/plugin-catalog-backend-module-unprocessed` was registering a full permissions router, which collided with the permissions router that the catalog backend itself was registering. This manifested in the form of 500 errors in the client during permission checks.

The catalog (both the builder and the extension points) now instead have the ability for modules to add permissions into the catalog backend's own permission router.

As part of this, we also ensured that the permissions client forwards upstream server errors properly.