### PR TITLE
Patch release pr 23789

### DIFF
--- a/.changeset/angry-chairs-brake.md
+++ b/.changeset/angry-chairs-brake.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-catalog-backend': minor
+'@backstage/plugin-catalog-node': minor
+---
+
+Added the ability to inject custom permissions from modules, on `CatalogBuilder` and `CatalogPermissionExtensionPoint`

--- a/.changeset/angry-chairs-brake.md
+++ b/.changeset/angry-chairs-brake.md
@@ -1,6 +1,0 @@
----
-'@backstage/plugin-catalog-backend': minor
-'@backstage/plugin-catalog-node': minor
----
-
-Added the ability to inject custom permissions from modules, on `CatalogBuilder` and `CatalogPermissionExtensionPoint`

--- a/.changeset/empty-spiders-pay.md
+++ b/.changeset/empty-spiders-pay.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-unprocessed': patch
+---
+
+Internal update that injects custom permissions into the catalog using its extension point

--- a/.changeset/empty-spiders-pay.md
+++ b/.changeset/empty-spiders-pay.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-catalog-backend-module-unprocessed': patch
----
-
-Internal update that injects custom permissions into the catalog using its extension point

--- a/.changeset/famous-rats-kick.md
+++ b/.changeset/famous-rats-kick.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-permission-backend': patch
----
-
-Properly forward causes of errors from upstream backends in the `PermissionIntegrationClient`

--- a/.changeset/famous-rats-kick.md
+++ b/.changeset/famous-rats-kick.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-permission-backend': patch
+---
+
+Properly forward causes of errors from upstream backends in the `PermissionIntegrationClient`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/backend-dynamic-feature-service/CHANGELOG.md
+++ b/packages/backend-dynamic-feature-service/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/backend-dynamic-feature-service
 
+## 0.2.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-backend@1.19.0
+
 ## 0.2.4
 
 ### Patch Changes

--- a/packages/backend-dynamic-feature-service/package.json
+++ b/packages/backend-dynamic-feature-service/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/backend-dynamic-feature-service",
   "description": "Backstage dynamic feature service",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/packages/backend-next/CHANGELOG.md
+++ b/packages/backend-next/CHANGELOG.md
@@ -1,5 +1,29 @@
 # example-backend-next
 
+## 0.0.22
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-backend@1.19.0
+  - @backstage/plugin-catalog-backend-module-unprocessed@0.4.1
+  - @backstage/plugin-permission-backend@0.5.38
+  - @backstage/plugin-catalog-backend-module-openapi@0.1.32
+  - @backstage/plugin-auth-backend@0.22.1
+  - @backstage/plugin-azure-devops-backend@0.6.1
+  - @backstage/plugin-catalog-backend-module-backstage-openapi@0.1.8
+  - @backstage/plugin-catalog-backend-module-scaffolder-entity-model@0.1.12
+  - @backstage/plugin-jenkins-backend@0.4.1
+  - @backstage/plugin-kubernetes-backend@0.16.1
+  - @backstage/plugin-lighthouse-backend@0.4.7
+  - @backstage/plugin-linguist-backend@0.5.12
+  - @backstage/plugin-scaffolder-backend@1.22.1
+  - @backstage/plugin-search-backend-module-catalog@0.1.19
+  - @backstage/plugin-search-backend-module-techdocs@0.1.19
+  - @backstage/plugin-todo-backend@0.3.13
+  - @backstage/plugin-auth-backend-module-github-provider@0.1.11
+  - @backstage/plugin-techdocs-backend@1.10.1
+
 ## 0.0.21
 
 ### Patch Changes

--- a/packages/backend-next/package.json
+++ b/packages/backend-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-backend-next",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/packages/backend/CHANGELOG.md
+++ b/packages/backend/CHANGELOG.md
@@ -1,5 +1,27 @@
 # example-backend
 
+## 0.2.94
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-backend@1.19.0
+  - @backstage/plugin-catalog-node@1.9.0
+  - @backstage/plugin-catalog-backend-module-unprocessed@0.4.1
+  - @backstage/plugin-permission-backend@0.5.38
+  - @backstage/plugin-auth-backend@0.22.1
+  - @backstage/plugin-azure-devops-backend@0.6.1
+  - @backstage/plugin-catalog-backend-module-scaffolder-entity-model@0.1.12
+  - @backstage/plugin-jenkins-backend@0.4.1
+  - @backstage/plugin-kubernetes-backend@0.16.1
+  - @backstage/plugin-lighthouse-backend@0.4.7
+  - @backstage/plugin-linguist-backend@0.5.12
+  - @backstage/plugin-scaffolder-backend@1.22.1
+  - @backstage/plugin-search-backend-module-catalog@0.1.19
+  - @backstage/plugin-search-backend-module-techdocs@0.1.19
+  - @backstage/plugin-todo-backend@0.3.13
+  - @backstage/plugin-techdocs-backend@1.10.1
+
 ## 0.2.93
 
 ### Patch Changes

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-backend",
-  "version": "0.2.93",
+  "version": "0.2.94",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/auth-backend-module-aws-alb-provider/CHANGELOG.md
+++ b/plugins/auth-backend-module-aws-alb-provider/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-auth-backend-module-aws-alb-provider
 
+## 0.1.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-auth-backend@0.22.1
+
 ## 0.1.5
 
 ### Patch Changes

--- a/plugins/auth-backend-module-aws-alb-provider/package.json
+++ b/plugins/auth-backend-module-aws-alb-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-auth-backend-module-aws-alb-provider",
   "description": "The aws-alb provider module for the Backstage auth backend.",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/auth-backend-module-oidc-provider/CHANGELOG.md
+++ b/plugins/auth-backend-module-oidc-provider/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-auth-backend-module-oidc-provider
 
+## 0.1.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-auth-backend@0.22.1
+
 ## 0.1.4
 
 ### Patch Changes

--- a/plugins/auth-backend-module-oidc-provider/package.json
+++ b/plugins/auth-backend-module-oidc-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-auth-backend-module-oidc-provider",
   "description": "The oidc-provider backend module for the auth plugin.",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/auth-backend/CHANGELOG.md
+++ b/plugins/auth-backend/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @backstage/plugin-auth-backend
 
+## 0.22.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-node@1.9.0
+  - @backstage/plugin-auth-backend-module-atlassian-provider@0.1.6
+  - @backstage/plugin-auth-backend-module-aws-alb-provider@0.1.6
+  - @backstage/plugin-auth-backend-module-github-provider@0.1.11
+  - @backstage/plugin-auth-backend-module-gitlab-provider@0.1.11
+  - @backstage/plugin-auth-backend-module-google-provider@0.1.11
+  - @backstage/plugin-auth-backend-module-microsoft-provider@0.1.9
+  - @backstage/plugin-auth-backend-module-oauth2-provider@0.1.11
+  - @backstage/plugin-auth-backend-module-oidc-provider@0.1.5
+  - @backstage/plugin-auth-backend-module-okta-provider@0.0.7
+
 ## 0.22.0
 
 ### Minor Changes

--- a/plugins/auth-backend/package.json
+++ b/plugins/auth-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-auth-backend",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "A Backstage backend plugin that handles authentication",
   "backstage": {
     "role": "backend-plugin"

--- a/plugins/azure-devops-backend/CHANGELOG.md
+++ b/plugins/azure-devops-backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-azure-devops-backend
 
+## 0.6.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-node@1.9.0
+
 ## 0.6.0
 
 ### Minor Changes

--- a/plugins/azure-devops-backend/package.json
+++ b/plugins/azure-devops-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-azure-devops-backend",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/azure-sites-backend/CHANGELOG.md
+++ b/plugins/azure-sites-backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-azure-sites-backend
 
+## 0.3.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-node@1.9.0
+
 ## 0.3.0
 
 ### Minor Changes

--- a/plugins/azure-sites-backend/package.json
+++ b/plugins/azure-sites-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-azure-sites-backend",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-backend-module-aws/CHANGELOG.md
+++ b/plugins/catalog-backend-module-aws/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-catalog-backend-module-aws
 
+## 0.3.9
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-node@1.9.0
+
 ## 0.3.8
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-aws/package.json
+++ b/plugins/catalog-backend-module-aws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-aws",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "A Backstage catalog backend module that helps integrate towards AWS",
   "backstage": {
     "role": "backend-plugin-module"

--- a/plugins/catalog-backend-module-azure/CHANGELOG.md
+++ b/plugins/catalog-backend-module-azure/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-catalog-backend-module-azure
 
+## 0.1.34
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-node@1.9.0
+
 ## 0.1.33
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-azure/package.json
+++ b/plugins/catalog-backend-module-azure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-azure",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "description": "A Backstage catalog backend module that helps integrate towards Azure",
   "backstage": {
     "role": "backend-plugin-module"

--- a/plugins/catalog-backend-module-backstage-openapi/CHANGELOG.md
+++ b/plugins/catalog-backend-module-backstage-openapi/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-catalog-backend-module-backstage-openapi
 
+## 0.1.8
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-node@1.9.0
+
 ## 0.1.7
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-backstage-openapi/package.json
+++ b/plugins/catalog-backend-module-backstage-openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-backstage-openapi",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "backstage": {
     "role": "backend-plugin-module"
   },

--- a/plugins/catalog-backend-module-bitbucket-cloud/CHANGELOG.md
+++ b/plugins/catalog-backend-module-bitbucket-cloud/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-catalog-backend-module-bitbucket-cloud
 
+## 0.2.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-node@1.9.0
+
 ## 0.2.0
 
 ### Minor Changes

--- a/plugins/catalog-backend-module-bitbucket-cloud/package.json
+++ b/plugins/catalog-backend-module-bitbucket-cloud/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-bitbucket-cloud",
   "description": "A Backstage catalog backend module that helps integrate towards Bitbucket Cloud",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-backend-module-bitbucket-server/CHANGELOG.md
+++ b/plugins/catalog-backend-module-bitbucket-server/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-catalog-backend-module-bitbucket-server
 
+## 0.1.28
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-node@1.9.0
+
 ## 0.1.27
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-bitbucket-server/package.json
+++ b/plugins/catalog-backend-module-bitbucket-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-bitbucket-server",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-backend-module-gcp/CHANGELOG.md
+++ b/plugins/catalog-backend-module-gcp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-catalog-backend-module-gcp
 
+## 0.1.15
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-node@1.9.0
+
 ## 0.1.14
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-gcp/package.json
+++ b/plugins/catalog-backend-module-gcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-gcp",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "A Backstage catalog backend module that helps integrate towards GCP",
   "backstage": {
     "role": "backend-plugin-module"

--- a/plugins/catalog-backend-module-gerrit/CHANGELOG.md
+++ b/plugins/catalog-backend-module-gerrit/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-catalog-backend-module-gerrit
 
+## 0.1.31
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-node@1.9.0
+
 ## 0.1.30
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-gerrit/package.json
+++ b/plugins/catalog-backend-module-gerrit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-gerrit",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "backstage": {
     "role": "backend-plugin-module"
   },

--- a/plugins/catalog-backend-module-github-org/CHANGELOG.md
+++ b/plugins/catalog-backend-module-github-org/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-catalog-backend-module-github-org
 
+## 0.1.9
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-node@1.9.0
+  - @backstage/plugin-catalog-backend-module-github@0.5.5
+
 ## 0.1.8
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-github-org/package.json
+++ b/plugins/catalog-backend-module-github-org/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-github-org",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "The github-org backend module for the catalog plugin.",
   "backstage": {
     "role": "backend-plugin-module"

--- a/plugins/catalog-backend-module-github/CHANGELOG.md
+++ b/plugins/catalog-backend-module-github/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-catalog-backend-module-github
 
+## 0.5.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-backend@1.19.0
+  - @backstage/plugin-catalog-node@1.9.0
+
 ## 0.5.4
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-github/package.json
+++ b/plugins/catalog-backend-module-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-github",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "A Backstage catalog backend module that helps integrate towards GitHub",
   "backstage": {
     "role": "backend-plugin-module"

--- a/plugins/catalog-backend-module-gitlab/CHANGELOG.md
+++ b/plugins/catalog-backend-module-gitlab/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-catalog-backend-module-gitlab
 
+## 0.3.12
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-node@1.9.0
+
 ## 0.3.11
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-gitlab/package.json
+++ b/plugins/catalog-backend-module-gitlab/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-gitlab",
   "description": "A Backstage catalog backend module that helps integrate towards GitLab",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-backend-module-incremental-ingestion/CHANGELOG.md
+++ b/plugins/catalog-backend-module-incremental-ingestion/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-catalog-backend-module-incremental-ingestion
 
+## 0.4.19
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-backend@1.19.0
+  - @backstage/plugin-catalog-node@1.9.0
+
 ## 0.4.18
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-incremental-ingestion/package.json
+++ b/plugins/catalog-backend-module-incremental-ingestion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-incremental-ingestion",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "description": "An entity provider for streaming large asset sources into the catalog",
   "backstage": {
     "role": "backend-plugin-module"

--- a/plugins/catalog-backend-module-ldap/CHANGELOG.md
+++ b/plugins/catalog-backend-module-ldap/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-catalog-backend-module-ldap
 
+## 0.5.30
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-node@1.9.0
+
 ## 0.5.29
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-ldap/package.json
+++ b/plugins/catalog-backend-module-ldap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-ldap",
   "description": "A Backstage catalog backend module that helps integrate towards LDAP",
-  "version": "0.5.29",
+  "version": "0.5.30",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-backend-module-msgraph/CHANGELOG.md
+++ b/plugins/catalog-backend-module-msgraph/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-catalog-backend-module-msgraph
 
+## 0.5.22
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-node@1.9.0
+
 ## 0.5.21
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-msgraph/package.json
+++ b/plugins/catalog-backend-module-msgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-msgraph",
-  "version": "0.5.21",
+  "version": "0.5.22",
   "description": "A Backstage catalog backend module that helps integrate towards Microsoft Graph",
   "backstage": {
     "role": "backend-plugin-module"

--- a/plugins/catalog-backend-module-openapi/CHANGELOG.md
+++ b/plugins/catalog-backend-module-openapi/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-catalog-backend-module-openapi
 
+## 0.1.32
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-backend@1.19.0
+  - @backstage/plugin-catalog-node@1.9.0
+
 ## 0.1.31
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-openapi/package.json
+++ b/plugins/catalog-backend-module-openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-openapi",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "description": "A Backstage catalog backend module that helps with OpenAPI specifications",
   "backstage": {
     "role": "backend-plugin-module"

--- a/plugins/catalog-backend-module-puppetdb/CHANGELOG.md
+++ b/plugins/catalog-backend-module-puppetdb/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-catalog-backend-module-puppetdb
 
+## 0.1.20
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-node@1.9.0
+
 ## 0.1.19
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-puppetdb/package.json
+++ b/plugins/catalog-backend-module-puppetdb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-puppetdb",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "A Backstage catalog backend module that helps integrate towards PuppetDB",
   "backstage": {
     "role": "backend-plugin-module"

--- a/plugins/catalog-backend-module-scaffolder-entity-model/CHANGELOG.md
+++ b/plugins/catalog-backend-module-scaffolder-entity-model/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-catalog-backend-module-scaffolder-entity-model
 
+## 0.1.12
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-node@1.9.0
+
 ## 0.1.11
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-scaffolder-entity-model/package.json
+++ b/plugins/catalog-backend-module-scaffolder-entity-model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-scaffolder-entity-model",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Adds support for the scaffolder specific entity model (e.g. the Template kind) to the catalog backend plugin.",
   "backstage": {
     "role": "backend-plugin-module"

--- a/plugins/catalog-backend-module-unprocessed/CHANGELOG.md
+++ b/plugins/catalog-backend-module-unprocessed/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-catalog-backend-module-unprocessed
 
+## 0.4.1
+
+### Patch Changes
+
+- 9c7fb30: Internal update that injects custom permissions into the catalog using its extension point
+- Updated dependencies
+  - @backstage/plugin-catalog-node@1.9.0
+
 ## 0.4.0
 
 ### Minor Changes

--- a/plugins/catalog-backend-module-unprocessed/package.json
+++ b/plugins/catalog-backend-module-unprocessed/package.json
@@ -40,9 +40,9 @@
     "@backstage/catalog-model": "workspace:^",
     "@backstage/errors": "workspace:^",
     "@backstage/plugin-auth-node": "workspace:^",
+    "@backstage/plugin-catalog-node": "workspace:^",
     "@backstage/plugin-catalog-unprocessed-entities-common": "workspace:^",
     "@backstage/plugin-permission-common": "workspace:^",
-    "@backstage/plugin-permission-node": "workspace:^",
     "express-promise-router": "^4.1.1",
     "knex": "^3.0.0"
   }

--- a/plugins/catalog-backend-module-unprocessed/package.json
+++ b/plugins/catalog-backend-module-unprocessed/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-unprocessed",
   "description": "Backstage Catalog module to view unprocessed entities",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-backend-module-unprocessed/src/UnprocessedEntitiesModule.ts
+++ b/plugins/catalog-backend-module-unprocessed/src/UnprocessedEntitiesModule.ts
@@ -34,7 +34,6 @@ import {
   AuthorizeResult,
   BasicPermission,
 } from '@backstage/plugin-permission-common';
-import { createPermissionIntegrationRouter } from '@backstage/plugin-permission-node';
 import { unprocessedEntitiesDeletePermission } from '@backstage/plugin-catalog-unprocessed-entities-common';
 import { NotAllowedError } from '@backstage/errors';
 import { createLegacyAuthAdapters } from '@backstage/backend-common';
@@ -145,10 +144,6 @@ export class UnprocessedEntitiesModule {
   }
 
   registerRoutes() {
-    const permissionIntegrationRouter = createPermissionIntegrationRouter({
-      permissions: [unprocessedEntitiesDeletePermission],
-    });
-
     const isRequestAuthorized = async (
       req: Request,
       permission: BasicPermission,
@@ -161,8 +156,6 @@ export class UnprocessedEntitiesModule {
 
       return decision.result !== AuthorizeResult.DENY;
     };
-
-    this.router.use(permissionIntegrationRouter);
 
     this.moduleRouter
       .get('/entities/unprocessed/failed', async (req, res) => {

--- a/plugins/catalog-backend-module-unprocessed/src/module.ts
+++ b/plugins/catalog-backend-module-unprocessed/src/module.ts
@@ -19,6 +19,8 @@ import {
   createBackendModule,
 } from '@backstage/backend-plugin-api';
 import { UnprocessedEntitiesModule } from './UnprocessedEntitiesModule';
+import { catalogPermissionExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
+import { unprocessedEntitiesDeletePermission } from '@backstage/plugin-catalog-unprocessed-entities-common';
 
 /**
  * Catalog Module for Unprocessed Entities
@@ -37,6 +39,7 @@ export const catalogModuleUnprocessedEntities = createBackendModule({
         httpAuth: coreServices.httpAuth,
         discovery: coreServices.discovery,
         permissions: coreServices.permissions,
+        catalogPermissions: catalogPermissionExtensionPoint,
       },
       async init({
         database,
@@ -45,6 +48,7 @@ export const catalogModuleUnprocessedEntities = createBackendModule({
         permissions,
         httpAuth,
         discovery,
+        catalogPermissions,
       }) {
         const module = UnprocessedEntitiesModule.create({
           database: await database.getClient(),
@@ -53,6 +57,8 @@ export const catalogModuleUnprocessedEntities = createBackendModule({
           discovery,
           httpAuth,
         });
+
+        catalogPermissions.addPermissions(unprocessedEntitiesDeletePermission);
 
         module.registerRoutes();
 

--- a/plugins/catalog-backend/CHANGELOG.md
+++ b/plugins/catalog-backend/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage/plugin-catalog-backend
 
+## 1.19.0
+
+### Minor Changes
+
+- 9c7fb30: Added the ability to inject custom permissions from modules, on `CatalogBuilder` and `CatalogPermissionExtensionPoint`
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-node@1.9.0
+  - @backstage/plugin-search-backend-module-catalog@0.1.19
+
 ## 1.18.0
 
 ### Minor Changes

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -148,6 +148,7 @@ export class CatalogBuilder {
       CatalogPermissionRuleInput | Array<CatalogPermissionRuleInput>
     >
   ): this;
+  addPermissions(...permissions: Array<Permission | Array<Permission>>): this;
   addProcessor(
     ...processors: Array<CatalogProcessor_2 | Array<CatalogProcessor_2>>
   ): CatalogBuilder;

--- a/plugins/catalog-backend/package.json
+++ b/plugins/catalog-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "The Backstage backend plugin that provides the Backstage catalog",
   "backstage": {
     "role": "backend-plugin"

--- a/plugins/catalog-backend/src/service/CatalogPlugin.ts
+++ b/plugins/catalog-backend/src/service/CatalogPlugin.ts
@@ -38,6 +38,7 @@ import {
 } from '@backstage/plugin-catalog-node';
 import { loggerToWinstonLogger } from '@backstage/backend-common';
 import { merge } from 'lodash';
+import { Permission } from '@backstage/plugin-permission-common';
 
 class CatalogProcessingExtensionPointImpl
   implements CatalogProcessingExtensionPoint
@@ -113,7 +114,12 @@ class CatalogAnalysisExtensionPointImpl
 class CatalogPermissionExtensionPointImpl
   implements CatalogPermissionExtensionPoint
 {
+  #permissions = new Array<Permission>();
   #permissionRules = new Array<CatalogPermissionRuleInput>();
+
+  addPermissions(...permission: Array<Permission | Array<Permission>>): void {
+    this.#permissions.push(...permission.flat());
+  }
 
   addPermissionRules(
     ...rules: Array<
@@ -121,6 +127,10 @@ class CatalogPermissionExtensionPointImpl
     >
   ): void {
     this.#permissionRules.push(...rules.flat());
+  }
+
+  get permissions() {
+    return this.#permissions;
   }
 
   get permissionRules() {
@@ -239,6 +249,7 @@ export const catalogPlugin = createBackendPlugin({
           ([key, resolver]) => builder.setPlaceholderResolver(key, resolver),
         );
         builder.addLocationAnalyzers(...analysisExtensions.locationAnalyzers);
+        builder.addPermissions(...permissionExtensions.permissions);
         builder.addPermissionRules(...permissionExtensions.permissionRules);
         builder.setFieldFormatValidators(modelExtensions.fieldValidators);
 

--- a/plugins/catalog-node/CHANGELOG.md
+++ b/plugins/catalog-node/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/plugin-catalog-node
 
+## 1.9.0
+
+### Minor Changes
+
+- 9c7fb30: Added the ability to inject custom permissions from modules, on `CatalogBuilder` and `CatalogPermissionExtensionPoint`
+
 ## 1.8.0
 
 ### Minor Changes

--- a/plugins/catalog-node/api-report-alpha.md
+++ b/plugins/catalog-node/api-report-alpha.md
@@ -10,6 +10,7 @@ import { EntitiesSearchFilter } from '@backstage/plugin-catalog-node';
 import { Entity } from '@backstage/catalog-model';
 import { EntityProvider } from '@backstage/plugin-catalog-node';
 import { ExtensionPoint } from '@backstage/backend-plugin-api';
+import { Permission } from '@backstage/plugin-permission-common';
 import { PermissionRule } from '@backstage/plugin-permission-node';
 import { PermissionRuleParams } from '@backstage/plugin-permission-common';
 import { PlaceholderResolver } from '@backstage/plugin-catalog-node';
@@ -43,6 +44,8 @@ export interface CatalogPermissionExtensionPoint {
       CatalogPermissionRuleInput | Array<CatalogPermissionRuleInput>
     >
   ): void;
+  // (undocumented)
+  addPermissions(...permissions: Array<Permission | Array<Permission>>): void;
 }
 
 // @alpha (undocumented)

--- a/plugins/catalog-node/package.json
+++ b/plugins/catalog-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-node",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "The plugin-catalog-node module for @backstage/plugin-catalog-backend",
   "backstage": {
     "role": "node-library"

--- a/plugins/catalog-node/src/extensions.ts
+++ b/plugins/catalog-node/src/extensions.ts
@@ -24,7 +24,10 @@ import {
   PlaceholderResolver,
   ScmLocationAnalyzer,
 } from '@backstage/plugin-catalog-node';
-import { PermissionRuleParams } from '@backstage/plugin-permission-common';
+import {
+  Permission,
+  PermissionRuleParams,
+} from '@backstage/plugin-permission-common';
 import { PermissionRule } from '@backstage/plugin-permission-node';
 
 /**
@@ -104,6 +107,7 @@ export type CatalogPermissionRuleInput<
  * @alpha
  */
 export interface CatalogPermissionExtensionPoint {
+  addPermissions(...permissions: Array<Permission | Array<Permission>>): void;
   addPermissionRules(
     ...rules: Array<
       CatalogPermissionRuleInput | Array<CatalogPermissionRuleInput>

--- a/plugins/jenkins-backend/CHANGELOG.md
+++ b/plugins/jenkins-backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-jenkins-backend
 
+## 0.4.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-node@1.9.0
+
 ## 0.4.0
 
 ### Minor Changes

--- a/plugins/jenkins-backend/package.json
+++ b/plugins/jenkins-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-jenkins-backend",
   "description": "A Backstage backend plugin that integrates towards Jenkins",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/kubernetes-backend/CHANGELOG.md
+++ b/plugins/kubernetes-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-kubernetes-backend
 
+## 0.16.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-node@1.9.0
+  - @backstage/plugin-kubernetes-node@0.1.8
+
 ## 0.16.0
 
 ### Minor Changes

--- a/plugins/kubernetes-backend/package.json
+++ b/plugins/kubernetes-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-kubernetes-backend",
   "description": "A Backstage backend plugin that integrates towards Kubernetes",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/lighthouse-backend/CHANGELOG.md
+++ b/plugins/lighthouse-backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-lighthouse-backend
 
+## 0.4.7
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-node@1.9.0
+
 ## 0.4.6
 
 ### Patch Changes

--- a/plugins/lighthouse-backend/package.json
+++ b/plugins/lighthouse-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-lighthouse-backend",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Backend functionalities for lighthouse",
   "backstage": {
     "role": "backend-plugin"

--- a/plugins/linguist-backend/CHANGELOG.md
+++ b/plugins/linguist-backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-linguist-backend
 
+## 0.5.12
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-node@1.9.0
+
 ## 0.5.11
 
 ### Patch Changes

--- a/plugins/linguist-backend/package.json
+++ b/plugins/linguist-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-linguist-backend",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "backstage": {
     "role": "backend-plugin"
   },

--- a/plugins/permission-backend/CHANGELOG.md
+++ b/plugins/permission-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/plugin-permission-backend
 
+## 0.5.38
+
+### Patch Changes
+
+- 9c7fb30: Properly forward causes of errors from upstream backends in the `PermissionIntegrationClient`
+
 ## 0.5.37
 
 ### Patch Changes

--- a/plugins/permission-backend/package.json
+++ b/plugins/permission-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-permission-backend",
-  "version": "0.5.37",
+  "version": "0.5.38",
   "backstage": {
     "role": "backend-plugin"
   },

--- a/plugins/permission-backend/src/service/PermissionIntegrationClient.ts
+++ b/plugins/permission-backend/src/service/PermissionIntegrationClient.ts
@@ -29,6 +29,7 @@ import {
   BackstageCredentials,
   DiscoveryService,
 } from '@backstage/backend-plugin-api';
+import { ResponseError } from '@backstage/errors';
 
 const responseSchema = z.object({
   items: z.array(
@@ -90,9 +91,7 @@ export class PermissionIntegrationClient {
     });
 
     if (!response.ok) {
-      throw new Error(
-        `Unexpected response from plugin upstream when applying conditions. Expected 200 but got ${response.status} - ${response.statusText}`,
-      );
+      throw await ResponseError.fromResponse(response);
     }
 
     const result = responseSchema.parse(await response.json());

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
@@ -162,7 +162,6 @@ const applyConditions = <TResourceType extends string, TResource>(
 };
 
 /**
-
  * Takes some permission conditions and returns a definitive authorization result
  * on the resource to which they apply.
  *

--- a/plugins/scaffolder-backend/CHANGELOG.md
+++ b/plugins/scaffolder-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-scaffolder-backend
 
+## 1.22.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-node@1.9.0
+  - @backstage/plugin-catalog-backend-module-scaffolder-entity-model@0.1.12
+
 ## 1.22.0
 
 ### Minor Changes

--- a/plugins/scaffolder-backend/package.json
+++ b/plugins/scaffolder-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-scaffolder-backend",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "description": "The Backstage backend plugin that helps you create new things",
   "backstage": {
     "role": "backend-plugin"

--- a/plugins/search-backend-module-catalog/CHANGELOG.md
+++ b/plugins/search-backend-module-catalog/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-search-backend-module-catalog
 
+## 0.1.19
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-node@1.9.0
+
 ## 0.1.18
 
 ### Patch Changes

--- a/plugins/search-backend-module-catalog/package.json
+++ b/plugins/search-backend-module-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-search-backend-module-catalog",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "A module for the search backend that exports catalog modules",
   "backstage": {
     "role": "backend-plugin-module"

--- a/plugins/search-backend-module-techdocs/CHANGELOG.md
+++ b/plugins/search-backend-module-techdocs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-search-backend-module-techdocs
 
+## 0.1.19
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-node@1.9.0
+
 ## 0.1.18
 
 ### Patch Changes

--- a/plugins/search-backend-module-techdocs/package.json
+++ b/plugins/search-backend-module-techdocs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-search-backend-module-techdocs",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "A module for the search backend that exports techdocs modules",
   "backstage": {
     "role": "backend-plugin-module"

--- a/plugins/techdocs-backend/CHANGELOG.md
+++ b/plugins/techdocs-backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-techdocs-backend
 
+## 1.10.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-search-backend-module-techdocs@0.1.19
+
 ## 1.10.0
 
 ### Minor Changes

--- a/plugins/techdocs-backend/package.json
+++ b/plugins/techdocs-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-techdocs-backend",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "The Backstage backend plugin that renders technical documentation for your components",
   "backstage": {
     "role": "backend-plugin"

--- a/plugins/todo-backend/CHANGELOG.md
+++ b/plugins/todo-backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-todo-backend
 
+## 0.3.13
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-node@1.9.0
+
 ## 0.3.12
 
 ### Patch Changes

--- a/plugins/todo-backend/package.json
+++ b/plugins/todo-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-todo-backend",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "A Backstage backend plugin that lets you browse TODO comments in your source code",
   "backstage": {
     "role": "backend-plugin"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5631,9 +5631,9 @@ __metadata:
     "@backstage/cli": "workspace:^"
     "@backstage/errors": "workspace:^"
     "@backstage/plugin-auth-node": "workspace:^"
+    "@backstage/plugin-catalog-node": "workspace:^"
     "@backstage/plugin-catalog-unprocessed-entities-common": "workspace:^"
     "@backstage/plugin-permission-common": "workspace:^"
-    "@backstage/plugin-permission-node": "workspace:^"
     "@types/express": ^4.17.6
     express-promise-router: ^4.1.1
     knex: ^3.0.0


### PR DESCRIPTION
This release fixes an issue where installing the `@backstage/plugin-catalog-backend-module-unprocessed`, while having permissions enabled, interfered with the way that permissions were resolved by the catalog backend itself.