### PR TITLE
Keep log stream open when running a container with KubernetesContainerRunner

### DIFF
--- a/.changeset/wise-moons-begin.md
+++ b/.changeset/wise-moons-begin.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+KubernetesContainerRunner.runContainer no longer closes the `logStream` is receives as input.

--- a/.changeset/wise-moons-begin.md
+++ b/.changeset/wise-moons-begin.md
@@ -2,4 +2,4 @@
 '@backstage/backend-common': patch
 ---
 
-KubernetesContainerRunner.runContainer no longer closes the `logStream` is receives as input.
+KubernetesContainerRunner.runContainer no longer closes the `logStream` it receives as input.

--- a/packages/backend-common/src/util/KubernetesContainerRunner.test.ts
+++ b/packages/backend-common/src/util/KubernetesContainerRunner.test.ts
@@ -204,6 +204,7 @@ describeIfKubernetes('KubernetesContainerRunner', () => {
     await containerRunner.runContainer(runOptions);
 
     expect(logStream.writableEnded).toBe(false);
+    expect(logStream.destroyed).toBe(false);
   });
 
   describe('with namespace test', () => {

--- a/packages/backend-common/src/util/KubernetesContainerRunner.test.ts
+++ b/packages/backend-common/src/util/KubernetesContainerRunner.test.ts
@@ -187,6 +187,25 @@ describeIfKubernetes('KubernetesContainerRunner', () => {
     );
   });
 
+  it('should not close the original log stream', async () => {
+    const options: KubernetesContainerRunnerOptions = {
+      kubeConfig,
+      name,
+      namespace: 'default',
+    };
+    const containerRunner = new KubernetesContainerRunner(options);
+    const logStream = new PassThrough();
+    const runOptions: RunContainerOptions = {
+      imageName: 'alpine',
+      args: ['echo', 'hello world'],
+      logStream,
+    };
+
+    await containerRunner.runContainer(runOptions);
+
+    expect(logStream.closed).toBe(false);
+  });
+
   describe('with namespace test', () => {
     let api: CoreV1Api;
     let authApi: RbacAuthorizationV1Api;

--- a/packages/backend-common/src/util/KubernetesContainerRunner.test.ts
+++ b/packages/backend-common/src/util/KubernetesContainerRunner.test.ts
@@ -203,7 +203,7 @@ describeIfKubernetes('KubernetesContainerRunner', () => {
 
     await containerRunner.runContainer(runOptions);
 
-    expect(logStream.closed).toBe(false);
+    expect(logStream.writableEnded).toBe(false);
   });
 
   describe('with namespace test', () => {

--- a/packages/backend-common/src/util/KubernetesContainerRunner.ts
+++ b/packages/backend-common/src/util/KubernetesContainerRunner.ts
@@ -132,11 +132,16 @@ export class KubernetesContainerRunner implements ContainerRunner {
       imageName,
       command,
       args,
-      logStream = new PassThrough(),
+      logStream,
       mountDirs = {},
       workingDir,
       envVars = {},
     } = options;
+
+    const containerLogStream = new PassThrough();
+    if (logStream) {
+      containerLogStream.pipe(logStream, { end: false });
+    }
 
     const commandArr = typeof command === 'string' ? [command] : command;
 
@@ -209,7 +214,7 @@ export class KubernetesContainerRunner implements ContainerRunner {
       },
     };
 
-    await this.runJob(jobSpec, taskId, logStream);
+    await this.runJob(jobSpec, taskId, containerLogStream);
   }
 
   private handleError(err: any, errorCallback: (reason: any) => void) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When using the scaffolder, you can run a a container with `KubernetesContainerRunner.runContainer`. It supports passing in a log stream, which makes it so logs from the container are streamed to the original log stream. It seems that `@kubernetes/client-node` which is used internally closes the stream when the container has finished running. This might come off as unexpected when the user passes in their log stream like this:

```ts
createTemplateAction({
  id: 'myaction',
  handler: async ctx => {
    const runner = new KubernetesContainerRunner({});
    runner.runContainer({
      imageName: 'ubuntu',
      args: [],
      logStream: ctx.logStream,
    })
  }
})
```

In this sample, `ctx.logStream` gets closed and the action will no longer be able to write logs.

This PR fixes this problem, by creating another stream that pipes data to the original stream. The new stream won't be able to close the original log stream.

closes #23770

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
