### PR TITLE
permission-backend: fix unauthenticated authorization

### DIFF
--- a/.changeset/empty-bugs-push.md
+++ b/.changeset/empty-bugs-push.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-permission-backend': patch
+---
+
+Fixed an issue where unauthorized requests were rejected by the `/authorize` endpoint, breaking unauthenticated permission flows.

--- a/plugins/permission-backend/src/plugin.ts
+++ b/plugins/permission-backend/src/plugin.ts
@@ -90,6 +90,10 @@ export const permissionPlugin = createBackendPlugin({
           path: '/health',
           allow: 'unauthenticated',
         });
+        http.addAuthPolicy({
+          path: '/authorize',
+          allow: 'unauthenticated',
+        });
       },
     });
   },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `/authorize` endpoint endpoint is supposed to be able to handle unauthenticated requests, as is evident here:

https://github.com/backstage/backstage/blob/9802004e10d4f97bdec40f49e50ea090498c5146/plugins/permission-backend/src/service/router.ts#L225-L227

This allows them through, ensuring that unauthenticated authorization isn't broken, which is particularly important when the default auth policy is disabled.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
