### PR TITLE
proxy-backend: allow unauthenticated requests

### DIFF
--- a/.changeset/five-grapes-love.md
+++ b/.changeset/five-grapes-love.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-proxy-backend': patch
+---
+
+Allow unauthenticated requests.

--- a/plugins/proxy-backend/src/alpha.ts
+++ b/plugins/proxy-backend/src/alpha.ts
@@ -44,6 +44,10 @@ export default createBackendPlugin({
             logger: loggerToWinstonLogger(logger),
           }),
         );
+        httpRouter.addAuthPolicy({
+          allow: 'unauthenticated',
+          path: '/',
+        });
       },
     });
   },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Requests to the proxy plugin should not require Backstage user authentication

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
