### PR TITLE
Fix rootHttpRouter service example

### DIFF
--- a/docs/backend-system/core-services/root-http-router.md
+++ b/docs/backend-system/core-services/root-http-router.md
@@ -27,11 +27,11 @@ createBackendPlugin({
       },
       async init({ rootHttpRouter }) {
         const router = Router();
-        router.get('/health', (request, response) => {
+        router.get('', (request, response) => {
           response.send('OK');
         });
 
-        rootHttpRouter.use(router);
+        rootHttpRouter.use('/health', router);
       },
     });
   },

--- a/docs/backend-system/core-services/root-http-router.md
+++ b/docs/backend-system/core-services/root-http-router.md
@@ -27,7 +27,7 @@ createBackendPlugin({
       },
       async init({ rootHttpRouter }) {
         const router = Router();
-        router.get('', (request, response) => {
+        router.get('/readiness', (request, response) => {
           response.send('OK');
         });
 


### PR DESCRIPTION
Hey 🙂  The example in the rootHttpRouter service documentation indicates that the router also exposes a `use(handler)` method, which is not the case. This PR updates that example.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- ~[ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))~
- [x] Added or updated documentation
- ~[ ] Tests for new functionality and regression tests for bug fixes~
- ~[ ] Screenshots attached (for UI changes)~
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
