### PR TITLE
Add backstage to Backstage Software Catalog

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -2,22 +2,7 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: backstage
-  description: |
-    Backstage is an open-source developer portal that puts the developer experience first.
-  links:
-    - title: Website
-      url: http://backstage.io
-    - title: Documentation
-      url: https://backstage.io/docs
-    - title: Storybook
-      url: https://backstage.io/storybook
-    - title: Discord Chat
-      url: https://discord.com/invite/EBHEGzX
-  annotations:
-    github.com/project-slug: backstage/backstage
-    backstage.io/techdocs-ref: dir:.
-    lighthouse.com/website-url: https://backstage.io
 spec:
-  type: library
-  owner: CNCF
+  type: service
   lifecycle: experimental
+  owner: sharks


### PR DESCRIPTION

## TL;DR

This pull request registers backstage, as a component in our Backstage Software Catalog. 
It lists our team, sharks, as the owners of this component.
After this file has merged, you can view this component in Backstage Software Catalog here: → http://localhost:3000/catalog

## What is Backstage?

[Backstage](https://backstage.io/) is an open platform for building developer portals. Powered by a centralized 
software catalog, Backstage restores order to your microservices and infrastructure and enables your product teams 
to ship high-quality code quickly without compromising autonomy.

Backstage unifies all your infrastructure tooling, services, and documentation to create a streamlined development environment from end to end.

[![What is Backstage? (Explainer Video)](https://img.youtube.com/vi/85TQEpNCaU0/hqdefault.jpg)](https://youtu.be/85TQEpNCaU0)
