### PR TITLE
Handle "null" statusCheckRollup values on commits

### DIFF
--- a/.changeset/twelve-comics-double.md
+++ b/.changeset/twelve-comics-double.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-github-pull-requests-board': patch
+---
+
+Handle null values returned from GitHub for the statusCheckRollup value on the commit object

--- a/plugins/github-pull-requests-board/src/components/Card/CardHeader.tsx
+++ b/plugins/github-pull-requests-board/src/components/Card/CardHeader.tsx
@@ -92,7 +92,7 @@ const CardHeader: FunctionComponent<Props> = (props: Props) => {
         <Box display="flex" alignItems="center" flexWrap="wrap" paddingTop={1}>
           <Typography variant="body2" component="p">
             Commit Status:{' '}
-            <strong>{status.commit.statusCheckRollup.state}</strong>
+            <strong>{status.commit.statusCheckRollup?.state || 'N/A'}</strong>
           </Typography>
         </Box>
       )}

--- a/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsCard/EntityTeamPullRequestsCard.test.tsx
+++ b/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsCard/EntityTeamPullRequestsCard.test.tsx
@@ -96,9 +96,7 @@ jest.mock('../../hooks/usePullRequestsByTeam', () => {
           isArchived: false,
           status: {
             commit: {
-              statusCheckRollup: {
-                state: 'FAILURE',
-              },
+              statusCheckRollup: null,
             },
           },
         }),

--- a/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsContent/EntityTeamPullRequestsContent.test.tsx
+++ b/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsContent/EntityTeamPullRequestsContent.test.tsx
@@ -96,9 +96,7 @@ jest.mock('../../hooks/usePullRequestsByTeam', () => {
           isArchived: false,
           status: {
             commit: {
-              statusCheckRollup: {
-                state: 'FAILURE',
-              },
+              statusCheckRollup: null,
             },
           },
         }),

--- a/plugins/github-pull-requests-board/src/utils/types.tsx
+++ b/plugins/github-pull-requests-board/src/utils/types.tsx
@@ -85,7 +85,7 @@ export type Status = {
   commit: {
     statusCheckRollup: {
       state: string;
-    };
+    } | null;
   };
 };
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The [0.1.25-next.0](https://www.npmjs.com/package/@backstage/plugin-github-pull-requests-board/v/0.1.25-next.0) release of the `@backstage/plugin-github-pull-requests-board` plugin added functionality to display the PR status. At least in our environment (GitHub Enterprise Server, v3.11.4), some pull requests return a `null` value for the `statusCheckRollup` field from the GitHub GraphQL endpoint. This PR adjusts the type definition as well as the usage of this field to handle `null` values safely.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
