### PR TITLE
fix: don't show login prompt if token is defined in state

### DIFF
--- a/.changeset/thick-pets-attend.md
+++ b/.changeset/thick-pets-attend.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Don't show login prompt if token is set in the state

--- a/plugins/scaffolder-react/api-report.md
+++ b/plugins/scaffolder-react/api-report.md
@@ -455,7 +455,9 @@ export interface ScaffolderUseTemplateSecrets {
 
 // @public
 export const SecretsContextProvider: (
-  props: PropsWithChildren<{}>,
+  props: PropsWithChildren<{
+    initialSecrets?: Record<string, string>;
+  }>,
 ) => React_2.JSX.Element;
 
 // @public

--- a/plugins/scaffolder-react/src/secrets/SecretsContext.test.tsx
+++ b/plugins/scaffolder-react/src/secrets/SecretsContext.test.tsx
@@ -35,4 +35,20 @@ describe('SecretsContext', () => {
 
     expect(result.current.hook?.secrets.foo).toEqual('bar');
   });
+
+  it('should create SecretsContextProvider with initial secrets', async () => {
+    const { result } = renderHook(
+      () => ({
+        hook: useTemplateSecrets(),
+      }),
+      {
+        wrapper: ({ children }: React.PropsWithChildren<{}>) => (
+          <SecretsContextProvider initialSecrets={{ foo: 'bar' }}>
+            {children}
+          </SecretsContextProvider>
+        ),
+      },
+    );
+    expect(result.current.hook?.secrets.foo).toEqual('bar');
+  });
 });

--- a/plugins/scaffolder-react/src/secrets/SecretsContext.tsx
+++ b/plugins/scaffolder-react/src/secrets/SecretsContext.tsx
@@ -43,8 +43,13 @@ const SecretsContext = createVersionedContext<{
  * The Context Provider that holds the state for the secrets.
  * @public
  */
-export const SecretsContextProvider = (props: PropsWithChildren<{}>) => {
-  const [secrets, setSecrets] = useState<Record<string, string>>({});
+export const SecretsContextProvider = (
+  props: PropsWithChildren<{ initialSecrets?: Record<string, string> }>,
+) => {
+  const { initialSecrets = {} } = props;
+  const [secrets, setSecrets] = useState<Record<string, string>>({
+    ...initialSecrets,
+  });
 
   return (
     <SecretsContext.Provider

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.test.tsx
@@ -58,9 +58,13 @@ describe('RepoUrlPicker', () => {
     byHost: () => ({ type: 'github' }),
   };
 
-  const mockScmAuthApi: Partial<ScmAuthApi> = {
-    getCredentials: jest.fn().mockResolvedValue({ token: 'abc123' }),
-  };
+  let mockScmAuthApi: Partial<ScmAuthApi>;
+
+  beforeEach(() => {
+    mockScmAuthApi = {
+      getCredentials: jest.fn().mockResolvedValue({ token: 'abc123' }),
+    };
+  });
 
   describe('happy path rendering', () => {
     it('should render the repo url picker with minimal props', async () => {
@@ -341,6 +345,65 @@ describe('RepoUrlPicker', () => {
           repoWrite: true,
         },
       });
+
+      const currentSecrets = JSON.parse(
+        getByTestId('current-secrets').textContent!,
+      );
+
+      expect(currentSecrets).toEqual({
+        secrets: { testKey: 'abc123' },
+      });
+    });
+
+    it('should not call the scmAuthApi if secret is available in the state', async () => {
+      const SecretsComponent = () => {
+        const { secrets } = useTemplateSecrets();
+        return (
+          <div data-testid="current-secrets">{JSON.stringify({ secrets })}</div>
+        );
+      };
+      const { getAllByRole, getByTestId } = await renderInTestApp(
+        <TestApiProvider
+          apis={[
+            [scmIntegrationsApiRef, mockIntegrationsApi],
+            [scmAuthApiRef, mockScmAuthApi],
+            [scaffolderApiRef, mockScaffolderApi],
+          ]}
+        >
+          <SecretsContextProvider initialSecrets={{ testKey: 'abc123' }}>
+            <Form
+              validator={validator}
+              schema={{ type: 'string' }}
+              uiSchema={{
+                'ui:field': 'RepoUrlPicker',
+                'ui:options': {
+                  requestUserCredentials: {
+                    secretsKey: 'testKey',
+                    additionalScopes: { github: ['workflow'] },
+                  },
+                },
+              }}
+              fields={{
+                RepoUrlPicker: RepoUrlPicker as ScaffolderRJSFField<string>,
+              }}
+            />
+            <SecretsComponent />
+          </SecretsContextProvider>
+        </TestApiProvider>,
+      );
+
+      const [ownerInput, repoInput] = getAllByRole('textbox');
+
+      await act(async () => {
+        fireEvent.change(ownerInput, { target: { value: 'backstage' } });
+        fireEvent.change(repoInput, { target: { value: 'repo123' } });
+
+        // need to wait for the debounce to finish
+        await new Promise(resolve => setTimeout(resolve, 600));
+      });
+
+      // as we already have a secret in the state, getCredentials should not be called again.
+      expect(mockScmAuthApi.getCredentials).toHaveBeenCalledTimes(0);
 
       const currentSecrets = JSON.parse(
         getByTestId('current-secrets').textContent!,

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
@@ -51,7 +51,7 @@ export const RepoUrlPicker = (props: RepoUrlPickerProps) => {
   );
   const integrationApi = useApi(scmIntegrationsApiRef);
   const scmAuthApi = useApi(scmAuthApiRef);
-  const { setSecrets } = useTemplateSecrets();
+  const { secrets, setSecrets } = useTemplateSecrets();
   const allowedHosts = useMemo(
     () => uiSchema?.['ui:options']?.allowedHosts ?? [],
     [uiSchema],
@@ -129,6 +129,11 @@ export const RepoUrlPicker = (props: RepoUrlPickerProps) => {
         !requestUserCredentials ||
         !(state.host && workspace && state.repoName)
       ) {
+        return;
+      }
+
+      // don't show login prompt if secret value is already in state
+      if (secrets[requestUserCredentials.secretsKey]) {
         return;
       }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
in scaffolder repo URL picker component, there is a bug which is described in this ticket #23761 

The suggested fix is, when there is a token in the state, don't attempt to request a new token if the value of the field (repo name) is changed.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
