### PR TITLE
fix(notifications): export notificationSeverities for reuse

### DIFF
--- a/.changeset/moody-pianos-notice.md
+++ b/.changeset/moody-pianos-notice.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-notifications-backend': patch
+'@backstage/plugin-notifications-common': patch
+---
+
+The ordered list of notifications' severities is exported by notifications-common for reusability.

--- a/.github/vale/config/vocabularies/Backstage/accept.txt
+++ b/.github/vale/config/vocabularies/Backstage/accept.txt
@@ -475,3 +475,4 @@ Zolotusky
 zoomable
 zsh
 scrollable
+severities

--- a/plugins/notifications-backend/src/database/DatabaseNotificationsStore.ts
+++ b/plugins/notifications-backend/src/database/DatabaseNotificationsStore.ts
@@ -25,6 +25,7 @@ import {
 import {
   Notification,
   NotificationSeverity,
+  notificationSeverities,
 } from '@backstage/plugin-notifications-common';
 import { Knex } from 'knex';
 
@@ -49,16 +50,9 @@ const NOTIFICATION_COLUMNS = [
   'saved',
 ];
 
-const severities: NotificationSeverity[] = [
-  'critical',
-  'high',
-  'normal',
-  'low',
-];
-
 export const normalizeSeverity = (input?: string): NotificationSeverity => {
   let lower = (input ?? 'normal').toLowerCase() as NotificationSeverity;
-  if (severities.indexOf(lower) < 0) {
+  if (notificationSeverities.indexOf(lower) < 0) {
     lower = 'normal';
   }
   return lower;
@@ -219,8 +213,8 @@ export class DatabaseNotificationsStore implements NotificationsStore {
     } // or match both if undefined
 
     if (options.minimumSeverity !== undefined) {
-      const idx = severities.indexOf(options.minimumSeverity);
-      const equalOrHigher = severities.slice(0, idx + 1);
+      const idx = notificationSeverities.indexOf(options.minimumSeverity);
+      const equalOrHigher = notificationSeverities.slice(0, idx + 1);
       query.whereIn('severity', equalOrHigher);
     }
 

--- a/plugins/notifications-common/api-report.md
+++ b/plugins/notifications-common/api-report.md
@@ -39,6 +39,9 @@ export type NotificationReadSignal = {
   notification_ids: string[];
 };
 
+// @public
+export const notificationSeverities: NotificationSeverity[];
+
 // @public (undocumented)
 export type NotificationSeverity = 'critical' | 'high' | 'normal' | 'low';
 

--- a/plugins/notifications-common/src/constants.ts
+++ b/plugins/notifications-common/src/constants.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 The Backstage Authors
+ * Copyright 2024 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,12 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { NotificationSeverity } from './types';
 
-/**
- * Common functionalities for the notifications plugin.
+/** Ordered list of severities used by the Notifications.
  *
- * @packageDocumentation
- */
-
-export * from './types';
-export * from './constants';
+ * @public */
+export const notificationSeverities: NotificationSeverity[] = [
+  'critical',
+  'high',
+  'normal',
+  'low',
+];


### PR DESCRIPTION
The ordered array of constants is exported by the notifications-common for reusability by other plugins.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
