### PR TITLE
fix(plugins/catalog-backend-module-backstage-openapi): do not route request through external url but rather the internal one

### DIFF
--- a/.changeset/hungry-suns-hope.md
+++ b/.changeset/hungry-suns-hope.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-backstage-openapi': patch
+---
+
+Use direct access of openapi.json files and not external route

--- a/plugins/catalog-backend-module-backstage-openapi/src/InternalOpenApiDocumentationProvider.ts
+++ b/plugins/catalog-backend-module-backstage-openapi/src/InternalOpenApiDocumentationProvider.ts
@@ -122,7 +122,7 @@ const loadSpecs = async ({
 }) => {
   const specs: OpenAPIObject[] = [];
   for (const pluginId of plugins) {
-    const url = await discovery.getExternalBaseUrl(pluginId);
+    const url = await discovery.getBaseUrl(pluginId);
     const openApiUrl = getOpenApiSpecRoute(url);
     const { token } = await auth.getPluginRequestToken({
       onBehalfOf: await auth.getOwnServiceCredentials(),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
This PR changes the route which the plugin will use to reach other plugins `openapi.json` endpoint. 
Before it used the external url which is not in every case reachable, which is the scenario we ran into. 
Rather it should use the direct internal one. 


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
