### PR TITLE
feat(home): Show relative time for recent visits from today

### DIFF
--- a/.changeset/chilly-fireants-roll.md
+++ b/.changeset/chilly-fireants-roll.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-home': patch
+---
+
+Use relative time when displaying visits from the same day

--- a/plugins/home/src/components/VisitList/ItemDetail.tsx
+++ b/plugins/home/src/components/VisitList/ItemDetail.tsx
@@ -35,9 +35,7 @@ const ItemDetailTimeAgo = ({ visit }: { visit: Visit }) => {
       color="textSecondary"
       dateTime={visitDate.toISO() ?? undefined}
     >
-      {visitDate >= DateTime.now().startOf('day')
-        ? visitDate.toFormat('HH:mm')
-        : visitDate.toRelative()}
+      {visitDate.toRelative()}
     </Typography>
   );
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This PR changes the time display when showing recently visited items to show relative time, even when displaying items which were visited today.  This is an opinionated end-user change, and welcome dialog or disagreement on it.  Adds on to the great work @aitherios did originally, and welcome any background if you recall the history of this.

On the demo site, if you view the custom homepage with the recent visits card, it looks something like this:

<img width="621" alt="image" src="https://github.com/backstage/backstage/assets/33203301/f93c380d-27bb-4217-83b7-d4c52def29c0">

I had to do a double take, and then check my clock, to make sure if these were recent or not.  (recent in the sense of, I appreciated they were today but I couldn't remember what time is was at first :) )

Personally, I think it would be easier to the end user to show these fully relative if they are today, i.e. "35 minutes ago" or "3 hours ago" as well?  On my local, it now looks like this which I personally prefer:

<img width="552" alt="image" src="https://github.com/backstage/backstage/assets/33203301/b92beee9-e2fb-43d5-a41c-26b54aa3bedb">

In this way we fully use the Luxon library both for any change prior to today, as well as today, and it also slightly simplifies the code.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
