### PR TITLE
fix(catalog-backend-module-github): support push events with catalogPath containing glob patterns

### DIFF
--- a/.changeset/pink-years-peel.md
+++ b/.changeset/pink-years-peel.md
@@ -2,5 +2,5 @@
 '@backstage/plugin-catalog-backend-module-github': patch
 ---
 
-GitHub push events now schedule a refresh on entities that have a refresh_key matching the `catalogPath` config itself.
+GitHub push events now schedule a refresh on entities that have a `refresh_key` matching the `catalogPath` config itself.
 This allows to support a `catalogPath` configuration that uses glob patterns.

--- a/.changeset/pink-years-peel.md
+++ b/.changeset/pink-years-peel.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+GitHub push events now schedule a refresh on entities that have a refresh_key matching the `catalogPath` config itself.
+This allows to support a `catalogPath` configuration that uses glob patterns.

--- a/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.ts
@@ -374,16 +374,23 @@ export class GithubEntityProvider implements EntityProvider, EventSubscriber {
     );
 
     if (modified.length > 0) {
+      const catalogPath = this.config.catalogPath.startsWith('/')
+        ? this.config.catalogPath.substring(1)
+        : this.config.catalogPath;
+
       await this.connection.refresh({
         keys: [
-          ...modified.map(
-            filePath =>
-              `url:${event.repository.url}/tree/${branch}/${filePath}`,
-          ),
-          ...modified.map(
-            filePath =>
-              `url:${event.repository.url}/blob/${branch}/${filePath}`,
-          ),
+          ...new Set([
+            ...modified.map(
+              filePath =>
+                `url:${event.repository.url}/tree/${branch}/${filePath}`,
+            ),
+            ...modified.map(
+              filePath =>
+                `url:${event.repository.url}/blob/${branch}/${filePath}`,
+            ),
+            `url:${event.repository.url}/tree/${branch}/${catalogPath}`,
+          ]),
         ],
       });
     }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes #23894 by scheduling a refresh on entities that have a refresh_key matching the catalogPath config, along with modified file paths that matches the entry.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] ~Added or updated documentation~
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] ~Screenshots attached (for UI changes)~
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
