### PR TITLE
(BUGFIX:  plugin-atlassian-auth-provider) pass scope to strategy

### DIFF
--- a/.changeset/curly-seals-pull.md
+++ b/.changeset/curly-seals-pull.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-atlassian-provider': patch
+---
+
+Read scopes from config and pass to AtlassianProvider as they are required

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -396,7 +396,7 @@ auth:
       development:
         clientId: ${AUTH_ATLASSIAN_CLIENT_ID}
         clientSecret: ${AUTH_ATLASSIAN_CLIENT_SECRET}
-        scopes: ${AUTH_ATLASSIAN_SCOPES}
+        scope: ${AUTH_ATLASSIAN_SCOPES}
     myproxy: {}
     guest: {}
 

--- a/docs/auth/atlassian/provider.md
+++ b/docs/auth/atlassian/provider.md
@@ -46,16 +46,16 @@ auth:
       development:
         clientId: ${AUTH_ATLASSIAN_CLIENT_ID}
         clientSecret: ${AUTH_ATLASSIAN_CLIENT_SECRET}
-        scopes: ${AUTH_ATLASSIAN_SCOPES}
+        scope: ${AUTH_ATLASSIAN_SCOPES}
 ```
 
 The Atlassian provider is a structure with three configuration keys:
 
 - `clientId`: The Key you generated in the developer console.
 - `clientSecret`: The Secret tied to the generated Key.
-- `scopes`: List of scopes the app has permissions for, separated by spaces.
+- `scope`: List of scopes the app has permissions for, separated by spaces.
 
-**NOTE:** the scopes `offline_access` and `read:me` are provided by default.
+**NOTE:** the scopes `offline_access`, `read:jira-work`, and `read:jira-user` are provided by default.
 
 ## Adding the provider to the Backstage frontend
 

--- a/plugins/auth-backend-module-atlassian-provider/config.d.ts
+++ b/plugins/auth-backend-module-atlassian-provider/config.d.ts
@@ -27,6 +27,7 @@ export interface Config {
           clientSecret: string;
           audience?: string;
           callbackUrl?: string;
+          scope?: string;
         };
       };
     };

--- a/plugins/auth-backend-module-atlassian-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-atlassian-provider/src/authenticator.ts
@@ -29,6 +29,9 @@ export const atlassianAuthenticator = createOAuthAuthenticator({
   initialize({ callbackUrl, config }) {
     const clientId = config.getString('clientId');
     const clientSecret = config.getString('clientSecret');
+    const scope =
+      config.getOptionalString('scope') ||
+      'offline_access read:jira-work read:jira-user';
     const baseUrl = 'https://auth.atlassian.com';
 
     return PassportOAuthAuthenticatorHelper.from(
@@ -41,6 +44,7 @@ export const atlassianAuthenticator = createOAuthAuthenticator({
           authorizationURL: `${baseUrl}/authorize`,
           tokenURL: `${baseUrl}/oauth/token`,
           profileURL: `${baseUrl}/api/v4/user`,
+          scope,
         },
         (
           accessToken: string,

--- a/plugins/auth-backend-module-atlassian-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-atlassian-provider/src/authenticator.ts
@@ -30,7 +30,8 @@ export const atlassianAuthenticator = createOAuthAuthenticator({
     const clientId = config.getString('clientId');
     const clientSecret = config.getString('clientSecret');
     const scope =
-      config.getOptionalString('scope') ||
+      config.getOptionalString('scope') ??
+      config.getOptionalString('scopes') ??
       'offline_access read:jira-work read:jira-user';
     const baseUrl = 'https://auth.atlassian.com';
 

--- a/plugins/auth-backend-module-atlassian-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-atlassian-provider/src/module.test.ts
@@ -75,7 +75,7 @@ describe('authModuleAtlassianProvider', () => {
       nonce: decodeURIComponent(nonceCookie.value),
     });
   });
-  it('should start with and use custom scopes', async () => {
+  it('should start with and use custom scopes from scope config field', async () => {
     const { server } = await startTestBackend({
       features: [
         import('@backstage/plugin-auth-backend'),
@@ -92,6 +92,62 @@ describe('authModuleAtlassianProvider', () => {
                     clientId: 'my-client-id',
                     clientSecret: 'my-client-secret',
                     scope: 'offline_access read:filter:jira read:jira-work',
+                  },
+                },
+              },
+            },
+          },
+        }),
+      ],
+    });
+
+    const agent = request.agent(server);
+
+    const res = await agent.get('/api/auth/atlassian/start?env=development');
+
+    expect(res.status).toEqual(302);
+
+    const nonceCookie = agent.jar.getCookie('atlassian-nonce', {
+      domain: 'localhost',
+      path: '/api/auth/atlassian/handler',
+      script: false,
+      secure: false,
+    });
+    expect(nonceCookie).toBeDefined();
+
+    const startUrl = new URL(res.get('location'));
+    expect(startUrl.origin).toBe('https://auth.atlassian.com');
+    expect(startUrl.pathname).toBe('/authorize');
+    expect(Object.fromEntries(startUrl.searchParams)).toEqual({
+      response_type: 'code',
+      client_id: 'my-client-id',
+      redirect_uri: `http://localhost:${server.port()}/api/auth/atlassian/handler/frame`,
+      state: expect.any(String),
+      scope: 'offline_access read:filter:jira read:jira-work',
+    });
+
+    expect(decodeOAuthState(startUrl.searchParams.get('state')!)).toEqual({
+      env: 'development',
+      nonce: decodeURIComponent(nonceCookie.value),
+    });
+  });
+  it('should start with and use custom scopes from scopes config field for backward compatibility', async () => {
+    const { server } = await startTestBackend({
+      features: [
+        import('@backstage/plugin-auth-backend'),
+        authModuleAtlassianProvider,
+        mockServices.rootConfig.factory({
+          data: {
+            app: {
+              baseUrl: 'http://localhost:3000',
+            },
+            auth: {
+              providers: {
+                atlassian: {
+                  development: {
+                    clientId: 'my-client-id',
+                    clientSecret: 'my-client-secret',
+                    scopes: 'offline_access read:filter:jira read:jira-work',
                   },
                 },
               },

--- a/plugins/auth-backend-module-atlassian-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-atlassian-provider/src/module.test.ts
@@ -67,6 +67,63 @@ describe('authModuleAtlassianProvider', () => {
       client_id: 'my-client-id',
       redirect_uri: `http://localhost:${server.port()}/api/auth/atlassian/handler/frame`,
       state: expect.any(String),
+      scope: 'offline_access read:jira-work read:jira-user',
+    });
+
+    expect(decodeOAuthState(startUrl.searchParams.get('state')!)).toEqual({
+      env: 'development',
+      nonce: decodeURIComponent(nonceCookie.value),
+    });
+  });
+  it('should start with and use custom scopes', async () => {
+    const { server } = await startTestBackend({
+      features: [
+        import('@backstage/plugin-auth-backend'),
+        authModuleAtlassianProvider,
+        mockServices.rootConfig.factory({
+          data: {
+            app: {
+              baseUrl: 'http://localhost:3000',
+            },
+            auth: {
+              providers: {
+                atlassian: {
+                  development: {
+                    clientId: 'my-client-id',
+                    clientSecret: 'my-client-secret',
+                    scope: 'offline_access read:filter:jira read:jira-work',
+                  },
+                },
+              },
+            },
+          },
+        }),
+      ],
+    });
+
+    const agent = request.agent(server);
+
+    const res = await agent.get('/api/auth/atlassian/start?env=development');
+
+    expect(res.status).toEqual(302);
+
+    const nonceCookie = agent.jar.getCookie('atlassian-nonce', {
+      domain: 'localhost',
+      path: '/api/auth/atlassian/handler',
+      script: false,
+      secure: false,
+    });
+    expect(nonceCookie).toBeDefined();
+
+    const startUrl = new URL(res.get('location'));
+    expect(startUrl.origin).toBe('https://auth.atlassian.com');
+    expect(startUrl.pathname).toBe('/authorize');
+    expect(Object.fromEntries(startUrl.searchParams)).toEqual({
+      response_type: 'code',
+      client_id: 'my-client-id',
+      redirect_uri: `http://localhost:${server.port()}/api/auth/atlassian/handler/frame`,
+      state: expect.any(String),
+      scope: 'offline_access read:filter:jira read:jira-work',
     });
 
     expect(decodeOAuthState(startUrl.searchParams.get('state')!)).toEqual({


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Read scopes from auth config and pass them to the passport `AtlassianStrategy`, where [scope is a required option](https://github.com/jsarafajr/passport-atlassian-oauth2/blob/master/lib/strategy.js#L49) to avoid the error message 

```
This app has not requested any supported Atlassian scopes. Check the authorization URL for your app and ensure that it includes valid scopes.
```

<img width="434" alt="image" src="https://github.com/backstage/backstage/assets/3301020/37249bb3-1812-4bfa-a78d-edfa35822728">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
