### PR TITLE
Add api type function

### DIFF
--- a/.changeset/witty-kings-smoke.md
+++ b/.changeset/witty-kings-smoke.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': minor
+---
+
+Add `isApiType()` to EntitySwitch routing functions.

--- a/plugins/catalog/api-report.md
+++ b/plugins/catalog/api-report.md
@@ -560,6 +560,11 @@ export interface HasSystemsCardProps {
 }
 
 // @public
+export function isApiType(
+  types: string | string[],
+): (entity: Entity) => boolean;
+
+// @public
 export function isComponentType(
   types: string | string[],
 ): (entity: Entity) => boolean;

--- a/plugins/catalog/src/components/EntitySwitch/conditions.test.ts
+++ b/plugins/catalog/src/components/EntitySwitch/conditions.test.ts
@@ -20,6 +20,7 @@ import {
   isKind,
   isNamespace,
   isResourceType,
+  isApiType,
   isEntityWith,
 } from './conditions';
 
@@ -63,6 +64,27 @@ const notComponent: Entity = {
   kind: 'not-component',
   metadata: { name: 'aService' },
   spec: { type: 'service' },
+};
+
+const graphqlApi: Entity = {
+  apiVersion: '',
+  kind: 'api',
+  metadata: { name: 'aProtocol' },
+  spec: { type: 'graphql' },
+};
+
+const grpcApi: Entity = {
+  apiVersion: '',
+  kind: 'api',
+  metadata: { name: 'aProtocol' },
+  spec: { type: 'grpc' },
+};
+
+const notApi: Entity = {
+  apiVersion: '',
+  kind: 'not-api',
+  metadata: { name: 'aProtocol' },
+  spec: { type: 'grpc' },
 };
 
 const missingSpecType: Entity = {
@@ -130,6 +152,26 @@ describe('isComponentType', () => {
 
     expect(checkEntity(serviceComponent)).toBeTruthy();
     expect(checkEntity(websiteComponent)).toBeTruthy();
+  });
+});
+
+describe('isApiType', () => {
+  it('should false on non API kinds', () => {
+    const checkEntity = isApiType('openapi');
+
+    expect(checkEntity(notApi)).not.toBeTruthy();
+  });
+  it('should check for the intended type', () => {
+    const checkEntity = isApiType('grpc');
+
+    expect(checkEntity(graphqlApi)).not.toBeTruthy();
+    expect(checkEntity(grpcApi)).toBeTruthy();
+  });
+  it('should check for multiple types', () => {
+    const checkEntity = isApiType(['grpc', 'graphql']);
+
+    expect(checkEntity(graphqlApi)).toBeTruthy();
+    expect(checkEntity(grpcApi)).toBeTruthy();
   });
 });
 

--- a/plugins/catalog/src/components/EntitySwitch/conditions.ts
+++ b/plugins/catalog/src/components/EntitySwitch/conditions.ts
@@ -61,6 +61,14 @@ export function isResourceType(types: string | string[]) {
 }
 
 /**
+ * For use in EntitySwitch.Case. Matches if the entity is an API of a given spec.type.
+ * @public
+ */
+export function isApiType(types: string | string[]) {
+  return isEntityWith({ kind: 'api', type: types });
+}
+
+/**
  * For use in EntitySwitch.Case. Matches if the entity is the specified kind and type (if present).
  * @public
  */

--- a/plugins/catalog/src/components/EntitySwitch/index.ts
+++ b/plugins/catalog/src/components/EntitySwitch/index.ts
@@ -22,5 +22,6 @@ export {
   isNamespace,
   isComponentType,
   isResourceType,
+  isApiType,
   isEntityWith,
 } from './conditions';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds isApiType() helper function to the EntitySwitch conditions set. Similar to the existing isComponentType & isResourceType, but for https://backstage.io/docs/features/software-catalog/descriptor-format/#kind-api.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
