### PR TITLE
fix not to add git commit link in about card edit button

### DIFF
--- a/.changeset/thirty-plums-shout.md
+++ b/.changeset/thirty-plums-shout.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend': patch
 ---
 
-Added a regex test to check commit hash.If url is from git commit branch ignore the edit url.
+Added a regex test to check commit hash. If url is from git commit branch ignore the edit url.

--- a/.changeset/thirty-plums-shout.md
+++ b/.changeset/thirty-plums-shout.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Added a regex test to check commit hash.If url is from git commit branch ignore the edit url.

--- a/plugins/catalog-backend/src/modules/core/AnnotateLocationEntityProcessor.test.ts
+++ b/plugins/catalog-backend/src/modules/core/AnnotateLocationEntityProcessor.test.ts
@@ -166,5 +166,53 @@ describe('AnnotateLocationEntityProcessor', () => {
         },
       });
     });
+    it('should not render edit button in about for invalid or git hash commit branch', async () => {
+      const entity: Entity = {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: {
+          name: 'my-component',
+        },
+      };
+
+      const location: LocationSpec = {
+        type: 'url',
+        target:
+          'https://github.com/backstage/backstage/blob/f1ba2bc6097a757c2827ff97fa301cff626de137/packages/app/catalog-info.yaml',
+      };
+      const originLocation: LocationSpec = {
+        type: 'url',
+        target:
+          'https://github.com/backstage/backstage/blob/f1ba2bc6097a757c2827ff97fa301cff626de137/catalog-info.yaml',
+      };
+
+      const integrations = ScmIntegrations.fromConfig(new ConfigReader({}));
+      const processor = new AnnotateLocationEntityProcessor({ integrations });
+
+      expect(
+        await processor.preProcessEntity(
+          entity,
+          location,
+          () => {},
+          originLocation,
+        ),
+      ).toEqual({
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: {
+          name: 'my-component',
+          annotations: {
+            'backstage.io/managed-by-location':
+              'url:https://github.com/backstage/backstage/blob/f1ba2bc6097a757c2827ff97fa301cff626de137/packages/app/catalog-info.yaml',
+            'backstage.io/managed-by-origin-location':
+              'url:https://github.com/backstage/backstage/blob/f1ba2bc6097a757c2827ff97fa301cff626de137/catalog-info.yaml',
+            'backstage.io/view-url':
+              'https://github.com/backstage/backstage/blob/f1ba2bc6097a757c2827ff97fa301cff626de137/packages/app/catalog-info.yaml',
+            'backstage.io/source-location':
+              'url:https://github.com/backstage/backstage/tree/f1ba2bc6097a757c2827ff97fa301cff626de137/packages/app/',
+          },
+        },
+      });
+    });
   });
 });

--- a/plugins/catalog-backend/src/modules/core/AnnotateLocationEntityProcessor.ts
+++ b/plugins/catalog-backend/src/modules/core/AnnotateLocationEntityProcessor.ts
@@ -53,7 +53,7 @@ export class AnnotateLocationEntityProcessor implements CatalogProcessor {
     let viewUrl;
     let editUrl;
     let sourceLocation;
-    const gitCommitBranchURLPattern = /\b[0-9a-f]{5,40}\b/;
+    const gitCommitBranchURLPattern = /\b[0-9a-f]{40,}\b/;
 
     if (location.type === 'url') {
       const scmIntegration = integrations.byUrl(location.target);

--- a/plugins/catalog-backend/src/modules/core/AnnotateLocationEntityProcessor.ts
+++ b/plugins/catalog-backend/src/modules/core/AnnotateLocationEntityProcessor.ts
@@ -31,6 +31,7 @@ import {
   CatalogProcessorEmit,
 } from '@backstage/plugin-catalog-node';
 
+const commitHashRegExp = /\b[0-9a-f]{40,}\b/;
 /** @public */
 export class AnnotateLocationEntityProcessor implements CatalogProcessor {
   constructor(
@@ -53,7 +54,6 @@ export class AnnotateLocationEntityProcessor implements CatalogProcessor {
     let viewUrl;
     let editUrl;
     let sourceLocation;
-    const commitHashRegExp = /\b[0-9a-f]{40,}\b/;
 
     if (location.type === 'url') {
       const scmIntegration = integrations.byUrl(location.target);

--- a/plugins/catalog-backend/src/modules/core/AnnotateLocationEntityProcessor.ts
+++ b/plugins/catalog-backend/src/modules/core/AnnotateLocationEntityProcessor.ts
@@ -53,12 +53,16 @@ export class AnnotateLocationEntityProcessor implements CatalogProcessor {
     let viewUrl;
     let editUrl;
     let sourceLocation;
+    const gitCommitBranchURLPattern = /\b[0-9a-f]{5,40}\b/;
 
     if (location.type === 'url') {
       const scmIntegration = integrations.byUrl(location.target);
 
       viewUrl = location.target;
-      editUrl = scmIntegration?.resolveEditUrl(location.target);
+
+      if (!gitCommitBranchURLPattern.test(location.target)) {
+        editUrl = scmIntegration?.resolveEditUrl(location.target);
+      }
 
       const sourceUrl = scmIntegration?.resolveUrl({
         url: './',

--- a/plugins/catalog-backend/src/modules/core/AnnotateLocationEntityProcessor.ts
+++ b/plugins/catalog-backend/src/modules/core/AnnotateLocationEntityProcessor.ts
@@ -53,14 +53,14 @@ export class AnnotateLocationEntityProcessor implements CatalogProcessor {
     let viewUrl;
     let editUrl;
     let sourceLocation;
-    const gitCommitBranchURLPattern = /\b[0-9a-f]{40,}\b/;
+    const commitHashRegExp = /\b[0-9a-f]{40,}\b/;
 
     if (location.type === 'url') {
       const scmIntegration = integrations.byUrl(location.target);
 
       viewUrl = location.target;
 
-      if (!gitCommitBranchURLPattern.test(location.target)) {
+      if (!commitHashRegExp.test(location.target)) {
         editUrl = scmIntegration?.resolveEditUrl(location.target);
       }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!
closes #22140 

check if URL link is of commit hash. Better regex suggestion ?
Should address this to user ?
like if user passes invalid link in app-config.yaml just get ignored.User is not notified that URL is wrong in some way.
<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
