### PR TITLE
fixed bug the treat as same as no cookie if existing cookie vas invalid.

### DIFF
--- a/.changeset/giant-olives-protect.md
+++ b/.changeset/giant-olives-protect.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+Fixed a bug where expired cookies would not be refreshed.

--- a/packages/backend-app-api/src/services/implementations/httpAuth/httpAuthServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/httpAuth/httpAuthServiceFactory.ts
@@ -235,14 +235,24 @@ class DefaultHttpAuthService implements HttpAuthService {
       return undefined;
     }
 
-    const existingCredentials = await this.#auth.authenticate(existingCookie, {
-      allowLimitedAccess: true,
-    });
-    if (!this.#auth.isPrincipal(existingCredentials, 'user')) {
-      return undefined;
-    }
+    try {
+      const existingCredentials = await this.#auth.authenticate(
+        existingCookie,
+        {
+          allowLimitedAccess: true,
+        },
+      );
+      if (!this.#auth.isPrincipal(existingCredentials, 'user')) {
+        return undefined;
+      }
 
-    return existingCredentials.expiresAt;
+      return existingCredentials.expiresAt;
+    } catch (error) {
+      if (error.name === 'AuthenticationError') {
+        return undefined;
+      }
+      throw error;
+    }
   }
 }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I've got error at /api/techdocs/cookie when I restarted backstage backend.

It was happend on the develop environment (using on-memory database).
It seemd it was happend because backend could not find the kid of JWT in the key store.

how to reproduce it.

1. Signin and show to techdocs page
2. Stop backend
3. Restart backend
4. Signin and try to show the same techdocs page.

This pr is for #23914 


<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
