### PR TITLE
Home react plugin

### DIFF
--- a/.changeset/giant-pots-count.md
+++ b/.changeset/giant-pots-count.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-home-react': patch
+---
+
+Added ESLint rule `no-top-level-material-ui-4-imports` in the `home-react` plugin to migrate the Material UI imports.

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -332,8 +332,8 @@ auth:
         clientSecret: ${AUTH_GOOGLE_CLIENT_SECRET}
     github:
       development:
-         clientId: ${AUTH_GOOGLE_CLIENT_ID}
-        clientSecret: ${AUTH_GOOGLE_CLIENT_SECRET}
+        clientId: ${AUTH_GITHUB_CLIENT_ID}
+        clientSecret: ${AUTH_GITHUB_CLIENT_SECRET}
         enterpriseInstanceUrl: ${AUTH_GITHUB_ENTERPRISE_INSTANCE_URL}
     gitlab:
       development:

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -332,8 +332,8 @@ auth:
         clientSecret: ${AUTH_GOOGLE_CLIENT_SECRET}
     github:
       development:
-        clientId: 66697c49158239373b26
-        clientSecret: 67e38219a58de5ed3e960956ed4b68060a097a26
+         clientId: ${AUTH_GOOGLE_CLIENT_ID}
+        clientSecret: ${AUTH_GOOGLE_CLIENT_SECRET}
         enterpriseInstanceUrl: ${AUTH_GITHUB_ENTERPRISE_INSTANCE_URL}
     gitlab:
       development:

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -332,8 +332,8 @@ auth:
         clientSecret: ${AUTH_GOOGLE_CLIENT_SECRET}
     github:
       development:
-        clientId: ${AUTH_GITHUB_CLIENT_ID}
-        clientSecret: ${AUTH_GITHUB_CLIENT_SECRET}
+        clientId: 66697c49158239373b26
+        clientSecret: 67e38219a58de5ed3e960956ed4b68060a097a26
         enterpriseInstanceUrl: ${AUTH_GITHUB_ENTERPRISE_INSTANCE_URL}
     gitlab:
       development:

--- a/plugins/home-react/.eslintrc.js
+++ b/plugins/home-react/.eslintrc.js
@@ -1,1 +1,5 @@
-module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
+    rules: {
+        '@backstage/no-top-level-material-ui-4-imports': 'error',
+    },
+});

--- a/plugins/home-react/src/components/SettingsModal.tsx
+++ b/plugins/home-react/src/components/SettingsModal.tsx
@@ -15,13 +15,11 @@
  */
 
 import React from 'react';
-import {
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-} from '@material-ui/core';
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogTitle from '@material-ui/core/DialogTitle';
 
 /** @public */
 export const SettingsModal = (props: {

--- a/plugins/home-react/src/extensions.tsx
+++ b/plugins/home-react/src/extensions.tsx
@@ -15,7 +15,7 @@
  */
 
 import React, { Suspense } from 'react';
-import { IconButton } from '@material-ui/core';
+import IconButton from '@material-ui/core/IconButton';
 import SettingsIcon from '@material-ui/icons/Settings';
 import { InfoCard } from '@backstage/core-components';
 import { SettingsModal } from './components';


### PR DESCRIPTION
Adds the no-top-level-material-ui-4-import ESLint rule to the git-release-manager plugin to aid with the migration to Material UI v5.
Issue: [#23467](https://github.com/backstage/backstage/issues/23467)