### PR TITLE
feat: allow overriding default techdocs preparers

### DIFF
--- a/.changeset/chatty-flies-worry.md
+++ b/.changeset/chatty-flies-worry.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-techdocs-backend': patch
+'@backstage/plugin-techdocs-node': patch
+---
+
+Allow overriding default techdocs preparers with new `TechdocsPreparerExtensionPoint`

--- a/plugins/techdocs-node/api-report.md
+++ b/plugins/techdocs-node/api-report.md
@@ -292,6 +292,15 @@ export type TechDocsMetadata = {
 };
 
 // @public
+export interface TechdocsPreparerExtensionPoint {
+  // (undocumented)
+  registerPreparer(protocol: RemoteProtocol, preparer: PreparerBase): void;
+}
+
+// @public
+export const techdocsPreparerExtensionPoint: ExtensionPoint<TechdocsPreparerExtensionPoint>;
+
+// @public
 export const transformDirLocation: (
   entity: Entity,
   dirAnnotation: ParsedLocationAnnotation,

--- a/plugins/techdocs-node/src/extensions.ts
+++ b/plugins/techdocs-node/src/extensions.ts
@@ -15,7 +15,7 @@
  */
 import { createExtensionPoint } from '@backstage/backend-plugin-api';
 import { DocsBuildStrategy } from './techdocsTypes';
-import { TechdocsGenerator } from './stages';
+import { PreparerBase, RemoteProtocol, TechdocsGenerator } from './stages';
 
 /**
  * Extension point type for configuring Techdocs builds.
@@ -53,4 +53,23 @@ export interface TechdocsGeneratorExtensionPoint {
 export const techdocsGeneratorExtensionPoint =
   createExtensionPoint<TechdocsGeneratorExtensionPoint>({
     id: 'techdocs.generator',
+  });
+
+/**
+ * Extension point type for configuring a custom Techdocs preparer
+ *
+ * @public
+ */
+export interface TechdocsPreparerExtensionPoint {
+  registerPreparer(protocol: RemoteProtocol, preparer: PreparerBase): void;
+}
+
+/**
+ * Extension point for configuring a custom Techdocs preparer
+ *
+ * @public
+ */
+export const techdocsPreparerExtensionPoint =
+  createExtensionPoint<TechdocsPreparerExtensionPoint>({
+    id: 'techdocs.preparer',
   });

--- a/plugins/techdocs-node/src/index.ts
+++ b/plugins/techdocs-node/src/index.ts
@@ -26,6 +26,8 @@ export * from './techdocsTypes';
 export {
   techdocsBuildsExtensionPoint,
   techdocsGeneratorExtensionPoint,
+  techdocsPreparerExtensionPoint,
   type TechdocsBuildsExtensionPoint,
   type TechdocsGeneratorExtensionPoint,
+  type TechdocsPreparerExtensionPoint,
 } from './extensions';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

a new extension point `TechdocsPreparerExtensionPoint` allows registering custom preparers for the techdocs plugin.

closes #21952

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
