### PR TITLE
fix: allow unauthenticated signals connection to fix 401

### DIFF
--- a/.changeset/ninety-toys-bake.md
+++ b/.changeset/ninety-toys-bake.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-signals-backend': patch
+---
+
+Fix unauthorized signals connection by allowing unauthenticated requests

--- a/plugins/signals-backend/src/plugin.ts
+++ b/plugins/signals-backend/src/plugin.ts
@@ -58,7 +58,7 @@ export const signalsPlugin = createBackendPlugin({
           }),
         );
         httpRouter.addAuthPolicy({
-          path: '*',
+          path: '/',
           allow: 'unauthenticated',
         });
       },

--- a/plugins/signals-backend/src/plugin.ts
+++ b/plugins/signals-backend/src/plugin.ts
@@ -58,7 +58,7 @@ export const signalsPlugin = createBackendPlugin({
           }),
         );
         httpRouter.addAuthPolicy({
-          path: '/health',
+          path: '*',
           allow: 'unauthenticated',
         });
       },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

the signals handles authentication itself in the middleware thus we should allow unauthenticated requests to pass through

closes #23927 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
