### PR TITLE
kubernetes-backend: fix reading credentials from undefined

### DIFF
--- a/.changeset/little-bats-admire.md
+++ b/.changeset/little-bats-admire.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Fixed a crash reading `credentials` from `undefined`.

--- a/plugins/kubernetes-backend/src/cluster-locator/CatalogClusterLocator.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/CatalogClusterLocator.ts
@@ -52,7 +52,7 @@ export class CatalogClusterLocator implements KubernetesClustersSupplier {
     return new CatalogClusterLocator(catalogApi, auth);
   }
 
-  async getClusters(options: {
+  async getClusters(options?: {
     credentials: BackstageCredentials;
   }): Promise<ClusterDetails[]> {
     const apiServerKey = `metadata.annotations.${ANNOTATION_KUBERNETES_API_SERVER}`;
@@ -71,7 +71,7 @@ export class CatalogClusterLocator implements KubernetesClustersSupplier {
       {
         filter: [filter],
       },
-      options.credentials
+      options?.credentials
         ? {
             token: (
               await this.auth.getPluginRequestToken({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Implementation was defining `options` as always present, but that's not what the cluster supplier interface promises. Kinda surprised TypeScript doesn't catch this tbh.

Short-term (and maybe long-term?) fix for #23876

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
