### PR TITLE
backend-app-api: add initialization option to createServiceFactory

### DIFF
--- a/.changeset/silver-carrots-sort.md
+++ b/.changeset/silver-carrots-sort.md
@@ -1,0 +1,6 @@
+---
+'@backstage/backend-plugin-api': patch
+'@backstage/backend-app-api': patch
+---
+
+Added `initialization` option to `createServiceFactory` which defines the initialization strategy for the service. The default strategy mimics the current behavior where plugin scoped services are initialized lazily by default and root scoped services are initialized eagerly.

--- a/packages/backend-app-api/src/wiring/BackendInitializer.ts
+++ b/packages/backend-app-api/src/wiring/BackendInitializer.ts
@@ -170,11 +170,7 @@ export class BackendInitializer {
     }
 
     // Initialize all root scoped services
-    for (const ref of this.#serviceRegistry.getServiceRefs()) {
-      if (ref.scope === 'root') {
-        await this.#serviceRegistry.get(ref, 'root');
-      }
-    }
+    await this.#serviceRegistry.initializeEagerServicesWithScope('root');
 
     const pluginInits = new Map<string, BackendRegisterInit>();
     const moduleInits = new Map<string, Map<string, BackendRegisterInit>>();
@@ -235,6 +231,12 @@ export class BackendInitializer {
     // All plugins are initialized in parallel
     await Promise.all(
       allPluginIds.map(async pluginId => {
+        // Initialize all eager services
+        await this.#serviceRegistry.initializeEagerServicesWithScope(
+          'plugin',
+          pluginId,
+        );
+
         // Modules are initialized before plugins, so that they can provide extension to the plugin
         const modules = moduleInits.get(pluginId);
         if (modules) {

--- a/packages/backend-plugin-api/src/services/system/types.ts
+++ b/packages/backend-plugin-api/src/services/system/types.ts
@@ -63,6 +63,7 @@ export interface InternalServiceFactory<
   TScope extends 'plugin' | 'root' = 'plugin' | 'root',
 > extends ServiceFactory<TService, TScope> {
   version: 'v1';
+  initialization?: 'always' | 'lazy';
   deps: { [key in string]: ServiceRef<unknown> };
   createRootContext?(deps: { [key in string]: unknown }): Promise<unknown>;
   factory(
@@ -140,6 +141,7 @@ export interface RootServiceFactoryConfig<
   TImpl extends TService,
   TDeps extends { [name in string]: ServiceRef<unknown> },
 > {
+  initialization?: 'always' | 'lazy';
   service: ServiceRef<TService, 'root'>;
   deps: TDeps;
   factory(deps: ServiceRefsToInstances<TDeps, 'root'>): TImpl | Promise<TImpl>;
@@ -152,6 +154,7 @@ export interface PluginServiceFactoryConfig<
   TImpl extends TService,
   TDeps extends { [name in string]: ServiceRef<unknown> },
 > {
+  initialization?: 'always' | 'lazy';
   service: ServiceRef<TService, 'plugin'>;
   deps: TDeps;
   createRootContext?(
@@ -251,6 +254,7 @@ export function createServiceFactory<
         $$type: '@backstage/BackendFeature',
         version: 'v1',
         service: c.service,
+        initialization: c.initialization,
         deps: c.deps,
         factory: async (deps: TDeps) => c.factory(deps),
       };
@@ -265,6 +269,7 @@ export function createServiceFactory<
       $$type: '@backstage/BackendFeature',
       version: 'v1',
       service: c.service,
+      initialization: c.initialization,
       ...('createRootContext' in c
         ? {
             createRootContext: async (deps: TDeps) =>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds a new  `initialization` option to `createServiceFactory`, allowing services to be initialized eagerly.
The PR doesn't change the default behaviour of the existing services.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
