### PR TITLE
backend-app-api: stop loading modules if parent plugin is not present

### DIFF
--- a/.changeset/lazy-rats-fail.md
+++ b/.changeset/lazy-rats-fail.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': minor
+---
+
+**BREAKING**: Modules are no longer loaded unless the plugin that they extend is present.

--- a/.changeset/pink-mirrors-jam.md
+++ b/.changeset/pink-mirrors-jam.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-test-utils': patch
+---
+
+`startTestBackend` will now add placeholder plugins when a modules are provided without their parent plugin.

--- a/packages/backend-app-api/src/alpha/featureDiscoveryServiceFactory.test.ts
+++ b/packages/backend-app-api/src/alpha/featureDiscoveryServiceFactory.test.ts
@@ -280,7 +280,7 @@ describe('featureDiscoveryServiceFactory', () => {
                   'detected-module',
                   'detected-plugin-with-alpha',
                 ],
-                exclude: ['detected-plugin'],
+                exclude: ['detected-module'],
               },
             },
           },
@@ -288,9 +288,9 @@ describe('featureDiscoveryServiceFactory', () => {
       ],
     });
 
-    expect(mock.warn).not.toHaveBeenCalledWith('detected-plugin');
+    expect(mock.warn).toHaveBeenCalledWith('detected-plugin');
     expect(mock.warn).not.toHaveBeenCalledWith('detected-library');
-    expect(mock.warn).toHaveBeenCalledWith('detected-module');
+    expect(mock.warn).not.toHaveBeenCalledWith('detected-module');
     expect(mock.warn).toHaveBeenCalledWith('detected-plugin-with-alpha');
   });
 

--- a/packages/backend-app-api/src/wiring/BackendInitializer.test.ts
+++ b/packages/backend-app-api/src/wiring/BackendInitializer.test.ts
@@ -60,6 +60,16 @@ const baseFactories = [
   loggerServiceFactory(),
 ];
 
+const testPlugin = createBackendPlugin({
+  pluginId: 'test',
+  register(reg) {
+    reg.registerInit({
+      deps: {},
+      async init() {},
+    });
+  },
+})();
+
 describe('BackendInitializer', () => {
   it('should initialize root scoped services', async () => {
     const rootFactory = jest.fn();
@@ -99,6 +109,7 @@ describe('BackendInitializer', () => {
     });
     const init = new BackendInitializer(baseFactories);
 
+    init.add(testPlugin);
     init.add(
       createBackendModule({
         pluginId: 'test',
@@ -172,6 +183,7 @@ describe('BackendInitializer', () => {
 
   it('should forward errors when modules fail to start', async () => {
     const init = new BackendInitializer([]);
+    init.add(testPlugin);
     init.add(
       createBackendModule({
         pluginId: 'test',
@@ -222,6 +234,7 @@ describe('BackendInitializer', () => {
 
   it('should reject duplicate modules', async () => {
     const init = new BackendInitializer([]);
+    init.add(testPlugin);
     init.add(
       createBackendModule({
         pluginId: 'test',
@@ -262,6 +275,7 @@ describe('BackendInitializer', () => {
         factory: () => new MockLogger(),
       })(),
     ]);
+    init.add(testPlugin);
     init.add(
       createBackendModule({
         pluginId: 'test',
@@ -308,9 +322,10 @@ describe('BackendInitializer', () => {
         },
       })(),
     );
+    init.add(testPlugin);
     init.add(
       createBackendModule({
-        pluginId: 'test-b',
+        pluginId: 'test',
         moduleId: 'mod',
         register(reg) {
           reg.registerInit({
@@ -321,7 +336,7 @@ describe('BackendInitializer', () => {
       })(),
     );
     await expect(init.start()).rejects.toThrow(
-      "Illegal dependency: Module 'mod' for plugin 'test-b' attempted to depend on extension point 'a' for plugin 'test-a'. Extension points can only be used within their plugin's scope.",
+      "Illegal dependency: Module 'mod' for plugin 'test' attempted to depend on extension point 'a' for plugin 'test-a'. Extension points can only be used within their plugin's scope.",
     );
   });
 });

--- a/packages/backend-app-api/src/wiring/BackendInitializer.ts
+++ b/packages/backend-app-api/src/wiring/BackendInitializer.ts
@@ -228,9 +228,7 @@ export class BackendInitializer {
       }
     }
 
-    const allPluginIds = [
-      ...new Set([...pluginInits.keys(), ...moduleInits.keys()]),
-    ];
+    const allPluginIds = [...pluginInits.keys()];
 
     // All plugins are initialized in parallel
     await Promise.all(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

So far we've been loading modules even if the parent plugin is not available. This was done for tests, since it's convenient to not always have to have the plugin present there. It's not really a sensible behavior though tbh, and thinking that it's best to simply not load modules if the plugin isn't present, just to make conditional loading a bit simpler. To fix the test part of that, `startTestBackend` will now detect orphan modules and add placeholder plugins if necessary.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
