### PR TITLE
Fix TechDocsAddonTester errors when jest mocks are reset

### DIFF
--- a/.changeset/gorgeous-cameras-cross.md
+++ b/.changeset/gorgeous-cameras-cross.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-addons-test-utils': patch
+---
+
+Fix bug in TechDocsAddonTester when jest.resetAllMocks is called between tests

--- a/plugins/techdocs-addons-test-utils/src/test-utils.tsx
+++ b/plugins/techdocs-addons-test-utils/src/test-utils.tsx
@@ -49,46 +49,6 @@ if (!global.TextEncoder) {
 const { renderToStaticMarkup } =
   require('react-dom/server') as typeof import('react-dom/server');
 
-const techdocsApi = {
-  getTechDocsMetadata: jest.fn(),
-  getEntityMetadata: jest.fn(),
-  getCookie: jest.fn().mockReturnValue({
-    // Expires in 10 minutes
-    expiresAt: new Date(Date.now() + 10 * 60 * 1000).toISOString(),
-  }),
-};
-
-const techdocsStorageApi = {
-  getApiOrigin: jest.fn(),
-  getBaseUrl: jest.fn(),
-  getEntityDocs: jest.fn(),
-  syncEntityDocs: jest.fn(),
-};
-
-const searchApi = {
-  query: jest.fn().mockResolvedValue({ results: [] }),
-};
-
-const scmIntegrationsApi = {
-  fromConfig: jest.fn().mockReturnValue({}),
-};
-
-const discoveryApi = {
-  getBaseUrl: jest
-    .fn()
-    .mockResolvedValue('https://backstage.example.com/api/techdocs'),
-};
-
-const fetchApi = {
-  fetch: jest.fn().mockResolvedValue({
-    ok: true,
-    json: jest.fn().mockResolvedValue({
-      // Expires in 10 minutes
-      expiresAt: new Date(Date.now() + 10 * 60 * 1000).toISOString(),
-    }),
-  }),
-};
-
 /** @ignore */
 type TechDocsAddonTesterTestApiPair<TApi> = TApi extends infer TImpl
   ? readonly [ApiRef<TApi>, Partial<TImpl>]
@@ -223,6 +183,46 @@ export class TechDocsAddonTester {
    * App instance, using the given Addon(s).
    */
   build() {
+    const techdocsApi = {
+      getTechDocsMetadata: jest.fn(),
+      getEntityMetadata: jest.fn(),
+      getCookie: jest.fn().mockReturnValue({
+        // Expires in 10 minutes
+        expiresAt: new Date(Date.now() + 10 * 60 * 1000).toISOString(),
+      }),
+    };
+
+    const techdocsStorageApi = {
+      getApiOrigin: jest.fn(),
+      getBaseUrl: jest.fn(),
+      getEntityDocs: jest.fn(),
+      syncEntityDocs: jest.fn(),
+    };
+
+    const searchApi = {
+      query: jest.fn().mockResolvedValue({ results: [] }),
+    };
+
+    const scmIntegrationsApi = {
+      fromConfig: jest.fn().mockReturnValue({}),
+    };
+
+    const discoveryApi = {
+      getBaseUrl: jest
+        .fn()
+        .mockResolvedValue('https://backstage.example.com/api/techdocs'),
+    };
+
+    const fetchApi = {
+      fetch: jest.fn().mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          // Expires in 10 minutes
+          expiresAt: new Date(Date.now() + 10 * 60 * 1000).toISOString(),
+        }),
+      }),
+    };
+
     const apis: TechdocsAddonTesterApis<any[]> = [
       [fetchApiRef, fetchApi],
       [discoveryApiRef, discoveryApi],


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is a fix for #23943. By moving the mock API creation to the `build` method tests we ensure that the mocked APIs are properly set up each time that `renderWithEffects` is called.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
