### PR TITLE
make elasticsearch provider optional if search.elasticsearch not defined

### DIFF
--- a/.changeset/tough-snakes-wink.md
+++ b/.changeset/tough-snakes-wink.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend-module-elasticsearch': minor
+---
+
+For new backend, make Elasticsearch provider optional if no config

--- a/.changeset/tough-snakes-wink.md
+++ b/.changeset/tough-snakes-wink.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-search-backend-module-elasticsearch': minor
 ---
 
-For new backend, make Elasticsearch provider optional if no config
+When using the New Backend System, the Elasticsearch provider will only be added if the `search.elasticsearch` config section exists.

--- a/plugins/search-backend-module-elasticsearch/src/alpha.ts
+++ b/plugins/search-backend-module-elasticsearch/src/alpha.ts
@@ -68,6 +68,12 @@ export default createBackendModule({
         config: coreServices.rootConfig,
       },
       async init({ searchEngineRegistry, logger, config }) {
+        const baseKey = 'search.elasticsearch';
+        const baseConfig = config.getOptional(baseKey);
+        if (!baseConfig) {
+          return;
+        }
+
         searchEngineRegistry.setSearchEngine(
           await ElasticSearchSearchEngine.fromConfig({
             logger,

--- a/plugins/search-backend-module-elasticsearch/src/alpha.ts
+++ b/plugins/search-backend-module-elasticsearch/src/alpha.ts
@@ -71,6 +71,7 @@ export default createBackendModule({
         const baseKey = 'search.elasticsearch';
         const baseConfig = config.getOptional(baseKey);
         if (!baseConfig) {
+          logger.info('No configuration found under "search.elasticsearch" key.  Skipping search engine inititalization.');
           return;
         }
 

--- a/plugins/search-backend-module-elasticsearch/src/alpha.ts
+++ b/plugins/search-backend-module-elasticsearch/src/alpha.ts
@@ -71,7 +71,9 @@ export default createBackendModule({
         const baseKey = 'search.elasticsearch';
         const baseConfig = config.getOptional(baseKey);
         if (!baseConfig) {
-          logger.info('No configuration found under "search.elasticsearch" key.  Skipping search engine inititalization.');
+          logger.warn(
+            'No configuration found under "search.elasticsearch" key.  Skipping search engine inititalization.',
+          );
           return;
         }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

For the new backend, make adding the elasticsearch search provider optional if `search.elasticsearch` is not defined in the config

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
