### PR TITLE
feat: catalog-backend-module-backstage-openapi: enable configuring entity `name` and `title`

### DIFF
--- a/.changeset/shaggy-books-mate.md
+++ b/.changeset/shaggy-books-mate.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-backstage-openapi': minor
+---
+
+The name and title of the returned openapi doc entity are now configurable

--- a/plugins/catalog-backend-module-backstage-openapi/README.md
+++ b/plugins/catalog-backend-module-backstage-openapi/README.md
@@ -18,18 +18,22 @@ backend.add(
 );
 ```
 
-Add a list of plugins (and optionally, a custom name/title) to your config like:
+Add a list of plugins and optional entity overrides to your config. For example:
 
 ```yaml title="app-config.yaml"
 catalog:
   providers:
     backstageOpenapi:
-      name: 'internal_backstage_api' # Optional
-      title: 'Backstage API' # Optional
       plugins:
         - catalog
         - todo
         - search
+      entityOverrides: # All optional
+        metadata:
+          name: 'my name'
+          title: 'my title'
+        spec:
+          owner: 'my team'
 ```
 
 We will attempt to load each plugin's OpenAPI spec hosted at `${pluginRoute}/openapi.json`. These are automatically added if you are using `@backstage/backend-openapi-utils`'s `createValidatedOpenApiRouter`.

--- a/plugins/catalog-backend-module-backstage-openapi/README.md
+++ b/plugins/catalog-backend-module-backstage-openapi/README.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-This module installs an entity provider that exports a single entity, your Backstage instance documentation, which merges as many backend plugins as you have defined in the config value `catalog.providers.openapi.plugins`.
+This module installs an entity provider that exports a single entity, your Backstage instance documentation, which merges as many backend plugins as you have defined in the config value `catalog.providers.backstageOpenapi.plugins`.
 
 ## Notes
 
@@ -10,7 +10,7 @@ This module installs an entity provider that exports a single entity, your Backs
 
 ## Installation
 
-To your new backend file, add
+To your new backend file, add:
 
 ```ts title="packages/backend/src/index.ts"
 backend.add(
@@ -18,12 +18,14 @@ backend.add(
 );
 ```
 
-Add a list of plugins to your config like,
+Add a list of plugins (and optionally, a custom name/title) to your config like:
 
 ```yaml title="app-config.yaml"
 catalog:
   providers:
-    openapi:
+    backstageOpenapi:
+      name: 'internal_backstage_api' # Optional
+      title: 'Backstage API' # Optional
       plugins:
         - catalog
         - todo

--- a/plugins/catalog-backend-module-backstage-openapi/config.d.ts
+++ b/plugins/catalog-backend-module-backstage-openapi/config.d.ts
@@ -28,17 +28,10 @@ export interface Config {
         /**
          * Options to ovveride the provided entity's default metadata and spec properties
          */
-        entityOverrides?: {
-          metadata?: {
-            name?: string;
-            title?: string;
-          };
-          spec?: {
-            type?: string;
-            lifecycle?: string;
-            owner?: string;
-          };
-        };
+        /**
+         * Properties to override on the final entity object.
+         */
+        entityOverrides?: object;
       };
     };
   };

--- a/plugins/catalog-backend-module-backstage-openapi/config.d.ts
+++ b/plugins/catalog-backend-module-backstage-openapi/config.d.ts
@@ -25,6 +25,20 @@ export interface Config {
          * A list of plugins, whose OpenAPI specs you want to collate in `InternalOpenApiDocumentationProvider`.
          */
         plugins: string[];
+        /**
+         * Options to ovveride the provided entity's default metadata and spec properties
+         */
+        entityOverrides?: {
+          metadata?: {
+            name?: string;
+            title?: string;
+          };
+          spec?: {
+            type?: string;
+            lifecycle?: string;
+            owner?: string;
+          };
+        };
       };
     };
   };

--- a/plugins/catalog-backend-module-backstage-openapi/config.d.ts
+++ b/plugins/catalog-backend-module-backstage-openapi/config.d.ts
@@ -26,9 +26,6 @@ export interface Config {
          */
         plugins: string[];
         /**
-         * Options to ovveride the provided entity's default metadata and spec properties
-         */
-        /**
          * Properties to override on the final entity object.
          */
         entityOverrides?: object;

--- a/plugins/catalog-backend-module-backstage-openapi/package.json
+++ b/plugins/catalog-backend-module-backstage-openapi/package.json
@@ -39,6 +39,7 @@
     "@backstage/errors": "workspace:^",
     "@backstage/plugin-catalog-node": "workspace:^",
     "cross-fetch": "^4.0.0",
+    "lodash": "^4.17.21",
     "openapi-merge": "^1.3.2",
     "uuid": "^9.0.0"
   },

--- a/plugins/catalog-backend-module-backstage-openapi/src/InternalOpenApiDocumentationProvider.ts
+++ b/plugins/catalog-backend-module-backstage-openapi/src/InternalOpenApiDocumentationProvider.ts
@@ -229,19 +229,22 @@ export class InternalOpenApiDocumentationProvider implements EntityProvider {
     const pluginsToMerge = this.config.getStringArray(
       'catalog.providers.backstageOpenapi.plugins',
     );
-    const name = this.config.getOptionalString(
-      'catalog.providers.backstageOpenapi.name',
-    );
-    const title = this.config.getOptionalString(
-      'catalog.providers.backstageOpenapi.title',
-    );
-    logger.info(`Loading specs from from ${pluginsToMerge}.`);
+
+    const getOverride = (key: string, fallbackValue: string = '') => {
+      return (
+        this.config.getOptionalString(
+          `catalog.providers.backstageOpenapi.entityOverrides.${key}`,
+        ) ?? fallbackValue
+      );
+    };
+
+    logger.info(`Loading specs from ${pluginsToMerge}.`);
     const documentationEntity: ApiEntity = {
       apiVersion: 'backstage.io/v1beta1',
       kind: 'API',
       metadata: {
-        name: name ?? 'INTERNAL_instance_openapi_doc',
-        title: title ?? 'Your Backstage Instance documentation',
+        name: getOverride('metadata.name', 'backstage_openapi_doc'),
+        title: getOverride('metadata.title', 'Backstage API Documentation'),
         annotations: {
           [ANNOTATION_LOCATION]:
             'internal-package:@backstage/plugin-catalog-backend-module-backstage-openapi',
@@ -250,9 +253,9 @@ export class InternalOpenApiDocumentationProvider implements EntityProvider {
         },
       },
       spec: {
-        type: 'openapi',
-        lifecycle: 'production',
-        owner: 'backstage',
+        type: getOverride('spec.type', 'openapi'),
+        lifecycle: getOverride('spec.lifecycle', 'production'),
+        owner: getOverride('spec.owner', 'backstage'),
         definition: JSON.stringify(
           await loadSpecs({
             baseUrl: this.config.getString('backend.baseUrl'),

--- a/plugins/catalog-backend-module-backstage-openapi/src/InternalOpenApiDocumentationProvider.ts
+++ b/plugins/catalog-backend-module-backstage-openapi/src/InternalOpenApiDocumentationProvider.ts
@@ -229,13 +229,19 @@ export class InternalOpenApiDocumentationProvider implements EntityProvider {
     const pluginsToMerge = this.config.getStringArray(
       'catalog.providers.backstageOpenapi.plugins',
     );
+    const name = this.config.getOptionalString(
+      'catalog.providers.backstageOpenapi.name',
+    );
+    const title = this.config.getOptionalString(
+      'catalog.providers.backstageOpenapi.title',
+    );
     logger.info(`Loading specs from from ${pluginsToMerge}.`);
     const documentationEntity: ApiEntity = {
       apiVersion: 'backstage.io/v1beta1',
       kind: 'API',
       metadata: {
-        name: 'INTERNAL_instance_openapi_doc',
-        title: 'Your Backstage Instance documentation',
+        name: name ?? 'INTERNAL_instance_openapi_doc',
+        title: title ?? 'Your Backstage Instance documentation',
         annotations: {
           [ANNOTATION_LOCATION]:
             'internal-package:@backstage/plugin-catalog-backend-module-backstage-openapi',

--- a/plugins/catalog-backend-module-backstage-openapi/src/InternalOpenApiDocumentationProvider.ts
+++ b/plugins/catalog-backend-module-backstage-openapi/src/InternalOpenApiDocumentationProvider.ts
@@ -236,12 +236,12 @@ export class InternalOpenApiDocumentationProvider implements EntityProvider {
 
     const baseConfig = {
       metadata: {
-        name: 'internal_backstage_plugin',
-        title: 'Default Backstage API',
+        name: 'internal_backstage_openapi_doc',
+        title: 'Backstage API',
       },
       spec: {
-        owner: 'backstage',
         lifecycle: 'production',
+        owner: 'backstage',
       },
     };
 
@@ -271,8 +271,9 @@ export class InternalOpenApiDocumentationProvider implements EntityProvider {
       },
     };
 
-    // Overwrite base config with options from config file.
+    // Overwrite baseConfig with options from config file.
     const mergedConfig = lodash.merge(baseConfig, configToMerge);
+
     // Overwite mergedConfig with requiredConfig (i.e., spec.type and spec.definition) to avoid bad configuration.
     const documentationEntity = lodash.merge(
       mergedConfig,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5473,6 +5473,7 @@ __metadata:
     "@backstage/errors": "workspace:^"
     "@backstage/plugin-catalog-node": "workspace:^"
     cross-fetch: ^4.0.0
+    lodash: ^4.17.21
     openapi-merge: ^1.3.2
     openapi3-ts: ^3.1.2
     uuid: ^9.0.0


### PR DESCRIPTION
## Hey, I just made a Pull Request!

- Added the ability to configure the `metadata` and `spec` of the returned openapi doc entity provided by `@backstage/plugin-catalog-backend-module-backstage-openapi`

We are using backstage to catalog our company-wide services, but wish to provide documentation for the API endpoints of backstage itself for other teams to reference. This module serves our purposes exactly, but it would be nice to configure the metadata and spec of the provided API doc :)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
