### PR TITLE
.github/workflows: fetch base branch to be able to verify release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,8 +198,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - name: fetch branch master
+      - name: fetch master branch
         run: git fetch origin master
+
+        # Need to fetch the base branch to be able to verify the release
+      - name: fetch base branch
+        if: github.event.pull_request.base.ref != 'master'
+        run: git fetch origin ${{ github.event.pull_request.base.ref }}
 
       - name: use node.js ${{ matrix.node-version }}
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2


### PR DESCRIPTION
Hoping to fix this failure when trying to ship a patch: https://github.com/backstage/backstage/actions/runs/8536061386/job/23383959963?pr=23955