### PR TITLE
Added link to GUI visualising OAS spec of software-catalog API

### DIFF
--- a/docs/features/software-catalog/api.md
+++ b/docs/features/software-catalog/api.md
@@ -7,6 +7,7 @@ description: The Software Catalog API
 The software catalog backend has a JSON based REST API, which can be leveraged
 by external systems. This page describes its shape and features. The OpenAPI spec
 for this API can be found [here](https://github.com/backstage/backstage/blob/master/plugins/catalog-backend/src/schema/openapi.yaml).
+A UI visualizing the OpenAPI endpoints including the ability to try them out in the browser can be found [here](https://www.postman.com/backstage-io/workspace/catalog-api/overview).
 
 ## Overview
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

* as a follow up to #23471 adding link to Postman workspace
* workspace provides to visualize software-catalog API
* workspace allows to try out API calls in browser

As @tudi2d [suggested](https://github.com/backstage/backstage/pull/23471#pullrequestreview-1927961399), adding a link to a [public workspace](https://www.postman.com/backstage-io/workspace/catalog-api/api/1beb18f3-c80b-4fde-9737-f48256106e10?action=share&creator=33530711) that visualises the OpenAPI definition including the ability to test API endpoints against localhost or any remote backstage instance.

![image](https://github.com/backstage/backstage/assets/1872314/07a6e979-2840-46f1-ad0b-75a2cf56daf4)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
