### PR TITLE
Patch release of #23933

### DIFF
--- a/.changeset/little-bats-admire.md
+++ b/.changeset/little-bats-admire.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-kubernetes-backend': patch
----
-
-Fixed a crash reading `credentials` from `undefined`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/backend-next/CHANGELOG.md
+++ b/packages/backend-next/CHANGELOG.md
@@ -1,5 +1,12 @@
 # example-backend-next
 
+## 0.0.25
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-kubernetes-backend@0.16.4
+
 ## 0.0.24
 
 ### Patch Changes

--- a/packages/backend-next/package.json
+++ b/packages/backend-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-backend-next",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/packages/backend/CHANGELOG.md
+++ b/packages/backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # example-backend
 
+## 0.2.97
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-kubernetes-backend@0.16.4
+
 ## 0.2.96
 
 ### Patch Changes

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-backend",
-  "version": "0.2.96",
+  "version": "0.2.97",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/kubernetes-backend/CHANGELOG.md
+++ b/plugins/kubernetes-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-kubernetes-backend
 
+## 0.16.4
+
+### Patch Changes
+
+- ba366f2: Fixed a crash reading `credentials` from `undefined`.
+- Updated dependencies
+  - @backstage/plugin-kubernetes-node@0.1.10
+
 ## 0.16.3
 
 ### Patch Changes

--- a/plugins/kubernetes-backend/package.json
+++ b/plugins/kubernetes-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-kubernetes-backend",
   "description": "A Backstage backend plugin that integrates towards Kubernetes",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
This release fixes an bug where the kubernetes plugin would crash reading `credentials` from `undefined`.