### PR TITLE
Propose changes to better support external notifications

### DIFF
--- a/beps/0001-notifications-system/README.md
+++ b/beps/0001-notifications-system/README.md
@@ -192,13 +192,17 @@ The following backend service interfaces are added as part of this proposal.
 ```ts
 // TODO - We may want to add an additional wrapping here with interfaces for Notification and NotificationParameters
 
-export type NotificationRecipients =
+export type NotificationRecipients[] =
   | {
       type: 'entity';
       entityRef: string | string[]; // typically a user or group entity, otherwise `spec.owner` of the entity/entities
     }
   | {
       type: 'broadcast'; // all users
+    }
+  | {
+      type: 'external'; // a value recognized by a NotificationProcessor for an external destination such as a Slack channel
+      externalRef: string;
     };
 
 export type NotificationSeverity = 'critical' | 'high' | 'normal' | 'low';
@@ -227,7 +231,7 @@ export type Notification = {
 };
 
 interface SendNotificationRequest {
-  recipients: NotificationRecipients;
+  recipients: NotificationRecipients[];
   payload: NotificationPayload;
 }
 


### PR DESCRIPTION
While it makes sense to send notifications to users (or broadcast) in many scenarios, its possible that external integrations via NotificationProcessor may not have a 1:1 relationship with users.

For example, while the current interface is adequate for sending Slack DMs to users or teams (via the team expansion code in the notifications-backend) it doesn't facilitate a way to choose a different destination such as a Slack channel or Email mailing list.

We could add another recipient type of `external` that would accept some arbitrary value that processors can choose to support. For example a value for `externalRef` may be something like `slack:C03SABTG6RX` or `slack:#abc` or `email:list@example.com`.

This would also change the interface for recipients to accept an array so that multiple types of recipients could be specified.

This would still allow for direct user notifications if desired, as well as separate external notifications sent for the same `SendNotificationRequest`.

One challenge with this approach might be if you want a notification to go to individual users using the WebProcessor and only 1 notification via the SlackProcessor as there is not a way for the processor to know whether it should act on all notifications it receives or not.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
