### PR TITLE
fix(github-providers): properly instantiate with EventsService when defined

### DIFF
--- a/.changeset/twenty-items-shave.md
+++ b/.changeset/twenty-items-shave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+Properly instantiate `GithubMultiOrgEntityProvider` and `GithubOrgEntityProvider` with `EventsService` if defined

--- a/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
@@ -208,6 +208,7 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
       orgs: options.orgs,
       userTransformer: options.userTransformer,
       teamTransformer: options.teamTransformer,
+      events: options.events,
     });
 
     provider.schedule(options.schedule);

--- a/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.ts
@@ -169,6 +169,7 @@ export class GithubOrgEntityProvider
         DefaultGithubCredentialsProvider.fromIntegrations(integrations),
       userTransformer: options.userTransformer,
       teamTransformer: options.teamTransformer,
+      events: options.events,
     });
 
     provider.schedule(options.schedule);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes an issue where the supplied `EventsService` option when instantiating these providers with `.fromConfig` weren't actually passing it into the constructor. This seems to have mistakenly been left out from https://github.com/backstage/backstage/pull/23695

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
