### PR TITLE
refactor(collators): allow tokenManager param to be optional

### DIFF
--- a/.changeset/wild-seahorses-grin.md
+++ b/.changeset/wild-seahorses-grin.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-search-backend-module-techdocs': patch
+'@backstage/plugin-search-backend-module-catalog': patch
+---
+
+Allow the `tokenManager` parameter to be optional when instantiating collator

--- a/plugins/search-backend-module-catalog/api-report.md
+++ b/plugins/search-backend-module-catalog/api-report.md
@@ -44,7 +44,7 @@ export class DefaultCatalogCollatorFactory implements DocumentCollatorFactory {
 export type DefaultCatalogCollatorFactoryOptions = {
   auth?: AuthService;
   discovery: PluginEndpointDiscovery;
-  tokenManager: TokenManager;
+  tokenManager?: TokenManager;
   locationTemplate?: string;
   filter?: GetEntitiesRequest['filter'];
   batchSize?: number;

--- a/plugins/search-backend-module-catalog/src/collators/DefaultCatalogCollatorFactory.ts
+++ b/plugins/search-backend-module-catalog/src/collators/DefaultCatalogCollatorFactory.ts
@@ -40,7 +40,7 @@ import { AuthService } from '@backstage/backend-plugin-api';
 export type DefaultCatalogCollatorFactoryOptions = {
   auth?: AuthService;
   discovery: PluginEndpointDiscovery;
-  tokenManager: TokenManager;
+  tokenManager?: TokenManager;
   /**
    * @deprecated Use the config key `search.collators.catalog.locationTemplate` instead.
    */
@@ -95,7 +95,6 @@ export class DefaultCatalogCollatorFactory implements DocumentCollatorFactory {
       entityTransformer: options.entityTransformer,
       auth: adaptedAuth,
       discovery: options.discovery,
-      tokenManager: options.tokenManager,
       catalogClient: options.catalogClient,
     });
   }
@@ -107,7 +106,6 @@ export class DefaultCatalogCollatorFactory implements DocumentCollatorFactory {
     entityTransformer?: CatalogCollatorEntityTransformer;
     auth: AuthService;
     discovery: PluginEndpointDiscovery;
-    tokenManager: TokenManager;
     catalogClient?: CatalogApi;
   }) {
     const {

--- a/plugins/search-backend-module-techdocs/api-report.md
+++ b/plugins/search-backend-module-techdocs/api-report.md
@@ -45,7 +45,7 @@ export type TechDocsCollatorEntityTransformer = (
 export type TechDocsCollatorFactoryOptions = {
   discovery: PluginEndpointDiscovery;
   logger: LoggerService;
-  tokenManager: TokenManager;
+  tokenManager?: TokenManager;
   auth?: AuthService;
   httpAuth?: HttpAuthService;
   locationTemplate?: string;

--- a/plugins/search-backend-module-techdocs/src/collators/DefaultTechDocsCollatorFactory.ts
+++ b/plugins/search-backend-module-techdocs/src/collators/DefaultTechDocsCollatorFactory.ts
@@ -61,7 +61,7 @@ interface MkSearchIndexDoc {
 export type TechDocsCollatorFactoryOptions = {
   discovery: PluginEndpointDiscovery;
   logger: LoggerService;
-  tokenManager: TokenManager;
+  tokenManager?: TokenManager;
   auth?: AuthService;
   httpAuth?: HttpAuthService;
   locationTemplate?: string;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When migrating to the new auth services, these required types prevent fully removing references to the deprecated `tokenManager` since it is required to be passed in

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
