### PR TITLE
fixed Azure DevOps pipeline for build definition annotation

### DIFF
--- a/.changeset/mean-tomatoes-sip.md
+++ b/.changeset/mean-tomatoes-sip.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-azure-devops': patch
+---
+
+Fixed bug in EntityPageAzurePipeline component where build definition annotation used for viewing pipelines

--- a/plugins/azure-devops/src/api/AzureDevOpsClient.ts
+++ b/plugins/azure-devops/src/api/AzureDevOpsClient.ts
@@ -166,6 +166,7 @@ export class AzureDevOpsClient implements AzureDevOpsApi {
           if (options?.top) {
             queryString.set('top', options.top.toString());
           }
+          queryString.append('entityRef', entityRef);
           const urlSegment = `builds/${encodeURIComponent(
             projectName,
           )}?${queryString}`;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

EntityPageAzurePipeline component is throwing error `Invalid entityRef, not a string` when build definition annotation used. This PR will fix this issue.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
