### PR TITLE
chore: open the PR in browser when running patch script

### DIFF
--- a/scripts/patch-release-for-pr.js
+++ b/scripts/patch-release-for-pr.js
@@ -169,9 +169,11 @@ async function main(args) {
     body: 'This release fixes an issue where',
     title: `Patch release of ${prNumbers.map(nr => `#${nr}`).join(', ')}`,
   });
-  console.log(
-    `https://github.com/backstage/backstage/compare/${patchBranch}...${branchName}?${params}`,
-  );
+
+  const url = `https://github.com/backstage/backstage/compare/${patchBranch}...${branchName}?${params}`;
+  console.log(`Opening ${url} ...`);
+
+  await run('open', url);
 }
 
 main(process.argv.slice(2)).catch(error => {


### PR DESCRIPTION
Hopefully will help avoid any issues creating PR's to the right branch.
