### PR TITLE
Patch release of #23980

### DIFF
--- a/.changeset/fuzzy-ducks-nail.md
+++ b/.changeset/fuzzy-ducks-nail.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-events-backend': patch
----
-
-Allow unauthenticated requests for HTTP ingress.

--- a/.changeset/fuzzy-ducks-nail.md
+++ b/.changeset/fuzzy-ducks-nail.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-events-backend': patch
+---
+
+Allow unauthenticated requests for HTTP ingress.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.25.1",
+  "version": "1.25.2",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/backend-dynamic-feature-service/CHANGELOG.md
+++ b/packages/backend-dynamic-feature-service/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/backend-dynamic-feature-service
 
+## 0.2.8
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-events-backend@0.3.3
+
 ## 0.2.7
 
 ### Patch Changes

--- a/packages/backend-dynamic-feature-service/package.json
+++ b/packages/backend-dynamic-feature-service/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/backend-dynamic-feature-service",
   "description": "Backstage dynamic feature service",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/packages/backend/CHANGELOG.md
+++ b/packages/backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # example-backend
 
+## 0.2.98
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-events-backend@0.3.3
+
 ## 0.2.97
 
 ### Patch Changes

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-backend",
-  "version": "0.2.97",
+  "version": "0.2.98",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/events-backend/CHANGELOG.md
+++ b/plugins/events-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/plugin-events-backend
 
+## 0.3.3
+
+### Patch Changes
+
+- 33248fa: Allow unauthenticated requests for HTTP ingress.
+
 ## 0.3.2
 
 ### Patch Changes

--- a/plugins/events-backend/package.json
+++ b/plugins/events-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-events-backend",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "backstage": {
     "role": "backend-plugin"
   },

--- a/plugins/events-backend/src/service/EventsPlugin.ts
+++ b/plugins/events-backend/src/service/EventsPlugin.ts
@@ -94,6 +94,10 @@ export const eventsPlugin = createBackendPlugin({
         const eventsRouter = Router();
         http.bind(eventsRouter);
         router.use(eventsRouter);
+        router.addAuthPolicy({
+          allow: 'unauthenticated',
+          path: '/http',
+        });
       },
     });
   },


### PR DESCRIPTION
This release fixes an issue where requests for the public `http` routes for the `events-backend` were authenticated causing 401 errors.