### PR TITLE
fix: retrieve relations when mapping group entities for notifications

### DIFF
--- a/.changeset/sour-ways-repeat.md
+++ b/.changeset/sour-ways-repeat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications-backend': patch
+---
+
+fix: retrieve relations and children when mapping group entities for notifications

--- a/plugins/notifications-backend/src/service/router.ts
+++ b/plugins/notifications-backend/src/service/router.ts
@@ -102,7 +102,7 @@ export async function createRouter(
     const entities = await catalogClient.getEntitiesByRefs(
       {
         entityRefs: refs,
-        fields: ['kind', 'metadata.name', 'metadata.namespace', 'relations'],
+        fields: ['kind', 'metadata.name', 'metadata.namespace', 'relations', 'spec.children'],
       },
       { token },
     );
@@ -123,7 +123,7 @@ export async function createRouter(
         const childGroups = await catalogClient.getEntitiesByRefs(
           {
             entityRefs: entity.spec.children,
-            fields: ['kind', 'metadata.name', 'metadata.namespace', 'relations'],
+            fields: ['kind', 'metadata.name', 'metadata.namespace', 'relations', 'spec.children'],
           },
           { token },
         );

--- a/plugins/notifications-backend/src/service/router.ts
+++ b/plugins/notifications-backend/src/service/router.ts
@@ -102,7 +102,7 @@ export async function createRouter(
     const entities = await catalogClient.getEntitiesByRefs(
       {
         entityRefs: refs,
-        fields: ['kind', 'metadata.name', 'metadata.namespace'],
+        fields: ['kind', 'metadata.name', 'metadata.namespace', 'relations'],
       },
       { token },
     );
@@ -123,7 +123,7 @@ export async function createRouter(
         const childGroups = await catalogClient.getEntitiesByRefs(
           {
             entityRefs: entity.spec.children,
-            fields: ['kind', 'metadata.name', 'metadata.namespace'],
+            fields: ['kind', 'metadata.name', 'metadata.namespace', 'relations'],
           },
           { token },
         );

--- a/plugins/notifications-backend/src/service/router.ts
+++ b/plugins/notifications-backend/src/service/router.ts
@@ -28,6 +28,7 @@ import {
   isGroupEntity,
   isUserEntity,
   RELATION_HAS_MEMBER,
+  RELATION_PARENT_OF,
   stringifyEntityRef,
 } from '@backstage/catalog-model';
 import { NotificationProcessor } from '@backstage/plugin-notifications-node';
@@ -102,7 +103,7 @@ export async function createRouter(
     const entities = await catalogClient.getEntitiesByRefs(
       {
         entityRefs: refs,
-        fields: ['kind', 'metadata.name', 'metadata.namespace', 'relations', 'spec.children'],
+        fields: ['kind', 'metadata.name', 'metadata.namespace', 'relations'],
       },
       { token },
     );
@@ -120,10 +121,23 @@ export async function createRouter(
               relation.type === RELATION_HAS_MEMBER && relation.targetRef,
           )
           .map(r => r.targetRef);
+
+        const childGroupRefs = entity.relations
+          .filter(
+            relation =>
+              relation.type === RELATION_PARENT_OF && relation.targetRef,
+          )
+          .map(r => r.targetRef);
+
         const childGroups = await catalogClient.getEntitiesByRefs(
           {
-            entityRefs: entity.spec.children,
-            fields: ['kind', 'metadata.name', 'metadata.namespace', 'relations', 'spec.children'],
+            entityRefs: childGroupRefs,
+            fields: [
+              'kind',
+              'metadata.name',
+              'metadata.namespace',
+              'relations',
+            ],
           },
           { token },
         );

--- a/plugins/notifications-backend/src/service/router.ts
+++ b/plugins/notifications-backend/src/service/router.ts
@@ -103,7 +103,13 @@ export async function createRouter(
     const entities = await catalogClient.getEntitiesByRefs(
       {
         entityRefs: refs,
-        fields: ['kind', 'metadata.name', 'metadata.namespace', 'relations'],
+        fields: [
+          'kind',
+          'metadata.name',
+          'metadata.namespace',
+          'relations',
+          'spec.owner',
+        ],
       },
       { token },
     );
@@ -137,6 +143,7 @@ export async function createRouter(
               'metadata.name',
               'metadata.namespace',
               'relations',
+              'spec.owner',
             ],
           },
           { token },


### PR DESCRIPTION
## Hey, I just made a Pull Request!
fix: retrieve relations when mapping group entities for notifications.

currently this condition can never be met because the field for `relations` is never returned. `spec.children` is also missing.
![image](https://github.com/backstage/backstage/assets/55280588/c4ef257d-1329-4a15-90b4-68c0478a4acf)

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
