### PR TITLE
feat(packages/backend-common): allow to provide authentification to DockerContainerRunner

### DIFF
--- a/.changeset/tame-pianos-hunt.md
+++ b/.changeset/tame-pianos-hunt.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/backend-common': minor
+'@backstage/backend-common': patch
 ---
 
 Added `pullOptions` to `DockerContainerRunner#runContainer` method to pass down options when pulling an image.

--- a/.changeset/tame-pianos-hunt.md
+++ b/.changeset/tame-pianos-hunt.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': minor
+---
+
+Allow to provide authentification which in turn allows usage of private registries

--- a/.changeset/tame-pianos-hunt.md
+++ b/.changeset/tame-pianos-hunt.md
@@ -2,4 +2,4 @@
 '@backstage/backend-common': minor
 ---
 
-Allow providing authentication which in turn allows usage of private registries
+Added `pullOptions` to `DockerContainerRunner#runContainer` method to pass down options when pulling an image.

--- a/.changeset/tame-pianos-hunt.md
+++ b/.changeset/tame-pianos-hunt.md
@@ -2,4 +2,4 @@
 '@backstage/backend-common': minor
 ---
 
-Allow to provide authentification which in turn allows usage of private registries
+Allow providing authentication which in turn allows usage of private registries

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -306,6 +306,20 @@ export type DatabaseManagerOptions = {
 };
 
 // @public
+export interface DockerAuthentication {
+  // (undocumented)
+  auth?: string;
+  // (undocumented)
+  email?: string;
+  // (undocumented)
+  password?: string;
+  // (undocumented)
+  serveraddress?: string;
+  // (undocumented)
+  username?: string;
+}
+
+// @public
 export class DockerContainerRunner implements ContainerRunner {
   constructor(options: { dockerClient: Docker });
   // (undocumented)
@@ -740,6 +754,7 @@ export type RunContainerOptions = {
   envVars?: Record<string, string>;
   pullImage?: boolean;
   defaultUser?: boolean;
+  authentication?: DockerAuthentication;
 };
 
 export { SearchOptions };

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -306,20 +306,6 @@ export type DatabaseManagerOptions = {
 };
 
 // @public
-export interface DockerAuthentication {
-  // (undocumented)
-  auth?: string;
-  // (undocumented)
-  email?: string;
-  // (undocumented)
-  password?: string;
-  // (undocumented)
-  serveraddress?: string;
-  // (undocumented)
-  username?: string;
-}
-
-// @public
 export class DockerContainerRunner implements ContainerRunner {
   constructor(options: { dockerClient: Docker });
   // (undocumented)
@@ -657,6 +643,21 @@ export { PluginDatabaseManager };
 export { PluginEndpointDiscovery };
 
 // @public
+export interface PullOptions {
+  // (undocumented)
+  [key: string]: unknown;
+  // (undocumented)
+  authconfig?: {
+    username?: string;
+    password?: string;
+    auth?: string;
+    email?: string;
+    serveraddress?: string;
+    [key: string]: unknown;
+  };
+}
+
+// @public
 export type ReaderFactory = (options: {
   config: Config;
   logger: LoggerService;
@@ -754,7 +755,7 @@ export type RunContainerOptions = {
   envVars?: Record<string, string>;
   pullImage?: boolean;
   defaultUser?: boolean;
-  authentication?: DockerAuthentication;
+  pullOptions?: PullOptions;
 };
 
 export { SearchOptions };

--- a/packages/backend-common/src/util/ContainerRunner.ts
+++ b/packages/backend-common/src/util/ContainerRunner.ts
@@ -23,12 +23,16 @@ import { Writable } from 'stream';
  *
  *   @public
  */
-export interface DockerAuthentication {
-  username?: string;
-  password?: string;
-  auth?: string;
-  email?: string;
-  serveraddress?: string;
+export interface PullOptions {
+  authconfig?: {
+    username?: string;
+    password?: string;
+    auth?: string;
+    email?: string;
+    serveraddress?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
 }
 
 /**
@@ -46,7 +50,7 @@ export type RunContainerOptions = {
   envVars?: Record<string, string>;
   pullImage?: boolean;
   defaultUser?: boolean;
-  authentication?: DockerAuthentication;
+  pullOptions?: PullOptions;
 };
 
 /**

--- a/packages/backend-common/src/util/ContainerRunner.ts
+++ b/packages/backend-common/src/util/ContainerRunner.ts
@@ -17,6 +17,21 @@
 import { Writable } from 'stream';
 
 /**
+ *   Allows defining access credentials for a registry
+ *   Follows dockerode auth configuration:
+ *   {@link https://github.com/apocas/dockerode?tab=readme-ov-file#pull-from-private-repos}
+ *
+ *   @public
+ */
+export interface DockerAuthentication {
+  username?: string;
+  password?: string;
+  auth?: string;
+  email?: string;
+  serveraddress?: string;
+}
+
+/**
  * Options passed to the {@link ContainerRunner.runContainer} method.
  *
  * @public
@@ -31,6 +46,7 @@ export type RunContainerOptions = {
   envVars?: Record<string, string>;
   pullImage?: boolean;
   defaultUser?: boolean;
+  authentication?: DockerAuthentication;
 };
 
 /**

--- a/packages/backend-common/src/util/DockerContainerRunner.test.ts
+++ b/packages/backend-common/src/util/DockerContainerRunner.test.ts
@@ -83,6 +83,28 @@ describe('DockerContainerRunner', () => {
     expect(mockDocker.run).toHaveBeenCalled();
   });
 
+  it('should pull the docker container with authentication', async () => {
+    await containerTaskApi.runContainer({
+      imageName,
+      args,
+      authentication: {
+        auth: 'aaaaaaaaa',
+      },
+    });
+
+    expect(mockDocker.pull).toHaveBeenCalledWith(
+      imageName,
+      {
+        authconfig: {
+          auth: 'aaaaaaaaa',
+        },
+      },
+      expect.any(Function),
+    );
+
+    expect(mockDocker.run).toHaveBeenCalled();
+  });
+
   it('should not pull the docker container when pullImage is false', async () => {
     await containerTaskApi.runContainer({
       imageName,

--- a/packages/backend-common/src/util/DockerContainerRunner.test.ts
+++ b/packages/backend-common/src/util/DockerContainerRunner.test.ts
@@ -87,8 +87,10 @@ describe('DockerContainerRunner', () => {
     await containerTaskApi.runContainer({
       imageName,
       args,
-      authentication: {
-        auth: 'aaaaaaaaa',
+      pullOptions: {
+        authconfig: {
+          auth: 'aaaaaaaaa',
+        },
       },
     });
 

--- a/packages/backend-common/src/util/DockerContainerRunner.ts
+++ b/packages/backend-common/src/util/DockerContainerRunner.ts
@@ -47,7 +47,7 @@ export class DockerContainerRunner implements ContainerRunner {
       envVars = {},
       pullImage = true,
       defaultUser = false,
-      authentication,
+      pullOptions = {},
     } = options;
 
     // Show a better error message when Docker is unavailable.
@@ -62,17 +62,13 @@ export class DockerContainerRunner implements ContainerRunner {
 
     if (pullImage) {
       await new Promise<void>((resolve, reject) => {
-        this.dockerClient.pull(
-          imageName,
-          { authconfig: authentication },
-          (err, stream) => {
-            if (err) return reject(err);
-            stream.pipe(logStream, { end: false });
-            stream.on('end', () => resolve());
-            stream.on('error', (error: Error) => reject(error));
-            return undefined;
-          },
-        );
+        this.dockerClient.pull(imageName, pullOptions, (err, stream) => {
+          if (err) return reject(err);
+          stream.pipe(logStream, { end: false });
+          stream.on('end', () => resolve());
+          stream.on('error', (error: Error) => reject(error));
+          return undefined;
+        });
       });
     }
 

--- a/packages/backend-common/src/util/DockerContainerRunner.ts
+++ b/packages/backend-common/src/util/DockerContainerRunner.ts
@@ -47,6 +47,7 @@ export class DockerContainerRunner implements ContainerRunner {
       envVars = {},
       pullImage = true,
       defaultUser = false,
+      authentication,
     } = options;
 
     // Show a better error message when Docker is unavailable.
@@ -61,13 +62,17 @@ export class DockerContainerRunner implements ContainerRunner {
 
     if (pullImage) {
       await new Promise<void>((resolve, reject) => {
-        this.dockerClient.pull(imageName, {}, (err, stream) => {
-          if (err) return reject(err);
-          stream.pipe(logStream, { end: false });
-          stream.on('end', () => resolve());
-          stream.on('error', (error: Error) => reject(error));
-          return undefined;
-        });
+        this.dockerClient.pull(
+          imageName,
+          { authconfig: authentication },
+          (err, stream) => {
+            if (err) return reject(err);
+            stream.pipe(logStream, { end: false });
+            stream.on('end', () => resolve());
+            stream.on('error', (error: Error) => reject(error));
+            return undefined;
+          },
+        );
       });
     }
 

--- a/packages/backend-common/src/util/index.ts
+++ b/packages/backend-common/src/util/index.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-export type { ContainerRunner, RunContainerOptions } from './ContainerRunner';
+export type {
+  ContainerRunner,
+  RunContainerOptions,
+  DockerAuthentication,
+} from './ContainerRunner';
 export { DockerContainerRunner } from './DockerContainerRunner';
 export type {
   KubernetesContainerRunnerOptions,

--- a/packages/backend-common/src/util/index.ts
+++ b/packages/backend-common/src/util/index.ts
@@ -17,7 +17,7 @@
 export type {
   ContainerRunner,
   RunContainerOptions,
-  DockerAuthentication,
+  PullOptions,
 } from './ContainerRunner';
 export { DockerContainerRunner } from './DockerContainerRunner';
 export type {


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Introduce a new field in `DockerRunOptions` which allows to provide the credentials. 

I have considered setting up a new facility to provide OCI credentials to the system, tough this would more discussion or even a BEP. 
This is a stop gap solution, tough can be integrated in a later one. E.g. credentials are provided by integrations by default, but users can overwrite authentication via DockerRunOptions. 
<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
