### PR TITLE
Fixed a bug where the `azureDevOps.token` was not truly optional

### DIFF
--- a/.changeset/soft-files-smash.md
+++ b/.changeset/soft-files-smash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-azure-devops-backend': patch
+---
+
+Fixed a bug where the `azureDevOps.token` was not truly optional

--- a/plugins/azure-devops-backend/config.d.ts
+++ b/plugins/azure-devops-backend/config.d.ts
@@ -28,7 +28,7 @@ export interface Config {
      * @visibility secret
      * @deprecated Use `integrations.azure` instead, see {@link https://backstage.io/docs/integrations/azure/locations}
      */
-    token: string;
+    token?: string;
     /**
      * The organization of the given Azure instance
      */

--- a/plugins/azure-devops-backend/src/service/router.ts
+++ b/plugins/azure-devops-backend/src/service/router.ts
@@ -59,7 +59,7 @@ export async function createRouter(
 ): Promise<express.Router> {
   const { logger, reader, config, permissions } = options;
 
-  if (config.getString('azureDevOps.token')) {
+  if (config.getOptionalString('azureDevOps.token')) {
     logger.warn(
       "The 'azureDevOps.token' has been deprecated, use 'integrations.azure' instead, for more details see: https://backstage.io/docs/integrations/azure/locations",
     );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixed a bug where the `azureDevOps.token` was not truly optional

Closes #23995

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
