### PR TITLE
[GCP Cloudbuild plugin] Change the hyperlink column

### DIFF
--- a/.changeset/lovely-flowers-promise.md
+++ b/.changeset/lovely-flowers-promise.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-cloudbuild': minor
+'@backstage/plugin-cloudbuild': patch
 ---
 
 Changed the column that serves as a hyperlink from SOURCE to BUILD.

--- a/.changeset/lovely-flowers-promise.md
+++ b/.changeset/lovely-flowers-promise.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-cloudbuild': minor
+---
+
+Changed the column that serves as a hyperlink from SOURCE to BUILD.

--- a/plugins/cloudbuild/src/components/WorkflowRunsTable/WorkflowRunsTable.tsx
+++ b/plugins/cloudbuild/src/components/WorkflowRunsTable/WorkflowRunsTable.tsx
@@ -48,11 +48,18 @@ const generatedColumns: TableColumn[] = [
     field: 'id',
     type: 'numeric',
     width: '150px',
-    render: (row: Partial<WorkflowRun>) => (
-      <Typography variant="body2" noWrap>
-        {row.id?.substring(0, 8)}
-      </Typography>
-    ),
+    render: (row: Partial<WorkflowRun>) => {
+      const LinkWrapper = () => {
+        const routeLink = useRouteRef(buildRouteRef);
+        return (
+          <Link data-testid="cell-source" to={routeLink({ id: row.id! })}>
+            {row.id?.substring(0, 8)}
+          </Link>
+        );
+      };
+
+      return <LinkWrapper />;
+    },
   },
   {
     title: 'Trigger Name',
@@ -67,18 +74,11 @@ const generatedColumns: TableColumn[] = [
     field: 'source',
     highlight: true,
     width: '200px',
-    render: (row: Partial<WorkflowRun>) => {
-      const LinkWrapper = () => {
-        const routeLink = useRouteRef(buildRouteRef);
-        return (
-          <Link data-testid="cell-source" to={routeLink({ id: row.id! })}>
-            {row.message}
-          </Link>
-        );
-      };
-
-      return <LinkWrapper />;
-    },
+    render: (row: Partial<WorkflowRun>) => (
+      <Typography variant="body2" noWrap>
+        {row.message}
+      </Typography>
+    ),
   },
   {
     title: 'Ref',


### PR DESCRIPTION
## Hey, I just made a Pull Request!
I changed the column that serves as a hyperlink from SOURCE to BUILD.
<img width="765" alt="スクリーンショット 2024-04-05 19 30 52" src="https://github.com/backstage/backstage/assets/12871716/2bb812aa-d15e-467a-ab6e-9140823e837f">


related issue: #23697

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
