### PR TITLE
run repo fix after yarn new

### DIFF
--- a/.changeset/tender-keys-happen.md
+++ b/.changeset/tender-keys-happen.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Run `repo fix` on newly created packages

--- a/packages/cli/src/lib/new/factories/backendModule.test.ts
+++ b/packages/cli/src/lib/new/factories/backendModule.test.ts
@@ -106,7 +106,7 @@ describe('backendModule factory', () => {
     expect(moduleFile).toContain(`pluginId: 'test',`);
     expect(moduleFile).toContain(`moduleId: 'tester-two',`);
 
-    expect(Task.forCommand).toHaveBeenCalledTimes(2);
+    expect(Task.forCommand).toHaveBeenCalledTimes(3);
     expect(Task.forCommand).toHaveBeenCalledWith('yarn install', {
       cwd: mockDir.resolve('plugins/test-backend-module-tester-two'),
       optional: true,
@@ -115,5 +115,12 @@ describe('backendModule factory', () => {
       cwd: mockDir.resolve('plugins/test-backend-module-tester-two'),
       optional: true,
     });
+    expect(Task.forCommand).toHaveBeenCalledWith(
+      'yarn backstage-cli repo fix',
+      {
+        cwd: mockDir.resolve('plugins/test-backend-module-tester-two'),
+        optional: true,
+      },
+    );
   });
 });

--- a/packages/cli/src/lib/new/factories/backendModule.ts
+++ b/packages/cli/src/lib/new/factories/backendModule.ts
@@ -100,5 +100,9 @@ export const backendModule = createFactory<Options>({
       cwd: targetDir,
       optional: true,
     });
+    await Task.forCommand('yarn backstage-cli repo fix', {
+      cwd: targetDir,
+      optional: true,
+    });
   },
 });

--- a/packages/cli/src/lib/new/factories/backendPlugin.test.ts
+++ b/packages/cli/src/lib/new/factories/backendPlugin.test.ts
@@ -99,7 +99,7 @@ describe('backendPlugin factory', () => {
       },
     });
 
-    expect(Task.forCommand).toHaveBeenCalledTimes(2);
+    expect(Task.forCommand).toHaveBeenCalledTimes(3);
     expect(Task.forCommand).toHaveBeenCalledWith('yarn install', {
       cwd: mockDir.resolve('plugins/test-backend'),
       optional: true,
@@ -108,5 +108,12 @@ describe('backendPlugin factory', () => {
       cwd: mockDir.resolve('plugins/test-backend'),
       optional: true,
     });
+    expect(Task.forCommand).toHaveBeenCalledWith(
+      'yarn backstage-cli repo fix',
+      {
+        cwd: mockDir.resolve('plugins/test-backend'),
+        optional: true,
+      },
+    );
   });
 });

--- a/packages/cli/src/lib/new/factories/backendPlugin.ts
+++ b/packages/cli/src/lib/new/factories/backendPlugin.ts
@@ -89,5 +89,9 @@ export const backendPlugin = createFactory<Options>({
       cwd: targetDir,
       optional: true,
     });
+    await Task.forCommand('yarn backstage-cli repo fix', {
+      cwd: targetDir,
+      optional: true,
+    });
   },
 });

--- a/packages/cli/src/lib/new/factories/frontendPlugin.test.ts
+++ b/packages/cli/src/lib/new/factories/frontendPlugin.test.ts
@@ -133,7 +133,7 @@ const router = (
 )
 `);
 
-    expect(Task.forCommand).toHaveBeenCalledTimes(2);
+    expect(Task.forCommand).toHaveBeenCalledTimes(3);
     expect(Task.forCommand).toHaveBeenCalledWith('yarn install', {
       cwd: mockDir.resolve('plugins/test'),
       optional: true,
@@ -142,6 +142,13 @@ const router = (
       cwd: mockDir.resolve('plugins/test'),
       optional: true,
     });
+    expect(Task.forCommand).toHaveBeenCalledWith(
+      'yarn backstage-cli repo fix',
+      {
+        cwd: mockDir.resolve('plugins/test'),
+        optional: true,
+      },
+    );
   });
 
   it('should create a frontend plugin with more options and codeowners', async () => {
@@ -198,7 +205,7 @@ const router = (
 )
 `);
 
-    expect(Task.forCommand).toHaveBeenCalledTimes(2);
+    expect(Task.forCommand).toHaveBeenCalledTimes(3);
     expect(Task.forCommand).toHaveBeenCalledWith('yarn install', {
       cwd: mockDir.resolve('plugins/test'),
       optional: true,
@@ -207,5 +214,12 @@ const router = (
       cwd: mockDir.resolve('plugins/test'),
       optional: true,
     });
+    expect(Task.forCommand).toHaveBeenCalledWith(
+      'yarn backstage-cli repo fix',
+      {
+        cwd: mockDir.resolve('plugins/test'),
+        optional: true,
+      },
+    );
   });
 });

--- a/packages/cli/src/lib/new/factories/frontendPlugin.ts
+++ b/packages/cli/src/lib/new/factories/frontendPlugin.ts
@@ -128,5 +128,9 @@ export const frontendPlugin = createFactory<Options>({
       cwd: targetDir,
       optional: true,
     });
+    await Task.forCommand('yarn backstage-cli repo fix', {
+      cwd: targetDir,
+      optional: true,
+    });
   },
 });

--- a/packages/cli/src/lib/new/factories/nodeLibraryPackage.test.ts
+++ b/packages/cli/src/lib/new/factories/nodeLibraryPackage.test.ts
@@ -99,7 +99,7 @@ describe('nodeLibraryPackage factory', () => {
       }),
     );
 
-    expect(Task.forCommand).toHaveBeenCalledTimes(2);
+    expect(Task.forCommand).toHaveBeenCalledTimes(3);
     expect(Task.forCommand).toHaveBeenCalledWith('yarn install', {
       cwd: mockDir.resolve('packages', expectedNodeLibraryPackageName),
       optional: true,
@@ -108,6 +108,13 @@ describe('nodeLibraryPackage factory', () => {
       cwd: mockDir.resolve('packages', expectedNodeLibraryPackageName),
       optional: true,
     });
+    expect(Task.forCommand).toHaveBeenCalledWith(
+      'yarn backstage-cli repo fix',
+      {
+        cwd: mockDir.resolve('packages', expectedNodeLibraryPackageName),
+        optional: true,
+      },
+    );
   });
 
   it('should create a node library plugin with options and codeowners', async () => {
@@ -136,7 +143,7 @@ describe('nodeLibraryPackage factory', () => {
       createTemporaryDirectory: () => fs.mkdtemp('test'),
     });
 
-    expect(Task.forCommand).toHaveBeenCalledTimes(2);
+    expect(Task.forCommand).toHaveBeenCalledTimes(3);
     expect(Task.forCommand).toHaveBeenCalledWith('yarn install', {
       cwd: mockDir.resolve(expectedNodeLibraryPackageName),
       optional: true,
@@ -145,5 +152,12 @@ describe('nodeLibraryPackage factory', () => {
       cwd: mockDir.resolve(expectedNodeLibraryPackageName),
       optional: true,
     });
+    expect(Task.forCommand).toHaveBeenCalledWith(
+      'yarn backstage-cli repo fix',
+      {
+        cwd: mockDir.resolve(expectedNodeLibraryPackageName),
+        optional: true,
+      },
+    );
   });
 });

--- a/packages/cli/src/lib/new/factories/nodeLibraryPackage.ts
+++ b/packages/cli/src/lib/new/factories/nodeLibraryPackage.ts
@@ -73,5 +73,9 @@ export const nodeLibraryPackage = createFactory<Options>({
       cwd: targetDir,
       optional: true,
     });
+    await Task.forCommand('yarn backstage-cli repo fix', {
+      cwd: targetDir,
+      optional: true,
+    });
   },
 });

--- a/packages/cli/src/lib/new/factories/pluginCommon.test.ts
+++ b/packages/cli/src/lib/new/factories/pluginCommon.test.ts
@@ -92,7 +92,7 @@ describe('pluginCommon factory', () => {
       }),
     );
 
-    expect(Task.forCommand).toHaveBeenCalledTimes(2);
+    expect(Task.forCommand).toHaveBeenCalledTimes(3);
     expect(Task.forCommand).toHaveBeenCalledWith('yarn install', {
       cwd: mockDir.resolve('plugins/test-common'),
       optional: true,
@@ -101,5 +101,12 @@ describe('pluginCommon factory', () => {
       cwd: mockDir.resolve('plugins/test-common'),
       optional: true,
     });
+    expect(Task.forCommand).toHaveBeenCalledWith(
+      'yarn backstage-cli repo fix',
+      {
+        cwd: mockDir.resolve('plugins/test-common'),
+        optional: true,
+      },
+    );
   });
 });

--- a/packages/cli/src/lib/new/factories/pluginCommon.ts
+++ b/packages/cli/src/lib/new/factories/pluginCommon.ts
@@ -73,5 +73,9 @@ export const pluginCommon = createFactory<Options>({
       cwd: targetDir,
       optional: true,
     });
+    await Task.forCommand('yarn backstage-cli repo fix', {
+      cwd: targetDir,
+      optional: true,
+    });
   },
 });

--- a/packages/cli/src/lib/new/factories/pluginNode.test.ts
+++ b/packages/cli/src/lib/new/factories/pluginNode.test.ts
@@ -92,7 +92,7 @@ describe('pluginNode factory', () => {
       }),
     );
 
-    expect(Task.forCommand).toHaveBeenCalledTimes(2);
+    expect(Task.forCommand).toHaveBeenCalledTimes(3);
     expect(Task.forCommand).toHaveBeenCalledWith('yarn install', {
       cwd: mockDir.resolve('plugins/test-node'),
       optional: true,
@@ -101,5 +101,12 @@ describe('pluginNode factory', () => {
       cwd: mockDir.resolve('plugins/test-node'),
       optional: true,
     });
+    expect(Task.forCommand).toHaveBeenCalledWith(
+      'yarn backstage-cli repo fix',
+      {
+        cwd: mockDir.resolve('plugins/test-node'),
+        optional: true,
+      },
+    );
   });
 });

--- a/packages/cli/src/lib/new/factories/pluginNode.ts
+++ b/packages/cli/src/lib/new/factories/pluginNode.ts
@@ -73,5 +73,9 @@ export const pluginNode = createFactory<Options>({
       cwd: targetDir,
       optional: true,
     });
+    await Task.forCommand('yarn backstage-cli repo fix', {
+      cwd: targetDir,
+      optional: true,
+    });
   },
 });

--- a/packages/cli/src/lib/new/factories/pluginWeb.test.ts
+++ b/packages/cli/src/lib/new/factories/pluginWeb.test.ts
@@ -99,7 +99,7 @@ describe('pluginWeb factory', () => {
       }),
     );
 
-    expect(Task.forCommand).toHaveBeenCalledTimes(2);
+    expect(Task.forCommand).toHaveBeenCalledTimes(3);
     expect(Task.forCommand).toHaveBeenCalledWith('yarn install', {
       cwd: mockDir.resolve('plugins/test-react'),
       optional: true,
@@ -108,5 +108,12 @@ describe('pluginWeb factory', () => {
       cwd: mockDir.resolve('plugins/test-react'),
       optional: true,
     });
+    expect(Task.forCommand).toHaveBeenCalledWith(
+      'yarn backstage-cli repo fix',
+      {
+        cwd: mockDir.resolve('plugins/test-react'),
+        optional: true,
+      },
+    );
   });
 });

--- a/packages/cli/src/lib/new/factories/pluginWeb.ts
+++ b/packages/cli/src/lib/new/factories/pluginWeb.ts
@@ -73,5 +73,9 @@ export const pluginWeb = createFactory<Options>({
       cwd: targetDir,
       optional: true,
     });
+    await Task.forCommand('yarn backstage-cli repo fix', {
+      cwd: targetDir,
+      optional: true,
+    });
   },
 });

--- a/packages/cli/src/lib/new/factories/scaffolderModule.test.ts
+++ b/packages/cli/src/lib/new/factories/scaffolderModule.test.ts
@@ -97,7 +97,7 @@ describe('scaffolderModule factory', () => {
       }),
     );
 
-    expect(Task.forCommand).toHaveBeenCalledTimes(2);
+    expect(Task.forCommand).toHaveBeenCalledTimes(3);
     expect(Task.forCommand).toHaveBeenCalledWith('yarn install', {
       cwd: mockDir.resolve('plugins/scaffolder-backend-module-test'),
       optional: true,
@@ -106,5 +106,12 @@ describe('scaffolderModule factory', () => {
       cwd: mockDir.resolve('plugins/scaffolder-backend-module-test'),
       optional: true,
     });
+    expect(Task.forCommand).toHaveBeenCalledWith(
+      'yarn backstage-cli repo fix',
+      {
+        cwd: mockDir.resolve('plugins/scaffolder-backend-module-test'),
+        optional: true,
+      },
+    );
   });
 });

--- a/packages/cli/src/lib/new/factories/scaffolderModule.ts
+++ b/packages/cli/src/lib/new/factories/scaffolderModule.ts
@@ -90,5 +90,9 @@ export const scaffolderModule = createFactory<Options>({
       cwd: targetDir,
       optional: true,
     });
+    await Task.forCommand('yarn backstage-cli repo fix', {
+      cwd: targetDir,
+      optional: true,
+    });
   },
 });

--- a/packages/cli/src/lib/new/factories/webLibraryPackage.test.ts
+++ b/packages/cli/src/lib/new/factories/webLibraryPackage.test.ts
@@ -99,7 +99,7 @@ describe('webLibraryPackage factory', () => {
       }),
     );
 
-    expect(Task.forCommand).toHaveBeenCalledTimes(2);
+    expect(Task.forCommand).toHaveBeenCalledTimes(3);
     expect(Task.forCommand).toHaveBeenCalledWith('yarn install', {
       cwd: mockDir.resolve('packages', expectedwebLibraryPackageName),
       optional: true,
@@ -108,6 +108,13 @@ describe('webLibraryPackage factory', () => {
       cwd: mockDir.resolve('packages', expectedwebLibraryPackageName),
       optional: true,
     });
+    expect(Task.forCommand).toHaveBeenCalledWith(
+      'yarn backstage-cli repo fix',
+      {
+        cwd: mockDir.resolve('packages', expectedwebLibraryPackageName),
+        optional: true,
+      },
+    );
   });
 
   it('should create a web library plugin with options and codeowners', async () => {
@@ -136,7 +143,7 @@ describe('webLibraryPackage factory', () => {
       createTemporaryDirectory: () => fs.mkdtemp('test'),
     });
 
-    expect(Task.forCommand).toHaveBeenCalledTimes(2);
+    expect(Task.forCommand).toHaveBeenCalledTimes(3);
     expect(Task.forCommand).toHaveBeenCalledWith('yarn install', {
       cwd: mockDir.resolve(expectedwebLibraryPackageName),
       optional: true,
@@ -145,5 +152,12 @@ describe('webLibraryPackage factory', () => {
       cwd: mockDir.resolve(expectedwebLibraryPackageName),
       optional: true,
     });
+    expect(Task.forCommand).toHaveBeenCalledWith(
+      'yarn backstage-cli repo fix',
+      {
+        cwd: mockDir.resolve(expectedwebLibraryPackageName),
+        optional: true,
+      },
+    );
   });
 });

--- a/packages/cli/src/lib/new/factories/webLibraryPackage.ts
+++ b/packages/cli/src/lib/new/factories/webLibraryPackage.ts
@@ -73,5 +73,9 @@ export const webLibraryPackage = createFactory<Options>({
       cwd: targetDir,
       optional: true,
     });
+    await Task.forCommand('yarn backstage-cli repo fix', {
+      cwd: targetDir,
+      optional: true,
+    });
   },
 });


### PR DESCRIPTION
When I made #23997, the build initially complained that I need to run repo fix. I gathered that this solution is safer than trying to put anything directly in the templates.