### PR TITLE
Fix automated release schedule message for releases >= 1.26

### DIFF
--- a/scripts/generate-merge-message.js
+++ b/scripts/generate-merge-message.js
@@ -60,7 +60,12 @@ function getReleaseSchedule() {
   return Array(100)
     .fill(0)
     .map((_, i) => {
-      const date = getReleaseOfMonth(firstReleaseYear, firstReleaseMonth + i);
+      // the 1.24 and 1.25 releases were both released in March 2024
+      const modifier = i >= 25 ? -1 : 0;
+      const date = getReleaseOfMonth(
+        firstReleaseYear,
+        firstReleaseMonth + i + modifier,
+      );
       return { version: `1.${i}.0`, date };
     });
 }

--- a/scripts/generate-merge-message.js
+++ b/scripts/generate-merge-message.js
@@ -57,14 +57,17 @@ function getReleaseSchedule() {
   const firstReleaseYear = 2022;
   const firstReleaseMonth = 2;
 
+  // for any releases that are off schedule (i.e. v1.25.0 was released
+  // in the same month as v1.24.0), we need to adjust the release date
+  const offScheduleReleases = [25];
+
   return Array(100)
     .fill(0)
     .map((_, i) => {
-      // the 1.24 and 1.25 releases were both released in March 2024
-      const modifier = i >= 25 ? -1 : 0;
+      const modifier = offScheduleReleases.filter(v => i >= v).length;
       const date = getReleaseOfMonth(
         firstReleaseYear,
-        firstReleaseMonth + i + modifier,
+        firstReleaseMonth + i - modifier,
       );
       return { version: `1.${i}.0`, date };
     });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

With Backstage v1.25 being released a month early, the automated merge messages don't reflect the actual/effective release date. This change adjusts the date to reflect that updated release schedule.

For instance, see this recent merge comment:

> Thank you for contributing to Backstage! The changes in this pull request will be part of the `1.26.0` release, scheduled for Tue, 14 May 2024.

_Originally posted by @github-actions[bot] in https://github.com/backstage/backstage/issues/23877#issuecomment-2032029825_

The correct date should be `Tue, 16 Apr 2024`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
