### PR TITLE
backend-app-api: add support for OBO tokens

### DIFF
--- a/.changeset/happy-suns-pay.md
+++ b/.changeset/happy-suns-pay.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+Make the auth service create and validate dedicated OBO tokens, containing the user identity proof.

--- a/.changeset/moody-bats-train.md
+++ b/.changeset/moody-bats-train.md
@@ -1,0 +1,9 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+Service-to-service authentication has been improved.
+
+Each plugin now has the capability to generate its own signing keys for token issuance. The generated public keys are stored in a database, and they are made accessible through a newly created endpoint: `/.backstage/auth/v1/jwks.json`.
+
+`AuthService` can now issue tokens with a reduced scope using the `getPluginRequestToken` method. This improvement enables plugins to identify the plugin originating the request.

--- a/packages/backend-app-api/src/services/implementations/auth/PluginTokenHandler.ts
+++ b/packages/backend-app-api/src/services/implementations/auth/PluginTokenHandler.ts
@@ -79,7 +79,9 @@ export class PluginTokenHandler {
     readonly discovery: DiscoveryService,
   ) {}
 
-  async verifyToken(token: string): Promise<{ subject: string } | undefined> {
+  async verifyToken(
+    token: string,
+  ): Promise<{ subject: string; limitedUserToken?: string } | undefined> {
     try {
       const { typ } = decodeProtectedHeader(token);
       if (typ !== tokenTypes.plugin.typParam) {
@@ -102,7 +104,7 @@ export class PluginTokenHandler {
     const jwksClient = await this.getJwksClient(pluginId);
     await jwksClient.refreshKeyStore(token); // TODO(Rugvip): Refactor so that this isn't needed
 
-    const { payload } = await jwtVerify<{ sub: string }>(
+    const { payload } = await jwtVerify<{ sub: string; obo?: string }>(
       token,
       jwksClient.getKey,
       {
@@ -114,21 +116,25 @@ export class PluginTokenHandler {
       throw new AuthenticationError('Invalid plugin token', e);
     });
 
-    return { subject: payload.sub };
+    return { subject: `plugin:${payload.sub}`, limitedUserToken: payload.obo };
   }
 
   async issueToken(options: {
     pluginId: string;
     targetPluginId: string;
+    onBehalfOf?: { token: string; expiresAt: Date };
   }): Promise<{ token: string }> {
+    const { pluginId, targetPluginId, onBehalfOf } = options;
     const key = await this.getKey();
 
-    const sub = options.pluginId;
-    const aud = options.targetPluginId;
+    const sub = pluginId;
+    const aud = targetPluginId;
     const iat = Math.floor(Date.now() / 1000);
-    const exp = iat + this.keyDurationSeconds;
+    const exp = onBehalfOf
+      ? Math.floor(onBehalfOf.expiresAt.getTime() / 1000)
+      : iat + this.keyDurationSeconds;
 
-    const claims = { sub, aud, iat, exp };
+    const claims = { sub, aud, iat, exp, obo: onBehalfOf?.token };
     const token = await new SignJWT(claims)
       .setProtectedHeader({
         typ: tokenTypes.plugin.typParam,
@@ -197,7 +203,7 @@ export class PluginTokenHandler {
     // Double check that the target plugin has a valid JWKS endpoint, otherwise avoid creating a remote key set
     if (!(await this.isTargetPluginSupported(pluginId))) {
       throw new AuthenticationError(
-        'Target plugin does not support self-signed tokens',
+        `Received a plugin token where the source '${pluginId}' plugin unexpectedly does not have a JWKS endpoint`,
       );
     }
 

--- a/packages/backend-app-api/src/services/implementations/auth/PluginTokenHandler.ts
+++ b/packages/backend-app-api/src/services/implementations/auth/PluginTokenHandler.ts
@@ -130,9 +130,10 @@ export class PluginTokenHandler {
     const sub = pluginId;
     const aud = targetPluginId;
     const iat = Math.floor(Date.now() / 1000);
+    const ourExp = iat + this.keyDurationSeconds;
     const exp = onBehalfOf
-      ? Math.floor(onBehalfOf.expiresAt.getTime() / 1000)
-      : iat + this.keyDurationSeconds;
+      ? Math.min(ourExp, Math.floor(onBehalfOf.expiresAt.getTime() / 1000))
+      : ourExp;
 
     const claims = { sub, aud, iat, exp, obo: onBehalfOf?.token };
     const token = await new SignJWT(claims)

--- a/packages/backend-app-api/src/services/implementations/auth/UserTokenHandler.ts
+++ b/packages/backend-app-api/src/services/implementations/auth/UserTokenHandler.ts
@@ -151,4 +151,13 @@ export class UserTokenHandler {
 
     return { token: limitedUserToken, expiresAt: new Date(payload.exp * 1000) };
   }
+
+  isLimitedUserToken(token: string): boolean {
+    try {
+      const { typ } = decodeProtectedHeader(token);
+      return typ === tokenTypes.limitedUser.typParam;
+    } catch {
+      return false;
+    }
+  }
 }

--- a/packages/backend-app-api/src/services/implementations/auth/authServiceFactory.test.ts
+++ b/packages/backend-app-api/src/services/implementations/auth/authServiceFactory.test.ts
@@ -22,6 +22,7 @@ import {
 import {
   InternalBackstageCredentials,
   authServiceFactory,
+  toInternalBackstageCredentials,
 } from './authServiceFactory';
 import { base64url, decodeJwt } from 'jose';
 import { discoveryServiceFactory } from '../discovery';
@@ -56,7 +57,14 @@ describe('authServiceFactory', () => {
     jest.useRealTimers();
   });
 
-  it('should authenticate issued tokens', async () => {
+  it('should authenticate issued tokens with legacy auth', async () => {
+    server.use(
+      rest.get(
+        'http://localhost:7007/api/catalog/.backstage/auth/v1/jwks.json',
+        (_req, res, ctx) => res(ctx.status(404)),
+      ),
+    );
+
     const tester = ServiceFactoryTester.from(authServiceFactory, {
       dependencies: mockDeps,
     });
@@ -87,7 +95,53 @@ describe('authServiceFactory', () => {
     );
   });
 
-  it('should forward user tokens', async () => {
+  it('should authenticate issued tokens with new auth', async () => {
+    const tester = ServiceFactoryTester.from(authServiceFactory, {
+      dependencies: mockDeps,
+    });
+
+    const searchAuth = await tester.get('search');
+    const catalogAuth = await tester.get('catalog');
+
+    server.use(
+      rest.get(
+        'http://localhost:7007/api/catalog/.backstage/auth/v1/jwks.json',
+        async (_req, res, ctx) =>
+          res(ctx.json(await catalogAuth.listPublicServiceKeys())),
+      ),
+      rest.get(
+        'http://localhost:7007/api/search/.backstage/auth/v1/jwks.json',
+        async (_req, res, ctx) =>
+          res(ctx.json(await searchAuth.listPublicServiceKeys())),
+      ),
+    );
+
+    const { token: searchToken } = await searchAuth.getPluginRequestToken({
+      onBehalfOf: await searchAuth.getOwnServiceCredentials(),
+      targetPluginId: 'catalog',
+    });
+
+    await expect(searchAuth.authenticate(searchToken)).rejects.toThrow(
+      'Invalid plugin token',
+    );
+    await expect(catalogAuth.authenticate(searchToken)).resolves.toEqual(
+      expect.objectContaining({
+        principal: {
+          type: 'service',
+          subject: 'plugin:search',
+        },
+      }),
+    );
+  });
+
+  it('should forward user token if target plugin does not support new auth service', async () => {
+    server.use(
+      rest.get(
+        'http://localhost:7007/api/permission/.backstage/auth/v1/jwks.json',
+        (_req, res, ctx) => res(ctx.status(404)),
+      ),
+    );
+
     const tester = ServiceFactoryTester.from(authServiceFactory, {
       dependencies: mockDeps,
     });
@@ -106,12 +160,19 @@ describe('authServiceFactory', () => {
             userEntityRef: 'user:default/alice',
           },
         } as InternalBackstageCredentials<BackstageUserPrincipal>,
-        targetPluginId: 'catalog',
+        targetPluginId: 'permission',
       }),
     ).resolves.toEqual({ token: 'alice-token' });
   });
 
-  it('should not forward service tokens', async () => {
+  it('should issue a new service token with token manager if target plugin does not support new auth service', async () => {
+    server.use(
+      rest.get(
+        'http://localhost:7007/api/permission/.backstage/auth/v1/jwks.json',
+        (_req, res, ctx) => res(ctx.status(404)),
+      ),
+    );
+
     const tester = ServiceFactoryTester.from(authServiceFactory, {
       dependencies: mockDeps,
     });
@@ -129,7 +190,7 @@ describe('authServiceFactory', () => {
           subject: 'external:upstream-service',
         },
       } as InternalBackstageCredentials<BackstageServicePrincipal>,
-      targetPluginId: 'catalog',
+      targetPluginId: 'permission',
     });
 
     expect(decodeJwt(token)).toEqual(
@@ -222,6 +283,108 @@ describe('authServiceFactory', () => {
     );
     expect(limitedCredentials.expiresAt).toEqual(
       new Date(expectedExpiresAt * 1000),
+    );
+  });
+
+  it('should issue service on-behalf-of user tokens', async () => {
+    const tester = ServiceFactoryTester.from(authServiceFactory, {
+      dependencies: mockDeps,
+    });
+
+    const searchAuth = await tester.get('search');
+    const catalogAuth = await tester.get('catalog');
+    const permissionAuth = await tester.get('permission');
+
+    server.use(
+      rest.get(
+        'http://localhost:7007/api/auth/.well-known/jwks.json',
+        (_req, res, ctx) =>
+          res(
+            ctx.json({
+              keys: [
+                {
+                  kty: 'EC',
+                  x: '78-Ei1H3nKM23ZpGMMzte2mVoYCcnfnSiLTm1P7vZM0',
+                  y: 'Z9-PjG_EU598tLLUc2f8sCqxT7bjs8WpoV-lHm9GJHY',
+                  crv: 'P-256',
+                  kid: '8d01c3db-56f9-45f0-86dd-05b3c835b3d3',
+                  alg: 'ES256',
+                },
+              ],
+            }),
+          ),
+      ),
+      rest.get(
+        'http://localhost:7007/api/catalog/.backstage/auth/v1/jwks.json',
+        async (_req, res, ctx) =>
+          res(ctx.json(await catalogAuth.listPublicServiceKeys())),
+      ),
+      rest.get(
+        'http://localhost:7007/api/search/.backstage/auth/v1/jwks.json',
+        async (_req, res, ctx) =>
+          res(ctx.json(await searchAuth.listPublicServiceKeys())),
+      ),
+      rest.get(
+        'http://localhost:7007/api/permission/.backstage/auth/v1/jwks.json',
+        async (_req, res, ctx) =>
+          res(ctx.json(await permissionAuth.listPublicServiceKeys())),
+      ),
+      rest.get(
+        'http://localhost:7007/api/kubernetes/.backstage/auth/v1/jwks.json',
+        (_req, res, ctx) => res(ctx.status(404)),
+      ),
+    );
+
+    const expectedIssuedAt = 1712071714;
+    const expectedExpiresAt = 1712075314;
+
+    jest.useFakeTimers({
+      now: expectedIssuedAt * 1000 + 600_000,
+    });
+
+    const fullToken =
+      'eyJ0eXAiOiJ2bmQuYmFja3N0YWdlLnVzZXIiLCJhbGciOiJFUzI1NiIsImtpZCI6IjhkMDFjM2RiLTU2ZjktNDVmMC04NmRkLTA1YjNjODM1YjNkMyJ9.eyJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjcwMDcvYXBpL2F1dGgiLCJzdWIiOiJ1c2VyOmRldmVsb3BtZW50L2d1ZXN0IiwiZW50IjpbInVzZXI6ZGV2ZWxvcG1lbnQvZ3Vlc3QiLCJncm91cDpkZWZhdWx0L3RlYW0tYSJdLCJhdWQiOiJiYWNrc3RhZ2UiLCJpYXQiOjE3MTIwNzE3MTQsImV4cCI6MTcxMjA3NTMxNCwidWlwIjoiMDFBUUJfSWpHTXRWc2gyWmgzZEg1NXhOX29pSVlhQ1F3ODJjeDZ5M1BQMXlpTjM4eGMzMVpMS2U0YVNDQlJTTy10cjFzZFUzT29ELUxJYV8tNV9RVUEifQ.mjIrZGqbZ2t68fS4U3crlGw-bYJZnMlhMHf-YL7q_u1HfaLr4NMTcHkxdnNS2wfJxCmUBxRfUS8b3nSAKsxcHA';
+
+    const credentials = await searchAuth.authenticate(fullToken);
+    if (!searchAuth.isPrincipal(credentials, 'user')) {
+      throw new Error('not a user principal');
+    }
+    const { token: limitedToken } = await searchAuth.getLimitedUserToken(
+      credentials,
+    );
+
+    const { token: oboToken } = await searchAuth.getPluginRequestToken({
+      onBehalfOf: credentials,
+      targetPluginId: 'catalog',
+    });
+    expect(oboToken).not.toBe(fullToken);
+    expect(decodeJwt(oboToken).obo).toBe(limitedToken);
+    expect(decodeJwt(oboToken).exp).toBe(expectedExpiresAt);
+
+    const oboCredentials = await catalogAuth.authenticate(oboToken);
+    if (!catalogAuth.isPrincipal(oboCredentials, 'user')) {
+      throw new Error('obo credential is not a user principal');
+    }
+    expect(oboCredentials.principal.userEntityRef).toBe(
+      'user:development/guest',
+    );
+    expect(toInternalBackstageCredentials(oboCredentials).token).toBe(
+      limitedToken,
+    );
+
+    const { token: oboToken2 } = await catalogAuth.getPluginRequestToken({
+      onBehalfOf: oboCredentials,
+      targetPluginId: 'permission',
+    });
+    expect(decodeJwt(oboToken2).obo).toBe(limitedToken);
+
+    await expect(
+      catalogAuth.getPluginRequestToken({
+        onBehalfOf: oboCredentials,
+        targetPluginId: 'kubernetes',
+      }),
+    ).rejects.toThrow(
+      "Unable to call 'kubernetes' plugin on behalf of user, because the target plugin does not support on-behalf-of tokens",
     );
   });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds support for proper plugin on-behalf-of user tokens. The limited user token is used as a proof of user identity, which is carried within a signed plugin service token that lets the token be used as a full access token as opposed to a limited token. Since the limited user proof is needed to create an OBO token plugins are unable to impersonate users, and because we're using the new plugin service token format the token is limited in scope to only be able to call the specific target plugin.

👀 @camilaibs, opened this to have a look at what CI says 😁 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
