### PR TITLE
Update CatalogTable to hide total count until entities are initialized

### DIFF
--- a/.changeset/swift-humans-hunt.md
+++ b/.changeset/swift-humans-hunt.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Avoiding pre-loading display total count undefined for table counts

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.test.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.test.tsx
@@ -343,7 +343,7 @@ describe('CatalogTable component', () => {
     expect(screen.getByText('Should be rendered')).toBeInTheDocument();
   });
 
-  it('should render the label column with customised title and value as specified', async () => {
+  it('should render the label column with customized title and value as specified', async () => {
     const columns = [
       CatalogTable.columns.createNameColumn({ defaultKind: 'API' }),
       CatalogTable.columns.createLabelColumn('category', { title: 'Category' }),
@@ -381,7 +381,7 @@ describe('CatalogTable component', () => {
     expect(labelCellValue).toBeInTheDocument();
   });
 
-  it('should render the label column with customised title and value as specified using function', async () => {
+  it('should render the label column with customized title and value as specified using function', async () => {
     const columns: CatalogTableColumnsFunc = ({
       filters,
       entities: entities1,

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -88,14 +88,8 @@ export const CatalogTable = (props: CatalogTableProps) => {
   } = props;
   const { isStarredEntity, toggleStarredEntity } = useStarredEntities();
   const entityListContext = useEntityList();
-  const {
-    loading,
-    error,
-    entities,
-    filters,
-    pageInfo,
-    totalItems = 0,
-  } = entityListContext;
+  const { loading, error, entities, filters, pageInfo, totalItems } =
+    entityListContext;
   const enablePagination = !!pageInfo;
   const tableColumns = useMemo(
     () =>
@@ -175,13 +169,20 @@ export const CatalogTable = (props: CatalogTableProps) => {
 
   const currentKind = filters.kind?.value || '';
   const currentType = filters.type?.value || '';
+  const currentCount = Number.isSafeInteger(totalItems)
+    ? `(${totalItems})`
+    : '';
   // TODO(timbonicus): remove the title from the CatalogTable once using EntitySearchBar
   const titlePreamble = capitalize(filters.user?.value ?? 'all');
-  const titleDisplay = [titlePreamble, currentType, pluralize(currentKind)]
+  const title = [
+    titlePreamble,
+    currentType,
+    pluralize(currentKind),
+    currentCount,
+  ]
     .filter(s => s)
     .join(' ');
 
-  const title = `${titleDisplay} (${totalItems})`;
   const actions = props.actions || defaultActions;
   const options = {
     actionsColumnIndex: -1,
@@ -197,7 +198,7 @@ export const CatalogTable = (props: CatalogTableProps) => {
         columns={tableColumns}
         emptyContent={emptyContent}
         isLoading={loading}
-        title={titleDisplay}
+        title={title}
         actions={actions}
         subtitle={subtitle}
         options={options}

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -88,10 +88,15 @@ export const CatalogTable = (props: CatalogTableProps) => {
   } = props;
   const { isStarredEntity, toggleStarredEntity } = useStarredEntities();
   const entityListContext = useEntityList();
-  const { loading, error, entities, filters, pageInfo, totalItems } =
-    entityListContext;
+  const {
+    loading,
+    error,
+    entities,
+    filters,
+    pageInfo,
+    totalItems = 0,
+  } = entityListContext;
   const enablePagination = !!pageInfo;
-
   const tableColumns = useMemo(
     () =>
       typeof columns === 'function' ? columns(entityListContext) : columns,

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -169,9 +169,7 @@ export const CatalogTable = (props: CatalogTableProps) => {
 
   const currentKind = filters.kind?.value || '';
   const currentType = filters.type?.value || '';
-  const currentCount = Number.isSafeInteger(totalItems)
-    ? `(${totalItems})`
-    : '';
+  const currentCount = typeof totalItems === 'number' ? `(${totalItems})` : '';
   // TODO(timbonicus): remove the title from the CatalogTable once using EntitySearchBar
   const titlePreamble = capitalize(filters.user?.value ?? 'all');
   const title = [


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Depending on latency in making the request the context can load without items and then refresh moments later with the correct count. Until the entities are loaded the total will show as "All (undefined)", which is not confidence inspiring.

<img width="802" alt="Screenshot 2024-04-06 at 2 28 21 PM" src="https://github.com/backstage/backstage/assets/133238823/b4ef8645-cfe8-4074-b5d1-5e95bf21ef86">

Making this change from GitHub UI so not sure if it included the package in the commit but did include a signoff:

```
---
'@backstage/catalog': minor
---
```

Closes #24034

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
