### PR TITLE
refactor(packages/catalog-model): add utility function for checking EntityRef strings

### DIFF
--- a/.changeset/weak-tables-drive.md
+++ b/.changeset/weak-tables-drive.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-model': minor
+---
+
+Adds `isEntityRef` to test strings if they represent the entityref format

--- a/packages/catalog-model/api-report.md
+++ b/packages/catalog-model/api-report.md
@@ -262,6 +262,9 @@ export function isComponentEntity(
 // @public (undocumented)
 export function isDomainEntity(entity: Entity): entity is DomainEntityV1alpha1;
 
+// @public
+export function isEntityRef(ref: string): boolean;
+
 // @public (undocumented)
 export function isGroupEntity(entity: Entity): entity is GroupEntityV1alpha1;
 

--- a/packages/catalog-model/src/entity/index.ts
+++ b/packages/catalog-model/src/entity/index.ts
@@ -23,4 +23,5 @@ export {
   getCompoundEntityRef,
   parseEntityRef,
   stringifyEntityRef,
+  isEntityRef,
 } from './ref';

--- a/packages/catalog-model/src/entity/ref.test.ts
+++ b/packages/catalog-model/src/entity/ref.test.ts
@@ -14,9 +14,23 @@
  * limitations under the License.
  */
 
-import { parseEntityRef } from './ref';
+import { isEntityRef, parseEntityRef } from './ref';
 
 describe('ref', () => {
+  describe('isEntityRef', () => {
+    it.each`
+      input                                                       | expected
+      ${''}                                                       | ${false}
+      ${'https://mygit.example.com/myOrg/myRepo'}                 | ${false}
+      ${'https://mygit.example.com/myOrg/myRepo/master/test.git'} | ${false}
+      ${'component:default/backstage-plugins-example'}            | ${true}
+      ${'default/backstage-plugins-example'}                      | ${true}
+      ${'component:backstage-plugins-example'}                    | ${true}
+      ${'backstage-plugins-example'}                              | ${true}
+    `(`$input should return $expected`, ({ input, expected }) => {
+      expect(isEntityRef(input)).toBe(expected);
+    });
+  });
   describe('parseEntityRef', () => {
     it('handles some omissions', () => {
       expect(parseEntityRef('a:b/c')).toEqual({

--- a/packages/catalog-model/src/entity/ref.ts
+++ b/packages/catalog-model/src/entity/ref.ts
@@ -45,6 +45,22 @@ function parseRefString(ref: string): {
 }
 
 /**
+ * Checks if ref is a string a entity string reference
+ * This function does not check the catalog for its existence but rather only checks the format
+ *
+ * @public
+ * @param ref - a string
+ */
+export function isEntityRef(ref: string): boolean {
+  try {
+    parseRefString(ref);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+/**
  * Extracts the kind, namespace and name that form the compound entity ref
  * triplet of the given entity.
  *


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Adds an utility function to check if a string fits the expected format for EntityRef strings.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
