### PR TITLE
fix: backend cli util to use the correct id

### DIFF
--- a/.changeset/shaggy-vans-return.md
+++ b/.changeset/shaggy-vans-return.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Fix the backend plugin to use correct plugin id

--- a/packages/cli/templates/default-backend-plugin/src/plugin.ts.hbs
+++ b/packages/cli/templates/default-backend-plugin/src/plugin.ts.hbs
@@ -10,7 +10,7 @@ import { createRouter } from './service/router';
  * @public
  */
 export const {{pluginVar}} = createBackendPlugin({
-  pluginId: '{{pluginVar}}',
+  pluginId: '{{id}}',
   register(env) {
     env.registerInit({
       deps: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

instead of using `pluginId: 'testPlugin'` now it uses the right id for
example `pluginId: 'test'`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
