### PR TITLE
backend-app-api: fix plugin token public key expiration

### DIFF
--- a/packages/backend-app-api/src/services/implementations/auth/PluginTokenHandler.test.ts
+++ b/packages/backend-app-api/src/services/implementations/auth/PluginTokenHandler.test.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mockServices } from '@backstage/backend-test-utils';
+import { PluginTokenHandler } from './PluginTokenHandler';
+import { decodeJwt } from 'jose';
+
+describe('PluginTokenHandler', () => {
+  beforeEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('issues token with correct expiration of token and generated key', async () => {
+    jest.useFakeTimers({
+      now: new Date(0),
+    });
+
+    const addKeyMock = jest.fn();
+    const handler = PluginTokenHandler.create({
+      discovery: mockServices.discovery(),
+      keyDurationSeconds: 10,
+      logger: mockServices.logger.mock(),
+      ownPluginId: 'test',
+      publicKeyStore: {
+        addKey: addKeyMock,
+        listKeys: jest.fn(),
+      },
+    });
+
+    const { token } = await handler.issueToken({
+      pluginId: 'test',
+      targetPluginId: 'other',
+    });
+    const payload = decodeJwt(token);
+    expect(payload.iat).toBe(0);
+    expect(payload.exp).toBe(10);
+
+    expect(addKeyMock).toHaveBeenCalledTimes(1);
+    expect(addKeyMock).toHaveBeenCalledWith({
+      id: expect.any(String),
+      key: expect.any(Object),
+      expiresAt: new Date(30_000),
+    });
+
+    jest.advanceTimersByTime(5_000);
+    await handler.issueToken({
+      pluginId: 'test',
+      targetPluginId: 'other',
+    });
+    expect(addKeyMock).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(10_000);
+    await handler.issueToken({
+      pluginId: 'test',
+      targetPluginId: 'other',
+    });
+    expect(addKeyMock).toHaveBeenCalledTimes(2);
+
+    expect(addKeyMock.mock.calls[0][0].id).not.toBe(
+      addKeyMock.mock.calls[1][0].id,
+    );
+
+    expect(addKeyMock).toHaveBeenNthCalledWith(2, {
+      id: expect.any(String),
+      key: expect.any(Object),
+      expiresAt: new Date(45_000),
+    });
+  });
+});


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes key expiration, we weren't keeping public keys around for long enough, found by @freben. No changeset for this one since it's not published yet.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
