### PR TITLE
feat(plugins/catalog): added custom sort on createLabelColumn

### DIFF
--- a/.changeset/slow-cows-worry.md
+++ b/.changeset/slow-cows-worry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': minor
+---
+
+added custom sort on createLabelColumn

--- a/.changeset/slow-cows-worry.md
+++ b/.changeset/slow-cows-worry.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-catalog': minor
+'@backstage/plugin-catalog': patch
 ---
 
-added custom sort on createLabelColumn
+Fixed sorting of columns created with `CatalogTable.columns.createLabelColumn`.

--- a/plugins/catalog/src/components/CatalogTable/columns.tsx
+++ b/plugins/catalog/src/components/CatalogTable/columns.tsx
@@ -184,11 +184,22 @@ export const columnFactories = Object.freeze({
     key: string,
     options?: { title?: string; defaultValue?: string },
   ): TableColumn<CatalogTableRow> {
+    function formatContent(keyLabel: string, entity: Entity): string {
+      const labels: Record<string, string> | undefined =
+        entity.metadata?.labels;
+      return (labels && labels[keyLabel]) || '';
+    }
+
     return {
       title: options?.title || 'Label',
       field: 'entity.metadata.labels',
       cellStyle: {
         padding: '0px 16px 0px 20px',
+      },
+      customSort({ entity: entity1 }, { entity: entity2 }) {
+        return formatContent(key, entity1).localeCompare(
+          formatContent(key, entity2),
+        );
       },
       render: ({ entity }: { entity: Entity }) => {
         const labels: Record<string, string> | undefined =


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR creates a custom Sort for columns of type label. It turns out that the sorting is not working for this column type.

The same technique used in the name column was used as a way of sorting.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
