### PR TITLE
Filter archived repositories on bitbucket server provider module added.

### DIFF
--- a/.changeset/curvy-planes-flash.md
+++ b/.changeset/curvy-planes-flash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-bitbucket-server': patch
+---
+
+Allow skipping archived repositories (`skipArchivedRepos` flag) on Bitbucket.

--- a/docs/integrations/bitbucketServer/discovery.md
+++ b/docs/integrations/bitbucketServer/discovery.md
@@ -63,6 +63,7 @@ catalog:
         filters: # optional
           projectKey: '^apis-.*$' # optional; RegExp
           repoSlug: '^service-.*$' # optional; RegExp
+          skipArchivedRepos: true # optional; boolean
         schedule: # same options as in TaskScheduleDefinition
           # supports cron, ISO duration, "human duration" as used in code
           frequency: { minutes: 30 }
@@ -81,6 +82,8 @@ catalog:
     Regular expression used to filter results based on the project key.
   - **`repoSlug`** _(optional)_:
     Regular expression used to filter results based on the repo slug.
+  - **`skipArchivedRepos`** _(optional)_:
+    Boolean flag to filter out archived repositories.
 - **`schedule`**:
   - **`frequency`**:
     How often you want the task to run. The system does its best to avoid overlapping invocations.

--- a/plugins/catalog-backend-module-bitbucket-server/api-report.md
+++ b/plugins/catalog-backend-module-bitbucket-server/api-report.md
@@ -109,5 +109,6 @@ export type BitbucketServerRepository = {
       href: string;
     }[]
   >;
+  archived: boolean;
 };
 ```

--- a/plugins/catalog-backend-module-bitbucket-server/config.d.ts
+++ b/plugins/catalog-backend-module-bitbucket-server/config.d.ts
@@ -46,6 +46,10 @@ export interface Config {
                * @visibility frontend
                */
               projectKey?: string;
+              /**
+               * (Optional) Skip archived repositories
+               */
+              skipArchivedRepos?: boolean;
             };
             /**
              * (Optional) TaskScheduleDefinition for the refresh.
@@ -74,6 +78,10 @@ export interface Config {
                  * @visibility frontend
                  */
                 projectKey?: string;
+                /**
+                 * (Optional) Skip archived repositories
+                 */
+                skipArchivedRepos?: boolean;
               };
               /**
                * (Optional) TaskScheduleDefinition for the refresh.

--- a/plugins/catalog-backend-module-bitbucket-server/src/lib/BitbucketServerClient.test.ts
+++ b/plugins/catalog-backend-module-bitbucket-server/src/lib/BitbucketServerClient.test.ts
@@ -121,6 +121,7 @@ describe('BitbucketServerClient', () => {
                       },
                     ],
                   },
+                  archived: false,
                 },
               ],
             };
@@ -198,6 +199,7 @@ describe('BitbucketServerClient', () => {
                 },
               ],
             },
+            archived: false,
           };
 
           return res(ctx.json(response));

--- a/plugins/catalog-backend-module-bitbucket-server/src/lib/types.ts
+++ b/plugins/catalog-backend-module-bitbucket-server/src/lib/types.ts
@@ -27,6 +27,7 @@ export type BitbucketServerRepository = {
       href: string;
     }[]
   >;
+  archived: boolean;
 };
 
 /** @public */

--- a/plugins/catalog-backend-module-bitbucket-server/src/providers/BitbucketServerEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-bitbucket-server/src/providers/BitbucketServerEntityProvider.test.ts
@@ -43,7 +43,7 @@ class PersistingTaskRunner implements TaskRunner {
 
 type Project = {
   key: string;
-  repos: [string];
+  repos: { name: string; archived?: true }[];
 };
 
 function pagedResponse(values: any): BitbucketServerPagedResponse<any> {
@@ -82,14 +82,15 @@ function setupStubs(projects: Project[], baseUrl: string) {
           const response = [];
           for (const repo of project.repos) {
             response.push({
-              slug: repo,
+              slug: repo.name,
               links: {
                 self: [
                   {
-                    href: `${baseUrl}/projects/${project.key}/repos/${repo}/browse`,
+                    href: `${baseUrl}/projects/${project.key}/repos/${repo.name}/browse`,
                   },
                 ],
               },
+              archived: repo.archived ?? false,
             });
           }
           return res(ctx.json(pagedResponse(response)));
@@ -216,6 +217,7 @@ describe('BitbucketServerEntityProvider', () => {
               filters: {
                 projectKey: 'project-.*',
                 repoSlug: 'repo-.*',
+                skipArchivedRepos: true,
               },
             },
           },
@@ -237,8 +239,14 @@ describe('BitbucketServerEntityProvider', () => {
 
     setupStubs(
       [
-        { key: 'project-test', repos: ['repo-test'] },
-        { key: 'other-project', repos: ['other-repo'] },
+        {
+          key: 'project-test',
+          repos: [
+            { name: 'repo-test' },
+            { name: 'repo-archived', archived: true },
+          ],
+        },
+        { key: 'other-project', repos: [{ name: 'other-repo' }] },
       ],
       `https://${host}`,
     );
@@ -313,8 +321,8 @@ describe('BitbucketServerEntityProvider', () => {
 
     setupStubs(
       [
-        { key: 'project-test', repos: ['repo-test'] },
-        { key: 'other-project', repos: ['other-repo'] },
+        { key: 'project-test', repos: [{ name: 'repo-test' }] },
+        { key: 'other-project', repos: [{ name: 'other-repo' }] },
       ],
       `https://${host}`,
     );
@@ -472,8 +480,8 @@ describe('BitbucketServerEntityProvider', () => {
 
     setupStubs(
       [
-        { key: 'project-test', repos: ['repo-test'] },
-        { key: 'other-project', repos: ['other-repo'] },
+        { key: 'project-test', repos: [{ name: 'repo-test' }] },
+        { key: 'other-project', repos: [{ name: 'other-repo' }] },
       ],
       `https://${host}`,
     );

--- a/plugins/catalog-backend-module-bitbucket-server/src/providers/BitbucketServerEntityProvider.ts
+++ b/plugins/catalog-backend-module-bitbucket-server/src/providers/BitbucketServerEntityProvider.ts
@@ -201,6 +201,9 @@ export class BitbucketServerEntityProvider implements EntityProvider {
         ) {
           continue;
         }
+        if (this.config?.filters?.skipArchivedRepos && repository.archived) {
+          continue;
+        }
         for await (const entity of this.parser({
           client,
           logger: this.logger,

--- a/plugins/catalog-backend-module-bitbucket-server/src/providers/BitbucketServerEntityProviderConfig.test.ts
+++ b/plugins/catalog-backend-module-bitbucket-server/src/providers/BitbucketServerEntityProviderConfig.test.ts
@@ -48,6 +48,7 @@ describe('readProviderConfigs', () => {
       filters: {
         projectKey: undefined,
         repoSlug: undefined,
+        skipArchivedRepos: undefined,
       },
     });
   });
@@ -87,6 +88,7 @@ describe('readProviderConfigs', () => {
       filters: {
         projectKey: undefined,
         repoSlug: undefined,
+        skipArchivedRepos: undefined,
       },
     });
     expect(providerConfigs[1]).toEqual({
@@ -96,6 +98,7 @@ describe('readProviderConfigs', () => {
       filters: {
         projectKey: undefined,
         repoSlug: undefined,
+        skipArchivedRepos: undefined,
       },
     });
     expect(providerConfigs[2]).toEqual({
@@ -105,6 +108,7 @@ describe('readProviderConfigs', () => {
       filters: {
         projectKey: undefined,
         repoSlug: undefined,
+        skipArchivedRepos: undefined,
       },
       schedule: {
         frequency: Duration.fromISO('PT30M'),
@@ -125,6 +129,7 @@ describe('readProviderConfigs', () => {
               filters: {
                 projectKey: 'project1',
                 repoSlug: '.*',
+                skipArchivedRepos: true,
               },
             },
           },
@@ -141,6 +146,7 @@ describe('readProviderConfigs', () => {
       filters: {
         projectKey: /project1/,
         repoSlug: /.*/,
+        skipArchivedRepos: true,
       },
     });
   });

--- a/plugins/catalog-backend-module-bitbucket-server/src/providers/BitbucketServerEntityProviderConfig.ts
+++ b/plugins/catalog-backend-module-bitbucket-server/src/providers/BitbucketServerEntityProviderConfig.ts
@@ -30,6 +30,7 @@ export type BitbucketServerEntityProviderConfig = {
   filters?: {
     projectKey?: RegExp;
     repoSlug?: RegExp;
+    skipArchivedRepos?: boolean;
   };
   schedule?: TaskScheduleDefinition;
 };
@@ -64,6 +65,9 @@ function readProviderConfig(
     config.getOptionalString('catalogPath') ?? DEFAULT_CATALOG_PATH;
   const projectKeyPattern = config.getOptionalString('filters.projectKey');
   const repoSlugPattern = config.getOptionalString('filters.repoSlug');
+  const skipArchivedReposFlag = config.getOptionalBoolean(
+    'filters.skipArchivedRepos',
+  );
 
   const schedule = config.has('schedule')
     ? readTaskScheduleDefinitionFromConfig(config.getConfig('schedule'))
@@ -76,6 +80,7 @@ function readProviderConfig(
     filters: {
       projectKey: projectKeyPattern ? new RegExp(projectKeyPattern) : undefined,
       repoSlug: repoSlugPattern ? new RegExp(repoSlugPattern) : undefined,
+      skipArchivedRepos: skipArchivedReposFlag,
     },
     schedule,
   };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I added the possibility of filtering out archived repositories on the Bitbucket server catalog module.
It is possible to do it by just adding an optional flag in the module config:

```diff
catalog:
  providers:
    mainProvider:
      catalogPath: '/catalog-info.yaml'
      host: 'bitbucket.mycompany.com'
      filters: 
        projectKey: 'test-project'
+++     skipArchivedRepos: true # optional
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
