### PR TITLE
Fix `plugin-github-pull-requests-board` failing to render because commit status returned by GraphQL query is a list

### DIFF
--- a/.changeset/beige-worms-deny.md
+++ b/.changeset/beige-worms-deny.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-github-pull-requests-board': minor
+---
+
+Fixed bug in CardHeader not expecting commit status as an array as returned by GraphQL

--- a/plugins/github-pull-requests-board/src/components/Card/Card.tsx
+++ b/plugins/github-pull-requests-board/src/components/Card/Card.tsx
@@ -29,7 +29,7 @@ type Props = {
   isDraft: boolean;
   repositoryIsArchived: boolean;
   labels?: Label[];
-  status?: Status;
+  status?: Status[];
 };
 
 const Card: FunctionComponent<PropsWithChildren<Props>> = (

--- a/plugins/github-pull-requests-board/src/components/Card/CardHeader.test.tsx
+++ b/plugins/github-pull-requests-board/src/components/Card/CardHeader.test.tsx
@@ -37,13 +37,15 @@ const props = {
       name: 'documentation',
     },
   ],
-  status: {
-    commit: {
-      statusCheckRollup: {
-        state: 'SUCCESS',
+  status: [
+    {
+      commit: {
+        statusCheckRollup: {
+          state: 'SUCCESS',
+        },
       },
     },
-  },
+  ],
 };
 
 describe('<CardHeader/>', () => {

--- a/plugins/github-pull-requests-board/src/components/Card/CardHeader.test.tsx
+++ b/plugins/github-pull-requests-board/src/components/Card/CardHeader.test.tsx
@@ -67,7 +67,7 @@ describe('<CardHeader/>', () => {
   it('finds commit status in PR Card Header', async () => {
     await renderInTestApp(<CardHeader {...props} />);
     expect(screen.getByText('Commit Status:')).toBeInTheDocument();
-    expect(props.status?.commit.statusCheckRollup.state).toBeTruthy();
+    expect(props.status[0].commit.statusCheckRollup.state).toBeTruthy();
   });
 
   it('does not find commit status in PR Card Header when PR does not include status', async () => {

--- a/plugins/github-pull-requests-board/src/components/Card/CardHeader.tsx
+++ b/plugins/github-pull-requests-board/src/components/Card/CardHeader.tsx
@@ -32,7 +32,7 @@ type Props = {
   isDraft: boolean;
   repositoryIsArchived: boolean;
   labels?: Label[];
-  status?: Status;
+  status?: Status[];
 };
 
 const CardHeader: FunctionComponent<Props> = (props: Props) => {
@@ -92,7 +92,9 @@ const CardHeader: FunctionComponent<Props> = (props: Props) => {
         <Box display="flex" alignItems="center" flexWrap="wrap" paddingTop={1}>
           <Typography variant="body2" component="p">
             Commit Status:{' '}
-            <strong>{status.commit.statusCheckRollup?.state || 'N/A'}</strong>
+            <strong>
+              {status[0].commit.statusCheckRollup?.state || 'N/A'}
+            </strong>
           </Typography>
         </Box>
       )}

--- a/plugins/github-pull-requests-board/src/components/Card/CardHeader.tsx
+++ b/plugins/github-pull-requests-board/src/components/Card/CardHeader.tsx
@@ -93,7 +93,7 @@ const CardHeader: FunctionComponent<Props> = (props: Props) => {
           <Typography variant="body2" component="p">
             Commit Status:{' '}
             <strong>
-              {status[0].commit.statusCheckRollup?.state || 'N/A'}
+              {status[0]?.commit.statusCheckRollup?.state || 'N/A'}
             </strong>
           </Typography>
         </Box>

--- a/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsCard/EntityTeamPullRequestsCard.test.tsx
+++ b/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsCard/EntityTeamPullRequestsCard.test.tsx
@@ -71,7 +71,7 @@ jest.mock('../../hooks/usePullRequestsByTeam', () => {
         nodes: [],
       },
       commits: {
-        nodes: status,
+        nodes: [status],
       },
       isDraft: isDraft,
       author: {

--- a/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsContent/EntityTeamPullRequestsContent.test.tsx
+++ b/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsContent/EntityTeamPullRequestsContent.test.tsx
@@ -71,7 +71,7 @@ jest.mock('../../hooks/usePullRequestsByTeam', () => {
         nodes: [],
       },
       commits: {
-        nodes: status,
+        nodes: [status],
       },
       isDraft: isDraft,
       author: {

--- a/plugins/github-pull-requests-board/src/components/PullRequestCard/PullRequestCard.tsx
+++ b/plugins/github-pull-requests-board/src/components/PullRequestCard/PullRequestCard.tsx
@@ -30,7 +30,7 @@ type Props = {
   author: Author;
   url: string;
   reviews: Reviews;
-  status?: Status;
+  status?: Status[];
   repositoryName: string;
   repositoryIsArchived: boolean;
   isDraft: boolean;

--- a/plugins/github-pull-requests-board/src/utils/types.tsx
+++ b/plugins/github-pull-requests-board/src/utils/types.tsx
@@ -99,7 +99,7 @@ export type PullRequest = {
     nodes: Reviews;
   };
   commits: {
-    nodes: Status;
+    nodes: Status[];
   };
   mergeable: boolean;
   state: string;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This change hopefully fixes #24017.

Please be aware that my React/Typescript skills are still limited. Any comments/improvements are welcome.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
