### PR TITLE
auth-backend: add initial userinfo endpoint

### DIFF
--- a/.changeset/stale-bikes-bake.md
+++ b/.changeset/stale-bikes-bake.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Initial implementation of the `/v1/userinfo` endpoint, which is now able to parse and return the `sub` and `ent` claims from a Backstage user token.

--- a/plugins/auth-backend/src/authPlugin.test.ts
+++ b/plugins/auth-backend/src/authPlugin.test.ts
@@ -38,7 +38,7 @@ describe('authPlugin', () => {
     );
     expect(res.status).toBe(200);
     expect(res.body).toMatchObject({
-      claims_supported: ['sub'],
+      claims_supported: ['sub', 'ent'],
       issuer: `http://localhost:${server.port()}/api/auth`,
     });
   });

--- a/plugins/auth-backend/src/authPlugin.ts
+++ b/plugins/auth-backend/src/authPlugin.ts
@@ -54,6 +54,8 @@ export const authPlugin = createBackendPlugin({
         database: coreServices.database,
         discovery: coreServices.discovery,
         tokenManager: coreServices.tokenManager,
+        auth: coreServices.auth,
+        httpAuth: coreServices.httpAuth,
         catalogApi: catalogServiceRef,
       },
       async init({
@@ -63,6 +65,8 @@ export const authPlugin = createBackendPlugin({
         database,
         discovery,
         tokenManager,
+        auth,
+        httpAuth,
         catalogApi,
       }) {
         const router = await createRouter({
@@ -71,6 +75,8 @@ export const authPlugin = createBackendPlugin({
           database,
           discovery,
           tokenManager,
+          auth,
+          httpAuth,
           catalogApi,
           providerFactories: Object.fromEntries(providers),
           disableDefaultProviderFactories: true,

--- a/plugins/auth-backend/src/identity/router.test.ts
+++ b/plugins/auth-backend/src/identity/router.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  coreServices,
+  createBackendPlugin,
+} from '@backstage/backend-plugin-api';
+import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
+import Router from 'express-promise-router';
+import request from 'supertest';
+import { bindOidcRouter } from './router';
+
+describe('bindOidcRouter', () => {
+  it('should return user info', async () => {
+    const auth = mockServices.auth.mock();
+    const { server } = await startTestBackend({
+      features: [
+        createBackendPlugin({
+          pluginId: 'auth',
+          register(reg) {
+            reg.registerInit({
+              deps: { httpRouter: coreServices.httpRouter },
+              async init({ httpRouter }) {
+                const router = Router();
+                bindOidcRouter(router, {
+                  baseUrl: 'http://localhost:7000',
+                  auth,
+                  tokenIssuer: {} as any,
+                });
+                httpRouter.use(router);
+                httpRouter.addAuthPolicy({
+                  path: '/',
+                  allow: 'unauthenticated',
+                });
+              },
+            });
+          },
+        }),
+      ],
+    });
+
+    auth.authenticate.mockResolvedValueOnce({} as any);
+    auth.isPrincipal.mockReturnValueOnce(true);
+
+    await request(server)
+      .get('/api/auth/v1/userinfo')
+      .set(
+        'Authorization',
+        `Bearer h.${btoa(
+          JSON.stringify({ sub: 'k/ns:n', ent: ['k/ns:a', 'k/ns:b'] }),
+        )}.s`,
+      )
+      .expect(200, {
+        sub: 'k/ns:n',
+        ent: ['k/ns:a', 'k/ns:b'],
+      });
+
+    expect('test').toBe('test');
+  });
+});

--- a/plugins/auth-backend/src/service/router.ts
+++ b/plugins/auth-backend/src/service/router.ts
@@ -151,6 +151,7 @@ export async function createRouter(
   });
 
   bindOidcRouter(router, {
+    auth,
     tokenIssuer,
     baseUrl: authUrl,
   });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds an initial implementation of the `/v1/userinfo` endpoint in the auth backend, which echoes back the claims in a full or limited user token. Getting this in place now will allow us to start calling this endpoint in the future with smaller impact.

It does not implement storage of the user info, so the `ent` claim still needs to be present in the provided token.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
