### PR TITLE
[Catalog] Wire up the entity presentation API in new frontend system apps

### DIFF
--- a/.changeset/catalog-next-presentation-tho.md
+++ b/.changeset/catalog-next-presentation-tho.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Fixed a bug that prevented the default `entityPresentationApi` from being set in apps using the new frontend system.

--- a/plugins/catalog/src/alpha/apis.tsx
+++ b/plugins/catalog/src/alpha/apis.tsx
@@ -24,9 +24,13 @@ import { CatalogClient } from '@backstage/catalog-client';
 import { createApiExtension } from '@backstage/frontend-plugin-api';
 import {
   catalogApiRef,
+  entityPresentationApiRef,
   starredEntitiesApiRef,
 } from '@backstage/plugin-catalog-react';
-import { DefaultStarredEntitiesApi } from '../apis';
+import {
+  DefaultEntityPresentationApi,
+  DefaultStarredEntitiesApi,
+} from '../apis';
 
 export const catalogApi = createApiExtension({
   factory: createApiFactory({
@@ -48,4 +52,13 @@ export const catalogStarredEntitiesApi = createApiExtension({
   }),
 });
 
-export default [catalogApi, catalogStarredEntitiesApi];
+export const entityPresentationApi = createApiExtension({
+  factory: createApiFactory({
+    api: entityPresentationApiRef,
+    deps: { catalogApiImp: catalogApiRef },
+    factory: ({ catalogApiImp }) =>
+      DefaultEntityPresentationApi.create({ catalogApi: catalogApiImp }),
+  }),
+});
+
+export default [catalogApi, catalogStarredEntitiesApi, entityPresentationApi];


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Probably just an oversight?

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
