### PR TITLE
fix eslint autofix for mui ThemeProvider

### DIFF
--- a/.changeset/sixty-cherries-lie.md
+++ b/.changeset/sixty-cherries-lie.md
@@ -1,0 +1,5 @@
+---
+'@backstage/eslint-plugin': patch
+---
+
+eslint autofix for mui ThemeProvider

--- a/.github/vale/config/vocabularies/Backstage/accept.txt
+++ b/.github/vale/config/vocabularies/Backstage/accept.txt
@@ -16,6 +16,7 @@ api
 asciidoc
 async
 Atlassian
+autofix
 automations
 autoscaling
 Autoscaling

--- a/packages/eslint-plugin/rules/no-top-level-material-ui-4-imports.js
+++ b/packages/eslint-plugin/rules/no-top-level-material-ui-4-imports.js
@@ -23,6 +23,7 @@ const KNOWN_STYLES = [
   'styled',
   'useTheme',
   'Theme',
+  'ThemeProvider',
 ];
 
 /** @type {import('eslint').Rule.RuleModule} */

--- a/packages/eslint-plugin/src/no-top-level-material-ui-4-imports.test.ts
+++ b/packages/eslint-plugin/src/no-top-level-material-ui-4-imports.test.ts
@@ -58,6 +58,11 @@ import Typography from '@material-ui/core/Typography';`,
       output: `import Box from '@material-ui/core/Box';`,
     },
     {
+      code: `import { ThemeProvider } from '@material-ui/core';`,
+      errors: [{ messageId: 'topLevelImport' }],
+      output: `import { ThemeProvider } from '@material-ui/core/styles';`,
+    },
+    {
       code: `import {
                   Box,
                   DialogActions,
@@ -65,6 +70,7 @@ import Typography from '@material-ui/core/Typography';`,
                   DialogTitle,
                   Grid,
                   makeStyles,
+                  ThemeProvider,
                 } from '@material-ui/core';`,
       errors: [{ messageId: 'topLevelImport' }],
       output: `import Box from '@material-ui/core/Box';
@@ -72,7 +78,7 @@ import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import Grid from '@material-ui/core/Grid';
-import { makeStyles } from '@material-ui/core/styles';`,
+import { makeStyles, ThemeProvider } from '@material-ui/core/styles';`,
     },
     {
       code: `import { Box, Button, makeStyles } from '@material-ui/core';`,


### PR DESCRIPTION
## Hey, I just made a Pull Request!
issue: 23467

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

imports of ThemeProvider are autofixed to
import ThemeProvider from '@material-ui/core/ThemeProvider'; but should be
import { ThemeProvider } from '@material-ui/core/styles';

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
