### PR TITLE
fix lint rule fixer for more than one `Component + Prop`

### DIFF
--- a/.changeset/angry-donuts-visit.md
+++ b/.changeset/angry-donuts-visit.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/eslint-plugin': minor
+'@backstage/eslint-plugin': patch
 ---
 
 fix lint rule fixer for more than one `Component + Prop`

--- a/.changeset/angry-donuts-visit.md
+++ b/.changeset/angry-donuts-visit.md
@@ -1,0 +1,5 @@
+---
+'@backstage/eslint-plugin': minor
+---
+
+fix lint rule fixer for more than one `Component + Prop`

--- a/packages/eslint-plugin/src/no-top-level-material-ui-4-imports.test.ts
+++ b/packages/eslint-plugin/src/no-top-level-material-ui-4-imports.test.ts
@@ -63,6 +63,18 @@ import Typography from '@material-ui/core/Typography';`,
       output: `import { ThemeProvider } from '@material-ui/core/styles';`,
     },
     {
+      code: `import { Grid, GridProps, Theme, makeStyles } from '@material-ui/core';`,
+      errors: [{ messageId: 'topLevelImport' }],
+      output: `import Grid, { GridProps } from '@material-ui/core/Grid';
+import { Theme, makeStyles } from '@material-ui/core/styles';`,
+    },
+    {
+      code: `import { Grid, GridProps, SvgIcon, SvgIconProps } from '@material-ui/core';`,
+      errors: [{ messageId: 'topLevelImport' }],
+      output: `import Grid, { GridProps } from '@material-ui/core/Grid';
+import SvgIcon, { SvgIconProps } from '@material-ui/core/SvgIcon';`,
+    },
+    {
       code: `import {
                   Box,
                   DialogActions,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

issue: https://github.com/backstage/backstage/issues/23467

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

For the component + prop combination the fixer was assuming only 1 Component+Prop

causing this kind of replacement:

```diff
- import { Grid, GridProps, Theme, makeStyles } from '@material-ui/core';
+ import Grid, { GridProps } from '@material-ui/core/Grid';
// Theme and makeStyles get ignored
```

```diff
- import { Grid, GridProps, SvgIcon, SvgIconProps } from '@material-ui/core';,
+ import Grid, { GridProps } from '@material-ui/core/Grid';
//  SvgIcon and SvgIconProps get ignored
```

on this PR I added those test cases, but also made a refactor of the logic to pre-calculate all the different cases

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
