### PR TITLE
Added Material UI 4 import rule to package @backstage/dev-utils

### DIFF
--- a/.changeset/swift-moles-shave.md
+++ b/.changeset/swift-moles-shave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/dev-utils': patch
+---
+
+add @backstage/no-top-level-material-ui-4-imports lint rule

--- a/packages/dev-utils/.eslintrc.js
+++ b/packages/dev-utils/.eslintrc.js
@@ -1,1 +1,5 @@
-module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
+  rules: {
+    '@backstage/no-top-level-material-ui-4-imports': 'error',
+  },
+});

--- a/packages/dev-utils/api-report.md
+++ b/packages/dev-utils/api-report.md
@@ -10,7 +10,7 @@ import { AppTheme } from '@backstage/core-plugin-api';
 import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { ComponentType } from 'react';
 import { Entity } from '@backstage/catalog-model';
-import { GridProps } from '@material-ui/core';
+import { GridProps } from '@material-ui/core/Grid';
 import { IconComponent } from '@backstage/core-plugin-api';
 import { PropsWithChildren } from 'react';
 import { ReactNode } from 'react';

--- a/packages/dev-utils/src/components/EntityGridItem/EntityGridItem.tsx
+++ b/packages/dev-utils/src/components/EntityGridItem/EntityGridItem.tsx
@@ -16,7 +16,8 @@
 
 import { Entity } from '@backstage/catalog-model';
 import { EntityProvider } from '@backstage/plugin-catalog-react';
-import { Grid, GridProps, Theme, makeStyles } from '@material-ui/core';
+import Grid, { GridProps } from '@material-ui/core/Grid';
+import { Theme, makeStyles } from '@material-ui/core/styles';
 import React from 'react';
 
 const useStyles = makeStyles<Theme, { entity: Entity }>(theme => ({

--- a/packages/dev-utils/src/devApp/SidebarThemeSwitcher.tsx
+++ b/packages/dev-utils/src/devApp/SidebarThemeSwitcher.tsx
@@ -15,7 +15,10 @@
  */
 import { SidebarItem } from '@backstage/core-components';
 import { appThemeApiRef, useApi } from '@backstage/core-plugin-api';
-import { ListItemIcon, ListItemText, Menu, MenuItem } from '@material-ui/core';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
 import AutoIcon from '@material-ui/icons/BrightnessAuto';
 import React, { cloneElement, useCallback, useState } from 'react';
 import useObservable from 'react-use/esm/useObservable';

--- a/packages/dev-utils/src/devApp/render.tsx
+++ b/packages/dev-utils/src/devApp/render.tsx
@@ -42,7 +42,7 @@ import {
   ScmIntegrationsApi,
   scmIntegrationsApiRef,
 } from '@backstage/integration-react';
-import { Box } from '@material-ui/core';
+import Box from '@material-ui/core/Box';
 import BookmarkIcon from '@material-ui/icons/Bookmark';
 import React, { ComponentType, ReactNode, PropsWithChildren } from 'react';
 import { createRoutesFromChildren, Route } from 'react-router-dom';


### PR DESCRIPTION
## Hey, I just made a Pull Request!


added the `@backstage/no-top-level-material-ui-4-imports` lint rule and fixed  the issues

issue: https://github.com/backstage/backstage/issues/23467

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
