### PR TITLE
Fix the `CatalogClient::getEntities` method to only sort the resulting entities in case no `order`-parameter is provided.

### DIFF
--- a/.changeset/seven-socks-study.md
+++ b/.changeset/seven-socks-study.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-client': patch
+---
+
+Fix the `CatalogClient::getEntities` method to only sort the resulting entities in case no `order`-parameter is provided.

--- a/packages/catalog-client/src/CatalogClient.test.ts
+++ b/packages/catalog-client/src/CatalogClient.test.ts
@@ -237,6 +237,10 @@ describe('CatalogClient', () => {
 
     it('handles ordering properly', async () => {
       expect.assertions(2);
+      const sortedEntities = [
+        { apiVersion: '1', kind: 'Component', metadata: { name: 'b' } },
+        { apiVersion: '1', kind: 'Component', metadata: { name: 'a' } },
+      ];
 
       server.use(
         rest.get(`${mockBaseUrl}/entities`, (req, res, ctx) => {
@@ -245,7 +249,7 @@ describe('CatalogClient', () => {
             'asc:kind',
             'desc:metadata.name',
           ]);
-          return res(ctx.json([]));
+          return res(ctx.json(sortedEntities));
         }),
       );
 
@@ -259,7 +263,7 @@ describe('CatalogClient', () => {
         { token },
       );
 
-      expect(response.items).toEqual([]);
+      expect(response.items).toEqual(sortedEntities);
     });
   });
 

--- a/packages/catalog-client/src/CatalogClient.ts
+++ b/packages/catalog-client/src/CatalogClient.ts
@@ -143,6 +143,11 @@ export class CatalogClient implements CatalogApi {
       ),
     );
 
+    // do not sort entities, if order is provided
+    if (encodedOrder.length) {
+      return { items: entities };
+    }
+
     const refCompare = (a: Entity, b: Entity) => {
       // in case field filtering is used, these fields might not be part of the response
       if (


### PR DESCRIPTION
Fix the `CatalogClient::getEntities` method to only sort the resulting entities in case no `order`-parameter is provided.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
