### PR TITLE
fix: entity owner relation resolution in notifications

### DIFF
--- a/.changeset/weak-feet-whisper.md
+++ b/.changeset/weak-feet-whisper.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications-backend': patch
+---
+
+Fix entity owner resolution in notifications

--- a/plugins/notifications-backend/src/service/router.ts
+++ b/plugins/notifications-backend/src/service/router.ts
@@ -28,6 +28,7 @@ import {
   isGroupEntity,
   isUserEntity,
   RELATION_HAS_MEMBER,
+  RELATION_OWNED_BY,
   RELATION_PARENT_OF,
   stringifyEntityRef,
 } from '@backstage/catalog-model';
@@ -99,17 +100,13 @@ export async function createRouter(
       return [];
     }
 
+    const fields = ['kind', 'metadata.name', 'metadata.namespace', 'relations'];
+
     const refs = Array.isArray(entityRef) ? entityRef : [entityRef];
     const entities = await catalogClient.getEntitiesByRefs(
       {
         entityRefs: refs,
-        fields: [
-          'kind',
-          'metadata.name',
-          'metadata.namespace',
-          'relations',
-          'spec.owner',
-        ],
+        fields,
       },
       { token },
     );
@@ -122,29 +119,17 @@ export async function createRouter(
         return [stringifyEntityRef(entity)];
       } else if (isGroupEntity(entity) && entity.relations) {
         const users = entity.relations
-          .filter(
-            relation =>
-              relation.type === RELATION_HAS_MEMBER && relation.targetRef,
-          )
+          .filter(relation => relation.type === RELATION_HAS_MEMBER)
           .map(r => r.targetRef);
 
         const childGroupRefs = entity.relations
-          .filter(
-            relation =>
-              relation.type === RELATION_PARENT_OF && relation.targetRef,
-          )
+          .filter(relation => relation.type === RELATION_PARENT_OF)
           .map(r => r.targetRef);
 
         const childGroups = await catalogClient.getEntitiesByRefs(
           {
             entityRefs: childGroupRefs,
-            fields: [
-              'kind',
-              'metadata.name',
-              'metadata.namespace',
-              'relations',
-              'spec.owner',
-            ],
+            fields,
           },
           { token },
         );
@@ -152,13 +137,16 @@ export async function createRouter(
           childGroups.items.map(mapEntity),
         );
         return [...users, ...childGroupUsers.flat(2)];
-      } else if (!isGroupEntity(entity) && entity.spec?.owner) {
-        const owner = await catalogClient.getEntityByRef(
-          entity.spec.owner as string,
-          { token },
-        );
-        if (owner) {
-          return mapEntity(owner);
+      } else if (entity.relations) {
+        const ownerRef = entity.relations.find(
+          relation => relation.type === RELATION_OWNED_BY,
+        )?.targetRef;
+
+        if (ownerRef) {
+          const owner = await catalogClient.getEntityByRef(ownerRef, { token });
+          if (owner) {
+            return mapEntity(owner);
+          }
         }
       }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

use relations instead `spec.owner` field

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
