### PR TITLE
frontend-plugin-api: fix useRouteRef types for optional external route refs

### DIFF
--- a/.changeset/tiny-pens-boil.md
+++ b/.changeset/tiny-pens-boil.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': patch
+---
+
+Fixed the type for `useRouteRef`, which wasn't handling optional external route refs correctly.

--- a/packages/frontend-plugin-api/api-report.md
+++ b/packages/frontend-plugin-api/api-report.md
@@ -1155,7 +1155,7 @@ export function useRouteRef<
   TParams extends AnyRouteRefParams,
 >(
   routeRef: ExternalRouteRef<TParams, TOptional>,
-): TParams extends true ? RouteFunc<TParams> | undefined : RouteFunc<TParams>;
+): TOptional extends true ? RouteFunc<TParams> | undefined : RouteFunc<TParams>;
 
 // @public
 export function useRouteRef<TParams extends AnyRouteRefParams>(

--- a/packages/frontend-plugin-api/src/routing/useRouteRef.tsx
+++ b/packages/frontend-plugin-api/src/routing/useRouteRef.tsx
@@ -38,7 +38,7 @@ export function useRouteRef<
   TParams extends AnyRouteRefParams,
 >(
   routeRef: ExternalRouteRef<TParams, TOptional>,
-): TParams extends true ? RouteFunc<TParams> | undefined : RouteFunc<TParams>;
+): TOptional extends true ? RouteFunc<TParams> | undefined : RouteFunc<TParams>;
 
 /**
  * React hook for constructing URLs to routes.


### PR DESCRIPTION
Oops 😅 