### PR TITLE
feat(catalog): introduce a new config for processing interval multiplier

### DIFF
--- a/.changeset/clever-toys-matter.md
+++ b/.changeset/clever-toys-matter.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Introduce a new config variable `catalog.processingIntervalMultiplier` to change the default processing interval multiplier

--- a/plugins/catalog-backend/config.d.ts
+++ b/plugins/catalog-backend/config.d.ts
@@ -182,5 +182,22 @@ export interface Config {
      * housing catalog-info files.
      */
     processingInterval?: HumanDuration;
+
+    /**
+     * The multiplier for maximum processing interval used to multiply the processingInterval
+     * with this value.
+     *
+     * Default is 1.5.
+     *
+     * @remarks
+     *
+     * Example:
+     *
+     * ```yaml
+     * catalog:
+     *   processingIntervalMultiplier: 3
+     * ```
+     */
+    processingIntervalMultiplier?: number;
   };
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

this allows changing the default processing interval multiplier with the new backend system as there is no access to CatalogBuilder anymore.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
