### PR TITLE
Update plugin/badges README instructions that show an export when it should be import

### DIFF
--- a/.changeset/spotty-ravens-whisper.md
+++ b/.changeset/spotty-ravens-whisper.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-badges': patch
+---
+
+Update README to fix invalid import command

--- a/plugins/badges/README.md
+++ b/plugins/badges/README.md
@@ -89,7 +89,7 @@ This plugin requires explicit registration, so you will need to add it to your A
 
 ```ts
 // ...
-export { badgesPlugin } from '@backstage/plugin-badges';
+import { badgesPlugin } from '@backstage/plugin-badges';
 ```
 
 If you don't have a `plugins.ts` file see: [troubleshooting](#troubleshooting)

--- a/plugins/badges/README.md
+++ b/plugins/badges/README.md
@@ -88,7 +88,6 @@ yarn --cwd packages/app add @backstage/plugin-badges
 This plugin requires explicit registration, so you will need to add it to your App's `plugins.ts` file:
 
 ```ts
-// ...
 import { badgesPlugin } from '@backstage/plugin-badges';
 ```
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In the documentation for the Backstage Badges plugin the instructions prompt the user to import the plugin module, but the code example displayed includes an export keyword. Anyone doing a copy and paste will have a moment of ... ??? what.

Change `export` to `import` to reflect what the user will be doing in their code.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
