### PR TITLE
ServerPermissionClient: fix targetPluginId

### DIFF
--- a/.changeset/eleven-apricots-wave.md
+++ b/.changeset/eleven-apricots-wave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-permission-node': patch
+---
+
+Fixed an issue causing `ServerPermissionClient` to generate an invalid token for authorizing permissions against the permission backend.

--- a/.changeset/sixty-impalas-admire.md
+++ b/.changeset/sixty-impalas-admire.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+Improved error message thrown by `AuthService` when requesting a token for plugins that don't support the new authentication tokens.

--- a/packages/backend-app-api/src/services/implementations/auth/authServiceFactory.test.ts
+++ b/packages/backend-app-api/src/services/implementations/auth/authServiceFactory.test.ts
@@ -384,7 +384,7 @@ describe('authServiceFactory', () => {
         targetPluginId: 'kubernetes',
       }),
     ).rejects.toThrow(
-      "Unable to call 'kubernetes' plugin on behalf of user, because the target plugin does not support on-behalf-of tokens",
+      "Unable to call 'kubernetes' plugin on behalf of user, because the target plugin does not support on-behalf-of tokens or the plugin doesn't exist",
     );
   });
 });

--- a/packages/backend-app-api/src/services/implementations/auth/authServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/auth/authServiceFactory.ts
@@ -240,7 +240,7 @@ class DefaultAuthService implements AuthService {
 
         if (this.userTokenHandler.isLimitedUserToken(token)) {
           throw new AuthenticationError(
-            `Unable to call '${targetPluginId}' plugin on behalf of user, because the target plugin does not support on-behalf-of tokens`,
+            `Unable to call '${targetPluginId}' plugin on behalf of user, because the target plugin does not support on-behalf-of tokens or the plugin doesn't exist`,
           );
         }
         return { token };

--- a/plugins/permission-node/src/ServerPermissionClient.test.ts
+++ b/plugins/permission-node/src/ServerPermissionClient.test.ts
@@ -277,7 +277,7 @@ describe('ServerPermissionClient', () => {
         ).toBe(
           mockCredentials.service.header({
             onBehalfOf: mockCredentials.user(),
-            targetPluginId: 'permissions',
+            targetPluginId: 'permission',
           }),
         );
       });
@@ -357,7 +357,7 @@ describe('ServerPermissionClient', () => {
         ).toBe(
           mockCredentials.service.header({
             onBehalfOf: mockCredentials.user(),
-            targetPluginId: 'permissions',
+            targetPluginId: 'permission',
           }),
         );
       });

--- a/plugins/permission-node/src/ServerPermissionClient.ts
+++ b/plugins/permission-node/src/ServerPermissionClient.ts
@@ -123,7 +123,7 @@ export class ServerPermissionClient implements PermissionsService {
 
       return this.#auth.getPluginRequestToken({
         onBehalfOf: options.credentials,
-        targetPluginId: 'permissions',
+        targetPluginId: 'permission',
       });
     }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

`ServerPermissionClient` was trying to generate a token with a wrong `targetPluginId`, which caused issues in verifying the token.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
