### PR TITLE
Support api-docs plugin component style overrides via theme

### DIFF
--- a/.changeset/wicked-ducks-draw.md
+++ b/.changeset/wicked-ducks-draw.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-api-docs': patch
+---
+
+Add support for overriding all style classes of OpenApiDefinition and AsynApiDefinition components from theme.

--- a/plugins/api-docs/README.md
+++ b/plugins/api-docs/README.md
@@ -222,6 +222,37 @@ security:
     - [read_pets, write_pets]
 ```
 
+### Override Component Styles
+
+It is possible to override the component styles from theme. To override components of this `api-docs` plugin use the corresponding class key while creating custom theme overrides.
+
+| Component to Override | Class key to use in theme overrides |
+| --------------------- | ----------------------------------- |
+| OpenApiDefinition     | PluginApiDocsOpenApiDefinition      |
+| AysncApiDefinition    | PluginApiDocsAsyncApiDefinition     |
+
+Below is an example of overriding `OpenApiDefinition` component from theme:
+
+```tsx
+export const createCustomThemeOverrides = (
+  theme: BackstageTheme,
+): BackstageOverrides => {
+  return {
+    PluginApiDocsOpenApiDefinition: {
+      root: {
+        '& .scheme-container': {
+          backgroundColor: 'blue',
+        },
+      },
+    },
+  };
+};
+```
+
+More information on overriding component styles can be found [here](https://backstage.io/docs/getting-started/app-custom-theme#overriding-backstage-and-material-ui-components-styles) from backstage documentation.
+
+**NOTE**: Currently overriding of styles is only available for OpenApiDefinition and AysncApiDefinition Components.
+
 ## Links
 
 - [The Backstage homepage](https://backstage.io)

--- a/plugins/api-docs/src/components/AsyncApiDefinitionWidget/AsyncApiDefinition.tsx
+++ b/plugins/api-docs/src/components/AsyncApiDefinitionWidget/AsyncApiDefinition.tsx
@@ -20,128 +20,131 @@ import { makeStyles, alpha, darken } from '@material-ui/core/styles';
 import React from 'react';
 import { useTheme } from '@material-ui/core/styles';
 
-const useStyles = makeStyles(theme => ({
-  root: {
-    fontFamily: 'inherit',
-    '& .bg-white': {
-      background: 'none',
-    },
-    '& .text-4xl': {
-      ...theme.typography.h3,
-    },
-    ' & h2': {
-      ...theme.typography.h4,
-    },
-    '& .border': {
-      borderColor: alpha(theme.palette.border, 0.1),
-    },
-    '& .min-w-min': {
-      minWidth: 'fit-content',
-    },
-    '& .examples': {
-      padding: '1rem',
-    },
-    '& .bg-teal-500': {
-      backgroundColor: theme.palette.status.ok,
-    },
-    '& .bg-blue-500': {
-      backgroundColor: theme.palette.info.main,
-    },
-    '& .bg-blue-400': {
-      backgroundColor: theme.palette.info.light,
-    },
-    '& .bg-indigo-400': {
-      backgroundColor: theme.palette.warning.main,
-    },
-    '& .text-teal-50': {
-      color: theme.palette.status.ok,
-    },
-    '& .text-red-600': {
-      color: theme.palette.error.main,
-    },
-    '& .text-orange-600': {
-      color: theme.palette.warning.main,
-    },
-    '& .text-teal-500': {
-      color: theme.palette.status.ok,
-    },
-    '& .text-blue-500': {
-      color: theme.palette.info.main,
-    },
-    '& .-rotate-90': {
-      '--tw-rotate': '0deg',
-    },
-    '& button': {
-      ...theme.typography.button,
-      borderRadius: theme.shape.borderRadius,
-      color: theme.palette.primary.main,
-      // override whatever may be in the theme's typography to ensure consistency with asyncapi
-      textTransform: 'inherit',
-    },
-    '& a': {
-      color: theme.palette.link,
-    },
-    '& a.no-underline': {
-      ...theme.typography.button,
-      background: 'none',
-      boxSizing: 'border-box',
-      minWidth: 64,
-      borderRadius: theme.shape.borderRadius,
-      transition: theme.transitions.create(
-        ['background-color', 'box-shadow', 'border'],
-        {
-          duration: theme.transitions.duration.short,
-        },
-      ),
-      padding: '5px 15px',
-      color: theme.palette.primary.main,
-      border: `1px solid ${alpha(theme.palette.primary.main, 0.5)}`,
-      '&:hover': {
-        textDecoration: 'none',
-        border: `1px solid ${theme.palette.primary.main}`,
-        backgroundColor: alpha(
-          theme.palette.primary.main,
-          theme.palette.action.hoverOpacity,
-        ),
+const useStyles = makeStyles(
+  theme => ({
+    root: {
+      fontFamily: 'inherit',
+      '& .bg-white': {
+        background: 'none',
       },
-    },
-    '& li.no-underline': {
+      '& .text-4xl': {
+        ...theme.typography.h3,
+      },
+      ' & h2': {
+        ...theme.typography.h4,
+      },
+      '& .border': {
+        borderColor: alpha(theme.palette.border, 0.1),
+      },
+      '& .min-w-min': {
+        minWidth: 'fit-content',
+      },
+      '& .examples': {
+        padding: '1rem',
+      },
+      '& .bg-teal-500': {
+        backgroundColor: theme.palette.status.ok,
+      },
+      '& .bg-blue-500': {
+        backgroundColor: theme.palette.info.main,
+      },
+      '& .bg-blue-400': {
+        backgroundColor: theme.palette.info.light,
+      },
+      '& .bg-indigo-400': {
+        backgroundColor: theme.palette.warning.main,
+      },
+      '& .text-teal-50': {
+        color: theme.palette.status.ok,
+      },
+      '& .text-red-600': {
+        color: theme.palette.error.main,
+      },
+      '& .text-orange-600': {
+        color: theme.palette.warning.main,
+      },
+      '& .text-teal-500': {
+        color: theme.palette.status.ok,
+      },
+      '& .text-blue-500': {
+        color: theme.palette.info.main,
+      },
+      '& .-rotate-90': {
+        '--tw-rotate': '0deg',
+      },
+      '& button': {
+        ...theme.typography.button,
+        borderRadius: theme.shape.borderRadius,
+        color: theme.palette.primary.main,
+        // override whatever may be in the theme's typography to ensure consistency with asyncapi
+        textTransform: 'inherit',
+      },
       '& a': {
-        textDecoration: 'none',
-        color: theme.palette.getContrastText(theme.palette.primary.main),
+        color: theme.palette.link,
+      },
+      '& a.no-underline': {
+        ...theme.typography.button,
+        background: 'none',
+        boxSizing: 'border-box',
+        minWidth: 64,
+        borderRadius: theme.shape.borderRadius,
+        transition: theme.transitions.create(
+          ['background-color', 'box-shadow', 'border'],
+          {
+            duration: theme.transitions.duration.short,
+          },
+        ),
+        padding: '5px 15px',
+        color: theme.palette.primary.main,
+        border: `1px solid ${alpha(theme.palette.primary.main, 0.5)}`,
+        '&:hover': {
+          textDecoration: 'none',
+          border: `1px solid ${theme.palette.primary.main}`,
+          backgroundColor: alpha(
+            theme.palette.primary.main,
+            theme.palette.action.hoverOpacity,
+          ),
+        },
+      },
+      '& li.no-underline': {
+        '& a': {
+          textDecoration: 'none',
+          color: theme.palette.getContrastText(theme.palette.primary.main),
+        },
       },
     },
-  },
-  dark: {
-    '& svg': {
-      fill: theme.palette.text.primary,
-    },
-    '& .prose': {
-      color: theme.palette.text.secondary,
-      '& h3': {
-        color: theme.palette.text.primary,
+    dark: {
+      '& svg': {
+        fill: theme.palette.text.primary,
+      },
+      '& .prose': {
+        color: theme.palette.text.secondary,
+        '& h3': {
+          color: theme.palette.text.primary,
+        },
+      },
+      '& .bg-gray-100, .bg-gray-200': {
+        backgroundColor: theme.palette.background.default,
+      },
+      '& .text-gray-600': {
+        color: theme.palette.grey['50'],
+      },
+      '& .text-gray-700': {
+        color: theme.palette.grey['100'],
+      },
+      '& .panel--right': {
+        background: darken(theme.palette.navigation.background, 0.1),
+      },
+      '& .examples': {
+        backgroundColor: darken(theme.palette.navigation.background, 0.1),
+        '& pre': {
+          backgroundColor: darken(theme.palette.background.default, 0.2),
+        },
       },
     },
-    '& .bg-gray-100, .bg-gray-200': {
-      backgroundColor: theme.palette.background.default,
-    },
-    '& .text-gray-600': {
-      color: theme.palette.grey['50'],
-    },
-    '& .text-gray-700': {
-      color: theme.palette.grey['100'],
-    },
-    '& .panel--right': {
-      background: darken(theme.palette.navigation.background, 0.1),
-    },
-    '& .examples': {
-      backgroundColor: darken(theme.palette.navigation.background, 0.1),
-      '& pre': {
-        backgroundColor: darken(theme.palette.background.default, 0.2),
-      },
-    },
-  },
-}));
+  }),
+  { name: 'PluginApiDocsAsyncApiDefinition' },
+);
 
 const httpsFetchResolver = {
   schema: 'https',

--- a/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinition.tsx
+++ b/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinition.tsx
@@ -19,37 +19,38 @@ import React, { useEffect, useState } from 'react';
 import SwaggerUI, { SwaggerUIProps } from 'swagger-ui-react';
 import 'swagger-ui-react/swagger-ui.css';
 
-const useStyles = makeStyles(theme => ({
-  root: {
-    '& .swagger-ui': {
-      fontFamily: theme.typography.fontFamily,
-      color: theme.palette.text.primary,
-
-      ['& .btn-clear']: {
+const useStyles = makeStyles(
+  theme => ({
+    root: {
+      '& .swagger-ui': {
+        fontFamily: theme.typography.fontFamily,
         color: theme.palette.text.primary,
-      },
-      [`& .scheme-container`]: {
-        backgroundColor: theme.palette.background.default,
-      },
-      [`& .opblock-tag,
+
+        ['& .btn-clear']: {
+          color: theme.palette.text.primary,
+        },
+        [`& .scheme-container`]: {
+          backgroundColor: theme.palette.background.default,
+        },
+        [`& .opblock-tag,
           .opblock-tag small,
           table thead tr td,
           table thead tr th`]: {
-        fontFamily: theme.typography.fontFamily,
-        color: theme.palette.text.primary,
-        borderColor: theme.palette.divider,
-      },
-      [`& section.models,
+          fontFamily: theme.typography.fontFamily,
+          color: theme.palette.text.primary,
+          borderColor: theme.palette.divider,
+        },
+        [`& section.models,
           section.models.is-open h4`]: {
-        borderColor: theme.palette.divider,
-      },
-      [`& .model-title,
+          borderColor: theme.palette.divider,
+        },
+        [`& .model-title,
           .model .renderedMarkdown,
           .model .description`]: {
-        fontFamily: theme.typography.fontFamily,
-        fontWeight: theme.typography.fontWeightRegular,
-      },
-      [`& h1, h2, h3, h4, h5, h6,
+          fontFamily: theme.typography.fontFamily,
+          fontWeight: theme.typography.fontWeightRegular,
+        },
+        [`& h1, h2, h3, h4, h5, h6,
           .errors h4, .error h4, .opblock h4, section.models h4,
           .response-control-media-type__accept-message,
           .opblock-summary-description,
@@ -67,19 +68,19 @@ const useStyles = makeStyles(theme => ({
           .error .btn,
           .info .title,
           .info .base-url`]: {
-        fontFamily: theme.typography.fontFamily,
-        color: theme.palette.text.primary,
-      },
-      [`& .opblock .opblock-section-header,
+          fontFamily: theme.typography.fontFamily,
+          color: theme.palette.text.primary,
+        },
+        [`& .opblock .opblock-section-header,
           .model-box,
           section.models .model-container`]: {
-        background: theme.palette.background.default,
-      },
-      [`& .prop-format,
+          background: theme.palette.background.default,
+        },
+        [`& .prop-format,
           .parameter__in`]: {
-        color: theme.palette.text.disabled,
-      },
-      [`& table.model,
+          color: theme.palette.text.disabled,
+        },
+        [`& table.model,
           .parameter__type,
           .model.model-title,
           .model-title,
@@ -90,49 +91,51 @@ const useStyles = makeStyles(theme => ({
           .model .renderedMarkdown,
           .model .description,
           .errors small`]: {
-        color: theme.palette.text.secondary,
-      },
-      [`& .parameter__name.required:after`]: {
-        color: theme.palette.warning.dark,
-      },
-      [`& table.model,
+          color: theme.palette.text.secondary,
+        },
+        [`& .parameter__name.required:after`]: {
+          color: theme.palette.warning.dark,
+        },
+        [`& table.model,
           table.model .model,
           .opblock-external-docs-wrapper`]: {
-        fontSize: theme.typography.fontSize,
-      },
-      [`& table.headers td`]: {
-        color: theme.palette.text.primary,
-        fontWeight: theme.typography.fontWeightRegular,
-      },
-      [`& .model-hint`]: {
-        color: theme.palette.text.secondary,
-        backgroundColor: theme.palette.background.paper,
-      },
-      [`& .opblock-summary-method,
+          fontSize: theme.typography.fontSize,
+        },
+        [`& table.headers td`]: {
+          color: theme.palette.text.primary,
+          fontWeight: theme.typography.fontWeightRegular,
+        },
+        [`& .model-hint`]: {
+          color: theme.palette.text.secondary,
+          backgroundColor: theme.palette.background.paper,
+        },
+        [`& .opblock-summary-method,
           .info a`]: {
-        fontFamily: theme.typography.fontFamily,
-      },
-      [`& .info, .opblock, .tab`]: {
-        [`& li, p`]: {
           fontFamily: theme.typography.fontFamily,
+        },
+        [`& .info, .opblock, .tab`]: {
+          [`& li, p`]: {
+            fontFamily: theme.typography.fontFamily,
+            color: theme.palette.text.primary,
+          },
+        },
+        [`& a`]: {
+          color: theme.palette.primary.main,
+        },
+        [`& .renderedMarkdown code`]: {
+          color: theme.palette.secondary.light,
+        },
+        [`& .property-row td:first-child`]: {
           color: theme.palette.text.primary,
         },
-      },
-      [`& a`]: {
-        color: theme.palette.primary.main,
-      },
-      [`& .renderedMarkdown code`]: {
-        color: theme.palette.secondary.light,
-      },
-      [`& .property-row td:first-child`]: {
-        color: theme.palette.text.primary,
-      },
-      [`& span.prop-type`]: {
-        color: theme.palette.success.light,
+        [`& span.prop-type`]: {
+          color: theme.palette.success.light,
+        },
       },
     },
-  },
-}));
+  }),
+  { name: 'PluginApiDocsOpenApiDefinition' },
+);
 
 export type OpenApiDefinitionProps = {
   definition: string;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
- Added support for overriding all style classes of OpenApiDefinition and AsyncApiDefinition components of api-docs plugin from theme overrides.

```diff
const useStyles = makeStyles(
    theme => ({
       root: {
           '& .swagger-ui': {
             // . . .
            }
      }),
+ { name: 'PluginApiDocsAsyncApiDefinition' },
);
```

- Also updated api-docs plugin `readme.md` file to reflect the documentation on usage of overriding these components from theme overrides.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Closes #22516