### PR TITLE
feat(gcp-iap): Add user id annotation sign-in resolver

### DIFF
--- a/.changeset/serious-snails-poke.md
+++ b/.changeset/serious-snails-poke.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-gcp-iap-provider': minor
+---
+
+Add user id annotation sign-in resolver

--- a/.changeset/serious-snails-poke.md
+++ b/.changeset/serious-snails-poke.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-auth-backend-module-gcp-iap-provider': minor
+'@backstage/plugin-auth-backend-module-gcp-iap-provider': patch
 ---
 
 Add user id annotation sign-in resolver

--- a/plugins/auth-backend-module-gcp-iap-provider/api-report.md
+++ b/plugins/auth-backend-module-gcp-iap-provider/api-report.md
@@ -37,6 +37,10 @@ export namespace gcpIapSignInResolvers {
     GcpIapResult,
     unknown
   >;
+  const idMatchingUserEntityAnnotation: SignInResolverFactory<
+    GcpIapResult,
+    unknown
+  >;
 }
 
 // @public

--- a/plugins/auth-backend-module-gcp-iap-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-gcp-iap-provider/src/resolvers.ts
@@ -46,4 +46,21 @@ export namespace gcpIapSignInResolvers {
       };
     },
   });
+
+  /**
+   * Looks up the user by matching their user ID to the `google.com/user-id` annotation.
+   */
+  export const idMatchingUserEntityAnnotation = createSignInResolverFactory({
+    create() {
+      return async (info: SignInInfo<GcpIapResult>, ctx) => {
+        const userId = info.result.iapToken.sub.split(':')[1];
+
+        return ctx.signInWithCatalogUser({
+          annotations: {
+            'google.com/user-id': userId,
+          },
+        });
+      };
+    },
+  });
 }


### PR DESCRIPTION
This adds a new sign-in resolver for the GCP IAP auth provider which tries to lookup catalog users by user ID. This is useful when paired with a Google Workspace Directory sourcing entity provider which adds this annotation to user entities.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
