### PR TITLE
guest-provider: Error if used outside of development environment 

### DIFF
--- a/.changeset/purple-waves-smile.md
+++ b/.changeset/purple-waves-smile.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-guest-provider': patch
+---
+
+Error if used outside of a development environment

--- a/.changeset/purple-waves-smile.md
+++ b/.changeset/purple-waves-smile.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-auth-backend-module-guest-provider': patch
 ---
 
-Error if used outside of a development environment
+Error if used outside of a development environment without explicit allowance

--- a/plugins/auth-backend-module-guest-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-guest-provider/src/authenticator.ts
@@ -15,12 +15,22 @@
  */
 
 import { createProxyAuthenticator } from '@backstage/plugin-auth-node';
+import { NotImplementedError } from '@backstage/errors';
 
 export const guestAuthenticator = createProxyAuthenticator({
   defaultProfileTransform: async () => {
     return { profile: {} };
   },
-  initialize() {},
+  initialize({ config }) {
+    const allowOutsideDev = config.getOptionalBoolean(
+      'dangerouslyAllowOutsideDevelopment',
+    );
+    if (process.env.NODE_ENV !== 'development' && allowOutsideDev !== true) {
+      throw new NotImplementedError(
+        'The guest provider cannot be used outside of a development environment',
+      );
+    }
+  },
   async authenticate() {
     return { result: {} };
   },

--- a/plugins/auth-backend-module-guest-provider/src/module.ts
+++ b/plugins/auth-backend-module-guest-provider/src/module.ts
@@ -31,16 +31,10 @@ export const authModuleGuestProvider = createBackendModule({
   register(reg) {
     reg.registerInit({
       deps: {
-        logger: coreServices.logger,
         providers: authProvidersExtensionPoint,
         config: coreServices.rootConfig,
       },
-      async init({ providers, logger, config }) {
-        if (process.env.NODE_ENV !== 'development') {
-          logger.warn(
-            'You should NOT be using the guest provider outside of a development environment.',
-          );
-        }
+      async init({ providers, config }) {
         providers.registerProvider({
           providerId: 'guest',
           factory: createProxyAuthProviderFactory({


### PR DESCRIPTION
Spare us one warning when running with `NODE_ENV !== 'development'`.

Fixes #24173

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
