### PR TITLE
fix: Scrollbarss don't pick up the theme in dark mode

### DIFF
--- a/.changeset/proud-doors-cheat.md
+++ b/.changeset/proud-doors-cheat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/theme': patch
+---
+
+Fixed bug where scrollbars don't pick up the theme when in dark mode

--- a/packages/theme/src/v5/defaultComponentThemes.ts
+++ b/packages/theme/src/v5/defaultComponentThemes.ts
@@ -34,6 +34,22 @@ export const defaultComponentThemes: ThemeOptions['components'] = {
         overscrollBehaviorY: 'none',
         fontSize: '0.875rem',
         lineHeight: 1.43,
+        '&::-webkit-scrollbar, & *::-webkit-scrollbar': {
+          backgroundColor: theme.palette.background.paper,
+          width: '1em',
+        },
+        '&::-webkit-scrollbar-thumb, & *::-webkit-scrollbar-thumb': {
+          borderRadius: 8,
+          backgroundColor: theme.palette.textVerySubtle,
+          border: `3px solid ${theme.palette.background.paper}`,
+        },
+        '&::-webkit-scrollbar-thumb:active, & *::-webkit-scrollbar-thumb:active':
+          {
+            backgroundColor:
+              theme.palette.mode === 'dark'
+                ? lighten(theme.palette.textVerySubtle, 0.2)
+                : darken(theme.palette.textVerySubtle, 0.2),
+          },
       },
       a: {
         color: 'inherit',

--- a/packages/theme/src/v5/defaultComponentThemes.ts
+++ b/packages/theme/src/v5/defaultComponentThemes.ts
@@ -50,6 +50,13 @@ export const defaultComponentThemes: ThemeOptions['components'] = {
                 ? lighten(theme.palette.textVerySubtle, 0.2)
                 : darken(theme.palette.textVerySubtle, 0.2),
           },
+        '&::-webkit-scrollbar-thumb:hover, & *::-webkit-scrollbar-thumb:hover':
+          {
+            backgroundColor:
+              theme.palette.mode === 'dark'
+                ? lighten(theme.palette.textVerySubtle, 0.2)
+                : darken(theme.palette.textVerySubtle, 0.2),
+          },
       },
       a: {
         color: 'inherit',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Scrollbars in both modes look like this at the moment. The one in dark mode doesn't look very aesthetic as it doesn't pick up the theme.

<img width="400" alt="Screenshot 2024-04-11 at 17 57 58" src="https://github.com/backstage/backstage/assets/155443125/20cb29c7-c0ea-420d-908d-88c937fffa23">
<img width="400" alt="Screenshot 2024-04-11 at 17 50 40" src="https://github.com/backstage/backstage/assets/155443125/2e012315-e8bf-4c5c-9b1a-499c322849cb">

---
When hovering: 

<img width="400" alt="Screenshot 2024-04-11 at 17 52 00" src="https://github.com/backstage/backstage/assets/155443125/a2d55c5f-f7c1-4a04-b34e-5bb605931125">
<img width="400" alt="Screenshot 2024-04-11 at 18 03 06" src="https://github.com/backstage/backstage/assets/155443125/80d1d39c-e3f0-414f-b2c5-40900c316427">

---

This PR modifies that so the scrollbars in both modes look like this now. 

<img width="400" alt="Screenshot 2024-04-11 at 17 51 23" src="https://github.com/backstage/backstage/assets/155443125/e8cafc65-bab8-4e55-a1c5-259b6415189b">
<img width="400" alt="Screenshot 2024-04-11 at 17 47 41" src="https://github.com/backstage/backstage/assets/155443125/16ff3a32-96fe-4fae-b725-ca9e8f470aa5">

---

When hovering: 

<img width="400" alt="Screenshot 2024-04-11 at 18 05 25" src="https://github.com/backstage/backstage/assets/155443125/5f2252c4-1790-4115-9431-41f22e8f2c9f">
<img width="400" alt="Screenshot 2024-04-11 at 18 05 49" src="https://github.com/backstage/backstage/assets/155443125/9756c471-997b-442e-97c3-1e2ceec1c533">

---

I have included both modes as the colours change slightly (I couldn't find the ideal ones in the palettes). Hope this is okay :) 

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
