### PR TITLE
config: trim strings when reading config

### DIFF
--- a/.changeset/chatty-parrots-trade.md
+++ b/.changeset/chatty-parrots-trade.md
@@ -1,0 +1,13 @@
+---
+'@backstage/config-loader': minor
+---
+
+The default environment variable substitution function will now trim whitespace characters from the substituted value. This alleviates bugs where whitespace characters are mistakenly included in environment variables.
+
+If you depend on the old behavior, you can override the default substitution function with your own, for example:
+
+```ts
+ConfigSources.default({
+  substitutionFunc: async name => process.env[name],
+});
+```

--- a/packages/config-loader/api-report.md
+++ b/packages/config-loader/api-report.md
@@ -25,7 +25,6 @@ export interface BaseConfigSourcesOptions {
   remote?: Pick<RemoteConfigSourceOptions, 'reloadInterval'>;
   // (undocumented)
   rootDir?: string;
-  // (undocumented)
   substitutionFunc?: EnvFunc;
   // (undocumented)
   watch?: boolean;

--- a/packages/config-loader/src/sources/ConfigSources.ts
+++ b/packages/config-loader/src/sources/ConfigSources.ts
@@ -74,6 +74,14 @@ export interface BaseConfigSourcesOptions {
   watch?: boolean;
   rootDir?: string;
   remote?: Pick<RemoteConfigSourceOptions, 'reloadInterval'>;
+
+  /**
+   * A custom substitution function that overrides the default one.
+   *
+   * @remarks
+   * The substitution function handles syntax like `${MY_ENV_VAR}` in configuration values.
+   * The default substitution will read the value from the environment and trim whitespace.
+   */
   substitutionFunc?: SubstitutionFunc;
 }
 

--- a/packages/config-loader/src/sources/transform/apply.test.ts
+++ b/packages/config-loader/src/sources/transform/apply.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { applyConfigTransforms } from './apply';
+import { applyConfigTransforms, createConfigTransformer } from './apply';
 
 describe('applyConfigTransforms', () => {
   it('should apply no transforms to input', async () => {
@@ -81,6 +81,35 @@ describe('applyConfigTransforms', () => {
         y: [null, true],
         z: null,
       },
+    });
+  });
+});
+
+describe('createConfigTransformer', () => {
+  const origEnv = process.env;
+  process.env = {
+    ...process.env,
+    SECRET: 'my-secret',
+    PADDED_SECRET: ' \nmy-space \t',
+  };
+
+  afterAll(() => {
+    process.env = origEnv;
+  });
+
+  it('should substitute environment variables', async () => {
+    const transformer = createConfigTransformer({});
+
+    await expect(
+      transformer({
+        testAlone: '${SECRET}',
+        testMiddle: 'hello ${SECRET}!',
+        testSpace: 'hello ${PADDED_SECRET}!',
+      }),
+    ).resolves.toEqual({
+      testAlone: 'my-secret',
+      testMiddle: 'hello my-secret!',
+      testSpace: 'hello my-space!',
     });
   });
 });

--- a/packages/config-loader/src/sources/transform/apply.ts
+++ b/packages/config-loader/src/sources/transform/apply.ts
@@ -105,8 +105,10 @@ export function createConfigTransformer(options: {
   substitutionFunc?: SubstitutionFunc;
   readFile?(path: string): Promise<string>;
 }): ConfigTransformer {
-  const { substitutionFunc = async name => process.env[name], readFile } =
-    options;
+  const {
+    substitutionFunc = async name => process.env[name]?.trim(),
+    readFile,
+  } = options;
   const substitutionTransform = createSubstitutionTransform(substitutionFunc);
   const transforms = [substitutionTransform];
   if (readFile) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This came up for an adopters as a tricky bug to track down, where a newline had crept into a secret env var. I think it's worth for us to trim whitespace when reading strings from config and to roll that out as a non-breaking change.

Eager to hear about examples where trimming whilespace might lead to bugs, but since our config is YAML based I do expect for this to only appear in cases where @sebrosander screws up the env vars 🍻 

Very much open to rolling this out in other ways, but I do think we should make some change as this isn't the first time a hard to track down bug has crept in because of newlines in config.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
