### PR TITLE
workflows: relax PR stalebot deadlines

### DIFF
--- a/.github/workflows/automate_stale.yml
+++ b/.github/workflows/automate_stale.yml
@@ -35,8 +35,8 @@ jobs:
             recent activity from the author. It will be closed if no further activity occurs.
             If the PR was closed and you want it re-opened, let us know
             and we'll re-open the PR so that you can continue the contribution!
-          days-before-pr-stale: 7
-          days-before-pr-close: 5
+          days-before-pr-stale: 14
+          days-before-pr-close: 7
           exempt-pr-labels: after-vacations,will-fix
           stale-pr-label: stale
           operations-per-run: 100


### PR DESCRIPTION
Suggesting that we relax our PR stalebox intervals a bit, really just to reflect reality. Would love to revert this at some point in the future, but with the current interval I feel it's an annoyance for contributors and added stress for maintainers