### PR TITLE
docs/integration/github/discovery: mention require scope and permissions

### DIFF
--- a/docs/integrations/github/discovery.md
+++ b/docs/integrations/github/discovery.md
@@ -115,7 +115,7 @@ You can check the official docs to [configure your webhook](https://docs.github.
 ## Configuration
 
 To use the discovery provider, you'll need a GitHub integration
-[set up](locations.md) with either a [Personal Access Token](../../getting-started/config/authentication.md) or [GitHub Apps](./github-apps.md).
+[set up](locations.md) with either a [Personal Access Token](../../getting-started/config/authentication.md) or [GitHub Apps](./github-apps.md). For Personal Access Tokens you should pay attention to the [required scopes](https://backstage.io/docs/integrations/github/locations/#token-scopes), where you will need at least the `repo` scope for reading components. For GitHub Apps you will need to grant it the [required permissions](https://backstage.io/docs/integrations/github/github-apps#app-permissions) instead, where you will need at least the `Contents: Read-only` permissions for reading components.
 
 Then you can add a `github` config to the catalog providers configuration:
 


### PR DESCRIPTION
🧹 , received feedback on the docs that we could mention the required scopes here, and I agree 👍 