### PR TITLE
[NBS Docs] Added SingIn Resolvers Config Details

### DIFF
--- a/docs/auth/atlassian/provider.md
+++ b/docs/auth/atlassian/provider.md
@@ -49,6 +49,7 @@ auth:
         scope: ${AUTH_ATLASSIAN_SCOPES}
         signIn:
           resolvers:
+            # typically you would pick one of these
             - resolver: emailMatchingUserEntityProfileEmail
             - resolver: emailLocalPartMatchingUserEntityName
             - resolver: usernameMatchingUserEntityName

--- a/docs/auth/atlassian/provider.md
+++ b/docs/auth/atlassian/provider.md
@@ -54,8 +54,6 @@ auth:
             - resolver: usernameMatchingUserEntityName
 ```
 
-> Note: the resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
-
 The Atlassian provider is a structure with three configuration keys:
 
 - `clientId`: The Key you generated in the developer console.
@@ -63,6 +61,18 @@ The Atlassian provider is a structure with three configuration keys:
 - `scope`: List of scopes the app has permissions for, separated by spaces.
 
 **NOTE:** the scopes `offline_access`, `read:jira-work`, and `read:jira-user` are provided by default.
+
+### Resolvers
+
+This provider includes several resolvers out of the box that you can use:
+
+- `emailMatchingUserEntityProfileEmail`: Matches the email address from the auth provider with the User entity that has a matching `spec.profile.email`. If no match is found it will throw a `NotFoundError`.
+- `emailLocalPartMatchingUserEntityName`: Matches the [local part](https://en.wikipedia.org/wiki/Email_address#Local-part) of the email address from the auth provider with the User entity that has a matching `name`. If no match is found it will throw a `NotFoundError`.
+- `usernameMatchingUserEntityName`: Matches the username from the auth provider with the User entity that has a matching `name`. If no match is found it will throw a `NotFoundError`.
+
+> Note: The resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
+
+If these resolvers do not fit your needs you can build a custom resolver, this is covered in the [Building Custom Resolvers](../identity-resolver.md#building-custom-resolvers) section of the Sign-in Identities and Resolvers documentation.
 
 ## Adding the provider to the Backstage frontend
 

--- a/docs/auth/atlassian/provider.md
+++ b/docs/auth/atlassian/provider.md
@@ -47,7 +47,14 @@ auth:
         clientId: ${AUTH_ATLASSIAN_CLIENT_ID}
         clientSecret: ${AUTH_ATLASSIAN_CLIENT_SECRET}
         scope: ${AUTH_ATLASSIAN_SCOPES}
+        signIn:
+          resolvers:
+            - resolver: emailMatchingUserEntityProfileEmail
+            - resolver: emailLocalPartMatchingUserEntityName
+            - resolver: usernameMatchingUserEntityName
 ```
+
+> Note: the resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
 
 The Atlassian provider is a structure with three configuration keys:
 

--- a/docs/auth/github/provider.md
+++ b/docs/auth/github/provider.md
@@ -48,8 +48,6 @@ auth:
             - resolver: usernameMatchingUserEntityName
 ```
 
-> Note: the resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
-
 The GitHub provider is a structure with three configuration keys:
 
 - `clientId`: The client ID that you generated on GitHub, e.g.
@@ -61,6 +59,18 @@ The GitHub provider is a structure with three configuration keys:
   initiating an OAuth flow, e.g.
   `https://your-intermediate-service.com/handler`. Only needed if Backstage is
   not the immediate receiver (e.g. one OAuth app for many backstage instances).
+
+### Resolvers
+
+This provider includes several resolvers out of the box that you can use:
+
+- `emailMatchingUserEntityProfileEmail`: Matches the email address from the auth provider with the User entity that has a matching `spec.profile.email`. If no match is found it will throw a `NotFoundError`.
+- `emailLocalPartMatchingUserEntityName`: Matches the [local part](https://en.wikipedia.org/wiki/Email_address#Local-part) of the email address from the auth provider with the User entity that has a matching `name`. If no match is found it will throw a `NotFoundError`.
+- `usernameMatchingUserEntityName`: Matches the username from the auth provider with the User entity that has a matching `name`. If no match is found it will throw a `NotFoundError`.
+
+> Note: The resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
+
+If these resolvers do not fit your needs you can build a custom resolver, this is covered in the [Building Custom Resolvers](../identity-resolver.md#building-custom-resolvers) section of the Sign-in Identities and Resolvers documentation.
 
 ## Adding the provider to the Backstage frontend
 

--- a/docs/auth/github/provider.md
+++ b/docs/auth/github/provider.md
@@ -41,7 +41,14 @@ auth:
         clientSecret: ${AUTH_GITHUB_CLIENT_SECRET}
         ## uncomment if using GitHub Enterprise
         # enterpriseInstanceUrl: ${AUTH_GITHUB_ENTERPRISE_INSTANCE_URL}
+        signIn:
+          resolvers:
+            - resolver: emailMatchingUserEntityProfileEmail
+            - resolver: emailLocalPartMatchingUserEntityName
+            - resolver: usernameMatchingUserEntityName
 ```
+
+> Note: the resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
 
 The GitHub provider is a structure with three configuration keys:
 

--- a/docs/auth/github/provider.md
+++ b/docs/auth/github/provider.md
@@ -43,6 +43,7 @@ auth:
         # enterpriseInstanceUrl: ${AUTH_GITHUB_ENTERPRISE_INSTANCE_URL}
         signIn:
           resolvers:
+            # typically you would pick one of these
             - resolver: emailMatchingUserEntityProfileEmail
             - resolver: emailLocalPartMatchingUserEntityName
             - resolver: usernameMatchingUserEntityName

--- a/docs/auth/gitlab/provider.md
+++ b/docs/auth/gitlab/provider.md
@@ -50,8 +50,6 @@ auth:
             - resolver: usernameMatchingUserEntityName
 ```
 
-> Note: the resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
-
 The GitLab provider is a structure with three configuration keys:
 
 - `clientId`: The Application ID that you generated on GitLab, e.g.
@@ -62,6 +60,18 @@ The GitLab provider is a structure with three configuration keys:
 - `callbackUrl` (optional): The URL matching the Redirect URI registered when creating your GitLab OAuth App, e.g.
   `https://$backstage.acme.corp/api/auth/gitlab/handler/frame`
   Note: Due to a peculiarity with GitLab OAuth, ensure there is no trailing `/` after 'frame' in the URL.
+
+### Resolvers
+
+This provider includes several resolvers out of the box that you can use:
+
+- `emailMatchingUserEntityProfileEmail`: Matches the email address from the auth provider with the User entity that has a matching `spec.profile.email`. If no match is found it will throw a `NotFoundError`.
+- `emailLocalPartMatchingUserEntityName`: Matches the [local part](https://en.wikipedia.org/wiki/Email_address#Local-part) of the email address from the auth provider with the User entity that has a matching `name`. If no match is found it will throw a `NotFoundError`.
+- `usernameMatchingUserEntityName`: Matches the username from the auth provider with the User entity that has a matching `name`. If no match is found it will throw a `NotFoundError`.
+
+> Note: The resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
+
+If these resolvers do not fit your needs you can build a custom resolver, this is covered in the [Building Custom Resolvers](../identity-resolver.md#building-custom-resolvers) section of the Sign-in Identities and Resolvers documentation.
 
 ## Adding the provider to the Backstage frontend
 

--- a/docs/auth/gitlab/provider.md
+++ b/docs/auth/gitlab/provider.md
@@ -45,6 +45,7 @@ auth:
         # callbackUrl: https://${BASE_URL}/api/auth/gitlab/handler/frame
         signIn:
           resolvers:
+            # typically you would pick one of these
             - resolver: emailMatchingUserEntityProfileEmail
             - resolver: emailLocalPartMatchingUserEntityName
             - resolver: usernameMatchingUserEntityName

--- a/docs/auth/gitlab/provider.md
+++ b/docs/auth/gitlab/provider.md
@@ -43,7 +43,14 @@ auth:
         # audience: https://gitlab.company.com
         ## uncomment if using a custom redirect URI
         # callbackUrl: https://${BASE_URL}/api/auth/gitlab/handler/frame
+        signIn:
+          resolvers:
+            - resolver: emailMatchingUserEntityProfileEmail
+            - resolver: emailLocalPartMatchingUserEntityName
+            - resolver: usernameMatchingUserEntityName
 ```
+
+> Note: the resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
 
 The GitLab provider is a structure with three configuration keys:
 

--- a/docs/auth/google/gcp-iap-auth.md
+++ b/docs/auth/google/gcp-iap-auth.md
@@ -55,9 +55,30 @@ If these resolvers do not fit your needs you can build a custom resolver, this i
 
 ## Backend Changes
 
-This provider is not enabled by default in the auth backend code, because
-besides the config section above, it also needs to be given one or more
-callbacks in actual code as well as described below.
+There is a module for this provider that you will need to add to your backend.
+
+First you'll want to run this command to add the module:
+
+```sh
+ yarn --cwd packages/backend add @backstage/plugin-auth-backend-module-gcp-iap-provider
+```
+
+Then you will need to add this to your backend:
+
+```ts title="packages/backend/src/index.ts"
+const backend = createBackend();
+
+backend.add(import('@backstage/plugin-auth-backend'));
+/* highlight-add-start */
+backend.add(import('@backstage/plugin-auth-backend-module-gcp-iap-provider'));
+/* highlight-add-end */
+```
+
+### Legacy Backend Changes
+
+If you are still using the legacy backend you will need to make the changes outlined here.
+
+This provider is not enabled by default in the auth backend code, because besides the config section above, it also needs to be given one or more callbacks in actual code as well as described below.
 
 Add a `providerFactories` entry to the router in
 `packages/backend/src/plugins/auth.ts`.
@@ -110,27 +131,6 @@ export default async function createPlugin(
 Now the backend is ready to serve auth requests on the
 `/api/auth/gcp-iap/refresh` endpoint. All that's left is to update the frontend
 sign-in mechanism to poll that endpoint through the IAP, on the user's behalf.
-
-### New Backend System
-
-There is a module for this provider that works with the new backend system.
-
-First you'll want to run this command to add the module:
-
-```sh
- yarn --cwd packages/backend add @backstage/plugin-auth-backend-module-gcp-iap-provider
-```
-
-Then you will need to add this to your backend:
-
-```ts title="packages/backend/src/index.ts"
-const backend = createBackend();
-
-backend.add(import('@backstage/plugin-auth-backend'));
-/* highlight-add-start */
-backend.add(import('@backstage/plugin-auth-backend-module-gcp-iap-provider'));
-/* highlight-add-end */
-```
 
 ## Frontend Changes
 

--- a/docs/auth/google/gcp-iap-auth.md
+++ b/docs/auth/google/gcp-iap-auth.md
@@ -34,14 +34,24 @@ auth:
           - resolver: emailMatchingUserEntityAnnotation
 ```
 
-> Note: the resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
-
 The full `audience` value can be obtained by visiting your [Identity-Aware Proxy Google Cloud console](https://console.cloud.google.com/security/iap), selecting your project, finding your Backend Service to proxy, clicking the 3 vertical dots then "Get JWT Audience Code", and copying from the resulting popup, which will look similar to the following:
 
 ![Identity-Aware Proxy JWT Audience Code popup](../../assets/auth/gcp-iap-jwt-audience-code-popup.png)
 
 This config section must be in place for the provider to load at all. Now let's
 add the provider itself.
+
+### Resolvers
+
+This provider includes several resolvers out of the box that you can use:
+
+- `emailMatchingUserEntityProfileEmail`: Matches the email address from the auth provider with the User entity that has a matching `spec.profile.email`. If no match is found it will throw a `NotFoundError`.
+- `emailLocalPartMatchingUserEntityName`: Matches the [local part](https://en.wikipedia.org/wiki/Email_address#Local-part) of the email address from the auth provider with the User entity that has a matching `name`. If no match is found it will throw a `NotFoundError`.
+- `emailMatchingUserEntityAnnotation`: Matches the email address from the auth provider with the User entity where the value of the `google.com/email` annotation matches. If no match is found it will throw a `NotFoundError`.
+
+> Note: The resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
+
+If these resolvers do not fit your needs you can build a custom resolver, this is covered in the [Building Custom Resolvers](../identity-resolver.md#building-custom-resolvers) section of the Sign-in Identities and Resolvers documentation.
 
 ## Backend Changes
 

--- a/docs/auth/google/gcp-iap-auth.md
+++ b/docs/auth/google/gcp-iap-auth.md
@@ -27,7 +27,14 @@ auth:
     gcp-iap:
       audience: '/projects/<project number>/global/backendServices/<backend service id>'
       jwtHeader: x-custom-header # Optional: Only if you are using a custom header for the IAP JWT
+      signIn:
+        resolvers:
+          - resolver: emailMatchingUserEntityProfileEmail
+          - resolver: emailLocalPartMatchingUserEntityName
+          - resolver: emailMatchingUserEntityAnnotation
 ```
+
+> Note: the resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
 
 The full `audience` value can be obtained by visiting your [Identity-Aware Proxy Google Cloud console](https://console.cloud.google.com/security/iap), selecting your project, finding your Backend Service to proxy, clicking the 3 vertical dots then "Get JWT Audience Code", and copying from the resulting popup, which will look similar to the following:
 
@@ -93,6 +100,27 @@ export default async function createPlugin(
 Now the backend is ready to serve auth requests on the
 `/api/auth/gcp-iap/refresh` endpoint. All that's left is to update the frontend
 sign-in mechanism to poll that endpoint through the IAP, on the user's behalf.
+
+### New Backend System
+
+There is a module for this provider that works with the new backend system.
+
+First you'll want to run this command to add the module:
+
+```sh
+ yarn --cwd packages/backend add @backstage/plugin-auth-backend-module-gcp-iap-provider
+```
+
+Then you will need to add this to your backend:
+
+```ts title="packages/backend/src/index.ts"
+const backend = createBackend();
+
+backend.add(import('@backstage/plugin-auth-backend'));
+/* highlight-add-start */
+backend.add(import('@backstage/plugin-auth-backend-module-gcp-iap-provider'));
+/* highlight-add-end */
+```
 
 ## Frontend Changes
 

--- a/docs/auth/google/gcp-iap-auth.md
+++ b/docs/auth/google/gcp-iap-auth.md
@@ -29,6 +29,7 @@ auth:
       jwtHeader: x-custom-header # Optional: Only if you are using a custom header for the IAP JWT
       signIn:
         resolvers:
+          # typically you would pick one of these
           - resolver: emailMatchingUserEntityProfileEmail
           - resolver: emailLocalPartMatchingUserEntityName
           - resolver: emailMatchingUserEntityAnnotation

--- a/docs/auth/google/provider.md
+++ b/docs/auth/google/provider.md
@@ -42,7 +42,14 @@ auth:
       development:
         clientId: ${AUTH_GOOGLE_CLIENT_ID}
         clientSecret: ${AUTH_GOOGLE_CLIENT_SECRET}
+        signIn:
+          resolvers:
+            - resolver: emailMatchingUserEntityProfileEmail
+            - resolver: emailLocalPartMatchingUserEntityName
+            - resolver: emailMatchingUserEntityAnnotation
 ```
+
+> Note: the resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
 
 The Google provider is a structure with two configuration keys:
 

--- a/docs/auth/google/provider.md
+++ b/docs/auth/google/provider.md
@@ -44,6 +44,7 @@ auth:
         clientSecret: ${AUTH_GOOGLE_CLIENT_SECRET}
         signIn:
           resolvers:
+            # typically you would pick one of these
             - resolver: emailMatchingUserEntityProfileEmail
             - resolver: emailLocalPartMatchingUserEntityName
             - resolver: emailMatchingUserEntityAnnotation

--- a/docs/auth/google/provider.md
+++ b/docs/auth/google/provider.md
@@ -49,13 +49,23 @@ auth:
             - resolver: emailMatchingUserEntityAnnotation
 ```
 
-> Note: the resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
-
 The Google provider is a structure with two configuration keys:
 
 - `clientId`: The client ID that you generated, e.g.
   `10023341500512-beui241gjwwkrdkr2eh7dprewj2pp1q.apps.googleusercontent.com`
 - `clientSecret`: The client secret tied to the generated client ID.
+
+### Resolvers
+
+This provider includes several resolvers out of the box that you can use:
+
+- `emailMatchingUserEntityProfileEmail`: Matches the email address from the auth provider with the User entity that has a matching `spec.profile.email`. If no match is found it will throw a `NotFoundError`.
+- `emailLocalPartMatchingUserEntityName`: Matches the [local part](https://en.wikipedia.org/wiki/Email_address#Local-part) of the email address from the auth provider with the User entity that has a matching `name`. If no match is found it will throw a `NotFoundError`.
+- `emailMatchingUserEntityAnnotation`: Matches the email address from the auth provider with the User entity where the value of the `google.com/email` annotation matches. If no match is found it will throw a `NotFoundError`.
+
+> Note: The resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
+
+If these resolvers do not fit your needs you can build a custom resolver, this is covered in the [Building Custom Resolvers](../identity-resolver.md#building-custom-resolvers) section of the Sign-in Identities and Resolvers documentation.
 
 ## Adding the provider to the Backstage frontend
 

--- a/docs/auth/microsoft/provider.md
+++ b/docs/auth/microsoft/provider.md
@@ -59,6 +59,7 @@ auth:
           - Mail.Send
         signIn:
           resolvers:
+            # typically you would pick one of these
             - resolver: emailMatchingUserEntityProfileEmail
             - resolver: emailLocalPartMatchingUserEntityName
             - resolver: emailMatchingUserEntityAnnotation

--- a/docs/auth/microsoft/provider.md
+++ b/docs/auth/microsoft/provider.md
@@ -57,7 +57,14 @@ auth:
         domainHint: ${AZURE_TENANT_ID}
         additionalScopes:
           - Mail.Send
+        signIn:
+          resolvers:
+            - resolver: emailMatchingUserEntityProfileEmail
+            - resolver: emailLocalPartMatchingUserEntityName
+            - resolver: emailMatchingUserEntityAnnotation
 ```
+
+> Note: the resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
 
 The Microsoft provider is a structure with three mandatory configuration keys:
 

--- a/docs/auth/microsoft/provider.md
+++ b/docs/auth/microsoft/provider.md
@@ -64,8 +64,6 @@ auth:
             - resolver: emailMatchingUserEntityAnnotation
 ```
 
-> Note: the resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
-
 The Microsoft provider is a structure with three mandatory configuration keys:
 
 - `clientId`: Application (client) ID, found on App Registration > Overview
@@ -76,6 +74,18 @@ The Microsoft provider is a structure with three mandatory configuration keys:
   When specified, this reduces login friction for users with accounts in multiple tenants by automatically filtering away accounts from other tenants.
   For more details, see [Home Realm Discovery](https://learn.microsoft.com/en-us/azure/active-directory/manage-apps/home-realm-discovery-policy)
 - `additionalScopes` (optional): List of scopes for the App Registration. The default and mandatory value is ['user.read'].
+
+### Resolvers
+
+This provider includes several resolvers out of the box that you can use:
+
+- `emailMatchingUserEntityProfileEmail`: Matches the email address from the auth provider with the User entity that has a matching `spec.profile.email`. If no match is found it will throw a `NotFoundError`.
+- `emailLocalPartMatchingUserEntityName`: Matches the [local part](https://en.wikipedia.org/wiki/Email_address#Local-part) of the email address from the auth provider with the User entity that has a matching `name`. If no match is found it will throw a `NotFoundError`.
+- `emailMatchingUserEntityAnnotation`: Matches the email address from the auth provider with the User entity where the value of the `microsoft.com/email` annotation matches. If no match is found it will throw a `NotFoundError`.
+
+> Note: The resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
+
+If these resolvers do not fit your needs you can build a custom resolver, this is covered in the [Building Custom Resolvers](../identity-resolver.md#building-custom-resolvers) section of the Sign-in Identities and Resolvers documentation.
 
 ## Adding the provider to the Backstage frontend
 

--- a/docs/auth/oauth2-proxy/provider.md
+++ b/docs/auth/oauth2-proxy/provider.md
@@ -26,6 +26,7 @@ auth:
       development:
         signIn:
           resolvers:
+            # typically you would pick one of these
             - resolver: emailMatchingUserEntityProfileEmail
             - resolver: emailLocalPartMatchingUserEntityName
             - resolver: forwardedUserMatchingUserEntityName

--- a/docs/auth/oauth2-proxy/provider.md
+++ b/docs/auth/oauth2-proxy/provider.md
@@ -31,43 +31,17 @@ auth:
             - resolver: forwardedUserMatchingUserEntityName
 ```
 
-> Note: the resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
+### Resolvers
 
-Right now no configuration options are supported, but the empty object is needed
-to enable the provider in the auth backend.
+This provider includes several resolvers out of the box that you can use:
 
-To use the `oauth2Proxy` provider you must also configure it with a sign-in resolver.
-For more information about the sign-in process in general, see the
-[Sign-in Identities and Resolvers](../identity-resolver.md) documentation.
+- `emailMatchingUserEntityProfileEmail`: Matches the email address from the auth provider with the User entity that has a matching `spec.profile.email`. If no match is found it will throw a `NotFoundError`.
+- `emailLocalPartMatchingUserEntityName`: Matches the [local part](https://en.wikipedia.org/wiki/Email_address#Local-part) of the email address from the auth provider with the User entity that has a matching `name`. If no match is found it will throw a `NotFoundError`.
+- `forwardedUserMatchingUserEntityName`: Matches the value in the `x-forwarded-user` header from the auth provider with the User entity that has a matching `name`. If no match is found it will throw a `NotFoundError`.
 
-For the `oauth2Proxy` provider, the sign-in result is quite different than other providers.
-Because it's a proxy provider that can be configured to forward information through
-arbitrary headers, the auth result simply just gives you access to the HTTP headers
-of the incoming request. Using these you can either extract the information directly,
-or grab ID or access tokens to look up additional information and/or validate the request.
+> Note: The resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
 
-A simple sign-in resolver might for example look like this:
-
-```ts
-providerFactories: {
-  ...defaultAuthProviderFactories,
-  oauth2Proxy: providers.oauth2Proxy.create({
-    signIn: {
-      async resolver({ result }, ctx) {
-        const name = result.getHeader('x-forwarded-user');
-        if (!name) {
-          throw new Error('Request did not contain a user')
-        }
-        return ctx.signInWithCatalogUser({
-          entityRef: { name },
-        });
-      },
-    },
-  }),
-},
-```
-
-[An example on how to sign a user in without a matching user](https://github.com/backstage/backstage/blob/master/packages/backend/src/plugins/auth.ts)
+If these resolvers do not fit your needs you can build a custom resolver, this is covered in the [Building Custom Resolvers](../identity-resolver.md#building-custom-resolvers) section of the Sign-in Identities and Resolvers documentation.
 
 ## Adding the provider to the Backstage frontend
 

--- a/docs/auth/oauth2-proxy/provider.md
+++ b/docs/auth/oauth2-proxy/provider.md
@@ -22,8 +22,16 @@ The provider configuration can be added to your `app-config.yaml` under the root
 auth:
   environment: development
   providers:
-    oauth2Proxy: {}
+    oauth2Proxy:
+      development:
+        signIn:
+          resolvers:
+            - resolver: emailMatchingUserEntityProfileEmail
+            - resolver: emailLocalPartMatchingUserEntityName
+            - resolver: forwardedUserMatchingUserEntityName
 ```
+
+> Note: the resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
 
 Right now no configuration options are supported, but the empty object is needed
 to enable the provider in the auth backend.

--- a/docs/auth/okta/provider.md
+++ b/docs/auth/okta/provider.md
@@ -49,6 +49,7 @@ auth:
         additionalScopes: ${AUTH_OKTA_ADDITIONAL_SCOPES} # Optional
         signIn:
           resolvers:
+            # typically you would pick one of these
             - resolver: emailMatchingUserEntityProfileEmail
             - resolver: emailLocalPartMatchingUserEntityName
             - resolver: emailMatchingUserEntityAnnotation

--- a/docs/auth/okta/provider.md
+++ b/docs/auth/okta/provider.md
@@ -29,7 +29,7 @@ To add Okta authentication, you must create an Application from Okta:
 
 The configuration examples provided above are suitable for local development. For a production deployment, substitute `http://localhost:7007` with the url that your Backstage instance is available at.
 
-# Configuration
+## Configuration
 
 The provider configuration can then be added to your `app-config.yaml` under the
 root `auth` configuration:
@@ -54,8 +54,6 @@ auth:
             - resolver: emailMatchingUserEntityAnnotation
 ```
 
-> Note: the resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
-
 The values referenced are found on the Application page on your Okta site.
 
 - `clientId`: The client ID that you generated on Okta, e.g.
@@ -67,6 +65,18 @@ The values referenced are found on the Application page on your Okta site.
 - `idp`: The identity provider for the application, e.g. `0oaulob4BFVa4zQvt0g3`
 
 `additionalScopes` is an optional value, a string of space separated scopes, that will be combined with the default `scope` value of `openid profile email offline_access` to adjust the `scope` sent to Okta during OAuth. This will have an impact on [the dependent claims returned](https://developer.okta.com/docs/reference/api/oidc/#scope-dependent-claims-not-always-returned). For example, setting the `additionalScopes` value to `groups` will result in the claim returning a list of the groups that the user is a member of that also match the ID token group filter of the client app.
+
+### Resolvers
+
+This provider includes several resolvers out of the box that you can use:
+
+- `emailMatchingUserEntityProfileEmail`: Matches the email address from the auth provider with the User entity that has a matching `spec.profile.email`. If no match is found it will throw a `NotFoundError`.
+- `emailLocalPartMatchingUserEntityName`: Matches the [local part](https://en.wikipedia.org/wiki/Email_address#Local-part) of the email address from the auth provider with the User entity that has a matching `name`. If no match is found it will throw a `NotFoundError`.
+- `emailMatchingUserEntityAnnotation`: Matches the email address from the auth provider with the User entity where the value of the `okta.com/email` annotation matches. If no match is found it will throw a `NotFoundError`.
+
+> Note: The resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
+
+If these resolvers do not fit your needs you can build a custom resolver, this is covered in the [Building Custom Resolvers](../identity-resolver.md#building-custom-resolvers) section of the Sign-in Identities and Resolvers documentation.
 
 ## Adding the provider to the Backstage frontend
 

--- a/docs/auth/okta/provider.md
+++ b/docs/auth/okta/provider.md
@@ -47,7 +47,14 @@ auth:
         idp: ${AUTH_OKTA_IDP} # Optional
         # https://developer.okta.com/docs/reference/api/oidc/#scope-dependent-claims-not-always-returned
         additionalScopes: ${AUTH_OKTA_ADDITIONAL_SCOPES} # Optional
+        signIn:
+          resolvers:
+            - resolver: emailMatchingUserEntityProfileEmail
+            - resolver: emailLocalPartMatchingUserEntityName
+            - resolver: emailMatchingUserEntityAnnotation
 ```
+
+> Note: the resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
 
 The values referenced are found on the Application page on your Okta site.
 

--- a/docs/auth/vmware-cloud/provider.md
+++ b/docs/auth/vmware-cloud/provider.md
@@ -156,7 +156,14 @@ auth:
       development:
         clientId: ${APP_ID}
         organizationId: ${ORG_ID}
+        signIn:
+          resolvers:
+            - resolver: emailMatchingUserEntityProfileEmail
+            - resolver: emailLocalPartMatchingUserEntityName
+            - resolver: vmwareCloudSignInResolvers
 ```
+
+> Note: the resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
 
 where `APP_ID` refers to the ID retrieved when creating the OAuth App, and
 `ORG_ID` is the [long ID of the

--- a/docs/auth/vmware-cloud/provider.md
+++ b/docs/auth/vmware-cloud/provider.md
@@ -107,10 +107,6 @@ export default async function createPlugin(
 In the above, `commonSignInResolvers.emailLocalPartMatchingUserEntityName()`
 can be replaced with a more suitable resolver for the app in question.
 
-## Configure Sign-in Resolution
-
-See [Sign-in Identities and Resolvers](../identity-resolver.md) for details.
-
 ## Add to Sign-in Page
 
 See the [Sign-In Configuration](../index.md#sign-in-configuration) docs for
@@ -163,9 +159,7 @@ auth:
             - resolver: vmwareCloudSignInResolvers
 ```
 
-> Note: the resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
-
-where `APP_ID` refers to the ID retrieved when creating the OAuth App, and
+Where `APP_ID` refers to the ID retrieved when creating the OAuth App, and
 `ORG_ID` is the [long ID of the
 Organization](https://docs.vmware.com/en/VMware-Cloud-services/services/Using-VMware-Cloud-Services/GUID-CF9E9318-B811-48CF-8499-9419997DC1F8.html#view-the-organization-id-1)
 in VMware Cloud for which you wish to enable sign-in.
@@ -176,3 +170,15 @@ library used by this provider requires the use of Express session middleware to
 do this. Therefore the value `your session secret` under `auth.session.secret`
 should be replaced with a long, complex and unique string which will act as a
 key for signing session cookies set by Backstage.
+
+### Resolvers
+
+This provider includes several resolvers out of the box that you can use:
+
+- `emailMatchingUserEntityProfileEmail`: Matches the email address from the auth provider with the User entity that has a matching `spec.profile.email`. If no match is found it will throw a `NotFoundError`.
+- `emailLocalPartMatchingUserEntityName`: Matches the [local part](https://en.wikipedia.org/wiki/Email_address#Local-part) of the email address from the auth provider with the User entity that has a matching `name`. If no match is found it will throw a `NotFoundError`.
+- `vmwareCloudSignInResolvers`: Matches the email address from the auth provider with the User entity that has a matching `spec.profile.email`. If no match is found it will sign in the user without associating with a catalog user.
+
+> Note: The resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
+
+If these resolvers do not fit your needs you can build a custom resolver, this is covered in the [Building Custom Resolvers](../identity-resolver.md#building-custom-resolvers) section of the Sign-in Identities and Resolvers documentation.

--- a/docs/auth/vmware-cloud/provider.md
+++ b/docs/auth/vmware-cloud/provider.md
@@ -154,6 +154,7 @@ auth:
         organizationId: ${ORG_ID}
         signIn:
           resolvers:
+            # typically you would pick one of these
             - resolver: emailMatchingUserEntityProfileEmail
             - resolver: emailLocalPartMatchingUserEntityName
             - resolver: vmwareCloudSignInResolvers

--- a/docs/backend-system/building-backends/08-migrating.md
+++ b/docs/backend-system/building-backends/08-migrating.md
@@ -816,9 +816,9 @@ auth:
         tenantId: ${AZURE_TENANT_ID}
         signIn:
           resolvers:
-            - resolver: emailMatchingUserEntityAnnotation
             - resolver: emailMatchingUserEntityProfileEmail
             - resolver: emailLocalPartMatchingUserEntityName
+            - resolver: emailMatchingUserEntityAnnotation
 ```
 
 > Note: the resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
@@ -848,7 +848,7 @@ Additional resolvers:
 
 - [usernameMatchingUserEntityName](https://github.com/backstage/backstage/blob/5447cffd23cf00772988fb799ced0ec5e54efb2e/plugins/auth-backend-module-atlassian-provider/src/resolvers.ts#L33C16-L33C46)
 
-##### GCP IAM
+##### GCP IAP (Google Identity-Aware Proxy)
 
 Setup:
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds the `signIn.resolvers` details to the auth docs for the following providers:

- Atlassian
- GCP IAP
- GitHub
- GitLab
- Google
- Microsoft
- oauth2 Proxy
- Okta
- VMware Cloud

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
