### PR TITLE
Add ESLint Rule to Git Release Manager Plugin

### DIFF
--- a/.changeset/fast-comics-look.md
+++ b/.changeset/fast-comics-look.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-git-release-manager': patch
+---
+
+Added the `no-top-level-material-ui-4-imports` ESLint rule to aid with the migration to Material UI v5

--- a/plugins/git-release-manager/.eslintrc.js
+++ b/plugins/git-release-manager/.eslintrc.js
@@ -1,1 +1,5 @@
-module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
+  rules: {
+    '@backstage/no-top-level-material-ui-4-imports': 'error',
+  },
+});

--- a/plugins/git-release-manager/dev/index.tsx
+++ b/plugins/git-release-manager/dev/index.tsx
@@ -16,7 +16,9 @@
 
 import React from 'react';
 import { createDevApp } from '@backstage/dev-utils';
-import { Box, Button, Typography } from '@material-ui/core';
+import Box from '@material-ui/core/Box';
+import Button from '@material-ui/core/Button';
+import Typography from '@material-ui/core/Typography';
 
 import { gitReleaseManagerPlugin, GitReleaseManagerPage } from '../src/plugin';
 import { InfoCardPlus } from '../src/components/InfoCardPlus';

--- a/plugins/git-release-manager/src/GitReleaseManager.tsx
+++ b/plugins/git-release-manager/src/GitReleaseManager.tsx
@@ -16,8 +16,8 @@
 
 import React from 'react';
 import useAsync from 'react-use/esm/useAsync';
-import { Alert } from '@material-ui/lab';
-import { Box } from '@material-ui/core';
+import Alert from '@material-ui/lab/Alert';
+import Box from '@material-ui/core/Box';
 import { useApi } from '@backstage/core-plugin-api';
 import { ContentHeader, Progress } from '@backstage/core-components';
 

--- a/plugins/git-release-manager/src/components/Divider.tsx
+++ b/plugins/git-release-manager/src/components/Divider.tsx
@@ -15,7 +15,8 @@
  */
 
 import React from 'react';
-import { Box, Divider as MaterialDivider } from '@material-ui/core';
+import Box from '@material-ui/core/Box';
+import MaterialDivider from '@material-ui/core/Divider';
 
 import { TEST_IDS } from '../test-helpers/test-ids';
 

--- a/plugins/git-release-manager/src/components/InfoCardPlus.tsx
+++ b/plugins/git-release-manager/src/components/InfoCardPlus.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-import { makeStyles } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
 import { TEST_IDS } from '../test-helpers/test-ids';
 import { InfoCard } from '@backstage/core-components';
 

--- a/plugins/git-release-manager/src/components/NoLatestRelease.tsx
+++ b/plugins/git-release-manager/src/components/NoLatestRelease.tsx
@@ -15,8 +15,8 @@
  */
 
 import React from 'react';
-import { Alert } from '@material-ui/lab';
-import { Box } from '@material-ui/core';
+import Alert from '@material-ui/lab/Alert';
+import Box from '@material-ui/core/Box';
 
 import { TEST_IDS } from '../test-helpers/test-ids';
 

--- a/plugins/git-release-manager/src/components/ResponseStepDialog/LinearProgressWithLabel.tsx
+++ b/plugins/git-release-manager/src/components/ResponseStepDialog/LinearProgressWithLabel.tsx
@@ -15,7 +15,9 @@
  */
 
 import React from 'react';
-import { Box, LinearProgress, Typography } from '@material-ui/core';
+import Box from '@material-ui/core/Box';
+import LinearProgress from '@material-ui/core/LinearProgress';
+import Typography from '@material-ui/core/Typography';
 
 import { ResponseStep } from '../../types/types';
 import { TEST_IDS } from '../../test-helpers/test-ids';

--- a/plugins/git-release-manager/src/components/ResponseStepDialog/ResponseStepDialog.tsx
+++ b/plugins/git-release-manager/src/components/ResponseStepDialog/ResponseStepDialog.tsx
@@ -15,12 +15,10 @@
  */
 
 import React from 'react';
-import {
-  Button,
-  Dialog as MaterialDialog,
-  DialogActions,
-  DialogTitle,
-} from '@material-ui/core';
+import Button from '@material-ui/core/Button';
+import MaterialDialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogTitle from '@material-ui/core/DialogTitle';
 
 import { LinearProgressWithLabel } from './LinearProgressWithLabel';
 import { ResponseStep } from '../../types/types';

--- a/plugins/git-release-manager/src/components/ResponseStepDialog/ResponseStepList.tsx
+++ b/plugins/git-release-manager/src/components/ResponseStepDialog/ResponseStepList.tsx
@@ -15,7 +15,8 @@
  */
 
 import React, { PropsWithChildren } from 'react';
-import { DialogContent, List } from '@material-ui/core';
+import DialogContent from '@material-ui/core/DialogContent';
+import List from '@material-ui/core/List';
 import { ResponseStep } from '../../types/types';
 
 import { ResponseStepListItem } from './ResponseStepListItem';

--- a/plugins/git-release-manager/src/components/ResponseStepDialog/ResponseStepListItem.tsx
+++ b/plugins/git-release-manager/src/components/ResponseStepDialog/ResponseStepListItem.tsx
@@ -15,14 +15,12 @@
  */
 
 import React from 'react';
-import {
-  colors,
-  IconButton,
-  ListItem,
-  ListItemIcon,
-  ListItemText,
-  makeStyles,
-} from '@material-ui/core';
+import colors from '@material-ui/core/colors';
+import IconButton from '@material-ui/core/IconButton';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
+import { makeStyles } from '@material-ui/core/styles';
 import CheckCircleOutline from '@material-ui/icons/CheckCircleOutline';
 import ErrorOutlineIcon from '@material-ui/icons/ErrorOutline';
 import FiberManualRecordIcon from '@material-ui/icons/FiberManualRecord';

--- a/plugins/git-release-manager/src/components/Transition.tsx
+++ b/plugins/git-release-manager/src/components/Transition.tsx
@@ -15,7 +15,7 @@
  */
 
 import React, { forwardRef, Ref } from 'react';
-import { Slide } from '@material-ui/core';
+import Slide from '@material-ui/core/Slide';
 import { TransitionProps } from '@material-ui/core/transitions';
 
 export const Transition = forwardRef(function Transition(

--- a/plugins/git-release-manager/src/features/CreateReleaseCandidate/CreateReleaseCandidate.tsx
+++ b/plugins/git-release-manager/src/features/CreateReleaseCandidate/CreateReleaseCandidate.tsx
@@ -15,16 +15,15 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { Alert, AlertTitle } from '@material-ui/lab';
-import {
-  Box,
-  Button,
-  FormControl,
-  InputLabel,
-  MenuItem,
-  Select,
-  Typography,
-} from '@material-ui/core';
+import Alert from '@material-ui/lab/Alert';
+import AlertTitle from '@material-ui/lab/AlertTitle';
+import Box from '@material-ui/core/Box';
+import Button from '@material-ui/core/Button';
+import FormControl from '@material-ui/core/FormControl';
+import InputLabel from '@material-ui/core/InputLabel';
+import MenuItem from '@material-ui/core/MenuItem';
+import Select from '@material-ui/core/Select';
+import Typography from '@material-ui/core/Typography';
 
 import {
   GetBranchResult,

--- a/plugins/git-release-manager/src/features/Features.tsx
+++ b/plugins/git-release-manager/src/features/Features.tsx
@@ -15,7 +15,8 @@
  */
 
 import React, { ComponentProps } from 'react';
-import { Alert, AlertTitle } from '@material-ui/lab';
+import Alert from '@material-ui/lab/Alert';
+import AlertTitle from '@material-ui/lab/AlertTitle';
 
 import { CreateReleaseCandidate } from './CreateReleaseCandidate/CreateReleaseCandidate';
 import { GitReleaseManager } from '../GitReleaseManager';

--- a/plugins/git-release-manager/src/features/Info/Info.tsx
+++ b/plugins/git-release-manager/src/features/Info/Info.tsx
@@ -15,7 +15,9 @@
  */
 
 import React, { useState } from 'react';
-import { Typography, Button, Box } from '@material-ui/core';
+import Typography from '@material-ui/core/Typography';
+import Button from '@material-ui/core/Button';
+import Box from '@material-ui/core/Box';
 import BarChartIcon from '@material-ui/icons/BarChart';
 
 import {

--- a/plugins/git-release-manager/src/features/Patch/Patch.tsx
+++ b/plugins/git-release-manager/src/features/Patch/Patch.tsx
@@ -15,8 +15,10 @@
  */
 
 import React from 'react';
-import { Typography, Box } from '@material-ui/core';
-import { Alert, AlertTitle } from '@material-ui/lab';
+import Typography from '@material-ui/core/Typography';
+import Box from '@material-ui/core/Box';
+import Alert from '@material-ui/lab/Alert';
+import AlertTitle from '@material-ui/lab/AlertTitle';
 
 import {
   GetBranchResult,

--- a/plugins/git-release-manager/src/features/Patch/PatchBody.tsx
+++ b/plugins/git-release-manager/src/features/Patch/PatchBody.tsx
@@ -16,20 +16,19 @@
 
 import React, { useState } from 'react';
 import useAsync from 'react-use/esm/useAsync';
-import { Alert, AlertTitle } from '@material-ui/lab';
-import {
-  Box,
-  Button,
-  Checkbox,
-  IconButton,
-  List,
-  ListItem,
-  ListItemIcon,
-  ListItemSecondaryAction,
-  ListItemText,
-  Paper,
-  Typography,
-} from '@material-ui/core';
+import Alert from '@material-ui/lab/Alert';
+import AlertTitle from '@material-ui/lab/AlertTitle';
+import Box from '@material-ui/core/Box';
+import Button from '@material-ui/core/Button';
+import Checkbox from '@material-ui/core/Checkbox';
+import IconButton from '@material-ui/core/IconButton';
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
+import ListItemText from '@material-ui/core/ListItemText';
+import Paper from '@material-ui/core/Paper';
+import Typography from '@material-ui/core/Typography';
 import FileCopyIcon from '@material-ui/icons/FileCopy';
 import OpenInNewIcon from '@material-ui/icons/OpenInNew';
 

--- a/plugins/git-release-manager/src/features/PromoteRc/PromoteRc.tsx
+++ b/plugins/git-release-manager/src/features/PromoteRc/PromoteRc.tsx
@@ -15,8 +15,10 @@
  */
 
 import React from 'react';
-import { Alert, AlertTitle } from '@material-ui/lab';
-import { Box, Typography } from '@material-ui/core';
+import Alert from '@material-ui/lab/Alert';
+import AlertTitle from '@material-ui/lab/AlertTitle';
+import Box from '@material-ui/core/Box';
+import Typography from '@material-ui/core/Typography';
 
 import { ComponentConfig, PromoteRcOnSuccessArgs } from '../../types/types';
 import { GetLatestReleaseResult } from '../../api/GitReleaseClient';

--- a/plugins/git-release-manager/src/features/PromoteRc/PromoteRcBody.tsx
+++ b/plugins/git-release-manager/src/features/PromoteRc/PromoteRcBody.tsx
@@ -15,7 +15,9 @@
  */
 
 import React from 'react';
-import { Button, Typography, Box } from '@material-ui/core';
+import Button from '@material-ui/core/Button';
+import Typography from '@material-ui/core/Typography';
+import Box from '@material-ui/core/Box';
 
 import { ComponentConfig, PromoteRcOnSuccessArgs } from '../../types/types';
 import { Differ } from '../../components/Differ';

--- a/plugins/git-release-manager/src/features/RepoDetailsForm/Owner.tsx
+++ b/plugins/git-release-manager/src/features/RepoDetailsForm/Owner.tsx
@@ -17,14 +17,12 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import useAsync from 'react-use/esm/useAsync';
-import {
-  FormControl,
-  FormHelperText,
-  InputLabel,
-  MenuItem,
-  Select,
-  Box,
-} from '@material-ui/core';
+import FormControl from '@material-ui/core/FormControl';
+import FormHelperText from '@material-ui/core/FormHelperText';
+import InputLabel from '@material-ui/core/InputLabel';
+import MenuItem from '@material-ui/core/MenuItem';
+import Select from '@material-ui/core/Select';
+import Box from '@material-ui/core/Box';
 
 import { gitReleaseManagerApiRef } from '../../api/serviceApiRef';
 import { TEST_IDS } from '../../test-helpers/test-ids';

--- a/plugins/git-release-manager/src/features/RepoDetailsForm/Repo.tsx
+++ b/plugins/git-release-manager/src/features/RepoDetailsForm/Repo.tsx
@@ -17,14 +17,12 @@
 import React from 'react';
 import useAsync from 'react-use/esm/useAsync';
 import { useNavigate } from 'react-router-dom';
-import {
-  FormControl,
-  FormHelperText,
-  InputLabel,
-  MenuItem,
-  Select,
-  Box,
-} from '@material-ui/core';
+import FormControl from '@material-ui/core/FormControl';
+import FormHelperText from '@material-ui/core/FormHelperText';
+import InputLabel from '@material-ui/core/InputLabel';
+import MenuItem from '@material-ui/core/MenuItem';
+import Select from '@material-ui/core/Select';
+import Box from '@material-ui/core/Box';
 
 import { gitReleaseManagerApiRef } from '../../api/serviceApiRef';
 import { TEST_IDS } from '../../test-helpers/test-ids';

--- a/plugins/git-release-manager/src/features/RepoDetailsForm/VersioningStrategy.tsx
+++ b/plugins/git-release-manager/src/features/RepoDetailsForm/VersioningStrategy.tsx
@@ -16,13 +16,11 @@
 
 import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import {
-  FormControl,
-  FormControlLabel,
-  FormLabel,
-  Radio,
-  RadioGroup,
-} from '@material-ui/core';
+import FormControl from '@material-ui/core/FormControl';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import FormLabel from '@material-ui/core/FormLabel';
+import Radio from '@material-ui/core/Radio';
+import RadioGroup from '@material-ui/core/RadioGroup';
 
 import { TEST_IDS } from '../../test-helpers/test-ids';
 import { useProjectContext } from '../../contexts/ProjectContext';

--- a/plugins/git-release-manager/src/features/RepoDetailsForm/styles.ts
+++ b/plugins/git-release-manager/src/features/RepoDetailsForm/styles.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { createStyles, makeStyles, Theme } from '@material-ui/core';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 
 export const useFormClasses = makeStyles((theme: Theme) =>
   createStyles({

--- a/plugins/git-release-manager/src/features/Stats/DialogBody.tsx
+++ b/plugins/git-release-manager/src/features/Stats/DialogBody.tsx
@@ -15,16 +15,14 @@
  */
 
 import React from 'react';
-import { Alert } from '@material-ui/lab';
-import {
-  makeStyles,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-} from '@material-ui/core';
+import Alert from '@material-ui/lab/Alert';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableContainer from '@material-ui/core/TableContainer';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
+import { makeStyles } from '@material-ui/core/styles';
 import { getMappedReleases } from './helpers/getMappedReleases';
 
 import { getReleaseStats } from './helpers/getReleaseStats';

--- a/plugins/git-release-manager/src/features/Stats/DialogTitle.tsx
+++ b/plugins/git-release-manager/src/features/Stats/DialogTitle.tsx
@@ -15,14 +15,14 @@
  */
 
 import React from 'react';
+import IconButton from '@material-ui/core/IconButton';
+import Typography from '@material-ui/core/Typography';
 import {
   createStyles,
-  IconButton,
   Theme,
-  Typography,
   withStyles,
   WithStyles,
-} from '@material-ui/core';
+} from '@material-ui/core/styles';
 import CloseIcon from '@material-ui/icons/Close';
 import MuiDialogTitle from '@material-ui/core/DialogTitle';
 

--- a/plugins/git-release-manager/src/features/Stats/Info/InDepth/InDepth.tsx
+++ b/plugins/git-release-manager/src/features/Stats/Info/InDepth/InDepth.tsx
@@ -15,12 +15,10 @@
  */
 
 import React from 'react';
-import {
-  Box,
-  Button,
-  Tooltip as MaterialTooltip,
-  Typography,
-} from '@material-ui/core';
+import Box from '@material-ui/core/Box';
+import Button from '@material-ui/core/Button';
+import MaterialTooltip from '@material-ui/core/Tooltip';
+import Typography from '@material-ui/core/Typography';
 import { useTheme } from '@material-ui/core/styles';
 import { BarChart, Bar, XAxis, YAxis, Legend, Tooltip } from 'recharts';
 

--- a/plugins/git-release-manager/src/features/Stats/Info/Info.tsx
+++ b/plugins/git-release-manager/src/features/Stats/Info/Info.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-import { Paper } from '@material-ui/core';
+import Paper from '@material-ui/core/Paper';
 
 import { InDepth } from './InDepth/InDepth';
 import { Summary } from './Summary';

--- a/plugins/git-release-manager/src/features/Stats/Info/Summary.tsx
+++ b/plugins/git-release-manager/src/features/Stats/Info/Summary.tsx
@@ -15,17 +15,15 @@
  */
 
 import React from 'react';
-import {
-  Box,
-  makeStyles,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Typography,
-} from '@material-ui/core';
+import Box from '@material-ui/core/Box';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableContainer from '@material-ui/core/TableContainer';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
 
 import { getDecimalNumber } from '../helpers/getDecimalNumber';
 import { getSummary } from '../helpers/getSummary';

--- a/plugins/git-release-manager/src/features/Stats/Row/Row.tsx
+++ b/plugins/git-release-manager/src/features/Stats/Row/Row.tsx
@@ -16,13 +16,11 @@
 
 import React, { useState } from 'react';
 import { DateTime } from 'luxon';
-import {
-  Collapse,
-  IconButton,
-  makeStyles,
-  TableCell,
-  TableRow,
-} from '@material-ui/core';
+import Collapse from '@material-ui/core/Collapse';
+import IconButton from '@material-ui/core/IconButton';
+import TableCell from '@material-ui/core/TableCell';
+import TableRow from '@material-ui/core/TableRow';
+import { makeStyles } from '@material-ui/core/styles';
 import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 import { ReleaseStats } from '../contexts/ReleaseStatsContext';

--- a/plugins/git-release-manager/src/features/Stats/Row/RowCollapsed/ReleaseTagList.tsx
+++ b/plugins/git-release-manager/src/features/Stats/Row/RowCollapsed/ReleaseTagList.tsx
@@ -15,7 +15,8 @@
  */
 
 import React from 'react';
-import { Box, Typography } from '@material-ui/core';
+import Box from '@material-ui/core/Box';
+import Typography from '@material-ui/core/Typography';
 
 import { ReleaseStats } from '../../contexts/ReleaseStatsContext';
 

--- a/plugins/git-release-manager/src/features/Stats/Row/RowCollapsed/ReleaseTime.tsx
+++ b/plugins/git-release-manager/src/features/Stats/Row/RowCollapsed/ReleaseTime.tsx
@@ -17,8 +17,9 @@
 import React from 'react';
 import useAsync from 'react-use/esm/useAsync';
 import { DateTime } from 'luxon';
-import { Box, Typography } from '@material-ui/core';
-import { Alert } from '@material-ui/lab';
+import Box from '@material-ui/core/Box';
+import Typography from '@material-ui/core/Typography';
+import Alert from '@material-ui/lab/Alert';
 
 import { getDecimalNumber } from '../../helpers/getDecimalNumber';
 import { getTagDates } from '../../helpers/getTagDates';

--- a/plugins/git-release-manager/src/features/Stats/Row/RowCollapsed/RowCollapsed.tsx
+++ b/plugins/git-release-manager/src/features/Stats/Row/RowCollapsed/RowCollapsed.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import React from 'react';
-import { Box } from '@material-ui/core';
+import Box from '@material-ui/core/Box';
 
 import { ReleaseStats } from '../../contexts/ReleaseStatsContext';
 import { ReleaseTagList } from './ReleaseTagList';

--- a/plugins/git-release-manager/src/features/Stats/Stats.tsx
+++ b/plugins/git-release-manager/src/features/Stats/Stats.tsx
@@ -15,7 +15,9 @@
  */
 
 import React from 'react';
-import { Button, Dialog, Theme, withStyles } from '@material-ui/core';
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import { Theme, withStyles } from '@material-ui/core/styles';
 import CloseIcon from '@material-ui/icons/Close';
 import MuiDialogActions from '@material-ui/core/DialogActions';
 import MuiDialogContent from '@material-ui/core/DialogContent';

--- a/plugins/git-release-manager/src/features/Stats/Warn.tsx
+++ b/plugins/git-release-manager/src/features/Stats/Warn.tsx
@@ -15,8 +15,9 @@
  */
 
 import React from 'react';
-import { Alert } from '@material-ui/lab';
-import { Box, Button } from '@material-ui/core';
+import Alert from '@material-ui/lab/Alert';
+import Box from '@material-ui/core/Box';
+import Button from '@material-ui/core/Button';
 
 import { useProjectContext } from '../../contexts/ProjectContext';
 import { useReleaseStatsContext } from './contexts/ReleaseStatsContext';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds the no-top-level-material-ui-4-import ESLint rule to the Git Release Manager plugin to aid with the migration to Material UI v5.

https://github.com/backstage/backstage/issues/23467

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
