### PR TITLE
Add ESLint Rule to Kubernetes React Plugin

### DIFF
--- a/.changeset/eight-eggs-deny.md
+++ b/.changeset/eight-eggs-deny.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-react': patch
+---
+
+Added the `no-top-level-material-ui-4-imports` ESLint rule to aid with the migration to Material UI v5

--- a/plugins/kubernetes-react/.eslintrc.js
+++ b/plugins/kubernetes-react/.eslintrc.js
@@ -1,1 +1,5 @@
-module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
+  rules: {
+    '@backstage/no-top-level-material-ui-4-imports': 'error',
+  },
+});

--- a/plugins/kubernetes-react/src/components/Cluster/Cluster.tsx
+++ b/plugins/kubernetes-react/src/components/Cluster/Cluster.tsx
@@ -15,13 +15,11 @@
  */
 
 import React from 'react';
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Grid,
-  Typography,
-} from '@material-ui/core';
+import Accordion from '@material-ui/core/Accordion';
+import AccordionDetails from '@material-ui/core/AccordionDetails';
+import AccordionSummary from '@material-ui/core/AccordionSummary';
+import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
 import {
   ClientPodStatus,
   ClusterObjects,

--- a/plugins/kubernetes-react/src/components/CronJobsAccordions/CronJobsAccordions.tsx
+++ b/plugins/kubernetes-react/src/components/CronJobsAccordions/CronJobsAccordions.tsx
@@ -14,13 +14,11 @@
  * limitations under the License.
  */
 import React, { useContext } from 'react';
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Grid,
-  Typography,
-} from '@material-ui/core';
+import Accordion from '@material-ui/core/Accordion';
+import AccordionDetails from '@material-ui/core/AccordionDetails';
+import AccordionSummary from '@material-ui/core/AccordionSummary';
+import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import { V1CronJob, V1Job } from '@kubernetes/client-node';
 import { JobsAccordions } from '../JobsAccordions';

--- a/plugins/kubernetes-react/src/components/CronJobsAccordions/CronJobsDrawer.tsx
+++ b/plugins/kubernetes-react/src/components/CronJobsAccordions/CronJobsDrawer.tsx
@@ -16,7 +16,9 @@
 import React from 'react';
 import { V1CronJob } from '@kubernetes/client-node';
 import { KubernetesStructuredMetadataTableDrawer } from '../KubernetesDrawer';
-import { Typography, Grid, Chip } from '@material-ui/core';
+import Typography from '@material-ui/core/Typography';
+import Grid from '@material-ui/core/Grid';
+import Chip from '@material-ui/core/Chip';
 
 export const CronJobDrawer = ({
   cronJob,

--- a/plugins/kubernetes-react/src/components/CustomResources/ArgoRollouts/Rollout.tsx
+++ b/plugins/kubernetes-react/src/components/CustomResources/ArgoRollouts/Rollout.tsx
@@ -15,13 +15,11 @@
  */
 
 import React, { useContext } from 'react';
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Grid,
-  Typography,
-} from '@material-ui/core';
+import Accordion from '@material-ui/core/Accordion';
+import AccordionDetails from '@material-ui/core/AccordionDetails';
+import AccordionSummary from '@material-ui/core/AccordionSummary';
+import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import { V1Pod, V1HorizontalPodAutoscaler } from '@kubernetes/client-node';
 import { PodsTable } from '../../Pods';

--- a/plugins/kubernetes-react/src/components/CustomResources/ArgoRollouts/RolloutDrawer.tsx
+++ b/plugins/kubernetes-react/src/components/CustomResources/ArgoRollouts/RolloutDrawer.tsx
@@ -16,7 +16,8 @@
 
 import React from 'react';
 import { KubernetesStructuredMetadataTableDrawer } from '../../KubernetesDrawer';
-import { Typography, Grid } from '@material-ui/core';
+import Typography from '@material-ui/core/Typography';
+import Grid from '@material-ui/core/Grid';
 
 export const RolloutDrawer = ({
   rollout,

--- a/plugins/kubernetes-react/src/components/CustomResources/ArgoRollouts/StepsProgress.tsx
+++ b/plugins/kubernetes-react/src/components/CustomResources/ArgoRollouts/StepsProgress.tsx
@@ -15,7 +15,9 @@
  */
 
 import React from 'react';
-import { Step, StepLabel, Stepper } from '@material-ui/core';
+import Step from '@material-ui/core/Step';
+import StepLabel from '@material-ui/core/StepLabel';
+import Stepper from '@material-ui/core/Stepper';
 import Typography from '@material-ui/core/Typography';
 import {
   ArgoRolloutCanaryStep,

--- a/plugins/kubernetes-react/src/components/CustomResources/DefaultCustomResource.tsx
+++ b/plugins/kubernetes-react/src/components/CustomResources/DefaultCustomResource.tsx
@@ -15,12 +15,10 @@
  */
 
 import React from 'react';
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Grid,
-} from '@material-ui/core';
+import Accordion from '@material-ui/core/Accordion';
+import AccordionDetails from '@material-ui/core/AccordionDetails';
+import AccordionSummary from '@material-ui/core/AccordionSummary';
+import Grid from '@material-ui/core/Grid';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import { DefaultCustomResourceDrawer } from './DefaultCustomResourceDrawer';
 import { StructuredMetadataTable } from '@backstage/core-components';

--- a/plugins/kubernetes-react/src/components/CustomResources/DefaultCustomResourceDrawer.tsx
+++ b/plugins/kubernetes-react/src/components/CustomResources/DefaultCustomResourceDrawer.tsx
@@ -16,7 +16,8 @@
 
 import React from 'react';
 import { KubernetesStructuredMetadataTableDrawer } from '../KubernetesDrawer';
-import { Typography, Grid } from '@material-ui/core';
+import Typography from '@material-ui/core/Typography';
+import Grid from '@material-ui/core/Grid';
 
 const capitalize = (str: string) =>
   str.charAt(0).toLocaleUpperCase('en-US') + str.slice(1);

--- a/plugins/kubernetes-react/src/components/DaemonSetsAccordions/DaemonSetsAccordions.tsx
+++ b/plugins/kubernetes-react/src/components/DaemonSetsAccordions/DaemonSetsAccordions.tsx
@@ -15,12 +15,10 @@
  */
 
 import React, { useContext } from 'react';
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Grid,
-} from '@material-ui/core';
+import Accordion from '@material-ui/core/Accordion';
+import AccordionDetails from '@material-ui/core/AccordionDetails';
+import AccordionSummary from '@material-ui/core/AccordionSummary';
+import Grid from '@material-ui/core/Grid';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import { V1Pod, V1DaemonSet } from '@kubernetes/client-node';
 import { PodsTable } from '../Pods';

--- a/plugins/kubernetes-react/src/components/DaemonSetsAccordions/DaemonSetsDrawer.tsx
+++ b/plugins/kubernetes-react/src/components/DaemonSetsAccordions/DaemonSetsDrawer.tsx
@@ -17,7 +17,9 @@
 import React from 'react';
 import { V1DaemonSet } from '@kubernetes/client-node';
 import { KubernetesStructuredMetadataTableDrawer } from '../KubernetesDrawer';
-import { Typography, Grid, Chip } from '@material-ui/core';
+import Typography from '@material-ui/core/Typography';
+import Grid from '@material-ui/core/Grid';
+import Chip from '@material-ui/core/Chip';
 
 export const DaemonSetDrawer = ({
   daemonset,

--- a/plugins/kubernetes-react/src/components/DeploymentsAccordions/DeploymentDrawer.tsx
+++ b/plugins/kubernetes-react/src/components/DeploymentsAccordions/DeploymentDrawer.tsx
@@ -18,7 +18,9 @@ import React from 'react';
 import { V1Deployment } from '@kubernetes/client-node';
 import { KubernetesStructuredMetadataTableDrawer } from '../KubernetesDrawer';
 import { renderCondition } from '../../utils/pod';
-import { Typography, Grid, Chip } from '@material-ui/core';
+import Typography from '@material-ui/core/Typography';
+import Grid from '@material-ui/core/Grid';
+import Chip from '@material-ui/core/Chip';
 
 export const DeploymentDrawer = ({
   deployment,

--- a/plugins/kubernetes-react/src/components/DeploymentsAccordions/DeploymentsAccordions.tsx
+++ b/plugins/kubernetes-react/src/components/DeploymentsAccordions/DeploymentsAccordions.tsx
@@ -15,13 +15,11 @@
  */
 
 import React, { useContext } from 'react';
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Grid,
-  Typography,
-} from '@material-ui/core';
+import Accordion from '@material-ui/core/Accordion';
+import AccordionDetails from '@material-ui/core/AccordionDetails';
+import AccordionSummary from '@material-ui/core/AccordionSummary';
+import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import {
   V1Deployment,

--- a/plugins/kubernetes-react/src/components/ErrorPanel/ErrorPanel.tsx
+++ b/plugins/kubernetes-react/src/components/ErrorPanel/ErrorPanel.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-import { Typography } from '@material-ui/core';
+import Typography from '@material-ui/core/Typography';
 import { ClusterObjects } from '@backstage/plugin-kubernetes-common';
 import { WarningPanel } from '@backstage/core-components';
 

--- a/plugins/kubernetes-react/src/components/IngressesAccordions/IngressDrawer.tsx
+++ b/plugins/kubernetes-react/src/components/IngressesAccordions/IngressDrawer.tsx
@@ -17,7 +17,8 @@
 import React from 'react';
 import { V1Ingress } from '@kubernetes/client-node';
 import { KubernetesStructuredMetadataTableDrawer } from '../KubernetesDrawer';
-import { Typography, Grid } from '@material-ui/core';
+import Typography from '@material-ui/core/Typography';
+import Grid from '@material-ui/core/Grid';
 
 export const IngressDrawer = ({
   ingress,

--- a/plugins/kubernetes-react/src/components/IngressesAccordions/IngressesAccordions.tsx
+++ b/plugins/kubernetes-react/src/components/IngressesAccordions/IngressesAccordions.tsx
@@ -15,12 +15,10 @@
  */
 
 import React, { useContext } from 'react';
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Grid,
-} from '@material-ui/core';
+import Accordion from '@material-ui/core/Accordion';
+import AccordionDetails from '@material-ui/core/AccordionDetails';
+import AccordionSummary from '@material-ui/core/AccordionSummary';
+import Grid from '@material-ui/core/Grid';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import { V1Ingress } from '@kubernetes/client-node';
 import { IngressDrawer } from './IngressDrawer';

--- a/plugins/kubernetes-react/src/components/JobsAccordions/JobsAccordions.tsx
+++ b/plugins/kubernetes-react/src/components/JobsAccordions/JobsAccordions.tsx
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 import React, { useContext } from 'react';
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Grid,
-} from '@material-ui/core';
+import Accordion from '@material-ui/core/Accordion';
+import AccordionDetails from '@material-ui/core/AccordionDetails';
+import AccordionSummary from '@material-ui/core/AccordionSummary';
+import Grid from '@material-ui/core/Grid';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import { V1Job, V1Pod } from '@kubernetes/client-node';
 import { PodsTable } from '../Pods';

--- a/plugins/kubernetes-react/src/components/JobsAccordions/JobsDrawer.tsx
+++ b/plugins/kubernetes-react/src/components/JobsAccordions/JobsDrawer.tsx
@@ -16,7 +16,8 @@
 import React from 'react';
 import { V1Job } from '@kubernetes/client-node';
 import { KubernetesStructuredMetadataTableDrawer } from '../KubernetesDrawer';
-import { Typography, Grid } from '@material-ui/core';
+import Typography from '@material-ui/core/Typography';
+import Grid from '@material-ui/core/Grid';
 
 export const JobDrawer = ({
   job,

--- a/plugins/kubernetes-react/src/components/KubernetesDialog/KubernetesDialog.tsx
+++ b/plugins/kubernetes-react/src/components/KubernetesDialog/KubernetesDialog.tsx
@@ -14,16 +14,12 @@
  * limitations under the License.
  */
 
-import {
-  Button,
-  Dialog,
-  DialogContent,
-  DialogTitle,
-  IconButton,
-  Theme,
-  createStyles,
-  makeStyles,
-} from '@material-ui/core';
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import IconButton from '@material-ui/core/IconButton';
+import { Theme, createStyles, makeStyles } from '@material-ui/core/styles';
 import CloseIcon from '@material-ui/icons/Close';
 import React, { useState } from 'react';
 

--- a/plugins/kubernetes-react/src/components/KubernetesDrawer/KubernetesDrawer.tsx
+++ b/plugins/kubernetes-react/src/components/KubernetesDrawer/KubernetesDrawer.tsx
@@ -16,19 +16,19 @@
 import React, { ChangeEvent, useState } from 'react';
 
 import { IObjectMeta } from '@kubernetes-models/apimachinery/apis/meta/v1/ObjectMeta';
+import Drawer from '@material-ui/core/Drawer';
+import Grid from '@material-ui/core/Grid';
+import IconButton from '@material-ui/core/IconButton';
+import Switch from '@material-ui/core/Switch';
+import Typography from '@material-ui/core/Typography';
+import Button from '@material-ui/core/Button';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
 import {
   createStyles,
-  Drawer,
   makeStyles,
   Theme,
-  Grid,
-  IconButton,
-  Switch,
-  Typography,
-  Button,
   withStyles,
-  FormControlLabel,
-} from '@material-ui/core';
+} from '@material-ui/core/styles';
 import CloseIcon from '@material-ui/icons/Close';
 import { ManifestYaml } from './ManifestYaml';
 

--- a/plugins/kubernetes-react/src/components/KubernetesDrawer/KubernetesStructuredMetadataTableDrawer.tsx
+++ b/plugins/kubernetes-react/src/components/KubernetesDrawer/KubernetesStructuredMetadataTableDrawer.tsx
@@ -15,18 +15,14 @@
  */
 
 import React, { ChangeEvent, useContext, useState } from 'react';
-import {
-  Button,
-  Typography,
-  makeStyles,
-  IconButton,
-  createStyles,
-  Theme,
-  Drawer,
-  Switch,
-  FormControlLabel,
-  Grid,
-} from '@material-ui/core';
+import Button from '@material-ui/core/Button';
+import Typography from '@material-ui/core/Typography';
+import IconButton from '@material-ui/core/IconButton';
+import Drawer from '@material-ui/core/Drawer';
+import Switch from '@material-ui/core/Switch';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Grid from '@material-ui/core/Grid';
+import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
 import Close from '@material-ui/icons/Close';
 import OpenInNewIcon from '@material-ui/icons/OpenInNew';
 import { V1ObjectMeta } from '@kubernetes/client-node';

--- a/plugins/kubernetes-react/src/components/KubernetesDrawer/ManifestYaml.tsx
+++ b/plugins/kubernetes-react/src/components/KubernetesDrawer/ManifestYaml.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 import { CodeSnippet } from '@backstage/core-components';
-import { FormControlLabel, Switch } from '@material-ui/core';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Switch from '@material-ui/core/Switch';
 import jsyaml from 'js-yaml';
 import React, { useState } from 'react';
 

--- a/plugins/kubernetes-react/src/components/PodExecTerminal/PodExecTerminal.tsx
+++ b/plugins/kubernetes-react/src/components/PodExecTerminal/PodExecTerminal.tsx
@@ -17,7 +17,7 @@ import 'xterm/css/xterm.css';
 
 import { discoveryApiRef, useApi } from '@backstage/core-plugin-api';
 import { ClusterAttributes } from '@backstage/plugin-kubernetes-common';
-import { createStyles, makeStyles, Theme } from '@material-ui/core';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import React, { useEffect, useMemo, useState } from 'react';
 import { Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';

--- a/plugins/kubernetes-react/src/components/Pods/ErrorList/ErrorList.tsx
+++ b/plugins/kubernetes-react/src/components/Pods/ErrorList/ErrorList.tsx
@@ -15,17 +15,13 @@
  */
 import React from 'react';
 
-import {
-  List,
-  ListItem,
-  ListItemText,
-  Divider,
-  createStyles,
-  makeStyles,
-  Theme,
-  Paper,
-  Grid,
-} from '@material-ui/core';
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemText from '@material-ui/core/ListItemText';
+import Divider from '@material-ui/core/Divider';
+import Paper from '@material-ui/core/Paper';
+import Grid from '@material-ui/core/Grid';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import { PodAndErrors } from '../types';
 import { FixDialog } from '../FixDialog/FixDialog';
 

--- a/plugins/kubernetes-react/src/components/Pods/Events/Events.tsx
+++ b/plugins/kubernetes-react/src/components/Pods/Events/Events.tsx
@@ -15,24 +15,22 @@
  */
 import React from 'react';
 
-import {
-  Avatar,
-  Container,
-  Grid,
-  List,
-  ListItem,
-  ListItemAvatar,
-  ListItemText,
-  Tooltip,
-  Typography,
-} from '@material-ui/core';
+import Avatar from '@material-ui/core/Avatar';
+import Container from '@material-ui/core/Container';
+import Grid from '@material-ui/core/Grid';
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemAvatar from '@material-ui/core/ListItemAvatar';
+import ListItemText from '@material-ui/core/ListItemText';
+import Tooltip from '@material-ui/core/Tooltip';
+import Typography from '@material-ui/core/Typography';
 
 import InfoIcon from '@material-ui/icons/Info';
 import WarningIcon from '@material-ui/icons/Warning';
 import { DateTime } from 'luxon';
 
 import { useEvents } from './useEvents';
-import { Skeleton } from '@material-ui/lab';
+import Skeleton from '@material-ui/lab/Skeleton';
 import { DismissableBanner } from '@backstage/core-components';
 import { Event } from 'kubernetes-models/v1';
 

--- a/plugins/kubernetes-react/src/components/Pods/FixDialog/FixDialog.tsx
+++ b/plugins/kubernetes-react/src/components/Pods/FixDialog/FixDialog.tsx
@@ -15,7 +15,8 @@
  */
 import React, { useState } from 'react';
 
-import { Button, Grid } from '@material-ui/core';
+import Button from '@material-ui/core/Button';
+import Grid from '@material-ui/core/Grid';
 import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';

--- a/plugins/kubernetes-react/src/components/Pods/PodDrawer/ContainerCard.tsx
+++ b/plugins/kubernetes-react/src/components/Pods/PodDrawer/ContainerCard.tsx
@@ -15,14 +15,12 @@
  */
 import { StructuredMetadataTable } from '@backstage/core-components';
 import { ClientContainerStatus } from '@backstage/plugin-kubernetes-common';
-import {
-  Card,
-  CardActions,
-  CardContent,
-  CardHeader,
-  Grid,
-  Typography,
-} from '@material-ui/core';
+import Card from '@material-ui/core/Card';
+import CardActions from '@material-ui/core/CardActions';
+import CardContent from '@material-ui/core/CardContent';
+import CardHeader from '@material-ui/core/CardHeader';
+import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
 import { IContainer, IContainerStatus } from 'kubernetes-models/v1';
 import { DateTime } from 'luxon';
 import React from 'react';

--- a/plugins/kubernetes-react/src/components/Pods/PodDrawer/PendingPodContent.tsx
+++ b/plugins/kubernetes-react/src/components/Pods/PodDrawer/PendingPodContent.tsx
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 import React from 'react';
-import { Grid, List, ListItem, Typography } from '@material-ui/core';
+import Grid from '@material-ui/core/Grid';
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import Typography from '@material-ui/core/Typography';
 import { IPodCondition, Pod } from 'kubernetes-models/v1';
 import {
   StatusError,

--- a/plugins/kubernetes-react/src/components/Pods/PodDrawer/PodDrawer.tsx
+++ b/plugins/kubernetes-react/src/components/Pods/PodDrawer/PodDrawer.tsx
@@ -17,13 +17,9 @@
 import React from 'react';
 
 import { ItemCardGrid } from '@backstage/core-components';
-import {
-  createStyles,
-  makeStyles,
-  Theme,
-  Grid,
-  Typography,
-} from '@material-ui/core';
+import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 
 import { Pod } from 'kubernetes-models/v1';
 

--- a/plugins/kubernetes-react/src/components/Pods/PodLogs/PodLogs.tsx
+++ b/plugins/kubernetes-react/src/components/Pods/PodLogs/PodLogs.tsx
@@ -20,8 +20,8 @@ import {
   EmptyState,
   LogViewer,
 } from '@backstage/core-components';
-import { Paper } from '@material-ui/core';
-import { Skeleton } from '@material-ui/lab';
+import Paper from '@material-ui/core/Paper';
+import Skeleton from '@material-ui/lab/Skeleton';
 
 import { ContainerScope } from './types';
 import { usePodLogs } from './usePodLogs';

--- a/plugins/kubernetes-react/src/components/Pods/PodsTable.tsx
+++ b/plugins/kubernetes-react/src/components/Pods/PodsTable.tsx
@@ -29,7 +29,7 @@ import { useMatchingErrors } from '../../hooks/useMatchingErrors';
 import { Pod } from 'kubernetes-models/v1/Pod';
 import { V1Pod } from '@kubernetes/client-node';
 import { usePodMetrics } from '../../hooks/usePodMetrics';
-import { Typography } from '@material-ui/core';
+import Typography from '@material-ui/core/Typography';
 
 /**
  *

--- a/plugins/kubernetes-react/src/components/ResourceUtilization/ResourceUtilization.tsx
+++ b/plugins/kubernetes-react/src/components/ResourceUtilization/ResourceUtilization.tsx
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Grid, Typography } from '@material-ui/core';
+import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
 
 import React from 'react';
 import { GaugePropsGetColor, LinearGauge } from '@backstage/core-components';

--- a/plugins/kubernetes-react/src/components/ServicesAccordions/ServiceDrawer.tsx
+++ b/plugins/kubernetes-react/src/components/ServicesAccordions/ServiceDrawer.tsx
@@ -17,7 +17,8 @@
 import React from 'react';
 import { V1Service } from '@kubernetes/client-node';
 import { KubernetesStructuredMetadataTableDrawer } from '../KubernetesDrawer';
-import { Typography, Grid } from '@material-ui/core';
+import Typography from '@material-ui/core/Typography';
+import Grid from '@material-ui/core/Grid';
 
 export const ServiceDrawer = ({
   service,

--- a/plugins/kubernetes-react/src/components/ServicesAccordions/ServicesAccordions.tsx
+++ b/plugins/kubernetes-react/src/components/ServicesAccordions/ServicesAccordions.tsx
@@ -15,13 +15,11 @@
  */
 
 import React, { useContext } from 'react';
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Grid,
-  Typography,
-} from '@material-ui/core';
+import Accordion from '@material-ui/core/Accordion';
+import AccordionDetails from '@material-ui/core/AccordionDetails';
+import AccordionSummary from '@material-ui/core/AccordionSummary';
+import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import { V1Service } from '@kubernetes/client-node';
 import { ServiceDrawer } from './ServiceDrawer';

--- a/plugins/kubernetes-react/src/components/StatefulSetsAccordions/StatefulSetDrawer.tsx
+++ b/plugins/kubernetes-react/src/components/StatefulSetsAccordions/StatefulSetDrawer.tsx
@@ -18,7 +18,9 @@ import React from 'react';
 import { V1StatefulSet } from '@kubernetes/client-node';
 import { KubernetesStructuredMetadataTableDrawer } from '../KubernetesDrawer';
 import { renderCondition } from '../../utils/pod';
-import { Typography, Grid, Chip } from '@material-ui/core';
+import Typography from '@material-ui/core/Typography';
+import Grid from '@material-ui/core/Grid';
+import Chip from '@material-ui/core/Chip';
 
 export const StatefulSetDrawer = ({
   statefulset,

--- a/plugins/kubernetes-react/src/components/StatefulSetsAccordions/StatefulSetsAccordions.tsx
+++ b/plugins/kubernetes-react/src/components/StatefulSetsAccordions/StatefulSetsAccordions.tsx
@@ -15,13 +15,11 @@
  */
 
 import React, { useContext } from 'react';
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Grid,
-  Typography,
-} from '@material-ui/core';
+import Accordion from '@material-ui/core/Accordion';
+import AccordionDetails from '@material-ui/core/AccordionDetails';
+import AccordionSummary from '@material-ui/core/AccordionSummary';
+import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import {
   V1Pod,

--- a/plugins/kubernetes-react/src/utils/pod.tsx
+++ b/plugins/kubernetes-react/src/utils/pod.tsx
@@ -20,7 +20,7 @@ import {
   V1DeploymentCondition,
 } from '@kubernetes/client-node';
 import React, { Fragment, ReactNode } from 'react';
-import { Chip } from '@material-ui/core';
+import Chip from '@material-ui/core/Chip';
 import {
   StatusAborted,
   StatusError,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds the no-top-level-material-ui-4-import ESLint rule to the Kubernetes React plugin to aid with the migration to Material UI v5.

https://github.com/backstage/backstage/issues/23467

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
