### PR TITLE
feat(events,github)!: remove use of `EventBroker` and `EventSubscriber`

### DIFF
--- a/.changeset/sweet-singers-argue.md
+++ b/.changeset/sweet-singers-argue.md
@@ -1,0 +1,19 @@
+---
+'@backstage/plugin-catalog-backend-module-github': minor
+---
+
+Remove use of `EventBroker` and `EventSubscriber` for the GitHub org data providers.
+
+BREAKING CHANGE:
+
+- `GithubOrgEntityProvider.onEvent` made private
+- `GithubOrgEntityProvider.supportsEventTopics` removed
+- `eventBroker` option was removed from `GithubMultiOrgEntityProvider.fromConfig`
+- `GithubMultiOrgEntityProvider.supportsEventTopics` removed
+
+This change only impacts users who still use the legacy backend system
+**and** who still use `eventBroker` as option when creating these
+entity providers.
+
+Please pass the `EventsService` instance as option `events` instead.
+You can find more information at the [installation documentation](https://backstage.io/docs/integrations/github/org/#legacy-backend-system).

--- a/plugins/catalog-backend-module-github/api-report.md
+++ b/plugins/catalog-backend-module-github/api-report.md
@@ -11,7 +11,6 @@ import { Config } from '@backstage/config';
 import { Entity } from '@backstage/catalog-model';
 import { EntityProvider } from '@backstage/plugin-catalog-node';
 import { EntityProviderConnection } from '@backstage/plugin-catalog-node';
-import { EventBroker } from '@backstage/plugin-events-node';
 import { EventParams } from '@backstage/plugin-events-node';
 import { EventsService } from '@backstage/plugin-events-node';
 import { EventSubscriber } from '@backstage/plugin-events-node';
@@ -166,8 +165,6 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
 
 // @public
 export interface GithubMultiOrgEntityProviderOptions {
-  // @deprecated
-  eventBroker?: EventBroker;
   events?: EventsService;
   githubCredentialsProvider?: GithubCredentialsProvider;
   githubUrl: string;
@@ -219,9 +216,7 @@ export class GitHubOrgEntityProvider extends GithubOrgEntityProvider {
 }
 
 // @public
-export class GithubOrgEntityProvider
-  implements EntityProvider, EventSubscriber
-{
+export class GithubOrgEntityProvider implements EntityProvider {
   constructor(options: {
     events?: EventsService;
     id: string;
@@ -241,11 +236,7 @@ export class GithubOrgEntityProvider
   ): GithubOrgEntityProvider;
   // (undocumented)
   getProviderName(): string;
-  // (undocumented)
-  onEvent(params: EventParams): Promise<void>;
   read(options?: { logger?: LoggerService }): Promise<void>;
-  // (undocumented)
-  supportsEventTopics(): string[];
 }
 
 // @public @deprecated (undocumented)

--- a/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
@@ -38,11 +38,7 @@ import {
   EntityProvider,
   EntityProviderConnection,
 } from '@backstage/plugin-catalog-node';
-import {
-  EventBroker,
-  EventParams,
-  EventsService,
-} from '@backstage/plugin-events-node';
+import { EventParams, EventsService } from '@backstage/plugin-events-node';
 import { graphql } from '@octokit/graphql';
 import {
   InstallationCreatedEvent,
@@ -157,13 +153,6 @@ export interface GithubMultiOrgEntityProviderOptions {
    * By default, groups will be namespaced according to their GitHub org.
    */
   teamTransformer?: TeamTransformer;
-
-  /**
-   * An EventBroker to subscribe this provider to GitHub events to trigger delta mutations
-   *
-   * @deprecated Use `events` instead.
-   */
-  eventBroker?: EventBroker;
 }
 
 type CreateDeltaOperation = (entities: Entity[]) => {
@@ -212,13 +201,6 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
     });
 
     provider.schedule(options.schedule);
-
-    if (options.eventBroker) {
-      options.eventBroker.subscribe({
-        supportsEventTopics: provider.supportsEventTopics.bind(provider),
-        onEvent: provider.onEvent.bind(provider),
-      });
-    }
 
     return provider;
   }
@@ -334,10 +316,6 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
     });
 
     markCommitComplete();
-  }
-
-  private supportsEventTopics(): string[] {
-    return EVENT_TOPICS;
   }
 
   private async onEvent(params: EventParams): Promise<void> {

--- a/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.test.ts
@@ -22,7 +22,10 @@ import {
 } from '@backstage/integration';
 import { EntityProviderConnection } from '@backstage/plugin-catalog-node';
 import { graphql } from '@octokit/graphql';
-import { EventParams } from '@backstage/plugin-events-node';
+import {
+  DefaultEventsService,
+  EventParams,
+} from '@backstage/plugin-events-node';
 import { GithubOrgEntityProvider } from './GithubOrgEntityProvider';
 import { withLocations } from '../lib/withLocations';
 
@@ -267,6 +270,7 @@ describe('GithubOrgEntityProvider', () => {
       };
 
       const logger = getVoidLogger();
+      const events = DefaultEventsService.create({ logger });
       const gitHubConfig: GithubIntegrationConfig = {
         host: 'github.com',
       };
@@ -281,6 +285,7 @@ describe('GithubOrgEntityProvider', () => {
       };
 
       const entityProvider = new GithubOrgEntityProvider({
+        events,
         id: 'my-id',
         githubCredentialsProvider,
         orgUrl: 'https://github.com/backstage',
@@ -288,7 +293,7 @@ describe('GithubOrgEntityProvider', () => {
         logger,
       });
 
-      entityProvider.connect(entityProviderConnection);
+      await entityProvider.connect(entityProviderConnection);
 
       const expectedEntity = {
         apiVersion: 'backstage.io/v1alpha1',
@@ -330,8 +335,7 @@ describe('GithubOrgEntityProvider', () => {
           },
         },
       };
-
-      await entityProvider.onEvent(event);
+      await events.publish(event);
 
       expect(entityProviderConnection.applyMutation).toHaveBeenCalledTimes(1);
       expect(entityProviderConnection.applyMutation).toHaveBeenCalledWith({
@@ -353,6 +357,7 @@ describe('GithubOrgEntityProvider', () => {
       };
 
       const logger = getVoidLogger();
+      const events = DefaultEventsService.create({ logger });
       const gitHubConfig: GithubIntegrationConfig = {
         host: 'github.com',
       };
@@ -367,6 +372,7 @@ describe('GithubOrgEntityProvider', () => {
       };
 
       const entityProvider = new GithubOrgEntityProvider({
+        events,
         id: 'my-id',
         githubCredentialsProvider,
         orgUrl: 'https://github.com/backstage',
@@ -374,7 +380,7 @@ describe('GithubOrgEntityProvider', () => {
         logger,
       });
 
-      entityProvider.connect(entityProviderConnection);
+      await entityProvider.connect(entityProviderConnection);
 
       const expectedEntity = {
         apiVersion: 'backstage.io/v1alpha1',
@@ -416,8 +422,7 @@ describe('GithubOrgEntityProvider', () => {
           },
         },
       };
-
-      await entityProvider.onEvent(event);
+      await events.publish(event);
 
       expect(entityProviderConnection.applyMutation).toHaveBeenCalledTimes(1);
       expect(entityProviderConnection.applyMutation).toHaveBeenCalledWith({
@@ -439,6 +444,7 @@ describe('GithubOrgEntityProvider', () => {
       };
 
       const logger = getVoidLogger();
+      const events = DefaultEventsService.create({ logger });
       const gitHubConfig: GithubIntegrationConfig = {
         host: 'github.com',
       };
@@ -453,6 +459,7 @@ describe('GithubOrgEntityProvider', () => {
       };
 
       const entityProvider = new GithubOrgEntityProvider({
+        events,
         id: 'my-id',
         githubCredentialsProvider,
         orgUrl: 'https://github.com/backstage',
@@ -508,7 +515,7 @@ describe('GithubOrgEntityProvider', () => {
         },
       };
 
-      await entityProvider.onEvent(event);
+      await events.publish(event);
 
       expect(entityProviderConnection.applyMutation).toHaveBeenCalledTimes(1);
       expect(entityProviderConnection.applyMutation).toHaveBeenCalledWith({
@@ -530,6 +537,7 @@ describe('GithubOrgEntityProvider', () => {
       };
 
       const logger = getVoidLogger();
+      const events = DefaultEventsService.create({ logger });
       const gitHubConfig: GithubIntegrationConfig = {
         host: 'github.com',
       };
@@ -544,6 +552,7 @@ describe('GithubOrgEntityProvider', () => {
       };
 
       const entityProvider = new GithubOrgEntityProvider({
+        events,
         id: 'my-id',
         githubCredentialsProvider,
         orgUrl: 'https://github.com/backstage',
@@ -551,7 +560,7 @@ describe('GithubOrgEntityProvider', () => {
         logger,
       });
 
-      entityProvider.connect(entityProviderConnection);
+      await entityProvider.connect(entityProviderConnection);
 
       const expectedEntity = {
         apiVersion: 'backstage.io/v1alpha1',
@@ -600,7 +609,7 @@ describe('GithubOrgEntityProvider', () => {
         },
       };
 
-      await entityProvider.onEvent(event);
+      await events.publish(event);
 
       expect(entityProviderConnection.applyMutation).toHaveBeenCalledTimes(1);
       expect(entityProviderConnection.applyMutation).toHaveBeenCalledWith({
@@ -622,6 +631,7 @@ describe('GithubOrgEntityProvider', () => {
       };
 
       const logger = getVoidLogger();
+      const events = DefaultEventsService.create({ logger });
       const gitHubConfig: GithubIntegrationConfig = {
         host: 'github.com',
       };
@@ -636,6 +646,7 @@ describe('GithubOrgEntityProvider', () => {
       };
 
       const entityProvider = new GithubOrgEntityProvider({
+        events,
         id: 'my-id',
         githubCredentialsProvider,
         orgUrl: 'https://github.com/backstage',
@@ -717,7 +728,7 @@ describe('GithubOrgEntityProvider', () => {
 
       (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
 
-      entityProvider.connect(entityProviderConnection);
+      await entityProvider.connect(entityProviderConnection);
 
       const event: EventParams = {
         topic: 'github.team',
@@ -744,7 +755,7 @@ describe('GithubOrgEntityProvider', () => {
         },
       };
 
-      await entityProvider.onEvent(event);
+      await events.publish(event);
       await new Promise(process.nextTick);
 
       expect(entityProviderConnection.applyMutation).toHaveBeenCalledTimes(1);
@@ -871,6 +882,7 @@ describe('GithubOrgEntityProvider', () => {
       };
 
       const logger = getVoidLogger();
+      const events = DefaultEventsService.create({ logger });
       const gitHubConfig: GithubIntegrationConfig = {
         host: 'github.com',
       };
@@ -885,6 +897,7 @@ describe('GithubOrgEntityProvider', () => {
       };
 
       const entityProvider = new GithubOrgEntityProvider({
+        events,
         id: 'my-id',
         githubCredentialsProvider,
         orgUrl: 'https://github.com/backstage',
@@ -965,7 +978,7 @@ describe('GithubOrgEntityProvider', () => {
         });
 
       (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
-      entityProvider.connect(entityProviderConnection);
+      await entityProvider.connect(entityProviderConnection);
 
       const event: EventParams = {
         topic: 'github.membership',
@@ -989,7 +1002,7 @@ describe('GithubOrgEntityProvider', () => {
         },
       };
 
-      await entityProvider.onEvent(event);
+      await events.publish(event);
       await new Promise(process.nextTick);
 
       expect(entityProviderConnection.applyMutation).toHaveBeenCalledTimes(1);
@@ -1117,6 +1130,7 @@ describe('GithubOrgEntityProvider', () => {
       };
 
       const logger = getVoidLogger();
+      const events = DefaultEventsService.create({ logger });
       const gitHubConfig: GithubIntegrationConfig = {
         host: 'github.com',
       };
@@ -1131,6 +1145,7 @@ describe('GithubOrgEntityProvider', () => {
       };
 
       const entityProvider = new GithubOrgEntityProvider({
+        events,
         id: 'my-id',
         githubCredentialsProvider,
         orgUrl: 'https://github.com/backstage',
@@ -1187,7 +1202,7 @@ describe('GithubOrgEntityProvider', () => {
         });
 
       (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
-      entityProvider.connect(entityProviderConnection);
+      await entityProvider.connect(entityProviderConnection);
 
       const event: EventParams = {
         topic: 'github.membership',
@@ -1211,7 +1226,7 @@ describe('GithubOrgEntityProvider', () => {
         },
       };
 
-      await entityProvider.onEvent(event);
+      await events.publish(event);
       await new Promise(process.nextTick);
 
       expect(entityProviderConnection.applyMutation).toHaveBeenCalledTimes(1);

--- a/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.ts
@@ -28,11 +28,7 @@ import {
   EntityProvider,
   EntityProviderConnection,
 } from '@backstage/plugin-catalog-node';
-import {
-  EventParams,
-  EventsService,
-  EventSubscriber,
-} from '@backstage/plugin-events-node';
+import { EventParams, EventsService } from '@backstage/plugin-events-node';
 import { graphql } from '@octokit/graphql';
 import {
   MembershipEvent,
@@ -138,9 +134,7 @@ export interface GithubOrgEntityProviderOptions {
  *
  * @public
  */
-export class GithubOrgEntityProvider
-  implements EntityProvider, EventSubscriber
-{
+export class GithubOrgEntityProvider implements EntityProvider {
   private readonly credentialsProvider: GithubCredentialsProvider;
   private connection?: EntityProviderConnection;
   private scheduleFn?: () => Promise<void>;
@@ -268,8 +262,7 @@ export class GithubOrgEntityProvider
     markCommitComplete();
   }
 
-  /** {@inheritdoc @backstage/plugin-events-node#EventSubscriber.onEvent} */
-  async onEvent(params: EventParams): Promise<void> {
+  private async onEvent(params: EventParams): Promise<void> {
     const { logger } = this.options;
     logger.debug(`Received event from ${params.topic}`);
 
@@ -333,11 +326,6 @@ export class GithubOrgEntityProvider
     }
 
     return;
-  }
-
-  /** {@inheritdoc @backstage/plugin-events-node#EventSubscriber.supportsEventTopics} */
-  supportsEventTopics(): string[] {
-    return EVENT_TOPICS;
   }
 
   private async onTeamEditedInOrganization(


### PR DESCRIPTION
Remove use legacy event implementation
including use of `EventBroker` and
`EventSubscriber`.

Tests migrated from the `EventBroker` to the `EventsService`.

BREAKING CHANGE:

- `GithubOrgEntityProvider.onEvent` made private
- `GithubOrgEntityProvider.supportsEventTopics` removed
- `eventBroker` option was removed from `GithubMultiOrgEntityProvider.fromConfig`
- `GithubMultiOrgEntityProvider.supportsEventTopics` removed

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
