### PR TITLE
backend-common: relax user token check in createLegacyAuthAdapters

### DIFF
--- a/.changeset/new-cobras-tap.md
+++ b/.changeset/new-cobras-tap.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Relax the user token check in the legacy auth service implementation to better support custom identity service implementations.

--- a/packages/backend-common/src/auth/createLegacyAuthAdapters.test.ts
+++ b/packages/backend-common/src/auth/createLegacyAuthAdapters.test.ts
@@ -122,7 +122,9 @@ describe('createLegacyAuthAdapters', () => {
         },
       },
       discovery: {} as any,
-      identity: mockServices.identity(),
+      identity: mockServices.identity.mock({
+        getIdentity: async () => undefined,
+      }),
     });
 
     const credentials = await httpAuth.credentials({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Potential fix for out current adapter being a bit too opinionated about the identity service implementation. Especially before we have a good way to customize the auth service in the new backend system this might be required.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
