### PR TITLE
Use the GitLab token for the CI/CD statistics GitLab plugin

### DIFF
--- a/plugins/cicd-statistics-module-gitlab/src/api/gitlab.ts
+++ b/plugins/cicd-statistics-module-gitlab/src/api/gitlab.ts
@@ -49,13 +49,16 @@ export type GitlabClient = {
 export class CicdStatisticsApiGitlab implements CicdStatisticsApi {
   readonly #gitLabAuthApi: OAuthApi;
   readonly #cicdDefaults: Partial<CicdDefaults>;
+  private readonly staticToken?: string;
 
   constructor(
     gitLabAuthApi: OAuthApi,
     cicdDefaults: Partial<CicdDefaults> = {},
+    staticToken?: string
   ) {
     this.#gitLabAuthApi = gitLabAuthApi;
     this.#cicdDefaults = cicdDefaults;
+    this.staticToken = staticToken;
   }
 
   public async createGitlabApi(
@@ -65,7 +68,10 @@ export class CicdStatisticsApiGitlab implements CicdStatisticsApi {
     const entityInfo = getEntitySourceLocation(entity);
     const url = new URL(entityInfo.target);
     const owner = url.pathname.split('/-/blob/')[0];
-    const oauthToken = await this.#gitLabAuthApi.getAccessToken(scopes);
+    const oauthToken = this.staticToken; // Use the static token if available
+    if (!oauthToken) { // If not available, fallback to OAuth token
+      oauthToken = await this.#gitLabAuthApi.getAccessToken(scopes);
+    }
     return {
       api: new Gitlab({
         host: `https://${url.host}`,


### PR DESCRIPTION
This MR aims to update the CI/CD statistics GitLab plugin to use GitLab access tokens if provided instead of asking users to sign in with GitLab.

## Why?

In some cases, people can rely on a different system for signing-in (i.e. Okta) and there is no need to add a sign-in method or change the current one, they already use the access token to fetch data for the Catalog so why not use the same for this one.


## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
