### PR TITLE
Added ESLint to package-app-next

### DIFF
--- a/packages/app-next/.eslintrc.js
+++ b/packages/app-next/.eslintrc.js
@@ -1,1 +1,5 @@
-module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
+    rules: {
+        '@backstage/no-top-level-material-ui-4-imports': 'error',
+    },
+});

--- a/packages/app-next/src/examples/notFoundErrorPageExtension.tsx
+++ b/packages/app-next/src/examples/notFoundErrorPageExtension.tsx
@@ -19,7 +19,8 @@ import {
   createComponentExtension,
   coreComponentRefs,
 } from '@backstage/frontend-plugin-api';
-import { Box, Typography } from '@material-ui/core';
+import Box from '@material-ui/core/Box';
+import Typography from '@material-ui/core/Typography';
 import { Button } from '@backstage/core-components';
 
 export function CustomNotFoundErrorPage() {


### PR DESCRIPTION
Adds the no-top-level-material-ui-4-import ESLint rule to the app-next package to aid with the migration to Material UI v5.
Issue: https://github.com/backstage/backstage/issues/23467