### PR TITLE
Added ESLint to backend-defaults package

### DIFF
--- a/packages/backend-defaults/.eslintrc.js
+++ b/packages/backend-defaults/.eslintrc.js
@@ -1,1 +1,5 @@
-module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
+    rules: {
+        '@backstage/no-top-level-material-ui-4-imports': 'error',
+    },
+});


### PR DESCRIPTION
Adds the no-top-level-material-ui-4-import ESLint rule to the  backend-defaults package to aid with the migration to Material UI v5.
Issue: #23467