### PR TITLE
app-backend,cli: move backstage-app-mode injection to build time

### DIFF
--- a/packages/cli/src/lib/bundler/config.ts
+++ b/packages/cli/src/lib/bundler/config.ts
@@ -130,6 +130,9 @@ export async function createConfig(
 
   plugins.push(
     new HtmlWebpackPlugin({
+      meta: {
+        'backstage-app-mode': options?.appMode ?? 'public',
+      },
       template: paths.targetHtml,
       templateParameters: {
         publicPath,

--- a/packages/cli/src/lib/bundler/types.ts
+++ b/packages/cli/src/lib/bundler/types.ts
@@ -27,6 +27,8 @@ export type BundlingOptions = {
   additionalEntryPoints?: string[];
   // Path to append to the detected public path, e.g. '/public'
   publicSubPath?: string;
+  // Mode that the app is running in, 'protected' or 'public', default is 'public'
+  appMode?: string;
 };
 
 export type ServeOptions = BundlingPathsOptions & {

--- a/plugins/app-backend/src/service/router.ts
+++ b/plugins/app-backend/src/service/router.ts
@@ -218,7 +218,6 @@ export async function createRouter(
 
     publicRouter.use(
       await createEntryPointRouter({
-        appMode: 'public',
         logger: logger.child({ entry: 'public' }),
         rootDir: publicDistDir,
         assetStore: assetStore?.withNamespace('public'),
@@ -231,7 +230,6 @@ export async function createRouter(
 
   router.use(
     await createEntryPointRouter({
-      appMode: enablePublicEntryPoint ? 'protected' : 'public',
       logger: logger.child({ entry: 'main' }),
       rootDir: appDistDir,
       assetStore,
@@ -243,49 +241,23 @@ export async function createRouter(
   return router;
 }
 
-async function injectAppMode(options: {
-  appMode: 'public' | 'protected';
-  rootDir: string;
-}) {
-  const { appMode, rootDir } = options;
-  const content = await fs.readFile(resolvePath(rootDir, 'index.html'), 'utf8');
-
-  const metaTag = `<meta name="backstage-app-mode" content="${appMode}">`;
-
-  let newContent;
-  if (content.includes('backstage-app-mode')) {
-    newContent = content.replace(
-      /<meta name="backstage-app-mode" content="[^"]+">/,
-      metaTag,
-    );
-  } else {
-    newContent = content.replace(/<head>/, `<head>${metaTag}`);
-  }
-
-  await fs.writeFile(resolvePath(rootDir, 'index.html'), newContent, 'utf8');
-}
-
 async function createEntryPointRouter({
   logger,
   rootDir,
   assetStore,
   staticFallbackHandler,
-  appMode,
   appConfigs,
 }: {
   logger: LoggerService;
   rootDir: string;
   assetStore?: StaticAssetsStore;
   staticFallbackHandler?: express.Handler;
-  appMode: 'public' | 'protected';
   appConfigs?: AppConfig[];
 }) {
   const staticDir = resolvePath(rootDir, 'static');
 
   const injectedConfigPath =
     appConfigs && (await injectConfig({ appConfigs, logger, staticDir }));
-
-  await injectAppMode({ appMode, rootDir });
 
   const router = Router();
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is a lot simpler than injecting the app mode at runtime 😁. Piggybacking on the existing changesets for this

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
