### PR TITLE
Added ESLint to core-plugin-api package

### DIFF
--- a/packages/core-plugin-api/.eslintrc.js
+++ b/packages/core-plugin-api/.eslintrc.js
@@ -1,1 +1,5 @@
-module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
+    rules: {
+        '@backstage/no-top-level-material-ui-4-imports': 'error',
+    },
+});


### PR DESCRIPTION
Adds the no-top-level-material-ui-4-import ESLint rule to the  core-plugin-api package to aid with the migration to Material UI v5.
Issue: #23467