### PR TITLE
fix: export `RelatedEntitiesCard` presets

### DIFF
--- a/.changeset/angry-mice-juggle.md
+++ b/.changeset/angry-mice-juggle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Export `RelatedEntitiesCard` presets to be reused.

--- a/plugins/catalog/src/components/RelatedEntitiesCard/RelatedEntitiesCard.tsx
+++ b/plugins/catalog/src/components/RelatedEntitiesCard/RelatedEntitiesCard.tsx
@@ -31,6 +31,17 @@ import {
   TableColumn,
   TableOptions,
 } from '@backstage/core-components';
+import {
+  asComponentEntities,
+  asResourceEntities,
+  asSystemEntities,
+  componentEntityColumns,
+  componentEntityHelpLink,
+  resourceEntityColumns,
+  resourceEntityHelpLink,
+  systemEntityColumns,
+  systemEntityHelpLink,
+} from './presets';
 import { catalogTranslationRef } from '../../translation';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 
@@ -59,9 +70,9 @@ export type RelatedEntitiesCardProps<T extends Entity> = {
  *
  * @public
  */
-export function RelatedEntitiesCard<T extends Entity>(
+export const RelatedEntitiesCard = <T extends Entity>(
   props: RelatedEntitiesCardProps<T>,
-) {
+) => {
   const {
     variant = 'gridItem',
     title,
@@ -116,4 +127,14 @@ export function RelatedEntitiesCard<T extends Entity>(
       tableOptions={tableOptions}
     />
   );
-}
+};
+
+RelatedEntitiesCard.componentEntityColumns = componentEntityColumns;
+RelatedEntitiesCard.componentEntityHelpLink = componentEntityHelpLink;
+RelatedEntitiesCard.asComponentEntities = asComponentEntities;
+RelatedEntitiesCard.resourceEntityColumns = resourceEntityColumns;
+RelatedEntitiesCard.resourceEntityHelpLink = resourceEntityHelpLink;
+RelatedEntitiesCard.asResourceEntities = asResourceEntities;
+RelatedEntitiesCard.systemEntityColumns = systemEntityColumns;
+RelatedEntitiesCard.systemEntityHelpLink = systemEntityHelpLink;
+RelatedEntitiesCard.asSystemEntities = asSystemEntities;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

By exporting the presets, we as a backstage plugin developer can reuse the defaults with the `RelatedEntitiesCard`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
