### PR TITLE
fix: handle lost+found directory in plugin scanner

### DIFF
--- a/.changeset/smart-avocados-invent.md
+++ b/.changeset/smart-avocados-invent.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-dynamic-feature-service': patch
+---
+
+Updates the `scanRoot` method in the `PluginScanner` class to specifically ignore the `lost+found` directory, which is a system-generated directory used for file recovery on Unix-like systems. Skipping this directory avoids unnecessary errors.

--- a/packages/backend-dynamic-feature-service/src/scanner/plugin-scanner.test.ts
+++ b/packages/backend-dynamic-feature-service/src/scanner/plugin-scanner.test.ts
@@ -636,6 +636,24 @@ Please add '${mockDir.resolve(
           ],
         },
       },
+      {
+        name: 'lost+found directory should be ignored',
+        fileSystem: {
+          backstageRoot: {
+            'dist-dynamic': {
+              'lost+found': {},
+            },
+          },
+        },
+        expectedPluginPackages: [],
+        expectedLogs: {
+          debugs: [
+            {
+              message: `skipping 'lost+found' system directory`,
+            },
+          ],
+        },
+      },
     ])('$name', async (tc: TestCase): Promise<void> => {
       const logger = new MockedLogger();
       const backstageRoot = mockDir.resolve('backstageRoot');

--- a/packages/backend-dynamic-feature-service/src/scanner/plugin-scanner.ts
+++ b/packages/backend-dynamic-feature-service/src/scanner/plugin-scanner.ts
@@ -136,6 +136,11 @@ export class PluginScanner {
       withFileTypes: true,
     })) {
       const pluginDir = dirEnt;
+
+      if (pluginDir.name === 'lost+found') {
+        this.logger.debug(`skipping '${pluginDir.name}' system directory`);
+        continue;
+      }
       const pluginHome = path.normalize(
         path.resolve(dynamicPluginsLocation, pluginDir.name),
       );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updates the scanRoot method in the PluginScanner class to specifically ignore the lost+found directory, which is a system-generated directory used for file recovery on Unix-like systems. Skipping this directory avoids unnecessary errors.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

----

This is my first PR to `backstage/backstage` - please let me know if I have missed anything!
