### PR TITLE
fix(plugins/catalog-backend-module-unprocessed): correctly translate owner to string in case of nullish value

### DIFF
--- a/.changeset/cyan-suns-shave.md
+++ b/.changeset/cyan-suns-shave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-unprocessed': patch
+---
+
+Correctly convert owner to string in case owner has not been provided

--- a/plugins/catalog-backend-module-unprocessed/src/UnprocessedEntitiesModule.ts
+++ b/plugins/catalog-backend-module-unprocessed/src/UnprocessedEntitiesModule.ts
@@ -162,7 +162,7 @@ export class UnprocessedEntitiesModule {
         return res.json(
           await this.unprocessed({
             reason: 'failed',
-            owner: String(req.query.owner),
+            owner: req.query.owner?.toString(),
           }),
         );
       })
@@ -170,7 +170,7 @@ export class UnprocessedEntitiesModule {
         return res.json(
           await this.unprocessed({
             reason: 'pending',
-            owner: String(req.query.owner),
+            owner: req.query.owner?.toString(),
           }),
         );
       })

--- a/plugins/catalog-backend-module-unprocessed/src/UnprocessedEntitiesModule.ts
+++ b/plugins/catalog-backend-module-unprocessed/src/UnprocessedEntitiesModule.ts
@@ -162,7 +162,8 @@ export class UnprocessedEntitiesModule {
         return res.json(
           await this.unprocessed({
             reason: 'failed',
-            owner: typeof req.query.owner === 'string' ? req.query.owner : undefined,
+            owner:
+              typeof req.query.owner === 'string' ? req.query.owner : undefined,
           }),
         );
       })
@@ -170,7 +171,8 @@ export class UnprocessedEntitiesModule {
         return res.json(
           await this.unprocessed({
             reason: 'pending',
-            owner: typeof req.query.owner === 'string' ? req.query.owner : undefined
+            owner:
+              typeof req.query.owner === 'string' ? req.query.owner : undefined,
           }),
         );
       })

--- a/plugins/catalog-backend-module-unprocessed/src/UnprocessedEntitiesModule.ts
+++ b/plugins/catalog-backend-module-unprocessed/src/UnprocessedEntitiesModule.ts
@@ -162,7 +162,7 @@ export class UnprocessedEntitiesModule {
         return res.json(
           await this.unprocessed({
             reason: 'failed',
-            owner: req.query.owner?.toString(),
+            owner: typeof req.query.owner === 'string' ? req.query.owner : undefined,
           }),
         );
       })
@@ -170,7 +170,7 @@ export class UnprocessedEntitiesModule {
         return res.json(
           await this.unprocessed({
             reason: 'pending',
-            owner: req.query.owner?.toString(),
+            owner: typeof req.query.owner === 'string' ? req.query.owner : undefined
           }),
         );
       })


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

In case no owner is provided while calling the API, then `owner` will be `undefined`. 
Currently this will be transformed to `"undefined"` as string, this leads to that the results will be filtered for entities with the owner of that value. 

This PR changes the behaviour so that `undefined` will not trigger any kind of filtering. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
