### PR TITLE
fix: uuid import isn't working as expected

### DIFF
--- a/.changeset/purple-parents-sin.md
+++ b/.changeset/purple-parents-sin.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-backstage-openapi': patch
+---
+
+Fix incorrect dependency import.

--- a/plugins/catalog-backend-module-backstage-openapi/src/InternalOpenApiDocumentationProvider.ts
+++ b/plugins/catalog-backend-module-backstage-openapi/src/InternalOpenApiDocumentationProvider.ts
@@ -38,7 +38,7 @@ import {
   DiscoveryService,
   LoggerService,
 } from '@backstage/backend-plugin-api';
-import uuid from 'uuid';
+import * as uuid from 'uuid';
 import lodash from 'lodash';
 import { PluginTaskScheduler, TaskRunner } from '@backstage/backend-tasks';
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The OpenAPI documentation provider is getting logs that read,
```
TypeError: Cannot read properties of undefined (reading 'v4') task=InternalOpenApiDocumentationProvider:refresh
```
due to a weird type mismatch with the actual exports of the package.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
