### PR TITLE
Improve techdocs search bar

### DIFF
--- a/.changeset/slimy-fans-raise.md
+++ b/.changeset/slimy-fans-raise.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Fix weird opening behaviour of the <TechDocsSearch /> component.

--- a/plugins/techdocs/src/search/components/TechDocsSearch.tsx
+++ b/plugins/techdocs/src/search/components/TechDocsSearch.tsx
@@ -63,6 +63,7 @@ const TechDocsSearchBar = (props: TechDocsSearchProps) => {
   const navigate = useNavigate();
   const {
     setFilters,
+    term,
     result: { loading, value: searchVal },
   } = useSearch();
   const [options, setOptions] = useState<any[]>([]);
@@ -109,7 +110,7 @@ const TechDocsSearchBar = (props: TechDocsSearchProps) => {
     <SearchAutocomplete
       data-testid="techdocs-search-bar"
       size="small"
-      open={open}
+      open={open && Boolean(term)}
       getOptionLabel={() => ''}
       filterOptions={x => {
         return x; // This is needed to get renderOption to be called after options change. Bug in material-ui?
@@ -117,7 +118,7 @@ const TechDocsSearchBar = (props: TechDocsSearchProps) => {
       onClose={() => {
         setOpen(false);
       }}
-      onFocus={() => {
+      onOpen={() => {
         setOpen(true);
       }}
       onChange={handleSelection}


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Small fix on the TechDocsSearch bar to open and close properly when clicked on the button instead of when it gets in focus.
Only show the autocomplete popper when there is a search term in the input field.

Before:

https://github.com/backstage/backstage/assets/24729496/0e2c3c14-bd7e-4fa0-8be6-a81b0237c161

After:

https://github.com/backstage/backstage/assets/24729496/90f78071-0200-4a97-8ca2-e2696c976374


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
