### PR TITLE
Add Nonce to OIDC Authorize Request

### DIFF
--- a/.changeset/perfect-points-hope.md
+++ b/.changeset/perfect-points-hope.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-oidc-provider': minor
+---
+
+Add nonce to authorize request to be added in id_token

--- a/plugins/auth-backend-module-oidc-provider/src/authenticator.test.ts
+++ b/plugins/auth-backend-module-oidc-provider/src/authenticator.test.ts
@@ -66,8 +66,6 @@ describe('oidcAuthenticator', () => {
     request_object_signing_alg_values_supported: ['RS256', 'RS512', 'HS256'],
   };
 
-  beforeAll(async () => {});
-
   beforeEach(() => {
     mswServer.use(
       rest.get(

--- a/plugins/auth-backend-module-oidc-provider/src/authenticator.test.ts
+++ b/plugins/auth-backend-module-oidc-provider/src/authenticator.test.ts
@@ -32,6 +32,7 @@ import express from 'express';
 describe('oidcAuthenticator', () => {
   let implementation: any;
   let oauthState: OAuthState;
+  let nonce: string;
   let idToken: string;
   let publicKey: JWK;
   const revokedTokenMap: Record<string, boolean> = {};
@@ -65,22 +66,7 @@ describe('oidcAuthenticator', () => {
     request_object_signing_alg_values_supported: ['RS256', 'RS512', 'HS256'],
   };
 
-  beforeAll(async () => {
-    const keyPair = await generateKeyPair('RS256');
-    const privateKey = await exportJWK(keyPair.privateKey);
-    publicKey = await exportJWK(keyPair.publicKey);
-    publicKey.alg = privateKey.alg = 'RS256';
-
-    idToken = await new SignJWT({
-      sub: 'test',
-      iss: 'https://oidc.test',
-      iat: Date.now(),
-      aud: 'clientId',
-      exp: Date.now() + 10000,
-    })
-      .setProtectedHeader({ alg: privateKey.alg, kid: privateKey.kid })
-      .sign(keyPair.privateKey);
-  });
+  beforeAll(async () => {});
 
   beforeEach(() => {
     mswServer.use(
@@ -96,6 +82,14 @@ describe('oidcAuthenticator', () => {
       rest.get('https://oidc.test/jwks.json', async (_req, res, ctx) =>
         res(ctx.status(200), ctx.json({ keys: [{ ...publicKey }] })),
       ),
+      rest.get(
+        'https://oidc.test/oauth2/authorize',
+        async (req, _res, _ctx) => {
+          nonce =
+            new URL(req.url).searchParams.get('nonce') ??
+            'nonceGeneratedByAuthServer';
+        },
+      ),
       rest.post('https://oidc.test/oauth2/token', async (req, res, ctx) => {
         const formBody = new URLSearchParams(await req.text());
         if (
@@ -104,6 +98,23 @@ describe('oidcAuthenticator', () => {
         ) {
           return res(ctx.json({}));
         }
+
+        const keyPair = await generateKeyPair('RS256');
+        const privateKey = await exportJWK(keyPair.privateKey);
+        publicKey = await exportJWK(keyPair.publicKey);
+        publicKey.alg = privateKey.alg = 'RS256';
+
+        idToken = await new SignJWT({
+          sub: 'test',
+          iss: 'https://oidc.test',
+          iat: Date.now(),
+          aud: 'clientId',
+          exp: Date.now() + 10000,
+          nonce,
+        })
+          .setProtectedHeader({ alg: privateKey.alg, kid: privateKey.kid })
+          .sign(keyPair.privateKey);
+
         return res(
           req.headers.get('Authorization')
             ? ctx.json({
@@ -196,6 +207,15 @@ describe('oidcAuthenticator', () => {
       const { searchParams } = new URL(startResponse.url);
 
       expect(searchParams.get('response_type')).toBe('code');
+    });
+
+    it('passes a nonce', async () => {
+      const startResponse = await oidcAuthenticator.start(
+        startRequest,
+        implementation,
+      );
+      const { searchParams } = new URL(startResponse.url);
+      expect(searchParams.get('nonce')).not.toBeNull();
     });
 
     it('passes client ID from config', async () => {

--- a/plugins/auth-backend-module-oidc-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-oidc-provider/src/authenticator.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import crypto from 'crypto';
 import {
   custom,
   CustomHttpOptionsProvider,
@@ -131,6 +132,7 @@ export const oidcAuthenticator = createOAuthAuthenticator({
     const options: Record<string, string> = {
       scope: input.scope || initializedScope || 'openid profile email',
       state: input.state,
+      nonce: crypto.randomBytes(16).toString('base64'),
     };
     const prompt = initializedPrompt || 'none';
     if (prompt !== 'auto') {

--- a/plugins/auth-backend-module-oidc-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-oidc-provider/src/module.test.ts
@@ -57,8 +57,6 @@ describe('authModuleOidcProvider', () => {
     request_object_signing_alg_values_supported: ['RS256', 'RS512', 'HS256'],
   };
 
-  beforeAll(async () => {});
-
   beforeEach(async () => {
     jest.clearAllMocks();
 

--- a/plugins/auth-backend-module-oidc-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-oidc-provider/src/module.test.ts
@@ -196,6 +196,7 @@ describe('authModuleOidcProvider', () => {
     expect(startUrl.origin).toBe('https://oidc.test');
     expect(startUrl.pathname).toBe('/oauth2/authorize');
     const expected = Object.fromEntries(startUrl.searchParams);
+    expect(expected.nonce).not.toBeNull();
     expect(expected).toEqual({
       response_type: 'code',
       scope: 'openid profile email',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
This PR resolves #23773 by adding a nonce to the request to the authorization_endpoint, which directs the Authorization Server to include the nonce in the ID Token.

This is to solve for the use case where an Authorization Server (such as AWS Cognito) includes its own `nonce` claim in the id_token if one is not provided.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation (N/A)
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes) (N/A)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
