### PR TITLE
feat: support to filter notification recipients after resolving

### DIFF
--- a/.changeset/four-cooks-serve.md
+++ b/.changeset/four-cooks-serve.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-notifications-backend': patch
+'@backstage/plugin-notifications-node': patch
+---
+
+Support for filtering entities from notification recipients after resolving them from the recipients

--- a/plugins/notifications-node/api-report.md
+++ b/plugins/notifications-node/api-report.md
@@ -41,6 +41,7 @@ export type NotificationRecipients =
   | {
       type: 'entity';
       entityRef: string | string[];
+      excludeEntityRef?: string | string[];
     }
   | {
       type: 'broadcast';

--- a/plugins/notifications-node/src/service/DefaultNotificationService.ts
+++ b/plugins/notifications-node/src/service/DefaultNotificationService.ts
@@ -28,7 +28,16 @@ export type NotificationServiceOptions = {
 export type NotificationRecipients =
   | {
       type: 'entity';
+      /**
+       * Entity references to send the notifications to
+       */
       entityRef: string | string[];
+      /**
+       * Optional entity reference(s) to filter out of the resolved recipients.
+       * Usually the currently logged-in user for preventing sending notification
+       * of user action to him/herself.
+       */
+      excludeEntityRef?: string | string[];
     }
   | { type: 'broadcast' };
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This feature allows to filter users after they have been resolved from the entity references (like components, systems, etc.). Usually, this contains the currently logged-in user as we don't want to send him/her notifications about things he/she did in the system but this also depends on the notification use case.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
