### PR TITLE
Add TextSizeContent addon

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -76,6 +76,7 @@ import {
   LightBox,
   ReportIssue,
   TextSize,
+  TextSizeContent,
 } from '@backstage/plugin-techdocs-module-addons-contrib';
 import {
   SettingsLayout,
@@ -212,6 +213,7 @@ const routes = (
         <ExpandableNavigation />
         <ReportIssue />
         <TextSize />
+        <TextSizeContent />
         <LightBox />
       </TechDocsAddons>
     </Route>

--- a/plugins/techdocs-module-addons-contrib/src/TextSize/TextSize.tsx
+++ b/plugins/techdocs-module-addons-contrib/src/TextSize/TextSize.tsx
@@ -38,7 +38,12 @@ import {
 import AddIcon from '@material-ui/icons/Add';
 import RemoveIcon from '@material-ui/icons/Remove';
 
-import { useShadowRootElements } from '@backstage/plugin-techdocs-react';
+import {
+  useShadowRootElements,
+  useShadowDomStylesLoading,
+  useShadowRoot,
+} from '@backstage/plugin-techdocs-react';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 const boxShadow =
   '0 3px 1px rgba(0,0,0,0.1),0 4px 8px rgba(0,0,0,0.13),0 0 0 1px rgba(0,0,0,0.02)';
@@ -137,6 +142,34 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
+export const TextSizeContentAddon = () => {
+  const theme = useTheme();
+  const [body] = useShadowRootElements(['body']);
+
+  const initialValue = localStorage?.getItem(settings.key);
+  const value = initialValue
+    ? parseInt(initialValue, 10)
+    : settings.defaultValue;
+
+  const updateFontSize = useCallback(() => {
+    if (!body) return;
+    const htmlFontSize =
+      (
+        theme.typography as Theme['typography'] & {
+          htmlFontSize?: number;
+        }
+      )?.htmlFontSize ?? 16;
+    body.style.setProperty(
+      '--md-typeset-font-size',
+      `${htmlFontSize * (value / 100)}px`,
+    );
+  }, [value, body, theme]);
+
+  useEffect(() => {
+    updateFontSize();
+  }, [updateFontSize]);
+  return null;
+};
 export const TextSizeAddon = () => {
   const classes = useStyles();
   const theme = useTheme();
@@ -177,8 +210,7 @@ export const TextSizeAddon = () => {
     },
     [index, values, handleChangeCommitted],
   );
-
-  useEffect(() => {
+  const updateFontSize = useCallback(() => {
     if (!body) return;
     const htmlFontSize =
       (
@@ -190,7 +222,11 @@ export const TextSizeAddon = () => {
       '--md-typeset-font-size',
       `${htmlFontSize * (value / 100)}px`,
     );
-  }, [body, value, theme]);
+  }, [value, body, theme]);
+
+  useEffect(() => {
+    updateFontSize();
+  }, [updateFontSize]);
 
   return (
     <MenuItem className={classes.menuItem} button disableRipple>

--- a/plugins/techdocs-module-addons-contrib/src/index.ts
+++ b/plugins/techdocs-module-addons-contrib/src/index.ts
@@ -25,6 +25,7 @@ export {
   ExpandableNavigation,
   ReportIssue,
   TextSize,
+  TextSizeContent,
   LightBox,
 } from './plugin';
 export type {

--- a/plugins/techdocs-module-addons-contrib/src/plugin.ts
+++ b/plugins/techdocs-module-addons-contrib/src/plugin.ts
@@ -21,7 +21,7 @@ import {
 } from '@backstage/plugin-techdocs-react';
 import { ExpandableNavigationAddon } from './ExpandableNavigation';
 import { ReportIssueAddon, ReportIssueProps } from './ReportIssue';
-import { TextSizeAddon } from './TextSize';
+import { TextSizeAddon, TextSizeContentAddon } from './TextSize';
 import { LightBoxAddon } from './LigthBox';
 
 /**
@@ -202,6 +202,19 @@ export const TextSize = techdocsModuleAddonsContribPlugin.provide(
     name: 'TextSize',
     location: TechDocsAddonLocations.Settings,
     component: TextSizeAddon,
+  }),
+);
+
+/**
+ * This TechDocs addon sets the selected text size to the whole content on page load. It works best with the <TextSize /> addon.
+ * @public
+ */
+
+export const TextSizeContent = techdocsModuleAddonsContribPlugin.provide(
+  createTechDocsAddonExtension({
+    name: 'TextSizeContent',
+    location: TechDocsAddonLocations.Content,
+    component: TextSizeContentAddon,
   }),
 );
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!
There is currently a bug in the <TextSize /> addon. If you set a certain size for your TechDocs text it works fine as long as you do not directly move to a new tab in the sidebar. See attached video. 
Bug:

https://github.com/backstage/backstage/assets/24729496/adf8b4ea-aaa0-43a2-b890-2cd05c44aa56

works:

https://github.com/backstage/backstage/assets/24729496/780be6ed-f72e-4beb-bdba-1232fc0a8d4c

I tried to fix this but was not able to do it properly. I couldn't make the addon run its hooks on the navigate event. I think this is because the settings addons are not in the shadow dom like the content addons. So as a last resort I was able to fix and make it apply your settings after navigation by basically duplicating the addon and registering once as a Content type and once as a Settings type. 

Do you guys have a better idea how could this problem be solved ? I think it's not the worst as one of your addons responsible to store your settings and the other one to apply them everytime on your current docs. However the current implementation is to have 2 addons and you need to register both for your techdocs addons which is really brittle and a bad user experience. 
Could we somehow expose a hook that the settings addons could use when the shadow dom content gets refreshed? Or hook into the navigation somehow for them so we could solve it within one addon ?

Any help appreciated with this. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
