### PR TITLE
cli: bump tsconfig.json from es2021 to es2022

### DIFF
--- a/.changeset/fluffy-hotels-wait.md
+++ b/.changeset/fluffy-hotels-wait.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Both the target and types library have been bumped from ES2021 to ES2022 in `@backstage/cli/config/tsconfig.json`.

--- a/packages/cli/config/tsconfig.json
+++ b/packages/cli/config/tsconfig.json
@@ -11,7 +11,7 @@
     "incremental": true,
     "isolatedModules": true,
     "jsx": "react",
-    "lib": ["DOM", "DOM.Iterable", "ScriptHost", "ES2021"],
+    "lib": ["DOM", "DOM.Iterable", "ScriptHost", "ES2022"],
     "module": "ESNext",
     "moduleResolution": "node",
     "noEmit": false,
@@ -32,7 +32,7 @@
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
     "stripInternal": true,
-    "target": "ES2021",
+    "target": "ES2022",
     "types": ["node", "jest", "webpack-env"],
     "useDefineForClassFields": true
   }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Turns out we've effectively had this for some time in the main repo, as some library explicitly brings in `es2022`, probably `@api-extractor/*`. Either way this is without our TypeScript and NodeJS release versioning policy. Not bumping to ES2023 yet because we'd need to bump TypeScript for that, but I wouldn't expect much trouble for anyone wanting to do that too.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
