### PR TITLE
doc: fix k8s deployment

### DIFF
--- a/docs/deployment/k8s.md
+++ b/docs/deployment/k8s.md
@@ -125,6 +125,14 @@ PostgreSQL needs a persistent volume to store data; we'll create one along with
 a `PersistentVolumeClaim`. In this case, we're claiming the whole volume - but
 claims can ask for only part of a volume as well.
 
+To ensure the `PersistentVolume` correctly, you must first create the `/mnt/data` 
+directory on the Minikube node.
+
+```sh
+minikube ssh 
+sudo mkdir -p /mnt/data
+```
+
 ```yaml
 # kubernetes/postgres-storage.yaml
 apiVersion: v1


### PR DESCRIPTION
Need to create /mnt/data first on the minikube node, otherwise the PV will fail and you will see following error when deploying the  postgres.
Warning  Failed     56s (x12 over 3m3s)  kubelet            Error: stat /mnt/data: no such file or directory

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
