### PR TITLE
fix(techdocs-cli): fix serve cmd with proper cookie endpoint mock

### DIFF
--- a/.changeset/eighty-apricots-kneel.md
+++ b/.changeset/eighty-apricots-kneel.md
@@ -1,0 +1,5 @@
+---
+'@techdocs/cli': patch
+---
+
+Fix cookie endpoint mock for `serve`

--- a/packages/techdocs-cli/src/lib/httpServer.ts
+++ b/packages/techdocs-cli/src/lib/httpServer.ts
@@ -62,7 +62,7 @@ export default class HTTPServer {
           // This endpoind is used by the frontend to issue a cookie for the user.
           // But the MkDocs server doesn't expose it as a the Backestage backend does.
           // So we need to fake it here to prevent 404 errors.
-          if (request.url === '/api/techdocs/cookie') {
+          if (request.url === '/api/techdocs/.backstage/auth/v1/cookie') {
             const oneHourInMilliseconds = 60 * 60 * 1000;
             const expiresAt = new Date(Date.now() + oneHourInMilliseconds);
             const cookie = { expiresAt: expiresAt.toISOString() };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

`serve` command was broken with 404 due to mocking old cookie endpoint 

Fixes https://github.com/backstage/backstage/issues/24452

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
