### PR TITLE
OWNERS.md: add events project area

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -45,15 +45,7 @@ yarn.lock                                         @backstage/maintainers @backst
 /plugins/devtools-common                          @backstage/maintainers @backstage/reviewers @awanlin
 /plugins/entity-feedback                          @backstage/maintainers @backstage/reviewers @kuangp
 /plugins/entity-feedback-*                        @backstage/maintainers @backstage/reviewers @kuangp
-/plugins/events-backend                           @backstage/maintainers @backstage/reviewers @pjungermann
-/plugins/events-backend-module-aws-sqs            @backstage/maintainers @backstage/reviewers @pjungermann
-/plugins/events-backend-module-azure              @backstage/maintainers @backstage/reviewers @pjungermann
-/plugins/events-backend-module-bitbucket-cloud    @backstage/maintainers @backstage/reviewers @pjungermann
-/plugins/events-backend-module-gerrit             @backstage/maintainers @backstage/reviewers @pjungermann
-/plugins/events-backend-module-github             @backstage/maintainers @backstage/reviewers @pjungermann
-/plugins/events-backend-module-gitlab             @backstage/maintainers @backstage/reviewers @pjungermann
-/plugins/events-backend-test-utils                @backstage/maintainers @backstage/reviewers @pjungermann
-/plugins/events-node                              @backstage/maintainers @backstage/reviewers @pjungermann
+/plugins/events-*                                 @backstage/maintainers @backstage/reviewers @backstage/events-maintainers
 /plugins/explore                                  @backstage/maintainers @backstage/reviewers @backstage/sda-se-reviewers
 /plugins/explore-react                            @backstage/maintainers @backstage/reviewers @backstage/sda-se-reviewers
 /plugins/fossa                                    @backstage/maintainers @backstage/reviewers @backstage/sda-se-reviewers

--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -2,6 +2,8 @@ area:techdocs:
   - '/(techdocs|tech-docs|tech docs)/i'
 area:discoverability:
   - '/search/i'
+area:events:
+  - '/events/i'
 area:catalog:
   - '/catalog/i'
 area:scaffolder:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -11,6 +11,10 @@ area:discoverability: # search + home
           - plugins/search-*/**/*
           - packages/search-*/**/*
           - plugins/home/**/*
+area:events:
+  - changed-files:
+      - any-glob-to-any-file:
+          - plugins/events-*/**/*
 area:kubernetes:
   - changed-files:
       - any-glob-to-any-file:

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -118,6 +118,16 @@ Scope: Tooling and Community Repo Maintainers for the Backstage [Community Plugi
 | Philipp Hugenroth    | Spotify      | [tudi2d](https://github.com/tudi2d)         | `tudi2d`     |
 | Vincenzo Scamporlino | Spotify      | [vinzscam](https://github.com/vinzscam)     | `vinzscam`   |
 
+### Events
+
+Team: @backstage/events-maintainers
+
+Scope: The Events plugin and library, along with events modules in the main repository
+
+| Name               | Organization              | GitHub                                        | Discord       |
+| ------------------ | ------------------------- | --------------------------------------------- | ------------- |
+| Patrick Jungermann | Bonial International GmbH | [pjungermann](https://github.com/pjungermann) | `pjungermann` |
+
 ### Notifications
 
 Team: @backstage/notifications-maintainers

--- a/plugins/events-backend-module-aws-sqs/catalog-info.yaml
+++ b/plugins/events-backend-module-aws-sqs/catalog-info.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-backend-plugin-module
-  owner: pjungermann
+  owner: maintainers

--- a/plugins/events-backend-module-azure/catalog-info.yaml
+++ b/plugins/events-backend-module-azure/catalog-info.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-backend-plugin-module
-  owner: pjungermann
+  owner: maintainers

--- a/plugins/events-backend-module-bitbucket-cloud/catalog-info.yaml
+++ b/plugins/events-backend-module-bitbucket-cloud/catalog-info.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-backend-plugin-module
-  owner: pjungermann
+  owner: maintainers

--- a/plugins/events-backend-module-gerrit/catalog-info.yaml
+++ b/plugins/events-backend-module-gerrit/catalog-info.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-backend-plugin-module
-  owner: pjungermann
+  owner: maintainers

--- a/plugins/events-backend-module-github/catalog-info.yaml
+++ b/plugins/events-backend-module-github/catalog-info.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-backend-plugin-module
-  owner: pjungermann
+  owner: maintainers

--- a/plugins/events-backend-module-gitlab/catalog-info.yaml
+++ b/plugins/events-backend-module-gitlab/catalog-info.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-backend-plugin-module
-  owner: pjungermann
+  owner: maintainers

--- a/plugins/events-backend-test-utils/catalog-info.yaml
+++ b/plugins/events-backend-test-utils/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-node-library
-  owner: pjungermann
+  owner: maintainers

--- a/plugins/events-backend/catalog-info.yaml
+++ b/plugins/events-backend/catalog-info.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-backend-plugin
-  owner: pjungermann
+  owner: maintainers

--- a/plugins/events-node/catalog-info.yaml
+++ b/plugins/events-node/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-node-library
-  owner: pjungermann
+  owner: maintainers


### PR DESCRIPTION
New incubating Project Area for the Events system 🎉

It's basically all built by @pjungermann and he's kept helping out to maintain and evolve it since its introduction ❤️ 

An open question here is whether the modules should be included in the scope of the area or not. I kept them in because you where listed as codeowner for them @pjungermann, but happy to keep them out of scope too.

@pjungermann @backstage/maintainers please approve if this all looks good
