### PR TITLE
Add new parameter: repoVisibility for the action: publish:gitea

### DIFF
--- a/.changeset/cool-elephants-march.md
+++ b/.changeset/cool-elephants-march.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gitea': patch
+---
+
+Allow defining `repoVisibility` field for the action `publish:gitea`

--- a/plugins/scaffolder-backend-module-gitea/README.md
+++ b/plugins/scaffolder-backend-module-gitea/README.md
@@ -35,7 +35,7 @@ integrations:
 ```
 
 **Important**: As backstage will issue `HTTPS/TLS` requests to the gitea instance, it is needed to configure `gitea` with a valid certificate or at least with a
-self-signed certificate `gitea cert --host localhost -ca` trusted by a CA authority. Don't forget to set the env var `NODE_EXTRA_CA_CERTS` to point to the CA file before launching backstage or to ignore using the following Node.js parameter: `NODE_TLS_REJECT_UNAUTHORIZED=0` !
+self-signed certificate `gitea cert --host localhost -ca` trusted by a CA authority. Don't forget to set the env var `NODE_EXTRA_CA_CERTS` to point to the CA file before launching backstage or you can set temporarily `NODE_TLS_REJECT_UNAUTHORIZED=0` but this is not recommended for production!
 
 When done, you can create a template which:
 

--- a/plugins/scaffolder-backend-module-gitea/README.md
+++ b/plugins/scaffolder-backend-module-gitea/README.md
@@ -10,6 +10,13 @@ To use this action, you will have to add the package using the following command
 yarn --cwd packages/backend add @backstage/plugin-scaffolder-backend-module-gitea
 ```
 
+Alternatively, if you use the new backend system, then register it like this:
+
+```typescript
+// packages/backend/src/index.ts
+backend.add(import('@backstage/plugin-scaffolder-backend-module-gitea'));
+```
+
 Configure the action (if not yet done):
 (you can check the [docs](https://backstage.io/docs/features/software-templates/writing-custom-actions#registering-custom-actions) to see all options):
 
@@ -27,29 +34,29 @@ integrations:
       password: '<GITEA_LOCALHOST_PASSWORD>'
 ```
 
-**Important**: As backstage will issue HTTPS/TLS requests to the gitea instance, it is needed to configure `gitea` with a valid certificate or at least with a
-self-signed certificate `gitea cert --host localhost -ca` trusted by a CA authority. Don't forget to set the env var `NODE_EXTRA_CA_CERTS` to point to the CA file before launching backstage !
+**Important**: As backstage will issue `HTTPS/TLS` requests to the gitea instance, it is needed to configure `gitea` with a valid certificate or at least with a
+self-signed certificate `gitea cert --host localhost -ca` trusted by a CA authority. Don't forget to set the env var `NODE_EXTRA_CA_CERTS` to point to the CA file before launching backstage or to ignore using the following Node.js parameter: `NODE_TLS_REJECT_UNAUTHORIZED=0` !
 
 When done, you can create a template which:
 
-- Declare the `RepoUrlPicker` within the `spec/parameters` section to select the gitea hosts
-- Include a step able to publish by example the newly generated project using the action `action: publish:gitea`
+- Declare the `RepoUrlPicker` within the `spec/parameters` section to select the gitea host and to provide the name of the repository
+- Add an enum list allowing the user to define the visibility about the repository to be created: `public` or `private`. If this field is omitted, `public` is then used by the action.
+- Include in a step the action: `publish:gitea`
+
+**Warning**: The list of the `allowedOwners` of the `repoUrlPicker` must match the list of the `organizations` which are available on the gitea host !
 
 ```yaml
-apiVersion: scaffolder.backstage.io/v1beta3
 kind: Template
 metadata:
-  name: quarkus-web-template
-  title: Quarkus Hello world
-  description: Create a simple microservice using Quarkus
-  tags:
-    - java
-    - quarkus
+  name: simple-gitea-project
+  title: Create a gitea repository
+  description: Create a gitea repository
 spec:
-  owner: quarkus
+  owner: guests
   type: service
+
   parameters:
-    - title: Git repository Information
+    - title: Choose a location
       required:
         - repoUrl
       properties:
@@ -58,42 +65,33 @@ spec:
           type: string
           ui:field: RepoUrlPicker
           ui:options:
+            allowedOwners:
+              - qteam
+              - qshift
             allowedHosts:
-              - gitea.<YOUR_DOMAIN>:<PORT>
-              - localhost:<PORT>
+              - gitea.localtest.me:3333
+
+        repoVisibility:
+          title: Visibility of the repository
+          type: string
+          default: 'public'
+          enum:
+            - 'public'
+            - 'private'
+          enumNames:
+            - 'public'
+            - 'private'
 
   steps:
-    - id: template
-      name: Generating component
-      action: fetch:template
-      input:
-        url: ./skeleton
-        values:
-          name: ${{ parameters.name }}
-
+    ...
     - id: publish
       name: Publishing to a gitea git repository
       action: publish:gitea
       input:
-        description: This is ${{ parameters.component_id }}
+        description: This is ${{ parameters.repoUrl | parseRepoUrl | pick('repo') }}
+        repoVisibility: ${{ parameters.repoVisibility }}
         repoUrl: ${{ parameters.repoUrl }}
         defaultBranch: main
-
-    - id: register
-      if: ${{ parameters.dryRun !== true }}
-      name: Register
-      action: catalog:register
-      input:
-        repoContentsUrl: ${{ steps['publish'].output.repoContentsUrl }}
-        catalogInfoPath: 'main/catalog-info.yaml'
-
-  output:
-    links:
-      - title: Source Code Repository
-        url: ${{ steps.publish.output.remoteUrl }}
-      - title: Open Component in catalog
-        icon: catalog
-        entityRef: ${{ steps.register.output.entityRef }}
 ```
 
 Access the newly gitea repository created using the `repoContentsUrl` ;-)

--- a/plugins/scaffolder-backend-module-gitea/README.md
+++ b/plugins/scaffolder-backend-module-gitea/README.md
@@ -40,7 +40,7 @@ self-signed certificate `gitea cert --host localhost -ca` trusted by a CA author
 When done, you can create a template which:
 
 - Declare the `RepoUrlPicker` within the `spec/parameters` section to select the gitea host and to provide the name of the repository
-- Add an enum list allowing the user to define the visibility about the repository to be created: `public` or `private`. If this field is omitted, `public` is then used by the action.
+- Add an `enum` list allowing the user to define the visibility about the repository to be created: `public` or `private`. If this field is omitted, `public` is then used by the action.
 - Include in a step the action: `publish:gitea`
 
 **Warning**: The list of the `allowedOwners` of the `repoUrlPicker` must match the list of the `organizations` which are available on the gitea host !

--- a/plugins/scaffolder-backend-module-gitea/api-report.md
+++ b/plugins/scaffolder-backend-module-gitea/api-report.md
@@ -18,6 +18,7 @@ export function createPublishGiteaAction(options: {
     repoUrl: string;
     description: string;
     defaultBranch?: string | undefined;
+    repoVisibility?: 'private' | 'public' | undefined;
     gitCommitMessage?: string | undefined;
     gitAuthorName?: string | undefined;
     gitAuthorEmail?: string | undefined;

--- a/plugins/scaffolder-backend-module-gitea/package.json
+++ b/plugins/scaffolder-backend-module-gitea/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-scaffolder-backend-module-gitea",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "The gitea module for @backstage/plugin-scaffolder-backend",
   "backstage": {
     "role": "backend-plugin-module"

--- a/plugins/scaffolder-backend-module-gitea/package.json
+++ b/plugins/scaffolder-backend-module-gitea/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-scaffolder-backend-module-gitea",
-  "version": "0.1.8",
+  "version": "0.1.7",
   "description": "The gitea module for @backstage/plugin-scaffolder-backend",
   "backstage": {
     "role": "backend-plugin-module"

--- a/plugins/scaffolder-backend-module-gitea/src/actions/gitea.examples.ts
+++ b/plugins/scaffolder-backend-module-gitea/src/actions/gitea.examples.ts
@@ -51,6 +51,23 @@ export const examples: TemplateExample[] = [
     }),
   },
   {
+    description: 'Initializes a private Gitea repository ',
+    example: yaml.stringify({
+      steps: [
+        {
+          id: 'publish',
+          action: 'publish:gitea',
+          name: 'Publish to Gitea',
+          input: {
+            repoUrl: 'gitea.com?repo=repo&owner=owner',
+            defaultBranch: 'main',
+            repoVisibility: 'private',
+          },
+        },
+      ],
+    }),
+  },
+  {
     description:
       'Initializes a Gitea repository with a default Branch, if not set defaults to main',
     example: yaml.stringify({
@@ -150,6 +167,7 @@ export const examples: TemplateExample[] = [
             gitAuthorName: 'John Doe',
             gitAuthorEmail: 'johndoe@email.com',
             sourcePath: 'repository/',
+            repoVisibility: 'public',
           },
         },
       ],

--- a/plugins/scaffolder-backend-module-gitea/src/actions/gitea.test.ts
+++ b/plugins/scaffolder-backend-module-gitea/src/actions/gitea.test.ts
@@ -53,6 +53,13 @@ describe('publish:gitea', () => {
       description,
     },
   });
+  const mockContextWithPublicRepoVisibility = createMockActionContext({
+    input: {
+      repoUrl: 'gitea.com?repo=repo&owner=owner',
+      description,
+      private: false,
+    },
+  });
 
   const server = setupServer();
   setupRequestMockHandlers(server);
@@ -111,6 +118,7 @@ describe('publish:gitea', () => {
         );
         expect(req.body).toEqual({
           name: 'repo',
+          private: false,
           description,
         });
         return res(
@@ -146,6 +154,71 @@ describe('publish:gitea', () => {
       'repoContentsUrl',
       'https://gitea.com/org1/repo/src/branch/main/',
     );
+  });
+
+  it('should create a Gitea repository where visibility is public', async () => {
+    server.use(
+      rest.get('https://gitea.com/api/v1/orgs/org1', (_req, res, ctx) => {
+        return res(
+          ctx.status(200),
+          ctx.set('Content-Type', 'application/json'),
+          ctx.json({
+            id: 1,
+            name: 'org1',
+            visibility: 'public',
+            repo_admin_change_team_access: false,
+            username: 'org1',
+          }),
+        );
+      }),
+      rest.get(
+        'https://gitea.com/org1/repo/src/branch/main',
+        (_req, res, ctx) => {
+          return res(
+            ctx.status(200),
+            ctx.set('Content-Type', 'application/json'),
+            ctx.json({}),
+          );
+        },
+      ),
+      rest.post('https://gitea.com/api/v1/orgs/org1/repos', (req, res, ctx) => {
+        // Basic auth must match the user and password defined part of the config
+        expect(req.headers.get('Authorization')).toBe(
+          'basic Z2l0ZWFfdXNlcjpnaXRlYV9wYXNzd29yZA==',
+        );
+        expect(req.body).toEqual({
+          name: 'repo',
+          private: false,
+          description,
+        });
+        return res(
+          ctx.status(201),
+          ctx.set('Content-Type', 'application/json'),
+          ctx.json({}),
+        );
+      }),
+    );
+
+    await action.handler({
+      ...mockContextWithPublicRepoVisibility,
+      input: {
+        ...mockContextWithPublicRepoVisibility.input,
+        repoUrl: 'gitea.com?repo=repo&owner=org1',
+      },
+    });
+
+    expect(initRepoAndPush).toHaveBeenCalledWith({
+      dir: mockContextWithPublicRepoVisibility.workspacePath,
+      remoteUrl: 'https://gitea.com/org1/repo.git',
+      defaultBranch: 'main',
+      auth: { username: 'gitea_user', password: 'gitea_password' },
+      logger: mockContextWithPublicRepoVisibility.logger,
+      commitMessage: expect.stringContaining('initial commit\n\nChange-Id:'),
+      gitAuthorInfo: {
+        email: undefined,
+        name: undefined,
+      },
+    });
   });
 
   afterEach(() => {

--- a/plugins/scaffolder-backend-module-gitea/src/actions/gitea.ts
+++ b/plugins/scaffolder-backend-module-gitea/src/actions/gitea.ts
@@ -81,7 +81,7 @@ const checkGiteaOrg = async (
     );
   } catch (e) {
     throw new Error(
-      `Unable to get the Organization: ${owner}; Error cause: ${e.cause.message}`,
+      `Unable to get the Organization: ${owner}; Error cause: ${e.message}, code: ${e.cause.code}`,
     );
   }
   if (response.status !== 200) {

--- a/plugins/scaffolder-backend-module-gitea/src/actions/gitea.ts
+++ b/plugins/scaffolder-backend-module-gitea/src/actions/gitea.ts
@@ -113,15 +113,15 @@ const createGiteaProject = async (
     This is the default scenario that we support currently
   */
   let response: Response;
-  let visibility: boolean;
+  let isPrivate: boolean;
 
   if (repoVisibility === 'private') {
-    visibility = true;
+    isPrivate = true;
   } else if (repoVisibility === 'public') {
-    visibility = false;
+    isPrivate = false;
   } else {
     // Provide a default value if repoVisibility is neither "private" nor "public"
-    visibility = false;
+    isPrivate = false;
   }
 
   const postOptions: RequestInit = {
@@ -129,7 +129,7 @@ const createGiteaProject = async (
     body: JSON.stringify({
       name: projectName,
       description,
-      private: visibility,
+      private: isPrivate,
     }),
     headers: {
       ...getGiteaRequestOptions(config).headers,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add a new parameter `repoVisibility` for the action `publish:gitea` to allow create public or private git repositories on gitea

Template used for the tests with a local gitea server: https://github.com/ch007m/my-backstage-templates/blob/main/gitea/template.yaml

### Results

![Screenshot 2024-04-19 at 12 29 00](https://github.com/backstage/backstage/assets/463790/b2fa1a02-ba0e-4f97-87af-a4db039e44aa)
![Screenshot 2024-04-19 at 12 29 05](https://github.com/backstage/backstage/assets/463790/6808d924-3c3f-444b-a452-95f090d41fb7)
![Screenshot 2024-04-19 at 12 30 11](https://github.com/backstage/backstage/assets/463790/4613cdf3-7715-4251-a45d-2bf1d9a337df)
![Screenshot 2024-04-19 at 12 30 20](https://github.com/backstage/backstage/assets/463790/250f36e6-c2f6-416c-bbb6-33465c176f62)

Issue: https://github.com/backstage/backstage/issues/24377

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
