### PR TITLE
Move the jwks registration outside of the lifecycle middleware

### DIFF
--- a/.changeset/fresh-crews-impress.md
+++ b/.changeset/fresh-crews-impress.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+Move the JWKS registration outside of the lifecycle middleware

--- a/packages/backend-app-api/src/services/implementations/httpRouter/httpRouterServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/httpRouter/httpRouterServiceFactory.ts
@@ -75,8 +75,8 @@ export const httpRouterServiceFactory = createServiceFactory(
         config,
       });
 
-      router.use(createLifecycleMiddleware({ lifecycle }));
       router.use(createAuthIntegrationRouter({ auth }));
+      router.use(createLifecycleMiddleware({ lifecycle }));
       router.use(credentialsBarrier.middleware);
       router.use(createCookieAuthRefreshMiddleware({ auth, httpAuth }));
 


### PR DESCRIPTION
This would help with the 503 errors when trying to request the JWKS while in the middle of startup