### PR TITLE
backend-plugin-api: cleanup ServiceRef interface

### DIFF
--- a/.changeset/young-olives-drop.md
+++ b/.changeset/young-olives-drop.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-plugin-api': patch
+---
+
+Removed explicit `toString()` method from `ServiceRef` type.

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -570,7 +570,6 @@ export type ServiceRef<
   id: string;
   scope: TScope;
   T: TService;
-  toString(): string;
   $$type: '@backstage/ServiceRef';
 };
 

--- a/packages/backend-plugin-api/src/services/system/types.ts
+++ b/packages/backend-plugin-api/src/services/system/types.ts
@@ -44,8 +44,6 @@ export type ServiceRef<
    */
   T: TService;
 
-  toString(): string;
-
   $$type: '@backstage/ServiceRef';
 };
 


### PR DESCRIPTION
🧹 , just a bit of cleanup, no use defining that here