### PR TITLE
.github: replace labeler action and label BEPs related things

### DIFF
--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -8,3 +8,5 @@ area:scaffolder:
   - '/scaffolder/i'
 area:permission:
   - '/permission/i'
+bep:
+  - '/\bbep\b/i'

--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -1,0 +1,10 @@
+area:techdocs:
+  - '/(techdocs|tech-docs|tech docs)/i'
+area:discoverability:
+  - '/search/i'
+area:catalog:
+  - '/catalog/i'
+area:scaffolder:
+  - '/scaffolder/i'
+area:permission:
+  - '/permission/i'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -31,6 +31,10 @@ area:techdocs:
           - plugins/techdocs/**/*
           - plugins/techdocs-*/**/*
           - packages/techdocs-*/**/*
+bep:
+  - changed-files:
+      - any-glob-to-any-file:
+          - beps/**/*
 auth:
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/workflows/issue.yaml
+++ b/.github/workflows/issue.yaml
@@ -14,5 +14,11 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Issue sync
-        uses: backstage/actions/issue-sync@caa4901322ee3b5af18814ffc837bd052f150073 # v0.6.6
+      - name: Add issue labels
+        uses: github/issue-labeler@c1b0f9f52a63158c4adc09425e858e87b32e9685 # v3.4
+        with:
+          include-title: 1
+          include-body: 0
+          configuration-path: .github/labeler.yml
+          not-before: 2024-04-19T15:03:51Z
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
Switching over to https://github.com/github/issue-labeler so we don't have to keep maintaining our own issue labeler and remove it.

On top of that I've added label configs for BEPs