### PR TITLE
Liveness probe added in ContainerCard component

### DIFF
--- a/.changeset/eight-moose-pull.md
+++ b/.changeset/eight-moose-pull.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-react': patch
+---
+
+Liveness Probe added in ContainerCard Component of PodDrawer

--- a/plugins/kubernetes-react/src/components/Pods/PodDrawer/ContainerCard.test.tsx
+++ b/plugins/kubernetes-react/src/components/Pods/PodDrawer/ContainerCard.test.tsx
@@ -40,6 +40,7 @@ describe('ContainerCard', () => {
           },
           containerSpec: {
             readinessProbe: {},
+            livenessProbe: {},
           },
           containerStatus: {
             name: 'some-name',
@@ -60,7 +61,7 @@ describe('ContainerCard', () => {
     expect(screen.getByText('Status: Running')).toBeInTheDocument();
     expect(screen.getByText('some-name')).toBeInTheDocument();
     expect(screen.getByText('gcr.io/some-proj/some-image')).toBeInTheDocument();
-    expect(screen.getAllByText('✅')).toHaveLength(5);
+    expect(screen.getAllByText('✅')).toHaveLength(6);
     expect(screen.queryByText('❌')).toBeNull();
   });
 
@@ -89,7 +90,7 @@ describe('ContainerCard', () => {
     );
     expect(screen.getByText('some-name')).toBeInTheDocument();
     expect(screen.getByText('gcr.io/some-proj/some-image')).toBeInTheDocument();
-    expect(screen.getAllByText('❌')).toHaveLength(5);
+    expect(screen.getAllByText('❌')).toHaveLength(6);
     expect(screen.queryByText('✅')).toBeNull();
   });
 

--- a/plugins/kubernetes-react/src/components/Pods/PodDrawer/ContainerCard.tsx
+++ b/plugins/kubernetes-react/src/components/Pods/PodDrawer/ContainerCard.tsx
@@ -48,6 +48,8 @@ const getContainerHealthChecks = (
     'no restarts': containerStatus.restartCount === 0,
     'readiness probe set':
       containerSpec && containerSpec?.readinessProbe !== undefined,
+    'liveness probe set':
+      containerSpec && containerSpec?.livenessProbe !== undefined,
   };
 };
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Only `Readiness` probe is showing in ContainerCard component in Kubernetes PodDrawer, this PR will enable the `Liveness Probe` too in PodDrawer.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
