### PR TITLE
Add ESLint Rule to Github Pull Requests Board

### DIFF
--- a/.changeset/healthy-suns-deny.md
+++ b/.changeset/healthy-suns-deny.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-github-pull-requests-board': patch
+---
+
+Added ESLint rule `no-top-level-material-ui-4-imports` in the `github-pull-requests-board` plugin to migrate the Material UI imports.

--- a/plugins/github-pull-requests-board/.eslintrc.js
+++ b/plugins/github-pull-requests-board/.eslintrc.js
@@ -1,3 +1,5 @@
-module.exports = {
-  extends: [require.resolve('@backstage/cli/config/eslint')],
-};
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
+  rules: {
+    '@backstage/no-top-level-material-ui-4-imports': 'error',
+  },
+});

--- a/plugins/github-pull-requests-board/src/components/Card/Card.tsx
+++ b/plugins/github-pull-requests-board/src/components/Card/Card.tsx
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 import React, { PropsWithChildren, FunctionComponent } from 'react';
-import { Box, Paper, CardActionArea } from '@material-ui/core';
+import Box from '@material-ui/core/Box';
+import Paper from '@material-ui/core/Paper';
+import CardActionArea from '@material-ui/core/CardActionArea';
 import CardHeader from './CardHeader';
 import { Label, Status } from '../../utils/types';
 

--- a/plugins/github-pull-requests-board/src/components/Card/CardHeader.tsx
+++ b/plugins/github-pull-requests-board/src/components/Card/CardHeader.tsx
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 import React, { FunctionComponent } from 'react';
-import { Typography, Box, Tooltip, Chip } from '@material-ui/core';
+import Typography from '@material-ui/core/Typography';
+import Box from '@material-ui/core/Box';
+import Tooltip from '@material-ui/core/Tooltip';
+import Chip from '@material-ui/core/Chip';
 import { getElapsedTime } from '../../utils/functions';
 import { UserHeader } from '../UserHeader';
 import { DraftPrIcon } from '../icons/DraftPr';

--- a/plugins/github-pull-requests-board/src/components/Card/styles.ts
+++ b/plugins/github-pull-requests-board/src/components/Card/styles.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { makeStyles } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
 
 export const useFormClasses = makeStyles(() => ({
   labelItem: {

--- a/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsCard/EntityTeamPullRequestsCard.tsx
+++ b/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsCard/EntityTeamPullRequestsCard.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 import React, { useState } from 'react';
-import { Grid, Typography } from '@material-ui/core';
+import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
 import FullscreenIcon from '@material-ui/icons/Fullscreen';
 import PeopleIcon from '@material-ui/icons/People';
 

--- a/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsContent/EntityTeamPullRequestsContent.tsx
+++ b/plugins/github-pull-requests-board/src/components/EntityTeamPullRequestsContent/EntityTeamPullRequestsContent.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 import React, { useState } from 'react';
-import { Grid, Typography } from '@material-ui/core';
+import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
 import PeopleIcon from '@material-ui/icons/People';
 import { Progress, InfoCard } from '@backstage/core-components';
 

--- a/plugins/github-pull-requests-board/src/components/InfoCardHeader/InfoCardHeader.tsx
+++ b/plugins/github-pull-requests-board/src/components/InfoCardHeader/InfoCardHeader.tsx
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 import React, { PropsWithChildren, FunctionComponent } from 'react';
-import { Typography, Box, IconButton } from '@material-ui/core';
+import Typography from '@material-ui/core/Typography';
+import Box from '@material-ui/core/Box';
+import IconButton from '@material-ui/core/IconButton';
 import RefreshIcon from '@material-ui/icons/Refresh';
 
 type Props = {

--- a/plugins/github-pull-requests-board/src/components/PullRequestBoardOptions/PullRequestBoardOptions.tsx
+++ b/plugins/github-pull-requests-board/src/components/PullRequestBoardOptions/PullRequestBoardOptions.tsx
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 import React, { ReactNode, FunctionComponent } from 'react';
-import { ToggleButton, ToggleButtonGroup } from '@material-ui/lab';
-import { Tooltip, Box } from '@material-ui/core';
+import ToggleButton from '@material-ui/lab/ToggleButton';
+import ToggleButtonGroup from '@material-ui/lab/ToggleButtonGroup';
+import Tooltip from '@material-ui/core/Tooltip';
+import Box from '@material-ui/core/Box';
 import { PRCardFormating } from '../../utils/types';
 
 type Option = {

--- a/plugins/github-pull-requests-board/src/components/UserHeader/UserHeader.tsx
+++ b/plugins/github-pull-requests-board/src/components/UserHeader/UserHeader.tsx
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 import React, { FunctionComponent } from 'react';
-import { Typography, Box, Avatar, makeStyles } from '@material-ui/core';
+import Typography from '@material-ui/core/Typography';
+import Box from '@material-ui/core/Box';
+import Avatar from '@material-ui/core/Avatar';
+import { makeStyles } from '@material-ui/core/styles';
 
 type Props = {
   name: string;

--- a/plugins/github-pull-requests-board/src/components/UserHeaderList/UserHeaderList.tsx
+++ b/plugins/github-pull-requests-board/src/components/UserHeaderList/UserHeaderList.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 import React, { FunctionComponent } from 'react';
-import { Typography, Box } from '@material-ui/core';
+import Typography from '@material-ui/core/Typography';
+import Box from '@material-ui/core/Box';
 import { filterSameUser } from '../../utils/functions';
 
 import { UserHeader } from '../UserHeader';

--- a/plugins/github-pull-requests-board/src/components/Wrapper/Wrapper.tsx
+++ b/plugins/github-pull-requests-board/src/components/Wrapper/Wrapper.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 import React, { PropsWithChildren, FunctionComponent } from 'react';
-import { Grid, Box } from '@material-ui/core';
+import Grid from '@material-ui/core/Grid';
+import Box from '@material-ui/core/Box';
 
 type Props = {
   fullscreen: boolean;


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Adds the no-top-level-material-ui-4-import ESLint rule to the `github-pull-requests-board` plugin to aid with the migration to Material UI v5.
<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Issue: #23467 

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
