### PR TITLE
feat(EntityPlaylistDialog): use EntityPresentationApi instead of humanizeEntityRef to display entity

### DIFF
--- a/.changeset/silent-donkeys-smash.md
+++ b/.changeset/silent-donkeys-smash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-playlist': minor
+---
+
+`EntityPlaylistDialog` uses `entityPresentationApi` instead of `humanizeEntityRef` to display Entity

--- a/plugins/playlist/package.json
+++ b/plugins/playlist/package.json
@@ -58,6 +58,7 @@
     "@backstage/cli": "workspace:^",
     "@backstage/core-app-api": "workspace:^",
     "@backstage/dev-utils": "workspace:^",
+    "@backstage/plugin-catalog": "workspace:^",
     "@backstage/plugin-search-common": "workspace:^",
     "@backstage/test-utils": "workspace:^",
     "@testing-library/dom": "^10.0.0",

--- a/plugins/playlist/src/components/EntityPlaylistDialog/EntityPlaylistDialog.test.tsx
+++ b/plugins/playlist/src/components/EntityPlaylistDialog/EntityPlaylistDialog.test.tsx
@@ -17,7 +17,11 @@
 import { Entity } from '@backstage/catalog-model';
 import { AlertApi, alertApiRef } from '@backstage/core-plugin-api';
 import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
-import { EntityProvider } from '@backstage/plugin-catalog-react';
+import {
+  CatalogApi,
+  EntityProvider,
+  entityPresentationApiRef,
+} from '@backstage/plugin-catalog-react';
 import { AuthorizeResult } from '@backstage/plugin-permission-common';
 import {
   PermissionApi,
@@ -30,6 +34,7 @@ import { SWRConfig } from 'swr';
 import { PlaylistApi, playlistApiRef } from '../../api';
 import { playlistRouteRef, rootRouteRef } from '../../routes';
 import { EntityPlaylistDialog } from './EntityPlaylistDialog';
+import { DefaultEntityPresentationApi } from '@backstage/plugin-catalog';
 
 const navigateMock = jest.fn();
 jest.mock('react-router-dom', () => ({
@@ -48,6 +53,7 @@ jest.mock('../PlaylistEditDialog', () => ({
 }));
 
 describe('EntityPlaylistDialog', () => {
+  let entities: Entity[];
   const samplePlaylists = [
     {
       id: 'id1',
@@ -75,6 +81,14 @@ describe('EntityPlaylistDialog', () => {
     createPlaylist: jest.fn().mockImplementation(async () => '123'),
     getAllPlaylists: jest.fn().mockImplementation(async () => samplePlaylists),
   };
+  const catalogApi: jest.Mocked<CatalogApi> = {
+    getLocationById: jest.fn(),
+    getEntityByName: jest.fn(),
+    getEntities: jest.fn(async () => ({ items: entities })),
+    addLocation: jest.fn(),
+    getLocationByRef: jest.fn(),
+    removeEntityByUid: jest.fn(),
+  } as any;
   const mockAuthorize = jest
     .fn()
     .mockImplementation(async () => ({ result: AuthorizeResult.ALLOW }));
@@ -95,6 +109,10 @@ describe('EntityPlaylistDialog', () => {
             [alertApiRef, alertApi],
             [permissionApiRef, permissionApi],
             [playlistApiRef, playlistApi],
+            [
+              entityPresentationApiRef,
+              DefaultEntityPresentationApi.create({ catalogApi }),
+            ],
           ]}
         >
           <EntityProvider entity={mockEntity}>

--- a/plugins/playlist/src/components/EntityPlaylistDialog/EntityPlaylistDialog.tsx
+++ b/plugins/playlist/src/components/EntityPlaylistDialog/EntityPlaylistDialog.tsx
@@ -18,7 +18,7 @@ import { parseEntityRef, stringifyEntityRef } from '@backstage/catalog-model';
 import { ResponseErrorPanel } from '@backstage/core-components';
 import { alertApiRef, useApi, useRouteRef } from '@backstage/core-plugin-api';
 import {
-  humanizeEntityRef,
+  entityPresentationApiRef,
   useAsyncEntity,
 } from '@backstage/plugin-catalog-react';
 import { usePermission } from '@backstage/plugin-permission-react';
@@ -85,6 +85,7 @@ export const EntityPlaylistDialog = (props: EntityPlaylistDialogProps) => {
   const { entity } = useAsyncEntity();
   const alertApi = useApi(alertApiRef);
   const playlistApi = useApi(playlistApiRef);
+  const entityPresentationApi = useApi(entityPresentationApiRef);
   const playlistRoute = useRouteRef(playlistRouteRef);
   const [search, setSearch] = useState('');
   const [openEditDialog, setOpenEditDialog] = useState(false);
@@ -256,10 +257,12 @@ export const EntityPlaylistDialog = (props: EntityPlaylistDialogProps) => {
                     >
                       <ListItemText
                         primary={list.name}
-                        secondary={`by ${humanizeEntityRef(
-                          parseEntityRef(list.owner),
-                          { defaultKind: 'group' },
-                        )} · ${list.entities} entities ${
+                        secondary={`by ${
+                          entityPresentationApi.forEntity(
+                            stringifyEntityRef(parseEntityRef(list.owner)),
+                            { defaultKind: 'group' },
+                          ).snapshot.primaryTitle
+                        } · ${list.entities} entities ${
                           !list.public ? '· Private' : ''
                         }`}
                       />

--- a/yarn.lock
+++ b/yarn.lock
@@ -8197,6 +8197,7 @@ __metadata:
     "@backstage/core-plugin-api": "workspace:^"
     "@backstage/dev-utils": "workspace:^"
     "@backstage/errors": "workspace:^"
+    "@backstage/plugin-catalog": "workspace:^"
     "@backstage/plugin-catalog-common": "workspace:^"
     "@backstage/plugin-catalog-react": "workspace:^"
     "@backstage/plugin-permission-common": "workspace:^"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR is done to resolve the issue #20955 . I have changed the way to display the entity by using `entityPresentationApi` instead of `humanizeEntityRef`. I have used `entityPresentationApi` here in React JSX because directly using `<EntityDisplayName />` was making ui changes which i thought should be avoided.
Below attached screenshot shows current UI
![image](https://github.com/backstage/backstage/assets/77385983/5ef51d68-2e48-4591-bab1-cb23f4ae20cf)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
