### PR TITLE
fix: infinite loop in notification title counter

### DIFF
--- a/.changeset/unlucky-days-play.md
+++ b/.changeset/unlucky-days-play.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications': patch
+---
+
+Fix infinite loop in the notification title counter

--- a/plugins/notifications/dev/index.tsx
+++ b/plugins/notifications/dev/index.tsx
@@ -20,9 +20,11 @@ import {
   notificationsPlugin,
   NotificationsSidebarItem,
 } from '../src';
+import { signalsPlugin } from '@backstage/plugin-signals';
 
 createDevApp()
   .registerPlugin(notificationsPlugin)
+  .registerPlugin(signalsPlugin)
   .addPage({
     element: (
       <NotificationsPage

--- a/plugins/notifications/package.json
+++ b/plugins/notifications/package.json
@@ -50,6 +50,7 @@
     "@backstage/cli": "workspace:^",
     "@backstage/core-app-api": "workspace:^",
     "@backstage/dev-utils": "workspace:^",
+    "@backstage/plugin-signals": "workspace:^",
     "@backstage/test-utils": "workspace:^",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^15.0.0",

--- a/plugins/notifications/src/components/NotificationsSideBarItem/NotificationsSideBarItem.tsx
+++ b/plugins/notifications/src/components/NotificationsSideBarItem/NotificationsSideBarItem.tsx
@@ -96,11 +96,14 @@ export const NotificationsSidebarItem = (props?: {
   useEffect(() => {
     if (!loading && !error && value) {
       setUnreadCount(value.unread);
-      if (titleCounterEnabled) {
-        setNotificationCount(value.unread);
-      }
     }
-  }, [loading, error, value, titleCounterEnabled, setNotificationCount]);
+  }, [loading, error, value]);
+
+  useEffect(() => {
+    if (titleCounterEnabled) {
+      setNotificationCount(unreadCount);
+    }
+  }, [titleCounterEnabled, unreadCount, setNotificationCount]);
 
   // TODO: Figure out if the count can be added to hasNotifications
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -6057,6 +6057,7 @@ __metadata:
     "@backstage/dev-utils": "workspace:^"
     "@backstage/errors": "workspace:^"
     "@backstage/plugin-notifications-common": "workspace:^"
+    "@backstage/plugin-signals": "workspace:^"
     "@backstage/plugin-signals-react": "workspace:^"
     "@backstage/test-utils": "workspace:^"
     "@backstage/theme": "workspace:^"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix infinite loop when setting the notification count in some cases. Also fix the React Helmet overwriting the title after the hook has finished.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
