### PR TITLE
fix: web notifications to show in foreground + duplicates prevented

### DIFF
--- a/.changeset/tasty-apes-learn.md
+++ b/.changeset/tasty-apes-learn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications': patch
+---
+
+Fix to show web notifications even when browser is on foreground. Fix duplicate notifications with multiple tabs.

--- a/plugins/notifications/api-report.md
+++ b/plugins/notifications/api-report.md
@@ -175,8 +175,9 @@ export function useTitleCounter(): {
 };
 
 // @public (undocumented)
-export function useWebNotifications(): {
+export function useWebNotifications(enabled: boolean): {
   sendWebNotification: (options: {
+    id: string;
     title: string;
     description: string;
     link?: string;

--- a/plugins/notifications/dev/index.tsx
+++ b/plugins/notifications/dev/index.tsx
@@ -20,9 +20,11 @@ import {
   notificationsPlugin,
   NotificationsSidebarItem,
 } from '../src';
+import { signalsPlugin } from '@backstage/plugin-signals';
 
 createDevApp()
   .registerPlugin(notificationsPlugin)
+  .registerPlugin(signalsPlugin)
   .addPage({
     element: (
       <NotificationsPage
@@ -32,5 +34,5 @@ createDevApp()
     ),
     path: '/notifications',
   })
-  .addSidebarItem(<NotificationsSidebarItem />)
+  .addSidebarItem(<NotificationsSidebarItem webNotificationsEnabled />)
   .render();

--- a/plugins/notifications/package.json
+++ b/plugins/notifications/package.json
@@ -50,6 +50,7 @@
     "@backstage/cli": "workspace:^",
     "@backstage/core-app-api": "workspace:^",
     "@backstage/dev-utils": "workspace:^",
+    "@backstage/plugin-signals": "workspace:^",
     "@backstage/test-utils": "workspace:^",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^15.0.0",

--- a/plugins/notifications/src/components/NotificationsSideBarItem/NotificationsSideBarItem.tsx
+++ b/plugins/notifications/src/components/NotificationsSideBarItem/NotificationsSideBarItem.tsx
@@ -51,7 +51,7 @@ export const NotificationsSidebarItem = (props?: {
   const notificationsRoute = useRouteRef(rootRouteRef);
   // TODO: Do we want to add long polling in case signals are not available
   const { lastSignal } = useSignal<NotificationSignal>('notifications');
-  const { sendWebNotification } = useWebNotifications();
+  const { sendWebNotification } = useWebNotifications(webNotificationsEnabled);
   const [refresh, setRefresh] = React.useState(false);
   const { setNotificationCount } = useTitleCounter();
 
@@ -75,6 +75,7 @@ export const NotificationsSidebarItem = (props?: {
             return;
           }
           sendWebNotification({
+            id: notification.id,
             title: notification.payload.title,
             description: notification.payload.description ?? '',
             link: notification.payload.link,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6057,6 +6057,7 @@ __metadata:
     "@backstage/dev-utils": "workspace:^"
     "@backstage/errors": "workspace:^"
     "@backstage/plugin-notifications-common": "workspace:^"
+    "@backstage/plugin-signals": "workspace:^"
     "@backstage/plugin-signals-react": "workspace:^"
     "@backstage/test-utils": "workspace:^"
     "@backstage/theme": "workspace:^"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix to show web notifications also when the browser is in foreground. Additionally fix duplicate web notifications when multiple tabs open.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
