### PR TITLE
feat: generate random notifications in local development

### DIFF
--- a/.changeset/tall-ads-shave.md
+++ b/.changeset/tall-ads-shave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications-backend': patch
+---
+
+Add possibility to generate random notifications on the fly in local development

--- a/plugins/notifications/dev/index.tsx
+++ b/plugins/notifications/dev/index.tsx
@@ -21,6 +21,8 @@ import {
   NotificationsSidebarItem,
 } from '../src';
 import { signalsPlugin } from '@backstage/plugin-signals';
+import { SidebarItem } from '@backstage/core-components';
+import AddAlert from '@material-ui/icons/AddAlert';
 
 createDevApp()
   .registerPlugin(notificationsPlugin)
@@ -35,4 +37,15 @@ createDevApp()
     path: '/notifications',
   })
   .addSidebarItem(<NotificationsSidebarItem webNotificationsEnabled />)
+  .addSidebarItem(
+    <SidebarItem
+      icon={AddAlert}
+      text="Random notification"
+      onClick={() => {
+        fetch('http://localhost:7007/api/notifications-debug/', {
+          method: 'POST',
+        });
+      }}
+    />,
+  )
   .render();


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Use HTTP router to generate random notifications in local development to more easily find issues with UI and UX.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
