### PR TITLE
fix: link to Dynatrace for Managed plugin

### DIFF
--- a/microsite/data/plugins/dynatrace-managed.yaml
+++ b/microsite/data/plugins/dynatrace-managed.yaml
@@ -4,7 +4,7 @@ author: Dynatrace
 authorUrl: https://github.com/dynatrace
 category: Monitoring
 description: View problem and synthetic information for services in your software catalog.
-documentation: https://github.com/backstage/backstage/tree/master/plugins/dynatrace
+documentation: https://github.com/backstage/community-plugins/tree/main/workspaces/dynatrace/plugins/dynatrace
 iconUrl: /img/dynatrace.svg
 npmPackageName: '@backstage/plugin-dynatrace'
 tags:

--- a/microsite/data/plugins/dynatrace-managed.yaml
+++ b/microsite/data/plugins/dynatrace-managed.yaml
@@ -6,7 +6,7 @@ category: Monitoring
 description: View problem and synthetic information for services in your software catalog.
 documentation: https://github.com/backstage/community-plugins/tree/main/workspaces/dynatrace/plugins/dynatrace
 iconUrl: /img/dynatrace.svg
-npmPackageName: '@backstage/plugin-dynatrace'
+npmPackageName: '@backstage-community/plugin-dynatrace'
 tags:
   - monitoring
   - observability


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Due to moving the plugins to the `https://github.com/backstage/community-plugins` directory, a link was broken for the Dynatrace for Manged plugin. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
