### PR TITLE
fix: Maximum call stack size exceeded

### DIFF
--- a/.changeset/fix-stackoverflow.md
+++ b/.changeset/fix-stackoverflow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-backend-module-incremental-ingestion': patch
+---
+
+Fix plugin/incremental-ingestion 'Maximum call stack size exceeded' error when ingest large entities.

--- a/plugins/catalog-backend-module-incremental-ingestion/src/database/IncrementalIngestionDatabaseManager.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/database/IncrementalIngestionDatabaseManager.ts
@@ -336,11 +336,9 @@ export class IncrementalIngestionDatabaseManager {
           .join('ingestions', 'ingestions.id', 'ingestion_marks.ingestion_id')
           .where('ingestions.id', previousIngestion.id);
 
-        removed.push(
-          ...stale.map(e => {
-            return { entityRef: e.ref };
-          }),
-        );
+        for (const entityRef of stale) {
+          removed.push({ entityRef: entityRef.ref });
+        }
       }
 
       return { total, removed };

--- a/plugins/catalog-backend-module-incremental-ingestion/src/engine/IncrementalIngestionEngine.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/engine/IncrementalIngestionEngine.ts
@@ -322,7 +322,9 @@ export class IncrementalIngestionEngine
         }
       }
       if (doRemoval) {
-        removed.push(...result.removed);
+        for (const entityRef of result.removed) {
+          removed.push(entityRef);
+        }
       }
     }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

fix plugin/incremental-ingestion 'Maximum call stack size exceeded' error when ingest large entities. Use '...' will cause node stack size overflow when one provider ingests more than one hundred thousand.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
