### PR TITLE
changesets: remove changesets for moved plugins

### DIFF
--- a/.changeset/chilled-phones-unite.md
+++ b/.changeset/chilled-phones-unite.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-pagerduty': patch
----
-
-This plugin has been deprecated, consider using [@pagerduty/backstage-plugin](https://github.com/pagerduty/backstage-plugin) instead

--- a/.changeset/migrate-1713426449436.md
+++ b/.changeset/migrate-1713426449436.md
@@ -1,6 +1,0 @@
----
-'@backstage/plugin-todo': patch
-'@backstage/plugin-todo-backend': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713465834005.md
+++ b/.changeset/migrate-1713465834005.md
@@ -1,7 +1,0 @@
----
-'@backstage/plugin-adr': patch
-'@backstage/plugin-adr-backend': patch
-'@backstage/plugin-adr-common': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713465844082.md
+++ b/.changeset/migrate-1713465844082.md
@@ -1,6 +1,0 @@
----
-'@backstage/plugin-airbrake': patch
-'@backstage/plugin-airbrake-backend': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713465852581.md
+++ b/.changeset/migrate-1713465852581.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-allure': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713465859342.md
+++ b/.changeset/migrate-1713465859342.md
@@ -1,7 +1,0 @@
----
-'@backstage/plugin-analytics-module-ga': patch
-'@backstage/plugin-analytics-module-ga4': patch
-'@backstage/plugin-analytics-module-newrelic-browser': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713465866151.md
+++ b/.changeset/migrate-1713465866151.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-apache-airflow': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713465873342.md
+++ b/.changeset/migrate-1713465873342.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-apollo-explorer': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713465880342.md
+++ b/.changeset/migrate-1713465880342.md
@@ -1,7 +1,0 @@
----
-'@backstage/plugin-azure-devops': patch
-'@backstage/plugin-azure-devops-backend': patch
-'@backstage/plugin-azure-devops-common': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713465887317.md
+++ b/.changeset/migrate-1713465887317.md
@@ -1,7 +1,0 @@
----
-'@backstage/plugin-azure-sites': patch
-'@backstage/plugin-azure-sites-backend': patch
-'@backstage/plugin-azure-sites-common': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713465894126.md
+++ b/.changeset/migrate-1713465894126.md
@@ -1,6 +1,0 @@
----
-'@backstage/plugin-badges': patch
-'@backstage/plugin-badges-backend': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713465901227.md
+++ b/.changeset/migrate-1713465901227.md
@@ -1,6 +1,0 @@
----
-'@backstage/plugin-bazaar': patch
-'@backstage/plugin-bazaar-backend': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713465908023.md
+++ b/.changeset/migrate-1713465908023.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-bitrise': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713465915010.md
+++ b/.changeset/migrate-1713465915010.md
@@ -1,6 +1,0 @@
----
-'@backstage/plugin-cicd-statistics': patch
-'@backstage/plugin-cicd-statistics-module-gitlab': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713465921873.md
+++ b/.changeset/migrate-1713465921873.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-circleci': patch
----
-
-This package has been deprecated in favour of the [Circle-CI](https://github.com/CircleCI-Public/backstage-plugin) plugin. Please migrate to that plugin instead.

--- a/.changeset/migrate-1713465928821.md
+++ b/.changeset/migrate-1713465928821.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-cloudbuild': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713465935674.md
+++ b/.changeset/migrate-1713465935674.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-code-climate': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713465942505.md
+++ b/.changeset/migrate-1713465942505.md
@@ -1,6 +1,0 @@
----
-'@backstage/plugin-code-coverage': patch
-'@backstage/plugin-code-coverage-backend': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713465949447.md
+++ b/.changeset/migrate-1713465949447.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-codescene': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713465957264.md
+++ b/.changeset/migrate-1713465957264.md
@@ -1,6 +1,0 @@
----
-'@backstage/plugin-cost-insights': patch
-'@backstage/plugin-cost-insights-common': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713465964371.md
+++ b/.changeset/migrate-1713465964371.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-dynatrace': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713465971344.md
+++ b/.changeset/migrate-1713465971344.md
@@ -1,7 +1,0 @@
----
-'@backstage/plugin-entity-feedback': patch
-'@backstage/plugin-entity-feedback-backend': patch
-'@backstage/plugin-entity-feedback-common': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713465978303.md
+++ b/.changeset/migrate-1713465978303.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-entity-validation': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713465986035.md
+++ b/.changeset/migrate-1713465986035.md
@@ -1,8 +1,0 @@
----
-'@backstage/plugin-explore': patch
-'@backstage/plugin-explore-backend': patch
-'@backstage/plugin-explore-common': patch
-'@backstage/plugin-explore-react': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713465993760.md
+++ b/.changeset/migrate-1713465993760.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-firehydrant': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713466000828.md
+++ b/.changeset/migrate-1713466000828.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-fossa': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713466008519.md
+++ b/.changeset/migrate-1713466008519.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-gcalendar': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713466015470.md
+++ b/.changeset/migrate-1713466015470.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-gcp-projects': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713466022480.md
+++ b/.changeset/migrate-1713466022480.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-git-release-manager': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713466030755.md
+++ b/.changeset/migrate-1713466030755.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-github-actions': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713466038274.md
+++ b/.changeset/migrate-1713466038274.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-github-deployments': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713466045590.md
+++ b/.changeset/migrate-1713466045590.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-github-issues': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713466052584.md
+++ b/.changeset/migrate-1713466052584.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-github-pull-requests-board': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713466060269.md
+++ b/.changeset/migrate-1713466060269.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-gitops-profiles': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713466067342.md
+++ b/.changeset/migrate-1713466067342.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-gocd': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713466074733.md
+++ b/.changeset/migrate-1713466074733.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-graphiql': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713466081822.md
+++ b/.changeset/migrate-1713466081822.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-graphql-voyager': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713466088770.md
+++ b/.changeset/migrate-1713466088770.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-ilert': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713466095837.md
+++ b/.changeset/migrate-1713466095837.md
@@ -1,7 +1,0 @@
----
-'@backstage/plugin-jenkins': patch
-'@backstage/plugin-jenkins-backend': patch
-'@backstage/plugin-jenkins-common': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713466103067.md
+++ b/.changeset/migrate-1713466103067.md
@@ -1,6 +1,0 @@
----
-'@backstage/plugin-kafka': patch
-'@backstage/plugin-kafka-backend': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713466110116.md
+++ b/.changeset/migrate-1713466110116.md
@@ -1,7 +1,0 @@
----
-'@backstage/plugin-lighthouse': patch
-'@backstage/plugin-lighthouse-backend': patch
-'@backstage/plugin-lighthouse-common': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713466117436.md
+++ b/.changeset/migrate-1713466117436.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-microsoft-calendar': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713466129151.md
+++ b/.changeset/migrate-1713466129151.md
@@ -1,6 +1,0 @@
----
-'@backstage/plugin-newrelic': patch
-'@backstage/plugin-newrelic-dashboard': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713466146663.md
+++ b/.changeset/migrate-1713466146663.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-octopus-deploy': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713466155177.md
+++ b/.changeset/migrate-1713466155177.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-opencost': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713466169253.md
+++ b/.changeset/migrate-1713466169253.md
@@ -1,6 +1,0 @@
----
-'@backstage/plugin-periskop': patch
-'@backstage/plugin-periskop-backend': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713466176492.md
+++ b/.changeset/migrate-1713466176492.md
@@ -1,7 +1,0 @@
----
-'@backstage/plugin-playlist': patch
-'@backstage/plugin-playlist-backend': patch
-'@backstage/plugin-playlist-common': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713466183571.md
+++ b/.changeset/migrate-1713466183571.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-puppetdb': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713466190774.md
+++ b/.changeset/migrate-1713466190774.md
@@ -1,6 +1,0 @@
----
-'@backstage/plugin-rollbar': patch
-'@backstage/plugin-rollbar-backend': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713466197726.md
+++ b/.changeset/migrate-1713466197726.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-sentry': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713466204983.md
+++ b/.changeset/migrate-1713466204983.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-shortcuts': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713466212008.md
+++ b/.changeset/migrate-1713466212008.md
@@ -1,7 +1,0 @@
----
-'@backstage/plugin-sonarqube': patch
-'@backstage/plugin-sonarqube-backend': patch
-'@backstage/plugin-sonarqube-react': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713466219338.md
+++ b/.changeset/migrate-1713466219338.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-splunk-on-call': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713466226880.md
+++ b/.changeset/migrate-1713466226880.md
@@ -1,6 +1,0 @@
----
-'@backstage/plugin-stack-overflow': patch
-'@backstage/plugin-stack-overflow-backend': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713466234510.md
+++ b/.changeset/migrate-1713466234510.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-stackstorm': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713466242003.md
+++ b/.changeset/migrate-1713466242003.md
@@ -1,9 +1,0 @@
----
-'@backstage/plugin-tech-insights': patch
-'@backstage/plugin-tech-insights-backend': patch
-'@backstage/plugin-tech-insights-backend-module-jsonfc': patch
-'@backstage/plugin-tech-insights-common': patch
-'@backstage/plugin-tech-insights-node': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713466249417.md
+++ b/.changeset/migrate-1713466249417.md
@@ -1,7 +1,0 @@
----
-'@backstage/plugin-vault': patch
-'@backstage/plugin-vault-backend': patch
-'@backstage/plugin-vault-node': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713466257285.md
+++ b/.changeset/migrate-1713466257285.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-xcmetrics': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713519093920.md
+++ b/.changeset/migrate-1713519093920.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-tech-radar': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713531195788.md
+++ b/.changeset/migrate-1713531195788.md
@@ -1,6 +1,0 @@
----
-'@backstage/plugin-nomad': patch
-'@backstage/plugin-nomad-backend': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.

--- a/.changeset/migrate-1713531212279.md
+++ b/.changeset/migrate-1713531212279.md
@@ -1,7 +1,0 @@
----
-'@backstage/plugin-linguist': patch
-'@backstage/plugin-linguist-backend': patch
-'@backstage/plugin-linguist-common': patch
----
-
-These packages have been migrated to the [backstage/community-plugins](https://github.com/backstage/community-plugins) repository.


### PR DESCRIPTION
Removing all changesets for moved plugins. These were used to generate patch releases but are now causing build errors.