### PR TITLE
feat(catalog): add Link to tags and other fields in AboutCard

### DIFF
--- a/.changeset/happy-moles-change.md
+++ b/.changeset/happy-moles-change.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': minor
+---
+
+Add clickable links for tags and other metadata fields in the AboutCard component

--- a/plugins/catalog/src/components/AboutCard/AboutCard.test.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutCard.test.tsx
@@ -25,7 +25,11 @@ import {
   scmIntegrationsApiRef,
 } from '@backstage/integration-react';
 import { TestApiProvider, renderInTestApp } from '@backstage/test-utils';
-import { createFromTemplateRouteRef, viewTechDocRouteRef } from '../../routes';
+import {
+  createFromTemplateRouteRef,
+  rootRouteRef,
+  viewTechDocRouteRef,
+} from '../../routes';
 
 import { AboutCard } from './AboutCard';
 import { ConfigReader } from '@backstage/core-app-api';
@@ -104,6 +108,7 @@ describe('<AboutCard />', () => {
       {
         mountedRoutes: {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
         },
       },
     );
@@ -161,6 +166,7 @@ describe('<AboutCard />', () => {
       {
         mountedRoutes: {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
         },
       },
     );
@@ -217,6 +223,7 @@ describe('<AboutCard />', () => {
       {
         mountedRoutes: {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
         },
       },
     );
@@ -260,6 +267,7 @@ describe('<AboutCard />', () => {
       {
         mountedRoutes: {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
         },
       },
     );
@@ -321,6 +329,7 @@ describe('<AboutCard />', () => {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
           '/create/templates/:namespace/:templateName':
             createFromTemplateRouteRef,
+          '/catalog': rootRouteRef,
         },
       },
     );
@@ -390,6 +399,7 @@ describe('<AboutCard />', () => {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
           '/create/templates/:namespace/:templateName':
             createFromTemplateRouteRef,
+          '/catalog': rootRouteRef,
         },
       },
     );
@@ -441,6 +451,7 @@ describe('<AboutCard />', () => {
       {
         mountedRoutes: {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
         },
       },
     );
@@ -496,6 +507,7 @@ describe('<AboutCard />', () => {
       {
         mountedRoutes: {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
         },
       },
     );
@@ -537,6 +549,7 @@ describe('<AboutCard />', () => {
       {
         mountedRoutes: {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
         },
       },
     );
@@ -593,6 +606,7 @@ describe('<AboutCard />', () => {
         mountedRoutes: {
           '/docs/:namespace/:kind/:name': viewTechDocRouteRef,
           '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
         },
       },
     );
@@ -650,6 +664,7 @@ describe('<AboutCard />', () => {
         mountedRoutes: {
           '/docs/:namespace/:kind/:name': viewTechDocRouteRef,
           '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
         },
       },
     );
@@ -703,6 +718,7 @@ describe('<AboutCard />', () => {
       {
         mountedRoutes: {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
         },
       },
     );
@@ -757,6 +773,7 @@ describe('<AboutCard />', () => {
       {
         mountedRoutes: {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
         },
       },
     );
@@ -806,6 +823,7 @@ describe('<AboutCard />', () => {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
           '/create/templates/:namespace/:templateName':
             createFromTemplateRouteRef,
+          '/catalog': rootRouteRef,
         },
       },
     );
@@ -874,6 +892,7 @@ describe('<AboutCard />', () => {
             '/catalog/:namespace/:kind/:name': entityRouteRef,
             '/create/templates/:namespace/:templateName':
               createFromTemplateRouteRef,
+            '/catalog': rootRouteRef,
           },
         },
       );
@@ -921,6 +940,7 @@ describe('<AboutCard />', () => {
       {
         mountedRoutes: {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
         },
       },
     );

--- a/plugins/catalog/src/components/AboutCard/AboutContent.test.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutContent.test.tsx
@@ -24,6 +24,7 @@ import { renderInTestApp } from '@backstage/test-utils';
 import { screen } from '@testing-library/react';
 import React from 'react';
 import { AboutContent } from './AboutContent';
+import { rootRouteRef } from '../../routes';
 
 describe('<AboutContent />', () => {
   describe('An unknown entity', () => {
@@ -66,6 +67,7 @@ describe('<AboutContent />', () => {
       await renderInTestApp(<AboutContent entity={entity} />, {
         mountedRoutes: {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
         },
       });
 
@@ -96,6 +98,7 @@ describe('<AboutContent />', () => {
       await renderInTestApp(<AboutContent entity={entity} />, {
         mountedRoutes: {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
         },
       });
 
@@ -151,6 +154,7 @@ describe('<AboutContent />', () => {
       await renderInTestApp(<AboutContent entity={entity} />, {
         mountedRoutes: {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
         },
       });
 
@@ -188,6 +192,7 @@ describe('<AboutContent />', () => {
       await renderInTestApp(<AboutContent entity={entity} />, {
         mountedRoutes: {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
         },
       });
 
@@ -256,6 +261,7 @@ describe('<AboutContent />', () => {
       await renderInTestApp(<AboutContent entity={entity} />, {
         mountedRoutes: {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
         },
       });
 
@@ -296,6 +302,7 @@ describe('<AboutContent />', () => {
       await renderInTestApp(<AboutContent entity={entity} />, {
         mountedRoutes: {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
         },
       });
 
@@ -352,6 +359,7 @@ describe('<AboutContent />', () => {
       await renderInTestApp(<AboutContent entity={entity} />, {
         mountedRoutes: {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
         },
       });
 
@@ -379,6 +387,7 @@ describe('<AboutContent />', () => {
       await renderInTestApp(<AboutContent entity={entity} />, {
         mountedRoutes: {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
         },
       });
 
@@ -424,6 +433,7 @@ describe('<AboutContent />', () => {
       await renderInTestApp(<AboutContent entity={entity} />, {
         mountedRoutes: {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
         },
       });
 
@@ -456,6 +466,7 @@ describe('<AboutContent />', () => {
       await renderInTestApp(<AboutContent entity={entity} />, {
         mountedRoutes: {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
         },
       });
 
@@ -512,6 +523,7 @@ describe('<AboutContent />', () => {
       await renderInTestApp(<AboutContent entity={entity} />, {
         mountedRoutes: {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
         },
       });
 
@@ -545,6 +557,7 @@ describe('<AboutContent />', () => {
       await renderInTestApp(<AboutContent entity={entity} />, {
         mountedRoutes: {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
         },
       });
 
@@ -603,6 +616,7 @@ describe('<AboutContent />', () => {
       await renderInTestApp(<AboutContent entity={entity} />, {
         mountedRoutes: {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
         },
       });
 
@@ -634,6 +648,7 @@ describe('<AboutContent />', () => {
       await renderInTestApp(<AboutContent entity={entity} />, {
         mountedRoutes: {
           '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
         },
       });
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added a Link component to the tags, lifecycle and type fields in the `AboutContent` inside `AboutCard`.

This makes the fields clickable and navigates the user to the catalog index page, with preselected filters.

Resolves #24213

![Screen Shot 2024-04-22 at 18 55 27](https://github.com/backstage/backstage/assets/19623278/16bb60e5-01fd-4fa2-9ba7-4c1c51612fc2)

<img width="497" alt="image" src="https://github.com/backstage/backstage/assets/19623278/68c3ba74-cb88-431a-bfbc-7c1f101e83af">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
