### PR TITLE
feat: allow overriding notifications page properties

### DIFF
--- a/.changeset/bright-pumpkins-rule.md
+++ b/.changeset/bright-pumpkins-rule.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications': patch
+---
+
+Allow overriding `NotificationsPage` page properties

--- a/plugins/notifications/api-report.md
+++ b/plugins/notifications/api-report.md
@@ -73,7 +73,19 @@ export class NotificationsClient implements NotificationsApi {
 }
 
 // @public (undocumented)
-export const NotificationsPage: () => JSX_2.Element;
+export const NotificationsPage: (
+  props?: NotificationsPageProps | undefined,
+) => JSX_2.Element;
+
+// @public (undocumented)
+export type NotificationsPageProps = {
+  title?: string;
+  themeId?: string;
+  subtitle?: string;
+  tooltip?: string;
+  type?: string;
+  typeLink?: string;
+};
 
 // @public (undocumented)
 export const notificationsPlugin: BackstagePlugin<

--- a/plugins/notifications/dev/index.tsx
+++ b/plugins/notifications/dev/index.tsx
@@ -15,13 +15,21 @@
  */
 import React from 'react';
 import { createDevApp } from '@backstage/dev-utils';
-import { NotificationsPage, notificationsPlugin } from '../src/plugin';
-import { NotificationsSidebarItem } from '../src';
+import {
+  NotificationsPage,
+  notificationsPlugin,
+  NotificationsSidebarItem,
+} from '../src';
 
 createDevApp()
   .registerPlugin(notificationsPlugin)
   .addPage({
-    element: <NotificationsPage />,
+    element: (
+      <NotificationsPage
+        title="Notifications (debug)"
+        subtitle="Notifications local development environment to showcase notification capabilities"
+      />
+    ),
     path: '/notifications',
   })
   .addSidebarItem(<NotificationsSidebarItem />)

--- a/plugins/notifications/src/components/NotificationsPage/NotificationsPage.tsx
+++ b/plugins/notifications/src/components/NotificationsPage/NotificationsPage.tsx
@@ -37,7 +37,26 @@ import { NotificationSeverity } from '@backstage/plugin-notifications-common';
 
 const ThrottleDelayMs = 2000;
 
-export const NotificationsPage = () => {
+/** @public */
+export type NotificationsPageProps = {
+  title?: string;
+  themeId?: string;
+  subtitle?: string;
+  tooltip?: string;
+  type?: string;
+  typeLink?: string;
+};
+
+export const NotificationsPage = (props?: NotificationsPageProps) => {
+  const {
+    title = 'Notifications',
+    themeId = 'tool',
+    subtitle,
+    tooltip,
+    type,
+    typeLink,
+  } = props ?? {};
+
   const [refresh, setRefresh] = React.useState(false);
   const { lastSignal } = useSignal('notifications');
   const [unreadOnly, setUnreadOnly] = React.useState<boolean | undefined>(true);
@@ -113,7 +132,14 @@ export const NotificationsPage = () => {
   }
 
   return (
-    <PageWithHeader title="Notifications" themeId="tool">
+    <PageWithHeader
+      title={title}
+      themeId={themeId}
+      tooltip={tooltip}
+      subtitle={subtitle}
+      type={type}
+      typeLink={typeLink}
+    >
       <Content>
         <Grid container>
           <Grid item xs={2}>

--- a/plugins/notifications/src/components/index.ts
+++ b/plugins/notifications/src/components/index.ts
@@ -15,3 +15,4 @@
  */
 export * from './NotificationsSideBarItem';
 export * from './NotificationsTable';
+export type { NotificationsPageProps } from './NotificationsPage';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Allow overriding page properties for `NotificationsPage` to support more customization.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
