### PR TITLE
Camila/new auth services search collator migration

### DIFF
--- a/.changeset/real-crabs-obey.md
+++ b/.changeset/real-crabs-obey.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend-module-explore': patch
+---
+
+Migrate search collator to use the new auth services.

--- a/plugins/search-backend-module-explore/src/alpha.ts
+++ b/plugins/search-backend-module-explore/src/alpha.ts
@@ -44,6 +44,7 @@ export default createBackendModule({
         discovery: coreServices.discovery,
         scheduler: coreServices.scheduler,
         tokenManager: coreServices.tokenManager,
+        auth: coreServices.auth,
         indexRegistry: searchIndexRegistryExtensionPoint,
       },
       async init({
@@ -51,8 +52,9 @@ export default createBackendModule({
         logger,
         discovery,
         scheduler,
-        indexRegistry,
         tokenManager,
+        auth,
+        indexRegistry,
       }) {
         const defaultSchedule = {
           frequency: { minutes: 10 },
@@ -71,6 +73,7 @@ export default createBackendModule({
           factory: ToolDocumentCollatorFactory.fromConfig(config, {
             discovery,
             logger,
+            auth,
             tokenManager,
           }),
         });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Refs: https://github.com/backstage/backstage/issues/24308

Migrate search `Explore` collator to use the new auth services and fix the following error that was preventing the search plugin to successfully index documents on local development:

> [!IMPORTANT]
> This error will continue happening if the "explore" plugin is not migrated to use the new Backend system

```
 Error: Unable to generate legacy token for communication with the 'explore' plugin. You will typically encounter this error when attempting to call a plugin that does not exist, or is deployed with an old version of Backstage; caused by Error: Unable to generate legacy token, no legacy keys are configured in 'backend.auth.keys' or 'backend.auth.externalAccess'
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
