### PR TITLE
yarn-plugin: validate version of yarn

### DIFF
--- a/packages/yarn-plugin/package.json
+++ b/packages/yarn-plugin/package.json
@@ -34,6 +34,7 @@
     "@backstage/release-manifests": "workspace:^",
     "@yarnpkg/core": "^4.0.3",
     "@yarnpkg/fslib": "^3.0.2",
+    "chalk": "^4.0.0",
     "semver": "^7.6.0"
   },
   "devDependencies": {

--- a/packages/yarn-plugin/src/index.ts
+++ b/packages/yarn-plugin/src/index.ts
@@ -21,9 +21,20 @@
  * @packageDocumentation
  */
 
-import { Plugin } from '@yarnpkg/core';
+import { Plugin, semverUtils, YarnVersion } from '@yarnpkg/core';
+import chalk from 'chalk';
 import { beforeWorkspacePacking } from './handlers/beforeWorkspacePacking';
 import { BackstageResolver } from './resolver/BackstageResolver';
+
+if (!semverUtils.satisfiesWithPrereleases(YarnVersion, '^4.1.1')) {
+  console.error();
+  console.error(
+    `${chalk.bold.red(
+      'Unsupported yarn version.',
+    )}: The Backstage yarn plugin only works with yarn ^4.1.1. Please upgrade yarn, or remove this plugin with "yarn plugin remove @yarnpkg/plugin-backstage".`,
+  );
+  console.error();
+}
 
 /**
  * @public

--- a/yarn.lock
+++ b/yarn.lock
@@ -44721,6 +44721,7 @@ __metadata:
     "@yarnpkg/builder": ^4.0.0
     "@yarnpkg/core": ^4.0.3
     "@yarnpkg/fslib": ^3.0.2
+    chalk: ^4.0.0
     nodemon: ^3.0.1
     semver: ^7.6.0
   languageName: unknown


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The plugin API changed significantly from yarn 3 to 4. Since the plugin only supports yarn 4, this change adds a check and logs a warning if the version detected is unsupported.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
