### PR TITLE
add property ownerPickerMode to TechDocsIndexPage and DefaultApiExplorerPage

### DIFF
--- a/.changeset/gentle-baboons-peel.md
+++ b/.changeset/gentle-baboons-peel.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-techdocs': minor
+'@backstage/plugin-techdocs': patch
 ---
 
-Added property ownerPickerMode to TechDocsIndexPage
+`TechDocsIndexPage` now accepts an optional `ownerPickerMode` for toggling the behavior of the `EntityOwnerPicker`, exposing a new mode `<TechDocsIndexPage ownerPickerMode="all" />` particularly suitable for larger catalogs. In this new mode, `EntityOwnerPicker` will display all the users and groups present in the catalog.

--- a/.changeset/gentle-baboons-peel.md
+++ b/.changeset/gentle-baboons-peel.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': minor
+---
+
+Added property ownerPickerMode to TechDocsIndexPage

--- a/.changeset/tiny-pandas-return.md
+++ b/.changeset/tiny-pandas-return.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-api-docs': patch
 ---
 
-Added property ownerPickerMode to DefaultApiExplorerPage
+`DefaultApiExplorerPage` now accepts an optional `ownerPickerMode` for toggling the behavior of the `EntityOwnerPicker`, exposing a new mode `<DefaultApiExplorerPage ownerPickerMode="all" />` particularly suitable for larger catalogs. In this new mode, `EntityOwnerPicker` will display all the users and groups present in the catalog.

--- a/.changeset/tiny-pandas-return.md
+++ b/.changeset/tiny-pandas-return.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-api-docs': patch
+---
+
+Added property ownerPickerMode to DefaultApiExplorerPage

--- a/plugins/api-docs/api-report.md
+++ b/plugins/api-docs/api-report.md
@@ -9,6 +9,7 @@ import { ApiEntity } from '@backstage/catalog-model';
 import { ApiRef } from '@backstage/core-plugin-api';
 import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { CatalogTableRow } from '@backstage/plugin-catalog';
+import { EntityOwnerPickerProps } from '@backstage/plugin-catalog-react';
 import { ExternalRouteRef } from '@backstage/core-plugin-api';
 import { InfoCardVariants } from '@backstage/core-components';
 import { JSX as JSX_2 } from 'react';
@@ -105,6 +106,7 @@ export type DefaultApiExplorerPageProps = {
   initiallySelectedFilter?: UserListFilterKind;
   columns?: TableColumn<CatalogTableRow>[];
   actions?: TableProps<CatalogTableRow>['actions'];
+  ownerPickerMode?: EntityOwnerPickerProps['mode'];
 };
 
 // @public (undocumented)

--- a/plugins/api-docs/src/components/ApiExplorerPage/DefaultApiExplorerPage.tsx
+++ b/plugins/api-docs/src/components/ApiExplorerPage/DefaultApiExplorerPage.tsx
@@ -35,6 +35,7 @@ import {
   UserListFilterKind,
   UserListPicker,
   CatalogFilterLayout,
+  EntityOwnerPickerProps,
 } from '@backstage/plugin-catalog-react';
 import React from 'react';
 import { registerComponentRouteRef } from '../../routes';
@@ -60,6 +61,7 @@ export type DefaultApiExplorerPageProps = {
   initiallySelectedFilter?: UserListFilterKind;
   columns?: TableColumn<CatalogTableRow>[];
   actions?: TableProps<CatalogTableRow>['actions'];
+  ownerPickerMode?: EntityOwnerPickerProps['mode'];
 };
 
 /**
@@ -67,7 +69,12 @@ export type DefaultApiExplorerPageProps = {
  * @public
  */
 export const DefaultApiExplorerPage = (props: DefaultApiExplorerPageProps) => {
-  const { initiallySelectedFilter = 'all', columns, actions } = props;
+  const {
+    initiallySelectedFilter = 'all',
+    columns,
+    actions,
+    ownerPickerMode,
+  } = props;
 
   const configApi = useApi(configApiRef);
   const generatedSubtitle = `${
@@ -101,7 +108,7 @@ export const DefaultApiExplorerPage = (props: DefaultApiExplorerPageProps) => {
               <EntityKindPicker initialFilter="api" hidden />
               <EntityTypePicker />
               <UserListPicker initialFilter={initiallySelectedFilter} />
-              <EntityOwnerPicker />
+              <EntityOwnerPicker mode={ownerPickerMode} />
               <EntityLifecyclePicker />
               <EntityTagPicker />
             </CatalogFilterLayout.Filters>

--- a/plugins/techdocs/api-report.md
+++ b/plugins/techdocs/api-report.md
@@ -12,6 +12,7 @@ import { Config } from '@backstage/config';
 import { CSSProperties } from '@material-ui/styles/withStyles';
 import { DiscoveryApi } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
+import { EntityOwnerPickerProps } from '@backstage/plugin-catalog-react';
 import { FetchApi } from '@backstage/core-plugin-api';
 import { IdentityApi } from '@backstage/core-plugin-api';
 import { JSX as JSX_2 } from 'react';
@@ -292,6 +293,7 @@ export type TechDocsIndexPageProps = {
   initialFilter?: UserListFilterKind;
   columns?: TableColumn<DocsTableRow>[];
   actions?: TableProps<DocsTableRow>['actions'];
+  ownerPickerMode?: EntityOwnerPickerProps['mode'];
 };
 
 // @public @deprecated (undocumented)

--- a/plugins/techdocs/src/home/components/DefaultTechDocsHome.tsx
+++ b/plugins/techdocs/src/home/components/DefaultTechDocsHome.tsx
@@ -46,7 +46,7 @@ export type DefaultTechDocsHomeProps = TechDocsIndexPageProps;
  * @public
  */
 export const DefaultTechDocsHome = (props: TechDocsIndexPageProps) => {
-  const { initialFilter = 'owned', columns, actions } = props;
+  const { initialFilter = 'owned', columns, actions, ownerPickerMode } = props;
   return (
     <TechDocsPageWrapper>
       <Content>
@@ -60,7 +60,7 @@ export const DefaultTechDocsHome = (props: TechDocsIndexPageProps) => {
             <CatalogFilterLayout.Filters>
               <TechDocsPicker />
               <UserListPicker initialFilter={initialFilter} />
-              <EntityOwnerPicker />
+              <EntityOwnerPicker mode={ownerPickerMode} />
               <EntityTagPicker />
             </CatalogFilterLayout.Filters>
             <CatalogFilterLayout.Content>

--- a/plugins/techdocs/src/home/components/TechDocsIndexPage.tsx
+++ b/plugins/techdocs/src/home/components/TechDocsIndexPage.tsx
@@ -17,7 +17,10 @@
 import React from 'react';
 import { useOutlet } from 'react-router-dom';
 import { TableColumn, TableProps } from '@backstage/core-components';
-import { UserListFilterKind } from '@backstage/plugin-catalog-react';
+import {
+  EntityOwnerPickerProps,
+  UserListFilterKind,
+} from '@backstage/plugin-catalog-react';
 import { DefaultTechDocsHome } from './DefaultTechDocsHome';
 import { DocsTableRow } from './Tables';
 
@@ -30,6 +33,7 @@ export type TechDocsIndexPageProps = {
   initialFilter?: UserListFilterKind;
   columns?: TableColumn<DocsTableRow>[];
   actions?: TableProps<DocsTableRow>['actions'];
+  ownerPickerMode?: EntityOwnerPickerProps['mode'];
 };
 
 export const TechDocsIndexPage = (props: TechDocsIndexPageProps) => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I noticed that `TechDocsIndexPage` and `DefaultApiExplorerPage` didn't contain the `ownerPickerMode` property like `CatalogIndexPage` does, so this PR adds this property to the other pages as well.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
