### PR TITLE
patch(notifications): skip rendering empty descriptions

### DIFF
--- a/.changeset/stupid-onions-know.md
+++ b/.changeset/stupid-onions-know.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications': patch
+---
+
+Empty descriptions are not rendered to improve the look&feel.

--- a/plugins/notifications/src/components/NotificationsTable/NotificationsTable.tsx
+++ b/plugins/notifications/src/components/NotificationsTable/NotificationsTable.tsx
@@ -181,9 +181,11 @@ export const NotificationsTable = ({
                       notification.payload.title
                     )}
                   </Typography>
-                  <Typography variant="body2" className={classes.description}>
-                    {notification.payload.description}
-                  </Typography>
+                  {notification.payload.description ? (
+                    <Typography variant="body2" className={classes.description}>
+                      {notification.payload.description}
+                    </Typography>
+                  ) : null}
                   <Typography variant="caption">
                     {notification.origin && (
                       <>{notification.origin}&nbsp;&bull;&nbsp;</>


### PR DESCRIPTION
Fix UX by skipping rendering of empty descriptions.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
