### PR TITLE
auth-react: handle missing cookie auth endpoint

### DIFF
--- a/.changeset/lovely-games-cry.md
+++ b/.changeset/lovely-games-cry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-react': patch
+---
+
+When using `CookieAuthRefreshProvider` or `useCookieAuthRefresh`, a 404 response from the cookie endpoint will now be treated as if cookie auth is disabled and is not needed.

--- a/plugins/auth-react/src/hooks/useCookieAuthRefresh/useCookieAuthRefresh.test.tsx
+++ b/plugins/auth-react/src/hooks/useCookieAuthRefresh/useCookieAuthRefresh.test.tsx
@@ -217,6 +217,39 @@ describe('useCookieAuthRefresh', () => {
     );
   });
 
+  it('should handle 404 as disabled cookie auth', async () => {
+    const { result } = renderHook(
+      () => useCookieAuthRefresh({ pluginId: 'techdocs' }),
+      {
+        wrapper: ({ children }) => (
+          <TestApiProvider
+            apis={[
+              [
+                fetchApiRef,
+                {
+                  fetch: jest.fn().mockResolvedValue({
+                    ok: false,
+                    status: 404,
+                  }),
+                },
+              ],
+              [discoveryApiRef, discoveryApiMock],
+            ]}
+          >
+            {children}
+          </TestApiProvider>
+        ),
+      },
+    );
+
+    await waitFor(() =>
+      expect(result.current).toEqual({
+        status: 'success',
+        data: { expiresAt: expect.any(Date) },
+      }),
+    );
+  });
+
   it('should call the api to get the cookie and use it', async () => {
     const { result } = renderHook(
       () => useCookieAuthRefresh({ pluginId: 'techdocs' }),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #24374. When deploying with the old backend system without any cookie auth endpoint you'd end up with a 404 error that broke TechDocs. This instead handles 404 as the lack of cookie auth and assumes that it is safe to continue without it.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
