### PR TITLE
fix(devApp): allow sign page to be optional

### DIFF
--- a/.changeset/many-dancers-flash.md
+++ b/.changeset/many-dancers-flash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/dev-utils': minor
+---
+
+Do not add a sign in page to dev app unless a sign in provider is explicitly added

--- a/packages/dev-utils/api-report.md
+++ b/packages/dev-utils/api-report.md
@@ -12,10 +12,10 @@ import { ComponentType } from 'react';
 import { Entity } from '@backstage/catalog-model';
 import { GridProps } from '@material-ui/core/Grid';
 import { IconComponent } from '@backstage/core-plugin-api';
+import { IdentityProviders } from '@backstage/core-components';
 import { PropsWithChildren } from 'react';
 import { default as React_2 } from 'react';
 import { ReactNode } from 'react';
-import { SignInProviderConfig } from '@backstage/core-components';
 
 // @public
 export function createDevApp(): DevAppBuilder;
@@ -25,7 +25,7 @@ export class DevAppBuilder {
   addPage(opts: DevAppPageOptions): DevAppBuilder;
   addRootChild(node: ReactNode): DevAppBuilder;
   addSidebarItem(sidebarItem: JSX.Element): DevAppBuilder;
-  addSignInProvider(provider: SignInProviderConfig): this;
+  addSignInProvider(provider: IdentityProviders[number]): this;
   addThemes(themes: AppTheme[]): this;
   build(): ComponentType<PropsWithChildren<{}>>;
   registerApi<

--- a/packages/dev-utils/src/devApp/render.test.tsx
+++ b/packages/dev-utils/src/devApp/render.test.tsx
@@ -39,6 +39,7 @@ describe('DevAppBuilder', () => {
     };
 
     const DevApp = createDevApp()
+      .addSignInProvider('guest')
       .addRootChild(<MyComponent key="test-key" />)
       .build();
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

https://github.com/backstage/backstage/pull/23346 broke our frontend only dev apps where we didn't have a running backend causing the default hooked up guest sign in provider to fail and prevent signing into the dev app. This allows the sign in functionality to be optional and not hooked up by default unless a sign in provider is explicitly added.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
