### PR TITLE
remove unnecessary alpha file markers

### DIFF
--- a/packages/backend-app-api/package.json
+++ b/packages/backend-app-api/package.json
@@ -38,7 +38,6 @@
   "files": [
     "dist",
     "config.d.ts",
-    "alpha",
     "migrations/**/*.{js,d.ts}"
   ],
   "scripts": {

--- a/packages/backend-app-api/package.json
+++ b/packages/backend-app-api/package.json
@@ -1,20 +1,30 @@
 {
   "name": "@backstage/backend-app-api",
-  "description": "Core API used by Backstage backend apps",
   "version": "0.7.1-next.0",
-  "main": "src/index.ts",
-  "types": "src/index.ts",
-  "publishConfig": {
-    "access": "public"
-  },
+  "description": "Core API used by Backstage backend apps",
   "backstage": {
     "role": "node-library"
   },
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "backstage"
+  ],
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "packages/backend-app-api"
+  },
+  "license": "Apache-2.0",
   "exports": {
     ".": "./src/index.ts",
     "./alpha": "./src/alpha.ts",
     "./package.json": "./package.json"
   },
+  "main": "src/index.ts",
+  "types": "src/index.ts",
   "typesVersions": {
     "*": {
       "alpha": [
@@ -25,16 +35,12 @@
       ]
     }
   },
-  "homepage": "https://backstage.io",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/backstage/backstage",
-    "directory": "packages/backend-app-api"
-  },
-  "keywords": [
-    "backstage"
+  "files": [
+    "dist",
+    "config.d.ts",
+    "alpha",
+    "migrations/**/*.{js,d.ts}"
   ],
-  "license": "Apache-2.0",
   "scripts": {
     "build": "backstage-cli package build",
     "clean": "backstage-cli package clean",
@@ -96,11 +102,5 @@
     "msw": "^1.0.0",
     "supertest": "^6.1.3"
   },
-  "configSchema": "config.d.ts",
-  "files": [
-    "dist",
-    "config.d.ts",
-    "alpha",
-    "migrations/**/*.{js,d.ts}"
-  ]
+  "configSchema": "config.d.ts"
 }

--- a/packages/backend-common/package.json
+++ b/packages/backend-common/package.json
@@ -41,8 +41,7 @@
   },
   "files": [
     "dist",
-    "config.d.ts",
-    "alpha"
+    "config.d.ts"
   ],
   "scripts": {
     "build": "backstage-cli package build",

--- a/packages/backend-common/package.json
+++ b/packages/backend-common/package.json
@@ -1,18 +1,31 @@
 {
   "name": "@backstage/backend-common",
-  "description": "Common functionality library for Backstage backends",
   "version": "0.21.8-next.0",
-  "main": "src/index.ts",
-  "types": "src/index.ts",
+  "description": "Common functionality library for Backstage backends",
+  "backstage": {
+    "role": "node-library"
+  },
   "publishConfig": {
     "access": "public"
   },
+  "keywords": [
+    "backstage"
+  ],
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "packages/backend-common"
+  },
+  "license": "Apache-2.0",
   "exports": {
     ".": "./src/index.ts",
     "./alpha": "./src/alpha.ts",
     "./testUtils": "./src/testUtils.ts",
     "./package.json": "./package.json"
   },
+  "main": "src/index.ts",
+  "types": "src/index.ts",
   "typesVersions": {
     "*": {
       "alpha": [
@@ -26,27 +39,19 @@
       ]
     }
   },
-  "backstage": {
-    "role": "node-library"
-  },
-  "homepage": "https://backstage.io",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/backstage/backstage",
-    "directory": "packages/backend-common"
-  },
-  "keywords": [
-    "backstage"
+  "files": [
+    "dist",
+    "config.d.ts",
+    "alpha"
   ],
-  "license": "Apache-2.0",
   "scripts": {
     "build": "backstage-cli package build",
+    "clean": "backstage-cli package clean",
     "lint": "backstage-cli package lint",
-    "test": "backstage-cli package test",
     "prepack": "backstage-cli package prepack",
     "postpack": "backstage-cli package postpack",
-    "clean": "backstage-cli package clean",
     "start": "backstage-cli package start",
+    "test": "backstage-cli package test",
     "test:kubernetes": "backstage-cli package test -t KubernetesContainerRunner --no-watch"
   },
   "dependencies": {
@@ -108,14 +113,6 @@
     "yauzl": "^3.0.0",
     "yn": "^4.0.0"
   },
-  "peerDependencies": {
-    "pg-connection-string": "^2.3.0"
-  },
-  "peerDependenciesMeta": {
-    "pg-connection-string": {
-      "optional": true
-    }
-  },
   "devDependencies": {
     "@aws-sdk/util-stream-node": "^3.350.0",
     "@backstage/backend-test-utils": "workspace:^",
@@ -138,10 +135,13 @@
     "mysql2": "^3.0.0",
     "supertest": "^6.1.3"
   },
-  "files": [
-    "dist",
-    "config.d.ts",
-    "alpha"
-  ],
+  "peerDependencies": {
+    "pg-connection-string": "^2.3.0"
+  },
+  "peerDependenciesMeta": {
+    "pg-connection-string": {
+      "optional": true
+    }
+  },
   "configSchema": "config.d.ts"
 }

--- a/packages/backend-plugin-api/package.json
+++ b/packages/backend-plugin-api/package.json
@@ -1,20 +1,30 @@
 {
   "name": "@backstage/backend-plugin-api",
-  "description": "Core API used by Backstage backend plugins",
   "version": "0.6.18-next.0",
-  "main": "src/index.ts",
-  "types": "src/index.ts",
-  "publishConfig": {
-    "access": "public"
-  },
+  "description": "Core API used by Backstage backend plugins",
   "backstage": {
     "role": "node-library"
   },
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "backstage"
+  ],
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "packages/backend-plugin-api"
+  },
+  "license": "Apache-2.0",
   "exports": {
     ".": "./src/index.ts",
     "./alpha": "./src/alpha.ts",
     "./package.json": "./package.json"
   },
+  "main": "src/index.ts",
+  "types": "src/index.ts",
   "typesVersions": {
     "*": {
       "alpha": [
@@ -25,24 +35,18 @@
       ]
     }
   },
-  "homepage": "https://backstage.io",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/backstage/backstage",
-    "directory": "packages/backend-plugin-api"
-  },
-  "keywords": [
-    "backstage"
+  "files": [
+    "dist",
+    "alpha"
   ],
-  "license": "Apache-2.0",
   "scripts": {
     "build": "backstage-cli package build",
+    "clean": "backstage-cli package clean",
     "lint": "backstage-cli package lint",
-    "test": "backstage-cli package test",
     "prepack": "backstage-cli package prepack",
     "postpack": "backstage-cli package postpack",
-    "clean": "backstage-cli package clean",
-    "start": "backstage-cli package start"
+    "start": "backstage-cli package start",
+    "test": "backstage-cli package test"
   },
   "dependencies": {
     "@backstage/backend-tasks": "workspace:^",
@@ -56,9 +60,5 @@
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^"
-  },
-  "files": [
-    "dist",
-    "alpha"
-  ]
+  }
 }

--- a/packages/backend-plugin-api/package.json
+++ b/packages/backend-plugin-api/package.json
@@ -36,8 +36,7 @@
     }
   },
   "files": [
-    "dist",
-    "alpha"
+    "dist"
   ],
   "scripts": {
     "build": "backstage-cli package build",

--- a/plugins/example-todo-list-backend/package.json
+++ b/plugins/example-todo-list-backend/package.json
@@ -20,8 +20,7 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "files": [
-    "dist",
-    "alpha"
+    "dist"
   ],
   "scripts": {
     "build": "backstage-cli package build",

--- a/plugins/proxy-backend/package.json
+++ b/plugins/proxy-backend/package.json
@@ -37,8 +37,7 @@
   },
   "files": [
     "dist",
-    "config.d.ts",
-    "alpha"
+    "config.d.ts"
   ],
   "scripts": {
     "build": "backstage-cli package build",

--- a/plugins/scaffolder-node/package.json
+++ b/plugins/scaffolder-node/package.json
@@ -33,7 +33,6 @@
     }
   },
   "files": [
-    "alpha",
     "dist"
   ],
   "scripts": {

--- a/plugins/techdocs-react/package.json
+++ b/plugins/techdocs-react/package.json
@@ -25,7 +25,6 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "files": [
-    "alpha",
     "dist"
   ],
   "scripts": {

--- a/plugins/user-settings-backend/package.json
+++ b/plugins/user-settings-backend/package.json
@@ -34,8 +34,7 @@
   },
   "files": [
     "dist",
-    "migrations",
-    "alpha"
+    "migrations"
   ],
   "scripts": {
     "build": "backstage-cli package build",


### PR DESCRIPTION
These are some form of remnant of the past.

Split into two commits where the first one ONLY re-sorts the files and then the second one removes entries. It's kinda hard to see otherwise :)

Skipping changesets since these do not affect the published packages in practice