### PR TITLE
Remove explicit alg check for user tokens in verifyToken

### DIFF
--- a/.changeset/loud-timers-flow.md
+++ b/.changeset/loud-timers-flow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+Remove explicit `alg` check for user tokens in `verifyToken`

--- a/packages/backend-app-api/src/services/implementations/auth/user/UserTokenHandler.test.ts
+++ b/packages/backend-app-api/src/services/implementations/auth/user/UserTokenHandler.test.ts
@@ -133,6 +133,34 @@ describe('UserTokenHandler', () => {
       ).rejects.toThrow('signature verification failed');
     });
 
+    it('should fail to verify tokens that have a bad alg', async () => {
+      const expectedIssuedAt = 1712071714;
+      const expectedExpiresAt = 1712075314;
+
+      jest.useFakeTimers({
+        now: expectedIssuedAt * 1000 + 600_000,
+      });
+
+      const header = encodeData({
+        typ: 'vnd.backstage.user',
+        alg: 'none',
+      });
+      const payload = encodeData({
+        iss: 'http://localhost:7007/api/auth',
+        sub: 'user:development/guest',
+        ent: ['user:development/guest', 'group:default/team-a'],
+        aud: 'backstage',
+        iat: expectedIssuedAt,
+        exp: expectedExpiresAt,
+        uip: 'proof',
+      });
+      const token = `${header}.${payload}.`;
+
+      await expect(userTokenHandler.verifyToken(token)).rejects.toThrow(
+        /Unsupported "alg" value/,
+      );
+    });
+
     it('should verify a valid legacy backstage token', async () => {
       const expectedIssuedAt = 1712071714;
       const expectedExpiresAt = 1712075314;
@@ -151,7 +179,7 @@ describe('UserTokenHandler', () => {
           sub: 'user:development/guest',
           ent: ['user:development/guest', 'group:default/team-a'],
           aud: 'backstage',
-          iat: 1712071714,
+          iat: expectedIssuedAt,
           exp: expectedExpiresAt,
         },
       };
@@ -179,7 +207,7 @@ describe('UserTokenHandler', () => {
           iss: 'http://localhost:7007/api/auth',
           ent: ['user:development/guest', 'group:default/team-a'],
           aud: 'backstage',
-          iat: 1712071714,
+          iat: expectedIssuedAt,
           exp: expectedExpiresAt,
         },
       };
@@ -209,7 +237,7 @@ describe('UserTokenHandler', () => {
           sub: 'user:development/guest',
           ent: ['user:development/guest', 'group:default/team-a'],
           aud: 'backstage',
-          iat: 1712071714,
+          iat: expectedIssuedAt,
           exp: expectedExpiresAt,
           uip: 'proof',
         },
@@ -239,7 +267,7 @@ describe('UserTokenHandler', () => {
         payload: {
           sub: 'user:development/guest',
           ent: ['user:development/guest', 'group:default/team-a'],
-          iat: 1712071714,
+          iat: expectedIssuedAt,
           exp: expectedExpiresAt,
         },
       };

--- a/packages/backend-app-api/src/services/implementations/auth/user/UserTokenHandler.ts
+++ b/packages/backend-app-api/src/services/implementations/auth/user/UserTokenHandler.ts
@@ -34,18 +34,14 @@ import { JwksClient } from '../JwksClient';
  */
 export class UserTokenHandler {
   static create(options: { discovery: DiscoveryService }): UserTokenHandler {
-    const algorithms = ['ES256']; // TODO: configurable?
     const jwksClient = new JwksClient(async () => {
       const url = await options.discovery.getBaseUrl('auth');
       return new URL(`${url}/.well-known/jwks.json`);
     });
-    return new UserTokenHandler(algorithms, jwksClient);
+    return new UserTokenHandler(jwksClient);
   }
 
-  constructor(
-    private readonly algorithms: string[],
-    private readonly jwksClient: JwksClient,
-  ) {}
+  constructor(private readonly jwksClient: JwksClient) {}
 
   async verifyToken(token: string) {
     const verifyOpts = this.#getTokenVerificationOptions(token);
@@ -79,7 +75,6 @@ export class UserTokenHandler {
 
       if (typ === tokenTypes.user.typParam) {
         return {
-          algorithms: this.algorithms,
           requiredClaims: ['iat', 'exp', 'sub'],
           typ: tokenTypes.user.typParam,
         };
@@ -87,7 +82,6 @@ export class UserTokenHandler {
 
       if (typ === tokenTypes.limitedUser.typParam) {
         return {
-          algorithms: this.algorithms,
           requiredClaims: ['iat', 'exp', 'sub'],
           typ: tokenTypes.limitedUser.typParam,
         };
@@ -96,7 +90,6 @@ export class UserTokenHandler {
       const { aud } = decodeJwt(token);
       if (aud === tokenTypes.user.audClaim) {
         return {
-          algorithms: this.algorithms,
           audience: tokenTypes.user.audClaim,
         };
       }


### PR DESCRIPTION
Background: https://discord.com/channels/687207715902193673/687235481154617364/1232688816737878067

As long as the auth backend has provably issued the token according to the JWKS, there's no reason for there to be any hard coded `alg` claim checks in the receiving end. That just adds friction when evolving the set of possible algorithms in the future.