### PR TITLE
feat: allow setting notification as read automatically when opening link

### DIFF
--- a/.changeset/young-guests-reflect.md
+++ b/.changeset/young-guests-reflect.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications': patch
+---
+
+Add option to set the notification as read automatically when the notification link is opened

--- a/plugins/notifications/api-report.md
+++ b/plugins/notifications/api-report.md
@@ -80,6 +80,7 @@ export const NotificationsPage: (
 
 // @public (undocumented)
 export type NotificationsPageProps = {
+  markAsReadOnLinkOpen?: boolean;
   title?: string;
   themeId?: string;
   subtitle?: string;
@@ -110,6 +111,7 @@ export const NotificationsSidebarItem: (props?: {
 
 // @public (undocumented)
 export const NotificationsTable: ({
+  markAsReadOnLinkOpen,
   isLoading,
   notifications,
   isUnread,
@@ -127,6 +129,7 @@ export type NotificationsTableProps = Pick<
   TableProps,
   'onPageChange' | 'onRowsPerPageChange' | 'page' | 'totalCount'
 > & {
+  markAsReadOnLinkOpen?: boolean;
   isLoading?: boolean;
   isUnread: boolean;
   notifications?: Notification_2[];

--- a/plugins/notifications/src/components/NotificationsPage/NotificationsPage.tsx
+++ b/plugins/notifications/src/components/NotificationsPage/NotificationsPage.tsx
@@ -43,6 +43,8 @@ const ThrottleDelayMs = 2000;
 
 /** @public */
 export type NotificationsPageProps = {
+  /** Mark notification as read when opening the link it contains, defaults to false */
+  markAsReadOnLinkOpen?: boolean;
   title?: string;
   themeId?: string;
   subtitle?: string;
@@ -59,6 +61,7 @@ export const NotificationsPage = (props?: NotificationsPageProps) => {
     tooltip,
     type,
     typeLink,
+    markAsReadOnLinkOpen,
   } = props ?? {};
 
   const [refresh, setRefresh] = React.useState(false);
@@ -171,6 +174,7 @@ export const NotificationsPage = (props?: NotificationsPageProps) => {
               <NotificationsTable
                 isLoading={loading}
                 isUnread={isUnread}
+                markAsReadOnLinkOpen={markAsReadOnLinkOpen}
                 notifications={notifications}
                 onUpdate={onUpdate}
                 setContainsText={setContainsText}

--- a/plugins/notifications/src/components/NotificationsTable/NotificationsTable.tsx
+++ b/plugins/notifications/src/components/NotificationsTable/NotificationsTable.tsx
@@ -28,8 +28,8 @@ import { alertApiRef, useApi } from '@backstage/core-plugin-api';
 import {
   Link,
   Table,
-  TableProps,
   TableColumn,
+  TableProps,
 } from '@backstage/core-components';
 
 import { notificationsApiRef } from '../../api';
@@ -55,6 +55,7 @@ export type NotificationsTableProps = Pick<
   TableProps,
   'onPageChange' | 'onRowsPerPageChange' | 'page' | 'totalCount'
 > & {
+  markAsReadOnLinkOpen?: boolean;
   isLoading?: boolean;
   isUnread: boolean;
   notifications?: Notification[];
@@ -65,6 +66,7 @@ export type NotificationsTableProps = Pick<
 
 /** @public */
 export const NotificationsTable = ({
+  markAsReadOnLinkOpen,
   isLoading,
   notifications = [],
   isUnread,
@@ -213,7 +215,14 @@ export const NotificationsTable = ({
                 <Box>
                   <Typography variant="subtitle2">
                     {notification.payload.link ? (
-                      <Link to={notification.payload.link}>
+                      <Link
+                        to={notification.payload.link}
+                        onClick={() => {
+                          if (markAsReadOnLinkOpen && !notification.read) {
+                            onSwitchReadStatus([notification.id], true);
+                          }
+                        }}
+                      >
                         {notification.payload.title}
                       </Link>
                     ) : (
@@ -267,6 +276,7 @@ export const NotificationsTable = ({
       },
     ],
     [
+      markAsReadOnLinkOpen,
       selectedNotifications,
       notifications,
       isUnread,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This allows to mark the notification as read when opening the (optional) link in the notification payload. By default this is false and the notification will remain `unread` until the user marks it as `read` manually. Just another customization option to make the notifications work best for different users.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
