### PR TITLE
fix: stitching queue count to not include entities from the future

### DIFF
--- a/.changeset/sweet-zoos-clap.md
+++ b/.changeset/sweet-zoos-clap.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Fixed bug in stitching queue gauge that included entities that are scheduled in the future.

--- a/plugins/catalog-backend/src/stitching/progressTracker.ts
+++ b/plugins/catalog-backend/src/stitching/progressTracker.ts
@@ -54,7 +54,8 @@ export function progressTracker(knex: Knex, logger: LoggerService) {
   stitchingQueueCount.addCallback(async result => {
     const total = await knex<DbRefreshStateRow>('refresh_state')
       .count({ count: '*' })
-      .whereNotNull('next_stitch_at');
+      .whereNotNull('next_stitch_at')
+      .where('next_stitch_at', '<=', knex.fn.now());
     result.observe(Number(total[0].count));
   });
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The idea behind the PR is that the current implementation of `catalog.stitching.queue.length` is somewhat misleading. I would assume, while it's named as queue, it should be somewhat close to zero once all entities have been processed and stitched together. 

However, it's not the case because the default stitcher schedules entities to be stitched in the future, so those entities are counted as well.

This becomes a problem once you look at the default stitcher when it fetches stitchable entities via query:

```sql
select "entity_ref", "next_stitch_at", "next_stitch_ticket" from "refresh_state"
	where "next_stitch_at" is not null and
	      "next_stitch_ticket" is not null and
	      "next_stitch_at" <= CURRENT_TIMESTAMP
	order by "next_stitch_at" asc, "next_stitch_at" asc
	limit 5
	for update skip locked
```

while queue counter uses the following query (roughly):

````sql
select count(*) where "next_stitch_at" is not null;
````

In the end, the gauge does not really tell, if the stitcher should be doing something or if it's just waiting time to pass until it has some more work to do. That leads us (I guess) to the reason why our graphs seems to be stuck at certain levels for long periods of time.

Without this fix, I'm not sure how to read, or how useful the gauge is..

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
