### PR TITLE
fix: fix issues with unprocessed entities backend not returning pending/failed entities.

### DIFF
--- a/plugins/catalog-backend-module-unprocessed/src/UnprocessedEntitiesModule.ts
+++ b/plugins/catalog-backend-module-unprocessed/src/UnprocessedEntitiesModule.ts
@@ -162,7 +162,7 @@ export class UnprocessedEntitiesModule {
         return res.json(
           await this.unprocessed({
             reason: 'failed',
-            owner: String(req.query.owner),
+            owner: String(req.query.owner ?? ''),
           }),
         );
       })
@@ -170,7 +170,7 @@ export class UnprocessedEntitiesModule {
         return res.json(
           await this.unprocessed({
             reason: 'pending',
-            owner: String(req.query.owner),
+            owner: String(req.query.owner ?? ''),
           }),
         );
       })


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixed the issue with catalog unprocessed module backend. Reset owner query parameter to be empty if not passed. As of now, the catalog unprocessed component returns empty pending and failed entities as it always assumes owner as not undefined but "undefined" and therefore did not find any entities.
 
closes https://github.com/backstage/backstage/issues/24516

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
