### PR TITLE
Updated docs of api deprecations

### DIFF
--- a/docs/api/deprecations.md
+++ b/docs/api/deprecations.md
@@ -55,12 +55,16 @@ const darkTheme = {
 };
 ```
 
-Note that the existing `AppTheme` type still requires the `theme` property to be
+:::note Note
+
+The existing `AppTheme` type still requires the `theme` property to be
 set since it's the type that's consumed in the `AppThemeApi`, and it would be a
 breaking change to make `theme` optional. This means that if you currently
 construct the themes that you pass on to `createApp` using `AppTheme` as an
 intermediate type, you will need to work around this in some way, for example by
 passing the themes to `createApp` more directly.
+
+:::
 
 ### Generic Auth API Refs
 


### PR DESCRIPTION
Current :

![image](https://github.com/backstage/backstage/assets/133481507/0ac02864-1de8-486d-9449-88f049d23709)



Updated :

![image](https://github.com/backstage/backstage/assets/133481507/f66a84d5-4cab-4975-af5c-9cb41cd2bd55)


