### PR TITLE
Azure AD disabling user photos (fix) and handle huge organizations

### DIFF
--- a/.changeset/chilly-shoes-doubt.md
+++ b/.changeset/chilly-shoes-doubt.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-msgraph': patch
+---
+
+Fixed disabling of user photo fetching. Previously, the config value wasn't propagated properly, so user photos was still being fetched despite disabled by config.

--- a/.changeset/silent-wombats-hang.md
+++ b/.changeset/silent-wombats-hang.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-msgraph': patch
+---
+
+Handle fetching huge amounts of users from Azure without crashing

--- a/docs/integrations/azure/org.md
+++ b/docs/integrations/azure/org.md
@@ -146,6 +146,18 @@ microsoftGraphOrg:
       search: '"description:One" AND ("displayName:Video" OR "displayName:Drive")'
 ```
 
+### User photos
+
+By default, the photos of users will be fetched and added to each user entity. For huge organizations this may be unfeasible, as it will take a _very_ long time, and can be disabled by setting `loadPhotos` to `false`:
+
+```yaml
+microsoftGraphOrg:
+  providerId:
+    user:
+      filter: ...
+      loadPhotos: false
+```
+
 ## Customizing Transformation
 
 Ingested entities can be customized by providing custom transformers.

--- a/plugins/catalog-backend-module-msgraph/README.md
+++ b/plugins/catalog-backend-module-msgraph/README.md
@@ -54,6 +54,8 @@ catalog:
           # and for the syntax https://docs.microsoft.com/en-us/graph/query-parameters#filter-parameter
           # This and userGroupMemberFilter are mutually exclusive, only one can be specified
           filter: accountEnabled eq true and userType eq 'member'
+          # Set to false to not load user photos.
+          loadPhotos: true
           # See  https://docs.microsoft.com/en-us/graph/api/resources/schemaextension?view=graph-rest-1.0
           select: ['id', 'displayName', 'description']
         # Optional configuration block

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/read.test.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/read.test.ts
@@ -955,6 +955,43 @@ describe('read microsoft graph', () => {
       );
     });
 
+    it('should ignore loading photos if loadPhotos is false', async () => {
+      client.getOrganization.mockResolvedValue(getExampleOrg());
+
+      client.getUsers.mockImplementation(getExampleUsers);
+      client.getUserPhotoWithSizeLimit.mockResolvedValue(
+        'data:image/jpeg;base64,...',
+      );
+
+      client.getGroups.mockImplementation(getExampleGroups);
+      client.getGroupMembers.mockImplementation(getExampleGroupMembers);
+      client.getGroupPhotoWithSizeLimit.mockResolvedValue(
+        'data:image/jpeg;base64,...',
+      );
+
+      await readMicrosoftGraphOrg(client, 'tenantid', {
+        logger: getVoidLogger(),
+        loadUserPhotos: false,
+      });
+
+      expect(client.getUserPhotoWithSizeLimit).toHaveBeenCalledTimes(0);
+
+      expect(client.getUsers).toHaveBeenCalledTimes(1);
+      expect(client.getUsers).toHaveBeenCalledWith(
+        {
+          top: 999,
+        },
+        undefined,
+      );
+      expect(client.getGroups).toHaveBeenCalledTimes(1);
+      expect(client.getGroups).toHaveBeenCalledWith(
+        {
+          top: 999,
+        },
+        undefined,
+      );
+    });
+
     it('should read users with userSelect', async () => {
       client.getOrganization.mockResolvedValue({
         id: 'tenantid',

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/read.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/read.ts
@@ -384,7 +384,7 @@ export async function readMicrosoftGraphOrg(
     logger: LoggerService;
   },
 ): Promise<{ users: UserEntity[]; groups: GroupEntity[] }> {
-  const users: UserEntity[] = [];
+  let users: UserEntity[] = [];
 
   if (options.userGroupMemberFilter || options.userGroupMemberSearch) {
     const { users: usersInGroups } = await readMicrosoftGraphUsersInGroups(
@@ -401,7 +401,7 @@ export async function readMicrosoftGraphOrg(
         logger: options.logger,
       },
     );
-    users.push(...usersInGroups);
+    users = usersInGroups;
   } else {
     const { users: usersWithFilter } = await readMicrosoftGraphUsers(client, {
       queryMode: options.queryMode,
@@ -412,7 +412,7 @@ export async function readMicrosoftGraphOrg(
       transformer: options.userTransformer,
       logger: options.logger,
     });
-    users.push(...usersWithFilter);
+    users = usersWithFilter;
   }
   const { groups, rootGroup, groupMember, groupMemberOf } =
     await readMicrosoftGraphGroups(client, tenantId, {

--- a/plugins/catalog-backend-module-msgraph/src/processors/MicrosoftGraphOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-msgraph/src/processors/MicrosoftGraphOrgEntityProvider.ts
@@ -310,6 +310,7 @@ export class MicrosoftGraphOrgEntityProvider implements EntityProvider {
         userExpand: provider.userExpand,
         userFilter: provider.userFilter,
         userSelect: provider.userSelect,
+        loadUserPhotos: provider.loadUserPhotos,
         userGroupMemberFilter: provider.userGroupMemberFilter,
         userGroupMemberSearch: provider.userGroupMemberSearch,
         groupExpand: provider.groupExpand,

--- a/plugins/catalog-backend-module-msgraph/src/processors/MicrosoftGraphOrgReaderProcessor.ts
+++ b/plugins/catalog-backend-module-msgraph/src/processors/MicrosoftGraphOrgReaderProcessor.ts
@@ -112,6 +112,7 @@ export class MicrosoftGraphOrgReaderProcessor implements CatalogProcessor {
       {
         userExpand: provider.userExpand,
         userFilter: provider.userFilter,
+        loadUserPhotos: provider.loadUserPhotos,
         userGroupMemberFilter: provider.userGroupMemberFilter,
         userGroupMemberSearch: provider.userGroupMemberSearch,
         groupExpand: provider.groupExpand,


### PR DESCRIPTION
## Azure AD user fetching fixes

### User photos

This PR fixes an issue with [the previous PR](https://github.com/backstage/backstage/pull/24003) with the same solution. Somehow in the PR creation process I missed including the code forwarding the config `loadPhotos` to the actual Entity Provider, so the logic was there, but not used 🤦

Included here is also a test case for disabling user photo loading, and documentation both in the README and in `/docs`, so people will know about the feature.

### Huge organizations

In huge organizations (hundreds of thousands of users), the code crashes with `RangeError: Maximum call stack size exceeded` when array expanding a too large array:

https://github.com/backstage/backstage/blob/e00bbc2d0dcf54aac087c264313a2b7c6762e7f0/plugins/catalog-backend-module-msgraph/src/microsoftGraph/read.ts#L415

This PR contains a fix for this, and a unit test to prevent regressions.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
