### PR TITLE
Fix catalog table when loading lots of entities

### DIFF
--- a/.changeset/brown-cycles-complain.md
+++ b/.changeset/brown-cycles-complain.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Include `requestedFilters` in `useEntityList()` to show while the catalog index is loading (instead of actual/previous filters)

--- a/.changeset/eleven-nails-grin.md
+++ b/.changeset/eleven-nails-grin.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Show requested filters instead of actual filters while the catalog index loads entities (prevents showing "All (undefined)")

--- a/plugins/catalog-react/api-report.md
+++ b/plugins/catalog-react/api-report.md
@@ -291,6 +291,7 @@ export const EntityListContext: React_2.Context<
 export type EntityListContextProps<
   EntityFilters extends DefaultEntityFilters = DefaultEntityFilters,
 > = {
+  requestedFilters: EntityFilters;
   filters: EntityFilters;
   entities: Entity[];
   backendEntities: Entity[];

--- a/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
@@ -71,6 +71,14 @@ export type EntityListContextProps<
   EntityFilters extends DefaultEntityFilters = DefaultEntityFilters,
 > = {
   /**
+   * The requested filters, adhering to the shape of DefaultEntityFilters or an extension
+   * of that default (to add custom filter types).
+   *
+   * These filters might not yet have been fulfilled, for that use `filters` instead.
+   */
+  requestedFilters: EntityFilters;
+
+  /**
    * The currently registered filters, adhering to the shape of DefaultEntityFilters or an extension
    * of that default (to add custom filter types).
    */
@@ -353,6 +361,7 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
 
   const value = useMemo(
     () => ({
+      requestedFilters,
       filters: outputState.appliedFilters,
       entities: outputState.entities,
       backendEntities: outputState.backendEntities,
@@ -363,7 +372,15 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
       pageInfo,
       totalItems: outputState.totalItems,
     }),
-    [outputState, updateFilters, queryParameters, loading, error, pageInfo],
+    [
+      requestedFilters,
+      outputState,
+      updateFilters,
+      queryParameters,
+      loading,
+      error,
+      pageInfo,
+    ],
   );
 
   return (

--- a/plugins/catalog-react/src/testUtils/providers.tsx
+++ b/plugins/catalog-react/src/testUtils/providers.tsx
@@ -67,6 +67,7 @@ export function MockEntityListContextProvider<
       entities: value?.entities ?? defaultValues.entities,
       backendEntities: value?.backendEntities ?? defaultValues.backendEntities,
       updateFilters: value?.updateFilters ?? updateFilters,
+      requestedFilters: filters,
       filters,
       loading: value?.loading ?? false,
       queryParameters: value?.queryParameters ?? defaultValues.queryParameters,

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -88,8 +88,15 @@ export const CatalogTable = (props: CatalogTableProps) => {
   } = props;
   const { isStarredEntity, toggleStarredEntity } = useStarredEntities();
   const entityListContext = useEntityList();
-  const { loading, error, entities, filters, pageInfo, totalItems } =
-    entityListContext;
+  const {
+    loading,
+    error,
+    entities,
+    requestedFilters,
+    filters,
+    pageInfo,
+    totalItems,
+  } = entityListContext;
   const enablePagination = !!pageInfo;
 
   const tableColumns = useMemo(
@@ -168,15 +175,16 @@ export const CatalogTable = (props: CatalogTableProps) => {
     },
   ];
 
-  const currentKind = filters.kind?.value || '';
-  const currentType = filters.type?.value || '';
+  const titleFilters = loading ? requestedFilters : filters;
+  const currentKind = titleFilters.kind?.value || '';
+  const currentType = titleFilters.type?.value || '';
   // TODO(timbonicus): remove the title from the CatalogTable once using EntitySearchBar
-  const titlePreamble = capitalize(filters.user?.value ?? 'all');
+  const titlePreamble = capitalize(titleFilters.user?.value ?? 'all');
   const titleDisplay = [titlePreamble, currentType, pluralize(currentKind)]
     .filter(s => s)
     .join(' ');
 
-  const title = `${titleDisplay} (${totalItems})`;
+  const title = loading ? titleDisplay : `${titleDisplay} (${totalItems})`;
   const actions = props.actions || defaultActions;
   const options = {
     actionsColumnIndex: -1,


### PR DESCRIPTION
## Improve the table header while loading entities

When loading an entity kind with a huge number of entities (components, users, ...), the loading may take many seconds. While this happens, the previous filter is shown, and the initial page load will show `(undefined)` as the count:

<img width="1163" alt="Skärmavbild 2024-04-26 kl  10 17 59" src="https://github.com/backstage/backstage/assets/5362579/a12af8f9-35b1-4b39-abb2-a42689aeded4">

This PR adds `requestedFilters` to the`useEntityList()` hook, and uses those filters when the page loads entities (otherwise shows the actual filters). It also won't show the ` (count)` suffix, since the count is unknown/undefined:

<img width="1018" alt="Skärmavbild 2024-04-26 kl  12 37 22" src="https://github.com/backstage/backstage/assets/5362579/b6cd374c-b420-45b9-b8f0-56ab9f3c4a89">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
