### PR TITLE
feat: allow setting notification read also from web notifications 

### DIFF
--- a/.changeset/ten-penguins-roll.md
+++ b/.changeset/ten-penguins-roll.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications': patch
+---
+
+Allow setting notification as read when opening snackbar or web notification link

--- a/.changeset/ten-penguins-roll.md
+++ b/.changeset/ten-penguins-roll.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-notifications': patch
+'@backstage/plugin-notifications': minor
 ---
 
-Allow setting notification as read when opening snackbar or web notification link
+By default, set notification as read when opening snackbar or web notification link

--- a/plugins/notifications/api-report.md
+++ b/plugins/notifications/api-report.md
@@ -103,6 +103,7 @@ export const NotificationsSidebarItem: (props?: {
   titleCounterEnabled?: boolean;
   snackbarEnabled?: boolean;
   snackbarAutoHideDuration?: number | null;
+  markAsReadOnLinkOpen?: boolean;
   className?: string;
   icon?: IconComponent;
   text?: string;
@@ -182,7 +183,10 @@ export function useTitleCounter(): {
 };
 
 // @public (undocumented)
-export function useWebNotifications(enabled: boolean): {
+export function useWebNotifications(
+  enabled: boolean,
+  markAsReadOnLinkOpen: boolean,
+): {
   sendWebNotification: (options: {
     id: string;
     title: string;

--- a/plugins/notifications/api-report.md
+++ b/plugins/notifications/api-report.md
@@ -177,23 +177,5 @@ export function useNotificationsApi<T>(
       value: T;
     };
 
-// @public (undocumented)
-export function useTitleCounter(): {
-  setNotificationCount: (newCount: number) => void;
-};
-
-// @public (undocumented)
-export function useWebNotifications(
-  enabled: boolean,
-  markAsReadOnLinkOpen: boolean,
-): {
-  sendWebNotification: (options: {
-    id: string;
-    title: string;
-    description: string;
-    link?: string;
-  }) => Notification | null;
-};
-
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/notifications/api-report.md
+++ b/plugins/notifications/api-report.md
@@ -103,7 +103,6 @@ export const NotificationsSidebarItem: (props?: {
   titleCounterEnabled?: boolean;
   snackbarEnabled?: boolean;
   snackbarAutoHideDuration?: number | null;
-  markAsReadOnLinkOpen?: boolean;
   className?: string;
   icon?: IconComponent;
   text?: string;

--- a/plugins/notifications/src/components/NotificationsSideBarItem/NotificationsSideBarItem.tsx
+++ b/plugins/notifications/src/components/NotificationsSideBarItem/NotificationsSideBarItem.tsx
@@ -84,7 +84,6 @@ export const NotificationsSidebarItem = (props?: {
   titleCounterEnabled?: boolean;
   snackbarEnabled?: boolean;
   snackbarAutoHideDuration?: number | null;
-  markAsReadOnLinkOpen?: boolean;
   className?: string;
   icon?: IconComponent;
   text?: string;
@@ -96,7 +95,6 @@ export const NotificationsSidebarItem = (props?: {
     titleCounterEnabled = true,
     snackbarEnabled = true,
     snackbarAutoHideDuration = 10000,
-    markAsReadOnLinkOpen = false,
     icon = NotificationsIcon,
     text = 'Notifications',
     ...restProps
@@ -105,7 +103,6 @@ export const NotificationsSidebarItem = (props?: {
     titleCounterEnabled: true,
     snackbarEnabled: true,
     snackbarAutoHideDuration: 10000,
-    markAsReadOnLinkOpen: false,
   };
 
   const { loading, error, value, retry } = useNotificationsApi(api =>
@@ -117,9 +114,8 @@ export const NotificationsSidebarItem = (props?: {
   const notificationsRoute = useRouteRef(rootRouteRef);
   // TODO: Do we want to add long polling in case signals are not available
   const { lastSignal } = useSignal<NotificationSignal>('notifications');
-  const { sendWebNotification } = useWebNotifications(
+  const { sendWebNotification, requestUserPermission } = useWebNotifications(
     webNotificationsEnabled,
-    markAsReadOnLinkOpen,
   );
   const [refresh, setRefresh] = React.useState(false);
   const { setNotificationCount } = useTitleCounter();
@@ -132,7 +128,7 @@ export const NotificationsSidebarItem = (props?: {
             component={Link}
             to={notification.payload.link ?? notificationsRoute()}
             onClick={() => {
-              if (markAsReadOnLinkOpen) {
+              if (notification.payload.link) {
                 notificationsApi
                   .updateNotifications({
                     ids: [notification.id],
@@ -175,7 +171,7 @@ export const NotificationsSidebarItem = (props?: {
 
       return { action };
     },
-    [notificationsRoute, markAsReadOnLinkOpen, notificationsApi, alertApi],
+    [notificationsRoute, notificationsApi, alertApi],
   );
 
   useEffect(() => {
@@ -278,6 +274,9 @@ export const NotificationsSidebarItem = (props?: {
       )}
       <SidebarItem
         to={notificationsRoute()}
+        onClick={() => {
+          requestUserPermission();
+        }}
         hasNotifications={!error && !!unreadCount}
         text={text}
         icon={icon}

--- a/plugins/notifications/src/hooks/useTitleCounter.ts
+++ b/plugins/notifications/src/hooks/useTitleCounter.ts
@@ -25,7 +25,7 @@ const throttledSetTitle = throttle((shownTitle: string) => {
   document.title = shownTitle;
 }, 100);
 
-/** @public */
+/** @internal */
 export function useTitleCounter() {
   const [title, setTitle] = useState(document.title);
   const [count, setCount] = useState(0);

--- a/plugins/notifications/src/hooks/useWebNotifications.ts
+++ b/plugins/notifications/src/hooks/useWebNotifications.ts
@@ -15,14 +15,19 @@
  */
 import { useCallback, useEffect, useState } from 'react';
 import { rootRouteRef } from '../routes';
-import { useRouteRef } from '@backstage/core-plugin-api';
+import { useApi, useRouteRef } from '@backstage/core-plugin-api';
 import { useNavigate } from 'react-router-dom';
+import { notificationsApiRef } from '../api';
 
 /** @public */
-export function useWebNotifications(enabled: boolean) {
+export function useWebNotifications(
+  enabled: boolean,
+  markAsReadOnLinkOpen: boolean,
+) {
   const [webNotificationPermission, setWebNotificationPermission] =
     useState('default');
   const notificationsRoute = useRouteRef(rootRouteRef);
+  const notificationsApi = useApi(notificationsApiRef);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -57,6 +62,12 @@ export function useWebNotifications(enabled: boolean) {
         event.preventDefault();
         if (options.link) {
           window.open(options.link, '_blank');
+          if (markAsReadOnLinkOpen) {
+            notificationsApi.updateNotifications({
+              ids: [options.id],
+              read: true,
+            });
+          }
         } else {
           navigate(notificationsRoute());
         }
@@ -65,7 +76,13 @@ export function useWebNotifications(enabled: boolean) {
 
       return notification;
     },
-    [webNotificationPermission, navigate, notificationsRoute],
+    [
+      webNotificationPermission,
+      markAsReadOnLinkOpen,
+      notificationsApi,
+      navigate,
+      notificationsRoute,
+    ],
   );
 
   return { sendWebNotification };

--- a/plugins/notifications/src/hooks/useWebNotifications.ts
+++ b/plugins/notifications/src/hooks/useWebNotifications.ts
@@ -13,24 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { rootRouteRef } from '../routes';
 import { useApi, useRouteRef } from '@backstage/core-plugin-api';
 import { useNavigate } from 'react-router-dom';
 import { notificationsApiRef } from '../api';
 
 /** @internal */
-export function useWebNotifications(
-  enabled: boolean,
-  markAsReadOnLinkOpen: boolean,
-) {
+export function useWebNotifications(enabled: boolean) {
   const [webNotificationPermission, setWebNotificationPermission] =
     useState('default');
   const notificationsRoute = useRouteRef(rootRouteRef);
   const notificationsApi = useApi(notificationsApiRef);
   const navigate = useNavigate();
 
-  useEffect(() => {
+  const requestUserPermission = useCallback(() => {
     if (
       enabled &&
       'Notification' in window &&
@@ -62,12 +59,10 @@ export function useWebNotifications(
         event.preventDefault();
         if (options.link) {
           window.open(options.link, '_blank');
-          if (markAsReadOnLinkOpen) {
-            notificationsApi.updateNotifications({
-              ids: [options.id],
-              read: true,
-            });
-          }
+          notificationsApi.updateNotifications({
+            ids: [options.id],
+            read: true,
+          });
         } else {
           navigate(notificationsRoute());
         }
@@ -76,14 +71,8 @@ export function useWebNotifications(
 
       return notification;
     },
-    [
-      webNotificationPermission,
-      markAsReadOnLinkOpen,
-      notificationsApi,
-      navigate,
-      notificationsRoute,
-    ],
+    [webNotificationPermission, notificationsApi, navigate, notificationsRoute],
   );
 
-  return { sendWebNotification };
+  return { sendWebNotification, requestUserPermission };
 }

--- a/plugins/notifications/src/hooks/useWebNotifications.ts
+++ b/plugins/notifications/src/hooks/useWebNotifications.ts
@@ -19,7 +19,7 @@ import { useApi, useRouteRef } from '@backstage/core-plugin-api';
 import { useNavigate } from 'react-router-dom';
 import { notificationsApiRef } from '../api';
 
-/** @public */
+/** @internal */
 export function useWebNotifications(
   enabled: boolean,
   markAsReadOnLinkOpen: boolean,

--- a/plugins/notifications/src/index.ts
+++ b/plugins/notifications/src/index.ts
@@ -15,5 +15,5 @@
  */
 export { notificationsPlugin, NotificationsPage } from './plugin';
 export * from './api';
-export * from './hooks';
+export { useNotificationsApi } from './hooks';
 export * from './components';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Allow setting notification read also from web notifications and snackbar when opening link similarly like in the #24508 for the notifications table.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
