### PR TITLE
Fix ownership card sometimes locking up for complex org structures

### DIFF
--- a/.changeset/wet-files-pretend.md
+++ b/.changeset/wet-files-pretend.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Fix ownership card sometimes locking up for complex org structures


### PR DESCRIPTION
Fixes #24530

This was limiting at the wrong level, so it became re-entrant.

Also downgraded it to five concurrent requests; 10 is borderline rudeness.