### PR TITLE
Updated commit status importance in the list of GitHub App permissions

### DIFF
--- a/docs/integrations/github/github-apps.md
+++ b/docs/integrations/github/github-apps.md
@@ -125,6 +125,7 @@ integration:
 
 - Reading software components:
   - `Contents`: `Read-only`
+  - `Commit statuses`: `Read-only`
 - Reading organization data:
   - `Members`: `Read-only`
 - Publishing software templates:
@@ -135,7 +136,6 @@ integration:
   - `Pull requests`: `Read & write`
   - `Issues`: `Read & write`
   - `Workflows`: `Read & write` (if templates include GitHub workflows)
-  - `Commit statuses`: `Read-only`
   - `Variables`: `Read & write` (if templates include GitHub Action Repository Variables)
   - `Secrets`: `Read & write` (if templates include GitHub Action Repository Secrets)
   - `Environments`: `Read & write` (if templates include GitHub Environments)


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updated commit status importance in the list of GitHub App permissions. You need to have the commit status permission to read repos or it will fail. Having it listed under "Publishing software templates" might make you think it's not needed.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
