### PR TITLE
 Add config prop `ensureSchemaExists`

### DIFF
--- a/.changeset/heavy-trainers-fly.md
+++ b/.changeset/heavy-trainers-fly.md
@@ -2,4 +2,4 @@
 '@backstage/backend-common': patch
 ---
 
-add ensureSchemaExists backend database config
+Added config prop `ensureSchemaExists` to support postgres instances where user can create schemas but not databases.

--- a/.changeset/heavy-trainers-fly.md
+++ b/.changeset/heavy-trainers-fly.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+add ensureSchemaExists backend database config

--- a/packages/backend-common/src/database/connectors/postgres.ts
+++ b/packages/backend-common/src/database/connectors/postgres.ts
@@ -321,7 +321,10 @@ export class PgConnector implements Connector {
     let schemaOverrides;
     if (this.getPluginDivisionModeConfig() === 'schema') {
       schemaOverrides = this.getSchemaOverrides(pluginId);
-      if (this.getEnsureSchemaExistsConfig(pluginId)) {
+      if (
+        this.getEnsureSchemaExistsConfig(pluginId) ||
+        this.getEnsureExistsConfig(pluginId)
+      ) {
         try {
           await pgConnector.ensureSchemaExists!(pluginConfig, pluginId);
         } catch (error) {
@@ -439,7 +442,7 @@ export class PgConnector implements Connector {
 
   private getEnsureSchemaExistsConfig(pluginId: string): boolean {
     const baseConfig =
-      this.config.getOptionalBoolean('ensureSchemaExists') ?? true;
+      this.config.getOptionalBoolean('ensureSchemaExists') ?? false;
     return (
       this.config.getOptionalBoolean(
         `${pluginPath(pluginId)}.getEnsureSchemaExistsConfig`,

--- a/packages/backend-common/src/database/connectors/postgres.ts
+++ b/packages/backend-common/src/database/connectors/postgres.ts
@@ -441,8 +441,9 @@ export class PgConnector implements Connector {
     const baseConfig =
       this.config.getOptionalBoolean('ensureSchemaExists') ?? true;
     return (
-      this.config.getOptionalBoolean(`${pluginPath(pluginId)}.ensureExists`) ??
-      baseConfig
+      this.config.getOptionalBoolean(
+        `${pluginPath(pluginId)}.getEnsureSchemaExistsConfig`,
+      ) ?? baseConfig
     );
   }
 

--- a/packages/backend-common/src/database/connectors/postgres.ts
+++ b/packages/backend-common/src/database/connectors/postgres.ts
@@ -321,7 +321,7 @@ export class PgConnector implements Connector {
     let schemaOverrides;
     if (this.getPluginDivisionModeConfig() === 'schema') {
       schemaOverrides = this.getSchemaOverrides(pluginId);
-      if (this.getEnsureExistsConfig(pluginId)) {
+      if (this.getEnsureSchemaExistsConfig(pluginId)) {
         try {
           await pgConnector.ensureSchemaExists!(pluginConfig, pluginId);
         } catch (error) {
@@ -431,6 +431,15 @@ export class PgConnector implements Connector {
 
   private getEnsureExistsConfig(pluginId: string): boolean {
     const baseConfig = this.config.getOptionalBoolean('ensureExists') ?? true;
+    return (
+      this.config.getOptionalBoolean(`${pluginPath(pluginId)}.ensureExists`) ??
+      baseConfig
+    );
+  }
+
+  private getEnsureSchemaExistsConfig(pluginId: string): boolean {
+    const baseConfig =
+      this.config.getOptionalBoolean('ensureSchemaExists') ?? true;
     return (
       this.config.getOptionalBoolean(`${pluginPath(pluginId)}.ensureExists`) ??
       baseConfig


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Added config prop `ensureSchemaExists` to support postgres instances where user can create schemas but not databases.

Solves #9250 with a config like:
```
  database:
    client: pg
    pluginDivisionMode: schema
    ensureExists: false
    ensureSchemaExists: true
    connection: ${DATABASE_URL}
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
