### PR TITLE
fix: email processor esm issue with p-throttle + config read

### DIFF
--- a/.changeset/cyan-eagles-hammer.md
+++ b/.changeset/cyan-eagles-hammer.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-notifications-backend-module-email': patch
+'@backstage/plugin-notifications-backend': patch
+---
+
+Fixed email processor `esm` issue and config reading

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -63,6 +63,10 @@
       allowedVersions: '<4.0.0',
     },
     {
+      matchPackageNames: ['p-throttle'],
+      allowedVersions: '<4.0.0',
+    },
+    {
       matchPackageNames: ['p-queue'],
       allowedVersions: '<7.0.0',
     },

--- a/plugins/notifications-backend-module-email/package.json
+++ b/plugins/notifications-backend-module-email/package.json
@@ -45,7 +45,7 @@
     "@backstage/types": "workspace:^",
     "lodash": "^4.17.21",
     "nodemailer": "^6.9.13",
-    "p-throttle": "^6.1.0"
+    "p-throttle": "^4.1.1"
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "workspace:^",

--- a/plugins/notifications-backend-module-email/src/processor/NotificationsEmailProcessor.test.ts
+++ b/plugins/notifications-backend-module-email/src/processor/NotificationsEmailProcessor.test.ts
@@ -52,7 +52,7 @@ describe('NotificationsEmailProcessor', () => {
         notifications: {
           processors: {
             email: {
-              transport: {
+              transportConfig: {
                 transport: 'smtp',
                 hostname: 'localhost',
                 port: 465,
@@ -98,7 +98,7 @@ describe('NotificationsEmailProcessor', () => {
         notifications: {
           processors: {
             email: {
-              transport: {
+              transportConfig: {
                 transport: 'ses',
                 region: 'us-west-2',
               },
@@ -138,7 +138,7 @@ describe('NotificationsEmailProcessor', () => {
         notifications: {
           processors: {
             email: {
-              transport: {
+              transportConfig: {
                 transport: 'sendmail',
                 path: '/usr/local/bin/sendmail',
               },
@@ -189,7 +189,7 @@ describe('NotificationsEmailProcessor', () => {
         notifications: {
           processors: {
             email: {
-              transport: {
+              transportConfig: {
                 transport: 'sendmail',
                 path: '/usr/local/bin/sendmail',
               },
@@ -246,7 +246,7 @@ describe('NotificationsEmailProcessor', () => {
         notifications: {
           processors: {
             email: {
-              transport: {
+              transportConfig: {
                 transport: 'sendmail',
                 path: '/usr/local/bin/sendmail',
               },
@@ -306,7 +306,7 @@ describe('NotificationsEmailProcessor', () => {
         notifications: {
           processors: {
             email: {
-              transport: {
+              transportConfig: {
                 transport: 'sendmail',
                 path: '/usr/local/bin/sendmail',
               },

--- a/plugins/notifications-backend-module-email/src/processor/NotificationsEmailProcessor.ts
+++ b/plugins/notifications-backend-module-email/src/processor/NotificationsEmailProcessor.ts
@@ -62,7 +62,7 @@ export class NotificationsEmailProcessor implements NotificationProcessor {
     const emailProcessorConfig = config.getConfig(
       'notifications.processors.email',
     );
-    this.transportConfig = emailProcessorConfig.getConfig('transport');
+    this.transportConfig = emailProcessorConfig.getConfig('transportConfig');
     this.broadcastConfig =
       emailProcessorConfig.getOptionalConfig('broadcastConfig');
     this.sender = emailProcessorConfig.getString('sender');

--- a/yarn.lock
+++ b/yarn.lock
@@ -6193,7 +6193,7 @@ __metadata:
     "@types/nodemailer": ^6.4.14
     lodash: ^4.17.21
     nodemailer: ^6.9.13
-    p-throttle: ^6.1.0
+    p-throttle: ^4.1.1
   languageName: unknown
   linkType: soft
 
@@ -33449,10 +33449,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-throttle@npm:^6.1.0":
-  version: 6.1.0
-  resolution: "p-throttle@npm:6.1.0"
-  checksum: c1947cca8844564c3d86f8c09067add5e7398b87898cb1f1aea5c48d2c211590d039a316d28a4b0d95364ffa0213c01dff6bf71175c468eab0e381f77715dbdb
+"p-throttle@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "p-throttle@npm:4.1.1"
+  checksum: fe8709f3c3b1da7c033479375c2c302e80c1a5d86449013afa7cd46d1dc210bc824a7e4a9d088e66d31987d00878c2b5491bb2fe76246d4d2fc9a1636f5f8298
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Change the version to `p-throttle` where it's not a pure ESM module (like it is done for `p-limit` and `p-queue` already). Also, fixes the config reading from `transport` to `transportConfig`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
