### PR TITLE
Patch release of #24511

### DIFF
--- a/.changeset/fuzzy-seahorses-tell.md
+++ b/.changeset/fuzzy-seahorses-tell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Fixed an internal circular import that broke Jest mocks.

--- a/.changeset/fuzzy-seahorses-tell.md
+++ b/.changeset/fuzzy-seahorses-tell.md
@@ -1,5 +1,0 @@
----
-'@backstage/core-components': patch
----
-
-Fixed an internal circular import that broke Jest mocks.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.26.4",
+  "version": "1.26.5",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/core-components/CHANGELOG.md
+++ b/packages/core-components/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/core-components
 
+## 0.14.6
+
+### Patch Changes
+
+- f5dc5c4: Fixed an internal circular import that broke Jest mocks.
+
 ## 0.14.5
 
 ### Patch Changes

--- a/packages/core-components/package.json
+++ b/packages/core-components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/core-components",
   "description": "Core components used by Backstage plugins and apps",
-  "version": "0.14.5",
+  "version": "0.14.6",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core-components/src/layout/HeaderTabs/HeaderTabs.tsx
+++ b/packages/core-components/src/layout/HeaderTabs/HeaderTabs.tsx
@@ -18,7 +18,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import TabUI, { TabProps } from '@material-ui/core/Tab';
 import Tabs from '@material-ui/core/Tabs';
 import React, { useCallback, useEffect, useState } from 'react';
-import { Link } from '@backstage/core-components';
+import { Link } from '../../components/Link';
 
 // TODO(blam): Remove this implementation when the Tabs are ready
 // This is just a temporary solution to implementing tabs for now


### PR DESCRIPTION
This release fixes an issue where it was not possible to mock and require the original `@backstage/core-components` package in Jest tests.