### PR TITLE
feat: allow defining custom build log transport for techdocs

### DIFF
--- a/.changeset/cuddly-eggs-sin.md
+++ b/.changeset/cuddly-eggs-sin.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-techdocs-backend': patch
+'@backstage/plugin-techdocs-node': patch
+---
+
+Allow defining custom build log transport for techdocs builder

--- a/plugins/techdocs-backend/src/plugin.ts
+++ b/plugins/techdocs-backend/src/plugin.ts
@@ -38,6 +38,7 @@ import {
 } from '@backstage/plugin-techdocs-node';
 import Docker from 'dockerode';
 import { createRouter } from '@backstage/plugin-techdocs-backend';
+import * as winston from 'winston';
 
 /**
  * The TechDocs plugin is responsible for serving and building documentation for any entity.
@@ -47,12 +48,19 @@ export const techdocsPlugin = createBackendPlugin({
   pluginId: 'techdocs',
   register(env) {
     let docsBuildStrategy: DocsBuildStrategy | undefined;
+    let buildLogTransport: winston.transport | undefined;
     env.registerExtensionPoint(techdocsBuildsExtensionPoint, {
       setBuildStrategy(buildStrategy: DocsBuildStrategy) {
         if (docsBuildStrategy) {
           throw new Error('DocsBuildStrategy may only be set once');
         }
         docsBuildStrategy = buildStrategy;
+      },
+      setBuildLogTransport(transport: winston.transport) {
+        if (buildLogTransport) {
+          throw new Error('BuildLogTransport may only be set once');
+        }
+        buildLogTransport = transport;
       },
     });
 
@@ -138,6 +146,7 @@ export const techdocsPlugin = createBackendPlugin({
             logger: winstonLogger,
             cache: cacheManager,
             docsBuildStrategy,
+            buildLogTransport,
             preparers,
             generators,
             publisher,

--- a/plugins/techdocs-node/api-report.md
+++ b/plugins/techdocs-node/api-report.md
@@ -16,6 +16,7 @@ import { Logger } from 'winston';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import { UrlReader } from '@backstage/backend-common';
+import * as winston from 'winston';
 import { Writable } from 'stream';
 
 // @public
@@ -240,6 +241,8 @@ export type SupportedGeneratorKey = 'techdocs' | string;
 
 // @public
 export interface TechdocsBuildsExtensionPoint {
+  // (undocumented)
+  setBuildLogTransport(transport: winston.transport): void;
   // (undocumented)
   setBuildStrategy(buildStrategy: DocsBuildStrategy): void;
 }

--- a/plugins/techdocs-node/src/extensions.ts
+++ b/plugins/techdocs-node/src/extensions.ts
@@ -16,6 +16,7 @@
 import { createExtensionPoint } from '@backstage/backend-plugin-api';
 import { DocsBuildStrategy } from './techdocsTypes';
 import { PreparerBase, RemoteProtocol, TechdocsGenerator } from './stages';
+import * as winston from 'winston';
 
 /**
  * Extension point type for configuring Techdocs builds.
@@ -24,6 +25,7 @@ import { PreparerBase, RemoteProtocol, TechdocsGenerator } from './stages';
  */
 export interface TechdocsBuildsExtensionPoint {
   setBuildStrategy(buildStrategy: DocsBuildStrategy): void;
+  setBuildLogTransport(transport: winston.transport): void;
 }
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

should enable way to overcome #24583 memory leak, maybe.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
