### PR TITLE
Add Docker container runner to techdocs-node

### DIFF
--- a/packages/backend/src/plugins/techdocs.ts
+++ b/packages/backend/src/plugins/techdocs.ts
@@ -14,14 +14,12 @@
  * limitations under the License.
  */
 
-import { DockerContainerRunner } from '@backstage/backend-common';
 import {
   createRouter,
   Generators,
   Preparers,
   Publisher,
 } from '@backstage/plugin-techdocs-backend';
-import Docker from 'dockerode';
 import { Router } from 'express';
 import { PluginEnvironment } from '../types';
 
@@ -34,14 +32,9 @@ export default async function createPlugin(
     reader: env.reader,
   });
 
-  // Docker client (conditionally) used by the generators, based on techdocs.generators config.
-  const dockerClient = new Docker();
-  const containerRunner = new DockerContainerRunner({ dockerClient });
-
   // Generators are used for generating documentation sites.
   const generators = await Generators.fromConfig(env.config, {
     logger: env.logger,
-    containerRunner,
   });
 
   // Publisher is used for

--- a/packages/techdocs-cli/src/commands/generate/generate.ts
+++ b/packages/techdocs-cli/src/commands/generate/generate.ts
@@ -17,16 +17,11 @@
 import { resolve } from 'path';
 import { OptionValues } from 'commander';
 import fs from 'fs-extra';
-import Docker from 'dockerode';
 import {
   TechdocsGenerator,
   ParsedLocationAnnotation,
   getMkdocsYml,
 } from '@backstage/plugin-techdocs-node';
-import {
-  ContainerRunner,
-  DockerContainerRunner,
-} from '@backstage/backend-common';
 import { ConfigReader } from '@backstage/config';
 import {
   convertTechDocsRefToLocationAnnotation,
@@ -75,14 +70,6 @@ export default async function generate(opts: OptionValues) {
     },
   });
 
-  // Docker client (conditionally) used by the generators, based on techdocs.generators config.
-  let containerRunner: ContainerRunner | undefined;
-
-  if (opts.docker) {
-    const dockerClient = new Docker();
-    containerRunner = new DockerContainerRunner({ dockerClient });
-  }
-
   let parsedLocationAnnotation = {} as ParsedLocationAnnotation;
   if (opts.techdocsRef) {
     try {
@@ -97,7 +84,6 @@ export default async function generate(opts: OptionValues) {
   // Generate docs using @backstage/plugin-techdocs-node
   const techdocsGenerator = await TechdocsGenerator.fromConfig(config, {
     logger,
-    containerRunner,
   });
 
   logger.info('Generating documentation...');

--- a/plugins/techdocs-backend/src/plugin.ts
+++ b/plugins/techdocs-backend/src/plugin.ts
@@ -16,7 +16,6 @@
 
 import {
   cacheToPluginCacheManager,
-  DockerContainerRunner,
   loggerToWinstonLogger,
 } from '@backstage/backend-common';
 import {
@@ -36,7 +35,6 @@ import {
   techdocsGeneratorExtensionPoint,
   techdocsPreparerExtensionPoint,
 } from '@backstage/plugin-techdocs-node';
-import Docker from 'dockerode';
 import { createRouter } from '@backstage/plugin-techdocs-backend';
 
 /**
@@ -110,14 +108,9 @@ export const techdocsPlugin = createBackendPlugin({
           preparers.register(protocol, preparer);
         }
 
-        // Docker client (conditionally) used by the generators, based on techdocs.generators config.
-        const dockerClient = new Docker();
-        const containerRunner = new DockerContainerRunner({ dockerClient });
-
         // Generators are used for generating documentation sites.
         const generators = await Generators.fromConfig(config, {
           logger: winstonLogger,
-          containerRunner,
           customGenerator: customTechdocsGenerator,
         });
 

--- a/plugins/techdocs-backend/src/service/standaloneServer.ts
+++ b/plugins/techdocs-backend/src/service/standaloneServer.ts
@@ -17,7 +17,6 @@
 import {
   CacheManager,
   createServiceBuilder,
-  DockerContainerRunner,
   HostDiscovery,
   UrlReader,
 } from '@backstage/backend-common';
@@ -29,7 +28,6 @@ import {
   Publisher,
   TechdocsGenerator,
 } from '@backstage/plugin-techdocs-node';
-import Docker from 'dockerode';
 import { Server } from 'http';
 import { Logger } from 'winston';
 import { createRouter } from './router';
@@ -66,13 +64,9 @@ export async function startStandaloneServer(
   });
   preparers.register('dir', directoryPreparer);
 
-  const dockerClient = new Docker();
-  const containerRunner = new DockerContainerRunner({ dockerClient });
-
   const generators = new Generators();
   const techdocsGenerator = TechdocsGenerator.fromConfig(config, {
     logger,
-    containerRunner,
   });
   generators.register('techdocs', techdocsGenerator);
 

--- a/plugins/techdocs-node/api-report.md
+++ b/plugins/techdocs-node/api-report.md
@@ -7,7 +7,6 @@
 
 import { CompoundEntityRef } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
-import { ContainerRunner } from '@backstage/backend-common';
 import { Entity } from '@backstage/catalog-model';
 import express from 'express';
 import { ExtensionPoint } from '@backstage/backend-plugin-api';
@@ -17,6 +16,11 @@ import { PluginEndpointDiscovery } from '@backstage/backend-common';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import { UrlReader } from '@backstage/backend-common';
 import { Writable } from 'stream';
+
+// @public
+export interface ContainerRunner {
+  runContainer(opts: RunContainerOptions): Promise<void>;
+}
 
 // @public
 export class DirectoryPreparer implements PreparerBase {
@@ -71,7 +75,6 @@ export class Generators implements GeneratorBuilder {
     config: Config,
     options: {
       logger: Logger;
-      containerRunner: ContainerRunner;
       customGenerator?: TechdocsGenerator;
     },
   ): Promise<GeneratorBuilder>;
@@ -234,6 +237,19 @@ export type ReadinessResponse = {
 
 // @public
 export type RemoteProtocol = 'url' | 'dir';
+
+// @public
+export type RunContainerOptions = {
+  imageName: string;
+  command?: string | string[];
+  args: string[];
+  logStream?: Writable;
+  mountDirs?: Record<string, string>;
+  workingDir?: string;
+  envVars?: Record<string, string>;
+  pullImage?: boolean;
+  defaultUser?: boolean;
+};
 
 // @public
 export type SupportedGeneratorKey = 'techdocs' | string;

--- a/plugins/techdocs-node/package.json
+++ b/plugins/techdocs-node/package.json
@@ -57,6 +57,7 @@
     "@smithy/node-http-handler": "^2.1.7",
     "@trendyol-js/openstack-swift-sdk": "^0.0.7",
     "@types/express": "^4.17.6",
+    "dockerode": "^4.0.0",
     "express": "^4.17.1",
     "fs-extra": "^11.2.0",
     "git-url-parse": "^14.0.0",

--- a/plugins/techdocs-node/src/stages/generate/DockerContainerRunner.test.ts
+++ b/plugins/techdocs-node/src/stages/generate/DockerContainerRunner.test.ts
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs-extra';
+import Docker from 'dockerode';
+import Stream, { PassThrough } from 'stream';
+import { DockerContainerRunner, UserOptions } from './DockerContainerRunner';
+import { createMockDirectory } from '@backstage/backend-test-utils';
+import { ContainerRunner } from './types';
+
+const mockDocker = new Docker() as jest.Mocked<Docker>;
+
+describe('DockerContainerRunner', () => {
+  let containerTaskApi: ContainerRunner;
+
+  const inputDir = createMockDirectory();
+  const outputDir = createMockDirectory();
+
+  beforeEach(() => {
+    inputDir.clear();
+    outputDir.clear();
+
+    jest.spyOn(mockDocker, 'pull').mockImplementation((async (
+      _image: string,
+      _something: any,
+      handler: (err: Error | undefined, stream: PassThrough) => void,
+    ) => {
+      const mockStream = new PassThrough();
+      handler(undefined, mockStream);
+      mockStream.end();
+    }) as any);
+
+    jest
+      .spyOn(mockDocker, 'run')
+      .mockResolvedValue([{ Error: null, StatusCode: 0 }]);
+
+    jest
+      .spyOn(mockDocker, 'ping')
+      .mockResolvedValue(Buffer.from('OK', 'utf-8'));
+
+    containerTaskApi = new DockerContainerRunner();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const imageName = 'dockerOrg/image';
+  const args = ['bash', '-c', 'echo test'];
+  const mountDirs = {
+    [inputDir.path]: '/input',
+    [outputDir.path]: '/output',
+  };
+  const workingDir = inputDir.path;
+  const envVars = { HOME: '/tmp', LOG_LEVEL: 'debug' };
+  const envVarsArray = ['HOME=/tmp', 'LOG_LEVEL=debug'];
+
+  it('should pull the docker container', async () => {
+    await containerTaskApi.runContainer({
+      imageName,
+      args,
+    });
+
+    expect(mockDocker.pull).toHaveBeenCalledWith(
+      imageName,
+      {},
+      expect.any(Function),
+    );
+
+    expect(mockDocker.run).toHaveBeenCalled();
+  });
+
+  it('should not pull the docker container when pullImage is false', async () => {
+    await containerTaskApi.runContainer({
+      imageName,
+      args,
+      pullImage: false,
+    });
+
+    expect(mockDocker.pull).not.toHaveBeenCalled();
+    expect(mockDocker.run).toHaveBeenCalled();
+  });
+
+  it('should call the dockerClient run command with the correct arguments passed through', async () => {
+    await containerTaskApi.runContainer({
+      imageName,
+      args,
+      mountDirs,
+      envVars,
+      workingDir,
+    });
+
+    expect(mockDocker.run).toHaveBeenCalledWith(
+      imageName,
+      args,
+      expect.any(Stream),
+      expect.objectContaining({
+        Env: envVarsArray,
+        WorkingDir: workingDir,
+        HostConfig: {
+          AutoRemove: true,
+          Binds: expect.arrayContaining([
+            `${await fs.realpath(inputDir.path)}:/input`,
+            `${await fs.realpath(outputDir.path)}:/output`,
+          ]),
+        },
+        Volumes: {
+          '/input': {},
+          '/output': {},
+        },
+      }),
+    );
+  });
+
+  it('should ping docker to test availability', async () => {
+    await containerTaskApi.runContainer({
+      imageName,
+      args,
+    });
+
+    expect(mockDocker.ping).toHaveBeenCalled();
+  });
+
+  it('should pass through the user and group id from the host machine and set the home dir', async () => {
+    await containerTaskApi.runContainer({
+      imageName,
+      args,
+    });
+
+    const userOptions: UserOptions = {};
+    if (process.getuid && process.getgid) {
+      userOptions.User = `${process.getuid()}:${process.getgid()}`;
+    }
+
+    expect(mockDocker.run).toHaveBeenCalledWith(
+      imageName,
+      args,
+      expect.any(Stream),
+      expect.objectContaining({
+        ...userOptions,
+      }),
+    );
+  });
+
+  it('throws a correct error if the command fails in docker', async () => {
+    mockDocker.run.mockResolvedValueOnce([
+      {
+        Error: new Error('Something went wrong with docker'),
+        StatusCode: 0,
+      },
+    ]);
+
+    await expect(
+      containerTaskApi.runContainer({
+        imageName,
+        args,
+      }),
+    ).rejects.toThrow(/Something went wrong with docker/);
+  });
+
+  describe('where docker is unavailable', () => {
+    const dockerError = 'a docker error';
+
+    beforeEach(() => {
+      jest.spyOn(mockDocker, 'ping').mockImplementationOnce(() => {
+        throw new Error(dockerError);
+      });
+    });
+
+    it('should throw with a descriptive error message including the docker error message', async () => {
+      await expect(
+        containerTaskApi.runContainer({
+          imageName,
+          args,
+        }),
+      ).rejects.toThrow(new RegExp(`.+: ${dockerError}`));
+    });
+  });
+
+  it('should pass through the log stream to the docker client', async () => {
+    const logStream = new PassThrough();
+    await containerTaskApi.runContainer({
+      imageName,
+      args,
+      logStream,
+    });
+
+    expect(mockDocker.run).toHaveBeenCalledWith(
+      imageName,
+      args,
+      logStream,
+      expect.objectContaining({
+        HostConfig: {
+          AutoRemove: true,
+          Binds: [],
+        },
+        Volumes: {},
+      }),
+    );
+  });
+});

--- a/plugins/techdocs-node/src/stages/generate/DockerContainerRunner.ts
+++ b/plugins/techdocs-node/src/stages/generate/DockerContainerRunner.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Docker from 'dockerode';
+import fs from 'fs-extra';
+import { ForwardedError } from '@backstage/errors';
+import { PassThrough } from 'stream';
+import { pipeline as pipelineStream } from 'stream';
+import { promisify } from 'util';
+import { ContainerRunner, RunContainerOptions } from './types';
+
+const pipeline = promisify(pipelineStream);
+
+export type UserOptions = {
+  User?: string;
+};
+
+/**
+ * A {@link ContainerRunner} for Docker containers.
+ *
+ * @public
+ */
+export class DockerContainerRunner implements ContainerRunner {
+  private readonly dockerClient: Docker;
+
+  constructor() {
+    this.dockerClient = new Docker();
+  }
+
+  async runContainer(options: RunContainerOptions) {
+    const {
+      imageName,
+      command,
+      args,
+      logStream = new PassThrough(),
+      mountDirs = {},
+      workingDir,
+      envVars = {},
+      pullImage = true,
+      defaultUser = false,
+    } = options;
+
+    // Show a better error message when Docker is unavailable.
+    try {
+      await this.dockerClient.ping();
+    } catch (e) {
+      throw new ForwardedError(
+        'This operation requires Docker. Docker does not appear to be available. Docker.ping() failed with',
+        e,
+      );
+    }
+
+    if (pullImage) {
+      await new Promise<void>((resolve, reject) => {
+        this.dockerClient.pull(imageName, {}, (err, stream) => {
+          if (err) {
+            reject(err);
+            return;
+          }
+
+          pipeline(stream, logStream, { end: false })
+            .then(resolve)
+            .catch(reject);
+        });
+      });
+    }
+
+    const userOptions: UserOptions = {};
+    if (!defaultUser && process.getuid && process.getgid) {
+      // Files that are created inside the Docker container will be owned by
+      // root on the host system on non Mac systems, because of reasons. Mainly the fact that
+      // volume sharing is done using NFS on Mac and actual mounts in Linux world.
+      // So we set the user in the container as the same user and group id as the host.
+      // On Windows we don't have process.getuid nor process.getgid
+      userOptions.User = `${process.getuid()}:${process.getgid()}`;
+    }
+
+    // Initialize volumes to mount based on mountDirs map
+    const Volumes: { [T: string]: object } = {};
+    for (const containerDir of Object.values(mountDirs)) {
+      Volumes[containerDir] = {};
+    }
+
+    // Create bind volumes
+    const Binds: string[] = [];
+    for (const [hostDir, containerDir] of Object.entries(mountDirs)) {
+      // Need to use realpath here as Docker mounting does not like
+      // symlinks for binding volumes
+      const realHostDir = await fs.realpath(hostDir);
+      Binds.push(`${realHostDir}:${containerDir}`);
+    }
+
+    // Create docker environment variables array
+    const Env = [];
+    for (const [key, value] of Object.entries(envVars)) {
+      Env.push(`${key}=${value}`);
+    }
+
+    const [{ Error: error, StatusCode: statusCode }] =
+      await this.dockerClient.run(imageName, args, logStream, {
+        Volumes,
+        HostConfig: {
+          AutoRemove: true,
+          Binds,
+        },
+        ...(workingDir ? { WorkingDir: workingDir } : {}),
+        Entrypoint: command,
+        Env,
+        ...userOptions,
+      } as Docker.ContainerCreateOptions);
+
+    if (error) {
+      throw new Error(
+        `Docker failed to run with the following error message: ${error}`,
+      );
+    }
+
+    if (statusCode !== 0) {
+      throw new Error(
+        `Docker container returned a non-zero exit code (${statusCode})`,
+      );
+    }
+  }
+}

--- a/plugins/techdocs-node/src/stages/generate/generators.ts
+++ b/plugins/techdocs-node/src/stages/generate/generators.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { ContainerRunner } from '@backstage/backend-common';
 import { Entity } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
 import { Logger } from 'winston';
@@ -42,7 +41,6 @@ export class Generators implements GeneratorBuilder {
     config: Config,
     options: {
       logger: Logger;
-      containerRunner: ContainerRunner;
       customGenerator?: TechdocsGenerator;
     },
   ): Promise<GeneratorBuilder> {

--- a/plugins/techdocs-node/src/stages/generate/index.ts
+++ b/plugins/techdocs-node/src/stages/generate/index.ts
@@ -17,6 +17,8 @@ export { TechdocsGenerator } from './techdocs';
 export { Generators } from './generators';
 export { getMkdocsYml } from './helpers';
 export type {
+  RunContainerOptions,
+  ContainerRunner,
   GeneratorBase,
   GeneratorOptions,
   GeneratorBuilder,

--- a/plugins/techdocs-node/src/stages/generate/techdocs.ts
+++ b/plugins/techdocs-node/src/stages/generate/techdocs.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { ContainerRunner } from '@backstage/backend-common';
 import { Config } from '@backstage/config';
 import path from 'path';
 import { Logger } from 'winston';
@@ -36,6 +35,7 @@ import {
   patchMkdocsYmlWithPlugins,
 } from './mkdocsPatchers';
 import {
+  ContainerRunner,
   GeneratorBase,
   GeneratorConfig,
   GeneratorOptions,
@@ -43,6 +43,7 @@ import {
   GeneratorRunOptions,
 } from './types';
 import { ForwardedError } from '@backstage/errors';
+import { DockerContainerRunner } from './DockerContainerRunner';
 
 /**
  * Generates documentation files
@@ -55,10 +56,9 @@ export class TechdocsGenerator implements GeneratorBase {
    */
   public static readonly defaultDockerImage = 'spotify/techdocs:v1.2.3';
   private readonly logger: Logger;
-  private readonly containerRunner?: ContainerRunner;
   private readonly options: GeneratorConfig;
   private readonly scmIntegrations: ScmIntegrationRegistry;
-
+  private containerRunner?: ContainerRunner;
   /**
    * Returns a instance of TechDocs generator
    * @param config - A Backstage configuration
@@ -157,9 +157,7 @@ export class TechdocsGenerator implements GeneratorBase {
           break;
         case 'docker':
           if (this.containerRunner === undefined) {
-            throw new Error(
-              "Invalid state: containerRunner cannot be undefined when runIn is 'docker'",
-            );
+            this.containerRunner = new DockerContainerRunner();
           }
           await this.containerRunner.runContainer({
             imageName:

--- a/plugins/techdocs-node/src/stages/generate/types.ts
+++ b/plugins/techdocs-node/src/stages/generate/types.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { ContainerRunner } from '@backstage/backend-common';
 import { Entity } from '@backstage/catalog-model';
 import { Writable } from 'stream';
 import { Logger } from 'winston';
@@ -99,3 +98,32 @@ export type DefaultMkdocsContent = {
   docs_dir: string;
   plugins: String[];
 };
+
+/**
+ * Options passed to the {@link ContainerRunner.runContainer} method.
+ *
+ * @public
+ */
+export type RunContainerOptions = {
+  imageName: string;
+  command?: string | string[];
+  args: string[];
+  logStream?: Writable;
+  mountDirs?: Record<string, string>;
+  workingDir?: string;
+  envVars?: Record<string, string>;
+  pullImage?: boolean;
+  defaultUser?: boolean;
+};
+
+/**
+ * Handles the running of containers, on behalf of others.
+ *
+ * @public
+ */
+export interface ContainerRunner {
+  /**
+   * Runs a container image to completion.
+   */
+  runContainer(opts: RunContainerOptions): Promise<void>;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7448,6 +7448,7 @@ __metadata:
     "@types/recursive-readdir": ^2.2.0
     "@types/supertest": ^2.0.8
     aws-sdk-client-mock: ^4.0.0
+    dockerode: ^4.0.0
     express: ^4.17.1
     fs-extra: ^11.2.0
     git-url-parse: ^14.0.0


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Since we are moving away from `@backstage/backend-common` this PR moves `DockerContainerRunner` to `techdocs-node`. 
Related to #24549

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
