### PR TITLE
cli: only warn when bump fails + fix forbidden duplicate filter

### DIFF
--- a/.changeset/kind-toes-scream.md
+++ b/.changeset/kind-toes-scream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+The `versions:bump` command will no longer exit with a non-zero status if the version bump fails due to forbidden duplicate package installations. It will now also provide more information about how to troubleshoot such an error. The set of forbidden duplicates has also been expanded to include all `@backstage/*-app-api` packages.

--- a/packages/cli/src/commands/versions/bump.test.ts
+++ b/packages/cli/src/commands/versions/bump.test.ts
@@ -894,30 +894,19 @@ describe('bump', () => {
       newVersions: [],
       newRanges: [
         {
-          name: 'first-duplicate',
-          oldRange: 'first-duplicate',
-          newRange: 'first-duplicate',
-          oldVersion: '1.0.0',
-          newVersion: '2.0.0',
-        },
-        {
-          name: 'second-duplicate',
-          oldRange: 'second-duplicate',
-          newRange: 'second-duplicate',
-          oldVersion: '1.0.0',
-          newVersion: '2.0.0',
-        },
-        {
-          name: 'third-duplicate',
-          oldRange: 'third-duplicate',
-          newRange: 'third-duplicate',
+          name: '@backstage/backend-app-api',
+          oldRange: '^1.0.0',
+          newRange: '^2.0.0',
           oldVersion: '1.0.0',
           newVersion: '2.0.0',
         },
       ],
     });
     mockDir.setContent({
-      'yarn.lock': lockfileMock,
+      'yarn.lock': `${HEADER}
+"@backstage/backend-app-api@^1.0.0":
+  version "1.0.0"
+`,
       'package.json': JSON.stringify({
         workspaces: {
           packages: ['packages/*'],
@@ -928,16 +917,7 @@ describe('bump', () => {
           'package.json': JSON.stringify({
             name: 'a',
             dependencies: {
-              '@backstage/core': '^1.0.5',
-            },
-          }),
-        },
-        b: {
-          'package.json': JSON.stringify({
-            name: 'b',
-            dependencies: {
-              '@backstage/core': '^1.0.3',
-              '@backstage/theme': '^1.0.0',
+              '@backstage/backend-app-api': '^1.0.0',
             },
           }),
         },
@@ -952,7 +932,12 @@ describe('bump', () => {
           res(
             ctx.status(200),
             ctx.json({
-              packages: [],
+              packages: [
+                {
+                  name: '@backstage/backend-app-api',
+                  version: '2.0.0',
+                },
+              ],
             }),
           ),
       ),
@@ -962,24 +947,20 @@ describe('bump', () => {
     });
     expectLogsToMatch(logs, [
       'Using default pattern glob @backstage/*',
-      'Checking for updates of @backstage/core',
-      'Checking for updates of @backstage/theme',
-      'Checking for updates of @backstage/core-api',
+      'Checking for updates of @backstage/backend-app-api',
+      'Checking for updates of @backstage/backend-app-api',
       'Some packages are outdated, updating',
-      'unlocking @backstage/core@^1.0.3 ~> 1.0.6',
-      'unlocking @backstage/core-api@^1.0.6 ~> 1.0.7',
-      'unlocking @backstage/core-api@^1.0.3 ~> 1.0.7',
-      'bumping @backstage/core in a to ^1.0.6',
-      'bumping @backstage/core in b to ^1.0.6',
-      'bumping @backstage/theme in b to ^2.0.0',
+      'bumping @backstage/backend-app-api in a to ^2.0.0',
       'Running yarn install to install new versions',
       'Checking for moved packages to the @backstage-community namespace...',
       '⚠️  The following packages may have breaking changes:',
-      '  @backstage/theme : 1.0.0 ~> 2.0.0',
-      '    https://github.com/backstage/backstage/blob/master/packages/theme/CHANGELOG.md',
+      '  @backstage/backend-app-api : 1.0.0 ~> 2.0.0',
+      '    https://github.com/backstage/backstage/blob/master/packages/backend-app-api/CHANGELOG.md',
       'Version bump complete!',
-      'The following packages have duplicates but have been allowed:',
-      'first-duplicate, second-duplicate, third-duplicate',
+      '  ⚠️ Warning! ⚠️',
+      '  The below package(s) have incompatible duplicate installations, likely due to a bad dependency in a plugin.',
+      '  You can investigate this by running `yarn why <package-name>`, and report the issue to the plugin maintainers.',
+      '    @backstage/backend-app-api',
     ]);
   });
 });

--- a/packages/cli/src/commands/versions/bump.ts
+++ b/packages/cli/src/commands/versions/bump.ts
@@ -331,24 +331,22 @@ export default async (opts: OptionValues) => {
     forbiddenDuplicatesFilter(name),
   );
   if (forbiddenNewRanges.length > 0) {
-    throw new Error(
-      `Version bump failed for ${forbiddenNewRanges
-        .map(i => i.name)
-        .join(', ')}`,
-    );
-  }
-
-  const allowedDuplicates = result.newRanges.filter(
-    ({ name }) => !forbiddenDuplicatesFilter(name),
-  );
-
-  if (allowedDuplicates.length > 0) {
+    console.log(chalk.yellow('  ⚠️ Warning! ⚠️'));
+    console.log();
     console.log(
       chalk.yellow(
-        'The following packages have duplicates but have been allowed:',
+        '  The below package(s) have incompatible duplicate installations, likely due to a bad dependency in a plugin.',
       ),
     );
-    console.log(chalk.yellow(allowedDuplicates.map(i => i.name).join(', ')));
+    console.log(
+      chalk.yellow(
+        '  You can investigate this by running `yarn why <package-name>`, and report the issue to the plugin maintainers.',
+      ),
+    );
+    console.log();
+    for (const { name } of forbiddenNewRanges) {
+      console.log(chalk.yellow(`    ${name}`));
+    }
   }
 };
 

--- a/packages/cli/src/commands/versions/lint.ts
+++ b/packages/cli/src/commands/versions/lint.ts
@@ -27,10 +27,7 @@ export const includedFilter = (name: string) =>
   INCLUDED.some(pattern => pattern.test(name));
 
 // Packages that are not allowed to have any duplicates
-const FORBID_DUPLICATES = [
-  /^@backstage\/core-app-api$/,
-  /^@backstage\/plugin-/,
-];
+const FORBID_DUPLICATES = [/^@backstage\/\w+-app-api$/, /^@backstage\/plugin-/];
 
 // There are some packages that ARE explicitly allowed to have duplicates since
 // they handle that appropriately. This takes precedence over FORBID_DUPLICATES


### PR DESCRIPTION
## Hey, I just made a Pull Request!

🧹, version bump failure now logs something like this instead, and doesn't exit with a non-zero code:

<img width="793" alt="image" src="https://github.com/backstage/backstage/assets/4984472/75129424-8263-4119-b723-e79ee870ccb6">

The packages there are just debugging examples, can't actually happen 😅 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
