### PR TITLE
feat: increase default and allow changing snackbar auto hide duration

### DIFF
--- a/.changeset/perfect-beers-explode.md
+++ b/.changeset/perfect-beers-explode.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications': patch
+---
+
+Increase default and allow modifying notification snackbar auto hide duration

--- a/plugins/notifications/api-report.md
+++ b/plugins/notifications/api-report.md
@@ -102,6 +102,7 @@ export const NotificationsSidebarItem: (props?: {
   webNotificationsEnabled?: boolean;
   titleCounterEnabled?: boolean;
   snackbarEnabled?: boolean;
+  snackbarAutoHideDuration?: number | null;
   className?: string;
   icon?: IconComponent;
   text?: string;

--- a/plugins/notifications/src/components/NotificationsSideBarItem/NotificationsSideBarItem.tsx
+++ b/plugins/notifications/src/components/NotificationsSideBarItem/NotificationsSideBarItem.tsx
@@ -83,6 +83,7 @@ export const NotificationsSidebarItem = (props?: {
   webNotificationsEnabled?: boolean;
   titleCounterEnabled?: boolean;
   snackbarEnabled?: boolean;
+  snackbarAutoHideDuration?: number | null;
   className?: string;
   icon?: IconComponent;
   text?: string;
@@ -93,6 +94,7 @@ export const NotificationsSidebarItem = (props?: {
     webNotificationsEnabled = false,
     titleCounterEnabled = true,
     snackbarEnabled = true,
+    snackbarAutoHideDuration = 10000,
     icon = NotificationsIcon,
     text = 'Notifications',
     ...restProps
@@ -100,6 +102,7 @@ export const NotificationsSidebarItem = (props?: {
     webNotificationsEnabled: false,
     titleCounterEnabled: true,
     snackbarEnabled: true,
+    snackbarAutoHideDuration: 10000,
   };
 
   const { loading, error, value, retry } = useNotificationsApi(api =>
@@ -196,6 +199,7 @@ export const NotificationsSidebarItem = (props?: {
               variant: notification.payload.severity,
               anchorOrigin: { vertical: 'bottom', horizontal: 'right' },
               action,
+              autoHideDuration: snackbarAutoHideDuration,
             } as OptionsWithExtraProps<VariantType>);
           }
         })
@@ -216,6 +220,7 @@ export const NotificationsSidebarItem = (props?: {
     sendWebNotification,
     webNotificationsEnabled,
     snackbarEnabled,
+    snackbarAutoHideDuration,
     notificationsApi,
     alertApi,
     getSnackbarProperties,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Increase default to 10 seconds as 5 seconds is pretty low to automatically hide the snackbars. Also allow users to configure this as they like.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
