### PR TITLE
Scaffolder move away from container runner

### DIFF
--- a/.changeset/nice-rules-wave.md
+++ b/.changeset/nice-rules-wave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-node': patch
+---
+
+Added `ContainerRunner` type for consumption of some scaffolder modules

--- a/.changeset/popular-kiwis-smoke.md
+++ b/.changeset/popular-kiwis-smoke.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-scaffolder-backend-module-cookiecutter': patch
+'@backstage/plugin-scaffolder-backend-module-rails': patch
+---
+
+`ContainerRunner` is now imported from `@backstage/plugin-scaffolder-node` instead of `@backstage/backend-common`

--- a/docs/features/software-templates/writing-custom-actions.md
+++ b/docs/features/software-templates/writing-custom-actions.md
@@ -146,7 +146,6 @@ should have something similar to the below in
 
 ```ts
 return await createRouter({
-  containerRunner,
   catalogClient,
   logger: env.logger,
   config: env.config,

--- a/plugins/scaffolder-backend-module-cookiecutter/api-report.md
+++ b/plugins/scaffolder-backend-module-cookiecutter/api-report.md
@@ -6,7 +6,7 @@
 /// <reference types="node" />
 
 import { BackendFeature } from '@backstage/backend-plugin-api';
-import { ContainerRunner } from '@backstage/backend-common';
+import { ContainerRunner } from '@backstage/plugin-scaffolder-node';
 import { JsonObject } from '@backstage/types';
 import { ScmIntegrations } from '@backstage/integration';
 import { TemplateAction } from '@backstage/plugin-scaffolder-node';

--- a/plugins/scaffolder-backend-module-cookiecutter/src/actions/fetch/cookiecutter.test.ts
+++ b/plugins/scaffolder-backend-module-cookiecutter/src/actions/fetch/cookiecutter.test.ts
@@ -14,14 +14,17 @@
  * limitations under the License.
  */
 
-import { UrlReader, ContainerRunner } from '@backstage/backend-common';
+import { UrlReader } from '@backstage/backend-common';
 import { ConfigReader } from '@backstage/config';
 import { JsonObject } from '@backstage/types';
 import { ScmIntegrations } from '@backstage/integration';
 import { createMockDirectory } from '@backstage/backend-test-utils';
 import { createFetchCookiecutterAction } from './cookiecutter';
 import { join } from 'path';
-import type { ActionContext } from '@backstage/plugin-scaffolder-node';
+import type {
+  ActionContext,
+  ContainerRunner,
+} from '@backstage/plugin-scaffolder-node';
 import { createMockActionContext } from '@backstage/plugin-scaffolder-node-test-utils';
 import { Writable } from 'stream';
 

--- a/plugins/scaffolder-backend-module-cookiecutter/src/actions/fetch/cookiecutter.ts
+++ b/plugins/scaffolder-backend-module-cookiecutter/src/actions/fetch/cookiecutter.ts
@@ -14,11 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  ContainerRunner,
-  UrlReader,
-  resolveSafeChildPath,
-} from '@backstage/backend-common';
+import { UrlReader, resolveSafeChildPath } from '@backstage/backend-common';
 import { JsonObject, JsonValue } from '@backstage/types';
 import { InputError } from '@backstage/errors';
 import { ScmIntegrations } from '@backstage/integration';
@@ -30,6 +26,7 @@ import {
   createTemplateAction,
   fetchContents,
   executeShellCommand,
+  ContainerRunner,
 } from '@backstage/plugin-scaffolder-node';
 
 export class CookiecutterRunner {

--- a/plugins/scaffolder-backend-module-gitlab/README.md
+++ b/plugins/scaffolder-backend-module-gitlab/README.md
@@ -47,7 +47,6 @@ const actions = [
 
 // Create Scaffolder Router
 return await createRouter({
-  containerRunner,
   catalogClient,
   actions,
   logger: env.logger,

--- a/plugins/scaffolder-backend-module-rails/README.md
+++ b/plugins/scaffolder-backend-module-rails/README.md
@@ -27,12 +27,10 @@ const actions = [
   createFetchRailsAction({
     integrations,
     reader: env.reader,
-    containerRunner,
   }),
 ];
 
 return await createRouter({
-  containerRunner,
   catalogClient,
   actions,
   logger: env.logger,
@@ -254,7 +252,6 @@ const actions = [
   createFetchRailsAction({
     integrations,
     reader: env.reader,
-    containerRunner,
     allowedImageNames: ['repository/rails:tag'],
   }),
 ];

--- a/plugins/scaffolder-backend-module-rails/api-report.md
+++ b/plugins/scaffolder-backend-module-rails/api-report.md
@@ -4,7 +4,7 @@
 
 ```ts
 import { BackendFeature } from '@backstage/backend-plugin-api';
-import { ContainerRunner } from '@backstage/backend-common';
+import { ContainerRunner } from '@backstage/plugin-scaffolder-node';
 import { JsonObject } from '@backstage/types';
 import { ScmIntegrations } from '@backstage/integration';
 import { TemplateAction } from '@backstage/plugin-scaffolder-node';

--- a/plugins/scaffolder-backend-module-rails/src/actions/fetch/rails/index.test.ts
+++ b/plugins/scaffolder-backend-module-rails/src/actions/fetch/rails/index.test.ts
@@ -27,12 +27,15 @@ jest.mock('./railsNewRunner', () => {
   };
 });
 
-import { ContainerRunner, UrlReader } from '@backstage/backend-common';
+import { UrlReader } from '@backstage/backend-common';
 import { ConfigReader } from '@backstage/config';
 import { ScmIntegrations } from '@backstage/integration';
 import { resolve as resolvePath } from 'path';
 import { createFetchRailsAction } from './index';
-import { fetchContents } from '@backstage/plugin-scaffolder-node';
+import {
+  ContainerRunner,
+  fetchContents,
+} from '@backstage/plugin-scaffolder-node';
 import { createMockDirectory } from '@backstage/backend-test-utils';
 import { createMockActionContext } from '@backstage/plugin-scaffolder-node-test-utils';
 import { Writable } from 'stream';

--- a/plugins/scaffolder-backend-module-rails/src/actions/fetch/rails/index.ts
+++ b/plugins/scaffolder-backend-module-rails/src/actions/fetch/rails/index.ts
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-import { ContainerRunner, UrlReader } from '@backstage/backend-common';
+import { UrlReader } from '@backstage/backend-common';
 import { JsonObject } from '@backstage/types';
 import { InputError } from '@backstage/errors';
 import { ScmIntegrations } from '@backstage/integration';
 import fs from 'fs-extra';
 import {
+  ContainerRunner,
   createTemplateAction,
   fetchContents,
 } from '@backstage/plugin-scaffolder-node';

--- a/plugins/scaffolder-backend-module-rails/src/actions/fetch/rails/railsNewRunner.test.ts
+++ b/plugins/scaffolder-backend-module-rails/src/actions/fetch/rails/railsNewRunner.test.ts
@@ -27,11 +27,11 @@ jest.mock(
       commandExists(...args),
 );
 
-import { ContainerRunner } from '@backstage/backend-common';
 import path from 'path';
 import { PassThrough } from 'stream';
 import { RailsNewRunner } from './railsNewRunner';
 import { createMockDirectory } from '@backstage/backend-test-utils';
+import { ContainerRunner } from '@backstage/plugin-scaffolder-node';
 
 describe('Rails Templater', () => {
   const containerRunner: jest.Mocked<ContainerRunner> = {

--- a/plugins/scaffolder-backend-module-rails/src/actions/fetch/rails/railsNewRunner.ts
+++ b/plugins/scaffolder-backend-module-rails/src/actions/fetch/rails/railsNewRunner.ts
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
-import { ContainerRunner } from '@backstage/backend-common';
 import fs from 'fs-extra';
 import path from 'path';
-import { executeShellCommand } from '@backstage/plugin-scaffolder-node';
+import {
+  ContainerRunner,
+  executeShellCommand,
+} from '@backstage/plugin-scaffolder-node';
 import commandExists from 'command-exists';
 import {
   railsArgumentResolver,

--- a/plugins/scaffolder-node/api-report.md
+++ b/plugins/scaffolder-node/api-report.md
@@ -131,6 +131,19 @@ export function commitAndPushRepo(input: {
   commitHash: string;
 }>;
 
+// @public
+export interface ContainerRunner {
+  runContainer(opts: {
+    imageName: string;
+    command?: string | string[];
+    args: string[];
+    logStream?: Writable;
+    mountDirs?: Record<string, string>;
+    workingDir?: string;
+    envVars?: Record<string, string>;
+  }): Promise<void>;
+}
+
 // @public (undocumented)
 export function createBranch(options: {
   dir: string;

--- a/plugins/scaffolder-node/src/index.ts
+++ b/plugins/scaffolder-node/src/index.ts
@@ -23,4 +23,4 @@
 export * from './actions';
 export * from './tasks';
 export * from './files';
-export type { TemplateFilter, TemplateGlobal } from './types';
+export type { TemplateFilter, TemplateGlobal, ContainerRunner } from './types';

--- a/plugins/scaffolder-node/src/types.ts
+++ b/plugins/scaffolder-node/src/types.ts
@@ -15,6 +15,7 @@
  */
 
 import { JsonValue } from '@backstage/types';
+import { Writable } from 'stream';
 
 /** @public */
 export type TemplateFilter = (...args: JsonValue[]) => JsonValue | undefined;
@@ -23,3 +24,23 @@ export type TemplateFilter = (...args: JsonValue[]) => JsonValue | undefined;
 export type TemplateGlobal =
   | ((...args: JsonValue[]) => JsonValue | undefined)
   | JsonValue;
+
+/**
+ * Handles the running of containers, on behalf of others.
+ *
+ * @public
+ */
+export interface ContainerRunner {
+  /**
+   * Runs a container image to completion.
+   */
+  runContainer(opts: {
+    imageName: string;
+    command?: string | string[];
+    args: string[];
+    logStream?: Writable;
+    mountDirs?: Record<string, string>;
+    workingDir?: string;
+    envVars?: Record<string, string>;
+  }): Promise<void>;
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Since we are moving away from `@backstage/backend-common` this PR moves the `ContainerRunner` type to `scaffolder-node`.
Related to https://github.com/backstage/backstage/issues/24549

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
