### PR TITLE
root: patch changesets to handle workspace ranges differently

### DIFF
--- a/.yarn/patches/@changesets-assemble-release-plan-npm-6.0.0-f7b3005037.patch
+++ b/.yarn/patches/@changesets-assemble-release-plan-npm-6.0.0-f7b3005037.patch
@@ -1,0 +1,32 @@
+diff --git a/dist/changesets-assemble-release-plan.cjs.js b/dist/changesets-assemble-release-plan.cjs.js
+index ee5c0f67fabadeb112e9f238d8b144a4d125830f..9b0e1a156dd88cee35f82faf718d82a8a8f80325 100644
+--- a/dist/changesets-assemble-release-plan.cjs.js
++++ b/dist/changesets-assemble-release-plan.cjs.js
+@@ -179,12 +179,23 @@ function getDependencyVersionRanges(dependentPkgJSON, dependencyRelease) {
+     if (!versionRange) continue;
+ 
+     if (versionRange.startsWith("workspace:")) {
++      // intentionally keep other workspace ranges untouched
++      // this has to be fixed but this should only be done when adding appropriate tests
++      let workspaceRange = versionRange.replace(/^workspace:/, "");
++      switch (workspaceRange) {
++        case "*":
++          // workspace:* actually means the current exact version, and not a wildcard similar to a reguler * range
++          workspaceRange = dependencyRelease.oldVersion;
++          break;
++        case "~":
++        case "^":
++          // Use ^oldVersion for workspace:^ or ~oldVersion for workspace:~.
++          // The version range might have changed in dependent package, but that should have its own changeset bumping that package.
++          workspaceRange += dependencyRelease.oldVersion;
++      }
+       dependencyVersionRanges.push({
+         depType: type,
+-        versionRange: // intentionally keep other workspace ranges untouched
+-        // this has to be fixed but this should only be done when adding appropriate tests
+-        versionRange === "workspace:*" ? // workspace:* actually means the current exact version, and not a wildcard similar to a reguler * range
+-        dependencyRelease.oldVersion : versionRange.replace(/^workspace:/, "")
++        versionRange: workspaceRange,
+       });
+     } else {
+       dependencyVersionRanges.push({

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
   },
   "prettier": "@spotify/prettier-config",
   "resolutions": {
+    "@changesets/assemble-release-plan@^6.0.0": "patch:@changesets/assemble-release-plan@npm%3A6.0.0#./.yarn/patches/@changesets-assemble-release-plan-npm-6.0.0-f7b3005037.patch",
     "@material-ui/pickers@^3.2.10": "patch:@material-ui/pickers@npm%3A3.3.11#./.yarn/patches/@material-ui-pickers-npm-3.3.11-1c8f68ea20.patch",
     "@material-ui/pickers@^3.3.10": "patch:@material-ui/pickers@npm%3A3.3.11#./.yarn/patches/@material-ui-pickers-npm-3.3.11-1c8f68ea20.patch",
     "@types/react": "^18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7817,7 +7817,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@changesets/assemble-release-plan@npm:^6.0.0":
+"@changesets/assemble-release-plan@npm:6.0.0":
   version: 6.0.0
   resolution: "@changesets/assemble-release-plan@npm:6.0.0"
   dependencies:
@@ -7828,6 +7828,20 @@ __metadata:
     "@manypkg/get-packages": ^1.1.3
     semver: ^7.5.3
   checksum: 0e6d25f25e0e3cc0e92aa8c43f5f496bae9464e2523be4ff81e31b6c9971b63bb1264821a2483c48d451d89d60af1acebe727e7f8c392ed48188a3ff26d0950e
+  languageName: node
+  linkType: hard
+
+"@changesets/assemble-release-plan@patch:@changesets/assemble-release-plan@npm%3A6.0.0#./.yarn/patches/@changesets-assemble-release-plan-npm-6.0.0-f7b3005037.patch::locator=root%40workspace%3A.":
+  version: 6.0.0
+  resolution: "@changesets/assemble-release-plan@patch:@changesets/assemble-release-plan@npm%3A6.0.0#./.yarn/patches/@changesets-assemble-release-plan-npm-6.0.0-f7b3005037.patch::version=6.0.0&hash=43c5e4&locator=root%40workspace%3A."
+  dependencies:
+    "@babel/runtime": ^7.20.1
+    "@changesets/errors": ^0.2.0
+    "@changesets/get-dependents-graph": ^2.0.0
+    "@changesets/types": ^6.0.0
+    "@manypkg/get-packages": ^1.1.3
+    semver: ^7.5.3
+  checksum: b7a68e28d03379bdc2a1d7171963990e1b88d0e5efca5f5ed490c0f583d66d0ccbd4c04ebf4e5cd1c38e1346ff0e5c4c16e1b4973cdd97fabdbad0c6996fe016
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This applies the fix from https://github.com/changesets/changesets/pull/1291

CC @Pike

I wanna try this out here 😁. It should fix our patch release process in that we no longer patch bump all dependents when we patch a package, which is currently the case.
