### PR TITLE
MultiEntityPicker field can be set as required

### DIFF
--- a/.changeset/sixty-bears-camp.md
+++ b/.changeset/sixty-bears-camp.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-scaffolder': minor
+'@backstage/plugin-scaffolder': patch
 ---
 
-`MultiEntityPicker` is able to be set as required
+Fixed a bug where the `MultiEntityPicker` was not able to be set as required

--- a/.changeset/sixty-bears-camp.md
+++ b/.changeset/sixty-bears-camp.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': minor
+---
+
+`MultiEntityPicker` is able to be set as required

--- a/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.tsx
@@ -173,7 +173,10 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
             FormHelperTextProps={{ margin: 'dense', style: { marginLeft: 0 } }}
             variant="outlined"
             required={required}
-            InputProps={params.InputProps}
+            InputProps={{
+              ...params.InputProps,
+              required: formData.length === 0 && required,
+            }}
           />
         )}
       />


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Fix: #23718 
Have added `required: formData.length === 0 && required` in `InputProps`

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
