### PR TITLE
repo fix command incorrect workspace property on windows

### DIFF
--- a/.changeset/slimy-kids-behave.md
+++ b/.changeset/slimy-kids-behave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Fixed an issue causing the `repo fix` command to set an incorrect `workspace` property using Windows

--- a/packages/cli/src/commands/repo/fix.ts
+++ b/packages/cli/src/commands/repo/fix.ts
@@ -22,11 +22,7 @@ import {
 } from '@backstage/cli-node';
 import { OptionValues } from 'commander';
 import fs from 'fs-extra';
-import {
-  resolve as resolvePath,
-  join as joinPath,
-  relative as relativePath,
-} from 'path';
+import { resolve as resolvePath, posix, relative as relativePath } from 'path';
 import { paths } from '../../lib/paths';
 
 /**
@@ -205,7 +201,7 @@ export function createRepositoryFieldFixer() {
   const rootDir = rootRepoField.directory || '';
 
   return (pkg: FixablePackage) => {
-    const expectedPath = joinPath(
+    const expectedPath = posix.join(
       rootDir,
       relativePath(paths.targetRoot, pkg.dir),
     );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes for https://github.com/backstage/community-plugins/pull/361#issuecomment-2087095343

It looks like on Windows the `repo fix` command had the side effect to set the `workspace` property using the wrong path separators.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
