### PR TITLE
chore(test): increase test coverage of WinstonLogger

### DIFF
--- a/packages/backend-app-api/src/logging/WinstonLogger.test.ts
+++ b/packages/backend-app-api/src/logging/WinstonLogger.test.ts
@@ -22,6 +22,17 @@ function msg(info: TransformableInfo): TransformableInfo {
 }
 
 describe('WinstonLogger', () => {
+  it('creates a winston logger instance with default options', () => {
+    const logger = WinstonLogger.create({});
+    expect(logger).toBeInstanceOf(WinstonLogger);
+  });
+
+  it('creates a child logger', () => {
+    const logger = WinstonLogger.create({});
+    const childLogger = logger.child({ plugin: 'test-plugin' });
+    expect(childLogger).toBeInstanceOf(WinstonLogger);
+  });
+
   it('redacter should redact and escape regex', () => {
     const redacter = WinstonLogger.redacter();
     const log = {
@@ -44,6 +55,26 @@ describe('WinstonLogger', () => {
         ...log,
         message: '[REDACTED] [REDACTED])',
         stack: '[REDACTED] [REDACTED]) from this file',
+      }),
+    );
+  });
+
+  it('redacter should redact nested object', () => {
+    const redacter = WinstonLogger.redacter();
+    const log = {
+      level: 'error',
+      message: {
+        nested: 'hello (world) from nested object',
+      },
+    };
+
+    redacter.add(['hello']);
+    expect(redacter.format.transform(msg(log))).toEqual(
+      msg({
+        ...log,
+        message: {
+          nested: '[REDACTED] (world) from nested',
+        },
       }),
     );
   });

--- a/packages/backend-app-api/src/logging/WinstonLogger.test.ts
+++ b/packages/backend-app-api/src/logging/WinstonLogger.test.ts
@@ -73,7 +73,7 @@ describe('WinstonLogger', () => {
       msg({
         ...log,
         message: {
-          nested: '[REDACTED] (world) from nested',
+          nested: '[REDACTED] (world) from nested object',
         },
       }),
     );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Somewhat refs https://github.com/backstage/backstage/pull/24478, but I suspect this is a file that would benefit from the increased coverage.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
