### PR TITLE
core-components: add lint rule to avoid circular imports

### DIFF
--- a/packages/core-components/.eslintrc.js
+++ b/packages/core-components/.eslintrc.js
@@ -5,6 +5,10 @@ module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
   },
   restrictedImports: [
     {
+      name: '@backstage/core-components',
+      message: "To avoid circular dependencies, use relative paths to import '@backstage/core-components' from its subdirectories."
+    },
+    {
       name: '@material-ui/core',
       message: "Please import '@material-ui/core/...' instead.",
     },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Trying to be proactive to avoid issues like https://github.com/backstage/backstage/pull/24511, so figured I'd propose adding a lint rule to `packages/core-components`. Here's what the lint output would have been:

```console 
$ yarn lint
Lint failed in packages/core-components:
✘  http://eslint.org/docs/rules/no-restricted-imports

     '@backstage/core-components' import is restricted from being used.  To avoid circular dependencies, use relative paths to import '@backstage/core-components' from its subdirectories

     src/layout/HeaderTabs/HeaderTabs.tsx:21:1
     19 | import Tabs from '@material-ui/core/Tabs';
     20 | import React, { useCallback, useEffect, useState } from 'react';
   > 21 | import { Link } from '@backstage/core-components';
        | ^
     22 | 
✘ 1 problem (1 error, 0 warnings)
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
