### PR TITLE
Adding support to override default author commit for github PRs

### DIFF
--- a/.changeset/nasty-papayas-heal.md
+++ b/.changeset/nasty-papayas-heal.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-scaffolder-backend-module-github': minor
+'@backstage/plugin-scaffolder-backend-module-github': patch
 ---
 
 Adding support to change the default commit author for `publish:github:pull-request`

--- a/.changeset/nasty-papayas-heal.md
+++ b/.changeset/nasty-papayas-heal.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-github': minor
+---
+
+Adding support to change the default commit author for pull-request github action"

--- a/.changeset/nasty-papayas-heal.md
+++ b/.changeset/nasty-papayas-heal.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-backend-module-github': minor
 ---
 
-Adding support to change the default commit author for pull-request github action"
+Adding support to change the default commit author for `publish:github:pull-request`

--- a/plugins/scaffolder-backend-module-github/api-report.md
+++ b/plugins/scaffolder-backend-module-github/api-report.md
@@ -128,7 +128,6 @@ export interface CreateGithubPullRequestActionOptions {
       } | null>;
     }
   >;
-  // (undocumented)
   config: Config;
   githubCredentialsProvider?: GithubCredentialsProvider;
   integrations: ScmIntegrationRegistry;

--- a/plugins/scaffolder-backend-module-github/api-report.md
+++ b/plugins/scaffolder-backend-module-github/api-report.md
@@ -389,6 +389,8 @@ export const createPublishGithubPullRequestAction: (
     commitMessage?: string | undefined;
     update?: boolean | undefined;
     forceFork?: boolean | undefined;
+    gitAuthorName?: string | undefined;
+    gitAuthorEmail?: string | undefined;
   },
   JsonObject
 >;

--- a/plugins/scaffolder-backend-module-github/api-report.md
+++ b/plugins/scaffolder-backend-module-github/api-report.md
@@ -128,6 +128,8 @@ export interface CreateGithubPullRequestActionOptions {
       } | null>;
     }
   >;
+  // (undocumented)
+  config: Config;
   githubCredentialsProvider?: GithubCredentialsProvider;
   integrations: ScmIntegrationRegistry;
 }

--- a/plugins/scaffolder-backend-module-github/api-report.md
+++ b/plugins/scaffolder-backend-module-github/api-report.md
@@ -128,7 +128,7 @@ export interface CreateGithubPullRequestActionOptions {
       } | null>;
     }
   >;
-  config: Config;
+  config?: Config;
   githubCredentialsProvider?: GithubCredentialsProvider;
   integrations: ScmIntegrationRegistry;
 }

--- a/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.examples.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.examples.test.ts
@@ -134,6 +134,10 @@ describe('publish:github:pull-request examples', () => {
               mode: '100644',
             },
           },
+          author: {
+            email: 'scaffolder@backstage.io',
+            name: 'Scaffolder',
+          },
         },
       ],
     });
@@ -174,6 +178,10 @@ describe('publish:github:pull-request examples', () => {
               mode: '100644',
             },
           },
+          author: {
+            email: 'scaffolder@backstage.io',
+            name: 'Scaffolder',
+          },
         },
       ],
     });
@@ -213,6 +221,10 @@ describe('publish:github:pull-request examples', () => {
               mode: '100644',
             },
           },
+          author: {
+            email: 'scaffolder@backstage.io',
+            name: 'Scaffolder',
+          },
         },
       ],
     });
@@ -251,6 +263,10 @@ describe('publish:github:pull-request examples', () => {
               encoding: 'base64',
               mode: '100644',
             },
+          },
+          author: {
+            email: 'scaffolder@backstage.io',
+            name: 'Scaffolder',
           },
         },
       ],
@@ -298,6 +314,10 @@ describe('publish:github:pull-request examples', () => {
               mode: '100644',
             },
           },
+          author: {
+            email: 'scaffolder@backstage.io',
+            name: 'Scaffolder',
+          },
         },
       ],
     });
@@ -338,6 +358,10 @@ describe('publish:github:pull-request examples', () => {
               mode: '100644',
             },
           },
+          author: {
+            email: 'scaffolder@backstage.io',
+            name: 'Scaffolder',
+          },
         },
       ],
     });
@@ -377,6 +401,10 @@ describe('publish:github:pull-request examples', () => {
               encoding: 'base64',
               mode: '100644',
             },
+          },
+          author: {
+            email: 'scaffolder@backstage.io',
+            name: 'Scaffolder',
           },
         },
       ],
@@ -424,6 +452,10 @@ describe('publish:github:pull-request examples', () => {
               mode: '100644',
             },
           },
+          author: {
+            email: 'scaffolder@backstage.io',
+            name: 'Scaffolder',
+          },
         },
       ],
     });
@@ -470,6 +502,54 @@ describe('publish:github:pull-request examples', () => {
               mode: '100644',
             },
           },
+          author: {
+            email: 'scaffolder@backstage.io',
+            name: 'Scaffolder',
+          },
+        },
+      ],
+    });
+
+    expect(fakeClient.rest.pulls.requestReviewers).not.toHaveBeenCalled();
+    expect(mockContext.output).toHaveBeenCalledTimes(3);
+    expect(mockContext.output).toHaveBeenCalledWith('targetBranchName', 'main');
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'remoteUrl',
+      'https://github.com/myorg/myrepo/pull/123',
+    );
+    expect(mockContext.output).toHaveBeenCalledWith('pullRequestNumber', 123);
+  });
+
+  it('Create a pull request with a git author', async () => {
+    const input = yaml.parse(examples[9].example).steps[0].input;
+
+    await action.handler({
+      ...mockContext,
+      workspacePath,
+      input,
+    });
+
+    expect(fakeClient.createPullRequest).toHaveBeenCalledWith({
+      owner: 'owner',
+      repo: 'repo',
+      title: 'Create my new app',
+      body: 'This PR is really good',
+      head: 'new-app',
+      draft: undefined,
+      changes: [
+        {
+          commit: 'Create my new app',
+          files: {
+            'file.txt': {
+              content: Buffer.from('Hello there!').toString('base64'),
+              encoding: 'base64',
+              mode: '100644',
+            },
+          },
+          author: {
+            email: 'foo@bar.example',
+            name: 'Foo Bar',
+          },
         },
       ],
     });
@@ -491,7 +571,7 @@ describe('publish:github:pull-request examples', () => {
         irrelevant: { 'bar.txt': 'Nothing to see here' },
       },
     });
-    const input = yaml.parse(examples[9].example).steps[0].input;
+    const input = yaml.parse(examples[10].example).steps[0].input;
 
     await action.handler({
       ...mockContext,
@@ -516,6 +596,10 @@ describe('publish:github:pull-request examples', () => {
               encoding: 'base64',
               mode: '100644',
             },
+          },
+          author: {
+            email: 'foo@bar.example',
+            name: 'Foo Bar',
           },
         },
       ],

--- a/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.examples.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.examples.test.ts
@@ -103,6 +103,7 @@ describe('publish:github:pull-request examples', () => {
       integrations,
       githubCredentialsProvider,
       clientFactory,
+      config,
     });
   });
 
@@ -133,10 +134,6 @@ describe('publish:github:pull-request examples', () => {
               encoding: 'base64',
               mode: '100644',
             },
-          },
-          author: {
-            email: 'scaffolder@backstage.io',
-            name: 'Scaffolder',
           },
         },
       ],
@@ -178,10 +175,6 @@ describe('publish:github:pull-request examples', () => {
               mode: '100644',
             },
           },
-          author: {
-            email: 'scaffolder@backstage.io',
-            name: 'Scaffolder',
-          },
         },
       ],
     });
@@ -221,10 +214,6 @@ describe('publish:github:pull-request examples', () => {
               mode: '100644',
             },
           },
-          author: {
-            email: 'scaffolder@backstage.io',
-            name: 'Scaffolder',
-          },
         },
       ],
     });
@@ -263,10 +252,6 @@ describe('publish:github:pull-request examples', () => {
               encoding: 'base64',
               mode: '100644',
             },
-          },
-          author: {
-            email: 'scaffolder@backstage.io',
-            name: 'Scaffolder',
           },
         },
       ],
@@ -314,10 +299,6 @@ describe('publish:github:pull-request examples', () => {
               mode: '100644',
             },
           },
-          author: {
-            email: 'scaffolder@backstage.io',
-            name: 'Scaffolder',
-          },
         },
       ],
     });
@@ -358,10 +339,6 @@ describe('publish:github:pull-request examples', () => {
               mode: '100644',
             },
           },
-          author: {
-            email: 'scaffolder@backstage.io',
-            name: 'Scaffolder',
-          },
         },
       ],
     });
@@ -401,10 +378,6 @@ describe('publish:github:pull-request examples', () => {
               encoding: 'base64',
               mode: '100644',
             },
-          },
-          author: {
-            email: 'scaffolder@backstage.io',
-            name: 'Scaffolder',
           },
         },
       ],
@@ -452,10 +425,6 @@ describe('publish:github:pull-request examples', () => {
               mode: '100644',
             },
           },
-          author: {
-            email: 'scaffolder@backstage.io',
-            name: 'Scaffolder',
-          },
         },
       ],
     });
@@ -502,10 +471,6 @@ describe('publish:github:pull-request examples', () => {
               mode: '100644',
             },
           },
-          author: {
-            email: 'scaffolder@backstage.io',
-            name: 'Scaffolder',
-          },
         },
       ],
     });
@@ -520,7 +485,7 @@ describe('publish:github:pull-request examples', () => {
     expect(mockContext.output).toHaveBeenCalledWith('pullRequestNumber', 123);
   });
 
-  it('Create a pull request with a git author', async () => {
+  it('Create a pull request with a git author name and email', async () => {
     const input = yaml.parse(examples[9].example).steps[0].input;
 
     await action.handler({
@@ -564,6 +529,94 @@ describe('publish:github:pull-request examples', () => {
     expect(mockContext.output).toHaveBeenCalledWith('pullRequestNumber', 123);
   });
 
+  it('Create a pull request with a git author name', async () => {
+    const input = yaml.parse(examples[10].example).steps[0].input;
+
+    await action.handler({
+      ...mockContext,
+      workspacePath,
+      input,
+    });
+
+    expect(fakeClient.createPullRequest).toHaveBeenCalledWith({
+      owner: 'owner',
+      repo: 'repo',
+      title: 'Create my new app',
+      body: 'This PR is really good',
+      head: 'new-app',
+      draft: undefined,
+      changes: [
+        {
+          commit: 'Create my new app',
+          files: {
+            'file.txt': {
+              content: Buffer.from('Hello there!').toString('base64'),
+              encoding: 'base64',
+              mode: '100644',
+            },
+          },
+          author: {
+            email: 'scaffolder@backstage.io',
+            name: 'Foo Bar',
+          },
+        },
+      ],
+    });
+
+    expect(fakeClient.rest.pulls.requestReviewers).not.toHaveBeenCalled();
+    expect(mockContext.output).toHaveBeenCalledTimes(3);
+    expect(mockContext.output).toHaveBeenCalledWith('targetBranchName', 'main');
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'remoteUrl',
+      'https://github.com/myorg/myrepo/pull/123',
+    );
+    expect(mockContext.output).toHaveBeenCalledWith('pullRequestNumber', 123);
+  });
+
+  it('Create a pull request with a git author email', async () => {
+    const input = yaml.parse(examples[11].example).steps[0].input;
+
+    await action.handler({
+      ...mockContext,
+      workspacePath,
+      input,
+    });
+
+    expect(fakeClient.createPullRequest).toHaveBeenCalledWith({
+      owner: 'owner',
+      repo: 'repo',
+      title: 'Create my new app',
+      body: 'This PR is really good',
+      head: 'new-app',
+      draft: undefined,
+      changes: [
+        {
+          commit: 'Create my new app',
+          files: {
+            'file.txt': {
+              content: Buffer.from('Hello there!').toString('base64'),
+              encoding: 'base64',
+              mode: '100644',
+            },
+          },
+          author: {
+            email: 'foo@bar.example',
+            name: 'Scaffolder',
+          },
+        },
+      ],
+    });
+
+    expect(fakeClient.rest.pulls.requestReviewers).not.toHaveBeenCalled();
+    expect(mockContext.output).toHaveBeenCalledTimes(3);
+    expect(mockContext.output).toHaveBeenCalledWith('targetBranchName', 'main');
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'remoteUrl',
+      'https://github.com/myorg/myrepo/pull/123',
+    );
+    expect(mockContext.output).toHaveBeenCalledWith('pullRequestNumber', 123);
+  });
+
   it('Create a pull request with all parameters', async () => {
     mockDir.setContent({
       [workspacePath]: {
@@ -571,7 +624,7 @@ describe('publish:github:pull-request examples', () => {
         irrelevant: { 'bar.txt': 'Nothing to see here' },
       },
     });
-    const input = yaml.parse(examples[10].example).steps[0].input;
+    const input = yaml.parse(examples[12].example).steps[0].input;
 
     await action.handler({
       ...mockContext,

--- a/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.examples.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.examples.ts
@@ -179,7 +179,7 @@ export const examples: TemplateExample[] = [
     }),
   },
   {
-    description: 'Create a pull request with a git author',
+    description: 'Create a pull request with a git author name and email',
     example: yaml.stringify({
       steps: [
         {
@@ -191,6 +191,46 @@ export const examples: TemplateExample[] = [
             title: 'Create my new app',
             description: 'This PR is really good',
             gitAuthorName: 'Foo Bar',
+            gitAuthorEmail: 'foo@bar.example',
+          },
+        },
+      ],
+    }),
+  },
+  {
+    description: 'Create a pull request with a git author name',
+    example: yaml.stringify({
+      steps: [
+        {
+          action: 'publish:github:pull-request',
+          name: 'Create a pull reuqest',
+          input: {
+            repoUrl: 'github.com?repo=repo&owner=owner',
+            branchName: 'new-app',
+            title: 'Create my new app',
+            description: 'This PR is really good',
+            // gitAuthorEmail will be 'scaffolder@backstage.io'
+            // once one author attribute has been set we need to set both
+            gitAuthorName: 'Foo Bar',
+          },
+        },
+      ],
+    }),
+  },
+  {
+    description: 'Create a pull request with a git author email',
+    example: yaml.stringify({
+      steps: [
+        {
+          action: 'publish:github:pull-request',
+          name: 'Create a pull reuqest',
+          input: {
+            repoUrl: 'github.com?repo=repo&owner=owner',
+            branchName: 'new-app',
+            title: 'Create my new app',
+            description: 'This PR is really good',
+            // gitAuthorName will be 'Scaffolder'
+            // once one author attribute has been set we need to set both
             gitAuthorEmail: 'foo@bar.example',
           },
         },

--- a/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.examples.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.examples.ts
@@ -179,6 +179,25 @@ export const examples: TemplateExample[] = [
     }),
   },
   {
+    description: 'Create a pull request with a git author',
+    example: yaml.stringify({
+      steps: [
+        {
+          action: 'publish:github:pull-request',
+          name: 'Create a pull reuqest',
+          input: {
+            repoUrl: 'github.com?repo=repo&owner=owner',
+            branchName: 'new-app',
+            title: 'Create my new app',
+            description: 'This PR is really good',
+            gitAuthorName: 'Foo Bar',
+            gitAuthorEmail: 'foo@bar.example',
+          },
+        },
+      ],
+    }),
+  },
+  {
     description: 'Create a pull request with all parameters',
     example: yaml.stringify({
       steps: [
@@ -198,6 +217,8 @@ export const examples: TemplateExample[] = [
             reviewers: ['foobar'],
             teamReviewers: ['team-foo'],
             commitMessage: 'Commit for foo changes',
+            gitAuthorName: 'Foo Bar',
+            gitAuthorEmail: 'foo@bar.example',
           },
         },
       ],

--- a/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.test.ts
@@ -155,6 +155,10 @@ describe('createPublishGithubPullRequestAction', () => {
                 mode: '100644',
               },
             },
+            author: {
+              email: 'scaffolder@backstage.io',
+              name: 'Scaffolder',
+            },
           },
         ],
       });
@@ -211,6 +215,10 @@ describe('createPublishGithubPullRequestAction', () => {
                 encoding: 'base64',
                 mode: '100644',
               },
+            },
+            author: {
+              email: 'scaffolder@backstage.io',
+              name: 'Scaffolder',
             },
           },
         ],
@@ -271,6 +279,10 @@ describe('createPublishGithubPullRequestAction', () => {
                 mode: '100644',
               },
             },
+            author: {
+              email: 'scaffolder@backstage.io',
+              name: 'Scaffolder',
+            },
           },
         ],
       });
@@ -321,6 +333,10 @@ describe('createPublishGithubPullRequestAction', () => {
                 encoding: 'base64',
                 mode: '100644',
               },
+            },
+            author: {
+              email: 'scaffolder@backstage.io',
+              name: 'Scaffolder',
             },
           },
         ],
@@ -449,6 +465,10 @@ describe('createPublishGithubPullRequestAction', () => {
                 mode: '120000',
               },
             },
+            author: {
+              email: 'scaffolder@backstage.io',
+              name: 'Scaffolder',
+            },
           },
         ],
       });
@@ -497,6 +517,10 @@ describe('createPublishGithubPullRequestAction', () => {
                 encoding: 'base64',
                 mode: '100755',
               },
+            },
+            author: {
+              email: 'scaffolder@backstage.io',
+              name: 'Scaffolder',
             },
           },
         ],
@@ -557,6 +581,10 @@ describe('createPublishGithubPullRequestAction', () => {
                 mode: '100755',
               },
             },
+            author: {
+              email: 'scaffolder@backstage.io',
+              name: 'Scaffolder',
+            },
           },
         ],
       });
@@ -612,6 +640,10 @@ describe('createPublishGithubPullRequestAction', () => {
                 mode: '100644',
               },
             },
+            author: {
+              email: 'scaffolder@backstage.io',
+              name: 'Scaffolder',
+            },
           },
         ],
       });
@@ -657,9 +689,63 @@ describe('createPublishGithubPullRequestAction', () => {
                 mode: '100644',
               },
             },
+            author: {
+              email: 'scaffolder@backstage.io',
+              name: 'Scaffolder',
+            },
           },
         ],
         forceFork: true,
+      });
+    });
+  });
+
+  describe('with author', () => {
+    let input: GithubPullRequestActionInput;
+    let ctx: ActionContext<GithubPullRequestActionInput>;
+
+    beforeEach(() => {
+      input = {
+        repoUrl: 'github.com?owner=myorg&repo=myrepo',
+        title: 'Create my new app',
+        branchName: 'new-app',
+        description: 'This PR is really good',
+        gitAuthorEmail: 'foo@bar.example',
+        gitAuthorName: 'Foo Bar',
+      };
+
+      mockDir.setContent({
+        [workspacePath]: { 'file.txt': 'Hello there!' },
+      });
+
+      ctx = createMockActionContext({ input, workspacePath });
+    });
+
+    it('creates a pull request', async () => {
+      await instance.handler(ctx);
+
+      expect(fakeClient.createPullRequest).toHaveBeenCalledWith({
+        owner: 'myorg',
+        repo: 'myrepo',
+        title: 'Create my new app',
+        head: 'new-app',
+        body: 'This PR is really good',
+        changes: [
+          {
+            commit: 'Create my new app',
+            files: {
+              'file.txt': {
+                content: Buffer.from('Hello there!').toString('base64'),
+                encoding: 'base64',
+                mode: '100644',
+              },
+            },
+            author: {
+              email: 'foo@bar.example',
+              name: 'Foo Bar',
+            },
+          },
+        ],
       });
     });
   });

--- a/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.ts
@@ -104,7 +104,7 @@ export interface CreateGithubPullRequestActionOptions {
   /**
    * An instance of {@link @backstage/config#Config} that will be used in the action.
    */
-  config: Config;
+  config?: Config;
 }
 
 type GithubPullRequest = {
@@ -351,7 +351,7 @@ export const createPublishGithubPullRequestAction = (
               files,
               commit:
                 commitMessage ??
-                config.getOptionalString('scaffolder.defaultCommitMessage') ??
+                config?.getOptionalString('scaffolder.defaultCommitMessage') ??
                 title,
             },
           ],
@@ -365,10 +365,10 @@ export const createPublishGithubPullRequestAction = (
         const gitAuthorInfo = {
           name:
             gitAuthorName ??
-            config.getOptionalString('scaffolder.defaultAuthor.name'),
+            config?.getOptionalString('scaffolder.defaultAuthor.name'),
           email:
             gitAuthorEmail ??
-            config.getOptionalString('scaffolder.defaultAuthor.email'),
+            config?.getOptionalString('scaffolder.defaultAuthor.email'),
         };
 
         if (gitAuthorInfo.name || gitAuthorInfo.email) {

--- a/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.ts
@@ -101,6 +101,9 @@ export interface CreateGithubPullRequestActionOptions {
       } | null>;
     }
   >;
+  /**
+   * An instance of {@link @backstage/config#Config} that will be used in the action.
+   */
   config: Config;
 }
 

--- a/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.ts
@@ -136,6 +136,8 @@ export const createPublishGithubPullRequestAction = (
     commitMessage?: string;
     update?: boolean;
     forceFork?: boolean;
+    gitAuthorName?: string;
+    gitAuthorEmail?: string;
   }>({
     id: 'publish:github:pull-request',
     examples,
@@ -223,6 +225,18 @@ export const createPublishGithubPullRequestAction = (
             title: 'Force Fork',
             description: 'Create pull request from a fork',
           },
+          gitAuthorName: {
+            type: 'string',
+            title: 'Default Author Name',
+            description:
+              "Sets the default author name for the commit. The default value is 'Scaffolder'",
+          },
+          gitAuthorEmail: {
+            type: 'string',
+            title: 'Default Author Email',
+            description:
+              "Sets the default author email for the commit. The default value is 'scaffolder@backstage.io'",
+          },
         },
       },
       output: {
@@ -262,6 +276,8 @@ export const createPublishGithubPullRequestAction = (
         commitMessage,
         update,
         forceFork,
+        gitAuthorEmail = 'scaffolder@backstage.io',
+        gitAuthorName = 'Scaffolder',
       } = ctx.input;
 
       const { owner, repo, host } = parseRepoUrl(repoUrl, integrations);
@@ -328,6 +344,10 @@ export const createPublishGithubPullRequestAction = (
             {
               files,
               commit: commitMessage ?? title,
+              author: {
+                name: gitAuthorName,
+                email: gitAuthorEmail,
+              },
             },
           ],
           body: description,
@@ -336,6 +356,7 @@ export const createPublishGithubPullRequestAction = (
           update,
           forceFork,
         };
+
         if (targetBranchName) {
           createOptions.base = targetBranchName;
         }

--- a/plugins/scaffolder-backend-module-github/src/module.ts
+++ b/plugins/scaffolder-backend-module-github/src/module.ts
@@ -89,6 +89,7 @@ export const githubModule = createBackendModule({
           createPublishGithubPullRequestAction({
             integrations,
             githubCredentialsProvider,
+            config,
           }),
         );
       },

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -285,6 +285,8 @@ export const createPublishGithubPullRequestAction: (
     commitMessage?: string | undefined;
     update?: boolean | undefined;
     forceFork?: boolean | undefined;
+    gitAuthorName?: string | undefined;
+    gitAuthorEmail?: string | undefined;
   },
   JsonObject
 >;

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/createBuiltinActions.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/createBuiltinActions.ts
@@ -178,6 +178,7 @@ export const createBuiltinActions = (
     createPublishGithubPullRequestAction({
       integrations,
       githubCredentialsProvider,
+      config,
     }),
     createPublishGitlabAction({
       integrations,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Adding support to override the default commit author when opening PRs using GitHub action (according publish action does):

```
gitAuthorName: Author name...
gitAuthorEmail: Author email...
```

<img width="1207" alt="SCR-20240503-rvel" src="https://github.com/backstage/backstage/assets/11684103/18edde5c-758b-4579-8637-7ec341a18292">

<img width="1187" alt="SCR-20240503-rvhz" src="https://github.com/backstage/backstage/assets/11684103/1437ec76-15a5-4995-a86b-65014ae857af">

<img width="1193" alt="SCR-20240503-rvjb" src="https://github.com/backstage/backstage/assets/11684103/eeb76c52-b599-4a26-ab25-b322587dc847">

<img width="1290" alt="SCR-20240503-ruka" src="https://github.com/backstage/backstage/assets/11684103/768d13e3-9cf7-4d5b-88ab-73b18d266e5c">

<img width="1278" alt="SCR-20240503-rulu" src="https://github.com/backstage/backstage/assets/11684103/5201fe80-7a25-4d59-ba49-c168f98d54b6">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
