### PR TITLE
Devtools Plugin ReadMe Update

### DIFF
--- a/.changeset/grumpy-toes-tap.md
+++ b/.changeset/grumpy-toes-tap.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-devtools-backend': patch
+---
+
+Added discovery property to the readme documentation to ensure that it will build when setting it up as new to a Backstage instance

--- a/plugins/devtools-backend/README.md
+++ b/plugins/devtools-backend/README.md
@@ -28,6 +28,7 @@ Here's how to get the DevTools Backend up and running:
        logger: env.logger,
        config: env.config,
        permissions: env.permissions,
+       discovery: env.discovery,
      });
    }
    ```


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I updated the devtools backend plugin readme document to add a missing property that will cause the build to fail without it. 

#### :heavy_check_mark: Checklist

---
'@backstage/plugins/devtools-backend': patch
---

Added `discovery` property to the readme documentation to ensure that it will build when setting it up as new to a Backstage instance


- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
