### PR TITLE
fix(plugin-template): new plugins fail the verify-docs & verify-types check

### DIFF
--- a/.changeset/shy-hounds-battle.md
+++ b/.changeset/shy-hounds-battle.md
@@ -2,4 +2,4 @@
 '@backstage/cli': patch
 ---
 
-Fix a bug in the backend plugin template that was creating an incorrect link.
+Fix a few minor issues with the backend template that were causing failing linting checks in the main repo.

--- a/.changeset/shy-hounds-battle.md
+++ b/.changeset/shy-hounds-battle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Fix a bug in the backend plugin template that was creating an incorrect link.

--- a/packages/cli/templates/default-backend-plugin/README.md.hbs
+++ b/packages/cli/templates/default-backend-plugin/README.md.hbs
@@ -11,4 +11,4 @@ start` in the root directory, and then navigating to [/{{pluginVar}}/health](htt
 
 You can also serve the plugin in isolation by running `yarn start` in the plugin directory.
 This method of serving the plugin provides quicker iteration speed and a faster startup and hot reloads.
-It is only meant for local development, and the setup for it can be found inside the [/dev](/dev) directory.
+It is only meant for local development, and the setup for it can be found inside the [/dev](./dev) directory.

--- a/packages/cli/templates/default-backend-plugin/package.json.hbs
+++ b/packages/cli/templates/default-backend-plugin/package.json.hbs
@@ -32,7 +32,6 @@
     "@backstage/backend-defaults": "{{versionQuery '@backstage/backend-defaults'}}",
     "@backstage/backend-plugin-api": "{{versionQuery '@backstage/backend-plugin-api'}}",
     "@backstage/config": "{{versionQuery '@backstage/config'}}",
-    "@types/express": "{{versionQuery '@types/express' '4.17.6'}}",
     "express": "{{versionQuery 'express' '4.17.1'}}",
     "express-promise-router": "{{versionQuery 'express-promise-router' '4.1.0'}}",
     "winston": "{{versionQuery 'winston' '3.2.1'}}",
@@ -43,6 +42,7 @@
     "@backstage/cli": "{{versionQuery '@backstage/cli'}}",
     "@backstage/plugin-auth-backend": "{{versionQuery '@backstage/plugin-auth-backend'}}",
     "@backstage/plugin-auth-backend-module-guest-provider": "{{versionQuery '@backstage/plugin-auth-backend-module-guest-provider'}}",
+    "@types/express": "{{versionQuery '@types/express' '4.17.6'}}",
     "@types/supertest": "{{versionQuery '@types/supertest' '2.0.12'}}",
     "supertest": "{{versionQuery 'supertest' '6.2.4'}}",
     "msw": "{{versionQuery 'msw' '1.0.0'}}"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

There is a block in the new plugin readme's that is causing issues for the verify-docs check and doesn't redirect to the desired relative `/dev` folder.

I also moved the `@types/express` dependency to a devDependency.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
