### PR TITLE
frontend-app-api: always shunt mentioned extensions to the top

### DIFF
--- a/.changeset/lazy-phones-worry.md
+++ b/.changeset/lazy-phones-worry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-app-api': minor
+---
+
+Extensions in app-config now always affect ordering. Previously, only when enabling disabled extensions did they rise to the top.

--- a/packages/frontend-app-api/src/tree/resolveAppNodeSpecs.test.ts
+++ b/packages/frontend-app-api/src/tree/resolveAppNodeSpecs.test.ts
@@ -111,16 +111,16 @@ describe('resolveAppNodeSpecs', () => {
       }),
     ).toEqual([
       {
+        id: 'b',
+        extension: b,
+        attachTo: { id: 'derp', input: 'default' },
+        disabled: false,
+      },
+      {
         id: 'test/a',
         extension: makeExt('test/a'),
         attachTo: { id: 'root', input: 'default' },
         source: pluginA,
-        disabled: false,
-      },
-      {
-        id: 'b',
-        extension: b,
-        attachTo: { id: 'derp', input: 'default' },
         disabled: false,
       },
     ]);
@@ -202,6 +202,70 @@ describe('resolveAppNodeSpecs', () => {
         extension: a,
         attachTo: { id: 'root', input: 'default' },
         disabled: false,
+      },
+    ]);
+  });
+
+  it('should place config-mentioned instances in the order that they were listed, irrespective of if the extension was enabled or not originally', () => {
+    const a = makeExt('a', 'disabled');
+    const b = makeExt('b', 'enabled');
+    const c = makeExt('c', 'disabled');
+    const d = makeExt('d', 'enabled');
+    const e = makeExt('e', 'disabled');
+    const f = makeExt('f', 'enabled');
+    const g = makeExt('g', 'disabled');
+    expect(
+      resolveAppNodeSpecs({
+        features: [createPlugin({ id: 'empty', extensions: [] })],
+        builtinExtensions: [a, b, c, d, e, f, g],
+        parameters: [
+          { id: 'e', disabled: false },
+          { id: 'd', disabled: false },
+          { id: 'c', disabled: false },
+        ],
+      }),
+    ).toEqual([
+      {
+        id: 'e',
+        extension: e,
+        attachTo: { id: 'root', input: 'default' },
+        disabled: false,
+      },
+      {
+        id: 'd',
+        extension: d,
+        attachTo: { id: 'root', input: 'default' },
+        disabled: false,
+      },
+      {
+        id: 'c',
+        extension: c,
+        attachTo: { id: 'root', input: 'default' },
+        disabled: false,
+      },
+      {
+        id: 'a',
+        extension: a,
+        attachTo: { id: 'root', input: 'default' },
+        disabled: true,
+      },
+      {
+        id: 'b',
+        extension: b,
+        attachTo: { id: 'root', input: 'default' },
+        disabled: false,
+      },
+      {
+        id: 'f',
+        extension: f,
+        attachTo: { id: 'root', input: 'default' },
+        disabled: false,
+      },
+      {
+        id: 'g',
+        extension: g,
+        attachTo: { id: 'root', input: 'default' },
+        disabled: true,
       },
     ]);
   });

--- a/packages/frontend-plugin-api/src/wiring/createPlugin.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createPlugin.test.ts
@@ -187,7 +187,7 @@ describe('createPlugin', () => {
 
     await expect(
       screen.findByText(
-        'Names: extension-1, extension-2-renamed, extension-3:child',
+        'Names: extension-2-renamed, extension-1, extension-3:child',
       ),
     ).resolves.toBeInTheDocument();
   });


### PR DESCRIPTION
I am not sure that this is the full solution that we want.

It's still true that forcibly reordering things (even if you just wanted to override some small config value or so) can be disruptive. I think that we want to amend this in the future with the ability to for example say

```yaml
    - entity-card:catalog-graph/relations:
        order: initial                         # or first, or last
        config:
          height: 300
```

The way i wrote the code here, it'll be easy to add a set of "first" items and a set of "last" items, and ensure that we follow those. Then the question is mainly whether we want the default to be initial, or whether it should be first. Or, indeed, whether it should depend on whether it was enabled before or not.

Happy for feedback on how to continue with this one.