### PR TITLE
feat: Add support for readTree in harness url reader

### DIFF
--- a/.changeset/orange-pianos-eat.md
+++ b/.changeset/orange-pianos-eat.md
@@ -1,0 +1,6 @@
+---
+'@backstage/backend-common': minor
+'@backstage/integration': minor
+---
+
+Implemented `readTree` for Harness provider to support TechDocs functionality

--- a/docs/features/techdocs/README.md
+++ b/docs/features/techdocs/README.md
@@ -70,6 +70,7 @@ See [TechDocs Architecture](architecture.md) to get an overview of where the bel
 | GitLab Enterprise            | Yes ✅         |
 | Gitea                        | Yes ✅         |
 | AWS CodeCommit               | Yes ✅         |
+| Harness Code                 | Yes ✅         |
 
 ### File storage providers
 

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -515,13 +515,18 @@ export class GitlabUrlReader implements UrlReader {
 
 // @public
 export class HarnessUrlReader implements UrlReader {
-  constructor(integration: HarnessIntegration);
+  constructor(
+    integration: HarnessIntegration,
+    deps: {
+      treeResponseFactory: ReadTreeResponseFactory;
+    },
+  );
   // (undocumented)
   static factory: ReaderFactory;
   // (undocumented)
   read(url: string): Promise<Buffer>;
   // (undocumented)
-  readTree(): Promise<ReadTreeResponse>;
+  readTree(url: string, options?: ReadTreeOptions): Promise<ReadTreeResponse>;
   // (undocumented)
   readUrl(url: string, options?: ReadUrlOptions): Promise<ReadUrlResponse>;
   // (undocumented)

--- a/packages/backend-common/src/reading/HarnessUrlReader.test.ts
+++ b/packages/backend-common/src/reading/HarnessUrlReader.test.ts
@@ -25,6 +25,9 @@ import { UrlReaderPredicateTuple } from './types';
 import { DefaultReadTreeResponseFactory } from './tree';
 import getRawBody from 'raw-body';
 import { HarnessUrlReader } from './HarnessUrlReader';
+import { NotFoundError, NotModifiedError } from '@backstage/errors';
+import fs from 'fs-extra';
+import path from 'path';
 
 const treeResponseFactory = DefaultReadTreeResponseFactory.create({
   config: new ConfigReader({}),
@@ -47,6 +50,7 @@ const harnessProcessor = new HarnessUrlReader(
       }),
     ),
   ),
+  { treeResponseFactory },
 );
 
 const createReader = (config: JsonObject): UrlReaderPredicateTuple[] => {
@@ -60,6 +64,7 @@ const responseBuffer = Buffer.from('Apache License');
 const harnessApiResponse = (content: any) => {
   return content;
 };
+const commitHash = '3bdd5457286abdf920db4b77bf2fef79a06190c2';
 
 const handlers = [
   rest.get(
@@ -91,6 +96,22 @@ const handlers = [
         ctx.status(200),
         ctx.body(harnessApiResponse(responseBuffer.toString())),
       );
+    },
+  ),
+  rest.get(
+    'https://app.harness.io/gateway/code/api/v1/repos/accountId/orgName2/projectName/repoName/:path+/content?routingId=accountId&include_commit=true&git_ref=refs/heads/branchName',
+    (_req, res, ctx) => {
+      return res(
+        ctx.status(200),
+        ctx.set('Content-Type', 'application/json'),
+        ctx.json({ latest_commit: { sha: commitHash } }),
+      );
+    },
+  ),
+  rest.get(
+    'https://app.harness.io/gateway/code/api/v1/repos/accountId/orgName3/projectName/repoName/:path+/content?routingId=accountId&include_commit=true&git_ref=refs/heads/branchName',
+    (_, res, ctx) => {
+      return res(ctx.status(404));
     },
   ),
 ];
@@ -168,7 +189,7 @@ describe('HarnessUrlReader', () => {
           'https://app.harness.io/ng/account/accountId/module/code/orgs/orgName/projects/projName/repos/repoName/files/refMain/~/404error.yaml',
         ),
       ).rejects.toThrow(
-        'https://app.harness.io/ng/account/accountId/module/code/orgs/orgName/projects/projName/repos/repoName/files/refMain/~/404error.yaml x https://app.harness.io/gateway/code/api/v1/repos/accountId/orgName/projName/repoName/+/raw/404error.yaml?routingId=accountId&git_ref=refMain, 404 Not Found',
+        'https://app.harness.io/ng/account/accountId/module/code/orgs/orgName/projects/projName/repos/repoName/files/refMain/~/404error.yaml x https://app.harness.io/gateway/code/api/v1/repos/accountId/orgName/projName/repoName/+/raw/404error.yaml?routingId=accountId&git_ref=refs/heads/refMain, 404 Not Found',
       );
     });
 
@@ -178,8 +199,60 @@ describe('HarnessUrlReader', () => {
           'https://app.harness.io/ng/account/accountId/module/code/orgs/orgName/projects/projName/repos/repoName/files/refMain/~/all-apis.yaml',
         ),
       ).rejects.toThrow(
-        'https://app.harness.io/ng/account/accountId/module/code/orgs/orgName/projects/projName/repos/repoName/files/refMain/~/all-apis.yaml x https://app.harness.io/gateway/code/api/v1/repos/accountId/orgName/projName/repoName/+/raw/all-apis.yaml?routingId=accountId&git_ref=refMain, 500 Internal Server Error',
+        'https://app.harness.io/ng/account/accountId/module/code/orgs/orgName/projects/projName/repos/repoName/files/refMain/~/all-apis.yaml x https://app.harness.io/gateway/code/api/v1/repos/accountId/orgName/projName/repoName/+/raw/all-apis.yaml?routingId=accountId&git_ref=refs/heads/refMain, 500 Internal Server Error',
       );
+    });
+  });
+
+  describe('readTree', () => {
+    const repoBuffer = fs.readFileSync(
+      path.resolve(__dirname, '__fixtures__/mock-main.zip'),
+    );
+
+    it('should be able to get archive', async () => {
+      worker.use(
+        rest.get(
+          'https://app.harness.io/gateway/code/api/v1/repos/accountId/orgName2/projectName/repoName/:path+/archive/branchName.zip',
+          (_, res, ctx) => {
+            return res(
+              ctx.status(200),
+              ctx.set('Content-Type', 'application/gzip'),
+              ctx.set(
+                'content-disposition',
+                'attachment; filename=backstage-mock.zip',
+              ),
+              ctx.body(repoBuffer),
+            );
+          },
+        ),
+      );
+
+      const response = await harnessProcessor.readTree(
+        'https://app.harness.io/ng/account/accountId/module/code/orgs/orgName2/projects/projectName/repos/repoName/files/branchName',
+      );
+      expect(response.etag).toBe(commitHash);
+
+      const files = await response.files();
+      expect(files.length).toBe(2);
+    });
+
+    it('should return not modified', async () => {
+      await expect(
+        harnessProcessor.readTree(
+          'https://app.harness.io/ng/account/accountId/module/code/orgs/orgName2/projects/projectName/repos/repoName/files/branchName2',
+          {
+            etag: commitHash,
+          },
+        ),
+      ).rejects.toThrow(NotModifiedError);
+    });
+
+    it('should return not found', async () => {
+      await expect(
+        harnessProcessor.readTree(
+          'https://app.harness.io/ng/account/accountId/module/code/orgs/orgName3/projects/projectName/repos/repoName/files/branchName3',
+        ),
+      ).rejects.toThrow(NotFoundError);
     });
   });
 });

--- a/packages/integration/api-report.md
+++ b/packages/integration/api-report.md
@@ -514,7 +514,19 @@ export function getGitLabRequestOptions(config: GitLabIntegrationConfig): {
 };
 
 // @public
+export function getHarnessArchiveUrl(
+  config: HarnessIntegrationConfig,
+  url: string,
+): string;
+
+// @public
 export function getHarnessFileContentsUrl(
+  config: HarnessIntegrationConfig,
+  url: string,
+): string;
+
+// @public
+export function getHarnessLatestCommitUrl(
   config: HarnessIntegrationConfig,
   url: string,
 ): string;
@@ -762,6 +774,21 @@ export function parseGiteaUrl(
   name: string;
   ref: string;
   path: string;
+};
+
+// @public
+export function parseHarnessUrl(
+  config: HarnessIntegrationConfig,
+  url: string,
+): {
+  baseUrl: string;
+  accountId: string;
+  orgName: string;
+  projectName: string;
+  refString: string;
+  repoName: string;
+  path: string;
+  refDashStr: string;
 };
 
 // @public

--- a/packages/integration/src/harness/core.test.ts
+++ b/packages/integration/src/harness/core.test.ts
@@ -18,9 +18,12 @@ import { setupServer } from 'msw/node';
 import { setupRequestMockHandlers } from '../helpers';
 import { HarnessIntegrationConfig } from './config';
 import {
+  getHarnessArchiveUrl,
   getHarnessEditContentsUrl,
   getHarnessFileContentsUrl,
+  getHarnessLatestCommitUrl,
   getHarnessRequestOptions,
+  parseHarnessUrl,
 } from './core';
 
 describe('Harness code core', () => {
@@ -38,7 +41,7 @@ describe('Harness code core', () => {
           'https://app.harness.io/ng/account/accountId/module/code/orgs/orgName/projects/projName/repos/repoName/files/refMain/~/all-apis.yaml',
         ),
       ).toEqual(
-        'https://app.harness.io/gateway/code/api/v1/repos/accountId/orgName/projName/repoName/+/raw/all-apis.yaml?routingId=accountId&git_ref=refMain',
+        'https://app.harness.io/gateway/code/api/v1/repos/accountId/orgName/projName/repoName/+/raw/all-apis.yaml?routingId=accountId&git_ref=refs/heads/refMain',
       );
     });
   });
@@ -55,6 +58,38 @@ describe('Harness code core', () => {
         ),
       ).toEqual(
         'https://app.harness.io/gateway/code/api/v1/repos/accountId/orgName/projName/repoName/+/edit/all-apis.yaml',
+      );
+    });
+  });
+
+  describe('getHarnessArchiveUrl', () => {
+    it('can create an url from arguments', () => {
+      const config: HarnessIntegrationConfig = {
+        host: 'app.harness.io',
+      };
+      expect(
+        getHarnessArchiveUrl(
+          config,
+          'https://app.harness.io/ng/account/accountId/module/code/orgs/orgName/projects/projectName/repos/repoName/files/branchName',
+        ),
+      ).toEqual(
+        'https://app.harness.io/gateway/code/api/v1/repos/accountId/orgName/projectName/repoName/+/archive/branchName.zip',
+      );
+    });
+  });
+
+  describe('getGiteaLatestCommitUrl', () => {
+    it('can create an url from arguments', () => {
+      const config: HarnessIntegrationConfig = {
+        host: 'app.harness.io',
+      };
+      expect(
+        getHarnessLatestCommitUrl(
+          config,
+          'https://app.harness.io/ng/account/accountId/module/code/orgs/orgName/projects/projectName/repos/repoName/files/branchName',
+        ),
+      ).toEqual(
+        'https://app.harness.io/gateway/code/api/v1/repos/accountId/orgName/projectName/repoName/+/content?routingId=accountId&include_commit=true&git_ref=refs/heads/branchName',
       );
     });
   });
@@ -86,6 +121,52 @@ describe('Harness code core', () => {
       expect(
         (getHarnessRequestOptions(authRequest).headers as any)['x-api-key'],
       ).toEqual('a');
+    });
+  });
+
+  describe('parseHarnessUrl', () => {
+    it('can fetch harness url', () => {
+      const config: HarnessIntegrationConfig = {
+        host: 'app.harness.io',
+      };
+      expect(
+        parseHarnessUrl(
+          config,
+          'https://app.harness.io/ng/account/accountId/module/code/orgs/orgName/projects/projectName/repos/repoName/files/branchName',
+        ),
+      ).toEqual({
+        accountId: 'accountId',
+        baseUrl: 'https://app.harness.io',
+        orgName: 'orgName',
+        path: '',
+        projectName: 'projectName',
+        refDashStr: '',
+        refString: '',
+        repoName: 'repoName',
+        branch: 'branchName',
+      });
+    });
+
+    it('provide path without starting slash', () => {
+      const config: HarnessIntegrationConfig = {
+        host: 'app.harness.io',
+      };
+      expect(
+        parseHarnessUrl(
+          config,
+          'https://app.harness.io/ng/account/accountId/module/code/orgs/orgName/projects/projectName/repos/repoName/files/branchName/simple/path',
+        ),
+      ).toEqual({
+        accountId: 'accountId',
+        baseUrl: 'https://app.harness.io',
+        orgName: 'orgName',
+        path: 'path',
+        projectName: 'projectName',
+        refDashStr: 'branchName-simple',
+        refString: 'branchName/simple',
+        repoName: 'repoName',
+        branch: 'branchName/simple/path',
+      });
     });
   });
 });

--- a/packages/integration/src/harness/index.ts
+++ b/packages/integration/src/harness/index.ts
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 export { HarnessIntegration } from './HarnessIntegration';
-export { getHarnessRequestOptions, getHarnessFileContentsUrl } from './core';
+export {
+  getHarnessRequestOptions,
+  getHarnessFileContentsUrl,
+  getHarnessArchiveUrl,
+  getHarnessLatestCommitUrl,
+  parseHarnessUrl,
+} from './core';
 export { readHarnessConfig } from './config';
 export type { HarnessIntegrationConfig } from './config';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add support for readTree in harness url reader

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
