### PR TITLE
added 30vh height for consistent ui to tasklogstream

### DIFF
--- a/.changeset/five-buses-retire.md
+++ b/.changeset/five-buses-retire.md
@@ -1,0 +1,6 @@
+---
+'@backstage/core-components': patch
+'@backstage/plugin-scaffolder-react': patch
+---
+
+Just added minimum height on `TaskLogStream` and replaced keypress(deprecated) with keydown in `RealLogViewer`.

--- a/packages/core-components/src/components/LogViewer/RealLogViewer.test.tsx
+++ b/packages/core-components/src/components/LogViewer/RealLogViewer.test.tsx
@@ -66,11 +66,8 @@ describe('RealLogViewer', () => {
     await userEvent.keyboard('{meta>}{enter}{/meta}');
     expect(rendered.getByText('Some Log Line')).toBeInTheDocument();
 
-    // Tab down to line #2 and click
-    await userEvent.tab();
-    await userEvent.tab();
-    await userEvent.tab();
-    await userEvent.click(document.activeElement!);
+    const anchors = rendered.getAllByRole('row');
+    await userEvent.type(anchors[1], '{Tab}'); // Focus on the second row
     await userEvent.click(rendered.getByTestId('copy-button'));
 
     expect(copyToClipboard).toHaveBeenCalledWith('Derp');

--- a/packages/core-components/src/components/LogViewer/RealLogViewer.tsx
+++ b/packages/core-components/src/components/LogViewer/RealLogViewer.tsx
@@ -60,14 +60,12 @@ export function RealLogViewer(props: RealLogViewerProps) {
       selection.setSelection(line, false);
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
   const handleSelectLine = (
     line: number,
     event: { shiftKey: boolean; preventDefault: () => void },
   ) => {
     selection.setSelection(line, event.shiftKey);
   };
-
   return (
     <AutoSizer>
       {({ height, width }: { height?: number; width?: number }) => (
@@ -110,7 +108,7 @@ export function RealLogViewer(props: RealLogViewerProps) {
                     href={`#line-${lineNumber}`}
                     className={classes.lineNumber}
                     onClick={event => handleSelectLine(lineNumber, event)}
-                    onKeyPress={event => handleSelectLine(lineNumber, event)}
+                    onKeyDown={event => handleSelectLine(lineNumber, event)}
                   >
                     {lineNumber}
                   </a>

--- a/plugins/scaffolder-react/src/next/components/TaskLogStream/TaskLogStream.tsx
+++ b/plugins/scaffolder-react/src/next/components/TaskLogStream/TaskLogStream.tsx
@@ -20,7 +20,7 @@ import { makeStyles } from '@material-ui/core/styles';
 const useStyles = makeStyles({
   root: {
     width: '100%',
-    height: '100%',
+    height: '30vh',
     position: 'relative',
   },
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!
prev 
![Screenshot from 2024-05-07 14-50-30](https://github.com/backstage/backstage/assets/43876655/1f358a78-542d-4c42-ad42-fdf4c98d0e8f)
now 
![Screenshot from 2024-05-07 14-47-10](https://github.com/backstage/backstage/assets/43876655/a2a7133b-15f5-4a3b-a706-b7a02d43585e)

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
