### PR TITLE
fix: correct position of the copy to clipboard button

### DIFF
--- a/.changeset/late-students-live.md
+++ b/.changeset/late-students-live.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Fixed bug in CopyToClipboardButton component where positioning of the "Copy to clipboard" button in techdocs code snippets was broken in some cases

--- a/plugins/techdocs/src/reader/transformers/copyToClipboard.tsx
+++ b/plugins/techdocs/src/reader/transformers/copyToClipboard.tsx
@@ -67,7 +67,7 @@ const CopyToClipboardButton = ({ text }: CopyToClipboardButtonProps) => {
       leaveDelay={1000}
     >
       <IconButton
-        style={{ color: 'inherit' }}
+        style={{ color: 'inherit', position: 'absolute' }}
         className="md-clipboard md-icon"
         onClick={handleClick}
       >


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In some cases `MuiButtonBase-root` styling overrides `md-clipboard` breaking the "Copy to clipboard" button positioning in techdocs. This PR fixes the bug.

Before:
<img width="558" alt="image" src="https://github.com/backstage/backstage/assets/150145013/910a89bf-1165-40d9-9c0d-fdd6458c5f69">

After:
<img width="555" alt="image" src="https://github.com/backstage/backstage/assets/150145013/4a4f2d71-094a-4096-a5a2-b63ea84b733e">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
