### PR TITLE
search-backend-module-elasticsearch: correctly resolve error handling promise

### DIFF
--- a/.changeset/afraid-ghosts-watch.md
+++ b/.changeset/afraid-ghosts-watch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend-module-elasticsearch': patch
+---
+
+Fix never resolved indexer promise.

--- a/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngine.ts
+++ b/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngine.ts
@@ -345,6 +345,7 @@ export class ElasticSearchSearchEngine implements SearchEngine {
 
           attempts++;
         }
+        done();
       });
 
       if (cleanupError) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

By investigating stale indices I ran into this error handling promise that is never resolved in the case that the indexDelete never succeeds.

Weirdly in our production instance we can see the cleanup logs: `Removed partial, failed index ${indexer.indexName}` but in local we can't see this log line (nor the failure log `Unable to clean up elastic index ${indexer.indexName}: ${cleanupError}`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] ~Added or updated documentation~
- [ ] ~Tests for new functionality and regression tests for bug fixes~
- [ ] ~Screenshots attached (for UI changes)~
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
