### PR TITLE
feat: add jwks access type to external token handler

### DIFF
--- a/.changeset/famous-monkeys-count.md
+++ b/.changeset/famous-monkeys-count.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+Add support for JWKS tokens in ExternalTokenHandler.

--- a/docs/auth/service-to-service-auth.md
+++ b/docs/auth/service-to-service-auth.md
@@ -81,6 +81,38 @@ header:
 Authorization: Bearer eZv5o+fW3KnR3kVabMW4ZcDNLPl8nmMW
 ```
 
+## JWKS Token Auth
+
+This access method allows for external caller token authentication using configured JWKS.
+This is useful for callers that are authenticating to your instance of Backstage with
+third-party tools, such as Auth0.
+
+You can configure this access method by adding one or more entries of type `jwks`
+to the `backend.auth.externalAccess` app-config key:
+
+```yaml title="in e.g. app-config.production.yaml"
+backend:
+  auth:
+    externalAccess:
+      - type: jwks
+        options:
+          uri: https://example.com/.well-known/jwks.json
+          issuers:
+            - https://example.com
+          algorithms:
+            - RS256
+          audiences:
+            - example
+      - type: jwks
+        options:
+          uri: https://another-example.com/.well-known/jwks.json
+          issuers:
+            - https://example.com
+```
+
+The subject returned from the token verification will become part of the
+credentials object that the request recipients get.
+
 ## Legacy Tokens
 
 Plugins and backends that are _not_ on the new backend system use a legacy token

--- a/docs/auth/service-to-service-auth.md
+++ b/docs/auth/service-to-service-auth.md
@@ -83,9 +83,9 @@ Authorization: Bearer eZv5o+fW3KnR3kVabMW4ZcDNLPl8nmMW
 
 ## JWKS Token Auth
 
-This access method allows for external caller token authentication using configured JWKS.
-This is useful for callers that are authenticating to your instance of Backstage with
-third-party tools, such as Auth0.
+This access method allows for external caller token authentication using configured
+JSON Web Key Sets (JWKS). This is useful for callers that are authenticating to our
+instance of Backstage with third-party tools, such as Auth0.
 
 You can configure this access method by adding one or more entries of type `jwks`
 to the `backend.auth.externalAccess` app-config key:
@@ -110,8 +110,22 @@ backend:
             - https://example.com
 ```
 
+The URI should point at an unauthenticated endpoint that returns the JWKS.
+
+Issuers specifies the issuer(s) of the JWT that the authenticating app will accept.
+Passed JWTs must have an `iss` claim which matches one of the specified issuers.
+
+Algorithms specifies the algorithm(s) that are used to verify the JWT. The passed JWTs
+must have been signed using one of the listed algorithms.
+
+Audiences speficies the intended audience(s) of the JWT. The passed JWTs must have an "aud"
+claim that matches one of the audiences specified, or have no audience specified.
+
+For additional details regarding the JWKS configuration, please consult your authentication
+provider's documentation.
+
 The subject returned from the token verification will become part of the
-credentials object that the request recipients get.
+credentials object that the request recipient plugins get.
 
 ## Legacy Tokens
 

--- a/packages/backend-app-api/src/services/implementations/auth/external/ExternalTokenHandler.ts
+++ b/packages/backend-app-api/src/services/implementations/auth/external/ExternalTokenHandler.ts
@@ -21,6 +21,7 @@ import {
 import { LegacyTokenHandler } from './legacy';
 import { StaticTokenHandler } from './static';
 import { TokenHandler } from './types';
+import { JWKSHandler } from './jwks';
 
 const NEW_CONFIG_KEY = 'backend.auth.externalAccess';
 const OLD_CONFIG_KEY = 'backend.auth.keys';
@@ -40,9 +41,11 @@ export class ExternalTokenHandler {
 
     const staticHandler = new StaticTokenHandler();
     const legacyHandler = new LegacyTokenHandler();
+    const jwksHandler = new JWKSHandler();
     const handlers: Record<string, TokenHandler> = {
       static: staticHandler,
       legacy: legacyHandler,
+      jwks: jwksHandler,
     };
 
     // Load the new-style handlers

--- a/packages/backend-app-api/src/services/implementations/auth/external/jwks.test.ts
+++ b/packages/backend-app-api/src/services/implementations/auth/external/jwks.test.ts
@@ -28,8 +28,6 @@ interface AnyJWK extends Record<string, string> {
   kty: string;
 }
 // Simplified copy of TokenFactory in @backstage/plugin-auth-backend
-// Since this is re-used in several tests, I wonder if it should get refactored
-// into @backstage/backend-test-utils
 class FakeTokenFactory {
   private readonly keys = new Array<AnyJWK>();
 

--- a/packages/backend-app-api/src/services/implementations/auth/external/jwks.test.ts
+++ b/packages/backend-app-api/src/services/implementations/auth/external/jwks.test.ts
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { setupRequestMockHandlers } from '@backstage/backend-test-utils';
+import { ConfigReader } from '@backstage/config';
+import { SignJWT, exportJWK, generateKeyPair } from 'jose';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { v4 as uuid } from 'uuid';
+import { JWKSHandler } from './jwks';
+
+interface AnyJWK extends Record<string, string> {
+  use: 'sig';
+  alg: string;
+  kid: string;
+  kty: string;
+}
+// Simplified copy of TokenFactory in @backstage/plugin-auth-backend
+// Since this is re-used in several tests, I wonder if it should get refactored
+// into @backstage/backend-test-utils
+class FakeTokenFactory {
+  private readonly keys = new Array<AnyJWK>();
+
+  constructor(
+    private readonly options: {
+      issuer: string;
+      keyDurationSeconds: number;
+    },
+  ) {}
+
+  async issueToken(params: {
+    claims: {
+      sub: string;
+      ent?: string[];
+    };
+  }): Promise<string> {
+    const pair = await generateKeyPair('RS256');
+    const publicKey = await exportJWK(pair.publicKey);
+    const kid = uuid();
+    publicKey.kid = kid;
+    this.keys.push(publicKey as AnyJWK);
+
+    const iss = this.options.issuer;
+    const sub = params.claims.sub;
+    const ent = params.claims.ent;
+    const aud = 'backstage';
+    const iat = Math.floor(Date.now() / 1000);
+    const exp = iat + this.options.keyDurationSeconds;
+
+    return new SignJWT({ iss, sub, aud, iat, exp, ent, kid })
+      .setProtectedHeader({ alg: 'RS256', ent: ent, kid: kid })
+      .setIssuer(iss)
+      .setAudience(aud)
+      .setSubject(sub)
+      .setIssuedAt(iat)
+      .setExpirationTime(exp)
+      .sign(pair.privateKey);
+  }
+
+  async listPublicKeys(): Promise<{ keys: AnyJWK[] }> {
+    return { keys: this.keys };
+  }
+}
+
+const server = setupServer();
+const mockBaseUrl = 'http://backstage:9191/i-am-a-mock-base';
+
+describe('JWKSHandler', () => {
+  let factory: FakeTokenFactory;
+  let mockSubject: string;
+  const keyDurationSeconds = 5;
+
+  setupRequestMockHandlers(server);
+
+  beforeEach(() => {
+    mockSubject = 'test_subject';
+
+    factory = new FakeTokenFactory({
+      issuer: mockBaseUrl,
+      keyDurationSeconds,
+    });
+
+    server.use(
+      rest.get(`${mockBaseUrl}/.well-known/jwks.json`, async (_, res, ctx) => {
+        const keys = await factory.listPublicKeys();
+        return res(ctx.json(keys));
+      }),
+    );
+  });
+
+  it('verifies token with valid entry', async () => {
+    const validEntry = {
+      uri: `${mockBaseUrl}/.well-known/jwks.json`,
+      algorithms: ['RS256'],
+      issuers: [mockBaseUrl],
+      audiences: ['backstage'],
+    };
+    const jwksHandler = new JWKSHandler();
+
+    jwksHandler.add(new ConfigReader(validEntry));
+
+    const token = await factory.issueToken({
+      claims: { sub: mockSubject },
+    });
+
+    const result = await jwksHandler.verifyToken(token);
+
+    expect(result).toEqual({ subject: mockSubject });
+  });
+
+  it('skips invalid entry and continues verification', async () => {
+    const invalidEntry = {
+      uri: `${mockBaseUrl}/.well-known/jwks.json`,
+      algorithms: ['RS256'],
+      issuers: ['fakeIssuer'],
+      audiences: ['fakeAud'],
+    };
+
+    const validEntry = {
+      uri: `${mockBaseUrl}/.well-known/jwks.json`,
+      algorithms: ['RS256'],
+      issuers: ['multiple-issuers', mockBaseUrl],
+      audiences: ['multiple-audiences', 'backstage'],
+    };
+    const jwksHandler = new JWKSHandler();
+
+    jwksHandler.add(new ConfigReader(invalidEntry));
+    jwksHandler.add(new ConfigReader(validEntry));
+
+    const token = await factory.issueToken({
+      claims: { sub: mockSubject },
+    });
+
+    const result = await jwksHandler.verifyToken(token);
+
+    expect(result).toEqual({ subject: mockSubject });
+  });
+
+  it('returns undefined if no valid entry found', async () => {
+    const invalidEntry1 = {
+      uri: `${mockBaseUrl}/.well-known/jwks.json`,
+      algorithms: ['RS256'],
+      issuers: [mockBaseUrl],
+      audiences: [],
+    };
+
+    const invalidEntry2 = {
+      uri: `${mockBaseUrl}/.well-known/jwks.json`,
+      algorithms: ['HS256'],
+      issuers: [],
+      audiences: ['backstage'],
+    };
+    const jwksHandler = new JWKSHandler();
+
+    jwksHandler.add(new ConfigReader(invalidEntry1));
+    jwksHandler.add(new ConfigReader(invalidEntry2));
+
+    const token = await factory.issueToken({
+      claims: { sub: mockSubject },
+    });
+
+    const result = await jwksHandler.verifyToken(token);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('rejects bad config', () => {
+    const jwksHandler = new JWKSHandler();
+
+    expect(() => {
+      jwksHandler.add(
+        new ConfigReader({
+          uri: 'https://exampl e.com/jwks',
+        }),
+      );
+    }).toThrow('Illegal URI, must be a set of non-space characters');
+    expect(() => {
+      jwksHandler.add(
+        new ConfigReader({
+          uri: 'https://example.com/jwks\n',
+        }),
+      );
+    }).toThrow('Illegal URI, must be a set of non-space characters');
+  });
+
+  it('gracefully handles no added tokens', async () => {
+    const handler = new JWKSHandler();
+    await expect(handler.verifyToken('ghi')).resolves.toBeUndefined();
+  });
+});

--- a/packages/backend-app-api/src/services/implementations/auth/external/jwks.ts
+++ b/packages/backend-app-api/src/services/implementations/auth/external/jwks.ts
@@ -34,7 +34,6 @@ export class JWKSHandler implements TokenHandler {
   add(options: Config) {
     const algorithms = options.getOptionalStringArray('algorithms') ?? [];
     const issuers = options.getOptionalStringArray('issuers') ?? [];
-    // if audience is unset, an empty string is valid, but an empty array is not
     const audiences = options.getOptionalStringArray('audiences') ?? '';
     const uri = options.getString('uri');
 

--- a/packages/backend-app-api/src/services/implementations/auth/external/jwks.ts
+++ b/packages/backend-app-api/src/services/implementations/auth/external/jwks.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { jwtVerify, createRemoteJWKSet } from 'jose';
+import { Config } from '@backstage/config';
+import { TokenHandler } from './types';
+
+/**
+ * Handles `type: jwks` access.
+ *
+ * @internal
+ */
+export class JWKSHandler implements TokenHandler {
+  #entries: Array<{
+    algorithms: string[];
+    audiences: string[];
+    issuers: string[];
+    uri: string;
+  }> = [];
+
+  add(options: Config) {
+    const algorithms = options.getOptionalStringArray('algorithms') ?? [];
+    const issuers = options.getOptionalStringArray('issuers') ?? [];
+    const audiences = options.getOptionalStringArray('audiences') ?? [];
+    const uri = options.getString('uri');
+
+    if (!uri.match(/^\S+$/)) {
+      throw new Error('Illegal token, must be a set of non-space characters');
+    }
+
+    if (!issuers.every(issuer => issuer.match(/^\S+$/))) {
+      throw new Error('Illegal issuer, must be a set of non-space characters');
+    }
+
+    this.#entries.push({ algorithms, audiences, issuers, uri });
+  }
+
+  async verifyToken(token: string) {
+    // not sure if we would need to support multiple jwks entries, but implementing to match static/legacy token handlers
+    for (const entry of this.#entries) {
+      try {
+        const jwks = createRemoteJWKSet(new URL(entry.uri));
+        const {
+          payload: { sub },
+        } = await jwtVerify(token, jwks, {
+          algorithms: entry.algorithms,
+          issuer: entry.issuers,
+          audience: entry.audiences,
+        });
+
+        if (sub) {
+          return { subject: sub };
+        }
+      } catch {
+        continue;
+      }
+    }
+    return undefined;
+  }
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Re-opening from #24679 after I got into some trouble with git. 

This pull request builds on [BEP-07](https://github.com/backstage/backstage/tree/master/beps/0007-auth-external-services) to expand the ExternalTokenHandler to support a configured JWKS auth strategy. This allows external callers to use 3rd party authentication via JWKS, enabling greater flexibility in providing ways to auth with Backstage via signed tokens.

A potential area of improvement for future PRs would be to move the TokenFactory used in the tests into the backend-test-utils plugin, since it is used with near-identical patterns in the jwks.test.ts file, as well as plugins/auth-node/src/identity/DefaultIdentityClient.test.ts, and plugins/auth-node/src/identity/IdentityClient.test.ts.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
