### PR TITLE
search-backend-module-elasticsearch: ensure all stale indices are deleted

### DIFF
--- a/.changeset/wild-eyes-grab.md
+++ b/.changeset/wild-eyes-grab.md
@@ -1,0 +1,10 @@
+---
+'@backstage/plugin-search-backend-module-elasticsearch': minor
+---
+
+**BREAKING** The ElasticSearch indexer will now delete stale indices matching the indexer's pattern.
+
+An indexer using the `some-type-index__*` pattern will remove indices matching this pattern after indexation
+to prevent stale indices leading to shards exhaustion.
+
+Note: The ElasticSearch indexer already uses wildcards patterns to remove aliases on these indices.

--- a/.changeset/wild-eyes-grab.md
+++ b/.changeset/wild-eyes-grab.md
@@ -2,9 +2,13 @@
 '@backstage/plugin-search-backend-module-elasticsearch': minor
 ---
 
-**BREAKING** The ElasticSearch indexer will now delete stale indices matching the indexer's pattern.
+**BREAKING**: The ElasticSearch indexer will now delete stale indices matching the indexer's pattern.
+The method `getAliases` of `ElasticSearchClientWrapper` has been deprecated and might be removed in future releases.
 
 An indexer using the `some-type-index__*` pattern will remove indices matching this pattern after indexation
 to prevent stale indices leading to shards exhaustion.
+
+Before upgrading ensure that the index pattern doesn't match indices that are not managed by Backstage
+and thus shouldn't be deleted.
 
 Note: The ElasticSearch indexer already uses wildcards patterns to remove aliases on these indices.

--- a/plugins/search-backend-module-elasticsearch/api-report.md
+++ b/plugins/search-backend-module-elasticsearch/api-report.md
@@ -154,17 +154,17 @@ export class ElasticSearchClientWrapper {
     options: ElasticSearchClientOptions,
   ): ElasticSearchClientWrapper;
   // (undocumented)
-  getAliases(options: {
-    aliases: string[];
-  }):
-    | TransportRequestPromise<ApiResponse<Record<string, any>, unknown>>
-    | TransportRequestPromise_2<ApiResponse_2<Record<string, any>, unknown>>;
-  // (undocumented)
   indexExists(options: {
     index: string | string[];
   }):
     | TransportRequestPromise<ApiResponse<boolean, unknown>>
     | TransportRequestPromise_2<ApiResponse_2<boolean, unknown>>;
+  // (undocumented)
+  listIndices(options: {
+    index: string;
+  }):
+    | TransportRequestPromise<ApiResponse<Record<string, any>, unknown>>
+    | TransportRequestPromise_2<ApiResponse_2<Record<string, any>, unknown>>;
   // (undocumented)
   putIndexTemplate(
     template: ElasticSearchCustomIndexTemplate,

--- a/plugins/search-backend-module-elasticsearch/api-report.md
+++ b/plugins/search-backend-module-elasticsearch/api-report.md
@@ -153,6 +153,12 @@ export class ElasticSearchClientWrapper {
   static fromClientOptions(
     options: ElasticSearchClientOptions,
   ): ElasticSearchClientWrapper;
+  // @deprecated (undocumented)
+  getAliases(options: {
+    aliases: string[];
+  }):
+    | TransportRequestPromise<ApiResponse<Record<string, any>, unknown>>
+    | TransportRequestPromise_2<ApiResponse_2<Record<string, any>, unknown>>;
   // (undocumented)
   indexExists(options: {
     index: string | string[];

--- a/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchClientWrapper.test.ts
+++ b/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchClientWrapper.test.ts
@@ -28,6 +28,11 @@ jest.mock('@elastic/elasticsearch', () => ({
     search: jest
       .fn()
       .mockImplementation(async args => ({ client: 'es', args })),
+    cat: {
+      aliases: jest
+        .fn()
+        .mockImplementation(async args => ({ client: 'es', args })),
+    },
     helpers: {
       bulk: jest
         .fn()
@@ -60,6 +65,11 @@ jest.mock('@opensearch-project/opensearch', () => ({
     search: jest
       .fn()
       .mockImplementation(async args => ({ client: 'os', args })),
+    cat: {
+      aliases: jest
+        .fn()
+        .mockImplementation(async args => ({ client: 'os', args })),
+    },
     helpers: {
       bulk: jest
         .fn()
@@ -189,6 +199,20 @@ describe('ElasticSearchClientWrapper', () => {
       expect(result.args).toStrictEqual(input);
     });
 
+    it('getAliases', async () => {
+      const wrapper = ElasticSearchClientWrapper.fromClientOptions(esOptions);
+
+      const input = { aliases: ['xyz'] };
+      const result = (await wrapper.getAliases(input)) as any;
+
+      // Should call the OpenSearch client with expected input.
+      expect(result.client).toBe('es');
+      expect(result.args).toStrictEqual({
+        format: 'json',
+        name: input.aliases,
+      });
+    });
+
     it('updateAliases', async () => {
       const wrapper = ElasticSearchClientWrapper.fromClientOptions(esOptions);
 
@@ -311,6 +335,20 @@ describe('ElasticSearchClientWrapper', () => {
       // Should call the OpenSearch client with expected input.
       expect(result.client).toBe('os');
       expect(result.args).toStrictEqual(input);
+    });
+
+    it('getAliases', async () => {
+      const wrapper = ElasticSearchClientWrapper.fromClientOptions(osOptions);
+
+      const input = { aliases: ['xyz'] };
+      const result = (await wrapper.getAliases(input)) as any;
+
+      // Should call the OpenSearch client with expected input.
+      expect(result.client).toBe('os');
+      expect(result.args).toStrictEqual({
+        format: 'json',
+        name: input.aliases,
+      });
     });
 
     it('updateAliases', async () => {

--- a/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchClientWrapper.test.ts
+++ b/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchClientWrapper.test.ts
@@ -28,17 +28,13 @@ jest.mock('@elastic/elasticsearch', () => ({
     search: jest
       .fn()
       .mockImplementation(async args => ({ client: 'es', args })),
-    cat: {
-      aliases: jest
-        .fn()
-        .mockImplementation(async args => ({ client: 'es', args })),
-    },
     helpers: {
       bulk: jest
         .fn()
         .mockImplementation(async args => ({ client: 'es', args })),
     },
     indices: {
+      get: jest.fn().mockImplementation(async args => ({ client: 'es', args })),
       create: jest
         .fn()
         .mockImplementation(async args => ({ client: 'es', args })),
@@ -64,17 +60,13 @@ jest.mock('@opensearch-project/opensearch', () => ({
     search: jest
       .fn()
       .mockImplementation(async args => ({ client: 'os', args })),
-    cat: {
-      aliases: jest
-        .fn()
-        .mockImplementation(async args => ({ client: 'os', args })),
-    },
     helpers: {
       bulk: jest
         .fn()
         .mockImplementation(async args => ({ client: 'os', args })),
     },
     indices: {
+      get: jest.fn().mockImplementation(async args => ({ client: 'os', args })),
       create: jest
         .fn()
         .mockImplementation(async args => ({ client: 'os', args })),
@@ -154,6 +146,16 @@ describe('ElasticSearchClientWrapper', () => {
       expect(result.args).toStrictEqual(indexTemplate);
     });
 
+    it('indexList', async () => {
+      const wrapper = ElasticSearchClientWrapper.fromClientOptions(esOptions);
+
+      const input = { index: 'xyz-*' };
+      const result = (await wrapper.listIndices(input)) as any;
+
+      expect(result.client).toBe('es');
+      expect(result.args).toStrictEqual(input);
+    });
+
     it('indexExists', async () => {
       const wrapper = ElasticSearchClientWrapper.fromClientOptions(esOptions);
 
@@ -185,20 +187,6 @@ describe('ElasticSearchClientWrapper', () => {
       // Should call the OpenSearch client with expected input.
       expect(result.client).toBe('es');
       expect(result.args).toStrictEqual(input);
-    });
-
-    it('getAliases', async () => {
-      const wrapper = ElasticSearchClientWrapper.fromClientOptions(esOptions);
-
-      const input = { aliases: ['xyz'] };
-      const result = (await wrapper.getAliases(input)) as any;
-
-      // Should call the OpenSearch client with expected input.
-      expect(result.client).toBe('es');
-      expect(result.args).toStrictEqual({
-        format: 'json',
-        name: input.aliases,
-      });
     });
 
     it('updateAliases', async () => {
@@ -282,6 +270,16 @@ describe('ElasticSearchClientWrapper', () => {
       expect(result.args).toStrictEqual(indexTemplate);
     });
 
+    it('indexList', async () => {
+      const wrapper = ElasticSearchClientWrapper.fromClientOptions(osOptions);
+
+      const input = { index: 'xyz-*' };
+      const result = (await wrapper.listIndices(input)) as any;
+
+      expect(result.client).toBe('os');
+      expect(result.args).toStrictEqual(input);
+    });
+
     it('indexExists', async () => {
       const wrapper = ElasticSearchClientWrapper.fromClientOptions(osOptions);
 
@@ -313,20 +311,6 @@ describe('ElasticSearchClientWrapper', () => {
       // Should call the OpenSearch client with expected input.
       expect(result.client).toBe('os');
       expect(result.args).toStrictEqual(input);
-    });
-
-    it('getAliases', async () => {
-      const wrapper = ElasticSearchClientWrapper.fromClientOptions(osOptions);
-
-      const input = { aliases: ['xyz'] };
-      const result = (await wrapper.getAliases(input)) as any;
-
-      // Should call the OpenSearch client with expected input.
-      expect(result.client).toBe('os');
-      expect(result.args).toStrictEqual({
-        format: 'json',
-        name: input.aliases,
-      });
     });
 
     it('updateAliases', async () => {

--- a/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchClientWrapper.ts
+++ b/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchClientWrapper.ts
@@ -141,6 +141,18 @@ export class ElasticSearchClientWrapper {
     throw new Error('No client defined');
   }
 
+  listIndices(options: { index: string }) {
+    if (this.openSearchClient) {
+      return this.openSearchClient.indices.get(options);
+    }
+
+    if (this.elasticSearchClient) {
+      return this.elasticSearchClient.indices.get(options);
+    }
+
+    throw new Error('No client defined');
+  }
+
   indexExists(options: { index: string | string[] }) {
     if (this.openSearchClient) {
       return this.openSearchClient.indices.exists(options);
@@ -172,26 +184,6 @@ export class ElasticSearchClientWrapper {
 
     if (this.elasticSearchClient) {
       return this.elasticSearchClient.indices.create(options);
-    }
-
-    throw new Error('No client defined');
-  }
-
-  getAliases(options: { aliases: string[] }) {
-    const { aliases } = options;
-
-    if (this.openSearchClient) {
-      return this.openSearchClient.cat.aliases({
-        format: 'json',
-        name: aliases,
-      });
-    }
-
-    if (this.elasticSearchClient) {
-      return this.elasticSearchClient.cat.aliases({
-        format: 'json',
-        name: aliases,
-      });
     }
 
     throw new Error('No client defined');

--- a/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchClientWrapper.ts
+++ b/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchClientWrapper.ts
@@ -177,6 +177,29 @@ export class ElasticSearchClientWrapper {
     throw new Error('No client defined');
   }
 
+  /**
+   * @deprecated unused by the ElasticSearch Engine, will be removed in the future
+   */
+  getAliases(options: { aliases: string[] }) {
+    const { aliases } = options;
+
+    if (this.openSearchClient) {
+      return this.openSearchClient.cat.aliases({
+        format: 'json',
+        name: aliases,
+      });
+    }
+
+    if (this.elasticSearchClient) {
+      return this.elasticSearchClient.cat.aliases({
+        format: 'json',
+        name: aliases,
+      });
+    }
+
+    throw new Error('No client defined');
+  }
+
   createIndex(options: { index: string }) {
     if (this.openSearchClient) {
       return this.openSearchClient.indices.create(options);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

We ran into a case where the indexer would fail but leave a half-filled index without deleting it (#24680 should allow us to understand why).
As indices are not deleted, we're exhausting the allowed number of shards on our OpenSearch cluster.

This PR changes the way stale indices are cleaned. Instead of relying on aliases, we simply list indices that match the indexer's pattern (`some-type-index__*`) and delete them after indexation.

I've marked the change as **breaking** because someone may use `some-type-index__some-index-that-shouldnt-be-deleted` as an index name (not managed by Backstage Search).
**However** the [wildcard pattern is already used to remove aliases](https://github.com/leboncoin/backstage/blob/99f0044557b0ce42a88941cb4513f1e6a5d5151b/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngineIndexer.ts#L170), so IMHO we can commit to use the pattern to detect and delete stale indices.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] ~Added or updated documentation~
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] ~Screenshots attached (for UI changes)~
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
