### PR TITLE
[cli] Remove manual yarn postpack invocation

### DIFF
--- a/.changeset/cli-postpack-schmostschmack.md
+++ b/.changeset/cli-postpack-schmostschmack.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+The `build-workspace` command no longer manually runs `yarn postpack`, relying instead on the fact that running `yarn pack` will automatically invoke the `postpack` script. No action is necessary if you are running the latest version of yarn 1, 3, or 4.

--- a/packages/cli/src/lib/packager/createDistWorkspace.ts
+++ b/packages/cli/src/lib/packager/createDistWorkspace.ts
@@ -309,10 +309,6 @@ async function moveToDistWorkspace(
     await run('yarn', ['pack', '--filename', archivePath], {
       cwd: target.dir,
     });
-    // TODO(Rugvip): yarn pack doesn't call postpack, once the bug is fixed this can be removed
-    if (target.packageJson?.scripts?.postpack) {
-      await run('yarn', ['postpack'], { cwd: target.dir });
-    }
 
     const outputDir = relativePath(paths.targetRoot, target.dir);
     const absoluteOutputPath = resolvePath(workspaceDir, outputDir);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Was seeing some flakey errors running `yarn build-workspace` that implied a yarn script was being invoked within a package with a `package.json` in an inconsistent state (invalid JSON because part of the file was missing).  Thinking this may be a race condition introduced as a result of this extra `yarn postpack` call.

Looks like the underlying bug in `yarn` was [fixed in v2](https://github.com/yarnpkg/yarn/issues/7924#issuecomment-753416427), and was evidently backported to `v1` at some point, because I can see it being invoked when running the latest stable `v1`:

![Screenshot 2024-05-08 at 14 46 56](https://github.com/backstage/backstage/assets/3496491/d7ce0b24-e118-4d90-a6b7-c25ab249a26e)

So this PR just removes the invocation.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
