### PR TITLE
core-app-api: remove fallback to provider expiration

### DIFF
--- a/.changeset/slimy-donkeys-laugh.md
+++ b/.changeset/slimy-donkeys-laugh.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-app-api': patch
+---
+
+The Backstage identity session expiration check will no longer fall back to using the provider expiration. This was introduced to smooth out the rollout of Backstage release 1.18, and is no longer needed.

--- a/packages/core-app-api/src/apis/implementations/auth/oauth2/OAuth2.ts
+++ b/packages/core-app-api/src/apis/implementations/auth/oauth2/OAuth2.ts
@@ -116,16 +116,11 @@ export default class OAuth2
           },
         };
         if (backstageIdentity) {
-          // TODO(Rugvip): This fallback can be removed a few releases after 1.18. It's there to avoid
-          //               breaking deployments that update their frontend before updating their backend.
-          const expInSec =
-            backstageIdentity.expiresInSeconds ??
-            res.providerInfo.expiresInSeconds;
           session.backstageIdentity = {
             token: backstageIdentity.token,
             identity: backstageIdentity.identity,
-            expiresAt: expInSec
-              ? new Date(Date.now() + expInSec * 1000)
+            expiresAt: backstageIdentity.expiresInSeconds
+              ? new Date(Date.now() + backstageIdentity.expiresInSeconds * 1000)
               : undefined,
           };
         }


### PR DESCRIPTION
🧹, explained in the changeset - no longer needed