### PR TITLE
fix(search-backend-module-elasticsearch): only refresh ES index being processed

### DIFF
--- a/.changeset/many-poets-visit.md
+++ b/.changeset/many-poets-visit.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend-module-elasticsearch': patch
+---
+
+stop refreshing \_all indexes and only refresh the index being processed

--- a/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngineIndexer.test.ts
+++ b/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngineIndexer.test.ts
@@ -216,6 +216,12 @@ describe('ElasticSearchSearchEngineIndexer', () => {
     // Ensure multiple bulk requests were made.
     expect(bulkSpy).toHaveBeenCalledTimes(2);
     expect(refreshSpy).toHaveBeenCalledTimes(1);
+    expect(refreshSpy).toHaveBeenCalledWith({
+      body: null,
+      querystring: {},
+      method: 'GET',
+      path: `/${indexer.indexName}/_refresh`,
+    });
 
     // Ensure the first and last documents were included in the payloads.
     const docLocations: string[] = [

--- a/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngineIndexer.ts
+++ b/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngineIndexer.ts
@@ -96,7 +96,7 @@ export class ElasticSearchSearchEngineIndexer extends BatchSearchEngineIndexer {
           index: { _index: that.indexName },
         };
       },
-      refreshOnCompletion: options.skipRefresh !== true,
+      refreshOnCompletion: options.skipRefresh ? false : that.indexName,
     });
 
     // Safely catch errors thrown by the bulk helper client, e.g. HTTP timeouts


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This change updates the ElasticSearch Search Plugin to only refresh the index being processed. The current behavior refreshes `_all` indexes which consumes a lot of resources and creates timeouts. The current behavior doesn't work very well when using a shared ElasticSearch instance with a lot of indexes.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
