### PR TITLE
Fixed import typo in example in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -66,7 +66,7 @@ The insecure example above should instead be written like this:
 ```ts
 // THIS IS GOOD, DO THIS
 
-import { resolveSafeChildPath } from '@backstaghe/backend-common';
+import { resolveSafeChildPath } from '@backstage/backend-common';
 import fs from 'fs-extra';
 
 function writeTemporaryFile(tmpDir: string, name: string, content: string) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Resolved small typo in an import statement of one of the code examples

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
