### PR TITLE
do not create a unique connection pool for every CacheService instance

### DIFF
--- a/.changeset/nervous-mayflies-float.md
+++ b/.changeset/nervous-mayflies-float.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Only create a single actual connection to memcache/redis, even in cases where many `CacheService` instances are made

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,15 @@ jobs:
           --health-retries 5
         ports:
           - 3306/tcp
+      redis:
+        image: redis
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379/tcp
 
     env:
       CI: true
@@ -231,6 +240,7 @@ jobs:
           BACKSTAGE_TEST_DATABASE_POSTGRES16_CONNECTION_STRING: postgresql://postgres:postgres@localhost:${{ job.services.postgres16.ports[5432] }}
           BACKSTAGE_TEST_DATABASE_POSTGRES12_CONNECTION_STRING: postgresql://postgres:postgres@localhost:${{ job.services.postgres12.ports[5432] }}
           BACKSTAGE_TEST_DATABASE_MYSQL8_CONNECTION_STRING: mysql://root:root@localhost:${{ job.services.mysql8.ports[3306] }}/ignored
+          BACKSTAGE_TEST_CACHE_REDIS_CONNECTION_STRING: redis://localhost:${{ job.services.redis.ports[6379] }}
 
       # We run the test cases before verifying the specs to prevent any failing tests from causing errors.
       - name: verify openapi specs against test cases

--- a/packages/backend-common/src/cache/CacheManager.integration.test.ts
+++ b/packages/backend-common/src/cache/CacheManager.integration.test.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ConfigReader } from '@backstage/config';
+import { CacheManager } from './CacheManager';
+import KeyvRedis from '@keyv/redis';
+
+// This test is in a separate file because the main test file uses other mocking
+// that might interfere with this one.
+
+// Contrived code because it's hard to spy on a default export
+jest.mock('@keyv/redis', () => {
+  const ActualKeyvRedis = jest.requireActual('@keyv/redis');
+  return jest
+    .fn()
+    .mockImplementation((...args: any[]) => new ActualKeyvRedis(...args));
+});
+
+describe('CacheManager integration', () => {
+  describe('redis', () => {
+    it('only creates one underlying connection', async () => {
+      const manager = CacheManager.fromConfig(
+        new ConfigReader({
+          backend: {
+            cache: {
+              store: 'redis',
+              // no actual connection errors will be seen since we don't interact with it
+              connection: 'redis://localhost:6379',
+            },
+          },
+        }),
+      );
+
+      manager.forPlugin('p1').getClient();
+      manager.forPlugin('p1').getClient({ defaultTtl: 200 });
+      manager.forPlugin('p2').getClient();
+      manager.forPlugin('p3').getClient({});
+
+      expect(KeyvRedis).toHaveBeenCalledTimes(1);
+    });
+
+    it('interacts correctly with redis', async () => {
+      // TODO(freben): This could be frameworkified as TestCaches just like
+      // TestDatabases, but that will have to come some other day
+      const connection =
+        process.env.BACKSTAGE_TEST_CACHE_REDIS_CONNECTION_STRING;
+      if (!connection) {
+        return;
+      }
+
+      const manager = CacheManager.fromConfig(
+        new ConfigReader({
+          backend: {
+            cache: {
+              store: 'redis',
+              connection,
+            },
+          },
+        }),
+      );
+
+      const plugin1 = manager.forPlugin('p1').getClient();
+      const plugin2a = manager.forPlugin('p2').getClient();
+      const plugin2b = manager.forPlugin('p2').getClient({ defaultTtl: 2000 });
+
+      await plugin1.set('a', 'plugin1');
+      await plugin2a.set('a', 'plugin2a');
+      await plugin2b.set('a', 'plugin2b');
+
+      await expect(plugin1.get('a')).resolves.toBe('plugin1');
+      await expect(plugin2a.get('a')).resolves.toBe('plugin2b');
+      await expect(plugin2b.get('a')).resolves.toBe('plugin2b');
+    });
+  });
+});


### PR DESCRIPTION
The old code created a new `@keyv/redis` or `@keyv/memcache` instance every time that anyone called `getClient`. That's fine if done once per plugin, but not if it's called over and over again. That creates a new connection pool per call, which gets abandoned by the caller (likely, if it's written in such a way that it calls `getClient` repeatedly in the first place) which piles up more and more active connections to the underlying cache store until it starts rejecting connections.

Could have gone all the way to memoizing on the `options` object to save on `Keyv` wrapper object overhead, but this felt like it would still cover all realistic use cases without having to worry about how that changes over time.

Ref: https://discord.com/channels/687207715902193673/1034089724664610938/1237307568410464256