### PR TITLE
feat: add notifications filtering by processors

### DIFF
--- a/.changeset/large-months-decide.md
+++ b/.changeset/large-months-decide.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-notifications-node': major
+'@backstage/plugin-notifications-node': minor
 ---
 
 add notifications filtering by processors

--- a/.changeset/large-months-decide.md
+++ b/.changeset/large-months-decide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications-node': major
+---
+
+add notifications filtering by processors

--- a/.changeset/polite-otters-talk.md
+++ b/.changeset/polite-otters-talk.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications-backend-module-email': minor
+---
+
+add notification filters

--- a/.changeset/wild-ears-walk.md
+++ b/.changeset/wild-ears-walk.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-notifications-backend': major
+'@backstage/plugin-notifications-backend': minor
 ---
 
 adding filtering of notifications by processors

--- a/.changeset/wild-ears-walk.md
+++ b/.changeset/wild-ears-walk.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications-backend': major
+---
+
+adding filtering of notifications by processors

--- a/plugins/notifications-backend-module-email/config.d.ts
+++ b/plugins/notifications-backend-module-email/config.d.ts
@@ -15,6 +15,7 @@
  */
 
 import { HumanDuration } from '@backstage/types';
+import { NotificationSeverity } from '@backstage/plugin-notifications-common';
 
 export interface Config {
   /**
@@ -116,6 +117,20 @@ export interface Config {
            * Email cache TTL, defaults to 1 hour
            */
           ttl?: HumanDuration;
+        };
+        filter?: {
+          /**
+           * Minimum severity. A notification with lower severity will not be emailed
+           */
+          minSeverity?: NotificationSeverity;
+          /**
+           * Maximum severity. A notification with higher severity will not be emailed
+           */
+          maxSeverity?: NotificationSeverity;
+          /**
+           * A notification who's topic is in this array will not be emailed
+           */
+          excludedTopics?: string[];
         };
       };
     };

--- a/plugins/notifications-node/api-report.md
+++ b/plugins/notifications-node/api-report.md
@@ -8,6 +8,7 @@ import { DiscoveryService } from '@backstage/backend-plugin-api';
 import { ExtensionPoint } from '@backstage/backend-plugin-api';
 import { Notification as Notification_2 } from '@backstage/plugin-notifications-common';
 import { NotificationPayload } from '@backstage/plugin-notifications-common';
+import { NotificationSeverity } from '@backstage/plugin-notifications-common';
 import { ServiceRef } from '@backstage/backend-plugin-api';
 
 // @public (undocumented)
@@ -23,6 +24,7 @@ export class DefaultNotificationService implements NotificationService {
 // @public
 export interface NotificationProcessor {
   getName(): string;
+  getNotificationFilters?(): NotificationProcessorFilters;
   postProcess?(
     notification: Notification_2,
     options: NotificationSendOptions,
@@ -35,6 +37,13 @@ export interface NotificationProcessor {
     options: NotificationSendOptions,
   ): Promise<NotificationSendOptions>;
 }
+
+// @public (undocumented)
+export type NotificationProcessorFilters = {
+  minSeverity?: NotificationSeverity;
+  maxSeverity?: NotificationSeverity;
+  excludedTopics?: string[];
+};
 
 // @public (undocumented)
 export type NotificationRecipients =

--- a/plugins/notifications-node/src/extensions.ts
+++ b/plugins/notifications-node/src/extensions.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 import { createExtensionPoint } from '@backstage/backend-plugin-api';
-import { Notification } from '@backstage/plugin-notifications-common';
+import {
+  Notification,
+  NotificationSeverity,
+} from '@backstage/plugin-notifications-common';
 import { NotificationSendOptions } from './service';
 
 /**
@@ -90,6 +93,11 @@ export interface NotificationProcessor {
     notification: Notification,
     options: NotificationSendOptions,
   ): Promise<void>;
+
+  /**
+   * notification filters are used to call the processor only in certain conditions
+   */
+  getNotificationFilters?(): NotificationProcessorFilters;
 }
 
 /**
@@ -108,3 +116,12 @@ export const notificationsProcessingExtensionPoint =
   createExtensionPoint<NotificationsProcessingExtensionPoint>({
     id: 'notifications.processing',
   });
+
+/**
+ * @public
+ */
+export type NotificationProcessorFilters = {
+  minSeverity?: NotificationSeverity;
+  maxSeverity?: NotificationSeverity;
+  excludedTopics?: string[];
+};


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Allow processors to distinguish low and high-importance notifications
The first use would be for email processor
Users usually want only high-importance notifications in their emails 
Implementation is based on this suggestion https://github.com/backstage/backstage/pull/24322#issuecomment-2075131200