### PR TITLE
Properly log the errorInfo in ErrorBoundary

### DIFF
--- a/.changeset/cool-garlics-clap.md
+++ b/.changeset/cool-garlics-clap.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Properly log the `errorInfo` in `ErrorBoundary`

--- a/packages/core-components/src/layout/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/core-components/src/layout/ErrorBoundary/ErrorBoundary.tsx
@@ -79,7 +79,7 @@ export const ErrorBoundary: ComponentClass<
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     // eslint-disable-next-line no-console
-    console.error(`ErrorBoundary, error: ${error}, info: ${errorInfo}`);
+    console.error(`ErrorBoundary, error: ${error}`, { error, errorInfo });
     this.setState({ error, errorInfo });
   }
 


### PR DESCRIPTION
This kept coming out as `[object Object]`