### PR TITLE
feat: prefer title in scaffolder EntityPicker

### DIFF
--- a/.changeset/tame-students-happen.md
+++ b/.changeset/tame-students-happen.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Prefer title in `EntityPicker` if `allowArbitraryValues` is `false`

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.test.tsx
@@ -90,7 +90,12 @@ describe('<EntityPicker />', () => {
       );
 
       expect(catalogApi.getEntities).toHaveBeenCalledWith({
-        fields: ['metadata.name', 'metadata.namespace', 'kind'],
+        fields: [
+          'metadata.name',
+          'metadata.namespace',
+          'metadata.title',
+          'kind',
+        ],
         filter: undefined,
       });
     });

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
@@ -67,7 +67,12 @@ export const EntityPicker = (props: EntityPickerProps) => {
   const catalogApi = useApi(catalogApiRef);
 
   const { value: entities, loading } = useAsync(async () => {
-    const fields = ['metadata.name', 'metadata.namespace', 'kind'];
+    const fields = [
+      'metadata.name',
+      'metadata.namespace',
+      'metadata.title',
+      'kind',
+    ];
     const { items } = await catalogApi.getEntities(
       catalogFilter
         ? { filter: catalogFilter, fields }
@@ -138,6 +143,20 @@ export const EntityPicker = (props: EntityPickerProps) => {
     }
   }, [entities, onChange, selectedEntity]);
 
+  const getOptionLabel = (option: Entity): string => {
+    // option can be a string due to freeSolo.
+    if (typeof option === 'string') return option;
+
+    const entityRef = humanizeEntityRef(option, {
+      defaultKind,
+      defaultNamespace,
+    });
+
+    if (allowArbitraryValues) return entityRef;
+
+    return option.metadata.title ?? entityRef;
+  };
+
   return (
     <FormControl
       margin="normal"
@@ -151,12 +170,7 @@ export const EntityPicker = (props: EntityPickerProps) => {
         loading={loading}
         onChange={onSelect}
         options={entities || []}
-        getOptionLabel={option =>
-          // option can be a string due to freeSolo.
-          typeof option === 'string'
-            ? option
-            : humanizeEntityRef(option, { defaultKind, defaultNamespace })!
-        }
+        getOptionLabel={getOptionLabel}
         autoSelect
         freeSolo={allowArbitraryValues}
         renderInput={params => (

--- a/plugins/scaffolder/src/components/fields/OwnerPicker/OwnerPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/OwnerPicker/OwnerPicker.test.tsx
@@ -99,7 +99,12 @@ describe('<OwnerPicker />', () => {
           filter: {
             kind: ['Group', 'User'],
           },
-          fields: ['metadata.name', 'metadata.namespace', 'kind'],
+          fields: [
+            'metadata.name',
+            'metadata.namespace',
+            'metadata.title',
+            'kind',
+          ],
         }),
       );
     });
@@ -132,7 +137,12 @@ describe('<OwnerPicker />', () => {
           filter: {
             kind: ['User'],
           },
-          fields: ['metadata.name', 'metadata.namespace', 'kind'],
+          fields: [
+            'metadata.name',
+            'metadata.namespace',
+            'metadata.title',
+            'kind',
+          ],
         }),
       );
     });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This pull requests makes the `EntityPicker` use the title of the entity if present, but only if `allowArbitraryValues` is `false`, since there is no way to differentiate between an arbitrary value and a label (the title in this case).

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
