### PR TITLE
Use linkTarget in ScaffolderField to enable parameter descriptions to open in a new tab as intended

### DIFF
--- a/.changeset/loud-pumpkins-bow.md
+++ b/.changeset/loud-pumpkins-bow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+Fixed a bug where links in scaffolder field markdown content e.g. - description was not able to be launched in a new tab. This fix makes it so that all links within Scaffolder Fields are launched in a new tab.

--- a/.changeset/loud-pumpkins-bow.md
+++ b/.changeset/loud-pumpkins-bow.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-react': patch
 ---
 
-Fixed a bug where links in scaffolder field markdown content e.g. - description was not able to be launched in a new tab. This fix makes it so that all links within Scaffolder Fields are launched in a new tab.
+Links that are rendered in the markdown in the `ScaffolderField` component are now opened in new tabs.

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -302,7 +302,10 @@ export const createPublishGitlabMergeRequestAction: (options: {
 }) => TemplateAction_2<
   {
     repoUrl: string;
-    title: string;
+    title: string
+    /**
+     * @public @deprecated use import from \@backstage/plugin-scaffolder-backend-module-github instead
+     */;
     description: string;
     branchName: string;
     targetBranchName?: string | undefined;

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -302,10 +302,7 @@ export const createPublishGitlabMergeRequestAction: (options: {
 }) => TemplateAction_2<
   {
     repoUrl: string;
-    title: string
-    /**
-     * @public @deprecated use import from \@backstage/plugin-scaffolder-backend-module-github instead
-     */;
+    title: string;
     description: string;
     branchName: string;
     targetBranchName?: string | undefined;

--- a/plugins/scaffolder-react/src/next/components/ScaffolderField/ScaffolderField.tsx
+++ b/plugins/scaffolder-react/src/next/components/ScaffolderField/ScaffolderField.tsx
@@ -76,6 +76,7 @@ export const ScaffolderField = (
       {displayLabel && rawDescription ? (
         <MarkdownContent
           content={rawDescription}
+          linkTarget="_blank"
           className={classes.markdownDescription}
         />
       ) : null}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
- software-templates: Use linkTarget property of `MarkdownContent` in order to pass "_blank" target to open links (if present) in a new tab

Fixes #24753

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
