### PR TITLE
fix: show all notifications by default in notifications page

### DIFF
--- a/.changeset/nice-scissors-jog.md
+++ b/.changeset/nice-scissors-jog.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications': patch
+---
+
+Show all notifications by default to match the sidebar item status

--- a/plugins/notifications/src/components/NotificationsPage/NotificationsPage.tsx
+++ b/plugins/notifications/src/components/NotificationsPage/NotificationsPage.tsx
@@ -71,7 +71,7 @@ export const NotificationsPage = (props?: NotificationsPageProps) => {
   const [pageNumber, setPageNumber] = React.useState(0);
   const [pageSize, setPageSize] = React.useState(5);
   const [containsText, setContainsText] = React.useState<string>();
-  const [createdAfter, setCreatedAfter] = React.useState<string>('lastWeek');
+  const [createdAfter, setCreatedAfter] = React.useState<string>('all');
   const [sorting, setSorting] = React.useState<SortBy>(
     SortByOptions.newest.sortBy,
   );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

to prevent confusion with sidebar item showing that you have new notifications but the table not showing any because the default filter is for last week only

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
