### PR TITLE
backend-app-api: add initialization logger

### DIFF
--- a/.changeset/pink-nails-warn.md
+++ b/.changeset/pink-nails-warn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+Added logging of all plugins being initialized, periodic status, and completion.

--- a/packages/backend-app-api/src/wiring/createInitializationLogger.ts
+++ b/packages/backend-app-api/src/wiring/createInitializationLogger.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RootLoggerService } from '@backstage/backend-plugin-api';
+
+const LOGGER_INTERVAL_MAX = 60_000;
+
+function joinIds(ids: Iterable<string>): string {
+  return [...ids].map(id => `'${id}'`).join(', ');
+}
+
+export function createInitializationLogger(
+  pluginIds: string[],
+  rootLogger?: RootLoggerService,
+): {
+  onPluginStarted(pluginId: string): void;
+  onAllStarted(): void;
+} {
+  const logger = rootLogger?.child({ type: 'initialization' });
+  const starting = new Set(pluginIds);
+  const started = new Set<string>();
+
+  logger?.info(`Plugin initialization started: ${joinIds(pluginIds)}`);
+
+  const getInitStatus = () => {
+    let status = '';
+    if (started.size > 0) {
+      status = `, newly initialized: ${joinIds(started)}`;
+      started.clear();
+    }
+    if (starting.size > 0) {
+      status += `, still initializing: ${joinIds(starting)}`;
+    }
+    return status;
+  };
+
+  // Periodically log the initialization status with a fibonacci backoff
+  let interval = 1000;
+  let prevInterval = 0;
+  let timeout: NodeJS.Timeout | undefined;
+  const onTimeout = () => {
+    logger?.info(`Plugin initialization in progress${getInitStatus()}`);
+
+    const nextInterval = Math.min(interval + prevInterval, LOGGER_INTERVAL_MAX);
+    prevInterval = interval;
+    interval = nextInterval;
+
+    timeout = setTimeout(onTimeout, nextInterval);
+  };
+  timeout = setTimeout(onTimeout, interval);
+
+  return {
+    onPluginStarted(pluginId: string) {
+      starting.delete(pluginId);
+      started.add(pluginId);
+    },
+    onAllStarted() {
+      logger?.info(`Plugin initialization complete${getInitStatus()}`);
+
+      if (timeout) {
+        clearTimeout(timeout);
+        timeout = undefined;
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds this kind of logging:

```
Plugin initialization started: 'auth', 'app', 'catalog', 'devtools', 'kubernetes', 'permission', 'proxy', 'scaffolder', 'search', 'techdocs', 'signals', 'notifications'
Plugin initialization in progress, newly initialized: 'proxy', 'devtools', 'permission', 'kubernetes', 'signals', 'search', 'app', 'auth', 'scaffolder', 'notifications', 'catalog', still initializing: 'techdocs'
Plugin initialization in progress, still initializing: 'techdocs'
Plugin initialization complete, newly initialized: 'techdocs' type=initialization
```

Idea is to more easily be able to see which plugins are being started, as see if any of them are hanging on initialization.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
