### PR TITLE
backend-app-api: fix object meta null proto crash

### DIFF
--- a/.changeset/brave-apples-move.md
+++ b/.changeset/brave-apples-move.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+Fixed a potential crash when passing an object with a `null` prototype as log meta.

--- a/packages/backend-app-api/src/logging/WinstonLogger.test.ts
+++ b/packages/backend-app-api/src/logging/WinstonLogger.test.ts
@@ -65,6 +65,10 @@ describe('WinstonLogger', () => {
       level: 'error',
       message: {
         nested: 'hello (world) from nested object',
+        null: null,
+        nullProto: Object.create(null, {
+          foo: { value: 'hello foo', enumerable: true },
+        }),
       },
     };
 
@@ -74,6 +78,10 @@ describe('WinstonLogger', () => {
         ...log,
         message: {
           nested: '[REDACTED] (world) from nested object',
+          null: null,
+          nullProto: {
+            foo: 'hello foo', // read only prop is not redacted
+          },
         },
       }),
     );

--- a/packages/backend-app-api/src/logging/WinstonLogger.ts
+++ b/packages/backend-app-api/src/logging/WinstonLogger.ts
@@ -87,11 +87,15 @@ export class WinstonLogger implements RootLoggerService {
 
     const replace = (obj: TransformableInfo) => {
       for (const key in obj) {
-        if (obj.hasOwnProperty(key)) {
+        if (Object.hasOwn(obj, key)) {
           if (typeof obj[key] === 'object') {
             obj[key] = replace(obj[key] as TransformableInfo);
           } else if (typeof obj[key] === 'string') {
-            obj[key] = obj[key]?.replace(redactionPattern, '[REDACTED]');
+            try {
+              obj[key] = obj[key]?.replace(redactionPattern, '[REDACTED]');
+            } catch {
+              /* ignore read only properties */
+            }
           }
         }
       }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is perhaps not a very likely crash when passing log meta manually, but if passing on log meta from a library this is a bit more likely. Objects with `null` prototypes are a common way to avoid prototype pollution vulnerabilities.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
