### PR TITLE
Patch release of #24766

### DIFF
--- a/.changeset/brave-apples-move.md
+++ b/.changeset/brave-apples-move.md
@@ -1,5 +1,0 @@
----
-'@backstage/backend-app-api': patch
----
-
-Fixed a potential crash when passing an object with a `null` prototype as log meta.

--- a/.changeset/brave-apples-move.md
+++ b/.changeset/brave-apples-move.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+Fixed a potential crash when passing an object with a `null` prototype as log meta.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/backend-app-api/CHANGELOG.md
+++ b/packages/backend-app-api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/backend-app-api
 
+## 0.7.4
+
+### Patch Changes
+
+- ce87d0e: Fixed a potential crash when passing an object with a `null` prototype as log meta.
+
 ## 0.7.3
 
 ### Patch Changes

--- a/packages/backend-app-api/package.json
+++ b/packages/backend-app-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/backend-app-api",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Core API used by Backstage backend apps",
   "backstage": {
     "role": "node-library"

--- a/packages/backend-app-api/src/logging/WinstonLogger.test.ts
+++ b/packages/backend-app-api/src/logging/WinstonLogger.test.ts
@@ -65,6 +65,10 @@ describe('WinstonLogger', () => {
       level: 'error',
       message: {
         nested: 'hello (world) from nested object',
+        null: null,
+        nullProto: Object.create(null, {
+          foo: { value: 'hello foo', enumerable: true },
+        }),
       },
     };
 
@@ -74,6 +78,10 @@ describe('WinstonLogger', () => {
         ...log,
         message: {
           nested: '[REDACTED] (world) from nested object',
+          null: null,
+          nullProto: {
+            foo: 'hello foo', // read only prop is not redacted
+          },
         },
       }),
     );

--- a/packages/backend-app-api/src/logging/WinstonLogger.ts
+++ b/packages/backend-app-api/src/logging/WinstonLogger.ts
@@ -87,11 +87,15 @@ export class WinstonLogger implements RootLoggerService {
 
     const replace = (obj: TransformableInfo) => {
       for (const key in obj) {
-        if (obj.hasOwnProperty(key)) {
+        if (Object.hasOwn(obj, key)) {
           if (typeof obj[key] === 'object') {
             obj[key] = replace(obj[key] as TransformableInfo);
           } else if (typeof obj[key] === 'string') {
-            obj[key] = obj[key]?.replace(redactionPattern, '[REDACTED]');
+            try {
+              obj[key] = obj[key]?.replace(redactionPattern, '[REDACTED]');
+            } catch {
+              /* ignore read only properties */
+            }
           }
         }
       }


### PR DESCRIPTION
This release fixes an issue where the backend logger services would throw an error when passing a log meta object with a `null` prototype.