### PR TITLE
Make the host of AWS Code Commit changeable

### DIFF
--- a/.changeset/poor-cats-rhyme.md
+++ b/.changeset/poor-cats-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+Make the host of AWS Code Commit changeable

--- a/packages/integration/src/awsCodeCommit/config.ts
+++ b/packages/integration/src/awsCodeCommit/config.ts
@@ -88,13 +88,17 @@ export function readAwsCodeCommitIntegrationConfigs(
   // First read all the explicit integrations
   const result = configs.map(readAwsCodeCommitIntegrationConfig);
 
-  // If no explicit console.aws.amazon.com integration was added, put one in the list as
-  // a convenience
-  if (!result.some(c => !c.host)) {
+  if (result.length === 0) {
     result.push({
       host: AMAZON_AWS_CODECOMMIT_HOST,
     });
   }
+
+  result.forEach(c => {
+    if (!c.hasOwnProperty('host')) {
+      c.host = AMAZON_AWS_CODECOMMIT_HOST;
+    }
+  });
 
   return result;
 }

--- a/packages/integration/src/awsCodeCommit/config.ts
+++ b/packages/integration/src/awsCodeCommit/config.ts
@@ -64,7 +64,7 @@ export function readAwsCodeCommitIntegrationConfig(
   const secretAccessKey = config.getOptionalString('secretAccessKey')?.trim();
   const roleArn = config.getOptionalString('roleArn');
   const externalId = config.getOptionalString('externalId');
-  const host = AMAZON_AWS_CODECOMMIT_HOST;
+  const host = config.getOptionalString('host') || AMAZON_AWS_CODECOMMIT_HOST;
 
   return {
     host,
@@ -90,7 +90,7 @@ export function readAwsCodeCommitIntegrationConfigs(
 
   // If no explicit console.aws.amazon.com integration was added, put one in the list as
   // a convenience
-  if (!result.some(c => c.host === AMAZON_AWS_CODECOMMIT_HOST)) {
+  if (!result.some(c => !c.host)) {
     result.push({
       host: AMAZON_AWS_CODECOMMIT_HOST,
     });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

As-Is : The catalog:register action does not work when using AWS Code Commit.

In the link below, config.host is forced to console.aws.amazon.com, so, If I set repoContentsUrl to {region}.console.aws.amazon.com in the catalog:register action, No Integration error occurs.
https://github.com/backstage/backstage/blob/master/packages/integration/src/awsCodeCommit/config.ts#L67

Instead, if I remove the region from the url, an error occurs due to the link below.
https://github.com/backstage/backstage/blob/master/packages/backend-common/src/reading/AwsCodeCommitUrlReader.ts#L70

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
