### PR TITLE
catalog-backend-module-gitlab: fix release

### DIFF
--- a/plugins/catalog-backend-module-gitlab/CHANGELOG.md
+++ b/plugins/catalog-backend-module-gitlab/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @backstage/plugin-catalog-backend-module-gitlab
 
-## 0.3.15
+## 0.3.16
 
 ### Patch Changes
 

--- a/plugins/catalog-backend-module-gitlab/package.json
+++ b/plugins/catalog-backend-module-gitlab/package.json
@@ -1,8 +1,53 @@
 {
+  "name": "@backstage/plugin-catalog-backend-module-gitlab",
+  "version": "0.3.16",
+  "description": "A Backstage catalog backend module that helps integrate towards GitLab",
   "backstage": {
     "role": "backend-plugin-module"
   },
-  "configSchema": "config.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "backstage"
+  ],
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/catalog-backend-module-gitlab"
+  },
+  "license": "Apache-2.0",
+  "exports": {
+    ".": "./src/index.ts",
+    "./alpha": "./src/alpha.ts",
+    "./package.json": "./package.json"
+  },
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "typesVersions": {
+    "*": {
+      "alpha": [
+        "src/alpha.ts"
+      ],
+      "package.json": [
+        "package.json"
+      ]
+    }
+  },
+  "files": [
+    "config.d.ts",
+    "dist"
+  ],
+  "scripts": {
+    "build": "backstage-cli package build",
+    "clean": "backstage-cli package clean",
+    "lint": "backstage-cli package lint",
+    "prepack": "backstage-cli package prepack",
+    "postpack": "backstage-cli package postpack",
+    "start": "backstage-cli package start",
+    "test": "backstage-cli package test"
+  },
   "dependencies": {
     "@backstage/backend-common": "workspace:^",
     "@backstage/backend-plugin-api": "workspace:^",
@@ -18,7 +63,6 @@
     "node-fetch": "^2.6.7",
     "uuid": "^9.0.0"
   },
-  "description": "A Backstage catalog backend module that helps integrate towards GitLab",
   "devDependencies": {
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
@@ -28,49 +72,5 @@
     "luxon": "^3.0.0",
     "msw": "^1.0.0"
   },
-  "exports": {
-    ".": "./src/index.ts",
-    "./alpha": "./src/alpha.ts",
-    "./package.json": "./package.json"
-  },
-  "files": [
-    "config.d.ts",
-    "dist"
-  ],
-  "homepage": "https://backstage.io",
-  "keywords": [
-    "backstage"
-  ],
-  "license": "Apache-2.0",
-  "main": "src/index.ts",
-  "name": "@backstage/plugin-catalog-backend-module-gitlab",
-  "publishConfig": {
-    "access": "public"
-  },
-  "repository": {
-    "directory": "plugins/catalog-backend-module-gitlab",
-    "type": "git",
-    "url": "https://github.com/backstage/backstage"
-  },
-  "scripts": {
-    "build": "backstage-cli package build",
-    "clean": "backstage-cli package clean",
-    "lint": "backstage-cli package lint",
-    "postpack": "backstage-cli package postpack",
-    "prepack": "backstage-cli package prepack",
-    "start": "backstage-cli package start",
-    "test": "backstage-cli package test"
-  },
-  "types": "src/index.ts",
-  "typesVersions": {
-    "*": {
-      "alpha": [
-        "src/alpha.ts"
-      ],
-      "package.json": [
-        "package.json"
-      ]
-    }
-  },
-  "version": "0.3.15"
+  "configSchema": "config.d.ts"
 }


### PR DESCRIPTION
🧹, spotted by @awanlin. The last couple of the release of the packages seems to have been messed up by the `1.26-next.0` and `1.27`. I did check the recent version bump of all packages and somehow this looks like the only one that's been affected.

This should simply publish the package, and if a GitHub release is published I'll remove it.
