### PR TITLE
core-*-api: backport support for external route ref default targets + config route binding

### DIFF
--- a/.changeset/chilled-planes-sniff.md
+++ b/.changeset/chilled-planes-sniff.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-api-docs': patch
+---
+
+The `registerComponent` external route will now by default bind to the catalog import page if it is available.

--- a/.changeset/cuddly-jobs-kick.md
+++ b/.changeset/cuddly-jobs-kick.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-compat-api': patch
+---
+
+Add support for forwarding default target from legacy external route refs.

--- a/.changeset/green-apricots-invite.md
+++ b/.changeset/green-apricots-invite.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+The `catalogIndex` external route is now optional and will by default bind to the catalog index page if it is available.

--- a/.changeset/honest-pandas-chew.md
+++ b/.changeset/honest-pandas-chew.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-plugin-api': patch
+---
+
+Added a new `defaultTarget` option to `createExternalRouteRef`. I lets you specify a default target of the route by name, for example `'catalog.catalogIndex'`, which will be used if the target route is present in the app and there is no explicit route binding.

--- a/.changeset/proud-readers-move.md
+++ b/.changeset/proud-readers-move.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-graph': patch
+---
+
+The `catalogEntity` external route will now by default bind to the catalog entity page if it is available.

--- a/.changeset/rich-teachers-agree.md
+++ b/.changeset/rich-teachers-agree.md
@@ -1,0 +1,9 @@
+---
+'@backstage/plugin-catalog': minor
+---
+
+Added the following default targets for external routes:
+
+- `createComponent` binds to the Scaffolder page.
+- `viewTechDoc` binds to the TechDocs entity documentation page.
+- `createFromTemplate` binds to the Scaffolder selected template page.

--- a/.changeset/serious-yaks-sit.md
+++ b/.changeset/serious-yaks-sit.md
@@ -1,0 +1,29 @@
+---
+'@backstage/core-app-api': patch
+---
+
+Added support for configuration of route bindings through static configuration, and default targets for external route refs.
+
+In addition to configuring route bindings through code, it is now also possible to configure route bindings under the `app.routes.bindings` key, for example:
+
+```yaml
+app:
+  routes:
+    bindings:
+      catalog.createComponent: catalog-import.importPage
+```
+
+Each key in the route binding object is of the form `<plugin-id>.<externalRouteName>`, where the route name is key used in the `externalRoutes` object passed to `createPlugin`. The value is of the same form, but with the name taken from the plugin `routes` option instead.
+
+The equivalent of the above configuration in code is the following:
+
+```ts
+const app = createApp({
+  // ...
+  bindRoutes({ bind }) {
+    bind(catalogPlugin.externalRoutes, {
+      createComponent: catalogImportPlugin.routes.importPage,
+    });
+  },
+});
+```

--- a/.changeset/warm-mayflies-yell.md
+++ b/.changeset/warm-mayflies-yell.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-scaffolder': minor
+---
+
+Added the following default targets for external routes:
+
+- `registerComponent` binds to the catalog import page.
+- `viewTechDoc` binds to the TechDocs entity documentation page.

--- a/docs/frontend-system/architecture/07-routes.md
+++ b/docs/frontend-system/architecture/07-routes.md
@@ -274,6 +274,21 @@ Note that we are not importing and using the `RouteRef`s directly in the app, an
 
 Another thing to note is that this indirection in the routing is particularly useful for open source plugins that need to provide flexibility in how they are integrated. For plugins that you build internally for your own Backstage application, you can choose to use direct imports or even concrete route path strings directly. Although there can be some benefits to using the full routing system even in internal plugins: it can help you structure your routes, and as you will see further down it also helps you manage route parameters.
 
+### Default Targets for External Route References
+
+It is possible to define a default target for an external route reference, potentially removing the need to bind the route in the app. This reduces the need for configuration when installing new plugins through providing a sensible default. It is of course still possible to override the route binding in the app.
+
+The default target uses the same syntax as the route binding configuration, and will only be used if the target plugin an route exists. For example, this is how the catalog can define a default target for the create component external route in a way that removes the need for the binding in the previous example:
+
+```tsx title="plugins/catalog/src/routes.ts"
+import { createExternalRouteRef } from '@backstage/frontend-plugin-api';
+
+export const createComponentExternalRouteRef = createExternalRouteRef({
+  // highlight-next-line
+  defaultTarget: 'scaffolder.createComponent',
+});
+```
+
 ### Optional External Route References
 
 It is possible to define an `ExternalRouteRef` as optional, so it is not required to bind it in the app.

--- a/docs/frontend-system/architecture/07-routes.md
+++ b/docs/frontend-system/architecture/07-routes.md
@@ -278,7 +278,7 @@ Another thing to note is that this indirection in the routing is particularly us
 
 It is possible to define a default target for an external route reference, potentially removing the need to bind the route in the app. This reduces the need for configuration when installing new plugins through providing a sensible default. It is of course still possible to override the route binding in the app.
 
-The default target uses the same syntax as the route binding configuration, and will only be used if the target plugin an route exists. For example, this is how the catalog can define a default target for the create component external route in a way that removes the need for the binding in the previous example:
+The default target uses the same syntax as the route binding configuration, and will only be used if the target plugin and route exist. For example, this is how the catalog can define a default target for the create component external route in a way that removes the need for the binding in the previous example:
 
 ```tsx title="plugins/catalog/src/routes.ts"
 import { createExternalRouteRef } from '@backstage/frontend-plugin-api';

--- a/docs/plugins/composability.md
+++ b/docs/plugins/composability.md
@@ -325,6 +325,33 @@ concrete routes directly. Although there can be some benefits to using the full
 routing system even in internal plugins. It can help you structure your routes,
 and as you will see further down it also helps you manage route parameters.
 
+You can also use static configuration to bind routes, removing the need to make
+changes to the app code. It does however mean that you won't get type safety
+when binding routes and compile-time validation of the bindings. Static
+configuration of route bindings is done under the `app.routes.bindings` key in
+`app-config.yaml`. It works the same way as [route bindings in the new frontend system](../frontend-system/architecture/07-routes.md#binding-external-route-references),
+for example:
+
+```yaml
+app:
+  routes:
+    bindings:
+      bar.headerLink: foo.root
+```
+
+### Default Targets for External Route References
+
+Following the `1.28` release of Backstage you can now define default targets for
+external route references. They work the same way as [default targets in the new frontend system](../frontend-system/architecture/07-routes.md#default-targets-for-external-route-references),
+for example:
+
+```ts
+export const createComponentExternalRouteRef = createExternalRouteRef({
+  // highlight-next-line
+  defaultTarget: 'scaffolder.createComponent',
+});
+```
+
 ### Optional External Routes
 
 When creating an `ExternalRouteRef` it is possible to mark it as optional:

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -33,22 +33,14 @@ import {
   OAuthRequestDialog,
   SignInPage,
 } from '@backstage/core-components';
-import { apiDocsPlugin, ApiExplorerPage } from '@backstage/plugin-api-docs';
-import {
-  CatalogEntityPage,
-  CatalogIndexPage,
-  catalogPlugin,
-} from '@backstage/plugin-catalog';
+import { ApiExplorerPage } from '@backstage/plugin-api-docs';
+import { CatalogEntityPage, CatalogIndexPage } from '@backstage/plugin-catalog';
 
 import { CatalogGraphPage } from '@backstage/plugin-catalog-graph';
-import {
-  CatalogImportPage,
-  catalogImportPlugin,
-} from '@backstage/plugin-catalog-import';
-import { orgPlugin } from '@backstage/plugin-org';
+import { CatalogImportPage } from '@backstage/plugin-catalog-import';
 import { HomepageCompositionRoot, VisitListener } from '@backstage/plugin-home';
 
-import { ScaffolderPage, scaffolderPlugin } from '@backstage/plugin-scaffolder';
+import { ScaffolderPage } from '@backstage/plugin-scaffolder';
 import {
   ScaffolderFieldExtensions,
   ScaffolderLayouts,
@@ -56,7 +48,6 @@ import {
 import { SearchPage } from '@backstage/plugin-search';
 import {
   TechDocsIndexPage,
-  techdocsPlugin,
   TechDocsReaderPage,
 } from '@backstage/plugin-techdocs';
 import { TechDocsAddons } from '@backstage/plugin-techdocs-react';
@@ -118,23 +109,6 @@ const app = createApp({
         />
       );
     },
-  },
-  bindRoutes({ bind }) {
-    bind(catalogPlugin.externalRoutes, {
-      createComponent: scaffolderPlugin.routes.root,
-      viewTechDoc: techdocsPlugin.routes.docRoot,
-      createFromTemplate: scaffolderPlugin.routes.selectedTemplate,
-    });
-    bind(apiDocsPlugin.externalRoutes, {
-      registerApi: catalogImportPlugin.routes.importPage,
-    });
-    bind(scaffolderPlugin.externalRoutes, {
-      registerComponent: catalogImportPlugin.routes.importPage,
-      viewTechDoc: techdocsPlugin.routes.docRoot,
-    });
-    bind(orgPlugin.externalRoutes, {
-      catalogIndex: catalogPlugin.routes.catalogIndex,
-    });
   },
 });
 

--- a/packages/core-app-api/src/app/AppManager.test.tsx
+++ b/packages/core-app-api/src/app/AppManager.test.tsx
@@ -20,7 +20,7 @@ import {
   renderWithEffects,
   withLogCollector,
 } from '@backstage/test-utils';
-import { render, screen, waitFor, act } from '@testing-library/react';
+import { screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React, { PropsWithChildren, ReactNode } from 'react';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
@@ -624,7 +624,7 @@ describe('Integration Test', () => {
     expect(capturedEvents).toHaveLength(2);
   });
 
-  it('should throw some error when the route has duplicate params', () => {
+  it('should throw some error when the route has duplicate params', async () => {
     const app = new AppManager({
       apis: [],
       defaultApis: [],
@@ -641,31 +641,43 @@ describe('Integration Test', () => {
       },
     });
 
+    const expectedMessage =
+      'Parameter :thing is duplicated in path test/:thing/some/:thing';
+
     const Provider = app.getProvider();
     const Router = app.getRouter();
-    const { error: errorLogs } = withLogCollector(() => {
-      render(
-        <Provider>
-          <Router>
-            <Routes>
-              <Route path="/test/:thing" element={<ExposedComponent />}>
-                <Route path="/some/:thing" element={<HiddenComponent />} />
-              </Route>
-            </Routes>
-          </Router>
-        </Provider>,
-      );
+    const { error: errorLogs } = await withLogCollector(async () => {
+      await expect(() =>
+        renderWithEffects(
+          <Provider>
+            <Router>
+              <Routes>
+                <Route path="/test/:thing" element={<ExposedComponent />}>
+                  <Route path="/some/:thing" element={<HiddenComponent />} />
+                </Route>
+              </Routes>
+            </Router>
+          </Provider>,
+        ),
+      ).rejects.toThrow(expectedMessage);
     });
+
     expect(errorLogs).toEqual([
       expect.objectContaining({
-        message: expect.stringContaining(
-          'Parameter :thing is duplicated in path test/:thing/some/:thing',
-        ),
+        detail: new Error(expectedMessage),
+        type: 'unhandled exception',
       }),
+      expect.objectContaining({
+        detail: new Error(expectedMessage),
+        type: 'unhandled exception',
+      }),
+      expect.stringContaining(
+        'The above error occurred in the <Provider> component:',
+      ),
     ]);
   });
 
-  it('should throw an error when required external plugin routes are not bound', () => {
+  it('should throw an error when required external plugin routes are not bound', async () => {
     const app = new AppManager({
       apis: [],
       defaultApis: [],
@@ -676,25 +688,36 @@ describe('Integration Test', () => {
       configLoader: async () => [],
     });
 
+    const expectedMessage =
+      "External route 'extRouteRef1' of the 'blob' plugin must be bound to a target route. See https://backstage.io/link?bind-routes for details.";
+
     const Provider = app.getProvider();
     const Router = app.getRouter();
-    const { error: errorLogs } = withLogCollector(() => {
-      render(
-        <Provider>
-          <Router>
-            <Routes>
-              <Route path="/test/:thing" element={<ExposedComponent />} />
-            </Routes>
-          </Router>
-        </Provider>,
-      );
+    const { error: errorLogs } = await withLogCollector(async () => {
+      await expect(() =>
+        renderWithEffects(
+          <Provider>
+            <Router>
+              <Routes>
+                <Route path="/test/:thing" element={<ExposedComponent />} />
+              </Routes>
+            </Router>
+          </Provider>,
+        ),
+      ).rejects.toThrow(expectedMessage);
     });
     expect(errorLogs).toEqual([
       expect.objectContaining({
-        message: expect.stringMatching(
-          /^External route 'extRouteRef1' of the 'blob' plugin must be bound to a target route/,
-        ),
+        detail: new Error(expectedMessage),
+        type: 'unhandled exception',
       }),
+      expect.objectContaining({
+        detail: new Error(expectedMessage),
+        type: 'unhandled exception',
+      }),
+      expect.stringContaining(
+        'The above error occurred in the <Provider> component:',
+      ),
     ]);
   });
 

--- a/packages/core-app-api/src/app/AppManager.tsx
+++ b/packages/core-app-api/src/app/AppManager.tsx
@@ -297,22 +297,22 @@ DEPRECATION WARNING: React Router Beta is deprecated and support for it will be 
         return loadedConfig.node;
       }
 
-      if (!routeBindings) {
-        routeBindings = resolveRouteBindings(
-          this.bindRoutes,
-          loadedConfig.api,
-          this.plugins,
-        );
-
+      if (routeValidationError) {
+        throw routeValidationError;
+      } else if (!routeBindings) {
         try {
+          routeBindings = resolveRouteBindings(
+            this.bindRoutes,
+            loadedConfig.api,
+            this.plugins,
+          );
+
           validateRouteParameters(routing.paths, routing.parents);
           validateRouteBindings(routeBindings, this.plugins);
         } catch (error) {
           routeValidationError = error;
           throw error;
         }
-      } else if (routeValidationError) {
-        throw routeValidationError;
       }
 
       // We can't register feature flags just after the element traversal, because the

--- a/packages/core-app-api/src/routing/validation.ts
+++ b/packages/core-app-api/src/routing/validation.ts
@@ -66,7 +66,12 @@ export function validateRouteParameters(
 // Validates that all non-optional external routes have been bound
 export function validateRouteBindings(
   routeBindings: Map<ExternalRouteRef, RouteRef | SubRouteRef>,
-  plugins: Iterable<BackstagePlugin<{}, Record<string, ExternalRouteRef>>>,
+  plugins: Iterable<
+    Pick<
+      BackstagePlugin<{}, Record<string, ExternalRouteRef>>,
+      'getId' | 'externalRoutes'
+    >
+  >,
 ) {
   for (const plugin of plugins) {
     if (!plugin.externalRoutes) {

--- a/packages/core-compat-api/src/convertLegacyRouteRef.ts
+++ b/packages/core-compat-api/src/convertLegacyRouteRef.ts
@@ -186,6 +186,10 @@ export function convertLegacyRouteRef(
       createExternalRouteRef<{ [key in string]: string }>({
         params: legacyRef.params as string[],
         optional: legacyRef.optional,
+        defaultTarget:
+          'getDefaultTarget' in legacyRef
+            ? (legacyRef.getDefaultTarget as () => string | undefined)()
+            : undefined,
       }),
     );
     return Object.assign(legacyRef, {
@@ -199,10 +203,8 @@ export function convertLegacyRouteRef(
       getDescription() {
         return legacyRefStr;
       },
-      getDefaultTarget() {
-        // TODO(freben): These are not yet supported in the old system; just returning undefined for now
-        return undefined;
-      },
+      // This might already be implemented in the legacy ref, but we override it just to be sure
+      getDefaultTarget: newRef.getDefaultTarget,
       setId(id: string) {
         newRef.setId(id);
       },

--- a/packages/core-compat-api/src/convertLegacyRouteRef.ts
+++ b/packages/core-compat-api/src/convertLegacyRouteRef.ts
@@ -204,7 +204,9 @@ export function convertLegacyRouteRef(
         return legacyRefStr;
       },
       // This might already be implemented in the legacy ref, but we override it just to be sure
-      getDefaultTarget: newRef.getDefaultTarget,
+      getDefaultTarget() {
+        return newRef.getDefaultTarget();
+      },
       setId(id: string) {
         newRef.setId(id);
       },

--- a/packages/core-plugin-api/api-report.md
+++ b/packages/core-plugin-api/api-report.md
@@ -314,6 +314,7 @@ export function createExternalRouteRef<
   id: string;
   params?: ParamKey[];
   optional?: Optional;
+  defaultTarget?: string;
 }): ExternalRouteRef<OptionalParams<Params>, Optional>;
 
 // @public

--- a/packages/core-plugin-api/src/routing/ExternalRouteRef.ts
+++ b/packages/core-plugin-api/src/routing/ExternalRouteRef.ts
@@ -38,10 +38,15 @@ export class ExternalRouteRefImpl<
     private readonly id: string,
     readonly params: ParamKeys<Params>,
     readonly optional: Optional,
+    readonly defaultTarget: string | undefined,
   ) {}
 
   toString() {
     return `routeRef{type=external,id=${this.id}}`;
+  }
+
+  getDefaultTarget() {
+    return this.defaultTarget;
   }
 }
 
@@ -77,10 +82,19 @@ export function createExternalRouteRef<
    * if they aren't, `useRouteRef` will return `undefined`.
    */
   optional?: Optional;
+
+  /**
+   * The route (typically in another plugin) that this should map to by default.
+   *
+   * The string is expected to be on the standard `<plugin id>.<route id>` form,
+   * for example `techdocs.docRoot`.
+   */
+  defaultTarget?: string;
 }): ExternalRouteRef<OptionalParams<Params>, Optional> {
   return new ExternalRouteRefImpl(
     options.id,
     (options.params ?? []) as ParamKeys<OptionalParams<Params>>,
     Boolean(options.optional) as Optional,
+    options?.defaultTarget,
   );
 }

--- a/plugins/api-docs/src/routes.ts
+++ b/plugins/api-docs/src/routes.ts
@@ -26,4 +26,5 @@ export const rootRoute = createRouteRef({
 export const registerComponentRouteRef = createExternalRouteRef({
   id: 'register-component',
   optional: true,
+  defaultTarget: 'catalog-import.importPage',
 });

--- a/plugins/catalog-graph/src/routes.ts
+++ b/plugins/catalog-graph/src/routes.ts
@@ -38,4 +38,5 @@ export const catalogEntityRouteRef = createExternalRouteRef({
   id: 'catalog-entity',
   params: ['namespace', 'kind', 'name'],
   optional: true,
+  defaultTarget: 'catalog.catalogEntity',
 });

--- a/plugins/catalog/src/routes.ts
+++ b/plugins/catalog/src/routes.ts
@@ -22,18 +22,21 @@ import {
 export const createComponentRouteRef = createExternalRouteRef({
   id: 'create-component',
   optional: true,
+  defaultTarget: 'scaffolder.createComponent',
 });
 
 export const viewTechDocRouteRef = createExternalRouteRef({
   id: 'view-techdoc',
   optional: true,
   params: ['namespace', 'kind', 'name'],
+  defaultTarget: 'techdocs.docRoot',
 });
 
 export const createFromTemplateRouteRef = createExternalRouteRef({
   id: 'create-from-template',
   optional: true,
   params: ['namespace', 'templateName'],
+  defaultTarget: 'scaffolder.selectedTemplate',
 });
 
 export const unregisterRedirectRouteRef = createExternalRouteRef({

--- a/plugins/org/api-report-alpha.md
+++ b/plugins/org/api-report-alpha.md
@@ -10,7 +10,7 @@ import { ExternalRouteRef } from '@backstage/frontend-plugin-api';
 const _default: BackstagePlugin<
   {},
   {
-    catalogIndex: ExternalRouteRef<undefined, false>;
+    catalogIndex: ExternalRouteRef<undefined, true>;
   }
 >;
 export default _default;

--- a/plugins/org/api-report.md
+++ b/plugins/org/api-report.md
@@ -70,7 +70,7 @@ export const MyGroupsSidebarItem: (props: {
 const orgPlugin: BackstagePlugin<
   {},
   {
-    catalogIndex: ExternalRouteRef<undefined, false>;
+    catalogIndex: ExternalRouteRef<undefined, true>;
   }
 >;
 export { orgPlugin };

--- a/plugins/org/src/components/Cards/OwnershipCard/ComponentsGrid.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/ComponentsGrid.tsx
@@ -69,38 +69,45 @@ const EntityCountTile = ({
   counter: number;
   type?: string;
   kind: string;
-  url: string;
+  url?: string;
 }) => {
   const classes = useStyles({ type: type ?? kind });
 
   const rawTitle = type ?? kind;
   const isLongText = rawTitle.length > 10;
 
-  return (
-    <Link to={url} variant="body2">
-      <Box
-        className={`${classes.card} ${classes.entityTypeBox}`}
-        display="flex"
-        flexDirection="column"
-        alignItems="center"
-      >
-        <Typography className={classes.bold} variant="h6">
-          {counter}
+  const tile = (
+    <Box
+      className={`${classes.card} ${classes.entityTypeBox}`}
+      display="flex"
+      flexDirection="column"
+      alignItems="center"
+    >
+      <Typography className={classes.bold} variant="h6">
+        {counter}
+      </Typography>
+      <Box sx={{ width: '100%', textAlign: 'center' }}>
+        <Typography
+          className={`${classes.bold} ${isLongText && classes.smallFont}`}
+          variant="h6"
+        >
+          <OverflowTooltip
+            text={pluralize(rawTitle.toLocaleUpperCase('en-US'), counter)}
+          />
         </Typography>
-        <Box sx={{ width: '100%', textAlign: 'center' }}>
-          <Typography
-            className={`${classes.bold} ${isLongText && classes.smallFont}`}
-            variant="h6"
-          >
-            <OverflowTooltip
-              text={pluralize(rawTitle.toLocaleUpperCase('en-US'), counter)}
-            />
-          </Typography>
-        </Box>
-        {type && <Typography variant="subtitle1">{kind}</Typography>}
       </Box>
-    </Link>
+      {type && <Typography variant="subtitle1">{kind}</Typography>}
+    </Box>
   );
+
+  if (url) {
+    return (
+      <Link to={url} variant="body2">
+        {tile}
+      </Link>
+    );
+  }
+  return tile;
 };
 
 export const ComponentsGrid = ({
@@ -138,7 +145,7 @@ export const ComponentsGrid = ({
             counter={c.counter}
             kind={c.kind}
             type={c.type}
-            url={`${catalogLink()}/?${c.queryParams}`}
+            url={catalogLink && `${catalogLink()}/?${c.queryParams}`}
           />
         </Grid>
       ))}

--- a/plugins/org/src/routes.ts
+++ b/plugins/org/src/routes.ts
@@ -18,4 +18,6 @@ import { createExternalRouteRef } from '@backstage/core-plugin-api';
 
 export const catalogIndexRouteRef = createExternalRouteRef({
   id: 'catalog-index',
+  optional: true,
+  defaultTarget: 'catalog.catalogIndex',
 });

--- a/plugins/scaffolder/src/routes.ts
+++ b/plugins/scaffolder/src/routes.ts
@@ -22,12 +22,14 @@ import {
 export const registerComponentRouteRef = createExternalRouteRef({
   id: 'register-component',
   optional: true,
+  defaultTarget: 'catalog-import.importPage',
 });
 
 export const viewTechDocRouteRef = createExternalRouteRef({
   id: 'view-techdoc',
   optional: true,
   params: ['namespace', 'kind', 'name'],
+  defaultTarget: 'techdocs.docRoot',
 });
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The new frontend system supports route binding through static configuration, for example:

```yaml
app:
  routes:
    bindings:
      catalog.createComponent: catalog-import.importPage
```

It also lets you define default targets for external route references, for example:

```ts
export const registerComponentRouteRef = createExternalRouteRef({
  optional: true,
  defaultTarget: 'catalog-import.importPage',
});
```

This adds support for both of these features in the existing frontend system.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
