### PR TITLE
fix(app-backend): restore external config schema support

### DIFF
--- a/.changeset/itchy-spoons-cry.md
+++ b/.changeset/itchy-spoons-cry.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-app-backend': patch
+---
+
+Restore the support of external config schema in the router of the `app-backend` plugin, which was broken in release `1.26.0`.
+This support is critical for dynamic frontend plugins to have access to their config values.

--- a/plugins/app-backend/src/service/__fixtures__/app-dir/dist/.config-schema.json
+++ b/plugins/app-backend/src/service/__fixtures__/app-dir/dist/.config-schema.json
@@ -1,0 +1,4 @@
+{
+  "backstageConfigSchemaVersion": 1,
+  "schemas": []
+}

--- a/plugins/app-backend/src/service/router.ts
+++ b/plugins/app-backend/src/service/router.ts
@@ -113,6 +113,7 @@ export async function createRouter(
     staticFallbackHandler,
     auth,
     httpAuth,
+    schema,
   } = options;
 
   const disableConfigInjection =
@@ -143,6 +144,7 @@ export async function createRouter(
         config,
         appDistDir,
         env: process.env,
+        schema,
       });
 
   const assetStore =


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR:
-  restores the support for external config schema in the `app-backend` plugin, which has been broken in release `1.26.0`.
- adds additional unit tests, to avoid a future regression. 

The support of an external config schema is critical to use the dynamic features service, and have dynamic frontend plugins find their configuration correctly.

This fixes issue https://github.com/backstage/backstage/issues/24778

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
