### PR TITLE
Add setProcessingIntervalSeconds to CatalogProcessingExtensionPoint

### DIFF
--- a/.changeset/kind-turkeys-grab.md
+++ b/.changeset/kind-turkeys-grab.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-catalog-backend': patch
+'@backstage/plugin-catalog-node': patch
+---
+
+Adds setProcessingIntervalSeconds to CatalogProcessingExtensionPoint

--- a/plugins/catalog-backend/src/service/CatalogPlugin.ts
+++ b/plugins/catalog-backend/src/service/CatalogPlugin.ts
@@ -50,6 +50,7 @@ class CatalogProcessingExtensionPointImpl
     unprocessedEntity: Entity;
     errors: Error[];
   }) => Promise<void> | void;
+  #processingIntervalSeconds?: number;
 
   addProcessor(
     ...processors: Array<CatalogProcessor | Array<CatalogProcessor>>
@@ -80,6 +81,10 @@ class CatalogProcessingExtensionPointImpl
     this.#onProcessingErrorHandler = handler;
   }
 
+  setProcessingIntervalSeconds(interval: number): void {
+    this.#processingIntervalSeconds = interval;
+  }
+
   get processors() {
     return this.#processors;
   }
@@ -94,6 +99,10 @@ class CatalogProcessingExtensionPointImpl
 
   get onProcessingErrorHandler() {
     return this.#onProcessingErrorHandler;
+  }
+
+  get processingIntervalSeconds() {
+    return this.#processingIntervalSeconds;
   }
 }
 
@@ -264,6 +273,11 @@ export const catalogPlugin = createBackendPlugin({
         builder.addPermissions(...permissionExtensions.permissions);
         builder.addPermissionRules(...permissionExtensions.permissionRules);
         builder.setFieldFormatValidators(modelExtensions.fieldValidators);
+        if (processingExtensions.processingIntervalSeconds) {
+          builder.setProcessingIntervalSeconds(
+            processingExtensions.processingIntervalSeconds,
+          );
+        }
 
         const { processingEngine, router } = await builder.build();
 

--- a/plugins/catalog-node/api-report-alpha.md
+++ b/plugins/catalog-node/api-report-alpha.md
@@ -82,6 +82,7 @@ export interface CatalogProcessingExtensionPoint {
       errors: Error[];
     }) => Promise<void> | void,
   ): void;
+  setProcessingIntervalSeconds(interval: number): void;
 }
 
 // @alpha (undocumented)

--- a/plugins/catalog-node/src/extensions.ts
+++ b/plugins/catalog-node/src/extensions.ts
@@ -48,6 +48,12 @@ export interface CatalogProcessingExtensionPoint {
       errors: Error[];
     }) => Promise<void> | void,
   ): void;
+  /**
+   * Processing interval determines how often entities should be processed.
+   * Seconds provided will be multiplied by 1.5
+   * The default processing interval is 100-150 seconds.
+   * setting this too low will potentially deplete request quotas to upstream services.
+   */
   setProcessingIntervalSeconds(interval: number): void;
 }
 

--- a/plugins/catalog-node/src/extensions.ts
+++ b/plugins/catalog-node/src/extensions.ts
@@ -48,6 +48,7 @@ export interface CatalogProcessingExtensionPoint {
       errors: Error[];
     }) => Promise<void> | void,
   ): void;
+  setProcessingIntervalSeconds(interval: number): void;
 }
 
 /** @alpha */


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Unlike old backend system, we cannot call `setProcessingIntervalSeconds` during initialization of catalog, to ensure we don't cross rate limits on upstream. Added a method to `CatalogProcessingExtensionPoint` since this configuration concerns catalog processing.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
