### PR TITLE
[Docs] Describe default Behaviour of branch filter in the Configuration of the Github discovery provider.

### DIFF
--- a/docs/integrations/github/discovery--old.md
+++ b/docs/integrations/github/discovery--old.md
@@ -200,6 +200,7 @@ This provider supports multiple organizations via unique provider IDs.
 - **`filters`** _(optional)_:
   - **`branch`** _(optional)_:
     String used to filter results based on the branch name.
+    Defaults to the default Branch of the repository.
   - **`repository`** _(optional)_:
     Regular expression used to filter results based on the repository name.
   - **`topic`** _(optional)_:

--- a/docs/integrations/github/discovery.md
+++ b/docs/integrations/github/discovery.md
@@ -141,6 +141,7 @@ This provider supports multiple organizations via unique provider IDs.
 - **`filters`** _(optional)_:
   - **`branch`** _(optional)_:
     String used to filter results based on the branch name.
+    Defaults to the default Branch of the repository.
   - **`repository`** _(optional)_:
     Regular expression used to filter results based on the repository name.
   - **`topic`** _(optional)_:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I just added a small hint in the docs about the default behaviour of the branch filter in the Configuration of the Github discovery provider. I myself assumed that not configuring a filter would lead to the discovery processor checking all branches for a catalog info file, so adding this will hopefully help others.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
