### PR TITLE
chore: Updating the redaction message to something a little less dramatic

### DIFF
--- a/.changeset/smooth-gifts-nail.md
+++ b/.changeset/smooth-gifts-nail.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+'@backstage/backend-app-api': patch
+---
+
+Updating the logger redaction message to something less dramatic

--- a/packages/backend-app-api/src/logging/WinstonLogger.test.ts
+++ b/packages/backend-app-api/src/logging/WinstonLogger.test.ts
@@ -50,7 +50,7 @@ describe('WinstonLogger', () => {
       expect.objectContaining({
         [MESSAGE]: JSON.stringify({
           level: 'error',
-          message: '[REDACTED]) from this file',
+          message: '***) from this file',
         }),
       }),
       expect.any(Function),
@@ -83,10 +83,10 @@ describe('WinstonLogger', () => {
         [MESSAGE]: JSON.stringify({
           level: 'error',
           message: 'something went wrong',
-          nested: '[REDACTED] (world) from nested object',
+          nested: '*** (world) from nested object',
           null: null,
           nullProto: {
-            foo: '[REDACTED] foo',
+            foo: '*** foo',
           },
         }),
       }),

--- a/packages/backend-app-api/src/logging/WinstonLogger.ts
+++ b/packages/backend-app-api/src/logging/WinstonLogger.ts
@@ -92,7 +92,7 @@ export class WinstonLogger implements RootLoggerService {
           return obj;
         }
 
-        obj[MESSAGE] = obj[MESSAGE]?.replace?.(redactionPattern, '[REDACTED]');
+        obj[MESSAGE] = obj[MESSAGE]?.replace?.(redactionPattern, '***');
 
         return obj;
       })(),

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
@@ -272,10 +272,7 @@ export class NunjucksWorkflowRunner implements WorkflowRunner {
 
       if (task.isDryRun) {
         const redactedSecrets = Object.fromEntries(
-          Object.entries(task.secrets ?? {}).map(secret => [
-            secret[0],
-            '[REDACTED]',
-          ]),
+          Object.entries(task.secrets ?? {}).map(secret => [secret[0], '***']),
         );
         const debugInput =
           (step.input &&

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/logger.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/logger.ts
@@ -114,7 +114,7 @@ export class WinstonLogger implements RootLoggerService {
           return obj;
         }
 
-        obj[MESSAGE] = obj[MESSAGE]?.replace?.(redactionPattern, '[REDACTED]');
+        obj[MESSAGE] = obj[MESSAGE]?.replace?.(redactionPattern, '***');
 
         return obj;
       })(),


### PR DESCRIPTION
Little pet peeve, but `[REDACTED]` is something i've been wanting to get rid of for a while. Thinking we take some inspiration from what GitHub actions does and just replace with `***` instead? 
