### PR TITLE
Split search backend plugin initialization into init and start phases

### DIFF
--- a/.changeset/seven-geese-raise.md
+++ b/.changeset/seven-geese-raise.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-search-backend-node': patch
+'@backstage/plugin-search-backend': patch
+---
+
+Split backend search plugin startup into "build" and "start" stages to ensure necessary initialization has happened before startup

--- a/.changeset/seven-geese-raise.md
+++ b/.changeset/seven-geese-raise.md
@@ -3,4 +3,4 @@
 '@backstage/plugin-search-backend': patch
 ---
 
-Split backend search plugin startup into "build" and "start" stages to ensure necessary initialization has happened before startup
+Split backend search plugin startup into "init" and "start" stages to ensure necessary initialization has happened before startup

--- a/plugins/search-backend-node/api-report-alpha.md
+++ b/plugins/search-backend-node/api-report-alpha.md
@@ -32,14 +32,14 @@ export const searchIndexRegistryExtensionPoint: ExtensionPoint<SearchIndexRegist
 
 // @alpha
 export interface SearchIndexService {
-  build(options: SearchIndexServiceBuildOptions): void;
   getDocumentTypes(): Record<string, DocumentTypeInfo>;
+  init(options: SearchIndexServiceInitOptions): void;
   start(): Promise<void>;
   stop(): Promise<void>;
 }
 
 // @alpha
-export type SearchIndexServiceBuildOptions = {
+export type SearchIndexServiceInitOptions = {
   searchEngine: SearchEngine;
   collators: RegisterCollatorParameters[];
   decorators: RegisterDecoratorParameters[];

--- a/plugins/search-backend-node/api-report-alpha.md
+++ b/plugins/search-backend-node/api-report-alpha.md
@@ -32,20 +32,21 @@ export const searchIndexRegistryExtensionPoint: ExtensionPoint<SearchIndexRegist
 
 // @alpha
 export interface SearchIndexService {
+  build(options: SearchIndexServiceBuildOptions): void;
   getDocumentTypes(): Record<string, DocumentTypeInfo>;
-  start(options: SearchIndexServiceStartOptions): Promise<void>;
+  start(): Promise<void>;
   stop(): Promise<void>;
 }
 
 // @alpha
-export const searchIndexServiceRef: ServiceRef<SearchIndexService, 'plugin'>;
-
-// @alpha
-export type SearchIndexServiceStartOptions = {
+export type SearchIndexServiceBuildOptions = {
   searchEngine: SearchEngine;
   collators: RegisterCollatorParameters[];
   decorators: RegisterDecoratorParameters[];
 };
+
+// @alpha
+export const searchIndexServiceRef: ServiceRef<SearchIndexService, 'plugin'>;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/search-backend-node/src/alpha.ts
+++ b/plugins/search-backend-node/src/alpha.ts
@@ -32,9 +32,9 @@ import {
 
 /**
  * @alpha
- * Options for build method on {@link SearchIndexService}.
+ * Options for the init method on {@link SearchIndexService}.
  */
-export type SearchIndexServiceBuildOptions = {
+export type SearchIndexServiceInitOptions = {
   searchEngine: SearchEngine;
   collators: RegisterCollatorParameters[];
   decorators: RegisterDecoratorParameters[];
@@ -48,7 +48,7 @@ export interface SearchIndexService {
   /**
    * Initializes state in preparation for starting the search index service
    */
-  build(options: SearchIndexServiceBuildOptions): void;
+  init(options: SearchIndexServiceInitOptions): void;
 
   /**
    * Starts indexing process
@@ -104,7 +104,7 @@ class DefaultSearchIndexService implements SearchIndexService {
     return new DefaultSearchIndexService(options);
   }
 
-  build(options: SearchIndexServiceBuildOptions): void {
+  init(options: SearchIndexServiceInitOptions): void {
     this.indexBuilder = new IndexBuilder({
       logger: this.logger,
       searchEngine: options.searchEngine,

--- a/plugins/search-backend-node/src/alpha.ts
+++ b/plugins/search-backend-node/src/alpha.ts
@@ -121,7 +121,7 @@ class DefaultSearchIndexService implements SearchIndexService {
 
   async start(): Promise<void> {
     if (!this.indexBuilder) {
-      throw new Error('IndexBuilder is not initialized, call build first');
+      throw new Error('IndexBuilder is not initialized, call init first');
     }
     const { scheduler } = await this.indexBuilder.build();
     this.scheduler = scheduler;

--- a/plugins/search-backend-node/src/alpha.ts
+++ b/plugins/search-backend-node/src/alpha.ts
@@ -34,7 +34,7 @@ import {
  * @alpha
  * Options for build method on {@link SearchIndexService}.
  */
-export type SearchIndexServiceStartOptions = {
+export type SearchIndexServiceBuildOptions = {
   searchEngine: SearchEngine;
   collators: RegisterCollatorParameters[];
   decorators: RegisterDecoratorParameters[];
@@ -46,14 +46,20 @@ export type SearchIndexServiceStartOptions = {
  */
 export interface SearchIndexService {
   /**
+   * Initializes state in preparation for starting the search index service
+   */
+  build(options: SearchIndexServiceBuildOptions): void;
+
+  /**
    * Starts indexing process
    */
-  start(options: SearchIndexServiceStartOptions): Promise<void>;
+  start(): Promise<void>;
 
   /**
    * Stops indexing process
    */
   stop(): Promise<void>;
+
   /**
    * Returns an index types list.
    */
@@ -83,7 +89,7 @@ type DefaultSearchIndexServiceOptions = {
 
 /**
  * @alpha
- * Reponsible for register the indexing task and start the schedule.
+ * Responsible for register the indexing task and start the schedule.
  */
 class DefaultSearchIndexService implements SearchIndexService {
   private readonly logger: LoggerService;
@@ -98,7 +104,7 @@ class DefaultSearchIndexService implements SearchIndexService {
     return new DefaultSearchIndexService(options);
   }
 
-  async start(options: SearchIndexServiceStartOptions): Promise<void> {
+  build(options: SearchIndexServiceBuildOptions): void {
     this.indexBuilder = new IndexBuilder({
       logger: this.logger,
       searchEngine: options.searchEngine,
@@ -111,8 +117,13 @@ class DefaultSearchIndexService implements SearchIndexService {
     options.decorators.forEach(decorator =>
       this.indexBuilder?.addDecorator(decorator),
     );
+  }
 
-    const { scheduler } = await this.indexBuilder?.build();
+  async start(): Promise<void> {
+    if (!this.indexBuilder) {
+      throw new Error('IndexBuilder is not initialized, call build first');
+    }
+    const { scheduler } = await this.indexBuilder.build();
     this.scheduler = scheduler;
     this.scheduler!.start();
   }

--- a/plugins/search-backend/src/alpha.ts
+++ b/plugins/search-backend/src/alpha.ts
@@ -121,13 +121,14 @@ export default createBackendPlugin({
 
         const collators = searchIndexRegistry.getCollators();
         const decorators = searchIndexRegistry.getDecorators();
+        searchIndexService.build({
+          searchEngine: searchEngine!,
+          collators,
+          decorators,
+        });
 
         lifecycle.addStartupHook(async () => {
-          await searchIndexService.start({
-            searchEngine: searchEngine!,
-            collators,
-            decorators,
-          });
+          await searchIndexService.start();
         });
 
         lifecycle.addShutdownHook(async () => {

--- a/plugins/search-backend/src/alpha.ts
+++ b/plugins/search-backend/src/alpha.ts
@@ -121,7 +121,7 @@ export default createBackendPlugin({
 
         const collators = searchIndexRegistry.getCollators();
         const decorators = searchIndexRegistry.getDecorators();
-        searchIndexService.build({
+        searchIndexService.init({
           searchEngine: searchEngine!,
           collators,
           decorators,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

As discussed over in #24794, the backend search plugin needs to have two phases during initialization: build and start.

The build phase is synchronous and ensures that the `searchIndexService` state is initialized before creating the HTTP router. This "build" phase is necessary to ensure the collators are all added to the `searchIndexService` object before trying to use that list of document types within the zod request schema that is used to validate incoming requests. Prior to this change, the set of types would be empty at initialization time and incoming requests would be rejected due to validation errors.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
