### PR TITLE
fix: sync mkdocs-material variables

### DIFF
--- a/.changeset/calm-plums-wink.md
+++ b/.changeset/calm-plums-wink.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+mkdocs-material have updated their CSS variable template, and a few are unset in Backstage. This patch adds the missing variables to ensure coverage.

--- a/plugins/techdocs/src/reader/transformers/styles/rules/variables.ts
+++ b/plugins/techdocs/src/reader/transformers/styles/rules/variables.ts
@@ -58,6 +58,9 @@ export default ({ theme }: RuleOptions) => `
 
   /* ACCENT */
   --md-accent-fg-color: var(--md-primary-fg-color);
+  --md-accent-fg-color--transparent: ${alpha(theme.palette.primary.main, 0.1)};
+  --md-accent-bg-color: var(--md-primary-bg-color);
+  --md-accent-bg-color--light: var(--md-primary-bg-color--light);
 
   /* SHADOW */
   --md-shadow-z1: ${theme.shadows[1]};
@@ -101,6 +104,7 @@ export default ({ theme }: RuleOptions) => `
   --md-code-fg-color: ${theme.palette.text.primary};
   --md-code-bg-color: ${theme.palette.background.paper};
   --md-code-hl-color: ${alpha(theme.palette.warning.main, 0.5)};
+  --md-code-hl-color--light: var(--md-code-hl-color);
   --md-code-hl-keyword-color: ${
     theme.palette.type === 'dark'
       ? theme.palette.primary.light
@@ -135,6 +139,7 @@ export default ({ theme }: RuleOptions) => `
   --md-typeset-color: var(--md-default-fg-color);
   --md-typeset-a-color: ${theme.palette.link};
   --md-typeset-table-color: ${theme.palette.text.primary};
+  --md-typeset-table-color--light: ${alpha(theme.palette.text.primary, 0.5)};
   --md-typeset-del-color: ${
     theme.palette.type === 'dark'
       ? alpha(theme.palette.error.dark, 0.5)
@@ -150,6 +155,9 @@ export default ({ theme }: RuleOptions) => `
       ? alpha(theme.palette.warning.dark, 0.5)
       : alpha(theme.palette.warning.light, 0.5)
   };
+  --md-typeset-kbd-color: var(--md-code-bg-color);
+  --md-typeset-kbd-accent-color var(--md-code-bg-color);
+  --md-typeset-kbd-border-color: var(--md-default-fg-color--light);
 }
 
 @media screen and (max-width: 76.1875em) {
@@ -165,4 +173,7 @@ export default ({ theme }: RuleOptions) => `
     --md-typeset-font-size: .7rem;
   }
 }
+
+  --md-footer-bg-color: var(--md-default-bg-color);
+  --md-footer-bg-color--dark: var(--md-default-bg-color);
 `;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

`mkdocs-material` have updated their CSS variable template, and a few are unset in Backstage.
This patch adds the missing variables to ensure coverage.

![Screenshot 2024-05-16 at 13 58 22](https://github.com/backstage/backstage/assets/7943407/187f7237-a271-439d-b74d-3fa3487772cf)
![Screenshot 2024-05-16 at 13 58 38](https://github.com/backstage/backstage/assets/7943407/f11d6326-d69b-4204-a9a0-efa9b3972fb9)
![Screenshot 2024-05-16 at 13 58 57](https://github.com/backstage/backstage/assets/7943407/fcede315-0d13-4f15-b29c-b31754be0029)



<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
