### PR TITLE
repo-tools: add additional properties to generate command

### DIFF
--- a/.changeset/strong-moose-work.md
+++ b/.changeset/strong-moose-work.md
@@ -1,0 +1,5 @@
+---
+'@backstage/repo-tools': minor
+---
+
+Add --additional-properties option to generate command to pass properties to @openapitools/openapi-generator-cli

--- a/.changeset/strong-moose-work.md
+++ b/.changeset/strong-moose-work.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/repo-tools': minor
+'@backstage/repo-tools': patch
 ---
 
-Add --client-additional-properties option to generate command to pass properties to @openapitools/openapi-generator-cli
+Add `--client-additional-properties` option to `openapi generate` command

--- a/.changeset/strong-moose-work.md
+++ b/.changeset/strong-moose-work.md
@@ -2,4 +2,4 @@
 '@backstage/repo-tools': minor
 ---
 
-Add --additional-properties option to generate command to pass properties to @openapitools/openapi-generator-cli
+Add --client-additional-properties option to generate command to pass properties to @openapitools/openapi-generator-cli

--- a/packages/repo-tools/src/commands/index.ts
+++ b/packages/repo-tools/src/commands/index.ts
@@ -54,6 +54,10 @@ function registerPackageCommand(program: Command) {
     .description(
       'Command to generate a client and/or a server stub from an OpenAPI spec.',
     )
+    .option('--additional-properties [properties]')
+    .description(
+      'Additional properties that can be passed to @openapitools/openapi-generator-cli',
+    )
     .action(
       lazy(() =>
         import('./package/schema/openapi/generate').then(m => m.command),

--- a/packages/repo-tools/src/commands/index.ts
+++ b/packages/repo-tools/src/commands/index.ts
@@ -54,7 +54,7 @@ function registerPackageCommand(program: Command) {
     .description(
       'Command to generate a client and/or a server stub from an OpenAPI spec.',
     )
-    .option('--additional-properties [properties]')
+    .option('--client-additional-properties [properties]')
     .description(
       'Additional properties that can be passed to @openapitools/openapi-generator-cli',
     )

--- a/packages/repo-tools/src/commands/package/schema/openapi/generate/client.ts
+++ b/packages/repo-tools/src/commands/package/schema/openapi/generate/client.ts
@@ -29,15 +29,15 @@ import { getPathToCurrentOpenApiSpec } from '../../../../../lib/openapi/helpers'
 
 async function generate(
   outputDirectory: string,
-  additionalProperties?: string,
+  clientAdditionalProperties?: string,
 ) {
   const resolvedOpenapiPath = await getPathToCurrentOpenApiSpec();
   const resolvedOutputDirectory = cliPaths.resolveTargetRoot(
     outputDirectory,
     OUTPUT_PATH,
   );
-  const openapiProperties = additionalProperties
-    ? `--additional-properties=${additionalProperties}`
+  const additionalProperties = clientAdditionalProperties
+    ? `--additional-properties=${clientAdditionalProperties}`
     : '';
   mkdirpSync(resolvedOutputDirectory);
 
@@ -66,7 +66,7 @@ async function generate(
       ),
       '--generator-key',
       'v3.0',
-      openapiProperties,
+      additionalProperties,
     ],
     {
       maxBuffer: Number.MAX_VALUE,
@@ -96,10 +96,10 @@ async function generate(
 
 export async function command(
   outputPackage: string,
-  additionalProperties?: string,
+  clientAdditionalProperties?: string,
 ): Promise<void> {
   try {
-    await generate(outputPackage, additionalProperties);
+    await generate(outputPackage, clientAdditionalProperties);
     console.log(
       chalk.green(`Generated client in ${outputPackage}/${OUTPUT_PATH}`),
     );

--- a/packages/repo-tools/src/commands/package/schema/openapi/generate/client.ts
+++ b/packages/repo-tools/src/commands/package/schema/openapi/generate/client.ts
@@ -27,12 +27,18 @@ import { exec } from '../../../../../lib/exec';
 import { resolvePackagePath } from '@backstage/backend-plugin-api';
 import { getPathToCurrentOpenApiSpec } from '../../../../../lib/openapi/helpers';
 
-async function generate(outputDirectory: string) {
+async function generate(
+  outputDirectory: string,
+  additionalProperties?: string,
+) {
   const resolvedOpenapiPath = await getPathToCurrentOpenApiSpec();
   const resolvedOutputDirectory = cliPaths.resolveTargetRoot(
     outputDirectory,
     OUTPUT_PATH,
   );
+  const openapiProperties = additionalProperties
+    ? `--additional-properties=${additionalProperties}`
+    : '';
   mkdirpSync(resolvedOutputDirectory);
 
   await fs.mkdirp(resolvedOutputDirectory);
@@ -60,6 +66,7 @@ async function generate(outputDirectory: string) {
       ),
       '--generator-key',
       'v3.0',
+      openapiProperties,
     ],
     {
       maxBuffer: Number.MAX_VALUE,
@@ -87,9 +94,12 @@ async function generate(outputDirectory: string) {
   });
 }
 
-export async function command(outputPackage: string): Promise<void> {
+export async function command(
+  outputPackage: string,
+  additionalProperties?: string,
+): Promise<void> {
   try {
-    await generate(outputPackage);
+    await generate(outputPackage, additionalProperties);
     console.log(
       chalk.green(`Generated client in ${outputPackage}/${OUTPUT_PATH}`),
     );

--- a/packages/repo-tools/src/commands/package/schema/openapi/generate/index.ts
+++ b/packages/repo-tools/src/commands/package/schema/openapi/generate/index.ts
@@ -26,7 +26,7 @@ export async function command(opts: OptionValues) {
     process.exit(1);
   }
   if (opts.clientPackage) {
-    await generateClient(opts.clientPackage, opts.additionalProperties);
+    await generateClient(opts.clientPackage, opts.clientAdditionalProperties);
   }
   if (opts.server) {
     await generateServer();

--- a/packages/repo-tools/src/commands/package/schema/openapi/generate/index.ts
+++ b/packages/repo-tools/src/commands/package/schema/openapi/generate/index.ts
@@ -26,7 +26,7 @@ export async function command(opts: OptionValues) {
     process.exit(1);
   }
   if (opts.clientPackage) {
-    await generateClient(opts.clientPackage);
+    await generateClient(opts.clientPackage, opts.additionalProperties);
   }
   if (opts.server) {
     await generateServer();


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds `--additional-properties` option to `backstage-repo-tools package schema openapi generate` command. The list of config options that can be passed with `--additional-properties` can be found [here](https://openapi-generator.tech/docs/generators/typescript#config-options).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
