### PR TITLE
Use fetch middlewares in event-source-polifyll (re: #23015)

### DIFF
--- a/packages/core-app-api/src/apis/implementations/FetchApi/IdentityAuthInjectorFetchMiddleware.ts
+++ b/packages/core-app-api/src/apis/implementations/FetchApi/IdentityAuthInjectorFetchMiddleware.ts
@@ -75,6 +75,16 @@ export class IdentityAuthInjectorFetchMiddleware implements FetchMiddleware {
       return next(request);
     };
   }
+
+  async headers(): Promise<Record<string, string>> {
+    const { token } = await this.identityApi.getCredentials();
+    if (!token) {
+      return {};
+    }
+    return {
+      [this.headerName]: this.headerValue(token),
+    };
+  }
 }
 
 function buildMatcher(options: {

--- a/packages/core-app-api/src/apis/implementations/FetchApi/createFetchApi.ts
+++ b/packages/core-app-api/src/apis/implementations/FetchApi/createFetchApi.ts
@@ -42,5 +42,12 @@ export function createFetchApi(options: {
 
   return {
     fetch: result,
+    headers: () => {
+      return Promise.all(
+        middleware.map(m => (m.headers ? m.headers() : Promise.resolve({}))),
+      ).then(headersList => {
+        return Object.assign({}, ...headersList);
+      });
+    },
   };
 }

--- a/packages/core-app-api/src/apis/implementations/FetchApi/types.ts
+++ b/packages/core-app-api/src/apis/implementations/FetchApi/types.ts
@@ -27,4 +27,9 @@ export interface FetchMiddleware {
    *               call out to as part of the request cycle.
    */
   apply(next: typeof fetch): typeof fetch;
+
+  /**
+   * Returns optional headers to be applied on the fetch request.
+   */
+  headers?(): Promise<Record<string, string>>;
 }

--- a/packages/core-plugin-api/src/apis/definitions/FetchApi.ts
+++ b/packages/core-plugin-api/src/apis/definitions/FetchApi.ts
@@ -27,6 +27,7 @@ export type FetchApi = {
    * The `fetch` implementation.
    */
   fetch: typeof fetch;
+  headers?: () => Promise<Record<string, string>>;
 };
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

PoC to validate this would be the way forward in #23015 (scaffolder, techdocs and catalog use event-source-polifyll that only allows headers to be passed but not the entire `fetch` implementation)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
