### PR TITLE
Update cache config.d.ts to reflect valid option

### DIFF
--- a/.changeset/cold-seas-end.md
+++ b/.changeset/cold-seas-end.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Updates config.d.ts to reflect valid redis cache config option

--- a/packages/backend-common/config.d.ts
+++ b/packages/backend-common/config.d.ts
@@ -191,6 +191,11 @@ export interface Config {
           connection: string;
           /** An optional default TTL (in milliseconds). */
           defaultTtl?: number;
+          /**
+           * Whether or not [useRedisSets](https://github.com/jaredwray/keyv/tree/main/packages/redis#useredissets) should be configured to this redis cache.
+           * Defaults to true if unspecified.
+           */
+          useRedisSets?: boolean;
         }
       | {
           store: 'memcache';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

A belated follow-up to https://github.com/backstage/backstage/pull/19849 which added the property `usesRedisSets` as a valid config option for redis caches, this adds it to the config.d.ts so validating the config (`backstage-cli config:check`) registers it as correct.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
