### PR TITLE
fix: move kubernetes autoscaling to v2

### DIFF
--- a/.changeset/stupid-tigers-bake.md
+++ b/.changeset/stupid-tigers-bake.md
@@ -2,7 +2,6 @@
 '@backstage/plugin-kubernetes-backend': minor
 '@backstage/plugin-kubernetes-common': minor
 '@backstage/plugin-kubernetes-react': minor
-'@backstage/plugin-kubernetes': minor
 ---
 
 Update kubernetes plugins to use autoscaling/v2

--- a/.changeset/stupid-tigers-bake.md
+++ b/.changeset/stupid-tigers-bake.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-kubernetes-backend': minor
+'@backstage/plugin-kubernetes-common': minor
+'@backstage/plugin-kubernetes-react': minor
+'@backstage/plugin-kubernetes': minor
+---
+
+Update kubernetes plugins to use autoscaling/v2

--- a/plugins/kubernetes-backend/examples/dice-roller/dice-roller-manifests.yaml
+++ b/plugins/kubernetes-backend/examples/dice-roller/dice-roller-manifests.yaml
@@ -221,7 +221,7 @@ spec:
             - containerPort: 80
 
 ---
-apiVersion: autoscaling/v1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: dice-roller

--- a/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.ts
@@ -103,7 +103,7 @@ export const DEFAULT_OBJECTS: ObjectToFetch[] = [
   },
   {
     group: 'autoscaling',
-    apiVersion: 'v1',
+    apiVersion: 'v2',
     plural: 'horizontalpodautoscalers',
     objectType: 'horizontalpodautoscalers',
   },

--- a/plugins/kubernetes-common/api-report.md
+++ b/plugins/kubernetes-common/api-report.md
@@ -14,7 +14,6 @@ import { V1ConfigMap } from '@kubernetes/client-node';
 import { V1CronJob } from '@kubernetes/client-node';
 import { V1DaemonSet } from '@kubernetes/client-node';
 import { V1Deployment } from '@kubernetes/client-node';
-import { V1HorizontalPodAutoscaler } from '@kubernetes/client-node';
 import { V1Ingress } from '@kubernetes/client-node';
 import { V1Job } from '@kubernetes/client-node';
 import { V1LimitRange } from '@kubernetes/client-node';
@@ -23,6 +22,7 @@ import { V1ReplicaSet } from '@kubernetes/client-node';
 import { V1ResourceQuota } from '@kubernetes/client-node';
 import { V1Service } from '@kubernetes/client-node';
 import { V1StatefulSet } from '@kubernetes/client-node';
+import { V2HorizontalPodAutoscaler } from '@kubernetes/client-node';
 
 // @public
 export const ANNOTATION_KUBERNETES_API_SERVER = 'kubernetes.io/api-server';
@@ -192,7 +192,7 @@ export interface DeploymentResources {
   // (undocumented)
   deployments: V1Deployment[];
   // (undocumented)
-  horizontalPodAutoscalers: V1HorizontalPodAutoscaler[];
+  horizontalPodAutoscalers: V2HorizontalPodAutoscaler[];
   // (undocumented)
   pods: V1Pod[];
   // (undocumented)
@@ -294,7 +294,7 @@ export const groupResponses: (
 // @public (undocumented)
 export interface HorizontalPodAutoscalersFetchResponse {
   // (undocumented)
-  resources: Array<V1HorizontalPodAutoscaler>;
+  resources: Array<V2HorizontalPodAutoscaler>;
   // (undocumented)
   type: 'horizontalpodautoscalers';
 }

--- a/plugins/kubernetes-common/src/error-detection/__fixtures__/hpa-healthy.json
+++ b/plugins/kubernetes-common/src/error-detection/__fixtures__/hpa-healthy.json
@@ -1,32 +1,77 @@
 {
+  "apiVersion": "autoscaling/v2",
+  "kind": "HorizontalPodAutoscaler",
   "metadata": {
-    "annotations": {
-      "autoscaling.alpha.kubernetes.io/conditions": "[{\"type\":\"AbleToScale\",\"status\":\"True\",\"lastTransitionTime\":\"2020-09-28T13:28:15Z\",\"reason\":\"SucceededGetScale\",\"message\":\"the HPA controller was able to get the target's current scale\"},{\"type\":\"ScalingActive\",\"status\":\"False\",\"lastTransitionTime\":\"2020-09-28T13:28:15Z\",\"reason\":\"FailedGetResourceMetric\",\"message\":\"the HPA was unable to compute the replica count: unable to get metrics for resource cpu: unable to fetch metrics from resource metrics API: the server could not find the requested resource (get pods.metrics.k8s.io)\"}]",
-      "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"autoscaling/v1\",\"kind\":\"HorizontalPodAutoscaler\",\"metadata\":{\"annotations\":{},\"labels\":{\"backstage.io/kubernetes-id\":\"dice-roller\"},\"name\":\"dice-roller\",\"namespace\":\"default\"},\"spec\":{\"maxReplicas\":15,\"minReplicas\":10,\"scaleTargetRef\":{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"name\":\"dice-roller\"},\"targetCPUUtilizationPercentage\":50}}\n"
-    },
-    "creationTimestamp": "2020-09-28T13:28:00.000Z",
+    "annotations": {},
+    "creationTimestamp": "2024-02-13T20:13:52Z",
     "labels": {
       "backstage.io/kubernetes-id": "dice-roller"
     },
     "name": "dice-roller",
     "namespace": "default",
-    "resourceVersion": "698957",
-    "selfLink": "/apis/autoscaling/v1/namespaces/default/horizontalpodautoscalers/dice-roller",
-    "uid": "a70c8a90-5605-4d7d-adea-05cfb8d9d446"
+    "resourceVersion": "6717s736",
+    "uid": "a34c90e1-8e8f-407f-b4c5-b4543bd56c1b"
   },
   "spec": {
-    "maxReplicas": 15,
-    "minReplicas": 10,
+    "maxReplicas": 2,
+    "metrics": [
+      {
+        "resource": {
+          "name": "cpu",
+          "target": {
+            "averageUtilization": 50,
+            "type": "Utilization"
+          }
+        },
+        "type": "Resource"
+      }
+    ],
+    "minReplicas": 1,
     "scaleTargetRef": {
       "apiVersion": "apps/v1",
       "kind": "Deployment",
       "name": "dice-roller"
-    },
-    "targetCPUUtilizationPercentage": 50
+    }
   },
   "status": {
-    "currentReplicas": 13,
-    "desiredReplicas": 14,
-    "currentCPUUtilizationPercentage": 30
+    "conditions": [
+      {
+        "lastTransitionTime": "2024-05-17T19:50:35Z",
+        "message": "recent recommendations were higher than current one, applying the highest recent recommendation",
+        "reason": "ScaleDownStabilized",
+        "status": "True",
+        "type": "AbleToScale"
+      },
+      {
+        "lastTransitionTime": "2024-05-16T06:21:01Z",
+        "message": "the HPA was able to successfully calculate a replica count from cpu resource utilization (percentage of request)",
+        "reason": "ValidMetricFound",
+        "status": "True",
+        "type": "ScalingActive"
+      },
+      {
+        "lastTransitionTime": "2024-05-16T06:21:01Z",
+        "message": "the desired replica count is more than the maximum replica count",
+        "reason": "TooManyReplicas",
+        "status": "True",
+        "type": "ScalingLimited"
+      }
+    ],
+    "currentMetrics": [
+      {
+        "resource": {
+          "current": {
+            "averageUtilization": 100,
+            "averageValue": "50m",
+            "value": "100m"
+          },
+          "name": "cpu"
+        },
+        "type": "Resource"
+      }
+    ],
+    "currentReplicas": 2,
+    "desiredReplicas": 2,
+    "lastScaleTime": "2024-02-13T20:14:23Z"
   }
 }

--- a/plugins/kubernetes-common/src/error-detection/__fixtures__/hpa-healthy.json
+++ b/plugins/kubernetes-common/src/error-detection/__fixtures__/hpa-healthy.json
@@ -13,7 +13,7 @@
     "uid": "a34c90e1-8e8f-407f-b4c5-b4543bd56c1b"
   },
   "spec": {
-    "maxReplicas": 2,
+    "maxReplicas": 10,
     "metrics": [
       {
         "resource": {

--- a/plugins/kubernetes-common/src/error-detection/__fixtures__/hpa-maxed-out.json
+++ b/plugins/kubernetes-common/src/error-detection/__fixtures__/hpa-maxed-out.json
@@ -13,7 +13,7 @@
     "uid": "a34c90e1-8e8f-407f-b4c5-b4543bd56c1b"
   },
   "spec": {
-    "maxReplicas": 2,
+    "maxReplicas": 10,
     "metrics": [
       {
         "resource": {
@@ -70,8 +70,8 @@
         "type": "Resource"
       }
     ],
-    "currentReplicas": 2,
-    "desiredReplicas": 2,
+    "currentReplicas": 10,
+    "desiredReplicas": 10,
     "lastScaleTime": "2024-02-13T20:14:23Z"
   }
 }

--- a/plugins/kubernetes-common/src/error-detection/__fixtures__/hpa-maxed-out.json
+++ b/plugins/kubernetes-common/src/error-detection/__fixtures__/hpa-maxed-out.json
@@ -1,32 +1,77 @@
 {
+  "apiVersion": "autoscaling/v2",
+  "kind": "HorizontalPodAutoscaler",
   "metadata": {
-    "annotations": {
-      "autoscaling.alpha.kubernetes.io/conditions": "[{\"type\":\"AbleToScale\",\"status\":\"True\",\"lastTransitionTime\":\"2020-09-28T13:28:15Z\",\"reason\":\"SucceededGetScale\",\"message\":\"the HPA controller was able to get the target's current scale\"},{\"type\":\"ScalingActive\",\"status\":\"False\",\"lastTransitionTime\":\"2020-09-28T13:28:15Z\",\"reason\":\"FailedGetResourceMetric\",\"message\":\"the HPA was unable to compute the replica count: unable to get metrics for resource cpu: unable to fetch metrics from resource metrics API: the server could not find the requested resource (get pods.metrics.k8s.io)\"}]",
-      "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"autoscaling/v1\",\"kind\":\"HorizontalPodAutoscaler\",\"metadata\":{\"annotations\":{},\"labels\":{\"backstage.io/kubernetes-id\":\"dice-roller\"},\"name\":\"dice-roller\",\"namespace\":\"default\"},\"spec\":{\"maxReplicas\":15,\"minReplicas\":10,\"scaleTargetRef\":{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"name\":\"dice-roller\"},\"targetCPUUtilizationPercentage\":50}}\n"
-    },
-    "creationTimestamp": "2020-09-28T13:28:00.000Z",
+    "annotations": {},
+    "creationTimestamp": "2024-02-13T20:13:52Z",
     "labels": {
       "backstage.io/kubernetes-id": "dice-roller"
     },
     "name": "dice-roller",
     "namespace": "default",
-    "resourceVersion": "698957",
-    "selfLink": "/apis/autoscaling/v1/namespaces/default/horizontalpodautoscalers/dice-roller",
-    "uid": "a70c8a90-5605-4d7d-adea-05cfb8d9d446"
+    "resourceVersion": "6717s736",
+    "uid": "a34c90e1-8e8f-407f-b4c5-b4543bd56c1b"
   },
   "spec": {
-    "maxReplicas": 10,
-    "minReplicas": 5,
+    "maxReplicas": 2,
+    "metrics": [
+      {
+        "resource": {
+          "name": "cpu",
+          "target": {
+            "averageUtilization": 50,
+            "type": "Utilization"
+          }
+        },
+        "type": "Resource"
+      }
+    ],
+    "minReplicas": 1,
     "scaleTargetRef": {
       "apiVersion": "apps/v1",
       "kind": "Deployment",
       "name": "dice-roller"
-    },
-    "targetCPUUtilizationPercentage": 70
+    }
   },
   "status": {
-    "currentReplicas": 10,
-    "desiredReplicas": 10,
-    "currentCPUUtilizationPercentage": 100
+    "conditions": [
+      {
+        "lastTransitionTime": "2024-05-17T19:50:35Z",
+        "message": "recent recommendations were higher than current one, applying the highest recent recommendation",
+        "reason": "ScaleDownStabilized",
+        "status": "True",
+        "type": "AbleToScale"
+      },
+      {
+        "lastTransitionTime": "2024-05-16T06:21:01Z",
+        "message": "the HPA was able to successfully calculate a replica count from cpu resource utilization (percentage of request)",
+        "reason": "ValidMetricFound",
+        "status": "True",
+        "type": "ScalingActive"
+      },
+      {
+        "lastTransitionTime": "2024-05-16T06:21:01Z",
+        "message": "the desired replica count is more than the maximum replica count",
+        "reason": "TooManyReplicas",
+        "status": "True",
+        "type": "ScalingLimited"
+      }
+    ],
+    "currentMetrics": [
+      {
+        "resource": {
+          "current": {
+            "averageUtilization": 100,
+            "averageValue": "50m",
+            "value": "100m"
+          },
+          "name": "cpu"
+        },
+        "type": "Resource"
+      }
+    ],
+    "currentReplicas": 2,
+    "desiredReplicas": 2,
+    "lastScaleTime": "2024-02-13T20:14:23Z"
   }
 }

--- a/plugins/kubernetes-common/src/error-detection/error-detection.test.ts
+++ b/plugins/kubernetes-common/src/error-detection/error-detection.test.ts
@@ -17,7 +17,7 @@
 import {
   V1Pod,
   V1Deployment,
-  V1HorizontalPodAutoscaler,
+  V2HorizontalPodAutoscaler,
 } from '@kubernetes/client-node';
 import { detectErrors } from './error-detection';
 import * as healthyPod from './__fixtures__/pod.json';
@@ -61,7 +61,7 @@ const oneDeployment = (deployment: V1Deployment): ObjectsByEntityResponse => {
   });
 };
 
-const oneHpa = (hpa: V1HorizontalPodAutoscaler): ObjectsByEntityResponse => {
+const oneHpa = (hpa: V2HorizontalPodAutoscaler): ObjectsByEntityResponse => {
   return oneItem({
     type: 'horizontalpodautoscalers',
     resources: [hpa],
@@ -328,7 +328,7 @@ describe('detectErrors', () => {
 
     expect(err1).toStrictEqual({
       sourceRef: {
-        apiGroup: 'autoscaling/v1',
+        apiGroup: 'autoscaling/v2',
         kind: 'HorizontalPodAutoscaler',
         name: 'dice-roller',
         namespace: 'default',

--- a/plugins/kubernetes-common/src/error-detection/error-detection.ts
+++ b/plugins/kubernetes-common/src/error-detection/error-detection.ts
@@ -21,7 +21,7 @@ import { detectErrorsInPods } from './pods';
 import { detectErrorsInDeployments } from './deployments';
 import { detectErrorsInHpa } from './hpas';
 import { Deployment } from 'kubernetes-models/apps/v1';
-import { HorizontalPodAutoscaler } from 'kubernetes-models/autoscaling/v1';
+import { HorizontalPodAutoscaler } from 'kubernetes-models/autoscaling/v2';
 import { Pod } from 'kubernetes-models/v1';
 
 /**

--- a/plugins/kubernetes-common/src/error-detection/hpas.ts
+++ b/plugins/kubernetes-common/src/error-detection/hpas.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { HorizontalPodAutoscaler } from 'kubernetes-models/autoscaling/v1';
+import { HorizontalPodAutoscaler } from 'kubernetes-models/autoscaling/v2';
 import { DetectedError, ErrorMapper } from './types';
 import { detectErrorsInObjects } from './common';
 
@@ -35,7 +35,7 @@ const hpaErrorMappers: ErrorMapper<HorizontalPodAutoscaler>[] = [
               name: hpa.metadata?.name ?? 'unknown hpa',
               namespace: hpa.metadata?.namespace ?? 'unknown namespace',
               kind: 'HorizontalPodAutoscaler',
-              apiGroup: 'autoscaling/v1',
+              apiGroup: 'autoscaling/v2',
             },
             occurrenceCount: 1,
           },

--- a/plugins/kubernetes-common/src/types.ts
+++ b/plugins/kubernetes-common/src/types.ts
@@ -21,7 +21,7 @@ import {
   V1CronJob,
   V1DaemonSet,
   V1Deployment,
-  V1HorizontalPodAutoscaler,
+  V2HorizontalPodAutoscaler,
   V1Ingress,
   V1Job,
   V1LimitRange,
@@ -186,7 +186,7 @@ export interface ResourceQuotaFetchResponse {
 /** @public */
 export interface HorizontalPodAutoscalersFetchResponse {
   type: 'horizontalpodautoscalers';
-  resources: Array<V1HorizontalPodAutoscaler>;
+  resources: Array<V2HorizontalPodAutoscaler>;
 }
 
 /** @public */
@@ -282,7 +282,7 @@ export interface DeploymentResources {
   pods: V1Pod[];
   replicaSets: V1ReplicaSet[];
   deployments: V1Deployment[];
-  horizontalPodAutoscalers: V1HorizontalPodAutoscaler[];
+  horizontalPodAutoscalers: V2HorizontalPodAutoscaler[];
 }
 
 /** @public */

--- a/plugins/kubernetes-react/api-report.md
+++ b/plugins/kubernetes-react/api-report.md
@@ -33,10 +33,10 @@ import { ProfileInfoApi } from '@backstage/core-plugin-api';
 import { default as React_2 } from 'react';
 import * as React_3 from 'react';
 import { TypeMeta } from '@kubernetes-models/base';
-import { V1HorizontalPodAutoscaler } from '@kubernetes/client-node';
 import { V1Job } from '@kubernetes/client-node';
 import { V1ObjectMeta } from '@kubernetes/client-node';
 import { V1Pod } from '@kubernetes/client-node';
+import { V2HorizontalPodAutoscaler } from '@kubernetes/client-node';
 import { WorkloadsByEntityRequest } from '@backstage/plugin-kubernetes-common';
 
 // @public (undocumented)
@@ -285,7 +285,7 @@ export const GroupedResponsesContext: React_2.Context<GroupedResponses>;
 
 // @public (undocumented)
 export const HorizontalPodAutoscalerDrawer: (props: {
-  hpa: V1HorizontalPodAutoscaler;
+  hpa: V2HorizontalPodAutoscaler;
   expanded?: boolean;
   children?: React_2.ReactNode;
 }) => React_2.JSX.Element;

--- a/plugins/kubernetes-react/src/__fixtures__/1-deployments.json
+++ b/plugins/kubernetes-react/src/__fixtures__/1-deployments.json
@@ -2826,85 +2826,80 @@
   ],
   "horizontalPodAutoscalers": [
     {
-      "apiVersion": "autoscaling/v1",
+      "apiVersion": "autoscaling/v2",
       "kind": "HorizontalPodAutoscaler",
       "metadata": {
-        "annotations": {
-          "autoscaling.alpha.kubernetes.io/conditions": "[{\"type\":\"AbleToScale\",\"status\":\"True\",\"lastTransitionTime\":\"2021-01-05T10:26:04Z\",\"reason\":\"SucceededGetScale\",\"message\":\"the HPA controller was able to get the target's current scale\"},{\"type\":\"ScalingActive\",\"status\":\"False\",\"lastTransitionTime\":\"2021-01-05T10:26:04Z\",\"reason\":\"FailedGetResourceMetric\",\"message\":\"the HPA was unable to compute the replica count: unable to get metrics for resource cpu: no metrics returned from resource metrics API\"}]",
-          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"autoscaling/v1\",\"kind\":\"HorizontalPodAutoscaler\",\"metadata\":{\"annotations\":{},\"labels\":{\"backstage.io/kubernetes-id\":\"dice-roller\"},\"name\":\"dice-roller\",\"namespace\":\"default\"},\"spec\":{\"maxReplicas\":15,\"minReplicas\":10,\"scaleTargetRef\":{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"name\":\"dice-roller\"},\"targetCPUUtilizationPercentage\":50}}\n"
-        },
-        "creationTimestamp": "2021-01-05T10:25:48Z",
+        "annotations": {},
+        "creationTimestamp": "2024-02-13T20:13:52Z",
         "labels": {
           "backstage.io/kubernetes-id": "dice-roller"
         },
-        "managedFields": [
-          {
-            "apiVersion": "autoscaling/v1",
-            "fieldsType": "FieldsV1",
-            "fieldsV1": {
-              "f:metadata": {
-                "f:annotations": {
-                  ".": {},
-                  "f:kubectl.kubernetes.io/last-applied-configuration": {}
-                },
-                "f:labels": {
-                  ".": {},
-                  "f:backstage.io/kubernetes-id": {}
-                }
-              },
-              "f:spec": {
-                "f:maxReplicas": {},
-                "f:minReplicas": {},
-                "f:scaleTargetRef": {
-                  "f:apiVersion": {},
-                  "f:kind": {},
-                  "f:name": {}
-                },
-                "f:targetCPUUtilizationPercentage": {}
-              }
-            },
-            "manager": "kubectl-client-side-apply",
-            "operation": "Update",
-            "time": "2021-01-05T10:25:48Z"
-          },
-          {
-            "apiVersion": "autoscaling/v1",
-            "fieldsType": "FieldsV1",
-            "fieldsV1": {
-              "f:metadata": {
-                "f:annotations": {
-                  "f:autoscaling.alpha.kubernetes.io/conditions": {}
-                }
-              },
-              "f:status": {
-                "f:currentReplicas": {}
-              }
-            },
-            "manager": "kube-controller-manager",
-            "operation": "Update",
-            "time": "2021-01-05T10:26:04Z"
-          }
-        ],
         "name": "dice-roller",
         "namespace": "default",
-        "resourceVersion": "598",
-        "selfLink": "/apis/autoscaling/v1/namespaces/default/horizontalpodautoscalers/dice-roller",
-        "uid": "dd7c5329-567c-43c2-b159-756808d90a8e"
+        "resourceVersion": "6717s736",
+        "uid": "a34c90e1-8e8f-407f-b4c5-b4543bd56c1b"
       },
       "spec": {
-        "maxReplicas": 15,
-        "minReplicas": 10,
+        "maxReplicas": 2,
+        "metrics": [
+          {
+            "resource": {
+              "name": "cpu",
+              "target": {
+                "averageUtilization": 50,
+                "type": "Utilization"
+              }
+            },
+            "type": "Resource"
+          }
+        ],
+        "minReplicas": 1,
         "scaleTargetRef": {
           "apiVersion": "apps/v1",
           "kind": "Deployment",
           "name": "dice-roller"
-        },
-        "targetCPUUtilizationPercentage": 50
+        }
       },
       "status": {
-        "currentReplicas": 10,
-        "desiredReplicas": 0,
-        "currentCPUUtilizationPercentage": 30
+        "conditions": [
+          {
+            "lastTransitionTime": "2024-05-17T19:50:35Z",
+            "message": "recent recommendations were higher than current one, applying the highest recent recommendation",
+            "reason": "ScaleDownStabilized",
+            "status": "True",
+            "type": "AbleToScale"
+          },
+          {
+            "lastTransitionTime": "2024-05-16T06:21:01Z",
+            "message": "the HPA was able to successfully calculate a replica count from cpu resource utilization (percentage of request)",
+            "reason": "ValidMetricFound",
+            "status": "True",
+            "type": "ScalingActive"
+          },
+          {
+            "lastTransitionTime": "2024-05-16T06:21:01Z",
+            "message": "the desired replica count is more than the maximum replica count",
+            "reason": "TooManyReplicas",
+            "status": "True",
+            "type": "ScalingLimited"
+          }
+        ],
+        "currentMetrics": [
+          {
+            "resource": {
+              "current": {
+                "averageUtilization": 100,
+                "averageValue": "50m",
+                "value": "100m"
+              },
+              "name": "cpu"
+            },
+            "type": "Resource"
+          }
+        ],
+        "currentReplicas": 2,
+        "desiredReplicas": 2,
+        "lastScaleTime": "2024-02-13T20:14:23Z"
       }
     }
   ]

--- a/plugins/kubernetes-react/src/__fixtures__/1-statefulsets.json
+++ b/plugins/kubernetes-react/src/__fixtures__/1-statefulsets.json
@@ -2827,85 +2827,80 @@
   ],
   "horizontalPodAutoscalers": [
     {
-      "apiVersion": "autoscaling/v1",
+      "apiVersion": "autoscaling/v2",
       "kind": "HorizontalPodAutoscaler",
       "metadata": {
-        "annotations": {
-          "autoscaling.alpha.kubernetes.io/conditions": "[{\"type\":\"AbleToScale\",\"status\":\"True\",\"lastTransitionTime\":\"2021-01-05T10:26:04Z\",\"reason\":\"SucceededGetScale\",\"message\":\"the HPA controller was able to get the target's current scale\"},{\"type\":\"ScalingActive\",\"status\":\"False\",\"lastTransitionTime\":\"2021-01-05T10:26:04Z\",\"reason\":\"FailedGetResourceMetric\",\"message\":\"the HPA was unable to compute the replica count: unable to get metrics for resource cpu: no metrics returned from resource metrics API\"}]",
-          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"autoscaling/v1\",\"kind\":\"HorizontalPodAutoscaler\",\"metadata\":{\"annotations\":{},\"labels\":{\"backstage.io/kubernetes-id\":\"dice-roller\"},\"name\":\"dice-roller\",\"namespace\":\"default\"},\"spec\":{\"maxReplicas\":15,\"minReplicas\":10,\"scaleTargetRef\":{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"name\":\"dice-roller\"},\"targetCPUUtilizationPercentage\":50}}\n"
-        },
-        "creationTimestamp": "2021-01-05T10:25:48Z",
+        "annotations": {},
+        "creationTimestamp": "2024-02-13T20:13:52Z",
         "labels": {
           "backstage.io/kubernetes-id": "dice-roller"
         },
-        "managedFields": [
-          {
-            "apiVersion": "autoscaling/v1",
-            "fieldsType": "FieldsV1",
-            "fieldsV1": {
-              "f:metadata": {
-                "f:annotations": {
-                  ".": {},
-                  "f:kubectl.kubernetes.io/last-applied-configuration": {}
-                },
-                "f:labels": {
-                  ".": {},
-                  "f:backstage.io/kubernetes-id": {}
-                }
-              },
-              "f:spec": {
-                "f:maxReplicas": {},
-                "f:minReplicas": {},
-                "f:scaleTargetRef": {
-                  "f:apiVersion": {},
-                  "f:kind": {},
-                  "f:name": {}
-                },
-                "f:targetCPUUtilizationPercentage": {}
-              }
-            },
-            "manager": "kubectl-client-side-apply",
-            "operation": "Update",
-            "time": "2021-01-05T10:25:48Z"
-          },
-          {
-            "apiVersion": "autoscaling/v1",
-            "fieldsType": "FieldsV1",
-            "fieldsV1": {
-              "f:metadata": {
-                "f:annotations": {
-                  "f:autoscaling.alpha.kubernetes.io/conditions": {}
-                }
-              },
-              "f:status": {
-                "f:currentReplicas": {}
-              }
-            },
-            "manager": "kube-controller-manager",
-            "operation": "Update",
-            "time": "2021-01-05T10:26:04Z"
-          }
-        ],
         "name": "dice-roller",
         "namespace": "default",
-        "resourceVersion": "598",
-        "selfLink": "/apis/autoscaling/v1/namespaces/default/horizontalpodautoscalers/dice-roller",
-        "uid": "dd7c5329-567c-43c2-b159-756808d90a8e"
+        "resourceVersion": "6717s736",
+        "uid": "a34c90e1-8e8f-407f-b4c5-b4543bd56c1b"
       },
       "spec": {
-        "maxReplicas": 15,
-        "minReplicas": 10,
+        "maxReplicas": 2,
+        "metrics": [
+          {
+            "resource": {
+              "name": "cpu",
+              "target": {
+                "averageUtilization": 50,
+                "type": "Utilization"
+              }
+            },
+            "type": "Resource"
+          }
+        ],
+        "minReplicas": 1,
         "scaleTargetRef": {
           "apiVersion": "apps/v1",
           "kind": "Deployment",
           "name": "dice-roller"
-        },
-        "targetCPUUtilizationPercentage": 50
+        }
       },
       "status": {
-        "currentReplicas": 10,
-        "desiredReplicas": 0,
-        "currentCPUUtilizationPercentage": 30
+        "conditions": [
+          {
+            "lastTransitionTime": "2024-05-17T19:50:35Z",
+            "message": "recent recommendations were higher than current one, applying the highest recent recommendation",
+            "reason": "ScaleDownStabilized",
+            "status": "True",
+            "type": "AbleToScale"
+          },
+          {
+            "lastTransitionTime": "2024-05-16T06:21:01Z",
+            "message": "the HPA was able to successfully calculate a replica count from cpu resource utilization (percentage of request)",
+            "reason": "ValidMetricFound",
+            "status": "True",
+            "type": "ScalingActive"
+          },
+          {
+            "lastTransitionTime": "2024-05-16T06:21:01Z",
+            "message": "the desired replica count is more than the maximum replica count",
+            "reason": "TooManyReplicas",
+            "status": "True",
+            "type": "ScalingLimited"
+          }
+        ],
+        "currentMetrics": [
+          {
+            "resource": {
+              "current": {
+                "averageUtilization": 100,
+                "averageValue": "50m",
+                "value": "100m"
+              },
+              "name": "cpu"
+            },
+            "type": "Resource"
+          }
+        ],
+        "currentReplicas": 2,
+        "desiredReplicas": 2,
+        "lastScaleTime": "2024-02-13T20:14:23Z"
       }
     }
   ]

--- a/plugins/kubernetes-react/src/__fixtures__/2-deployments.json
+++ b/plugins/kubernetes-react/src/__fixtures__/2-deployments.json
@@ -4434,85 +4434,80 @@
   ],
   "horizontalPodAutoscalers": [
     {
-      "apiVersion": "autoscaling/v1",
+      "apiVersion": "autoscaling/v2",
       "kind": "HorizontalPodAutoscaler",
       "metadata": {
-        "annotations": {
-          "autoscaling.alpha.kubernetes.io/conditions": "[{\"type\":\"AbleToScale\",\"status\":\"True\",\"lastTransitionTime\":\"2021-01-05T10:26:04Z\",\"reason\":\"SucceededGetScale\",\"message\":\"the HPA controller was able to get the target's current scale\"},{\"type\":\"ScalingActive\",\"status\":\"False\",\"lastTransitionTime\":\"2021-01-05T10:26:04Z\",\"reason\":\"FailedGetResourceMetric\",\"message\":\"the HPA was unable to compute the replica count: unable to get metrics for resource cpu: no metrics returned from resource metrics API\"}]",
-          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"autoscaling/v1\",\"kind\":\"HorizontalPodAutoscaler\",\"metadata\":{\"annotations\":{},\"labels\":{\"backstage.io/kubernetes-id\":\"dice-roller\"},\"name\":\"dice-roller\",\"namespace\":\"default\"},\"spec\":{\"maxReplicas\":15,\"minReplicas\":10,\"scaleTargetRef\":{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"name\":\"dice-roller\"},\"targetCPUUtilizationPercentage\":50}}\n"
-        },
-        "creationTimestamp": "2021-01-05T10:25:48Z",
+        "annotations": {},
+        "creationTimestamp": "2024-02-13T20:13:52Z",
         "labels": {
           "backstage.io/kubernetes-id": "dice-roller"
         },
-        "managedFields": [
-          {
-            "apiVersion": "autoscaling/v1",
-            "fieldsType": "FieldsV1",
-            "fieldsV1": {
-              "f:metadata": {
-                "f:annotations": {
-                  ".": {},
-                  "f:kubectl.kubernetes.io/last-applied-configuration": {}
-                },
-                "f:labels": {
-                  ".": {},
-                  "f:backstage.io/kubernetes-id": {}
-                }
-              },
-              "f:spec": {
-                "f:maxReplicas": {},
-                "f:minReplicas": {},
-                "f:scaleTargetRef": {
-                  "f:apiVersion": {},
-                  "f:kind": {},
-                  "f:name": {}
-                },
-                "f:targetCPUUtilizationPercentage": {}
-              }
-            },
-            "manager": "kubectl-client-side-apply",
-            "operation": "Update",
-            "time": "2021-01-05T10:25:48Z"
-          },
-          {
-            "apiVersion": "autoscaling/v1",
-            "fieldsType": "FieldsV1",
-            "fieldsV1": {
-              "f:metadata": {
-                "f:annotations": {
-                  "f:autoscaling.alpha.kubernetes.io/conditions": {}
-                }
-              },
-              "f:status": {
-                "f:currentReplicas": {}
-              }
-            },
-            "manager": "kube-controller-manager",
-            "operation": "Update",
-            "time": "2021-01-05T10:26:04Z"
-          }
-        ],
         "name": "dice-roller",
         "namespace": "default",
-        "resourceVersion": "598",
-        "selfLink": "/apis/autoscaling/v1/namespaces/default/horizontalpodautoscalers/dice-roller",
-        "uid": "dd7c5329-567c-43c2-b159-756808d90a8e"
+        "resourceVersion": "6717s736",
+        "uid": "a34c90e1-8e8f-407f-b4c5-b4543bd56c1b"
       },
       "spec": {
         "maxReplicas": 15,
+        "metrics": [
+          {
+            "resource": {
+              "name": "cpu",
+              "target": {
+                "averageUtilization": 50,
+                "type": "Utilization"
+              }
+            },
+            "type": "Resource"
+          }
+        ],
         "minReplicas": 10,
         "scaleTargetRef": {
           "apiVersion": "apps/v1",
           "kind": "Deployment",
           "name": "dice-roller"
-        },
-        "targetCPUUtilizationPercentage": 50
+        }
       },
       "status": {
-        "currentReplicas": 10,
-        "desiredReplicas": 0,
-        "currentCPUUtilizationPercentage": 30
+        "conditions": [
+          {
+            "lastTransitionTime": "2024-05-17T19:50:35Z",
+            "message": "recent recommendations were higher than current one, applying the highest recent recommendation",
+            "reason": "ScaleDownStabilized",
+            "status": "True",
+            "type": "AbleToScale"
+          },
+          {
+            "lastTransitionTime": "2024-05-16T06:21:01Z",
+            "message": "the HPA was able to successfully calculate a replica count from cpu resource utilization (percentage of request)",
+            "reason": "ValidMetricFound",
+            "status": "True",
+            "type": "ScalingActive"
+          },
+          {
+            "lastTransitionTime": "2024-05-16T06:21:01Z",
+            "message": "the desired replica count is more than the maximum replica count",
+            "reason": "TooManyReplicas",
+            "status": "True",
+            "type": "ScalingLimited"
+          }
+        ],
+        "currentMetrics": [
+          {
+            "resource": {
+              "current": {
+                "averageUtilization": 30,
+                "averageValue": "50m",
+                "value": "100m"
+              },
+              "name": "cpu"
+            },
+            "type": "Resource"
+          }
+        ],
+        "currentReplicas": 2,
+        "desiredReplicas": 2,
+        "lastScaleTime": "2024-02-13T20:14:23Z"
       }
     }
   ]

--- a/plugins/kubernetes-react/src/__fixtures__/2-statefulsets.json
+++ b/plugins/kubernetes-react/src/__fixtures__/2-statefulsets.json
@@ -4436,85 +4436,80 @@
   ],
   "horizontalPodAutoscalers": [
     {
-      "apiVersion": "autoscaling/v1",
+      "apiVersion": "autoscaling/v2",
       "kind": "HorizontalPodAutoscaler",
       "metadata": {
-        "annotations": {
-          "autoscaling.alpha.kubernetes.io/conditions": "[{\"type\":\"AbleToScale\",\"status\":\"True\",\"lastTransitionTime\":\"2021-01-05T10:26:04Z\",\"reason\":\"SucceededGetScale\",\"message\":\"the HPA controller was able to get the target's current scale\"},{\"type\":\"ScalingActive\",\"status\":\"False\",\"lastTransitionTime\":\"2021-01-05T10:26:04Z\",\"reason\":\"FailedGetResourceMetric\",\"message\":\"the HPA was unable to compute the replica count: unable to get metrics for resource cpu: no metrics returned from resource metrics API\"}]",
-          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"autoscaling/v1\",\"kind\":\"HorizontalPodAutoscaler\",\"metadata\":{\"annotations\":{},\"labels\":{\"backstage.io/kubernetes-id\":\"dice-roller\"},\"name\":\"dice-roller\",\"namespace\":\"default\"},\"spec\":{\"maxReplicas\":15,\"minReplicas\":10,\"scaleTargetRef\":{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"name\":\"dice-roller\"},\"targetCPUUtilizationPercentage\":50}}\n"
-        },
-        "creationTimestamp": "2021-01-05T10:25:48Z",
+        "annotations": {},
+        "creationTimestamp": "2024-02-13T20:13:52Z",
         "labels": {
           "backstage.io/kubernetes-id": "dice-roller"
         },
-        "managedFields": [
-          {
-            "apiVersion": "autoscaling/v1",
-            "fieldsType": "FieldsV1",
-            "fieldsV1": {
-              "f:metadata": {
-                "f:annotations": {
-                  ".": {},
-                  "f:kubectl.kubernetes.io/last-applied-configuration": {}
-                },
-                "f:labels": {
-                  ".": {},
-                  "f:backstage.io/kubernetes-id": {}
-                }
-              },
-              "f:spec": {
-                "f:maxReplicas": {},
-                "f:minReplicas": {},
-                "f:scaleTargetRef": {
-                  "f:apiVersion": {},
-                  "f:kind": {},
-                  "f:name": {}
-                },
-                "f:targetCPUUtilizationPercentage": {}
-              }
-            },
-            "manager": "kubectl-client-side-apply",
-            "operation": "Update",
-            "time": "2021-01-05T10:25:48Z"
-          },
-          {
-            "apiVersion": "autoscaling/v1",
-            "fieldsType": "FieldsV1",
-            "fieldsV1": {
-              "f:metadata": {
-                "f:annotations": {
-                  "f:autoscaling.alpha.kubernetes.io/conditions": {}
-                }
-              },
-              "f:status": {
-                "f:currentReplicas": {}
-              }
-            },
-            "manager": "kube-controller-manager",
-            "operation": "Update",
-            "time": "2021-01-05T10:26:04Z"
-          }
-        ],
         "name": "dice-roller",
         "namespace": "default",
-        "resourceVersion": "598",
-        "selfLink": "/apis/autoscaling/v1/namespaces/default/horizontalpodautoscalers/dice-roller",
-        "uid": "dd7c5329-567c-43c2-b159-756808d90a8e"
+        "resourceVersion": "6717s736",
+        "uid": "a34c90e1-8e8f-407f-b4c5-b4543bd56c1b"
       },
       "spec": {
-        "maxReplicas": 15,
-        "minReplicas": 10,
+        "maxReplicas": 2,
+        "metrics": [
+          {
+            "resource": {
+              "name": "cpu",
+              "target": {
+                "averageUtilization": 50,
+                "type": "Utilization"
+              }
+            },
+            "type": "Resource"
+          }
+        ],
+        "minReplicas": 1,
         "scaleTargetRef": {
           "apiVersion": "apps/v1",
           "kind": "Deployment",
           "name": "dice-roller"
-        },
-        "targetCPUUtilizationPercentage": 50
+        }
       },
       "status": {
-        "currentReplicas": 10,
-        "desiredReplicas": 0,
-        "currentCPUUtilizationPercentage": 30
+        "conditions": [
+          {
+            "lastTransitionTime": "2024-05-17T19:50:35Z",
+            "message": "recent recommendations were higher than current one, applying the highest recent recommendation",
+            "reason": "ScaleDownStabilized",
+            "status": "True",
+            "type": "AbleToScale"
+          },
+          {
+            "lastTransitionTime": "2024-05-16T06:21:01Z",
+            "message": "the HPA was able to successfully calculate a replica count from cpu resource utilization (percentage of request)",
+            "reason": "ValidMetricFound",
+            "status": "True",
+            "type": "ScalingActive"
+          },
+          {
+            "lastTransitionTime": "2024-05-16T06:21:01Z",
+            "message": "the desired replica count is more than the maximum replica count",
+            "reason": "TooManyReplicas",
+            "status": "True",
+            "type": "ScalingLimited"
+          }
+        ],
+        "currentMetrics": [
+          {
+            "resource": {
+              "current": {
+                "averageUtilization": 100,
+                "averageValue": "50m",
+                "value": "100m"
+              },
+              "name": "cpu"
+            },
+            "type": "Resource"
+          }
+        ],
+        "currentReplicas": 2,
+        "desiredReplicas": 2,
+        "lastScaleTime": "2024-02-13T20:14:23Z"
       }
     }
   ]

--- a/plugins/kubernetes-react/src/components/CustomResources/ArgoRollouts/Rollout.tsx
+++ b/plugins/kubernetes-react/src/components/CustomResources/ArgoRollouts/Rollout.tsx
@@ -21,7 +21,7 @@ import AccordionSummary from '@material-ui/core/AccordionSummary';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
-import { V1Pod, V1HorizontalPodAutoscaler } from '@kubernetes/client-node';
+import { V1Pod, V2HorizontalPodAutoscaler } from '@kubernetes/client-node';
 import { PodsTable } from '../../Pods';
 import { HorizontalPodAutoscalerDrawer } from '../../HorizontalPodAutoscalers';
 import { RolloutDrawer } from './RolloutDrawer';
@@ -50,7 +50,7 @@ type RolloutAccordionProps = {
   rollout: any;
   ownedPods: V1Pod[];
   defaultExpanded?: boolean;
-  matchingHpa?: V1HorizontalPodAutoscaler;
+  matchingHpa?: V2HorizontalPodAutoscaler;
   children?: React.ReactNode;
 };
 
@@ -58,7 +58,7 @@ type RolloutSummaryProps = {
   rollout: any;
   numberOfCurrentPods: number;
   numberOfPodsWithErrors: number;
-  hpa?: V1HorizontalPodAutoscaler;
+  hpa?: V2HorizontalPodAutoscaler;
   children?: React.ReactNode;
 };
 
@@ -93,6 +93,13 @@ const RolloutSummary = ({
     (p: any) => p.reason === 'CanaryPauseStep',
   )?.startTime;
   const abortedMessage = findAbortedMessage(rollout);
+  const specCpuUtil = hpa?.spec?.metrics?.find(
+    metric => metric.type === 'Resource' && metric.resource?.name === 'cpu',
+  )?.resource?.target.averageUtilization;
+
+  const cpuUtil = hpa?.status?.currentMetrics?.find(
+    metric => metric.type === 'Resource' && metric.resource?.name === 'cpu',
+  )?.resource?.current.averageUtilization;
 
   return (
     <Grid
@@ -124,14 +131,12 @@ const RolloutSummary = ({
               </Grid>
               <Grid item>
                 <Typography variant="subtitle2">
-                  current CPU usage:{' '}
-                  {hpa.status?.currentCPUUtilizationPercentage ?? '?'}%
+                  current CPU usage: {cpuUtil ?? '?'}%
                 </Typography>
               </Grid>
               <Grid item>
                 <Typography variant="subtitle2">
-                  target CPU usage:{' '}
-                  {hpa.spec?.targetCPUUtilizationPercentage ?? '?'}%
+                  target CPU usage: {specCpuUtil ?? '?'}%
                 </Typography>
               </Grid>
             </Grid>

--- a/plugins/kubernetes-react/src/components/DeploymentsAccordions/DeploymentsAccordions.tsx
+++ b/plugins/kubernetes-react/src/components/DeploymentsAccordions/DeploymentsAccordions.tsx
@@ -24,7 +24,7 @@ import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import {
   V1Deployment,
   V1Pod,
-  V1HorizontalPodAutoscaler,
+  V2HorizontalPodAutoscaler,
 } from '@kubernetes/client-node';
 import { PodsTable } from '../Pods';
 import { DeploymentDrawer } from './DeploymentDrawer';
@@ -47,7 +47,7 @@ type DeploymentsAccordionsProps = {
 type DeploymentAccordionProps = {
   deployment: V1Deployment;
   ownedPods: V1Pod[];
-  matchingHpa?: V1HorizontalPodAutoscaler;
+  matchingHpa?: V2HorizontalPodAutoscaler;
   children?: React.ReactNode;
 };
 
@@ -55,7 +55,7 @@ type DeploymentSummaryProps = {
   deployment: V1Deployment;
   numberOfCurrentPods: number;
   numberOfPodsWithErrors: number;
-  hpa?: V1HorizontalPodAutoscaler;
+  hpa?: V2HorizontalPodAutoscaler;
   children?: React.ReactNode;
 };
 
@@ -65,6 +65,14 @@ const DeploymentSummary = ({
   numberOfPodsWithErrors,
   hpa,
 }: DeploymentSummaryProps) => {
+  const specCpuUtil = hpa?.spec?.metrics?.find(
+    metric => metric.type === 'Resource' && metric.resource?.name === 'cpu',
+  )?.resource?.target.averageUtilization;
+
+  const cpuUtil = hpa?.status?.currentMetrics?.find(
+    metric => metric.type === 'Resource' && metric.resource?.name === 'cpu',
+  )?.resource?.current.averageUtilization;
+
   return (
     <Grid
       container
@@ -95,14 +103,12 @@ const DeploymentSummary = ({
               </Grid>
               <Grid item>
                 <Typography variant="subtitle2">
-                  current CPU usage:{' '}
-                  {hpa.status?.currentCPUUtilizationPercentage ?? '?'}%
+                  current CPU usage: {cpuUtil ?? '?'}%
                 </Typography>
               </Grid>
               <Grid item>
                 <Typography variant="subtitle2">
-                  target CPU usage:{' '}
-                  {hpa.spec?.targetCPUUtilizationPercentage ?? '?'}%
+                  target CPU usage: {specCpuUtil ?? '?'}%
                 </Typography>
               </Grid>
             </Grid>

--- a/plugins/kubernetes-react/src/components/HorizontalPodAutoscalers/HorizontalPodAutoscalerDrawer.tsx
+++ b/plugins/kubernetes-react/src/components/HorizontalPodAutoscalers/HorizontalPodAutoscalerDrawer.tsx
@@ -15,32 +15,39 @@
  */
 
 import React from 'react';
-import { V1HorizontalPodAutoscaler } from '@kubernetes/client-node';
+import { V2HorizontalPodAutoscaler } from '@kubernetes/client-node';
 import { KubernetesStructuredMetadataTableDrawer } from '../KubernetesDrawer';
 
 /** @public */
 export const HorizontalPodAutoscalerDrawer = (props: {
-  hpa: V1HorizontalPodAutoscaler;
+  hpa: V2HorizontalPodAutoscaler;
   expanded?: boolean;
   children?: React.ReactNode;
 }) => {
   const { hpa, expanded, children } = props;
+
+  const specCpuUtil = hpa?.spec?.metrics?.find(
+    metric => metric.type === 'Resource' && metric.resource?.name === 'cpu',
+  )?.resource?.target.averageUtilization;
+
+  const cpuUtil = hpa?.status?.currentMetrics?.find(
+    metric => metric.type === 'Resource' && metric.resource?.name === 'cpu',
+  )?.resource?.current.averageUtilization;
 
   return (
     <KubernetesStructuredMetadataTableDrawer
       kind="HorizontalPodAutoscaler"
       object={hpa}
       expanded={expanded}
-      renderObject={(hpaObject: V1HorizontalPodAutoscaler) => {
+      renderObject={(hpaObject: V2HorizontalPodAutoscaler) => {
         return {
-          targetCPUUtilizationPercentage:
-            hpaObject.spec?.targetCPUUtilizationPercentage,
-          currentCPUUtilizationPercentage:
-            hpaObject.status?.currentCPUUtilizationPercentage,
+          targetCPUUtilizationPercentage: specCpuUtil,
+          currentCPUUtilizationPercentage: cpuUtil,
           minReplicas: hpaObject.spec?.minReplicas,
           maxReplicas: hpaObject.spec?.maxReplicas,
           currentReplicas: hpaObject.status?.currentReplicas,
           desiredReplicas: hpaObject.status?.desiredReplicas,
+          lastScaleTime: hpa?.status?.lastScaleTime,
         };
       }}
     >

--- a/plugins/kubernetes-react/src/components/HorizontalPodAutoscalers/__fixtures__/horizontalpodautoscalers.json
+++ b/plugins/kubernetes-react/src/components/HorizontalPodAutoscalers/__fixtures__/horizontalpodautoscalers.json
@@ -1,82 +1,79 @@
 [
   {
+    "apiVersion": "autoscaling/v2",
+    "kind": "HorizontalPodAutoscaler",
     "metadata": {
-      "annotations": {
-        "autoscaling.alpha.kubernetes.io/conditions": "[{\"type\":\"AbleToScale\",\"status\":\"True\",\"lastTransitionTime\":\"2020-09-28T13:28:15Z\",\"reason\":\"SucceededGetScale\",\"message\":\"the HPA controller was able to get the target's current scale\"},{\"type\":\"ScalingActive\",\"status\":\"False\",\"lastTransitionTime\":\"2020-09-28T13:28:15Z\",\"reason\":\"FailedGetResourceMetric\",\"message\":\"the HPA was unable to compute the replica count: unable to get metrics for resource cpu: unable to fetch metrics from resource metrics API: the server could not find the requested resource (get pods.metrics.k8s.io)\"}]",
-        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"autoscaling/v1\",\"kind\":\"HorizontalPodAutoscaler\",\"metadata\":{\"annotations\":{},\"labels\":{\"backstage.io/kubernetes-id\":\"dice-roller\"},\"name\":\"dice-roller\",\"namespace\":\"default\"},\"spec\":{\"maxReplicas\":15,\"minReplicas\":10,\"scaleTargetRef\":{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"name\":\"dice-roller\"},\"targetCPUUtilizationPercentage\":50}}\n"
-      },
-      "creationTimestamp": "2020-09-28T13:28:00.000Z",
+      "annotations": {},
+      "creationTimestamp": "2024-02-13T20:13:52Z",
       "labels": {
         "backstage.io/kubernetes-id": "dice-roller"
       },
-      "managedFields": [
-        {
-          "apiVersion": "autoscaling/v1",
-          "fieldsType": "FieldsV1",
-          "fieldsV1": {
-            "f:metadata": {
-              "f:annotations": {
-                "f:autoscaling.alpha.kubernetes.io/conditions": {}
-              }
-            },
-            "f:status": {
-              "f:currentReplicas": {}
-            }
-          },
-          "manager": "kube-controller-manager",
-          "operation": "Update",
-          "time": "2020-09-28T13:28:15.000Z"
-        },
-        {
-          "apiVersion": "autoscaling/v1",
-          "fieldsType": "FieldsV1",
-          "fieldsV1": {
-            "f:metadata": {
-              "f:annotations": {
-                ".": {},
-                "f:kubectl.kubernetes.io/last-applied-configuration": {}
-              },
-              "f:labels": {
-                ".": {},
-                "f:backstage.io/kubernetes-id": {}
-              }
-            },
-            "f:spec": {
-              "f:maxReplicas": {},
-              "f:minReplicas": {},
-              "f:scaleTargetRef": {
-                "f:apiVersion": {},
-                "f:kind": {},
-                "f:name": {}
-              },
-              "f:targetCPUUtilizationPercentage": {}
-            }
-          },
-          "manager": "kubectl",
-          "operation": "Update",
-          "time": "2020-09-28T13:28:21.000Z"
-        }
-      ],
       "name": "dice-roller",
       "namespace": "default",
-      "resourceVersion": "698957",
-      "selfLink": "/apis/autoscaling/v1/namespaces/default/horizontalpodautoscalers/dice-roller",
-      "uid": "a70c8a90-5605-4d7d-adea-05cfb8d9d446"
+      "resourceVersion": "6717s736",
+      "uid": "a34c90e1-8e8f-407f-b4c5-b4543bd56c1b"
     },
     "spec": {
       "maxReplicas": 15,
+      "metrics": [
+        {
+          "resource": {
+            "name": "cpu",
+            "target": {
+              "averageUtilization": 30,
+              "type": "Utilization"
+            }
+          },
+          "type": "Resource"
+        }
+      ],
       "minReplicas": 10,
       "scaleTargetRef": {
         "apiVersion": "apps/v1",
         "kind": "Deployment",
         "name": "dice-roller"
-      },
-      "targetCPUUtilizationPercentage": 50
+      }
     },
     "status": {
+      "conditions": [
+        {
+          "lastTransitionTime": "2024-05-17T19:50:35Z",
+          "message": "recent recommendations were higher than current one, applying the highest recent recommendation",
+          "reason": "ScaleDownStabilized",
+          "status": "True",
+          "type": "AbleToScale"
+        },
+        {
+          "lastTransitionTime": "2024-05-16T06:21:01Z",
+          "message": "the HPA was able to successfully calculate a replica count from cpu resource utilization (percentage of request)",
+          "reason": "ValidMetricFound",
+          "status": "True",
+          "type": "ScalingActive"
+        },
+        {
+          "lastTransitionTime": "2024-05-16T06:21:01Z",
+          "message": "the desired replica count is more than the maximum replica count",
+          "reason": "TooManyReplicas",
+          "status": "True",
+          "type": "ScalingLimited"
+        }
+      ],
+      "currentMetrics": [
+        {
+          "resource": {
+            "current": {
+              "averageUtilization": 50,
+              "averageValue": "50m",
+              "value": "100m"
+            },
+            "name": "cpu"
+          },
+          "type": "Resource"
+        }
+      ],
       "currentReplicas": 13,
       "desiredReplicas": 14,
-      "currentCPUUtilizationPercentage": 30
+      "lastScaleTime": "2024-02-13T20:14:23Z"
     }
   }
 ]

--- a/plugins/kubernetes-react/src/components/StatefulSetsAccordions/StatefulSetsAccordions.tsx
+++ b/plugins/kubernetes-react/src/components/StatefulSetsAccordions/StatefulSetsAccordions.tsx
@@ -23,7 +23,7 @@ import Typography from '@material-ui/core/Typography';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import {
   V1Pod,
-  V1HorizontalPodAutoscaler,
+  V2HorizontalPodAutoscaler,
   V1StatefulSet,
 } from '@kubernetes/client-node';
 import { PodsTable } from '../Pods';
@@ -44,7 +44,7 @@ type StatefulSetsAccordionsProps = {
 type StatefulSetAccordionProps = {
   statefulset: V1StatefulSet;
   ownedPods: V1Pod[];
-  matchingHpa?: V1HorizontalPodAutoscaler;
+  matchingHpa?: V2HorizontalPodAutoscaler;
   children?: React.ReactNode;
 };
 
@@ -52,7 +52,7 @@ type StatefulSetSummaryProps = {
   statefulset: V1StatefulSet;
   numberOfCurrentPods: number;
   numberOfPodsWithErrors: number;
-  hpa?: V1HorizontalPodAutoscaler;
+  hpa?: V2HorizontalPodAutoscaler;
   children?: React.ReactNode;
 };
 
@@ -62,6 +62,14 @@ const StatefulSetSummary = ({
   numberOfPodsWithErrors,
   hpa,
 }: StatefulSetSummaryProps) => {
+  const specCpuUtil = hpa?.spec?.metrics?.find(
+    metric => metric.type === 'Resource' && metric.resource?.name === 'cpu',
+  )?.resource?.target.averageUtilization;
+
+  const cpuUtil = hpa?.status?.currentMetrics?.find(
+    metric => metric.type === 'Resource' && metric.resource?.name === 'cpu',
+  )?.resource?.current.averageUtilization;
+
   return (
     <Grid
       container
@@ -92,14 +100,12 @@ const StatefulSetSummary = ({
               </Grid>
               <Grid item>
                 <Typography variant="subtitle2">
-                  current CPU usage:{' '}
-                  {hpa.status?.currentCPUUtilizationPercentage ?? '?'}%
+                  current CPU usage: {cpuUtil ?? '?'}%
                 </Typography>
               </Grid>
               <Grid item>
                 <Typography variant="subtitle2">
-                  target CPU usage:{' '}
-                  {hpa.spec?.targetCPUUtilizationPercentage ?? '?'}%
+                  target CPU usage: {specCpuUtil ?? '?'}%
                 </Typography>
               </Grid>
             </Grid>

--- a/plugins/kubernetes-react/src/utils/owner.ts
+++ b/plugins/kubernetes-react/src/utils/owner.ts
@@ -16,7 +16,7 @@
 
 import { V1ObjectMeta } from '@kubernetes/client-node/dist/gen/model/v1ObjectMeta';
 import {
-  V1HorizontalPodAutoscaler,
+  V2HorizontalPodAutoscaler,
   V1Pod,
   V1ReplicaSet,
 } from '@kubernetes/client-node';
@@ -62,8 +62,8 @@ interface ResourceRef {
 
 export const getMatchingHpa = (
   owner: ResourceRef,
-  hpas: V1HorizontalPodAutoscaler[],
-): V1HorizontalPodAutoscaler | undefined => {
+  hpas: V2HorizontalPodAutoscaler[],
+): V2HorizontalPodAutoscaler | undefined => {
   return hpas.find(hpa => {
     return (
       (hpa.spec?.scaleTargetRef?.kind ?? '').toLocaleLowerCase('en-US') ===

--- a/plugins/kubernetes/src/__fixtures__/1-deployments.json
+++ b/plugins/kubernetes/src/__fixtures__/1-deployments.json
@@ -2826,85 +2826,80 @@
   ],
   "horizontalPodAutoscalers": [
     {
-      "apiVersion": "autoscaling/v1",
+      "apiVersion": "autoscaling/v2",
       "kind": "HorizontalPodAutoscaler",
       "metadata": {
-        "annotations": {
-          "autoscaling.alpha.kubernetes.io/conditions": "[{\"type\":\"AbleToScale\",\"status\":\"True\",\"lastTransitionTime\":\"2021-01-05T10:26:04Z\",\"reason\":\"SucceededGetScale\",\"message\":\"the HPA controller was able to get the target's current scale\"},{\"type\":\"ScalingActive\",\"status\":\"False\",\"lastTransitionTime\":\"2021-01-05T10:26:04Z\",\"reason\":\"FailedGetResourceMetric\",\"message\":\"the HPA was unable to compute the replica count: unable to get metrics for resource cpu: no metrics returned from resource metrics API\"}]",
-          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"autoscaling/v1\",\"kind\":\"HorizontalPodAutoscaler\",\"metadata\":{\"annotations\":{},\"labels\":{\"backstage.io/kubernetes-id\":\"dice-roller\"},\"name\":\"dice-roller\",\"namespace\":\"default\"},\"spec\":{\"maxReplicas\":15,\"minReplicas\":10,\"scaleTargetRef\":{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"name\":\"dice-roller\"},\"targetCPUUtilizationPercentage\":50}}\n"
-        },
-        "creationTimestamp": "2021-01-05T10:25:48Z",
+        "annotations": {},
+        "creationTimestamp": "2024-02-13T20:13:52Z",
         "labels": {
           "backstage.io/kubernetes-id": "dice-roller"
         },
-        "managedFields": [
-          {
-            "apiVersion": "autoscaling/v1",
-            "fieldsType": "FieldsV1",
-            "fieldsV1": {
-              "f:metadata": {
-                "f:annotations": {
-                  ".": {},
-                  "f:kubectl.kubernetes.io/last-applied-configuration": {}
-                },
-                "f:labels": {
-                  ".": {},
-                  "f:backstage.io/kubernetes-id": {}
-                }
-              },
-              "f:spec": {
-                "f:maxReplicas": {},
-                "f:minReplicas": {},
-                "f:scaleTargetRef": {
-                  "f:apiVersion": {},
-                  "f:kind": {},
-                  "f:name": {}
-                },
-                "f:targetCPUUtilizationPercentage": {}
-              }
-            },
-            "manager": "kubectl-client-side-apply",
-            "operation": "Update",
-            "time": "2021-01-05T10:25:48Z"
-          },
-          {
-            "apiVersion": "autoscaling/v1",
-            "fieldsType": "FieldsV1",
-            "fieldsV1": {
-              "f:metadata": {
-                "f:annotations": {
-                  "f:autoscaling.alpha.kubernetes.io/conditions": {}
-                }
-              },
-              "f:status": {
-                "f:currentReplicas": {}
-              }
-            },
-            "manager": "kube-controller-manager",
-            "operation": "Update",
-            "time": "2021-01-05T10:26:04Z"
-          }
-        ],
         "name": "dice-roller",
         "namespace": "default",
-        "resourceVersion": "598",
-        "selfLink": "/apis/autoscaling/v1/namespaces/default/horizontalpodautoscalers/dice-roller",
-        "uid": "dd7c5329-567c-43c2-b159-756808d90a8e"
+        "resourceVersion": "6717s736",
+        "uid": "a34c90e1-8e8f-407f-b4c5-b4543bd56c1b"
       },
       "spec": {
-        "maxReplicas": 15,
-        "minReplicas": 10,
+        "maxReplicas": 2,
+        "metrics": [
+          {
+            "resource": {
+              "name": "cpu",
+              "target": {
+                "averageUtilization": 50,
+                "type": "Utilization"
+              }
+            },
+            "type": "Resource"
+          }
+        ],
+        "minReplicas": 1,
         "scaleTargetRef": {
           "apiVersion": "apps/v1",
           "kind": "Deployment",
           "name": "dice-roller"
-        },
-        "targetCPUUtilizationPercentage": 50
+        }
       },
       "status": {
-        "currentReplicas": 10,
-        "desiredReplicas": 0,
-        "currentCPUUtilizationPercentage": 30
+        "conditions": [
+          {
+            "lastTransitionTime": "2024-05-17T19:50:35Z",
+            "message": "recent recommendations were higher than current one, applying the highest recent recommendation",
+            "reason": "ScaleDownStabilized",
+            "status": "True",
+            "type": "AbleToScale"
+          },
+          {
+            "lastTransitionTime": "2024-05-16T06:21:01Z",
+            "message": "the HPA was able to successfully calculate a replica count from cpu resource utilization (percentage of request)",
+            "reason": "ValidMetricFound",
+            "status": "True",
+            "type": "ScalingActive"
+          },
+          {
+            "lastTransitionTime": "2024-05-16T06:21:01Z",
+            "message": "the desired replica count is more than the maximum replica count",
+            "reason": "TooManyReplicas",
+            "status": "True",
+            "type": "ScalingLimited"
+          }
+        ],
+        "currentMetrics": [
+          {
+            "resource": {
+              "current": {
+                "averageUtilization": 100,
+                "averageValue": "50m",
+                "value": "100m"
+              },
+              "name": "cpu"
+            },
+            "type": "Resource"
+          }
+        ],
+        "currentReplicas": 2,
+        "desiredReplicas": 2,
+        "lastScaleTime": "2024-02-13T20:14:23Z"
       }
     }
   ]

--- a/plugins/kubernetes/src/__fixtures__/1-statefulsets.json
+++ b/plugins/kubernetes/src/__fixtures__/1-statefulsets.json
@@ -2827,85 +2827,80 @@
   ],
   "horizontalPodAutoscalers": [
     {
-      "apiVersion": "autoscaling/v1",
+      "apiVersion": "autoscaling/v2",
       "kind": "HorizontalPodAutoscaler",
       "metadata": {
-        "annotations": {
-          "autoscaling.alpha.kubernetes.io/conditions": "[{\"type\":\"AbleToScale\",\"status\":\"True\",\"lastTransitionTime\":\"2021-01-05T10:26:04Z\",\"reason\":\"SucceededGetScale\",\"message\":\"the HPA controller was able to get the target's current scale\"},{\"type\":\"ScalingActive\",\"status\":\"False\",\"lastTransitionTime\":\"2021-01-05T10:26:04Z\",\"reason\":\"FailedGetResourceMetric\",\"message\":\"the HPA was unable to compute the replica count: unable to get metrics for resource cpu: no metrics returned from resource metrics API\"}]",
-          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"autoscaling/v1\",\"kind\":\"HorizontalPodAutoscaler\",\"metadata\":{\"annotations\":{},\"labels\":{\"backstage.io/kubernetes-id\":\"dice-roller\"},\"name\":\"dice-roller\",\"namespace\":\"default\"},\"spec\":{\"maxReplicas\":15,\"minReplicas\":10,\"scaleTargetRef\":{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"name\":\"dice-roller\"},\"targetCPUUtilizationPercentage\":50}}\n"
-        },
-        "creationTimestamp": "2021-01-05T10:25:48Z",
+        "annotations": {},
+        "creationTimestamp": "2024-02-13T20:13:52Z",
         "labels": {
           "backstage.io/kubernetes-id": "dice-roller"
         },
-        "managedFields": [
-          {
-            "apiVersion": "autoscaling/v1",
-            "fieldsType": "FieldsV1",
-            "fieldsV1": {
-              "f:metadata": {
-                "f:annotations": {
-                  ".": {},
-                  "f:kubectl.kubernetes.io/last-applied-configuration": {}
-                },
-                "f:labels": {
-                  ".": {},
-                  "f:backstage.io/kubernetes-id": {}
-                }
-              },
-              "f:spec": {
-                "f:maxReplicas": {},
-                "f:minReplicas": {},
-                "f:scaleTargetRef": {
-                  "f:apiVersion": {},
-                  "f:kind": {},
-                  "f:name": {}
-                },
-                "f:targetCPUUtilizationPercentage": {}
-              }
-            },
-            "manager": "kubectl-client-side-apply",
-            "operation": "Update",
-            "time": "2021-01-05T10:25:48Z"
-          },
-          {
-            "apiVersion": "autoscaling/v1",
-            "fieldsType": "FieldsV1",
-            "fieldsV1": {
-              "f:metadata": {
-                "f:annotations": {
-                  "f:autoscaling.alpha.kubernetes.io/conditions": {}
-                }
-              },
-              "f:status": {
-                "f:currentReplicas": {}
-              }
-            },
-            "manager": "kube-controller-manager",
-            "operation": "Update",
-            "time": "2021-01-05T10:26:04Z"
-          }
-        ],
         "name": "dice-roller",
         "namespace": "default",
-        "resourceVersion": "598",
-        "selfLink": "/apis/autoscaling/v1/namespaces/default/horizontalpodautoscalers/dice-roller",
-        "uid": "dd7c5329-567c-43c2-b159-756808d90a8e"
+        "resourceVersion": "6717s736",
+        "uid": "a34c90e1-8e8f-407f-b4c5-b4543bd56c1b"
       },
       "spec": {
-        "maxReplicas": 15,
-        "minReplicas": 10,
+        "maxReplicas": 2,
+        "metrics": [
+          {
+            "resource": {
+              "name": "cpu",
+              "target": {
+                "averageUtilization": 50,
+                "type": "Utilization"
+              }
+            },
+            "type": "Resource"
+          }
+        ],
+        "minReplicas": 1,
         "scaleTargetRef": {
           "apiVersion": "apps/v1",
           "kind": "Deployment",
           "name": "dice-roller"
-        },
-        "targetCPUUtilizationPercentage": 50
+        }
       },
       "status": {
-        "currentReplicas": 10,
-        "desiredReplicas": 0,
-        "currentCPUUtilizationPercentage": 30
+        "conditions": [
+          {
+            "lastTransitionTime": "2024-05-17T19:50:35Z",
+            "message": "recent recommendations were higher than current one, applying the highest recent recommendation",
+            "reason": "ScaleDownStabilized",
+            "status": "True",
+            "type": "AbleToScale"
+          },
+          {
+            "lastTransitionTime": "2024-05-16T06:21:01Z",
+            "message": "the HPA was able to successfully calculate a replica count from cpu resource utilization (percentage of request)",
+            "reason": "ValidMetricFound",
+            "status": "True",
+            "type": "ScalingActive"
+          },
+          {
+            "lastTransitionTime": "2024-05-16T06:21:01Z",
+            "message": "the desired replica count is more than the maximum replica count",
+            "reason": "TooManyReplicas",
+            "status": "True",
+            "type": "ScalingLimited"
+          }
+        ],
+        "currentMetrics": [
+          {
+            "resource": {
+              "current": {
+                "averageUtilization": 100,
+                "averageValue": "50m",
+                "value": "100m"
+              },
+              "name": "cpu"
+            },
+            "type": "Resource"
+          }
+        ],
+        "currentReplicas": 2,
+        "desiredReplicas": 2,
+        "lastScaleTime": "2024-02-13T20:14:23Z"
       }
     }
   ]

--- a/plugins/kubernetes/src/__fixtures__/2-deployments.json
+++ b/plugins/kubernetes/src/__fixtures__/2-deployments.json
@@ -4434,85 +4434,80 @@
   ],
   "horizontalPodAutoscalers": [
     {
-      "apiVersion": "autoscaling/v1",
+      "apiVersion": "autoscaling/v2",
       "kind": "HorizontalPodAutoscaler",
       "metadata": {
-        "annotations": {
-          "autoscaling.alpha.kubernetes.io/conditions": "[{\"type\":\"AbleToScale\",\"status\":\"True\",\"lastTransitionTime\":\"2021-01-05T10:26:04Z\",\"reason\":\"SucceededGetScale\",\"message\":\"the HPA controller was able to get the target's current scale\"},{\"type\":\"ScalingActive\",\"status\":\"False\",\"lastTransitionTime\":\"2021-01-05T10:26:04Z\",\"reason\":\"FailedGetResourceMetric\",\"message\":\"the HPA was unable to compute the replica count: unable to get metrics for resource cpu: no metrics returned from resource metrics API\"}]",
-          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"autoscaling/v1\",\"kind\":\"HorizontalPodAutoscaler\",\"metadata\":{\"annotations\":{},\"labels\":{\"backstage.io/kubernetes-id\":\"dice-roller\"},\"name\":\"dice-roller\",\"namespace\":\"default\"},\"spec\":{\"maxReplicas\":15,\"minReplicas\":10,\"scaleTargetRef\":{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"name\":\"dice-roller\"},\"targetCPUUtilizationPercentage\":50}}\n"
-        },
-        "creationTimestamp": "2021-01-05T10:25:48Z",
+        "annotations": {},
+        "creationTimestamp": "2024-02-13T20:13:52Z",
         "labels": {
           "backstage.io/kubernetes-id": "dice-roller"
         },
-        "managedFields": [
-          {
-            "apiVersion": "autoscaling/v1",
-            "fieldsType": "FieldsV1",
-            "fieldsV1": {
-              "f:metadata": {
-                "f:annotations": {
-                  ".": {},
-                  "f:kubectl.kubernetes.io/last-applied-configuration": {}
-                },
-                "f:labels": {
-                  ".": {},
-                  "f:backstage.io/kubernetes-id": {}
-                }
-              },
-              "f:spec": {
-                "f:maxReplicas": {},
-                "f:minReplicas": {},
-                "f:scaleTargetRef": {
-                  "f:apiVersion": {},
-                  "f:kind": {},
-                  "f:name": {}
-                },
-                "f:targetCPUUtilizationPercentage": {}
-              }
-            },
-            "manager": "kubectl-client-side-apply",
-            "operation": "Update",
-            "time": "2021-01-05T10:25:48Z"
-          },
-          {
-            "apiVersion": "autoscaling/v1",
-            "fieldsType": "FieldsV1",
-            "fieldsV1": {
-              "f:metadata": {
-                "f:annotations": {
-                  "f:autoscaling.alpha.kubernetes.io/conditions": {}
-                }
-              },
-              "f:status": {
-                "f:currentReplicas": {}
-              }
-            },
-            "manager": "kube-controller-manager",
-            "operation": "Update",
-            "time": "2021-01-05T10:26:04Z"
-          }
-        ],
         "name": "dice-roller",
         "namespace": "default",
-        "resourceVersion": "598",
-        "selfLink": "/apis/autoscaling/v1/namespaces/default/horizontalpodautoscalers/dice-roller",
-        "uid": "dd7c5329-567c-43c2-b159-756808d90a8e"
+        "resourceVersion": "6717s736",
+        "uid": "a34c90e1-8e8f-407f-b4c5-b4543bd56c1b"
       },
       "spec": {
-        "maxReplicas": 15,
-        "minReplicas": 10,
+        "maxReplicas": 2,
+        "metrics": [
+          {
+            "resource": {
+              "name": "cpu",
+              "target": {
+                "averageUtilization": 50,
+                "type": "Utilization"
+              }
+            },
+            "type": "Resource"
+          }
+        ],
+        "minReplicas": 1,
         "scaleTargetRef": {
           "apiVersion": "apps/v1",
           "kind": "Deployment",
           "name": "dice-roller"
-        },
-        "targetCPUUtilizationPercentage": 50
+        }
       },
       "status": {
-        "currentReplicas": 10,
-        "desiredReplicas": 0,
-        "currentCPUUtilizationPercentage": 30
+        "conditions": [
+          {
+            "lastTransitionTime": "2024-05-17T19:50:35Z",
+            "message": "recent recommendations were higher than current one, applying the highest recent recommendation",
+            "reason": "ScaleDownStabilized",
+            "status": "True",
+            "type": "AbleToScale"
+          },
+          {
+            "lastTransitionTime": "2024-05-16T06:21:01Z",
+            "message": "the HPA was able to successfully calculate a replica count from cpu resource utilization (percentage of request)",
+            "reason": "ValidMetricFound",
+            "status": "True",
+            "type": "ScalingActive"
+          },
+          {
+            "lastTransitionTime": "2024-05-16T06:21:01Z",
+            "message": "the desired replica count is more than the maximum replica count",
+            "reason": "TooManyReplicas",
+            "status": "True",
+            "type": "ScalingLimited"
+          }
+        ],
+        "currentMetrics": [
+          {
+            "resource": {
+              "current": {
+                "averageUtilization": 100,
+                "averageValue": "50m",
+                "value": "100m"
+              },
+              "name": "cpu"
+            },
+            "type": "Resource"
+          }
+        ],
+        "currentReplicas": 2,
+        "desiredReplicas": 2,
+        "lastScaleTime": "2024-02-13T20:14:23Z"
       }
     }
   ]

--- a/plugins/kubernetes/src/__fixtures__/2-statefulsets.json
+++ b/plugins/kubernetes/src/__fixtures__/2-statefulsets.json
@@ -4436,85 +4436,80 @@
   ],
   "horizontalPodAutoscalers": [
     {
-      "apiVersion": "autoscaling/v1",
+      "apiVersion": "autoscaling/v2",
       "kind": "HorizontalPodAutoscaler",
       "metadata": {
-        "annotations": {
-          "autoscaling.alpha.kubernetes.io/conditions": "[{\"type\":\"AbleToScale\",\"status\":\"True\",\"lastTransitionTime\":\"2021-01-05T10:26:04Z\",\"reason\":\"SucceededGetScale\",\"message\":\"the HPA controller was able to get the target's current scale\"},{\"type\":\"ScalingActive\",\"status\":\"False\",\"lastTransitionTime\":\"2021-01-05T10:26:04Z\",\"reason\":\"FailedGetResourceMetric\",\"message\":\"the HPA was unable to compute the replica count: unable to get metrics for resource cpu: no metrics returned from resource metrics API\"}]",
-          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"autoscaling/v1\",\"kind\":\"HorizontalPodAutoscaler\",\"metadata\":{\"annotations\":{},\"labels\":{\"backstage.io/kubernetes-id\":\"dice-roller\"},\"name\":\"dice-roller\",\"namespace\":\"default\"},\"spec\":{\"maxReplicas\":15,\"minReplicas\":10,\"scaleTargetRef\":{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"name\":\"dice-roller\"},\"targetCPUUtilizationPercentage\":50}}\n"
-        },
-        "creationTimestamp": "2021-01-05T10:25:48Z",
+        "annotations": {},
+        "creationTimestamp": "2024-02-13T20:13:52Z",
         "labels": {
           "backstage.io/kubernetes-id": "dice-roller"
         },
-        "managedFields": [
-          {
-            "apiVersion": "autoscaling/v1",
-            "fieldsType": "FieldsV1",
-            "fieldsV1": {
-              "f:metadata": {
-                "f:annotations": {
-                  ".": {},
-                  "f:kubectl.kubernetes.io/last-applied-configuration": {}
-                },
-                "f:labels": {
-                  ".": {},
-                  "f:backstage.io/kubernetes-id": {}
-                }
-              },
-              "f:spec": {
-                "f:maxReplicas": {},
-                "f:minReplicas": {},
-                "f:scaleTargetRef": {
-                  "f:apiVersion": {},
-                  "f:kind": {},
-                  "f:name": {}
-                },
-                "f:targetCPUUtilizationPercentage": {}
-              }
-            },
-            "manager": "kubectl-client-side-apply",
-            "operation": "Update",
-            "time": "2021-01-05T10:25:48Z"
-          },
-          {
-            "apiVersion": "autoscaling/v1",
-            "fieldsType": "FieldsV1",
-            "fieldsV1": {
-              "f:metadata": {
-                "f:annotations": {
-                  "f:autoscaling.alpha.kubernetes.io/conditions": {}
-                }
-              },
-              "f:status": {
-                "f:currentReplicas": {}
-              }
-            },
-            "manager": "kube-controller-manager",
-            "operation": "Update",
-            "time": "2021-01-05T10:26:04Z"
-          }
-        ],
         "name": "dice-roller",
         "namespace": "default",
-        "resourceVersion": "598",
-        "selfLink": "/apis/autoscaling/v1/namespaces/default/horizontalpodautoscalers/dice-roller",
-        "uid": "dd7c5329-567c-43c2-b159-756808d90a8e"
+        "resourceVersion": "6717s736",
+        "uid": "a34c90e1-8e8f-407f-b4c5-b4543bd56c1b"
       },
       "spec": {
-        "maxReplicas": 15,
-        "minReplicas": 10,
+        "maxReplicas": 2,
+        "metrics": [
+          {
+            "resource": {
+              "name": "cpu",
+              "target": {
+                "averageUtilization": 50,
+                "type": "Utilization"
+              }
+            },
+            "type": "Resource"
+          }
+        ],
+        "minReplicas": 1,
         "scaleTargetRef": {
           "apiVersion": "apps/v1",
           "kind": "Deployment",
           "name": "dice-roller"
-        },
-        "targetCPUUtilizationPercentage": 50
+        }
       },
       "status": {
-        "currentReplicas": 10,
-        "desiredReplicas": 0,
-        "currentCPUUtilizationPercentage": 30
+        "conditions": [
+          {
+            "lastTransitionTime": "2024-05-17T19:50:35Z",
+            "message": "recent recommendations were higher than current one, applying the highest recent recommendation",
+            "reason": "ScaleDownStabilized",
+            "status": "True",
+            "type": "AbleToScale"
+          },
+          {
+            "lastTransitionTime": "2024-05-16T06:21:01Z",
+            "message": "the HPA was able to successfully calculate a replica count from cpu resource utilization (percentage of request)",
+            "reason": "ValidMetricFound",
+            "status": "True",
+            "type": "ScalingActive"
+          },
+          {
+            "lastTransitionTime": "2024-05-16T06:21:01Z",
+            "message": "the desired replica count is more than the maximum replica count",
+            "reason": "TooManyReplicas",
+            "status": "True",
+            "type": "ScalingLimited"
+          }
+        ],
+        "currentMetrics": [
+          {
+            "resource": {
+              "current": {
+                "averageUtilization": 100,
+                "averageValue": "50m",
+                "value": "100m"
+              },
+              "name": "cpu"
+            },
+            "type": "Resource"
+          }
+        ],
+        "currentReplicas": 2,
+        "desiredReplicas": 2,
+        "lastScaleTime": "2024-02-13T20:14:23Z"
       }
     }
   ]


### PR DESCRIPTION
This version of autoscaling [went GA back in December 2021](https://kubernetes.io/blog/2021/12/07/kubernetes-1-23-release-announcement/#horizontalpodautoscaler-v2-graduates-to-ga) I think we can switch to it now. I don't think this is even a breaking change since you would need to be on a very old version of k8s to notice an issue.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
