### PR TITLE
[NBS 1.0] Deprecate legacy router handlers and contexts

### DIFF
--- a/.changeset/spicy-camels-happen.md
+++ b/.changeset/spicy-camels-happen.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+We are deprecating the legacy router handlers and contexts in preparation for the new backend system stable release.

--- a/packages/backend-common/api-report-alpha.md
+++ b/packages/backend-common/api-report-alpha.md
@@ -5,14 +5,14 @@
 ```ts
 import { Duration } from 'luxon';
 
-// @alpha
+// @alpha @deprecated
 export interface Context {
   readonly abortSignal: AbortSignal;
   readonly deadline: Date | undefined;
   value<T = unknown>(key: string): T | undefined;
 }
 
-// @alpha
+// @alpha @deprecated
 export class Contexts {
   static root(): Context;
   static withAbort(

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -309,7 +309,7 @@ export function dropDatabase(
   ...databaseNames: string[]
 ): Promise<void>;
 
-// @public
+// @public @deprecated
 export function errorHandler(
   options?: ErrorHandlerOptions,
 ): ErrorRequestHandler;
@@ -532,7 +532,7 @@ export class HarnessUrlReader implements UrlReader {
   toString(): string;
 }
 
-// @public
+// @public @deprecated
 export const HostDiscovery: typeof HostDiscovery_2;
 
 // @public @deprecated (undocumented)
@@ -733,7 +733,7 @@ export function redactWinstonLogLine(
   info: winston.Logform.TransformableInfo,
 ): winston.Logform.TransformableInfo;
 
-// @public
+// @public @deprecated
 export function requestLoggingHandler(logger?: LoggerService): RequestHandler;
 
 // @public

--- a/packages/backend-common/src/context/Contexts.ts
+++ b/packages/backend-common/src/context/Contexts.ts
@@ -24,6 +24,7 @@ import { ValueContext } from './ValueContext';
  * Common context decorators.
  *
  * @alpha
+ * @deprecated This class is not used in the new Backend system, so it is going to be removed in a near future.
  */
 export class Contexts {
   /**

--- a/packages/backend-common/src/context/types.ts
+++ b/packages/backend-common/src/context/types.ts
@@ -19,6 +19,7 @@
  * to pass along scoped information and abort signals.
  *
  * @alpha
+ * @deprecated This type is not used in the new Backend system, so it is going to be removed in a near future.
  */
 export interface Context {
   /**

--- a/packages/backend-common/src/discovery/HostDiscovery.ts
+++ b/packages/backend-common/src/discovery/HostDiscovery.ts
@@ -27,6 +27,7 @@ export type { DiscoveryService as PluginEndpointDiscovery } from '@backstage/bac
  * resolved to the same host, so there won't be any balancing of internal traffic.
  *
  * @public
+ * @deprecated Please import from `@backstage/backend-defaults/discovery` instead.
  */
 export const HostDiscovery = _HostDiscovery;
 

--- a/packages/backend-common/src/middleware/errorHandler.ts
+++ b/packages/backend-common/src/middleware/errorHandler.ts
@@ -61,6 +61,7 @@ export type ErrorHandlerOptions = {
  *
  * @public
  * @returns An Express error request handler
+ * @deprecated Use {@link @backstage/backend-app-api#MiddlewareFactory.create.error} instead
  */
 export function errorHandler(
   options: ErrorHandlerOptions = {},

--- a/packages/backend-common/src/middleware/requestLoggingHandler.ts
+++ b/packages/backend-common/src/middleware/requestLoggingHandler.ts
@@ -26,6 +26,7 @@ import { ConfigReader } from '@backstage/config';
  * @public
  * @param logger - An optional logger to use. If not specified, the root logger will be used.
  * @returns An Express request handler
+ * @deprecated @deprecated Use {@link @backstage/backend-app-api#MiddlewareFactory.create.logging} instead
  */
 export function requestLoggingHandler(logger?: LoggerService): RequestHandler {
   return MiddlewareFactory.create({

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
@@ -481,6 +481,7 @@ export function createPermissionIntegrationRouter<
     },
   );
 
+  // TODO(belugas): Remove this when dropping support to the legacy backend system because setting the error handler manually is no logger required in the new system.
   router.use(errorHandler());
 
   return router;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Refs: https://github.com/backstage/backstage/issues/24803

It is part of the effort to deprecate the legacy backend system and this pull request deprecates the **router handlers and contexts**.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
