### PR TITLE
plugins: export catalogTranslationRef

### DIFF
--- a/.changeset/tall-lies-fetch.md
+++ b/.changeset/tall-lies-fetch.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog': patch
 ---
 
-Variable 'catalogTranslationRef' is exported in translation.ts, but it was forgotten to also add it to the alpha entrypoint, so the code never became "visible"
+Export `catalogTranslationRef` under `/alpha`

--- a/.changeset/tall-lies-fetch.md
+++ b/.changeset/tall-lies-fetch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Variable 'catalogTranslationRef' is exported in translation.ts, but it was forgotten to also add it to the alpha entrypoint, so the code never became "visible"

--- a/plugins/catalog/api-report-alpha.md
+++ b/plugins/catalog/api-report-alpha.md
@@ -11,6 +11,16 @@ import { ExtensionDefinition } from '@backstage/frontend-plugin-api';
 import { ExternalRouteRef } from '@backstage/frontend-plugin-api';
 import { PortableSchema } from '@backstage/frontend-plugin-api';
 import { RouteRef } from '@backstage/frontend-plugin-api';
+import { TranslationRef } from '@backstage/core-plugin-api/alpha';
+
+// @alpha (undocumented)
+export const catalogTranslationRef: TranslationRef<
+  'catalog',
+  {
+    readonly 'indexPage.title': '{{orgName}} Catalog';
+    readonly 'indexPage.createButtonTitle': 'Create';
+  }
+>;
 
 // @alpha (undocumented)
 export function createCatalogFilterExtension<

--- a/plugins/catalog/src/alpha.ts
+++ b/plugins/catalog/src/alpha.ts
@@ -16,3 +16,4 @@
 
 export * from './alpha/index';
 export { default } from './alpha/index';
+export { catalogTranslationRef } from './translation';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

`catalogTranslationRef` is exported in [translation.ts](https://github.com/backstage/backstage/blob/2c3f493ee32d67d3a300d13e73e352f91145a3ee/plugins/catalog/src/translation.ts#L20)

But it was forgotten to also add it to the [alpha entrypoint](https://github.com/backstage/backstage/blob/2c3f493ee32d67d3a300d13e73e352f91145a3ee/plugins/catalog/src/alpha.ts)

So the code never became "visible"

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
