### PR TITLE
prefixed url reader types with the service name

### DIFF
--- a/.changeset/fluffy-bottles-relax.md
+++ b/.changeset/fluffy-bottles-relax.md
@@ -1,0 +1,15 @@
+---
+'@backstage/backend-plugin-api': patch
+---
+
+Deprecated all of the `UrlReader` type names and replaced them with prefixed versions. Please update your imports.
+
+- `ReadTreeOptions` was renamed to `UrlReaderReadTreeOptions`
+- `ReadTreeResponse` was renamed to `UrlReaderReadTreeResponse`
+- `ReadTreeResponseDirOptions` was renamed to `UrlReaderReadTreeResponseDirOptions`
+- `ReadTreeResponseFile` was renamed to `UrlReaderReadTreeResponseFile`
+- `ReadUrlResponse` was renamed to `UrlReaderReadUrlResponse`
+- `ReadUrlOptions` was renamed to `UrlReaderReadUrlOptions`
+- `SearchOptions` was renamed to `UrlReaderSearchOptions`
+- `SearchResponse` was renamed to `UrlReaderSearchResponse`
+- `SearchResponseFile` was renamed to `UrlReaderSearchResponseFile`

--- a/packages/backend-app-api/api-report.md
+++ b/packages/backend-app-api/api-report.md
@@ -42,7 +42,7 @@ import { ServiceFactory } from '@backstage/backend-plugin-api';
 import { ServiceFactoryOrFunction } from '@backstage/backend-plugin-api';
 import { TokenManagerService } from '@backstage/backend-plugin-api';
 import { transport } from 'winston';
-import { UrlReader } from '@backstage/backend-common';
+import { UrlReaderService } from '@backstage/backend-plugin-api';
 import { UserInfoService } from '@backstage/backend-plugin-api';
 
 // @public (undocumented)
@@ -339,7 +339,10 @@ export const tokenManagerServiceFactory: () => ServiceFactory<
 >;
 
 // @public @deprecated (undocumented)
-export const urlReaderServiceFactory: () => ServiceFactory<UrlReader, 'plugin'>;
+export const urlReaderServiceFactory: () => ServiceFactory<
+  UrlReaderService,
+  'plugin'
+>;
 
 // @public (undocumented)
 export const userInfoServiceFactory: () => ServiceFactory<

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -48,26 +48,26 @@ import { PluginMetadataService } from '@backstage/backend-plugin-api';
 import { PushResult } from 'isomorphic-git';
 import { Readable } from 'stream';
 import { ReadCommitResult } from 'isomorphic-git';
-import { ReadTreeOptions } from '@backstage/backend-plugin-api';
-import { ReadTreeResponse } from '@backstage/backend-plugin-api';
-import { ReadTreeResponseDirOptions } from '@backstage/backend-plugin-api';
-import { ReadTreeResponseFile } from '@backstage/backend-plugin-api';
-import { ReadUrlOptions } from '@backstage/backend-plugin-api';
-import { ReadUrlResponse } from '@backstage/backend-plugin-api';
 import { RequestHandler } from 'express';
 import { resolvePackagePath as resolvePackagePath_2 } from '@backstage/backend-plugin-api';
 import { resolveSafeChildPath as resolveSafeChildPath_2 } from '@backstage/backend-plugin-api';
 import { RootConfigService } from '@backstage/backend-plugin-api';
 import { Router } from 'express';
 import { SchedulerService } from '@backstage/backend-plugin-api';
-import { SearchOptions } from '@backstage/backend-plugin-api';
-import { SearchResponse } from '@backstage/backend-plugin-api';
-import { SearchResponseFile } from '@backstage/backend-plugin-api';
 import { Server } from 'http';
 import { ServiceRef } from '@backstage/backend-plugin-api';
 import { TokenManagerService as TokenManager } from '@backstage/backend-plugin-api';
 import { TransportStreamOptions } from 'winston-transport';
-import { UrlReaderService as UrlReader } from '@backstage/backend-plugin-api';
+import { UrlReaderReadTreeOptions } from '@backstage/backend-plugin-api';
+import { UrlReaderReadTreeResponse } from '@backstage/backend-plugin-api';
+import { UrlReaderReadTreeResponseDirOptions } from '@backstage/backend-plugin-api';
+import { UrlReaderReadTreeResponseFile } from '@backstage/backend-plugin-api';
+import { UrlReaderReadUrlOptions } from '@backstage/backend-plugin-api';
+import { UrlReaderReadUrlResponse } from '@backstage/backend-plugin-api';
+import { UrlReaderSearchOptions } from '@backstage/backend-plugin-api';
+import { UrlReaderSearchResponse } from '@backstage/backend-plugin-api';
+import { UrlReaderSearchResponseFile } from '@backstage/backend-plugin-api';
+import { UrlReaderService } from '@backstage/backend-plugin-api';
 import { UserInfoService } from '@backstage/backend-plugin-api';
 import { V1PodTemplateSpec } from '@kubernetes/client-node';
 import * as winston from 'winston';
@@ -582,7 +582,7 @@ export const legacyPlugin: (
           permissions: PermissionsService;
           scheduler: SchedulerService;
           tokenManager: TokenManager;
-          reader: UrlReader;
+          reader: UrlReaderService;
           identity: IdentityService;
         },
         {
@@ -668,28 +668,31 @@ export type ReaderFactory = (options: {
   treeResponseFactory: ReadTreeResponseFactory;
 }) => UrlReaderPredicateTuple[];
 
-export { ReadTreeOptions };
+// @public @deprecated (undocumented)
+export type ReadTreeOptions = UrlReaderReadTreeOptions;
 
-export { ReadTreeResponse };
+// @public @deprecated (undocumented)
+export type ReadTreeResponse = UrlReaderReadTreeResponse;
 
-export { ReadTreeResponseDirOptions };
+// @public @deprecated (undocumented)
+export type ReadTreeResponseDirOptions = UrlReaderReadTreeResponseDirOptions;
 
 // @public @deprecated
 export interface ReadTreeResponseFactory {
   // (undocumented)
   fromReadableArray(
     options: FromReadableArrayOptions,
-  ): Promise<ReadTreeResponse>;
+  ): Promise<UrlReaderReadTreeResponse>;
   // (undocumented)
   fromTarArchive(
     options: ReadTreeResponseFactoryOptions & {
       stripFirstDirectory?: boolean;
     },
-  ): Promise<ReadTreeResponse>;
+  ): Promise<UrlReaderReadTreeResponse>;
   // (undocumented)
   fromZipArchive(
     options: ReadTreeResponseFactoryOptions,
-  ): Promise<ReadTreeResponse>;
+  ): Promise<UrlReaderReadTreeResponse>;
 }
 
 // @public @deprecated
@@ -705,11 +708,14 @@ export type ReadTreeResponseFactoryOptions = {
   ) => boolean;
 };
 
-export { ReadTreeResponseFile };
+// @public @deprecated (undocumented)
+export type ReadTreeResponseFile = UrlReaderReadTreeResponseFile;
 
-export { ReadUrlOptions };
+// @public @deprecated (undocumented)
+export type ReadUrlOptions = UrlReaderReadUrlOptions;
 
-export { ReadUrlResponse };
+// @public @deprecated (undocumented)
+export type ReadUrlResponse = UrlReaderReadUrlResponse;
 
 // @public @deprecated
 export class ReadUrlResponseFactory {
@@ -762,11 +768,14 @@ export type RunContainerOptions = {
   pullOptions?: PullOptions;
 };
 
-export { SearchOptions };
+// @public @deprecated (undocumented)
+export type SearchOptions = UrlReaderSearchOptions;
 
-export { SearchResponse };
+// @public @deprecated (undocumented)
+export type SearchResponse = UrlReaderSearchResponse;
 
-export { SearchResponseFile };
+// @public @deprecated (undocumented)
+export type SearchResponseFile = UrlReaderSearchResponseFile;
 
 // @public
 export class ServerTokenManager implements TokenManager {
@@ -845,18 +854,19 @@ export interface StatusCheckHandlerOptions {
 
 export { TokenManager };
 
-export { UrlReader };
+// @public @deprecated (undocumented)
+export type UrlReader = UrlReaderService;
 
 // @public @deprecated
 export type UrlReaderPredicateTuple = {
   predicate: (url: URL) => boolean;
-  reader: UrlReader;
+  reader: UrlReaderService;
 };
 
 // @public @deprecated
 export class UrlReaders {
   static create(options: UrlReadersOptions): UrlReader;
-  static default(options: UrlReadersOptions): UrlReader;
+  static default(options: UrlReadersOptions): UrlReaderService;
 }
 
 // @public @deprecated

--- a/packages/backend-common/src/reading/types.ts
+++ b/packages/backend-common/src/reading/types.ts
@@ -18,22 +18,68 @@ import { Readable } from 'stream';
 import { Config } from '@backstage/config';
 import {
   UrlReaderService,
-  ReadTreeResponse,
   LoggerService,
+  UrlReaderReadTreeOptions,
+  UrlReaderReadTreeResponse,
+  UrlReaderReadTreeResponseDirOptions,
+  UrlReaderReadTreeResponseFile,
+  UrlReaderReadUrlResponse,
+  UrlReaderReadUrlOptions,
+  UrlReaderSearchOptions,
+  UrlReaderSearchResponse,
+  UrlReaderSearchResponseFile,
 } from '@backstage/backend-plugin-api';
 
-export type {
-  UrlReaderService as UrlReader,
-  ReadTreeOptions,
-  ReadTreeResponse,
-  ReadTreeResponseDirOptions,
-  ReadTreeResponseFile,
-  ReadUrlResponse,
-  ReadUrlOptions,
-  SearchOptions,
-  SearchResponse,
-  SearchResponseFile,
-} from '@backstage/backend-plugin-api';
+/**
+ * @public
+ * @deprecated Use `UrlReaderService` from `@backstage/backend-plugin-api` instead
+ */
+export type UrlReader = UrlReaderService;
+/**
+ * @public
+ * @deprecated Use `UrlReaderReadTreeOptions` from `@backstage/backend-plugin-api` instead
+ */
+export type ReadTreeOptions = UrlReaderReadTreeOptions;
+/**
+ * @public
+ * @deprecated Use `UrlReaderReadTreeResponse` from `@backstage/backend-plugin-api` instead
+ */
+export type ReadTreeResponse = UrlReaderReadTreeResponse;
+/**
+ * @public
+ * @deprecated Use `UrlReaderReadTreeResponseDirOptions` from `@backstage/backend-plugin-api` instead
+ */
+export type ReadTreeResponseDirOptions = UrlReaderReadTreeResponseDirOptions;
+/**
+ * @public
+ * @deprecated Use `UrlReaderReadTreeResponseFile` from `@backstage/backend-plugin-api` instead
+ */
+export type ReadTreeResponseFile = UrlReaderReadTreeResponseFile;
+/**
+ * @public
+ * @deprecated Use `UrlReaderReadUrlResponse` from `@backstage/backend-plugin-api` instead
+ */
+export type ReadUrlResponse = UrlReaderReadUrlResponse;
+/**
+ * @public
+ * @deprecated Use `UrlReaderReadUrlOptions` from `@backstage/backend-plugin-api` instead
+ */
+export type ReadUrlOptions = UrlReaderReadUrlOptions;
+/**
+ * @public
+ * @deprecated Use `UrlReaderSearchOptions` from `@backstage/backend-plugin-api` instead
+ */
+export type SearchOptions = UrlReaderSearchOptions;
+/**
+ * @public
+ * @deprecated Use `UrlReaderSearchResponse` from `@backstage/backend-plugin-api` instead
+ */
+export type SearchResponse = UrlReaderSearchResponse;
+/**
+ * @public
+ * @deprecated Use `UrlReaderSearchResponseFile` from `@backstage/backend-plugin-api` instead
+ */
+export type SearchResponseFile = UrlReaderSearchResponseFile;
 
 /**
  * A predicate that decides whether a specific {@link @backstage/backend-plugin-api#UrlReaderService} can handle a
@@ -129,11 +175,11 @@ export interface ReadTreeResponseFactory {
        */
       stripFirstDirectory?: boolean;
     },
-  ): Promise<ReadTreeResponse>;
+  ): Promise<UrlReaderReadTreeResponse>;
   fromZipArchive(
     options: ReadTreeResponseFactoryOptions,
-  ): Promise<ReadTreeResponse>;
+  ): Promise<UrlReaderReadTreeResponse>;
   fromReadableArray(
     options: FromReadableArrayOptions,
-  ): Promise<ReadTreeResponse>;
+  ): Promise<UrlReaderReadTreeResponse>;
 }

--- a/packages/backend-defaults/api-report-urlReader.md
+++ b/packages/backend-defaults/api-report-urlReader.md
@@ -21,13 +21,13 @@ import { GitLabIntegration } from '@backstage/integration';
 import { HarnessIntegration } from '@backstage/integration';
 import { LoggerService } from '@backstage/backend-plugin-api';
 import { Readable } from 'stream';
-import { ReadTreeOptions } from '@backstage/backend-plugin-api';
-import { ReadTreeResponse } from '@backstage/backend-plugin-api';
-import { ReadUrlOptions } from '@backstage/backend-plugin-api';
-import { ReadUrlResponse } from '@backstage/backend-plugin-api';
-import { SearchOptions } from '@backstage/backend-plugin-api';
-import { SearchResponse } from '@backstage/backend-plugin-api';
 import { ServiceFactory } from '@backstage/backend-plugin-api';
+import { UrlReaderReadTreeOptions } from '@backstage/backend-plugin-api';
+import { UrlReaderReadTreeResponse } from '@backstage/backend-plugin-api';
+import { UrlReaderReadUrlOptions } from '@backstage/backend-plugin-api';
+import { UrlReaderReadUrlResponse } from '@backstage/backend-plugin-api';
+import { UrlReaderSearchOptions } from '@backstage/backend-plugin-api';
+import { UrlReaderSearchResponse } from '@backstage/backend-plugin-api';
 import { UrlReaderService } from '@backstage/backend-plugin-api';
 
 // @public
@@ -44,11 +44,17 @@ export class AwsS3UrlReader implements UrlReaderService {
   // (undocumented)
   read(url: string): Promise<Buffer>;
   // (undocumented)
-  readTree(url: string, options?: ReadTreeOptions): Promise<ReadTreeResponse>;
+  readTree(
+    url: string,
+    options?: UrlReaderReadTreeOptions,
+  ): Promise<UrlReaderReadTreeResponse>;
   // (undocumented)
-  readUrl(url: string, options?: ReadUrlOptions): Promise<ReadUrlResponse>;
+  readUrl(
+    url: string,
+    options?: UrlReaderReadUrlOptions,
+  ): Promise<UrlReaderReadUrlResponse>;
   // (undocumented)
-  search(): Promise<SearchResponse>;
+  search(): Promise<UrlReaderSearchResponse>;
   // (undocumented)
   toString(): string;
 }
@@ -67,11 +73,20 @@ export class AzureUrlReader implements UrlReaderService {
   // (undocumented)
   read(url: string): Promise<Buffer>;
   // (undocumented)
-  readTree(url: string, options?: ReadTreeOptions): Promise<ReadTreeResponse>;
+  readTree(
+    url: string,
+    options?: UrlReaderReadTreeOptions,
+  ): Promise<UrlReaderReadTreeResponse>;
   // (undocumented)
-  readUrl(url: string, options?: ReadUrlOptions): Promise<ReadUrlResponse>;
+  readUrl(
+    url: string,
+    options?: UrlReaderReadUrlOptions,
+  ): Promise<UrlReaderReadUrlResponse>;
   // (undocumented)
-  search(url: string, options?: SearchOptions): Promise<SearchResponse>;
+  search(
+    url: string,
+    options?: UrlReaderSearchOptions,
+  ): Promise<UrlReaderSearchResponse>;
   // (undocumented)
   toString(): string;
 }
@@ -89,11 +104,20 @@ export class BitbucketCloudUrlReader implements UrlReaderService {
   // (undocumented)
   read(url: string): Promise<Buffer>;
   // (undocumented)
-  readTree(url: string, options?: ReadTreeOptions): Promise<ReadTreeResponse>;
+  readTree(
+    url: string,
+    options?: UrlReaderReadTreeOptions,
+  ): Promise<UrlReaderReadTreeResponse>;
   // (undocumented)
-  readUrl(url: string, options?: ReadUrlOptions): Promise<ReadUrlResponse>;
+  readUrl(
+    url: string,
+    options?: UrlReaderReadUrlOptions,
+  ): Promise<UrlReaderReadUrlResponse>;
   // (undocumented)
-  search(url: string, options?: SearchOptions): Promise<SearchResponse>;
+  search(
+    url: string,
+    options?: UrlReaderSearchOptions,
+  ): Promise<UrlReaderSearchResponse>;
   // (undocumented)
   toString(): string;
 }
@@ -111,11 +135,20 @@ export class BitbucketServerUrlReader implements UrlReaderService {
   // (undocumented)
   read(url: string): Promise<Buffer>;
   // (undocumented)
-  readTree(url: string, options?: ReadTreeOptions): Promise<ReadTreeResponse>;
+  readTree(
+    url: string,
+    options?: UrlReaderReadTreeOptions,
+  ): Promise<UrlReaderReadTreeResponse>;
   // (undocumented)
-  readUrl(url: string, options?: ReadUrlOptions): Promise<ReadUrlResponse>;
+  readUrl(
+    url: string,
+    options?: UrlReaderReadUrlOptions,
+  ): Promise<UrlReaderReadUrlResponse>;
   // (undocumented)
-  search(url: string, options?: SearchOptions): Promise<SearchResponse>;
+  search(
+    url: string,
+    options?: UrlReaderSearchOptions,
+  ): Promise<UrlReaderSearchResponse>;
   // (undocumented)
   toString(): string;
 }
@@ -134,11 +167,20 @@ export class BitbucketUrlReader implements UrlReaderService {
   // (undocumented)
   read(url: string): Promise<Buffer>;
   // (undocumented)
-  readTree(url: string, options?: ReadTreeOptions): Promise<ReadTreeResponse>;
+  readTree(
+    url: string,
+    options?: UrlReaderReadTreeOptions,
+  ): Promise<UrlReaderReadTreeResponse>;
   // (undocumented)
-  readUrl(url: string, options?: ReadUrlOptions): Promise<ReadUrlResponse>;
+  readUrl(
+    url: string,
+    options?: UrlReaderReadUrlOptions,
+  ): Promise<UrlReaderReadUrlResponse>;
   // (undocumented)
-  search(url: string, options?: SearchOptions): Promise<SearchResponse>;
+  search(
+    url: string,
+    options?: UrlReaderSearchOptions,
+  ): Promise<UrlReaderSearchResponse>;
   // (undocumented)
   toString(): string;
 }
@@ -149,11 +191,14 @@ export class FetchUrlReader implements UrlReaderService {
   // (undocumented)
   read(url: string): Promise<Buffer>;
   // (undocumented)
-  readTree(): Promise<ReadTreeResponse>;
+  readTree(): Promise<UrlReaderReadTreeResponse>;
   // (undocumented)
-  readUrl(url: string, options?: ReadUrlOptions): Promise<ReadUrlResponse>;
+  readUrl(
+    url: string,
+    options?: UrlReaderReadUrlOptions,
+  ): Promise<UrlReaderReadUrlResponse>;
   // (undocumented)
-  search(): Promise<SearchResponse>;
+  search(): Promise<UrlReaderSearchResponse>;
   // (undocumented)
   toString(): string;
 }
@@ -179,11 +224,17 @@ export class GerritUrlReader implements UrlReaderService {
   // (undocumented)
   read(url: string): Promise<Buffer>;
   // (undocumented)
-  readTree(url: string, options?: ReadTreeOptions): Promise<ReadTreeResponse>;
+  readTree(
+    url: string,
+    options?: UrlReaderReadTreeOptions,
+  ): Promise<UrlReaderReadTreeResponse>;
   // (undocumented)
-  readUrl(url: string, options?: ReadUrlOptions): Promise<ReadUrlResponse>;
+  readUrl(
+    url: string,
+    options?: UrlReaderReadUrlOptions,
+  ): Promise<UrlReaderReadUrlResponse>;
   // (undocumented)
-  search(): Promise<SearchResponse>;
+  search(): Promise<UrlReaderSearchResponse>;
   // (undocumented)
   toString(): string;
 }
@@ -201,11 +252,17 @@ export class GiteaUrlReader implements UrlReaderService {
   // (undocumented)
   read(url: string): Promise<Buffer>;
   // (undocumented)
-  readTree(url: string, options?: ReadTreeOptions): Promise<ReadTreeResponse>;
+  readTree(
+    url: string,
+    options?: UrlReaderReadTreeOptions,
+  ): Promise<UrlReaderReadTreeResponse>;
   // (undocumented)
-  readUrl(url: string, options?: ReadUrlOptions): Promise<ReadUrlResponse>;
+  readUrl(
+    url: string,
+    options?: UrlReaderReadUrlOptions,
+  ): Promise<UrlReaderReadUrlResponse>;
   // (undocumented)
-  search(): Promise<SearchResponse>;
+  search(): Promise<UrlReaderSearchResponse>;
   // (undocumented)
   toString(): string;
 }
@@ -224,11 +281,20 @@ export class GithubUrlReader implements UrlReaderService {
   // (undocumented)
   read(url: string): Promise<Buffer>;
   // (undocumented)
-  readTree(url: string, options?: ReadTreeOptions): Promise<ReadTreeResponse>;
+  readTree(
+    url: string,
+    options?: UrlReaderReadTreeOptions,
+  ): Promise<UrlReaderReadTreeResponse>;
   // (undocumented)
-  readUrl(url: string, options?: ReadUrlOptions): Promise<ReadUrlResponse>;
+  readUrl(
+    url: string,
+    options?: UrlReaderReadUrlOptions,
+  ): Promise<UrlReaderReadUrlResponse>;
   // (undocumented)
-  search(url: string, options?: SearchOptions): Promise<SearchResponse>;
+  search(
+    url: string,
+    options?: UrlReaderSearchOptions,
+  ): Promise<UrlReaderSearchResponse>;
   // (undocumented)
   toString(): string;
 }
@@ -246,11 +312,20 @@ export class GitlabUrlReader implements UrlReaderService {
   // (undocumented)
   read(url: string): Promise<Buffer>;
   // (undocumented)
-  readTree(url: string, options?: ReadTreeOptions): Promise<ReadTreeResponse>;
+  readTree(
+    url: string,
+    options?: UrlReaderReadTreeOptions,
+  ): Promise<UrlReaderReadTreeResponse>;
   // (undocumented)
-  readUrl(url: string, options?: ReadUrlOptions): Promise<ReadUrlResponse>;
+  readUrl(
+    url: string,
+    options?: UrlReaderReadUrlOptions,
+  ): Promise<UrlReaderReadUrlResponse>;
   // (undocumented)
-  search(url: string, options?: SearchOptions): Promise<SearchResponse>;
+  search(
+    url: string,
+    options?: UrlReaderSearchOptions,
+  ): Promise<UrlReaderSearchResponse>;
   // (undocumented)
   toString(): string;
 }
@@ -263,11 +338,14 @@ export class HarnessUrlReader implements UrlReaderService {
   // (undocumented)
   read(url: string): Promise<Buffer>;
   // (undocumented)
-  readTree(): Promise<ReadTreeResponse>;
+  readTree(): Promise<UrlReaderReadTreeResponse>;
   // (undocumented)
-  readUrl(url: string, options?: ReadUrlOptions): Promise<ReadUrlResponse>;
+  readUrl(
+    url: string,
+    options?: UrlReaderReadUrlOptions,
+  ): Promise<UrlReaderReadUrlResponse>;
   // (undocumented)
-  search(): Promise<SearchResponse>;
+  search(): Promise<UrlReaderSearchResponse>;
   // (undocumented)
   toString(): string;
 }
@@ -284,17 +362,17 @@ export interface ReadTreeResponseFactory {
   // (undocumented)
   fromReadableArray(
     options: FromReadableArrayOptions,
-  ): Promise<ReadTreeResponse>;
+  ): Promise<UrlReaderReadTreeResponse>;
   // (undocumented)
   fromTarArchive(
     options: ReadTreeResponseFactoryOptions & {
       stripFirstDirectory?: boolean;
     },
-  ): Promise<ReadTreeResponse>;
+  ): Promise<UrlReaderReadTreeResponse>;
   // (undocumented)
   fromZipArchive(
     options: ReadTreeResponseFactoryOptions,
-  ): Promise<ReadTreeResponse>;
+  ): Promise<UrlReaderReadTreeResponse>;
 }
 
 // @public
@@ -315,11 +393,11 @@ export class ReadUrlResponseFactory {
   static fromNodeJSReadable(
     oldStyleStream: NodeJS.ReadableStream,
     options?: ReadUrlResponseFactoryFromStreamOptions,
-  ): Promise<ReadUrlResponse>;
+  ): Promise<UrlReaderReadUrlResponse>;
   static fromReadable(
     stream: Readable,
     options?: ReadUrlResponseFactoryFromStreamOptions,
-  ): Promise<ReadUrlResponse>;
+  ): Promise<UrlReaderReadUrlResponse>;
 }
 
 // @public

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsCodeCommitUrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsCodeCommitUrlReader.ts
@@ -38,11 +38,11 @@ import { ReadUrlResponseFactory } from './ReadUrlResponseFactory';
 import { relative } from 'path/posix';
 import { AbortController } from '@aws-sdk/abort-controller';
 import {
-  ReadTreeOptions,
-  ReadTreeResponse,
-  ReadUrlOptions,
-  ReadUrlResponse,
-  SearchResponse,
+  UrlReaderReadTreeOptions,
+  UrlReaderReadTreeResponse,
+  UrlReaderReadUrlOptions,
+  UrlReaderReadUrlResponse,
+  UrlReaderSearchResponse,
   UrlReaderService,
 } from '@backstage/backend-plugin-api';
 
@@ -221,8 +221,8 @@ export class AwsCodeCommitUrlReader implements UrlReaderService {
 
   async readUrl(
     url: string,
-    options?: ReadUrlOptions,
-  ): Promise<ReadUrlResponse> {
+    options?: UrlReaderReadUrlOptions,
+  ): Promise<UrlReaderReadUrlResponse> {
     // etag and lastModifiedAfter are not supported by the CodeCommit API
     try {
       const { path, repositoryName, region, commitSpecifier } = parseUrl(
@@ -325,8 +325,8 @@ export class AwsCodeCommitUrlReader implements UrlReaderService {
 
   async readTree(
     url: string,
-    options?: ReadTreeOptions,
-  ): Promise<ReadTreeResponse> {
+    options?: UrlReaderReadTreeOptions,
+  ): Promise<UrlReaderReadTreeResponse> {
     // url: https://eu-west-1.console.aws.amazon.com/codesuite/codecommit/repositories/test-stijn-delete-techdocs/browse?region=eu-west-1
     try {
       const { path, repositoryName, region, commitSpecifier } = parseUrl(url);
@@ -379,7 +379,7 @@ export class AwsCodeCommitUrlReader implements UrlReaderService {
     }
   }
 
-  async search(): Promise<SearchResponse> {
+  async search(): Promise<UrlReaderSearchResponse> {
     throw new Error('AwsCodeCommitReader does not implement search');
   }
 

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.ts
@@ -25,11 +25,11 @@ import {
 import { fromTemporaryCredentials } from '@aws-sdk/credential-providers';
 import { AwsCredentialIdentityProvider } from '@aws-sdk/types';
 import {
-  ReadTreeOptions,
-  ReadTreeResponse,
-  ReadUrlOptions,
-  ReadUrlResponse,
-  SearchResponse,
+  UrlReaderReadTreeOptions,
+  UrlReaderReadTreeResponse,
+  UrlReaderReadUrlOptions,
+  UrlReaderReadUrlResponse,
+  UrlReaderSearchResponse,
   UrlReaderService,
 } from '@backstage/backend-plugin-api';
 import { ForwardedError, NotModifiedError } from '@backstage/errors';
@@ -252,8 +252,8 @@ export class AwsS3UrlReader implements UrlReaderService {
 
   async readUrl(
     url: string,
-    options?: ReadUrlOptions,
-  ): Promise<ReadUrlResponse> {
+    options?: UrlReaderReadUrlOptions,
+  ): Promise<UrlReaderReadUrlResponse> {
     const { etag, lastModifiedAfter } = options ?? {};
 
     try {
@@ -299,8 +299,8 @@ export class AwsS3UrlReader implements UrlReaderService {
 
   async readTree(
     url: string,
-    options?: ReadTreeOptions,
-  ): Promise<ReadTreeResponse> {
+    options?: UrlReaderReadTreeOptions,
+  ): Promise<UrlReaderReadTreeResponse> {
     try {
       const { path, bucket, region } = parseUrl(url, this.integration.config);
       const s3Client = await this.buildS3Client(
@@ -356,7 +356,7 @@ export class AwsS3UrlReader implements UrlReaderService {
     }
   }
 
-  async search(): Promise<SearchResponse> {
+  async search(): Promise<UrlReaderSearchResponse> {
     throw new Error('AwsS3Reader does not implement search');
   }
 

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/AzureUrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/AzureUrlReader.ts
@@ -30,12 +30,12 @@ import { NotFoundError, NotModifiedError } from '@backstage/errors';
 import { ReadTreeResponseFactory, ReaderFactory } from './types';
 import { ReadUrlResponseFactory } from './ReadUrlResponseFactory';
 import {
-  ReadTreeOptions,
-  ReadTreeResponse,
-  ReadUrlOptions,
-  ReadUrlResponse,
-  SearchOptions,
-  SearchResponse,
+  UrlReaderReadTreeOptions,
+  UrlReaderReadTreeResponse,
+  UrlReaderReadUrlOptions,
+  UrlReaderReadUrlResponse,
+  UrlReaderSearchOptions,
+  UrlReaderSearchResponse,
   UrlReaderService,
 } from '@backstage/backend-plugin-api';
 
@@ -74,8 +74,8 @@ export class AzureUrlReader implements UrlReaderService {
 
   async readUrl(
     url: string,
-    options?: ReadUrlOptions,
-  ): Promise<ReadUrlResponse> {
+    options?: UrlReaderReadUrlOptions,
+  ): Promise<UrlReaderReadUrlResponse> {
     // TODO: etag is not implemented yet.
     const { signal } = options ?? {};
 
@@ -113,8 +113,8 @@ export class AzureUrlReader implements UrlReaderService {
 
   async readTree(
     url: string,
-    options?: ReadTreeOptions,
-  ): Promise<ReadTreeResponse> {
+    options?: UrlReaderReadTreeOptions,
+  ): Promise<UrlReaderReadTreeResponse> {
     const { etag, filter, signal } = options ?? {};
 
     // TODO: Support filepath based reading tree feature like other providers
@@ -179,7 +179,10 @@ export class AzureUrlReader implements UrlReaderService {
     });
   }
 
-  async search(url: string, options?: SearchOptions): Promise<SearchResponse> {
+  async search(
+    url: string,
+    options?: UrlReaderSearchOptions,
+  ): Promise<UrlReaderSearchResponse> {
     const treeUrl = new URL(url);
 
     const path = treeUrl.searchParams.get('path');

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/BitbucketCloudUrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/BitbucketCloudUrlReader.ts
@@ -32,12 +32,12 @@ import { ReaderFactory, ReadTreeResponseFactory } from './types';
 import { ReadUrlResponseFactory } from './ReadUrlResponseFactory';
 import { parseLastModified } from './util';
 import {
-  ReadTreeOptions,
-  ReadTreeResponse,
-  ReadUrlOptions,
-  ReadUrlResponse,
-  SearchOptions,
-  SearchResponse,
+  UrlReaderReadTreeOptions,
+  UrlReaderReadTreeResponse,
+  UrlReaderReadUrlOptions,
+  UrlReaderReadUrlResponse,
+  UrlReaderSearchOptions,
+  UrlReaderSearchResponse,
   UrlReaderService,
 } from '@backstage/backend-plugin-api';
 
@@ -78,8 +78,8 @@ export class BitbucketCloudUrlReader implements UrlReaderService {
 
   async readUrl(
     url: string,
-    options?: ReadUrlOptions,
-  ): Promise<ReadUrlResponse> {
+    options?: UrlReaderReadUrlOptions,
+  ): Promise<UrlReaderReadUrlResponse> {
     const { etag, lastModifiedAfter, signal } = options ?? {};
     const bitbucketUrl = getBitbucketCloudFileFetchUrl(
       url,
@@ -133,8 +133,8 @@ export class BitbucketCloudUrlReader implements UrlReaderService {
 
   async readTree(
     url: string,
-    options?: ReadTreeOptions,
-  ): Promise<ReadTreeResponse> {
+    options?: UrlReaderReadTreeOptions,
+  ): Promise<UrlReaderReadTreeResponse> {
     const { filepath } = parseGitUrl(url);
 
     const lastCommitShortHash = await this.getLastCommitShortHash(url);
@@ -166,7 +166,10 @@ export class BitbucketCloudUrlReader implements UrlReaderService {
     });
   }
 
-  async search(url: string, options?: SearchOptions): Promise<SearchResponse> {
+  async search(
+    url: string,
+    options?: UrlReaderSearchOptions,
+  ): Promise<UrlReaderSearchResponse> {
     const { filepath } = parseGitUrl(url);
     const matcher = new Minimatch(filepath);
 

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/BitbucketServerUrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/BitbucketServerUrlReader.ts
@@ -31,12 +31,12 @@ import { ReaderFactory, ReadTreeResponseFactory } from './types';
 import { ReadUrlResponseFactory } from './ReadUrlResponseFactory';
 import { parseLastModified } from './util';
 import {
-  ReadTreeOptions,
-  ReadTreeResponse,
-  ReadUrlOptions,
-  ReadUrlResponse,
-  SearchOptions,
-  SearchResponse,
+  UrlReaderReadTreeOptions,
+  UrlReaderReadTreeResponse,
+  UrlReaderReadUrlOptions,
+  UrlReaderReadUrlResponse,
+  UrlReaderSearchOptions,
+  UrlReaderSearchResponse,
   UrlReaderService,
 } from '@backstage/backend-plugin-api';
 
@@ -69,8 +69,8 @@ export class BitbucketServerUrlReader implements UrlReaderService {
 
   async readUrl(
     url: string,
-    options?: ReadUrlOptions,
-  ): Promise<ReadUrlResponse> {
+    options?: UrlReaderReadUrlOptions,
+  ): Promise<UrlReaderReadUrlResponse> {
     const { etag, lastModifiedAfter, signal } = options ?? {};
     const bitbucketUrl = getBitbucketServerFileFetchUrl(
       url,
@@ -124,8 +124,8 @@ export class BitbucketServerUrlReader implements UrlReaderService {
 
   async readTree(
     url: string,
-    options?: ReadTreeOptions,
-  ): Promise<ReadTreeResponse> {
+    options?: UrlReaderReadTreeOptions,
+  ): Promise<UrlReaderReadTreeResponse> {
     const { filepath } = parseGitUrl(url);
 
     const lastCommitShortHash = await this.getLastCommitShortHash(url);
@@ -157,7 +157,10 @@ export class BitbucketServerUrlReader implements UrlReaderService {
     });
   }
 
-  async search(url: string, options?: SearchOptions): Promise<SearchResponse> {
+  async search(
+    url: string,
+    options?: UrlReaderSearchOptions,
+  ): Promise<UrlReaderSearchResponse> {
     const { filepath } = parseGitUrl(url);
     const matcher = new Minimatch(filepath);
 

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/BitbucketUrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/BitbucketUrlReader.ts
@@ -16,12 +16,12 @@
 
 import {
   LoggerService,
-  ReadTreeOptions,
-  ReadTreeResponse,
-  ReadUrlOptions,
-  ReadUrlResponse,
-  SearchOptions,
-  SearchResponse,
+  UrlReaderReadTreeOptions,
+  UrlReaderReadTreeResponse,
+  UrlReaderReadUrlOptions,
+  UrlReaderReadUrlResponse,
+  UrlReaderSearchOptions,
+  UrlReaderSearchResponse,
   UrlReaderService,
 } from '@backstage/backend-plugin-api';
 import { NotFoundError, NotModifiedError } from '@backstage/errors';
@@ -94,8 +94,8 @@ export class BitbucketUrlReader implements UrlReaderService {
 
   async readUrl(
     url: string,
-    options?: ReadUrlOptions,
-  ): Promise<ReadUrlResponse> {
+    options?: UrlReaderReadUrlOptions,
+  ): Promise<UrlReaderReadUrlResponse> {
     const { etag, lastModifiedAfter, signal } = options ?? {};
     const bitbucketUrl = getBitbucketFileFetchUrl(url, this.integration.config);
     const requestOptions = getBitbucketRequestOptions(this.integration.config);
@@ -144,8 +144,8 @@ export class BitbucketUrlReader implements UrlReaderService {
 
   async readTree(
     url: string,
-    options?: ReadTreeOptions,
-  ): Promise<ReadTreeResponse> {
+    options?: UrlReaderReadTreeOptions,
+  ): Promise<UrlReaderReadTreeResponse> {
     const { filepath } = parseGitUrl(url);
 
     const lastCommitShortHash = await this.getLastCommitShortHash(url);
@@ -177,7 +177,10 @@ export class BitbucketUrlReader implements UrlReaderService {
     });
   }
 
-  async search(url: string, options?: SearchOptions): Promise<SearchResponse> {
+  async search(
+    url: string,
+    options?: UrlReaderSearchOptions,
+  ): Promise<UrlReaderSearchResponse> {
     const { filepath } = parseGitUrl(url);
     const matcher = new Minimatch(filepath);
 

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/FetchUrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/FetchUrlReader.ts
@@ -15,10 +15,10 @@
  */
 
 import {
-  ReadTreeResponse,
-  ReadUrlOptions,
-  ReadUrlResponse,
-  SearchResponse,
+  UrlReaderReadTreeResponse,
+  UrlReaderReadUrlOptions,
+  UrlReaderReadUrlResponse,
+  UrlReaderSearchResponse,
   UrlReaderService,
 } from '@backstage/backend-plugin-api';
 import { NotFoundError, NotModifiedError } from '@backstage/errors';
@@ -121,8 +121,8 @@ export class FetchUrlReader implements UrlReaderService {
 
   async readUrl(
     url: string,
-    options?: ReadUrlOptions,
-  ): Promise<ReadUrlResponse> {
+    options?: UrlReaderReadUrlOptions,
+  ): Promise<UrlReaderReadUrlResponse> {
     let response: Response;
     try {
       response = await fetch(url, {
@@ -165,11 +165,11 @@ export class FetchUrlReader implements UrlReaderService {
     throw new Error(message);
   }
 
-  async readTree(): Promise<ReadTreeResponse> {
+  async readTree(): Promise<UrlReaderReadTreeResponse> {
     throw new Error('FetchUrlReader does not implement readTree');
   }
 
-  async search(): Promise<SearchResponse> {
+  async search(): Promise<UrlReaderSearchResponse> {
     throw new Error('FetchUrlReader does not implement search');
   }
 

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/GerritUrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/GerritUrlReader.ts
@@ -38,11 +38,11 @@ import { NotFoundError, NotModifiedError } from '@backstage/errors';
 import { ReadTreeResponseFactory, ReaderFactory } from './types';
 import { Git } from './git';
 import {
-  ReadTreeOptions,
-  ReadTreeResponse,
-  ReadUrlOptions,
-  ReadUrlResponse,
-  SearchResponse,
+  UrlReaderReadTreeOptions,
+  UrlReaderReadTreeResponse,
+  UrlReaderReadUrlOptions,
+  UrlReaderReadUrlResponse,
+  UrlReaderSearchResponse,
   UrlReaderService,
 } from '@backstage/backend-plugin-api';
 
@@ -121,8 +121,8 @@ export class GerritUrlReader implements UrlReaderService {
 
   async readUrl(
     url: string,
-    options?: ReadUrlOptions,
-  ): Promise<ReadUrlResponse> {
+    options?: UrlReaderReadUrlOptions,
+  ): Promise<UrlReaderReadUrlResponse> {
     const apiUrl = getGerritFileContentsApiUrl(this.integration.config, url);
     let response: Response;
     try {
@@ -166,8 +166,8 @@ export class GerritUrlReader implements UrlReaderService {
 
   async readTree(
     url: string,
-    options?: ReadTreeOptions,
-  ): Promise<ReadTreeResponse> {
+    options?: UrlReaderReadTreeOptions,
+  ): Promise<UrlReaderReadTreeResponse> {
     const apiUrl = getGerritBranchApiUrl(this.integration.config, url);
     let response: Response;
     try {
@@ -203,7 +203,7 @@ export class GerritUrlReader implements UrlReaderService {
     return this.readTreeFromGitClone(url, branchInfo.revision, options);
   }
 
-  async search(): Promise<SearchResponse> {
+  async search(): Promise<UrlReaderSearchResponse> {
     throw new Error('GerritReader does not implement search');
   }
 
@@ -215,7 +215,7 @@ export class GerritUrlReader implements UrlReaderService {
   private async readTreeFromGitClone(
     url: string,
     revision: string,
-    options?: ReadTreeOptions,
+    options?: UrlReaderReadTreeOptions,
   ) {
     const { filePath } = parseGerritGitilesUrl(this.integration.config, url);
 
@@ -258,7 +258,7 @@ export class GerritUrlReader implements UrlReaderService {
   private async readTreeFromGitiles(
     url: string,
     revision: string,
-    options?: ReadTreeOptions,
+    options?: UrlReaderReadTreeOptions,
   ) {
     const { branch, filePath, project } = parseGerritGitilesUrl(
       this.integration.config,

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/GiteaUrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/GiteaUrlReader.ts
@@ -33,11 +33,11 @@ import {
 import { Readable } from 'stream';
 import { parseLastModified } from './util';
 import {
-  ReadTreeOptions,
-  ReadTreeResponse,
-  ReadUrlOptions,
-  ReadUrlResponse,
-  SearchResponse,
+  UrlReaderReadTreeOptions,
+  UrlReaderReadTreeResponse,
+  UrlReaderReadUrlOptions,
+  UrlReaderReadUrlResponse,
+  UrlReaderSearchResponse,
   UrlReaderService,
 } from '@backstage/backend-plugin-api';
 
@@ -73,8 +73,8 @@ export class GiteaUrlReader implements UrlReaderService {
 
   async readUrl(
     url: string,
-    options?: ReadUrlOptions,
-  ): Promise<ReadUrlResponse> {
+    options?: UrlReaderReadUrlOptions,
+  ): Promise<UrlReaderReadUrlResponse> {
     let response: Response;
     const blobUrl = getGiteaFileContentsUrl(this.integration.config, url);
 
@@ -125,8 +125,8 @@ export class GiteaUrlReader implements UrlReaderService {
 
   async readTree(
     url: string,
-    options?: ReadTreeOptions,
-  ): Promise<ReadTreeResponse> {
+    options?: UrlReaderReadTreeOptions,
+  ): Promise<UrlReaderReadTreeResponse> {
     const lastCommitHash = await this.getLastCommitHash(url);
     if (options?.etag && options.etag === lastCommitHash) {
       throw new NotModifiedError();
@@ -155,7 +155,7 @@ export class GiteaUrlReader implements UrlReaderService {
     });
   }
 
-  search(): Promise<SearchResponse> {
+  search(): Promise<UrlReaderSearchResponse> {
     throw new Error('GiteaUrlReader search not implemented.');
   }
 

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/GithubUrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/GithubUrlReader.ts
@@ -32,13 +32,13 @@ import { ReadTreeResponseFactory, ReaderFactory } from './types';
 import { ReadUrlResponseFactory } from './ReadUrlResponseFactory';
 import { parseLastModified } from './util';
 import {
-  ReadTreeOptions,
-  ReadTreeResponse,
-  ReadUrlOptions,
-  ReadUrlResponse,
-  SearchOptions,
-  SearchResponse,
-  SearchResponseFile,
+  UrlReaderReadTreeOptions,
+  UrlReaderReadTreeResponse,
+  UrlReaderReadUrlOptions,
+  UrlReaderReadUrlResponse,
+  UrlReaderSearchOptions,
+  UrlReaderSearchResponse,
+  UrlReaderSearchResponseFile,
   UrlReaderService,
 } from '@backstage/backend-plugin-api';
 
@@ -112,8 +112,8 @@ export class GithubUrlReader implements UrlReaderService {
 
   async readUrl(
     url: string,
-    options?: ReadUrlOptions,
-  ): Promise<ReadUrlResponse> {
+    options?: UrlReaderReadUrlOptions,
+  ): Promise<UrlReaderReadUrlResponse> {
     const credentials = await this.getCredentials(url, options);
 
     const ghUrl = getGithubFileFetchUrl(
@@ -148,8 +148,8 @@ export class GithubUrlReader implements UrlReaderService {
 
   async readTree(
     url: string,
-    options?: ReadTreeOptions,
-  ): Promise<ReadTreeResponse> {
+    options?: UrlReaderReadTreeOptions,
+  ): Promise<UrlReaderReadTreeResponse> {
     const repoDetails = await this.getRepoDetails(url);
     const commitSha = repoDetails.commitSha;
 
@@ -175,7 +175,10 @@ export class GithubUrlReader implements UrlReaderService {
     );
   }
 
-  async search(url: string, options?: SearchOptions): Promise<SearchResponse> {
+  async search(
+    url: string,
+    options?: UrlReaderSearchOptions,
+  ): Promise<UrlReaderSearchResponse> {
     const repoDetails = await this.getRepoDetails(url);
     const commitSha = repoDetails.commitSha;
 
@@ -208,8 +211,8 @@ export class GithubUrlReader implements UrlReaderService {
     sha: string,
     subpath: string,
     init: RequestInit,
-    options?: ReadTreeOptions,
-  ): Promise<ReadTreeResponse> {
+    options?: UrlReaderReadTreeOptions,
+  ): Promise<UrlReaderReadTreeResponse> {
     // archive_url looks like "https://api.github.com/repos/owner/repo/{archive_format}{/ref}"
     const archive = await this.fetchResponse(
       archiveUrl
@@ -235,7 +238,7 @@ export class GithubUrlReader implements UrlReaderService {
     sha: string,
     query: string,
     init: RequestInit,
-  ): Promise<SearchResponseFile[]> {
+  ): Promise<UrlReaderSearchResponseFile[]> {
     function pathToUrl(path: string): string {
       // TODO(freben): Use the integration package facility for this instead
       // pathname starts as /backstage/backstage/blob/master/<path>

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/GitlabUrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/GitlabUrlReader.ts
@@ -31,12 +31,12 @@ import { trimEnd, trimStart } from 'lodash';
 import { ReadUrlResponseFactory } from './ReadUrlResponseFactory';
 import { parseLastModified } from './util';
 import {
-  ReadTreeOptions,
-  ReadTreeResponse,
-  ReadUrlOptions,
-  ReadUrlResponse,
-  SearchOptions,
-  SearchResponse,
+  UrlReaderReadTreeOptions,
+  UrlReaderReadTreeResponse,
+  UrlReaderReadUrlOptions,
+  UrlReaderReadUrlResponse,
+  UrlReaderSearchOptions,
+  UrlReaderSearchResponse,
   UrlReaderService,
 } from '@backstage/backend-plugin-api';
 
@@ -69,8 +69,8 @@ export class GitlabUrlReader implements UrlReaderService {
 
   async readUrl(
     url: string,
-    options?: ReadUrlOptions,
-  ): Promise<ReadUrlResponse> {
+    options?: UrlReaderReadUrlOptions,
+  ): Promise<UrlReaderReadUrlResponse> {
     const { etag, lastModifiedAfter, signal } = options ?? {};
     const builtUrl = await this.getGitlabFetchUrl(url);
 
@@ -118,8 +118,8 @@ export class GitlabUrlReader implements UrlReaderService {
 
   async readTree(
     url: string,
-    options?: ReadTreeOptions,
-  ): Promise<ReadTreeResponse> {
+    options?: UrlReaderReadTreeOptions,
+  ): Promise<UrlReaderReadTreeResponse> {
     const { etag, signal } = options ?? {};
     const { ref, full_name, filepath } = parseGitUrl(url);
 
@@ -235,7 +235,10 @@ export class GitlabUrlReader implements UrlReaderService {
     });
   }
 
-  async search(url: string, options?: SearchOptions): Promise<SearchResponse> {
+  async search(
+    url: string,
+    options?: UrlReaderSearchOptions,
+  ): Promise<UrlReaderSearchResponse> {
     const { filepath } = parseGitUrl(url);
     const staticPart = this.getStaticPart(filepath);
     const matcher = new Minimatch(filepath);

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/GoogleGcsUrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/GoogleGcsUrlReader.ts
@@ -25,10 +25,10 @@ import { Readable } from 'stream';
 import { ReadUrlResponseFactory } from './ReadUrlResponseFactory';
 import packageinfo from '../../../../package.json';
 import {
-  ReadTreeResponse,
-  ReadUrlOptions,
-  ReadUrlResponse,
-  SearchResponse,
+  UrlReaderReadTreeResponse,
+  UrlReaderReadUrlOptions,
+  UrlReaderReadUrlResponse,
+  UrlReaderSearchResponse,
   UrlReaderService,
 } from '@backstage/backend-plugin-api';
 
@@ -106,18 +106,18 @@ export class GoogleGcsUrlReader implements UrlReaderService {
 
   async readUrl(
     url: string,
-    _options?: ReadUrlOptions,
-  ): Promise<ReadUrlResponse> {
+    _options?: UrlReaderReadUrlOptions,
+  ): Promise<UrlReaderReadUrlResponse> {
     // TODO etag is not implemented yet.
     const stream = this.readStreamFromUrl(url);
     return ReadUrlResponseFactory.fromReadable(stream);
   }
 
-  async readTree(): Promise<ReadTreeResponse> {
+  async readTree(): Promise<UrlReaderReadTreeResponse> {
     throw new Error('GcsUrlReader does not implement readTree');
   }
 
-  async search(url: string): Promise<SearchResponse> {
+  async search(url: string): Promise<UrlReaderSearchResponse> {
     const { bucket, key: pattern } = parseURL(url);
 
     if (!pattern.endsWith('*') || pattern.indexOf('*') !== pattern.length - 1) {

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/HarnessUrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/HarnessUrlReader.ts
@@ -15,10 +15,10 @@
  */
 
 import {
-  ReadTreeResponse,
-  ReadUrlOptions,
-  ReadUrlResponse,
-  SearchResponse,
+  UrlReaderReadTreeResponse,
+  UrlReaderReadUrlOptions,
+  UrlReaderReadUrlResponse,
+  UrlReaderSearchResponse,
   UrlReaderService,
 } from '@backstage/backend-plugin-api';
 import {
@@ -65,8 +65,8 @@ export class HarnessUrlReader implements UrlReaderService {
 
   async readUrl(
     url: string,
-    options?: ReadUrlOptions,
-  ): Promise<ReadUrlResponse> {
+    options?: UrlReaderReadUrlOptions,
+  ): Promise<UrlReaderReadUrlResponse> {
     let response: Response;
     const blobUrl = getHarnessFileContentsUrl(this.integration.config, url);
 
@@ -111,10 +111,10 @@ export class HarnessUrlReader implements UrlReaderService {
     throw new Error(message);
   }
 
-  readTree(): Promise<ReadTreeResponse> {
+  readTree(): Promise<UrlReaderReadTreeResponse> {
     throw new Error('HarnessUrlReader readTree not implemented.');
   }
-  search(): Promise<SearchResponse> {
+  search(): Promise<UrlReaderSearchResponse> {
     throw new Error('HarnessUrlReader search not implemented.');
   }
 

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/ReadUrlResponseFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/ReadUrlResponseFactory.ts
@@ -18,7 +18,7 @@ import { ConflictError } from '@backstage/errors';
 import getRawBody from 'raw-body';
 import { Readable } from 'stream';
 import { ReadUrlResponseFactoryFromStreamOptions } from './types';
-import { ReadUrlResponse } from '@backstage/backend-plugin-api';
+import { UrlReaderReadUrlResponse } from '@backstage/backend-plugin-api';
 
 /**
  * Utility class for UrlReader implementations to create valid ReadUrlResponse
@@ -33,7 +33,7 @@ export class ReadUrlResponseFactory {
   static async fromReadable(
     stream: Readable,
     options?: ReadUrlResponseFactoryFromStreamOptions,
-  ): Promise<ReadUrlResponse> {
+  ): Promise<UrlReaderReadUrlResponse> {
     // Reference to eventual buffer enables callers to call buffer() multiple
     // times without consequence.
     let buffer: Promise<Buffer>;
@@ -69,7 +69,7 @@ export class ReadUrlResponseFactory {
   static async fromNodeJSReadable(
     oldStyleStream: NodeJS.ReadableStream,
     options?: ReadUrlResponseFactoryFromStreamOptions,
-  ): Promise<ReadUrlResponse> {
+  ): Promise<UrlReaderReadUrlResponse> {
     const readable = Readable.from(oldStyleStream);
     return ReadUrlResponseFactory.fromReadable(readable, options);
   }

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/UrlReaderPredicateMux.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/UrlReaderPredicateMux.ts
@@ -17,12 +17,12 @@
 import { NotAllowedError } from '@backstage/errors';
 import { UrlReaderPredicateTuple } from './types';
 import {
-  ReadTreeOptions,
-  ReadTreeResponse,
-  ReadUrlOptions,
-  ReadUrlResponse,
-  SearchOptions,
-  SearchResponse,
+  UrlReaderReadTreeOptions,
+  UrlReaderReadTreeResponse,
+  UrlReaderReadUrlOptions,
+  UrlReaderReadUrlResponse,
+  UrlReaderSearchOptions,
+  UrlReaderSearchResponse,
   UrlReaderService,
 } from '@backstage/backend-plugin-api';
 
@@ -47,8 +47,8 @@ export class UrlReaderPredicateMux implements UrlReaderService {
 
   async readUrl(
     url: string,
-    options?: ReadUrlOptions,
-  ): Promise<ReadUrlResponse> {
+    options?: UrlReaderReadUrlOptions,
+  ): Promise<UrlReaderReadUrlResponse> {
     const parsed = new URL(url);
 
     for (const { predicate, reader } of this.readers) {
@@ -62,8 +62,8 @@ export class UrlReaderPredicateMux implements UrlReaderService {
 
   async readTree(
     url: string,
-    options?: ReadTreeOptions,
-  ): Promise<ReadTreeResponse> {
+    options?: UrlReaderReadTreeOptions,
+  ): Promise<UrlReaderReadTreeResponse> {
     const parsed = new URL(url);
 
     for (const { predicate, reader } of this.readers) {
@@ -75,7 +75,10 @@ export class UrlReaderPredicateMux implements UrlReaderService {
     throw new NotAllowedError(notAllowedMessage(url));
   }
 
-  async search(url: string, options?: SearchOptions): Promise<SearchResponse> {
+  async search(
+    url: string,
+    options?: UrlReaderSearchOptions,
+  ): Promise<UrlReaderSearchResponse> {
     const parsed = new URL(url);
 
     for (const { predicate, reader } of this.readers) {

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/tree/ReadTreeResponseFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/tree/ReadTreeResponseFactory.ts
@@ -24,7 +24,7 @@ import {
 import { TarArchiveResponse } from './TarArchiveResponse';
 import { ZipArchiveResponse } from './ZipArchiveResponse';
 import { ReadableArrayResponse } from './ReadableArrayResponse';
-import { ReadTreeResponse } from '@backstage/backend-plugin-api';
+import { UrlReaderReadTreeResponse } from '@backstage/backend-plugin-api';
 
 export class DefaultReadTreeResponseFactory implements ReadTreeResponseFactory {
   static create(options: { config: Config }): DefaultReadTreeResponseFactory {
@@ -40,7 +40,7 @@ export class DefaultReadTreeResponseFactory implements ReadTreeResponseFactory {
     options: ReadTreeResponseFactoryOptions & {
       stripFirstDirectory?: boolean;
     },
-  ): Promise<ReadTreeResponse> {
+  ): Promise<UrlReaderReadTreeResponse> {
     return new TarArchiveResponse(
       options.stream,
       options.subpath ?? '',
@@ -53,7 +53,7 @@ export class DefaultReadTreeResponseFactory implements ReadTreeResponseFactory {
 
   async fromZipArchive(
     options: ReadTreeResponseFactoryOptions,
-  ): Promise<ReadTreeResponse> {
+  ): Promise<UrlReaderReadTreeResponse> {
     return new ZipArchiveResponse(
       options.stream,
       options.subpath ?? '',
@@ -65,7 +65,7 @@ export class DefaultReadTreeResponseFactory implements ReadTreeResponseFactory {
 
   async fromReadableArray(
     options: FromReadableArrayOptions,
-  ): Promise<ReadTreeResponse> {
+  ): Promise<UrlReaderReadTreeResponse> {
     return new ReadableArrayResponse(options, this.workDir, '');
   }
 }

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/tree/ReadableArrayResponse.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/tree/ReadableArrayResponse.ts
@@ -22,9 +22,9 @@ import { promisify } from 'util';
 import tar from 'tar';
 import { pipeline as pipelineCb, Readable } from 'stream';
 import {
-  ReadTreeResponse,
-  ReadTreeResponseDirOptions,
-  ReadTreeResponseFile,
+  UrlReaderReadTreeResponse,
+  UrlReaderReadTreeResponseDirOptions,
+  UrlReaderReadTreeResponseFile,
 } from '@backstage/backend-plugin-api';
 import { FromReadableArrayOptions } from '../types';
 
@@ -33,7 +33,7 @@ const pipeline = promisify(pipelineCb);
 /**
  * Wraps a array of Readable objects into a tree response reader.
  */
-export class ReadableArrayResponse implements ReadTreeResponse {
+export class ReadableArrayResponse implements UrlReaderReadTreeResponse {
   private read = false;
 
   constructor(
@@ -52,10 +52,10 @@ export class ReadableArrayResponse implements ReadTreeResponse {
     this.read = true;
   }
 
-  async files(): Promise<ReadTreeResponseFile[]> {
+  async files(): Promise<UrlReaderReadTreeResponseFile[]> {
     this.onlyOnce();
 
-    const files = Array<ReadTreeResponseFile>();
+    const files = Array<UrlReaderReadTreeResponseFile>();
 
     for (let i = 0; i < this.stream.length; i++) {
       if (!this.stream[i].path.endsWith('/')) {
@@ -86,7 +86,7 @@ export class ReadableArrayResponse implements ReadTreeResponse {
     }
   }
 
-  async dir(options?: ReadTreeResponseDirOptions): Promise<string> {
+  async dir(options?: UrlReaderReadTreeResponseDirOptions): Promise<string> {
     this.onlyOnce();
 
     const dir =

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/tree/TarArchiveResponse.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/tree/TarArchiveResponse.ts
@@ -15,9 +15,9 @@
  */
 
 import {
-  ReadTreeResponse,
-  ReadTreeResponseDirOptions,
-  ReadTreeResponseFile,
+  UrlReaderReadTreeResponse,
+  UrlReaderReadTreeResponseDirOptions,
+  UrlReaderReadTreeResponseFile,
 } from '@backstage/backend-plugin-api';
 import concatStream from 'concat-stream';
 import fs from 'fs-extra';
@@ -35,7 +35,7 @@ const pipeline = promisify(pipelineCb);
 /**
  * Wraps a tar archive stream into a tree response reader.
  */
-export class TarArchiveResponse implements ReadTreeResponse {
+export class TarArchiveResponse implements UrlReaderReadTreeResponse {
   private read = false;
 
   constructor(
@@ -68,10 +68,10 @@ export class TarArchiveResponse implements ReadTreeResponse {
     this.read = true;
   }
 
-  async files(): Promise<ReadTreeResponseFile[]> {
+  async files(): Promise<UrlReaderReadTreeResponseFile[]> {
     this.onlyOnce();
 
-    const files = Array<ReadTreeResponseFile>();
+    const files = Array<UrlReaderReadTreeResponseFile>();
     const parser = new TarParseStream();
 
     parser.on('entry', (entry: ReadEntry & Readable) => {
@@ -142,7 +142,7 @@ export class TarArchiveResponse implements ReadTreeResponse {
     }
   }
 
-  async dir(options?: ReadTreeResponseDirOptions): Promise<string> {
+  async dir(options?: UrlReaderReadTreeResponseDirOptions): Promise<string> {
     this.onlyOnce();
 
     const dir =

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/tree/ZipArchiveResponse.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/tree/ZipArchiveResponse.ts
@@ -15,9 +15,9 @@
  */
 
 import {
-  ReadTreeResponse,
-  ReadTreeResponseDirOptions,
-  ReadTreeResponseFile,
+  UrlReaderReadTreeResponse,
+  UrlReaderReadTreeResponseDirOptions,
+  UrlReaderReadTreeResponseFile,
   resolveSafeChildPath,
 } from '@backstage/backend-plugin-api';
 import archiver from 'archiver';
@@ -30,7 +30,7 @@ import { streamToBuffer } from './util';
 /**
  * Wraps a zip archive stream into a tree response reader.
  */
-export class ZipArchiveResponse implements ReadTreeResponse {
+export class ZipArchiveResponse implements UrlReaderReadTreeResponse {
   private read = false;
 
   constructor(
@@ -141,9 +141,9 @@ export class ZipArchiveResponse implements ReadTreeResponse {
     });
   }
 
-  async files(): Promise<ReadTreeResponseFile[]> {
+  async files(): Promise<UrlReaderReadTreeResponseFile[]> {
     this.onlyOnce();
-    const files = Array<ReadTreeResponseFile>();
+    const files = Array<UrlReaderReadTreeResponseFile>();
     const temporary = await this.streamToTemporaryFile(this.stream);
 
     await this.forEveryZipEntry(temporary.fileName, async (entry, content) => {
@@ -184,7 +184,7 @@ export class ZipArchiveResponse implements ReadTreeResponse {
     return archive;
   }
 
-  async dir(options?: ReadTreeResponseDirOptions): Promise<string> {
+  async dir(options?: UrlReaderReadTreeResponseDirOptions): Promise<string> {
     this.onlyOnce();
     const dir =
       options?.targetDir ??

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/types.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/types.ts
@@ -18,7 +18,7 @@ import { Readable } from 'stream';
 import { Config } from '@backstage/config';
 import {
   UrlReaderService,
-  ReadTreeResponse,
+  UrlReaderReadTreeResponse,
   LoggerService,
 } from '@backstage/backend-plugin-api';
 
@@ -110,11 +110,11 @@ export interface ReadTreeResponseFactory {
        */
       stripFirstDirectory?: boolean;
     },
-  ): Promise<ReadTreeResponse>;
+  ): Promise<UrlReaderReadTreeResponse>;
   fromZipArchive(
     options: ReadTreeResponseFactoryOptions,
-  ): Promise<ReadTreeResponse>;
+  ): Promise<UrlReaderReadTreeResponse>;
   fromReadableArray(
     options: FromReadableArrayOptions,
-  ): Promise<ReadTreeResponse>;
+  ): Promise<UrlReaderReadTreeResponse>;
 }

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -461,54 +461,23 @@ export function readSchedulerServiceTaskScheduleDefinitionFromConfig(
   config: Config,
 ): SchedulerServiceTaskScheduleDefinition;
 
-// @public
-export type ReadTreeOptions = {
-  filter?(
-    path: string,
-    info?: {
-      size: number;
-    },
-  ): boolean;
-  etag?: string;
-  signal?: AbortSignal;
-  token?: string;
-};
+// @public @deprecated (undocumented)
+export type ReadTreeOptions = UrlReaderReadTreeOptions;
 
-// @public
-export type ReadTreeResponse = {
-  files(): Promise<ReadTreeResponseFile[]>;
-  archive(): Promise<NodeJS.ReadableStream>;
-  dir(options?: ReadTreeResponseDirOptions): Promise<string>;
-  etag: string;
-};
+// @public @deprecated (undocumented)
+export type ReadTreeResponse = UrlReaderReadTreeResponse;
 
-// @public
-export type ReadTreeResponseDirOptions = {
-  targetDir?: string;
-};
+// @public @deprecated (undocumented)
+export type ReadTreeResponseDirOptions = UrlReaderReadTreeResponseDirOptions;
 
-// @public
-export type ReadTreeResponseFile = {
-  path: string;
-  content(): Promise<Buffer>;
-  lastModifiedAt?: Date;
-};
+// @public @deprecated (undocumented)
+export type ReadTreeResponseFile = UrlReaderReadTreeResponseFile;
 
-// @public
-export type ReadUrlOptions = {
-  etag?: string;
-  lastModifiedAfter?: Date;
-  signal?: AbortSignal;
-  token?: string;
-};
+// @public @deprecated (undocumented)
+export type ReadUrlOptions = UrlReaderReadUrlOptions;
 
-// @public
-export type ReadUrlResponse = {
-  buffer(): Promise<Buffer>;
-  stream?(): Readable;
-  etag?: string;
-  lastModifiedAt?: Date;
-};
+// @public @deprecated (undocumented)
+export type ReadUrlResponse = UrlReaderReadUrlResponse;
 
 // @public
 export function resolvePackagePath(name: string, ...paths: string[]): string;
@@ -612,25 +581,14 @@ export interface SchedulerServiceTaskScheduleDefinitionConfig {
   timeout: string | HumanDuration;
 }
 
-// @public
-export type SearchOptions = {
-  etag?: string;
-  signal?: AbortSignal;
-  token?: string;
-};
+// @public @deprecated (undocumented)
+export type SearchOptions = UrlReaderSearchOptions;
 
-// @public
-export type SearchResponse = {
-  files: SearchResponseFile[];
-  etag: string;
-};
+// @public @deprecated (undocumented)
+export type SearchResponse = UrlReaderSearchResponse;
 
-// @public
-export type SearchResponseFile = {
-  url: string;
-  content(): Promise<Buffer>;
-  lastModifiedAt?: Date;
-};
+// @public @deprecated (undocumented)
+export type SearchResponseFile = UrlReaderSearchResponseFile;
 
 // @public (undocumented)
 export interface ServiceFactory<
@@ -676,10 +634,88 @@ export interface TokenManagerService {
 }
 
 // @public
+export type UrlReaderReadTreeOptions = {
+  filter?(
+    path: string,
+    info?: {
+      size: number;
+    },
+  ): boolean;
+  etag?: string;
+  signal?: AbortSignal;
+  token?: string;
+};
+
+// @public
+export type UrlReaderReadTreeResponse = {
+  files(): Promise<UrlReaderReadTreeResponseFile[]>;
+  archive(): Promise<NodeJS.ReadableStream>;
+  dir(options?: UrlReaderReadTreeResponseDirOptions): Promise<string>;
+  etag: string;
+};
+
+// @public
+export type UrlReaderReadTreeResponseDirOptions = {
+  targetDir?: string;
+};
+
+// @public
+export type UrlReaderReadTreeResponseFile = {
+  path: string;
+  content(): Promise<Buffer>;
+  lastModifiedAt?: Date;
+};
+
+// @public
+export type UrlReaderReadUrlOptions = {
+  etag?: string;
+  lastModifiedAfter?: Date;
+  signal?: AbortSignal;
+  token?: string;
+};
+
+// @public
+export type UrlReaderReadUrlResponse = {
+  buffer(): Promise<Buffer>;
+  stream?(): Readable;
+  etag?: string;
+  lastModifiedAt?: Date;
+};
+
+// @public
+export type UrlReaderSearchOptions = {
+  etag?: string;
+  signal?: AbortSignal;
+  token?: string;
+};
+
+// @public
+export type UrlReaderSearchResponse = {
+  files: UrlReaderSearchResponseFile[];
+  etag: string;
+};
+
+// @public
+export type UrlReaderSearchResponseFile = {
+  url: string;
+  content(): Promise<Buffer>;
+  lastModifiedAt?: Date;
+};
+
+// @public
 export interface UrlReaderService {
-  readTree(url: string, options?: ReadTreeOptions): Promise<ReadTreeResponse>;
-  readUrl(url: string, options?: ReadUrlOptions): Promise<ReadUrlResponse>;
-  search(url: string, options?: SearchOptions): Promise<SearchResponse>;
+  readTree(
+    url: string,
+    options?: UrlReaderReadTreeOptions,
+  ): Promise<UrlReaderReadTreeResponse>;
+  readUrl(
+    url: string,
+    options?: UrlReaderReadUrlOptions,
+  ): Promise<UrlReaderReadUrlResponse>;
+  search(
+    url: string,
+    options?: UrlReaderSearchOptions,
+  ): Promise<UrlReaderSearchResponse>;
 }
 
 // @public (undocumented)

--- a/packages/backend-plugin-api/src/services/definitions/UrlReaderService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/UrlReaderService.ts
@@ -25,17 +25,26 @@ export interface UrlReaderService {
   /**
    * Reads a single file and return its content.
    */
-  readUrl(url: string, options?: ReadUrlOptions): Promise<ReadUrlResponse>;
+  readUrl(
+    url: string,
+    options?: UrlReaderReadUrlOptions,
+  ): Promise<UrlReaderReadUrlResponse>;
 
   /**
    * Reads a full or partial file tree.
    */
-  readTree(url: string, options?: ReadTreeOptions): Promise<ReadTreeResponse>;
+  readTree(
+    url: string,
+    options?: UrlReaderReadTreeOptions,
+  ): Promise<UrlReaderReadTreeResponse>;
 
   /**
    * Searches for a file in a tree using a glob pattern.
    */
-  search(url: string, options?: SearchOptions): Promise<SearchResponse>;
+  search(
+    url: string,
+    options?: UrlReaderSearchOptions,
+  ): Promise<UrlReaderSearchResponse>;
 }
 
 /**
@@ -43,7 +52,7 @@ export interface UrlReaderService {
  *
  * @public
  */
-export type ReadUrlOptions = {
+export type UrlReaderReadUrlOptions = {
   /**
    * An ETag which can be provided to check whether a
    * {@link UrlReaderService.readUrl} response has changed from a previous execution.
@@ -54,7 +63,7 @@ export type ReadUrlOptions = {
    * the data. The ETag is a unique identifier of the data, usually the commit
    * SHA or ETag from the target.
    *
-   * When an ETag is given in ReadUrlOptions, {@link UrlReaderService.readUrl} will
+   * When an ETag is given in these options, {@link UrlReaderService.readUrl} will
    * first compare the ETag against the ETag of the target. If they match,
    * {@link UrlReaderService.readUrl} will throw a
    * {@link @backstage/errors#NotModifiedError} indicating that the response
@@ -111,7 +120,7 @@ export type ReadUrlOptions = {
  *
  * @public
  */
-export type ReadUrlResponse = {
+export type UrlReaderReadUrlResponse = {
   /**
    * Returns the data that was read from the remote URL.
    */
@@ -146,7 +155,7 @@ export type ReadUrlResponse = {
  *
  * @public
  */
-export type ReadTreeOptions = {
+export type UrlReaderReadTreeOptions = {
   /**
    * A filter that can be used to select which files should be included.
    *
@@ -206,11 +215,11 @@ export type ReadTreeOptions = {
 };
 
 /**
- * Options that control {@link ReadTreeResponse.dir} execution.
+ * Options that control {@link UrlReaderReadTreeResponse.dir} execution.
  *
  * @public
  */
-export type ReadTreeResponseDirOptions = {
+export type UrlReaderReadTreeResponseDirOptions = {
   /**
    * The directory to write files to.
    *
@@ -226,12 +235,12 @@ export type ReadTreeResponseDirOptions = {
  *
  * @public
  */
-export type ReadTreeResponse = {
+export type UrlReaderReadTreeResponse = {
   /**
    * Returns an array of all the files inside the tree, and corresponding
    * functions to read their content.
    */
-  files(): Promise<ReadTreeResponseFile[]>;
+  files(): Promise<UrlReaderReadTreeResponseFile[]>;
 
   /**
    * Returns the tree contents as a binary archive, using a stream.
@@ -244,7 +253,7 @@ export type ReadTreeResponse = {
    *
    * **NOTE**: It is the responsibility of the caller to remove the directory after use.
    */
-  dir(options?: ReadTreeResponseDirOptions): Promise<string>;
+  dir(options?: UrlReaderReadTreeResponseDirOptions): Promise<string>;
 
   /**
    * Etag returned by content provider.
@@ -261,7 +270,7 @@ export type ReadTreeResponse = {
  *
  * @public
  */
-export type ReadTreeResponseFile = {
+export type UrlReaderReadTreeResponseFile = {
   /**
    * The filepath of the data.
    */
@@ -283,7 +292,7 @@ export type ReadTreeResponseFile = {
  *
  * @public
  */
-export type SearchOptions = {
+export type UrlReaderSearchOptions = {
   /**
    * An etag can be provided to check whether the search response has changed from a previous execution.
    *
@@ -324,11 +333,11 @@ export type SearchOptions = {
  *
  * @public
  */
-export type SearchResponse = {
+export type UrlReaderSearchResponse = {
   /**
    * The files that matched the search query.
    */
-  files: SearchResponseFile[];
+  files: UrlReaderSearchResponseFile[];
 
   /**
    * A unique identifier of the current remote tree, usually the commit SHA or etag from the target.
@@ -341,7 +350,7 @@ export type SearchResponse = {
  *
  * @public
  */
-export type SearchResponseFile = {
+export type UrlReaderSearchResponseFile = {
   /**
    * The full URL to the file.
    */
@@ -357,3 +366,49 @@ export type SearchResponseFile = {
    */
   lastModifiedAt?: Date;
 };
+
+/**
+ * @public
+ * @deprecated Use `UrlReaderReadTreeOptions` instead
+ */
+export type ReadTreeOptions = UrlReaderReadTreeOptions;
+/**
+ * @public
+ * @deprecated Use `UrlReaderReadTreeResponse` instead
+ */
+export type ReadTreeResponse = UrlReaderReadTreeResponse;
+/**
+ * @public
+ * @deprecated Use `UrlReaderReadTreeResponseDirOptions` instead
+ */
+export type ReadTreeResponseDirOptions = UrlReaderReadTreeResponseDirOptions;
+/**
+ * @public
+ * @deprecated Use `UrlReaderReadTreeResponseFile` instead
+ */
+export type ReadTreeResponseFile = UrlReaderReadTreeResponseFile;
+/**
+ * @public
+ * @deprecated Use `UrlReaderReadUrlResponse` instead
+ */
+export type ReadUrlResponse = UrlReaderReadUrlResponse;
+/**
+ * @public
+ * @deprecated Use `UrlReaderReadUrlOptions` instead
+ */
+export type ReadUrlOptions = UrlReaderReadUrlOptions;
+/**
+ * @public
+ * @deprecated Use `UrlReaderSearchOptions` instead
+ */
+export type SearchOptions = UrlReaderSearchOptions;
+/**
+ * @public
+ * @deprecated Use `UrlReaderSearchResponse` instead
+ */
+export type SearchResponse = UrlReaderSearchResponse;
+/**
+ * @public
+ * @deprecated Use `UrlReaderSearchResponseFile` instead
+ */
+export type SearchResponseFile = UrlReaderSearchResponseFile;

--- a/packages/backend-plugin-api/src/services/definitions/index.ts
+++ b/packages/backend-plugin-api/src/services/definitions/index.ts
@@ -65,6 +65,16 @@ export type {
 } from './SchedulerService';
 export type { TokenManagerService } from './TokenManagerService';
 export type {
+  UrlReaderReadTreeOptions,
+  UrlReaderReadTreeResponse,
+  UrlReaderReadTreeResponseDirOptions,
+  UrlReaderReadTreeResponseFile,
+  UrlReaderReadUrlResponse,
+  UrlReaderReadUrlOptions,
+  UrlReaderSearchOptions,
+  UrlReaderSearchResponse,
+  UrlReaderSearchResponseFile,
+  UrlReaderService,
   ReadTreeOptions,
   ReadTreeResponse,
   ReadTreeResponseDirOptions,
@@ -74,7 +84,6 @@ export type {
   SearchOptions,
   SearchResponse,
   SearchResponseFile,
-  UrlReaderService,
 } from './UrlReaderService';
 export type { BackstageUserInfo, UserInfoService } from './UserInfoService';
 export type { IdentityService } from './IdentityService';


### PR DESCRIPTION
This is a continuation of https://github.com/backstage/backstage/pull/24724, ensuring that the `UrlReader` related types in `@backstage/backend-plugin-api` have nice prefixes.

Note that it's on top of https://github.com/backstage/backstage/pull/24849, which should be merged first. But therefore, piggybacking on its changesets.