### PR TITLE
Having overflowTooltip inherit font size

### DIFF
--- a/.changeset/brown-bananas-talk.md
+++ b/.changeset/brown-bananas-talk.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Having tooltip inherit font size for consistency in catalog table columns

--- a/packages/core-components/src/components/OverflowTooltip/OverflowTooltip.tsx
+++ b/packages/core-components/src/components/OverflowTooltip/OverflowTooltip.tsx
@@ -34,6 +34,7 @@ const useStyles = makeStyles(
       overflow: 'visible !important',
     },
     typo: {
+      fontSize: 'inherit',
       overflow: 'hidden',
       textOverflow: 'ellipsis',
       display: '-webkit-box',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Noticed the description column was a different size font in our catalog tables, changing font inheritance in the tooltip to make it consistent
Before:
<img width="1057" alt="Screenshot 2024-05-21 at 1 58 30 PM" src="https://github.com/backstage/backstage/assets/7171310/3c4fc553-8984-44aa-8a86-0fb869f6bc20">

After:
<img width="1030" alt="Screenshot 2024-05-21 at 1 56 54 PM" src="https://github.com/backstage/backstage/assets/7171310/683a8aa3-a46c-4b89-b1ab-10ed214cd125">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
