### PR TITLE
Bugfix: handle missing orgEnabled config key gracefully

### DIFF
--- a/.changeset/nine-hairs-kick.md
+++ b/.changeset/nine-hairs-kick.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend-module-gitlab': patch
 ---
 
-Fixed an issue in `GitlabOrgDiscoveryEntityProvider` where a missing `orgEnabled`config key was throwing an error instead of just returning.
+Fixed an issue in `GitlabOrgDiscoveryEntityProvider` where a missing `orgEnabled` config key was throwing an error.

--- a/.changeset/nine-hairs-kick.md
+++ b/.changeset/nine-hairs-kick.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-gitlab': patch
+---
+
+Fixed an issue in `GitlabOrgDiscoveryEntityProvider` where a missing `orgEnabled`config key was throwing an error instead of just returning.

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.test.ts
@@ -75,16 +75,16 @@ describe('GitlabOrgDiscoveryEntityProvider - configuration', () => {
     }).toThrow('No gitlab integration found that matches host example.com');
   });
 
-  it('should throw error when org configuration not found', () => {
+  it('should log a message and return when org configuration not found', () => {
     const schedule = new PersistingTaskRunner();
     const config = new ConfigReader(mock.config_no_org_integration);
 
-    expect(() => {
-      GitlabOrgDiscoveryEntityProvider.fromConfig(config, {
-        logger,
-        schedule,
-      });
-    }).toThrow('Org not enabled for test-id');
+    GitlabOrgDiscoveryEntityProvider.fromConfig(config, {
+      logger,
+      schedule,
+    });
+
+    expect(logger.info).toHaveBeenCalledWith('Org not enabled for test-id.');
   });
 
   it('should throw error when saas without group configuration', () => {

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { LoggerService } from '@backstage/backend-plugin-api';
 import { PluginTaskScheduler, TaskRunner } from '@backstage/backend-tasks';
 import {
   ANNOTATION_LOCATION,
@@ -28,7 +29,6 @@ import {
 import { EventsService } from '@backstage/plugin-events-node';
 import { merge } from 'lodash';
 import * as uuid from 'uuid';
-import { LoggerService } from '@backstage/backend-plugin-api';
 
 import {
   GitLabClient,
@@ -133,7 +133,8 @@ export class GitlabOrgDiscoveryEntityProvider implements EntityProvider {
       const integration = integrations.byHost(providerConfig.host);
 
       if (!providerConfig.orgEnabled) {
-        throw new Error(`Org not enabled for ${providerConfig.id}.`);
+        options.logger.info(`Org not enabled for ${providerConfig.id}.`);
+        return;
       }
 
       if (!integration) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes an introduced bug in the GitlabOrgDiscoveryEntityProvider where an error was thrown when the orgEnabled config key was missing, instead of simply returning.
This fixes #24857

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
