### PR TITLE
permission-node: remove references from backend-common

### DIFF
--- a/.changeset/selfish-pugs-lick.md
+++ b/.changeset/selfish-pugs-lick.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-permission-node': patch
+---
+
+Import `tokenManager` definition from `@backstage/backend-plugin-api`

--- a/plugins/permission-node/api-report.md
+++ b/plugins/permission-node/api-report.md
@@ -25,7 +25,7 @@ import { PermissionsServiceRequestOptions } from '@backstage/backend-plugin-api'
 import { PolicyDecision } from '@backstage/plugin-permission-common';
 import { QueryPermissionRequest } from '@backstage/plugin-permission-common';
 import { ResourcePermission } from '@backstage/plugin-permission-common';
-import { TokenManager } from '@backstage/backend-common';
+import { TokenManagerService } from '@backstage/backend-plugin-api';
 import { z } from 'zod';
 import zodToJsonSchema from 'zod-to-json-schema';
 
@@ -289,7 +289,7 @@ export class ServerPermissionClient implements PermissionsService {
     config: Config,
     options: {
       discovery: DiscoveryService;
-      tokenManager: TokenManager;
+      tokenManager: TokenManagerService;
       auth?: AuthService;
     },
   ): ServerPermissionClient;

--- a/plugins/permission-node/src/ServerPermissionClient.ts
+++ b/plugins/permission-node/src/ServerPermissionClient.ts
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  TokenManager,
-  createLegacyAuthAdapters,
-} from '@backstage/backend-common';
+import { createLegacyAuthAdapters } from '@backstage/backend-common';
 import {
   AuthService,
   BackstageCredentials,
@@ -25,6 +22,7 @@ import {
   DiscoveryService,
   PermissionsService,
   PermissionsServiceRequestOptions,
+  TokenManagerService,
 } from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
 import {
@@ -53,7 +51,7 @@ export class ServerPermissionClient implements PermissionsService {
     config: Config,
     options: {
       discovery: DiscoveryService;
-      tokenManager: TokenManager;
+      tokenManager: TokenManagerService;
       auth?: AuthService;
     },
   ) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

`tokenManager` definition is now imported from `@backstage/backend-plugin-api`.

Closes #24869

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
