### PR TITLE
Task Schedule Definition Config Deprecation Correction

### DIFF
--- a/.changeset/forty-adults-roll.md
+++ b/.changeset/forty-adults-roll.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-tasks': patch
+---
+
+Updated the `TaskScheduleDefinitionConfig` deprecated comment to point to `SchedulerServiceTaskScheduleDefinitionConfig`

--- a/packages/backend-tasks/src/tasks/types.ts
+++ b/packages/backend-tasks/src/tasks/types.ts
@@ -157,7 +157,7 @@ export interface TaskScheduleDefinition {
  * that control the scheduling of a task.
  *
  * @public
- * @deprecated Please import `SchedulerServiceTaskDefinitionConfig` from `@backstage/backend-plugin-api` instead
+ * @deprecated Please import `SchedulerServiceTaskScheduleDefinitionConfig` from `@backstage/backend-plugin-api` instead
  */
 export interface TaskScheduleDefinitionConfig {
   /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updated the `TaskScheduleDefinitionConfig` deprecated comment to point to `SchedulerServiceTaskScheduleDefinitionConfig`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
