### PR TITLE
fix jwks fetch with new backend system behind corporate proxy

### DIFF
--- a/.changeset/tender-kangaroos-march.md
+++ b/.changeset/tender-kangaroos-march.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': minor
+---
+
+Fixed plugin token handler to use node-fetch instead of native fetch to support corporate proxies when fetching `jwks.json`. This request will now respect `global-agent` proxy configurations.

--- a/contrib/docs/tutorials/help-im-behind-a-corporate-proxy.md
+++ b/contrib/docs/tutorials/help-im-behind-a-corporate-proxy.md
@@ -56,6 +56,7 @@ There are however some ways to get this to work without too much effort.
 
    ```sh
    export GLOBAL_AGENT_HTTP_PROXY=http://username:password@proxy.example.net:8888
+   export GLOBAL_AGENT_NO_PROXY='localhost:7007' # calls to local backend do not use http proxy e.g. fetching jwks
    yarn start
    ```
 

--- a/packages/backend-app-api/package.json
+++ b/packages/backend-app-api/package.json
@@ -79,6 +79,7 @@
     "minimatch": "^9.0.0",
     "minimist": "^1.2.5",
     "morgan": "^1.10.0",
+    "node-fetch": "^2.6.7",
     "node-forge": "^1.3.1",
     "path-to-regexp": "^6.2.1",
     "selfsigned": "^2.0.0",

--- a/packages/backend-app-api/src/services/implementations/auth/plugin/PluginTokenHandler.ts
+++ b/packages/backend-app-api/src/services/implementations/auth/plugin/PluginTokenHandler.ts
@@ -31,6 +31,7 @@ import { jwtVerify } from 'jose';
 import { tokenTypes } from '@backstage/plugin-auth-node';
 import { JwksClient } from '../JwksClient';
 import { HumanDuration, durationToMilliseconds } from '@backstage/types';
+import fetch from 'node-fetch';
 
 /**
  * The margin for how many times longer we make the public key available

--- a/yarn.lock
+++ b/yarn.lock
@@ -3325,6 +3325,7 @@ __metadata:
     minimist: ^1.2.5
     morgan: ^1.10.0
     msw: ^1.0.0
+    node-fetch: ^2.6.7
     node-forge: ^1.3.1
     path-to-regexp: ^6.2.1
     selfsigned: ^2.0.0


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR fixes issue #24841. With the new backend `PluginTokenHandler.ts:doCheck()` makes a native `fetch` call to get `jwks.json`. This causes an error when Backstage backend is configured to run behind a corporate proxy i.e. following the steps described [here](https://github.com/backstage/backstage/blob/master/contrib/docs/tutorials/help-im-behind-a-corporate-proxy.md). Because of this, the catalog plugin and others will fail to load.

```
[1] 2024-05-21T19:40:38.901Z backstage error Unexpected failure for target JWKS check fetch failed stack=TypeError: fetch failed
[1]     at node:internal/deps/undici/undici:12502:13
[1]     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

Following the guide to setup a proxy, `global-agent` addresses `node-fetch` proxying and `undici` for native fetch. However, unlike `global-agent`, the `undici` package does not support `no_proxy` variables. Therefore, the `fetch` in `PluginTokenHandler.ts:doCheck()` will go thru the http proxy to reach `localhost` and cause an exception.

This PR changes the `fetch` in `PluginTokenHandler.ts:doCheck()` to `node-fetch` which can be configured by the `global-agent` proxy settings. Using the `node-fetch` for backend node ppackages is the recommended approach as referenced in [ADR013](https://github.com/backstage/backstage/blob/master/docs/architecture-decisions/adr013-use-node-fetch.md).

With this change, a user can now configure `GLOBAL_AGENT_NO_PROXY` to fix the exception above. E.g:

```
export GLOBAL_AGENT_NO_PROXY='localhost:7007'
yarn start
```


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
