### PR TITLE
fix: Avoid infinite loop in the NotificationsSidebarItem title counter

### DIFF
--- a/.changeset/little-cooks-approve.md
+++ b/.changeset/little-cooks-approve.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications': patch
+---
+
+Fixes performance issue with Notifications title counter.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #24866


#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
