### PR TITLE
Changing shrinking screen size entity title behavior

### DIFF
--- a/.changeset/cyan-ducks-roll.md
+++ b/.changeset/cyan-ducks-roll.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Having entity title wrap instead of truncate to increase readability and accessibility

--- a/plugins/catalog/src/components/EntityLayout/EntityLayout.tsx
+++ b/plugins/catalog/src/components/EntityLayout/EntityLayout.tsx
@@ -47,6 +47,7 @@ import {
   useAsyncEntity,
 } from '@backstage/plugin-catalog-react';
 import Box from '@material-ui/core/Box';
+import makeStyles from '@material-ui/core/styles/makeStyles';
 import { TabProps } from '@material-ui/core/Tab';
 import Alert from '@material-ui/lab/Alert';
 import React, { useEffect, useState } from 'react';
@@ -63,6 +64,25 @@ export type EntityLayoutRouteProps = {
   tabProps?: TabProps<React.ElementType, { component?: React.ElementType }>;
 };
 
+const useStyles = makeStyles({
+  header: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    minHeight: '1em',
+    maxWidth: '95%',
+  },
+  box: {
+    display: 'flex',
+    flexWrap: 'nowrap',
+    gap: '1em',
+    paddingLeft: '15px',
+    paddingTop: '20px',
+  },
+  labels: {
+    minWidth: '5em',
+  },
+});
+
 const dataKey = 'plugin.catalog.entityLayoutRoute';
 
 const Route: (props: EntityLayoutRouteProps) => null = () => null;
@@ -73,15 +93,11 @@ function EntityLayoutTitle(props: {
   title: string;
   entity: Entity | undefined;
 }) {
+  const classes = useStyles();
   const { entity, title } = props;
   return (
-    <Box display="inline-flex" alignItems="center" height="1em" maxWidth="100%">
-      <Box
-        component="span"
-        textOverflow="ellipsis"
-        whiteSpace="nowrap"
-        overflow="hidden"
-      >
+    <Box className={classes.header}>
+      <Box component="span">
         {entity ? <EntityDisplayName entityRef={entity} hideIcon /> : title}
       </Box>
       {entity && <FavoriteEntity entity={entity} />}
@@ -116,27 +132,32 @@ function headerProps(
 
 function EntityLabels(props: { entity: Entity }) {
   const { entity } = props;
+  const classes = useStyles();
   const ownedByRelations = getEntityRelations(entity, RELATION_OWNED_BY);
   return (
     <>
       {ownedByRelations.length > 0 && (
-        <HeaderLabel
-          label="Owner"
-          contentTypograpyRootComponent="p"
-          value={
-            <EntityRefLinks
-              entityRefs={ownedByRelations}
-              defaultKind="Group"
-              color="inherit"
-            />
-          }
-        />
+        <div className={classes.labels}>
+          <HeaderLabel
+            label="Owner"
+            contentTypograpyRootComponent="p"
+            value={
+              <EntityRefLinks
+                entityRefs={ownedByRelations}
+                defaultKind="Group"
+                color="inherit"
+              />
+            }
+          />
+        </div>
       )}
       {entity.spec?.lifecycle && (
-        <HeaderLabel
-          label="Lifecycle"
-          value={entity.spec.lifecycle?.toString()}
-        />
+        <div className={classes.labels}>
+          <HeaderLabel
+            label="Lifecycle"
+            value={entity.spec.lifecycle?.toString()}
+          />
+        </div>
       )}
     </>
   );
@@ -193,6 +214,7 @@ export const EntityLayout = (props: EntityLayoutProps) => {
   const { kind, namespace, name } = useRouteRefParams(entityRouteRef);
   const { entity, loading, error } = useAsyncEntity();
   const location = useLocation();
+  const classes = useStyles();
   const routes = useElementFilter(
     children,
     elements =>
@@ -259,7 +281,7 @@ export const EntityLayout = (props: EntityLayoutProps) => {
         type={headerType}
       >
         {entity && (
-          <>
+          <Box className={classes.box}>
             <EntityLabels entity={entity} />
             <EntityContextMenu
               UNSTABLE_extraContextMenuItems={UNSTABLE_extraContextMenuItems}
@@ -267,7 +289,7 @@ export const EntityLayout = (props: EntityLayoutProps) => {
               onUnregisterEntity={() => setConfirmationDialogOpen(true)}
               onInspectEntity={() => setInspectionDialogOpen(true)}
             />
-          </>
+          </Box>
         )}
       </Header>
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

It seems some work done for screen sizing has been lost (ex [this PR](https://github.com/backstage/backstage/pull/6497)) and longer names get cut off for entities and the formatting of the header can become jumbled.

For both better readability and easier accessibility, I've made it so the name wraps to keep the user provided with full information and formatted the owner, lifecycle, and menu to always stay together and move as unit.

Before:
<img width="1506" alt="Screenshot 2024-05-23 at 10 44 15 AM" src="https://github.com/backstage/backstage/assets/7171310/6c75705e-2edf-4dd7-bccf-ff7471bb24ab">
<img width="964" alt="Screenshot 2024-05-23 at 10 44 43 AM" src="https://github.com/backstage/backstage/assets/7171310/1cf1b950-1e55-4c9c-8712-6eeef52065c9">
<img width="498" alt="Screenshot 2024-05-23 at 10 44 55 AM" src="https://github.com/backstage/backstage/assets/7171310/02d1df68-69ed-4e0e-9232-8693565d3046">


After:
<img width="1511" alt="Screenshot 2024-05-23 at 10 45 27 AM" src="https://github.com/backstage/backstage/assets/7171310/3d44685d-c797-433c-9ee7-4ae584572f02">
<img width="1002" alt="Screenshot 2024-05-23 at 10 45 21 AM" src="https://github.com/backstage/backstage/assets/7171310/32eacc46-be8d-472a-8cc2-b5237877f990">
<img width="506" alt="Screenshot 2024-05-23 at 10 45 15 AM" src="https://github.com/backstage/backstage/assets/7171310/6c0805c8-44c7-4499-a292-d94b853069c8">

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
