### PR TITLE
Ensure `getCompoundEntityRef` in `@backstage/catalog-model` normalizes its values to lowercase

### DIFF
--- a/.changeset/quiet-eels-taste.md
+++ b/.changeset/quiet-eels-taste.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-model': patch
+---
+
+The `getEntityCompoundRef` function now returns the kind, name and namespace as lowercase to be consistent with other compound refs.

--- a/packages/catalog-model/src/entity/ref.test.ts
+++ b/packages/catalog-model/src/entity/ref.test.ts
@@ -14,9 +14,44 @@
  * limitations under the License.
  */
 
-import { parseEntityRef } from './ref';
+import { getCompoundEntityRef, parseEntityRef } from './ref';
 
 describe('ref', () => {
+  describe('getCompoundEntityRef', () => {
+    it('should normalize to lowercase', () => {
+      expect(
+        getCompoundEntityRef({
+          apiVersion: 'backstage.io/v1alpha1',
+          kind: 'Component',
+          metadata: {
+            namespace: 'NameSpace',
+            name: 'MyComponent',
+          },
+        }),
+      ).toEqual({
+        kind: 'component',
+        name: 'mycomponent',
+        namespace: 'namespace',
+      });
+    });
+
+    it('should handle omissions', () => {
+      expect(
+        getCompoundEntityRef({
+          apiVersion: 'backstage.io/v1alpha1',
+          kind: 'Component',
+          metadata: {
+            name: 'my-component',
+          },
+        }),
+      ).toEqual({
+        kind: 'component',
+        name: 'my-component',
+        namespace: 'default',
+      });
+    });
+  });
+
   describe('parseEntityRef', () => {
     it('handles some omissions', () => {
       expect(parseEntityRef('a:b/c')).toEqual({

--- a/packages/catalog-model/src/entity/ref.ts
+++ b/packages/catalog-model/src/entity/ref.ts
@@ -54,9 +54,11 @@ function parseRefString(ref: string): {
  */
 export function getCompoundEntityRef(entity: Entity): CompoundEntityRef {
   return {
-    kind: entity.kind,
-    namespace: entity.metadata.namespace || DEFAULT_NAMESPACE,
-    name: entity.metadata.name,
+    kind: entity.kind.toLocaleLowerCase('en-US'),
+    namespace:
+      entity.metadata.namespace?.toLocaleLowerCase('en-US') ||
+      DEFAULT_NAMESPACE,
+    name: entity.metadata.name.toLocaleLowerCase('en-US'),
   };
 }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This PR changes `getCompoundEntityRef` so that it returns the parts of the compound ref as lowercase. This fixes an issue I've been facing in the `MyGroupsSidebarItem`. This component would like to `/catalog/default/Group/my-group` instead of `/catalog/default/group/my-group` (uppercase G vs lowercase g). This ends up being a problem for us because our analytics treat those two paths as different when in reality they are not.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
