### PR TITLE
fix(core-components): set variant to inherit on OverflowTooltip Typography

### DIFF
--- a/.changeset/gentle-llamas-cross.md
+++ b/.changeset/gentle-llamas-cross.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Use `inherit` variant on OverflowTooltip underlying Typography component.

--- a/packages/core-components/src/components/OverflowTooltip/OverflowTooltip.tsx
+++ b/packages/core-components/src/components/OverflowTooltip/OverflowTooltip.tsx
@@ -52,7 +52,9 @@ export function OverflowTooltip(props: Props) {
       title={props.title ?? (props.text || '')}
       placement={props.placement}
     >
-      <Typography className={classes.typo}>{props.text}</Typography>
+      <Typography className={classes.typo} variant="inherit">
+        {props.text}
+      </Typography>
     </Tooltip>
   );
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes a regression introduced by https://github.com/backstage/backstage/pull/24391 (shipped in 1.27), which makes use of a `Typography` component.

The default variant for the `Typography` component is `body1` but it isn't overridable in the `OverflowTooltip` component.

This sets the variant to `inherit`, which allows to change the variant by wrapping the `OverflowTooltip` in a parent Typography component.

This change is visible in the Catalog table for the description field.

Comparaison before/after:
![image](https://github.com/backstage/backstage/assets/2379631/b91e64da-37d0-48db-8b20-75bf148375a3)
![image](https://github.com/backstage/backstage/assets/2379631/20a8ab0e-ceb3-435e-9680-7948eb16a64c)


#### :heavy_check_mark: Checklist


- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
