### PR TITLE
Remove tech radar sidebar entry

### DIFF
--- a/.changeset/strange-flowers-burn.md
+++ b/.changeset/strange-flowers-burn.md
@@ -1,5 +1,0 @@
----
-'@backstage/create-app': patch
----
-
-Remove Tech-Radar menu from scaffolded app sidebar to align with backend removal of tech-radar plugin.

--- a/.changeset/strange-flowers-burn.md
+++ b/.changeset/strange-flowers-burn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Remove Tech-Radar menu from scaffolded app sidebar to align with backend removal of tech-radar plugin.

--- a/.changeset/tall-bananas-reflect.md
+++ b/.changeset/tall-bananas-reflect.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Remove Tech Radar menu item from sidebar of scaffolded app to align with removal of tech-radar plugin from backend

--- a/packages/create-app/templates/default-app/packages/app/src/components/Root/Root.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/components/Root/Root.tsx
@@ -2,7 +2,6 @@ import React, { PropsWithChildren } from 'react';
 import { makeStyles } from '@material-ui/core';
 import HomeIcon from '@material-ui/icons/Home';
 import ExtensionIcon from '@material-ui/icons/Extension';
-import MapIcon from '@material-ui/icons/MyLocation';
 import LibraryBooks from '@material-ui/icons/LibraryBooks';
 import CreateComponentIcon from '@material-ui/icons/AddCircleOutline';
 import LogoFull from './LogoFull';

--- a/packages/create-app/templates/default-app/packages/app/src/components/Root/Root.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/components/Root/Root.tsx
@@ -70,8 +70,7 @@ export const Root = ({ children }: PropsWithChildren<{}>) => (
         <SidebarItem icon={CreateComponentIcon} to="create" text="Create..." />
         {/* End global nav */}
         <SidebarDivider />
-        <SidebarScrollWrapper>
-        </SidebarScrollWrapper>
+        <SidebarScrollWrapper />
       </SidebarGroup>
       <SidebarSpace />
       <SidebarDivider />

--- a/packages/create-app/templates/default-app/packages/app/src/components/Root/Root.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/components/Root/Root.tsx
@@ -72,7 +72,6 @@ export const Root = ({ children }: PropsWithChildren<{}>) => (
         {/* End global nav */}
         <SidebarDivider />
         <SidebarScrollWrapper>
-          <SidebarItem icon={MapIcon} to="tech-radar" text="Tech Radar" />
         </SidebarScrollWrapper>
       </SidebarGroup>
       <SidebarSpace />

--- a/packages/create-app/templates/default-app/packages/app/src/components/Root/Root.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/components/Root/Root.tsx
@@ -71,7 +71,7 @@ export const Root = ({ children }: PropsWithChildren<{}>) => (
         {/* End global nav */}
         <SidebarDivider />
         <SidebarScrollWrapper>
-          { /* Items in this group will be scrollable if they run out of space */ }
+        { /* Items in this group will be scrollable if they run out of space */ }
         </SidebarScrollWrapper>
       </SidebarGroup>
       <SidebarSpace />

--- a/packages/create-app/templates/default-app/packages/app/src/components/Root/Root.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/components/Root/Root.tsx
@@ -71,7 +71,7 @@ export const Root = ({ children }: PropsWithChildren<{}>) => (
         {/* End global nav */}
         <SidebarDivider />
         <SidebarScrollWrapper>
-        {/* Items in this group will be scrollable if they run out of space */}
+          {/* Items in this group will be scrollable if they run out of space */}
         </SidebarScrollWrapper>
       </SidebarGroup>
       <SidebarSpace />

--- a/packages/create-app/templates/default-app/packages/app/src/components/Root/Root.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/components/Root/Root.tsx
@@ -70,7 +70,9 @@ export const Root = ({ children }: PropsWithChildren<{}>) => (
         <SidebarItem icon={CreateComponentIcon} to="create" text="Create..." />
         {/* End global nav */}
         <SidebarDivider />
-        <SidebarScrollWrapper />
+        <SidebarScrollWrapper>
+          { /* Items in this group will be scrollable if they run out of space */ }
+        </SidebarScrollWrapper>
       </SidebarGroup>
       <SidebarSpace />
       <SidebarDivider />

--- a/packages/create-app/templates/default-app/packages/app/src/components/Root/Root.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/components/Root/Root.tsx
@@ -71,7 +71,7 @@ export const Root = ({ children }: PropsWithChildren<{}>) => (
         {/* End global nav */}
         <SidebarDivider />
         <SidebarScrollWrapper>
-        { /* Items in this group will be scrollable if they run out of space */ }
+        {/* Items in this group will be scrollable if they run out of space */}
         </SidebarScrollWrapper>
       </SidebarGroup>
       <SidebarSpace />


### PR DESCRIPTION
This is a one-line PR to remove the Tech Radar sidebar item from the scaffolded app front-end created by @backstage/create-app. (The backend Tech Radar plugin was removed by a recent commit)

Resulting scaffolded app looks like this:

![Screenshot at 2024-05-24 17-45-33](https://github.com/backstage/backstage/assets/8081753/aea45f15-d8d7-4cae-b0d8-5a0641172675)


#### :heavy_check_mark: Checklist
- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
