### PR TITLE
Fix readme for new backend plugins created using cli

### DIFF
--- a/.changeset/eighty-yaks-switch.md
+++ b/.changeset/eighty-yaks-switch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Fix readme for new plugins created using cli

--- a/packages/cli/templates/default-backend-plugin/README.md.hbs
+++ b/packages/cli/templates/default-backend-plugin/README.md.hbs
@@ -7,7 +7,7 @@ _This plugin was created through the Backstage CLI_
 ## Getting started
 
 Your plugin has been added to the example app in this repository, meaning you'll be able to access it by running `yarn
-start` in the root directory, and then navigating to [/{{pluginVar}}/health](http://localhost:7007/api/{{pluginVar}}/health).
+start` in the root directory, and then navigating to [/{{id}}/health](http://localhost:7007/api/{{id}}/health).
 
 You can also serve the plugin in isolation by running `yarn start` in the plugin directory.
 This method of serving the plugin provides quicker iteration speed and a faster startup and hot reloads.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The templates in readme for new backend plugins created using CLI incorrectly uses `{{pluginVar}}` instead of `{{id}}` in the sample link to the `/health` endpoint.

Current incorrect link example: `[/testServicePlugin/health](http://localhost:7007/api/testServicePlugin/health)`
Results in 404 error.

Updated link example: `[/test-service/health](http://localhost:7007/api/test-service/health)`
Result in 200 status OK with response.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
