### PR TITLE
[NBS 1.0] Rename factory configs to options

### DIFF
--- a/.changeset/warm-bees-hope.md
+++ b/.changeset/warm-bees-hope.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-plugin-api': patch
+---
+
+We renamed `BackendPluginConfig`, `BackendModuleConfig`, and `ExtensionPointConfig` respectively to `CreateBackendPluginOptions`, `CreateBackendModuleOptions`, and `CreateExtensionPointOptions` in order to standardize frontend and backend factories signatures.

--- a/.changeset/warm-bees-hope.md
+++ b/.changeset/warm-bees-hope.md
@@ -2,4 +2,4 @@
 '@backstage/backend-plugin-api': patch
 ---
 
-We renamed `BackendPluginConfig`, `BackendModuleConfig`, and `ExtensionPointConfig` respectively to `CreateBackendPluginOptions`, `CreateBackendModuleOptions`, and `CreateExtensionPointOptions` in order to standardize frontend and backend factories signatures.
+Renamed `BackendPluginConfig`, `BackendModuleConfig`, and `ExtensionPointConfig` respectively to `CreateBackendPluginOptions`, `CreateBackendModuleOptions`, and `CreateExtensionPointOptions` to standardize frontend and backend factories signatures.

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -70,13 +70,8 @@ export interface BackendFeature {
   $$type: '@backstage/BackendFeature';
 }
 
-// @public
-export interface BackendModuleConfig {
-  moduleId: string;
-  pluginId: string;
-  // (undocumented)
-  register(reg: BackendModuleRegistrationPoints): void;
-}
+// @public @deprecated (undocumented)
+export type BackendModuleConfig = CreateBackendModuleOptions;
 
 // @public
 export interface BackendModuleRegistrationPoints {
@@ -98,12 +93,8 @@ export interface BackendModuleRegistrationPoints {
   }): void;
 }
 
-// @public
-export interface BackendPluginConfig {
-  pluginId: string;
-  // (undocumented)
-  register(reg: BackendPluginRegistrationPoints): void;
-}
+// @public @deprecated (undocumented)
+export type BackendPluginConfig = CreateBackendPluginOptions;
 
 // @public
 export interface BackendPluginRegistrationPoints {
@@ -223,18 +214,38 @@ export namespace coreServices {
 
 // @public
 export function createBackendModule(
-  config: BackendModuleConfig,
+  options: CreateBackendModuleOptions,
 ): () => BackendFeature;
+
+// @public
+export interface CreateBackendModuleOptions {
+  moduleId: string;
+  pluginId: string;
+  // (undocumented)
+  register(reg: BackendModuleRegistrationPoints): void;
+}
 
 // @public
 export function createBackendPlugin(
-  config: BackendPluginConfig,
+  options: CreateBackendPluginOptions,
 ): () => BackendFeature;
 
 // @public
+export interface CreateBackendPluginOptions {
+  pluginId: string;
+  // (undocumented)
+  register(reg: BackendPluginRegistrationPoints): void;
+}
+
+// @public
 export function createExtensionPoint<T>(
-  config: ExtensionPointConfig,
+  options: CreateExtensionPointOptions,
 ): ExtensionPoint<T>;
+
+// @public
+export interface CreateExtensionPointOptions {
+  id: string;
+}
 
 // @public
 export function createServiceFactory<
@@ -320,10 +331,8 @@ export type ExtensionPoint<T> = {
   $$type: '@backstage/ExtensionPoint';
 };
 
-// @public
-export interface ExtensionPointConfig {
-  id: string;
-}
+// @public @deprecated (undocumented)
+export type ExtensionPointConfig = CreateExtensionPointOptions;
 
 // @public (undocumented)
 export interface HttpAuthService {

--- a/packages/backend-plugin-api/src/wiring/factories.ts
+++ b/packages/backend-plugin-api/src/wiring/factories.ts
@@ -30,7 +30,7 @@ import {
  * @see {@link https://backstage.io/docs/backend-system/architecture/extension-points | The architecture of extension points}
  * @see {@link https://backstage.io/docs/backend-system/architecture/naming-patterns | Recommended naming patterns}
  */
-export interface ExtensionPointConfig {
+export interface CreateExtensionPointOptions {
   /**
    * The ID of this extension point.
    *
@@ -46,15 +46,15 @@ export interface ExtensionPointConfig {
  * @see {@link https://backstage.io/docs/backend-system/architecture/extension-points | The architecture of extension points}
  */
 export function createExtensionPoint<T>(
-  config: ExtensionPointConfig,
+  options: CreateExtensionPointOptions,
 ): ExtensionPoint<T> {
   return {
-    id: config.id,
+    id: options.id,
     get T(): T {
       throw new Error(`tried to read ExtensionPoint.T of ${this}`);
     },
     toString() {
-      return `extensionPoint{${config.id}}`;
+      return `extensionPoint{${options.id}}`;
     },
     $$type: '@backstage/ExtensionPoint',
   };
@@ -67,7 +67,7 @@ export function createExtensionPoint<T>(
  * @see {@link https://backstage.io/docs/backend-system/architecture/plugins | The architecture of plugins}
  * @see {@link https://backstage.io/docs/backend-system/architecture/naming-patterns | Recommended naming patterns}
  */
-export interface BackendPluginConfig {
+export interface CreateBackendPluginOptions {
   /**
    * The ID of this plugin.
    *
@@ -85,7 +85,7 @@ export interface BackendPluginConfig {
  * @see {@link https://backstage.io/docs/backend-system/architecture/naming-patterns | Recommended naming patterns}
  */
 export function createBackendPlugin(
-  config: BackendPluginConfig,
+  options: CreateBackendPluginOptions,
 ): () => BackendFeature {
   const factory: BackendFeatureFactory = () => {
     let registrations: InternalBackendPluginRegistration[];
@@ -102,7 +102,7 @@ export function createBackendPlugin(
         let init: InternalBackendPluginRegistration['init'] | undefined =
           undefined;
 
-        config.register({
+        options.register({
           registerExtensionPoint(ext, impl) {
             if (init) {
               throw new Error(
@@ -124,14 +124,14 @@ export function createBackendPlugin(
 
         if (!init) {
           throw new Error(
-            `registerInit was not called by register in ${config.pluginId}`,
+            `registerInit was not called by register in ${options.pluginId}`,
           );
         }
 
         registrations = [
           {
             type: 'plugin',
-            pluginId: config.pluginId,
+            pluginId: options.pluginId,
             extensionPoints,
             init,
           },
@@ -152,7 +152,7 @@ export function createBackendPlugin(
  * @see {@link https://backstage.io/docs/backend-system/architecture/modules | The architecture of modules}
  * @see {@link https://backstage.io/docs/backend-system/architecture/naming-patterns | Recommended naming patterns}
  */
-export interface BackendModuleConfig {
+export interface CreateBackendModuleOptions {
   /**
    * Should exactly match the `id` of the plugin that the module extends.
    *
@@ -175,7 +175,7 @@ export interface BackendModuleConfig {
  * @see {@link https://backstage.io/docs/backend-system/architecture/naming-patterns | Recommended naming patterns}
  */
 export function createBackendModule(
-  config: BackendModuleConfig,
+  options: CreateBackendModuleOptions,
 ): () => BackendFeature {
   const factory: BackendFeatureFactory = () => {
     let registrations: InternalBackendModuleRegistration[];
@@ -192,7 +192,7 @@ export function createBackendModule(
         let init: InternalBackendModuleRegistration['init'] | undefined =
           undefined;
 
-        config.register({
+        options.register({
           registerExtensionPoint(ext, impl) {
             if (init) {
               throw new Error(
@@ -214,15 +214,15 @@ export function createBackendModule(
 
         if (!init) {
           throw new Error(
-            `registerInit was not called by register in ${config.moduleId} module for ${config.pluginId}`,
+            `registerInit was not called by register in ${options.moduleId} module for ${options.pluginId}`,
           );
         }
 
         registrations = [
           {
             type: 'module',
-            pluginId: config.pluginId,
-            moduleId: config.moduleId,
+            pluginId: options.pluginId,
+            moduleId: options.moduleId,
             extensionPoints,
             init,
           },

--- a/packages/backend-plugin-api/src/wiring/index.ts
+++ b/packages/backend-plugin-api/src/wiring/index.ts
@@ -14,18 +14,44 @@
  * limitations under the License.
  */
 
-export type {
-  BackendModuleConfig,
-  BackendPluginConfig,
-  ExtensionPointConfig,
+import type {
+  CreateBackendPluginOptions,
+  CreateBackendModuleOptions,
+  CreateExtensionPointOptions,
 } from './factories';
+
 export {
   createBackendModule,
   createBackendPlugin,
   createExtensionPoint,
 } from './factories';
+
 export type {
   BackendModuleRegistrationPoints,
   BackendPluginRegistrationPoints,
   ExtensionPoint,
 } from './types';
+
+export type {
+  CreateBackendPluginOptions,
+  CreateBackendModuleOptions,
+  CreateExtensionPointOptions,
+};
+
+/**
+ * @public
+ * @deprecated Use {@link CreateBackendPluginOptions} instead.
+ */
+export type BackendPluginConfig = CreateBackendPluginOptions;
+
+/**
+ * @public
+ * @deprecated Use {@link CreateBackendModuleOptions} instead.
+ */
+export type BackendModuleConfig = CreateBackendModuleOptions;
+
+/**
+ * @public
+ * @deprecated Use {@link CreateExtensionPointOptions} instead.
+ */
+export type ExtensionPointConfig = CreateExtensionPointOptions;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes: #24854, #24855, #24910

Rename `BackendPluginConfig`, `BackendModuleConfig`, and `ExtensionPointConfig` types respectively to `CreateBackendPluginOptions`, `CreateBackendModuleOptions`, and `CreateExtensionPointOptions` in order to standardize frontend and backend factories signatures.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
