### PR TITLE
scaffolder: `formData` should be allowed to be undefined

### DIFF
--- a/.changeset/spicy-brooms-hang.md
+++ b/.changeset/spicy-brooms-hang.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+'@backstage/plugin-scaffolder': patch
+---
+
+Fixing bug in `formData` type as it should be `optional` as it's possibly undefined

--- a/plugins/scaffolder-react/api-report.md
+++ b/plugins/scaffolder-react/api-report.md
@@ -304,7 +304,7 @@ export interface ScaffolderRJSFFieldProps<
   disabled: boolean;
   errorSchema?: ErrorSchema<T>;
   formContext?: F;
-  formData: T;
+  formData?: T;
   hideError?: boolean;
   idPrefix?: string;
   idSchema: IdSchema<T>;

--- a/plugins/scaffolder-react/src/extensions/rjsf.ts
+++ b/plugins/scaffolder-react/src/extensions/rjsf.ts
@@ -64,7 +64,7 @@ export interface ScaffolderRJSFFieldProps<
   /** The tree of unique ids for every child field */
   idSchema: IdSchema<T>;
   /** The data for this field */
-  formData: T;
+  formData?: T;
   /** The tree of errors for this field and its children */
   errorSchema?: ErrorSchema<T>;
   /** The field change event handler; called with the updated form data and an optional `ErrorSchema` */

--- a/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.tsx
@@ -115,7 +115,7 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
             }
 
             // We need to check against formData here as that's the previous value for this field.
-            if (formData.includes(ref) || allowArbitraryValues) {
+            if (formData?.includes(ref) || allowArbitraryValues) {
               return entityRef;
             }
           }
@@ -173,7 +173,7 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
             required={required}
             InputProps={{
               ...params.InputProps,
-              required: formData.length === 0 && required,
+              required: formData?.length === 0 && required,
             }}
           />
         )}


### PR DESCRIPTION
Little torn on if this is a breaking change or not. Problem is, is that `formData` is `undefined` on first render, and there's no real way around this, and the type is masking that this is a problem as we've seen in https://github.com/backstage/backstage/issues/23718. I think in reality, people have probably run into this issue already and ended up doing `formData?.` even though the type says that it's never optional.

We also can't default `formData` to something sensible as this is the current value of the field, and defaulting to something like `{}` could break other logic which I really don't want to make this a pain.

Thinking that we ship this as a `minor` as the fix is pretty self explanatory to any one familiar with typescript. The other option that we have here is that we don't fix this type issue, and just do `formData?.` in the `MultiPicker` to work around the broken type and then ship this fix as a breaking change when we're ready. But it's a little unfortunate.

Looking for some thoughts @backstage/scaffolder-maintainers  @backstage/maintainers
