### PR TITLE
fix(openapi-tooling): breaking changes check

### DIFF
--- a/.github/workflows/api-breaking-changes.yml
+++ b/.github/workflows/api-breaking-changes.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: breaking changes check
         run: |
-          yarn backstage-repo-tools repo schema openapi check --since origin/${{ github.base_ref }} > comment.md
+          yarn backstage-repo-tools repo schema openapi diff --since origin/${{ github.base_ref }} > comment.md
 
       - name: Upload Rendered Comment as Artifact
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixing the command name that runs. Should fix the failing check in #24916.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
