### PR TITLE
fix(ci): workflow files aren't saving artifacts as expected

### DIFF
--- a/.github/workflows/api-breaking-changes.yml
+++ b/.github/workflows/api-breaking-changes.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           yarn backstage-repo-tools repo schema openapi check --since origin/${{ github.base_ref }} > comment.md
 
-      - name: Upload Rendered Comment as Artifact
+      - name: Upload Artifacts
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
         with:
           name: preview-spec

--- a/.github/workflows/api-breaking-changes.yml
+++ b/.github/workflows/api-breaking-changes.yml
@@ -54,4 +54,3 @@ jobs:
             event.json
           retention-days: 2
           overwrite: true
-

--- a/.github/workflows/api-breaking-changes.yml
+++ b/.github/workflows/api-breaking-changes.yml
@@ -41,9 +41,9 @@ jobs:
         run: |
           yarn backstage-repo-tools repo schema openapi check --since origin/${{ github.base_ref }} > comment.md
 
-      - name: clone github events.json to local path
+      - name: clone artifacts to current directory
         run: |
-          cat ${{ github.event_path }} > events.json
+          cat ${{ github.event_path }} > event.json
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
@@ -51,7 +51,7 @@ jobs:
           name: preview-spec
           path: |
             comment.md
-            events.json
+            event.json
           retention-days: 2
           overwrite: true
 

--- a/.github/workflows/api-breaking-changes.yml
+++ b/.github/workflows/api-breaking-changes.yml
@@ -45,14 +45,9 @@ jobs:
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
         with:
           name: preview-spec
-          path: comment.md
+          path: |
+            comment.md
+            ${{ github.event_path }}
           retention-days: 2
           overwrite: true
 
-      - name: Upload PR Event as Artifact
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
-        with:
-          name: preview-spec
-          path: ${{ github.event_path }}
-          retention-days: 2
-          overwrite: true

--- a/.github/workflows/api-breaking-changes.yml
+++ b/.github/workflows/api-breaking-changes.yml
@@ -41,13 +41,17 @@ jobs:
         run: |
           yarn backstage-repo-tools repo schema openapi check --since origin/${{ github.base_ref }} > comment.md
 
+      - name: clone github events.json to local path
+        run: |
+          cat ${{ github.event_path }} > events.json
+
       - name: Upload Artifacts
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
         with:
           name: preview-spec
           path: |
             comment.md
-            ${{ github.event_path }}
+            events.json
           retention-days: 2
           overwrite: true
 

--- a/.github/workflows/uffizzi-build.yml
+++ b/.github/workflows/uffizzi-build.yml
@@ -97,18 +97,13 @@ jobs:
           kustomize edit set image backstage=${{ needs.build-backstage.outputs.tags }}
           kustomize build . > manifests.rendered.yml
           cat manifests.rendered.yml
-      - name: Upload Rendered Manifests File as Artifact
+      - name: Upload Artifacts
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
         with:
           name: preview-spec
-          path: ./.github/uffizzi/k8s/manifests/manifests.rendered.yml
-          retention-days: 2
-          overwrite: true
-      - name: Upload PR Event as Artifact
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
-        with:
-          name: preview-spec
-          path: ${{ github.event_path }}
+          path: |
+            ./.github/uffizzi/k8s/manifests/manifests.rendered.yml
+            ${{ github.event_path }}
           retention-days: 2
           overwrite: true
 

--- a/.github/workflows/uffizzi-build.yml
+++ b/.github/workflows/uffizzi-build.yml
@@ -97,13 +97,18 @@ jobs:
           kustomize edit set image backstage=${{ needs.build-backstage.outputs.tags }}
           kustomize build . > manifests.rendered.yml
           cat manifests.rendered.yml
+
+      - name: clone github events.json locally
+        run: |
+          cat ${{ github.event_path }} > events.json
+
       - name: Upload Artifacts
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
         with:
           name: preview-spec
           path: |
             ./.github/uffizzi/k8s/manifests/manifests.rendered.yml
-            ${{ github.event_path }}
+            events.json
           retention-days: 2
           overwrite: true
 

--- a/.github/workflows/uffizzi-build.yml
+++ b/.github/workflows/uffizzi-build.yml
@@ -98,17 +98,18 @@ jobs:
           kustomize build . > manifests.rendered.yml
           cat manifests.rendered.yml
 
-      - name: clone github events.json locally
+      - name: clone artifacts into current directory
         run: |
-          cat ${{ github.event_path }} > events.json
+          cat ${{ github.event_path }} > event.json
+          cp ./.github/uffizzi/k8s/manifests/manifests.rendered.yml manifests.rendered.yml
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
         with:
           name: preview-spec
           path: |
-            ./.github/uffizzi/k8s/manifests/manifests.rendered.yml
-            events.json
+            manifests.rendered.yml
+            event.json
           retention-days: 2
           overwrite: true
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Noticed this while verifying that a comment was posted in #24916 (it wasn't 😞). The double artifact upload wasn't correctly uploading both required files and the workflow was failing. Going forward we'll probably want an alert or something for these workflows as they don't show as PR status checks.

I think this hasn't been working for a minute, https://github.com/backstage/backstage/pull/24267 with the overwrite option caused the second upload to overwrite the first, but even before then uploading 2 files to the same name with different jobs smells like trouble. I updated this to 2 steps, one that "stages" the files into the current directory and another that uploads both files.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
