### PR TITLE
Updating SupportButton title ui characteristics

### DIFF
--- a/.changeset/twenty-masks-dance.md
+++ b/.changeset/twenty-masks-dance.md
@@ -2,4 +2,4 @@
 '@backstage/core-components': patch
 ---
 
-Fixed bug in SupportButton where the title was rendered with the characteristics of a button.
+Fixed a bug in `SupportButton` where the title was rendered with the characteristics of a button.

--- a/.changeset/twenty-masks-dance.md
+++ b/.changeset/twenty-masks-dance.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Fixed bug in SupportButton where the title was rendered with the characteristics of a button.

--- a/packages/core-components/src/components/SupportButton/SupportButton.tsx
+++ b/packages/core-components/src/components/SupportButton/SupportButton.tsx
@@ -151,7 +151,11 @@ export function SupportButton(props: SupportButtonProps) {
           autoFocusItem={Boolean(anchorEl)}
         >
           {title && (
-            <MenuItem alignItems="flex-start" className={classes.menuItem}>
+            <MenuItem
+              button={false}
+              alignItems="flex-start"
+              className={classes.menuItem}
+            >
               <Typography variant="subtitle1">{title}</Typography>
             </MenuItem>
           )}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When the title prop is provided for `SupportButton` it is rendered as a `MenuItem` which by default has the ui characteristics of a Button(has cursor as `pointer`, has click animation).

This change passes `false` as value to the button prop of `MenuItem`, which prevents the button UI characteristics from being included.

Screenshots:
Before:

https://github.com/backstage/backstage/assets/14274064/8b0d72a1-7079-428d-99a6-449d96596d9a


After:

https://github.com/backstage/backstage/assets/14274064/906e116c-0e3b-49fc-a323-8edcbe7b4dea





#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
