### PR TITLE
[NBS 1.0] Rename service config to options type

### DIFF
--- a/.changeset/tall-walls-learn.md
+++ b/.changeset/tall-walls-learn.md
@@ -1,0 +1,9 @@
+---
+'@backstage/backend-plugin-api': patch
+---
+
+All service config types were renamed to option types in order to standardize frontend and backend `create*` function signatures:
+
+- The `ServiceRefConfig` type was renamed to`ServiceRefOptions`;
+- The `RootServiceFactoryConfig` type was renamed to `RootServiceFactoryOptions`;
+- The `PluginServiceFactoryConfig` type was renamed to `PluginServiceFactoryOptions`

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -256,7 +256,7 @@ export function createServiceFactory<
   },
   TOpts extends object | undefined = undefined,
 >(
-  config: RootServiceFactoryConfig<TService, TImpl, TDeps>,
+  options: RootServiceFactoryOptions<TService, TImpl, TDeps>,
 ): () => ServiceFactory<TService, 'root'>;
 
 // @public
@@ -268,7 +268,9 @@ export function createServiceFactory<
   },
   TOpts extends object | undefined = undefined,
 >(
-  config: (options?: TOpts) => RootServiceFactoryConfig<TService, TImpl, TDeps>,
+  options: (
+    options?: TOpts,
+  ) => RootServiceFactoryOptions<TService, TImpl, TDeps>,
 ): (options?: TOpts) => ServiceFactory<TService, 'root'>;
 
 // @public
@@ -281,7 +283,7 @@ export function createServiceFactory<
   TContext = undefined,
   TOpts extends object | undefined = undefined,
 >(
-  config: PluginServiceFactoryConfig<TService, TContext, TImpl, TDeps>,
+  options: PluginServiceFactoryOptions<TService, TContext, TImpl, TDeps>,
 ): () => ServiceFactory<TService, 'plugin'>;
 
 // @public
@@ -294,19 +296,19 @@ export function createServiceFactory<
   TContext = undefined,
   TOpts extends object | undefined = undefined,
 >(
-  config: (
+  options: (
     options?: TOpts,
-  ) => PluginServiceFactoryConfig<TService, TContext, TImpl, TDeps>,
+  ) => PluginServiceFactoryOptions<TService, TContext, TImpl, TDeps>,
 ): (options?: TOpts) => ServiceFactory<TService, 'plugin'>;
 
 // @public
 export function createServiceRef<TService>(
-  config: ServiceRefConfig<TService, 'plugin'>,
+  options: ServiceRefOptions<TService, 'plugin'>,
 ): ServiceRef<TService, 'plugin'>;
 
 // @public
 export function createServiceRef<TService>(
-  config: ServiceRefConfig<TService, 'root'>,
+  options: ServiceRefOptions<TService, 'root'>,
 ): ServiceRef<TService, 'root'>;
 
 // @public
@@ -450,8 +452,18 @@ export interface PluginMetadataService {
   getId(): string;
 }
 
+// @public @deprecated (undocumented)
+export type PluginServiceFactoryConfig<
+  TService,
+  TContext,
+  TImpl extends TService,
+  TDeps extends {
+    [name in string]: ServiceRef<unknown>;
+  },
+> = PluginServiceFactoryOptions<TService, TContext, TImpl, TDeps>;
+
 // @public (undocumented)
-export interface PluginServiceFactoryConfig<
+export interface PluginServiceFactoryOptions<
   TService,
   TContext,
   TImpl extends TService,
@@ -549,8 +561,17 @@ export interface RootLifecycleService extends LifecycleService {}
 // @public (undocumented)
 export interface RootLoggerService extends LoggerService {}
 
+// @public @deprecated (undocumented)
+export type RootServiceFactoryConfig<
+  TService,
+  TImpl extends TService,
+  TDeps extends {
+    [name in string]: ServiceRef<unknown>;
+  },
+> = RootServiceFactoryOptions<TService, TImpl, TDeps>;
+
 // @public (undocumented)
-export interface RootServiceFactoryConfig<
+export interface RootServiceFactoryOptions<
   TService,
   TImpl extends TService,
   TDeps extends {
@@ -674,8 +695,14 @@ export type ServiceRef<
   $$type: '@backstage/ServiceRef';
 };
 
+// @public @deprecated (undocumented)
+export type ServiceRefConfig<
+  TService,
+  TScope extends 'root' | 'plugin',
+> = ServiceRefOptions<TService, TScope>;
+
 // @public (undocumented)
-export interface ServiceRefConfig<TService, TScope extends 'root' | 'plugin'> {
+export interface ServiceRefOptions<TService, TScope extends 'root' | 'plugin'> {
   // (undocumented)
   defaultFactory?: (
     service: ServiceRef<TService, TScope>,

--- a/packages/backend-plugin-api/src/deprecated.ts
+++ b/packages/backend-plugin-api/src/deprecated.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ServiceRef,
+  ServiceRefOptions,
+  RootServiceFactoryOptions,
+  PluginServiceFactoryOptions,
+} from './services';
+
+/**
+ * @public
+ * @deprecated Use {@link ServiceRefOptions} instead
+ */
+export type ServiceRefConfig<
+  TService,
+  TScope extends 'root' | 'plugin',
+> = ServiceRefOptions<TService, TScope>;
+
+/**
+ * @public
+ * @deprecated Use {@link RootServiceFactoryOptions} instead
+ */
+export type RootServiceFactoryConfig<
+  TService,
+  TImpl extends TService,
+  TDeps extends { [name in string]: ServiceRef<unknown> },
+> = RootServiceFactoryOptions<TService, TImpl, TDeps>;
+
+/**
+ * @public
+ * @deprecated Use {@link PluginServiceFactoryOptions} instead
+ */
+export type PluginServiceFactoryConfig<
+  TService,
+  TContext,
+  TImpl extends TService,
+  TDeps extends { [name in string]: ServiceRef<unknown> },
+> = PluginServiceFactoryOptions<TService, TContext, TImpl, TDeps>;

--- a/packages/backend-plugin-api/src/index.ts
+++ b/packages/backend-plugin-api/src/index.ts
@@ -24,3 +24,4 @@ export * from './services';
 export type { BackendFeature } from './types';
 export * from './paths';
 export * from './wiring';
+export * from './deprecated';

--- a/packages/backend-plugin-api/src/services/system/index.ts
+++ b/packages/backend-plugin-api/src/services/system/index.ts
@@ -16,10 +16,10 @@
 
 export type {
   ServiceRef,
-  ServiceRefConfig,
+  ServiceRefOptions,
   ServiceFactory,
-  PluginServiceFactoryConfig,
-  RootServiceFactoryConfig,
+  PluginServiceFactoryOptions,
+  RootServiceFactoryOptions,
   ServiceFactoryOrFunction,
 } from './types';
 export { createServiceRef, createServiceFactory } from './types';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes: https://github.com/backstage/backstage/issues/24923

Rename all `*Service*Config` types to `*Service*Options` types in order to standardize frontend and backend `create*` function signatures:

- Rename `ServiceRefConfig` to `ServiceRefOptions`
- Rename `RootServiceFactoryConfig` to `RootServiceFactoryOptions`
- Rename `PluginServiceFactoryConfig` to `PluginServiceFactoryOptions`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
