### PR TITLE
feat: run mkdocs via Docker Engine API

### DIFF
--- a/.changeset/modern-cobras-cry.md
+++ b/.changeset/modern-cobras-cry.md
@@ -1,0 +1,5 @@
+---
+'@techdocs/cli': minor
+---
+
+Connect to Docker socket instead of invoking docker's CLI.

--- a/packages/techdocs-cli/src/commands/serve/utils.ts
+++ b/packages/techdocs-cli/src/commands/serve/utils.ts
@@ -14,17 +14,16 @@
  * limitations under the License.
  */
 
-import { promisify } from 'util';
 import * as winston from 'winston';
-import { execFile } from 'child_process';
+import Docker from 'dockerode';
 
 export async function checkIfDockerIsOperational(
   logger: winston.Logger,
+  client: Docker,
 ): Promise<boolean> {
   logger.info('Checking Docker status...');
   try {
-    const runCheck = promisify(execFile);
-    await runCheck('docker', ['info'], { shell: true });
+    await client.ping();
     logger.info(
       'Docker is up and running. Proceed to starting up mkdocs server',
     );


### PR DESCRIPTION
Hey :wave:!

I wanted to create a draft PR to gauge interest in this approach from the Backstage devs before fixing all the tests I've broken.

My goal was to migrate from calling the Docker CLI to making calls against the Engine API, such that nothing changes for existing users, but `techdocs-cli serve` starts working for users that have a different engine implementation at the docker socket path, or have `DOCKER_HOST` set in their environment.

Is this something you'd be interested in merging, or is there a preference for a different implementation?

---

The system may not have the Docker CLI installed while still having access to an implementation of the Docker Engine API. For example, if the daemon is running in a VM with shared folders, or when another container runtime is being used.

This changeset modifies techdocs-cli to interact with Docker via the Engine API instead of the Docker CLI. The local Docker Engine UDS is used by default, but another location can be specified with the `DOCKER_HOST` environment variable.

Fixes: #12028

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
