### PR TITLE
root: bump to TS 5.2 + 5.4

### DIFF
--- a/.changeset/real-ghosts-return.md
+++ b/.changeset/real-ghosts-return.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Bumped TypeScript to version `5.4`.

--- a/microsite/package.json
+++ b/microsite/package.json
@@ -43,7 +43,7 @@
     "@types/webpack-env": "^1.18.0",
     "js-yaml": "^4.1.0",
     "prettier": "^2.6.2",
-    "typescript": "~5.1.0",
+    "typescript": "~5.2.0",
     "yaml-loader": "^0.8.0"
   }
 }

--- a/microsite/yarn.lock
+++ b/microsite/yarn.lock
@@ -3865,7 +3865,7 @@ __metadata:
     react-dom: ^18.0.0
     sass: ^1.57.1
     swc-loader: ^0.2.3
-    typescript: ~5.1.0
+    typescript: ~5.2.0
     yaml-loader: ^0.8.0
   languageName: unknown
   linkType: soft
@@ -11266,23 +11266,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~5.1.0":
-  version: 5.1.6
-  resolution: "typescript@npm:5.1.6"
+"typescript@npm:~5.2.0":
+  version: 5.2.2
+  resolution: "typescript@npm:5.2.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: b2f2c35096035fe1f5facd1e38922ccb8558996331405eb00a5111cc948b2e733163cc22fab5db46992aba7dd520fff637f2c1df4996ff0e134e77d3249a7350
+  checksum: 7912821dac4d962d315c36800fe387cdc0a6298dba7ec171b350b4a6e988b51d7b8f051317786db1094bd7431d526b648aba7da8236607febb26cf5b871d2d3c
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@~5.1.0#~builtin<compat/typescript>":
-  version: 5.1.6
-  resolution: "typescript@patch:typescript@npm%3A5.1.6#~builtin<compat/typescript>::version=5.1.6&hash=5da071"
+"typescript@patch:typescript@~5.2.0#~builtin<compat/typescript>":
+  version: 5.2.2
+  resolution: "typescript@patch:typescript@npm%3A5.2.2#~builtin<compat/typescript>::version=5.2.2&hash=f3b441"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: f53bfe97f7c8b2b6d23cf572750d4e7d1e0c5fff1c36d859d0ec84556a827b8785077bc27676bf7e71fae538e517c3ecc0f37e7f593be913d884805d931bc8be
+  checksum: 0f4da2f15e6f1245e49db15801dbee52f2bbfb267e1c39225afdab5afee1a72839cd86000e65ee9d7e4dfaff12239d28beaf5ee431357fcced15fb08583d72ca
   languageName: node
   linkType: hard
 

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "shx": "^0.3.2",
     "sloc": "^0.3.1",
     "sort-package-json": "^2.8.0",
-    "typescript": "~5.1.0"
+    "typescript": "~5.2.0"
   },
   "packageManager": "yarn@3.8.1",
   "engines": {

--- a/packages/create-app/templates/default-app/package.json.hbs
+++ b/packages/create-app/templates/default-app/package.json.hbs
@@ -39,7 +39,7 @@
     "lerna": "^7.3.0",
     "node-gyp": "^9.0.0",
     "prettier": "^2.3.2",
-    "typescript": "~5.3.0"
+    "typescript": "~5.4.0"
   },
   "resolutions": {
     "@types/react": "^18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -38986,7 +38986,7 @@ __metadata:
     shx: ^0.3.2
     sloc: ^0.3.1
     sort-package-json: ^2.8.0
-    typescript: ~5.1.0
+    typescript: ~5.2.0
   languageName: unknown
   linkType: soft
 
@@ -42140,6 +42140,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:~5.2.0":
+  version: 5.2.2
+  resolution: "typescript@npm:5.2.2"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 7912821dac4d962d315c36800fe387cdc0a6298dba7ec171b350b4a6e988b51d7b8f051317786db1094bd7431d526b648aba7da8236607febb26cf5b871d2d3c
+  languageName: node
+  linkType: hard
+
 "typescript@patch:typescript@~5.0.4#~builtin<compat/typescript>":
   version: 5.0.4
   resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=b5f058"
@@ -42157,6 +42167,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: f53bfe97f7c8b2b6d23cf572750d4e7d1e0c5fff1c36d859d0ec84556a827b8785077bc27676bf7e71fae538e517c3ecc0f37e7f593be913d884805d931bc8be
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@~5.2.0#~builtin<compat/typescript>":
+  version: 5.2.2
+  resolution: "typescript@patch:typescript@npm%3A5.2.2#~builtin<compat/typescript>::version=5.2.2&hash=f3b441"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 0f4da2f15e6f1245e49db15801dbee52f2bbfb267e1c39225afdab5afee1a72839cd86000e65ee9d7e4dfaff12239d28beaf5ee431357fcced15fb08583d72ca
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
TypeScript 5.4 is out so let's bump up to that.

Tried this a while back and hit a blocking issue, but afaik the community plugins repo move resolved that for this repo.