### PR TITLE
Fixed SubmenuSubtitle is always white including on light background

### DIFF
--- a/.changeset/popular-carrots-love.md
+++ b/.changeset/popular-carrots-love.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Fixed an issue causing `SidebarSubmenu` text to not follow the theme color

--- a/packages/core-components/src/layout/Sidebar/SidebarSubmenu.tsx
+++ b/packages/core-components/src/layout/Sidebar/SidebarSubmenu.tsx
@@ -80,7 +80,7 @@ const useStyles = makeStyles<
     title: {
       fontSize: theme.typography.h5.fontSize,
       fontWeight: theme.typography.fontWeightMedium,
-      color: theme.palette.common.white,
+      color: theme.palette.navigation.color,
       padding: theme.spacing(2.5),
       [theme.breakpoints.down('xs')]: {
         display: 'none',


### PR DESCRIPTION
Changed the default colour of submenu title to be coherent with the rest of the menus.
Fixes #24315

Screenshots with a dark theme and a light test theme after the change:
<img width="459" alt="Screenshot 2024-05-29 at 13 27 49" src="https://github.com/backstage/backstage/assets/59442277/45d1dccf-9054-4ecd-96bd-7603e38d3ee5">
<img width="459" alt="Screenshot 2024-05-29 at 15 37 31" src="https://github.com/backstage/backstage/assets/59442277/b7bf8098-3cb5-4200-9cee-c6fc70ffca8f">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screeynshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
