### PR TITLE
Add relationType option to EntityMembersListCard component

### DIFF
--- a/.changeset/little-games-fail.md
+++ b/.changeset/little-games-fail.md
@@ -2,4 +2,6 @@
 '@backstage/plugin-org': patch
 ---
 
-Added relationship option to EntityMembersListCard component
+Added `relationType` property to EntityMembersListCard component that allows for display users related to a group via some other relationship aside from `memberOf`.
+
+Also, as a side effect, the `relationsType` property has been deprecated in favor of a more accurately named `relationAggregation` property.

--- a/.changeset/little-games-fail.md
+++ b/.changeset/little-games-fail.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Added relationship option to EntityMembersListCard component

--- a/plugins/org/api-report.md
+++ b/plugins/org/api-report.md
@@ -23,6 +23,7 @@ export const EntityMembersListCard: (props: {
   memberDisplayTitle?: string | undefined;
   pageSize?: number | undefined;
   showAggregateMembersToggle?: boolean | undefined;
+  relationship?: string | undefined;
   relationsType?: EntityRelationAggregation | undefined;
 }) => JSX_2.Element;
 
@@ -55,6 +56,7 @@ export const MembersListCard: (props: {
   memberDisplayTitle?: string;
   pageSize?: number;
   showAggregateMembersToggle?: boolean;
+  relationship?: string;
   relationsType?: EntityRelationAggregation;
 }) => React_2.JSX.Element;
 

--- a/plugins/org/api-report.md
+++ b/plugins/org/api-report.md
@@ -23,8 +23,9 @@ export const EntityMembersListCard: (props: {
   memberDisplayTitle?: string | undefined;
   pageSize?: number | undefined;
   showAggregateMembersToggle?: boolean | undefined;
-  relationship?: string | undefined;
+  relationType?: string | undefined;
   relationsType?: EntityRelationAggregation | undefined;
+  relationAggregation?: EntityRelationAggregation | undefined;
 }) => JSX_2.Element;
 
 // @public (undocumented)
@@ -33,6 +34,7 @@ export const EntityOwnershipCard: (props: {
   entityFilterKind?: string[] | undefined;
   hideRelationsToggle?: boolean | undefined;
   relationsType?: EntityRelationAggregation | undefined;
+  relationAggregation?: EntityRelationAggregation | undefined;
   entityLimit?: number | undefined;
 }) => JSX_2.Element;
 
@@ -56,8 +58,9 @@ export const MembersListCard: (props: {
   memberDisplayTitle?: string;
   pageSize?: number;
   showAggregateMembersToggle?: boolean;
-  relationship?: string;
+  relationType?: string;
   relationsType?: EntityRelationAggregation;
+  relationAggregation?: EntityRelationAggregation;
 }) => React_2.JSX.Element;
 
 // @public
@@ -84,6 +87,7 @@ export const OwnershipCard: (props: {
   entityFilterKind?: string[];
   hideRelationsToggle?: boolean;
   relationsType?: EntityRelationAggregation;
+  relationAggregation?: EntityRelationAggregation;
   entityLimit?: number;
 }) => React_2.JSX.Element;
 

--- a/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.test.tsx
+++ b/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.test.tsx
@@ -99,6 +99,7 @@ describe('MemberTab Test', () => {
         ] as Entity[],
       }),
   };
+  const getEntitiesSpy = jest.spyOn(catalogApi, 'getEntities');
 
   it('Display Profile Card', async () => {
     await renderInTestApp(
@@ -115,6 +116,12 @@ describe('MemberTab Test', () => {
         },
       },
     );
+    expect(getEntitiesSpy).toHaveBeenCalledWith({
+      filter: {
+        kind: 'User',
+        'relations.memberOf': ['group:default/team-d'],
+      },
+    });
 
     expect(screen.getByAltText('Tara MacGovern')).toHaveAttribute(
       'src',
@@ -147,6 +154,29 @@ describe('MemberTab Test', () => {
     );
 
     expect(screen.getByText('Testers (1)')).toBeInTheDocument();
+  });
+
+  it('Can query a different relationship', async () => {
+    await renderInTestApp(
+      <TestApiProvider apis={[[catalogApiRef, catalogApi]]}>
+        <EntityProvider entity={groupEntity}>
+          <MembersListCard relationship="leaderOf" />
+        </EntityProvider>
+      </TestApiProvider>,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
+        },
+      },
+    );
+
+    expect(getEntitiesSpy).toHaveBeenCalledWith({
+      filter: {
+        kind: 'User',
+        'relations.leaderOf': ['group:default/team-d'],
+      },
+    });
   });
 
   describe('Aggregate members toggle', () => {

--- a/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.test.tsx
+++ b/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.test.tsx
@@ -160,7 +160,7 @@ describe('MemberTab Test', () => {
     await renderInTestApp(
       <TestApiProvider apis={[[catalogApiRef, catalogApi]]}>
         <EntityProvider entity={groupEntity}>
-          <MembersListCard relationship="leaderOf" />
+          <MembersListCard relationType="leaderOf" />
         </EntityProvider>
       </TestApiProvider>,
       {
@@ -376,7 +376,7 @@ describe('MemberTab Test', () => {
             <EntityLayout.Route path="/" title="Title">
               <MembersListCard
                 showAggregateMembersToggle
-                relationsType="aggregated"
+                relationAggregation="aggregated"
               />
             </EntityLayout.Route>
           </EntityLayout>
@@ -414,7 +414,7 @@ describe('MemberTab Test', () => {
         <EntityProvider entity={groupA}>
           <EntityLayout>
             <EntityLayout.Route path="/" title="Title">
-              <MembersListCard relationsType="aggregated" />
+              <MembersListCard relationAggregation="aggregated" />
             </EntityLayout.Route>
           </EntityLayout>
         </EntityProvider>

--- a/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.test.tsx
+++ b/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.test.tsx
@@ -119,7 +119,7 @@ describe('MemberTab Test', () => {
     expect(getEntitiesSpy).toHaveBeenCalledWith({
       filter: {
         kind: 'User',
-        'relations.memberOf': ['group:default/team-d'],
+        'relations.memberof': ['group:default/team-d'],
       },
     });
 
@@ -174,7 +174,7 @@ describe('MemberTab Test', () => {
     expect(getEntitiesSpy).toHaveBeenCalledWith({
       filter: {
         kind: 'User',
-        'relations.leaderOf': ['group:default/team-d'],
+        'relations.leaderof': ['group:default/team-d'],
       },
     });
   });

--- a/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
+++ b/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
@@ -138,12 +138,14 @@ export const MembersListCard = (props: {
   memberDisplayTitle?: string;
   pageSize?: number;
   showAggregateMembersToggle?: boolean;
+  relationship?: string;
   relationsType?: EntityRelationAggregation;
 }) => {
   const {
     memberDisplayTitle = 'Members',
     pageSize = 50,
     showAggregateMembersToggle,
+    relationship = 'memberOf',
     relationsType = 'direct',
   } = props;
   const classes = useListStyles();
@@ -187,7 +189,7 @@ export const MembersListCard = (props: {
     const membersList = await catalogApi.getEntities({
       filter: {
         kind: 'User',
-        'relations.memberof': [
+        [`relations.${relationship}`]: [
           stringifyEntityRef({
             kind: 'group',
             namespace: groupNamespace.toLocaleLowerCase('en-US'),

--- a/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
+++ b/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
@@ -145,7 +145,7 @@ export const MembersListCard = (props: {
     memberDisplayTitle = 'Members',
     pageSize = 50,
     showAggregateMembersToggle,
-    relationship = 'memberOf',
+    relationship = 'memberof',
     relationsType = 'direct',
   } = props;
   const classes = useListStyles();
@@ -179,6 +179,7 @@ export const MembersListCard = (props: {
       return await getAllDesendantMembersForGroupEntity(
         groupEntity,
         catalogApi,
+        relationship,
       );
     }, [catalogApi, groupEntity, showAggregateMembers]);
   const {
@@ -189,7 +190,7 @@ export const MembersListCard = (props: {
     const membersList = await catalogApi.getEntities({
       filter: {
         kind: 'User',
-        [`relations.${relationship}`]: [
+        [`relations.${relationship.toLocaleLowerCase('en-US')}`]: [
           stringifyEntityRef({
             kind: 'group',
             namespace: groupNamespace.toLocaleLowerCase('en-US'),

--- a/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
+++ b/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
@@ -138,16 +138,19 @@ export const MembersListCard = (props: {
   memberDisplayTitle?: string;
   pageSize?: number;
   showAggregateMembersToggle?: boolean;
-  relationship?: string;
+  relationType?: string;
+  /** @deprecated Please use `relationAggregation` instead */
   relationsType?: EntityRelationAggregation;
+  relationAggregation?: EntityRelationAggregation;
 }) => {
   const {
     memberDisplayTitle = 'Members',
     pageSize = 50,
     showAggregateMembersToggle,
-    relationship = 'memberof',
-    relationsType = 'direct',
+    relationType = 'memberof',
   } = props;
+  const relationAggregation =
+    props.relationAggregation ?? props.relationsType ?? 'direct';
   const classes = useListStyles();
 
   const { entity: groupEntity } = useEntity<GroupEntity>();
@@ -167,7 +170,7 @@ export const MembersListCard = (props: {
   };
 
   const [showAggregateMembers, setShowAggregateMembers] = useState(
-    relationsType === 'aggregated',
+    relationAggregation === 'aggregated',
   );
 
   const { loading: loadingDescendantMembers, value: descendantMembers } =
@@ -179,7 +182,7 @@ export const MembersListCard = (props: {
       return await getAllDesendantMembersForGroupEntity(
         groupEntity,
         catalogApi,
-        relationship,
+        relationType,
       );
     }, [catalogApi, groupEntity, showAggregateMembers]);
   const {
@@ -190,7 +193,7 @@ export const MembersListCard = (props: {
     const membersList = await catalogApi.getEntities({
       filter: {
         kind: 'User',
-        [`relations.${relationship.toLocaleLowerCase('en-US')}`]: [
+        [`relations.${relationType.toLocaleLowerCase('en-US')}`]: [
           stringifyEntityRef({
             kind: 'group',
             namespace: groupNamespace.toLocaleLowerCase('en-US'),

--- a/plugins/org/src/components/Cards/OwnershipCard/ComponentsGrid.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/ComponentsGrid.tsx
@@ -107,19 +107,27 @@ export const ComponentsGrid = ({
   className,
   entity,
   relationsType,
+  relationAggregation,
   entityFilterKind,
   entityLimit = 6,
 }: {
   className?: string;
   entity: Entity;
-  relationsType: EntityRelationAggregation;
+  /** @deprecated Please use relationAggregation instead */
+  relationsType?: EntityRelationAggregation;
+  relationAggregation?: EntityRelationAggregation;
   entityFilterKind?: string[];
   entityLimit?: number;
 }) => {
   const catalogLink = useRouteRef(catalogIndexRouteRef);
+  if (!relationsType && !relationAggregation) {
+    throw new Error(
+      'The relationAggregation property must be set as an EntityRelationAggregation type.',
+    );
+  }
   const { componentsWithCounters, loading, error } = useGetEntities(
     entity,
-    relationsType,
+    (relationAggregation ?? relationsType)!, // we can safely use the non-null assertion here because of the run-time check above
     entityFilterKind,
     entityLimit,
   );

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.test.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.test.tsx
@@ -288,7 +288,7 @@ describe('OwnershipCard', () => {
     const { getByText } = await renderInTestApp(
       <TestApiProvider apis={[[catalogApiRef, catalogApi]]}>
         <EntityProvider entity={userEntity}>
-          <OwnershipCard relationsType="aggregated" />
+          <OwnershipCard relationAggregation="aggregated" />
         </EntityProvider>
       </TestApiProvider>,
       {

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
@@ -67,31 +67,34 @@ export const OwnershipCard = (props: {
   variant?: InfoCardVariants;
   entityFilterKind?: string[];
   hideRelationsToggle?: boolean;
+  /** @deprecated Please use relationAggregation instead */
   relationsType?: EntityRelationAggregation;
+  relationAggregation?: EntityRelationAggregation;
   entityLimit?: number;
 }) => {
   const {
     variant,
     entityFilterKind,
     hideRelationsToggle,
-    relationsType,
     entityLimit = 6,
   } = props;
+  const relationAggregation = props.relationAggregation ?? props.relationsType;
   const relationsToggle =
     hideRelationsToggle === undefined ? false : hideRelationsToggle;
   const classes = useStyles();
   const { entity } = useEntity();
 
-  const defaultRelationsType = entity.kind === 'User' ? 'aggregated' : 'direct';
-  const [getRelationsType, setRelationsType] = useState(
-    relationsType ?? defaultRelationsType,
+  const defaultRelationAggregation =
+    entity.kind === 'User' ? 'aggregated' : 'direct';
+  const [getRelationAggregation, setRelationAggregation] = useState(
+    relationAggregation ?? defaultRelationAggregation,
   );
 
   useEffect(() => {
-    if (!relationsType) {
-      setRelationsType(defaultRelationsType);
+    if (!relationAggregation) {
+      setRelationAggregation(defaultRelationAggregation);
     }
-  }, [setRelationsType, defaultRelationsType, relationsType]);
+  }, [setRelationAggregation, defaultRelationAggregation, relationAggregation]);
 
   return (
     <InfoCard
@@ -112,16 +115,18 @@ export const OwnershipCard = (props: {
                 placement="top"
                 arrow
                 title={`${
-                  getRelationsType === 'direct' ? 'Direct' : 'Aggregated'
+                  getRelationAggregation === 'direct' ? 'Direct' : 'Aggregated'
                 } Relations`}
               >
                 <Switch
                   color="primary"
-                  checked={getRelationsType !== 'direct'}
+                  checked={getRelationAggregation !== 'direct'}
                   onChange={() => {
-                    const updatedRelationsType =
-                      getRelationsType === 'direct' ? 'aggregated' : 'direct';
-                    setRelationsType(updatedRelationsType);
+                    const updatedRelationAggregation =
+                      getRelationAggregation === 'direct'
+                        ? 'aggregated'
+                        : 'direct';
+                    setRelationAggregation(updatedRelationAggregation);
                   }}
                   name="pin"
                   inputProps={{ 'aria-label': 'Ownership Type Switch' }}
@@ -136,7 +141,7 @@ export const OwnershipCard = (props: {
         className={classes.grid}
         entity={entity}
         entityLimit={entityLimit}
-        relationsType={getRelationsType}
+        relationAggregation={getRelationAggregation}
         entityFilterKind={entityFilterKind}
       />
     </InfoCard>

--- a/plugins/org/src/components/Cards/OwnershipCard/useGetEntities.test.ts
+++ b/plugins/org/src/components/Cards/OwnershipCard/useGetEntities.test.ts
@@ -64,7 +64,7 @@ describe('useGetEntities', () => {
       ]),
     });
 
-  describe('given aggregated relationsType', () => {
+  describe('given aggregated relationAggregation', () => {
     const whenHookIsCalledWith = async (_entity: Entity) => {
       const { result } = renderHook(
         ({ entity }) => useGetEntities(entity, 'aggregated'),
@@ -205,7 +205,7 @@ describe('useGetEntities', () => {
     });
   });
 
-  describe('given direct relationsType', () => {
+  describe('given direct relationAggregation', () => {
     const whenHookIsCalledWith = async (_entity: Entity) => {
       const { result } = renderHook(
         ({ entity }) => useGetEntities(entity, 'direct'),

--- a/plugins/org/src/components/Cards/OwnershipCard/useGetEntities.ts
+++ b/plugins/org/src/components/Cards/OwnershipCard/useGetEntities.ts
@@ -125,11 +125,11 @@ const getChildOwnershipEntityRefs = async (
 
 const getOwners = async (
   entity: Entity,
-  relations: EntityRelationAggregation,
+  relationAggregation: EntityRelationAggregation,
   catalogApi: CatalogApi,
 ): Promise<string[]> => {
   const isGroup = entity.kind === 'Group';
-  const isAggregated = relations === 'aggregated';
+  const isAggregated = relationAggregation === 'aggregated';
   const isUserEntity = entity.kind === 'User';
 
   if (isAggregated && isGroup) {
@@ -166,7 +166,7 @@ const getOwnedEntitiesByOwners = (
 
 export function useGetEntities(
   entity: Entity,
-  relations: EntityRelationAggregation,
+  relationAggregation: EntityRelationAggregation,
   entityFilterKind?: string[],
   entityLimit = 6,
 ): {
@@ -189,7 +189,7 @@ export function useGetEntities(
     error,
     value: componentsWithCounters,
   } = useAsync(async () => {
-    const owners = await getOwners(entity, relations, catalogApi);
+    const owners = await getOwners(entity, relationAggregation, catalogApi);
 
     const ownedEntitiesList = await getOwnedEntitiesByOwners(
       owners,
@@ -230,7 +230,7 @@ export function useGetEntities(
       kind: string;
       queryParams: string;
     }>;
-  }, [catalogApi, entity, relations]);
+  }, [catalogApi, entity, relationAggregation]);
 
   return {
     componentsWithCounters,

--- a/plugins/org/src/helpers/helpers.ts
+++ b/plugins/org/src/helpers/helpers.ts
@@ -31,6 +31,7 @@ import {
 export const getMembersFromGroups = async (
   groups: CompoundEntityRef[],
   catalogApi: CatalogApi,
+  relationship = 'memberof',
 ) => {
   const membersList =
     groups.length === 0
@@ -38,13 +39,14 @@ export const getMembersFromGroups = async (
       : await catalogApi.getEntities({
           filter: {
             kind: 'User',
-            'relations.memberof': groups.map(group =>
-              stringifyEntityRef({
-                kind: 'group',
-                namespace: group.namespace.toLocaleLowerCase('en-US'),
-                name: group.name.toLocaleLowerCase('en-US'),
-              }),
-            ),
+            [`relations.${relationship.toLocaleLowerCase('en-US')}`]:
+              groups.map(group =>
+                stringifyEntityRef({
+                  kind: 'group',
+                  namespace: group.namespace.toLocaleLowerCase('en-US'),
+                  name: group.name.toLocaleLowerCase('en-US'),
+                }),
+              ),
           },
         });
 
@@ -99,10 +101,12 @@ export const getDescendantGroupsFromGroup = async (
 export const getAllDesendantMembersForGroupEntity = async (
   groupEntity: GroupEntity,
   catalogApi: CatalogApi,
+  relationship = 'memberof',
 ) =>
   getMembersFromGroups(
     await getDescendantGroupsFromGroup(groupEntity, catalogApi),
     catalogApi,
+    relationship,
   );
 
 export const removeDuplicateEntitiesFrom = (entityArray: Entity[]) => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

I would like to be able to display multiple "Members" cards on a Group page, each displaying User entities that have a different relationship to the Group entity being viewed.

By default, this component displays all User entities that have a `memberOf` relationship to the Group. I would also like to display a list of users that have a `leaderOf` relationship to the same group. This PR allows the relationship type to be passed in and used when querying the catalog API.

(This was a small amount of effort so if this does not fit the vision/philosophy that you want to adhere to for this component, I'm fine with you closing without merging. It just seemed like a reasonable feature addition without complicating the default behavior and is a much simpler solution that forking/duplicating the component for )

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
