### PR TITLE
Docs should state `createNewFileAction()` rather than `new createNewF…

### DIFF
--- a/docs/features/software-templates/writing-custom-actions.md
+++ b/docs/features/software-templates/writing-custom-actions.md
@@ -216,7 +216,7 @@ const scaffolderModuleCustomExtensions = createBackendModule({
       async init({ scaffolder /* ..., other dependencies */ }) {
         // Here you have the opportunity to interact with the extension
         // point before the plugin itself gets instantiated
-        scaffolder.addActions(new createNewFileAction()); // just an example
+        scaffolder.addActions(createNewFileAction()); // just an example
       },
     });
   },


### PR DESCRIPTION
…ileAction()`

## Hey, I just made a Pull Request!

Fix error in docs when documenting how to call scaffolder.addActions().

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
