### PR TITLE
Removed View Techdocs button from component details

### DIFF
--- a/.changeset/young-wasps-wink.md
+++ b/.changeset/young-wasps-wink.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Removed the button `viewInTechDocs` from `AboutCard` so that `View Techdocs` button is not visible in component details.

--- a/plugins/catalog/src/components/AboutCard/AboutCard.test.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutCard.test.tsx
@@ -708,8 +708,8 @@ describe('<AboutCard />', () => {
       },
     );
 
-    expect(screen.getByText('View TechDocs')).toBeVisible();
-    expect(screen.getByText('View TechDocs').closest('a')).toBeNull();
+    // expect(screen.getByText('View TechDocs')).toBeInTheDocument();
+    expect(screen.queryByText('View TechDocs')).toBeNull();
   });
 
   it('renders disabled techdocs link when route is not bound', async () => {
@@ -762,8 +762,8 @@ describe('<AboutCard />', () => {
       },
     );
 
-    expect(screen.getByText('View TechDocs')).toBeVisible();
-    expect(screen.getByText('View TechDocs').closest('a')).toBeNull();
+    // expect(screen.getByText('View TechDocs')).toBeVisible();
+    expect(screen.queryByText('View TechDocs')).toBeNull();
   });
 
   it('renders launch template link', async () => {

--- a/plugins/catalog/src/components/AboutCard/AboutCard.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutCard.tsx
@@ -147,30 +147,34 @@ export function AboutCard(props: AboutCardProps) {
     icon: <ScmIntegrationIcon type={entitySourceLocation?.integrationType} />,
     href: entitySourceLocation?.locationTargetUrl,
   };
-  // const viewInTechDocs: IconLinkVerticalProps = {
-  //   label: 'View TechDocs',
-  //   disabled:
-  //     !(
-  //       entity.metadata.annotations?.[TECHDOCS_ANNOTATION] ||
-  //       entity.metadata.annotations?.[TECHDOCS_EXTERNAL_ANNOTATION]
-  //     ) || !viewTechdocLink,
-  //   icon: <DocsIcon />,
-  //   href:
-  //     viewTechdocLink &&
-  //     (techdocsRef
-  //       ? viewTechdocLink({
-  //           namespace: techdocsRef.namespace || DEFAULT_NAMESPACE,
-  //           kind: techdocsRef.kind,
-  //           name: techdocsRef.name,
-  //         })
-  //       : viewTechdocLink({
-  //           namespace: entity.metadata.namespace || DEFAULT_NAMESPACE,
-  //           kind: entity.kind,
-  //           name: entity.metadata.name,
-  //         })),
-  // };
+  const viewInTechDocs: IconLinkVerticalProps = {
+    label: 'View TechDocs',
+    disabled:
+      !(
+        entity.metadata.annotations?.[TECHDOCS_ANNOTATION] ||
+        entity.metadata.annotations?.[TECHDOCS_EXTERNAL_ANNOTATION]
+      ) || !viewTechdocLink,
+    icon: <DocsIcon />,
+    href:
+      viewTechdocLink &&
+      (techdocsRef
+        ? viewTechdocLink({
+            namespace: techdocsRef.namespace || DEFAULT_NAMESPACE,
+            kind: techdocsRef.kind,
+            name: techdocsRef.name,
+          })
+        : viewTechdocLink({
+            namespace: entity.metadata.namespace || DEFAULT_NAMESPACE,
+            kind: entity.kind,
+            name: entity.metadata.name,
+          })),
+  };
 
   const subHeaderLinks = [viewInSource];
+
+  if (!viewInTechDocs?.disabled) {
+    subHeaderLinks.push(viewInTechDocs);
+  }
 
   if (isTemplateEntityV1beta3(entity)) {
     const Icon = app.getSystemIcon('scaffolder') ?? CreateComponentIcon;

--- a/plugins/catalog/src/components/AboutCard/AboutCard.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutCard.tsx
@@ -172,7 +172,7 @@ export function AboutCard(props: AboutCardProps) {
 
   const subHeaderLinks = [viewInSource];
 
-  if (!viewInTechDocs?.disabled) {
+  if (viewTechdocLink) {
     subHeaderLinks.push(viewInTechDocs);
   }
 

--- a/plugins/catalog/src/components/AboutCard/AboutCard.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutCard.tsx
@@ -147,30 +147,30 @@ export function AboutCard(props: AboutCardProps) {
     icon: <ScmIntegrationIcon type={entitySourceLocation?.integrationType} />,
     href: entitySourceLocation?.locationTargetUrl,
   };
-  const viewInTechDocs: IconLinkVerticalProps = {
-    label: 'View TechDocs',
-    disabled:
-      !(
-        entity.metadata.annotations?.[TECHDOCS_ANNOTATION] ||
-        entity.metadata.annotations?.[TECHDOCS_EXTERNAL_ANNOTATION]
-      ) || !viewTechdocLink,
-    icon: <DocsIcon />,
-    href:
-      viewTechdocLink &&
-      (techdocsRef
-        ? viewTechdocLink({
-            namespace: techdocsRef.namespace || DEFAULT_NAMESPACE,
-            kind: techdocsRef.kind,
-            name: techdocsRef.name,
-          })
-        : viewTechdocLink({
-            namespace: entity.metadata.namespace || DEFAULT_NAMESPACE,
-            kind: entity.kind,
-            name: entity.metadata.name,
-          })),
-  };
+  // const viewInTechDocs: IconLinkVerticalProps = {
+  //   label: 'View TechDocs',
+  //   disabled:
+  //     !(
+  //       entity.metadata.annotations?.[TECHDOCS_ANNOTATION] ||
+  //       entity.metadata.annotations?.[TECHDOCS_EXTERNAL_ANNOTATION]
+  //     ) || !viewTechdocLink,
+  //   icon: <DocsIcon />,
+  //   href:
+  //     viewTechdocLink &&
+  //     (techdocsRef
+  //       ? viewTechdocLink({
+  //           namespace: techdocsRef.namespace || DEFAULT_NAMESPACE,
+  //           kind: techdocsRef.kind,
+  //           name: techdocsRef.name,
+  //         })
+  //       : viewTechdocLink({
+  //           namespace: entity.metadata.namespace || DEFAULT_NAMESPACE,
+  //           kind: entity.kind,
+  //           name: entity.metadata.name,
+  //         })),
+  // };
 
-  const subHeaderLinks = [viewInSource, viewInTechDocs];
+  const subHeaderLinks = [viewInSource];
 
   if (isTemplateEntityV1beta3(entity)) {
     const Icon = app.getSystemIcon('scaffolder') ?? CreateComponentIcon;


### PR DESCRIPTION
Removed the disabled "View Techdocs" button from the component details.

Old:
<img width="737" alt="image" src="https://github.com/backstage/backstage/assets/136452216/9981eaa8-c240-4fc1-a066-3922b5338c6a">

Updated:
<img width="755" alt="image" src="https://github.com/backstage/backstage/assets/136452216/3d491822-789b-473c-a230-385d6c122fb1">

Issue: #24960


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
