### PR TITLE
attempt to fix the `_a.destroy is not a function` error

### DIFF
--- a/plugins/proxy-backend/src/service/router.credentials.test.ts
+++ b/plugins/proxy-backend/src/service/router.credentials.test.ts
@@ -18,11 +18,7 @@ import {
   authServiceFactory,
   httpAuthServiceFactory,
 } from '@backstage/backend-app-api';
-import {
-  mockServices,
-  setupRequestMockHandlers,
-  startTestBackend,
-} from '@backstage/backend-test-utils';
+import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
 import { ResponseError } from '@backstage/errors';
 import { JsonObject } from '@backstage/types';
 import { HttpResponse, http, passthrough } from 'msw';
@@ -34,7 +30,8 @@ import fetch from 'node-fetch';
 
 describe('credentials', () => {
   const worker = setupServer();
-  setupRequestMockHandlers(worker);
+  beforeAll(() => worker.listen({ onUnhandledRequest: 'error' }));
+  afterEach(() => worker.resetHandlers());
 
   it('handles all valid credentials settings', async () => {
     const config = {


### PR DESCRIPTION
I think there may be a race where this handler gets torn down either twice, or at the wrong point in time, leading to `_a.destroy is not a function` errors in CI. Trying to do the mock handlers manually instead of the test-utils one, skipping calling `close()` at all for now.