### PR TITLE
Fix error message when vale is not installed

### DIFF
--- a/scripts/check-docs-quality.js
+++ b/scripts/check-docs-quality.js
@@ -74,7 +74,7 @@ async function exitIfMissingVale() {
     console.log(
       `Language linter (vale) was not found. Please install vale linter (https://vale.sh/docs/vale-cli/installation/).\n`,
     );
-    process.exit(1);
+    process.exit(process.env.CI ? 1 : 0);
   }
 }
 

--- a/scripts/check-docs-quality.js
+++ b/scripts/check-docs-quality.js
@@ -71,15 +71,10 @@ async function exitIfMissingVale() {
     // eslint-disable-next-line @backstage/no-undeclared-imports
     await require('command-exists')('vale');
   } catch (e) {
-    if (process.env.CI) {
-      console.log(
-        `Language linter (vale) was not found. Please install vale linter (https://vale.sh/docs/vale-cli/installation/).\n`,
-      );
-      process.exit(1);
-    }
-    console.log(`Language linter (vale) generated errors. Please check the errors and review any markdown files that you changed.
-  Possibly update .github/vale/config/vocabularies/Backstage/accept.txt to add new valid words.\n`);
-    process.exit(0);
+    console.log(
+      `Language linter (vale) was not found. Please install vale linter (https://vale.sh/docs/vale-cli/installation/).\n`,
+    );
+    process.exit(1);
   }
 }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixed error message when `vale` is not installed.
Related issue - https://github.com/backstage/backstage/issues/25000

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
