### PR TITLE
Revert "attempt to fix the `_a.destroy is not a function` error"

### DIFF
--- a/plugins/proxy-backend/src/service/router.credentials.test.ts
+++ b/plugins/proxy-backend/src/service/router.credentials.test.ts
@@ -18,7 +18,11 @@ import {
   authServiceFactory,
   httpAuthServiceFactory,
 } from '@backstage/backend-app-api';
-import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
+import {
+  mockServices,
+  setupRequestMockHandlers,
+  startTestBackend,
+} from '@backstage/backend-test-utils';
 import { ResponseError } from '@backstage/errors';
 import { JsonObject } from '@backstage/types';
 import { HttpResponse, http, passthrough } from 'msw';
@@ -30,8 +34,7 @@ import fetch from 'node-fetch';
 
 describe('credentials', () => {
   const worker = setupServer();
-  beforeAll(() => worker.listen({ onUnhandledRequest: 'error' }));
-  afterEach(() => worker.resetHandlers());
+  setupRequestMockHandlers(worker);
 
   it('handles all valid credentials settings', async () => {
     const config = {


### PR DESCRIPTION
Reverts backstage/backstage#24992

Maybe the build errors that happened because of this can give some insight into where the "leak" happens, something is going on between tests I think https://github.com/backstage/backstage/actions/runs/9309084380/job/25623928502?pr=24997#step:10:10246