### PR TITLE
fix: Prefer accountId for AwsOrganizationCloudAccountProcessor authentication

### DIFF
--- a/.changeset/swift-kings-sparkle.md
+++ b/.changeset/swift-kings-sparkle.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend-module-aws': patch
 ---
 
-AwsOrganizationCloudAccountProcessor configuration field roleArn is deprecated in favor of new field accountId
+`AwsOrganizationCloudAccountProcessor` configuration field `roleArn` is deprecated in favor of new field `accountId`

--- a/.changeset/swift-kings-sparkle.md
+++ b/.changeset/swift-kings-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-aws': patch
+---
+
+AwsOrganizationCloudAccountProcessor configuration field roleArn is deprecated in favor of new field accountId

--- a/plugins/catalog-backend-module-aws/config.d.ts
+++ b/plugins/catalog-backend-module-aws/config.d.ts
@@ -26,8 +26,14 @@ export interface Config {
         provider: {
           /**
            * The role to be assumed by this processor
+           * @deprecated Use `accountId` instead.
            */
           roleArn?: string;
+
+          /**
+           * The AWS account ID to query for organizational data
+           */
+          accountId?: string;
         };
       };
     };

--- a/plugins/catalog-backend-module-aws/src/awsOrganization/config.test.ts
+++ b/plugins/catalog-backend-module-aws/src/awsOrganization/config.test.ts
@@ -22,11 +22,13 @@ describe('readAwsOrganizationConfig', () => {
     const config = {
       provider: {
         roleArn: 'aws::arn::foo',
+        accountId: '111111111111',
       },
     };
     const actual = readAwsOrganizationConfig(new ConfigReader(config));
     const expected = {
       roleArn: 'aws::arn::foo',
+      accountId: '111111111111',
     };
     expect(actual).toEqual(expected);
   });

--- a/plugins/catalog-backend-module-aws/src/awsOrganization/config.ts
+++ b/plugins/catalog-backend-module-aws/src/awsOrganization/config.ts
@@ -24,6 +24,11 @@ export type AwsOrganizationProviderConfig = {
    * The role to assume for the processor.
    */
   roleArn?: string;
+
+  /**
+   * The AWS accountId
+   */
+  accountId?: string;
 };
 
 export function readAwsOrganizationConfig(
@@ -32,7 +37,9 @@ export function readAwsOrganizationConfig(
   const providerConfig = config.getOptionalConfig('provider');
 
   const roleArn = providerConfig?.getOptionalString('roleArn');
+  const accountId = providerConfig?.getOptionalString('accountId');
   return {
     roleArn,
+    accountId,
   };
 }

--- a/plugins/catalog-backend-module-aws/src/awsOrganization/config.ts
+++ b/plugins/catalog-backend-module-aws/src/awsOrganization/config.ts
@@ -22,6 +22,7 @@ import { Config } from '@backstage/config';
 export type AwsOrganizationProviderConfig = {
   /**
    * The role to assume for the processor.
+   * @deprecated Use `accountId` instead.
    */
   roleArn?: string;
 

--- a/plugins/catalog-backend-module-aws/src/processors/AwsOrganizationCloudAccountProcessor.ts
+++ b/plugins/catalog-backend-module-aws/src/processors/AwsOrganizationCloudAccountProcessor.ts
@@ -106,27 +106,23 @@ export class AwsOrganizationCloudAccountProcessor implements CatalogProcessor {
 
     this.logger?.info('Discovering AWS Organization Account objects');
 
-    try {
-      (await this.getAwsAccounts())
-        .map(account => this.mapAccountToComponent(account))
-        .filter(entity => {
-          if (location.target !== '') {
-            if (entity.metadata.annotations) {
-              return (
-                entity.metadata.annotations[ORGANIZATION_ANNOTATION] ===
-                location.target
-              );
-            }
-            return false;
+    (await this.getAwsAccounts())
+      .map(account => this.mapAccountToComponent(account))
+      .filter(entity => {
+        if (location.target !== '') {
+          if (entity.metadata.annotations) {
+            return (
+              entity.metadata.annotations[ORGANIZATION_ANNOTATION] ===
+              location.target
+            );
           }
-          return true;
-        })
-        .forEach(entity => {
-          emit(processingResult.entity(location, entity));
-        });
-    } catch (e) {
-      this.logger?.error(e);
-    }
+          return false;
+        }
+        return true;
+      })
+      .forEach(entity => {
+        emit(processingResult.entity(location, entity));
+      });
 
     return true;
   }


### PR DESCRIPTION
…tication

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Closes #18052 - update for AwsOrganizationCloudAccountProcessor to use accountId as preferred

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
