### PR TITLE
[Github Scaffolder Module] Add boolean flag to discard authors information in createPullRequest action

### DIFF
--- a/.changeset/young-apes-thank.md
+++ b/.changeset/young-apes-thank.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-github': minor
+---
+
+Allow empty author info in createPullRequest action for Github

--- a/plugins/scaffolder-backend-module-github/api-report.md
+++ b/plugins/scaffolder-backend-module-github/api-report.md
@@ -392,6 +392,7 @@ export const createPublishGithubPullRequestAction: (
     forceFork?: boolean | undefined;
     gitAuthorName?: string | undefined;
     gitAuthorEmail?: string | undefined;
+    forceEmptyGitAuthor?: boolean | undefined;
   },
   JsonObject
 >;

--- a/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.test.ts
@@ -1026,5 +1026,40 @@ describe('createPublishGithubPullRequestAction', () => {
         ],
       });
     });
+    it('discards author name and email if forceEmptyGitAuthor is set', async () => {
+      input.forceEmptyGitAuthor = true;
+      const clientFactory = jest.fn(async () => fakeClient as any);
+      const githubCredentialsProvider: GithubCredentialsProvider = {
+        getCredentials: jest.fn(),
+      };
+
+      const instanceWithConfig = createPublishGithubPullRequestAction({
+        integrations,
+        githubCredentialsProvider,
+        clientFactory,
+      });
+
+      await instanceWithConfig.handler(ctx);
+
+      expect(fakeClient.createPullRequest).toHaveBeenCalledWith({
+        owner: 'myorg',
+        repo: 'myrepo',
+        title: 'Create my new app',
+        head: 'new-app',
+        body: 'This PR is really good',
+        changes: [
+          {
+            commit: 'Create my new app',
+            files: {
+              'file.txt': {
+                content: Buffer.from('Hello there!').toString('base64'),
+                encoding: 'base64',
+                mode: '100644',
+              },
+            },
+          },
+        ],
+      });
+    });
   });
 });

--- a/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.ts
@@ -414,7 +414,6 @@ export const createPublishGithubPullRequestAction = (
           }
         }
 
-
         if (targetBranchName) {
           createOptions.base = targetBranchName;
         }

--- a/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.ts
@@ -146,6 +146,7 @@ export const createPublishGithubPullRequestAction = (
     forceFork?: boolean;
     gitAuthorName?: string;
     gitAuthorEmail?: string;
+    forceEmptyGitAuthor?: boolean;
   }>({
     id: 'publish:github:pull-request',
     examples,
@@ -246,6 +247,12 @@ export const createPublishGithubPullRequestAction = (
             description:
               "Sets the default author email for the commit. The default value is the authenticated user or 'scaffolder@backstage.io'",
           },
+          forceEmptyGitAuthor: {
+            type: 'boolean',
+            title: 'Force Empty Git Author',
+            description:
+              'Forces the author to be empty. This is useful when using a Github App, it permit the commit to be verified on Github',
+          },
         },
       },
       output: {
@@ -287,6 +294,7 @@ export const createPublishGithubPullRequestAction = (
         forceFork,
         gitAuthorEmail,
         gitAuthorName,
+        forceEmptyGitAuthor,
       } = ctx.input;
 
       const { owner, repo, host } = parseRepoUrl(repoUrl, integrations);
@@ -384,25 +392,28 @@ export const createPublishGithubPullRequestAction = (
             config?.getOptionalString('scaffolder.defaultAuthor.email'),
         };
 
-        if (gitAuthorInfo.name || gitAuthorInfo.email) {
-          if (Array.isArray(createOptions.changes)) {
-            createOptions.changes = createOptions.changes.map(change => ({
-              ...change,
-              author: {
-                name: gitAuthorInfo.name || 'Scaffolder',
-                email: gitAuthorInfo.email || 'scaffolder@backstage.io',
-              },
-            }));
-          } else {
-            createOptions.changes = {
-              ...createOptions.changes,
-              author: {
-                name: gitAuthorInfo.name || 'Scaffolder',
-                email: gitAuthorInfo.email || 'scaffolder@backstage.io',
-              },
-            };
+        if (!forceEmptyGitAuthor) {
+          if (gitAuthorInfo.name || gitAuthorInfo.email) {
+            if (Array.isArray(createOptions.changes)) {
+              createOptions.changes = createOptions.changes.map(change => ({
+                ...change,
+                author: {
+                  name: gitAuthorInfo.name || 'Scaffolder',
+                  email: gitAuthorInfo.email || 'scaffolder@backstage.io',
+                },
+              }));
+            } else {
+              createOptions.changes = {
+                ...createOptions.changes,
+                author: {
+                  name: gitAuthorInfo.name || 'Scaffolder',
+                  email: gitAuthorInfo.email || 'scaffolder@backstage.io',
+                },
+              };
+            }
           }
         }
+
 
         if (targetBranchName) {
           createOptions.base = targetBranchName;

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -289,6 +289,7 @@ export const createPublishGithubPullRequestAction: (
     forceFork?: boolean | undefined;
     gitAuthorName?: string | undefined;
     gitAuthorEmail?: string | undefined;
+    forceEmptyGitAuthor?: boolean | undefined;
   },
   JsonObject
 >;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Hi ! This PR introduces a boolean flag to force discarding of authors information in the Github Pull Request scaffolder action. The primary goal is to be able to have an empty `author` field in the commit payload because when using Github Apps, the bot commits are verified on Github side only if no authors customizations are passed in the commit payload

[Github documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#signature-verification-for-bots)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
