### PR TITLE
Fixed select field width on wide monitors

### DIFF
--- a/.changeset/swift-islands-leave.md
+++ b/.changeset/swift-islands-leave.md
@@ -2,4 +2,4 @@
 '@backstage/core-components': patch
 ---
 
-Made `Select` field bug where it was not in full width on large screens.
+Removed max width from `Select` component.

--- a/.changeset/swift-islands-leave.md
+++ b/.changeset/swift-islands-leave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Made `Select` field bug where it was not in full width on large screens.

--- a/packages/core-components/src/components/Select/Select.tsx
+++ b/packages/core-components/src/components/Select/Select.tsx
@@ -78,7 +78,6 @@ const useStyles = makeStyles(
     createStyles({
       formControl: {
         margin: theme.spacing(1, 0),
-        maxWidth: 300,
       },
       label: {
         transform: 'initial',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR fixes the [issue](https://github.com/backstage/backstage/issues/22980) where select fields appear shorter on wide-screen monitors. See screenshots for more info,

Fixes - https://github.com/backstage/backstage/issues/22980

**Before**
<img width="1317" alt="image" src="https://github.com/backstage/backstage/assets/37075892/eccd33ef-15ec-411f-893d-7dcdbb5bac25">
**After**
<img width="1329" alt="image" src="https://github.com/backstage/backstage/assets/37075892/c17dfae9-e56c-4842-b9cf-338c53ce1a37">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
