### PR TITLE
Export EntityContextMenu from Catalog plugin

### DIFF
--- a/.changeset/warm-tomatoes-lick.md
+++ b/.changeset/warm-tomatoes-lick.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-catalog': major
+'@backstage/plugin-catalog': patch
 ---
 
-Export EntityContextMenu for use in other projects (e.g., custom EntityLayout implementations) without duplicating code
+Exported `EntityContextMenu` component.

--- a/.changeset/warm-tomatoes-lick.md
+++ b/.changeset/warm-tomatoes-lick.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': major
+---
+
+Export EntityContextMenu for use in other projects (e.g., custom EntityLayout implementations) without duplicating code

--- a/plugins/catalog/report.api.md
+++ b/plugins/catalog/report.api.md
@@ -347,6 +347,14 @@ export interface DependsOnResourcesCardProps {
 // @public
 export const EntityAboutCard: (props: AboutCardProps) => JSX.Element;
 
+// Warning: (ae-forgotten-export) The symbol "EntityContextMenuProps" needs to be exported by the entry point index.d.ts
+// Warning: (ae-missing-release-tag) "EntityContextMenu" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export function EntityContextMenu(
+  props: EntityContextMenuProps,
+): React_2.JSX.Element;
+
 // @public (undocumented)
 export type EntityContextMenuClassKey = 'button';
 
@@ -418,10 +426,10 @@ export interface EntityLayoutProps {
   //
   // (undocumented)
   UNSTABLE_contextMenuOptions?: EntityContextMenuOptions;
-  // Warning: (ae-forgotten-export) The symbol "ExtraContextMenuItem" needs to be exported by the entry point index.d.ts
+  // Warning: (ae-forgotten-export) The symbol "ExtraContextMenuItem_2" needs to be exported by the entry point index.d.ts
   //
   // (undocumented)
-  UNSTABLE_extraContextMenuItems?: ExtraContextMenuItem[];
+  UNSTABLE_extraContextMenuItems?: ExtraContextMenuItem_2[];
 }
 
 // @public (undocumented)

--- a/plugins/catalog/report.api.md
+++ b/plugins/catalog/report.api.md
@@ -347,13 +347,13 @@ export interface DependsOnResourcesCardProps {
 // @public
 export const EntityAboutCard: (props: AboutCardProps) => JSX.Element;
 
-// Warning: (ae-forgotten-export) The symbol "EntityContextMenuProps" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "EntityContextMenu" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
-export function EntityContextMenu(
-  props: EntityContextMenuProps,
-): React_2.JSX.Element;
+export function EntityContextMenu(props: {
+  UNSTABLE_extraContextMenuItems?: ExtraContextMenuItem[];
+  UNSTABLE_contextMenuOptions?: UnregisterEntityOptions;
+  onUnregisterEntity: () => void;
+  onInspectEntity: () => void;
+}): React_2.JSX.Element;
 
 // @public (undocumented)
 export type EntityContextMenuClassKey = 'button';
@@ -731,6 +731,9 @@ export type SystemDiagramCardClassKey =
 // src/components/DependsOnResourcesCard/DependsOnResourcesCard.d.ts:8:5 - (ae-undocumented) Missing documentation for "columns".
 // src/components/DependsOnResourcesCard/DependsOnResourcesCard.d.ts:9:5 - (ae-undocumented) Missing documentation for "tableOptions".
 // src/components/EntityContextMenu/EntityContextMenu.d.ts:5:1 - (ae-undocumented) Missing documentation for "EntityContextMenuClassKey".
+// src/components/EntityContextMenu/EntityContextMenu.d.ts:12:1 - (ae-undocumented) Missing documentation for "EntityContextMenu".
+// src/components/EntityContextMenu/EntityContextMenu.d.ts:13:5 - (ae-forgotten-export) The symbol "ExtraContextMenuItem" needs to be exported by the entry point index.d.ts
+// src/components/EntityContextMenu/EntityContextMenu.d.ts:14:5 - (ae-forgotten-export) The symbol "UnregisterEntityOptions" needs to be exported by the entry point index.d.ts
 // src/components/EntityLabelsCard/EntityLabelsCard.d.ts:4:1 - (ae-undocumented) Missing documentation for "EntityLabelsCardProps".
 // src/components/EntityLabelsCard/EntityLabelsCard.d.ts:5:5 - (ae-undocumented) Missing documentation for "variant".
 // src/components/EntityLabelsCard/EntityLabelsCard.d.ts:6:5 - (ae-undocumented) Missing documentation for "title".

--- a/plugins/catalog/report.api.md
+++ b/plugins/catalog/report.api.md
@@ -349,8 +349,14 @@ export const EntityAboutCard: (props: AboutCardProps) => JSX.Element;
 
 // @public (undocumented)
 export function EntityContextMenu(props: {
-  UNSTABLE_extraContextMenuItems?: ExtraContextMenuItem[];
-  UNSTABLE_contextMenuOptions?: UnregisterEntityOptions;
+  UNSTABLE_extraContextMenuItems?: Array<{
+    title: string;
+    Icon: IconComponent;
+    onClick: () => void;
+  }>;
+  UNSTABLE_contextMenuOptions?: {
+    disableUnregister: boolean | 'visible' | 'hidden' | 'disable';
+  };
   onUnregisterEntity: () => void;
   onInspectEntity: () => void;
 }): React_2.JSX.Element;
@@ -426,10 +432,10 @@ export interface EntityLayoutProps {
   //
   // (undocumented)
   UNSTABLE_contextMenuOptions?: EntityContextMenuOptions;
-  // Warning: (ae-forgotten-export) The symbol "ExtraContextMenuItem_2" needs to be exported by the entry point index.d.ts
+  // Warning: (ae-forgotten-export) The symbol "ExtraContextMenuItem" needs to be exported by the entry point index.d.ts
   //
   // (undocumented)
-  UNSTABLE_extraContextMenuItems?: ExtraContextMenuItem_2[];
+  UNSTABLE_extraContextMenuItems?: ExtraContextMenuItem[];
 }
 
 // @public (undocumented)
@@ -730,10 +736,8 @@ export type SystemDiagramCardClassKey =
 // src/components/DependsOnResourcesCard/DependsOnResourcesCard.d.ts:7:5 - (ae-undocumented) Missing documentation for "title".
 // src/components/DependsOnResourcesCard/DependsOnResourcesCard.d.ts:8:5 - (ae-undocumented) Missing documentation for "columns".
 // src/components/DependsOnResourcesCard/DependsOnResourcesCard.d.ts:9:5 - (ae-undocumented) Missing documentation for "tableOptions".
-// src/components/EntityContextMenu/EntityContextMenu.d.ts:5:1 - (ae-undocumented) Missing documentation for "EntityContextMenuClassKey".
-// src/components/EntityContextMenu/EntityContextMenu.d.ts:12:1 - (ae-undocumented) Missing documentation for "EntityContextMenu".
-// src/components/EntityContextMenu/EntityContextMenu.d.ts:13:5 - (ae-forgotten-export) The symbol "ExtraContextMenuItem" needs to be exported by the entry point index.d.ts
-// src/components/EntityContextMenu/EntityContextMenu.d.ts:14:5 - (ae-forgotten-export) The symbol "UnregisterEntityOptions" needs to be exported by the entry point index.d.ts
+// src/components/EntityContextMenu/EntityContextMenu.d.ts:4:1 - (ae-undocumented) Missing documentation for "EntityContextMenuClassKey".
+// src/components/EntityContextMenu/EntityContextMenu.d.ts:6:1 - (ae-undocumented) Missing documentation for "EntityContextMenu".
 // src/components/EntityLabelsCard/EntityLabelsCard.d.ts:4:1 - (ae-undocumented) Missing documentation for "EntityLabelsCardProps".
 // src/components/EntityLabelsCard/EntityLabelsCard.d.ts:5:5 - (ae-undocumented) Missing documentation for "variant".
 // src/components/EntityLabelsCard/EntityLabelsCard.d.ts:6:5 - (ae-undocumented) Missing documentation for "title".

--- a/plugins/catalog/src/components/EntityContextMenu/EntityContextMenu.tsx
+++ b/plugins/catalog/src/components/EntityContextMenu/EntityContextMenu.tsx
@@ -58,14 +58,13 @@ interface ExtraContextMenuItem {
   onClick: () => void;
 }
 
-interface EntityContextMenuProps {
+/** @public */
+export function EntityContextMenu(props: {
   UNSTABLE_extraContextMenuItems?: ExtraContextMenuItem[];
   UNSTABLE_contextMenuOptions?: UnregisterEntityOptions;
   onUnregisterEntity: () => void;
   onInspectEntity: () => void;
-}
-
-export function EntityContextMenu(props: EntityContextMenuProps) {
+}) {
   const {
     UNSTABLE_extraContextMenuItems,
     UNSTABLE_contextMenuOptions,

--- a/plugins/catalog/src/components/EntityContextMenu/EntityContextMenu.tsx
+++ b/plugins/catalog/src/components/EntityContextMenu/EntityContextMenu.tsx
@@ -30,7 +30,7 @@ import React, { useEffect, useState } from 'react';
 import { IconComponent } from '@backstage/core-plugin-api';
 import { useEntityPermission } from '@backstage/plugin-catalog-react/alpha';
 import { catalogEntityDeletePermission } from '@backstage/plugin-catalog-common/alpha';
-import { UnregisterEntity, UnregisterEntityOptions } from './UnregisterEntity';
+import { UnregisterEntity } from './UnregisterEntity';
 import { useApi, alertApiRef } from '@backstage/core-plugin-api';
 import useCopyToClipboard from 'react-use/esm/useCopyToClipboard';
 import { catalogTranslationRef } from '../../alpha/translation';
@@ -50,18 +50,16 @@ const useStyles = makeStyles(
   { name: 'PluginCatalogEntityContextMenu' },
 );
 
-// NOTE(freben): Intentionally not exported at this point, since it's part of
-// the unstable extra context menu items concept below
-interface ExtraContextMenuItem {
-  title: string;
-  Icon: IconComponent;
-  onClick: () => void;
-}
-
 /** @public */
 export function EntityContextMenu(props: {
-  UNSTABLE_extraContextMenuItems?: ExtraContextMenuItem[];
-  UNSTABLE_contextMenuOptions?: UnregisterEntityOptions;
+  UNSTABLE_extraContextMenuItems?: Array<{
+    title: string;
+    Icon: IconComponent;
+    onClick: () => void;
+  }>;
+  UNSTABLE_contextMenuOptions?: {
+    disableUnregister: boolean | 'visible' | 'hidden' | 'disable';
+  };
   onUnregisterEntity: () => void;
   onInspectEntity: () => void;
 }) {

--- a/plugins/catalog/src/index.ts
+++ b/plugins/catalog/src/index.ts
@@ -30,6 +30,7 @@ export type {
 export { AboutContent, AboutField } from './components/AboutCard';
 export * from './components/CatalogKindHeader';
 export * from './components/CatalogTable';
+export * from './components/EntityContextMenu';
 export * from './components/EntityLayout';
 export * from './components/EntityOrphanWarning';
 export * from './components/EntityRelationWarning';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Exported `EntityContextMenu` to allow for a custom `EntityLayout` implementation without having to duplicate the entire context menu and its `UnregisterEntity` subcomponent. (This PR is a reproduction of #21525 which was closed due to inactivity from the original author.)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
~~- [ ] Tests for new functionality and regression tests for bug fixes~~
~~- [ ] Screenshots attached (for UI changes)~~
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
