### PR TITLE
Add topic filter to notifications-backend

### DIFF
--- a/.changeset/sour-jokes-sneeze.md
+++ b/.changeset/sour-jokes-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications-backend': patch
+---
+
+Added an option to filter notifications by topic

--- a/plugins/notifications-backend/src/database/DatabaseNotificationsStore.test.ts
+++ b/plugins/notifications-backend/src/database/DatabaseNotificationsStore.test.ts
@@ -271,6 +271,20 @@ describe.each(databases.eachSupportedId())(
         expect(notifications.length).toBe(1);
         expect(notifications.at(0)?.id).toEqual(id2);
       });
+
+      it('should filter notifications based on topic', async () => {
+        await storage.saveNotification(testNotification1);
+        await storage.saveNotification(testNotification2);
+        await storage.saveNotification(testNotification3);
+
+        const notifications = await storage.getNotifications({
+          user,
+          topic: 'efgh-topic',
+        });
+
+        expect(notifications.length).toBe(1);
+        expect(notifications.at(0)?.id).toEqual(id1);
+      });
     });
 
     describe('getNotifications filters on severity', () => {

--- a/plugins/notifications-backend/src/database/DatabaseNotificationsStore.ts
+++ b/plugins/notifications-backend/src/database/DatabaseNotificationsStore.ts
@@ -204,6 +204,10 @@ export class DatabaseNotificationsStore implements NotificationsStore {
       query.whereNull('read');
     } // or match both if undefined
 
+    if (options.topic) {
+      query.where('topic', '=', options.topic);
+    }
+
     if (options.saved) {
       query.whereNotNull('saved');
     } else if (options.saved === false) {

--- a/plugins/notifications-backend/src/database/NotificationsStore.ts
+++ b/plugins/notifications-backend/src/database/NotificationsStore.ts
@@ -35,6 +35,7 @@ export type NotificationGetOptions = {
   limit?: number;
   search?: string;
   orderField?: EntityOrder[];
+  topic?: string;
   read?: boolean;
   saved?: boolean;
   createdAfter?: Date;

--- a/plugins/notifications-backend/src/service/router.ts
+++ b/plugins/notifications-backend/src/service/router.ts
@@ -302,6 +302,11 @@ export async function createRouter(
       opts.read = false;
       // or keep undefined
     }
+
+    if (req.query.topic) {
+      opts.topic = req.query.topic.toString();
+    }
+
     if (req.query.saved === 'true') {
       opts.saved = true;
     } else if (req.query.saved === 'false') {


### PR DESCRIPTION
This PR adds a query parameter to filter notifications by their topic. Our use case for this is having separate views for different categories of notifications.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
