### PR TITLE
Updated `node-gyp` for `create-app` to v10

### DIFF
--- a/.changeset/wise-beers-doubt.md
+++ b/.changeset/wise-beers-doubt.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Updated `node-gyp` to v10

--- a/packages/create-app/templates/default-app/package.json.hbs
+++ b/packages/create-app/templates/default-app/package.json.hbs
@@ -37,7 +37,7 @@
     "@spotify/prettier-config": "^12.0.0",
     "concurrently": "^8.0.0",
     "lerna": "^7.3.0",
-    "node-gyp": "^9.0.0",
+    "node-gyp": "^10.0.0",
     "prettier": "^2.3.2",
     "typescript": "~5.4.0"
   },

--- a/packages/create-app/templates/default-app/packages/backend/package.json.hbs
+++ b/packages/create-app/templates/default-app/packages/backend/package.json.hbs
@@ -41,7 +41,7 @@
     "app": "link:../app",
     "better-sqlite3": "^9.0.0",
     "dockerode": "^3.3.1",
-    "node-gyp": "^9.0.0",
+    "node-gyp": "^10.0.0",
     "pg": "^8.11.3",
     "winston": "^3.2.1"
   },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updated `node-gyp` for `create-app` to v10. I recently upgraded python to v3.12 and began to have issues with helping test problems reported with `create-app`, seems they removed a package that `node-gyp` uses and v10 resolves the issue. More details here: https://github.com/nodejs/node-gyp/issues/2869

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
