### PR TITLE
Display labels in AboutContent.tsx

### DIFF
--- a/.changeset/gentle-grapes-run.md
+++ b/.changeset/gentle-grapes-run.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': minor
+---
+
+add labels to EntityAboutCard

--- a/.changeset/gentle-grapes-run.md
+++ b/.changeset/gentle-grapes-run.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-catalog': minor
+'@backstage/plugin-catalog': patch
 ---
 
 add labels to EntityAboutCard

--- a/plugins/catalog/src/components/AboutCard/AboutContent.test.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutContent.test.tsx
@@ -37,6 +37,9 @@ describe('<AboutContent />', () => {
           name: 'software',
           description: 'This is the description',
           tags: ['tag-1'],
+          labels: {
+            'label-1': 'foo-bar',
+          },
         },
         spec: {
           owner: 'o',
@@ -86,10 +89,15 @@ describe('<AboutContent />', () => {
       expect(screen.getByText('Lifecycle').nextSibling).toHaveTextContent('l');
       expect(screen.getByText('Tags')).toBeInTheDocument();
       expect(screen.getByText('Tags').nextSibling).toHaveTextContent('tag-1');
+      expect(screen.getByText('Labels')).toBeInTheDocument();
+      expect(screen.getByText('Labels').nextSibling).toHaveTextContent(
+        'label-1: foo-bar',
+      );
     });
 
     it('highlights missing required fields', async () => {
       delete entity.metadata.tags;
+      delete entity.metadata.labels;
       entity.spec = {};
       entity.relations = [];
 
@@ -126,6 +134,9 @@ describe('<AboutContent />', () => {
           name: 'software',
           description: 'This is the description',
           tags: ['tag-1'],
+          labels: {
+            'label-1': 'foo-bar',
+          },
         },
         spec: {
           type: 'openapi',
@@ -176,10 +187,15 @@ describe('<AboutContent />', () => {
       );
       expect(screen.getByText('Tags')).toBeInTheDocument();
       expect(screen.getByText('Tags').nextSibling).toHaveTextContent('tag-1');
+      expect(screen.getByText('Labels')).toBeInTheDocument();
+      expect(screen.getByText('Labels').nextSibling).toHaveTextContent(
+        'label-1: foo-bar',
+      );
     });
 
     it('highlights missing required fields', async () => {
       delete entity.metadata.tags;
+      delete entity.metadata.labels;
       delete entity.spec!.type;
       delete entity.spec!.lifecycle;
       delete entity.spec!.system;
@@ -213,6 +229,10 @@ describe('<AboutContent />', () => {
       );
       expect(screen.getByText('Tags')).toBeInTheDocument();
       expect(screen.getByText('Tags').nextSibling).toHaveTextContent('No Tags');
+      expect(screen.getByText('Labels')).toBeInTheDocument();
+      expect(screen.getByText('Labels').nextSibling).toHaveTextContent(
+        'No labels',
+      );
     });
   });
 
@@ -227,6 +247,9 @@ describe('<AboutContent />', () => {
           name: 'software',
           description: 'This is the description',
           tags: ['tag-1'],
+          labels: {
+            'label-1': 'foo-bar',
+          },
         },
         spec: {
           owner: 'guest',
@@ -284,10 +307,15 @@ describe('<AboutContent />', () => {
       );
       expect(screen.getByText('Tags')).toBeInTheDocument();
       expect(screen.getByText('Tags').nextSibling).toHaveTextContent('tag-1');
+      expect(screen.getByText('Labels')).toBeInTheDocument();
+      expect(screen.getByText('Labels').nextSibling).toHaveTextContent(
+        'label-1: foo-bar',
+      );
     });
 
     it('highlights missing required fields', async () => {
       delete entity.metadata.tags;
+      delete entity.metadata.labels;
       delete entity.spec!.type;
       delete entity.spec!.lifecycle;
       delete entity.spec!.system;
@@ -321,6 +349,10 @@ describe('<AboutContent />', () => {
       );
       expect(screen.getByText('Tags')).toBeInTheDocument();
       expect(screen.getByText('Tags').nextSibling).toHaveTextContent('No Tags');
+      expect(screen.getByText('Labels')).toBeInTheDocument();
+      expect(screen.getByText('Labels').nextSibling).toHaveTextContent(
+        'No labels',
+      );
     });
   });
 
@@ -335,6 +367,9 @@ describe('<AboutContent />', () => {
           name: 'software',
           description: 'This is the description',
           tags: ['tag-1'],
+          labels: {
+            'label-1': 'foo-bar',
+          },
         },
         spec: {
           owner: 'guest',
@@ -370,10 +405,15 @@ describe('<AboutContent />', () => {
       expect(screen.queryByText('Lifecycle')).not.toBeInTheDocument();
       expect(screen.getByText('Tags')).toBeInTheDocument();
       expect(screen.getByText('Tags').nextSibling).toHaveTextContent('tag-1');
+      expect(screen.getByText('Labels')).toBeInTheDocument();
+      expect(screen.getByText('Labels').nextSibling).toHaveTextContent(
+        'label-1: foo-bar',
+      );
     });
 
     it('highlights missing required fields', async () => {
       delete entity.metadata.tags;
+      delete entity.metadata.labels;
       entity.relations = [];
 
       await renderInTestApp(<AboutContent entity={entity} />, {
@@ -397,6 +437,10 @@ describe('<AboutContent />', () => {
       expect(screen.queryByText('Lifecycle')).not.toBeInTheDocument();
       expect(screen.getByText('Tags')).toBeInTheDocument();
       expect(screen.getByText('Tags').nextSibling).toHaveTextContent('No Tags');
+      expect(screen.getByText('Labels')).toBeInTheDocument();
+      expect(screen.getByText('Labels').nextSibling).toHaveTextContent(
+        'No labels',
+      );
     });
   });
 
@@ -411,6 +455,9 @@ describe('<AboutContent />', () => {
           name: 'software',
           description: 'This is the description',
           tags: ['tag-1'],
+          labels: {
+            'label-1': 'foo-bar',
+          },
         },
         spec: {
           type: 'root',
@@ -447,10 +494,15 @@ describe('<AboutContent />', () => {
       expect(screen.getByText('Targets').nextSibling).toHaveTextContent(
         'https://backstage.io',
       );
+      expect(screen.getByText('Labels')).toBeInTheDocument();
+      expect(screen.getByText('Labels').nextSibling).toHaveTextContent(
+        'label-1: foo-bar',
+      );
     });
 
     it('highlights missing required fields', async () => {
       delete entity.metadata.tags;
+      delete entity.metadata.labels;
       delete entity.spec!.type;
 
       await renderInTestApp(<AboutContent entity={entity} />, {
@@ -475,6 +527,10 @@ describe('<AboutContent />', () => {
       expect(screen.queryByText('Lifecycle')).not.toBeInTheDocument();
       expect(screen.getByText('Tags')).toBeInTheDocument();
       expect(screen.getByText('Tags').nextSibling).toHaveTextContent('No Tags');
+      expect(screen.getByText('Labels')).toBeInTheDocument();
+      expect(screen.getByText('Labels').nextSibling).toHaveTextContent(
+        'No labels',
+      );
     });
   });
 
@@ -489,6 +545,9 @@ describe('<AboutContent />', () => {
           name: 'software',
           description: 'This is the description',
           tags: ['tag-1'],
+          labels: {
+            'label-1': 'foo-bar',
+          },
         },
         spec: {
           type: 's3',
@@ -534,10 +593,15 @@ describe('<AboutContent />', () => {
       expect(screen.queryByText('Lifecycle')).not.toBeInTheDocument();
       expect(screen.getByText('Tags')).toBeInTheDocument();
       expect(screen.getByText('Tags').nextSibling).toHaveTextContent('tag-1');
+      expect(screen.getByText('Labels')).toBeInTheDocument();
+      expect(screen.getByText('Labels').nextSibling).toHaveTextContent(
+        'label-1: foo-bar',
+      );
     });
 
     it('highlights missing required fields', async () => {
       delete entity.metadata.tags;
+      delete entity.metadata.labels;
       delete entity.spec!.type;
       delete entity.spec!.system;
       entity.relations = [];
@@ -567,6 +631,10 @@ describe('<AboutContent />', () => {
       expect(screen.queryByText('Lifecycle')).not.toBeInTheDocument();
       expect(screen.getByText('Tags')).toBeInTheDocument();
       expect(screen.getByText('Tags').nextSibling).toHaveTextContent('No Tags');
+      expect(screen.getByText('Labels')).toBeInTheDocument();
+      expect(screen.getByText('Labels').nextSibling).toHaveTextContent(
+        'No labels',
+      );
     });
   });
 
@@ -581,6 +649,9 @@ describe('<AboutContent />', () => {
           name: 'software',
           description: 'This is the description',
           tags: ['tag-1'],
+          labels: {
+            'label-1': 'foo-bar',
+          },
         },
         spec: {
           owner: 'guest',
@@ -624,10 +695,15 @@ describe('<AboutContent />', () => {
       expect(screen.queryByText('Lifecycle')).not.toBeInTheDocument();
       expect(screen.getByText('Tags')).toBeInTheDocument();
       expect(screen.getByText('Tags').nextSibling).toHaveTextContent('tag-1');
+      expect(screen.getByText('Labels')).toBeInTheDocument();
+      expect(screen.getByText('Labels').nextSibling).toHaveTextContent(
+        'label-1: foo-bar',
+      );
     });
 
     it('highlights missing required fields', async () => {
       delete entity.metadata.tags;
+      delete entity.metadata.labels;
       delete entity.spec!.domain;
       entity.relations = [];
 
@@ -655,6 +731,10 @@ describe('<AboutContent />', () => {
       expect(screen.queryByText('Lifecycle')).not.toBeInTheDocument();
       expect(screen.getByText('Tags')).toBeInTheDocument();
       expect(screen.getByText('Tags').nextSibling).toHaveTextContent('No Tags');
+      expect(screen.getByText('Labels')).toBeInTheDocument();
+      expect(screen.getByText('Labels').nextSibling).toHaveTextContent(
+        'No labels',
+      );
     });
   });
 });

--- a/plugins/catalog/src/components/AboutCard/AboutContent.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutContent.tsx
@@ -202,6 +202,17 @@ export function AboutContent(props: AboutContentProps) {
           <Chip key={t} size="small" label={t} />
         ))}
       </AboutField>
+      <AboutField
+        label="Labels"
+        value="No labels"
+        gridSizes={{ xs: 12, sm: 6, lg: 4 }}
+      >
+        {Object.entries(entity.metadata.labels || {}).map(([key, value]) => (
+          <Grid item key={key}>
+            <Chip key={key} size="small" label={`${key}: ${value}`} />
+          </Grid>
+        ))}
+      </AboutField>
       {isLocation && (entity?.spec?.targets || entity?.spec?.target) && (
         <AboutField label="Targets" gridSizes={{ xs: 12 }}>
           <LinksGridList


### PR DESCRIPTION
In the Entity model its described that labels is a common [part of a entity ](https://backstage.io/docs/features/software-catalog/descriptor-format/), but its not displayed, so this PR adds the labels in the view.
<img width="633" alt="Screenshot 2024-06-03 at 14 49 37" src="https://github.com/backstage/backstage/assets/22368613/99479a67-03e4-46a2-9c77-98bea392bb4c">
<img width="748" alt="Screenshot 2024-06-03 at 15 10 47" src="https://github.com/backstage/backstage/assets/22368613/974fca6d-d041-4cc1-a706-d66d8750909d">


The org i work at atm wants to use custom labels for their internal systems, and want to display these. 

If anyone has any ideas / thoughts about how to solve the issue if there is 50 labels / 50 tags, how to properly display that?

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
