### PR TITLE
update package ref to alpha

### DIFF
--- a/docs/backend-system/building-plugins-and-modules/08-migrating.md
+++ b/docs/backend-system/building-plugins-and-modules/08-migrating.md
@@ -39,7 +39,7 @@ import {
   coreServices,
   createBackendPlugin,
 } from '@backstage/backend-plugin-api';
-import { catalogServiceRef } from '@backstage/plugin-catalog-node';
+import { catalogServiceRef } from '@backstage/plugin-catalog-node/alpha';
 import { Router } from 'express';
 import { KubernetesBuilder } from './KubernetesBuilder';
 


### PR DESCRIPTION
Import from slash alpha

Without `/alpha` I see error `Module '"@backstage/plugin-catalog-node"' has no exported member 'catalogServiceRef'.ts(2305)`