### PR TITLE
feat(api-docs): Columns override on ComponentsCards

### DIFF
--- a/.changeset/forty-geckos-change.md
+++ b/.changeset/forty-geckos-change.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-api-docs': patch
 ---
 
-Custom columns can now be optionally provided to ConsumingComponentsCard and ProvidingComponentsCard
+`ConsumingComponentsCard` and `ProvidingComponentsCard` will now optionally accept `columns` to override which table columns are displayed

--- a/.changeset/forty-geckos-change.md
+++ b/.changeset/forty-geckos-change.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-api-docs': patch
+---
+
+Custom columns can now be optionally provided to ConsumingComponentsCard and ProvidingComponentsCard

--- a/plugins/api-docs/api-report.md
+++ b/plugins/api-docs/api-report.md
@@ -9,6 +9,7 @@ import { ApiEntity } from '@backstage/catalog-model';
 import { ApiRef } from '@backstage/core-plugin-api';
 import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { CatalogTableRow } from '@backstage/plugin-catalog';
+import { ComponentEntity } from '@backstage/catalog-model';
 import { EntityOwnerPickerProps } from '@backstage/plugin-catalog-react';
 import { ExternalRouteRef } from '@backstage/core-plugin-api';
 import { InfoCardVariants } from '@backstage/core-components';
@@ -94,6 +95,7 @@ export const ConsumedApisCard: (props: {
 // @public (undocumented)
 export const ConsumingComponentsCard: (props: {
   variant?: InfoCardVariants;
+  columns?: TableColumn<ComponentEntity>[];
 }) => React_2.JSX.Element;
 
 // @public
@@ -124,6 +126,7 @@ export const EntityConsumedApisCard: (props: {
 // @public (undocumented)
 export const EntityConsumingComponentsCard: (props: {
   variant?: InfoCardVariants | undefined;
+  columns?: TableColumn<ComponentEntity>[] | undefined;
 }) => JSX_2.Element;
 
 // @public (undocumented)
@@ -141,6 +144,7 @@ export const EntityProvidedApisCard: (props: {
 // @public (undocumented)
 export const EntityProvidingComponentsCard: (props: {
   variant?: InfoCardVariants | undefined;
+  columns?: TableColumn<ComponentEntity>[] | undefined;
 }) => JSX_2.Element;
 
 // @public (undocumented)
@@ -191,6 +195,7 @@ export const ProvidedApisCard: (props: {
 // @public (undocumented)
 export const ProvidingComponentsCard: (props: {
   variant?: InfoCardVariants;
+  columns?: TableColumn<ComponentEntity>[];
 }) => React_2.JSX.Element;
 
 // @public (undocumented)

--- a/plugins/api-docs/src/components/ComponentsCards/ConsumingComponentsCard.tsx
+++ b/plugins/api-docs/src/components/ComponentsCards/ConsumingComponentsCard.tsx
@@ -31,6 +31,7 @@ import {
   InfoCardVariants,
   Link,
   Progress,
+  TableColumn,
   WarningPanel,
 } from '@backstage/core-components';
 
@@ -39,8 +40,10 @@ import {
  */
 export const ConsumingComponentsCard = (props: {
   variant?: InfoCardVariants;
+  columns?: TableColumn<ComponentEntity>[];
 }) => {
-  const { variant = 'gridItem' } = props;
+  const { variant = 'gridItem', columns = EntityTable.componentEntityColumns } =
+    props;
   const { entity } = useEntity();
   const { entities, loading, error } = useRelatedEntities(entity, {
     type: RELATION_API_CONSUMED_BY,
@@ -82,7 +85,7 @@ export const ConsumingComponentsCard = (props: {
           </Typography>
         </div>
       }
-      columns={EntityTable.componentEntityColumns}
+      columns={columns}
       entities={entities as ComponentEntity[]}
     />
   );

--- a/plugins/api-docs/src/components/ComponentsCards/ProvidingComponentsCard.tsx
+++ b/plugins/api-docs/src/components/ComponentsCards/ProvidingComponentsCard.tsx
@@ -31,14 +31,17 @@ import {
   InfoCardVariants,
   Link,
   Progress,
+  TableColumn,
   WarningPanel,
 } from '@backstage/core-components';
 
 /** @public */
 export const ProvidingComponentsCard = (props: {
   variant?: InfoCardVariants;
+  columns?: TableColumn<ComponentEntity>[];
 }) => {
-  const { variant = 'gridItem' } = props;
+  const { variant = 'gridItem', columns = EntityTable.componentEntityColumns } =
+    props;
   const { entity } = useEntity();
   const { entities, loading, error } = useRelatedEntities(entity, {
     type: RELATION_API_PROVIDED_BY,
@@ -80,7 +83,7 @@ export const ProvidingComponentsCard = (props: {
           </Typography>
         </div>
       }
-      columns={EntityTable.componentEntityColumns}
+      columns={columns}
       entities={entities as ComponentEntity[]}
     />
   );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

`ConsumingComponentsCard` and `ProvidingComponentsCard` will now optionally accept the `columns` prop to override which table columns are displayed.

Changes were made based on the same prop on `ConsumedApisCard`/`ProvidedApisCard`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
