### PR TITLE
cli-common: fix workspace check

### DIFF
--- a/.changeset/purple-mugs-beg.md
+++ b/.changeset/purple-mugs-beg.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli-common': patch
+---
+
+The monorepo root check in `findPaths` will now accept a shorthand `workspaces` config in `package.json`, no longer requiring `workspaces.packages`.

--- a/packages/cli-common/src/paths.test.ts
+++ b/packages/cli-common/src/paths.test.ts
@@ -19,6 +19,10 @@ import { resolve as resolvePath } from 'path';
 import { findPaths, findRootPath, findOwnDir, findOwnRootDir } from './paths';
 
 describe('paths', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('findOwnDir and findOwnRootDir should find owns paths', () => {
     const dir = findOwnDir(__dirname);
     const root = findOwnRootDir(dir);
@@ -91,5 +95,29 @@ describe('paths', () => {
     expect(paths.resolveTargetRoot('./derp.txt')).toBe(
       resolvePath(root, 'derp.txt'),
     );
+  });
+
+  it('findPaths should find workspace root with object', () => {
+    jest.spyOn(JSON, 'parse').mockReturnValue({ workspaces: { packages: [] } });
+    jest.spyOn(process, 'cwd').mockReturnValue(__dirname);
+
+    const paths = findPaths(__dirname);
+
+    expect(paths.targetDir).toBe(
+      resolvePath(__dirname, '../../cli-common/src'),
+    );
+    expect(paths.targetRoot).toBe(resolvePath(__dirname, '../../cli-common'));
+  });
+
+  it('findPaths should find workspace root with array', () => {
+    jest.spyOn(JSON, 'parse').mockReturnValue({ workspaces: [] });
+    jest.spyOn(process, 'cwd').mockReturnValue(__dirname);
+
+    const paths = findPaths(__dirname);
+
+    expect(paths.targetDir).toBe(
+      resolvePath(__dirname, '../../cli-common/src'),
+    );
+    expect(paths.targetRoot).toBe(resolvePath(__dirname, '../../cli-common'));
   });
 });

--- a/packages/cli-common/src/paths.ts
+++ b/packages/cli-common/src/paths.ts
@@ -141,7 +141,7 @@ export function findPaths(searchDir: string): Paths {
           try {
             const content = fs.readFileSync(path, 'utf8');
             const data = JSON.parse(content);
-            return Boolean(data.workspaces?.packages);
+            return Boolean(data.workspaces);
           } catch (error) {
             throw new Error(
               `Failed to parse package.json file while searching for root, ${error}`,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Checking for `workspaces.packages` is too strict, you can also define workspaces as just `workspaces: [...]`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
