### PR TITLE
owners: update community plugin maintainers

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -117,7 +117,6 @@ Scope: Tooling and Community Repo Maintainers for the Backstage [Community Plugi
 | André Wanlin         | Spotify      | [awanlin](https://github.com/awanlin)       | `ahhhndre`   |
 | Bethany Griggs       | Red Hat      | [BethGriggs](https://github.com/BethGriggs) | `bethgriggs` |
 | Nick Boldt           | Red Hat      | [nickboldt](https://github.com/nickboldt)   | `nboldt`     |
-| Tomas Kral           | Red Hat      | [kadel](https://github.com/kadel)           | `tomkral`    |
 | Vincenzo Scamporlino | Spotify      | [vinzscam](https://github.com/vinzscam)     | `vinzscam`   |
 
 ### Events

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -114,10 +114,10 @@ Scope: Tooling and Community Repo Maintainers for the Backstage [Community Plugi
 
 | Name                 | Organization | GitHub                                      | Discord      |
 | -------------------- | ------------ | ------------------------------------------- | ------------ |
-| Bethany Griggs       | Red Hat      | [BethGriggs](https://github.com/BethGriggs) | `bethgriggs` |
-| Tomas Kral           | Red Hat      | [kadel](https://github.com/kadel)           | `tomkral`    |
 | André Wanlin         | Spotify      | [awanlin](https://github.com/awanlin)       | `ahhhndre`   |
-| Philipp Hugenroth    | Spotify      | [tudi2d](https://github.com/tudi2d)         | `tudi2d`     |
+| Bethany Griggs       | Red Hat      | [BethGriggs](https://github.com/BethGriggs) | `bethgriggs` |
+| Nick Boldt           | Red Hat      | [nickboldt](https://github.com/nickboldt)   | `nboldt`     |
+| Tomas Kral           | Red Hat      | [kadel](https://github.com/kadel)           | `tomkral`    |
 | Vincenzo Scamporlino | Spotify      | [vinzscam](https://github.com/vinzscam)     | `vinzscam`   |
 
 ### Events


### PR DESCRIPTION
A couple of updates to the community plugin maintainers:

- Reordered to be alphabetical
- Removed @tudi2d, who is now at @lmu
- Added @nickboldt

Please approve if these are all fine @backstage/community-plugins-maintainers 