### PR TITLE
bump better-sqlite3 from  9.0.0 to  11.0.0

### DIFF
--- a/.changeset/weak-boats-float.md
+++ b/.changeset/weak-boats-float.md
@@ -1,0 +1,9 @@
+---
+'@backstage/plugin-catalog-backend': minor
+'@backstage/backend-test-utils': patch
+'@backstage/backend-defaults': patch
+'@backstage/backend-common': patch
+'example-backend-legacy': patch
+---
+
+bumped better-sqlite3 from ^9.0.0 to ^11.0.0

--- a/.changeset/weak-boats-float.md
+++ b/.changeset/weak-boats-float.md
@@ -3,7 +3,6 @@
 '@backstage/backend-test-utils': patch
 '@backstage/backend-defaults': patch
 '@backstage/backend-common': patch
-'example-backend-legacy': patch
 ---
 
 bumped better-sqlite3 from ^9.0.0 to ^11.0.0

--- a/packages/backend-common/package.json
+++ b/packages/backend-common/package.json
@@ -137,7 +137,7 @@
     "@types/webpack-env": "^1.15.2",
     "@types/yauzl": "^2.10.0",
     "aws-sdk-client-mock": "^4.0.0",
-    "better-sqlite3": "^9.0.0",
+    "better-sqlite3": "^11.0.0",
     "http-errors": "^2.0.0",
     "msw": "^1.0.0",
     "mysql2": "^3.0.0",

--- a/packages/backend-defaults/package.json
+++ b/packages/backend-defaults/package.json
@@ -143,7 +143,7 @@
     "@types/express": "^4.17.6",
     "archiver": "^6.0.0",
     "base64-stream": "^1.0.0",
-    "better-sqlite3": "^9.0.0",
+    "better-sqlite3": "^11.0.0",
     "compression": "^1.7.4",
     "concat-stream": "^2.0.0",
     "cookie": "^0.6.0",

--- a/packages/backend-legacy/package.json
+++ b/packages/backend-legacy/package.json
@@ -66,7 +66,7 @@
     "@gitbeaker/node": "^35.1.0",
     "@octokit/rest": "^19.0.3",
     "azure-devops-node-api": "^12.0.0",
-    "better-sqlite3": "^9.0.0",
+    "better-sqlite3": "^11.0.0",
     "dockerode": "^4.0.0",
     "example-app": "link:../app",
     "express": "^4.17.1",

--- a/packages/backend-test-utils/package.json
+++ b/packages/backend-test-utils/package.json
@@ -56,7 +56,7 @@
     "@keyv/memcache": "^1.3.5",
     "@keyv/redis": "^2.5.3",
     "@types/keyv": "^4.2.0",
-    "better-sqlite3": "^9.0.0",
+    "better-sqlite3": "^11.0.0",
     "cookie": "^0.6.0",
     "express": "^4.17.1",
     "fs-extra": "^11.0.0",

--- a/plugins/catalog-backend/package.json
+++ b/plugins/catalog-backend/package.json
@@ -110,7 +110,7 @@
     "@types/lodash": "^4.14.151",
     "@types/supertest": "^2.0.8",
     "@types/uuid": "^9.0.0",
-    "better-sqlite3": "^9.0.0",
+    "better-sqlite3": "^11.0.0",
     "luxon": "^3.0.0",
     "msw": "^1.0.0",
     "supertest": "^6.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3559,7 +3559,7 @@ __metadata:
     archiver: ^6.0.0
     aws-sdk-client-mock: ^4.0.0
     base64-stream: ^1.0.0
-    better-sqlite3: ^9.0.0
+    better-sqlite3: ^11.0.0
     compression: ^1.7.4
     concat-stream: ^2.0.0
     cors: ^2.8.5
@@ -3647,7 +3647,7 @@ __metadata:
     archiver: ^6.0.0
     aws-sdk-client-mock: ^4.0.0
     base64-stream: ^1.0.0
-    better-sqlite3: ^9.0.0
+    better-sqlite3: ^11.0.0
     compression: ^1.7.4
     concat-stream: ^2.0.0
     cookie: ^0.6.0
@@ -3818,7 +3818,7 @@ __metadata:
     "@keyv/redis": ^2.5.3
     "@types/keyv": ^4.2.0
     "@types/supertest": ^2.0.8
-    better-sqlite3: ^9.0.0
+    better-sqlite3: ^11.0.0
     cookie: ^0.6.0
     express: ^4.17.1
     fs-extra: ^11.0.0
@@ -5694,7 +5694,7 @@ __metadata:
     "@types/lodash": ^4.14.151
     "@types/supertest": ^2.0.8
     "@types/uuid": ^9.0.0
-    better-sqlite3: ^9.0.0
+    better-sqlite3: ^11.0.0
     codeowners-utils: ^1.0.2
     core-js: ^3.6.5
     express: ^4.17.1
@@ -21618,14 +21618,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"better-sqlite3@npm:^9.0.0":
-  version: 9.6.0
-  resolution: "better-sqlite3@npm:9.6.0"
+"better-sqlite3@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "better-sqlite3@npm:11.0.0"
   dependencies:
     bindings: ^1.5.0
     node-gyp: latest
     prebuild-install: ^7.1.1
-  checksum: be3a1d2a3f6f9b5141be6607a38c0a51fa5849495b071955e507bc0c2a2fb08430852c1bf03796eec1a53344b25645807db48dcb51c71b0662b74c5a70420bb0
+  checksum: 7bf02ea6ba3253f53cb36bd872f86379ebf1a66cb103d39b91c610995c4396dde2b976bdf866f07eb7d67eb6f5433aa5490a6a4f4264244f83a53562f68832dc
   languageName: node
   linkType: hard
 
@@ -26624,7 +26624,7 @@ __metadata:
     "@types/express-serve-static-core": ^4.17.5
     "@types/luxon": ^3.0.0
     azure-devops-node-api: ^12.0.0
-    better-sqlite3: ^9.0.0
+    better-sqlite3: ^11.0.0
     dockerode: ^4.0.0
     example-app: "link:../app"
     express: ^4.17.1


### PR DESCRIPTION
## Hey, I just made a Pull Request!

bump better-sqlite3 from  9.0.0 to  11.0.0

Based on [release notes](https://github.com/WiseLibs/better-sqlite3/releases) from v10.0.0 and v11.0.0 this is compatible with the stated Backstage node engines -> https://github.com/backstage/backstage/blob/master/package.json#L136.

This updates to the latest version of better-sqlite3 to keep things up to date.

Tested on our instance of backstage and no issues.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
