### PR TITLE
Fix bug in root repo import where catalog-info.yaml.hcl file breaks import

### DIFF
--- a/.changeset/orange-beans-float.md
+++ b/.changeset/orange-beans-float.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+Fix bug in root repo import where catalog-info.yaml.hcl file is found by search and breaks the import

--- a/plugins/catalog-backend-module-github/src/analyzers/GithubLocationAnalyzer.test.ts
+++ b/plugins/catalog-backend-module-github/src/analyzers/GithubLocationAnalyzer.test.ts
@@ -112,7 +112,7 @@ describe('GithubLocationAnalyzer', () => {
 
   it('should analyze', async () => {
     octokit.search.code.mockImplementation((opts: { q: string }) => {
-      if (opts.q === 'filename:catalog-info.yaml repo:foo/bar') {
+      if (opts.q === 'filename:catalog-info.yaml extension:yaml repo:foo/bar') {
         return Promise.resolve({
           data: { items: [{ path: 'catalog-info.yaml' }], total_count: 1 },
         });
@@ -139,7 +139,7 @@ describe('GithubLocationAnalyzer', () => {
 
   it('should use the provided entity filename for search', async () => {
     octokit.search.code.mockImplementation((opts: { q: string }) => {
-      if (opts.q === 'filename:anvil.yaml repo:foo/bar') {
+      if (opts.q === 'filename:anvil.yaml extension:yaml repo:foo/bar') {
         return Promise.resolve({
           data: { items: [{ path: 'anvil.yaml' }], total_count: 1 },
         });

--- a/plugins/catalog-backend-module-github/src/analyzers/GithubLocationAnalyzer.ts
+++ b/plugins/catalog-backend-module-github/src/analyzers/GithubLocationAnalyzer.ts
@@ -76,8 +76,13 @@ export class GithubLocationAnalyzer implements ScmLocationAnalyzer {
     const { owner, name: repo } = parseGitUrl(url);
 
     const catalogFile = catalogFilename || 'catalog-info.yaml';
+    const fileParts = catalogFile.split('.');
+    const extension =
+      fileParts.length > 0
+        ? `extension:${fileParts[fileParts.length - 1]}`
+        : '';
 
-    const query = `filename:${catalogFile} repo:${owner}/${repo}`;
+    const query = `filename:${catalogFile} ${extension} repo:${owner}/${repo}`;
 
     const integration = this.integrations.github.byUrl(url);
     if (!integration) {

--- a/plugins/catalog-backend-module-github/src/analyzers/GithubLocationAnalyzer.ts
+++ b/plugins/catalog-backend-module-github/src/analyzers/GithubLocationAnalyzer.ts
@@ -78,7 +78,9 @@ export class GithubLocationAnalyzer implements ScmLocationAnalyzer {
 
     const catalogFile = catalogFilename || 'catalog-info.yaml';
     const extension = extname(catalogFile);
-    const extensionQuery = !isEmpty(extension) ? `extension:${extension}` : '';
+    const extensionQuery = !isEmpty(extension)
+      ? `extension:${extension.replace('.', '')}`
+      : '';
 
     const query = `filename:${catalogFile} ${extensionQuery} repo:${owner}/${repo}`;
 

--- a/plugins/catalog-backend-module-github/src/analyzers/GithubLocationAnalyzer.ts
+++ b/plugins/catalog-backend-module-github/src/analyzers/GithubLocationAnalyzer.ts
@@ -22,7 +22,7 @@ import {
   ScmIntegrations,
 } from '@backstage/integration';
 import { Octokit } from '@octokit/rest';
-import { trimEnd } from 'lodash';
+import { isEmpty, trimEnd } from 'lodash';
 import parseGitUrl from 'git-url-parse';
 import {
   AnalyzeOptions,
@@ -35,6 +35,7 @@ import {
 } from '@backstage/backend-common';
 import { Config } from '@backstage/config';
 import { AuthService } from '@backstage/backend-plugin-api';
+import { extname } from 'path';
 
 /** @public */
 export type GithubLocationAnalyzerOptions = {
@@ -76,13 +77,10 @@ export class GithubLocationAnalyzer implements ScmLocationAnalyzer {
     const { owner, name: repo } = parseGitUrl(url);
 
     const catalogFile = catalogFilename || 'catalog-info.yaml';
-    const fileParts = catalogFile.split('.');
-    const extension =
-      fileParts.length > 0
-        ? `extension:${fileParts[fileParts.length - 1]}`
-        : '';
+    const extension = extname(catalogFile);
+    const extensionQuery = !isEmpty(extension) ? `extension:${extension}` : '';
 
-    const query = `filename:${catalogFile} ${extension} repo:${owner}/${repo}`;
+    const query = `filename:${catalogFile} ${extensionQuery} repo:${owner}/${repo}`;
 
     const integration = this.integrations.github.byUrl(url);
     if (!integration) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!
When importing a repository from GitHub using the root repo url, if the repo has any templated catalog-info files (as is the case with the backstage repo itself, the search analyser finds the .hcl file and attempts to import it as a location. This breaks the import with a unclear 500 error
<img width="514" alt="336828088-9d8e44f2-0bec-4415-a05d-6f57e1571296" src="https://github.com/backstage/backstage/assets/7934833/19c68fb4-108c-450e-b0fb-c32288f71076">

Old pr https://github.com/backstage/backstage/pull/25071

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
