### PR TITLE
Added `MyGroupsSidebarItem` to the sidebar in the `create-app` template

### DIFF
--- a/.changeset/bright-fireants-sit.md
+++ b/.changeset/bright-fireants-sit.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Added `MyGroupsSidebarItem` to the sidebar in the `create-app` template

--- a/packages/create-app/templates/default-app/packages/app/src/components/Root/Root.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/components/Root/Root.tsx
@@ -25,6 +25,8 @@ import {
 } from '@backstage/core-components';
 import MenuIcon from '@material-ui/icons/Menu';
 import SearchIcon from '@material-ui/icons/Search';
+import { MyGroupsSidebarItem } from '@backstage/plugin-org';
+import GroupIcon from '@material-ui/icons/People';
 
 const useSidebarLogoStyles = makeStyles({
   root: {
@@ -65,6 +67,11 @@ export const Root = ({ children }: PropsWithChildren<{}>) => (
       <SidebarGroup label="Menu" icon={<MenuIcon />}>
         {/* Global nav, not org-specific */}
         <SidebarItem icon={HomeIcon} to="catalog" text="Home" />
+        <MyGroupsSidebarItem
+          singularTitle="My Group"
+          pluralTitle="My Groups"
+          icon={GroupIcon}
+        />
         <SidebarItem icon={ExtensionIcon} to="api-docs" text="APIs" />
         <SidebarItem icon={LibraryBooks} to="docs" text="Docs" />
         <SidebarItem icon={CreateComponentIcon} to="create" text="Create..." />


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added `MyGroupsSidebarItem` to the sidebar in the `create-app` template. This component has been in the code base for a long time and would add value to those starting out by having it as part of the default. It works as described here in the [Org plugin `README`](https://github.com/backstage/backstage/tree/master/plugins/org#:~:text=Once%20added%20MyGroupsSidebarItem%20will%20work%20in%20three%20ways)
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
