### PR TITLE
Add pattern matching support to entity search filter

### DIFF
--- a/.changeset/funny-snails-argue.md
+++ b/.changeset/funny-snails-argue.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-catalog-backend': minor
+'@backstage/plugin-catalog-node': minor
+---
+
+Add pattern matching to `EntitiesSearchFilter` to support more complex entity queries

--- a/plugins/catalog-node/api-report.md
+++ b/plugins/catalog-node/api-report.md
@@ -111,6 +111,7 @@ export type DeferredEntity = {
 export type EntitiesSearchFilter = {
   key: string;
   values?: string[];
+  patterns?: string[];
 };
 
 // @public

--- a/plugins/catalog-node/src/api/common.ts
+++ b/plugins/catalog-node/src/api/common.ts
@@ -84,4 +84,12 @@ export type EntitiesSearchFilter = {
    * always case insensitive.
    */
   values?: string[];
+
+  /**
+   * Match on patterns.
+   *
+   * Match on values to any of the given patterns. Patterns should use
+   * standard SQL pattern string expressions. Matches are always case insensitive.
+   */
+  patterns?: string[];
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds a new optional `patterns` option to the entity search filter to match values on SQL pattern expression. Currently, the only option for filtering is passing in array of `values` which performs a basic equality check.

You may use `patterns` without providing `values` or you can provide both in which case you will return any values that match `values` equality check OR `values` pattern match. Pattern matching will be case insensitive.

Examples:
```typescript
// filter based on patterns only
const filter = {
  key: 'metadata.annotations.backstage.io/managed-by-location',
  // we don't care where the catalog-info.yml file is, only the repo its in
  patterns: ['url:https://github.com/x/y%', 'url:https://github.com/x/z%'],
};

// filter based on value equality or pattern matching
const filter = {
  key: 'metadata.name',
  // return values that match 'superuser-entity' or any entity that starts with 'admin-'
  values: ['superuser-entity'],
  patterns: ['admin-%'],
};
```

Motivation:
We've created a custom permission policy that allows read access to catalog entities only if a user is a member of a GitHub team that provides such access. To do this we need to map a list of GitHub repo slugs to entities using the `backstage.io/managed-by-location` annotation which is a URL pointing to `catalog-info.yml` file on GitHub. The only way we found to do this mapping is to use Catalog API to get list of all entities, iterate thru them and pattern match on the annotation. Then we can use the list of matched entities to create a conditional decision based on annotation value. Fetching every catalog entity and running this pattern matching for each policy check is not scalable.

If this PR is merged, instead of getting list of all entities and doing pattern matching, we can simply create a new permission rule that accepts an array of patterns in the `toQuery` implementation to match GitHub repos. I.e: `patterns: ['url:https://github.com/XX/YYYY%, ...]`.

Please let me know any feedback or changes requested!!! Thanks!!

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
