### PR TITLE
Increase max wait time in debug:wait action to 10 minutes

### DIFF
--- a/.changeset/twelve-pumpkins-fold.md
+++ b/.changeset/twelve-pumpkins-fold.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Increase max wait time in debug:wait action to 10 minutes

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/debug/wait.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/debug/wait.test.ts
@@ -57,7 +57,7 @@ describe('debug:wait', () => {
     await expect(async () => {
       await action.handler(context);
     }).rejects.toThrow(
-      'Waiting duration is longer than the maximum threshold of 0 hours, 0 minutes, 30 seconds',
+      'Waiting duration is longer than the maximum threshold of 0 hours, 10 minutes, 0 seconds',
     );
   });
 });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/debug/wait.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/debug/wait.ts
@@ -21,7 +21,7 @@ import { examples } from './wait.examples';
 
 const id = 'debug:wait';
 
-const MAX_WAIT_TIME_IN_ISO = 'T00:00:30';
+const MAX_WAIT_TIME_IN_ISO = 'T00:10:00';
 
 /**
  * Waits for a certain period of time.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Change for the concern raised here: https://github.com/backstage/backstage/issues/24846

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
