### PR TITLE
databases: remove the connectors

### DIFF
--- a/.changeset/popular-boxes-press.md
+++ b/.changeset/popular-boxes-press.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Internal minor refactors of the database connectors

--- a/packages/backend-defaults/src/entrypoints/database/connectors/index.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/index.ts
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-export * from './mysql';
-export * from './postgres';
-export * from './sqlite3';
+export { MysqlConnector } from './mysql';
+export { PgConnector } from './postgres';
+export { Sqlite3Connector } from './sqlite3';

--- a/packages/backend-defaults/src/entrypoints/database/connectors/mysql.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/mysql.ts
@@ -245,20 +245,6 @@ function normalizeConnection(
     : connection;
 }
 
-function createNameOverride(
-  client: string,
-  name: string,
-): Partial<Knex.Config> {
-  try {
-    return defaultNameOverride(name);
-  } catch (e) {
-    throw new InputError(
-      `Unable to create database name override for '${client}' connector`,
-      e,
-    );
-  }
-}
-
 export class MysqlConnector implements Connector {
   constructor(
     private readonly config: Config,
@@ -454,8 +440,6 @@ export class MysqlConnector implements Connector {
    */
   private getDatabaseOverrides(pluginId: string): Knex.Config {
     const databaseName = this.getDatabaseName(pluginId);
-    return databaseName
-      ? createNameOverride(this.getClientType(pluginId).client, databaseName)
-      : {};
+    return databaseName ? defaultNameOverride(databaseName) : {};
   }
 }

--- a/packages/backend-defaults/src/entrypoints/database/connectors/sqlite3.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/sqlite3.ts
@@ -20,7 +20,6 @@ import {
   PluginMetadataService,
 } from '@backstage/backend-plugin-api';
 import { Config, ConfigReader } from '@backstage/config';
-import { InputError } from '@backstage/errors';
 import { JsonObject } from '@backstage/types';
 import { ensureDirSync } from 'fs-extra';
 import knexFactory, { Knex } from 'knex';
@@ -174,20 +173,6 @@ function normalizeConnection(
   return typeof connection === 'string' || connection instanceof String
     ? parseSqliteConnectionString(connection as string)
     : connection;
-}
-
-function createNameOverride(
-  client: string,
-  name: string,
-): Partial<Knex.Config> {
-  try {
-    return createSqliteNameOverride(name);
-  } catch (e) {
-    throw new InputError(
-      `Unable to create database name override for '${client}' connector`,
-      e,
-    );
-  }
 }
 
 export class Sqlite3Connector implements Connector {
@@ -388,8 +373,6 @@ export class Sqlite3Connector implements Connector {
    */
   private getDatabaseOverrides(pluginId: string): Knex.Config {
     const databaseName = this.getDatabaseName(pluginId);
-    return databaseName
-      ? createNameOverride(this.getClientType(pluginId).client, databaseName)
-      : {};
+    return databaseName ? createSqliteNameOverride(databaseName) : {};
   }
 }


### PR DESCRIPTION
Micro-effort for small movement on database setup code: removing the old "connector" intermediaries that were just dumbly forklifted as part of the previous step.

Related to #17466 