### PR TITLE
Netvolart/gitlab mr automerge

### DIFF
--- a/.changeset/neat-adults-unite.md
+++ b/.changeset/neat-adults-unite.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gitlab': patch
+---
+
+add auto-merge functionality to GitLab scaffolder action

--- a/plugins/scaffolder-backend-module-gitlab/api-report.md
+++ b/plugins/scaffolder-backend-module-gitlab/api-report.md
@@ -197,6 +197,7 @@ export const createPublishGitlabMergeRequestAction: (options: {
     projectid?: string | undefined;
     removeSourceBranch?: boolean | undefined;
     assignee?: string | undefined;
+    autoMerge?: boolean | undefined;
   },
   JsonObject
 >;

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabMergeRequest.examples.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabMergeRequest.examples.ts
@@ -139,4 +139,26 @@ export const examples: TemplateExample[] = [
       ],
     }),
   },
+  {
+    description:
+      'Create a merge request with an auto-merge after pipeline success',
+    example: yaml.stringify({
+      steps: [
+        {
+          id: 'createMergeRequest',
+          action: 'publish:gitlab:merge-request',
+          name: 'Create a Merge Request',
+          input: {
+            repoUrl: 'gitlab.com?repo=repo&owner=owner',
+            title: 'Create my new MR',
+            branchName: 'new-mr',
+            description: 'MR description',
+            commitAction: 'update',
+            targetPath: 'source',
+            autoMerge: 'true',
+          },
+        },
+      ],
+    }),
+  },
 ];

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -314,6 +314,7 @@ export const createPublishGitlabMergeRequestAction: (options: {
     projectid?: string | undefined;
     removeSourceBranch?: boolean | undefined;
     assignee?: string | undefined;
+    autoMerge?: boolean | undefined;
   },
   JsonObject
 >;


### PR DESCRIPTION
## [Scaffolder Gitlab Module] Add auto-merge functionality 


1) Run some pipelines for IaC from Backstage.

The steps are: 
- Create MR with changes.
- Merge MR
- Run pipeline from main, because it's a source of truth.

2) If we want to publish the template's content into a repository, created not via standard GitLab action.  For example, we are managing GitLab repos via Terraform to keep configuration in a code for controlled changes in the future.
So the flow is:
- Create a repo via Terraform from Backstage.
- Create MR (because the main is protected)
- Merge it from backstage. 

it's possible to merge it manually but from the User Experience perspective, it pushes the user to go from backstage somewhere. 
Or breaks the template steps with a manual action.

So I've created a PR with Auto Merge functionality.
If the GitLab repo doesn't have an MR  Pipeline - the merge is almost immediate. 
Otherwise, it will wait until MR is ready to merge.
It fails with an error if the MR pipeline fails or if there are some conflicts you should resolve manually.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
