### PR TITLE
Slim down `minimal-hardened-image`

### DIFF
--- a/contrib/docker/minimal-hardened-image/Dockerfile
+++ b/contrib/docker/minimal-hardened-image/Dockerfile
@@ -11,6 +11,7 @@
 
 # syntax = docker/dockerfile:1.4
 
+# Build Python environment in a separate builder stage
 FROM cgr.dev/chainguard/python:latest-dev as python-builder
 
 RUN --mount=type=cache,target=/home/nonroot/.cache/pip,uid=65532,gid=65532 \

--- a/contrib/docker/minimal-hardened-image/Dockerfile
+++ b/contrib/docker/minimal-hardened-image/Dockerfile
@@ -14,11 +14,11 @@
 # Build Python environment in a separate builder stage
 FROM cgr.dev/chainguard/python:latest-dev as python-builder
 
-RUN --mount=type=cache,target=/home/nonroot/.cache/pip,uid=65532,gid=65532 \
-    python3 -m venv /home/nonroot/venv
 ENV PATH=/venv/bin:$PATH
 
-RUN /home/nonroot/venv/bin/pip install mkdocs-techdocs-core==1.3.3
+RUN --mount=type=cache,target=/home/nonroot/.cache/pip,uid=65532,gid=65532 \
+    python3 -m venv /home/nonroot/venv && \
+    /home/nonroot/venv/bin/pip install mkdocs-techdocs-core==1.3.3
 
 # Build Node environment in a separate builder stage
 FROM cgr.dev/chainguard/wolfi-base:latest as node-builder

--- a/contrib/docker/minimal-hardened-image/Dockerfile
+++ b/contrib/docker/minimal-hardened-image/Dockerfile
@@ -66,14 +66,13 @@ RUN --mount=type=cache,target=/var/cache/apk,sharing=locked,uid=65532,gid=65532 
         tini
 
 WORKDIR /app
+
+COPY package.json app-config.yaml ./
+ADD packages/backend/dist/skeleton.tar.gz packages/backend/dist/bundle.tar.gz ./
+
 RUN chown -R 65532:65532 /app
-USER nonroot
-
-COPY --chown=65532:65532 package.json packages/backend/dist/skeleton.tar.gz ./
-RUN tar xzf skeleton.tar.gz && rm skeleton.tar.gz
-
-COPY --chown=65532:65532 packages/backend/dist/bundle.tar.gz app-config*.yaml ./
-RUN tar xzf bundle.tar.gz && rm bundle.tar.gz
+RUN chown -R 65532:65532 /tmp
+USER 65532:65532
 
 COPY --from=node-builder --chown=65532:65532 /app/node_modules ./node_modules
 COPY --from=python-builder --chown=65532:65532 /home/nonroot/venv /home/nonroot/venv

--- a/contrib/docker/minimal-hardened-image/Dockerfile
+++ b/contrib/docker/minimal-hardened-image/Dockerfile
@@ -9,53 +9,78 @@
 #
 # Once the commands have been run, you can build the image using `yarn docker-build`
 
-FROM cgr.dev/chainguard/wolfi-base:latest
+# syntax = docker/dockerfile:1.4
 
-ENV NODE_VERSION 18=~18.19
+FROM cgr.dev/chainguard/python:latest-dev as python-builder
+
+RUN --mount=type=cache,target=/home/nonroot/.cache/pip,uid=65532,gid=65532 \
+    python3 -m venv /home/nonroot/venv
+ENV PATH=/venv/bin:$PATH
+
+RUN /home/nonroot/venv/bin/pip install mkdocs-techdocs-core==1.3.3
+
+FROM cgr.dev/chainguard/wolfi-base:latest as node-builder
+
 ENV PYTHON_VERSION 3.12=~3.12
-
-RUN apk add nodejs-$NODE_VERSION yarn
-
-# Install sqlite3 dependencies. You can skip this if you don't use sqlite3 in the image,
-# in which case you should also move better-sqlite3 to "devDependencies" in package.json.
-# Additionally, we install dependencies for `techdocs.generator.runIn: local`.
-# https://backstage.io/docs/features/techdocs/getting-started#disabling-docker-in-docker-situation-optional
-RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \
-    --mount=type=cache,target=/var/lib/apk,sharing=locked \
-    apk update && \
-    apk add sqlite-dev python-$PYTHON_VERSION py3-pip python-3-dev py3-setuptools build-base gcc libffi-dev glibc-dev openssl-dev brotli-dev c-ares-dev nghttp2-dev icu-dev zlib-dev gcc-12 libuv-dev && \
-    yarn config set python /usr/bin/python3
-
-# Set up a virtual environment for mkdocs-techdocs-core.
-ENV VIRTUAL_ENV=/opt/venv
-RUN python3 -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-
-RUN pip3 install mkdocs-techdocs-core==1.3.3
-
-# From here on we use the least-privileged `node` user to run the backend.
-WORKDIR /app
-RUN chown nonroot:nonroot /app
-USER nonroot
-
-# This switches many Node.js dependencies to production mode.
+ENV NODE_VERSION 20=~20.11
 ENV NODE_ENV production
 
-# Copy over Yarn 3 configuration, release, and plugins
-COPY --chown=nonroot:nonroot .yarn ./.yarn
-COPY --chown=nonroot:nonroot .yarnrc.yml ./
+RUN --mount=type=cache,target=/var/cache/apk,sharing=locked,uid=65532,gid=65532 \
+    --mount=type=cache,target=/var/lib/apk,sharing=locked,uid=65532,gid=65532 \
+    apk update && \
+    apk add python-$PYTHON_VERSION nodejs-$NODE_VERSION yarn \
+    # Install isolate-vm dependencies, these are needed by the @backstage/plugin-scaffolder-backend.
+    openssl-dev brotli-dev c-ares-dev nghttp2-dev icu-dev zlib-dev gcc-12 libuv-dev build-base
 
-# Copy repo skeleton first, to avoid unnecessary docker cache invalidation.
-# The skeleton contains the package.json of each package in the monorepo,
-# and along with yarn.lock and the root package.json, that's enough to run yarn install.
-COPY --chown=nonroot:nonroot yarn.lock package.json packages/backend/dist/skeleton.tar.gz ./
+WORKDIR /app
+RUN chown -R nonroot:nonroot /app
+
+RUN mkdir -p /home/nonroot/.yarn/berry && chown -R 65532:65532 /home/nonroot/.yarn/berry
+
+USER nonroot
+
+COPY --chown=65532:65532 .yarn ./.yarn
+COPY --chown=65532:65532 .yarnrc.yml ./
+
+COPY --chown=65532:65532 yarn.lock package.json packages/backend/dist/skeleton.tar.gz ./
 RUN tar xzf skeleton.tar.gz && rm skeleton.tar.gz
 
-RUN --mount=type=cache,target=/home/node/.yarn/berry/cache,sharing=locked,uid=1000,gid=1000 \
-    yarn workspaces focus --all --production
+RUN --mount=type=cache,target=/home/nonroot/.yarn/berry/cache,sharing=locked,uid=65532,gid=65532 \
+    yarn workspaces focus --all --production && yarn cache clean --all
 
-# Then copy the rest of the backend bundle, along with any other files we might want.
-COPY --chown=nonroot:nonroot packages/backend/dist/bundle.tar.gz app-config*.yaml ./
+FROM cgr.dev/chainguard/wolfi-base:latest
+
+ENV PYTHON_VERSION 3.12=~3.12
+ENV NODE_VERSION 20=~20.14
+ENV NODE_ENV production
+
+RUN --mount=type=cache,target=/var/cache/apk,sharing=locked,uid=65532,gid=65532 \
+    --mount=type=cache,target=/var/lib/apk,sharing=locked,uid=65532,gid=65532 \
+    apk update && \
+    apk add \
+    # add node for backstage
+        nodejs-$NODE_VERSION \
+    # add python for backstage techdocs
+        python-$PYTHON_VERSION \
+    # add tini for init process
+        tini
+
+WORKDIR /app
+RUN chown -R 65532:65532 /app
+USER nonroot
+
+COPY --chown=65532:65532 package.json packages/backend/dist/skeleton.tar.gz ./
+RUN tar xzf skeleton.tar.gz && rm skeleton.tar.gz
+
+COPY --chown=65532:65532 packages/backend/dist/bundle.tar.gz app-config*.yaml ./
 RUN tar xzf bundle.tar.gz && rm bundle.tar.gz
 
+COPY --from=node-builder --chown=65532:65532 /app/node_modules ./node_modules
+COPY --from=python-builder --chown=65532:65532 /home/nonroot/venv /home/nonroot/venv
+ENV PATH=/home/nonroot/venv/bin:$PATH
+
+ENV NODE_OPTIONS="--no-node-snapshot"
+ENV GIT_PYTHON_REFRESH="quiet"
+
+ENTRYPOINT ["tini", "--"]
 CMD ["node", "packages/backend", "--config", "app-config.yaml"]

--- a/contrib/docker/minimal-hardened-image/Dockerfile
+++ b/contrib/docker/minimal-hardened-image/Dockerfile
@@ -19,6 +19,7 @@ ENV PATH=/venv/bin:$PATH
 
 RUN /home/nonroot/venv/bin/pip install mkdocs-techdocs-core==1.3.3
 
+# Build Node environment in a separate builder stage
 FROM cgr.dev/chainguard/wolfi-base:latest as node-builder
 
 ENV PYTHON_VERSION 3.12=~3.12

--- a/contrib/docker/minimal-hardened-image/Dockerfile
+++ b/contrib/docker/minimal-hardened-image/Dockerfile
@@ -23,14 +23,13 @@ RUN /home/nonroot/venv/bin/pip install mkdocs-techdocs-core==1.3.3
 # Build Node environment in a separate builder stage
 FROM cgr.dev/chainguard/wolfi-base:latest as node-builder
 
-ENV PYTHON_VERSION 3.12=~3.12
 ENV NODE_VERSION 20=~20.11
 ENV NODE_ENV production
 
 RUN --mount=type=cache,target=/var/cache/apk,sharing=locked,uid=65532,gid=65532 \
     --mount=type=cache,target=/var/lib/apk,sharing=locked,uid=65532,gid=65532 \
     apk update && \
-    apk add python-$PYTHON_VERSION nodejs-$NODE_VERSION yarn \
+    apk add nodejs-$NODE_VERSION yarn \
     # Install isolate-vm dependencies, these are needed by the @backstage/plugin-scaffolder-backend.
     openssl-dev brotli-dev c-ares-dev nghttp2-dev icu-dev zlib-dev gcc-12 libuv-dev build-base
 

--- a/contrib/docker/minimal-hardened-image/Dockerfile
+++ b/contrib/docker/minimal-hardened-image/Dockerfile
@@ -50,6 +50,7 @@ RUN tar xzf skeleton.tar.gz && rm skeleton.tar.gz
 RUN --mount=type=cache,target=/home/nonroot/.yarn/berry/cache,sharing=locked,uid=65532,gid=65532 \
     yarn workspaces focus --all --production && yarn cache clean --all
 
+# Final stage to build the application image
 FROM cgr.dev/chainguard/wolfi-base:latest
 
 ENV PYTHON_VERSION 3.12=~3.12

--- a/contrib/docker/minimal-hardened-image/README.md
+++ b/contrib/docker/minimal-hardened-image/README.md
@@ -4,6 +4,19 @@ DockerHub images in general did not seem ideal for Backstage as the number of vu
 
 The `Dockerfile` in this directory uses a [wolfi-base](https://github.com/wolfi-dev) image from Chainguard Images. This improves the security of the application and reduces false positives in scanners.
 
+## Steps taken
+
+When converting, I utilized the upstream Dockerfile as a starting point.
+
+- Multi-stage build - The Dockerfile has been split up into a multistage build which reduces the files, packages, executables, and directories in the final image.
+  - Size savings = ~900mb
+  - Reduced attack surface
+- Base Image - Swap to [wolfi-base](https://github.com/wolfi-dev) image from Chainguard Images
+  - Vulnerability Savings = ~239 at the time of updating this README
+- Entrypoint - Swap from `node` to `tini` as entrypoint to ensure that the default signal handlers work and zombie processes are handled properly
+- Use `ADD` instead of `COPY` in dockerfile to reduce copied compressed files
+  - When a `rm` is used to remove a compressed file it still makes its way into the final image. Using `ADD` is safe with local files.
+
 ## Pinning Digest
 
 To reduce maintenance, the digest of the image has been removed from the `./Dockerfile` file. A complete example with the digest would be `cgr.dev/chainguard/wolfi-base:latest@sha256:3d6dece13cdb5546cd03b20e14f9af354bc1a56ab5a7b47dca3e6c1557211fcf` and it is suggested to update the `FROM` line in the `Dockerfile` to use a digest.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I found an opportunity to refactor the Dockerfile for the contributed minimal-hardened-image to reduce the size of the image. Located at `contrib/docker/minimal-hardened-image/Dockerfile`. This reduced the image size, vulnerabilities, packages, files, locations, and executables.

To validate I created a new backstage application and built it from the defaults. I build the dockerfile using the defaults.
I then swapped the Dockerfile for the current minimal-hardened-image and run the same commands.
Finally I updated the minimal-hardened-image with the new Dockerfile and built the image again.

Below are the results I found.

### updated minimal-hardened-image

Size = 642MB

```
 ✔ Cataloged contents                                                                                                                 ad07372ccc330922e83dbc1ca292b3b415fa60c4b697670ecde7e122d5d8b229
   ├── ✔ Packages                        [1,301 packages]
   ├── ✔ File digests                    [2,214 files]
   ├── ✔ File metadata                   [2,214 locations]
   └── ✔ Executables                     [177 executables]
 ✔ Scanned for vulnerabilities     [2 vulnerability matches]
   ├── by severity: 0 critical, 0 high, 2 medium, 0 low, 0 negligible
   └── by status:   1 fixed, 1 not-fixed, 0 ignored
```

### current minimal-hardened-image

Size = 1.54GB

```
 ✔ Cataloged contents                                                                                                                 2ef4b6441590984e81e3637ee4e6a7c90eb78a80cc7cb0e4bacab3e23779c34b
   ├── ✔ Packages                        [1,555 packages]
   ├── ✔ File digests                    [10,341 files]
   ├── ✔ File metadata                   [10,341 locations]
   └── ✔ Executables                     [287 executables]
 ✔ Scanned for vulnerabilities     [6 vulnerability matches]
   ├── by severity: 0 critical, 1 high, 4 medium, 0 low, 0 negligible (1 unknown)
   └── by status:   2 fixed, 4 not-fixed, 0 ignored
```

### current dockerfile from new backstage application

Size = 988MB

```
 ✔ Cataloged contents                                                                                                                 c156f323bde7a7e93c6f55ba936d90339a0ad5c04600d6a7201f006814d2c05f
   ├── ✔ Packages                        [1,590 packages]
   ├── ✔ File digests                    [7,883 files]
   ├── ✔ File metadata                   [7,883 locations]
   └── ✔ Executables                     [900 executables]
 ✔ Scanned for vulnerabilities     [239 vulnerability matches]
   ├── by severity: 1 critical, 33 high, 83 medium, 4 low, 202 negligible (235 unknown)
   └── by status:   1 fixed, 557 not-fixed, 319 ignored
```


<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
