### PR TITLE
Update gitlab.examples.ts

### DIFF
--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlab.examples.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlab.examples.ts
@@ -121,12 +121,12 @@ export const examples: TemplateExample[] = [
               {
                 name: 'dev',
                 create: true,
-                protected: true,
+                protect: true,
                 ref: 'master',
               },
               {
                 name: 'master',
-                protected: true,
+                protect: true,
               },
             ],
           },


### PR DESCRIPTION
documentation fix.
The correct name is `protect`.
`protected` is use for variables.

## fix gitlab action documentation
the documentation example must say protect, protected is for variables.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
