### PR TITLE
Fix bug in Azure Scaffolder that can produce a wrong repoContentsUrl

### DIFF
--- a/.changeset/nasty-doors-grab.md
+++ b/.changeset/nasty-doors-grab.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-azure': patch
+---
+
+Use `GitRepository.webUrl` instead of `GitRepository.remoteUrl` to set the value of `repoContentsUrl` as `remoteUrl` can sometimes return an URL with the wrong format (e.g. https://<organization>@dev.azure.com/<organization>/<project>/\_git/<repository>).

--- a/.changeset/nasty-doors-grab.md
+++ b/.changeset/nasty-doors-grab.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-backend-module-azure': patch
 ---
 
-Use `GitRepository.webUrl` instead of `GitRepository.remoteUrl` to set the value of `repoContentsUrl` as `remoteUrl` can sometimes return an URL with the wrong format (e.g. https://<organization>@dev.azure.com/<organization>/<project>/\_git/<repository>).
+Use `GitRepository.webUrl` instead of `GitRepository.remoteUrl` to set the value of `repoContentsUrl` as `remoteUrl` can sometimes return an URL with the wrong format (e.g. `https://<organization>@dev.azure.com/<organization>/<project>/\_git/<repository>`).

--- a/plugins/scaffolder-backend-module-azure/src/actions/azure.examples.test.ts
+++ b/plugins/scaffolder-backend-module-azure/src/actions/azure.examples.test.ts
@@ -72,6 +72,7 @@ describe('publish:azure examples', () => {
   it('should call initRepoAndPush with the correct values', async () => {
     mockGitClient.createRepository.mockResolvedValue({
       remoteUrl: 'https://dev.azure.com/organization/project/_git/repo',
+      webUrl: 'https://dev.azure.com/organization/project/_git/repo',
       id: '709e891c-dee7-4f91-b963-534713c0737f',
     });
 
@@ -94,6 +95,7 @@ describe('publish:azure examples', () => {
   it('should call initRepoAndPush with a changed default branch', async () => {
     mockGitClient.createRepository.mockResolvedValue({
       remoteUrl: 'https://dev.azure.com/organization/project/_git/repo',
+      webUrl: 'https://dev.azure.com/organization/project/_git/repo',
       id: '709e891c-dee7-4f91-b963-534713c0737f',
     });
 

--- a/plugins/scaffolder-backend-module-azure/src/actions/azure.test.ts
+++ b/plugins/scaffolder-backend-module-azure/src/actions/azure.test.ts
@@ -131,6 +131,7 @@ describe('publish:azure', () => {
   it('should not throw if there is a token provided through ctx.input', async () => {
     mockGitClient.createRepository.mockImplementation(() => ({
       remoteUrl: 'http://google.com',
+      webUrl: 'http://google.com',
       id: '709e891c-dee7-4f91-b963-534713c0737f',
     }));
 
@@ -188,6 +189,7 @@ describe('publish:azure', () => {
   it('should call the azureApis with the correct values', async () => {
     mockGitClient.createRepository.mockImplementation(() => ({
       remoteUrl: 'http://google.com',
+      webUrl: 'http://google.com',
       id: '709e891c-dee7-4f91-b963-534713c0737f',
     }));
 
@@ -214,6 +216,7 @@ describe('publish:azure', () => {
   it('should call initRepoAndPush with the correct values', async () => {
     mockGitClient.createRepository.mockImplementation(() => ({
       remoteUrl: 'https://dev.azure.com/organization/project/_git/repo',
+      webUrl: 'https://dev.azure.com/organization/project/_git/repo',
       id: '709e891c-dee7-4f91-b963-534713c0737f',
     }));
 
@@ -233,6 +236,7 @@ describe('publish:azure', () => {
   it('should call initRepoAndPush with the correct default branch', async () => {
     mockGitClient.createRepository.mockImplementation(() => ({
       remoteUrl: 'https://dev.azure.com/organization/project/_git/repo',
+      webUrl: 'https://dev.azure.com/organization/project/_git/repo',
       id: '709e891c-dee7-4f91-b963-534713c0737f',
     }));
 
@@ -283,6 +287,7 @@ describe('publish:azure', () => {
 
     mockGitClient.createRepository.mockImplementation(() => ({
       remoteUrl: 'https://dev.azure.com/organization/project/_git/repo',
+      webUrl: 'https://dev.azure.com/organization/project/_git/repo',
       id: '709e891c-dee7-4f91-b963-534713c0737f',
     }));
 
@@ -324,6 +329,7 @@ describe('publish:azure', () => {
 
     mockGitClient.createRepository.mockImplementation(() => ({
       remoteUrl: 'https://dev.azure.com/organization/project/_git/repo',
+      webUrl: 'https://dev.azure.com/organization/project/_git/repo',
       id: '709e891c-dee7-4f91-b963-534713c0737f',
     }));
 
@@ -343,6 +349,7 @@ describe('publish:azure', () => {
   it('should call output with the remoteUrl the repoContentsUrl and the repositoryId', async () => {
     mockGitClient.createRepository.mockImplementation(() => ({
       remoteUrl: 'https://dev.azure.com/organization/project/_git/repo',
+      webUrl: 'https://dev.azure.com/organization/project/_git/repo',
       id: '709e891c-dee7-4f91-b963-534713c0737f',
     }));
 

--- a/plugins/scaffolder-backend-module-azure/src/actions/azure.test.ts
+++ b/plugins/scaffolder-backend-module-azure/src/actions/azure.test.ts
@@ -159,6 +159,7 @@ describe('publish:azure', () => {
   it('should throw if there is no remoteUrl returned', async () => {
     mockGitClient.createRepository.mockImplementation(() => ({
       remoteUrl: null,
+      webUrl: 'http://google.com',
       id: '709e891c-dee7-4f91-b963-534713c0737f',
     }));
     await expect(
@@ -174,6 +175,7 @@ describe('publish:azure', () => {
   it('should throw if there is no repositoryId returned', async () => {
     mockGitClient.createRepository.mockImplementation(() => ({
       remoteUrl: 'http://google.com',
+      webUrl: 'http://google.com',
       id: null,
     }));
     await expect(
@@ -184,6 +186,22 @@ describe('publish:azure', () => {
         },
       }),
     ).rejects.toThrow(/No Id returned/);
+  });
+
+  it('should throw if there is no repoContentsUrl returned', async () => {
+    mockGitClient.createRepository.mockImplementation(() => ({
+      remoteUrl: 'http://google.com',
+      webUrl: null,
+      id: '709e891c-dee7-4f91-b963-534713c0737f',
+    }));
+    await expect(
+      action.handler({
+        ...mockContext,
+        input: {
+          repoUrl: 'dev.azure.com?repo=bob&owner=owner&organization=org',
+        },
+      }),
+    ).rejects.toThrow(/No web URL returned/);
   });
 
   it('should call the azureApis with the correct values', async () => {

--- a/plugins/scaffolder-backend-module-azure/src/actions/azure.ts
+++ b/plugins/scaffolder-backend-module-azure/src/actions/azure.ts
@@ -187,9 +187,13 @@ export function createPublishAzureAction(options: {
         throw new InputError('No Id returned from create repository for Azure');
       }
 
-      // blam: Repo contents is serialized into the path,
-      // so it's just the base path I think
-      const repoContentsUrl = remoteUrl;
+      const repoContentsUrl = returnedRepo.webUrl;
+
+      if (!repoContentsUrl) {
+        throw new InputError(
+          'No web URL returned from create repository for Azure',
+        );
+      }
 
       const gitAuthorInfo = {
         name: gitAuthorName


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

The ```repoContentsUrl``` property was setted by the ```GitRepository.remoteUrl``` property, and in some cases this can return an URL with the bad format like ```https://<organization>@dev.azure.com/<organization>/<project>/_git/<repository>```.

So, when we clicked on the "view source" link from the entity page we were redirected to a blank page.

I propose to use the property ```GitRepository.webUrl``` to set the value ```repoContentsUrl``` in order to have always the correct URL format.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
