### PR TITLE
feat(gerrit): make the gitilesBaseUrl config mandatory

### DIFF
--- a/.changeset/polite-emus-invent.md
+++ b/.changeset/polite-emus-invent.md
@@ -1,0 +1,8 @@
+---
+'@backstage/backend-defaults': minor
+---
+
+**BREAKING**: The `workdir` argument have been removed from The `GerritUrlReader` constructor.
+
+**BREAKING**: The Gerrit `readTree` implementation will now only use the Gitiles api. Support
+for using git to clone the repo has been removed.

--- a/.changeset/wicked-dingos-heal.md
+++ b/.changeset/wicked-dingos-heal.md
@@ -1,0 +1,7 @@
+---
+'@backstage/integration': minor
+---
+
+**BREAKING**: `gitilesBaseUrl` is now mandatory for the Gerrit integration. The
+ability to override this requirement using the `DISABLE_GERRIT_GITILES_REQUIREMENT`
+environment variable has been removed.

--- a/docs/integrations/gerrit/locations.md
+++ b/docs/integrations/gerrit/locations.md
@@ -19,9 +19,9 @@ To use this integration, add at least one Gerrit configuration to your root `app
 integrations:
   gerrit:
     - host: gerrit.company.com
+      gitilesBaseUrl: https://gerrit.company.com/gitiles
       baseUrl: https://gerrit.company.com/gerrit
       cloneUrl: https://gerrit.company.com/clone
-      gitilesBaseUrl: https://gerrit.company.com/gitiles
       username: ${GERRIT_USERNAME}
       password: ${GERRIT_PASSWORD}
 ```
@@ -31,16 +31,12 @@ you can list the Gerrit instances you want to fetch data from. Each entry is
 a structure with up to six elements:
 
 - `host`: The host of the Gerrit instance, e.g. `gerrit.company.com`.
+- `gitilesBaseUrl`: The base url of the Gitiles instance.
 - `baseUrl` (optional): Needed if the Gerrit instance is not reachable at
   the base of the `host` option (e.g. `https://gerrit.company.com`) set the
   address here. This is the address that you would open in a browser.
 - `cloneUrl` (optional): The base URL for HTTP clones. Will default to `baseUrl` if
   not set. The address used to clone a repo is the `cloneUrl` plus the repo name.
-- `gitilesBaseUrl` (optional): This is needed for creating a valid user-friendly URL
-  that can be used for browsing the content of the provider. If not set a default
-  value will be created in the same way as the `baseUrl` option. There is no
-  requirement to have Gitiles for the Backstage Gerrit integration but without it
-  some links in the Backstage UI will be broken.
 - `username` (optional): The Gerrit username to use in API requests. If
   neither a username nor password are supplied, anonymous access will be used.
 - `password` (optional): The password or http token for the Gerrit user.

--- a/packages/backend-defaults/api-report-urlReader.md
+++ b/packages/backend-defaults/api-report-urlReader.md
@@ -217,7 +217,6 @@ export class GerritUrlReader implements UrlReaderService {
     deps: {
       treeResponseFactory: ReadTreeResponseFactory;
     },
-    workDir: string,
   );
   // (undocumented)
   static factory: ReaderFactory;

--- a/packages/integration/api-report.md
+++ b/packages/integration/api-report.md
@@ -326,7 +326,7 @@ export type GerritIntegrationConfig = {
   host: string;
   baseUrl?: string;
   cloneUrl?: string;
-  gitilesBaseUrl?: string;
+  gitilesBaseUrl: string;
   username?: string;
   password?: string;
 };

--- a/packages/integration/config.d.ts
+++ b/packages/integration/config.d.ts
@@ -152,6 +152,11 @@ export interface Config {
        */
       baseUrl?: string;
       /**
+       * The gitiles base url.
+       * @visibility frontend
+       */
+      gitilesBaseUrl: string;
+      /**
        * The base url for cloning repos.
        * @visibility frontend
        */

--- a/packages/integration/src/gerrit/GerritIntegration.test.ts
+++ b/packages/integration/src/gerrit/GerritIntegration.test.ts
@@ -27,6 +27,8 @@ describe('GerritIntegration', () => {
               host: 'gerrit-review.example.com',
               username: 'gerrituser',
               baseUrl: 'https://gerrit-review.example.com/gerrit',
+              gitilesBaseUrl:
+                'https://gerrit-review.example.com/gerrit/plugins/gitiles',
               password: '1234',
             },
           ],

--- a/packages/integration/src/gerrit/config.test.ts
+++ b/packages/integration/src/gerrit/config.test.ts
@@ -76,13 +76,14 @@ describe('readGerritIntegrationConfig', () => {
     const output = readGerritIntegrationConfig(
       buildConfig({
         host: 'a.com',
+        gitilesBaseUrl: 'https://a.com/gerrit/plugins/gitiles',
       }),
     );
     expect(output).toEqual({
       host: 'a.com',
       baseUrl: 'https://a.com',
       cloneUrl: 'https://a.com',
-      gitilesBaseUrl: 'https://a.com',
+      gitilesBaseUrl: 'https://a.com/gerrit/plugins/gitiles',
       username: undefined,
       password: undefined,
     });
@@ -106,6 +107,7 @@ describe('readGerritIntegrationConfig', () => {
         await buildFrontendConfig({
           host: 'a.com',
           baseUrl: 'https://a.com/gerrit',
+          gitilesBaseUrl: 'https://a.com/gerrit/plugins/gitiles',
           username: 'u',
           password: 'p',
         }),
@@ -114,7 +116,7 @@ describe('readGerritIntegrationConfig', () => {
       host: 'a.com',
       baseUrl: 'https://a.com/gerrit',
       cloneUrl: 'https://a.com/gerrit',
-      gitilesBaseUrl: 'https://a.com',
+      gitilesBaseUrl: 'https://a.com/gerrit/plugins/gitiles',
     });
   });
 });
@@ -130,12 +132,14 @@ describe('readGerritIntegrationConfigs', () => {
         {
           host: 'a.com',
           baseUrl: 'https://a.com/api',
+          gitilesBaseUrl: 'https://a.com/gerrit/plugins/gitiles',
           username: 'u',
           password: 'p',
         },
         {
           host: 'b.com',
           baseUrl: 'https://b.com/api',
+          gitilesBaseUrl: 'https://b.com/gerrit/plugins/gitiles',
         },
       ]),
     );
@@ -144,7 +148,7 @@ describe('readGerritIntegrationConfigs', () => {
         host: 'a.com',
         baseUrl: 'https://a.com/api',
         cloneUrl: 'https://a.com/api',
-        gitilesBaseUrl: 'https://a.com',
+        gitilesBaseUrl: 'https://a.com/gerrit/plugins/gitiles',
         username: 'u',
         password: 'p',
       },
@@ -152,7 +156,7 @@ describe('readGerritIntegrationConfigs', () => {
         host: 'b.com',
         baseUrl: 'https://b.com/api',
         cloneUrl: 'https://b.com/api',
-        gitilesBaseUrl: 'https://b.com',
+        gitilesBaseUrl: 'https://b.com/gerrit/plugins/gitiles',
         username: undefined,
         password: undefined,
       },

--- a/packages/integration/src/gerrit/config.ts
+++ b/packages/integration/src/gerrit/config.ts
@@ -45,12 +45,11 @@ export type GerritIntegrationConfig = {
   cloneUrl?: string;
 
   /**
-   * Optional base url for Gitiles. This is needed for creating a valid
+   * Base url for Gitiles. This is needed for creating a valid
    * user-friendly url that can be used for browsing the content of the
-   * provider. If not set a default value will be created in the same way
-   * as the "baseUrl" option.
+   * provider.
    */
-  gitilesBaseUrl?: string;
+  gitilesBaseUrl: string;
 
   /**
    * The username to use for requests to gerrit.
@@ -76,7 +75,7 @@ export function readGerritIntegrationConfig(
   const host = config.getString('host');
   let baseUrl = config.getOptionalString('baseUrl');
   let cloneUrl = config.getOptionalString('cloneUrl');
-  let gitilesBaseUrl = config.getOptionalString('gitilesBaseUrl');
+  let gitilesBaseUrl = config.getString('gitilesBaseUrl');
   const username = config.getOptionalString('username');
   const password = config.getOptionalString('password')?.trim();
 
@@ -92,7 +91,7 @@ export function readGerritIntegrationConfig(
     throw new Error(
       `Invalid Gerrit integration config, '${cloneUrl}' is not a valid cloneUrl`,
     );
-  } else if (gitilesBaseUrl && !isValidUrl(gitilesBaseUrl)) {
+  } else if (!isValidUrl(gitilesBaseUrl)) {
     throw new Error(
       `Invalid Gerrit integration config, '${gitilesBaseUrl}' is not a valid gitilesBaseUrl`,
     );

--- a/packages/integration/src/gerrit/core.test.ts
+++ b/packages/integration/src/gerrit/core.test.ts
@@ -134,9 +134,11 @@ describe('gerrit core', () => {
         host: 'gerrit.com',
         username: 'U',
         password: 'P',
+        gitilesBaseUrl: 'https://gerrit.com/gerrit/plugins/gitiles',
       };
       const anonymousRequest: GerritIntegrationConfig = {
         host: 'gerrit.com',
+        gitilesBaseUrl: 'https://gerrit.com/gerrit/plugins/gitiles',
       };
       expect(
         (getGerritRequestOptions(authRequest).headers as any).Authorization,

--- a/plugins/catalog-backend-module-gerrit/src/providers/GerritEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gerrit/src/providers/GerritEntityProvider.test.ts
@@ -166,9 +166,11 @@ describe('GerritEntityProvider', () => {
         gerrit: [
           {
             host: 'gerrit1.com',
+            gitilesBaseUrl: 'https://gerrit1.com/gitiles',
           },
           {
             host: 'gerrit2.com',
+            gitilesBaseUrl: 'https://gerrit2.com/gitiles',
           },
         ],
       },
@@ -201,6 +203,7 @@ describe('GerritEntityProvider', () => {
         gerrit: [
           {
             host: 'gerrit1.com',
+            gitilesBaseUrl: 'https://gerrit1.com/gitiles',
           },
         ],
       },

--- a/plugins/scaffolder-backend-module-gerrit/src/actions/gerrit.test.ts
+++ b/plugins/scaffolder-backend-module-gerrit/src/actions/gerrit.test.ts
@@ -42,6 +42,7 @@ describe('publish:gerrit', () => {
       gerrit: [
         {
           host: 'gerrithost.org',
+          gitilesBaseUrl: 'https://gerrithost.org/gitiles',
           username: 'gerrituser',
           password: 'usertoken',
         },
@@ -133,7 +134,7 @@ describe('publish:gerrit', () => {
     );
     expect(mockContext.output).toHaveBeenCalledWith(
       'repoContentsUrl',
-      'https://gerrithost.org/repo/+/refs/heads/master',
+      'https://gerrithost.org/gitiles/repo/+/refs/heads/master',
     );
   });
 
@@ -184,7 +185,7 @@ describe('publish:gerrit', () => {
     );
     expect(mockContext.output).toHaveBeenCalledWith(
       'repoContentsUrl',
-      'https://gerrithost.org/repo/+/refs/heads/master',
+      'https://gerrithost.org/gitiles/repo/+/refs/heads/master',
     );
   });
 
@@ -235,7 +236,7 @@ describe('publish:gerrit', () => {
     );
     expect(mockContext.output).toHaveBeenCalledWith(
       'repoContentsUrl',
-      'https://gerrithost.org/repo/+/refs/heads/master',
+      'https://gerrithost.org/gitiles/repo/+/refs/heads/master',
     );
   });
 
@@ -286,7 +287,7 @@ describe('publish:gerrit', () => {
     );
     expect(mockContext.output).toHaveBeenCalledWith(
       'repoContentsUrl',
-      'https://gerrithost.org/repo/+/refs/heads/main',
+      'https://gerrithost.org/gitiles/repo/+/refs/heads/main',
     );
   });
 

--- a/plugins/scaffolder-backend-module-gerrit/src/actions/gerritReview.examples.test.ts
+++ b/plugins/scaffolder-backend-module-gerrit/src/actions/gerritReview.examples.test.ts
@@ -35,6 +35,7 @@ describe('publish:gerrit:review', () => {
       gerrit: [
         {
           host: 'gerrithost.org',
+          gitilesBaseUrl: 'https://gerrithost.org/gitiles',
           username: 'gerrituser',
           password: 'usertoken',
         },
@@ -77,7 +78,7 @@ describe('publish:gerrit:review', () => {
 
     expect(mockContext.output).toHaveBeenCalledWith(
       'repoContentsUrl',
-      'https://gerrithost.org/repo/+/refs/heads/master',
+      'https://gerrithost.org/gitiles/repo/+/refs/heads/master',
     );
     expect(mockContext.output).toHaveBeenCalledWith(
       'reviewUrl',
@@ -109,7 +110,7 @@ describe('publish:gerrit:review', () => {
 
     expect(mockContext.output).toHaveBeenCalledWith(
       'repoContentsUrl',
-      'https://gerrithost.org/repo/+/refs/heads/master',
+      'https://gerrithost.org/gitiles/repo/+/refs/heads/master',
     );
     expect(mockContext.output).toHaveBeenCalledWith(
       'reviewUrl',
@@ -141,7 +142,7 @@ describe('publish:gerrit:review', () => {
 
     expect(mockContext.output).toHaveBeenCalledWith(
       'repoContentsUrl',
-      'https://gerrithost.org/repo/+/refs/heads/master',
+      'https://gerrithost.org/gitiles/repo/+/refs/heads/master',
     );
     expect(mockContext.output).toHaveBeenCalledWith(
       'reviewUrl',
@@ -170,7 +171,7 @@ describe('publish:gerrit:review', () => {
 
     expect(mockContext.output).toHaveBeenCalledWith(
       'repoContentsUrl',
-      'https://gerrithost.org/repo/+/refs/heads/develop',
+      'https://gerrithost.org/gitiles/repo/+/refs/heads/develop',
     );
     expect(mockContext.output).toHaveBeenCalledWith(
       'reviewUrl',
@@ -199,7 +200,7 @@ describe('publish:gerrit:review', () => {
 
     expect(mockContext.output).toHaveBeenCalledWith(
       'repoContentsUrl',
-      'https://gerrithost.org/repo/+/refs/heads/master',
+      'https://gerrithost.org/gitiles/repo/+/refs/heads/master',
     );
     expect(mockContext.output).toHaveBeenCalledWith(
       'reviewUrl',
@@ -231,7 +232,7 @@ describe('publish:gerrit:review', () => {
 
     expect(mockContext.output).toHaveBeenCalledWith(
       'repoContentsUrl',
-      'https://gerrithost.org/repo/+/refs/heads/develop',
+      'https://gerrithost.org/gitiles/repo/+/refs/heads/develop',
     );
     expect(mockContext.output).toHaveBeenCalledWith(
       'reviewUrl',

--- a/plugins/scaffolder-backend-module-gerrit/src/actions/gerritReview.test.ts
+++ b/plugins/scaffolder-backend-module-gerrit/src/actions/gerritReview.test.ts
@@ -33,6 +33,7 @@ describe('publish:gerrit:review', () => {
       gerrit: [
         {
           host: 'gerrithost.org',
+          gitilesBaseUrl: 'https://gerrithost.org/gitiles',
           username: 'gerrituser',
           password: 'usertoken',
         },
@@ -104,7 +105,7 @@ describe('publish:gerrit:review', () => {
 
     expect(mockContext.output).toHaveBeenCalledWith(
       'repoContentsUrl',
-      'https://gerrithost.org/repo/+/refs/heads/master',
+      'https://gerrithost.org/gitiles/repo/+/refs/heads/master',
     );
     expect(mockContext.output).toHaveBeenCalledWith(
       'reviewUrl',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is the final part of the RFC in #22500 to make the "gitilesBaseUrl" config option mandatory for the Gerrit integrations. Since 1.23.0 this has been deprecated and required an environmental variable to override.

The "gitilesBaseUrl" config is now mandatory and the ability to override this has been removed. This ability for the Gerrit "readTree" to use "git clone" has been removed, it will now always use the Gitiles api.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
