### PR TITLE
[NBS1.0] Rename `MockDirectoryOptions` to `CreateMockDirectoryOptions`

### DIFF
--- a/.changeset/honest-badgers-ring.md
+++ b/.changeset/honest-badgers-ring.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-test-utils': patch
+---
+
+The type `MockDirectoryOptions` was renamed to `CreateMockDirectoryOptions` so that it's clear these options are exclusive to the mock directory factory.

--- a/packages/backend-test-utils/api-report.md
+++ b/packages/backend-test-utils/api-report.md
@@ -45,8 +45,14 @@ import { UserInfoService } from '@backstage/backend-plugin-api';
 
 // @public
 export function createMockDirectory(
-  options?: MockDirectoryOptions,
+  options?: CreateMockDirectoryOptions,
 ): MockDirectory;
+
+// @public
+export interface CreateMockDirectoryOptions {
+  content?: MockDirectoryContent;
+  mockOsTmpDir?: boolean;
+}
 
 // @public (undocumented)
 export function isDockerDisabledForTests(): boolean;
@@ -136,11 +142,8 @@ export interface MockDirectoryContentOptions {
   shouldReadAsText?: boolean | ((path: string, buffer: Buffer) => boolean);
 }
 
-// @public
-export interface MockDirectoryOptions {
-  content?: MockDirectoryContent;
-  mockOsTmpDir?: boolean;
-}
+// @public @deprecated (undocumented)
+export type MockDirectoryOptions = CreateMockDirectoryOptions;
 
 // @public (undocumented)
 export namespace mockServices {

--- a/packages/backend-test-utils/src/deprecated.ts
+++ b/packages/backend-test-utils/src/deprecated.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 The Backstage Authors
+ * Copyright 2024 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 
-export {
-  createMockDirectory,
-  type CreateMockDirectoryOptions,
-  type MockDirectory,
-  type MockDirectoryContent,
-  type MockDirectoryContentOptions,
-  type MockDirectoryContentCallback,
-  type MockDirectoryContentCallbackContext,
-} from './MockDirectory';
+import { CreateMockDirectoryOptions } from './filesystem';
+
+/**
+ * @public
+ * @deprecated Use `CreateMockDirectoryOptions` from `@backstage/backend-test-utils` instead.
+ */
+export type MockDirectoryOptions = CreateMockDirectoryOptions;

--- a/packages/backend-test-utils/src/filesystem/MockDirectory.ts
+++ b/packages/backend-test-utils/src/filesystem/MockDirectory.ts
@@ -347,7 +347,7 @@ class MockDirectoryImpl {
  *
  * @public
  */
-export interface MockDirectoryOptions {
+export interface CreateMockDirectoryOptions {
   /**
    * In addition to creating a temporary directory, also mock `os.tmpdir()` to return the
    * mock directory path until the end of the test suite.
@@ -386,7 +386,7 @@ export interface MockDirectoryOptions {
  * ```
  */
 export function createMockDirectory(
-  options?: MockDirectoryOptions,
+  options?: CreateMockDirectoryOptions,
 ): MockDirectory {
   const tmpDir = process.env.RUNNER_TEMP || os.tmpdir(); // GitHub Actions
   const root = fs.mkdtempSync(joinPath(tmpDir, 'backstage-tmp-test-dir-'));

--- a/packages/backend-test-utils/src/index.ts
+++ b/packages/backend-test-utils/src/index.ts
@@ -20,6 +20,7 @@
  * @packageDocumentation
  */
 
+export * from './deprecated';
 export * from './cache';
 export * from './database';
 export * from './msw';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes: https://github.com/backstage/backstage/issues/25128

Prefix the `MockDirectoryOptions` type with the name of the `createMockDirectory` method so that it is clear that these options are exclusive to the mock directory factory.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
