### PR TITLE
fix: update getHarnessEditContentsUrl

### DIFF
--- a/.changeset/dull-moose-cough.md
+++ b/.changeset/dull-moose-cough.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': minor
+---
+
+Updated function for getHarnessEditContentsUrl

--- a/.changeset/dull-moose-cough.md
+++ b/.changeset/dull-moose-cough.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/integration': minor
+'@backstage/integration': patch
 ---
 
 Updated function for getHarnessEditContentsUrl

--- a/packages/integration/src/harness/HarnessIntegration.test.ts
+++ b/packages/integration/src/harness/HarnessIntegration.test.ts
@@ -117,7 +117,7 @@ describe('HarnessIntegration', () => {
         'https://app.harness.io/ng/account/accountId/module/code/orgs/orgName/projects/projName/repos/repoName/edit/refMain/~/all-apis.yaml',
       ),
     ).toBe(
-      'https://app.harness.io/ng/account/accountId/module/code/orgs/orgName/projects/projName/repoName/files/refMain/~/all-apis.yaml',
+      'https://app.harness.io/ng/account/accountId/module/code/orgs/orgName/projects/projName/repos/repoName/files/refMain/~/all-apis.yaml',
     );
   });
 });

--- a/packages/integration/src/harness/core.test.ts
+++ b/packages/integration/src/harness/core.test.ts
@@ -57,7 +57,7 @@ describe('Harness code core', () => {
           'https://app.harness.io/ng/account/accountId/module/code/orgs/orgName/projects/projName/repos/repoName/edit/refMain/~/all-apis.yaml',
         ),
       ).toEqual(
-        'https://app.harness.io/ng/account/accountId/module/code/orgs/orgName/projects/projName/repoName/files/refMain/~/all-apis.yaml',
+        'https://app.harness.io/ng/account/accountId/module/code/orgs/orgName/projects/projName/repos/repoName/files/refMain/~/all-apis.yaml',
       );
     });
   });

--- a/packages/integration/src/harness/core.ts
+++ b/packages/integration/src/harness/core.ts
@@ -34,7 +34,7 @@ export function getHarnessEditContentsUrl(
   url: string,
 ) {
   const parsedUrl = parseHarnessUrl(config, url);
-  return `${parsedUrl.baseUrl}/ng/account/${parsedUrl.accountId}/module/code/orgs/${parsedUrl.orgName}/projects/${parsedUrl.projectName}/${parsedUrl.repoName}/files/${parsedUrl.branch}/~/${parsedUrl.path}`;
+  return `${parsedUrl.baseUrl}/ng/account/${parsedUrl.accountId}/module/code/orgs/${parsedUrl.orgName}/projects/${parsedUrl.projectName}/repos/${parsedUrl.repoName}/files/${parsedUrl.branch}/~/${parsedUrl.path}`;
 }
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updated function for getHarnessEditContentsUrl as it was missing 'repos'

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
