### PR TITLE
[NBS1.0] Complete deprecating the legacy backend utilities

### DIFF
--- a/.changeset/twenty-seals-guess.md
+++ b/.changeset/twenty-seals-guess.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Finalizes the deprecation of legacy backend utilities. Deprecated utilities include the `ServiceBuilder` type, `notFoundHandler` and `redactWintonLogLine` functions.

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -467,7 +467,7 @@ export function makeLegacyPlugin<
   }>,
 ) => BackendFeature;
 
-// @public
+// @public @deprecated
 export function notFoundHandler(): RequestHandler;
 
 // @public (undocumented)
@@ -540,7 +540,7 @@ export const ReadUrlResponseFactory: typeof ReadUrlResponseFactory_2;
 export type ReadUrlResponseFactoryFromStreamOptions =
   ReadUrlResponseFactoryFromStreamOptions_2;
 
-// @public
+// @public @deprecated
 export function redactWinstonLogLine(
   info: winston.Logform.TransformableInfo,
 ): winston.Logform.TransformableInfo;
@@ -604,7 +604,7 @@ export interface ServerTokenManagerOptions {
   logger: LoggerService;
 }
 
-// @public
+// @public @deprecated
 export type ServiceBuilder = {
   loadConfig(config: Config): ServiceBuilder;
   setPort(port: number): ServiceBuilder;

--- a/packages/backend-common/src/logging/createRootLogger.ts
+++ b/packages/backend-common/src/logging/createRootLogger.ts
@@ -43,6 +43,8 @@ export const setRootLoggerRedactionList = (
  * and replaces them with the corresponding identifier.
  *
  * @public
+ * @deprecated This utility is being deprecated along with the {@link https://github.com/backstage/backstage/issues/24493 |legacy backend system}.
+ * Migrate your {@link https://backstage.io/docs/backend-system/building-backends/migrating | backend} and {@link https://backstage.io/docs/backend-system/building-plugins-and-modules/migrating | plugin} to the new system and use the {@link https://github.com/backstage/backstage/pull/24730 | RedactionsService} for customization instead.
  */
 export function redactWinstonLogLine(
   info: winston.Logform.TransformableInfo,

--- a/packages/backend-common/src/middleware/notFoundHandler.ts
+++ b/packages/backend-common/src/middleware/notFoundHandler.ts
@@ -27,6 +27,7 @@ import { getRootLogger } from '../logging';
  *
  * @public
  * @returns An Express request handler
+ * @deprecated Use {@link @backstage/backend-app-api#MiddlewareFactory.create.notFound} instead
  */
 export function notFoundHandler(): RequestHandler {
   return MiddlewareFactory.create({

--- a/packages/backend-common/src/service/types.ts
+++ b/packages/backend-common/src/service/types.ts
@@ -24,6 +24,7 @@ import { LoggerService } from '@backstage/backend-plugin-api';
  * A helper for building backend service instances.
  *
  * @public
+ * @deprecated This type is being deprecated along with the {@link @backstage/backend-common#createServiceBuilder} function.
  */
 export type ServiceBuilder = {
   /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Ref: https://github.com/backstage/backstage/issues/25148

Finalizes the deprecation of legacy backend utilities. Deprecated utilities include the `ServiceBuilder` type, `notFoundHandler` and `redactWintonLogLine` functions.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
