### PR TITLE
cli: plugin metadata tweaks for some package edge cases

### DIFF
--- a/packages/cli-node/api-report.md
+++ b/packages/cli-node/api-report.md
@@ -18,7 +18,7 @@ export interface BackstagePackageJson {
   backstage?: {
     role?: PackageRole;
     moved?: string;
-    pluginId?: string;
+    pluginId?: string | null;
     pluginPackage?: string;
     pluginPackages?: string[];
   };

--- a/packages/cli-node/src/monorepo/PackageGraph.ts
+++ b/packages/cli-node/src/monorepo/PackageGraph.ts
@@ -48,7 +48,7 @@ export interface BackstagePackageJson {
     moved?: string;
 
     /**
-     * The ID of the plugin if this is a plugin package. Must always be set for plugin and module packages, and may be set for library packages.
+     * The ID of the plugin if this is a plugin package. Must always be set for plugin and module packages, and may be set for library packages. A `null` value means that the package is explicitly not a plugin package.
      */
     pluginId?: string | null;
 

--- a/packages/cli-node/src/monorepo/PackageGraph.ts
+++ b/packages/cli-node/src/monorepo/PackageGraph.ts
@@ -50,7 +50,7 @@ export interface BackstagePackageJson {
     /**
      * The ID of the plugin if this is a plugin package. Must always be set for plugin and module packages, and may be set for library packages.
      */
-    pluginId?: string;
+    pluginId?: string | null;
 
     /**
      * The parent plugin package of a module. Must always and only be set for module packages.

--- a/packages/cli/src/commands/repo/fix.ts
+++ b/packages/cli/src/commands/repo/fix.ts
@@ -363,7 +363,8 @@ export function fixPluginPackages(
     if (
       role === 'common-library' ||
       role === 'web-library' ||
-      role === 'node-library'
+      role === 'node-library' ||
+      role === 'frontend-plugin-module' // TODO(Rugvip): Remove this once frontend modules are required to have a plugin ID
     ) {
       return;
     }

--- a/packages/cli/src/commands/repo/fix.ts
+++ b/packages/cli/src/commands/repo/fix.ts
@@ -277,7 +277,7 @@ export function fixPluginId(pkg: FixablePackage) {
 
   const currentId = pkg.packageJson.backstage?.pluginId;
   if (currentId !== undefined) {
-    if (typeof currentId !== 'string') {
+    if (typeof currentId !== 'string' && currentId !== null) {
       throw new Error(
         `Invalid 'backstage.pluginId' field in "${pkg.packageJson.name}", must be a string`,
       );

--- a/packages/cli/src/lib/publishing.ts
+++ b/packages/cli/src/lib/publishing.ts
@@ -30,8 +30,9 @@ export function publishPreflightCheck(pkg: BackstagePackage): void {
   if (
     role === 'backend-plugin' ||
     role === 'backend-plugin-module' ||
-    role === 'frontend-plugin' ||
-    role === 'frontend-plugin-module'
+    role === 'frontend-plugin'
+    // TODO(Rugvip): We currently support plugin-less frontend modules for the new frontend system, but it needs a different solution
+    // || role === 'frontend-plugin-module'
   ) {
     if (!backstage.pluginId) {
       throw new Error(
@@ -62,7 +63,8 @@ export function publishPreflightCheck(pkg: BackstagePackage): void {
   }
 
   if (role === 'backend-plugin-module' || role === 'frontend-plugin-module') {
-    if (!backstage.pluginPackage) {
+    // TODO(Rugvip): Remove this .pluginId check once frontend modules are required to have a plugin ID
+    if (backstage.pluginId && !backstage.pluginPackage) {
       throw new Error(
         `Plugin module package ${name} is missing a backstage.pluginPackage, please run 'backstage-cli repo fix --publish'`,
       );


### PR DESCRIPTION
Two tweaks to package metadata to support some edge cases. One is to allow an explicitly `null` plugin ID, in the event that a package is named in such a way that the `repo fix` command wants to set a `pluginId` where the package shouldn't actually have one.

The other is to allow frontend modules to not have a plugin ID. I expect this to be a more temporary fix as we figure out a better pattern for frontend modules in the new frontend system. For the time being there are many frontend modules that aren't tied to a particular plugin.