### PR TITLE
Index name + title of entity in default catalog collator

### DIFF
--- a/.changeset/violet-ducks-care.md
+++ b/.changeset/violet-ducks-care.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Ensure name and title are both indexed by the DefaultCatalogCollator

--- a/plugins/catalog-backend/src/search/DefaultCatalogCollator.test.ts
+++ b/plugins/catalog-backend/src/search/DefaultCatalogCollator.test.ts
@@ -117,7 +117,7 @@ describe('DefaultCatalogCollator', () => {
       },
     });
     expect(documents[1]).toMatchObject({
-      title: expectedEntities[1].metadata.title,
+      title: `${expectedEntities[1].metadata.title} (${expectedEntities[1].metadata.name})`,
       location: '/catalog/default/component/test-entity-2',
       text: expectedEntities[1].metadata.description,
       namespace: 'default',

--- a/plugins/catalog-backend/src/search/DefaultCatalogCollator.ts
+++ b/plugins/catalog-backend/src/search/DefaultCatalogCollator.ts
@@ -115,7 +115,9 @@ export class DefaultCatalogCollator {
     );
     return response.items.map((entity: Entity): CatalogEntityDocument => {
       return {
-        title: entity.metadata.title ?? entity.metadata.name,
+        title: entity.metadata.title
+          ? `${entity.metadata.title} (${entity.metadata.name})`
+          : entity.metadata.name,
         location: this.applyArgsToFormat(this.locationTemplate, {
           namespace: entity.metadata.namespace || 'default',
           kind: entity.kind,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

It's confusing to no longer be able to search for an entity based on name when the entity has a title specified. This changes the behavior so that it's searchable on both.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
