### PR TITLE
feat(gerrit-integration): Update the gerrit url resolver

### DIFF
--- a/.changeset/red-squids-own.md
+++ b/.changeset/red-squids-own.md
@@ -1,0 +1,11 @@
+---
+'@backstage/integration': minor
+---
+
+The Gerrit integration can now resolve Gitiles urls that point to the following
+refs:
+
+- HEAD
+- A SHA
+- Tag
+- Branch

--- a/packages/integration/api-report.md
+++ b/packages/integration/api-report.md
@@ -767,6 +767,18 @@ export function parseGiteaUrl(
 };
 
 // @public
+export function parseGitilesUrlRef(
+  config: GerritIntegrationConfig,
+  url: string,
+): {
+  project: string;
+  path: string;
+  ref: string;
+  refType: 'sha' | 'branch' | 'tag' | 'head';
+  basePath: string;
+};
+
+// @public
 export function parseHarnessUrl(
   config: HarnessIntegrationConfig,
   url: string,

--- a/packages/integration/src/gerrit/GerritIntegration.test.ts
+++ b/packages/integration/src/gerrit/GerritIntegration.test.ts
@@ -83,11 +83,10 @@ describe('GerritIntegration', () => {
   });
 
   describe('resolves with a relative url', () => {
-    it('works for valid urls', () => {
-      const integration = new GerritIntegration({
-        host: 'gerrit-review.example.com',
-      } as any);
-
+    const integration = new GerritIntegration({
+      host: 'gerrit-review.example.com',
+    } as any);
+    it('works for valid urls pointing to a branch', () => {
       expect(
         integration.resolveUrl({
           url: './skeleton',
@@ -97,15 +96,24 @@ describe('GerritIntegration', () => {
         'https://gerrit-review.example.com/gerrit/plugins/repo/+/refs/heads/master/skeleton',
       );
     });
+    it('works for urls pointing to a tag', () => {
+      expect(
+        integration.resolveUrl({
+          url: './skeleton.yaml',
+          base: 'https://gerrit-review.example.com/gerrit/plugins/repo/+/refs/tags/v.1.2.3/src/template.yaml',
+        }),
+      ).toBe(
+        'https://gerrit-review.example.com/gerrit/plugins/repo/+/refs/tags/v.1.2.3/src/skeleton.yaml',
+      );
+    });
   });
 
   describe('resolves with an absolute url', () => {
-    it('works for valid urls', () => {
-      const integration = new GerritIntegration({
-        host: 'gerrit-review.example.com',
-        gitilesBaseUrl: 'https://gerrit-review.example.com/gitiles',
-      } as any);
-
+    const integration = new GerritIntegration({
+      host: 'gerrit-review.example.com',
+      gitilesBaseUrl: 'https://gerrit-review.example.com/gitiles',
+    } as any);
+    it('works for valid urls pointing to a branch', () => {
       expect(
         integration.resolveUrl({
           url: '/catalog-info.yaml',
@@ -113,6 +121,16 @@ describe('GerritIntegration', () => {
         }),
       ).toBe(
         'https://gerrit-review.example.com/gitiles/repo/+/refs/heads/master/catalog-info.yaml',
+      );
+    });
+    it('works for urls pointing to a tag', () => {
+      expect(
+        integration.resolveUrl({
+          url: '/skeleton.yaml',
+          base: 'https://gerrit-review.example.com/gerrit/plugins/repo/+/refs/tags/v.1.2.3/src/template.yaml',
+        }),
+      ).toBe(
+        'https://gerrit-review.example.com/gerrit/plugins/repo/+/refs/tags/v.1.2.3/skeleton.yaml',
       );
     });
   });

--- a/packages/integration/src/gerrit/GerritIntegration.ts
+++ b/packages/integration/src/gerrit/GerritIntegration.ts
@@ -20,7 +20,7 @@ import {
   GerritIntegrationConfig,
   readGerritIntegrationConfigs,
 } from './config';
-import { parseGerritGitilesUrl, buildGerritGitilesUrl } from './core';
+import { parseGitilesUrlRef } from './core';
 
 /**
  * A Gerrit based integration.
@@ -60,8 +60,8 @@ export class GerritIntegration implements ScmIntegration {
     const { url, base, lineNumber } = options;
     let updated;
     if (url.startsWith('/')) {
-      const { branch, project } = parseGerritGitilesUrl(this.config, base);
-      return buildGerritGitilesUrl(this.config, project, branch, url);
+      const { basePath } = parseGitilesUrlRef(this.config, base);
+      return basePath + url;
     }
     if (url) {
       updated = new URL(url, base);

--- a/packages/integration/src/gerrit/index.ts
+++ b/packages/integration/src/gerrit/index.ts
@@ -27,6 +27,7 @@ export {
   getGerritRequestOptions,
   parseGerritJsonResponse,
   parseGerritGitilesUrl,
+  parseGitilesUrlRef,
 } from './core';
 
 export type { GerritIntegrationConfig } from './config';


### PR DESCRIPTION
Currently the only Gitiles urls that can be resolved is urls that point to the tip of a specific branch.

This change adds support for resolving urls that points to the following refs:

* HEAD
* A commit sha
* Tag

The plan is to update the Gerrit entity provider with the ability to use HEAD instead of using a hard coded branch.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
