### PR TITLE
feat: support for stream transport for debug purposes

### DIFF
--- a/.changeset/shy-games-poke.md
+++ b/.changeset/shy-games-poke.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications-backend-module-email': patch
+---
+
+Add support for stream transport for debugging purposes

--- a/plugins/notifications-backend-module-email/README.md
+++ b/plugins/notifications-backend-module-email/README.md
@@ -2,7 +2,7 @@
 
 Adds support for sending Backstage notifications as emails to users.
 
-Supports sending emails using `SMTP`, `SES`, or `sendmail`.
+Supports sending emails using `SMTP`, `SES`, `sendmail`, or `stream` (for debugging purposes).
 
 ## Customizing email content
 

--- a/plugins/notifications-backend-module-email/config.d.ts
+++ b/plugins/notifications-backend-module-email/config.d.ts
@@ -79,6 +79,10 @@ export interface Config {
                * Newline style, defaults to 'unix'
                */
               newline?: 'unix' | 'windows';
+            }
+          | {
+              /** Only for debugging, disables the actual sending of emails */
+              transport: 'stream';
             };
         /**
          * Sender email address

--- a/plugins/notifications-backend-module-email/src/processor/NotificationsEmailProcessor.ts
+++ b/plugins/notifications-backend-module-email/src/processor/NotificationsEmailProcessor.ts
@@ -38,6 +38,7 @@ import {
   createSendmailTransport,
   createSesTransport,
   createSmtpTransport,
+  createStreamTransport,
 } from './transports';
 import { UserEntity } from '@backstage/catalog-model';
 import { compact } from 'lodash';
@@ -129,6 +130,8 @@ export class NotificationsEmailProcessor implements NotificationProcessor {
       );
     } else if (transport === 'sendmail') {
       this.transporter = createSendmailTransport(this.transportConfig);
+    } else if (transport === 'stream') {
+      this.transporter = createStreamTransport();
     } else {
       throw new Error(`Unsupported transport: ${transport}`);
     }
@@ -229,6 +232,7 @@ export class NotificationsEmailProcessor implements NotificationProcessor {
 
   private async sendMail(options: Mail.Options) {
     try {
+      this.logger.debug(`Sending notification email to ${options.to}`);
       await this.transporter.sendMail(options);
     } catch (e) {
       this.logger.error(`Failed to send email to ${options.to}: ${e}`);

--- a/plugins/notifications-backend-module-email/src/processor/transports/stream.ts
+++ b/plugins/notifications-backend-module-email/src/processor/transports/stream.ts
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { createSmtpTransport } from './smtp';
-export { createSesTransport } from './ses';
-export { createSendmailTransport } from './sendmail';
-export { createStreamTransport } from './stream';
+import { createTransport } from 'nodemailer';
+
+export const createStreamTransport = () => {
+  return createTransport({ streamTransport: true });
+};


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add new `stream` transport for the email notification processor for local debugging

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
