### PR TITLE
Make sure fetch request against authentication providers includes creds

### DIFF
--- a/.changeset/green-grapes-rush.md
+++ b/.changeset/green-grapes-rush.md
@@ -1,0 +1,8 @@
+---
+'@backstage/core-app-api': patch
+---
+
+Make sure fetch request to the authentication providers includes credentials. As mentioned in the
+[HTTP CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#requests_with_credentials) docs,
+the `credentials: include` might not be enough and browsers can reject it if the header
+`Access-Control-Allow-Credentials` is not explicitly set to `true`.

--- a/packages/core-app-api/src/lib/AuthConnector/DefaultAuthConnector.ts
+++ b/packages/core-app-api/src/lib/AuthConnector/DefaultAuthConnector.ts
@@ -142,6 +142,7 @@ export class DefaultAuthConnector<AuthSession>
       {
         headers: {
           'x-requested-with': 'XMLHttpRequest',
+          'Access-Control-Allow-Credentials': 'true',
         },
         credentials: 'include',
       },
@@ -174,6 +175,7 @@ export class DefaultAuthConnector<AuthSession>
       method: 'POST',
       headers: {
         'x-requested-with': 'XMLHttpRequest',
+        'Access-Control-Allow-Credentials': 'true',
       },
       credentials: 'include',
     }).catch(error => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!


As mentioned in the docs (https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#requests_with_credentials), having the "credentials: include" might not be enough and the browsers can still reject the obtained response. Adding the header "Access-Control-Allow-Credentials" should make sure the browsers will accept the credentials.

This is fixing https://github.com/backstage/backstage/issues/25161

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
