### PR TITLE
fix: enable support for edit_url in TechDocs

### DIFF
--- a/.changeset/tasty-forks-compare.md
+++ b/.changeset/tasty-forks-compare.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-node': patch
+---
+
+Updated getRepoUrlFromLocationAnnotation to check for harness scm integration

--- a/.changeset/tasty-forks-compare.md
+++ b/.changeset/tasty-forks-compare.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-techdocs-node': patch
 ---
 
-Updated getRepoUrlFromLocationAnnotation to check for harness scm integration
+Updated `getRepoUrlFromLocationAnnotation` to check for Harness SCM integration

--- a/plugins/techdocs-node/src/stages/generate/helpers.ts
+++ b/plugins/techdocs-node/src/stages/generate/helpers.ts
@@ -101,11 +101,13 @@ export const getRepoUrlFromLocationAnnotation = (
   if (locationType === 'url') {
     const integration = scmIntegrations.byUrl(target);
 
-    // We only support it for github, gitlab and bitbucketServer for now as the edit_uri
+    // We only support it for github, gitlab, bitbucketServer and harness for now as the edit_uri
     // is not properly supported for others yet.
     if (
       integration &&
-      ['github', 'gitlab', 'bitbucketServer'].includes(integration.type)
+      ['github', 'gitlab', 'bitbucketServer', 'harness'].includes(
+        integration.type,
+      )
     ) {
       // handle the case where a user manually writes url:https://github.com/backstage/backstage i.e. without /blob/...
       const { filepathtype } = gitUrlParse(target);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

enable support for edit_url in TechDocs

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
