### PR TITLE
Typo Found In org.md

### DIFF
--- a/docs/integrations/ldap/org.md
+++ b/docs/integrations/ldap/org.md
@@ -301,11 +301,11 @@ map:
 In case you want to customize the ingested entities, the provider allows to pass
 transformers for users and groups.
 
-Transformers can be configured by extending `ldapOrgEntityProviderTransformExtensionPoint`. Here is an example:
+Transformers can be configured by extending `ldapOrgEntityProviderTransformsExtensionPoint`. Here is an example:
 
 ```ts title="packages/backend/src/index.ts"
 import { createBackendModule } from '@backstage/backend-plugin-api';
-import { ldapOrgEntityProviderTransformExtensionPoint } from '@backstage/plugin-catalog-backend-module-ldap';
+import { ldapOrgEntityProviderTransformsExtensionPoint } from '@backstage/plugin-catalog-backend-module-ldap';
 import { myUserTransformer, myGroupTransformer } from './transformers';
 
 backend.add(
@@ -316,7 +316,7 @@ backend.add(
       env.registerInit({
         deps: {
           /* highlight-add-start */
-          ldapTransformers: ldapOrgEntityProviderTransformExtensionPoint,
+          ldapTransformers: ldapOrgEntityProviderTransformsExtensionPoint,
           /* highlight-add-end */
         },
         async init({ ldapTransformers }) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Typo in this documentation

`ldapOrgEntityProviderTransformExtensionPoint` to `ldapOrgEntityProviderTransformsExtensionPoint`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
