### PR TITLE
Fix user entity not being fetched for scaffolder dry runner

### DIFF
--- a/.changeset/young-fishes-lie.md
+++ b/.changeset/young-fishes-lie.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Fix user entity not being fetched for scaffolder dry runner

--- a/plugins/scaffolder-backend/src/scaffolder/dryrun/createDryRunner.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/dryrun/createDryRunner.ts
@@ -38,12 +38,17 @@ import {
   BackstageCredentials,
   resolveSafeChildPath,
 } from '@backstage/backend-plugin-api';
+import type { UserEntity } from '@backstage/catalog-model';
 
 interface DryRunInput {
   spec: TaskSpec;
   secrets?: TaskSecrets;
   directoryContents: SerializedFile[];
   credentials: BackstageCredentials;
+  user?: {
+    entity?: UserEntity;
+    ref?: string;
+  };
 }
 
 interface DryRunResult {

--- a/plugins/scaffolder-backend/src/service/router.test.ts
+++ b/plugins/scaffolder-backend/src/service/router.test.ts
@@ -691,6 +691,34 @@ data: {"id":1,"taskId":"a-random-id","type":"completion","createdAt":"","body":{
         expect(subscriber!.closed).toBe(true);
       });
     });
+
+    describe('POST /v2/dry-run', () => {
+      it('should get user entity', async () => {
+        const mockToken = mockCredentials.user.token();
+        const mockTemplate = getMockTemplate();
+
+        const catalogSpy = jest.spyOn(catalogClient, 'getEntityByRef');
+
+        await request(app)
+          .post('/v2/dry-run')
+          .set('Authorization', `Bearer ${mockToken}`)
+          .send({
+            template: mockTemplate,
+            values: {
+              requiredParameter1: 'required-value-1',
+              requiredParameter2: 'required-value-2',
+            },
+            directoryContents: [],
+          });
+
+        expect(catalogSpy).toHaveBeenCalledTimes(1);
+
+        expect(catalogSpy).toHaveBeenCalledWith(
+          'user:default/mock',
+          expect.anything(),
+        );
+      });
+    });
   });
 
   describe('providing an identity api', () => {

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -730,6 +730,14 @@ export async function createRouter(
         targetPluginId: 'catalog',
       });
 
+      const userEntityRef = auth.isPrincipal(credentials, 'user')
+        ? credentials.principal.userEntityRef
+        : undefined;
+
+      const userEntity = userEntityRef
+        ? await catalogClient.getEntityByRef(userEntityRef, { token })
+        : undefined;
+
       for (const parameters of [template.spec.parameters ?? []].flat()) {
         const result = validate(body.values, parameters);
         if (!result.valid) {
@@ -750,6 +758,10 @@ export async function createRouter(
           steps,
           output: template.spec.output ?? {},
           parameters: body.values as JsonObject,
+          user: {
+            entity: userEntity as UserEntity,
+            ref: userEntityRef,
+          },
         },
         directoryContents: (body.directoryContents ?? []).map(file => ({
           path: file.path,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR fixes issue #25231 

**The problem**: User signed in details was not usable in the template dry runner e.g. `${{ user.ref }}` or `${{ user.entity }}`. 
**The fix**: User entity was not being fetched from catalog or passed into the dry runner input in the `/v2/dry-run` endpoint. With this fix it will now do this similarly to the `/v2/tasks` endpoint.

Before fix:
<img width="1382" alt="image" src="https://github.com/backstage/backstage/assets/31711200/479d106f-a8ba-48a9-b64c-d017777dc7c3">

After fix:
<img width="1382" alt="image" src="https://github.com/backstage/backstage/assets/31711200/033dde97-43aa-44ef-8f6a-dd24c7d6fc55">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
