### PR TITLE
fix iso duration parsing in schedules

### DIFF
--- a/.changeset/curvy-teachers-smell.md
+++ b/.changeset/curvy-teachers-smell.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-catalog-backend-module-ldap': patch
+'@backstage/backend-plugin-api': patch
+'@backstage/backend-defaults': patch
+'@backstage/backend-tasks': patch
+---
+
+Fix bug where ISO durations could no longer be used for schedules

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/PluginTaskSchedulerImpl.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/PluginTaskSchedulerImpl.ts
@@ -152,7 +152,7 @@ export class PluginTaskSchedulerImpl implements SchedulerService {
 export function parseDuration(
   frequency: SchedulerServiceTaskScheduleDefinition['frequency'],
 ): string {
-  if ('cron' in frequency) {
+  if (typeof frequency === 'object' && 'cron' in frequency) {
     return frequency.cron;
   }
 

--- a/packages/backend-plugin-api/src/services/definitions/SchedulerService.test.ts
+++ b/packages/backend-plugin-api/src/services/definitions/SchedulerService.test.ts
@@ -16,7 +16,6 @@
 
 import { ConfigReader } from '@backstage/config';
 import { HumanDuration } from '@backstage/types';
-import { Duration } from 'luxon';
 import { readSchedulerServiceTaskScheduleDefinitionFromConfig } from './SchedulerService';
 
 describe('readSchedulerServiceTaskScheduleDefinitionFromConfig', () => {
@@ -35,7 +34,7 @@ describe('readSchedulerServiceTaskScheduleDefinitionFromConfig', () => {
     const result = readSchedulerServiceTaskScheduleDefinitionFromConfig(config);
 
     expect((result.frequency as { cron: string }).cron).toBe('0 30 * * * *');
-    expect(result.timeout).toEqual(Duration.fromISO('PT3M'));
+    expect(result.timeout).toEqual({ minutes: 3 });
     expect((result.initialDelay as HumanDuration).minutes).toEqual(20);
     expect(result.scope).toBe('global');
   });
@@ -51,7 +50,7 @@ describe('readSchedulerServiceTaskScheduleDefinitionFromConfig', () => {
     const result = readSchedulerServiceTaskScheduleDefinitionFromConfig(config);
 
     expect((result.frequency as { cron: string }).cron).toBe('0 30 * * * *');
-    expect(result.timeout).toEqual(Duration.fromISO('PT3M'));
+    expect(result.timeout).toEqual({ minutes: 3 });
     expect(result.initialDelay).toBeUndefined();
     expect(result.scope).toBeUndefined();
   });

--- a/packages/backend-plugin-api/src/services/definitions/SchedulerService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/SchedulerService.ts
@@ -348,14 +348,14 @@ export interface SchedulerService {
   getScheduledTasks(): Promise<SchedulerServiceTaskDescriptor[]>;
 }
 
-function readDuration(config: Config, key: string): Duration | HumanDuration {
+function readDuration(config: Config, key: string): HumanDuration {
   if (typeof config.get(key) === 'string') {
     const value = config.getString(key);
     const duration = Duration.fromISO(value);
     if (!duration.isValid) {
       throw new Error(`Invalid duration: ${value}`);
     }
-    return duration;
+    return duration.toObject();
   }
 
   return readDurationFromConfig(config, { key });
@@ -364,7 +364,7 @@ function readDuration(config: Config, key: string): Duration | HumanDuration {
 function readCronOrDuration(
   config: Config,
   key: string,
-): { cron: string } | Duration | HumanDuration {
+): { cron: string } | HumanDuration {
   const value = config.get(key);
   if (typeof value === 'object' && (value as { cron?: string }).cron) {
     return value as { cron: string };

--- a/packages/backend-tasks/src/tasks/readTaskScheduleDefinitionFromConfig.test.ts
+++ b/packages/backend-tasks/src/tasks/readTaskScheduleDefinitionFromConfig.test.ts
@@ -16,7 +16,6 @@
 
 import { ConfigReader } from '@backstage/config';
 import { HumanDuration } from '@backstage/types';
-import { Duration } from 'luxon';
 import { readTaskScheduleDefinitionFromConfig } from './readTaskScheduleDefinitionFromConfig';
 
 describe('readTaskScheduleDefinitionFromConfig', () => {
@@ -35,7 +34,7 @@ describe('readTaskScheduleDefinitionFromConfig', () => {
     const result = readTaskScheduleDefinitionFromConfig(config);
 
     expect((result.frequency as { cron: string }).cron).toBe('0 30 * * * *');
-    expect(result.timeout).toEqual(Duration.fromISO('PT3M'));
+    expect(result.timeout).toEqual({ minutes: 3 });
     expect((result.initialDelay as HumanDuration).minutes).toEqual(20);
     expect(result.scope).toBe('global');
   });
@@ -51,7 +50,7 @@ describe('readTaskScheduleDefinitionFromConfig', () => {
     const result = readTaskScheduleDefinitionFromConfig(config);
 
     expect((result.frequency as { cron: string }).cron).toBe('0 30 * * * *');
-    expect(result.timeout).toEqual(Duration.fromISO('PT3M'));
+    expect(result.timeout).toEqual({ minutes: 3 });
     expect(result.initialDelay).toBeUndefined();
     expect(result.scope).toBeUndefined();
   });

--- a/packages/backend-tasks/src/tasks/readTaskScheduleDefinitionFromConfig.ts
+++ b/packages/backend-tasks/src/tasks/readTaskScheduleDefinitionFromConfig.ts
@@ -19,14 +19,14 @@ import { HumanDuration } from '@backstage/types';
 import { TaskScheduleDefinition } from './types';
 import { Duration } from 'luxon';
 
-function readDuration(config: Config, key: string): Duration | HumanDuration {
+function readDuration(config: Config, key: string): HumanDuration {
   if (typeof config.get(key) === 'string') {
     const value = config.getString(key);
     const duration = Duration.fromISO(value);
     if (!duration.isValid) {
       throw new Error(`Invalid duration: ${value}`);
     }
-    return duration;
+    return duration.toObject();
   }
 
   return readDurationFromConfig(config, { key });

--- a/plugins/catalog-backend-module-aws/src/module/catalogModuleAwsS3EntityProvider.test.ts
+++ b/plugins/catalog-backend-module-aws/src/module/catalogModuleAwsS3EntityProvider.test.ts
@@ -17,7 +17,6 @@
 import { TaskScheduleDefinition } from '@backstage/backend-tasks';
 import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
-import { Duration } from 'luxon';
 import { catalogModuleAwsS3EntityProvider } from './catalogModuleAwsS3EntityProvider';
 import { AwsS3EntityProvider } from '../providers';
 
@@ -62,8 +61,8 @@ describe('catalogModuleAwsS3EntityProvider', () => {
       ],
     });
 
-    expect(usedSchedule?.frequency).toEqual(Duration.fromISO('P1M'));
-    expect(usedSchedule?.timeout).toEqual(Duration.fromISO('PT3M'));
+    expect(usedSchedule?.frequency).toEqual({ months: 1 });
+    expect(usedSchedule?.timeout).toEqual({ minutes: 3 });
     expect(addedProviders?.length).toEqual(1);
     expect(addedProviders?.pop()?.getProviderName()).toEqual(
       'awsS3-provider:default',

--- a/plugins/catalog-backend-module-aws/src/providers/config.test.ts
+++ b/plugins/catalog-backend-module-aws/src/providers/config.test.ts
@@ -15,7 +15,6 @@
  */
 
 import { ConfigReader } from '@backstage/config';
-import { Duration } from 'luxon';
 import { readAwsS3Configs } from './config';
 
 describe('readAwsS3Configs', () => {
@@ -92,7 +91,7 @@ describe('readAwsS3Configs', () => {
       id: 'provider4',
       schedule: {
         ...provider4.schedule,
-        frequency: Duration.fromISO(provider4.schedule.frequency),
+        frequency: { minutes: 30 },
       },
     });
   });

--- a/plugins/catalog-backend-module-azure/src/module/catalogModuleAzureDevOpsEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-azure/src/module/catalogModuleAzureDevOpsEntityProvider.test.ts
@@ -17,7 +17,6 @@
 import { TaskScheduleDefinition } from '@backstage/backend-tasks';
 import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
-import { Duration } from 'luxon';
 import { catalogModuleAzureDevOpsEntityProvider } from './catalogModuleAzureDevOpsEntityProvider';
 import { AzureDevOpsEntityProvider } from '../providers';
 
@@ -66,8 +65,8 @@ describe('catalogModuleAzureDevOpsEntityProvider', () => {
       ],
     });
 
-    expect(usedSchedule?.frequency).toEqual(Duration.fromISO('P1M'));
-    expect(usedSchedule?.timeout).toEqual(Duration.fromISO('PT3M'));
+    expect(usedSchedule?.frequency).toEqual({ months: 1 });
+    expect(usedSchedule?.timeout).toEqual({ minutes: 3 });
     expect(addedProviders?.length).toEqual(1);
     expect(addedProviders?.pop()?.getProviderName()).toEqual(
       'AzureDevOpsEntityProvider:test',

--- a/plugins/catalog-backend-module-azure/src/providers/config.test.ts
+++ b/plugins/catalog-backend-module-azure/src/providers/config.test.ts
@@ -15,7 +15,6 @@
  */
 
 import { ConfigReader } from '@backstage/config';
-import { Duration } from 'luxon';
 import { readAzureDevOpsConfigs } from './config';
 
 describe('readAzureDevOpsConfigs', () => {
@@ -95,7 +94,7 @@ describe('readAzureDevOpsConfigs', () => {
       id: 'provider4',
       schedule: {
         ...provider4.schedule,
-        frequency: Duration.fromISO(provider4.schedule.frequency),
+        frequency: { minutes: 30 },
       },
     });
     expect(actual[4]).toEqual({

--- a/plugins/catalog-backend-module-bitbucket-cloud/src/module/catalogModuleBitbucketCloudEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-bitbucket-cloud/src/module/catalogModuleBitbucketCloudEntityProvider.test.ts
@@ -21,7 +21,6 @@ import { EntityProviderConnection } from '@backstage/plugin-catalog-node';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
 import { TestEventsService } from '@backstage/plugin-events-backend-test-utils';
 import { eventsServiceRef } from '@backstage/plugin-events-node';
-import { Duration } from 'luxon';
 import { catalogModuleBitbucketCloudEntityProvider } from './catalogModuleBitbucketCloudEntityProvider';
 import { BitbucketCloudEntityProvider } from '../providers/BitbucketCloudEntityProvider';
 
@@ -78,8 +77,8 @@ describe('catalogModuleBitbucketCloudEntityProvider', () => {
       ],
     });
 
-    expect(usedSchedule?.frequency).toEqual(Duration.fromISO('P1M'));
-    expect(usedSchedule?.timeout).toEqual(Duration.fromISO('PT3M'));
+    expect(usedSchedule?.frequency).toEqual({ months: 1 });
+    expect(usedSchedule?.timeout).toEqual({ minutes: 3 });
     expect(addedProviders?.length).toEqual(1);
     expect(runner).not.toHaveBeenCalled();
     const provider = addedProviders!.pop()!;

--- a/plugins/catalog-backend-module-bitbucket-cloud/src/providers/BitbucketCloudEntityProviderConfig.test.ts
+++ b/plugins/catalog-backend-module-bitbucket-cloud/src/providers/BitbucketCloudEntityProviderConfig.test.ts
@@ -15,7 +15,6 @@
  */
 
 import { ConfigReader } from '@backstage/config';
-import { Duration } from 'luxon';
 import { readProviderConfigs } from './BitbucketCloudEntityProviderConfig';
 
 describe('readProviderConfigs', () => {
@@ -130,7 +129,7 @@ describe('readProviderConfigs', () => {
         repoSlug: undefined,
       },
       schedule: {
-        frequency: Duration.fromISO('PT30M'),
+        frequency: { minutes: 30 },
         timeout: {
           minutes: 3,
         },

--- a/plugins/catalog-backend-module-bitbucket-server/src/module/catalogModuleBitbucketServerEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-bitbucket-server/src/module/catalogModuleBitbucketServerEntityProvider.test.ts
@@ -18,7 +18,6 @@ import { TaskScheduleDefinition } from '@backstage/backend-tasks';
 import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
 import { catalogModuleBitbucketServerEntityProvider } from './catalogModuleBitbucketServerEntityProvider';
-import { Duration } from 'luxon';
 import { BitbucketServerEntityProvider } from '../providers';
 
 describe('catalogModuleBitbucketServerEntityProvider', () => {
@@ -70,8 +69,8 @@ describe('catalogModuleBitbucketServerEntityProvider', () => {
       ],
     });
 
-    expect(usedSchedule?.frequency).toEqual(Duration.fromISO('P1M'));
-    expect(usedSchedule?.timeout).toEqual(Duration.fromISO('PT3M'));
+    expect(usedSchedule?.frequency).toEqual({ months: 1 });
+    expect(usedSchedule?.timeout).toEqual({ minutes: 3 });
     expect(addedProviders?.length).toEqual(1);
     expect(addedProviders?.pop()?.getProviderName()).toEqual(
       'bitbucketServer-provider:default',

--- a/plugins/catalog-backend-module-bitbucket-server/src/providers/BitbucketServerEntityProviderConfig.test.ts
+++ b/plugins/catalog-backend-module-bitbucket-server/src/providers/BitbucketServerEntityProviderConfig.test.ts
@@ -15,7 +15,6 @@
  */
 
 import { ConfigReader } from '@backstage/config';
-import { Duration } from 'luxon';
 import { readProviderConfigs } from './BitbucketServerEntityProviderConfig';
 
 describe('readProviderConfigs', () => {
@@ -111,7 +110,7 @@ describe('readProviderConfigs', () => {
         skipArchivedRepos: undefined,
       },
       schedule: {
-        frequency: Duration.fromISO('PT30M'),
+        frequency: { minutes: 30 },
         timeout: {
           minutes: 3,
         },

--- a/plugins/catalog-backend-module-gerrit/src/module/catalogModuleGerritEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gerrit/src/module/catalogModuleGerritEntityProvider.test.ts
@@ -17,7 +17,6 @@
 import { TaskScheduleDefinition } from '@backstage/backend-tasks';
 import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
-import { Duration } from 'luxon';
 import { catalogModuleGerritEntityProvider } from './catalogModuleGerritEntityProvider';
 import { GerritEntityProvider } from '../providers/GerritEntityProvider';
 
@@ -76,8 +75,8 @@ describe('catalogModuleGerritEntityProvider', () => {
       ],
     });
 
-    expect(usedSchedule?.frequency).toEqual(Duration.fromISO('P1M'));
-    expect(usedSchedule?.timeout).toEqual(Duration.fromISO('PT3M'));
+    expect(usedSchedule?.frequency).toEqual({ months: 1 });
+    expect(usedSchedule?.timeout).toEqual({ minutes: 3 });
     expect(addedProviders?.length).toEqual(1);
     expect(addedProviders?.pop()?.getProviderName()).toEqual(
       'gerrit-provider:test',

--- a/plugins/catalog-backend-module-gerrit/src/providers/config.test.ts
+++ b/plugins/catalog-backend-module-gerrit/src/providers/config.test.ts
@@ -15,7 +15,6 @@
  */
 
 import { ConfigReader } from '@backstage/config';
-import { Duration } from 'luxon';
 import { readGerritConfigs } from './config';
 
 describe('readGerritConfigs', () => {
@@ -63,7 +62,7 @@ describe('readGerritConfigs', () => {
       id: 'active-g3',
       schedule: {
         ...provider3.schedule,
-        frequency: Duration.fromISO(provider3.schedule.frequency),
+        frequency: { minutes: 30 },
       },
     });
   });

--- a/plugins/catalog-backend-module-github-org/src/module.test.ts
+++ b/plugins/catalog-backend-module-github-org/src/module.test.ts
@@ -18,7 +18,6 @@ import { TaskScheduleDefinition } from '@backstage/backend-tasks';
 import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
 import { EntityProvider } from '@backstage/plugin-catalog-node';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
-import { Duration } from 'luxon';
 import { catalogModuleGithubOrgEntityProvider } from './module';
 
 describe('catalogModuleGithubOrgEntityProvider', () => {
@@ -66,8 +65,8 @@ describe('catalogModuleGithubOrgEntityProvider', () => {
       ],
     });
 
-    expect(usedSchedule?.frequency).toEqual(Duration.fromISO('P1M'));
-    expect(usedSchedule?.timeout).toEqual(Duration.fromISO('PT3M'));
+    expect(usedSchedule?.frequency).toEqual({ months: 1 });
+    expect(usedSchedule?.timeout).toEqual({ minutes: 3 });
     expect(addedProviders?.length).toEqual(1);
     expect(addedProviders![0].getProviderName()).toEqual(
       'GithubMultiOrgEntityProvider:default',

--- a/plugins/catalog-backend-module-github/src/module/githubCatalogModule.test.ts
+++ b/plugins/catalog-backend-module-github/src/module/githubCatalogModule.test.ts
@@ -21,7 +21,6 @@ import {
   catalogAnalysisExtensionPoint,
   catalogProcessingExtensionPoint,
 } from '@backstage/plugin-catalog-node/alpha';
-import { Duration } from 'luxon';
 import { githubCatalogModule } from './githubCatalogModule';
 import { GithubLocationAnalyzer } from '../analyzers/GithubLocationAnalyzer';
 
@@ -75,8 +74,8 @@ describe('githubCatalogModule', () => {
       ],
     });
 
-    expect(usedSchedule?.frequency).toEqual(Duration.fromISO('P1M'));
-    expect(usedSchedule?.timeout).toEqual(Duration.fromISO('PT3M'));
+    expect(usedSchedule?.frequency).toEqual({ months: 1 });
+    expect(usedSchedule?.timeout).toEqual({ minutes: 3 });
     expect(addedProviders?.length).toEqual(1);
     expect(addedProviders?.pop()?.getProviderName()).toEqual(
       'github-provider:default',

--- a/plugins/catalog-backend-module-github/src/providers/GithubEntityProviderConfig.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubEntityProviderConfig.test.ts
@@ -15,7 +15,6 @@
  */
 
 import { ConfigReader } from '@backstage/config';
-import { Duration } from 'luxon';
 import { readProviderConfigs } from './GithubEntityProviderConfig';
 
 describe('readProviderConfigs', () => {
@@ -270,7 +269,7 @@ describe('readProviderConfigs', () => {
         visibility: undefined,
       },
       schedule: {
-        frequency: Duration.fromISO('PT30M'),
+        frequency: { minutes: 30 },
         timeout: {
           minutes: 3,
         },

--- a/plugins/catalog-backend-module-gitlab-org/src/catalogModuleGitlabOrgDiscoveryEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gitlab-org/src/catalogModuleGitlabOrgDiscoveryEntityProvider.test.ts
@@ -22,7 +22,6 @@ import { EntityProviderConnection } from '@backstage/plugin-catalog-node';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
 import { TestEventsService } from '@backstage/plugin-events-backend-test-utils';
 import { eventsServiceRef } from '@backstage/plugin-events-node';
-import { Duration } from 'luxon';
 import { catalogModuleGitlabOrgDiscoveryEntityProvider } from './catalogModuleGitlabOrgDiscoveryEntityProvider';
 
 describe('catalogModuleGitlabOrgDiscoveryEntityProvider', () => {
@@ -90,8 +89,8 @@ describe('catalogModuleGitlabOrgDiscoveryEntityProvider', () => {
       ],
     });
 
-    expect(usedSchedule?.frequency).toEqual(Duration.fromISO('P1M'));
-    expect(usedSchedule?.timeout).toEqual(Duration.fromISO('PT3M'));
+    expect(usedSchedule?.frequency).toEqual({ months: 1 });
+    expect(usedSchedule?.timeout).toEqual({ minutes: 3 });
     expect(addedProviders?.length).toEqual(1);
     expect(runner).not.toHaveBeenCalled();
 

--- a/plugins/catalog-backend-module-gitlab/src/module/catalogModuleGitlabDiscoveryEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/module/catalogModuleGitlabDiscoveryEntityProvider.test.ts
@@ -21,7 +21,6 @@ import { EntityProviderConnection } from '@backstage/plugin-catalog-node';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
 import { TestEventsService } from '@backstage/plugin-events-backend-test-utils';
 import { eventsServiceRef } from '@backstage/plugin-events-node';
-import { Duration } from 'luxon';
 import { GitlabDiscoveryEntityProvider } from '../providers';
 import { catalogModuleGitlabDiscoveryEntityProvider } from './catalogModuleGitlabDiscoveryEntityProvider';
 
@@ -89,8 +88,8 @@ describe('catalogModuleGitlabDiscoveryEntityProvider', () => {
       ],
     });
 
-    expect(usedSchedule?.frequency).toEqual(Duration.fromISO('P1M'));
-    expect(usedSchedule?.timeout).toEqual(Duration.fromISO('PT3M'));
+    expect(usedSchedule?.frequency).toEqual({ months: 1 });
+    expect(usedSchedule?.timeout).toEqual({ minutes: 3 });
     expect(addedProviders?.length).toEqual(1);
     expect(runner).not.toHaveBeenCalled();
 

--- a/plugins/catalog-backend-module-gitlab/src/providers/config.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/config.test.ts
@@ -15,7 +15,6 @@
  */
 
 import { ConfigReader } from '@backstage/config';
-import { Duration } from 'luxon';
 import { readGitlabConfigs } from './config';
 
 describe('config', () => {
@@ -179,7 +178,7 @@ describe('config', () => {
         allowInherited: false,
         skipForkedRepos: false,
         schedule: {
-          frequency: Duration.fromISO('PT30M'),
+          frequency: { minutes: 30 },
           timeout: {
             minutes: 3,
           },

--- a/plugins/catalog-backend-module-ldap/api-report.md
+++ b/plugins/catalog-backend-module-ldap/api-report.md
@@ -16,11 +16,11 @@ import { GroupTransformer as GroupTransformer_2 } from '@backstage/plugin-catalo
 import { JsonValue } from '@backstage/types';
 import { LocationSpec } from '@backstage/plugin-catalog-common';
 import { LoggerService } from '@backstage/backend-plugin-api';
-import { PluginTaskScheduler } from '@backstage/backend-tasks';
+import { SchedulerService } from '@backstage/backend-plugin-api';
+import { SchedulerServiceTaskRunner } from '@backstage/backend-plugin-api';
+import { SchedulerServiceTaskScheduleDefinition } from '@backstage/backend-plugin-api';
 import { SearchEntry } from 'ldapjs';
 import { SearchOptions } from 'ldapjs';
-import { TaskRunner } from '@backstage/backend-tasks';
-import { TaskScheduleDefinition } from '@backstage/backend-tasks';
 import { UserEntity } from '@backstage/catalog-model';
 import { UserTransformer as UserTransformer_2 } from '@backstage/plugin-catalog-backend-module-ldap';
 
@@ -135,7 +135,7 @@ export interface LdapOrgEntityProviderLegacyOptions {
   groupTransformer?: GroupTransformer;
   id: string;
   logger: LoggerService;
-  schedule: 'manual' | TaskRunner;
+  schedule: 'manual' | SchedulerServiceTaskRunner;
   target: string;
   userTransformer?: UserTransformer;
 }
@@ -145,8 +145,8 @@ export type LdapOrgEntityProviderOptions =
   | LdapOrgEntityProviderLegacyOptions
   | {
       logger: LoggerService;
-      schedule?: 'manual' | TaskRunner;
-      scheduler?: PluginTaskScheduler;
+      schedule?: 'manual' | SchedulerServiceTaskRunner;
+      scheduler?: SchedulerService;
       userTransformer?: UserTransformer | Record<string, UserTransformer>;
       groupTransformer?: GroupTransformer | Record<string, GroupTransformer>;
     };
@@ -199,7 +199,7 @@ export type LdapProviderConfig = {
   bind?: BindConfig;
   users: UserConfig;
   groups: GroupConfig;
-  schedule?: TaskScheduleDefinition;
+  schedule?: SchedulerServiceTaskScheduleDefinition;
 };
 
 // @public

--- a/plugins/catalog-backend-module-ldap/src/ldap/config.test.ts
+++ b/plugins/catalog-backend-module-ldap/src/ldap/config.test.ts
@@ -79,6 +79,75 @@ describe('readLdapConfig', () => {
     expect(actual).toEqual(expected);
   });
 
+  it('reads schedules well', () => {
+    const config = {
+      catalog: {
+        providers: {
+          ldapOrg: {
+            default: {
+              schedule: {
+                frequency: 'PT3M', // should work for ISO durations
+                timeout: { minutes: 1 },
+              },
+              target: 'target',
+              users: {
+                dn: 'udn',
+              },
+              groups: {
+                dn: 'gdn',
+              },
+            },
+          },
+        },
+      },
+    };
+    const actual = readProviderConfigs(new ConfigReader(config));
+    const expected = [
+      {
+        id: 'default',
+        target: 'target',
+        bind: undefined,
+        schedule: {
+          frequency: { minutes: 3 },
+          timeout: { minutes: 1 },
+        },
+        users: {
+          dn: 'udn',
+          options: {
+            scope: 'one',
+            attributes: ['*', '+'],
+          },
+          set: undefined,
+          map: {
+            rdn: 'uid',
+            name: 'uid',
+            displayName: 'cn',
+            email: 'mail',
+            memberOf: 'memberOf',
+          },
+        },
+        groups: {
+          dn: 'gdn',
+          options: {
+            scope: 'one',
+            attributes: ['*', '+'],
+          },
+          set: undefined,
+          map: {
+            rdn: 'cn',
+            name: 'cn',
+            description: 'description',
+            type: 'groupType',
+            displayName: 'cn',
+            memberOf: 'memberOf',
+            members: 'member',
+          },
+        },
+      },
+    ];
+    expect(actual).toEqual(expected);
+  });
+
   it('reads all the values', () => {
     const config = {
       catalog: {

--- a/plugins/catalog-backend-module-ldap/src/ldap/config.ts
+++ b/plugins/catalog-backend-module-ldap/src/ldap/config.ts
@@ -15,9 +15,9 @@
  */
 
 import {
-  readTaskScheduleDefinitionFromConfig,
-  TaskScheduleDefinition,
-} from '@backstage/backend-tasks';
+  SchedulerServiceTaskScheduleDefinition,
+  readSchedulerServiceTaskScheduleDefinitionFromConfig,
+} from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
 import { JsonValue } from '@backstage/types';
 import { SearchOptions } from 'ldapjs';
@@ -46,7 +46,7 @@ export type LdapProviderConfig = {
   // The settings that govern the reading and interpretation of groups
   groups: GroupConfig;
   // Schedule configuration for refresh tasks.
-  schedule?: TaskScheduleDefinition;
+  schedule?: SchedulerServiceTaskScheduleDefinition;
 };
 
 /**
@@ -380,7 +380,9 @@ export function readProviderConfigs(config: Config): LdapProviderConfig[] {
     const c = providersConfig.getConfig(id);
 
     const schedule = c.has('schedule')
-      ? readTaskScheduleDefinitionFromConfig(c.getConfig('schedule'))
+      ? readSchedulerServiceTaskScheduleDefinitionFromConfig(
+          c.getConfig('schedule'),
+        )
       : undefined;
 
     const newConfig = {

--- a/plugins/catalog-backend-module-ldap/src/processors/LdapOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-ldap/src/processors/LdapOrgEntityProvider.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { PluginTaskScheduler, TaskRunner } from '@backstage/backend-tasks';
 import {
   ANNOTATION_LOCATION,
   ANNOTATION_ORIGIN_LOCATION,
@@ -35,7 +34,11 @@ import {
   readLdapOrg,
   UserTransformer,
 } from '../ldap';
-import { LoggerService } from '@backstage/backend-plugin-api';
+import {
+  LoggerService,
+  SchedulerService,
+  SchedulerServiceTaskRunner,
+} from '@backstage/backend-plugin-api';
 import { readLdapLegacyConfig, readProviderConfigs } from '../ldap';
 
 /**
@@ -60,16 +63,16 @@ export type LdapOrgEntityProviderOptions =
        * manually at some interval.
        *
        * But more commonly you will pass in the result of
-       * {@link @backstage/backend-tasks#PluginTaskScheduler.createScheduledTaskRunner}
+       * {@link @backstage/backend-plugin-api#SchedulerService.createScheduledTaskRunner}
        * to enable automatic scheduling of tasks.
        */
-      schedule?: 'manual' | TaskRunner;
+      schedule?: 'manual' | SchedulerServiceTaskRunner;
 
       /**
        * Scheduler used to schedule refreshes based on
        * the schedule config.
        */
-      scheduler?: PluginTaskScheduler;
+      scheduler?: SchedulerService;
 
       /**
        * The function that transforms a user entry in msgraph to an entity.
@@ -122,10 +125,10 @@ export interface LdapOrgEntityProviderLegacyOptions {
    * manually at some interval.
    *
    * But more commonly you will pass in the result of
-   * {@link @backstage/backend-tasks#PluginTaskScheduler.createScheduledTaskRunner}
+   * {@link @backstage/backend-plugin-api#SchedulerService.createScheduledTaskRunner}
    * to enable automatic scheduling of tasks.
    */
-  schedule: 'manual' | TaskRunner;
+  schedule: 'manual' | SchedulerServiceTaskRunner;
 
   /**
    * The function that transforms a user entry in LDAP to an entity.
@@ -311,7 +314,7 @@ export class LdapOrgEntityProvider implements EntityProvider {
     markCommitComplete();
   }
 
-  private schedule(taskRunner: TaskRunner) {
+  private schedule(taskRunner: SchedulerServiceTaskRunner) {
     this.scheduleFn = async () => {
       const id = `${this.getProviderName()}:refresh`;
       await taskRunner.run({

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/config.test.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/config.test.ts
@@ -15,7 +15,6 @@
  */
 
 import { ConfigReader } from '@backstage/config';
-import { Duration } from 'luxon';
 import { readMicrosoftGraphConfig, readProviderConfigs } from './config';
 
 describe('readMicrosoftGraphConfig', () => {
@@ -204,7 +203,7 @@ describe('readProviderConfigs', () => {
         groupSelect: ['id', 'displayName', 'description'],
         groupFilter: 'securityEnabled eq false',
         schedule: {
-          frequency: Duration.fromISO('PT30M'),
+          frequency: { minutes: 30 },
           timeout: {
             minutes: 3,
           },

--- a/plugins/catalog-backend-module-msgraph/src/module/catalogModuleMicrosoftGraphOrgEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-msgraph/src/module/catalogModuleMicrosoftGraphOrgEntityProvider.test.ts
@@ -17,7 +17,6 @@
 import { TaskScheduleDefinition } from '@backstage/backend-tasks';
 import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
-import { Duration } from 'luxon';
 import { catalogModuleMicrosoftGraphOrgEntityProvider } from './catalogModuleMicrosoftGraphOrgEntityProvider';
 import { MicrosoftGraphOrgEntityProvider } from '../processors';
 
@@ -67,8 +66,8 @@ describe('catalogModuleMicrosoftGraphOrgEntityProvider', () => {
       ],
     });
 
-    expect(usedSchedule?.frequency).toEqual(Duration.fromISO('PT30M'));
-    expect(usedSchedule?.timeout).toEqual(Duration.fromISO('PT3M'));
+    expect(usedSchedule?.frequency).toEqual({ minutes: 30 });
+    expect(usedSchedule?.timeout).toEqual({ minutes: 3 });
     expect(addedProviders?.length).toEqual(1);
     expect(addedProviders?.pop()?.getProviderName()).toEqual(
       'MicrosoftGraphOrgEntityProvider:customProviderId',

--- a/plugins/catalog-backend-module-puppetdb/src/providers/PuppetDbEntityProviderConfig.test.ts
+++ b/plugins/catalog-backend-module-puppetdb/src/providers/PuppetDbEntityProviderConfig.test.ts
@@ -16,7 +16,6 @@
 
 import { ConfigReader } from '@backstage/config';
 import { readProviderConfigs } from './PuppetDbEntityProviderConfig';
-import { Duration } from 'luxon';
 
 describe('readProviderConfigs', () => {
   afterEach(() => jest.resetAllMocks());
@@ -120,10 +119,8 @@ describe('readProviderConfigs', () => {
 
     expect(providerConfigs).toHaveLength(1);
     expect(providerConfigs[0].schedule).toEqual({
-      frequency: Duration.fromISO('PT30M'),
-      timeout: {
-        minutes: 10,
-      },
+      frequency: { minutes: 30 },
+      timeout: { minutes: 10 },
     });
   });
 });


### PR DESCRIPTION
Fixes #25115

This was actually caused by the `freeze` functionality, which JSON serialized and then deserialized objects to recursively freeze them. JSON serializing a luxon Duration produces an ISO string.