### PR TITLE
feat(scaffolder): use virtualization with MultiEntityPicker

### DIFF
--- a/.changeset/heavy-moose-pull.md
+++ b/.changeset/heavy-moose-pull.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder': minor
 ---
 
-Use virtualization with MultiEntityPicker. Fixes performance issues with large data sets.
+Use virtualization with `MultiEntityPicker`. Fixes performance issues with large data sets.

--- a/.changeset/heavy-moose-pull.md
+++ b/.changeset/heavy-moose-pull.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': minor
+---
+
+Use virtualization with MultiEntityPicker. Fixes performance issues with large data sets.

--- a/plugins/scaffolder/package.json
+++ b/plugins/scaffolder/package.json
@@ -97,6 +97,7 @@
     "luxon": "^3.0.0",
     "qs": "^6.9.4",
     "react-use": "^17.2.4",
+    "react-window": "^1.8.10",
     "yaml": "^2.0.0",
     "zen-observable": "^0.10.0",
     "zod": "^3.22.4",
@@ -115,6 +116,7 @@
     "@testing-library/user-event": "^14.0.0",
     "@types/humanize-duration": "^3.18.1",
     "@types/json-schema": "^7.0.9",
+    "@types/react-window": "^1.8.8",
     "msw": "^1.0.0",
     "swr": "^2.0.0"
   },

--- a/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.tsx
@@ -35,6 +35,7 @@ import Autocomplete, {
   AutocompleteChangeReason,
 } from '@material-ui/lab/Autocomplete';
 import React, { useCallback, useEffect } from 'react';
+import { FixedSizeList, ListChildComponentProps } from 'react-window';
 import useAsync from 'react-use/esm/useAsync';
 import { FieldValidation } from '@rjsf/utils';
 import {
@@ -45,6 +46,38 @@ import {
 } from './schema';
 
 export { MultiEntityPickerSchema } from './schema';
+
+const renderRow = (props: ListChildComponentProps) => {
+  const { data, index, style } = props;
+  return React.cloneElement(data[index], { style });
+};
+
+const ListboxComponent = React.forwardRef<
+  HTMLDivElement,
+  { children?: React.ReactNode }
+>((props, ref) => {
+  const itemData = React.Children.toArray(props.children);
+  const itemCount = itemData.length;
+
+  const itemSize = 36;
+
+  const itemsToShow = Math.min(10, itemCount);
+  const height = Math.max(itemSize, itemsToShow * itemSize - 0.5 * itemSize);
+
+  return (
+    <div ref={ref}>
+      <FixedSizeList
+        height={height}
+        itemData={itemData}
+        itemCount={itemCount}
+        itemSize={itemSize}
+        width="100%"
+      >
+        {renderRow}
+      </FixedSizeList>
+    </div>
+  );
+});
 
 /**
  * The underlying component that is rendered in the form for the `MultiEntityPicker`
@@ -177,6 +210,7 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
             }}
           />
         )}
+        ListboxComponent={ListboxComponent}
       />
     </FormControl>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -7138,6 +7138,7 @@ __metadata:
     "@types/humanize-duration": ^3.18.1
     "@types/json-schema": ^7.0.9
     "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    "@types/react-window": ^1.8.8
     "@uiw/react-codemirror": ^4.9.3
     classnames: ^2.2.6
     git-url-parse: ^14.0.0
@@ -7150,6 +7151,7 @@ __metadata:
     msw: ^1.0.0
     qs: ^6.9.4
     react-use: ^17.2.4
+    react-window: ^1.8.10
     swr: ^2.0.0
     yaml: ^2.0.0
     zen-observable: ^0.10.0
@@ -18077,7 +18079,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-window@npm:^1.8.5":
+"@types/react-window@npm:^1.8.5, @types/react-window@npm:^1.8.8":
   version: 1.8.8
   resolution: "@types/react-window@npm:1.8.8"
   dependencies:
@@ -38305,7 +38307,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-window@npm:^1.8.6":
+"react-window@npm:^1.8.10, react-window@npm:^1.8.6":
   version: 1.8.10
   resolution: "react-window@npm:1.8.10"
   dependencies:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Use [virtualization](https://v4.mui.com/components/autocomplete/#virtualization) with MultiEntityPicker. This fixes performance issues with large data sets. Fixes https://github.com/backstage/backstage/issues/25243.

### Testing
Not sure how you would test this with `testing-library` as the issue manifests itself only in real browser environment. However have tested this locally by comparing behaviour between `master` branch and this as follows:

- Generate `catalog-info.yaml` containing a large number (~5k will do it) of entities using a script like so:
```sh
#!/bin/bash

# Check if exactly one argument is passed
if [ "$#" -ne 1 ]; then
  echo "Usage: $0 <number_of_entries>"
  exit 1
fi

# Check if the argument is a positive integer
if ! [[ "$1" =~ ^[0-9]+$ ]]; then
  echo "Error: Argument must be a positive integer."
  exit 1
fi

# Number of entries to generate
NUM_ENTRIES=$1

# Output file
OUTPUT_FILE="generated-$NUM_ENTRIES.yaml"

# Create or clear the output file
>"$OUTPUT_FILE"

# Generate YAML entries
for ((i = 1; i <= NUM_ENTRIES; i++)); do
  cat <<EOL >>"$OUTPUT_FILE"
apiVersion: backstage.io/v1alpha1
kind: Component
metadata:
  name: example-app-$i
  title: example-app-$i
spec:
  lifecycle: experimental
  type: backstage-frontend
  owner: maintainers
---
EOL
done

echo "Generated $NUM_ENTRIES entries in $OUTPUT_FILE"
```
- Include entities in app config
```yaml
# app-config.yaml
...
catalog:
    ...
    - type: file
      target: ../../generated-10000.yaml
      rules:
        - allow: [Component]
```
- Start the app with `yarn dev` and wait until all entities have been ingested
- Open `Custom Field Explorer` from http://localhost:3000/create/edit and select `MultiEntityPicker`
- Open dropdown menu. Scrolling, searching and selecting items should work as expected without lag. Whereas compared to `master` branch browser (tested with latest Chrome) quickly becomes unresponsive and finally hangs:
 
![Screenshot 2024-06-19 at 9 16 51](https://github.com/backstage/backstage/assets/2776729/be2cb5e9-0722-4bb5-bf6e-df810bcd4d9b)

I have tested this with 5k, 10k and 100k entities and in all cases the input remains responsive. Here's demo with 100k entities

https://github.com/backstage/backstage/assets/2776729/d5307928-d66d-4fd2-8fe0-c2a2705ede16



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
