### PR TITLE
feat(apidocs): add resolvers prop to AsyncApiDefinitionWidget

### DIFF
--- a/.changeset/plenty-mails-do.md
+++ b/.changeset/plenty-mails-do.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-api-docs': patch
+---
+
+Added `resolvers` prop to `AsyncApiDefinitionWidget`. This allows to override the default http/https resolvers, for example to add authentication to requests to internal schema registries.

--- a/plugins/api-docs/api-report.md
+++ b/plugins/api-docs/api-report.md
@@ -83,6 +83,15 @@ export const AsyncApiDefinitionWidget: (
 // @public (undocumented)
 export type AsyncApiDefinitionWidgetProps = {
   definition: string;
+  resolvers?: AsyncApiResolver[];
+};
+
+// @public (undocumented)
+export type AsyncApiResolver = {
+  schema: string;
+  order: number;
+  canRead: boolean;
+  read(uri: any): Promise<string>;
 };
 
 // @public (undocumented)

--- a/plugins/api-docs/src/components/AsyncApiDefinitionWidget/AsyncApiDefinition.tsx
+++ b/plugins/api-docs/src/components/AsyncApiDefinitionWidget/AsyncApiDefinition.tsx
@@ -19,6 +19,7 @@ import '@asyncapi/react-component/styles/default.css';
 import { makeStyles, alpha, darken } from '@material-ui/core/styles';
 import React from 'react';
 import { useTheme } from '@material-ui/core/styles';
+import { AsyncApiResolver } from './AsyncApiDefinitionWidget';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -143,7 +144,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-const httpsFetchResolver = {
+const httpsFetchResolver: AsyncApiResolver = {
   schema: 'https',
   order: 1,
   canRead: true,
@@ -153,7 +154,7 @@ const httpsFetchResolver = {
   },
 };
 
-const httpFetchResolver = {
+const httpFetchResolver: AsyncApiResolver = {
   schema: 'http',
   order: 1,
   canRead: true,
@@ -175,14 +176,23 @@ const config = {
 
 type Props = {
   definition: string;
+  resolvers?: AsyncApiResolver[];
 };
 
-export const AsyncApiDefinition = ({ definition }: Props): JSX.Element => {
+export const AsyncApiDefinition = ({
+  definition,
+  resolvers,
+}: Props): JSX.Element => {
   const classes = useStyles();
   const theme = useTheme();
   const classNames = `${classes.root} ${
     theme.palette.type === 'dark' ? classes.dark : ''
   }`;
+
+  // Overwrite default resolvers if custom ones are set
+  if (resolvers) {
+    config.parserOptions.__unstable.resolver.resolvers = resolvers;
+  }
 
   return (
     <div className={classNames}>

--- a/plugins/api-docs/src/components/AsyncApiDefinitionWidget/AsyncApiDefinition.tsx
+++ b/plugins/api-docs/src/components/AsyncApiDefinitionWidget/AsyncApiDefinition.tsx
@@ -19,7 +19,14 @@ import '@asyncapi/react-component/styles/default.css';
 import { makeStyles, alpha, darken } from '@material-ui/core/styles';
 import React from 'react';
 import { useTheme } from '@material-ui/core/styles';
-import { AsyncApiResolver } from './AsyncApiDefinitionWidget';
+
+/** @public */
+export type AsyncApiResolver = {
+  schema: string;
+  order: number;
+  canRead: boolean;
+  read(uri: any): Promise<string>;
+};
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -164,16 +171,6 @@ const httpFetchResolver: AsyncApiResolver = {
   },
 };
 
-const config = {
-  parserOptions: {
-    __unstable: {
-      resolver: {
-        resolvers: [httpsFetchResolver, httpFetchResolver],
-      },
-    },
-  },
-};
-
 type Props = {
   definition: string;
   resolvers?: AsyncApiResolver[];
@@ -188,6 +185,16 @@ export const AsyncApiDefinition = ({
   const classNames = `${classes.root} ${
     theme.palette.type === 'dark' ? classes.dark : ''
   }`;
+
+  const config = {
+    parserOptions: {
+      __unstable: {
+        resolver: {
+          resolvers: [httpsFetchResolver, httpFetchResolver],
+        },
+      },
+    },
+  };
 
   // Overwrite default resolvers if custom ones are set
   if (resolvers) {

--- a/plugins/api-docs/src/components/AsyncApiDefinitionWidget/AsyncApiDefinitionWidget.tsx
+++ b/plugins/api-docs/src/components/AsyncApiDefinitionWidget/AsyncApiDefinitionWidget.tsx
@@ -16,6 +16,7 @@
 
 import { Progress } from '@backstage/core-components';
 import React, { Suspense } from 'react';
+import { AsyncApiResolver } from './AsyncApiDefinition';
 
 // The asyncapi component and related CSS has a significant size, only load it
 // if the element is actually used.
@@ -24,14 +25,6 @@ const LazyAsyncApiDefinition = React.lazy(() =>
     default: m.AsyncApiDefinition,
   })),
 );
-
-/** @public */
-export type AsyncApiResolver = {
-  schema: string;
-  order: number;
-  canRead: boolean;
-  read(uri: any): Promise<string>;
-};
 
 /** @public */
 export type AsyncApiDefinitionWidgetProps = {

--- a/plugins/api-docs/src/components/AsyncApiDefinitionWidget/AsyncApiDefinitionWidget.tsx
+++ b/plugins/api-docs/src/components/AsyncApiDefinitionWidget/AsyncApiDefinitionWidget.tsx
@@ -26,8 +26,17 @@ const LazyAsyncApiDefinition = React.lazy(() =>
 );
 
 /** @public */
+export type AsyncApiResolver = {
+  schema: string;
+  order: number;
+  canRead: boolean;
+  read(uri: any): Promise<string>;
+};
+
+/** @public */
 export type AsyncApiDefinitionWidgetProps = {
   definition: string;
+  resolvers?: AsyncApiResolver[];
 };
 
 /** @public */

--- a/plugins/api-docs/src/components/AsyncApiDefinitionWidget/index.ts
+++ b/plugins/api-docs/src/components/AsyncApiDefinitionWidget/index.ts
@@ -15,7 +15,5 @@
  */
 
 export { AsyncApiDefinitionWidget } from './AsyncApiDefinitionWidget';
-export type {
-  AsyncApiDefinitionWidgetProps,
-  AsyncApiResolver,
-} from './AsyncApiDefinitionWidget';
+export type { AsyncApiDefinitionWidgetProps } from './AsyncApiDefinitionWidget';
+export type { AsyncApiResolver } from './AsyncApiDefinition';

--- a/plugins/api-docs/src/components/AsyncApiDefinitionWidget/index.ts
+++ b/plugins/api-docs/src/components/AsyncApiDefinitionWidget/index.ts
@@ -15,4 +15,7 @@
  */
 
 export { AsyncApiDefinitionWidget } from './AsyncApiDefinitionWidget';
-export type { AsyncApiDefinitionWidgetProps } from './AsyncApiDefinitionWidget';
+export type {
+  AsyncApiDefinitionWidgetProps,
+  AsyncApiResolver,
+} from './AsyncApiDefinitionWidget';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds `resolvers` prop to `AsyncApiDefinitionWidget` which allows to override the default http/https resolvers, for example to add authentication to requests to internal schema registries.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
