### PR TITLE
Fix `MiddlewareFactory` legacy wrapping

### DIFF
--- a/.changeset/young-houses-unite.md
+++ b/.changeset/young-houses-unite.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+Fixing issue with `MiddlewareFactory` deprecation wrapping

--- a/packages/backend-app-api/api-report.md
+++ b/packages/backend-app-api/api-report.md
@@ -208,8 +208,7 @@ export const loggerServiceFactory: () => ServiceFactory<
 export class MiddlewareFactory {
   compression(): RequestHandler;
   cors(): RequestHandler;
-  // Warning: (ae-forgotten-export) The symbol "MiddlewareFactory_2" needs to be exported by the entry point index.d.ts
-  static create(options: MiddlewareFactoryOptions): MiddlewareFactory_2;
+  static create(options: MiddlewareFactoryOptions): MiddlewareFactory;
   error(options?: MiddlewareFactoryErrorOptions): ErrorRequestHandler;
   helmet(): RequestHandler;
   logging(): RequestHandler;

--- a/packages/backend-app-api/src/http/index.ts
+++ b/packages/backend-app-api/src/http/index.ts
@@ -58,7 +58,7 @@ export class MiddlewareFactory {
    * Creates a new {@link MiddlewareFactory}.
    */
   static create(options: MiddlewareFactoryOptions) {
-    return _MiddlewareFactory.create(options);
+    return new MiddlewareFactory(_MiddlewareFactory.create(options));
   }
 
   private constructor(private readonly impl: _MiddlewareFactory) {}


### PR DESCRIPTION
Fixes `error TS2345: Argument of type 'MiddlewareFactory$1' is not assignable to parameter of type 'MiddlewareFactory'.
  Property 'impl' is missing in type 'MiddlewareFactory$1' but required in type 'MiddlewareFactory'.`