### PR TITLE
Patch release of #25326, #25330

### DIFF
--- a/.changeset/grumpy-wolves-hang.md
+++ b/.changeset/grumpy-wolves-hang.md
@@ -1,5 +1,0 @@
----
-'@backstage/cli': patch
----
-
-Fix issue with CLI that was preventing upgrading from 1.28

--- a/.changeset/grumpy-wolves-hang.md
+++ b/.changeset/grumpy-wolves-hang.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Fix issue with CLI that was preventing upgrading from 1.28

--- a/.changeset/young-houses-unite.md
+++ b/.changeset/young-houses-unite.md
@@ -1,5 +1,0 @@
----
-'@backstage/backend-app-api': patch
----
-
-Fixing issue with `MiddlewareFactory` deprecation wrapping

--- a/.changeset/young-houses-unite.md
+++ b/.changeset/young-houses-unite.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+Fixing issue with `MiddlewareFactory` deprecation wrapping

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.28.1",
+  "version": "1.28.2",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/app-next/CHANGELOG.md
+++ b/packages/app-next/CHANGELOG.md
@@ -1,5 +1,48 @@
 # example-app-next
 
+## 0.0.14
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/cli@0.26.9
+  - @backstage/app-defaults@1.5.6
+  - @backstage/catalog-model@1.5.0
+  - @backstage/config@1.2.0
+  - @backstage/core-app-api@1.12.6
+  - @backstage/core-compat-api@0.2.6
+  - @backstage/core-components@0.14.8
+  - @backstage/core-plugin-api@1.9.3
+  - @backstage/frontend-app-api@0.7.1
+  - @backstage/frontend-plugin-api@0.6.6
+  - @backstage/integration-react@1.1.28
+  - @backstage/theme@0.5.6
+  - @backstage/plugin-api-docs@0.11.6
+  - @backstage/plugin-app-visualizer@0.1.7
+  - @backstage/plugin-auth-react@0.1.3
+  - @backstage/plugin-catalog@1.21.0
+  - @backstage/plugin-catalog-common@1.0.24
+  - @backstage/plugin-catalog-graph@0.4.6
+  - @backstage/plugin-catalog-import@0.12.0
+  - @backstage/plugin-catalog-react@1.12.1
+  - @backstage/plugin-catalog-unprocessed-entities@0.2.5
+  - @backstage/plugin-home@0.7.5
+  - @backstage/plugin-kubernetes@0.11.11
+  - @backstage/plugin-kubernetes-cluster@0.0.12
+  - @backstage/plugin-notifications@0.2.2
+  - @backstage/plugin-org@0.6.26
+  - @backstage/plugin-permission-react@0.4.23
+  - @backstage/plugin-scaffolder@1.21.0
+  - @backstage/plugin-scaffolder-react@1.9.0
+  - @backstage/plugin-search@1.4.12
+  - @backstage/plugin-search-common@1.2.12
+  - @backstage/plugin-search-react@1.7.12
+  - @backstage/plugin-signals@0.0.7
+  - @backstage/plugin-techdocs@1.10.6
+  - @backstage/plugin-techdocs-module-addons-contrib@1.1.11
+  - @backstage/plugin-techdocs-react@1.2.5
+  - @backstage/plugin-user-settings@0.8.7
+
 ## 0.0.13
 
 ### Patch Changes

--- a/packages/app-next/package.json
+++ b/packages/app-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-app-next",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -1,5 +1,46 @@
 # example-app
 
+## 0.2.100
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/cli@0.26.9
+  - @backstage/app-defaults@1.5.6
+  - @backstage/catalog-model@1.5.0
+  - @backstage/config@1.2.0
+  - @backstage/core-app-api@1.12.6
+  - @backstage/core-components@0.14.8
+  - @backstage/core-plugin-api@1.9.3
+  - @backstage/frontend-app-api@0.7.1
+  - @backstage/integration-react@1.1.28
+  - @backstage/theme@0.5.6
+  - @backstage/plugin-api-docs@0.11.6
+  - @backstage/plugin-auth-react@0.1.3
+  - @backstage/plugin-catalog@1.21.0
+  - @backstage/plugin-catalog-common@1.0.24
+  - @backstage/plugin-catalog-graph@0.4.6
+  - @backstage/plugin-catalog-import@0.12.0
+  - @backstage/plugin-catalog-react@1.12.1
+  - @backstage/plugin-catalog-unprocessed-entities@0.2.5
+  - @backstage/plugin-devtools@0.1.15
+  - @backstage/plugin-home@0.7.5
+  - @backstage/plugin-kubernetes@0.11.11
+  - @backstage/plugin-kubernetes-cluster@0.0.12
+  - @backstage/plugin-notifications@0.2.2
+  - @backstage/plugin-org@0.6.26
+  - @backstage/plugin-permission-react@0.4.23
+  - @backstage/plugin-scaffolder@1.21.0
+  - @backstage/plugin-scaffolder-react@1.9.0
+  - @backstage/plugin-search@1.4.12
+  - @backstage/plugin-search-common@1.2.12
+  - @backstage/plugin-search-react@1.7.12
+  - @backstage/plugin-signals@0.0.7
+  - @backstage/plugin-techdocs@1.10.6
+  - @backstage/plugin-techdocs-module-addons-contrib@1.1.11
+  - @backstage/plugin-techdocs-react@1.2.5
+  - @backstage/plugin-user-settings@0.8.7
+
 ## 0.2.99
 
 ### Patch Changes

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-app",
-  "version": "0.2.99",
+  "version": "0.2.100",
   "backstage": {
     "role": "frontend"
   },

--- a/packages/backend-app-api/CHANGELOG.md
+++ b/packages/backend-app-api/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @backstage/backend-app-api
 
+## 0.7.8
+
+### Patch Changes
+
+- c5957b0: Fixing issue with `MiddlewareFactory` deprecation wrapping
+- Updated dependencies
+  - @backstage/backend-common@0.23.1
+  - @backstage/backend-plugin-api@0.6.20
+  - @backstage/backend-tasks@0.5.25
+  - @backstage/cli-common@0.1.14
+  - @backstage/cli-node@0.2.6
+  - @backstage/config@1.2.0
+  - @backstage/config-loader@1.8.1
+  - @backstage/errors@1.2.4
+  - @backstage/types@1.1.1
+  - @backstage/plugin-auth-node@0.4.15
+  - @backstage/plugin-permission-node@0.7.31
+
 ## 0.7.7
 
 ### Patch Changes

--- a/packages/backend-app-api/api-report.md
+++ b/packages/backend-app-api/api-report.md
@@ -208,8 +208,7 @@ export const loggerServiceFactory: () => ServiceFactory<
 export class MiddlewareFactory {
   compression(): RequestHandler;
   cors(): RequestHandler;
-  // Warning: (ae-forgotten-export) The symbol "MiddlewareFactory_2" needs to be exported by the entry point index.d.ts
-  static create(options: MiddlewareFactoryOptions): MiddlewareFactory_2;
+  static create(options: MiddlewareFactoryOptions): MiddlewareFactory;
   error(options?: MiddlewareFactoryErrorOptions): ErrorRequestHandler;
   helmet(): RequestHandler;
   logging(): RequestHandler;

--- a/packages/backend-app-api/package.json
+++ b/packages/backend-app-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/backend-app-api",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "Core API used by Backstage backend apps",
   "backstage": {
     "role": "node-library"

--- a/packages/backend-app-api/src/http/index.ts
+++ b/packages/backend-app-api/src/http/index.ts
@@ -58,7 +58,7 @@ export class MiddlewareFactory {
    * Creates a new {@link MiddlewareFactory}.
    */
   static create(options: MiddlewareFactoryOptions) {
-    return _MiddlewareFactory.create(options);
+    return new MiddlewareFactory(_MiddlewareFactory.create(options));
   }
 
   private constructor(private readonly impl: _MiddlewareFactory) {}

--- a/packages/backend-defaults/CHANGELOG.md
+++ b/packages/backend-defaults/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @backstage/backend-defaults
 
+## 0.3.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-app-api@0.7.8
+  - @backstage/backend-common@0.23.1
+  - @backstage/backend-dev-utils@0.1.4
+  - @backstage/backend-plugin-api@0.6.20
+  - @backstage/cli-common@0.1.14
+  - @backstage/config@1.2.0
+  - @backstage/config-loader@1.8.1
+  - @backstage/errors@1.2.4
+  - @backstage/integration@1.12.0
+  - @backstage/integration-aws-node@0.1.12
+  - @backstage/types@1.1.1
+  - @backstage/plugin-auth-node@0.4.15
+  - @backstage/plugin-events-node@0.3.6
+  - @backstage/plugin-permission-node@0.7.31
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/backend-defaults/package.json
+++ b/packages/backend-defaults/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/backend-defaults",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Backend defaults used by Backstage backend apps",
   "backstage": {
     "role": "node-library"

--- a/packages/backend-dynamic-feature-service/CHANGELOG.md
+++ b/packages/backend-dynamic-feature-service/CHANGELOG.md
@@ -1,5 +1,31 @@
 # @backstage/backend-dynamic-feature-service
 
+## 0.2.13
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-app-api@0.7.8
+  - @backstage/backend-common@0.23.1
+  - @backstage/backend-plugin-api@0.6.20
+  - @backstage/backend-tasks@0.5.25
+  - @backstage/cli-common@0.1.14
+  - @backstage/cli-node@0.2.6
+  - @backstage/config@1.2.0
+  - @backstage/config-loader@1.8.1
+  - @backstage/errors@1.2.4
+  - @backstage/types@1.1.1
+  - @backstage/plugin-app-node@0.1.20
+  - @backstage/plugin-auth-node@0.4.15
+  - @backstage/plugin-catalog-backend@1.23.1
+  - @backstage/plugin-events-backend@0.3.7
+  - @backstage/plugin-events-node@0.3.6
+  - @backstage/plugin-permission-common@0.7.14
+  - @backstage/plugin-permission-node@0.7.31
+  - @backstage/plugin-scaffolder-node@0.4.6
+  - @backstage/plugin-search-backend-node@1.2.25
+  - @backstage/plugin-search-common@1.2.12
+
 ## 0.2.12
 
 ### Patch Changes

--- a/packages/backend-dynamic-feature-service/package.json
+++ b/packages/backend-dynamic-feature-service/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/backend-dynamic-feature-service",
   "description": "Backstage dynamic feature service",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/packages/backend-legacy/CHANGELOG.md
+++ b/packages/backend-legacy/CHANGELOG.md
@@ -1,5 +1,47 @@
 # example-backend-legacy
 
+## 0.2.101
+
+### Patch Changes
+
+- Updated dependencies
+  - example-app@0.2.100
+  - @backstage/backend-common@0.23.1
+  - @backstage/backend-tasks@0.5.25
+  - @backstage/catalog-client@1.6.5
+  - @backstage/catalog-model@1.5.0
+  - @backstage/config@1.2.0
+  - @backstage/integration@1.12.0
+  - @backstage/plugin-app-backend@0.3.69
+  - @backstage/plugin-auth-backend@0.22.7
+  - @backstage/plugin-auth-node@0.4.15
+  - @backstage/plugin-catalog-backend@1.23.1
+  - @backstage/plugin-catalog-backend-module-scaffolder-entity-model@0.1.18
+  - @backstage/plugin-catalog-backend-module-unprocessed@0.4.7
+  - @backstage/plugin-catalog-node@1.12.2
+  - @backstage/plugin-devtools-backend@0.3.6
+  - @backstage/plugin-events-backend@0.3.7
+  - @backstage/plugin-events-node@0.3.6
+  - @backstage/plugin-kubernetes-backend@0.18.1
+  - @backstage/plugin-permission-backend@0.5.44
+  - @backstage/plugin-permission-common@0.7.14
+  - @backstage/plugin-permission-node@0.7.31
+  - @backstage/plugin-proxy-backend@0.5.1
+  - @backstage/plugin-scaffolder-backend@1.22.10
+  - @backstage/plugin-scaffolder-backend-module-confluence-to-markdown@0.2.21
+  - @backstage/plugin-scaffolder-backend-module-gitlab@0.4.2
+  - @backstage/plugin-scaffolder-backend-module-rails@0.4.37
+  - @backstage/plugin-search-backend@1.5.12
+  - @backstage/plugin-search-backend-module-catalog@0.1.26
+  - @backstage/plugin-search-backend-module-elasticsearch@1.5.1
+  - @backstage/plugin-search-backend-module-explore@0.1.26
+  - @backstage/plugin-search-backend-module-pg@0.5.30
+  - @backstage/plugin-search-backend-module-techdocs@0.1.25
+  - @backstage/plugin-search-backend-node@1.2.25
+  - @backstage/plugin-signals-backend@0.1.6
+  - @backstage/plugin-signals-node@0.1.6
+  - @backstage/plugin-techdocs-backend@1.10.7
+
 ## 0.2.100
 
 ### Patch Changes

--- a/packages/backend-legacy/package.json
+++ b/packages/backend-legacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-backend-legacy",
-  "version": "0.2.100",
+  "version": "0.2.101",
   "backstage": {
     "role": "backend"
   },

--- a/packages/backend-test-utils/CHANGELOG.md
+++ b/packages/backend-test-utils/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @backstage/backend-test-utils
 
+## 0.4.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-app-api@0.7.8
+  - @backstage/backend-defaults@0.3.2
+  - @backstage/backend-plugin-api@0.6.20
+  - @backstage/config@1.2.0
+  - @backstage/errors@1.2.4
+  - @backstage/types@1.1.1
+  - @backstage/plugin-auth-node@0.4.15
+  - @backstage/plugin-events-node@0.3.6
+
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/backend-test-utils/package.json
+++ b/packages/backend-test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/backend-test-utils",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Test helpers library for Backstage backends",
   "backstage": {
     "role": "node-library"

--- a/packages/backend/CHANGELOG.md
+++ b/packages/backend/CHANGELOG.md
@@ -1,5 +1,42 @@
 # example-backend
 
+## 0.0.29
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-defaults@0.3.2
+  - @backstage/backend-plugin-api@0.6.20
+  - @backstage/backend-tasks@0.5.25
+  - @backstage/catalog-model@1.5.0
+  - @backstage/plugin-app-backend@0.3.69
+  - @backstage/plugin-auth-backend@0.22.7
+  - @backstage/plugin-auth-backend-module-github-provider@0.1.17
+  - @backstage/plugin-auth-backend-module-guest-provider@0.1.6
+  - @backstage/plugin-auth-node@0.4.15
+  - @backstage/plugin-catalog-backend@1.23.1
+  - @backstage/plugin-catalog-backend-module-backstage-openapi@0.2.3
+  - @backstage/plugin-catalog-backend-module-openapi@0.1.38
+  - @backstage/plugin-catalog-backend-module-scaffolder-entity-model@0.1.18
+  - @backstage/plugin-catalog-backend-module-unprocessed@0.4.7
+  - @backstage/plugin-devtools-backend@0.3.6
+  - @backstage/plugin-kubernetes-backend@0.18.1
+  - @backstage/plugin-notifications-backend@0.3.1
+  - @backstage/plugin-permission-backend@0.5.44
+  - @backstage/plugin-permission-backend-module-allow-all-policy@0.1.17
+  - @backstage/plugin-permission-common@0.7.14
+  - @backstage/plugin-permission-node@0.7.31
+  - @backstage/plugin-proxy-backend@0.5.1
+  - @backstage/plugin-scaffolder-backend@1.22.10
+  - @backstage/plugin-scaffolder-backend-module-github@0.3.1
+  - @backstage/plugin-search-backend@1.5.12
+  - @backstage/plugin-search-backend-module-catalog@0.1.26
+  - @backstage/plugin-search-backend-module-explore@0.1.26
+  - @backstage/plugin-search-backend-module-techdocs@0.1.25
+  - @backstage/plugin-search-backend-node@1.2.25
+  - @backstage/plugin-signals-backend@0.1.6
+  - @backstage/plugin-techdocs-backend@1.10.7
+
 ## 0.0.28
 
 ### Patch Changes

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-backend",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @backstage/cli
 
+## 0.26.9
+
+### Patch Changes
+
+- 9a0481c: Fix issue with CLI that was preventing upgrading from 1.28
+- Updated dependencies
+  - @backstage/catalog-model@1.5.0
+  - @backstage/cli-common@0.1.14
+  - @backstage/cli-node@0.2.6
+  - @backstage/config@1.2.0
+  - @backstage/config-loader@1.8.1
+  - @backstage/errors@1.2.4
+  - @backstage/eslint-plugin@0.1.8
+  - @backstage/integration@1.12.0
+  - @backstage/release-manifests@0.0.11
+  - @backstage/types@1.1.1
+
 ## 0.26.8
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/cli",
-  "version": "0.26.8",
+  "version": "0.26.9",
   "description": "CLI for developing Backstage plugins and apps",
   "backstage": {
     "role": "cli"

--- a/packages/techdocs-cli-embedded-app/CHANGELOG.md
+++ b/packages/techdocs-cli-embedded-app/CHANGELOG.md
@@ -1,5 +1,24 @@
 # techdocs-cli-embedded-app
 
+## 0.2.99
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/cli@0.26.9
+  - @backstage/app-defaults@1.5.6
+  - @backstage/catalog-model@1.5.0
+  - @backstage/config@1.2.0
+  - @backstage/core-app-api@1.12.6
+  - @backstage/core-components@0.14.8
+  - @backstage/core-plugin-api@1.9.3
+  - @backstage/integration-react@1.1.28
+  - @backstage/test-utils@1.5.6
+  - @backstage/theme@0.5.6
+  - @backstage/plugin-catalog@1.21.0
+  - @backstage/plugin-techdocs@1.10.6
+  - @backstage/plugin-techdocs-react@1.2.5
+
 ## 0.2.98
 
 ### Patch Changes

--- a/packages/techdocs-cli-embedded-app/package.json
+++ b/packages/techdocs-cli-embedded-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "techdocs-cli-embedded-app",
-  "version": "0.2.98",
+  "version": "0.2.99",
   "private": true,
   "backstage": {
     "role": "frontend"

--- a/packages/techdocs-cli/CHANGELOG.md
+++ b/packages/techdocs-cli/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @techdocs/cli
 
+## 1.8.14
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-defaults@0.3.2
+  - @backstage/catalog-model@1.5.0
+  - @backstage/cli-common@0.1.14
+  - @backstage/config@1.2.0
+  - @backstage/plugin-techdocs-node@1.12.6
+
 ## 1.8.13
 
 ### Patch Changes

--- a/packages/techdocs-cli/package.json
+++ b/packages/techdocs-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@techdocs/cli",
   "description": "Utility CLI for managing TechDocs sites in Backstage.",
-  "version": "1.8.13",
+  "version": "1.8.14",
   "publishConfig": {
     "access": "public"
   },

--- a/plugins/scaffolder-backend-module-yeoman/CHANGELOG.md
+++ b/plugins/scaffolder-backend-module-yeoman/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/plugin-scaffolder-backend-module-yeoman
 
+## 0.3.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-plugin-api@0.6.20
+  - @backstage/types@1.1.1
+  - @backstage/plugin-scaffolder-node@0.4.6
+  - @backstage/plugin-scaffolder-node-test-utils@0.1.7
+
 ## 0.3.3
 
 ### Patch Changes

--- a/plugins/scaffolder-backend-module-yeoman/package.json
+++ b/plugins/scaffolder-backend-module-yeoman/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-scaffolder-backend-module-yeoman",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "backstage": {
     "role": "backend-plugin-module",
     "pluginId": "scaffolder",

--- a/plugins/scaffolder-node-test-utils/CHANGELOG.md
+++ b/plugins/scaffolder-node-test-utils/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/plugin-scaffolder-node-test-utils
 
+## 0.1.7
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.23.1
+  - @backstage/backend-test-utils@0.4.2
+  - @backstage/types@1.1.1
+  - @backstage/plugin-scaffolder-node@0.4.6
+
 ## 0.1.6
 
 ### Patch Changes

--- a/plugins/scaffolder-node-test-utils/package.json
+++ b/plugins/scaffolder-node-test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-scaffolder-node-test-utils",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "backstage": {
     "role": "node-library",
     "pluginId": "scaffolder",

--- a/plugins/search-backend-module-pg/CHANGELOG.md
+++ b/plugins/search-backend-module-pg/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage/plugin-search-backend-module-pg
 
+## 0.5.30
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-app-api@0.7.8
+  - @backstage/backend-common@0.23.1
+  - @backstage/backend-plugin-api@0.6.20
+  - @backstage/config@1.2.0
+  - @backstage/plugin-search-backend-node@1.2.25
+  - @backstage/plugin-search-common@1.2.12
+
 ## 0.5.29
 
 ### Patch Changes

--- a/plugins/search-backend-module-pg/package.json
+++ b/plugins/search-backend-module-pg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-search-backend-module-pg",
-  "version": "0.5.29",
+  "version": "0.5.30",
   "description": "A module for the search backend that implements search using PostgreSQL",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/search-backend/CHANGELOG.md
+++ b/plugins/search-backend/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @backstage/plugin-search-backend
 
+## 1.5.12
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.23.1
+  - @backstage/backend-defaults@0.3.2
+  - @backstage/backend-openapi-utils@0.1.13
+  - @backstage/backend-plugin-api@0.6.20
+  - @backstage/config@1.2.0
+  - @backstage/errors@1.2.4
+  - @backstage/types@1.1.1
+  - @backstage/plugin-permission-common@0.7.14
+  - @backstage/plugin-permission-node@0.7.31
+  - @backstage/plugin-search-backend-node@1.2.25
+  - @backstage/plugin-search-common@1.2.12
+
 ## 1.5.11
 
 ### Patch Changes

--- a/plugins/search-backend/package.json
+++ b/plugins/search-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-search-backend",
-  "version": "1.5.11",
+  "version": "1.5.12",
   "description": "The Backstage backend plugin that provides your backstage app with search",
   "backstage": {
     "role": "backend-plugin",


### PR DESCRIPTION
This release fixes two issues:

- Fixing issue with `versions:bump` script not working correctly since 1.28.0
- Fixing issue with `MiddlewareFactory` deprecated type not being compatible with the old type