### PR TITLE
Add setShadowRootVersionHash to force shadowRoot to update in provide…

### DIFF
--- a/.changeset/clever-waves-judge.md
+++ b/.changeset/clever-waves-judge.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-techdocs-react': patch
+'@backstage/plugin-techdocs': patch
+---
+
+Fixed a bug with the TechDocsReaderPageProvider not re-rendering when setShadowDom is called, meaning that the useShadowDom hooks were inconsistent. This issue caused the TextSize addon changes not to reapply during navigation.

--- a/plugins/techdocs-react/api-report.md
+++ b/plugins/techdocs-react/api-report.md
@@ -116,6 +116,8 @@ export type TechDocsReaderPageValue = {
   entityMetadata: AsyncState<TechDocsEntityMetadata>;
   shadowRoot?: ShadowRoot;
   setShadowRoot: Dispatch<SetStateAction<ShadowRoot | undefined>>;
+  shadowRootVersion: number;
+  incShadowRootVersion: () => void;
   title: string;
   setTitle: Dispatch<SetStateAction<string>>;
   subtitle: string;

--- a/plugins/techdocs-react/src/context.tsx
+++ b/plugins/techdocs-react/src/context.tsx
@@ -64,6 +64,7 @@ export type TechDocsReaderPageValue = {
   entityMetadata: AsyncState<TechDocsEntityMetadata>;
   shadowRoot?: ShadowRoot;
   setShadowRoot: Dispatch<SetStateAction<ShadowRoot | undefined>>;
+  setShadowRootVersionHash: Dispatch<SetStateAction<string | undefined>>;
   title: string;
   setTitle: Dispatch<SetStateAction<string>>;
   subtitle: string;
@@ -80,6 +81,7 @@ const defaultTechDocsReaderPageValue: TechDocsReaderPageValue = {
   setTitle: () => {},
   setSubtitle: () => {},
   setShadowRoot: () => {},
+  setShadowRootVersionHash: () => {},
   metadata: { loading: true },
   entityMetadata: { loading: true },
   entityRef: { kind: '', name: '', namespace: '' },
@@ -134,6 +136,9 @@ export const TechDocsReaderPageProvider = memo(
     const [shadowRoot, setShadowRoot] = useState<ShadowRoot | undefined>(
       defaultTechDocsReaderPageValue.shadowRoot,
     );
+    const [, setShadowRootVersionHash] = useState<string | undefined>(
+      undefined,
+    );
 
     useEffect(() => {
       if (shadowRoot && !metadata.value && !metadata.loading) {
@@ -153,6 +158,7 @@ export const TechDocsReaderPageProvider = memo(
       entityMetadata,
       shadowRoot,
       setShadowRoot,
+      setShadowRootVersionHash,
       title,
       setTitle,
       subtitle,
@@ -190,6 +196,5 @@ export const useTechDocsReaderPage = () => {
   if (context === undefined) {
     throw new Error('No context found for version 1.');
   }
-
   return context;
 };

--- a/plugins/techdocs-react/src/context.tsx
+++ b/plugins/techdocs-react/src/context.tsx
@@ -139,7 +139,7 @@ export const TechDocsReaderPageProvider = memo(
     const [shadowRoot, setShadowRoot] = useState<ShadowRoot | undefined>(
       defaultTechDocsReaderPageValue.shadowRoot,
     );
-    const [shadowRootVersion, { inc }] = useCounter(0);
+    const [shadowRootVersion, { inc: incShadowRootVersion }] = useCounter(0);
 
     useEffect(() => {
       if (shadowRoot && !metadata.value && !metadata.loading) {
@@ -160,7 +160,7 @@ export const TechDocsReaderPageProvider = memo(
       shadowRoot,
       setShadowRoot,
       shadowRootVersion,
-      incShadowRootVersion: inc,
+      incShadowRootVersion,
       title,
       setTitle,
       subtitle,

--- a/plugins/techdocs-react/src/context.tsx
+++ b/plugins/techdocs-react/src/context.tsx
@@ -25,6 +25,7 @@ import React, {
 } from 'react';
 import useAsync, { AsyncState } from 'react-use/esm/useAsync';
 import useAsyncRetry from 'react-use/esm/useAsyncRetry';
+import useCounter from 'react-use/esm/useCounter';
 
 import {
   CompoundEntityRef,
@@ -64,7 +65,8 @@ export type TechDocsReaderPageValue = {
   entityMetadata: AsyncState<TechDocsEntityMetadata>;
   shadowRoot?: ShadowRoot;
   setShadowRoot: Dispatch<SetStateAction<ShadowRoot | undefined>>;
-  setShadowRootVersionHash: Dispatch<SetStateAction<string | undefined>>;
+  shadowRootVersion: number;
+  incShadowRootVersion: () => void;
   title: string;
   setTitle: Dispatch<SetStateAction<string>>;
   subtitle: string;
@@ -81,7 +83,8 @@ const defaultTechDocsReaderPageValue: TechDocsReaderPageValue = {
   setTitle: () => {},
   setSubtitle: () => {},
   setShadowRoot: () => {},
-  setShadowRootVersionHash: () => {},
+  shadowRootVersion: 0,
+  incShadowRootVersion: () => {},
   metadata: { loading: true },
   entityMetadata: { loading: true },
   entityRef: { kind: '', name: '', namespace: '' },
@@ -136,9 +139,7 @@ export const TechDocsReaderPageProvider = memo(
     const [shadowRoot, setShadowRoot] = useState<ShadowRoot | undefined>(
       defaultTechDocsReaderPageValue.shadowRoot,
     );
-    const [, setShadowRootVersionHash] = useState<string | undefined>(
-      undefined,
-    );
+    const [shadowRootVersion, { inc }] = useCounter(0);
 
     useEffect(() => {
       if (shadowRoot && !metadata.value && !metadata.loading) {
@@ -158,7 +159,8 @@ export const TechDocsReaderPageProvider = memo(
       entityMetadata,
       shadowRoot,
       setShadowRoot,
-      setShadowRootVersionHash,
+      shadowRootVersion,
+      incShadowRootVersion: inc,
       title,
       setTitle,
       subtitle,

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/TechDocsReaderPageContent.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/TechDocsReaderPageContent.tsx
@@ -34,6 +34,8 @@ import { TechDocsStateIndicator } from '../TechDocsStateIndicator';
 import { useTechDocsReaderDom } from './dom';
 import { withTechDocsReaderProvider } from '../TechDocsReaderProvider';
 import { TechDocsReaderPageContentAddons } from './TechDocsReaderPageContentAddons';
+// eslint-disable-next-line no-restricted-imports
+import { createHash } from 'crypto';
 
 const useStyles = makeStyles({
   search: {
@@ -80,6 +82,7 @@ export const TechDocsReaderPageContent = withTechDocsReaderProvider(
       entityMetadata: { value: entityMetadata, loading: entityMetadataLoading },
       entityRef,
       setShadowRoot,
+      setShadowRootVersionHash,
     } = useTechDocsReaderPage();
     const dom = useTechDocsReaderDom(entityRef);
     const path = window.location.pathname;
@@ -101,12 +104,16 @@ export const TechDocsReaderPageContent = withTechDocsReaderProvider(
 
     const handleAppend = useCallback(
       (newShadowRoot: ShadowRoot) => {
+        const newShadowRootVersionHash = createHash('sha256')
+          .update(newShadowRoot.innerHTML)
+          .digest('hex');
         setShadowRoot(newShadowRoot);
+        setShadowRootVersionHash(newShadowRootVersionHash);
         if (onReady instanceof Function) {
           onReady();
         }
       },
-      [setShadowRoot, onReady],
+      [setShadowRoot, setShadowRootVersionHash, onReady],
     );
 
     // No entity metadata = 404. Don't render content at all.

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/TechDocsReaderPageContent.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/TechDocsReaderPageContent.tsx
@@ -34,8 +34,6 @@ import { TechDocsStateIndicator } from '../TechDocsStateIndicator';
 import { useTechDocsReaderDom } from './dom';
 import { withTechDocsReaderProvider } from '../TechDocsReaderProvider';
 import { TechDocsReaderPageContentAddons } from './TechDocsReaderPageContentAddons';
-// eslint-disable-next-line no-restricted-imports
-import { createHash } from 'crypto';
 
 const useStyles = makeStyles({
   search: {
@@ -82,7 +80,7 @@ export const TechDocsReaderPageContent = withTechDocsReaderProvider(
       entityMetadata: { value: entityMetadata, loading: entityMetadataLoading },
       entityRef,
       setShadowRoot,
-      setShadowRootVersionHash,
+      incShadowRootVersion,
     } = useTechDocsReaderPage();
     const dom = useTechDocsReaderDom(entityRef);
     const path = window.location.pathname;
@@ -104,16 +102,13 @@ export const TechDocsReaderPageContent = withTechDocsReaderProvider(
 
     const handleAppend = useCallback(
       (newShadowRoot: ShadowRoot) => {
-        const newShadowRootVersionHash = createHash('sha256')
-          .update(newShadowRoot.innerHTML)
-          .digest('hex');
         setShadowRoot(newShadowRoot);
-        setShadowRootVersionHash(newShadowRootVersionHash);
+        incShadowRootVersion();
         if (onReady instanceof Function) {
           onReady();
         }
       },
-      [setShadowRoot, setShadowRootVersionHash, onReady],
+      [setShadowRoot, incShadowRootVersion, onReady],
     );
 
     // No entity metadata = 404. Don't render content at all.


### PR DESCRIPTION
Add setShadowRootVersionHash to force shadowRoot to update in provider when version changes. The setShadowRoot doesn't cause a re-render because a ref is passed to it. This hash is a work around to force the update. This PR builds off the investigation done in this [PR](https://github.com/backstage/backstage/pull/24355) that points out the useShadowRoot hooks do not behave as expected.

....

Update: Instead of hash we are going to use a simple counter. The hash may affect performance. We really just need some type of simple state that can force the side-effects that setShadowRoot is not. 

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
