### PR TITLE
feat: support tag based policies

### DIFF
--- a/.changeset/short-flowers-cry.md
+++ b/.changeset/short-flowers-cry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-github': minor
+---
+
+Adds support for custom tag policies when creating GitHub environments.

--- a/plugins/scaffolder-backend-module-github/api-report.md
+++ b/plugins/scaffolder-backend-module-github/api-report.md
@@ -77,6 +77,7 @@ export function createGithubEnvironmentAction(options: {
         }
       | undefined;
     customBranchPolicyNames?: string[] | undefined;
+    customTagPolicyNames?: string[] | undefined;
     environmentVariables?:
       | {
           [key: string]: string;

--- a/plugins/scaffolder-backend-module-github/src/actions/githubEnvironment.examples.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubEnvironment.examples.test.ts
@@ -171,6 +171,7 @@ describe('github:environment:create examples', () => {
       repo: 'repository',
       environment_name: 'envname',
       name: 'main',
+      type: 'branch',
     });
 
     expect(
@@ -180,6 +181,7 @@ describe('github:environment:create examples', () => {
       repo: 'repository',
       environment_name: 'envname',
       name: '*.*.*',
+      type: 'branch',
     });
 
     expect(

--- a/plugins/scaffolder-backend-module-github/src/actions/githubEnvironment.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubEnvironment.test.ts
@@ -121,6 +121,7 @@ describe('github:environment:create', () => {
       },
     });
   });
+
   it('should work specify deploymentBranchPolicy custom', async () => {
     await action.handler({
       ...mockContext,
@@ -153,6 +154,7 @@ describe('github:environment:create', () => {
       repo: 'repository',
       environment_name: 'envname',
       name: 'main',
+      type: 'branch',
     });
     expect(
       mockOctokit.rest.repos.createDeploymentBranchPolicy,
@@ -161,6 +163,52 @@ describe('github:environment:create', () => {
       repo: 'repository',
       environment_name: 'envname',
       name: '*.*.*',
+      type: 'branch',
+    });
+  });
+
+  it('should work specify deploymentTagPolicy custom', async () => {
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        deploymentBranchPolicy: {
+          protected_branches: false,
+          custom_branch_policies: true,
+        },
+        customTagPolicyNames: ['main', '*.*.*'],
+      },
+    });
+
+    expect(
+      mockOctokit.rest.repos.createOrUpdateEnvironment,
+    ).toHaveBeenCalledWith({
+      owner: 'owner',
+      repo: 'repository',
+      environment_name: 'envname',
+      deployment_branch_policy: {
+        protected_branches: false,
+        custom_branch_policies: true,
+      },
+    });
+
+    expect(
+      mockOctokit.rest.repos.createDeploymentBranchPolicy,
+    ).toHaveBeenCalledWith({
+      owner: 'owner',
+      repo: 'repository',
+      environment_name: 'envname',
+      name: 'main',
+      type: 'tag',
+    });
+    expect(
+      mockOctokit.rest.repos.createDeploymentBranchPolicy,
+    ).toHaveBeenCalledWith({
+      owner: 'owner',
+      repo: 'repository',
+      environment_name: 'envname',
+      name: '*.*.*',
+      type: 'tag',
     });
   });
 

--- a/plugins/scaffolder-backend-module-github/src/actions/githubEnvironment.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubEnvironment.ts
@@ -44,6 +44,7 @@ export function createGithubEnvironmentAction(options: {
       custom_branch_policies: boolean;
     };
     customBranchPolicyNames?: string[];
+    customTagPolicyNames?: string[];
     environmentVariables?: { [key: string]: string };
     secrets?: { [key: string]: string };
     token?: string;
@@ -94,6 +95,16 @@ export function createGithubEnvironmentAction(options: {
               type: 'string',
             },
           },
+          customTagPolicyNames: {
+            title: 'Custom Tag Policy Name',
+            description: `The name pattern that tags must match in order to deploy to the environment.
+
+            Wildcard characters will not match /. For example, to match tags that begin with release/ and contain an additional single slash, use release/*/*. For more information about pattern matching syntax, see the Ruby File.fnmatch documentation.`,
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+          },
           environmentVariables: {
             title: 'Environment Variables',
             description: `Environment variables attached to the deployment environment`,
@@ -118,6 +129,7 @@ export function createGithubEnvironmentAction(options: {
         name,
         deploymentBranchPolicy,
         customBranchPolicyNames,
+        customTagPolicyNames,
         environmentVariables,
         secrets,
         token: providedToken,
@@ -153,6 +165,19 @@ export function createGithubEnvironmentAction(options: {
           await client.rest.repos.createDeploymentBranchPolicy({
             owner: owner,
             repo: repo,
+            type: 'branch',
+            environment_name: name,
+            name: item,
+          });
+        }
+      }
+
+      if (customTagPolicyNames) {
+        for (const item of customTagPolicyNames) {
+          await client.rest.repos.createDeploymentBranchPolicy({
+            owner: owner,
+            repo: repo,
+            type: 'tag',
             environment_name: name,
             name: item,
           });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This should address #25232. It looks like the scaffolder action currently defaults to `branch` based protections. I added a new input to make this a non-breaking change. This could also be implemented by updating the structure of the parameter `customBranchPolicyNames` (and probably re-naming the input) to be an object. i.e. something like...

```yaml
protections:
 - name: releases/*
   type: tag
```

https://docs.github.com/en/rest/deployments/branch-policies?apiVersion=2022-11-28#create-a-deployment-branch-policy

I tested this with a software template that looks like:

```yaml
apiVersion: scaffolder.backstage.io/v1beta3
kind: Template
metadata:
  name: v1beta3-demo
  title: Test Action template
  description: scaffolder v1beta3 template demo
spec:
  owner: backstage/techdocs-core
  type: service

  parameters:
    - title: Fill in some steps
      required:
        - name
      properties:
        name:
          title: Name
          type: string
          description: Unique name not used

  # here's the steps that are executed in series in the scaffolder backend
  steps:
    - id: github-env
      name: GitHub Env
      action: github:environment:create
      input:
        repoUrl: github.com?repo=repo-name&owner=owner-name
        name: testing
        token: <redacted>
        deploymentBranchPolicy:
          custom_branch_policies: true
          protected_branches: false
        customTagPolicyNames:
          - releases/*
```

<img width="823" alt="Screenshot 2024-06-20 at 5 22 55 PM" src="https://github.com/backstage/backstage/assets/20445982/d18b2cf6-1c85-4d86-bfd8-f58773f7b0d6">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
