### PR TITLE
feat: add parsing configuration option for `ConfigSource`s

### DIFF
--- a/.changeset/young-peaches-shake.md
+++ b/.changeset/young-peaches-shake.md
@@ -1,0 +1,5 @@
+---
+'@backstage/config-loader': minor
+---
+
+Add configuration key to File and Remote `ConfigSource`s that enables configuration of parsing logic. Previously limited to yaml, these `ConfigSource`s now allow for a multitude of parsing options (e.g. JSON).

--- a/packages/config-loader/api-report.md
+++ b/packages/config-loader/api-report.md
@@ -141,6 +141,7 @@ export class FileConfigSource implements ConfigSource {
 
 // @public
 export interface FileConfigSourceOptions {
+  parser?: Parser;
   path: string;
   substitutionFunc?: EnvFunc;
   watch?: boolean;
@@ -219,6 +220,11 @@ export interface MutableConfigSourceOptions {
 }
 
 // @public
+export type Parser = ({ contents }: { contents: string }) => Promise<{
+  result?: JsonObject;
+}>;
+
+// @public
 export interface ReadConfigDataOptions {
   // (undocumented)
   signal?: AbortSignal;
@@ -242,6 +248,7 @@ export class RemoteConfigSource implements ConfigSource {
 
 // @public
 export interface RemoteConfigSourceOptions {
+  parser?: Parser;
   reloadInterval?: HumanDuration;
   substitutionFunc?: EnvFunc;
   url: string;

--- a/packages/config-loader/src/sources/FileConfigSource.test.ts
+++ b/packages/config-loader/src/sources/FileConfigSource.test.ts
@@ -59,6 +59,19 @@ describe('FileConfigSource', () => {
     ]);
   });
 
+  it('should read a config file with optional parser', async () => {
+    const tmp = await tmpFiles({ 'a.json': JSON.stringify({ a: 1 }) });
+
+    const source = FileConfigSource.create({
+      path: tmp.resolve('a.json'),
+      parser: async ({ contents }) => ({ result: JSON.parse(contents) }),
+    });
+
+    await expect(readN(source, 1)).resolves.toEqual([
+      [{ data: { a: 1 }, context: 'a.json', path: tmp.resolve('a.json') }],
+    ]);
+  });
+
   it('should watch config files', async () => {
     const tmp = await tmpFiles({ 'a.yaml': 'a: 1' });
 

--- a/packages/config-loader/src/sources/RemoteConfigSource.test.ts
+++ b/packages/config-loader/src/sources/RemoteConfigSource.test.ts
@@ -59,6 +59,45 @@ app:
     ]);
   });
 
+  it('should load and parse config from a remote URL', async () => {
+    worker.use(
+      rest.get('http://localhost/config.json', (_req, res, ctx) =>
+        res(
+          ctx.body(
+            JSON.stringify({
+              app: {
+                title: 'Example App',
+                substituted: 'x',
+                escaped: '$${VALUE}',
+              },
+            }),
+          ),
+        ),
+      ),
+    );
+
+    const source = RemoteConfigSource.create({
+      url: 'http://localhost/config.json',
+      substitutionFunc: async () => 'x',
+      parser: async ({ contents }) => ({ result: JSON.parse(contents) }),
+    });
+
+    await expect(readN(source, 1)).resolves.toEqual([
+      [
+        {
+          context: 'http://localhost/config.json',
+          data: {
+            app: {
+              title: 'Example App',
+              substituted: 'x',
+              escaped: '${VALUE}',
+            },
+          },
+        },
+      ],
+    ]);
+  });
+
   it('should reload config from a remote URL', async () => {
     let fetched = false;
 

--- a/packages/config-loader/src/sources/index.ts
+++ b/packages/config-loader/src/sources/index.ts
@@ -38,4 +38,5 @@ export type {
   ConfigSourceData,
   ReadConfigDataOptions,
   AsyncConfigSourceGenerator,
+  Parser,
 } from './types';

--- a/packages/config-loader/src/sources/types.ts
+++ b/packages/config-loader/src/sources/types.ts
@@ -15,6 +15,7 @@
  */
 
 import { AppConfig } from '@backstage/config';
+import { JsonObject } from '@backstage/types';
 
 /**
  * The data returned by {@link ConfigSource.readConfigData}.
@@ -89,3 +90,18 @@ export interface ConfigSource {
  * @public
  */
 export type SubstitutionFunc = (name: string) => Promise<string | undefined>;
+
+/**
+ * A custom function to be used for parsing configuration content.
+ *
+ * @remarks
+ *
+ * The default parsing function will parse configuration content as yaml.
+ *
+ * @public
+ */
+export type Parser = ({
+  contents,
+}: {
+  contents: string;
+}) => Promise<{ result?: JsonObject }>;

--- a/packages/config-loader/src/sources/utils.ts
+++ b/packages/config-loader/src/sources/utils.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import { Parser } from './types';
+import yaml from 'yaml';
+
 /** @internal */
 export interface SimpleDeferred<T> {
   promise: Promise<T>;
@@ -55,3 +58,9 @@ export async function waitOrAbort<T>(
     signals.forEach(s => s.addEventListener('abort', onAbort));
   });
 }
+
+/** @internal */
+export const parseYamlContent: Parser = async ({ contents }) => {
+  const parsed = yaml.parse(contents);
+  return { result: parsed === null ? undefined : parsed };
+};


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add configuration key to File and Remote `ConfigSource`s that enables configuration of parsing logic. Previously limited to yaml, these `ConfigSource`s now allow for a multitude of parsing options (e.g. JSON, whatever you can toss in a synchronous function).

### Motivation

I have a need to load config from non-yaml files. The new backend system and `ConfigSource`s makes this pretty easy and obvious, but it's fairly duplicative to maintain `JSONFileConfigSource`, `TomlFileConfigSource` or similar when all I really want to change is `yaml.parse(...)`. 

`yaml` is still the default, no backward incompatible changes, but there is an avenue to use other file types.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
