### PR TITLE
Hide NotificationsPage toolbar for empty list

### DIFF
--- a/.changeset/metal-suits-drum.md
+++ b/.changeset/metal-suits-drum.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications': patch
+---
+
+The toolbar on the Notifications page is hidden when there are no listed notifications.

--- a/plugins/notifications/src/components/NotificationsTable/NotificationsTable.tsx
+++ b/plugins/notifications/src/components/NotificationsTable/NotificationsTable.tsx
@@ -173,12 +173,14 @@ export const NotificationsTable = ({
     }
   }, [notifications, selectedNotifications]);
 
-  const compactColumns = React.useMemo(
-    (): TableColumn<Notification>[] => [
+  const compactColumns = React.useMemo((): TableColumn<Notification>[] => {
+    const showToolbar = notifications.length > 0;
+
+    return [
       {
         /* selection column */
         width: '1rem',
-        title: (
+        title: showToolbar ? (
           <SelectAll
             count={selectedNotifications.size}
             totalCount={notifications.length}
@@ -189,7 +191,7 @@ export const NotificationsTable = ({
               )
             }
           />
-        ),
+        ) : undefined,
         render: (notification: Notification) => (
           <CheckBox
             color="primary"
@@ -254,7 +256,7 @@ export const NotificationsTable = ({
       {
         /* actions column */
         width: '1rem',
-        title: (
+        title: showToolbar ? (
           <BulkActions
             notifications={notifications}
             selectedNotifications={selectedNotifications}
@@ -263,7 +265,7 @@ export const NotificationsTable = ({
             onSwitchSavedStatus={onSwitchSavedStatus}
             onMarkAllRead={onMarkAllRead}
           />
-        ),
+        ) : undefined,
         render: (notification: Notification) => (
           <BulkActions
             notifications={[notification]}
@@ -274,20 +276,19 @@ export const NotificationsTable = ({
           />
         ),
       },
-    ],
-    [
-      markAsReadOnLinkOpen,
-      selectedNotifications,
-      notifications,
-      isUnread,
-      onSwitchReadStatus,
-      onSwitchSavedStatus,
-      onMarkAllRead,
-      onNotificationsSelectChange,
-      classes.severityItem,
-      classes.description,
-    ],
-  );
+    ];
+  }, [
+    markAsReadOnLinkOpen,
+    selectedNotifications,
+    notifications,
+    isUnread,
+    onSwitchReadStatus,
+    onSwitchSavedStatus,
+    onMarkAllRead,
+    onNotificationsSelectChange,
+    classes.severityItem,
+    classes.description,
+  ]);
 
   return (
     <Table<Notification>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

On the NotificationsPage, the `Select All` checbox and mass-action buttons are hidden for empty data set.
Prior this change, the components were disabled but present which did not look nice.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
