### PR TITLE
backstage-cli (templates): update dependencies of the backend plugins

### DIFF
--- a/.changeset/friendly-stingrays-occur.md
+++ b/.changeset/friendly-stingrays-occur.md
@@ -1,0 +1,7 @@
+---
+'@backstage/cli': patch
+---
+
+- remove unused dependencies `winston` and `yn` from the template of backend plugins;
+- update `msw` to version `2.3.1` in the template of backend plugins;
+  starting with v1 and switching later to v2 is tedious and not straight forward; it's easier to start with v2;

--- a/packages/cli/templates/default-backend-plugin/package.json.hbs
+++ b/packages/cli/templates/default-backend-plugin/package.json.hbs
@@ -35,9 +35,7 @@
     "@types/express": "{{versionQuery '@types/express' '4.17.6'}}",
     "express": "{{versionQuery 'express' '4.17.1'}}",
     "express-promise-router": "{{versionQuery 'express-promise-router' '4.1.0'}}",
-    "winston": "{{versionQuery 'winston' '3.2.1'}}",
-    "node-fetch": "{{versionQuery 'node-fetch' '2.6.7'}}",
-    "yn": "{{versionQuery 'yn' '4.0.0'}}"
+    "node-fetch": "{{versionQuery 'node-fetch' '2.6.7'}}"
   },
   "devDependencies": {
     "@backstage/cli": "{{versionQuery '@backstage/cli'}}",
@@ -45,7 +43,7 @@
     "@backstage/plugin-auth-backend-module-guest-provider": "{{versionQuery '@backstage/plugin-auth-backend-module-guest-provider'}}",
     "@types/supertest": "{{versionQuery '@types/supertest' '2.0.12'}}",
     "supertest": "{{versionQuery 'supertest' '6.2.4'}}",
-    "msw": "{{versionQuery 'msw' '1.0.0'}}"
+    "msw": "{{versionQuery 'msw' '2.3.1'}}"
   },
   "files": [
     "dist"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The template used by `yarn new` to create a new backend plugin contains some outdated dependencies.
The changes in this PR:
* remove unused dependencies `winston` and `yn` from the template of backend plugins;
* use `msw` v2 on the backend plugins; migrating later from v1 to v2 is not straight forward, it is better to start with v2.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
