### PR TITLE
feat: add spacing to theme options

### DIFF
--- a/packages/theme/src/base/createBaseThemeOptions.ts
+++ b/packages/theme/src/base/createBaseThemeOptions.ts
@@ -21,6 +21,7 @@ const DEFAULT_HTML_FONT_SIZE = 16;
 const DEFAULT_FONT_FAMILY =
   '"Helvetica Neue", Helvetica, Roboto, Arial, sans-serif';
 const DEFAULT_PAGE_THEME = 'home';
+const DEFAULT_SPACING = 8;
 
 /**
  * Default Typography settings.
@@ -74,6 +75,7 @@ export interface BaseThemeOptionsInput<PaletteOptions> {
   fontFamily?: string;
   htmlFontSize?: number;
   typography?: BackstageTypography;
+  spacing?: number | number[];
 }
 
 /**
@@ -91,6 +93,7 @@ export function createBaseThemeOptions<PaletteOptions>(
     defaultPageTheme = DEFAULT_PAGE_THEME,
     pageTheme = defaultPageThemes,
     typography,
+    spacing,
   } = options;
 
   if (!pageTheme[defaultPageTheme]) {
@@ -103,6 +106,7 @@ export function createBaseThemeOptions<PaletteOptions>(
   return {
     palette,
     typography: typography ?? defaultTypography,
+    spacing: spacing ?? DEFAULT_SPACING,
     page: pageTheme[defaultPageTheme],
     getPageTheme: ({ themeId }: PageThemeSelector) =>
       pageTheme[themeId] ?? pageTheme[defaultPageTheme],

--- a/packages/theme/src/unified/UnifiedTheme.tsx
+++ b/packages/theme/src/unified/UnifiedTheme.tsx
@@ -65,6 +65,7 @@ export interface UnifiedThemeOptions {
   htmlFontSize?: number;
   components?: ThemeOptionsV5['components'];
   typography?: BackstageTypography;
+  spacing?: number | number[];
 }
 
 /**


### PR DESCRIPTION
This will add `spacing` to the theme options, which allows user to customize the Mui spacing, by passing in a number of array of numbers (see: https://mui.com/material-ui/customization/spacing/#custom-spacing)

The default (`8`) is set and the UI is unchanged:
     
![image](https://github.com/backstage/backstage/assets/34198573/dbd80fdd-c7d8-4a54-b31a-5285b0c40192)

When using `24` instead, it will look like this: 

![image](https://github.com/backstage/backstage/assets/34198573/170cbc30-9eba-43cc-b791-d052da797ad9)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
