### PR TITLE
fix(docs): invalid snippet code

### DIFF
--- a/docs/plugins/backend-plugin.md
+++ b/docs/plugins/backend-plugin.md
@@ -281,14 +281,14 @@ export async function createRouter(
       allow: ['user'],
     });
 
-    const userInfo = await userInfo.getUserInfo(credentials);
+    const user = await userInfo.getUserInfo(credentials);
 
     res.json({
       // The catalog entity ref of the user.
-      userEntityRef: userInfo.userEntityRef,
+      userEntityRef: user.userEntityRef,
 
       // The list of entities that this user or any teams this user is a part of owns.
-      ownershipEntityRefs: userInfo.ownershipEntityRefs,
+      ownershipEntityRefs: user.ownershipEntityRefs,
     });
   });
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

On [Making Use of the User's Identity](https://backstage.io/docs/plugins/backend-plugin#making-use-of-the-users-identity) docs, the snippet that shows how to extract the identity from the request is invalid. It's invalid because `userInfo` variable is defined multiple times. If anyone try to copy and paste the code into an IDE it will throw an error.

For example:

![image](https://github.com/backstage/backstage/assets/62035389/ef4a3903-e88f-47e8-8663-9c8993888e5a)


<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
