### PR TITLE
Support catalogFilter array on OwnedEntityPicker; addresses https://g…

### DIFF
--- a/.changeset/silent-moose-eat.md
+++ b/.changeset/silent-moose-eat.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder': patch
 ---
 
-Support catalogFilter array on OwnedEntityPicker
+Support `catalogFilter` array on `OwnedEntityPicker`

--- a/.changeset/silent-moose-eat.md
+++ b/.changeset/silent-moose-eat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Support catalogFilter array on OwnedEntityPicker

--- a/plugins/scaffolder/src/components/fields/OwnedEntityPicker/OwnedEntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/OwnedEntityPicker/OwnedEntityPicker.tsx
@@ -90,21 +90,22 @@ function buildEntityPickerUISchema(
     uiSchema?.['ui:options'] || {};
   const allowedKinds = uiOptions.allowedKinds;
 
-  const catalogFilter = {
-    ...uiOptions.catalogFilter,
-    ...(allowedKinds
-      ? {
-          kind: allowedKinds,
-          [`relations.${RELATION_OWNED_BY}`]: identityRefs || [],
-        }
-      : {
-          [`relations.${RELATION_OWNED_BY}`]: identityRefs || [],
-        }),
-  };
+  const catalogFilter = asArray(uiOptions.catalogFilter).map(e => ({
+    ...e,
+    ...(allowedKinds ? { kind: allowedKinds } : {}),
+    [`relations.${RELATION_OWNED_BY}`]: identityRefs || [],
+  }));
 
   return {
     'ui:options': {
       catalogFilter,
     },
   };
+}
+
+function asArray(catalogFilter: any): any[] {
+  if (catalogFilter) {
+    return Array.isArray(catalogFilter) ? catalogFilter : [catalogFilter];
+  }
+  return [{}];
 }


### PR DESCRIPTION
…ithub.com/backstage/backstage/issues/25358

## Hey, I just made a Pull Request!
Ensure that array values are supported as `catalogFilter` on `OwnedEntityPicker` as reported in #25358 .

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
