### PR TITLE
GitHub: support repository events

### DIFF
--- a/.changeset/poor-cheetahs-raise.md
+++ b/.changeset/poor-cheetahs-raise.md
@@ -1,0 +1,30 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+Adds support for `repository` events.
+
+The provider adds a subscription to the topic `github.repository`.
+
+Hereby, it supports events of type `repository` with actions
+
+- `archived`
+- `deleted`
+- `edited`
+- `renamed`
+- `transferred`
+- `unarchived`
+
+Actions skipped as they don't require entity changes:
+
+- `created`
+- `privatized`
+- `publicized`
+
+If the config option `validateLocationsExist` is enabled, an API request
+is necessary and will be executed.
+This affects the actions `renamed`, `transferred`, and `unarchive`
+of event type `repository`.
+
+Catalog entities related to the `GithubEntityProvider` instance will be adjusted
+according to action and its meaning for them.

--- a/docs/integrations/github/discovery.md
+++ b/docs/integrations/github/discovery.md
@@ -40,8 +40,9 @@ backend.add(import('@backstage/plugin-catalog-backend-module-github/alpha'));
 ## Events Support
 
 The catalog module for GitHub comes with events support enabled.
-This will make it subscribe to its relevant topics (`github.push`)
-and expects these events to be published via the `EventsService`.
+This will make it subscribe to its relevant topics (`github.push`,
+`github.repository`) and expects these events to be published
+via the `EventsService`.
 
 Additionally, you should install the
 [event router by `events-backend-module-github`](https://github.com/backstage/backstage/tree/master/plugins/events-backend-module-github/README.md)
@@ -55,7 +56,15 @@ You can decide between the following options (extensible):
 - [via HTTP endpoint](https://github.com/backstage/backstage/tree/master/plugins/events-backend/README.md)
 - [via an AWS SQS queue](https://github.com/backstage/backstage/tree/master/plugins/events-backend-module-aws-sqs/README.md)
 
-You can check the official docs to [configure your webhook](https://docs.github.com/en/developers/webhooks-and-events/webhooks/creating-webhooks) and to [secure your request](https://docs.github.com/en/developers/webhooks-and-events/webhooks/securing-your-webhooks). The webhook will need to be configured to forward `push` events.
+You can check the official docs to [configure your webhook](https://docs.github.com/en/developers/webhooks-and-events/webhooks/creating-webhooks) and to [secure your request](https://docs.github.com/en/developers/webhooks-and-events/webhooks/securing-your-webhooks).
+
+The webhook(s) will need to be configured to react to `push` and
+`repository` events.
+
+Certain actions like `transferred` by the `repository` event type
+will not be supported when you use repository webhooks.
+Please check the GitHubs documentation for these event types and
+its actions.
 
 ## Configuration
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Support repository events.

The provider adds a subscription to the topic `github.repository`.

Hereby, it supports events of type `repository` with actions

- `archived`
- `deleted`
- `edited`
- `renamed`
- `transferred`
- `unarchived`

Actions skipped as they don't require entity changes:

- `created`
- `privatized`
- `publicized`

If the config option `validateLocationsExist` is enabled, an API request
is necessary and will be executed.
This affects the actions `renamed`, `transferred`, and `unarchive`
of event type `repository`.

Catalog entities related to the `GithubEntityProvider` instance will be adjusted
according to action and its meaning for them.

Closes: #21906

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
