### PR TITLE
TechDocs: Add publisher extension point

### DIFF
--- a/.changeset/fair-fans-flow.md
+++ b/.changeset/fair-fans-flow.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-techdocs-backend': patch
+'@backstage/plugin-techdocs-node': patch
+---
+
+Adds extension point for publishers to the techdocs backend

--- a/plugins/techdocs-node/api-report.md
+++ b/plugins/techdocs-node/api-report.md
@@ -183,11 +183,15 @@ export class Preparers implements PreparerBuilder {
 }
 
 // @public
-export class Publisher {
+export class Publisher implements PublisherBuilder {
   static fromConfig(
     config: Config,
     options: PublisherFactory,
   ): Promise<PublisherBase>;
+  // (undocumented)
+  get(config: Config): PublisherBase;
+  // (undocumented)
+  register(type: PublisherType | 'techdocs', publisher: PublisherBase): void;
 }
 
 // @public
@@ -203,9 +207,16 @@ export interface PublisherBase {
 }
 
 // @public
+export type PublisherBuilder = {
+  register(type: PublisherType, publisher: PublisherBase): void;
+  get(config: Config): PublisherBase;
+};
+
+// @public
 export type PublisherFactory = {
   logger: Logger;
   discovery: PluginEndpointDiscovery;
+  customPublisher?: PublisherBase | undefined;
 };
 
 // @public
@@ -302,6 +313,15 @@ export interface TechdocsPreparerExtensionPoint {
 
 // @public
 export const techdocsPreparerExtensionPoint: ExtensionPoint<TechdocsPreparerExtensionPoint>;
+
+// @public
+export interface TechdocsPublisherExtensionPoint {
+  // (undocumented)
+  registerPublisher(type: PublisherType, publisher: PublisherBase): void;
+}
+
+// @public
+export const techdocsPublisherExtensionPoint: ExtensionPoint<TechdocsPublisherExtensionPoint>;
 
 // @public
 export const transformDirLocation: (

--- a/plugins/techdocs-node/src/extensions.ts
+++ b/plugins/techdocs-node/src/extensions.ts
@@ -15,7 +15,13 @@
  */
 import { createExtensionPoint } from '@backstage/backend-plugin-api';
 import { DocsBuildStrategy } from './techdocsTypes';
-import { PreparerBase, RemoteProtocol, TechdocsGenerator } from './stages';
+import {
+  PreparerBase,
+  PublisherBase,
+  PublisherType,
+  RemoteProtocol,
+  TechdocsGenerator,
+} from './stages';
 import * as winston from 'winston';
 
 /**
@@ -74,4 +80,23 @@ export interface TechdocsPreparerExtensionPoint {
 export const techdocsPreparerExtensionPoint =
   createExtensionPoint<TechdocsPreparerExtensionPoint>({
     id: 'techdocs.preparer',
+  });
+
+/**
+ * Extension point type for configuring a custom Techdocs publisher
+ *
+ * @public
+ */
+export interface TechdocsPublisherExtensionPoint {
+  registerPublisher(type: PublisherType, publisher: PublisherBase): void;
+}
+
+/**
+ * Extension point for configuring a custom Techdocs publisher
+ *
+ * @public
+ */
+export const techdocsPublisherExtensionPoint =
+  createExtensionPoint<TechdocsPublisherExtensionPoint>({
+    id: 'techdocs.publisher',
   });

--- a/plugins/techdocs-node/src/index.ts
+++ b/plugins/techdocs-node/src/index.ts
@@ -27,7 +27,9 @@ export {
   techdocsBuildsExtensionPoint,
   techdocsGeneratorExtensionPoint,
   techdocsPreparerExtensionPoint,
+  techdocsPublisherExtensionPoint,
   type TechdocsBuildsExtensionPoint,
   type TechdocsGeneratorExtensionPoint,
   type TechdocsPreparerExtensionPoint,
+  type TechdocsPublisherExtensionPoint,
 } from './extensions';

--- a/plugins/techdocs-node/src/stages/publish/index.ts
+++ b/plugins/techdocs-node/src/stages/publish/index.ts
@@ -23,4 +23,5 @@ export type {
   MigrateRequest,
   ReadinessResponse,
   TechDocsMetadata,
+  PublisherBuilder,
 } from './types';

--- a/plugins/techdocs-node/src/stages/publish/publish.test.ts
+++ b/plugins/techdocs-node/src/stages/publish/publish.test.ts
@@ -25,6 +25,7 @@ import { AwsS3Publish } from './awsS3';
 import { AzureBlobStoragePublish } from './azureBlobStorage';
 import { OpenStackSwiftPublish } from './openStackSwift';
 import { mockServices } from '@backstage/backend-test-utils';
+import { PublisherBase } from './types';
 
 const logger = loggerToWinstonLogger(mockServices.logger.mock());
 const discovery: jest.Mocked<PluginEndpointDiscovery> = {
@@ -183,5 +184,21 @@ describe('Publisher', () => {
       discovery,
     });
     expect(publisher).toBeInstanceOf(OpenStackSwiftPublish);
+  });
+
+  it('registers a custom publisher if provided', async () => {
+    const mockConfig = new ConfigReader({});
+
+    const customPublisher = {
+      publish: jest.fn(),
+    } as unknown as PublisherBase;
+
+    const publisher = await Publisher.fromConfig(mockConfig, {
+      logger,
+      discovery,
+      customPublisher,
+    });
+
+    expect(publisher).toBe(customPublisher);
   });
 });

--- a/plugins/techdocs-node/src/stages/publish/publish.ts
+++ b/plugins/techdocs-node/src/stages/publish/publish.ts
@@ -20,14 +20,47 @@ import { AzureBlobStoragePublish } from './azureBlobStorage';
 import { GoogleGCSPublish } from './googleStorage';
 import { LocalPublish } from './local';
 import { OpenStackSwiftPublish } from './openStackSwift';
-import { PublisherFactory, PublisherBase, PublisherType } from './types';
+import {
+  PublisherFactory,
+  PublisherBase,
+  PublisherType,
+  PublisherBuilder,
+} from './types';
 
 /**
  * Factory class to create a TechDocs publisher based on defined publisher type in app config.
  * Uses `techdocs.publisher.type`.
  * @public
  */
-export class Publisher {
+
+type CustomPublisherType = PublisherType | 'techdocs';
+
+export class Publisher implements PublisherBuilder {
+  private publishers: Map<CustomPublisherType, PublisherBase> = new Map();
+
+  register(type: CustomPublisherType, publisher: PublisherBase): void {
+    this.publishers.set(type, publisher);
+  }
+
+  get(config: Config): PublisherBase {
+    const publisherType = (config.getOptionalString(
+      'techdocs.publisher.type',
+    ) ?? 'local') as PublisherType;
+
+    if (!publisherType) {
+      throw new Error('TechDocs publisher type not specified for the entity');
+    }
+
+    const publisher = this.publishers.get(publisherType);
+    if (!publisher) {
+      throw new Error(
+        `TechDocs publisher '${publisherType}' is not registered`,
+      );
+    }
+
+    return publisher;
+  }
+
   /**
    * Returns a instance of TechDocs publisher
    * @param config - A Backstage configuration
@@ -37,7 +70,14 @@ export class Publisher {
     config: Config,
     options: PublisherFactory,
   ): Promise<PublisherBase> {
-    const { logger, discovery } = options;
+    const { logger, discovery, customPublisher } = options;
+
+    const publishers = new Publisher();
+
+    if (customPublisher) {
+      publishers.register('techdocs', customPublisher);
+      return customPublisher;
+    }
 
     const publisherType = (config.getOptionalString(
       'techdocs.publisher.type',
@@ -46,26 +86,51 @@ export class Publisher {
     switch (publisherType) {
       case 'googleGcs':
         logger.info('Creating Google Storage Bucket publisher for TechDocs');
-        return GoogleGCSPublish.fromConfig(config, logger);
+        publishers.register(
+          publisherType,
+          GoogleGCSPublish.fromConfig(config, logger),
+        );
+        break;
       case 'awsS3':
         logger.info('Creating AWS S3 Bucket publisher for TechDocs');
-        return await AwsS3Publish.fromConfig(config, logger);
+        publishers.register(
+          publisherType,
+          await AwsS3Publish.fromConfig(config, logger),
+        );
+        break;
       case 'azureBlobStorage':
         logger.info(
           'Creating Azure Blob Storage Container publisher for TechDocs',
         );
-        return AzureBlobStoragePublish.fromConfig(config, logger);
+        publishers.register(
+          publisherType,
+          AzureBlobStoragePublish.fromConfig(config, logger),
+        );
+        break;
       case 'openStackSwift':
         logger.info(
           'Creating OpenStack Swift Container publisher for TechDocs',
         );
-        return OpenStackSwiftPublish.fromConfig(config, logger);
+        publishers.register(
+          publisherType,
+          OpenStackSwiftPublish.fromConfig(config, logger),
+        );
+        break;
       case 'local':
         logger.info('Creating Local publisher for TechDocs');
-        return LocalPublish.fromConfig(config, logger, discovery);
+        publishers.register(
+          publisherType,
+          LocalPublish.fromConfig(config, logger, discovery),
+        );
+        break;
       default:
         logger.info('Creating Local publisher for TechDocs');
-        return LocalPublish.fromConfig(config, logger, discovery);
+        publishers.register(
+          publisherType,
+          LocalPublish.fromConfig(config, logger, discovery),
+        );
     }
+
+    return publishers.get(config);
   }
 }

--- a/plugins/techdocs-node/src/stages/publish/publish.ts
+++ b/plugins/techdocs-node/src/stages/publish/publish.ts
@@ -32,13 +32,11 @@ import {
  * Uses `techdocs.publisher.type`.
  * @public
  */
-
-type CustomPublisherType = PublisherType | 'techdocs';
-
 export class Publisher implements PublisherBuilder {
-  private publishers: Map<CustomPublisherType, PublisherBase> = new Map();
+  private publishers: Map<PublisherType | 'techdocs', PublisherBase> =
+    new Map();
 
-  register(type: CustomPublisherType, publisher: PublisherBase): void {
+  register(type: PublisherType | 'techdocs', publisher: PublisherBase): void {
     this.publishers.set(type, publisher);
   }
 

--- a/plugins/techdocs-node/src/stages/publish/types.ts
+++ b/plugins/techdocs-node/src/stages/publish/types.ts
@@ -17,6 +17,7 @@ import { Entity, CompoundEntityRef } from '@backstage/catalog-model';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
 import { Logger } from 'winston';
 import express from 'express';
+import { Config } from '@backstage/config';
 
 /**
  * Options for building publishers
@@ -25,6 +26,7 @@ import express from 'express';
 export type PublisherFactory = {
   logger: Logger;
   discovery: PluginEndpointDiscovery;
+  customPublisher?: PublisherBase | undefined;
 };
 
 /**
@@ -157,3 +159,12 @@ export interface PublisherBase {
    */
   migrateDocsCase?(migrateRequest: MigrateRequest): Promise<void>;
 }
+
+/**
+ * Definition for a TechDocs publisher builder
+ * @public
+ */
+export type PublisherBuilder = {
+  register(type: PublisherType, publisher: PublisherBase): void;
+  get(config: Config): PublisherBase;
+};


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds an extension point to allow adopters to customize their own implementations of publishers for TechDocs.

Closes https://github.com/backstage/backstage/issues/23861.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
