### PR TITLE
Make useFacetsEntities fetches full entities from entity references

### DIFF
--- a/.changeset/metal-jokes-add.md
+++ b/.changeset/metal-jokes-add.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Make EntityOwnerPicker display metadata.title or spec.profile.displayName for mode=only-owners instead of metadata.name

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.test.tsx
@@ -395,6 +395,10 @@ describe('<EntityOwnerPicker mode="owners-only" />', () => {
         ],
       },
     });
+
+    mockedGetEntitiesByRef.mockResolvedValue({
+      items: [...ownerEntitiesBatch1, ...ownerEntitiesBatch2],
+    });
   });
 
   it('renders all users and groups', async () => {
@@ -410,14 +414,16 @@ describe('<EntityOwnerPicker mode="owners-only" />', () => {
     fireEvent.click(screen.getByTestId('owner-picker-expand'));
 
     await waitFor(() =>
-      expect(screen.getByText('another-owner')).toBeInTheDocument(),
+      expect(screen.getByText('Another Owner')).toBeInTheDocument(),
     );
 
-    ['some-owner', 'some-owner-2', 'test-namespace/another-owner-2'].forEach(
-      owner => {
-        expect(screen.getByText(owner)).toBeInTheDocument();
-      },
-    );
+    [
+      'some-owner',
+      'Some Owner 2',
+      'Another Owner in Another Namespace',
+    ].forEach(owner => {
+      expect(screen.getByText(owner)).toBeInTheDocument();
+    });
 
     expect(mockedGetEntityFacets).toHaveBeenCalledTimes(1);
 
@@ -429,8 +435,8 @@ describe('<EntityOwnerPicker mode="owners-only" />', () => {
 
     [
       'some-owner-batch-2',
-      'some-owner-2-batch-2',
-      'test-namespace/another-owner-2-batch-2',
+      'Some Owner Batch 2',
+      'Another Owner in Another Namespace Batch 2',
     ].forEach(owner => {
       expect(screen.getByText(owner)).toBeInTheDocument();
     });
@@ -470,7 +476,11 @@ describe('<EntityOwnerPicker mode="owners-only" />', () => {
         </MockEntityListContextProvider>
       </ApiProvider>,
     );
-    expect(mockedGetEntitiesByRef).not.toHaveBeenCalled();
+    expect(mockedGetEntitiesByRef).toHaveBeenCalledWith({
+      entityRefs: [...ownerEntitiesBatch1, ...ownerEntitiesBatch2].map(entity =>
+        stringifyEntityRef(entity),
+      ),
+    });
     expect(updateFilters).toHaveBeenLastCalledWith({
       owners: undefined,
     });

--- a/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.test.tsx
+++ b/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.test.tsx
@@ -121,6 +121,26 @@ describe('DefaultCatalogPage', () => {
         ],
       },
     })),
+    getEntitiesByRefs: jest.fn().mockImplementation(async () => ({
+      items: [
+        {
+          apiVersion: 'backstage.io/v1alpha1',
+          kind: 'Group',
+          metadata: {
+            name: 'not-tools',
+            namespace: 'default',
+          },
+        },
+        {
+          apiVersion: 'backstage.io/v1alpha1',
+          kind: 'Group',
+          metadata: {
+            name: 'tools',
+            namespace: 'default',
+          },
+        },
+      ],
+    })),
     queryEntities: jest
       .fn()
       .mockImplementation(async (request: QueryEntitiesInitialRequest) => {


### PR DESCRIPTION
EntityOwnerPicker will then display `title` or `displayName` if present for `mode='owners-only'`.

From the demo app,
BEFORE:
![Screenshot from 2024-06-24 09-49-31](https://github.com/backstage/backstage/assets/18347399/5496b676-6b07-463f-bb86-12ae19c21a27)

AFTER:
![Screenshot from 2024-06-24 09-36-37](https://github.com/backstage/backstage/assets/18347399/1d967cf5-a53e-47c5-817a-dbf806180b40)

Fixes #25348 