### PR TITLE
feat: matching plugin type to output

### DIFF
--- a/.changeset/funny-laws-tease.md
+++ b/.changeset/funny-laws-tease.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Updated the scaffolding output message for `plugin-common` in `backstage-cli`. Now, when executing `backstage-cli new` to create a new `plugin-common` package, the output message accurately reflects the action by displaying `Creating common plugin package...` instead of the previous, less accurate `Creating backend plugin...`.

--- a/packages/cli/src/lib/new/factories/pluginCommon.test.ts
+++ b/packages/cli/src/lib/new/factories/pluginCommon.test.ts
@@ -67,7 +67,7 @@ describe('pluginCommon factory', () => {
     expect(modified).toBe(true);
 
     expectLogsToMatch(output, [
-      'Creating backend plugin backstage-plugin-test-common',
+      'Creating common plugin package backstage-plugin-test-common',
       'Checking Prerequisites:',
       `availability  plugins${sep}test-common`,
       'creating      temp dir',

--- a/packages/cli/src/lib/new/factories/pluginCommon.ts
+++ b/packages/cli/src/lib/new/factories/pluginCommon.ts
@@ -46,7 +46,7 @@ export const pluginCommon = createFactory<Options>({
     });
 
     Task.log();
-    Task.log(`Creating backend plugin ${chalk.cyan(name)}`);
+    Task.log(`Creating common plugin package ${chalk.cyan(name)}`);
 
     const targetDir = ctx.isMonoRepo
       ? paths.resolveTargetRoot('plugins', suffix)


### PR DESCRIPTION
We had some internal plugin developers being confused of the output when they chose to create a new `plugin-common`.


To fix this, this PR changes to the logging messages in the `pluginCommon` factory and its corresponding test file in the `packages/cli` directory. The changes modify the log messages to correctly state that a common plugin package is being created, rather than a backend plugin.

Important changes include:

Logging message corrections:
* [`packages/cli/src/lib/new/factories/pluginCommon.test.ts`](diffhunk://#diff-7bda7c10d5736f43b1b32300b647f85a71a36d44ccc0c92cadeb16a654e2b74aL70-R70): The expected log message in the `pluginCommon` factory test has been updated to match the new log message in the `pluginCommon` factory.
* [`packages/cli/src/lib/new/factories/pluginCommon.ts`](diffhunk://#diff-c635d48b2df71a16b8186497b2986e42d2c7dd05cb02065392bc74d96027d940L49-R49): The log message in the `pluginCommon` factory has been corrected to state that a common plugin package is being created.## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
