### PR TITLE
Automatically integrate new backend plugins & modules into index.ts

### DIFF
--- a/.changeset/silent-lobsters-tease.md
+++ b/.changeset/silent-lobsters-tease.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+The backendPlugin factory now includes a step for automatically adding the new backend plugin to the `index.ts` file of the backend.

--- a/.changeset/silent-lobsters-tease.md
+++ b/.changeset/silent-lobsters-tease.md
@@ -2,4 +2,4 @@
 '@backstage/cli': patch
 ---
 
-The backendPlugin and backendModule factory now includes a step for automatically adding the new backend plugin/module to the `index.ts` file of the backend.
+The `backendPlugin` and `backendModule` factory now includes a step for automatically adding the new backend plugin/module to the `index.ts` file of the backend.

--- a/.changeset/silent-lobsters-tease.md
+++ b/.changeset/silent-lobsters-tease.md
@@ -2,4 +2,4 @@
 '@backstage/cli': patch
 ---
 
-The backendPlugin factory now includes a step for automatically adding the new backend plugin to the `index.ts` file of the backend.
+The backendPlugin and backendModule factory now includes a step for automatically adding the new backend plugin/module to the `index.ts` file of the backend.

--- a/packages/cli/src/lib/new/factories/backendModule.test.ts
+++ b/packages/cli/src/lib/new/factories/backendModule.test.ts
@@ -26,6 +26,14 @@ import {
 import { backendModule } from './backendModule';
 import { createMockDirectory } from '@backstage/backend-test-utils';
 
+const backendIndexTsContent = `
+import { createBackend } from '@backstage/backend-defaults';
+
+const backend = createBackend();
+
+backend.start();
+`;
+
 describe('backendModule factory', () => {
   const mockDir = createMockDirectory();
 
@@ -44,6 +52,9 @@ describe('backendModule factory', () => {
       packages: {
         backend: {
           'package.json': JSON.stringify({}),
+          src: {
+            'index.ts': backendIndexTsContent,
+          },
         },
       },
       plugins: {},
@@ -86,7 +97,19 @@ describe('backendModule factory', () => {
       'Installing:',
       `moving        plugins${sep}test-backend-module-tester-two`,
       'backend       adding dependency',
+      'backend       adding module',
     ]);
+
+    await expect(
+      fs.readFile(mockDir.resolve('packages/backend/src/index.ts'), 'utf8'),
+    ).resolves.toBe(`
+import { createBackend } from '@backstage/backend-defaults';
+
+const backend = createBackend();
+
+backend.add(import('backstage-plugin-test-backend-module-tester-two'));
+backend.start();
+`);
 
     await expect(
       fs.readJson(mockDir.resolve('packages/backend/package.json')),

--- a/packages/cli/src/lib/new/factories/backendModule.ts
+++ b/packages/cli/src/lib/new/factories/backendModule.ts
@@ -91,6 +91,31 @@ export const backendModule = createFactory<Options>({
       });
     }
 
+    await Task.forItem('backend', 'adding module', async () => {
+      const backendFilePath = paths.resolveTargetRoot(
+        'packages/backend/src/index.ts',
+      );
+      if (!(await fs.pathExists(backendFilePath))) {
+        return;
+      }
+
+      const content = await fs.readFile(backendFilePath, 'utf8');
+      const lines = content.split('\n');
+      const backendAddLine = `backend.add(import('${name}'));`;
+
+      const backendStartIndex = lines.findIndex(line =>
+        line.match(/backend.start/),
+      );
+
+      if (backendStartIndex !== -1) {
+        const [indentation] = lines[backendStartIndex].match(/^\s*/) ?? [];
+        lines.splice(backendStartIndex, 0, indentation + backendAddLine);
+
+        const newContent = lines.join('\n');
+        await fs.writeFile(backendFilePath, newContent, 'utf8');
+      }
+    });
+
     if (options.owner) {
       await addCodeownersEntry(`/plugins/${dirName}`, options.owner);
     }

--- a/packages/cli/src/lib/new/factories/backendModule.ts
+++ b/packages/cli/src/lib/new/factories/backendModule.ts
@@ -91,10 +91,7 @@ export const backendModule = createFactory<Options>({
       });
     }
 
-    await addToBackend(name, {
-      defaultVersion: ctx.defaultVersion,
-      type: 'module',
-    });
+    await addToBackend(name, 'module');
 
     if (options.owner) {
       await addCodeownersEntry(`/plugins/${dirName}`, options.owner);

--- a/packages/cli/src/lib/new/factories/backendModule.ts
+++ b/packages/cli/src/lib/new/factories/backendModule.ts
@@ -91,7 +91,9 @@ export const backendModule = createFactory<Options>({
       });
     }
 
-    await addToBackend(name, 'module');
+    await addToBackend(name, {
+      type: 'module',
+    });
 
     if (options.owner) {
       await addCodeownersEntry(`/plugins/${dirName}`, options.owner);

--- a/packages/cli/src/lib/new/factories/backendPlugin.test.ts
+++ b/packages/cli/src/lib/new/factories/backendPlugin.test.ts
@@ -98,7 +98,7 @@ describe('backendPlugin factory', () => {
       'Installing:',
       `moving        plugins${sep}test-backend`,
       'backend       adding dependency',
-      'backend       adding import and plugin',
+      'backend       adding plugin',
     ]);
 
     await expect(

--- a/packages/cli/src/lib/new/factories/backendPlugin.test.ts
+++ b/packages/cli/src/lib/new/factories/backendPlugin.test.ts
@@ -27,10 +27,10 @@ import { backendPlugin } from './backendPlugin';
 import { createMockDirectory } from '@backstage/backend-test-utils';
 
 const backendIndexTsContent = `
-import { createBackend } from '@backstage/backend-defaults';  
-  
-const backend = createBackend();  
-  
+import { createBackend } from '@backstage/backend-defaults';
+
+const backend = createBackend();
+
 backend.start();
 `;
 
@@ -112,11 +112,11 @@ describe('backendPlugin factory', () => {
     await expect(
       fs.readFile(mockDir.resolve('packages/backend/src/index.ts'), 'utf8'),
     ).resolves.toBe(`
-import { createBackend } from '@backstage/backend-defaults';  
+import { createBackend } from '@backstage/backend-defaults';
 
-const backend = createBackend();  
-  
-backend.add(import("backstage-plugin-test-backend"));  
+const backend = createBackend();
+
+backend.add(import('backstage-plugin-test-backend'));
 backend.start();
 `);
 
@@ -174,12 +174,13 @@ backend.start();
     await expect(
       fs.readFile(mockDir.resolve('packages/backend/src/index.ts'), 'utf8'),
     ).resolves.toBe(`
-import { createBackend } from '@backstage/backend-defaults';  
-  
-const backend = createBackend();  
-  
-backend.add(import("@internal/backstage-plugin-test-backend"));  
-backend.start();`);
+import { createBackend } from '@backstage/backend-defaults';
+
+const backend = createBackend();
+
+backend.add(import('@internal/backstage-plugin-test-backend'));
+backend.start();
+`);
 
     expect(Task.forCommand).toHaveBeenCalledTimes(2);
     expect(Task.forCommand).toHaveBeenCalledWith('yarn install', {

--- a/packages/cli/src/lib/new/factories/backendPlugin.test.ts
+++ b/packages/cli/src/lib/new/factories/backendPlugin.test.ts
@@ -38,7 +38,9 @@ describe('backendPlugin factory', () => {
   const mockDir = createMockDirectory();
 
   beforeEach(() => {
-    mockPaths({ targetRoot: mockDir.path });
+    mockPaths({
+      targetRoot: mockDir.path,
+    });
   });
 
   afterEach(() => {
@@ -117,68 +119,6 @@ import { createBackend } from '@backstage/backend-defaults';
 const backend = createBackend();
 
 backend.add(import('backstage-plugin-test-backend'));
-backend.start();
-`);
-
-    expect(Task.forCommand).toHaveBeenCalledTimes(2);
-    expect(Task.forCommand).toHaveBeenCalledWith('yarn install', {
-      cwd: mockDir.resolve('plugins/test-backend'),
-      optional: true,
-    });
-    expect(Task.forCommand).toHaveBeenCalledWith('yarn lint --fix', {
-      cwd: mockDir.resolve('plugins/test-backend'),
-      optional: true,
-    });
-  });
-
-  it('should create a backend plugin with more options and codeowners', async () => {
-    mockDir.setContent({
-      CODEOWNERS: '',
-      packages: {
-        backend: {
-          'package.json': JSON.stringify({}),
-          src: {
-            'index.ts': backendIndexTsContent,
-          },
-        },
-      },
-      plugins: {},
-    });
-
-    const options = await FactoryRegistry.populateOptions(backendPlugin, {
-      id: 'test',
-      owner: '@test-user',
-    });
-
-    const [, mockStream] = createMockOutputStream();
-    jest.spyOn(process, 'stderr', 'get').mockReturnValue(mockStream);
-    jest.spyOn(Task, 'forCommand').mockResolvedValue();
-
-    await backendPlugin.create(options, {
-      scope: 'internal',
-      private: true,
-      isMonoRepo: true,
-      defaultVersion: '1.0.0',
-      markAsModified: () => {},
-      createTemporaryDirectory: () => fs.mkdtemp('test'),
-    });
-
-    await expect(
-      fs.readJson(mockDir.resolve('packages/backend/package.json')),
-    ).resolves.toEqual({
-      dependencies: {
-        '@internal/backstage-plugin-test-backend': '^1.0.0',
-      },
-    });
-
-    await expect(
-      fs.readFile(mockDir.resolve('packages/backend/src/index.ts'), 'utf8'),
-    ).resolves.toBe(`
-import { createBackend } from '@backstage/backend-defaults';
-
-const backend = createBackend();
-
-backend.add(import('@internal/backstage-plugin-test-backend'));
 backend.start();
 `);
 

--- a/packages/cli/src/lib/new/factories/backendPlugin.test.ts
+++ b/packages/cli/src/lib/new/factories/backendPlugin.test.ts
@@ -26,13 +26,19 @@ import {
 import { backendPlugin } from './backendPlugin';
 import { createMockDirectory } from '@backstage/backend-test-utils';
 
+const backendIndexTsContent = `
+import { createBackend } from '@backstage/backend-defaults';  
+  
+const backend = createBackend();  
+  
+backend.start();
+`;
+
 describe('backendPlugin factory', () => {
   const mockDir = createMockDirectory();
 
   beforeEach(() => {
-    mockPaths({
-      targetRoot: mockDir.path,
-    });
+    mockPaths({ targetRoot: mockDir.path });
   });
 
   afterEach(() => {
@@ -44,6 +50,9 @@ describe('backendPlugin factory', () => {
       packages: {
         backend: {
           'package.json': JSON.stringify({}),
+          src: {
+            'index.ts': backendIndexTsContent,
+          },
         },
       },
       plugins: {},
@@ -89,6 +98,7 @@ describe('backendPlugin factory', () => {
       'Installing:',
       `moving        plugins${sep}test-backend`,
       'backend       adding dependency',
+      'backend       adding import and plugin',
     ]);
 
     await expect(
@@ -98,6 +108,78 @@ describe('backendPlugin factory', () => {
         'backstage-plugin-test-backend': '^1.0.0',
       },
     });
+
+    await expect(
+      fs.readFile(mockDir.resolve('packages/backend/src/index.ts'), 'utf8'),
+    ).resolves.toBe(`
+import { createBackend } from '@backstage/backend-defaults';  
+
+const backend = createBackend();  
+  
+backend.add(import("backstage-plugin-test-backend"));  
+backend.start();
+`);
+
+    expect(Task.forCommand).toHaveBeenCalledTimes(2);
+    expect(Task.forCommand).toHaveBeenCalledWith('yarn install', {
+      cwd: mockDir.resolve('plugins/test-backend'),
+      optional: true,
+    });
+    expect(Task.forCommand).toHaveBeenCalledWith('yarn lint --fix', {
+      cwd: mockDir.resolve('plugins/test-backend'),
+      optional: true,
+    });
+  });
+
+  it('should create a backend plugin with more options and codeowners', async () => {
+    mockDir.setContent({
+      CODEOWNERS: '',
+      packages: {
+        backend: {
+          'package.json': JSON.stringify({}),
+          src: {
+            'index.ts': backendIndexTsContent,
+          },
+        },
+      },
+      plugins: {},
+    });
+
+    const options = await FactoryRegistry.populateOptions(backendPlugin, {
+      id: 'test',
+      owner: '@test-user',
+    });
+
+    const [, mockStream] = createMockOutputStream();
+    jest.spyOn(process, 'stderr', 'get').mockReturnValue(mockStream);
+    jest.spyOn(Task, 'forCommand').mockResolvedValue();
+
+    await backendPlugin.create(options, {
+      scope: 'internal',
+      private: true,
+      isMonoRepo: true,
+      defaultVersion: '1.0.0',
+      markAsModified: () => {},
+      createTemporaryDirectory: () => fs.mkdtemp('test'),
+    });
+
+    await expect(
+      fs.readJson(mockDir.resolve('packages/backend/package.json')),
+    ).resolves.toEqual({
+      dependencies: {
+        '@internal/backstage-plugin-test-backend': '^1.0.0',
+      },
+    });
+
+    await expect(
+      fs.readFile(mockDir.resolve('packages/backend/src/index.ts'), 'utf8'),
+    ).resolves.toBe(`
+import { createBackend } from '@backstage/backend-defaults';  
+  
+const backend = createBackend();  
+  
+backend.add(import("@internal/backstage-plugin-test-backend"));  
+backend.start();`);
 
     expect(Task.forCommand).toHaveBeenCalledTimes(2);
     expect(Task.forCommand).toHaveBeenCalledWith('yarn install', {

--- a/packages/cli/src/lib/new/factories/backendPlugin.ts
+++ b/packages/cli/src/lib/new/factories/backendPlugin.ts
@@ -79,7 +79,7 @@ export const backendPlugin = createFactory<Options>({
         );
       });
 
-      await Task.forItem('backend', 'adding import and plugin', async () => {
+      await Task.forItem('backend', 'adding plugin', async () => {
         const backendFilePath = paths.resolveTargetRoot(
           'packages/backend/src/index.ts',
         );

--- a/packages/cli/src/lib/new/factories/backendPlugin.ts
+++ b/packages/cli/src/lib/new/factories/backendPlugin.ts
@@ -96,7 +96,7 @@ export const backendPlugin = createFactory<Options>({
         );
 
         if (backendStartIndex !== -1) {
-          const [indentation] = lines[backendStartIndex].match(/^\s*/) ?? [];
+          const [indentation] = lines[backendStartIndex].match(/^\s*/)!;
           lines.splice(backendStartIndex, 0, `${indentation}${backendAddLine}`);
 
           const newContent = lines.join('\n');

--- a/packages/cli/src/lib/new/factories/backendPlugin.ts
+++ b/packages/cli/src/lib/new/factories/backendPlugin.ts
@@ -97,7 +97,7 @@ export const backendPlugin = createFactory<Options>({
 
         if (backendStartIndex !== -1) {
           const [indentation] = lines[backendStartIndex].match(/^\s*/) ?? [];
-          lines.splice(backendStartIndex, 0, indentation + backendAddLine);
+          lines.splice(backendStartIndex, 0, `${indentation}${backendAddLine}`);
 
           const newContent = lines.join('\n');
           await fs.writeFile(backendFilePath, newContent, 'utf8');

--- a/packages/cli/src/lib/new/factories/backendPlugin.ts
+++ b/packages/cli/src/lib/new/factories/backendPlugin.ts
@@ -79,7 +79,9 @@ export const backendPlugin = createFactory<Options>({
         );
       });
 
-      await addToBackend(name, 'plugin');
+      await addToBackend(name, {
+        type: 'plugin',
+      });
     }
 
     if (options.owner) {

--- a/packages/cli/src/lib/new/factories/backendPlugin.ts
+++ b/packages/cli/src/lib/new/factories/backendPlugin.ts
@@ -79,10 +79,7 @@ export const backendPlugin = createFactory<Options>({
         );
       });
 
-      await addToBackend(name, {
-        defaultVersion: ctx.defaultVersion,
-        type: 'plugin',
-      });
+      await addToBackend(name, 'plugin');
     }
 
     if (options.owner) {

--- a/packages/cli/src/lib/tasks.ts
+++ b/packages/cli/src/lib/tasks.ts
@@ -23,6 +23,7 @@ import { basename, dirname } from 'path';
 import recursive from 'recursive-readdir';
 import { exec as execCb } from 'child_process';
 import { assertError } from '@backstage/errors';
+import { paths } from './paths';
 
 const exec = promisify(execCb);
 
@@ -197,12 +198,9 @@ export async function addPackageDependency(
   }
 }
 
-export async function addToBackend(
-  name: string,
-  ctx: { defaultVersion: string; type: 'plugin' | 'module' },
-) {
+export async function addToBackend(name: string, type: 'plugin' | 'module') {
   if (await fs.pathExists(paths.resolveTargetRoot('packages/backend'))) {
-    await Task.forItem('backend', `adding ${ctx.type}`, async () => {
+    await Task.forItem('backend', `adding ${type}`, async () => {
       const backendFilePath = paths.resolveTargetRoot(
         'packages/backend/src/index.ts',
       );

--- a/packages/cli/src/lib/tasks.ts
+++ b/packages/cli/src/lib/tasks.ts
@@ -198,9 +198,14 @@ export async function addPackageDependency(
   }
 }
 
-export async function addToBackend(name: string, type: 'plugin' | 'module') {
+export async function addToBackend(
+  name: string,
+  options: {
+    type: 'plugin' | 'module';
+  },
+) {
   if (await fs.pathExists(paths.resolveTargetRoot('packages/backend'))) {
-    await Task.forItem('backend', `adding ${type}`, async () => {
+    await Task.forItem('backend', `adding ${options.type}`, async () => {
       const backendFilePath = paths.resolveTargetRoot(
         'packages/backend/src/index.ts',
       );


### PR DESCRIPTION
Just like with the scaffolding of a frontend plugin, it would be cool to automatically add the new backend plugin to the `packages/backend/src/index.ts` file.

This PR focuses on that, by enhancing the `backendPlugin` factory in the `packages/cli/src/lib/new/factories/backendPlugin.ts` and `packages/cli/src/lib/new/factories/backendPlugin.test.ts` files. The major changes include the addition of a new `backendIndexTsContent` constant, modifications to the `backendPlugin` factory, and updates to the corresponding test cases.

Addition of new constant:

* [`packages/cli/src/lib/new/factories/backendPlugin.test.ts`](diffhunk://#diff-70dae794397e964542eadbbcb07b488ee221ad7013eb8340f691dff071112c0dR29-R41): Introduced a new constant `backendIndexTsContent` that contains the template for the `index.ts` file in the backend. This constant is used to mock the content of the `index.ts` file in the test cases.

Updates to the `backendPlugin` factory:

* [`packages/cli/src/lib/new/factories/backendPlugin.ts`](diffhunk://#diff-55e9a12d35c4fd7dd979c2c40df4d6340952e9eb35a996d3838d9959b2ca81dcR81-R114): Added a new task in the `backendPlugin` factory to include the import and plugin addition in the `index.ts` of the backend. This task reads the existing content of the `index.ts` file, identifies the last import and `backend.add` lines, and inserts the new plugin addition line accordingly.

Modifications to the test cases:

* [`packages/cli/src/lib/new/factories/backendPlugin.test.ts`](diffhunk://#diff-70dae794397e964542eadbbcb07b488ee221ad7013eb8340f691dff071112c0dR53-R55): Updated the test cases to include the new `backendIndexTsContent` in the mock directory structure. Also, the expected logs and the content of the `index.ts` file in the assertions have been updated to reflect the new changes. [[1]](diffhunk://#diff-70dae794397e964542eadbbcb07b488ee221ad7013eb8340f691dff071112c0dR53-R55) [[2]](diffhunk://#diff-70dae794397e964542eadbbcb07b488ee221ad7013eb8340f691dff071112c0dR101) [[3]](diffhunk://#diff-70dae794397e964542eadbbcb07b488ee221ad7013eb8340f691dff071112c0dR112-R183)## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
