### PR TITLE
feat(scaffolder): use virtualization with EntityPicker

### DIFF
--- a/.changeset/calm-jeans-ring.md
+++ b/.changeset/calm-jeans-ring.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': minor
+---
+
+Use virtualization with `EntityPicker` as done earlier with `MultiEntityPicker` to fix performance issues with large data sets. `VirtualizedListbox` extracted into reusable component.

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
@@ -43,6 +43,7 @@ import {
   EntityPickerUiOptions,
   EntityPickerFilterQuery,
 } from './schema';
+import { VirtualizedListbox } from '../VirtualizedListbox';
 
 export { EntityPickerSchema } from './schema';
 
@@ -205,6 +206,7 @@ export const EntityPicker = (props: EntityPickerProps) => {
             entities?.entityRefToPresentation.get(stringifyEntityRef(option))
               ?.primaryTitle!,
         })}
+        ListboxComponent={VirtualizedListbox}
       />
     </FormControl>
   );

--- a/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.tsx
@@ -35,7 +35,6 @@ import Autocomplete, {
   AutocompleteChangeReason,
 } from '@material-ui/lab/Autocomplete';
 import React, { useCallback, useEffect } from 'react';
-import { FixedSizeList, ListChildComponentProps } from 'react-window';
 import useAsync from 'react-use/esm/useAsync';
 import { FieldValidation } from '@rjsf/utils';
 import {
@@ -44,40 +43,9 @@ import {
   MultiEntityPickerUiOptions,
   MultiEntityPickerFilterQuery,
 } from './schema';
+import { VirtualizedListbox } from '../VirtualizedListbox';
 
 export { MultiEntityPickerSchema } from './schema';
-
-const renderRow = (props: ListChildComponentProps) => {
-  const { data, index, style } = props;
-  return React.cloneElement(data[index], { style });
-};
-
-const ListboxComponent = React.forwardRef<
-  HTMLDivElement,
-  { children?: React.ReactNode }
->((props, ref) => {
-  const itemData = React.Children.toArray(props.children);
-  const itemCount = itemData.length;
-
-  const itemSize = 36;
-
-  const itemsToShow = Math.min(10, itemCount);
-  const height = Math.max(itemSize, itemsToShow * itemSize - 0.5 * itemSize);
-
-  return (
-    <div ref={ref}>
-      <FixedSizeList
-        height={height}
-        itemData={itemData}
-        itemCount={itemCount}
-        itemSize={itemSize}
-        width="100%"
-      >
-        {renderRow}
-      </FixedSizeList>
-    </div>
-  );
-});
 
 /**
  * The underlying component that is rendered in the form for the `MultiEntityPicker`
@@ -210,7 +178,7 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
             }}
           />
         )}
-        ListboxComponent={ListboxComponent}
+        ListboxComponent={VirtualizedListbox}
       />
     </FormControl>
   );

--- a/plugins/scaffolder/src/components/fields/VirtualizedListbox.tsx
+++ b/plugins/scaffolder/src/components/fields/VirtualizedListbox.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { FixedSizeList, ListChildComponentProps } from 'react-window';
+
+const renderRow = (props: ListChildComponentProps) => {
+  const { data, index, style } = props;
+  return React.cloneElement(data[index], { style });
+};
+
+export const VirtualizedListbox = React.forwardRef<
+  HTMLDivElement,
+  { children?: React.ReactNode }
+>((props, ref) => {
+  const itemData = React.Children.toArray(props.children);
+  const itemCount = itemData.length;
+
+  const itemSize = 36;
+
+  const itemsToShow = Math.min(10, itemCount);
+  const height = Math.max(itemSize, itemsToShow * itemSize - 0.5 * itemSize);
+
+  return (
+    <div ref={ref}>
+      <FixedSizeList
+        height={height}
+        itemData={itemData}
+        itemCount={itemCount}
+        itemSize={itemSize}
+        width="100%"
+      >
+        {renderRow}
+      </FixedSizeList>
+    </div>
+  );
+});


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Addition of `renderOption` to `Autocomplete` (used by `EntityPicker`) in #24081 unfortunately introduced performance issues when processing large number (~1k+) entities. Use same fix as with `MultiEntityPicker` done earlier in #25315. Fixes #25340.  

Same story as with #25315; this is difficult test without a real browser environment so no unit tests added. I have however tested this with catalogs having 5k and 100k entities and both worked just fine.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
