### PR TITLE
Add testid to Select component

### DIFF
--- a/.changeset/new-sheep-arrive.md
+++ b/.changeset/new-sheep-arrive.md
@@ -2,4 +2,4 @@
 '@backstage/core-components': patch
 ---
 
-Modified the Select component to take in a testid parameter that sets the data-testid of the material ui Select sub-component, ensuring backwards compatibility with default value corresponding to previously hardcoded data-testid of "select".
+Modified the `Select` component to take in a `data-testid` parameter ensuring backwards compatibility with default value corresponding to previously hardcoded `data-testid` of "select".

--- a/.changeset/new-sheep-arrive.md
+++ b/.changeset/new-sheep-arrive.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Modified the Select component to take in a testid parameter that sets the data-testid of the material ui Select sub-component, ensuring backwards compatibility with default value corresponding to previously hardcoded data-testid of "select".

--- a/packages/core-components/src/components/Select/Select.test.tsx
+++ b/packages/core-components/src/components/Select/Select.test.tsx
@@ -66,4 +66,12 @@ describe('<Select />', () => {
 
     expect(getByTestId('select').textContent).toBe('All results');
   });
+
+  it('should function correctly when a custom data-testid is provided', async () => {
+    const { getByTestId } = render(
+      <Select {...minProps} data-testid="custom-select" />,
+    );
+    const input = getByTestId('custom-select');
+    expect(input.textContent).toBe('All results');
+  });
 });

--- a/packages/core-components/src/components/Select/Select.tsx
+++ b/packages/core-components/src/components/Select/Select.tsx
@@ -32,7 +32,6 @@ import React, { useEffect, useState } from 'react';
 
 import ClosedDropdown from './static/ClosedDropdown';
 import OpenedDropdown from './static/OpenedDropdown';
-import { string } from 'zod';
 
 /** @public */
 export type SelectInputBaseClassKey = 'root' | 'input';

--- a/packages/core-components/src/components/Select/Select.tsx
+++ b/packages/core-components/src/components/Select/Select.tsx
@@ -32,6 +32,7 @@ import React, { useEffect, useState } from 'react';
 
 import ClosedDropdown from './static/ClosedDropdown';
 import OpenedDropdown from './static/OpenedDropdown';
+import { string } from 'zod';
 
 /** @public */
 export type SelectInputBaseClassKey = 'root' | 'input';
@@ -136,6 +137,7 @@ export type SelectProps = {
   native?: boolean;
   disabled?: boolean;
   margin?: 'dense' | 'none';
+  testid?: string;
 };
 
 /** @public */
@@ -151,6 +153,7 @@ export function SelectComponent(props: SelectProps) {
     native = false,
     disabled = false,
     margin,
+    testid = 'select',
   } = props;
   const classes = useStyles();
   const [value, setValue] = useState<SelectedItems>(
@@ -203,7 +206,7 @@ export function SelectComponent(props: SelectProps) {
           value={value}
           native={native}
           disabled={disabled}
-          data-testid="select"
+          data-testid={testid}
           displayEmpty
           multiple={multiple}
           margin={margin}

--- a/packages/core-components/src/components/Select/Select.tsx
+++ b/packages/core-components/src/components/Select/Select.tsx
@@ -136,7 +136,7 @@ export type SelectProps = {
   native?: boolean;
   disabled?: boolean;
   margin?: 'dense' | 'none';
-  testid?: string;
+  'data-testid'?: string;
 };
 
 /** @public */
@@ -152,7 +152,7 @@ export function SelectComponent(props: SelectProps) {
     native = false,
     disabled = false,
     margin,
-    testid = 'select',
+    'data-testid': dataTestId = 'select',
   } = props;
   const classes = useStyles();
   const [value, setValue] = useState<SelectedItems>(
@@ -205,7 +205,7 @@ export function SelectComponent(props: SelectProps) {
           value={value}
           native={native}
           disabled={disabled}
-          data-testid={testid}
+          data-testid={dataTestId}
           displayEmpty
           multiple={multiple}
           margin={margin}

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPickerHost.test.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPickerHost.test.tsx
@@ -64,7 +64,7 @@ describe('RepoUrlPickerHostField', () => {
       </TestApiProvider>,
     );
 
-    fireEvent.mouseDown(getByTestId('select'));
+    fireEvent.mouseDown(getByTestId('host-select'));
     expect(getByText('gitlab.com')).toBeInTheDocument();
 
     const listbox = within(getByRole('combobox'));
@@ -93,7 +93,7 @@ describe('RepoUrlPickerHostField', () => {
       </TestApiProvider>,
     );
 
-    fireEvent.mouseDown(getByTestId('select'));
+    fireEvent.mouseDown(getByTestId('host-select'));
     expect(getByText('gitlab.com')).toBeInTheDocument();
 
     const listbox = within(getByRole('combobox'));


### PR DESCRIPTION
Currently the data-testid for the Select component is hardcoded to "select" which creates problems for testing. I modified the Select component to take in a testid parameter that sets the data-testid of the material ui Select sub-component, ensuring backwards compatibility with default value corresponding to previously hardcoded data-testid of "select".

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
-  [ ] N/A: Added or updated documentation
- [ ]  N/A: Tests for new functionality and regression tests for bug fixes
- [ ]  N/A:  Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
