### PR TITLE
fix(scaffolder-backend-module-github): some octokit calls missing mandatory params in actions

### DIFF
--- a/.changeset/ten-dancers-drum.md
+++ b/.changeset/ten-dancers-drum.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-github': patch
+---
+
+Fixed issue with octokit call missing owner and repo when creating environment variables using github:environment:create action

--- a/.changeset/ten-dancers-drum.md
+++ b/.changeset/ten-dancers-drum.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-backend-module-github': patch
 ---
 
-Fixed issue with octokit call missing owner and repo when creating environment variables using github:environment:create action
+Fixed issue with octokit call missing owner and repo when creating environment variables and secrets using github:environment:create action

--- a/plugins/scaffolder-backend-module-github/src/actions/githubEnvironment.examples.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubEnvironment.examples.test.ts
@@ -245,6 +245,8 @@ describe('github:environment:create examples', () => {
       mockOctokit.rest.actions.createOrUpdateEnvironmentSecret,
     ).toHaveBeenCalledWith({
       repository_id: 'repoid',
+      owner: 'owner',
+      repo: 'repository',
       environment_name: 'envname',
       secret_name: 'secret1',
       key_id: 'keyid',
@@ -254,6 +256,8 @@ describe('github:environment:create examples', () => {
       mockOctokit.rest.actions.createOrUpdateEnvironmentSecret,
     ).toHaveBeenCalledWith({
       repository_id: 'repoid',
+      owner: 'owner',
+      repo: 'repository',
       environment_name: 'envname',
       secret_name: 'secret2',
       key_id: 'keyid',

--- a/plugins/scaffolder-backend-module-github/src/actions/githubEnvironment.examples.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubEnvironment.examples.test.ts
@@ -221,6 +221,8 @@ describe('github:environment:create examples', () => {
       mockOctokit.rest.actions.createEnvironmentVariable,
     ).toHaveBeenCalledWith({
       repository_id: 'repoid',
+      owner: 'owner',
+      repo: 'repository',
       environment_name: 'envname',
       name: 'key1',
       value: 'val1',
@@ -229,6 +231,8 @@ describe('github:environment:create examples', () => {
       mockOctokit.rest.actions.createEnvironmentVariable,
     ).toHaveBeenCalledWith({
       repository_id: 'repoid',
+      owner: 'owner',
+      repo: 'repository',
       environment_name: 'envname',
       name: 'key2',
       value: 'val2',

--- a/plugins/scaffolder-backend-module-github/src/actions/githubEnvironment.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubEnvironment.test.ts
@@ -240,6 +240,8 @@ describe('github:environment:create', () => {
       mockOctokit.rest.actions.createEnvironmentVariable,
     ).toHaveBeenCalledWith({
       repository_id: 'repoid',
+      owner: 'owner',
+      repo: 'repository',
       environment_name: 'envname',
       name: 'key1',
       value: 'val1',
@@ -248,6 +250,8 @@ describe('github:environment:create', () => {
       mockOctokit.rest.actions.createEnvironmentVariable,
     ).toHaveBeenCalledWith({
       repository_id: 'repoid',
+      owner: 'owner',
+      repo: 'repository',
       environment_name: 'envname',
       name: 'key2',
       value: 'val2',

--- a/plugins/scaffolder-backend-module-github/src/actions/githubEnvironment.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubEnvironment.test.ts
@@ -286,6 +286,8 @@ describe('github:environment:create', () => {
       mockOctokit.rest.actions.createOrUpdateEnvironmentSecret,
     ).toHaveBeenCalledWith({
       repository_id: 'repoid',
+      owner: 'owner',
+      repo: 'repository',
       environment_name: 'envname',
       secret_name: 'key1',
       key_id: 'keyid',
@@ -295,6 +297,8 @@ describe('github:environment:create', () => {
       mockOctokit.rest.actions.createOrUpdateEnvironmentSecret,
     ).toHaveBeenCalledWith({
       repository_id: 'repoid',
+      owner: 'owner',
+      repo: 'repository',
       environment_name: 'envname',
       secret_name: 'key2',
       key_id: 'keyid',

--- a/plugins/scaffolder-backend-module-github/src/actions/githubEnvironment.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubEnvironment.ts
@@ -187,6 +187,8 @@ export function createGithubEnvironmentAction(options: {
       for (const [key, value] of Object.entries(environmentVariables ?? {})) {
         await client.rest.actions.createEnvironmentVariable({
           repository_id: repository.data.id,
+          owner: owner,
+          repo: repo,
           environment_name: name,
           name: key,
           value,

--- a/plugins/scaffolder-backend-module-github/src/actions/githubEnvironment.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubEnvironment.ts
@@ -220,6 +220,8 @@ export function createGithubEnvironmentAction(options: {
 
           await client.rest.actions.createOrUpdateEnvironmentSecret({
             repository_id: repository.data.id,
+            owner: owner,
+            repo: repo,
             environment_name: name,
             secret_name: key,
             encrypted_value: encryptedBase64Secret,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Try to fix #25042 updating the octokit call with owner and repo

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
