### PR TITLE
fix: update cli default backend plugin to use non-deprecated imports

### DIFF
--- a/.changeset/khaki-rivers-obey.md
+++ b/.changeset/khaki-rivers-obey.md
@@ -1,0 +1,6 @@
+---
+'@backstage/backend-common': patch
+'@backstage/cli': patch
+---
+
+Update default backend plugin created by the cli to use non-deprecated error handling middleware

--- a/packages/backend-common/src/deprecated/middleware/errorHandler.ts
+++ b/packages/backend-common/src/deprecated/middleware/errorHandler.ts
@@ -63,7 +63,7 @@ export type ErrorHandlerOptions = {
  *
  * @public
  * @returns An Express error request handler
- * @deprecated Use {@link @backstage/backend-app-api#MiddlewareFactory.create.error} instead
+ * @deprecated Use {@link @backstage/backend-defaults/rootHttpRouter#MiddlewareFactory.create.error} instead
  */
 export function errorHandler(
   options: ErrorHandlerOptions = {},

--- a/packages/cli/templates/default-backend-plugin/package.json.hbs
+++ b/packages/cli/templates/default-backend-plugin/package.json.hbs
@@ -38,6 +38,7 @@
     "node-fetch": "{{versionQuery 'node-fetch' '2.6.7'}}"
   },
   "devDependencies": {
+    "@backstage/backend-test-utils": "{{versionQuery '@backstage/backend-test-utils'}}",
     "@backstage/cli": "{{versionQuery '@backstage/cli'}}",
     "@backstage/plugin-auth-backend": "{{versionQuery '@backstage/plugin-auth-backend'}}",
     "@backstage/plugin-auth-backend-module-guest-provider": "{{versionQuery '@backstage/plugin-auth-backend-module-guest-provider'}}",

--- a/packages/cli/templates/default-backend-plugin/src/plugin.ts.hbs
+++ b/packages/cli/templates/default-backend-plugin/src/plugin.ts.hbs
@@ -16,14 +16,17 @@ export const {{pluginVar}} = createBackendPlugin({
       deps: {
         httpRouter: coreServices.httpRouter,
         logger: coreServices.logger,
+        config: coreServices.rootConfig,
       },
       async init({
         httpRouter,
         logger,
+        config,
       }) {
         httpRouter.use(
           await createRouter({
             logger,
+            config,
           }),
         );
         httpRouter.addAuthPolicy({

--- a/packages/cli/templates/default-backend-plugin/src/service/router.test.ts
+++ b/packages/cli/templates/default-backend-plugin/src/service/router.test.ts
@@ -1,4 +1,4 @@
-import { getVoidLogger } from '@backstage/backend-common';
+import { mockServices } from '@backstage/backend-test-utils';
 import express from 'express';
 import request from 'supertest';
 
@@ -9,7 +9,8 @@ describe('createRouter', () => {
 
   beforeAll(async () => {
     const router = await createRouter({
-      logger: getVoidLogger(),
+      logger: mockServices.logger.mock(),
+      config: mockServices.rootConfig(),
     });
     app = express().use(router);
   });

--- a/packages/cli/templates/default-backend-plugin/src/service/router.ts
+++ b/packages/cli/templates/default-backend-plugin/src/service/router.ts
@@ -1,16 +1,18 @@
-import { errorHandler } from '@backstage/backend-common';
+import { MiddlewareFactory } from '@backstage/backend-defaults/rootHttpRouter';
 import { LoggerService } from '@backstage/backend-plugin-api';
+import { Config } from '@backstage/config';
 import express from 'express';
 import Router from 'express-promise-router';
 
 export interface RouterOptions {
   logger: LoggerService;
+  config: Config;
 }
 
 export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {
-  const { logger } = options;
+  const { logger, config } = options;
 
   const router = Router();
   router.use(express.json());
@@ -20,6 +22,8 @@ export async function createRouter(
     response.json({ status: 'ok' });
   });
 
-  router.use(errorHandler());
+  const middleware = MiddlewareFactory.create({ logger, config });
+
+  router.use(middleware.error());
   return router;
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Resolves issue: #25379 

- Fix deprecation notice for `@backstage/backstage-common#errorHandler` so it points directly to the updated method
- Update default backend plugin created using cli to use updated error handling middleware from `@backstage/backend-defaults/rootHttpRouter`
- Update default backend plugin router test to use updated mocks from `@backstage/backend-test-utils` instead of deprecated imports from `@backstage/backstage-common`

Let me know any feedback! Thank you!

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
