### PR TITLE
e2e-tests: wait for plugins before start

### DIFF
--- a/packages/e2e-test/src/commands/run.ts
+++ b/packages/e2e-test/src/commands/run.ts
@@ -537,7 +537,9 @@ async function testBackendStart(appDir: string, ...args: string[]) {
 
   try {
     await waitFor(
-      () => stdout.includes('Listening on ') || filterStderr(stderr).length > 0,
+      () =>
+        stdout.includes('Plugin initialization complete') ||
+        filterStderr(stderr).length > 0,
     );
     const stderrLines = filterStderr(stderr);
     if (stderrLines.length > 0) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR should fix some flakiness of the e2e tests. Example error:

```
2024-06-21T18:31:52.560Z backstage info Found 2 new secrets in config that will be redacted
2024-06-21T18:31:52.569Z rootHttpRouter info Listening on :7007
2024-06-21T18:31:52.571Z backstage info Plugin initialization started: 'app', 'proxy', 'scaffolder', 'techdocs', 'auth', 'catalog', 'permission', 'search' type=initialization
2024-06-21T18:31:52.709Z app info Serving static app content from /tmp/backstage-e2e-9zriiq/test-app/packages/app/dist
2024-06-21T18:31:53.242Z app info Replacing injected env config in module-backstage.161c78a3.js entry=main
2024-06-21T18:31:53.257Z app info Storing 0 updated assets and 290 new assets
2024-06-21T18:31:53.364Z scaffolder info Starting scaffolder with the following actions enabled fetch:plain, fetch:plain:file, fetch:template, debug:log, debug:wait, catalog:register, catalog:fetch, catalog:write, fs:delete, fs:rename
2024-06-21T18:31:53.482Z techdocs info Creating Local publisher for TechDocs
2024-06-21T18:31:53.536Z auth info Configuring "database" as KeyStore provider
2024-06-21T18:31:53.572Z backstage info Plugin initialization in progress, newly initialized: 'proxy', 'techdocs', 'scaffolder', still initializing: 'app', 'auth', 'catalog', 'permission', 'search' type=initialization
Try to fetch entities from the backend

Stopping the child process
2024-06-21T18:31:53.621Z rootHttpRouter info ::1 - - [21/Jun/2024:18:31:53 +0000] "GET /api/catalog/entities HTTP/1.1" 404 - "-" "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)" type=incomingRequest
2024-06-21T18:31:53.666Z catalog info Performing database migration
/home/runner/work/backstage/backstage/packages/e2e-test/src/commands/run.ts:547
        throw new Error(`Backend failed to startup: ${error}`);
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
