### PR TITLE
Update PluginEnvironment Type in IncrementalEntityProvider to use non-deprecated types

### DIFF
--- a/.changeset/chatty-crabs-eat.md
+++ b/.changeset/chatty-crabs-eat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-incremental-ingestion': minor
+---
+
+Add support for new, non-deprecated types in IncrementalCatalogBuilder

--- a/plugins/catalog-backend-module-incremental-ingestion/README.md
+++ b/plugins/catalog-backend-module-incremental-ingestion/README.md
@@ -42,13 +42,16 @@ The Incremental Entity Provider backend is designed for data sources that provid
 ## Installation
 
 1. Install `@backstage/plugin-catalog-backend-module-incremental-ingestion` with `yarn --cwd packages/backend add @backstage/plugin-catalog-backend-module-incremental-ingestion` from the Backstage root directory.
-2. In your catalog.ts, import `IncrementalCatalogBuilder` from `@backstage/plugin-catalog-backend-module-incremental-ingestion` and instantiate it with `await IncrementalCatalogBuilder.create(env, builder)`. You have to pass `builder` into `IncrementalCatalogBuilder.create` function because `IncrementalCatalogBuilder` will convert an `IncrementalEntityProvider` into an `EntityProvider` and call `builder.addEntityProvider`.
+2. In your catalog.ts, import `IncrementalCatalogBuilder` from `@backstage/plugin-catalog-backend-module-incremental-ingestion` and instantiate it with `await IncrementalCatalogBuilder.createV2(env, builder)`. You have to pass `builder` into `IncrementalCatalogBuilder.create` function because `IncrementalCatalogBuilder` will convert an `IncrementalEntityProvider` into an `EntityProvider` and call `builder.addEntityProvider`.
 
 ```ts
-const builder = CatalogBuilder.create(env);
+const builder = CatalogBuilder.createV2(env);
 // incremental builder receives builder because it'll register
 // incremental entity providers with the builder
-const incrementalBuilder = await IncrementalCatalogBuilder.create(env, builder);
+const incrementalBuilder = await IncrementalCatalogBuilder.createV2(
+  env,
+  builder,
+);
 ```
 
 3. After building the regular `CatalogBuilder`, build the incremental builder:
@@ -63,21 +66,21 @@ const { incrementalAdminRouter } = await incrementBuilder.build();
 
 The final result should look something like this,
 
-```ts
+````ts
 import { CatalogBuilder } from '@backstage/plugin-catalog-backend';
 import { ScaffolderEntitiesProcessor } from '@backstage/plugin-scaffolder-backend';
 import { IncrementalCatalogBuilder } from '@backstage/plugin-catalog-backend-module-incremental-ingestion';
 import { Router } from 'express';
 import { Duration } from 'luxon';
-import { PluginEnvironment } from '../types';
+import { PluginEnvironmentV2 } from '../types';
 
 export default async function createPlugin(
-  env: PluginEnvironment,
+  env: PluginEnvironmentV2,
 ): Promise<Router> {
   const builder = CatalogBuilder.create(env);
   // incremental builder receives builder because it'll register
   // incremental entity providers with the builder
-  const incrementalBuilder = await IncrementalCatalogBuilder.create(
+  const incrementalBuilder = await IncrementalCatalogBuilder.createV2(
     env,
     builder,
   );
@@ -93,7 +96,11 @@ export default async function createPlugin(
 
   return router;
 }
-```
+
+> **Note**
+>
+> If you are using an older plugin that does not use the necessary types required for `PluginEnvironmentV2`,
+> you can use the `create()` method instead of `createV2()`
 
 ## Administrative Routes
 
@@ -149,7 +156,7 @@ interface IncrementalEntityProvider<TCursor, TContext> {
    */
   around(burst: (context: TContext) => Promise<void>): Promise<void>;
 }
-```
+````
 
 For this tutorial, we'll write an Incremental Entity Provider that will call an imaginary API. This imaginary API will return a list of imaginary services. The imaginary API has an imaginary API client with the following interface.
 
@@ -312,7 +319,10 @@ Now that you have your new Incremental Entity Provider, we can connect it to the
 We'll assume you followed the <a href="#installation">Installation</a> instructions. After you create your `incrementalBuilder`, you can instantiate your Entity Provider and pass it to the `addIncrementalEntityProvider` method.
 
 ```ts
-const incrementalBuilder = await IncrementalCatalogBuilder.create(env, builder);
+const incrementalBuilder = await IncrementalCatalogBuilder.createV2(
+  env,
+  builder,
+);
 
 // Assuming the token for the API comes from config
 const token = config.getString('myApiClient.token');

--- a/plugins/catalog-backend-module-incremental-ingestion/api-report.md
+++ b/plugins/catalog-backend-module-incremental-ingestion/api-report.md
@@ -7,6 +7,7 @@
 
 import { CatalogBuilder } from '@backstage/plugin-catalog-backend';
 import type { Config } from '@backstage/config';
+import { DatabaseService } from '@backstage/backend-plugin-api';
 import type { DeferredEntity } from '@backstage/plugin-catalog-node';
 import type { DurationObjectUnits } from 'luxon';
 import { EventParams } from '@backstage/plugin-events-node';
@@ -16,7 +17,9 @@ import type { PermissionEvaluator } from '@backstage/plugin-permission-common';
 import type { PluginDatabaseManager } from '@backstage/backend-common';
 import type { PluginTaskScheduler } from '@backstage/backend-tasks';
 import { Router } from 'express';
+import { SchedulerService } from '@backstage/backend-plugin-api';
 import type { UrlReader } from '@backstage/backend-common';
+import { UrlReaderService } from '@backstage/backend-plugin-api';
 
 // @public
 export type EntityIteratorResult<T> =
@@ -42,8 +45,13 @@ export class IncrementalCatalogBuilder {
   build(): Promise<{
     incrementalAdminRouter: Router;
   }>;
+  // @deprecated
   static create(
     env: PluginEnvironment,
+    builder: CatalogBuilder,
+  ): Promise<IncrementalCatalogBuilder>;
+  static createV2(
+    env: PluginEnvironmentV2,
     builder: CatalogBuilder,
   ): Promise<IncrementalCatalogBuilder>;
 }
@@ -85,13 +93,23 @@ export interface IncrementalEntityProviderOptions {
   restLength: DurationObjectUnits;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type PluginEnvironment = {
   logger: Logger;
   database: PluginDatabaseManager;
   scheduler: PluginTaskScheduler;
   config: Config;
   reader: UrlReader;
+  permissions: PermissionEvaluator;
+};
+
+// @public (undocumented)
+export type PluginEnvironmentV2 = {
+  logger: Logger;
+  database: DatabaseService;
+  scheduler: SchedulerService;
+  config: Config;
+  reader: UrlReaderService;
   permissions: PermissionEvaluator;
 };
 ```

--- a/plugins/catalog-backend-module-incremental-ingestion/src/index.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/index.ts
@@ -27,4 +27,5 @@ export {
   type IncrementalEntityProvider,
   type IncrementalEntityProviderOptions,
   type PluginEnvironment,
+  type PluginEnvironmentV2,
 } from './types';

--- a/plugins/catalog-backend-module-incremental-ingestion/src/service/IncrementalCatalogBuilder.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/service/IncrementalCatalogBuilder.ts
@@ -18,6 +18,7 @@ import {
   IncrementalEntityProvider,
   IncrementalEntityProviderOptions,
   PluginEnvironment,
+  PluginEnvironmentV2,
 } from '../types';
 import { CatalogBuilder as CoreCatalogBuilder } from '@backstage/plugin-catalog-backend';
 import { Duration } from 'luxon';
@@ -36,8 +37,15 @@ export class IncrementalCatalogBuilder {
    * @param env - PluginEnvironment
    * @param builder - CatalogBuilder
    * @returns IncrementalCatalogBuilder
+   * @deprecated Use the createV2 method with the PluginEnvironmentV2 type instead.
    */
   static async create(env: PluginEnvironment, builder: CoreCatalogBuilder) {
+    const client = await env.database.getClient();
+    const manager = new IncrementalIngestionDatabaseManager({ client });
+    return new IncrementalCatalogBuilder(env, builder, client, manager);
+  }
+
+  static async createV2(env: PluginEnvironmentV2, builder: CoreCatalogBuilder) {
     const client = await env.database.getClient();
     const manager = new IncrementalIngestionDatabaseManager({ client });
     return new IncrementalCatalogBuilder(env, builder, client, manager);
@@ -46,7 +54,7 @@ export class IncrementalCatalogBuilder {
   private ready: Deferred<void>;
 
   private constructor(
-    private env: PluginEnvironment,
+    private env: PluginEnvironment | PluginEnvironmentV2,
     private builder: CoreCatalogBuilder,
     private client: Knex,
     private manager: IncrementalIngestionDatabaseManager,

--- a/plugins/catalog-backend-module-incremental-ingestion/src/service/IncrementalCatalogBuilder.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/service/IncrementalCatalogBuilder.ts
@@ -45,6 +45,12 @@ export class IncrementalCatalogBuilder {
     return new IncrementalCatalogBuilder(env, builder, client, manager);
   }
 
+  /**
+   * Creates the incremental catalog builder, which extends the regular catalog builder.
+   * @param env - PluginEnvironmentV2
+   * @param builder - CatalogBuilder
+   * @returns IncrementalCatalogBuilder
+   */
   static async createV2(env: PluginEnvironmentV2, builder: CoreCatalogBuilder) {
     const client = await env.database.getClient();
     const manager = new IncrementalIngestionDatabaseManager({ client });

--- a/plugins/catalog-backend-module-incremental-ingestion/src/types.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/types.ts
@@ -32,7 +32,12 @@ import type { PermissionEvaluator } from '@backstage/plugin-permission-common';
 import type { DurationObjectUnits } from 'luxon';
 import type { Logger } from 'winston';
 import { IncrementalIngestionDatabaseManager } from './database/IncrementalIngestionDatabaseManager';
-import { LoggerService } from '@backstage/backend-plugin-api';
+import {
+  DatabaseService,
+  LoggerService,
+  SchedulerService,
+  UrlReaderService,
+} from '@backstage/backend-plugin-api';
 
 /**
  * Ingest entities into the catalog in bite-sized chunks.
@@ -186,13 +191,28 @@ export interface IncrementalEntityProviderOptions {
   rejectEmptySourceCollections?: boolean;
 }
 
-/** @public */
+/**
+ * @public
+ * @deprecated Many types here are deprecated. Use PluginEnvironmentV2 instead.
+ */
 export type PluginEnvironment = {
   logger: Logger;
   database: PluginDatabaseManager;
   scheduler: PluginTaskScheduler;
   config: Config;
   reader: UrlReader;
+  permissions: PermissionEvaluator;
+};
+
+/**
+ * @public
+ */
+export type PluginEnvironmentV2 = {
+  logger: Logger;
+  database: DatabaseService;
+  scheduler: SchedulerService;
+  config: Config;
+  reader: UrlReaderService;
   permissions: PermissionEvaluator;
 };
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

PluginEnvironment contains several deprecated types. This PR creates a PluginEnvironmentV2 type which contains the non-deprecates/new types (`DatabaseService`, `LoggerService`, `SchedulerService`, `UrlReaderService`).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
