### PR TITLE
techdocs: fix double scroll bug

### DIFF
--- a/.changeset/metal-parents-brush.md
+++ b/.changeset/metal-parents-brush.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Fix double scrollbar bug in reader

--- a/plugins/techdocs/src/reader/transformers/styles/rules/layout.ts
+++ b/plugins/techdocs/src/reader/transformers/styles/rules/layout.ts
@@ -74,6 +74,7 @@ export default ({ theme, sidebar }: RuleOptions) => `
 }
 .md-sidebar .md-sidebar__scrollwrap {
   width: calc(12.1rem);
+  overflow-y: hidden;
 }
 .md-sidebar--secondary {
   right: ${theme.spacing(3)}px;
@@ -234,7 +235,7 @@ export default ({ theme, sidebar }: RuleOptions) => `
   #toggle-sidebar {
     display: none;
   }
-  
+
   .md-content {
     margin: 0;
     width: 100%;


### PR DESCRIPTION
Part of #22745

Before:

https://github.com/backstage/backstage/assets/3097461/eaeb58d4-5fc0-45bd-ab0b-29b4766af5ed

After:

https://github.com/backstage/backstage/assets/3097461/977e3952-87bf-4728-8d42-8293ca600ce7

The sidebars still have scrollbars _if they are shorter_ than the viewport height. That's intentional since they are made to be sticky, and the user should be able to still select any target on any screen size, when there are lots of entries in them.

Note that after this change, specifically in Firefox there used to be an _additional_ problem with scrollbars and those are now down one problem fewer. So in Firefox there were two bugs to fix and this only fixes one of them.