### PR TITLE
Update useGetEntities.ts

### DIFF
--- a/plugins/org/src/components/Cards/OwnershipCard/useGetEntities.ts
+++ b/plugins/org/src/components/Cards/OwnershipCard/useGetEntities.ts
@@ -34,7 +34,7 @@ import qs from 'qs';
 import { EntityRelationAggregation } from '../types';
 import { uniq } from 'lodash';
 
-const limiter = limiterFactory(5);
+const limiter = limiterFactory(20);
 
 type EntityTypeProps = {
   kind: string;


### PR DESCRIPTION
Increasing concurrency of limiter factory to fix keep-on-loading during aggregating ownership. https://github.com/backstage/backstage/issues/25396

In Group page, there is ownership card which keeps loading when the data is /by-refs concurrency goes beyond given value. Increasing the value to load the necessary aggregated ownership.
