### PR TITLE
improve default docs sorting

### DIFF
--- a/.changeset/eleven-radios-begin.md
+++ b/.changeset/eleven-radios-begin.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Improve default sorting of docs table

--- a/plugins/techdocs/src/home/components/Tables/DocsTable.tsx
+++ b/plugins/techdocs/src/home/components/Tables/DocsTable.tsx
@@ -51,6 +51,13 @@ export type DocsTableProps = {
   options?: TableOptions<DocsTableRow>;
 };
 
+const defaultColumns: TableColumn<DocsTableRow>[] = [
+  columnFactories.createNameColumn(),
+  columnFactories.createOwnerColumn(),
+  columnFactories.createKindColumn(),
+  columnFactories.createTypeColumn(),
+];
+
 /**
  * Component which renders a table documents
  *
@@ -83,13 +90,6 @@ export const DocsTable = (props: DocsTableProps) => {
       },
     };
   });
-
-  const defaultColumns: TableColumn<DocsTableRow>[] = [
-    columnFactories.createNameColumn(),
-    columnFactories.createOwnerColumn(),
-    columnFactories.createKindColumn(),
-    columnFactories.createTypeColumn(),
-  ];
 
   const defaultActions: TableProps<DocsTableRow>['actions'] = [
     actionFactories.createCopyDocsUrlAction(copyToClipboard),

--- a/plugins/techdocs/src/home/components/Tables/columns.tsx
+++ b/plugins/techdocs/src/home/components/Tables/columns.tsx
@@ -35,6 +35,12 @@ export const columnFactories = {
       title: 'Document',
       field: 'entity.metadata.name',
       highlight: true,
+      defaultSort: 'asc',
+      customSort: (row1, row2) => {
+        const title1 = customTitle(row1.entity).toLocaleLowerCase();
+        const title2 = customTitle(row2.entity).toLocaleLowerCase();
+        return title1.localeCompare(title2);
+      },
       render: (row: DocsTableRow) => (
         <SubvalueCell
           value={


### PR DESCRIPTION
Before this PR, the documentation table typically found at `/docs` had two problems:

- The entries were unsorted by default. I.e. whatever the catalog response entity order was, was also the row order in the table
- When ordering by the first column by clicking on its header cell, if some of the entities had titles, the sorting was not properly lexicographical

After this PR:

- Ordering by the first column is enabled by default (ascending, case insensitive) so that you normally get sorted results
- The sorting uses the same string as the one which is rendered, making it less confusing