### PR TITLE
feat(visitsApi): make use of `limit` query param in `.list()` function

### DIFF
--- a/.changeset/olive-walls-wave.md
+++ b/.changeset/olive-walls-wave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-home': minor
+---
+
+**BREAKING** Implement usage of unused `limit` query param in visits API `.list()` function

--- a/plugins/home/src/api/VisitsStorageApi.ts
+++ b/plugins/home/src/api/VisitsStorageApi.ts
@@ -30,6 +30,8 @@ export type VisitsStorageApiOptions = {
 
 type ArrayElement<A> = A extends readonly (infer T)[] ? T : never;
 
+const DEFAULT_LIST_LIMIT = 8;
+
 /**
  * @public
  * This is an implementation of VisitsApi that relies on a StorageApi.
@@ -83,7 +85,7 @@ export class VisitsStorageApi implements VisitsApi {
       });
     });
 
-    return visits;
+    return visits.slice(0, queryParams?.limit ?? DEFAULT_LIST_LIMIT);
   }
 
   /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I added the usage of `limit` query param in visitsApi `.list()` function. It was possible to pass a limit to the function but without any effect

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

#### Issue

#25417 
