### PR TITLE
support negation of full text search

### DIFF
--- a/.changeset/lemon-suns-sparkle.md
+++ b/.changeset/lemon-suns-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': minor
+---
+
+Support negation of full text search in `/entities/by-query` of catalog API.

--- a/plugins/catalog-backend/src/catalog/types.ts
+++ b/plugins/catalog-backend/src/catalog/types.ts
@@ -198,11 +198,16 @@ export interface QueryEntitiesInitialRequest {
   limit?: number;
   filter?: EntityFilter;
   orderFields?: EntityOrder[];
-  fullTextFilter?: {
-    term: string;
-    fields?: string[];
-  };
+  fullTextFilter?: FullTextFilter | { not: FullTextFilter };
 }
+
+/**
+ * The structure of a full text filter.
+ */
+export type FullTextFilter = {
+  term: string;
+  fields?: string[];
+};
 
 /**
  * Request for {@link EntitiesCatalog.queryEntities} used to
@@ -264,10 +269,7 @@ export type Cursor = {
   /**
    * Used for performing full text filtering on the given fields.
    */
-  fullTextFilter?: {
-    term: string;
-    fields?: string[];
-  };
+  fullTextFilter?: FullTextFilter | { not: FullTextFilter };
   /**
    * The value of the fields of the first returned item used for paginating the data.
    * The catalog uses this field internally to understand if the beginning

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -35,6 +35,7 @@ import {
   EntityFacetsResponse,
   EntityOrder,
   EntityPagination,
+  FullTextFilter,
   QueryEntitiesRequest,
   QueryEntitiesResponse,
 } from '../catalog/types';
@@ -151,6 +152,12 @@ function isOrEntityFilter(
 function isNegationEntityFilter(
   filter: { not: EntityFilter } | EntityFilter,
 ): filter is { not: EntityFilter } {
+  return filter.hasOwnProperty('not');
+}
+
+function isNegationFullTextFilter(
+  filter: { not: FullTextFilter } | FullTextFilter,
+): filter is { not: FullTextFilter } {
   return filter.hasOwnProperty('not');
 }
 
@@ -394,34 +401,43 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
         'final_entities.entity_id',
       );
     }
-
-    const normalizedFullTextFilterTerm = cursor.fullTextFilter?.term?.trim();
-    const textFilterFields = cursor.fullTextFilter?.fields ?? [sortField.field];
-    if (normalizedFullTextFilterTerm) {
-      if (
-        textFilterFields.length === 1 &&
-        textFilterFields[0] === sortField.field
-      ) {
-        // If there is one item, apply the like query to the top level query which is already
-        //   filtered based on the singular sortField.
-        dbQuery.andWhereRaw(
-          'value like ?',
-          `%${normalizedFullTextFilterTerm.toLocaleLowerCase('en-US')}%`,
-        );
+    if (cursor.fullTextFilter) {
+      let fullTextFilter: FullTextFilter;
+      let fullTextCompare: string;
+      if (isNegationFullTextFilter(cursor.fullTextFilter)) {
+        fullTextFilter = cursor.fullTextFilter.not;
+        fullTextCompare = 'value not like ?';
       } else {
-        const matchQuery = db<DbSearchRow>('search')
-          .select('search.entity_id')
-          .whereIn('key', textFilterFields)
-          .andWhere(function keyFilter() {
-            this.andWhereRaw(
-              'value like ?',
-              `%${normalizedFullTextFilterTerm.toLocaleLowerCase('en-US')}%`,
-            );
-          });
-        dbQuery.andWhere('final_entities.entity_id', 'in', matchQuery);
+        fullTextFilter = cursor.fullTextFilter;
+        fullTextCompare = 'value like ?';
+      }
+      const normalizedFullTextFilterTerm = fullTextFilter.term?.trim();
+      const textFilterFields = fullTextFilter.fields ?? [sortField.field];
+      if (normalizedFullTextFilterTerm) {
+        if (
+          textFilterFields.length === 1 &&
+          textFilterFields[0] === sortField.field
+        ) {
+          // If there is one item, apply the like query to the top level query which is already
+          //   filtered based on the singular sortField.
+          dbQuery.andWhereRaw(
+            fullTextCompare,
+            `%${normalizedFullTextFilterTerm.toLocaleLowerCase('en-US')}%`,
+          );
+        } else {
+          const matchQuery = db<DbSearchRow>('search')
+            .select('search.entity_id')
+            .whereIn('key', textFilterFields)
+            .andWhere(function keyFilter() {
+              this.andWhereRaw(
+                fullTextCompare,
+                `%${normalizedFullTextFilterTerm.toLocaleLowerCase('en-US')}%`,
+              );
+            });
+          dbQuery.andWhere('final_entities.entity_id', 'in', matchQuery);
+        }
       }
     }
-
     const countQuery = dbQuery.clone();
 
     const isOrderingDescending = sortField.order === 'desc';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Support negation of full text search in `/entities/by-query` of catalog API.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
