### PR TITLE
Shadow Root MutationObserver

### DIFF
--- a/.changeset/clever-waves-judge.md
+++ b/.changeset/clever-waves-judge.md
@@ -1,6 +1,5 @@
 ---
 '@backstage/plugin-techdocs-react': patch
-'@backstage/plugin-techdocs': patch
 ---
 
-Fixed a bug with the TechDocsReaderPageProvider not re-rendering when setShadowDom is called, meaning that the useShadowDom hooks were inconsistent. This issue caused the TextSize addon changes not to reapply during navigation.
+Resolved the issue where changes in TechDoc add-ons, including the TextSize add-on, were not reapplying during navigation

--- a/plugins/techdocs-react/api-report.md
+++ b/plugins/techdocs-react/api-report.md
@@ -116,8 +116,6 @@ export type TechDocsReaderPageValue = {
   entityMetadata: AsyncState<TechDocsEntityMetadata>;
   shadowRoot?: ShadowRoot;
   setShadowRoot: Dispatch<SetStateAction<ShadowRoot | undefined>>;
-  shadowRootVersion: number;
-  incShadowRootVersion: () => void;
   title: string;
   setTitle: Dispatch<SetStateAction<string>>;
   subtitle: string;

--- a/plugins/techdocs-react/src/context.tsx
+++ b/plugins/techdocs-react/src/context.tsx
@@ -25,7 +25,6 @@ import React, {
 } from 'react';
 import useAsync, { AsyncState } from 'react-use/esm/useAsync';
 import useAsyncRetry from 'react-use/esm/useAsyncRetry';
-import useCounter from 'react-use/esm/useCounter';
 
 import {
   CompoundEntityRef,
@@ -65,8 +64,6 @@ export type TechDocsReaderPageValue = {
   entityMetadata: AsyncState<TechDocsEntityMetadata>;
   shadowRoot?: ShadowRoot;
   setShadowRoot: Dispatch<SetStateAction<ShadowRoot | undefined>>;
-  shadowRootVersion: number;
-  incShadowRootVersion: () => void;
   title: string;
   setTitle: Dispatch<SetStateAction<string>>;
   subtitle: string;
@@ -83,8 +80,6 @@ const defaultTechDocsReaderPageValue: TechDocsReaderPageValue = {
   setTitle: () => {},
   setSubtitle: () => {},
   setShadowRoot: () => {},
-  shadowRootVersion: 0,
-  incShadowRootVersion: () => {},
   metadata: { loading: true },
   entityMetadata: { loading: true },
   entityRef: { kind: '', name: '', namespace: '' },
@@ -139,7 +134,6 @@ export const TechDocsReaderPageProvider = memo(
     const [shadowRoot, setShadowRoot] = useState<ShadowRoot | undefined>(
       defaultTechDocsReaderPageValue.shadowRoot,
     );
-    const [shadowRootVersion, { inc: incShadowRootVersion }] = useCounter(0);
 
     useEffect(() => {
       if (shadowRoot && !metadata.value && !metadata.loading) {
@@ -159,8 +153,6 @@ export const TechDocsReaderPageProvider = memo(
       entityMetadata,
       shadowRoot,
       setShadowRoot,
-      shadowRootVersion,
-      incShadowRootVersion,
       title,
       setTitle,
       subtitle,
@@ -198,5 +190,6 @@ export const useTechDocsReaderPage = () => {
   if (context === undefined) {
     throw new Error('No context found for version 1.');
   }
+
   return context;
 };

--- a/plugins/techdocs-react/src/hooks.ts
+++ b/plugins/techdocs-react/src/hooks.ts
@@ -39,13 +39,13 @@ export const useShadowRootElements = <
   selectors: string[],
 ): TReturnedElement[] => {
   const shadowRoot = useShadowRoot();
-  const [root, setRootNode] = useState(shadowRoot?.querySelector('html'));
+  const [render, rerender] = useState(false);
 
   useEffect(() => {
     let observer: MutationObserver;
     if (shadowRoot) {
       observer = new MutationObserver(() => {
-        setRootNode(shadowRoot.querySelector('html'));
+        rerender(!render);
       });
       observer.observe(shadowRoot, {
         attributes: true,
@@ -55,12 +55,12 @@ export const useShadowRootElements = <
       });
     }
     return () => observer?.disconnect();
-  }, [shadowRoot]);
+  }, [shadowRoot, render, rerender]);
 
-  if (!root) return [];
+  if (!shadowRoot) return [];
 
   return selectors
-    .map(selector => root.querySelectorAll<TReturnedElement>(selector))
+    .map(selector => shadowRoot.querySelectorAll<TReturnedElement>(selector))
     .filter(nodeList => nodeList.length)
     .map(nodeList => Array.from(nodeList))
     .flat();

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/TechDocsReaderPageContent.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/TechDocsReaderPageContent.tsx
@@ -80,7 +80,6 @@ export const TechDocsReaderPageContent = withTechDocsReaderProvider(
       entityMetadata: { value: entityMetadata, loading: entityMetadataLoading },
       entityRef,
       setShadowRoot,
-      incShadowRootVersion,
     } = useTechDocsReaderPage();
     const dom = useTechDocsReaderDom(entityRef);
     const path = window.location.pathname;
@@ -103,12 +102,11 @@ export const TechDocsReaderPageContent = withTechDocsReaderProvider(
     const handleAppend = useCallback(
       (newShadowRoot: ShadowRoot) => {
         setShadowRoot(newShadowRoot);
-        incShadowRootVersion();
         if (onReady instanceof Function) {
           onReady();
         }
       },
-      [setShadowRoot, incShadowRootVersion, onReady],
+      [setShadowRoot, onReady],
     );
 
     // No entity metadata = 404. Don't render content at all.


### PR DESCRIPTION


## Hey, I just made a Pull Request!

Rollback the changes in #25332 as it caused a [regression bug](https://github.com/backstage/backstage/issues/25414) 

The new fix for the issue raised in #24355 adds MutationObserver in useShadowRootElements so we can trigger updates when the elements under the shadow root change. Previously it was waiting for side-effects from the shadow root itself changing to update. However, that element doesn't change once it's created, new elements are appended to it. The MutationObserver listens for these appends and triggers the relevant side effects.


https://github.com/backstage/backstage/assets/671432/d0496605-498d-4d06-8323-ad81ceb4bdfb



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
