### PR TITLE
GitlabUrlReader: Allow fetch:plain Scaffolder action to use user-provided token

### DIFF
--- a/.changeset/nice-peas-retire.md
+++ b/.changeset/nice-peas-retire.md
@@ -1,0 +1,6 @@
+---
+'@backstage/integration': minor
+'@backstage/backend-defaults': patch
+---
+
+Updated `GitlabUrlReader.readUrl` and `GitlabUrlReader.readTree` to accept a user-provided token, supporting both bearer and private tokens.

--- a/packages/integration/api-report.md
+++ b/packages/integration/api-report.md
@@ -508,7 +508,10 @@ export function getGitLabIntegrationRelativePath(
 ): string;
 
 // @public
-export function getGitLabRequestOptions(config: GitLabIntegrationConfig): {
+export function getGitLabRequestOptions(
+  config: GitLabIntegrationConfig,
+  token?: string,
+): {
   headers: Record<string, string>;
 };
 

--- a/packages/integration/src/gitlab/core.test.ts
+++ b/packages/integration/src/gitlab/core.test.ts
@@ -189,15 +189,30 @@ describe('gitlab core', () => {
 
   describe('getGitLabRequestOptions', () => {
     it('should return Authorization header when oauthToken is provided', () => {
-      const oauthToken = 'mock-oauth-token';
+      const token =
+        'de6780bc506a0446309bd9362820ba8aed28aa506c71eedbe1c5c4f9dd350e54';
       const result = getGitLabRequestOptions(
         configSelfHosteWithRelativePath,
-        oauthToken,
+        token,
       );
 
       expect(result).toEqual({
         headers: {
-          Authorization: `Bearer ${oauthToken}`,
+          Authorization: `Bearer ${token}`,
+        },
+      });
+    });
+
+    it('should return private-token header when gl-token is provided', () => {
+      const token = 'glpat-1234566';
+      const result = getGitLabRequestOptions(
+        configSelfHosteWithRelativePath,
+        token,
+      );
+
+      expect(result).toEqual({
+        headers: {
+          'PRIVATE-TOKEN': token,
         },
       });
     });
@@ -208,7 +223,6 @@ describe('gitlab core', () => {
         configSelfHosteWithRelativePath,
         oauthToken,
       );
-
       expect(result).toEqual({
         headers: {
           'PRIVATE-TOKEN': configSelfHosteWithRelativePath.token,

--- a/packages/integration/src/gitlab/core.test.ts
+++ b/packages/integration/src/gitlab/core.test.ts
@@ -17,7 +17,7 @@
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { GitLabIntegrationConfig } from './config';
-import { getGitLabFileFetchUrl } from './core';
+import { getGitLabFileFetchUrl, getGitLabRequestOptions } from './core';
 
 const worker = setupServer();
 
@@ -183,6 +183,36 @@ describe('gitlab core', () => {
         await expect(
           getGitLabFileFetchUrl(target, configWithNoToken),
         ).resolves.toBe(fetchUrl);
+      });
+    });
+  });
+
+  describe('getGitLabRequestOptions', () => {
+    it('should return Authorization header when oauthToken is provided', () => {
+      const oauthToken = 'mock-oauth-token';
+      const result = getGitLabRequestOptions(
+        configSelfHosteWithRelativePath,
+        oauthToken,
+      );
+
+      expect(result).toEqual({
+        headers: {
+          Authorization: `Bearer ${oauthToken}`,
+        },
+      });
+    });
+
+    it('should return private-token header when oauthToken is undefined', () => {
+      const oauthToken = undefined;
+      const result = getGitLabRequestOptions(
+        configSelfHosteWithRelativePath,
+        oauthToken,
+      );
+
+      expect(result).toEqual({
+        headers: {
+          'PRIVATE-TOKEN': configSelfHosteWithRelativePath.token,
+        },
       });
     });
   });

--- a/packages/integration/src/gitlab/core.test.ts
+++ b/packages/integration/src/gitlab/core.test.ts
@@ -189,8 +189,7 @@ describe('gitlab core', () => {
 
   describe('getGitLabRequestOptions', () => {
     it('should return Authorization header when oauthToken is provided', () => {
-      const token =
-        'de6780bc506a0446309bd9362820ba8aed28aa506c71eedbe1c5c4f9dd350e54';
+      const token = '1234567890';
       const result = getGitLabRequestOptions(
         configSelfHosteWithRelativePath,
         token,

--- a/packages/integration/src/gitlab/core.ts
+++ b/packages/integration/src/gitlab/core.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+import fetch from 'cross-fetch';
 import {
   getGitLabIntegrationRelativePath,
   GitLabIntegrationConfig,
 } from './config';
-import fetch from 'cross-fetch';
 
 /**
  * Given a URL pointing to a file on a provider, returns a URL that is suitable
@@ -51,9 +51,18 @@ export async function getGitLabFileFetchUrl(
  * @param config - The relevant provider config
  * @public
  */
-export function getGitLabRequestOptions(config: GitLabIntegrationConfig): {
-  headers: Record<string, string>;
-} {
+export function getGitLabRequestOptions(
+  config: GitLabIntegrationConfig,
+  oauthToken?: string,
+): { headers: Record<string, string> } {
+  if (oauthToken) {
+    return {
+      headers: {
+        Authorization: `Bearer ${oauthToken}`,
+      },
+    };
+  }
+
   const { token = '' } = config;
   return {
     headers: {

--- a/packages/integration/src/gitlab/core.ts
+++ b/packages/integration/src/gitlab/core.ts
@@ -53,21 +53,21 @@ export async function getGitLabFileFetchUrl(
  */
 export function getGitLabRequestOptions(
   config: GitLabIntegrationConfig,
-  oauthToken?: string,
+  token?: string,
 ): { headers: Record<string, string> } {
-  if (oauthToken) {
+  if (token) {
+    // If token comes from the user and starts with "gl", it's a private token (see https://docs.gitlab.com/ee/security/token_overview.html#token-prefixes)
     return {
-      headers: {
-        Authorization: `Bearer ${oauthToken}`,
-      },
+      headers: token.startsWith('gl')
+        ? { 'PRIVATE-TOKEN': token }
+        : { Authorization: `Bearer ${token}` }, // Otherwise, it's a bearer token
     };
   }
 
-  const { token = '' } = config;
+  // If token not provided, fetch the integration token
+  const { token: configToken = '' } = config;
   return {
-    headers: {
-      'PRIVATE-TOKEN': token,
-    },
+    headers: { 'PRIVATE-TOKEN': configToken },
   };
 }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The Scaffolder action fetch:plain allows the user to input a token, however, in the GitLab case,  the action fallsback to the integration token.
This PR allows user-provided tokens (private or bearer) to be used in the requests. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
