### PR TITLE
chore: remove personal identifiable information (PII) from logs

### DIFF
--- a/.changeset/funny-tips-push.md
+++ b/.changeset/funny-tips-push.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+update the `morgan` middleware to use a custom format to prevent PII from being logged

--- a/.github/vale/config/vocabularies/Backstage/accept.txt
+++ b/.github/vale/config/vocabularies/Backstage/accept.txt
@@ -243,6 +243,7 @@ Mkdocs
 monorepo
 Monorepo
 monorepos
+morgan
 msgraph
 msw
 mutex

--- a/packages/backend-defaults/src/entrypoints/rootHttpRouter/http/MiddlewareFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/rootHttpRouter/http/MiddlewareFactory.ts
@@ -140,8 +140,9 @@ export class MiddlewareFactory {
     const logger = this.#logger.child({
       type: 'incomingRequest',
     });
-
-    return morgan('combined', {
+    const customMorganFormat =
+      '[:date[clf]] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent"';
+    return morgan(customMorganFormat, {
       stream: {
         write(message: string) {
           logger.info(message.trimEnd());


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Currently the logs for requests to the backend routers will log PII of the requester, namely the [`ip`](https://github.com/expressjs/morgan?tab=readme-ov-file#remote-addr) and [`remote-user`](https://github.com/expressjs/morgan?tab=readme-ov-file#remote-user) making the request due to the router logging middleware using the [`combined` format of the `morgan` middleware](https://github.com/expressjs/morgan?tab=readme-ov-file#combined).

This PR applies a [custom `morgan` format](https://github.com/expressjs/morgan?tab=readme-ov-file#using-format-string-of-predefined-tokens) that removes the exposed PII while keeping everything else logged by the `combined` format.

Before (tested locally so it's using `::1` as the ip):
```bash
2024-06-27T20:59:01.057Z rootHttpRouter info ::1 - - [27/Jun/2024:20:59:01 +0000] "GET /api/scaffolder/v2/actions HTTP/1.1" 304 - "http://localhost:3000/" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36" type=incomingRequest trace_id=1a9848fb2c604d83dffc11d25e9f015a span_id=9053cd6cf70330a2 trace_flags=01
```
After:
```
2024-06-27T20:55:14.493Z rootHttpRouter info [27/Jun/2024:20:55:14 +0000] "GET /api/scaffolder/v2/actions HTTP/1.1" 200 - "http://localhost:3000/" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36" type=incomingRequest trace_id=4400d1a197c3e4e0025feba34de665b0 span_id=3748f795a3b30fbd trace_flags=01
```
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
