### PR TITLE
Config schema to support app.routes.bindings

### DIFF
--- a/.changeset/friendly-experts-fail.md
+++ b/.changeset/friendly-experts-fail.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-app-api': patch
+---
+
+Updated config schema to support app.routes.bindings

--- a/packages/core-app-api/config.d.ts
+++ b/packages/core-app-api/config.d.ts
@@ -65,6 +65,18 @@ export interface Config {
         }>;
       }>;
     };
+
+    routes?: {
+      /**
+       * Maps external route references to regular route references. Both the
+       * key and the value is expected to be on the form `<pluginId>.<routeId>`.
+       * If the value is `false`, the route will be disabled even if it has a
+       * default mapping.
+       *
+       * @deepVisibility frontend
+       */
+      bindings?: { [externalRouteRefId: string]: string | false };
+    };
   };
 
   /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds app.routes.bindings to core-app-api package

This is so that the config value can be used when initialising route bindings in AppManager: https://github.com/backstage/backstage/blob/master/packages/core-app-api/src/app/resolveRouteBindings.ts#L102

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
