### PR TITLE
feat: update ConfigSources options to match process.env typings

### DIFF
--- a/.changeset/neat-bears-divide.md
+++ b/.changeset/neat-bears-divide.md
@@ -1,0 +1,28 @@
+---
+'@backstage/config-loader': major
+---
+
+**BREAKING** The `env` property on the `ConfigSourcesDefaultOptions` interface allows for undefined members.
+
+This change makes `ConfigSourcesDefaultOptions.env` consistent with other parts of this package and the wider
+`node` ecosystem. Specifically, with this update `ConfigSourcesDefaultOptions.env`'s types match:
+
+#### EnvConfigSource
+
+- [`EnvConfigSource.constructor`](https://github.com/backstage/backstage/blob/c780320418b7775f18fc0d2cc279ee7db9c7cb25/packages/config-loader/src/sources/EnvConfigSource.ts#L68)
+- [`EnvConfigSourceOptions`](https://github.com/backstage/backstage/blob/c780320418b7775f18fc0d2cc279ee7db9c7cb25/packages/config-loader/src/sources/EnvConfigSource.ts#L31)
+- [`readEnvConfig`](https://github.com/backstage/backstage/blob/c780320418b7775f18fc0d2cc279ee7db9c7cb25/packages/config-loader/src/sources/EnvConfigSource.ts#L114)
+
+#### NodeJS process.env
+
+- [`ProcessEnv`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/aa121ee3a7a3caa16433b66c1103df5904f612ea/types/node/v18/process.d.ts#L137)
+  which extends [`Dict`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/aa121ee3a7a3caa16433b66c1103df5904f612ea/types/node/v18/globals.d.ts#L333-L335)
+
+While this is a somewhat trivial change, it does loosen typings on a public interface, so by definition it's a breaking
+change and a major version bump.
+
+You may meed to update your backstage instance if you have built an implementation of `ConfigSources` or any other
+functionality that relies on `ConfigSourcesDefaultOptions`. This change means you'll have to update that code to account
+for the possibility of `undefined` values inside `ConfigSourcesDefaultOptions.env`, although it is very likely already
+accounted for as the typings for [`process.env`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/aa121ee3a7a3caa16433b66c1103df5904f612ea/types/node/v18/process.d.ts#L137)
+already include the possibility of [`undefined`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/aa121ee3a7a3caa16433b66c1103df5904f612ea/types/node/v18/globals.d.ts#L333-L335).

--- a/.changeset/neat-bears-divide.md
+++ b/.changeset/neat-bears-divide.md
@@ -1,28 +1,5 @@
 ---
-'@backstage/config-loader': major
+'@backstage/config-loader': patch
 ---
 
-**BREAKING** The `env` property on the `ConfigSourcesDefaultOptions` interface allows for undefined members.
-
-This change makes `ConfigSourcesDefaultOptions.env` consistent with other parts of this package and the wider
-`node` ecosystem. Specifically, with this update `ConfigSourcesDefaultOptions.env`'s types match:
-
-#### EnvConfigSource
-
-- [`EnvConfigSource.constructor`](https://github.com/backstage/backstage/blob/c780320418b7775f18fc0d2cc279ee7db9c7cb25/packages/config-loader/src/sources/EnvConfigSource.ts#L68)
-- [`EnvConfigSourceOptions`](https://github.com/backstage/backstage/blob/c780320418b7775f18fc0d2cc279ee7db9c7cb25/packages/config-loader/src/sources/EnvConfigSource.ts#L31)
-- [`readEnvConfig`](https://github.com/backstage/backstage/blob/c780320418b7775f18fc0d2cc279ee7db9c7cb25/packages/config-loader/src/sources/EnvConfigSource.ts#L114)
-
-#### NodeJS process.env
-
-- [`ProcessEnv`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/aa121ee3a7a3caa16433b66c1103df5904f612ea/types/node/v18/process.d.ts#L137)
-  which extends [`Dict`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/aa121ee3a7a3caa16433b66c1103df5904f612ea/types/node/v18/globals.d.ts#L333-L335)
-
-While this is a somewhat trivial change, it does loosen typings on a public interface, so by definition it's a breaking
-change and a major version bump.
-
-You may meed to update your backstage instance if you have built an implementation of `ConfigSources` or any other
-functionality that relies on `ConfigSourcesDefaultOptions`. This change means you'll have to update that code to account
-for the possibility of `undefined` values inside `ConfigSourcesDefaultOptions.env`, although it is very likely already
-accounted for as the typings for [`process.env`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/aa121ee3a7a3caa16433b66c1103df5904f612ea/types/node/v18/process.d.ts#L137)
-already include the possibility of [`undefined`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/aa121ee3a7a3caa16433b66c1103df5904f612ea/types/node/v18/globals.d.ts#L333-L335).
+The `env` option of `ConfigSources.default` now correctly allows undefined members.

--- a/packages/config-loader/api-report.md
+++ b/packages/config-loader/api-report.md
@@ -87,7 +87,7 @@ export interface ConfigSourcesDefaultOptions extends BaseConfigSourcesOptions {
   // (undocumented)
   argv?: string[];
   // (undocumented)
-  env?: Record<string, string>;
+  env?: Record<string, string | undefined>;
 }
 
 // @public

--- a/packages/config-loader/src/sources/ConfigSources.ts
+++ b/packages/config-loader/src/sources/ConfigSources.ts
@@ -102,7 +102,7 @@ export interface ConfigSourcesDefaultForTargetsOptions
  */
 export interface ConfigSourcesDefaultOptions extends BaseConfigSourcesOptions {
   argv?: string[];
-  env?: Record<string, string>;
+  env?: Record<string, string | undefined>;
 }
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

**BREAKING** The `env` property on the `ConfigSourcesDefaultOptions` interface now allows for undefined members.

This change makes `ConfigSourcesDefaultOptions.env` consistent with other parts of this package and the wider
`node` ecosystem.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
