### PR TITLE
Gitlab Scaffolder: TriggerPipelineAction - Add missing ability to pass variables to the pipelines

### DIFF
--- a/.changeset/three-carpets-smoke.md
+++ b/.changeset/three-carpets-smoke.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gitlab': minor
+---
+
+Fixed trigger pipeline accepting input variables

--- a/.changeset/three-carpets-smoke.md
+++ b/.changeset/three-carpets-smoke.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-scaffolder-backend-module-gitlab': minor
+'@backstage/plugin-scaffolder-backend-module-gitlab': patch
 ---
 
-Fixed trigger pipeline accepting input variables
+Added support for passing `variables` to `gitlab:pipeline:trigger`

--- a/plugins/scaffolder-backend-module-gitlab/api-report.md
+++ b/plugins/scaffolder-backend-module-gitlab/api-report.md
@@ -211,6 +211,7 @@ export const createTriggerGitlabPipelineAction: (options: {
     projectId: number;
     tokenDescription: string;
     token?: string | undefined;
+    variables?: Record<string, string> | undefined;
   },
   {
     pipelineUrl: string;

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabPipelineTrigger.examples.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabPipelineTrigger.examples.ts
@@ -33,6 +33,7 @@ export const examples: TemplateExample[] = [
               'This is the text that will appear in the pipeline token',
             token: 'glpt-xxxxxxxxxxxx',
             branch: 'main',
+            variables: { var_one: 'one', var_two: 'two' },
           },
         },
       ],

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabPipelineTrigger.test.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabPipelineTrigger.test.ts
@@ -101,6 +101,7 @@ describe('gitlab:pipeline:trigger', () => {
       123,
       'main',
       'glptt-abcdef',
+      { variables: undefined },
     );
 
     expect(mockGitlabClient.PipelineTriggerTokens.remove).toHaveBeenCalledWith(
@@ -189,6 +190,7 @@ describe('gitlab:pipeline:trigger', () => {
       123,
       'main',
       'glptt-abcdef',
+      { variables: undefined },
     );
 
     expect(mockGitlabClient.PipelineTriggerTokens.remove).toHaveBeenCalledWith(
@@ -196,6 +198,7 @@ describe('gitlab:pipeline:trigger', () => {
       42,
     );
   });
+
   it('should clean up pipeline token on failure', async () => {
     const mockContext = createMockActionContext({
       input: {
@@ -230,6 +233,32 @@ describe('gitlab:pipeline:trigger', () => {
     expect(mockGitlabClient.PipelineTriggerTokens.remove).toHaveBeenCalledWith(
       123,
       42,
+    );
+  });
+
+  it('should succeed trigger and pass variables', async () => {
+    const mockContext = createMockActionContext({
+      input: {
+        repoUrl: 'gitlab.com?repo=repo&owner=owner',
+        projectId: 123,
+        tokenDescription: 'My cool pipeline token',
+        branch: 'main',
+        variables: { var_one: 'val1', var_two: 'val2' },
+      },
+      workspacePath: 'seen2much',
+    });
+
+    await expect(
+      action.handler({
+        ...mockContext,
+      }),
+    ).rejects.toThrow('Failed to trigger pipeline');
+
+    expect(mockGitlabClient.PipelineTriggerTokens.trigger).toHaveBeenCalledWith(
+      123,
+      'main',
+      'glptt-abcdef',
+      { variables: { var_one: 'val1', var_two: 'val2' } },
     );
   });
 });

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabPipelineTrigger.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabPipelineTrigger.ts
@@ -30,6 +30,12 @@ const pipelineInputProperties = z.object({
   projectId: z.number().describe('Project Id'),
   tokenDescription: z.string().describe('Pipeline token description'),
   branch: z.string().describe('Project branch'),
+  variables: z
+    .record(z.string(), z.string())
+    .optional()
+    .describe(
+      'A object/record of key-valued strings containing the pipeline variables.',
+    ),
 });
 
 const pipelineOutputProperties = z.object({
@@ -57,7 +63,7 @@ export const createTriggerGitlabPipelineAction = (options: {
     async handler(ctx) {
       let pipelineTokenResponse: PipelineTriggerTokenSchema | null = null;
 
-      const { repoUrl, projectId, tokenDescription, token, branch } =
+      const { repoUrl, projectId, tokenDescription, token, branch, variables } =
         commonGitlabConfig.merge(pipelineInputProperties).parse(ctx.input);
 
       const { host } = parseRepoUrl(repoUrl, integrations);
@@ -84,6 +90,7 @@ export const createTriggerGitlabPipelineAction = (options: {
             projectId,
             branch,
             pipelineTokenResponse.token,
+            { variables },
           )) as ExpandedPipelineSchema;
 
         if (!pipelineTriggerResponse.id) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I've added the ability to pass environment variables into the TriggerPipelineAction using Record<string,string>

#### :heavy_check_mark: Checklist

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [N/A] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

See Issue: #25461 

I've closed #25466  and replaced with this cleaner PR @elaine-mattos 
