### PR TITLE
Allow the oauth token to be used in the createGitlabProjectVariableAction Scaffolder action

### DIFF
--- a/.changeset/grumpy-owls-suffer.md
+++ b/.changeset/grumpy-owls-suffer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gitlab': patch
+---
+
+Allow the `createGitlabProjectVariableAction` to use oauth tokens

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabProjectVariableCreate.examples.test.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabProjectVariableCreate.examples.test.ts
@@ -26,7 +26,7 @@ const mockGitlabClient = {
     create: jest.fn(),
   },
 };
-jest.mock('@gitbeaker/node', () => ({
+jest.mock('@gitbeaker/rest', () => ({
   Gitlab: class {
     constructor() {
       return mockGitlabClient;
@@ -41,7 +41,7 @@ describe('gitlab:projectVariableAction: create examples', () => {
         {
           host: 'gitlab.com',
           token: 'tokenlols',
-          apiBaseUrl: 'https://api.gitlab.com',
+          apiBaseUrl: 'https://api.gitlab.com/api/v4',
         },
         {
           host: 'hosted.gitlab.com',
@@ -79,17 +79,18 @@ describe('gitlab:projectVariableAction: create examples', () => {
 
     expect(mockGitlabClient.ProjectVariables.create).toHaveBeenCalledWith(
       '123',
+      'MY_VARIABLE',
+      'my_value',
       {
-        key: 'MY_VARIABLE',
-        value: 'my_value',
-        variable_type: 'env_var',
-        environment_scope: '*',
+        variableType: 'env_var', // Correctly using variableType
+        environmentScope: '*',
         masked: false,
         protected: false,
         raw: false,
       },
     );
   });
+
   it(`Should ${examples[1].description}`, async () => {
     mockGitlabClient.ProjectVariables.create.mockResolvedValue({
       token: 'TOKEN',
@@ -102,14 +103,14 @@ describe('gitlab:projectVariableAction: create examples', () => {
 
     expect(mockGitlabClient.ProjectVariables.create).toHaveBeenCalledWith(
       '123',
+      'MY_VARIABLE',
+      'my-file-content',
       {
-        key: 'MY_VARIABLE',
-        value: 'my-file-content',
+        variableType: 'file', // Correctly using variableType
         protected: false,
         masked: false,
         raw: false,
-        environment_scope: '*',
-        variable_type: 'file',
+        environmentScope: '*',
       },
     );
   });
@@ -126,13 +127,13 @@ describe('gitlab:projectVariableAction: create examples', () => {
 
     expect(mockGitlabClient.ProjectVariables.create).toHaveBeenCalledWith(
       '456',
+      'MY_VARIABLE',
+      'my_value',
       {
-        key: 'MY_VARIABLE',
-        value: 'my_value',
         masked: false,
         raw: false,
-        environment_scope: '*',
-        variable_type: 'env_var',
+        environmentScope: '*',
+        variableType: 'env_var', // Correctly using variableType
         protected: true,
       },
     );
@@ -150,13 +151,13 @@ describe('gitlab:projectVariableAction: create examples', () => {
 
     expect(mockGitlabClient.ProjectVariables.create).toHaveBeenCalledWith(
       '789',
+      'DB_PASSWORD',
+      'password123',
       {
-        key: 'DB_PASSWORD',
-        value: 'password123',
         protected: false,
         raw: false,
-        environment_scope: '*',
-        variable_type: 'env_var',
+        environmentScope: '*',
+        variableType: 'env_var', // Correctly using variableType
         masked: true,
       },
     );
@@ -174,12 +175,12 @@ describe('gitlab:projectVariableAction: create examples', () => {
 
     expect(mockGitlabClient.ProjectVariables.create).toHaveBeenCalledWith(
       '123',
+      'MY_VARIABLE',
+      'my_value',
       {
-        key: 'MY_VARIABLE',
-        value: 'my_value',
         protected: false,
-        environment_scope: '*',
-        variable_type: 'env_var',
+        environmentScope: '*',
+        variableType: 'env_var', // Correctly using variableType
         masked: false,
         raw: true,
       },
@@ -198,14 +199,14 @@ describe('gitlab:projectVariableAction: create examples', () => {
 
     expect(mockGitlabClient.ProjectVariables.create).toHaveBeenCalledWith(
       '123',
+      'MY_VARIABLE',
+      'my_value',
       {
-        key: 'MY_VARIABLE',
-        value: 'my_value',
         protected: false,
-        variable_type: 'env_var',
+        variableType: 'env_var', // Correctly using variableType
         masked: false,
         raw: false,
-        environment_scope: 'production',
+        environmentScope: 'production',
       },
     );
   });
@@ -222,14 +223,14 @@ describe('gitlab:projectVariableAction: create examples', () => {
 
     expect(mockGitlabClient.ProjectVariables.create).toHaveBeenCalledWith(
       '123',
+      'MY_VARIABLE',
+      'my_value',
       {
-        key: 'MY_VARIABLE',
-        value: 'my_value',
         protected: false,
-        variable_type: 'env_var',
+        variableType: 'env_var', // Correctly using variableType
         masked: false,
         raw: false,
-        environment_scope: '*',
+        environmentScope: '*',
       },
     );
   });


### PR DESCRIPTION

## Hey, I just made a Pull Request!


This PR addresses the following issues:

1. Fixes the problem where `createGitlabProjectVariableAction` was unable to use OAuth tokens when provided, defaulting instead to the integration token. (This default behavior prevented the creation of project variables when the integration token user's permissions were insufficient. )
1. Replaces the [deprecated](https://www.npmjs.com/package/@gitbeaker/node) `gitbeaker/node` library with the recommended `gitbeaker/rest`.

This relates to https://github.com/backstage/backstage/issues/25488

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
