### PR TITLE
[Search] add fetch api to deps

### DIFF
--- a/.changeset/thick-moose-decide.md
+++ b/.changeset/thick-moose-decide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search': patch
+---
+
+Update deps in search api extension to include fetch api

--- a/plugins/search/src/alpha.tsx
+++ b/plugins/search/src/alpha.tsx
@@ -33,7 +33,7 @@ import {
   useApi,
   DiscoveryApi,
   discoveryApiRef,
-  identityApiRef,
+  fetchApiRef,
   FetchApi,
 } from '@backstage/core-plugin-api';
 
@@ -79,7 +79,7 @@ import {
 export const searchApi = createApiExtension({
   factory: {
     api: searchApiRef,
-    deps: { discoveryApi: discoveryApiRef, identityApi: identityApiRef },
+    deps: { discoveryApi: discoveryApiRef, fetchApi: fetchApiRef },
     factory: ({
       fetchApi,
       discoveryApi,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Seems like the deps were not updated for the search api extension in https://github.com/backstage/backstage/pull/24878

This caused a bug for the search page when using the new frontend system (alpha exports):

![Screenshot 2024-07-04 at 10 43 53](https://github.com/backstage/backstage/assets/25153114/cfbf9ddc-f520-4d0e-97f0-24357c49f47d)

This PR should fix that
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
