### PR TITLE
Allow custom implementation of OAuthCookieManager

### DIFF
--- a/.changeset/tough-bikes-smash.md
+++ b/.changeset/tough-bikes-smash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-node': minor
+---
+
+Added possibility to customize OAuthCookieManager implementation. Interface was created basing on public methods of that class. Class itself was renamed to DefaultOAuthCookieManager, said interface was implemented in it and it was exported to ensure that the class can be extended further. While calling createOAuthProviderFactory function custom implementation can be injected by providing custom factory function.

--- a/plugins/auth-node/api-report.md
+++ b/plugins/auth-node/api-report.md
@@ -183,6 +183,7 @@ export function createOAuthProviderFactory<TProfile>(options: {
       unknown
     >;
   };
+  oAuthCookieManagerFactory?: OAuthCookieManagerFactory;
 }): AuthProviderFactory;
 
 // @public (undocumented)
@@ -236,6 +237,33 @@ export class DefaultIdentityClient implements IdentityApi {
   getIdentity(
     options: IdentityApiGetIdentityRequest,
   ): Promise<BackstageIdentityResponse | undefined>;
+}
+
+// @public (undocumented)
+export class DefaultOAuthCookieManager implements OAuthCookieManager {
+  constructor(options: {
+    providerId: string;
+    defaultAppOrigin: string;
+    baseUrl: string;
+    callbackUrl: string;
+    cookieConfigurer?: CookieConfigurer;
+  });
+  // (undocumented)
+  getGrantedScopes(req: Request_2): string | undefined;
+  // (undocumented)
+  getNonce(req: Request_2): string | undefined;
+  // (undocumented)
+  getRefreshToken(req: Request_2): string | undefined;
+  // (undocumented)
+  removeGrantedScopes(res: Response_2, origin?: string): void;
+  // (undocumented)
+  removeRefreshToken(res: Response_2, origin?: string): void;
+  // (undocumented)
+  setGrantedScopes(res: Response_2, scope: string, origin?: string): void;
+  // (undocumented)
+  setNonce(res: Response_2, nonce: string, origin?: string): void;
+  // (undocumented)
+  setRefreshToken(res: Response_2, refreshToken: string, origin?: string): void;
 }
 
 // @public (undocumented)
@@ -365,6 +393,35 @@ export interface OAuthAuthenticatorStartInput {
 }
 
 // @public (undocumented)
+export interface OAuthCookieManager {
+  // (undocumented)
+  getGrantedScopes(req: Request_2): string | undefined;
+  // (undocumented)
+  getNonce(req: Request_2): string | undefined;
+  // (undocumented)
+  getRefreshToken(req: Request_2): string | undefined;
+  // (undocumented)
+  removeGrantedScopes(res: Response_2, origin?: string): void;
+  // (undocumented)
+  removeRefreshToken(res: Response_2, origin?: string): void;
+  // (undocumented)
+  setGrantedScopes(res: Response_2, scope: string, origin?: string): void;
+  // (undocumented)
+  setNonce(res: Response_2, nonce: string, origin?: string): void;
+  // (undocumented)
+  setRefreshToken(res: Response_2, refreshToken: string, origin?: string): void;
+}
+
+// @public (undocumented)
+export type OAuthCookieManagerFactory = (options: {
+  cookieConfigurer?: CookieConfigurer;
+  providerId: string;
+  defaultAppOrigin: string;
+  baseUrl: string;
+  callbackUrl: string;
+}) => OAuthCookieManager;
+
+// @public (undocumented)
 export class OAuthEnvironmentHandler implements AuthProviderRouteHandlers {
   constructor(handlers: Map<string, AuthProviderRouteHandlers>);
   // (undocumented)
@@ -398,6 +455,8 @@ export interface OAuthRouteHandlersOptions<TProfile> {
   cookieConfigurer?: CookieConfigurer;
   // (undocumented)
   isOriginAllowed: (origin: string) => boolean;
+  // (undocumented)
+  oAuthCookieManagerFactory?: OAuthCookieManagerFactory;
   // (undocumented)
   profileTransform?: ProfileTransform<OAuthAuthenticatorResult<TProfile>>;
   // (undocumented)

--- a/plugins/auth-node/src/oauth/CookieScopeManager.test.ts
+++ b/plugins/auth-node/src/oauth/CookieScopeManager.test.ts
@@ -19,8 +19,8 @@ import {
   OAuthAuthenticator,
   OAuthAuthenticatorResult,
   OAuthAuthenticatorScopeOptions,
+  OAuthCookieManager,
 } from './types';
-import { OAuthCookieManager } from './OAuthCookieManager';
 import { OAuthState } from './state';
 import { CookieScopeManager } from './CookieScopeManager';
 import { ConfigReader } from '@backstage/config';

--- a/plugins/auth-node/src/oauth/CookieScopeManager.ts
+++ b/plugins/auth-node/src/oauth/CookieScopeManager.ts
@@ -19,8 +19,8 @@ import {
   OAuthAuthenticator,
   OAuthAuthenticatorResult,
   OAuthAuthenticatorScopeOptions,
+  OAuthCookieManager,
 } from './types';
-import { OAuthCookieManager } from './OAuthCookieManager';
 import { OAuthState } from './state';
 import { AuthenticationError } from '@backstage/errors';
 import { Config } from '@backstage/config';

--- a/plugins/auth-node/src/oauth/DefaultOAuthCookieManager.ts
+++ b/plugins/auth-node/src/oauth/DefaultOAuthCookieManager.ts
@@ -16,6 +16,7 @@
 
 import { Request, Response } from 'express';
 import { CookieConfigurer } from '../types';
+import { OAuthCookieManager } from './types';
 
 const THOUSAND_DAYS_MS = 1000 * 24 * 60 * 60 * 1000;
 const TEN_MINUTES_MS = 600 * 1000;
@@ -47,8 +48,8 @@ const defaultCookieConfigurer: CookieConfigurer = ({
   return { domain, path, secure, sameSite };
 };
 
-/** @internal */
-export class OAuthCookieManager {
+/** @public */
+export class DefaultOAuthCookieManager implements OAuthCookieManager {
   private readonly cookieConfigurer: CookieConfigurer;
   private readonly nonceCookie: string;
   private readonly refreshTokenCookie: string;
@@ -85,35 +86,35 @@ export class OAuthCookieManager {
     };
   }
 
-  setNonce(res: Response, nonce: string, origin?: string) {
+  setNonce(res: Response, nonce: string, origin?: string): void {
     res.cookie(this.nonceCookie, nonce, {
       maxAge: TEN_MINUTES_MS,
       ...this.getConfig(origin, '/handler'),
     });
   }
 
-  setRefreshToken(res: Response, refreshToken: string, origin?: string) {
+  setRefreshToken(res: Response, refreshToken: string, origin?: string): void {
     res.cookie(this.refreshTokenCookie, refreshToken, {
       maxAge: THOUSAND_DAYS_MS,
       ...this.getConfig(origin),
     });
   }
 
-  removeRefreshToken(res: Response, origin?: string) {
+  removeRefreshToken(res: Response, origin?: string): void {
     res.cookie(this.refreshTokenCookie, '', {
       maxAge: 0,
       ...this.getConfig(origin),
     });
   }
 
-  removeGrantedScopes(res: Response, origin?: string) {
+  removeGrantedScopes(res: Response, origin?: string): void {
     res.cookie(this.grantedScopeCookie, '', {
       maxAge: 0,
       ...this.getConfig(origin),
     });
   }
 
-  setGrantedScopes(res: Response, scope: string, origin?: string) {
+  setGrantedScopes(res: Response, scope: string, origin?: string): void {
     res.cookie(this.grantedScopeCookie, scope, {
       maxAge: THOUSAND_DAYS_MS,
       ...this.getConfig(origin),

--- a/plugins/auth-node/src/oauth/createOAuthProviderFactory.ts
+++ b/plugins/auth-node/src/oauth/createOAuthProviderFactory.ts
@@ -23,7 +23,11 @@ import {
 import { OAuthEnvironmentHandler } from './OAuthEnvironmentHandler';
 import { createOAuthRouteHandlers } from './createOAuthRouteHandlers';
 import { OAuthStateTransform } from './state';
-import { OAuthAuthenticator, OAuthAuthenticatorResult } from './types';
+import {
+  OAuthAuthenticator,
+  OAuthAuthenticatorResult,
+  OAuthCookieManagerFactory,
+} from './types';
 import { SignInResolverFactory } from '../sign-in/createSignInResolverFactory';
 
 /** @public */
@@ -39,6 +43,7 @@ export function createOAuthProviderFactory<TProfile>(options: {
       unknown
     >;
   };
+  oAuthCookieManagerFactory?: OAuthCookieManagerFactory;
 }): AuthProviderFactory {
   return ctx => {
     return OAuthEnvironmentHandler.mapConfig(ctx.config, envConfig => {
@@ -61,6 +66,7 @@ export function createOAuthProviderFactory<TProfile>(options: {
         additionalScopes: options.additionalScopes,
         stateTransform: options.stateTransform,
         profileTransform: options.profileTransform,
+        oAuthCookieManagerFactory: options.oAuthCookieManagerFactory,
         signInResolver,
       });
     });

--- a/plugins/auth-node/src/oauth/index.ts
+++ b/plugins/auth-node/src/oauth/index.ts
@@ -24,6 +24,7 @@ export {
   type PassportOAuthPrivateInfo,
   type PassportOAuthResult,
 } from './PassportOAuthAuthenticatorHelper';
+export { DefaultOAuthCookieManager } from './DefaultOAuthCookieManager';
 export { OAuthEnvironmentHandler } from './OAuthEnvironmentHandler';
 export { createOAuthProviderFactory } from './createOAuthProviderFactory';
 export {
@@ -42,4 +43,6 @@ export {
   type OAuthAuthenticatorScopeOptions,
   type OAuthAuthenticatorStartInput,
   type OAuthSession,
+  type OAuthCookieManager,
+  type OAuthCookieManagerFactory,
 } from './types';

--- a/plugins/auth-node/src/oauth/types.ts
+++ b/plugins/auth-node/src/oauth/types.ts
@@ -15,8 +15,8 @@
  */
 
 import { Config } from '@backstage/config';
-import { Request } from 'express';
-import { ProfileTransform } from '../types';
+import { Response, Request } from 'express';
+import { CookieConfigurer, ProfileTransform } from '../types';
 
 /** @public */
 export interface OAuthSession {
@@ -98,6 +98,27 @@ export interface OAuthAuthenticator<TContext, TProfile> {
   ): Promise<OAuthAuthenticatorResult<TProfile>>;
   logout?(input: OAuthAuthenticatorLogoutInput, ctx: TContext): Promise<void>;
 }
+
+/** @public */
+export interface OAuthCookieManager {
+  setNonce(res: Response, nonce: string, origin?: string): void;
+  setRefreshToken(res: Response, refreshToken: string, origin?: string): void;
+  setGrantedScopes(res: Response, scope: string, origin?: string): void;
+  removeRefreshToken(res: Response, origin?: string): void;
+  removeGrantedScopes(res: Response, origin?: string): void;
+  getNonce(req: Request): string | undefined;
+  getRefreshToken(req: Request): string | undefined;
+  getGrantedScopes(req: Request): string | undefined;
+}
+
+/** @public */
+export type OAuthCookieManagerFactory = (options: {
+  cookieConfigurer?: CookieConfigurer;
+  providerId: string;
+  defaultAppOrigin: string;
+  baseUrl: string;
+  callbackUrl: string;
+}) => OAuthCookieManager;
 
 /** @public */
 export function createOAuthAuthenticator<TContext, TProfile>(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

`OAuthCookieManager` class was slightly refactored - previous implementation was renamed to `DefaultOAuthCookieManager`, interface based on public methods was created under old name and previous implementation now implements newly created interface - it was also exported so that it can be used as a base class for custom implementation.  Factory function creating `OAuthCookieManager` interface implementation was added as an optional parameter in `createOAuthProviderFactory` function (if it's not provided default implementation is initialized). It's possible to provide custom implementation of that manager after those changes (we need those changes in our project that uses backstage - currently we had to fork the whole plugin just to customize this class). 

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
