### PR TITLE
chore(docs): Fix broken Note admonition

### DIFF
--- a/docs/integrations/github/github-apps.md
+++ b/docs/integrations/github/github-apps.md
@@ -109,8 +109,8 @@ integrations:
           webhookSecret: ${AUTH_ORG_WEBHOOK_SECRET}
 ```
 
-:::Note
-Note that in both examples above `apps` is an array which means you can add multiple GitHub Apps using `$include` or environment variables as long as they are each for a different GitHub Org as mentioned under the [Caveats](#caveats) section
+:::note
+Note that in both examples above `apps` is an array which means you can add multiple GitHub Apps using `$include` or environment variables as long as they are each for a different GitHub Org as mentioned under the [Caveats](#caveats) section.
 :::
 
 ## Limiting the GitHub App installations


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Noticed a warning in the Docusaurus startup for the microsite:

```text
[WARNING] Docusaurus found 1 unused Markdown directives in file "../docs/integrations/github/github-apps.md"
- :::Note (112:1)
Your content might render in an unexpected way. Visit https://github.com/facebook/docusaurus/pull/9394 to find out why and how to fix it.
```

Turns out this is an easy one, is that the `note` admonition can't be capitalized. When fixed, it looks much better!

| Current Published Site | Fixed on my local |
| --- | --- |
|  <img width="945" alt="image" src="https://github.com/backstage/backstage/assets/33203301/262d2e4d-6ec5-4c18-bc9e-60352a2b8903"> |  <img width="945" alt="image" src="https://github.com/backstage/backstage/assets/33203301/a34f62f9-0c5e-476a-afc0-ec7bd6f6e099"> |

https://backstage.io/docs/integrations/github/github-apps#including-in-integrations-config

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
