### PR TITLE
Add TechdocsContainerRunner interface as successor of deprecated ContainerRunner for TechdocsGenerator

### DIFF
--- a/.changeset/big-garlics-punch.md
+++ b/.changeset/big-garlics-punch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-node': patch
+---
+
+Move `TechdocsContainerRunner` from `publish` to `generate`.

--- a/plugins/techdocs-node/src/stages/generate/DockerContainerRunner.ts
+++ b/plugins/techdocs-node/src/stages/generate/DockerContainerRunner.ts
@@ -20,6 +20,7 @@ import { ForwardedError } from '@backstage/errors';
 import { PassThrough } from 'stream';
 import { pipeline as pipelineStream } from 'stream';
 import { promisify } from 'util';
+import { TechDocsContainerRunner } from './types';
 import { Writable } from 'stream';
 
 const pipeline = promisify(pipelineStream);
@@ -31,7 +32,7 @@ export type UserOptions = {
 /**
  * @internal
  */
-export class DockerContainerRunner {
+export class DockerContainerRunner implements TechDocsContainerRunner {
   private readonly dockerClient: Docker;
 
   constructor() {

--- a/plugins/techdocs-node/src/stages/generate/generators.ts
+++ b/plugins/techdocs-node/src/stages/generate/generators.ts
@@ -24,7 +24,7 @@ import {
   SupportedGeneratorKey,
 } from './types';
 import { LoggerService } from '@backstage/backend-plugin-api';
-import { TechDocsContainerRunner } from '../publish/types';
+import { TechDocsContainerRunner } from './types';
 
 /**
  * Collection of docs generators

--- a/plugins/techdocs-node/src/stages/generate/index.ts
+++ b/plugins/techdocs-node/src/stages/generate/index.ts
@@ -22,6 +22,7 @@ export type {
   GeneratorBuilder,
   GeneratorRunOptions,
   SupportedGeneratorKey,
+  TechDocsContainerRunner,
 } from './types';
 import { getMkdocsYml } from './helpers';
 /**

--- a/plugins/techdocs-node/src/stages/generate/techdocs.ts
+++ b/plugins/techdocs-node/src/stages/generate/techdocs.ts
@@ -43,7 +43,7 @@ import {
 import { ForwardedError } from '@backstage/errors';
 import { DockerContainerRunner } from './DockerContainerRunner';
 import { LoggerService } from '@backstage/backend-plugin-api';
-import { TechDocsContainerRunner } from '../publish/types';
+import { TechDocsContainerRunner } from './types';
 
 /**
  * Generates documentation files

--- a/plugins/techdocs-node/src/stages/generate/types.ts
+++ b/plugins/techdocs-node/src/stages/generate/types.ts
@@ -19,9 +19,11 @@ import { Writable } from 'stream';
 import { Logger } from 'winston';
 import { ParsedLocationAnnotation } from '../../helpers';
 import { LoggerService } from '@backstage/backend-plugin-api';
-import { TechDocsContainerRunner } from '../publish/types';
 
-// Determines where the generator will be run
+/**
+ * Determines where the generator will be run. `'docker'` is a shorthand for running the generator in a container.
+ * If no {@link GeneratorOptions.containerRunner} is specified, the internal `DockerContainerRunner` will be used.
+ */
 export type GeneratorRunInType = 'docker' | 'local';
 
 /**
@@ -30,10 +32,6 @@ export type GeneratorRunInType = 'docker' | 'local';
  */
 export type GeneratorOptions = {
   logger: LoggerService;
-  /**
-   * @deprecated containerRunner is now instantiated in
-   * the generator and this option will be removed in the future
-   */
   containerRunner?: TechDocsContainerRunner;
 };
 
@@ -104,3 +102,39 @@ export type DefaultMkdocsContent = {
   docs_dir: string;
   plugins: String[];
 };
+
+/**
+ * Handles the running of containers to generate TechDocs.
+ *
+ * Custom implementations, e.g. for Kubernetes or other execution environments, can be inspired by the internal default
+ * implementation `DockerContainerRunner`.
+ *
+ * @public
+ */
+export interface TechDocsContainerRunner {
+  /**
+   * Runs a container image to completion.
+   */
+  runContainer(opts: {
+    imageName: string;
+    command?: string | string[];
+    args: string[];
+    logStream?: Writable;
+    mountDirs?: Record<string, string>;
+    workingDir?: string;
+    envVars?: Record<string, string>;
+    pullImage?: boolean;
+    defaultUser?: boolean;
+    pullOptions?: {
+      authconfig?: {
+        username?: string;
+        password?: string;
+        auth?: string;
+        email?: string;
+        serveraddress?: string;
+        [key: string]: unknown;
+      };
+      [key: string]: unknown;
+    };
+  }): Promise<void>;
+}

--- a/plugins/techdocs-node/src/stages/publish/index.ts
+++ b/plugins/techdocs-node/src/stages/publish/index.ts
@@ -24,5 +24,4 @@ export type {
   MigrateRequest,
   ReadinessResponse,
   TechDocsMetadata,
-  TechDocsContainerRunner,
 } from './types';

--- a/plugins/techdocs-node/src/stages/publish/types.ts
+++ b/plugins/techdocs-node/src/stages/publish/types.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Writable } from 'stream';
 import express from 'express';
 import { Config } from '@backstage/config';
 import { DiscoveryService, LoggerService } from '@backstage/backend-plugin-api';
@@ -168,36 +167,3 @@ export type PublisherBuilder = {
   register(type: PublisherType, publisher: PublisherBase): void;
   get(config: Config): PublisherBase;
 };
-
-/**
- * Handles the running of containers, on behalf of others.
- *
- * @public
- */
-export interface TechDocsContainerRunner {
-  /**
-   * Runs a container image to completion.
-   */
-  runContainer(opts: {
-    imageName: string;
-    command?: string | string[];
-    args: string[];
-    logStream?: Writable;
-    mountDirs?: Record<string, string>;
-    workingDir?: string;
-    envVars?: Record<string, string>;
-    pullImage?: boolean;
-    defaultUser?: boolean;
-    pullOptions?: {
-      authconfig?: {
-        username?: string;
-        password?: string;
-        auth?: string;
-        email?: string;
-        serveraddress?: string;
-        [key: string]: unknown;
-      };
-      [key: string]: unknown;
-    };
-  }): Promise<void>;
-}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Based on the discussion in #24928 the `ContainerRunner` has [been deprecated](https://github.com/backstage/backstage/commit/f2f41aad7e6152f13c9b5d50674511382847f298). 

In the current state, once the `ContainerRunner` interface is removed, the only alternative to generate TechDocs in another environment (e.g. Kubernetes or any kind of workflow engine) would be to replace the `TechdocsGenerator` with a complete individual implementation. In that case one has also to take care about `mkdocs.yml` validation and modification as well as the post processing. Both seem crucial for security and the TechDocs cache and workflow and should imho not be part of individual implementations when the only goal is another execution environment.

This PR aims to provide the `ContainerRunner` interface specifically for TechDocs generation in `plugin-techdocs-node` as `TechdocsContainerRunner`, so that `ContainerRunner` in `backend-common` can be removed one day and `TechdocsGenerator` still supports individual execution environments.

The new interface and types still support the original `ContainerRunner` interface so that this change is not breaking. I would appreciate that this can be confirmed by an expert, as I'm mostly a Java developer and quite new to TypeScript.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
