### PR TITLE
search: add missing createApiFactory

### DIFF
--- a/plugins/search/src/alpha.tsx
+++ b/plugins/search/src/alpha.tsx
@@ -31,10 +31,9 @@ import {
 } from '@backstage/core-components';
 import {
   useApi,
-  DiscoveryApi,
   discoveryApiRef,
   fetchApiRef,
-  FetchApi,
+  createApiFactory,
 } from '@backstage/core-plugin-api';
 
 import {
@@ -77,17 +76,12 @@ import {
 
 /** @alpha */
 export const searchApi = createApiExtension({
-  factory: {
+  factory: createApiFactory({
     api: searchApiRef,
     deps: { discoveryApi: discoveryApiRef, fetchApi: fetchApiRef },
-    factory: ({
-      fetchApi,
-      discoveryApi,
-    }: {
-      fetchApi: FetchApi;
-      discoveryApi: DiscoveryApi;
-    }) => new SearchClient({ discoveryApi, fetchApi }),
-  },
+    factory: ({ discoveryApi, fetchApi }) =>
+      new SearchClient({ discoveryApi, fetchApi }),
+  }),
 });
 
 const useSearchPageStyles = makeStyles((theme: Theme) => ({


### PR DESCRIPTION
Followup for #25519 and piggybacking on the same changeset. There was a missing `createApiFactory` wrapping that caused type checking to be disabled for the factory config.

The `createApiExtension` is likely to change in some form to avoid the need for this or to make it more explicitly required, but leaving that for a later fix.