### PR TITLE
feat: add automatic commited action for merge-request gitlab

### DIFF
--- a/.changeset/wild-eggs-exist.md
+++ b/.changeset/wild-eggs-exist.md
@@ -1,0 +1,10 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gitlab': patch
+---
+
+Add custom action for merge request: **auto**
+
+The **Auto** action selects the committed action between _create_ and _update_.
+
+The **Auto** action fetches files using the **/projects/repository/tree endpoint**.
+After fetching, it checks if the file exists locally and in the repository. If it does, it chooses **update**; otherwise, it chooses **create**.

--- a/plugins/scaffolder-backend-module-gitlab/api-report.md
+++ b/plugins/scaffolder-backend-module-gitlab/api-report.md
@@ -33,11 +33,11 @@ export const createGitlabIssueAction: (options: {
     projectId: number;
     labels?: string | undefined;
     description?: string | undefined;
-    weight?: number | undefined;
     token?: string | undefined;
+    weight?: number | undefined;
     assignees?: number[] | undefined;
-    createdAt?: string | undefined;
     confidential?: boolean | undefined;
+    createdAt?: string | undefined;
     milestoneId?: number | undefined;
     epicId?: number | undefined;
     dueDate?: string | undefined;
@@ -61,8 +61,8 @@ export const createGitlabProjectAccessTokenAction: (options: {
     projectId: string | number;
     name?: string | undefined;
     token?: string | undefined;
-    scopes?: string[] | undefined;
     expiresAt?: string | undefined;
+    scopes?: string[] | undefined;
     accessLevel?: number | undefined;
   },
   {
@@ -118,7 +118,7 @@ export const createGitlabRepoPushAction: (options: {
     sourcePath?: string | undefined;
     targetPath?: string | undefined;
     token?: string | undefined;
-    commitAction?: 'update' | 'delete' | 'create' | undefined;
+    commitAction?: 'update' | 'create' | 'delete' | undefined;
   },
   JsonObject
 >;
@@ -193,7 +193,7 @@ export const createPublishGitlabMergeRequestAction: (options: {
     sourcePath?: string | undefined;
     targetPath?: string | undefined;
     token?: string | undefined;
-    commitAction?: 'update' | 'delete' | 'create' | undefined;
+    commitAction?: 'auto' | 'update' | 'create' | 'delete' | undefined;
     projectid?: string | undefined;
     removeSourceBranch?: boolean | undefined;
     assignee?: string | undefined;
@@ -206,8 +206,8 @@ export const createTriggerGitlabPipelineAction: (options: {
   integrations: ScmIntegrationRegistry;
 }) => TemplateAction<
   {
-    branch: string;
     repoUrl: string;
+    branch: string;
     projectId: number;
     tokenDescription: string;
     token?: string | undefined;
@@ -229,8 +229,8 @@ export const editGitlabIssueAction: (options: {
     title?: string | undefined;
     labels?: string | undefined;
     description?: string | undefined;
-    weight?: number | undefined;
     token?: string | undefined;
+    weight?: number | undefined;
     assignees?: number[] | undefined;
     addLabels?: string | undefined;
     confidential?: boolean | undefined;

--- a/plugins/scaffolder-backend-module-gitlab/api-report.md
+++ b/plugins/scaffolder-backend-module-gitlab/api-report.md
@@ -33,11 +33,11 @@ export const createGitlabIssueAction: (options: {
     projectId: number;
     labels?: string | undefined;
     description?: string | undefined;
-    token?: string | undefined;
     weight?: number | undefined;
+    token?: string | undefined;
     assignees?: number[] | undefined;
-    confidential?: boolean | undefined;
     createdAt?: string | undefined;
+    confidential?: boolean | undefined;
     milestoneId?: number | undefined;
     epicId?: number | undefined;
     dueDate?: string | undefined;
@@ -61,8 +61,8 @@ export const createGitlabProjectAccessTokenAction: (options: {
     projectId: string | number;
     name?: string | undefined;
     token?: string | undefined;
-    expiresAt?: string | undefined;
     scopes?: string[] | undefined;
+    expiresAt?: string | undefined;
     accessLevel?: number | undefined;
   },
   {
@@ -118,7 +118,7 @@ export const createGitlabRepoPushAction: (options: {
     sourcePath?: string | undefined;
     targetPath?: string | undefined;
     token?: string | undefined;
-    commitAction?: 'update' | 'create' | 'delete' | undefined;
+    commitAction?: 'update' | 'delete' | 'create' | undefined;
   },
   JsonObject
 >;
@@ -193,7 +193,7 @@ export const createPublishGitlabMergeRequestAction: (options: {
     sourcePath?: string | undefined;
     targetPath?: string | undefined;
     token?: string | undefined;
-    commitAction?: 'auto' | 'update' | 'create' | 'delete' | undefined;
+    commitAction?: 'auto' | 'update' | 'delete' | 'create' | undefined;
     projectid?: string | undefined;
     removeSourceBranch?: boolean | undefined;
     assignee?: string | undefined;
@@ -206,8 +206,8 @@ export const createTriggerGitlabPipelineAction: (options: {
   integrations: ScmIntegrationRegistry;
 }) => TemplateAction<
   {
-    repoUrl: string;
     branch: string;
+    repoUrl: string;
     projectId: number;
     tokenDescription: string;
     token?: string | undefined;
@@ -229,8 +229,8 @@ export const editGitlabIssueAction: (options: {
     title?: string | undefined;
     labels?: string | undefined;
     description?: string | undefined;
-    token?: string | undefined;
     weight?: number | undefined;
+    token?: string | undefined;
     assignees?: number[] | undefined;
     addLabels?: string | undefined;
     confidential?: boolean | undefined;

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabMergeRequest.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabMergeRequest.ts
@@ -33,13 +33,13 @@ function getFileAction(
   remoteFiles: Types.RepositoryTreeSchema[],
   defaultCommitAction: 'create' | 'delete' | 'update' | 'auto' | undefined,
 ): 'create' | 'delete' | 'update' {
-  if (defaultCommitAction === 'auto') {
+  if (!defaultCommitAction || defaultCommitAction === 'auto') {
     return remoteFiles &&
       remoteFiles.some(remoteFile => remoteFile.path === file.path)
       ? 'update'
       : 'create';
   }
-  return defaultCommitAction ?? 'create';
+  return defaultCommitAction;
 }
 
 /**
@@ -126,7 +126,7 @@ export const createPublishGitlabMergeRequestAction = (options: {
             type: 'string',
             enum: ['create', 'update', 'delete', 'auto'],
             description:
-              'The action to be used for git commit. Defaults to create. "auto" is custom action provide by backstage, (automatic assign create or update action) /!\\ Use more api calls /!\\ *',
+              'The action to be used for git commit. Defaults to auto. "auto" is custom action provide by backstage, (automatic assign create or update action) /!\\ Use more api calls /!\\ *',
           },
           removeSourceBranch: {
             title: 'Delete source branch',

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -312,7 +312,7 @@ export const createPublishGitlabMergeRequestAction: (options: {
     sourcePath?: string | undefined;
     targetPath?: string | undefined;
     token?: string | undefined;
-    commitAction?: 'update' | 'delete' | 'create' | undefined;
+    commitAction?: 'auto' | 'update' | 'delete' | 'create' | undefined;
     projectid?: string | undefined;
     removeSourceBranch?: boolean | undefined;
     assignee?: string | undefined;

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -312,10 +312,7 @@ export const createPublishGitlabMergeRequestAction: (options: {
     sourcePath?: string | undefined;
     targetPath?: string | undefined;
     token?: string | undefined;
-    commitAction?: 'auto' | 'update' | 'delete' | 'create' | undefined
-    /**
-     * @public @deprecated use import from \@backstage/plugin-scaffolder-backend-module-github instead
-     */;
+    commitAction?: 'auto' | 'update' | 'delete' | 'create' | undefined;
     projectid?: string | undefined;
     removeSourceBranch?: boolean | undefined;
     assignee?: string | undefined;

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -312,7 +312,10 @@ export const createPublishGitlabMergeRequestAction: (options: {
     sourcePath?: string | undefined;
     targetPath?: string | undefined;
     token?: string | undefined;
-    commitAction?: 'auto' | 'update' | 'delete' | 'create' | undefined;
+    commitAction?: 'auto' | 'update' | 'delete' | 'create' | undefined
+    /**
+     * @public @deprecated use import from \@backstage/plugin-scaffolder-backend-module-github instead
+     */;
     projectid?: string | undefined;
     removeSourceBranch?: boolean | undefined;
     assignee?: string | undefined;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add custom action for merge request: **auto**

The **Auto** action selects the committed action between _create_ and _update_.

The **Auto** action fetches files using the **/projects/repository/tree endpoint**.
After fetching, it checks if the file exists locally and in the repository. If it does, it chooses **update**; otherwise, it chooses **create**. 

close #16662

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [ ] Added or updated documentation
- [ ] Screenshots attached (for UI changes)
