### PR TITLE
Export `defaultEksClusterEntityTransformer` from `catalog-backend-module-aws`

### DIFF
--- a/.changeset/mighty-keys-bow.md
+++ b/.changeset/mighty-keys-bow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-aws': patch
+---
+
+Export `defaultEksClusterEntityTransformer` to allow library consumers to layer additional changes on top of the default transformer.

--- a/plugins/catalog-backend-module-aws/api-report.md
+++ b/plugins/catalog-backend-module-aws/api-report.md
@@ -107,6 +107,9 @@ export class AwsS3EntityProvider implements EntityProvider {
 }
 
 // @public
+export const defaultEksClusterEntityTransformer: EksClusterEntityTransformer;
+
+// @public
 export type EksClusterEntityTransformer = (
   cluster: Cluster,
   accountId: string,

--- a/plugins/catalog-backend-module-aws/src/index.ts
+++ b/plugins/catalog-backend-module-aws/src/index.ts
@@ -24,3 +24,4 @@ export * from './processors';
 export * from './providers';
 export * from './types';
 export * from './constants';
+export { defaultEksClusterEntityTransformer } from './lib';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR addresses issue #25450, taking the first recommendation provided by @camilaibs: The default transformer could be exported from its package so that it can be imported and reused.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
