### PR TITLE
Kubernetes react -> Warning: validateDOMNesting(...): <ul> cannot appear as a descendant of <p>

### DIFF
--- a/.changeset/short-impalas-suffer.md
+++ b/.changeset/short-impalas-suffer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-react': patch
+---
+
+fix the html markup of the FixDialog component, ul li is not allowed inside a p

--- a/.changeset/short-impalas-suffer.md
+++ b/.changeset/short-impalas-suffer.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-kubernetes-react': patch
 ---
 
-fix the html markup of the FixDialog component, ul li is not allowed inside a p
+Fix the `HTML` markup of the `FixDialog` component, `ul` and `li` are not allowed inside a `p` tag.

--- a/plugins/kubernetes-react/src/components/Pods/FixDialog/FixDialog.tsx
+++ b/plugins/kubernetes-react/src/components/Pods/FixDialog/FixDialog.tsx
@@ -33,6 +33,8 @@ import { DetectedError } from '@backstage/plugin-kubernetes-common';
 import { PodLogs } from '../PodLogs';
 import { Events } from '../Events';
 import { LinkButton } from '@backstage/core-components';
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -96,17 +98,15 @@ export const FixDialog: React.FC<FixDialogProps> = ({
         </Grid>
         <Grid item xs={12}>
           <Typography variant="h6">Fix:</Typography>
-          <Typography>
-            <ul>
-              {(error.proposedFix?.actions ?? []).map((fix, i) => {
-                return (
-                  <li key={`${pod.metadata?.name ?? 'unknown'}-pf-${i}`}>
-                    {fix}
-                  </li>
-                );
-              })}
-            </ul>
-          </Typography>
+          <List>
+            {(error.proposedFix?.actions ?? []).map((fix, i) => {
+              return (
+                <ListItem key={`${pod.metadata?.name ?? 'unknown'}-pf-${i}`}>
+                  {fix}
+                </ListItem>
+              );
+            })}
+          </List>
         </Grid>
 
         {pf && pf.type === 'logs' && (


### PR DESCRIPTION
## Hey, I just made a Pull Request!

PR to fix the issue: https://github.com/backstage/backstage/issues/24533

```
Warning: validateDOMNesting(...): <ul> cannot appear as a descendant of <p>
```

Style of the main error is still the same:
<img width="863" alt="Screenshot 2024-07-09 at 21 53 19" src="https://github.com/backstage/backstage/assets/17096352/0bd9a91e-7747-41d1-9e54-a81228ea596e">

Now the fixes are showing in a list outside the `p` element, they are styled based on the `@material-ui/core/List` component
<img width="1171" alt="Screenshot 2024-07-09 at 21 58 34" src="https://github.com/backstage/backstage/assets/17096352/089e4d7b-dc1f-41de-94b9-74e9be64f7cd">



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
