### PR TITLE
backend-defaults: removed the deprecated getPath option from httpRouterServiceFactory

### DIFF
--- a/.changeset/cold-jars-punch.md
+++ b/.changeset/cold-jars-punch.md
@@ -1,0 +1,6 @@
+---
+'@backstage/backend-defaults': minor
+'@backstage/backend-app-api': minor
+---
+
+**BREAKING**: Removed the depreacted `getPath` option from `httpRouterServiceFactory`, as well as the `HttpRouterFactoryOptions` type.

--- a/packages/backend-app-api/api-report.md
+++ b/packages/backend-app-api/api-report.md
@@ -146,15 +146,11 @@ export const httpAuthServiceFactory: () => ServiceFactory<
   'plugin'
 >;
 
-// Warning: (ae-forgotten-export) The symbol "HttpRouterFactoryOptions_2" needs to be exported by the entry point index.d.ts
-//
-// @public @deprecated (undocumented)
-export type HttpRouterFactoryOptions = HttpRouterFactoryOptions_2;
-
 // @public @deprecated
-export const httpRouterServiceFactory: (
-  options?: HttpRouterFactoryOptions_2 | undefined,
-) => ServiceFactory<HttpRouterService, 'plugin'>;
+export const httpRouterServiceFactory: () => ServiceFactory<
+  HttpRouterService,
+  'plugin'
+>;
 
 // Warning: (ae-forgotten-export) The symbol "HttpServerCertificateOptions_2" needs to be exported by the entry point index.d.ts
 //

--- a/packages/backend-app-api/src/services/implementations/httpRouter/httpRouterServiceFactory.ts
+++ b/packages/backend-app-api/src/services/implementations/httpRouter/httpRouterServiceFactory.ts
@@ -15,16 +15,7 @@
  */
 
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
-import {
-  httpRouterServiceFactory as _httpRouterServiceFactory,
-  type HttpRouterFactoryOptions as _HttpRouterFactoryOptions,
-} from '../../../../../backend-defaults/src/entrypoints/httpRouter/httpRouterServiceFactory';
-
-/**
- * @public
- * @deprecated Please import from `@backstage/backend-defaults/httpRouter` instead.
- */
-export type HttpRouterFactoryOptions = _HttpRouterFactoryOptions;
+import { httpRouterServiceFactory as _httpRouterServiceFactory } from '../../../../../backend-defaults/src/entrypoints/httpRouter/httpRouterServiceFactory';
 
 /**
  * HTTP route registration for plugins.

--- a/packages/backend-app-api/src/services/implementations/httpRouter/index.ts
+++ b/packages/backend-app-api/src/services/implementations/httpRouter/index.ts
@@ -15,6 +15,5 @@
  */
 
 export { httpRouterServiceFactory } from './httpRouterServiceFactory';
-export type { HttpRouterFactoryOptions } from './httpRouterServiceFactory';
 export { createLifecycleMiddleware } from './createLifecycleMiddleware';
 export type { LifecycleMiddlewareOptions } from './createLifecycleMiddleware';

--- a/packages/backend-defaults/api-report-httpRouter.md
+++ b/packages/backend-defaults/api-report-httpRouter.md
@@ -14,15 +14,11 @@ export function createLifecycleMiddleware(
   options: LifecycleMiddlewareOptions,
 ): RequestHandler;
 
-// @public (undocumented)
-export interface HttpRouterFactoryOptions {
-  getPath?(pluginId: string): string;
-}
-
 // @public
-export const httpRouterServiceFactory: (
-  options?: HttpRouterFactoryOptions | undefined,
-) => ServiceFactory<HttpRouterService, 'plugin'>;
+export const httpRouterServiceFactory: () => ServiceFactory<
+  HttpRouterService,
+  'plugin'
+>;
 
 // @public
 export interface LifecycleMiddlewareOptions {

--- a/packages/backend-defaults/src/entrypoints/httpRouter/httpRouterServiceFactory.test.ts
+++ b/packages/backend-defaults/src/entrypoints/httpRouter/httpRouterServiceFactory.test.ts
@@ -52,32 +52,6 @@ describe('httpRouterFactory', () => {
     );
   });
 
-  it('should use custom path generator', async () => {
-    const rootHttpRouter = mockServices.rootHttpRouter.mock();
-    const tester = ServiceFactoryTester.from(
-      httpRouterServiceFactory({
-        getPath: id => `/some/${id}/path`,
-      }),
-      { dependencies: [rootHttpRouter.factory] },
-    );
-
-    const router1 = await tester.get('test1');
-    router1.use(() => {});
-    expect(rootHttpRouter.use).toHaveBeenCalledTimes(1);
-    expect(rootHttpRouter.use).toHaveBeenCalledWith(
-      '/some/test1/path',
-      expect.any(Function),
-    );
-
-    const router2 = await tester.get('test2');
-    router2.use(() => {});
-    expect(rootHttpRouter.use).toHaveBeenCalledTimes(2);
-    expect(rootHttpRouter.use).toHaveBeenCalledWith(
-      '/some/test2/path',
-      expect.any(Function),
-    );
-  });
-
   describe('auth services', () => {
     const pluginSubject = createBackendPlugin({
       pluginId: 'test',

--- a/packages/backend-defaults/src/entrypoints/httpRouter/index.ts
+++ b/packages/backend-defaults/src/entrypoints/httpRouter/index.ts
@@ -15,6 +15,5 @@
  */
 
 export { httpRouterServiceFactory } from './httpRouterServiceFactory';
-export type { HttpRouterFactoryOptions } from './httpRouterServiceFactory';
 export { createLifecycleMiddleware } from './createLifecycleMiddleware';
 export type { LifecycleMiddlewareOptions } from './createLifecycleMiddleware';

--- a/packages/backend-test-utils/api-report.md
+++ b/packages/backend-test-utils/api-report.md
@@ -22,7 +22,6 @@ import { EventsService } from '@backstage/plugin-events-node';
 import { ExtendedHttpServer } from '@backstage/backend-app-api';
 import { ExtensionPoint } from '@backstage/backend-plugin-api';
 import { HttpAuthService } from '@backstage/backend-plugin-api';
-import { HttpRouterFactoryOptions } from '@backstage/backend-defaults/httpRouter';
 import { HttpRouterService } from '@backstage/backend-plugin-api';
 import { IdentityService } from '@backstage/backend-plugin-api';
 import { JsonObject } from '@backstage/types';
@@ -221,9 +220,7 @@ export namespace mockServices {
   // (undocumented)
   export namespace httpRouter {
     const // (undocumented)
-      factory: (
-        options?: HttpRouterFactoryOptions | undefined,
-      ) => ServiceFactory<HttpRouterService, 'plugin'>;
+      factory: () => ServiceFactory<HttpRouterService, 'plugin'>;
     const // (undocumented)
       mock: (
         partialImpl?: Partial<HttpRouterService> | undefined,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This was deprecated in #24023, released in 1.26.0, and can now be removed. Since the `HttpRouterFactoryOptions` is now useless it's also been removed.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
