### PR TITLE
[NBS 1.0] Rename `ServiceFactoryTester.get` to `ServiceFactoryTester.getSubject`

### DIFF
--- a/.changeset/chilly-coats-report.md
+++ b/.changeset/chilly-coats-report.md
@@ -1,0 +1,7 @@
+---
+'@backstage/backend-test-utils': patch
+'@backstage/backend-defaults': patch
+'@backstage/backend-app-api': patch
+---
+
+The `ServiceFactoryTest.get` method was deprecated and the `ServiceFactoryTest.getSubject` should be used instead. The `getSubject` method has the same behavior, but has a better method name to indicate that the service instance returned is the subject currently being tested.

--- a/packages/backend-app-api/src/services/implementations/scheduler/schedulerServiceFactory.test.ts
+++ b/packages/backend-app-api/src/services/implementations/scheduler/schedulerServiceFactory.test.ts
@@ -22,7 +22,7 @@ describe('schedulerFactory', () => {
   it('creates sidecar database features', async () => {
     const tester = ServiceFactoryTester.from(schedulerServiceFactory());
 
-    const scheduler = await tester.get();
+    const scheduler = await tester.getSubject();
     await scheduler.scheduleTask({
       id: 'task1',
       timeout: { seconds: 1 },

--- a/packages/backend-app-api/src/services/implementations/tokenManager/tokenManagerServiceFactory.test.ts
+++ b/packages/backend-app-api/src/services/implementations/tokenManager/tokenManagerServiceFactory.test.ts
@@ -21,7 +21,7 @@ describe('tokenManagerFactory', () => {
   it('should create a disabled manager without configuration', async () => {
     const tokenManager = await ServiceFactoryTester.from(
       tokenManagerServiceFactory,
-    ).get();
+    ).getSubject();
 
     await expect(tokenManager.authenticate('abc')).rejects.toThrow(
       'no legacy keys are configured',

--- a/packages/backend-defaults/src/entrypoints/auth/authServiceFactory.test.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/authServiceFactory.test.ts
@@ -86,8 +86,8 @@ describe('authServiceFactory', () => {
       dependencies: mockDeps,
     });
 
-    const searchAuth = await tester.get('search');
-    const catalogAuth = await tester.get('catalog');
+    const searchAuth = await tester.getSubject('search');
+    const catalogAuth = await tester.getSubject('catalog');
 
     const { token: searchToken } = await searchAuth.getPluginRequestToken({
       onBehalfOf: await searchAuth.getOwnServiceCredentials(),
@@ -117,8 +117,8 @@ describe('authServiceFactory', () => {
       dependencies: mockDeps,
     });
 
-    const searchAuth = await tester.get('search');
-    const catalogAuth = await tester.get('catalog');
+    const searchAuth = await tester.getSubject('search');
+    const catalogAuth = await tester.getSubject('catalog');
 
     server.use(
       rest.get(
@@ -163,7 +163,7 @@ describe('authServiceFactory', () => {
       dependencies: mockDeps,
     });
 
-    const catalogAuth = await tester.get('catalog');
+    const catalogAuth = await tester.getSubject('catalog');
 
     await expect(
       catalogAuth.getPluginRequestToken({
@@ -194,7 +194,7 @@ describe('authServiceFactory', () => {
       dependencies: mockDeps,
     });
 
-    const catalogAuth = await tester.get('catalog');
+    const catalogAuth = await tester.getSubject('catalog');
 
     const { token } = await catalogAuth.getPluginRequestToken({
       onBehalfOf: {
@@ -261,7 +261,7 @@ describe('authServiceFactory', () => {
       dependencies: mockDeps,
     });
 
-    const catalogAuth = await tester.get('catalog');
+    const catalogAuth = await tester.getSubject('catalog');
 
     const fullToken =
       'eyJ0eXAiOiJ2bmQuYmFja3N0YWdlLnVzZXIiLCJhbGciOiJFUzI1NiIsImtpZCI6IjhkMDFjM2RiLTU2ZjktNDVmMC04NmRkLTA1YjNjODM1YjNkMyJ9.eyJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjcwMDcvYXBpL2F1dGgiLCJzdWIiOiJ1c2VyOmRldmVsb3BtZW50L2d1ZXN0IiwiZW50IjpbInVzZXI6ZGV2ZWxvcG1lbnQvZ3Vlc3QiLCJncm91cDpkZWZhdWx0L3RlYW0tYSJdLCJhdWQiOiJiYWNrc3RhZ2UiLCJpYXQiOjE3MTIwNzE3MTQsImV4cCI6MTcxMjA3NTMxNCwidWlwIjoiSmwxVEpycG9VUjR1NENjUE9nalJMeHpEMi1FMGZPR3ptSm81UWI2eS1aN19meG5oVVBEdWVWRE1CS0l6WF9pc0lvSDhlZm9EUFA5bG9aQnpPblB5Z2cifQ.1gVMq1ofO8PzRctu72D6c4IMqXuIabT79WdGEhW6vIrBRs_qhuWAa94Wvz_KYKpBTb2nxgzXJ5OeddeoYApMyQ';
@@ -318,9 +318,9 @@ describe('authServiceFactory', () => {
       dependencies: mockDeps,
     });
 
-    const searchAuth = await tester.get('search');
-    const catalogAuth = await tester.get('catalog');
-    const permissionAuth = await tester.get('permission');
+    const searchAuth = await tester.getSubject('search');
+    const catalogAuth = await tester.getSubject('catalog');
+    const permissionAuth = await tester.getSubject('permission');
 
     /* Corresponding private key in case this test needs to be updated in the future:
      {
@@ -431,7 +431,7 @@ describe('authServiceFactory', () => {
       dependencies: mockDeps,
     });
 
-    const catalogAuth = await tester.get('catalog');
+    const catalogAuth = await tester.getSubject('catalog');
 
     await expect(
       catalogAuth.authenticate('limited-static-token'),
@@ -450,7 +450,7 @@ describe('authServiceFactory', () => {
       },
     });
 
-    const scaffolderAuth = await tester.get('scaffolder');
+    const scaffolderAuth = await tester.getSubject('scaffolder');
 
     await expect(
       scaffolderAuth.authenticate('limited-static-token'),

--- a/packages/backend-defaults/src/entrypoints/httpRouter/httpRouterServiceFactory.test.ts
+++ b/packages/backend-defaults/src/entrypoints/httpRouter/httpRouterServiceFactory.test.ts
@@ -35,7 +35,7 @@ describe('httpRouterFactory', () => {
       dependencies: [rootHttpRouter.factory],
     });
 
-    const router1 = await tester.get('test1');
+    const router1 = await tester.getSubject('test1');
     router1.use(() => {});
     expect(rootHttpRouter.use).toHaveBeenCalledTimes(1);
     expect(rootHttpRouter.use).toHaveBeenCalledWith(
@@ -43,7 +43,7 @@ describe('httpRouterFactory', () => {
       expect.any(Function),
     );
 
-    const router2 = await tester.get('test2');
+    const router2 = await tester.getSubject('test2');
     router2.use(() => {});
     expect(rootHttpRouter.use).toHaveBeenCalledTimes(2);
     expect(rootHttpRouter.use).toHaveBeenCalledWith(

--- a/packages/backend-defaults/src/entrypoints/scheduler/schedulerServiceFactory.test.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/schedulerServiceFactory.test.ts
@@ -22,7 +22,7 @@ describe('schedulerFactory', () => {
   it('creates sidecar database features', async () => {
     const tester = ServiceFactoryTester.from(schedulerServiceFactory());
 
-    const scheduler = await tester.get();
+    const scheduler = await tester.getSubject();
     await scheduler.scheduleTask({
       id: 'task1',
       timeout: { seconds: 1 },

--- a/packages/backend-test-utils/api-report.md
+++ b/packages/backend-test-utils/api-report.md
@@ -373,6 +373,7 @@ export class ServiceFactoryTester<TService, TScope extends 'root' | 'plugin'> {
       | (() => ServiceFactory<TService, TScope>),
     options?: ServiceFactoryTesterOptions,
   ): ServiceFactoryTester<TService, TScope>;
+  // @deprecated
   get(
     ...args: 'root' extends TScope ? [] : [pluginId?: string]
   ): Promise<TService>;
@@ -380,6 +381,9 @@ export class ServiceFactoryTester<TService, TScope extends 'root' | 'plugin'> {
     service: ServiceRef<TGetService, TGetScope>,
     ...args: 'root' extends TGetScope ? [] : [pluginId?: string]
   ): Promise<TGetService>;
+  getSubject(
+    ...args: 'root' extends TScope ? [] : [pluginId?: string]
+  ): Promise<TService>;
 }
 
 // @public

--- a/packages/backend-test-utils/src/next/wiring/ServiceFactoryTester.test.ts
+++ b/packages/backend-test-utils/src/next/wiring/ServiceFactoryTester.test.ts
@@ -56,34 +56,34 @@ describe('ServiceFactoryTester', () => {
   it('should test a root service factory', async () => {
     const tester = ServiceFactoryTester.from(rootFactory);
 
-    await expect(tester.get()).resolves.toBe('root');
+    await expect(tester.getSubject()).resolves.toBe('root');
   });
 
   it('should test a plugin service factory', async () => {
     const tester = ServiceFactoryTester.from(pluginFactory);
 
-    await expect(tester.get('x')).resolves.toBe('x-plugin');
-    await expect(tester.get('y')).resolves.toBe('y-plugin');
-    await expect(tester.get('z')).resolves.toBe('z-plugin');
+    await expect(tester.getSubject('x')).resolves.toBe('x-plugin');
+    await expect(tester.getSubject('y')).resolves.toBe('y-plugin');
+    await expect(tester.getSubject('z')).resolves.toBe('z-plugin');
   });
 
   it('should test a plugin service factory with root context', async () => {
     const tester = ServiceFactoryTester.from(sharedPluginFactory);
 
-    await expect(tester.get('x')).resolves.toBe('x-1-plugin');
-    await expect(tester.get('y')).resolves.toBe('y-2-plugin');
-    await expect(tester.get('y')).resolves.toBe('y-2-plugin');
-    await expect(tester.get('y')).resolves.toBe('y-2-plugin');
-    await expect(tester.get('z')).resolves.toBe('z-3-plugin');
+    await expect(tester.getSubject('x')).resolves.toBe('x-1-plugin');
+    await expect(tester.getSubject('y')).resolves.toBe('y-2-plugin');
+    await expect(tester.getSubject('y')).resolves.toBe('y-2-plugin');
+    await expect(tester.getSubject('y')).resolves.toBe('y-2-plugin');
+    await expect(tester.getSubject('z')).resolves.toBe('z-3-plugin');
 
     const tester2 = ServiceFactoryTester.from(sharedPluginFactory);
 
-    await expect(tester2.get('z')).resolves.toBe('z-1-plugin');
-    await expect(tester2.get('y')).resolves.toBe('y-2-plugin');
-    await expect(tester2.get('x')).resolves.toBe('x-3-plugin');
-    await expect(tester2.get('x')).resolves.toBe('x-3-plugin');
-    await expect(tester2.get('y')).resolves.toBe('y-2-plugin');
-    await expect(tester2.get('z')).resolves.toBe('z-1-plugin');
+    await expect(tester2.getSubject('z')).resolves.toBe('z-1-plugin');
+    await expect(tester2.getSubject('y')).resolves.toBe('y-2-plugin');
+    await expect(tester2.getSubject('x')).resolves.toBe('x-3-plugin');
+    await expect(tester2.getSubject('x')).resolves.toBe('x-3-plugin');
+    await expect(tester2.getSubject('y')).resolves.toBe('y-2-plugin');
+    await expect(tester2.getSubject('z')).resolves.toBe('z-1-plugin');
   });
 
   it('should use dependencies', async () => {
@@ -96,7 +96,7 @@ describe('ServiceFactoryTester', () => {
       { dependencies: [rootFactory, pluginFactory()] },
     );
 
-    await expect(tester.get('x')).resolves.toBe('root, x-plugin');
+    await expect(tester.getSubject('x')).resolves.toBe('root, x-plugin');
   });
 
   it('should use dependencies with root context', async () => {
@@ -109,11 +109,11 @@ describe('ServiceFactoryTester', () => {
       { dependencies: [sharedPluginFactory(), pluginFactory] },
     );
 
-    await expect(tester.get('x')).resolves.toBe('x-1-plugin, x-plugin');
-    await expect(tester.get('y')).resolves.toBe('y-2-plugin, y-plugin');
-    await expect(tester.get('y')).resolves.toBe('y-2-plugin, y-plugin');
-    await expect(tester.get('y')).resolves.toBe('y-2-plugin, y-plugin');
-    await expect(tester.get('z')).resolves.toBe('z-3-plugin, z-plugin');
+    await expect(tester.getSubject('x')).resolves.toBe('x-1-plugin, x-plugin');
+    await expect(tester.getSubject('y')).resolves.toBe('y-2-plugin, y-plugin');
+    await expect(tester.getSubject('y')).resolves.toBe('y-2-plugin, y-plugin');
+    await expect(tester.getSubject('y')).resolves.toBe('y-2-plugin, y-plugin');
+    await expect(tester.getSubject('z')).resolves.toBe('z-3-plugin, z-plugin');
   });
 
   it('should prioritize the subject implementation', async () => {
@@ -126,7 +126,7 @@ describe('ServiceFactoryTester', () => {
       { dependencies: [rootFactory] },
     );
 
-    await expect(tester.get()).resolves.toBe('other-root');
+    await expect(tester.getSubject()).resolves.toBe('other-root');
   });
 
   it('should throw on missing dependencies', async () => {
@@ -138,7 +138,7 @@ describe('ServiceFactoryTester', () => {
       }),
     );
 
-    await expect(tester.get('x')).rejects.toThrow(
+    await expect(tester.getSubject('x')).rejects.toThrow(
       "Failed to instantiate service 'b' for 'x' because the following dependent services are missing: 'a'",
     );
   });

--- a/packages/backend-test-utils/src/next/wiring/ServiceFactoryTester.ts
+++ b/packages/backend-test-utils/src/next/wiring/ServiceFactoryTester.ts
@@ -82,6 +82,17 @@ export class ServiceFactoryTester<TService, TScope extends 'root' | 'plugin'> {
   /**
    * Returns the service instance for the subject.
    *
+   * @deprecated Use `getSubject` instead.
+   */
+  async get(
+    ...args: 'root' extends TScope ? [] : [pluginId?: string]
+  ): Promise<TService> {
+    return this.getSubject(...args);
+  }
+
+  /**
+   * Returns the service instance for the subject.
+   *
    * @remarks
    *
    * If the subject is a plugin scoped service factory a plugin ID
@@ -89,7 +100,7 @@ export class ServiceFactoryTester<TService, TScope extends 'root' | 'plugin'> {
    *
    * By default the plugin ID 'test' is used.
    */
-  async get(
+  async getSubject(
     ...args: 'root' extends TScope ? [] : [pluginId?: string]
   ): Promise<TService> {
     const [pluginId] = args;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes https://github.com/backstage/backstage/issues/25564

#### :heavy_check_mark: Checklist

The `ServiceFactoryTest.get` method was deprecated and the `ServiceFactoryTest.getSubject` should be used instead. The `getSubject` method has the same behavior, but has a better method name to indicate that the service instance returned is the subject currently being tested.

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
