### PR TITLE
[NBS 1.0] Deprecate the `isDockerDisabledForTests` in test-utils

### DIFF
--- a/.changeset/forty-buttons-cover.md
+++ b/.changeset/forty-buttons-cover.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-test-utils': patch
+---
+
+The function `isDockerDisabledForTests` is deprecated and will no longer be exported in the near future as it should only be used internally.

--- a/packages/backend-test-utils/api-report.md
+++ b/packages/backend-test-utils/api-report.md
@@ -54,7 +54,7 @@ export interface CreateMockDirectoryOptions {
   mockOsTmpDir?: boolean;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export function isDockerDisabledForTests(): boolean;
 
 // @public (undocumented)

--- a/packages/backend-test-utils/src/deprecated.ts
+++ b/packages/backend-test-utils/src/deprecated.ts
@@ -15,9 +15,18 @@
  */
 
 import { CreateMockDirectoryOptions } from './filesystem';
+import { isDockerDisabledForTests as _isDockerDisabledForTests } from './util';
 
 /**
  * @public
  * @deprecated Use `CreateMockDirectoryOptions` from `@backstage/backend-test-utils` instead.
  */
 export type MockDirectoryOptions = CreateMockDirectoryOptions;
+
+/**
+ * @public
+ * @deprecated This is an internal function and will no longer be exported from this package.
+ */
+export function isDockerDisabledForTests(): boolean {
+  return _isDockerDisabledForTests();
+}

--- a/packages/backend-test-utils/src/index.ts
+++ b/packages/backend-test-utils/src/index.ts
@@ -26,4 +26,3 @@ export * from './database';
 export * from './msw';
 export * from './filesystem';
 export * from './next';
-export * from './util';

--- a/packages/backend-test-utils/src/util/isDockerDisabledForTests.ts
+++ b/packages/backend-test-utils/src/util/isDockerDisabledForTests.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-/** @public */
 export function isDockerDisabledForTests() {
   // If we are not running in continuous integration, the default is to skip
   // the (relatively heavy, long running) docker based tests. If you want to


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes https://github.com/backstage/backstage/issues/25562

The function `isDockerDisabledForTests` is deprecated and will no longer be exported in the near future as it should only be used internally.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
