### PR TITLE
Scaffolder action `catalog:write` incorrectly outputs a log message of `Writing catalog-info.yaml`

### DIFF
--- a/.changeset/dirty-wasps-do.md
+++ b/.changeset/dirty-wasps-do.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Catalog:Write scaffolder action shows incorrect log message

--- a/.changeset/dirty-wasps-do.md
+++ b/.changeset/dirty-wasps-do.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-backend': patch
 ---
 
-Catalog:Write scaffolder action shows incorrect log message
+Updated `catalog:write` scaffolder action to show correct file path location in log message

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/catalog/write.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/catalog/write.ts
@@ -49,10 +49,10 @@ export function createCatalogWriteAction() {
     examples,
     supportsDryRun: true,
     async handler(ctx) {
-      ctx.logger.info(`Writing catalog-info.yaml`);
       const { filePath, entity } = ctx.input;
       const entityRef = ctx.templateInfo?.entityRef;
       const path = filePath ?? 'catalog-info.yaml';
+      ctx.logger.info(`Writing ${path}`);
 
       await fs.writeFile(
         resolveSafeChildPath(ctx.workspacePath, path),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The built in scaffolder action `catalog:write` incorrectly outputs a log message of `Writing catalog-info.yaml` regardless of the `filePath` input paramenter. This causes confusion when debugging scaffolder templates

#### :heavy_check_mark: Checklist

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
