### PR TITLE
fix(scaffolder-backend-module-github): octokit getEnvironmentPublicKey missed mandatory params in actions

### DIFF
--- a/plugins/scaffolder-backend-module-github/src/actions/githubEnvironment.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubEnvironment.ts
@@ -200,6 +200,8 @@ export function createGithubEnvironmentAction(options: {
           await client.rest.actions.getEnvironmentPublicKey({
             repository_id: repository.data.id,
             environment_name: name,
+            owner,
+            repo,
           });
 
         await Sodium.ready;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
