### PR TITLE
fix(scaffolder-backend-module-github): octokit call "getEnvironmentPublicKey" missing mandatory params in action github:environment:create

### DIFF
--- a/.changeset/giant-seas-approve.md
+++ b/.changeset/giant-seas-approve.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-github': patch
+---
+
+fix action github:environment:create - some octokit calls missing mandatory params in actions (lack of owner and repo in createEnvironmentVariable).

--- a/plugins/scaffolder-backend-module-github/src/actions/githubEnvironment.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubEnvironment.ts
@@ -200,6 +200,8 @@ export function createGithubEnvironmentAction(options: {
           await client.rest.actions.getEnvironmentPublicKey({
             repository_id: repository.data.id,
             environment_name: name,
+            owner,
+            repo,
           });
 
         await Sodium.ready;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Lack of required params, 
Octokit and github rest API documentation:
https://octokit.github.io/rest.js/v20#actions-get-environment-public-key
https://docs.github.com/en/rest/actions/secrets?apiVersion=2022-11-28#get-an-environment-public-key


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
