### PR TITLE
Fix extra divider displayed on user list picker component

### DIFF
--- a/.changeset/pink-gorillas-brake.md
+++ b/.changeset/pink-gorillas-brake.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Fix extra divider displayed on user list picker component

--- a/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
@@ -247,11 +247,11 @@ export const UserListPicker = (props: UserListPickerProps) => {
           </Typography>
           <Card className={classes.groupWrapper}>
             <List disablePadding dense role="menu" aria-label={group.name}>
-              {group.items.map(item => (
+              {group.items.map((item, index) => (
                 <MenuItem
                   role="none presentation"
                   key={item.id}
-                  divider
+                  divider={index !== group.items.length - 1}
                   onClick={() => setSelectedUserFilter(item.id)}
                   selected={item.id === filters.user?.value}
                   className={classes.menuItem}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

A divider is used for every item in the user list picker component, even if they're not dividing anything i.e. the last item in the group. This PR fixes the minor visual bug where an extra divider is displayed for the last item in the group list.

In the example below, with the changes in this PR you can see the thin divider line at the bottom of "Starred" and "All" buttons are removed.

Before:
<img width="213" alt="Screenshot 2024-07-10 at 8 41 11 PM" src="https://github.com/backstage/backstage/assets/31711200/df63022f-8562-4f52-b4c6-f40b9fea438f">

After:
<img width="213" alt="Screenshot 2024-07-10 at 8 42 38 PM" src="https://github.com/backstage/backstage/assets/31711200/50193d80-4955-4ba4-ba63-c3f05343b178">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
