### PR TITLE
backend-app-api: avoid using service factory options for plugin meta service

### DIFF
--- a/.changeset/nice-cats-nail.md
+++ b/.changeset/nice-cats-nail.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+Internal refactor that avoids the use of service factory options.

--- a/packages/backend-app-api/src/wiring/ServiceRegistry.ts
+++ b/packages/backend-app-api/src/wiring/ServiceRegistry.ts
@@ -48,13 +48,13 @@ function toInternalServiceFactory<TService, TScope extends 'plugin' | 'root'>(
   return f;
 }
 
-const pluginMetadataServiceFactory = createServiceFactory(
-  (options?: { pluginId: string }) => ({
+function createPluginMetadataServiceFactory(pluginId: string) {
+  return createServiceFactory({
     service: coreServices.pluginMetadata,
     deps: {},
-    factory: async () => ({ getId: () => options?.pluginId! }),
-  }),
-);
+    factory: async () => ({ getId: () => pluginId }),
+  });
+}
 
 export class ServiceRegistry {
   static create(factories: Array<ServiceFactory>): ServiceRegistry {
@@ -97,7 +97,7 @@ export class ServiceRegistry {
     // Special case handling of the plugin metadata service, generating a custom factory for it each time
     if (ref.id === coreServices.pluginMetadata.id) {
       return Promise.resolve(
-        toInternalServiceFactory(pluginMetadataServiceFactory({ pluginId })),
+        toInternalServiceFactory(createPluginMetadataServiceFactory(pluginId)),
       );
     }
 


### PR DESCRIPTION
🧹, on top of #25570