### PR TITLE
backend-defaults: deprecate config service options

### DIFF
--- a/.changeset/wet-rivers-travel.md
+++ b/.changeset/wet-rivers-travel.md
@@ -2,4 +2,4 @@
 '@backstage/backend-defaults': patch
 ---
 
-The `RootConfigFactoryOptions` have been deprecated alongside the deprecation of service factory options. For more information on how to customize the config service, see the [Root Config Service docs](https://backstage.io/docs/backend-system/core-services/root-config#configuring-the-service).
+Refactor of `rootConfigServiceFactory` to allow it to be constructed with options, but without declaring options via `createServiceFactory`.

--- a/.changeset/wet-rivers-travel.md
+++ b/.changeset/wet-rivers-travel.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+The `RootConfigFactoryOptions` have been deprecated alongside the deprecation of service factory options. For more information on how to customize the config service, see the [Root Config Service docs](https://backstage.io/docs/backend-system/core-services/root-config#configuring-the-service).

--- a/docs/backend-system/core-services/root-config.md
+++ b/docs/backend-system/core-services/root-config.md
@@ -36,15 +36,36 @@ createBackendPlugin({
 
 ## Configuring the service
 
-There are several APIs from the `@backstage/config-loader` package that allow you to customize the implementation of the config service. The default implementation uses the `ConfigSources.default` method, which has several options, for example:
+There's additional configuration that you can optionally pass to setup the `config` core service.
 
 - `argv` - Override the arguments that are passed to the config loader, instead of using `process.argv`
 - `remote` - Configure remote configuration loading
 
-You can use these to create your own config service implementation:
+You can configure these additional options by adding an override for the core service when calling `createBackend` like follows:
 
 ```ts
 import { rootConfigServiceFactory } from '@backstage/backend-app-api';
+
+const backend = createBackend();
+
+backend.add(
+  rootConfigServiceFactory({
+    argv: [
+      '--config',
+      '/backstage/app-config.development.yaml',
+      '--config',
+      '/backstage/app-config.yaml',
+    ],
+    remote: { reloadIntervalSeconds: 60 },
+  }),
+);
+```
+
+For more advanced customization, there are several APIs from the `@backstage/config-loader` package that allow you to customize the implementation of the config service. The default implementation uses the `ConfigSources.default` method, which has the same options as the `rootConfigServiceFactory` function. You can use these to create your own config service implementation:
+
+```ts
+import { ConfigSources } from '@backstage/config-loader';
+import { createServiceFactory } from '@backstage/backend-plugin-api';
 
 const backend = createBackend();
 

--- a/packages/backend-defaults/api-report-rootConfig.md
+++ b/packages/backend-defaults/api-report-rootConfig.md
@@ -17,7 +17,7 @@ export function createConfigSecretEnumerator(options: {
   schema?: ConfigSchema;
 }): Promise<(config: Config) => Iterable<string>>;
 
-// @public
+// @public @deprecated
 export interface RootConfigFactoryOptions {
   argv?: string[];
   remote?: Pick<RemoteConfigSourceOptions, 'reloadInterval'>;

--- a/packages/backend-defaults/api-report-rootConfig.md
+++ b/packages/backend-defaults/api-report-rootConfig.md
@@ -8,7 +8,7 @@ import { ConfigSchema } from '@backstage/config-loader';
 import { LoggerService } from '@backstage/backend-plugin-api';
 import { RemoteConfigSourceOptions } from '@backstage/config-loader';
 import { RootConfigService } from '@backstage/backend-plugin-api';
-import { ServiceFactoryCompat } from '@backstage/backend-plugin-api';
+import { ServiceFactory } from '@backstage/backend-plugin-api';
 
 // @public (undocumented)
 export function createConfigSecretEnumerator(options: {
@@ -17,7 +17,7 @@ export function createConfigSecretEnumerator(options: {
   schema?: ConfigSchema;
 }): Promise<(config: Config) => Iterable<string>>;
 
-// @public @deprecated
+// @public
 export interface RootConfigFactoryOptions {
   argv?: string[];
   remote?: Pick<RemoteConfigSourceOptions, 'reloadInterval'>;
@@ -26,11 +26,10 @@ export interface RootConfigFactoryOptions {
 }
 
 // @public (undocumented)
-export const rootConfigServiceFactory: ServiceFactoryCompat<
-  RootConfigService,
-  'root',
-  RootConfigFactoryOptions
->;
+export const rootConfigServiceFactory: ((
+  options?: RootConfigFactoryOptions,
+) => ServiceFactory<RootConfigService, 'root'>) &
+  ServiceFactory<RootConfigService, 'root'>;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/packages/backend-defaults/src/entrypoints/rootConfig/rootConfigServiceFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/rootConfig/rootConfigServiceFactory.ts
@@ -31,6 +31,7 @@ import {
  * for more information.
  *
  * @public
+ * @deprecated These service options will be removed, please use the `ConfigSources` API from `@backstage/config-loader` to implement your own version of the service factory instead.
  */
 export interface RootConfigFactoryOptions {
   /**

--- a/packages/backend-defaults/src/entrypoints/rootConfig/rootConfigServiceFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/rootConfig/rootConfigServiceFactory.ts
@@ -31,7 +31,6 @@ import {
  * for more information.
  *
  * @public
- * @deprecated These service options will be removed, please use the `ConfigSources` API from `@backstage/config-loader` to implement your own version of the service factory instead.
  */
 export interface RootConfigFactoryOptions {
   /**
@@ -46,11 +45,10 @@ export interface RootConfigFactoryOptions {
   watch?: boolean;
 }
 
-/**
- * @public
- */
-export const rootConfigServiceFactory = createServiceFactory(
-  (options?: RootConfigFactoryOptions) => ({
+export const rootConfigServiceFactoryWithOptions = (
+  options?: RootConfigFactoryOptions,
+) =>
+  createServiceFactory({
     service: coreServices.rootConfig,
     deps: {},
     async factory() {
@@ -62,5 +60,12 @@ export const rootConfigServiceFactory = createServiceFactory(
       console.log(`Loading config from ${source}`);
       return await ConfigSources.toConfig(source);
     },
-  }),
+  })();
+
+/**
+ * @public
+ */
+export const rootConfigServiceFactory = Object.assign(
+  rootConfigServiceFactoryWithOptions,
+  rootConfigServiceFactoryWithOptions(),
 );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Update for the root config service related to #25570. Just a documentation update since we already have pretty good APIs for constructing config service implementations.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
