### PR TITLE
backend-defaults: deprecate root http router service options, add startRootHttpServer

### DIFF
--- a/.changeset/nasty-trees-sin.md
+++ b/.changeset/nasty-trees-sin.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+The `RootHttpRouterFactoryOptions` have been deprecated alongside the deprecation of service factory options. A new `startRootHttpServer` function is now exported to instead help simplify re-implementation of the root HTTP service. For more information on how to customize the root HTTP router service, see the [Root HTTP Router Service docs](https://backstage.io/docs/backend-system/core-services/root-http-router#configuring-the-service).

--- a/packages/backend-app-api/api-report.md
+++ b/packages/backend-app-api/api-report.md
@@ -33,6 +33,7 @@ import { RemoteConfigSourceOptions } from '@backstage/config-loader';
 import { RequestHandler } from 'express';
 import { RequestListener } from 'http';
 import { RootConfigService } from '@backstage/backend-plugin-api';
+import { RootHealthService } from '@backstage/backend-plugin-api';
 import { RootHttpRouterService } from '@backstage/backend-plugin-api';
 import { RootLifecycleService } from '@backstage/backend-plugin-api';
 import { RootLoggerService } from '@backstage/backend-plugin-api';
@@ -265,9 +266,11 @@ export type RootHttpRouterConfigureContext = RootHttpRouterConfigureContext_2;
 // @public @deprecated
 export type RootHttpRouterFactoryOptions = RootHttpRouterFactoryOptions_2;
 
+// Warning: (ae-forgotten-export) The symbol "StartRootHttpServerOptions" needs to be exported by the entry point index.d.ts
+//
 // @public @deprecated (undocumented)
 export const rootHttpRouterServiceFactory: (
-  options?: RootHttpRouterFactoryOptions_2 | undefined,
+  options?: StartRootHttpServerOptions | undefined,
 ) => ServiceFactory<RootHttpRouterService, 'root'>;
 
 // @public @deprecated

--- a/packages/backend-defaults/api-report-rootHttpRouter.md
+++ b/packages/backend-defaults/api-report-rootHttpRouter.md
@@ -17,9 +17,13 @@ import { LoggerService } from '@backstage/backend-plugin-api';
 import { RequestHandler } from 'express';
 import { RequestListener } from 'http';
 import { RootConfigService } from '@backstage/backend-plugin-api';
+import { RootHealthService } from '@backstage/backend-plugin-api';
 import { RootHttpRouterService } from '@backstage/backend-plugin-api';
+import { RootLifecycleService } from '@backstage/backend-plugin-api';
+import { RootLoggerService } from '@backstage/backend-plugin-api';
 import type { Server } from 'node:http';
 import { ServiceFactory } from '@backstage/backend-plugin-api';
+import { ServiceRef } from '@backstage/backend-plugin-api';
 
 // @public
 export function createHttpServer(
@@ -134,16 +138,38 @@ export interface RootHttpRouterConfigureContext {
   server: Server;
 }
 
-// @public
-export type RootHttpRouterFactoryOptions = {
-  indexPath?: string | false;
-  configure?(context: RootHttpRouterConfigureContext): void;
-};
+// @public @deprecated (undocumented)
+export type RootHttpRouterFactoryOptions = StartRootHttpServerOptions;
 
 // @public (undocumented)
 export const rootHttpRouterServiceFactory: (
-  options?: RootHttpRouterFactoryOptions | undefined,
+  options?: StartRootHttpServerOptions | undefined,
 ) => ServiceFactory<RootHttpRouterService, 'root'>;
+
+// @public
+export function startRootHttpServer(
+  options: StartRootHttpServerOptions,
+): Promise<RootHttpRouterService>;
+
+// @public (undocumented)
+export namespace startRootHttpServer {
+  const deps: {
+    config: ServiceRef<RootConfigService, 'root'>;
+    logger: ServiceRef<RootLoggerService, 'root'>;
+    lifecycle: ServiceRef<RootLifecycleService, 'root'>;
+    health: ServiceRef<RootHealthService, 'root'>;
+  };
+}
+
+// @public
+export type StartRootHttpServerOptions = {
+  indexPath?: string | false;
+  configure?(context: RootHttpRouterConfigureContext): void;
+  config: RootConfigService;
+  logger: RootLoggerService;
+  lifecycle: RootLifecycleService;
+  health: RootHealthService;
+};
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/packages/backend-defaults/src/entrypoints/rootHttpRouter/index.ts
+++ b/packages/backend-defaults/src/entrypoints/rootHttpRouter/index.ts
@@ -21,6 +21,8 @@ export {
 export * from './http';
 export {
   rootHttpRouterServiceFactory,
+  startRootHttpServer,
   type RootHttpRouterConfigureContext,
   type RootHttpRouterFactoryOptions,
+  type StartRootHttpServerOptions,
 } from './rootHttpRouterServiceFactory';

--- a/packages/backend-test-utils/api-report.md
+++ b/packages/backend-test-utils/api-report.md
@@ -32,13 +32,13 @@ import { LoggerService } from '@backstage/backend-plugin-api';
 import { PermissionsService } from '@backstage/backend-plugin-api';
 import { RootConfigService } from '@backstage/backend-plugin-api';
 import { RootHealthService } from '@backstage/backend-plugin-api';
-import { RootHttpRouterFactoryOptions } from '@backstage/backend-defaults/rootHttpRouter';
 import { RootHttpRouterService } from '@backstage/backend-plugin-api';
 import { RootLifecycleService } from '@backstage/backend-plugin-api';
 import { RootLoggerService } from '@backstage/backend-plugin-api';
 import { SchedulerService } from '@backstage/backend-plugin-api';
 import { ServiceFactory } from '@backstage/backend-plugin-api';
 import { ServiceRef } from '@backstage/backend-plugin-api';
+import { StartRootHttpServerOptions } from '@backstage/backend-defaults/rootHttpRouter';
 import { TokenManagerService } from '@backstage/backend-plugin-api';
 import { UrlReaderService } from '@backstage/backend-plugin-api';
 import { UserInfoService } from '@backstage/backend-plugin-api';
@@ -290,7 +290,7 @@ export namespace mockServices {
   export namespace rootHttpRouter {
     const // (undocumented)
       factory: (
-        options?: RootHttpRouterFactoryOptions | undefined,
+        options?: StartRootHttpServerOptions | undefined,
       ) => ServiceFactory<RootHttpRouterService, 'root'>;
     const // (undocumented)
       mock: (


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Update for the root HTTP router service related to #25570. Since it's pretty cumbersome to re-implement the service I'm suggesting we add a new `startRootHttpServer` that wraps up all existing logic with the same options.

A slight downside to this new pattern is that these helpers may change their service dependencies over time, and therefore require manual code updates for those that have re-implemented the service. That's all within the boundaries of our versioning policy though and a cost that you pay for this deeper customization. Still, I figured we could try out a pattern where we export a dependency map declaration that matches the required options, in this case `startRootHttpServer.deps`. It doesn't scale super well, but at least it also allows the custom implementation to add additional dependencies without too much trouble. The benefit of it of course being that if we need to change the dependencies of `startRootHttpServer` in the future, no code changes are required for those using this pattern. I think a proper solution to this is likely some form of dependency container abstraction, but that's a bit much for now.

There's a competing solution to this in #25589

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
