### PR TITLE
backend-test-utils: refactor mock service factories to define options on its own

### DIFF
--- a/.changeset/wicked-impalas-explode.md
+++ b/.changeset/wicked-impalas-explode.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-test-utils': patch
+---
+
+Internal refactor of `mockServices.httpAuth.factory` to allow it to still be constructed with options, but without declaring options via `createServiceFactory`.

--- a/packages/backend-test-utils/api-report.md
+++ b/packages/backend-test-utils/api-report.md
@@ -206,13 +206,10 @@ export namespace mockServices {
   }): HttpAuthService;
   // (undocumented)
   export namespace httpAuth {
-    const factory: ServiceFactoryCompat<
-      HttpAuthService,
-      'plugin',
-      {
-        defaultCredentials?: BackstageCredentials | undefined;
-      }
-    >;
+    const factory: ((options?: {
+      defaultCredentials?: BackstageCredentials;
+    }) => ServiceFactory<HttpAuthService, 'plugin'>) &
+      ServiceFactory<HttpAuthService, 'plugin'>;
     const // (undocumented)
       mock: (
         partialImpl?: Partial<HttpAuthService> | undefined,

--- a/packages/backend-test-utils/api-report.md
+++ b/packages/backend-test-utils/api-report.md
@@ -229,7 +229,7 @@ export namespace mockServices {
   // (undocumented)
   export namespace identity {
     const // (undocumented)
-      factory: () => ServiceFactory<IdentityService, 'plugin'>;
+      factory: ServiceFactoryCompat<IdentityService, 'plugin', undefined>;
     const // (undocumented)
       mock: (
         partialImpl?: Partial<IdentityService> | undefined,
@@ -271,9 +271,10 @@ export namespace mockServices {
       data?: JsonObject;
     };
     const // (undocumented)
-      factory: (
-        options?: Options | undefined,
-      ) => ServiceFactory<RootConfigService, 'root'>;
+      factory: ServiceFactory<RootConfigService, 'root'> &
+        ((
+          options?: Options | undefined,
+        ) => ServiceFactory<RootConfigService, 'root'>);
   }
   // (undocumented)
   export namespace rootHealth {
@@ -315,9 +316,10 @@ export namespace mockServices {
       level?: 'none' | 'error' | 'warn' | 'info' | 'debug';
     };
     const // (undocumented)
-      factory: (
-        options?: Options | undefined,
-      ) => ServiceFactory<LoggerService, 'root'>;
+      factory: ServiceFactory<LoggerService, 'root'> &
+        ((
+          options?: Options | undefined,
+        ) => ServiceFactory<LoggerService, 'root'>);
     const // (undocumented)
       mock: (
         partialImpl?: Partial<RootLoggerService> | undefined,
@@ -337,7 +339,7 @@ export namespace mockServices {
   // (undocumented)
   export namespace tokenManager {
     const // (undocumented)
-      factory: () => ServiceFactory<TokenManagerService, 'plugin'>;
+      factory: ServiceFactoryCompat<TokenManagerService, 'plugin', undefined>;
     const // (undocumented)
       mock: (
         partialImpl?: Partial<TokenManagerService> | undefined,

--- a/packages/backend-test-utils/src/next/services/mockServices.ts
+++ b/packages/backend-test-utils/src/next/services/mockServices.ts
@@ -70,21 +70,28 @@ function createLoggerMock() {
 }
 
 /** @internal */
-function simpleFactory<
+function simpleFactoryWithOptions<
   TService,
   TScope extends 'root' | 'plugin',
   TOptions extends [options?: object] = [],
 >(
   ref: ServiceRef<TService, TScope>,
   factory: (...options: TOptions) => TService,
-): (...options: TOptions) => ServiceFactory<TService, TScope> {
-  return createServiceFactory((options: unknown) => ({
-    service: ref as ServiceRef<TService, any>,
-    deps: {},
-    async factory() {
-      return (factory as any)(options);
-    },
-  })) as (...options: TOptions) => ServiceFactory<TService, any>;
+): ServiceFactory<TService, TScope> &
+  ((...options: TOptions) => ServiceFactory<TService, TScope>) {
+  const factoryWithOptions = (...options: TOptions) =>
+    createServiceFactory({
+      service: ref as ServiceRef<TService, any>,
+      deps: {},
+      async factory() {
+        return factory(...options);
+      },
+    })();
+  return Object.assign(
+    factoryWithOptions,
+    factoryWithOptions(...([undefined] as unknown as TOptions)),
+  ) as ServiceFactory<TService, TScope> &
+    ((...options: TOptions) => ServiceFactory<TService, TScope>);
 }
 
 /** @public */
@@ -134,7 +141,10 @@ export namespace mockServices {
   export namespace rootConfig {
     export type Options = { data?: JsonObject };
 
-    export const factory = simpleFactory(coreServices.rootConfig, rootConfig);
+    export const factory = simpleFactoryWithOptions(
+      coreServices.rootConfig,
+      rootConfig,
+    );
   }
 
   export function rootLogger(options?: rootLogger.Options): LoggerService {
@@ -145,7 +155,10 @@ export namespace mockServices {
       level?: 'none' | 'error' | 'warn' | 'info' | 'debug';
     };
 
-    export const factory = simpleFactory(coreServices.rootLogger, rootLogger);
+    export const factory = simpleFactoryWithOptions(
+      coreServices.rootLogger,
+      rootLogger,
+    );
     export const mock = simpleMock(coreServices.rootLogger, () => ({
       child: jest.fn(),
       debug: jest.fn(),
@@ -168,10 +181,11 @@ export namespace mockServices {
     };
   }
   export namespace tokenManager {
-    export const factory = simpleFactory(
-      coreServices.tokenManager,
-      tokenManager,
-    );
+    export const factory = createServiceFactory({
+      service: coreServices.tokenManager,
+      deps: {},
+      factory: () => tokenManager(),
+    });
     export const mock = simpleMock(coreServices.tokenManager, () => ({
       authenticate: jest.fn(),
       getToken: jest.fn(),
@@ -182,7 +196,11 @@ export namespace mockServices {
     return new MockIdentityService();
   }
   export namespace identity {
-    export const factory = simpleFactory(coreServices.identity, identity);
+    export const factory = createServiceFactory({
+      service: coreServices.identity,
+      deps: {},
+      factory: () => identity(),
+    });
     export const mock = simpleMock(coreServices.identity, () => ({
       getIdentity: jest.fn(),
     }));

--- a/packages/backend-test-utils/src/next/services/mockServices.ts
+++ b/packages/backend-test-utils/src/next/services/mockServices.ts
@@ -270,15 +270,10 @@ export namespace mockServices {
     );
   }
   export namespace httpAuth {
-    /**
-     * Creates a mock service factory for the `HttpAuthService`.
-     *
-     * By default all requests without credentials are treated as requests from
-     * the default mock user principal. This behavior can be configured with the
-     * `defaultCredentials` option.
-     */
-    export const factory = createServiceFactory(
-      (options?: { defaultCredentials?: BackstageCredentials }) => ({
+    const factoryWithOptions = (options?: {
+      defaultCredentials?: BackstageCredentials;
+    }) =>
+      createServiceFactory({
         service: coreServices.httpAuth,
         deps: { plugin: coreServices.pluginMetadata },
         factory: ({ plugin }) =>
@@ -286,7 +281,17 @@ export namespace mockServices {
             plugin.getId(),
             options?.defaultCredentials ?? mockCredentials.user(),
           ),
-      }),
+      })();
+    /**
+     * Creates a mock service factory for the `HttpAuthService`.
+     *
+     * By default all requests without credentials are treated as requests from
+     * the default mock user principal. This behavior can be configured with the
+     * `defaultCredentials` option.
+     */
+    export const factory = Object.assign(
+      factoryWithOptions,
+      factoryWithOptions(),
     );
     export const mock = simpleMock(coreServices.httpAuth, () => ({
       credentials: jest.fn(),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In preparation for #25570, this maintains the ability to create a factory using options, but doesn't do it via `createServiceFactory`. Since you won't be able to pass callback-based features to backend-like things anymore, this also provides an instance of the service factory with the default options merged into the factory function itself.

As opposed to #25589, these test utilities aren't really affected by the lack of dependency injection in the options as much as the real service implementations are, which is why I'm thinking this is definitely the way to go here.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
