### PR TITLE
backend-defaults: refactor rootHttpRouterServiceFactory to define options on its own

### DIFF
--- a/.changeset/lucky-wolves-pull.md
+++ b/.changeset/lucky-wolves-pull.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Refactor of `rootHttpRouterServiceFactory` to allow it to be constructed with options, but without declaring options via `createServiceFactory`.

--- a/packages/backend-app-api/api-report.md
+++ b/packages/backend-app-api/api-report.md
@@ -292,11 +292,10 @@ export type RootHttpRouterConfigureContext = RootHttpRouterConfigureContext_2;
 export type RootHttpRouterFactoryOptions = RootHttpRouterFactoryOptions_2;
 
 // @public @deprecated (undocumented)
-export const rootHttpRouterServiceFactory: ServiceFactoryCompat<
-  RootHttpRouterService,
-  'root',
-  RootHttpRouterFactoryOptions_2
->;
+export const rootHttpRouterServiceFactory: ((
+  options?: RootHttpRouterFactoryOptions_2 | undefined,
+) => ServiceFactory<RootHttpRouterService, 'root'>) &
+  ServiceFactory<RootHttpRouterService, 'root'>;
 
 // @public @deprecated
 export const rootLifecycleServiceFactory: ServiceFactoryCompat<

--- a/packages/backend-defaults/api-report-rootHttpRouter.md
+++ b/packages/backend-defaults/api-report-rootHttpRouter.md
@@ -19,7 +19,7 @@ import { RequestListener } from 'http';
 import { RootConfigService } from '@backstage/backend-plugin-api';
 import { RootHttpRouterService } from '@backstage/backend-plugin-api';
 import type { Server } from 'node:http';
-import { ServiceFactoryCompat } from '@backstage/backend-plugin-api';
+import { ServiceFactory } from '@backstage/backend-plugin-api';
 
 // @public
 export function createHttpServer(
@@ -141,11 +141,10 @@ export type RootHttpRouterFactoryOptions = {
 };
 
 // @public (undocumented)
-export const rootHttpRouterServiceFactory: ServiceFactoryCompat<
-  RootHttpRouterService,
-  'root',
-  RootHttpRouterFactoryOptions
->;
+export const rootHttpRouterServiceFactory: ((
+  options?: RootHttpRouterFactoryOptions,
+) => ServiceFactory<RootHttpRouterService, 'root'>) &
+  ServiceFactory<RootHttpRouterService, 'root'>;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/packages/backend-defaults/src/entrypoints/rootHttpRouter/rootHttpRouterServiceFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/rootHttpRouter/rootHttpRouterServiceFactory.ts
@@ -69,9 +69,10 @@ function defaultConfigure({ applyDefaults }: RootHttpRouterConfigureContext) {
   applyDefaults();
 }
 
-/** @public */
-export const rootHttpRouterServiceFactory = createServiceFactory(
-  (options?: RootHttpRouterFactoryOptions) => ({
+const rootHttpRouterServiceFactoryWithOptions = (
+  options?: RootHttpRouterFactoryOptions,
+) =>
+  createServiceFactory({
     service: coreServices.rootHttpRouter,
     deps: {
       config: coreServices.rootConfig,
@@ -122,5 +123,10 @@ export const rootHttpRouterServiceFactory = createServiceFactory(
 
       return router;
     },
-  }),
+  })();
+
+/** @public */
+export const rootHttpRouterServiceFactory = Object.assign(
+  rootHttpRouterServiceFactoryWithOptions,
+  rootHttpRouterServiceFactoryWithOptions(),
 );

--- a/packages/backend-test-utils/api-report.md
+++ b/packages/backend-test-utils/api-report.md
@@ -290,11 +290,10 @@ export namespace mockServices {
   // (undocumented)
   export namespace rootHttpRouter {
     const // (undocumented)
-      factory: ServiceFactoryCompat<
-        RootHttpRouterService,
-        'root',
-        RootHttpRouterFactoryOptions
-      >;
+      factory: ((
+        options?: RootHttpRouterFactoryOptions | undefined,
+      ) => ServiceFactory<RootHttpRouterService, 'root'>) &
+        ServiceFactory<RootHttpRouterService, 'root'>;
     const // (undocumented)
       mock: (
         partialImpl?: Partial<RootHttpRouterService> | undefined,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In preparation for #25570, this maintains the ability to create a factory using options, but doesn't do it via createServiceFactory. Since you won't be able to pass callback-based features to backend-like things anymore, this also provides an instance of the service factory with the default options merged into the factory function itself.

This is a competing solution to #25586 which avoids the breaking change. Perhaps the main downsides of this approach is that the definition of the service factory is a bit awkward, and it also doesn't encourage exporting building blocks for easy re-implementation. The main different between this and `startRootHttpServer` for that last point is that when using `startRootHttpServer` you have access to dependency injection, and the lack of that remains the biggest downside with this approach.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
