### PR TITLE
TechDocs - Navigation page flicker

### DIFF
--- a/.changeset/chatty-adults-boil.md
+++ b/.changeset/chatty-adults-boil.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Fixed an issue that was causing techdocs pages unnecessarily re-render on navigate.

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/useNavigateUrl.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/useNavigateUrl.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { configApiRef, useApi } from '@backstage/core-plugin-api';
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 /**
@@ -53,7 +53,8 @@ export function resolveUrlToRelative(url: string, baseUrl: string) {
  * @public
  */
 export function useNavigateUrl() {
-  const navigate = useNavigate();
+  // useRef prevents useNavigate from causing unnecessary re-renders
+  const navigate = useRef(useNavigate());
   const configApi = useApi(configApiRef);
   const appBaseUrl = configApi.getOptionalString('app.baseUrl');
   const navigateFn = useCallback(
@@ -70,9 +71,9 @@ export function useNavigateUrl() {
           // URL passed in was relative.
         }
       }
-      navigate(url);
+      navigate.current(url);
     },
-    [navigate, appBaseUrl],
+    [appBaseUrl],
   );
   return navigateFn;
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This `navigate` dependency from the `useNavigateUrl` hook [here](https://github.com/backstage/backstage/blob/66930ceeedaed1c3a975cd94af8acf7f5a92f98a/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx#L246) caused the render `useEffect` ([link](https://github.com/backstage/backstage/blob/66930ceeedaed1c3a975cd94af8acf7f5a92f98a/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx#L249)) to run too early (before the new page has been loaded) when navigating. This effectively dispatched the loading event + styles updates on the previous page. The new page/dom would then get loaded again and go through the same renders causing another styles + loading update. This was the main cause of the flickering.

The fix in this PR:
Wrapping `useNavigate` in a `useRef` such that it does not cause a re-render when updated.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
