### PR TITLE
frontend-app-api: make all config under the app key visible in the frontend

### DIFF
--- a/packages/frontend-app-api/config.d.ts
+++ b/packages/frontend-app-api/config.d.ts
@@ -15,12 +15,12 @@
  */
 
 export interface Config {
+  /**
+   * @visibility frontend
+   * @deepVisibility frontend
+   */
   app?: {
     experimental?: {
-      /**
-       * @visibility frontend
-       * @deepVisibility frontend
-       */
       packages?: 'all' | { include?: string[]; exclude?: string[] };
     };
 
@@ -30,15 +30,10 @@ export interface Config {
        * key and the value is expected to be on the form `<pluginId>.<routeId>`.
        * If the value is `false`, the route will be disabled even if it has a
        * default mapping.
-       *
-       * @deepVisibility frontend
        */
       bindings?: { [externalRouteRefId: string]: string | false };
     };
 
-    /**
-     * @deepVisibility frontend
-     */
     extensions?: Array<
       | string
       | {


### PR DESCRIPTION
This switches the built-in config schema in the new frontend system to make all config under `app.` visible in the frontend. In addition to this, the idea is to also recommend to not use any config outside of `app.` in the frontend. A bit longer term this means that we move over the `app.` simply being the frontend configuration, and the need for `frontend` visibility is removed altogether.

Of course we still need a way to configure frontend plugins, which we instead intend to be managed via configuration of individual extensions in the new system: https://backstage.io/docs/frontend-system/architecture/extensions#extension-configuration
