### PR TITLE
Add optional target prop to EntityRelation type

### DIFF
--- a/.changeset/sweet-colts-sip.md
+++ b/.changeset/sweet-colts-sip.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-model': patch
+---
+
+Add an optional target prop to EntityRelation type definition

--- a/packages/catalog-model/src/entity/Entity.ts
+++ b/packages/catalog-model/src/entity/Entity.ts
@@ -165,6 +165,11 @@ export type EntityRelation = {
   type: string;
 
   /**
+   * The target of this relation.
+   */
+  target?: string;
+
+  /**
    * The entity ref of the target of this relation.
    */
   targetRef: string;


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Add a missing `target` property to `EntityRelation` type definition.

An entity relation can have a `target` property, like so:

```
"relations": [
    {
      "type": "ownedBy",
      "targetRef": "user:default/someuser",
      "target": {
        "kind": "user",
        "namespace": "default",
        "name": "someuser"
      }
    }
  ] 
```

However, `EntityRelation` type definition is missing `target` property, throwing a typescript error when we try to use it. For example, `const target= entity.relations?.target` throws this error `Property 'target' does not exist on type 'EntityRelation[]'`.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
