### PR TITLE
Allow manual trigger frequency for SchedulerService and backend-tasks

### DIFF
--- a/.changeset/hip-fishes-guess.md
+++ b/.changeset/hip-fishes-guess.md
@@ -1,0 +1,6 @@
+---
+'@backstage/backend-plugin-api': patch
+'@backstage/backend-defaults': patch
+---
+
+The `SchedulerService` now allows tasks with `frequency: { trigger: 'manual' }`. This means that the task will not be scheduled, but rather run only when manually triggered with `SchedulerService.triggerTask`.

--- a/.changeset/metal-planes-nail.md
+++ b/.changeset/metal-planes-nail.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-tasks': patch
+---
+
+The `PluginTaskScheduler` now allows tasks with `frequency: { trigger: 'manual' }`. This means that the task will not be scheduled, but rather run only when manually triggered with `PluginTaskScheduler.triggerTask`.

--- a/packages/backend-defaults/migrations.test.ts
+++ b/packages/backend-defaults/migrations.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Backstage Authors
+ * Copyright 2024 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/backend-defaults/migrations/scheduler/20240712211735_nullable_next_run.js
+++ b/packages/backend-defaults/migrations/scheduler/20240712211735_nullable_next_run.js
@@ -31,6 +31,10 @@ exports.up = async function up(knex) {
  * @returns { Promise<void> }
  */
 exports.down = async function down(knex) {
+  await knex
+    .delete()
+    .from('backstage_backend_tasks__tasks')
+    .where({ next_run_start_at: null });
   await knex.schema.alterTable('backstage_backend_tasks__tasks', table => {
     table.dropNullable('next_run_start_at');
   });

--- a/packages/backend-defaults/migrations/scheduler/20240712211735_nullable_next_run.js
+++ b/packages/backend-defaults/migrations/scheduler/20240712211735_nullable_next_run.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @ts-check
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function up(knex) {
+  await knex.schema.alterTable('backstage_backend_tasks__tasks', table => {
+    table.setNullable('next_run_start_at');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function down(knex) {
+  await knex.schema.alterTable('backstage_backend_tasks__tasks', table => {
+    table.dropNullable('next_run_start_at');
+  });
+};

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/PluginTaskSchedulerImpl.test.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/PluginTaskSchedulerImpl.test.ts
@@ -347,6 +347,9 @@ describe('PluginTaskManagerImpl', () => {
       expect(parseDuration({ milliseconds: 5000 })).toEqual('PT5S');
       expect(parseDuration(Duration.fromMillis(5000))).toEqual('PT5S');
       expect(parseDuration({ cron: '1 * * * *' })).toEqual('1 * * * *');
+      expect(parseDuration({ trigger: 'manual' })).toEqual({
+        trigger: 'manual',
+      });
     });
   });
 });

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/PluginTaskSchedulerImpl.test.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/PluginTaskSchedulerImpl.test.ts
@@ -347,9 +347,7 @@ describe('PluginTaskManagerImpl', () => {
       expect(parseDuration({ milliseconds: 5000 })).toEqual('PT5S');
       expect(parseDuration(Duration.fromMillis(5000))).toEqual('PT5S');
       expect(parseDuration({ cron: '1 * * * *' })).toEqual('1 * * * *');
-      expect(parseDuration({ trigger: 'manual' })).toEqual({
-        trigger: 'manual',
-      });
+      expect(parseDuration({ trigger: 'manual' })).toEqual('manual');
     });
   });
 });

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/PluginTaskSchedulerImpl.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/PluginTaskSchedulerImpl.ts
@@ -155,6 +155,9 @@ export function parseDuration(
   if (typeof frequency === 'object' && 'cron' in frequency) {
     return frequency.cron;
   }
+  if (typeof frequency === 'object' && 'trigger' in frequency) {
+    return frequency.trigger;
+  }
 
   const parsed = Duration.isDuration(frequency)
     ? frequency

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.ts
@@ -53,8 +53,8 @@ export class TaskWorker {
     );
 
     let workCheckFrequency = this.workCheckFrequency;
-    const isCron = !settings?.cadence.startsWith('P');
-    if (!isCron) {
+    const isDuration = settings?.cadence.startsWith('P');
+    if (isDuration) {
       const cadence = Duration.fromISO(settings.cadence);
       if (cadence < workCheckFrequency) {
         workCheckFrequency = cadence;
@@ -175,7 +175,9 @@ export class TaskWorker {
     // read it back again.
     taskSettingsV2Schema.parse(settings);
 
-    const isCron = !settings?.cadence.startsWith('P');
+    const isManual = settings?.cadence === 'manual';
+    const isDuration = settings?.cadence.startsWith('P');
+    const isCron = !isManual && !isDuration;
 
     let startAt: Knex.Raw | undefined;
     let nextStartAt: Knex.Raw | undefined;
@@ -193,6 +195,9 @@ export class TaskWorker {
         .toUTC();
 
       nextStartAt = this.nextRunAtRaw(time);
+      startAt ||= nextStartAt;
+    } else if (isManual) {
+      nextStartAt = this.knex.raw('null');
       startAt ||= nextStartAt;
     } else {
       startAt ||= this.knex.fn.now();
@@ -317,7 +322,9 @@ export class TaskWorker {
     ticket: string,
     settings: TaskSettingsV2,
   ): Promise<boolean> {
-    const isCron = !settings?.cadence.startsWith('P');
+    const isManual = settings?.cadence === 'manual';
+    const isDuration = settings?.cadence.startsWith('P');
+    const isCron = !isManual && !isDuration;
 
     let nextRun: Knex.Raw;
     if (isCron) {
@@ -325,6 +332,8 @@ export class TaskWorker {
       this.logger.debug(`task: ${this.taskId} will next occur around ${time}`);
 
       nextRun = this.nextRunAtRaw(time);
+    } else if (isManual) {
+      nextRun = this.knex.raw('null');
     } else {
       const dt = Duration.fromISO(settings.cadence).as('seconds');
       this.logger.debug(

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/types.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/types.ts
@@ -40,6 +40,10 @@ function isValidCronFormat(c: string | undefined): boolean {
   }
 }
 
+function isValidTrigger(t: string): boolean {
+  return t === 'manual';
+}
+
 export const taskSettingsV1Schema = z.object({
   version: z.literal(1),
   initialDelayDuration: z
@@ -68,6 +72,11 @@ export const taskSettingsV2Schema = z.object({
   cadence: z
     .string()
     .refine(isValidCronFormat, { message: 'Invalid cron' })
+    .or(
+      z.string().refine(isValidTrigger, {
+        message: "Invalid trigger, expecting 'manual'",
+      }),
+    )
     .or(
       z.string().refine(isValidOptionalDurationString, {
         message: 'Invalid duration, expecting ISO Period',

--- a/packages/backend-defaults/src/migrations.test.ts
+++ b/packages/backend-defaults/src/migrations.test.ts
@@ -18,7 +18,7 @@ import { Knex } from 'knex';
 import { TestDatabases } from '@backstage/backend-test-utils';
 import fs from 'fs';
 
-const migrationsDir = `${__dirname}/../migrations`;
+const migrationsDir = `${__dirname}/../migrations/scheduler`;
 const migrationsFiles = fs.readdirSync(migrationsDir).sort();
 
 async function migrateUpOnce(knex: Knex): Promise<void> {

--- a/packages/backend-defaults/src/migrations.test.ts
+++ b/packages/backend-defaults/src/migrations.test.ts
@@ -107,11 +107,6 @@ describe('migrations', () => {
         },
       ]);
 
-      await knex
-        .delete()
-        .from('backstage_backend_tasks__tasks')
-        .where({ next_run_start_at: null });
-
       await migrateDownOnce(knex);
 
       await expect(

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -608,7 +608,10 @@ export interface SchedulerServiceTaskScheduleDefinition {
         cron: string;
       }
     | Duration
-    | HumanDuration;
+    | HumanDuration
+    | {
+        trigger: 'manual';
+      };
   initialDelay?: Duration | HumanDuration;
   scope?: 'global' | 'local';
   timeout: Duration | HumanDuration;
@@ -621,7 +624,14 @@ export interface SchedulerServiceTaskScheduleDefinitionConfig {
         cron: string;
       }
     | string
-    | HumanDuration;
+    | HumanDuration
+    /**
+     * This task will only run when manually triggered with the `triggerTask` method; no automatic
+     * scheduling. This is useful for locking of global tasks that should not be run concurrently.
+     */
+    | {
+        trigger: 'manual';
+      };
   initialDelay?: string | HumanDuration;
   scope?: 'global' | 'local';
   timeout: string | HumanDuration;

--- a/packages/backend-tasks/api-report.md
+++ b/packages/backend-tasks/api-report.md
@@ -62,7 +62,14 @@ export interface TaskScheduleDefinition {
         cron: string;
       }
     | Duration
-    | HumanDuration_2;
+    | HumanDuration_2
+    /**
+     * This task will only run when manually triggered with the `triggerTask` method; no automatic
+     * scheduling. This is useful for locking of global tasks that should not be run concurrently.
+     */
+    | {
+        trigger: 'manual';
+      };
   initialDelay?: Duration | HumanDuration_2;
   scope?: 'global' | 'local';
   timeout: Duration | HumanDuration_2;

--- a/packages/backend-tasks/migrations/20240712211735_nullable_next_run.js
+++ b/packages/backend-tasks/migrations/20240712211735_nullable_next_run.js
@@ -31,6 +31,10 @@ exports.up = async function up(knex) {
  * @returns { Promise<void> }
  */
 exports.down = async function down(knex) {
+  await knex
+    .delete()
+    .from('backstage_backend_tasks__tasks')
+    .where({ next_run_start_at: null });
   await knex.schema.alterTable('backstage_backend_tasks__tasks', table => {
     table.dropNullable('next_run_start_at');
   });

--- a/packages/backend-tasks/migrations/20240712211735_nullable_next_run.js
+++ b/packages/backend-tasks/migrations/20240712211735_nullable_next_run.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @ts-check
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function up(knex) {
+  await knex.schema.alterTable('backstage_backend_tasks__tasks', table => {
+    table.setNullable('next_run_start_at');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function down(knex) {
+  await knex.schema.alterTable('backstage_backend_tasks__tasks', table => {
+    table.dropNullable('next_run_start_at');
+  });
+};

--- a/packages/backend-tasks/src/migrations.test.ts
+++ b/packages/backend-tasks/src/migrations.test.ts
@@ -107,11 +107,6 @@ describe('migrations', () => {
         },
       ]);
 
-      await knex
-        .delete()
-        .from('backstage_backend_tasks__tasks')
-        .where({ next_run_start_at: null });
-
       await migrateDownOnce(knex);
 
       await expect(

--- a/packages/backend-tasks/src/tasks/PluginTaskSchedulerImpl.test.ts
+++ b/packages/backend-tasks/src/tasks/PluginTaskSchedulerImpl.test.ts
@@ -345,6 +345,7 @@ describe('PluginTaskManagerImpl', () => {
       expect(parseDuration({ milliseconds: 5000 })).toEqual('PT5S');
       expect(parseDuration(Duration.fromMillis(5000))).toEqual('PT5S');
       expect(parseDuration({ cron: '1 * * * *' })).toEqual('1 * * * *');
+      expect(parseDuration({ trigger: 'manual' })).toEqual('manual');
     });
   });
 });

--- a/packages/backend-tasks/src/tasks/PluginTaskSchedulerImpl.ts
+++ b/packages/backend-tasks/src/tasks/PluginTaskSchedulerImpl.ts
@@ -152,6 +152,9 @@ export function parseDuration(
   if ('cron' in frequency) {
     return frequency.cron;
   }
+  if ('trigger' in frequency) {
+    return frequency.trigger;
+  }
 
   const parsed = Duration.isDuration(frequency)
     ? frequency

--- a/packages/backend-tasks/src/tasks/readTaskScheduleDefinitionFromConfig.ts
+++ b/packages/backend-tasks/src/tasks/readTaskScheduleDefinitionFromConfig.ts
@@ -32,13 +32,19 @@ function readDuration(config: Config, key: string): HumanDuration {
   return readDurationFromConfig(config, { key });
 }
 
-function readCronOrDuration(
+function readFrequency(
   config: Config,
   key: string,
-): { cron: string } | Duration | HumanDuration {
+): { cron: string } | Duration | HumanDuration | { trigger: 'manual' } {
   const value = config.get(key);
   if (typeof value === 'object' && (value as { cron?: string }).cron) {
     return value as { cron: string };
+  }
+  if (
+    typeof value === 'object' &&
+    (value as { trigger?: string }).trigger === 'manual'
+  ) {
+    return { trigger: 'manual' };
   }
 
   return readDuration(config, key);
@@ -56,7 +62,7 @@ function readCronOrDuration(
 export function readTaskScheduleDefinitionFromConfig(
   config: Config,
 ): TaskScheduleDefinition {
-  const frequency = readCronOrDuration(config, 'frequency');
+  const frequency = readFrequency(config, 'frequency');
   const timeout = readDuration(config, 'timeout');
 
   const initialDelay = config.has('initialDelay')

--- a/packages/backend-tasks/src/tasks/types.ts
+++ b/packages/backend-tasks/src/tasks/types.ts
@@ -100,7 +100,12 @@ export interface TaskScheduleDefinition {
         cron: string;
       }
     | Duration
-    | HumanDuration;
+    | HumanDuration
+    /**
+     * This task will only run when manually triggered with the `triggerTask` method; no automatic
+     * scheduling. This is useful for locking of global tasks that should not be run concurrently.
+     */
+    | { trigger: 'manual' };
 
   /**
    * The maximum amount of time that a single task invocation can take, before

--- a/packages/backend-tasks/src/tasks/types.ts
+++ b/packages/backend-tasks/src/tasks/types.ts
@@ -378,6 +378,10 @@ function isValidCronFormat(c: string | undefined): boolean {
   }
 }
 
+function isValidTrigger(t: string): boolean {
+  return t === 'manual';
+}
+
 export const taskSettingsV1Schema = z.object({
   version: z.literal(1),
   initialDelayDuration: z
@@ -406,6 +410,11 @@ export const taskSettingsV2Schema = z.object({
   cadence: z
     .string()
     .refine(isValidCronFormat, { message: 'Invalid cron' })
+    .or(
+      z.string().refine(isValidTrigger, {
+        message: "Invalid trigger, expecting 'manual'",
+      }),
+    )
     .or(
       z.string().refine(isValidOptionalDurationString, {
         message: 'Invalid duration, expecting ISO Period',


### PR DESCRIPTION
The `backend-tasks` package and `SchedulerService` allow for scheduling and triggering tasks between horizontally-scaled backend instances. There are tasks which are desirable to lock between instances, but are kicked off manually rather than scheduled on a cadence.

I discussed with @freben the idea of allowing a `frequency` property of `manual`, rather than a cron expression or Duration. I found an object slightly easier to work with given the current code, so settled on `{ trigger: 'manual' }`.

To support this, the `next_run_start_at` column must be nullable in the database. I created a migration to drop the `NOT NULL` constraint. I also considered setting `next_run_start_at` to `nowPlus({ years: 1_000 })` but that was a bit too hacky.

This is akin to #24116, which would perhaps be a more comprehensive solution for similar needs. This was a small lift as compared to designing a whole QueueService, so it seems like a valuable capability in the meantime.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
