### PR TITLE
Update writing-custom-actions.md

### DIFF
--- a/docs/features/software-templates/writing-custom-actions.md
+++ b/docs/features/software-templates/writing-custom-actions.md
@@ -195,7 +195,7 @@ const scaffolderModuleCustomExtensions = createBackendModule({
 const backend = createBackend();
 backend.add(import('@backstage/plugin-scaffolder-backend/alpha'));
 /* highlight-add-next-line */
-backend.add(scaffolderModuleCustomExtensions());
+backend.add(scaffolderModuleCustomExtensions);
 ```
 
 If your custom action requires core services such as `config` or `cache` they can be imported in the dependencies and passed to the custom action function.


### PR DESCRIPTION
With parentheses it shows this message:
```
@deprecated — You do not need to use this call signature; use the type directly instead by removing the () parentheses at the end. This call signature will be removed in a future release.
```