### PR TITLE
backend-common: deprecate remaining methods

### DIFF
--- a/.changeset/nine-cherries-decide.md
+++ b/.changeset/nine-cherries-decide.md
@@ -1,0 +1,14 @@
+---
+'@backstage/backend-common': patch
+---
+
+The remaining exports in the package have now been deprecated:
+
+- `cacheToPluginCacheManager`
+- `createLegacyAuthAdapters`
+- `LegacyCreateRouter`
+- `legacyPlugin`
+- `loggerToWinstonLogger`
+- `makeLegacyPlugin`
+
+Users of these export should fully [migrate to the new backend system](https://backstage.io/docs/backend-system/building-backends/migrating).

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -129,7 +129,7 @@ export class CacheManager extends CacheManager_2 {}
 // @public @deprecated (undocumented)
 export type CacheManagerOptions = CacheManagerOptions_2;
 
-// @public
+// @public @deprecated
 export function cacheToPluginCacheManager(cache: CacheService): {
   getClient(options?: CacheServiceOptions): CacheService;
 };
@@ -142,7 +142,7 @@ export interface ContainerRunner {
   runContainer(opts: RunContainerOptions): Promise<void>;
 }
 
-// @public
+// @public @deprecated
 export function createLegacyAuthAdapters<
   TOptions extends {
     auth?: AuthService;
@@ -401,10 +401,10 @@ export type KubernetesContainerRunnerOptions = {
   timeoutMs?: number;
 };
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type LegacyCreateRouter<TEnv> = (deps: TEnv) => Promise<RequestHandler>;
 
-// @public
+// @public @deprecated
 export const legacyPlugin: (
   name: string,
   createRouterImport: Promise<{
@@ -447,13 +447,13 @@ export function loadBackendConfig(options: {
   watch?: boolean;
 }): Promise<Config>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export function loggerToWinstonLogger(
   logger: LoggerService,
   opts?: TransportStreamOptions,
 ): Logger;
 
-// @public
+// @public @deprecated
 export function makeLegacyPlugin<
   TEnv extends Record<string, unknown>,
   TEnvTransforms extends {

--- a/packages/backend-common/src/compat/auth/createLegacyAuthAdapters.ts
+++ b/packages/backend-common/src/compat/auth/createLegacyAuthAdapters.ts
@@ -292,6 +292,7 @@ export class UserInfoCompat implements UserInfoService {
 /**
  * An adapter that ensures presence of the auth and/or httpAuth services.
  * @public
+ * @deprecated Migrate to use the new backend system and auth services instead.
  */
 export function createLegacyAuthAdapters<
   TOptions extends {

--- a/packages/backend-common/src/compat/cache/cacheToPluginCacheManager.ts
+++ b/packages/backend-common/src/compat/cache/cacheToPluginCacheManager.ts
@@ -24,6 +24,7 @@ import {
  * old-backend plugin cache manager.
  *
  * @public
+ * @deprecated Migrate to use the new CacheService instead.
  */
 export function cacheToPluginCacheManager(cache: CacheService): {
   getClient(options?: CacheServiceOptions): CacheService;

--- a/packages/backend-common/src/compat/legacy/legacy.ts
+++ b/packages/backend-common/src/compat/legacy/legacy.ts
@@ -27,6 +27,7 @@ import { TokenManager } from '../../deprecated';
 
 /**
  * @public
+ * @deprecated Fully use the new backend system instead.
  */
 export type LegacyCreateRouter<TEnv> = (deps: TEnv) => Promise<RequestHandler>;
 
@@ -69,6 +70,7 @@ function wrapTokenManager(tokenManager: TokenManager, auth: AuthService) {
  * Creates a new custom plugin compatibility wrapper.
  *
  * @public
+ * @deprecated Fully use the new backend system instead.
  * @remarks
  *
  * Usually you can use {@link legacyPlugin} directly instead, but you might
@@ -128,6 +130,7 @@ export function makeLegacyPlugin<
  * register it with the http router based on the plugin id.
  *
  * @public
+ * @deprecated Fully use the new backend system instead.
  * @remarks
  *
  * This is intended to be used by plugin authors to ease the transition to the

--- a/packages/backend-common/src/compat/logging/loggerToWinstonLogger.ts
+++ b/packages/backend-common/src/compat/logging/loggerToWinstonLogger.ts
@@ -53,7 +53,10 @@ class BackstageLoggerTransport extends Transport {
   }
 }
 
-/** @public */
+/**
+ * @public
+ * @deprecated Migrate to use the new LoggerService instead.
+ */
 export function loggerToWinstonLogger(
   logger: LoggerService,
   opts?: TransportStreamOptions,


### PR DESCRIPTION
Bit of cleanup, 🧹. This deprecates the remaining methods in `backend-common`.

Wherever possible all existing apps and plugins should move over to using the new backend system fully, rather than relying on these methods. There will need to be some usage of these still, in particular in plugins that need to support both the old and the new system. This is mainly an additional nudge towards using the new system fully, as that typically produces fewer headaches at this point.
