### PR TITLE
chore(cli): bump tsconfig.json from es2022 to es2023

### DIFF
--- a/.changeset/clever-ghosts-watch.md
+++ b/.changeset/clever-ghosts-watch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Both the target and types library have been bumped from ES2022 to ES2023 in `@backstage/cli/config/tsconfig.json`. Additionally, `ES2023.Array` has been added to `lib` to take advantage of the new array methods.

--- a/packages/cli/config/tsconfig.json
+++ b/packages/cli/config/tsconfig.json
@@ -11,7 +11,7 @@
     "incremental": true,
     "isolatedModules": true,
     "jsx": "react",
-    "lib": ["DOM", "DOM.Iterable", "ScriptHost", "ES2022"],
+    "lib": ["DOM", "DOM.Iterable", "ScriptHost", "ES2023", "ES2023.Array"],
     "module": "ESNext",
     "moduleResolution": "node",
     "noEmit": false,
@@ -32,7 +32,7 @@
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
     "stripInternal": true,
-    "target": "ES2022",
+    "target": "ES2023",
     "types": ["node", "jest", "webpack-env"],
     "useDefineForClassFields": true
   }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The target and types library in `@backstage/cli/config/tsconfig.json` have been updated from ES2022 to ES2023. Additionally, `ES2023.Array` has been added to `lib` to leverage the new array methods. Support for ES2023 was introduced in TypeScript 5.2, which is now three versions old (5.5).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
