### PR TITLE
backend-defaults: fixed routing of health endpoints

### DIFF
--- a/.changeset/selfish-bees-think.md
+++ b/.changeset/selfish-bees-think.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Fixed the routing of the new health check service, the health endpoints should now properly be available at `/.backstage/health/v1/readiness` and `/.backstage/health/v1/liveness`.

--- a/packages/backend-defaults/src/entrypoints/rootHttpRouter/createHealthRouter.ts
+++ b/packages/backend-defaults/src/entrypoints/rootHttpRouter/createHealthRouter.ts
@@ -23,7 +23,7 @@ export function createHealthRouter(options: { health: RootHealthService }) {
   const router = Router();
 
   router.get(
-    '.backstage/health/v1/readiness',
+    '/.backstage/health/v1/readiness',
     async (_request: Request, response: Response) => {
       const { status, payload } = await options.health.getReadiness();
       response.status(status).json(payload);
@@ -31,7 +31,7 @@ export function createHealthRouter(options: { health: RootHealthService }) {
   );
 
   router.get(
-    '.backstage/health/v1/liveness',
+    '/.backstage/health/v1/liveness',
     async (_request: Request, response: Response) => {
       const { status, payload } = await options.health.getLiveness();
       response.status(status).json(payload);


### PR DESCRIPTION
Fix for the new health check service not being routed quite right.