### PR TITLE
Fix margin for EntityTagsPicker and EntityNamePicker

### DIFF
--- a/.changeset/spicy-lies-listen.md
+++ b/.changeset/spicy-lies-listen.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder': patch
 ---
 
-Fix helper text margin for scaffolder EntityNamePicker and EntityTagsPicker when using outlined textfield
+Fix helper text margin for scaffolder EntityNamePicker and EntityTagsPicker when using outlined text field

--- a/.changeset/spicy-lies-listen.md
+++ b/.changeset/spicy-lies-listen.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Fix helper text margin for scaffolder EntityNamePicker and EntityTagsPicker when using outlined textfield

--- a/plugins/scaffolder/src/components/fields/EntityNamePicker/EntityNamePicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityNamePicker/EntityNamePicker.tsx
@@ -46,6 +46,7 @@ export const EntityNamePicker = (props: EntityNamePickerProps) => {
       margin="normal"
       error={rawErrors?.length > 0 && !formData}
       inputProps={{ autoFocus }}
+      FormHelperTextProps={{ margin: 'dense', style: { marginLeft: 0 } }}
     />
   );
 };

--- a/plugins/scaffolder/src/components/fields/EntityTagsPicker/EntityTagsPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityTagsPicker/EntityTagsPicker.tsx
@@ -116,6 +116,7 @@ export const EntityTagsPicker = (props: EntityTagsPickerProps) => {
               helperText ??
               "Add any relevant tags, hit 'Enter' to add new tags. Valid format: [a-z0-9+#] separated by [-], at most 63 characters"
             }
+            FormHelperTextProps={{ margin: 'dense', style: { marginLeft: 0 } }}
           />
         )}
       />


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `EntityTagsPicker` and `EntityNamePicker` are missing some style overrides for the helper text which are already present on the other built-in scaffolder custom fields. This becomes apparent when using a custom theme to set the default variant of text field component to outlined and the margin of the helper text messes up.

Before:
<img width="549" alt="Screenshot 2024-07-16 at 8 50 09 PM" src="https://github.com/user-attachments/assets/ef348d64-f448-49ac-aec6-e83b2c4a731d">

After:
<img width="549" alt="Screenshot 2024-07-16 at 8 49 38 PM" src="https://github.com/user-attachments/assets/25c60119-b3ef-422c-97ec-a98006a0aea1">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
