### PR TITLE
Add `signIn.resolvers` to auth providers config schema

### DIFF
--- a/.changeset/breezy-jeans-tie.md
+++ b/.changeset/breezy-jeans-tie.md
@@ -1,0 +1,18 @@
+---
+'@backstage/plugin-auth-backend-module-cloudflare-access-provider': patch
+'@backstage/plugin-auth-backend-module-vmware-cloud-provider': patch
+'@backstage/plugin-auth-backend-module-atlassian-provider': patch
+'@backstage/plugin-auth-backend-module-bitbucket-provider': patch
+'@backstage/plugin-auth-backend-module-microsoft-provider': patch
+'@backstage/plugin-auth-backend-module-onelogin-provider': patch
+'@backstage/plugin-auth-backend-module-aws-alb-provider': patch
+'@backstage/plugin-auth-backend-module-gcp-iap-provider': patch
+'@backstage/plugin-auth-backend-module-github-provider': patch
+'@backstage/plugin-auth-backend-module-gitlab-provider': patch
+'@backstage/plugin-auth-backend-module-google-provider': patch
+'@backstage/plugin-auth-backend-module-oauth2-provider': patch
+'@backstage/plugin-auth-backend-module-oidc-provider': patch
+'@backstage/plugin-auth-backend-module-okta-provider': patch
+---
+
+Add `signIn` to authentication provider configuration schema

--- a/plugins/auth-backend-module-atlassian-provider/config.d.ts
+++ b/plugins/auth-backend-module-atlassian-provider/config.d.ts
@@ -28,6 +28,13 @@ export interface Config {
           audience?: string;
           callbackUrl?: string;
           additionalScopes?: string | string[];
+          signIn?: {
+            resolvers: Array<
+              | { resolver: 'usernameMatchingUserEntityName' }
+              | { resolver: 'emailLocalPartMatchingUserEntityName' }
+              | { resolver: 'emailMatchingUserEntityProfileEmail' }
+            >;
+          };
         };
       };
     };

--- a/plugins/auth-backend-module-aws-alb-provider/config.d.ts
+++ b/plugins/auth-backend-module-aws-alb-provider/config.d.ts
@@ -21,6 +21,12 @@ export interface Config {
       awsalb?: {
         issuer?: string;
         region: string;
+        signIn?: {
+          resolvers: Array<
+            | { resolver: 'emailLocalPartMatchingUserEntityName' }
+            | { resolver: 'emailMatchingUserEntityProfileEmail' }
+          >;
+        };
       };
     };
   };

--- a/plugins/auth-backend-module-bitbucket-provider/config.d.ts
+++ b/plugins/auth-backend-module-bitbucket-provider/config.d.ts
@@ -26,6 +26,13 @@ export interface Config {
            */
           clientSecret: string;
           additionalScopes?: string | string[];
+          signIn?: {
+            resolvers: Array<
+              | { resolver: 'userIdMatchingUserEntityAnnotation' }
+              | { resolver: 'emailLocalPartMatchingUserEntityName' }
+              | { resolver: 'emailMatchingUserEntityProfileEmail' }
+            >;
+          };
         };
       };
     };

--- a/plugins/auth-backend-module-cloudflare-access-provider/config.d.ts
+++ b/plugins/auth-backend-module-cloudflare-access-provider/config.d.ts
@@ -27,6 +27,12 @@ export interface Config {
           token: string;
           subject: string;
         }>;
+        signIn?: {
+          resolvers: Array<
+            | { resolver: 'emailLocalPartMatchingUserEntityName' }
+            | { resolver: 'emailMatchingUserEntityProfileEmail' }
+          >;
+        };
       };
       /**
        * The backstage token expiration.

--- a/plugins/auth-backend-module-gcp-iap-provider/config.d.ts
+++ b/plugins/auth-backend-module-gcp-iap-provider/config.d.ts
@@ -32,6 +32,15 @@ export interface Config {
            * The name of the header to read the JWT token from, defaults to `'x-goog-iap-jwt-assertion'`.
            */
           jwtHeader?: string;
+
+          signIn?: {
+            resolvers: Array<
+              | { resolver: 'emailMatchingUserEntityAnnotation' }
+              | { resolver: 'idMatchingUserEntityAnnotation' }
+              | { resolver: 'emailLocalPartMatchingUserEntityName' }
+              | { resolver: 'emailMatchingUserEntityProfileEmail' }
+            >;
+          };
         };
       };
     };

--- a/plugins/auth-backend-module-github-provider/config.d.ts
+++ b/plugins/auth-backend-module-github-provider/config.d.ts
@@ -28,6 +28,13 @@ export interface Config {
           callbackUrl?: string;
           enterpriseInstanceUrl?: string;
           additionalScopes?: string | string[];
+          signIn?: {
+            resolvers: Array<
+              | { resolver: 'usernameMatchingUserEntityName' }
+              | { resolver: 'emailLocalPartMatchingUserEntityName' }
+              | { resolver: 'emailMatchingUserEntityProfileEmail' }
+            >;
+          };
         };
       };
     };

--- a/plugins/auth-backend-module-gitlab-provider/config.d.ts
+++ b/plugins/auth-backend-module-gitlab-provider/config.d.ts
@@ -28,6 +28,13 @@ export interface Config {
           audience?: string;
           callbackUrl?: string;
           additionalScopes?: string | string[];
+          signIn?: {
+            resolvers: Array<
+              | { resolver: 'usernameMatchingUserEntityName' }
+              | { resolver: 'emailLocalPartMatchingUserEntityName' }
+              | { resolver: 'emailMatchingUserEntityProfileEmail' }
+            >;
+          };
         };
       };
     };

--- a/plugins/auth-backend-module-google-provider/config.d.ts
+++ b/plugins/auth-backend-module-google-provider/config.d.ts
@@ -27,6 +27,13 @@ export interface Config {
           clientSecret: string;
           callbackUrl?: string;
           additionalScopes?: string | string[];
+          signIn?: {
+            resolvers: Array<
+              | { resolver: 'emailMatchingUserEntityAnnotation' }
+              | { resolver: 'emailLocalPartMatchingUserEntityName' }
+              | { resolver: 'emailMatchingUserEntityProfileEmail' }
+            >;
+          };
         };
       };
     };

--- a/plugins/auth-backend-module-microsoft-provider/config.d.ts
+++ b/plugins/auth-backend-module-microsoft-provider/config.d.ts
@@ -29,6 +29,13 @@ export interface Config {
           domainHint?: string;
           callbackUrl?: string;
           additionalScopes?: string | string[];
+          signIn?: {
+            resolvers: Array<
+              | { resolver: 'emailMatchingUserEntityAnnotation' }
+              | { resolver: 'emailLocalPartMatchingUserEntityName' }
+              | { resolver: 'emailMatchingUserEntityProfileEmail' }
+            >;
+          };
         };
       };
     };

--- a/plugins/auth-backend-module-oauth2-provider/config.d.ts
+++ b/plugins/auth-backend-module-oauth2-provider/config.d.ts
@@ -32,6 +32,13 @@ export interface Config {
           additionalScopes?: string | string[];
           disableRefresh?: boolean;
           includeBasicAuth?: boolean;
+          signIn?: {
+            resolvers: Array<
+              | { resolver: 'usernameMatchingUserEntityName' }
+              | { resolver: 'emailLocalPartMatchingUserEntityName' }
+              | { resolver: 'emailMatchingUserEntityProfileEmail' }
+            >;
+          };
         };
       };
     };

--- a/plugins/auth-backend-module-oidc-provider/config.d.ts
+++ b/plugins/auth-backend-module-oidc-provider/config.d.ts
@@ -31,6 +31,12 @@ export interface Config {
           tokenSignedResponseAlg?: string;
           additionalScopes?: string | string[];
           prompt?: string;
+          signIn?: {
+            resolvers: Array<
+              | { resolver: 'emailLocalPartMatchingUserEntityName' }
+              | { resolver: 'emailMatchingUserEntityProfileEmail' }
+            >;
+          };
         };
       };
     };

--- a/plugins/auth-backend-module-okta-provider/config.d.ts
+++ b/plugins/auth-backend-module-okta-provider/config.d.ts
@@ -30,6 +30,13 @@ export interface Config {
           idp?: string;
           callbackUrl?: string;
           additionalScopes?: string | string[];
+          signIn?: {
+            resolvers: Array<
+              | { resolver: 'emailMatchingUserEntityAnnotation' }
+              | { resolver: 'emailLocalPartMatchingUserEntityName' }
+              | { resolver: 'emailMatchingUserEntityProfileEmail' }
+            >;
+          };
         };
       };
     };

--- a/plugins/auth-backend-module-onelogin-provider/config.d.ts
+++ b/plugins/auth-backend-module-onelogin-provider/config.d.ts
@@ -27,6 +27,13 @@ export interface Config {
           clientSecret: string;
           issuer: string;
           callbackUrl?: string;
+          signIn?: {
+            resolvers: Array<
+              | { resolver: 'usernameMatchingUserEntityName' }
+              | { resolver: 'emailLocalPartMatchingUserEntityName' }
+              | { resolver: 'emailMatchingUserEntityProfileEmail' }
+            >;
+          };
         };
       };
     };

--- a/plugins/auth-backend-module-vmware-cloud-provider/config.d.ts
+++ b/plugins/auth-backend-module-vmware-cloud-provider/config.d.ts
@@ -25,6 +25,13 @@ export interface Config {
           scope?: string;
           consoleEndpoint?: string;
           additionalScopes?: string | string[];
+          signIn?: {
+            resolvers: Array<
+              | { resolver: 'profileEmailMatchingUserEntityEmail' }
+              | { resolver: 'emailLocalPartMatchingUserEntityName' }
+              | { resolver: 'emailMatchingUserEntityProfileEmail' }
+            >;
+          };
         };
       };
     };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Related to #25648

This PR adds the `signIn` options to the config schema of auth modules. I've done this for modules that had a config schema which covers most providers.

The solution here is pretty "dumb" or simple. I just added the schema to the respective `config.d.ts` files. It's easy to implement and understand but I'm not super fond of it because it feels like it's error prone and hard to maintain. My fear is that when resolvers change, people will forget to update the config or there's going to be a mismatch between the real resolver names and the ones in the config.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
