### PR TITLE
cli: add support for forcing use of react development when building

### DIFF
--- a/.changeset/little-bulldogs-guess.md
+++ b/.changeset/little-bulldogs-guess.md
@@ -2,16 +2,4 @@
 '@backstage/cli': patch
 ---
 
-Add ability to force use of the development versions of `react` and `react-dom`
-to allow for detailed error messages and use of fast-refresh. Note that builds
-with the development versions of `react` and `react-dom` should not be
-deployed in production.
-
-This feature can be used by setting the `FORCE_REACT_DEVELOPMENT` environment
-variable to `true`:
-
-```bash
-EXPERIMENTAL_MODULE_FEDERATION=true \
-FORCE_REACT_DEVELOPMENT=true \
-yarn build:all
-```
+The experimental module federation build now has the ability to force the use of development versions of `react` and `react-dom` by setting the `FORCE_REACT_DEVELOPMENT` flag.

--- a/.changeset/little-bulldogs-guess.md
+++ b/.changeset/little-bulldogs-guess.md
@@ -3,6 +3,15 @@
 ---
 
 Add ability to force use of the development versions of `react` and `react-dom`
-by setting the `FORCE_REACT_DEVELOPMENT` environment variable to `true` when
-building, for example by using a command like `FORCE_REACT_DEVELOPMENT=true yarn
-build:all`.
+to allow for detailed error messages and use of fast-refresh. Note that builds
+with the development versions of `react` and `react-dom` should not be
+deployed in production.
+
+This feature can be used by setting the `FORCE_REACT_DEVELOPMENT` environment
+variable to `true`:
+
+```bash
+EXPERIMENTAL_MODULE_FEDERATION=true \
+FORCE_REACT_DEVELOPMENT=true \
+yarn build:all
+```

--- a/.changeset/little-bulldogs-guess.md
+++ b/.changeset/little-bulldogs-guess.md
@@ -1,0 +1,8 @@
+---
+'@backstage/cli': patch
+---
+
+Add ability to force use of the development versions of `react` and `react-dom`
+by setting the `FORCE_REACT_DEVELOPMENT` environment variable to `true` when
+building, for example by using a command like `FORCE_REACT_DEVELOPMENT=true yarn
+build:all`.

--- a/packages/cli/src/lib/bundler/config.ts
+++ b/packages/cli/src/lib/bundler/config.ts
@@ -238,8 +238,8 @@ export async function createConfig(
 
   if (
     mode === 'production' &&
-    !!process.env.EXPERIMENTAL_MODULE_FEDERATION &&
-    !!process.env.FORCE_REACT_DEVELOPMENT
+    process.env.EXPERIMENTAL_MODULE_FEDERATION &&
+    process.env.FORCE_REACT_DEVELOPMENT
   ) {
     console.log(
       chalk.yellow(

--- a/packages/cli/src/lib/bundler/config.ts
+++ b/packages/cli/src/lib/bundler/config.ts
@@ -15,7 +15,8 @@
  */
 
 import { BackendBundlingOptions, BundlingOptions } from './types';
-import { posix as posixPath, resolve as resolvePath } from 'path';
+import { posix as posixPath, resolve as resolvePath, dirname } from 'path';
+import chalk from 'chalk';
 import webpack, { ProvidePlugin } from 'webpack';
 
 import { BackstagePackage } from '@backstage/cli-node';
@@ -33,7 +34,7 @@ import fs from 'fs-extra';
 import { getPackages } from '@manypkg/get-packages';
 import { isChildPath } from '@backstage/cli-common';
 import nodeExternals from 'webpack-node-externals';
-import { optimization } from './optimization';
+import { optimization as optimizationConfig } from './optimization';
 import pickBy from 'lodash/pickBy';
 import { readEntryPoints } from '../entryPoints';
 import { runPlain } from '../run';
@@ -232,12 +233,47 @@ export async function createConfig(
     require.resolve('react-refresh'),
   ];
 
+  const mode = isDev ? 'development' : 'production';
+  const optimization = optimizationConfig(options);
+
+  if (process.env.FORCE_REACT_DEVELOPMENT === 'true') {
+    console.log(
+      chalk.yellow(
+        `⚠️  WARNING: Forcing react and react-dom into development mode. This build should not be used in production.`,
+      ),
+    );
+
+    const reactPackageDirs = [
+      `${dirname(require.resolve('react/package.json'))}/`,
+      `${dirname(require.resolve('react-dom/package.json'))}/`,
+    ];
+
+    // Don't define process.env.NODE_ENV with value matching config.mode.
+    optimization.nodeEnv = false;
+
+    // Instead, provide a custom definition which always uses "development" if
+    // the module is part of `react` or `react-dom`, and `config.mode` otherwise.
+    plugins.push(
+      new webpack.DefinePlugin({
+        'process.env.NODE_ENV': webpack.DefinePlugin.runtimeValue(
+          ({ module }) => {
+            if (reactPackageDirs.some(val => module.resource.startsWith(val))) {
+              return '"development"';
+            }
+
+            return `"${mode}"`;
+          },
+        ),
+      }),
+    );
+  }
+
   const withCache = yn(process.env[BUILD_CACHE_ENV_VAR], { default: false });
 
   return {
-    mode: isDev ? 'development' : 'production',
+    mode,
     profile: false,
-    optimization: optimization(options),
+    optimization,
     bail: false,
     performance: {
       hints: false, // we check the gzip size instead

--- a/packages/cli/src/lib/bundler/config.ts
+++ b/packages/cli/src/lib/bundler/config.ts
@@ -237,8 +237,8 @@ export async function createConfig(
   const optimization = optimizationConfig(options);
 
   if (
-    process.env.EXPERIMENTAL_MODULE_FEDERATION === 'true' &&
-    process.env.FORCE_REACT_DEVELOPMENT === 'true'
+    !!process.env.EXPERIMENTAL_MODULE_FEDERATION &&
+    !!process.env.FORCE_REACT_DEVELOPMENT
   ) {
     console.log(
       chalk.yellow(

--- a/packages/cli/src/lib/bundler/config.ts
+++ b/packages/cli/src/lib/bundler/config.ts
@@ -236,7 +236,10 @@ export async function createConfig(
   const mode = isDev ? 'development' : 'production';
   const optimization = optimizationConfig(options);
 
-  if (process.env.FORCE_REACT_DEVELOPMENT === 'true') {
+  if (
+    process.env.EXPERIMENTAL_MODULE_FEDERATION === 'true' &&
+    process.env.FORCE_REACT_DEVELOPMENT === 'true'
+  ) {
     console.log(
       chalk.yellow(
         `⚠️  WARNING: Forcing react and react-dom into development mode. This build should not be used in production.`,

--- a/packages/cli/src/lib/bundler/config.ts
+++ b/packages/cli/src/lib/bundler/config.ts
@@ -251,7 +251,9 @@ export async function createConfig(
       `${dirname(require.resolve('react-dom/package.json'))}/`,
     ];
 
-    // Don't define process.env.NODE_ENV with value matching config.mode.
+    // Don't define process.env.NODE_ENV with value matching config.mode. If we
+    // don't set this to false, webpack will define the value of
+    // process.env.NODE_ENV for us, and the definition below will be ignored.
     optimization.nodeEnv = false;
 
     // Instead, provide a custom definition which always uses "development" if

--- a/packages/cli/src/lib/bundler/config.ts
+++ b/packages/cli/src/lib/bundler/config.ts
@@ -237,6 +237,7 @@ export async function createConfig(
   const optimization = optimizationConfig(options);
 
   if (
+    mode === 'production' &&
     !!process.env.EXPERIMENTAL_MODULE_FEDERATION &&
     !!process.env.FORCE_REACT_DEVELOPMENT
   ) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

With the arrival of experimental dynamic plugins support in the Backstage CLI, it's useful to be able to force react and react-dom into development mode during a build. This allows for "almost-production" builds of a main app that can be used when developing dynamic plugins, retaining the useful react development mode features like detailed error messages and support for fast refresh.

This PR allows react and react-dom to be forced into development mode when building Backstage by setting the `FORCE_REACT_DEVELOPMENT` environment variable to `true`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
