### PR TITLE
cli: allow linting packages with role dynamic-frontend-container

### DIFF
--- a/.changeset/bright-trainers-brake.md
+++ b/.changeset/bright-trainers-brake.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Add frontend-dynamic-container role to eslint config factory

--- a/packages/cli/config/eslint-factory.js
+++ b/packages/cli/config/eslint-factory.js
@@ -201,6 +201,7 @@ function createConfigForRole(dir, role, extraConfig = {}) {
     case 'frontend':
     case 'frontend-plugin':
     case 'frontend-plugin-module':
+    case 'frontend-dynamic-container':
       return createConfig(dir, {
         ...extraConfig,
         extends: [


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds the `frontend-dynamic-container` role in eslint-factory to allow linting dynamic plugin container packages.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
