### PR TITLE
cli: switch to async mode for dynamic plugins

### DIFF
--- a/packages/cli/src/lib/bundler/bundle.ts
+++ b/packages/cli/src/lib/bundler/bundle.ts
@@ -62,6 +62,7 @@ export async function buildBundle(options: BuildOptions) {
     const detectedModulesEntryPoint = await createDetectedModulesEntryPoint({
       config: options.fullConfig,
       targetPath: paths.targetPath,
+      dynamic: !!options.moduleFederation,
     });
 
     configs.push(

--- a/packages/cli/src/lib/bundler/config.ts
+++ b/packages/cli/src/lib/bundler/config.ts
@@ -192,45 +192,37 @@ export async function createConfig(
           react: {
             singleton: true,
             requiredVersion: '*',
-            eager: !isRemote,
           },
           'react-dom': {
             singleton: true,
             requiredVersion: '*',
-            eager: !isRemote,
           },
           // React Router
           'react-router': {
             singleton: true,
             requiredVersion: '*',
-            eager: !isRemote,
           },
           'react-router-dom': {
             singleton: true,
             requiredVersion: '*',
-            eager: !isRemote,
           },
           // MUI v4
           '@material-ui/core/styles': {
             singleton: true,
             requiredVersion: '*',
-            eager: !isRemote,
           },
           '@material-ui/styles': {
             singleton: true,
             requiredVersion: '*',
-            eager: !isRemote,
           },
           // MUI v5
           '@mui/material/styles/': {
             singleton: true,
             requiredVersion: '*',
-            eager: !isRemote,
           },
           '@emotion/react': {
             singleton: true,
             requiredVersion: '*',
-            eager: !isRemote,
           },
         },
       }),

--- a/packages/cli/src/lib/bundler/server.ts
+++ b/packages/cli/src/lib/bundler/server.ts
@@ -136,6 +136,7 @@ DEPRECATION WARNING: React Router Beta is deprecated and support for it will be 
   const detectedModulesEntryPoint = await createDetectedModulesEntryPoint({
     config: fullConfig,
     targetPath: paths.targetPath,
+    dynamic: !!options.moduleFederation,
     watch() {
       webpackServer?.invalidate();
       viteServer?.restart();


### PR DESCRIPTION
## Hey, I just made a Pull Request!

It seems like avoiding eager loading of shared modules results in a more stable experience when working with dynamic plugins, so opening this just to give us something to test against.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
