### PR TITLE
frontend-plugin-api: infer ExtensionBoundary routable prop from outputs

### DIFF
--- a/.changeset/early-trees-dance.md
+++ b/.changeset/early-trees-dance.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': patch
+---
+
+The `ExtensionBoundary` now by default infers whether its routable from whether it outputs a route path.

--- a/.changeset/mighty-dolls-retire.md
+++ b/.changeset/mighty-dolls-retire.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Internal refactor to remove unnecessary `routable` prop in the implementation of the `createEntityContentExtension` alpha export.

--- a/docs/frontend-system/architecture/03-extensions.md
+++ b/docs/frontend-system/architecture/03-extensions.md
@@ -337,7 +337,7 @@ Similar to plugins the `ErrorBoundary` for extension allows to pass in a fallbac
 
 ### Analytics
 
-Analytics information are provided through the `AnalyticsContext`, which will give `extensionId` & `pluginId` as context to analytics event fired inside of the extension. Additionally `RouteTracker` will capture an analytics event for routable extension to inform which extension metadata gets associated with a navigation event when the route navigated to is a gathered `mountPoint`.
+Analytics information are provided through the `AnalyticsContext`, which will give `extensionId` & `pluginId` as context to analytics event fired inside of the extension. Additionally `RouteTracker` will capture an analytics event for routable extension to inform which extension metadata gets associated with a navigation event when the route navigated to is a gathered `mountPoint`. Whether an extension is routable is inferred from its outputs, but you can also explicitly control this behavior by passing the `routable` prop to `ExtensionBoundary`.
 
 The `ExtensionBoundary` can be used like the following in an extension creator:
 
@@ -359,7 +359,7 @@ export function createSomeExtension<
         path: config.path,
         routeRef: options.routeRef,
         element: (
-          <ExtensionBoundary node={node} routable>
+          <ExtensionBoundary node={node}>
             <ExtensionComponent />
           </ExtensionBoundary>
         ),

--- a/packages/frontend-plugin-api/api-report.md
+++ b/packages/frontend-plugin-api/api-report.md
@@ -844,7 +844,6 @@ export interface ExtensionBoundaryProps {
   children: ReactNode;
   // (undocumented)
   node: AppNode;
-  // (undocumented)
   routable?: boolean;
 }
 

--- a/packages/frontend-plugin-api/src/components/ExtensionBoundary.test.tsx
+++ b/packages/frontend-plugin-api/src/components/ExtensionBoundary.test.tsx
@@ -15,15 +15,24 @@
  */
 
 import React, { useEffect } from 'react';
-import { screen, waitFor } from '@testing-library/react';
-import { MockAnalyticsApi, TestApiProvider } from '@backstage/test-utils';
+import { act, screen, waitFor } from '@testing-library/react';
+import {
+  MockAnalyticsApi,
+  TestApiProvider,
+  withLogCollector,
+} from '@backstage/test-utils';
 import { ExtensionBoundary } from './ExtensionBoundary';
 import { coreExtensionData, createExtension } from '../wiring';
-import { analyticsApiRef, useAnalytics } from '@backstage/core-plugin-api';
+import {
+  analyticsApiRef,
+  createApiFactory,
+  useAnalytics,
+} from '@backstage/core-plugin-api';
 import { createRouteRef } from '../routing';
 import { createExtensionTester } from '@backstage/frontend-test-utils';
+import { createApiExtension } from '../extensions';
 
-const wrapInBoundaryExtension = (element: JSX.Element) => {
+const wrapInBoundaryExtension = (element?: JSX.Element) => {
   const routeRef = createRouteRef();
   return createExtension({
     name: 'test',
@@ -54,12 +63,25 @@ describe('ExtensionBoundary', () => {
   });
 
   it('should show app error component when an error is thrown', async () => {
-    const error = 'Something went wrong';
+    const errorMsg = 'Something went wrong';
     const ErrorComponent = () => {
-      throw new Error(error);
+      throw new Error(errorMsg);
     };
-    createExtensionTester(wrapInBoundaryExtension(<ErrorComponent />)).render();
-    await waitFor(() => expect(screen.getByText(error)).toBeInTheDocument());
+    const { error } = await withLogCollector(['error'], async () => {
+      createExtensionTester(
+        wrapInBoundaryExtension(<ErrorComponent />),
+      ).render();
+      await waitFor(() =>
+        expect(screen.getByText(errorMsg)).toBeInTheDocument(),
+      );
+    });
+    expect(error).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          message: expect.stringContaining(errorMsg),
+        }),
+      ]),
+    );
   });
 
   it('should wrap children with analytics context', async () => {
@@ -96,5 +118,39 @@ describe('ExtensionBoundary', () => {
         },
       });
     });
+  });
+
+  // TODO(Rugvip): It's annoying to test the inverse of this currently, because the extension tester overrides the subject to always output a path
+  it('should emit analytics events if routable', async () => {
+    const Emitter = () => {
+      const analytics = useAnalytics();
+      useEffect(() => {
+        analytics.captureEvent('dummy', 'dummy');
+      });
+      return null;
+    };
+    const analyticsApiMock = new MockAnalyticsApi();
+
+    await act(async () => {
+      createExtensionTester(wrapInBoundaryExtension(<Emitter />))
+        .add(
+          createApiExtension({
+            factory: createApiFactory(analyticsApiRef, analyticsApiMock),
+          }),
+        )
+        .render();
+    });
+
+    expect(analyticsApiMock.getEvents()).toEqual([
+      expect.objectContaining({
+        action: 'navigate',
+        subject: '/',
+        context: expect.objectContaining({
+          pluginId: 'root',
+          extensionId: 'test',
+        }),
+      }),
+      expect.objectContaining({ action: 'dummy' }),
+    ]);
   });
 });

--- a/packages/frontend-plugin-api/src/components/ExtensionBoundary.tsx
+++ b/packages/frontend-plugin-api/src/components/ExtensionBoundary.tsx
@@ -26,6 +26,7 @@ import { ErrorBoundary } from './ErrorBoundary';
 import { routableExtensionRenderedEvent } from '../../../core-plugin-api/src/analytics/Tracker';
 import { AppNode, useComponentRef } from '../apis';
 import { coreComponentRefs } from './coreComponentRefs';
+import { coreExtensionData } from '../wiring';
 
 type RouteTrackerProps = PropsWithChildren<{
   disableTracking?: boolean;
@@ -50,6 +51,11 @@ const RouteTracker = (props: RouteTrackerProps) => {
 /** @public */
 export interface ExtensionBoundaryProps {
   node: AppNode;
+  /**
+   * This explicitly marks the extension as routable for the purpose of
+   * capturing analytics events. If not provided, the extension boundary will be
+   * marked as routable if it outputs a routePath.
+   */
   routable?: boolean;
   children: ReactNode;
 }
@@ -57,6 +63,10 @@ export interface ExtensionBoundaryProps {
 /** @public */
 export function ExtensionBoundary(props: ExtensionBoundaryProps) {
   const { node, routable, children } = props;
+
+  const doesOutputRoutePath = Boolean(
+    node.instance?.getData(coreExtensionData.routePath),
+  );
 
   const plugin = node.spec.source;
   const Progress = useComponentRef(coreComponentRefs.progress);
@@ -72,7 +82,9 @@ export function ExtensionBoundary(props: ExtensionBoundaryProps) {
     <Suspense fallback={<Progress />}>
       <ErrorBoundary plugin={plugin} Fallback={fallback}>
         <AnalyticsContext attributes={attributes}>
-          <RouteTracker disableTracking={!routable}>{children}</RouteTracker>
+          <RouteTracker disableTracking={!(routable ?? doesOutputRoutePath)}>
+            {children}
+          </RouteTracker>
         </AnalyticsContext>
       </ErrorBoundary>
     </Suspense>

--- a/packages/frontend-plugin-api/src/extensions/createPageExtension.tsx
+++ b/packages/frontend-plugin-api/src/extensions/createPageExtension.tsx
@@ -87,7 +87,7 @@ export function createPageExtension<
         path: config.path,
         routeRef: options.routeRef,
         element: (
-          <ExtensionBoundary node={node} routable>
+          <ExtensionBoundary node={node}>
             <ExtensionComponent />
           </ExtensionBoundary>
         ),

--- a/plugins/catalog-react/src/alpha.tsx
+++ b/plugins/catalog-react/src/alpha.tsx
@@ -166,7 +166,7 @@ export function createEntityContentExtension<
         title: config.title,
         routeRef: options.routeRef,
         element: (
-          <ExtensionBoundary node={node} routable>
+          <ExtensionBoundary node={node}>
             <ExtensionComponent />
           </ExtensionBoundary>
         ),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes #25666

I'm fairly certain this is a safe approach, but we do need to keep the prop around to explicitly be able to declare it for example [here](https://github.com/backstage/backstage/blob/d4149bf6d44fa45303a993d6df378060b903ca4d/packages/frontend-plugin-api/src/extensions/createSignInPageExtension.tsx#L69). This should remove the risk that extension authors forget to add this prop and therefore don't get navigation analytics events for the extension.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
