### PR TITLE
feat(gerrit): support glob discovery

### DIFF
--- a/.changeset/chatty-starfishes-sit.md
+++ b/.changeset/chatty-starfishes-sit.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': minor
+---
+
+Export `buildGerritGitilesUrl` and `getGitilesAuthenticationUrl` to be used by `GerritUrlReader`.

--- a/.changeset/dull-mugs-fail.md
+++ b/.changeset/dull-mugs-fail.md
@@ -1,0 +1,20 @@
+---
+'@backstage/plugin-catalog-backend-module-gerrit': patch
+---
+
+Allow to specify a custom `catalogPath` in the `catalog.providers.gerrit` configuration.
+
+If not set, it defaults to `catalog-info.yaml` files at the root of repositories. This default was the value before this change.
+
+With the changes in the `GerritUrlReader`, `catalogPath` also allows to use `minimatch`'s glob-patterns.
+
+```diff
+catalog:
+  providers:
+    gerrit:
+      all: # identifies your dataset / provider independent of config changes
+        host: gerrit.company.com
+        query: 'state=ACTIVE&type=CODE'
++       # This will search for catalog manifests anywhere in the repositories
++       catalogPath: '**/catalog-info.{yml,yaml}'
+```

--- a/.changeset/dull-mugs-fail.md
+++ b/.changeset/dull-mugs-fail.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-catalog-backend-module-gerrit': patch
+'@backstage/plugin-catalog-backend-module-gerrit': minor
 ---
 
 Allow to specify a custom `catalogPath` in the `catalog.providers.gerrit` configuration.
@@ -18,3 +18,6 @@ catalog:
 +       # This will search for catalog manifests anywhere in the repositories
 +       catalogPath: '**/catalog-info.{yml,yaml}'
 ```
+
+**BREAKING** The optional `branch` configuration parameter now defaults to the default branch of the project (where `HEAD` points to).
+This parameter was previously using `master` as the default value. In most cases this change should be transparent as Gerrit defaults to using `master`.

--- a/.changeset/shiny-ways-knock.md
+++ b/.changeset/shiny-ways-knock.md
@@ -1,0 +1,7 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+`GerritUrlReader` now implements the `search` method, which can be used to find files matching a glob pattern (using `minimatch` patterns).
+
+This allows the Gerrit Discovery to find all Backstage manifests (`catalog-info.yaml` files inside a repository).

--- a/.changeset/violet-otters-punch.md
+++ b/.changeset/violet-otters-punch.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+`UrlReaderProcessor` detects wildcards by parsing the URL's path and query string instead of using `git-url-parse`.
+
+This allows to support wildcards for URLs which are not correctly parsed by `git-url-parse` (such as Gerrit Gitiles URLs).

--- a/docs/integrations/gerrit/discovery.md
+++ b/docs/integrations/gerrit/discovery.md
@@ -45,8 +45,9 @@ catalog:
     gerrit:
       yourProviderId: # identifies your dataset / provider independent of config changes
         host: gerrit-your-company.com
-        branch: master # Optional
+        branch: master # Optional, defaults to master
         query: 'state=ACTIVE&prefix=webapps'
+        catalogPath: 'catalog-info.yaml' # Optional, defaults to catalog-info.yaml
         schedule:
           # supports cron, ISO duration, "human duration" as used in code
           frequency: { minutes: 30 }
@@ -56,12 +57,15 @@ catalog:
         host: gerrit-your-company.com
         branch: master # Optional
         query: 'state=ACTIVE&prefix=backend'
+        # catalogPath can be a glob-pattern supported by the minimatch library
+        catalogPath: '{**/catalog-info.{yml,yaml},**/.catalog-info/*.{yml,yaml}}'
 ```
 
-The provider configuration is composed of three parts:
+The provider configuration is composed of four parts:
 
 - **`host`**: the host of the Gerrit integration to use.
 - **`branch`** _(optional)_: the branch where we will look for catalog entities (defaults to "master").
 - **`query`**: this string is directly used as the argument to the "List Project" API.
   Typically, you will want to have some filter here to exclude projects that will
   never contain any catalog files.
+- **`catalogPath`**: path relative to the root of the repository where the Backstage manifests are stored. It can also be a glob pattern supported by [`minimatch`](https://github.com/isaacs/minimatch) to load multiple files.

--- a/docs/integrations/gerrit/discovery.md
+++ b/docs/integrations/gerrit/discovery.md
@@ -61,7 +61,7 @@ catalog:
         catalogPath: '{**/catalog-info.{yml,yaml},**/.catalog-info/*.{yml,yaml}}'
 ```
 
-The provider configuration is composed of four parts:
+The provider configuration consists of the following parts:
 
 - **`host`**: the host of the Gerrit integration to use.
 - **`branch`** _(optional)_: the branch where we will look for catalog entities (defaults to "master").

--- a/packages/backend-defaults/report-urlReader.api.md
+++ b/packages/backend-defaults/report-urlReader.api.md
@@ -234,7 +234,10 @@ export class GerritUrlReader implements UrlReaderService {
     options?: UrlReaderServiceReadUrlOptions,
   ): Promise<UrlReaderServiceReadUrlResponse>;
   // (undocumented)
-  search(): Promise<UrlReaderServiceSearchResponse>;
+  search(
+    url: string,
+    options?: UrlReaderServiceSearchOptions,
+  ): Promise<UrlReaderServiceSearchResponse>;
   // (undocumented)
   toString(): string;
 }

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/GerritUrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/GerritUrlReader.ts
@@ -260,13 +260,8 @@ export class GerritUrlReader implements UrlReaderService {
       // https://github.com/backstage/backstage/issues/8242
       signal: options?.signal as any,
     });
-    if (treeResponse.status === 404) {
-      throw new NotFoundError(`Not found: ${gitilesUrl}`);
-    }
     if (!treeResponse.ok) {
-      throw new Error(
-        `${url} could not be read as ${treeUrl}, ${treeResponse.status} ${treeResponse.statusText}`,
-      );
+      throw await ResponseError.fromResponse(treeResponse);
     }
 
     const res = (await parseGerritJsonResponse(treeResponse as any)) as {

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/GerritUrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/GerritUrlReader.ts
@@ -38,7 +38,11 @@ import {
   parseGerritGitilesUrl,
   parseGerritJsonResponse,
 } from '@backstage/integration';
-import { NotFoundError, NotModifiedError } from '@backstage/errors';
+import {
+  NotFoundError,
+  NotModifiedError,
+  ResponseError,
+} from '@backstage/errors';
 import { ReadTreeResponseFactory, ReaderFactory } from './types';
 import { Minimatch } from 'minimatch';
 
@@ -246,7 +250,6 @@ export class GerritUrlReader implements UrlReaderService {
       url,
     );
 
-    /** TODO: export something else from integrations */
     const gitilesUrl = getGitilesAuthenticationUrl(this.integration.config);
     const treeUrl = `${gitilesUrl}/${project}/+/refs/heads/${branch}/?format=JSON&recursive`;
 

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/__fixtures__/gerrit/tree-recursive-response.txt
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/__fixtures__/gerrit/tree-recursive-response.txt
@@ -1,0 +1,30 @@
+)]}'
+{
+  "id": "d84874ac8e27a8592ece6eb3e61e1fc3cd668348",
+  "entries": [
+    {
+      "mode": 40960,
+      "type": "blob",
+      "id": "9abe6322fdb76e3c2d972f12aad46088fa785fbc",
+      "name": "catalog-info.yaml"
+    },
+    {
+      "mode": 33188,
+      "type": "blob",
+      "id": "7a472379c27f165a1472f0c3d455fa3b811585b9",
+      "name": "README.md"
+    },
+    {
+      "mode": 33199,
+      "type": "blob",
+      "id": "1a472379c27f165a1472f0c3d455fa3b811585b9",
+      "name": "microservices/petstore-api/catalog-info.yaml"
+    },
+    {
+      "mode": 32199,
+      "type": "blob",
+      "id": "2a472379c27f165a1472f0c3d455fa3b811585b9",
+      "name": "microservices/petstore-consumer/catalog-info.yaml"
+    }
+  ]
+}

--- a/packages/integration/report.api.md
+++ b/packages/integration/report.api.md
@@ -258,6 +258,14 @@ export function buildGerritGitilesArchiveUrl(
 ): string;
 
 // @public
+export function buildGerritGitilesUrl(
+  config: GerritIntegrationConfig,
+  project: string,
+  branch: string,
+  filePath: string,
+): string;
+
+// @public
 export class DefaultAzureDevOpsCredentialsProvider
   implements AzureDevOpsCredentialsProvider
 {
@@ -495,6 +503,11 @@ export function getGitHubRequestOptions(
 ): {
   headers: Record<string, string>;
 };
+
+// @public
+export function getGitilesAuthenticationUrl(
+  config: GerritIntegrationConfig,
+): string;
 
 // @public
 export function getGitLabFileFetchUrl(

--- a/packages/integration/src/gerrit/core.ts
+++ b/packages/integration/src/gerrit/core.ts
@@ -257,6 +257,7 @@ export function getAuthenticationPrefix(
  * be used.
  *
  * @param config - A Gerrit provider config.
+ * @public
  */
 export function getGitilesAuthenticationUrl(
   config: GerritIntegrationConfig,

--- a/packages/integration/src/gerrit/index.ts
+++ b/packages/integration/src/gerrit/index.ts
@@ -20,14 +20,16 @@ export {
 } from './config';
 export {
   buildGerritGitilesArchiveUrl,
+  buildGerritGitilesUrl,
   getGerritBranchApiUrl,
   getGerritCloneRepoUrl,
   getGerritFileContentsApiUrl,
   getGerritProjectsApiUrl,
   getGerritRequestOptions,
-  parseGerritJsonResponse,
+  getGitilesAuthenticationUrl,
   parseGerritGitilesUrl,
   parseGitilesUrlRef,
+  parseGerritJsonResponse,
 } from './core';
 
 export type { GerritIntegrationConfig } from './config';

--- a/plugins/catalog-backend-module-gerrit/config.d.ts
+++ b/plugins/catalog-backend-module-gerrit/config.d.ts
@@ -44,6 +44,12 @@ export interface Config {
            */
           branch?: string;
           /**
+           * (Optional) Path where the catalog YAML manifest file is expected in the repository.
+           * Can contain glob patterns supported by minimatch.
+           * Defaults to "catalog-info.yaml".
+           */
+          catalogPath?: string;
+          /**
            * (Optional) TaskScheduleDefinition for the discovery.
            */
           schedule?: SchedulerServiceTaskScheduleDefinition;

--- a/plugins/catalog-backend-module-gerrit/config.d.ts
+++ b/plugins/catalog-backend-module-gerrit/config.d.ts
@@ -40,7 +40,7 @@ export interface Config {
           query: string;
           /**
            * (Optional) Branch.
-           * The branch where the provider will try to find entities. Defaults to "master".
+           * The branch where the provider will try to find entities. Uses the default branch where HEAD points to.
            */
           branch?: string;
           /**

--- a/plugins/catalog-backend-module-gerrit/package.json
+++ b/plugins/catalog-backend-module-gerrit/package.json
@@ -51,9 +51,11 @@
     "@backstage/config": "workspace:^",
     "@backstage/errors": "workspace:^",
     "@backstage/integration": "workspace:^",
+    "@backstage/plugin-catalog-common": "workspace:^",
     "@backstage/plugin-catalog-node": "workspace:^",
     "fs-extra": "^11.2.0",
     "node-fetch": "^2.7.0",
+    "p-limit": "^3.1.0",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/plugins/catalog-backend-module-gerrit/src/providers/GerritEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gerrit/src/providers/GerritEntityProvider.test.ts
@@ -18,6 +18,7 @@ import {
   SchedulerService,
   SchedulerServiceTaskRunner,
   SchedulerServiceTaskInvocationDefinition,
+  LoggerService,
 } from '@backstage/backend-plugin-api';
 import {
   mockServices,
@@ -54,10 +55,16 @@ class PersistingTaskRunner implements SchedulerServiceTaskRunner {
   }
 }
 
-const logger = mockServices.logger.mock();
-
 describe('GerritEntityProvider', () => {
+  let schedule: PersistingTaskRunner;
+  let logger: LoggerService;
+
   registerMswTestHooks(server);
+
+  beforeEach(() => {
+    schedule = new PersistingTaskRunner();
+    logger = mockServices.logger.mock();
+  });
 
   afterEach(() => {
     jest.clearAllMocks();
@@ -85,7 +92,6 @@ describe('GerritEntityProvider', () => {
       ],
     },
   });
-  const schedule = new PersistingTaskRunner();
 
   const entityProviderConnection: EntityProviderConnection = {
     applyMutation: jest.fn(),
@@ -109,6 +115,70 @@ describe('GerritEntityProvider', () => {
     );
 
     const provider = GerritEntityProvider.fromConfig(config, {
+      logger,
+      schedule,
+    })[0];
+    expect(provider.getProviderName()).toEqual(
+      'gerrit-provider:active-training',
+    );
+
+    await provider.connect(entityProviderConnection);
+
+    const taskDef = schedule.getTasks()[0];
+    expect(taskDef.id).toEqual('gerrit-provider:active-training:refresh');
+    await (taskDef.fn as () => Promise<void>)();
+
+    expect(entityProviderConnection.applyMutation).toHaveBeenCalledWith(
+      expected,
+    );
+  });
+
+  it('discovers the default branch when not explicitly configured.', async () => {
+    const repoBuffer = fs.readFileSync(
+      path.resolve(__dirname, '__fixtures__/listProjectsBody.txt'),
+    );
+    const expected = getJsonFixture('expectedProviderEntities.json');
+
+    server.use(
+      rest.get('https://g.com/gerrit/projects/', (_, res, ctx) =>
+        res(
+          ctx.status(200),
+          ctx.set('Content-Type', 'application/json'),
+          ctx.body(repoBuffer),
+        ),
+      ),
+      rest.get('https://g.com/gerrit/projects/:project/HEAD', (_, res, ctx) =>
+        res(
+          ctx.status(200),
+          ctx.set('Content-Type', 'application/json'),
+          ctx.body(`)]}'\n"refs/heads/main"`),
+        ),
+      ),
+    );
+
+    const configWithoutBranch = new ConfigReader({
+      catalog: {
+        providers: {
+          gerrit: {
+            'active-training': {
+              host: 'g.com',
+              query: 'state=ACTIVE&prefix=training',
+            },
+          },
+        },
+      },
+      integrations: {
+        gerrit: [
+          {
+            host: 'g.com',
+            baseUrl: 'https://g.com/gerrit',
+            gitilesBaseUrl: 'https:/g.com/gitiles',
+          },
+        ],
+      },
+    });
+
+    const provider = GerritEntityProvider.fromConfig(configWithoutBranch, {
       logger,
       schedule,
     })[0];

--- a/plugins/catalog-backend-module-gerrit/src/providers/GerritEntityProvider.ts
+++ b/plugins/catalog-backend-module-gerrit/src/providers/GerritEntityProvider.ts
@@ -219,7 +219,7 @@ export class GerritEntityProvider implements EntityProvider {
     // Gerrit responds with something like `refs/heads/master`
     const projectHeadResponse = (await parseGerritJsonResponse(
       response as any,
-    )) as GerritProjectQueryResult;
+    )) as string;
 
     return {
       type: 'url',

--- a/plugins/catalog-backend-module-gerrit/src/providers/GerritEntityProvider.ts
+++ b/plugins/catalog-backend-module-gerrit/src/providers/GerritEntityProvider.ts
@@ -15,7 +15,7 @@
  */
 
 import { Config } from '@backstage/config';
-import { InputError } from '@backstage/errors';
+import { InputError, ResponseError } from '@backstage/errors';
 import {
   EntityProvider,
   EntityProviderConnection,
@@ -211,9 +211,7 @@ export class GerritEntityProvider implements EntityProvider {
     }
 
     if (!response.ok) {
-      throw new Error(
-        `Failed to get project's HEAD for ${project}, got ${response.statusText}`,
-      );
+      throw await ResponseError.fromResponse(response);
     }
 
     // Gerrit responds with something like `refs/heads/master`

--- a/plugins/catalog-backend-module-gerrit/src/providers/GerritEntityProvider.ts
+++ b/plugins/catalog-backend-module-gerrit/src/providers/GerritEntityProvider.ts
@@ -19,9 +19,9 @@ import { InputError } from '@backstage/errors';
 import {
   EntityProvider,
   EntityProviderConnection,
-  LocationSpec,
   locationSpecToLocationEntity,
 } from '@backstage/plugin-catalog-node';
+import { LocationSpec } from '@backstage/plugin-catalog-common';
 import fetch, { Response } from 'node-fetch';
 import {
   GerritIntegration,
@@ -31,6 +31,7 @@ import {
   ScmIntegrations,
 } from '@backstage/integration';
 import * as uuid from 'uuid';
+import pLimit from 'p-limit';
 
 import { readGerritConfigs } from './config';
 import { GerritProjectQueryResult, GerritProviderConfig } from './types';
@@ -168,7 +169,11 @@ export class GerritEntityProvider implements EntityProvider {
     )) as GerritProjectQueryResult;
     const projects = Object.keys(gerritProjectsResponse);
 
-    const locations = projects.map(project => this.createLocationSpec(project));
+    const limit = pLimit(5);
+    const locations = await Promise.all(
+      projects.map(project => limit(() => this.createLocationSpec(project))),
+    );
+
     await this.connection.applyMutation({
       type: 'full',
       entities: locations.map(location => ({
@@ -179,10 +184,46 @@ export class GerritEntityProvider implements EntityProvider {
     logger.info(`Found ${locations.length} locations.`);
   }
 
-  private createLocationSpec(project: string): LocationSpec {
+  private async createLocationSpec(project: string): Promise<LocationSpec> {
+    // If a branch has been configured, we can use it directly
+    if (this.config.branch) {
+      return {
+        type: 'url',
+        target: `${this.integration.config.gitilesBaseUrl}/${project}/+/refs/heads/${this.config.branch}/${this.config.catalogPath}`,
+        presence: 'optional',
+      };
+    }
+
+    // Else we call Gerrit API to know on which branch HEAD is pointing to
+    let response: Response;
+    const baseProjectApiUrl = getGerritProjectsApiUrl(this.integration.config);
+    const projectGetHeadUrl = `${baseProjectApiUrl}${encodeURIComponent(
+      project,
+    )}/HEAD`;
+
+    try {
+      response = await fetch(projectGetHeadUrl, {
+        method: 'GET',
+        ...getGerritRequestOptions(this.integration.config),
+      });
+    } catch (e) {
+      throw new Error(`Failed to get project's HEAD for ${project}, ${e}`);
+    }
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to get project's HEAD for ${project}, got ${response.statusText}`,
+      );
+    }
+
+    // Gerrit responds with something like `refs/heads/master`
+    const projectHeadResponse = (await parseGerritJsonResponse(
+      response as any,
+    )) as GerritProjectQueryResult;
+
     return {
       type: 'url',
-      target: `${this.integration.config.gitilesBaseUrl}/${project}/+/refs/heads/${this.config.branch}/${this.config.catalogPath}`,
+      target: `${this.integration.config.gitilesBaseUrl}/${project}/+/${projectHeadResponse}/${this.config.catalogPath}`,
       presence: 'optional',
     };
   }

--- a/plugins/catalog-backend-module-gerrit/src/providers/GerritEntityProvider.ts
+++ b/plugins/catalog-backend-module-gerrit/src/providers/GerritEntityProvider.ts
@@ -182,7 +182,7 @@ export class GerritEntityProvider implements EntityProvider {
   private createLocationSpec(project: string): LocationSpec {
     return {
       type: 'url',
-      target: `${this.integration.config.gitilesBaseUrl}/${project}/+/refs/heads/${this.config.branch}/catalog-info.yaml`,
+      target: `${this.integration.config.gitilesBaseUrl}/${project}/+/refs/heads/${this.config.branch}/${this.config.catalogPath}`,
       presence: 'optional',
     };
   }

--- a/plugins/catalog-backend-module-gerrit/src/providers/config.test.ts
+++ b/plugins/catalog-backend-module-gerrit/src/providers/config.test.ts
@@ -28,6 +28,7 @@ describe('readGerritConfigs', () => {
       host: 'gerrit2.com',
       query: 'state=ACTIVE',
       branch: 'main',
+      catalogPath: '**/catalog-info.yaml',
     };
     const provider3 = {
       host: 'gerrit1.com',
@@ -55,11 +56,20 @@ describe('readGerritConfigs', () => {
     const actual = readGerritConfigs(new ConfigReader(config));
 
     expect(actual).toHaveLength(3);
-    expect(actual[0]).toEqual({ ...provider1, id: 'active-g1' });
-    expect(actual[1]).toEqual({ ...provider2, id: 'active-g2' });
+    expect(actual[0]).toEqual({
+      ...provider1,
+      id: 'active-g1',
+      catalogPath: 'catalog-info.yaml',
+    });
+    expect(actual[1]).toEqual({
+      ...provider2,
+      id: 'active-g2',
+      catalogPath: '**/catalog-info.yaml',
+    });
     expect(actual[2]).toEqual({
       ...provider3,
       id: 'active-g3',
+      catalogPath: 'catalog-info.yaml',
       schedule: {
         ...provider3.schedule,
         frequency: { minutes: 30 },
@@ -85,6 +95,7 @@ describe('readGerritConfigs', () => {
     expect(actual).toHaveLength(1);
     expect(actual[0]).toEqual({
       branch: 'master',
+      catalogPath: 'catalog-info.yaml',
       id: 'active-g1',
       ...provider,
     });

--- a/plugins/catalog-backend-module-gerrit/src/providers/config.test.ts
+++ b/plugins/catalog-backend-module-gerrit/src/providers/config.test.ts
@@ -94,7 +94,6 @@ describe('readGerritConfigs', () => {
     const actual = readGerritConfigs(new ConfigReader(config));
     expect(actual).toHaveLength(1);
     expect(actual[0]).toEqual({
-      branch: 'master',
       catalogPath: 'catalog-info.yaml',
       id: 'active-g1',
       ...provider,

--- a/plugins/catalog-backend-module-gerrit/src/providers/config.ts
+++ b/plugins/catalog-backend-module-gerrit/src/providers/config.ts
@@ -19,7 +19,7 @@ import { Config } from '@backstage/config';
 import { GerritProviderConfig } from './types';
 
 function readGerritConfig(id: string, config: Config): GerritProviderConfig {
-  const branch = config.getOptionalString('branch') ?? 'master';
+  const branch = config.getOptionalString('branch');
   const catalogPath =
     config.getOptionalString('catalogPath') ?? 'catalog-info.yaml';
   const host = config.getString('host');

--- a/plugins/catalog-backend-module-gerrit/src/providers/config.ts
+++ b/plugins/catalog-backend-module-gerrit/src/providers/config.ts
@@ -20,6 +20,8 @@ import { GerritProviderConfig } from './types';
 
 function readGerritConfig(id: string, config: Config): GerritProviderConfig {
   const branch = config.getOptionalString('branch') ?? 'master';
+  const catalogPath =
+    config.getOptionalString('catalogPath') ?? 'catalog-info.yaml';
   const host = config.getString('host');
   const query = config.getString('query');
 
@@ -31,6 +33,7 @@ function readGerritConfig(id: string, config: Config): GerritProviderConfig {
 
   return {
     branch,
+    catalogPath,
     host,
     id,
     query,

--- a/plugins/catalog-backend-module-gerrit/src/providers/types.ts
+++ b/plugins/catalog-backend-module-gerrit/src/providers/types.ts
@@ -26,9 +26,10 @@ export type GerritProjectInfo = {
 export type GerritProjectQueryResult = Record<string, GerritProjectInfo>;
 
 export type GerritProviderConfig = {
+  id: string;
   host: string;
   query: string;
-  id: string;
   branch?: string;
   schedule?: SchedulerServiceTaskScheduleDefinition;
+  catalogPath?: string;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5508,12 +5508,14 @@ __metadata:
     "@backstage/config": "workspace:^"
     "@backstage/errors": "workspace:^"
     "@backstage/integration": "workspace:^"
+    "@backstage/plugin-catalog-common": "workspace:^"
     "@backstage/plugin-catalog-node": "workspace:^"
     "@types/fs-extra": ^11.0.0
     fs-extra: ^11.2.0
     luxon: ^3.0.0
     msw: ^1.0.0
     node-fetch: ^2.7.0
+    p-limit: ^3.1.0
     uuid: ^9.0.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds support for wildcards in the Gerrit discovery configuration:

```diff
catalog:
  providers:
    gerrit:
      all:
        host: gerrit.company.com
        query: 'state=ACTIVE&type=CODE'
+       catalogPath: '**/catalog-info.{yml,yaml}'
```

To support this, the `GerritUrlReader` now implements the `search` method. This search, just like the `GithubUrlReader` downloads the tree of the repository using Gitiles API. It then iterates and filters the result using `minimatch`.

For this to work I also needed to change how the `UrlReaderProcessor` detects wildcards, since Gerrit Gitiles URLs are not parsed by the `git-url-parse` library.
I found a similar attempt that has been rollbacked with #22502. I believe that matching wildcards in the URL's path or in  the querystring should work (to support Azure DevOps pattern).

Also for testing purposes I re-enabled the tests disabled in #20077 (https://github.com/backstage/backstage/commit/95dab5827e50c25f78d81a4d5aaaaed06674f229). Let me know if you want to keep those skipped.

This was tested locally using our Gerrit instance and it allows to find all Backstage catalog manifests in our 500+ repositories including one monorepo with ~800 catalog files. It takes less than one minute to ingest all of these 🚀 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [X] ~Screenshots attached (for UI changes)~
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
