### PR TITLE
frontend-plugin-api: update extension data ref declaration to allow embedding of ID in type

### DIFF
--- a/.changeset/dull-ghosts-double.md
+++ b/.changeset/dull-ghosts-double.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-catalog-react': patch
+'@backstage/plugin-search-react': patch
+'@backstage/plugin-home': patch
+---
+
+Updated alpha definitions of extension data references.

--- a/.changeset/tiny-oranges-pretend.md
+++ b/.changeset/tiny-oranges-pretend.md
@@ -1,0 +1,19 @@
+---
+'@backstage/frontend-plugin-api': patch
+---
+
+Extension data references can now be defined in a way that encapsulates the ID string in the type, in addition to the data type itself. The old way of creating extension data references is deprecated and will be removed in a future release.
+
+For example, the following code:
+
+```ts
+export const myExtension = createExtensionDataRef<MyType>('my-plugin.my-data');
+```
+
+Should be updated to the following:
+
+```ts
+export const myExtension = createExtensionDataRef<MyType>().with({
+  id: 'my-plugin.my-data',
+});
+```

--- a/docs/frontend-system/architecture/03-extensions.md
+++ b/docs/frontend-system/architecture/03-extensions.md
@@ -91,7 +91,9 @@ To create a new extension data reference to represent a type of shared extension
 
 ```ts
 export const reactElementExtensionDataRef =
-  createExtensionDataRef<React.JSX.Element>('my-plugin.reactElement');
+  createExtensionDataRef<React.JSX.Element>().with({
+    id: 'my-plugin.reactElement',
+  });
 ```
 
 The `ExtensionDataRef` can then be used to describe an output property of the extension. This will enforce typing on the return value of the extension factory:

--- a/docs/frontend-system/architecture/08-naming-patterns.md
+++ b/docs/frontend-system/architecture/08-naming-patterns.md
@@ -98,9 +98,9 @@ export interface SearchResultItemExtensionData {
 }
 
 export const searchResultItemExtensionDataRef =
-  createExtensionDataRef<SearchResultItemExtensionData>(
-    'search.search-result-item',
-  );
+  createExtensionDataRef<SearchResultItemExtensionData>().with({
+    id: 'search.search-result-item',
+  });
 ```
 
 #### Grouped Extension Data
@@ -109,8 +109,12 @@ This way of defining extension data is similar to the standalone way, but it use
 
 ```ts
 export const coreExtensionData = {
-  reactElement: createExtensionDataRef<ReactElement>('core.react-element'),
-  routePath: createExtensionDataRef<string>('core.route-path'),
+  reactElement: createExtensionDataRef<ReactElement>().with({
+    id: 'core.react-element',
+  }),
+  routePath: createExtensionDataRef<string>().with({
+    id: 'core.route-path',
+  }),
 };
 ```
 
@@ -125,9 +129,9 @@ export function createGraphiQLEndpointExtension(options) {
 
 // Use a TypeScript namespace to merge the extension data references with the extension creator
 export namespace createGraphiQLEndpointExtension {
-  export const endpointDataRef = createExtensionDataRef</* ... */>(
-    'graphiql.graphiql-endpoint.endpoint',
-  );
+  export const endpointDataRef = createExtensionDataRef</* ... */>().with({
+    id: 'graphiql.graphiql-endpoint.endpoint',
+  });
 }
 ```
 

--- a/packages/frontend-app-api/src/tree/instantiateAppNodeTree.test.ts
+++ b/packages/frontend-app-api/src/tree/instantiateAppNodeTree.test.ts
@@ -32,9 +32,11 @@ import { resolveAppTree } from './resolveAppTree';
 import { resolveExtensionDefinition } from '../../../frontend-plugin-api/src/wiring/resolveExtensionDefinition';
 import { withLogCollector } from '@backstage/test-utils';
 
-const testDataRef = createExtensionDataRef<string>('test');
-const otherDataRef = createExtensionDataRef<number>('other');
-const inputMirrorDataRef = createExtensionDataRef<unknown>('mirror');
+const testDataRef = createExtensionDataRef<string>().with({ id: 'test' });
+const otherDataRef = createExtensionDataRef<number>().with({ id: 'other' });
+const inputMirrorDataRef = createExtensionDataRef<unknown>().with({
+  id: 'mirror',
+});
 
 const simpleExtension = resolveExtensionDefinition(
   createExtension({

--- a/packages/frontend-plugin-api/api-report.md
+++ b/packages/frontend-plugin-api/api-report.md
@@ -151,6 +151,7 @@ export { AnyApiRef };
 export type AnyExtensionDataMap = {
   [name in string]: ExtensionDataRef<
     unknown,
+    string,
     {
       optional?: true;
     }
@@ -317,13 +318,15 @@ export { configApiRef };
 
 // @public (undocumented)
 export interface ConfigurableExtensionDataRef<
+  TId extends string,
   TData,
   TConfig extends {
     optional?: true;
   } = {},
-> extends ExtensionDataRef<TData, TConfig> {
+> extends ExtensionDataRef<TData, TId, TConfig> {
   // (undocumented)
   optional(): ConfigurableExtensionDataRef<
+    TId,
     TData,
     TData & {
       optional: true;
@@ -347,9 +350,17 @@ export type CoreErrorBoundaryFallbackProps = {
 
 // @public (undocumented)
 export const coreExtensionData: {
-  reactElement: ConfigurableExtensionDataRef<JSX_2.Element, {}>;
-  routePath: ConfigurableExtensionDataRef<string, {}>;
-  routeRef: ConfigurableExtensionDataRef<RouteRef<AnyRouteRefParams>, {}>;
+  reactElement: ConfigurableExtensionDataRef<
+    'core.reactElement',
+    JSX_2.Element,
+    {}
+  >;
+  routePath: ConfigurableExtensionDataRef<'core.routing.path', string, {}>;
+  routeRef: ConfigurableExtensionDataRef<
+    'core.routing.ref',
+    RouteRef<AnyRouteRefParams>,
+    {}
+  >;
 };
 
 // @public (undocumented)
@@ -385,7 +396,11 @@ export function createApiExtension<
 // @public (undocumented)
 export namespace createApiExtension {
   const // (undocumented)
-    factoryDataRef: ConfigurableExtensionDataRef<AnyApiFactory, {}>;
+    factoryDataRef: ConfigurableExtensionDataRef<
+      'core.api.factory',
+      AnyApiFactory,
+      {}
+    >;
 }
 
 export { createApiFactory };
@@ -440,6 +455,7 @@ export function createAppRootWrapperExtension<
 export namespace createAppRootWrapperExtension {
   const // (undocumented)
     componentDataRef: ConfigurableExtensionDataRef<
+      'app.root.wrapper',
       React_2.ComponentType<{
         children?: React_2.ReactNode;
       }>,
@@ -477,6 +493,7 @@ export function createComponentExtension<
 export namespace createComponentExtension {
   const // (undocumented)
     componentDataRef: ConfigurableExtensionDataRef<
+      'core.component.component',
       {
         ref: ComponentRef;
         impl: ComponentType;
@@ -544,10 +561,17 @@ export interface CreateExtensionBlueprintOptions<
   output: TOutput;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export function createExtensionDataRef<TData>(
   id: string,
-): ConfigurableExtensionDataRef<TData>;
+): ConfigurableExtensionDataRef<string, TData>;
+
+// @public (undocumented)
+export function createExtensionDataRef<TData>(): {
+  with<TId extends string>(options: {
+    id: TId;
+  }): ConfigurableExtensionDataRef<TId, TData>;
+};
 
 // @public (undocumented)
 export function createExtensionInput<
@@ -646,6 +670,7 @@ export function createNavItemExtension(options: {
 export namespace createNavItemExtension {
   const // (undocumented)
     targetDataRef: ConfigurableExtensionDataRef<
+      'core.nav-item.target',
       {
         title: string;
         icon: IconComponent_2;
@@ -667,6 +692,7 @@ export function createNavLogoExtension(options: {
 export namespace createNavLogoExtension {
   const // (undocumented)
     logoElementsDataRef: ConfigurableExtensionDataRef<
+      'core.nav-logo.logo-elements',
       {
         logoIcon?: JSX.Element | undefined;
         logoFull?: JSX.Element | undefined;
@@ -760,6 +786,7 @@ export function createRouterExtension<
 export namespace createRouterExtension {
   const // (undocumented)
     componentDataRef: ConfigurableExtensionDataRef<
+      'app.router.wrapper',
       React_2.ComponentType<{
         children?: React_2.ReactNode;
       }>,
@@ -796,6 +823,7 @@ export function createSignInPageExtension<
 export namespace createSignInPageExtension {
   const // (undocumented)
     componentDataRef: ConfigurableExtensionDataRef<
+      'core.sign-in-page.component',
       React_2.ComponentType<SignInPageProps>,
       {}
     >;
@@ -818,7 +846,11 @@ export function createThemeExtension(
 // @public (undocumented)
 export namespace createThemeExtension {
   const // (undocumented)
-    themeDataRef: ConfigurableExtensionDataRef<AppTheme, {}>;
+    themeDataRef: ConfigurableExtensionDataRef<
+      'core.theme.theme',
+      AppTheme,
+      {}
+    >;
 }
 
 // @public (undocumented)
@@ -831,6 +863,7 @@ export function createTranslationExtension(options: {
 export namespace createTranslationExtension {
   const // (undocumented)
     translationDataRef: ConfigurableExtensionDataRef<
+      'core.translation.translation',
       | TranslationResource<string>
       | TranslationMessages<
           string,
@@ -934,11 +967,12 @@ export interface ExtensionBoundaryProps {
 // @public (undocumented)
 export type ExtensionDataRef<
   TData,
+  TId extends string = string,
   TConfig extends {
     optional?: true;
   } = {},
 > = {
-  id: string;
+  id: TId;
   T: TData;
   config: TConfig;
   $$type: '@backstage/ExtensionDataRef';

--- a/packages/frontend-plugin-api/src/extensions/createApiExtension.ts
+++ b/packages/frontend-plugin-api/src/extensions/createApiExtension.ts
@@ -72,6 +72,7 @@ export function createApiExtension<
 
 /** @public */
 export namespace createApiExtension {
-  export const factoryDataRef =
-    createExtensionDataRef<AnyApiFactory>('core.api.factory');
+  export const factoryDataRef = createExtensionDataRef<AnyApiFactory>().with({
+    id: 'core.api.factory',
+  });
 }

--- a/packages/frontend-plugin-api/src/extensions/createAppRootWrapperExtension.tsx
+++ b/packages/frontend-plugin-api/src/extensions/createAppRootWrapperExtension.tsx
@@ -77,8 +77,7 @@ export function createAppRootWrapperExtension<
 
 /** @public */
 export namespace createAppRootWrapperExtension {
-  export const componentDataRef =
-    createExtensionDataRef<ComponentType<PropsWithChildren<{}>>>(
-      'app.root.wrapper',
-    );
+  export const componentDataRef = createExtensionDataRef<
+    ComponentType<PropsWithChildren<{}>>
+  >().with({ id: 'app.root.wrapper' });
 }

--- a/packages/frontend-plugin-api/src/extensions/createComponentExtension.tsx
+++ b/packages/frontend-plugin-api/src/extensions/createComponentExtension.tsx
@@ -92,5 +92,5 @@ export namespace createComponentExtension {
   export const componentDataRef = createExtensionDataRef<{
     ref: ComponentRef;
     impl: ComponentType;
-  }>('core.component.component');
+  }>().with({ id: 'core.component.component' });
 }

--- a/packages/frontend-plugin-api/src/extensions/createNavItemExtension.tsx
+++ b/packages/frontend-plugin-api/src/extensions/createNavItemExtension.tsx
@@ -61,5 +61,5 @@ export namespace createNavItemExtension {
     title: string;
     icon: IconComponent;
     routeRef: RouteRef<undefined>;
-  }>('core.nav-item.target');
+  }>().with({ id: 'core.nav-item.target' });
 }

--- a/packages/frontend-plugin-api/src/extensions/createNavLogoExtension.tsx
+++ b/packages/frontend-plugin-api/src/extensions/createNavLogoExtension.tsx
@@ -51,5 +51,5 @@ export namespace createNavLogoExtension {
   export const logoElementsDataRef = createExtensionDataRef<{
     logoIcon?: JSX.Element;
     logoFull?: JSX.Element;
-  }>('core.nav-logo.logo-elements');
+  }>().with({ id: 'core.nav-logo.logo-elements' });
 }

--- a/packages/frontend-plugin-api/src/extensions/createRouterExtension.tsx
+++ b/packages/frontend-plugin-api/src/extensions/createRouterExtension.tsx
@@ -77,8 +77,7 @@ export function createRouterExtension<
 
 /** @public */
 export namespace createRouterExtension {
-  export const componentDataRef =
-    createExtensionDataRef<ComponentType<PropsWithChildren<{}>>>(
-      'app.router.wrapper',
-    );
+  export const componentDataRef = createExtensionDataRef<
+    ComponentType<PropsWithChildren<{}>>
+  >().with({ id: 'app.router.wrapper' });
 }

--- a/packages/frontend-plugin-api/src/extensions/createSignInPageExtension.tsx
+++ b/packages/frontend-plugin-api/src/extensions/createSignInPageExtension.tsx
@@ -79,5 +79,5 @@ export function createSignInPageExtension<
 export namespace createSignInPageExtension {
   export const componentDataRef = createExtensionDataRef<
     ComponentType<SignInPageProps>
-  >('core.sign-in-page.component');
+  >().with({ id: 'core.sign-in-page.component' });
 }

--- a/packages/frontend-plugin-api/src/extensions/createThemeExtension.ts
+++ b/packages/frontend-plugin-api/src/extensions/createThemeExtension.ts
@@ -33,6 +33,7 @@ export function createThemeExtension(theme: AppTheme) {
 
 /** @public */
 export namespace createThemeExtension {
-  export const themeDataRef =
-    createExtensionDataRef<AppTheme>('core.theme.theme');
+  export const themeDataRef = createExtensionDataRef<AppTheme>().with({
+    id: 'core.theme.theme',
+  });
 }

--- a/packages/frontend-plugin-api/src/extensions/createTranslationExtension.ts
+++ b/packages/frontend-plugin-api/src/extensions/createTranslationExtension.ts
@@ -38,5 +38,5 @@ export function createTranslationExtension(options: {
 export namespace createTranslationExtension {
   export const translationDataRef = createExtensionDataRef<
     TranslationResource | TranslationMessages
-  >('core.translation.translation');
+  >().with({ id: 'core.translation.translation' });
 }

--- a/packages/frontend-plugin-api/src/wiring/coreExtensionData.ts
+++ b/packages/frontend-plugin-api/src/wiring/coreExtensionData.ts
@@ -20,7 +20,9 @@ import { createExtensionDataRef } from './createExtensionDataRef';
 
 /** @public */
 export const coreExtensionData = {
-  reactElement: createExtensionDataRef<JSX.Element>('core.reactElement'),
-  routePath: createExtensionDataRef<string>('core.routing.path'),
-  routeRef: createExtensionDataRef<RouteRef>('core.routing.ref'),
+  reactElement: createExtensionDataRef<JSX.Element>().with({
+    id: 'core.reactElement',
+  }),
+  routePath: createExtensionDataRef<string>().with({ id: 'core.routing.path' }),
+  routeRef: createExtensionDataRef<RouteRef>().with({ id: 'core.routing.ref' }),
 };

--- a/packages/frontend-plugin-api/src/wiring/createExtension.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.test.ts
@@ -18,7 +18,7 @@ import { createExtension } from './createExtension';
 import { createExtensionDataRef } from './createExtensionDataRef';
 import { createExtensionInput } from './createExtensionInput';
 
-const stringData = createExtensionDataRef<string>('string');
+const stringData = createExtensionDataRef<string>().with({ id: 'string' });
 
 function unused(..._any: any[]) {}
 

--- a/packages/frontend-plugin-api/src/wiring/createExtension.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.ts
@@ -22,7 +22,7 @@ import { ExtensionInput } from './createExtensionInput';
 
 /** @public */
 export type AnyExtensionDataMap = {
-  [name in string]: ExtensionDataRef<unknown, { optional?: true }>;
+  [name in string]: ExtensionDataRef<unknown, string, { optional?: true }>;
 };
 
 /** @public */

--- a/packages/frontend-plugin-api/src/wiring/createExtensionDataRef.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionDataRef.test.ts
@@ -18,6 +18,15 @@ import { createExtensionDataRef } from './createExtensionDataRef';
 
 describe('createExtensionDataRef', () => {
   it('can be created and read', () => {
+    const ref = createExtensionDataRef().with({ id: 'foo' });
+    expect(ref.id).toBe('foo');
+    expect(String(ref)).toBe('ExtensionDataRef{id=foo,optional=false}');
+    const refOptional = ref.optional();
+    expect(refOptional.id).toBe('foo');
+    expect(String(refOptional)).toBe('ExtensionDataRef{id=foo,optional=true}');
+  });
+
+  it('can be created and read in the deprecated way', () => {
     const ref = createExtensionDataRef('foo');
     expect(ref.id).toBe('foo');
     expect(String(ref)).toBe('ExtensionDataRef{id=foo,optional=false}');

--- a/packages/frontend-plugin-api/src/wiring/createPlugin.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createPlugin.test.ts
@@ -27,7 +27,9 @@ import { MockConfigApi, renderWithEffects } from '@backstage/test-utils';
 import { createExtensionInput } from './createExtensionInput';
 import { BackstagePlugin } from './types';
 
-const nameExtensionDataRef = createExtensionDataRef<string>('name');
+const nameExtensionDataRef = createExtensionDataRef<string>().with({
+  id: 'name',
+});
 
 const Extension1 = createExtension({
   name: '1',

--- a/plugins/catalog-react/api-report-alpha.md
+++ b/plugins/catalog-react/api-report-alpha.md
@@ -17,12 +17,21 @@ import { TranslationRef } from '@backstage/core-plugin-api/alpha';
 
 // @alpha (undocumented)
 export const catalogExtensionData: {
-  entityContentTitle: ConfigurableExtensionDataRef<string, {}>;
+  entityContentTitle: ConfigurableExtensionDataRef<
+    'catalog.entity-content-title',
+    string,
+    {}
+  >;
   entityFilterFunction: ConfigurableExtensionDataRef<
+    'catalog.entity-filter-function',
     (entity: Entity) => boolean,
     {}
   >;
-  entityFilterExpression: ConfigurableExtensionDataRef<string, {}>;
+  entityFilterExpression: ConfigurableExtensionDataRef<
+    'catalog.entity-filter-expression',
+    string,
+    {}
+  >;
 };
 
 // @alpha (undocumented)

--- a/plugins/catalog-react/src/alpha.tsx
+++ b/plugins/catalog-react/src/alpha.tsx
@@ -36,15 +36,15 @@ export * from './translation';
 
 /** @alpha */
 export const catalogExtensionData = {
-  entityContentTitle: createExtensionDataRef<string>(
-    'catalog.entity-content-title',
-  ),
-  entityFilterFunction: createExtensionDataRef<(entity: Entity) => boolean>(
-    'catalog.entity-filter-function',
-  ),
-  entityFilterExpression: createExtensionDataRef<string>(
-    'catalog.entity-filter-expression',
-  ),
+  entityContentTitle: createExtensionDataRef<string>().with({
+    id: 'catalog.entity-content-title',
+  }),
+  entityFilterFunction: createExtensionDataRef<
+    (entity: Entity) => boolean
+  >().with({ id: 'catalog.entity-filter-function' }),
+  entityFilterExpression: createExtensionDataRef<string>().with({
+    id: 'catalog.entity-filter-expression',
+  }),
 };
 
 // TODO: Figure out how to merge with provided config schema

--- a/plugins/home/api-report-alpha.md
+++ b/plugins/home/api-report-alpha.md
@@ -11,7 +11,11 @@ const _default: BackstagePlugin<{}, {}>;
 export default _default;
 
 // @alpha (undocumented)
-export const titleExtensionDataRef: ConfigurableExtensionDataRef<string, {}>;
+export const titleExtensionDataRef: ConfigurableExtensionDataRef<
+  'title',
+  string,
+  {}
+>;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/home/src/alpha.tsx
+++ b/plugins/home/src/alpha.tsx
@@ -31,7 +31,9 @@ const rootRouteRef = createRouteRef();
 /**
  * @alpha
  */
-export const titleExtensionDataRef = createExtensionDataRef<string>('title');
+export const titleExtensionDataRef = createExtensionDataRef<string>().with({
+  id: 'title',
+});
 
 const homePage = createPageExtension({
   defaultPath: '/home',

--- a/plugins/search-react/api-report-alpha.md
+++ b/plugins/search-react/api-report-alpha.md
@@ -31,6 +31,7 @@ export function createSearchResultListItemExtension<
 export namespace createSearchResultListItemExtension {
   const // (undocumented)
     itemDataRef: ConfigurableExtensionDataRef<
+      'search.search-result-list-item.item',
       {
         predicate?: SearchResultItemExtensionPredicate | undefined;
         component: SearchResultItemExtensionComponent;

--- a/plugins/search-react/src/alpha.tsx
+++ b/plugins/search-react/src/alpha.tsx
@@ -137,5 +137,5 @@ export namespace createSearchResultListItemExtension {
   export const itemDataRef = createExtensionDataRef<{
     predicate?: SearchResultItemExtensionPredicate;
     component: SearchResultItemExtensionComponent;
-  }>('search.search-result-list-item.item');
+  }>().with({ id: 'search.search-result-list-item.item' });
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes #25667. This updates how extension data refs are declared in the new frontend system. By embedding the ID in the type we'll be able to key data by the ID in other types, which for example allows us to embed input and output types in extensions.

Since the encapsulated type in data refs need to be an explicit type, we can't mix it with inferring the ID in a single function call, it's a TypeScript limitation. Here are some other approaches I considered:

```ts
const fooRef = createExtensionDataRef<FooType, 'foo'>({ id: 'foo' });
const fooRef = createExtensionDataRef<FooType>()({ id: 'foo' });
const fooRef = createExtensionDataRef({ id: 'foo' })<FooType>();
const fooRef = createExtensionDataRef({ id: 'foo' }).type<FooType>();
const fooRef = createExtensionDataRef({ id: 'foo', type(_: FooType) {} });
const fooRef = createExtensionDataRef((_: FooType) => 'foo');
```

But in the end I felt that `.with` was the one that was clearest and indented the best:

```ts
const fooRef = createExtensionDataRef<FooType>().with({ id: 'foo' });
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
