### PR TITLE
fix: Update default backend plugin to use `RootConfigService`

### DIFF
--- a/.changeset/heavy-numbers-love.md
+++ b/.changeset/heavy-numbers-love.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Updated default backend plugin to use `RootConfigService` instead of `Config`. This also removes the dependency on `@backstage/config` as it's no longer used.

--- a/packages/cli/templates/default-backend-plugin/package.json.hbs
+++ b/packages/cli/templates/default-backend-plugin/package.json.hbs
@@ -31,7 +31,6 @@
     "@backstage/backend-common": "{{versionQuery '@backstage/backend-common'}}",
     "@backstage/backend-defaults": "{{versionQuery '@backstage/backend-defaults'}}",
     "@backstage/backend-plugin-api": "{{versionQuery '@backstage/backend-plugin-api'}}",
-    "@backstage/config": "{{versionQuery '@backstage/config'}}",
     "express": "{{versionQuery 'express' '4.17.1'}}",
     "express-promise-router": "{{versionQuery 'express-promise-router' '4.1.0'}}",
     "node-fetch": "{{versionQuery 'node-fetch' '2.6.7'}}"

--- a/packages/cli/templates/default-backend-plugin/src/service/router.ts
+++ b/packages/cli/templates/default-backend-plugin/src/service/router.ts
@@ -1,12 +1,11 @@
 import { MiddlewareFactory } from '@backstage/backend-defaults/rootHttpRouter';
-import { LoggerService } from '@backstage/backend-plugin-api';
-import { Config } from '@backstage/config';
+import { LoggerService, RootConfigService } from '@backstage/backend-plugin-api';
 import express from 'express';
 import Router from 'express-promise-router';
 
 export interface RouterOptions {
   logger: LoggerService;
-  config: Config;
+  config: RootConfigService;
 }
 
 export async function createRouter(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#25386 added `rootConfigService` dependency to default backend plugins and uses `Config` type from `@backstage/config`. It probably makes more sense to use `RootConfigService` type from `@backstage/backend-plugin-api` instead. With this change, there's also no need for dependency to `@backstage/config` in the `package.json` since its not used.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
