### PR TITLE
auth-backend-module-microsoft-provider: update scope handling to define required scopes in backend

### DIFF
--- a/.changeset/new-scissors-try.md
+++ b/.changeset/new-scissors-try.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-microsoft-provider': patch
+---
+
+Updated the Microsoft authenticator to accurately define required scopes, but to also omit the required and additional scopes when requesting resource scopes.

--- a/docs/auth/microsoft/provider.md
+++ b/docs/auth/microsoft/provider.md
@@ -67,8 +67,6 @@ auth:
         clientSecret: ${AZURE_CLIENT_SECRET}
         tenantId: ${AZURE_TENANT_ID}
         domainHint: ${AZURE_TENANT_ID}
-        additionalScopes:
-          - Mail.Send
         signIn:
           resolvers:
             # typically you would pick one of these
@@ -86,7 +84,7 @@ The Microsoft provider is a structure with three mandatory configuration keys:
   Leave blank if your app registration is multi tenant.
   When specified, this reduces login friction for users with accounts in multiple tenants by automatically filtering away accounts from other tenants.
   For more details, see [Home Realm Discovery](https://learn.microsoft.com/en-us/azure/active-directory/manage-apps/home-realm-discovery-policy)
-- `additionalScopes` (optional): List of scopes for the App Registration. The default and mandatory value is ['user.read'].
+- `additionalScopes` (optional): List of scopes for the App Registration, to be requested in addition to the required ones.
 
 ### Resolvers
 

--- a/plugins/auth-backend-module-microsoft-provider/package.json
+++ b/plugins/auth-backend-module-microsoft-provider/package.json
@@ -38,9 +38,7 @@
     "@backstage/plugin-auth-node": "workspace:^",
     "express": "^4.18.2",
     "jose": "^5.0.0",
-    "lodash": "^4.17.21",
     "node-fetch": "^2.6.7",
-    "passport": "^0.7.0",
     "passport-microsoft": "^1.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4861,10 +4861,8 @@ __metadata:
     "@types/passport-microsoft": ^1.0.0
     express: ^4.18.2
     jose: ^5.0.0
-    lodash: ^4.17.21
     msw: ^1.0.0
     node-fetch: ^2.6.7
-    passport: ^0.7.0
     passport-microsoft: ^1.0.0
     supertest: ^6.3.3
   languageName: unknown


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Following #24743 the Microsoft provider was left in a bit of an awkward state, with the `additionalScopes` config being respected but included even when requesting scopes for a resource. This refactors the Microsoft provider to use the new `scopes` config and declaring the required scopes in the backend, but also transforming the request scopes to account for the resource scope separation that's managed in the frontend here: https://github.com/backstage/backstage/blob/b645d70034a05b424d63f3e7ef8a64638d3733a3/packages/core-app-api/src/apis/implementations/auth/microsoft/MicrosoftAuth.ts#L93-L156

Think it could be good to have some eyes on this from some Microsoft users: @afscrome @TheGemmell @pjungermann @awanlin 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
