### PR TITLE
app-next,docs: add example for public index entry point in new frontend system

### DIFF
--- a/docs/tutorials/enable-public-entry.md
+++ b/docs/tutorials/enable-public-entry.md
@@ -100,3 +100,46 @@ With that, Backstage's cli and backend will detect public entry point and serve 
 5. Finally, as soon as you log in, you will be redirected to the main app home page (inspect the page and see that the protected bundle was served from the app backend after the redirect).
 
 That's it!
+
+## New Frontend System
+
+If your app uses the new frontend system, you can still use the public entry point feature. The `index-public-experimental.tsx` file does end up looking a bit different in this case:
+
+```tsx title="in packages/app/src/index-public-experimental.tsx"
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { CookieAuthRedirect } from '@backstage/plugin-auth-react';
+import { createApp } from '@backstage/frontend-app-api';
+import {
+  coreExtensionData,
+  createExtension,
+  createExtensionOverrides,
+} from '@backstage/frontend-plugin-api';
+
+const signInPage = createSignInPageExtension({
+  name: 'guest',
+  loader: async () => props => <SignInPage {...props} providers={['guest']} />,
+});
+
+const authRedirectExtension = createExtension({
+  namespace: 'app',
+  name: 'layout',
+  attachTo: { id: 'app/root', input: 'children' },
+  output: {
+    element: coreExtensionData.reactElement,
+  },
+  factory: () => ({
+    element: <CookieAuthRedirect />,
+  }),
+});
+
+const app = createApp({
+  features: [
+    createExtensionOverrides({
+      extensions: [signInPage, authRedirectExtension],
+    }),
+  ],
+});
+
+ReactDOM.createRoot(document.getElementById('root')!).render(app.createRoot());
+```

--- a/packages/app-next/src/App.tsx
+++ b/packages/app-next/src/App.tsx
@@ -36,18 +36,13 @@ import { convertLegacyApp } from '@backstage/core-compat-api';
 import { FlatRoutes } from '@backstage/core-app-api';
 import { Route } from 'react-router';
 import { CatalogImportPage } from '@backstage/plugin-catalog-import';
-import {
-  createApiFactory,
-  configApiRef,
-  SignInPageProps,
-} from '@backstage/core-plugin-api';
+import { createApiFactory, configApiRef } from '@backstage/core-plugin-api';
 import {
   ScmAuth,
   ScmIntegrationsApi,
   scmIntegrationsApiRef,
 } from '@backstage/integration-react';
-import { createSignInPageExtension } from '@backstage/frontend-plugin-api';
-import { SignInPage } from '@backstage/core-components';
+import { signInPageOverrides } from './overrides/SignInPage';
 
 /*
 
@@ -90,12 +85,6 @@ const homePageExtension = createExtension({
   },
 });
 
-const signInPage = createSignInPageExtension({
-  name: 'guest',
-  loader: async () => (props: SignInPageProps) =>
-    <SignInPage {...props} providers={['guest']} />,
-});
-
 const scmAuthExtension = createApiExtension({
   factory: ScmAuth.createDefaultApiFactory(),
 });
@@ -121,13 +110,13 @@ const app = createApp({
     userSettingsPlugin,
     homePlugin,
     appVisualizerPlugin,
+    signInPageOverrides,
     ...collectedLegacyPlugins,
     createExtensionOverrides({
       extensions: [
         homePageExtension,
         scmAuthExtension,
         scmIntegrationApi,
-        signInPage,
         notFoundErrorPage,
       ],
     }),

--- a/packages/app-next/src/index-public-experimental.tsx
+++ b/packages/app-next/src/index-public-experimental.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { CookieAuthRedirect } from '@backstage/plugin-auth-react';
+import { createApp } from '@backstage/frontend-app-api';
+import { signInPageOverrides } from './overrides/SignInPage';
+import {
+  coreExtensionData,
+  createExtension,
+  createExtensionOverrides,
+} from '@backstage/frontend-plugin-api';
+
+const authRedirectExtension = createExtension({
+  namespace: 'app',
+  name: 'layout',
+  attachTo: { id: 'app/root', input: 'children' },
+  output: {
+    element: coreExtensionData.reactElement,
+  },
+  factory: () => ({
+    element: <CookieAuthRedirect />,
+  }),
+});
+
+const app = createApp({
+  features: [
+    signInPageOverrides,
+    createExtensionOverrides({
+      extensions: [authRedirectExtension],
+    }),
+  ],
+});
+
+ReactDOM.createRoot(document.getElementById('root')!).render(app.createRoot());

--- a/packages/app-next/src/overrides/SignInPage.tsx
+++ b/packages/app-next/src/overrides/SignInPage.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { SignInPage } from '@backstage/core-components';
+import {
+  createExtensionOverrides,
+  createSignInPageExtension,
+} from '@backstage/frontend-plugin-api';
+
+const signInPage = createSignInPageExtension({
+  name: 'guest',
+  loader: async () => props => <SignInPage {...props} providers={['guest']} />,
+});
+
+export const signInPageOverrides = createExtensionOverrides({
+  extensions: [signInPage],
+});


### PR DESCRIPTION
This adds an example of how to set up the new public index entry point in the new frontend system too for completeness. When moving this entry point to stable we'll want to make sure the new frontend system is well supported too. Ideally there's a slightly more slim API than overriding `app/layout` in the future as well.