### PR TITLE
cli: fix forwarding of target dir when resolving optional bundling paths

### DIFF
--- a/.changeset/violet-jokes-wave.md
+++ b/.changeset/violet-jokes-wave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Fix for `repo build --all` not properly detecting the experimental public entry point.

--- a/packages/cli/src/lib/bundler/bundle.ts
+++ b/packages/cli/src/lib/bundler/bundle.ts
@@ -42,6 +42,7 @@ export async function buildBundle(options: BuildOptions) {
 
   const paths = resolveBundlingPaths(options);
   const publicPaths = await resolveOptionalBundlingPaths({
+    targetDir: options.targetDir,
     entry: 'src/index-public-experimental',
     dist: 'dist/public',
   });


### PR DESCRIPTION
🧹 