### PR TITLE
GitHub: Allow operators to set entity ingestion namespace

### DIFF
--- a/.changeset/fast-sheep-sip.md
+++ b/.changeset/fast-sheep-sip.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-catalog-backend-module-github': minor
+'@backstage/plugin-catalog-backend-module-github': patch
 ---
 
 Provide option for setting namespaces for entities ingested with `GithubEntityProvider`

--- a/.changeset/fast-sheep-sip.md
+++ b/.changeset/fast-sheep-sip.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': minor
+---
+
+Provide option for setting namespaces for entities ingested with `GithubEntityProvider`

--- a/docs/integrations/github/discovery.md
+++ b/docs/integrations/github/discovery.md
@@ -173,6 +173,8 @@ If you do so, `default` will be used as provider ID.
 - **`organization`**:
   Name of your organization account/workspace.
   If you want to add multiple organizations, you need to add one provider config each.
+- **`namespace`** _(optional)_:
+  The namespace to assign to ingested entities. Uses the `default` namespace if not provided.
 - **`validateLocationsExist`** _(optional)_:
   Whether to validate locations that exist before emitting them.
   This option avoids generating locations for catalog info files that do not exist in the source repository.

--- a/plugins/catalog-backend-module-github/config.d.ts
+++ b/plugins/catalog-backend-module-github/config.d.ts
@@ -68,7 +68,7 @@ export interface Config {
             /**
              * (Optional) The namespace to assign to ingested entities.  Uses the `default` namespace if not provided.
              */
-            namespace: string;
+            namespace?: string;
             /**
              * (Optional) Path where to look for `catalog-info.yaml` files.
              * You can use wildcards - `*` or `**` - to search the path and/or the filename

--- a/plugins/catalog-backend-module-github/config.d.ts
+++ b/plugins/catalog-backend-module-github/config.d.ts
@@ -66,6 +66,10 @@ export interface Config {
              */
             organization: string;
             /**
+             * (Optional) The namespace to assign to ingested entities.  Uses the `default` namespace if not provided.
+             */
+            namespace: string;
+            /**
              * (Optional) Path where to look for `catalog-info.yaml` files.
              * You can use wildcards - `*` or `**` - to search the path and/or the filename
              * Default: `/catalog-info.yaml`.

--- a/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.test.ts
@@ -35,6 +35,7 @@ import {
   RepositoryEvent,
   RepositoryRenamedEvent,
 } from '@octokit/webhooks-types';
+import { DEFAULT_NAMESPACE } from '@backstage/catalog-model';
 
 jest.mock('../lib/github', () => {
   return {
@@ -92,6 +93,7 @@ describe('GithubEntityProvider', () => {
           apiVersion: 'backstage.io/v1alpha1',
           kind: 'Location',
           metadata: {
+            namespace: DEFAULT_NAMESPACE,
             annotations: {
               'backstage.io/managed-by-location': `url:${url}`,
               'backstage.io/managed-by-origin-location': `url:${url}`,

--- a/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.test.ts
@@ -96,7 +96,7 @@ describe('GithubEntityProvider', () => {
           apiVersion: 'backstage.io/v1alpha1',
           kind: 'Location',
           metadata: {
-            namespace: DEFAULT_NAMESPACE,
+            namespace,
             annotations: {
               'backstage.io/managed-by-location': `url:${url}`,
               'backstage.io/managed-by-origin-location': `url:${url}`,
@@ -170,9 +170,11 @@ describe('GithubEntityProvider', () => {
   });
 
   it('apply full update on scheduled execution with basic filters', async () => {
+    const namespace = 'bippitboppityboo';
     const config = createSingleProviderConfig({
       providerConfig: {
         catalogPath: 'custom/path/catalog-custom.yaml',
+        namespace,
         filters: {
           branch: 'main',
           repository: 'test-.*',
@@ -225,10 +227,7 @@ describe('GithubEntityProvider', () => {
     await (taskDef.fn as () => Promise<void>)();
 
     const url = `https://github.com/test-org/test-repo/blob/main/custom/path/catalog-custom.yaml`;
-    const expectedEntities = createExpectedEntitiesForUrl(
-      url,
-      'bippitboppityboo',
-    );
+    const expectedEntities = createExpectedEntitiesForUrl(url, namespace);
 
     expect(entityProviderConnection.applyMutation).toHaveBeenCalledTimes(1);
     expect(entityProviderConnection.applyMutation).toHaveBeenCalledWith({

--- a/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.test.ts
@@ -86,7 +86,10 @@ describe('GithubEntityProvider', () => {
     });
   };
 
-  const createExpectedEntitiesForUrl = (url: string): DeferredEntity[] => {
+  const createExpectedEntitiesForUrl = (
+    url: string,
+    namespace: string = DEFAULT_NAMESPACE,
+  ): DeferredEntity[] => {
     return [
       {
         entity: {
@@ -222,7 +225,10 @@ describe('GithubEntityProvider', () => {
     await (taskDef.fn as () => Promise<void>)();
 
     const url = `https://github.com/test-org/test-repo/blob/main/custom/path/catalog-custom.yaml`;
-    const expectedEntities = createExpectedEntitiesForUrl(url);
+    const expectedEntities = createExpectedEntitiesForUrl(
+      url,
+      'bippitboppityboo',
+    );
 
     expect(entityProviderConnection.applyMutation).toHaveBeenCalledTimes(1);
     expect(entityProviderConnection.applyMutation).toHaveBeenCalledWith({

--- a/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.ts
@@ -700,8 +700,9 @@ export class GithubEntityProvider implements EntityProvider, EventSubscriber {
     return targets
       .map(target => {
         const location = GithubEntityProvider.toLocationSpec(target);
-
-        return locationSpecToLocationEntity({ location });
+        const entity = locationSpecToLocationEntity({ location });
+        entity.metadata.namespace = this.config.namespace;
+        return entity;
       })
       .map(entity => {
         return {
@@ -718,9 +719,11 @@ export class GithubEntityProvider implements EntityProvider, EventSubscriber {
       .map(repository => this.createLocationUrl(repository))
       .map(GithubEntityProvider.toLocationSpec)
       .map(location => {
+        const entity = locationSpecToLocationEntity({ location });
+        entity.metadata.namespace = this.config.namespace;
         return {
           locationKey: this.getProviderName(),
-          entity: locationSpecToLocationEntity({ location }),
+          entity,
         };
       });
   }

--- a/plugins/catalog-backend-module-github/src/providers/GithubEntityProviderConfig.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubEntityProviderConfig.test.ts
@@ -16,6 +16,7 @@
 
 import { ConfigReader } from '@backstage/config';
 import { readProviderConfigs } from './GithubEntityProviderConfig';
+import { DEFAULT_NAMESPACE } from '@backstage/catalog-model';
 
 describe('readProviderConfigs', () => {
   afterEach(() => jest.resetAllMocks());
@@ -112,6 +113,7 @@ describe('readProviderConfigs', () => {
     expect(providerConfigs[0]).toEqual({
       id: 'providerOrganizationOnly',
       organization: 'test-org1',
+      namespace: DEFAULT_NAMESPACE,
       catalogPath: '/catalog-info.yaml',
       host: 'github.com',
       filters: {
@@ -130,6 +132,7 @@ describe('readProviderConfigs', () => {
     expect(providerConfigs[1]).toEqual({
       id: 'providerCustomCatalogPath',
       organization: 'test-org2',
+      namespace: DEFAULT_NAMESPACE,
       catalogPath: 'custom/path/catalog-info.yaml',
       host: 'github.com',
       filters: {
@@ -148,6 +151,7 @@ describe('readProviderConfigs', () => {
     expect(providerConfigs[2]).toEqual({
       id: 'providerWithRepositoryFilter',
       organization: 'test-org3', // organization
+      namespace: DEFAULT_NAMESPACE,
       catalogPath: '/catalog-info.yaml', // file
       host: 'github.com',
       filters: {
@@ -166,6 +170,7 @@ describe('readProviderConfigs', () => {
     expect(providerConfigs[3]).toEqual({
       id: 'providerWithBranchFilter',
       organization: 'test-org4',
+      namespace: DEFAULT_NAMESPACE,
       catalogPath: '/catalog-info.yaml',
       host: 'github.com',
       filters: {
@@ -184,6 +189,7 @@ describe('readProviderConfigs', () => {
     expect(providerConfigs[4]).toEqual({
       id: 'providerWithTopicFilter',
       organization: 'test-org5',
+      namespace: DEFAULT_NAMESPACE,
       catalogPath: '/catalog-info.yaml',
       host: 'github.com',
       filters: {
@@ -202,6 +208,7 @@ describe('readProviderConfigs', () => {
     expect(providerConfigs[5]).toEqual({
       id: 'providerWithForkFilter',
       organization: 'test-org6',
+      namespace: DEFAULT_NAMESPACE,
       catalogPath: '/catalog-info.yaml',
       host: 'github.com',
       filters: {
@@ -220,6 +227,7 @@ describe('readProviderConfigs', () => {
     expect(providerConfigs[6]).toEqual({
       id: 'providerWithVisibilityFilter',
       organization: 'test-org6',
+      namespace: DEFAULT_NAMESPACE,
       catalogPath: '/catalog-info.yaml',
       host: 'github.com',
       filters: {
@@ -238,6 +246,7 @@ describe('readProviderConfigs', () => {
     expect(providerConfigs[7]).toEqual({
       id: 'providerWithHost',
       organization: 'test-org1',
+      namespace: DEFAULT_NAMESPACE,
       catalogPath: '/catalog-info.yaml',
       host: 'ghe.internal.com',
       filters: {
@@ -256,6 +265,7 @@ describe('readProviderConfigs', () => {
     expect(providerConfigs[8]).toEqual({
       id: 'providerWithSchedule',
       organization: 'test-org1',
+      namespace: DEFAULT_NAMESPACE,
       catalogPath: '/catalog-info.yaml',
       host: 'github.com',
       filters: {

--- a/plugins/catalog-backend-module-github/src/providers/GithubEntityProviderConfig.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubEntityProviderConfig.ts
@@ -71,7 +71,7 @@ function readProviderConfig(
   config: Config,
 ): GithubEntityProviderConfig {
   const organization = config.getString('organization');
-  const namespace = config.getOptionalString('namespace');
+  const namespace = config.getOptionalString('namespace') ?? DEFAULT_NAMESPACE;
   const catalogPath =
     config.getOptionalString('catalogPath') ?? DEFAULT_CATALOG_PATH;
   const host = config.getOptionalString('host') ?? 'github.com';
@@ -106,7 +106,7 @@ function readProviderConfig(
     id,
     catalogPath,
     organization,
-    namespace: namespace ?? DEFAULT_NAMESPACE,
+    namespace,
     host,
     filters: {
       repository: repositoryPattern

--- a/plugins/catalog-backend-module-github/src/providers/GithubEntityProviderConfig.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubEntityProviderConfig.ts
@@ -18,6 +18,7 @@ import {
   readTaskScheduleDefinitionFromConfig,
   TaskScheduleDefinition,
 } from '@backstage/backend-tasks';
+import { DEFAULT_NAMESPACE } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
 
 const DEFAULT_CATALOG_PATH = '/catalog-info.yaml';
@@ -27,6 +28,7 @@ export type GithubEntityProviderConfig = {
   id: string;
   catalogPath: string;
   organization: string;
+  namespace?: string;
   host: string;
   filters?: {
     repository?: RegExp;
@@ -69,6 +71,7 @@ function readProviderConfig(
   config: Config,
 ): GithubEntityProviderConfig {
   const organization = config.getString('organization');
+  const namespace = config.getOptionalString('namespace');
   const catalogPath =
     config.getOptionalString('catalogPath') ?? DEFAULT_CATALOG_PATH;
   const host = config.getOptionalString('host') ?? 'github.com';
@@ -103,6 +106,7 @@ function readProviderConfig(
     id,
     catalogPath,
     organization,
+    namespace: namespace ?? DEFAULT_NAMESPACE,
     host,
     filters: {
       repository: repositoryPattern


### PR DESCRIPTION
## Hey, I just made a Pull Request!
This PR modifies the configuration for `GithubEntityProvider`.  It allows an operator to configure an optional `namespace` that ingested locations are written to.

### Sample usecase
Your company has acquired another company (hooray!).  This company has a github org you'd like to add to backstage.  However, several repositories between the organizations have the exact same name.  This will result in the `conflictingEntityRef` message if `orgA/Repo` and `orgB/Repo` are both added to the `default` namespace.  This PR aims to solve that

### Outstanding issues
I couldn't find the spot in the code where locations are fetched, only written 😓 .  I'm not sure if `Location` namespaces are respected/copied to their corresponding `Component`/`Resource`/`Whatever` Entities.

If there's a better place to submit this modification, please let me know!

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] (Not applicable) Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
