### PR TITLE
Wrap scheduler tasks in Open Telemetry spans

### DIFF
--- a/.changeset/rich-bees-tickle.md
+++ b/.changeset/rich-bees-tickle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Wrap scheduled tasks from the scheduler core service now in OpenTelemetry spans

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/PluginTaskSchedulerImpl.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/PluginTaskSchedulerImpl.ts
@@ -23,13 +23,7 @@ import {
   SchedulerServiceTaskRunner,
   SchedulerServiceTaskScheduleDefinition,
 } from '@backstage/backend-plugin-api';
-import {
-  Counter,
-  Histogram,
-  metrics,
-  SpanStatusCode,
-  trace,
-} from '@opentelemetry/api';
+import { Counter, Histogram, metrics, trace } from '@opentelemetry/api';
 import { Knex } from 'knex';
 import { Duration } from 'luxon';
 import { LocalTaskWorker } from './LocalTaskWorker';

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/PluginTaskSchedulerImpl.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/PluginTaskSchedulerImpl.ts
@@ -23,13 +23,21 @@ import {
   SchedulerServiceTaskRunner,
   SchedulerServiceTaskScheduleDefinition,
 } from '@backstage/backend-plugin-api';
-import { Counter, Histogram, metrics } from '@opentelemetry/api';
+import {
+  Counter,
+  Histogram,
+  metrics,
+  SpanStatusCode,
+  trace,
+} from '@opentelemetry/api';
 import { Knex } from 'knex';
 import { Duration } from 'luxon';
 import { LocalTaskWorker } from './LocalTaskWorker';
 import { TaskWorker } from './TaskWorker';
 import { TaskSettingsV2 } from './types';
-import { validateId } from './util';
+import { TRACER_ID, validateId } from './util';
+
+const tracer = trace.getTracer(TRACER_ID);
 
 /**
  * Implements the actual task management.
@@ -85,7 +93,7 @@ export class PluginTaskSchedulerImpl implements SchedulerService {
       const knex = await this.databaseFactory();
       const worker = new TaskWorker(
         task.id,
-        this.wrapInMetrics(task.fn, { labels: { taskId: task.id, scope } }),
+        this.instrumentedFunction(task, scope),
         knex,
         this.logger.child({ task: task.id }),
       );
@@ -93,7 +101,7 @@ export class PluginTaskSchedulerImpl implements SchedulerService {
     } else {
       const worker = new LocalTaskWorker(
         task.id,
-        this.wrapInMetrics(task.fn, { labels: { taskId: task.id, scope } }),
+        this.instrumentedFunction(task, scope),
         this.logger.child({ task: task.id }),
       );
       worker.start(settings, { signal: task.signal });
@@ -121,20 +129,33 @@ export class PluginTaskSchedulerImpl implements SchedulerService {
     return this.allScheduledTasks;
   }
 
-  private wrapInMetrics(
-    fn: SchedulerServiceTaskFunction,
-    opts: { labels: Record<string, string> },
+  private instrumentedFunction(
+    task: SchedulerServiceTaskInvocationDefinition,
+    scope: string,
   ): SchedulerServiceTaskFunction {
     return async abort => {
-      const labels = {
-        ...opts.labels,
+      const labels: Record<string, string> = {
+        taskId: task.id,
+        scope,
       };
       this.counter.add(1, { ...labels, result: 'started' });
 
       const startTime = process.hrtime();
 
       try {
-        await fn(abort);
+        await tracer.startActiveSpan(`task ${task.id}`, async span => {
+          try {
+            span.setAttributes(labels);
+            await task.fn(abort);
+          } catch (error) {
+            if (error instanceof Error) {
+              span.recordException(error);
+            }
+            throw error;
+          } finally {
+            span.end();
+          }
+        });
         labels.result = 'completed';
       } catch (ex) {
         labels.result = 'failed';

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/util.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/util.ts
@@ -18,6 +18,8 @@ import { InputError } from '@backstage/errors';
 import { Knex } from 'knex';
 import { DateTime, Duration } from 'luxon';
 
+export const TRACER_ID = 'backstage.scheduler';
+
 // Keep the IDs compatible with e.g. Prometheus labels
 export function validateId(id: string) {
   if (typeof id !== 'string' || !id.trim()) {

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/util.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/util.ts
@@ -18,7 +18,7 @@ import { InputError } from '@backstage/errors';
 import { Knex } from 'knex';
 import { DateTime, Duration } from 'luxon';
 
-export const TRACER_ID = '@backstage/backend-defaults/scheduler';
+export const TRACER_ID = 'backstage-backend-defaults-scheduler';
 
 // Keep the IDs compatible with e.g. Prometheus labels
 export function validateId(id: string) {

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/util.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/util.ts
@@ -18,7 +18,7 @@ import { InputError } from '@backstage/errors';
 import { Knex } from 'knex';
 import { DateTime, Duration } from 'luxon';
 
-export const TRACER_ID = 'backstage-backend-defaults-scheduler';
+export const TRACER_ID = 'backstage-service-scheduler';
 
 // Keep the IDs compatible with e.g. Prometheus labels
 export function validateId(id: string) {

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/util.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/util.ts
@@ -18,7 +18,7 @@ import { InputError } from '@backstage/errors';
 import { Knex } from 'knex';
 import { DateTime, Duration } from 'luxon';
 
-export const TRACER_ID = 'backstage.scheduler';
+export const TRACER_ID = '@backstage/backend-defaults/scheduler';
 
 // Keep the IDs compatible with e.g. Prometheus labels
 export function validateId(id: string) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This PR changes the scheduler so that tasks are wrapped in Open Telemetry spans.

Before this change, when trying to troubleshoot a scheduled task through an OTEL trace, spans would be incorrectly grouped. This lead to the scheduled task being split in many traces. By adding a span around the task itself, all the work a task does can now be grouped into that task in a single span.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
