### PR TITLE
Patch release of #25742

### DIFF
--- a/.changeset/thirty-paws-hope.md
+++ b/.changeset/thirty-paws-hope.md
@@ -1,5 +1,0 @@
----
-'@backstage/core-app-api': patch
----
-
-The request to delete the session cookie when running the app in protected mode is now done with a plain `fetch` rather than `FetchApi`. This fixes a bug where the app would immediately try to sign-in again when removing the cookie during logout.

--- a/.changeset/thirty-paws-hope.md
+++ b/.changeset/thirty-paws-hope.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-app-api': patch
+---
+
+The request to delete the session cookie when running the app in protected mode is now done with a plain `fetch` rather than `FetchApi`. This fixes a bug where the app would immediately try to sign-in again when removing the cookie during logout.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.29.1",
+  "version": "1.29.2",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/app-defaults/CHANGELOG.md
+++ b/packages/app-defaults/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/app-defaults
 
+## 1.5.9
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/core-app-api@1.14.1
+  - @backstage/core-components@0.14.9
+  - @backstage/core-plugin-api@1.9.3
+  - @backstage/plugin-permission-react@0.4.24
+
 ## 1.5.8
 
 ### Patch Changes

--- a/packages/app-defaults/package.json
+++ b/packages/app-defaults/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/app-defaults",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "description": "Provides the default wiring of a Backstage App",
   "backstage": {
     "role": "web-library"

--- a/packages/app-next/CHANGELOG.md
+++ b/packages/app-next/CHANGELOG.md
@@ -1,5 +1,43 @@
 # example-app-next
 
+## 0.0.14
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/core-app-api@1.14.1
+  - @backstage/app-defaults@1.5.9
+  - @backstage/cli@0.26.11
+  - @backstage/core-compat-api@0.2.7
+  - @backstage/core-components@0.14.9
+  - @backstage/core-plugin-api@1.9.3
+  - @backstage/frontend-app-api@0.7.4
+  - @backstage/plugin-api-docs@0.11.7
+  - @backstage/plugin-catalog@1.21.1
+  - @backstage/plugin-catalog-graph@0.4.7
+  - @backstage/plugin-catalog-import@0.12.1
+  - @backstage/plugin-catalog-react@1.12.2
+  - @backstage/plugin-home@0.7.8
+  - @backstage/plugin-notifications@0.2.3
+  - @backstage/plugin-org@0.6.27
+  - @backstage/plugin-scaffolder@1.23.0
+  - @backstage/plugin-scaffolder-react@1.10.0
+  - @backstage/plugin-search@1.4.14
+  - @backstage/plugin-search-react@1.7.13
+  - @backstage/plugin-signals@0.0.8
+  - @backstage/plugin-techdocs@1.10.7
+  - @backstage/plugin-user-settings@0.8.10
+  - @backstage/integration-react@1.1.29
+  - @backstage/plugin-catalog-unprocessed-entities@0.2.6
+  - @backstage/plugin-kubernetes@0.11.12
+  - @backstage/frontend-plugin-api@0.6.7
+  - @backstage/config@1.2.0
+  - @backstage/plugin-auth-react@0.1.4
+  - @backstage/plugin-kubernetes-cluster@0.0.13
+  - @backstage/plugin-permission-react@0.4.24
+  - @backstage/plugin-techdocs-module-addons-contrib@1.1.12
+  - @backstage/plugin-techdocs-react@1.2.6
+
 ## 0.0.13
 
 ### Patch Changes

--- a/packages/app-next/package.json
+++ b/packages/app-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-app-next",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -1,5 +1,42 @@
 # example-app
 
+## 0.2.100
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/core-app-api@1.14.1
+  - @backstage/app-defaults@1.5.9
+  - @backstage/cli@0.26.11
+  - @backstage/core-components@0.14.9
+  - @backstage/core-plugin-api@1.9.3
+  - @backstage/frontend-app-api@0.7.4
+  - @backstage/plugin-api-docs@0.11.7
+  - @backstage/plugin-catalog@1.21.1
+  - @backstage/plugin-catalog-graph@0.4.7
+  - @backstage/plugin-catalog-import@0.12.1
+  - @backstage/plugin-catalog-react@1.12.2
+  - @backstage/plugin-home@0.7.8
+  - @backstage/plugin-notifications@0.2.3
+  - @backstage/plugin-org@0.6.27
+  - @backstage/plugin-scaffolder@1.23.0
+  - @backstage/plugin-scaffolder-react@1.10.0
+  - @backstage/plugin-search@1.4.14
+  - @backstage/plugin-search-react@1.7.13
+  - @backstage/plugin-signals@0.0.8
+  - @backstage/plugin-techdocs@1.10.7
+  - @backstage/plugin-user-settings@0.8.10
+  - @backstage/integration-react@1.1.29
+  - @backstage/plugin-catalog-unprocessed-entities@0.2.6
+  - @backstage/plugin-devtools@0.1.16
+  - @backstage/plugin-kubernetes@0.11.12
+  - @backstage/config@1.2.0
+  - @backstage/plugin-auth-react@0.1.4
+  - @backstage/plugin-kubernetes-cluster@0.0.13
+  - @backstage/plugin-permission-react@0.4.24
+  - @backstage/plugin-techdocs-module-addons-contrib@1.1.12
+  - @backstage/plugin-techdocs-react@1.2.6
+
 ## 0.2.99
 
 ### Patch Changes

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-app",
-  "version": "0.2.99",
+  "version": "0.2.100",
   "backstage": {
     "role": "frontend"
   },

--- a/packages/core-app-api/CHANGELOG.md
+++ b/packages/core-app-api/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/core-app-api
 
+## 1.14.1
+
+### Patch Changes
+
+- cf675fb: The request to delete the session cookie when running the app in protected mode is now done with a plain `fetch` rather than `FetchApi`. This fixes a bug where the app would immediately try to sign-in again when removing the cookie during logout.
+- Updated dependencies
+  - @backstage/core-plugin-api@1.9.3
+  - @backstage/config@1.2.0
+
 ## 1.14.0
 
 ### Minor Changes

--- a/packages/core-app-api/package.json
+++ b/packages/core-app-api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/core-app-api",
   "description": "Core app API used by Backstage apps",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core-app-api/src/apis/implementations/IdentityApi/AppIdentityProxy.ts
+++ b/packages/core-app-api/src/apis/implementations/IdentityApi/AppIdentityProxy.ts
@@ -153,8 +153,9 @@ export class AppIdentityProxy implements IdentityApi {
       // It is fine if we do NOT worry yet about deleting cookies for OTHER backends like techdocs
       const appBaseUrl = await ctx.discoveryApi.getBaseUrl('app');
       try {
-        await ctx.fetchApi.fetch(`${appBaseUrl}/.backstage/auth/v1/cookie`, {
+        await fetch(`${appBaseUrl}/.backstage/auth/v1/cookie`, {
           method: 'DELETE',
+          credentials: 'include',
         });
       } catch {
         // Ignore the error for those who use static serving of the frontend

--- a/packages/dev-utils/CHANGELOG.md
+++ b/packages/dev-utils/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage/dev-utils
 
+## 1.0.36
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/core-app-api@1.14.1
+  - @backstage/app-defaults@1.5.9
+  - @backstage/core-components@0.14.9
+  - @backstage/core-plugin-api@1.9.3
+  - @backstage/plugin-catalog-react@1.12.2
+  - @backstage/integration-react@1.1.29
+
 ## 1.0.35
 
 ### Patch Changes

--- a/packages/dev-utils/package.json
+++ b/packages/dev-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/dev-utils",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "description": "Utilities for developing Backstage plugins.",
   "backstage": {
     "role": "web-library"

--- a/packages/frontend-app-api/CHANGELOG.md
+++ b/packages/frontend-app-api/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage/frontend-app-api
 
+## 0.7.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/core-app-api@1.14.1
+  - @backstage/core-components@0.14.9
+  - @backstage/core-plugin-api@1.9.3
+  - @backstage/frontend-plugin-api@0.6.7
+  - @backstage/config@1.2.0
+
 ## 0.7.3
 
 ### Patch Changes

--- a/packages/frontend-app-api/package.json
+++ b/packages/frontend-app-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/frontend-app-api",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "backstage": {
     "role": "web-library"
   },

--- a/packages/frontend-test-utils/CHANGELOG.md
+++ b/packages/frontend-test-utils/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/frontend-test-utils
 
+## 0.1.11
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/frontend-app-api@0.7.4
+  - @backstage/test-utils@1.5.9
+  - @backstage/frontend-plugin-api@0.6.7
+
 ## 0.1.10
 
 ### Patch Changes

--- a/packages/frontend-test-utils/package.json
+++ b/packages/frontend-test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/frontend-test-utils",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "backstage": {
     "role": "web-library"
   },

--- a/packages/techdocs-cli-embedded-app/CHANGELOG.md
+++ b/packages/techdocs-cli-embedded-app/CHANGELOG.md
@@ -1,5 +1,22 @@
 # techdocs-cli-embedded-app
 
+## 0.2.99
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/core-app-api@1.14.1
+  - @backstage/app-defaults@1.5.9
+  - @backstage/cli@0.26.11
+  - @backstage/core-components@0.14.9
+  - @backstage/core-plugin-api@1.9.3
+  - @backstage/test-utils@1.5.9
+  - @backstage/plugin-catalog@1.21.1
+  - @backstage/plugin-techdocs@1.10.7
+  - @backstage/integration-react@1.1.29
+  - @backstage/config@1.2.0
+  - @backstage/plugin-techdocs-react@1.2.6
+
 ## 0.2.98
 
 ### Patch Changes

--- a/packages/techdocs-cli-embedded-app/package.json
+++ b/packages/techdocs-cli-embedded-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "techdocs-cli-embedded-app",
-  "version": "0.2.98",
+  "version": "0.2.99",
   "private": true,
   "backstage": {
     "role": "frontend"

--- a/packages/test-utils/CHANGELOG.md
+++ b/packages/test-utils/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/test-utils
 
+## 1.5.9
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/core-app-api@1.14.1
+  - @backstage/core-plugin-api@1.9.3
+  - @backstage/config@1.2.0
+  - @backstage/plugin-permission-react@0.4.24
+
 ## 1.5.8
 
 ### Patch Changes

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/test-utils",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "description": "Utilities to test Backstage plugins and apps.",
   "backstage": {
     "role": "web-library"

--- a/plugins/home/CHANGELOG.md
+++ b/plugins/home/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage/plugin-home
 
+## 0.7.8
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/core-app-api@1.14.1
+  - @backstage/core-compat-api@0.2.7
+  - @backstage/core-components@0.14.9
+  - @backstage/core-plugin-api@1.9.3
+  - @backstage/plugin-catalog-react@1.12.2
+  - @backstage/frontend-plugin-api@0.6.7
+  - @backstage/config@1.2.0
+
 ## 0.7.7
 
 ### Patch Changes

--- a/plugins/home/package.json
+++ b/plugins/home/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-home",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "A Backstage plugin that helps you build a home page",
   "backstage": {
     "role": "frontend-plugin",

--- a/plugins/techdocs-addons-test-utils/CHANGELOG.md
+++ b/plugins/techdocs-addons-test-utils/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @backstage/plugin-techdocs-addons-test-utils
 
+## 1.0.36
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/core-app-api@1.14.1
+  - @backstage/core-plugin-api@1.9.3
+  - @backstage/test-utils@1.5.9
+  - @backstage/plugin-catalog@1.21.1
+  - @backstage/plugin-catalog-react@1.12.2
+  - @backstage/plugin-search-react@1.7.13
+  - @backstage/plugin-techdocs@1.10.7
+  - @backstage/integration-react@1.1.29
+  - @backstage/plugin-techdocs-react@1.2.6
+
 ## 1.0.35
 
 ### Patch Changes

--- a/plugins/techdocs-addons-test-utils/package.json
+++ b/plugins/techdocs-addons-test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-techdocs-addons-test-utils",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "backstage": {
     "role": "web-library",
     "pluginId": "techdocs-addons",

--- a/plugins/user-settings/CHANGELOG.md
+++ b/plugins/user-settings/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage/plugin-user-settings
 
+## 0.8.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/core-app-api@1.14.1
+  - @backstage/core-compat-api@0.2.7
+  - @backstage/core-components@0.14.9
+  - @backstage/core-plugin-api@1.9.3
+  - @backstage/plugin-catalog-react@1.12.2
+  - @backstage/frontend-plugin-api@0.6.7
+  - @backstage/plugin-signals-react@0.0.4
+
 ## 0.8.9
 
 ### Patch Changes

--- a/plugins/user-settings/package.json
+++ b/plugins/user-settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-user-settings",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "A Backstage plugin that provides a settings page",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
This release fixes an issue where sign-out would not work when using the [experimental public entry point](https://backstage.io/docs/tutorials/enable-public-entry).