### PR TITLE
Change NotificationTemplateRenderer methods to return a promise

### DIFF
--- a/.changeset/spicy-planets-provide.md
+++ b/.changeset/spicy-planets-provide.md
@@ -1,0 +1,46 @@
+---
+'@backstage/plugin-notifications-backend-module-email': minor
+---
+
+**BREAKING** Following `NotificationTemplateRenderer` methods now return a Promise and **must** be awaited: `getSubject`, `getText` and `getHtml`.
+
+Required changes and example usage:
+
+```diff
+import { notificationsEmailTemplateExtensionPoint } from '@backstage/plugin-notifications-backend-module-email';
+import { Notification } from '@backstage/plugin-notifications-common';
++import { getNotificationSubject, getNotificationTextContent, getNotificationHtmlContent } from 'my-notification-processing-library`
+export const notificationsModuleEmailDecorator = createBackendModule({
+  pluginId: 'notifications',
+  moduleId: 'email.templates',
+  register(reg) {
+    reg.registerInit({
+      deps: {
+        emailTemplates: notificationsEmailTemplateExtensionPoint,
+      },
+      async init({ emailTemplates }) {
+        emailTemplates.setTemplateRenderer({
+-          getSubject(notification) {
++          async getSubject(notification) {
+-            return `New notification from ${notification.source}`;
++            const subject = await getNotificationSubject(notification);
++            return `New notification from ${subject}`;
+          },
+-          getText(notification) {
++          async getText(notification) {
+-            return notification.content;
++            const text = await getNotificationTextContent(notification);
++            return text;
+          },
+-          getHtml(notification) {
++          async getHtml(notification) {
+-            return `<p>${notification.content}</p>`;
++            const html = await getNotificationHtmlContent(notification);
++            return html;
+          },
+        });
+      },
+    });
+  },
+});
+```

--- a/plugins/notifications-backend-module-email/api-report.md
+++ b/plugins/notifications-backend-module-email/api-report.md
@@ -23,10 +23,10 @@ export default notificationsModuleEmail;
 // @public (undocumented)
 export interface NotificationTemplateRenderer {
   // (undocumented)
-  getHtml?(notification: Notification_2): string;
+  getHtml?(notification: Notification_2): Promise<string>;
   // (undocumented)
-  getSubject?(notification: Notification_2): string;
+  getSubject?(notification: Notification_2): Promise<string>;
   // (undocumented)
-  getText?(notification: Notification_2): string;
+  getText?(notification: Notification_2): Promise<string>;
 }
 ```

--- a/plugins/notifications-backend-module-email/src/extensions.ts
+++ b/plugins/notifications-backend-module-email/src/extensions.ts
@@ -20,9 +20,9 @@ import { Notification } from '@backstage/plugin-notifications-common';
  * @public
  */
 export interface NotificationTemplateRenderer {
-  getSubject?(notification: Notification): string;
-  getText?(notification: Notification): string;
-  getHtml?(notification: Notification): string;
+  getSubject?(notification: Notification): Promise<string>;
+  getText?(notification: Notification): Promise<string>;
+  getHtml?(notification: Notification): Promise<string>;
 }
 
 /**

--- a/plugins/notifications-backend-module-email/src/processor/NotificationsEmailProcessor.ts
+++ b/plugins/notifications-backend-module-email/src/processor/NotificationsEmailProcessor.ts
@@ -280,10 +280,10 @@ export class NotificationsEmailProcessor implements NotificationProcessor {
     const mailOptions = {
       from: this.sender,
       subject:
-        this.templateRenderer?.getSubject?.(notification) ??
+        (await this.templateRenderer?.getSubject?.(notification)) ??
         notification.payload.title,
-      html: this.templateRenderer?.getHtml?.(notification),
-      text: this.templateRenderer?.getText?.(notification),
+      html: await this.templateRenderer?.getHtml?.(notification),
+      text: await this.templateRenderer?.getText?.(notification),
       replyTo: this.replyTo,
     };
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Change NotificationTemplateRenderer methods to return a promise, closes #25630.

Had a chat with @drodil and concluded that it's better to change all `NotificationTemplateRenderer` methods to return a Promise and that there's no nice way to provide backwards compatibility.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
