### PR TITLE
feat(catalog-react): correct alignment of EntityDisplayName's icon

### DIFF
--- a/.changeset/few-wasps-hug.md
+++ b/.changeset/few-wasps-hug.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Correct `EntityDisplayName`'s icon alignment with the text.

--- a/plugins/catalog-react/src/components/EntityDisplayName/EntityDisplayName.tsx
+++ b/plugins/catalog-react/src/components/EntityDisplayName/EntityDisplayName.tsx
@@ -38,7 +38,9 @@ const useStyles = makeStyles(
     icon: {
       marginRight: theme.spacing(0.5),
       color: theme.palette.text.secondary,
-      lineHeight: 0,
+      '& svg': {
+        verticalAlign: 'middle',
+      },
     },
   }),
   { name: 'CatalogReactEntityDisplayName' },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Correct the alignment of the `EntityDisplayName`'s icon with the rest of the text.

Before / After:
![image](https://github.com/user-attachments/assets/af65ce53-1325-478b-9854-767fe3d00fe1)
![image](https://github.com/user-attachments/assets/16fdc956-15e2-4124-8366-345e6d31140e)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] ~Added or updated documentation~
- [ ] ~Tests for new functionality and regression tests for bug fixes~
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
