### PR TITLE
fix: scaffolder action catalog:write not working in nested folders

### DIFF
--- a/.changeset/thick-hotels-know.md
+++ b/.changeset/thick-hotels-know.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Fix scaffolder action catalog:write to work in nested folders.

--- a/.changeset/thick-hotels-know.md
+++ b/.changeset/thick-hotels-know.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-backend': patch
 ---
 
-Fix scaffolder action catalog:write to work in nested folders.
+Fix scaffolder action `catalog:write` to write to directories that don't already exist

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/catalog/write.examples.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/catalog/write.examples.test.ts
@@ -55,8 +55,8 @@ describe('catalog:write', () => {
       input: yaml.parse(examples[0].example).steps[0].input,
     });
 
-    expect(fsMock.writeFile).toHaveBeenCalledTimes(1);
-    expect(fsMock.writeFile).toHaveBeenCalledWith(
+    expect(fsMock.outputFile).toHaveBeenCalledTimes(1);
+    expect(fsMock.outputFile).toHaveBeenCalledWith(
       resolvePath(mockContext.workspacePath, 'catalog-info.yaml'),
       yaml.stringify(entity),
     );

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/catalog/write.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/catalog/write.test.ts
@@ -59,8 +59,8 @@ describe('catalog:write', () => {
       },
     });
 
-    expect(fsMock.writeFile).toHaveBeenCalledTimes(1);
-    expect(fsMock.writeFile).toHaveBeenCalledWith(
+    expect(fsMock.outputFile).toHaveBeenCalledTimes(1);
+    expect(fsMock.outputFile).toHaveBeenCalledWith(
       resolvePath(mockContext.workspacePath, 'catalog-info.yaml'),
       yaml.stringify(entity),
     );
@@ -88,8 +88,8 @@ describe('catalog:write', () => {
       },
     });
 
-    expect(fsMock.writeFile).toHaveBeenCalledTimes(1);
-    expect(fsMock.writeFile).toHaveBeenCalledWith(
+    expect(fsMock.outputFile).toHaveBeenCalledTimes(1);
+    expect(fsMock.outputFile).toHaveBeenCalledWith(
       resolvePath(mockContext.workspacePath, 'some-dir/entity-info.yaml'),
       yaml.stringify(entity),
     );
@@ -118,8 +118,8 @@ describe('catalog:write', () => {
       'backstage.io/source-template': 'template:default/test-skeleton',
     };
 
-    expect(fsMock.writeFile).toHaveBeenCalledTimes(1);
-    expect(fsMock.writeFile).toHaveBeenCalledWith(
+    expect(fsMock.outputFile).toHaveBeenCalledTimes(1);
+    expect(fsMock.outputFile).toHaveBeenCalledWith(
       resolvePath(mockContext.workspacePath, 'catalog-info.yaml'),
       yaml.stringify(expectedEntity),
     );

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/catalog/write.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/catalog/write.ts
@@ -54,7 +54,7 @@ export function createCatalogWriteAction() {
       const path = filePath ?? 'catalog-info.yaml';
       ctx.logger.info(`Writing ${path}`);
 
-      await fs.writeFile(
+      await fs.outputFile(
         resolveSafeChildPath(ctx.workspacePath, path),
         yaml.stringify({
           ...entity,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

From the design of `catalog:write`, it is meant to support writing to a nested file path, e.g. `backstage/catalog-info.yaml`.

However, if the directory doesn't exists, then `fs.writeFile` will throw an error. This commit fixed the issue by using `fs.outputFile` instead which will create the parent directory if it does not exist: https://github.com/jprichardson/node-fs-extra/blob/master/docs/outputFile.md

The test `'should support a custom filename'` in `write.test.ts` did not catch this issue because `fs` is mocked. It is better to use fake instead of mock, e.g. create a throwaway temp folder for the tests since the file operations are part of the feature. However fixing of the tests as a whole is out of scope for this PR.

EDIT: updated to reflect the latest code

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
