### PR TITLE
cli: use lowercase es2022

### DIFF
--- a/.changeset/shaggy-dodos-applaud.md
+++ b/.changeset/shaggy-dodos-applaud.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Switched the target from `'ES2022'` to `'es2022'` for better compatibility with older versions of `swc`.

--- a/packages/cli/src/lib/bundler/transforms.ts
+++ b/packages/cli/src/lib/bundler/transforms.ts
@@ -57,7 +57,7 @@ export const transforms = (options: TransformOptions): Transforms => {
           loader: require.resolve('swc-loader'),
           options: {
             jsc: {
-              target: 'ES2022',
+              target: 'es2022',
               externalHelpers: !isBackend,
               parser: {
                 syntax: 'typescript',
@@ -85,7 +85,7 @@ export const transforms = (options: TransformOptions): Transforms => {
           loader: require.resolve('swc-loader'),
           options: {
             jsc: {
-              target: 'ES2022',
+              target: 'es2022',
               externalHelpers: !isBackend,
               parser: {
                 syntax: 'ecmascript',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Turns out that being able to define this as `'ES2022'` is a bit of a newer thing, introduced in https://github.com/swc-project/swc/pull/8653. This means that projects that are still on older versions of `swc` would break without this fix.

If anyone encounters this issue on the latest next release, I recommend bumping `@swc/core`.

Shoutout @mtlewis and @awanlin for reporting and finding a fix

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
