### PR TITLE
In the Gettin Started/authentication document removing duplicate import SignInPage

### DIFF
--- a/docs/getting-started/config/authentication.md
+++ b/docs/getting-started/config/authentication.md
@@ -50,7 +50,6 @@ Open `packages/app/src/App.tsx` and below the last `import` line, add:
 
 ```typescript title="packages/app/src/App.tsx"
 import { githubAuthApiRef } from '@backstage/core-plugin-api';
-import { SignInPage } from '@backstage/core-components';
 ```
 
 Search for `const app = createApp({` in this file, and below `apis,` add:


### PR DESCRIPTION
SignInPage is already imported. Removing the duplicate import that causes compilation error:
import { SignInPage } from '@backstage/core-components';

## Hey, I just made a Pull Request!

In https://backstage.io/docs/getting-started/config/authentication/ page there is a reference to add 
import { SignInPage } from '@backstage/core-components'; to packages/app/src/App.tsx
SignInPage is already imported further up in the code and adding the duplicate causes compilation error.

![duplicateImportError](https://github.com/user-attachments/assets/ded3b639-9174-4249-9993-94d731f56c3e)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
