### PR TITLE
Plugin search backend module StackOverflow collator call issue

### DIFF
--- a/.changeset/quiet-deers-visit.md
+++ b/.changeset/quiet-deers-visit.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend-module-stack-overflow-collator': minor
+---
+
+Always set default request parameters for requests to stackoverflow while allow to overwrite them. Remove site parameter as causing the request to fail.

--- a/plugins/search-backend-module-stack-overflow-collator/src/collators/StackOverflowQuestionsCollatorFactory.test.ts
+++ b/plugins/search-backend-module-stack-overflow-collator/src/collators/StackOverflowQuestionsCollatorFactory.test.ts
@@ -25,7 +25,7 @@ import { TestPipeline } from '@backstage/plugin-search-backend-node';
 import { ConfigReader } from '@backstage/config';
 import { Readable } from 'stream';
 import { setupServer } from 'msw/node';
-import { rest } from 'msw';
+import { rest, RestRequest } from 'msw';
 
 const logger = mockServices.logger.mock();
 
@@ -68,9 +68,17 @@ const mockOverrideQuestion = {
   has_more: false,
 };
 
-const testSearchQuery = (request, expectedSearch) => {
-  const executedSearch = {};
-  request.url.searchParams.forEach((value, key) => {
+const testSearchQuery = (
+  request: RestRequest | undefined,
+  expectedSearch: unknown,
+) => {
+  if (!request) {
+    expect(request).not.toBeFalsy();
+    return;
+  }
+
+  const executedSearch: { [key: string]: string } = {};
+  request.url.searchParams.forEach((value: string, key: string) => {
     executedSearch[key] = value;
   });
   expect(executedSearch).toEqual(expectedSearch);

--- a/plugins/search-backend-module-stack-overflow-collator/src/collators/StackOverflowQuestionsCollatorFactory.ts
+++ b/plugins/search-backend-module-stack-overflow-collator/src/collators/StackOverflowQuestionsCollatorFactory.ts
@@ -86,7 +86,6 @@ export class StackOverflowQuestionsCollatorFactory
     this.requestParams = options.requestParams ?? {
       order: 'desc',
       sort: 'activity',
-      site: 'stackoverflow',
       ...(options.requestParams ?? {}),
     };
     this.logger = options.logger.child({ documentType: this.type });

--- a/plugins/search-backend-module-stack-overflow-collator/src/collators/StackOverflowQuestionsCollatorFactory.ts
+++ b/plugins/search-backend-module-stack-overflow-collator/src/collators/StackOverflowQuestionsCollatorFactory.ts
@@ -40,7 +40,7 @@ export interface StackOverflowDocument extends IndexableDocument {
  * @public
  */
 export type StackOverflowQuestionsRequestParams = {
-  [key: string]: string | string[] | number | null;
+  [key: string]: string | string[] | number;
 };
 
 /**

--- a/plugins/search-backend-module-stack-overflow-collator/src/collators/StackOverflowQuestionsCollatorFactory.ts
+++ b/plugins/search-backend-module-stack-overflow-collator/src/collators/StackOverflowQuestionsCollatorFactory.ts
@@ -83,7 +83,7 @@ export class StackOverflowQuestionsCollatorFactory
     this.maxPage = options.maxPage;
     // Sets the same default request parameters as the official API documentation
     // See https://api.stackexchange.com/docs/questions
-    this.requestParams = options.requestParams ?? {
+    this.requestParams = {
       order: 'desc',
       sort: 'activity',
       ...(options.requestParams ?? {}),


### PR DESCRIPTION
Remove site property from StackOverflowQuestionsCollatorFactory.requestParams

## Hey, I just made a Pull Request!

The search module to collect data from stack overflow is failing to create a search index for the questions.
The issue is not  in creating the index itself but with the collector failing to make successful requests. The request to the questions endpoint is adding an extra parameter that is not accepted by stack overflow. This parameter is `site: stackoverflow`.

This should be enough but we could get one step further filtering out all params that are not accepted by that endpoint.
I did not add this filter to the PR as I think it's a bit overkilling and removing the offending parameter is enough for now.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
