### PR TITLE
fix(catalog-backend): preserve default allowedLocationTypes

### DIFF
--- a/.changeset/odd-books-share.md
+++ b/.changeset/odd-books-share.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Preserve default `allowedLocationTypes` when `setAllowedLocationTypes()` of `CatalogLocationsExtensionPoint` is not called.

--- a/plugins/catalog-backend/src/service/CatalogPlugin.ts
+++ b/plugins/catalog-backend/src/service/CatalogPlugin.ts
@@ -46,7 +46,7 @@ import { ForwardedError } from '@backstage/errors';
 class CatalogLocationsExtensionPointImpl
   implements CatalogLocationsExtensionPoint
 {
-  #locationTypes = new Array<string>();
+  #locationTypes: string[] | undefined;
 
   setAllowedLocationTypes(locationTypes: Array<string>) {
     this.#locationTypes = locationTypes;
@@ -293,9 +293,11 @@ export const catalogPlugin = createBackendPlugin({
         builder.addPermissionRules(...permissionExtensions.permissionRules);
         builder.setFieldFormatValidators(modelExtensions.fieldValidators);
 
-        builder.setAllowedLocationTypes(
-          locationTypeExtensions.allowedLocationTypes,
-        );
+        if (locationTypeExtensions.allowedLocationTypes) {
+          builder.setAllowedLocationTypes(
+            locationTypeExtensions.allowedLocationTypes,
+          );
+        }
 
         const { processingEngine, router } = await builder.build();
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes a regression introduced in https://github.com/backstage/backstage/pull/25452 which causes the `allowedLocationTypes` to be `[]` instead of the default `['url']`.

This prevents registering locations from the `/catalog-import` for example.

#### :heavy_check_mark: Checklist

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] ~Added or updated documentation~
- [ ] ~Tests for new functionality and regression tests for bug fixes~
- [ ] ~Screenshots attached (for UI changes)~
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
