### PR TITLE
fix(catalog-backend): error if metadata.annotations isn't a valid object

### DIFF
--- a/.changeset/cuddly-penguins-glow.md
+++ b/.changeset/cuddly-penguins-glow.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+`ProcessorOutputCollector` returns an error when receiving deferred entities that have an invalid `metadata.annotations` format.
+
+This allows to return an error on an actual validation issue instead of reporting that the location annotations are missing afterwards, which is misleading for the users.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Giving a shot on a fix for #25622.

The error `does not have the annotation backstage.io/managed-by-location` seems to come from this: https://github.com/backstage/backstage/blob/d5a1fe189b6a8a7471935ccf5f5ed7be650fe649/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.ts#L144

I'm not sure on this but from what I understand:
- the `LocationService` [creates a `Location`](https://github.com/backstage/backstage/blob/d5a1fe189b6a8a7471935ccf5f5ed7be650fe649/plugins/catalog-backend/src/service/DefaultLocationService.ts#L126) entity from the location url provided by the user (ie, in the import page)
- the orchestrator is called to process this location, which emits the entity
- if the entity has an invalid `metadata.annotations` (eg, an array or a string), the location annotations are not added
- but [they are required shortly after](https://github.com/backstage/backstage/blob/d5a1fe189b6a8a7471935ccf5f5ed7be650fe649/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.ts#L144) (which throws an error)

This PR implements some kind of safeguard, since if we set the annotations anyway, it will potentially overwrite it if it's not an object. This would silently ignore some errors in the entity schema.

One other way could be to add the `metadata.annotations` to the [EntityEnvelope.schema.json](https://github.com/backstage/backstage/blob/7b8047943a6caa4906d893995ac0b5cd09768511/packages/catalog-model/src/schema/EntityEnvelope.schema.json) since the processing relies on a valid one. But I'm not confident in changing the model 😅 

Let me know what do you think of this

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] ~Added or updated documentation~
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] ~Screenshots attached (for UI changes)~
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
