### PR TITLE
Add regex to JSON schema to validate tags

### DIFF
--- a/packages/catalog-model/src/schema/EntityMeta.schema.json
+++ b/packages/catalog-model/src/schema/EntityMeta.schema.json
@@ -81,7 +81,9 @@
       "description": "A list of single-valued strings, to for example classify catalog entities in various ways.",
       "items": {
         "type": "string",
-        "minLength": 1
+        "minLength": 1,
+        "maxLength": 63,
+        "pattern": "^[a-z0-9:+#]+(-[a-z0-9:+#]+)*$"
       }
     },
     "links": {


### PR DESCRIPTION
As described in the docs 
https://backstage.io/docs/features/software-catalog/descriptor-format/#:~:text=Each%20tag%20must%20be%20sequences%20of%20%5Ba%2Dz0%2D9%3A%2B%23%5D%20separated%20by%20%2D%2C%20at%20most%2063%20characters%20in%20total

## Hey, I just made a Pull Request!

I wasted a few hours yesterday figuring out why my entity including the tag "node.js" wasn't  ingested into backstage. Then i learned it was because of the "." inside the tag, as it's referenced [here](https://backstage.io/docs/features/software-catalog/descriptor-format/#:~:text=Each%20tag%20must%20be%20sequences%20of%20%5Ba%2Dz0%2D9%3A%2B%23%5D%20separated%20by%20%2D%2C%20at%20most%2063%20characters%20in%20total)
Adding this to the json schema would prevent this in the future (at least for anybody that has their IDE configured to validate against the schema)
I also don't understand that this wasn't logged, not even in debug mode.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
