### PR TITLE
chore(repo-tools): add --skipLibCheck option to generateTypeDeclarations

### DIFF
--- a/.changeset/afraid-mails-cough.md
+++ b/.changeset/afraid-mails-cough.md
@@ -1,0 +1,5 @@
+---
+'@backstage/repo-tools': patch
+---
+
+Added `skipLibCheck` parameter to `generateTypeDeclarations` while preserving the default value `false`. This allows plugins that use the `--skipLibCheck` in their `tsconfig.json` to generate type declarations.

--- a/packages/repo-tools/src/commands/api-reports/api-reports.test.ts
+++ b/packages/repo-tools/src/commands/api-reports/api-reports.test.ts
@@ -529,5 +529,20 @@ describe('buildApiReports', () => {
 
       expect(generateTypeDeclarations).toHaveBeenCalled();
     });
+
+    it('should pass skipLibCheck option to generateTypeDeclarations', async () => {
+      const opts = {
+        tsc: true,
+        skipLibCheck: true,
+      };
+      const paths = ['packages/*'];
+
+      await buildApiReports(paths, opts);
+
+      expect(generateTypeDeclarations).toHaveBeenCalledWith(
+        expect.any(String),
+        true,
+      );
+    });
   });
 });

--- a/packages/repo-tools/src/commands/api-reports/api-reports.ts
+++ b/packages/repo-tools/src/commands/api-reports/api-reports.ts
@@ -33,6 +33,7 @@ type Options = {
   allowAllWarnings?: boolean;
   omitMessages?: string;
   validateReleaseTags?: boolean;
+  skipLibCheck?: boolean;
 } & OptionValues;
 
 export const buildApiReports = async (paths: string[] = [], opts: Options) => {
@@ -46,6 +47,7 @@ export const buildApiReports = async (paths: string[] = [], opts: Options) => {
   const allowWarnings = parseArrayOption(opts.allowWarnings);
   const allowAllWarnings = opts.allowAllWarnings;
   const omitMessages = parseArrayOption(opts.omitMessages);
+  const skipLibCheck = opts.skipLibCheck ?? false;
 
   const isAllPackages = !paths?.length;
   const selectedPackageDirs = await resolvePackagePaths({
@@ -75,7 +77,7 @@ export const buildApiReports = async (paths: string[] = [], opts: Options) => {
 
   if (runTsc) {
     console.log('# Compiling TypeScript');
-    await generateTypeDeclarations(tsconfigFilePath);
+    await generateTypeDeclarations(tsconfigFilePath, skipLibCheck);
   }
 
   const { tsPackageDirs, cliPackageDirs } = await categorizePackageDirs(

--- a/packages/repo-tools/src/commands/api-reports/generateTypeDeclarations.ts
+++ b/packages/repo-tools/src/commands/api-reports/generateTypeDeclarations.ts
@@ -26,16 +26,20 @@ import { paths as cliPaths } from '../../lib/paths';
  * If the `tsc` command exits with a non-zero exit code, the process will be terminated with the same exit code.
  *
  * @param tsconfigFilePath {string} The path to the `tsconfig.json` file to use for generating the declaration files.
+ * @param skipLibCheck {boolean} Whether to skip type checking of all declaration files.
  * @returns {Promise<void>} A promise that resolves when the declaration files have been generated.
  */
-export async function generateTypeDeclarations(tsconfigFilePath: string) {
+export async function generateTypeDeclarations(
+  tsconfigFilePath: string,
+  skipLibCheck: boolean = false,
+) {
   await fs.remove(cliPaths.resolveTargetRoot('dist-types'));
   const { status } = spawnSync(
     'yarn',
     [
       'tsc',
       ['--project', tsconfigFilePath],
-      ['--skipLibCheck', 'false'],
+      ['--skipLibCheck', skipLibCheck.toString()],
       ['--incremental', 'false'],
     ].flat(),
     {


### PR DESCRIPTION
Added `skipLibCheck` parameter to `generateTypeDeclarations` while preserving the default value `false`. This allows plugins that use the `--skipLibCheck` in their `tsconfig.json` to generate type declarations. 

## Hey, I just made a Pull Request!

A number of the plugins migrated to `backstage/community-plugins` pass the `--skipLibCheck` option to their `tsc` build commands. Currently, `api-reports/generateTypeDeclarations.ts` manually forces `--skipLibCheck false`, which means new errors surface between running `yarn tsc:full` and `yarn build:api-reports`. 

I know ideally we should preserve `--skipLibCheck false` and that indicates types issues needing to be resolved in dependencies. But, I think being able to override this will assist with initial CI issues when migrating new community plugins.  

(I at least encountered these issues in both https://github.com/backstage/community-plugins/pull/622 and https://github.com/backstage/community-plugins/pull/712)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
