### PR TITLE
fix(catalog-backend): fix sonarqube findings

### DIFF
--- a/.changeset/giant-trainers-hammer.md
+++ b/.changeset/giant-trainers-hammer.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+In `PlaceholderProcessor`, removed unnecessary escape characters in resolvers exceptions.
+The YAML placeholder resolver throws YAML document errors with the error message instead of the whole object.

--- a/plugins/catalog-backend/src/modules/core/PlaceholderProcessor.test.ts
+++ b/plugins/catalog-backend/src/modules/core/PlaceholderProcessor.test.ts
@@ -472,7 +472,7 @@ describe('yamlPlaceholderResolver', () => {
   it('rejects invalid yaml', async () => {
     read.mockResolvedValue(Buffer.from('a: 1\n----\n', 'utf-8'));
     await expect(yamlPlaceholderResolver(params)).rejects.toThrow(
-      /Placeholder \$a found an error in the data at .\/file.yaml, YAMLParseError: Implicit map keys need to be followed by map values at line 2, column 1:\s+a: 1/,
+      /Placeholder \$a found an error in the data at .\/file.yaml, Implicit map keys need to be followed by map values at line 2, column 1:\s+a: 1/,
     );
   });
 

--- a/plugins/catalog-backend/src/modules/core/PlaceholderProcessor.ts
+++ b/plugins/catalog-backend/src/modules/core/PlaceholderProcessor.ts
@@ -143,13 +143,13 @@ export async function yamlPlaceholderResolver(
     documents = yaml.parseAllDocuments(content).filter(d => d);
   } catch (e) {
     throw new Error(
-      `Placeholder \$${params.key} failed to parse YAML data at ${params.value}, ${e}`,
+      `Placeholder $${params.key} failed to parse YAML data at ${params.value}, ${e}`,
     );
   }
 
   if (documents.length !== 1) {
     throw new Error(
-      `Placeholder \$${params.key} expected to find exactly one document of data at ${params.value}, found ${documents.length}`,
+      `Placeholder $${params.key} expected to find exactly one document of data at ${params.value}, found ${documents.length}`,
     );
   }
 
@@ -157,7 +157,7 @@ export async function yamlPlaceholderResolver(
 
   if (document.errors?.length) {
     throw new Error(
-      `Placeholder \$${params.key} found an error in the data at ${params.value}, ${document.errors[0]}`,
+      `Placeholder $${params.key} found an error in the data at ${params.value}, ${document.errors[0].message}`,
     );
   }
 
@@ -175,7 +175,7 @@ export async function jsonPlaceholderResolver(
     return JSON.parse(content);
   } catch (e) {
     throw new Error(
-      `Placeholder \$${params.key} failed to parse JSON data at ${params.value}, ${e}`,
+      `Placeholder $${params.key} failed to parse JSON data at ${params.value}, ${e}`,
     );
   }
 }
@@ -204,7 +204,7 @@ async function readTextLocation(
     return { content: data.toString('utf-8'), url: newUrl };
   } catch (e) {
     throw new Error(
-      `Placeholder \$${params.key} could not read location ${params.value}, ${e}`,
+      `Placeholder $${params.key} could not read location ${params.value}, ${e}`,
     );
   }
 }
@@ -217,7 +217,7 @@ function relativeUrl({
 }: PlaceholderResolverParams): string {
   if (typeof value !== 'string') {
     throw new Error(
-      `Placeholder \$${key} expected a string value parameter, in the form of an absolute URL or a relative path`,
+      `Placeholder $${key} expected a string value parameter, in the form of an absolute URL or a relative path`,
     );
   }
 
@@ -229,7 +229,7 @@ function relativeUrl({
     // path traversal attacks and access to any file on the host system. Implementing this
     // would require additional security measures.
     throw new Error(
-      `Placeholder \$${key} could not form a URL out of ${baseUrl} and ${value}, ${e}`,
+      `Placeholder $${key} could not form a URL out of ${baseUrl} and ${value}, ${e}`,
     );
   }
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

By copying the definitions of those in our codebase we had some findings from Sonarqube:

- Unnecessary escape characters on `\$${...}`
- `${document.errors[0]}` will be stringified to `[Object object]`

I also fixed a deprecation for the `UrlService`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] ~Added or updated documentation~
- [X] Tests for new functionality and regression tests for bug fixes
- [x] ~Screenshots attached (for UI changes)~
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
