### PR TITLE
yarn-plugin: memoize manifest fetching

### DIFF
--- a/packages/yarn-plugin/package.json
+++ b/packages/yarn-plugin/package.json
@@ -35,6 +35,7 @@
     "@yarnpkg/core": "^4.0.3",
     "@yarnpkg/fslib": "^3.0.2",
     "chalk": "^4.0.0",
+    "lodash": "^4.17.21",
     "semver": "^7.6.0"
   },
   "devDependencies": {

--- a/packages/yarn-plugin/src/util.ts
+++ b/packages/yarn-plugin/src/util.ts
@@ -16,10 +16,16 @@
 
 import { ppath, xfs } from '@yarnpkg/fslib';
 import { valid as semverValid } from 'semver';
-import { getManifestByVersion } from '@backstage/release-manifests';
+import { memoize } from 'lodash';
+import { getManifestByVersion as getManifestByVersionBase } from '@backstage/release-manifests';
 import { BACKSTAGE_JSON, findPaths } from '@backstage/cli-common';
 import { Descriptor, structUtils } from '@yarnpkg/core';
 import { PROTOCOL } from './constants';
+
+const getManifestByVersion = memoize(
+  getManifestByVersionBase,
+  ({ version }) => version,
+);
 
 export const getCurrentBackstageVersion = () => {
   const workspaceRoot = ppath.resolve(findPaths(ppath.cwd()).targetRoot);

--- a/yarn.lock
+++ b/yarn.lock
@@ -45239,6 +45239,7 @@ __metadata:
     "@yarnpkg/core": ^4.0.3
     "@yarnpkg/fslib": ^3.0.2
     chalk: ^4.0.0
+    lodash: ^4.17.21
     nodemon: ^3.0.1
     semver: ^7.6.0
   languageName: unknown


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Memoizes calls to `getManifestByVersion` so we're not spamming versions.backstage.io when running `yarn` operations.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
