### PR TITLE
yarn-plugin: implement `BackstageResolver#getSatisfying`

### DIFF
--- a/packages/yarn-plugin/src/resolver/BackstageResolver.test.ts
+++ b/packages/yarn-plugin/src/resolver/BackstageResolver.test.ts
@@ -178,4 +178,87 @@ describe('BackstageResolver', () => {
       ).rejects.toThrow(/invalid backstage version/i);
     });
   });
+
+  describe('getSatisfying', () => {
+    it('filters out locators for other packages', async () => {
+      await expect(
+        backstageResolver.getSatisfying(
+          structUtils.makeDescriptor(
+            structUtils.makeIdent('backstage', 'core'),
+            'backstage:1.23.45',
+          ),
+          {},
+          [
+            structUtils.makeLocator(
+              structUtils.makeIdent('backstage', 'foo'),
+              'npm:1.2.3',
+            ),
+            structUtils.makeLocator(
+              structUtils.makeIdent('backstage', 'core'),
+              'npm:6.7.8',
+            ),
+            structUtils.makeLocator(
+              structUtils.makeIdent('backstage', 'bar'),
+              'npm:1.2.3',
+            ),
+          ],
+        ),
+      ).resolves.toEqual({
+        locators: [
+          structUtils.makeLocator(
+            structUtils.makeIdent('backstage', 'core'),
+            'npm:6.7.8',
+          ),
+        ],
+        sorted: true,
+      });
+    });
+
+    it('filters out locators for other package versions', async () => {
+      await expect(
+        backstageResolver.getSatisfying(
+          structUtils.makeDescriptor(
+            structUtils.makeIdent('backstage', 'core'),
+            'backstage:1.23.45',
+          ),
+          {},
+          [
+            structUtils.makeLocator(
+              structUtils.makeIdent('backstage', 'core'),
+              'npm:5.6.7',
+            ),
+            structUtils.makeLocator(
+              structUtils.makeIdent('backstage', 'core'),
+              'npm:6.7.8',
+            ),
+            structUtils.makeLocator(
+              structUtils.makeIdent('backstage', 'bar'),
+              'npm:7.8.9',
+            ),
+          ],
+        ),
+      ).resolves.toEqual({
+        locators: [
+          structUtils.makeLocator(
+            structUtils.makeIdent('backstage', 'core'),
+            'npm:6.7.8',
+          ),
+        ],
+        sorted: true,
+      });
+    });
+
+    it('throws for non `backstage:` descriptors', async () => {
+      await expect(
+        backstageResolver.getSatisfying(
+          structUtils.makeDescriptor(
+            structUtils.makeIdent('backstage', 'core'),
+            'npm:1.2.3',
+          ),
+          {},
+          [],
+        ),
+      ).rejects.toThrow(/unexpected npm: range/i);
+    });
+  });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

It turns out this method is called for `backstage:` descriptors during `yarn dedupe`, so we need to implement it. It's nice and simple, since each Backstage release corresponds to exactly one version for each package - we just need to filter everything except locators for that exact version.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
