### PR TITLE
frontend-plugin-api: move away from data maps when declaring extension inputs and outputs

### DIFF
--- a/.changeset/dry-squids-tap.md
+++ b/.changeset/dry-squids-tap.md
@@ -11,13 +11,9 @@ This allows the creation of extension instances with the following pattern:
 const EntityCardBlueprint = createExtensionBlueprint({
   kind: 'entity-card',
   attachTo: { id: 'test', input: 'default' },
-  output: {
-    element: coreExtensionData.reactElement,
-  },
+  output: [coreExtensionData.reactElement],
   factory(params: { text: string }) {
-    return {
-      element: <h1>{params.text}</h1>,
-    };
+    return [coreExtensionData.reactElement(<h1>{params.text}</h1>)];
   },
 });
 

--- a/.changeset/green-planets-reflect.md
+++ b/.changeset/green-planets-reflect.md
@@ -1,0 +1,6 @@
+---
+'@backstage/frontend-test-utils': patch
+'@backstage/frontend-app-api': patch
+---
+
+Added support for v2 extensions, which declare their inputs and outputs without using a data map.

--- a/.changeset/rare-foxes-compete.md
+++ b/.changeset/rare-foxes-compete.md
@@ -1,0 +1,57 @@
+---
+'@backstage/frontend-plugin-api': patch
+---
+
+Extensions have been changed to be declared with an array of inputs and outputs, rather than a map of named data refs. This change was made to reduce confusion around the role of the input and output names, as well as enable more powerful APIs for overriding extensions.
+
+An extension that was previously declared like this:
+
+```tsx
+const exampleExtension = createExtension({
+  name: 'example',
+  inputs: {
+    items: createExtensionInput({
+      element: coreExtensionData.reactElement,
+    }),
+  },
+  output: {
+    element: coreExtensionData.reactElement,
+  },
+  factory({ inputs }) {
+    return {
+      element: (
+        <div>
+          Example
+          {inputs.items.map(item => {
+            return <div>{item.output.element}</div>;
+          })}
+        </div>
+      ),
+    };
+  },
+});
+```
+
+Should be migrated to the following:
+
+```tsx
+const exampleExtension = createExtension({
+  name: 'example',
+  inputs: {
+    items: createExtensionInput([coreExtensionData.reactElement]),
+  },
+  output: [coreExtensionData.reactElement],
+  factory({ inputs }) {
+    return [
+      coreExtensionData.reactElement(
+        <div>
+          Example
+          {inputs.items.map(item => {
+            return <div>{item.get(coreExtensionData.reactElement)}</div>;
+          })}
+        </div>,
+      ),
+    ];
+  },
+});
+```

--- a/packages/frontend-app-api/src/tree/instantiateAppNodeTree.test.ts
+++ b/packages/frontend-app-api/src/tree/instantiateAppNodeTree.test.ts
@@ -17,6 +17,8 @@
 import {
   AppNode,
   Extension,
+  ExtensionInput,
+  ResolvedExtensionInput,
   createExtension,
   createExtensionDataRef,
   createExtensionInput,
@@ -37,27 +39,6 @@ const otherDataRef = createExtensionDataRef<number>().with({ id: 'other' });
 const inputMirrorDataRef = createExtensionDataRef<unknown>().with({
   id: 'mirror',
 });
-
-const simpleExtension = resolveExtensionDefinition(
-  createExtension({
-    namespace: 'app',
-    name: 'test',
-    attachTo: { id: 'ignored', input: 'ignored' },
-    output: {
-      test: testDataRef,
-      other: otherDataRef.optional(),
-    },
-    configSchema: createSchemaFromZod(z =>
-      z.object({
-        output: z.string().default('test'),
-        other: z.number().optional(),
-      }),
-    ),
-    factory({ config }) {
-      return { test: config.output, other: config.other };
-    },
-  }),
-);
 
 function makeSpec<TConfig, TConfigInput>(
   extension: Extension<TConfig, TConfigInput>,
@@ -100,78 +81,54 @@ function makeInstanceWithId<TConfig, TConfigInput>(
 }
 
 describe('instantiateAppNodeTree', () => {
-  it('should instantiate a single node', () => {
-    const tree = resolveAppTree('root-node', [
-      makeSpec(simpleExtension, { id: 'root-node' }),
-    ]);
-    expect(tree.root.instance).not.toBeDefined();
-    instantiateAppNodeTree(tree.root);
-    expect(tree.root.instance).toBeDefined();
-    expect(tree.root.instance?.getData(testDataRef)).toBe('test');
-
-    // Multiple calls should have no effect
-    instantiateAppNodeTree(tree.root);
-    expect(tree.root.instance).toBeDefined();
-  });
-
-  it('should not instantiate disabled nodes', () => {
-    const tree = resolveAppTree('root-node', [
-      makeSpec(simpleExtension, { id: 'root-node', disabled: true }),
-    ]);
-    expect(tree.root.instance).not.toBeDefined();
-    instantiateAppNodeTree(tree.root);
-    expect(tree.root.instance).not.toBeDefined();
-  });
-
-  it('should instantiate a node with attachments', () => {
-    const tree = resolveAppTree('root-node', [
-      makeSpec(
-        resolveExtensionDefinition(
-          createExtension({
-            namespace: 'root-node',
-            attachTo: { id: 'ignored', input: 'ignored' },
-            inputs: {
-              test: createExtensionInput({ test: testDataRef }),
-            },
-            output: {
-              inputMirror: inputMirrorDataRef,
-            },
-            factory({ inputs }) {
-              return { inputMirror: inputs };
-            },
+  describe('v1', () => {
+    const simpleExtension = resolveExtensionDefinition(
+      createExtension({
+        namespace: 'app',
+        name: 'test',
+        attachTo: { id: 'ignored', input: 'ignored' },
+        output: {
+          test: testDataRef,
+          other: otherDataRef.optional(),
+        },
+        configSchema: createSchemaFromZod(z =>
+          z.object({
+            output: z.string().default('test'),
+            other: z.number().optional(),
           }),
         ),
-      ),
-      makeSpec(simpleExtension, {
-        id: 'child-node',
-        attachTo: { id: 'root-node', input: 'test' },
+        factory({ config }) {
+          return { test: config.output, other: config.other };
+        },
       }),
-    ]);
+    );
 
-    const childNode = tree.nodes.get('child-node');
-    expect(childNode).toBeDefined();
+    it('should instantiate a single node', () => {
+      const tree = resolveAppTree('root-node', [
+        makeSpec(simpleExtension, { id: 'root-node' }),
+      ]);
+      expect(tree.root.instance).not.toBeDefined();
+      instantiateAppNodeTree(tree.root);
+      expect(tree.root.instance).toBeDefined();
+      expect(tree.root.instance?.getData(testDataRef)).toBe('test');
 
-    expect(tree.root.instance).not.toBeDefined();
-    expect(childNode?.instance).not.toBeDefined();
-    instantiateAppNodeTree(tree.root);
-    expect(tree.root.instance).toBeDefined();
-    expect(childNode?.instance).toBeDefined();
-    expect(tree.root.instance?.getData(inputMirrorDataRef)).toMatchObject({
-      test: [
-        { node: { spec: { id: 'child-node' } }, output: { test: 'test' } },
-      ],
+      // Multiple calls should have no effect
+      instantiateAppNodeTree(tree.root);
+      expect(tree.root.instance).toBeDefined();
     });
 
-    // Multiple calls should have no effect
-    instantiateAppNodeTree(tree.root);
-    expect(tree.root.instance).toBeDefined();
-    expect(childNode?.instance).toBeDefined();
-  });
+    it('should not instantiate disabled nodes', () => {
+      const tree = resolveAppTree('root-node', [
+        makeSpec(simpleExtension, { id: 'root-node', disabled: true }),
+      ]);
+      expect(tree.root.instance).not.toBeDefined();
+      instantiateAppNodeTree(tree.root);
+      expect(tree.root.instance).not.toBeDefined();
+    });
 
-  it('should not instantiate disabled attachments', () => {
-    const tree = resolveAppTree('root-node', [
-      {
-        ...makeSpec(
+    it('should instantiate a node with attachments', () => {
+      const tree = resolveAppTree('root-node', [
+        makeSpec(
           resolveExtensionDefinition(
             createExtension({
               namespace: 'root-node',
@@ -188,437 +145,1061 @@ describe('instantiateAppNodeTree', () => {
             }),
           ),
         ),
-      },
-      {
-        ...makeSpec(simpleExtension),
-        id: 'child-node',
-        // Using an invalid input should not be an error when disabled
-        attachTo: { id: 'root-node', input: 'invalid' },
-        disabled: true,
-      },
-    ]);
+        makeSpec(simpleExtension, {
+          id: 'child-node',
+          attachTo: { id: 'root-node', input: 'test' },
+        }),
+      ]);
 
-    const childNode = tree.nodes.get('child-node');
-    expect(childNode).toBeDefined();
+      const childNode = tree.nodes.get('child-node');
+      expect(childNode).toBeDefined();
 
-    expect(tree.root.instance).not.toBeDefined();
-    expect(childNode?.instance).not.toBeDefined();
-    instantiateAppNodeTree(tree.root);
-    expect(tree.root.instance).toBeDefined();
-    expect(childNode?.instance).not.toBeDefined();
-    expect(tree.root.instance?.getData(inputMirrorDataRef)).toEqual({
-      test: [],
-    });
-  });
-});
+      expect(tree.root.instance).not.toBeDefined();
+      expect(childNode?.instance).not.toBeDefined();
+      instantiateAppNodeTree(tree.root);
+      expect(tree.root.instance).toBeDefined();
+      expect(childNode?.instance).toBeDefined();
+      expect(tree.root.instance?.getData(inputMirrorDataRef)).toMatchObject({
+        test: [
+          { node: { spec: { id: 'child-node' } }, output: { test: 'test' } },
+        ],
+      });
 
-describe('createAppNodeInstance', () => {
-  it('should create a simple extension instance', () => {
-    const attachments = new Map();
-    const instance = createAppNodeInstance({
-      node: makeNode(simpleExtension),
-      attachments,
+      // Multiple calls should have no effect
+      instantiateAppNodeTree(tree.root);
+      expect(tree.root.instance).toBeDefined();
+      expect(childNode?.instance).toBeDefined();
     });
 
-    expect(Array.from(instance.getDataRefs())).toEqual([
-      testDataRef,
-      otherDataRef.optional(),
-    ]);
-    expect(instance.getData(testDataRef)).toEqual('test');
-  });
-
-  it('should create an extension with different kind of inputs', () => {
-    const attachments = new Map([
-      [
-        'optionalSingletonPresent',
-        [
-          makeInstanceWithId(simpleExtension, {
-            output: 'optionalSingletonPresent',
-          }),
-        ],
-      ],
-      [
-        'singleton',
-        [
-          makeInstanceWithId(simpleExtension, {
-            output: 'singleton',
-            other: 2,
-          }),
-        ],
-      ],
-      [
-        'many',
-        [
-          makeInstanceWithId(simpleExtension, { output: 'many1' }),
-          makeInstanceWithId(simpleExtension, { output: 'many2', other: 3 }),
-        ],
-      ],
-    ]);
-    const instance = createAppNodeInstance({
-      attachments,
-      node: makeNode(
-        resolveExtensionDefinition(
-          createExtension({
-            namespace: 'app',
-            name: 'test',
-            attachTo: { id: 'ignored', input: 'ignored' },
-            inputs: {
-              optionalSingletonPresent: createExtensionInput(
-                {
-                  test: testDataRef,
-                  other: otherDataRef.optional(),
-                },
-                { singleton: true, optional: true },
-              ),
-              optionalSingletonMissing: createExtensionInput(
-                {
-                  test: testDataRef,
-                  other: otherDataRef.optional(),
-                },
-                { singleton: true, optional: true },
-              ),
-              singleton: createExtensionInput(
-                {
-                  test: testDataRef,
-                  other: otherDataRef.optional(),
-                },
-                { singleton: true },
-              ),
-              many: createExtensionInput({
-                test: testDataRef,
-                other: otherDataRef.optional(),
-              }),
-            },
-            output: {
-              inputMirror: inputMirrorDataRef,
-            },
-            factory({ inputs }) {
-              return { inputMirror: inputs };
-            },
-          }),
-        ),
-      ),
-    });
-
-    expect(Array.from(instance.getDataRefs())).toEqual([inputMirrorDataRef]);
-    expect(instance.getData(inputMirrorDataRef)).toMatchObject({
-      optionalSingletonPresent: {
-        node: { spec: { id: 'app/test' } },
-        output: { test: 'optionalSingletonPresent' },
-      },
-      singleton: {
-        node: { spec: { id: 'app/test' } },
-        output: { test: 'singleton', other: 2 },
-      },
-      many: [
-        { node: { spec: { id: 'app/test' } }, output: { test: 'many1' } },
+    it('should not instantiate disabled attachments', () => {
+      const tree = resolveAppTree('root-node', [
         {
-          node: { spec: { id: 'app/test' } },
-          output: { test: 'many2', other: 3 },
+          ...makeSpec(
+            resolveExtensionDefinition(
+              createExtension({
+                namespace: 'root-node',
+                attachTo: { id: 'ignored', input: 'ignored' },
+                inputs: {
+                  test: createExtensionInput({ test: testDataRef }),
+                },
+                output: {
+                  inputMirror: inputMirrorDataRef,
+                },
+                factory({ inputs }) {
+                  return { inputMirror: inputs };
+                },
+              }),
+            ),
+          ),
         },
-      ],
+        {
+          ...makeSpec(simpleExtension),
+          id: 'child-node',
+          // Using an invalid input should not be an error when disabled
+          attachTo: { id: 'root-node', input: 'invalid' },
+          disabled: true,
+        },
+      ]);
+
+      const childNode = tree.nodes.get('child-node');
+      expect(childNode).toBeDefined();
+
+      expect(tree.root.instance).not.toBeDefined();
+      expect(childNode?.instance).not.toBeDefined();
+      instantiateAppNodeTree(tree.root);
+      expect(tree.root.instance).toBeDefined();
+      expect(childNode?.instance).not.toBeDefined();
+      expect(tree.root.instance?.getData(inputMirrorDataRef)).toEqual({
+        test: [],
+      });
+    });
+
+    describe('createAppNodeInstance', () => {
+      it('should create a simple extension instance', () => {
+        const attachments = new Map();
+        const instance = createAppNodeInstance({
+          node: makeNode(simpleExtension),
+          attachments,
+        });
+
+        expect(Array.from(instance.getDataRefs())).toEqual([
+          testDataRef,
+          otherDataRef.optional(),
+        ]);
+        expect(instance.getData(testDataRef)).toEqual('test');
+      });
+
+      it('should create an extension with different kind of inputs', () => {
+        const attachments = new Map([
+          [
+            'optionalSingletonPresent',
+            [
+              makeInstanceWithId(simpleExtension, {
+                output: 'optionalSingletonPresent',
+              }),
+            ],
+          ],
+          [
+            'singleton',
+            [
+              makeInstanceWithId(simpleExtension, {
+                output: 'singleton',
+                other: 2,
+              }),
+            ],
+          ],
+          [
+            'many',
+            [
+              makeInstanceWithId(simpleExtension, { output: 'many1' }),
+              makeInstanceWithId(simpleExtension, {
+                output: 'many2',
+                other: 3,
+              }),
+            ],
+          ],
+        ]);
+        const instance = createAppNodeInstance({
+          attachments,
+          node: makeNode(
+            resolveExtensionDefinition(
+              createExtension({
+                namespace: 'app',
+                name: 'test',
+                attachTo: { id: 'ignored', input: 'ignored' },
+                inputs: {
+                  optionalSingletonPresent: createExtensionInput(
+                    {
+                      test: testDataRef,
+                      other: otherDataRef.optional(),
+                    },
+                    { singleton: true, optional: true },
+                  ),
+                  optionalSingletonMissing: createExtensionInput(
+                    {
+                      test: testDataRef,
+                      other: otherDataRef.optional(),
+                    },
+                    { singleton: true, optional: true },
+                  ),
+                  singleton: createExtensionInput(
+                    {
+                      test: testDataRef,
+                      other: otherDataRef.optional(),
+                    },
+                    { singleton: true },
+                  ),
+                  many: createExtensionInput({
+                    test: testDataRef,
+                    other: otherDataRef.optional(),
+                  }),
+                },
+                output: {
+                  inputMirror: inputMirrorDataRef,
+                },
+                factory({ inputs }) {
+                  return { inputMirror: inputs };
+                },
+              }),
+            ),
+          ),
+        });
+
+        expect(Array.from(instance.getDataRefs())).toEqual([
+          inputMirrorDataRef,
+        ]);
+        expect(instance.getData(inputMirrorDataRef)).toMatchObject({
+          optionalSingletonPresent: {
+            node: { spec: { id: 'app/test' } },
+            output: { test: 'optionalSingletonPresent' },
+          },
+          singleton: {
+            node: { spec: { id: 'app/test' } },
+            output: { test: 'singleton', other: 2 },
+          },
+          many: [
+            { node: { spec: { id: 'app/test' } }, output: { test: 'many1' } },
+            {
+              node: { spec: { id: 'app/test' } },
+              output: { test: 'many2', other: 3 },
+            },
+          ],
+        });
+      });
+
+      it('should refuse to create an extension with invalid config', () => {
+        expect(() =>
+          createAppNodeInstance({
+            node: makeNode(simpleExtension, {
+              config: { other: 'not-a-number' },
+            }),
+            attachments: new Map(),
+          }),
+        ).toThrow(
+          "Invalid configuration for extension 'app/test'; caused by Error: Expected number, received string at 'other'",
+        );
+      });
+
+      it('should forward extension factory errors', () => {
+        expect(() =>
+          createAppNodeInstance({
+            node: makeNode(
+              resolveExtensionDefinition(
+                createExtension({
+                  namespace: 'app',
+                  name: 'test',
+                  attachTo: { id: 'ignored', input: 'ignored' },
+                  output: {},
+                  factory() {
+                    const error = new Error('NOPE');
+                    error.name = 'NopeError';
+                    throw error;
+                  },
+                }),
+              ),
+            ),
+            attachments: new Map(),
+          }),
+        ).toThrow(
+          "Failed to instantiate extension 'app/test'; caused by NopeError: NOPE",
+        );
+      });
+
+      it('should refuse to create an instance with duplicate output', () => {
+        expect(() =>
+          createAppNodeInstance({
+            node: makeNode(
+              resolveExtensionDefinition(
+                createExtension({
+                  namespace: 'app',
+                  name: 'test',
+                  attachTo: { id: 'ignored', input: 'ignored' },
+                  output: {
+                    test1: testDataRef,
+                    test2: testDataRef,
+                  },
+                  factory({}) {
+                    return { test1: 'test', test2: 'test2' };
+                  },
+                }),
+              ),
+            ),
+            attachments: new Map(),
+          }),
+        ).toThrow(
+          "Failed to instantiate extension 'app/test', duplicate extension data 'test' received via output 'test2'",
+        );
+      });
+
+      it('should refuse to create an instance with disconnected output data', () => {
+        expect(() =>
+          createAppNodeInstance({
+            node: makeNode(
+              resolveExtensionDefinition(
+                createExtension({
+                  namespace: 'app',
+                  name: 'test',
+                  attachTo: { id: 'ignored', input: 'ignored' },
+                  output: {
+                    test: testDataRef,
+                  },
+                  factory({}) {
+                    return { nonexistent: 'test' } as any;
+                  },
+                }),
+              ),
+            ),
+            attachments: new Map(),
+          }),
+        ).toThrow(
+          "Failed to instantiate extension 'app/test', unknown output provided via 'nonexistent'",
+        );
+      });
+
+      it('should refuse to create an instance with missing required input', () => {
+        expect(() =>
+          createAppNodeInstance({
+            node: makeNode(
+              resolveExtensionDefinition(
+                createExtension({
+                  namespace: 'app',
+                  name: 'test',
+                  attachTo: { id: 'ignored', input: 'ignored' },
+                  inputs: {
+                    singleton: createExtensionInput(
+                      {
+                        test: testDataRef,
+                      },
+                      { singleton: true },
+                    ),
+                  },
+                  output: {},
+                  factory: () => ({}),
+                }),
+              ),
+            ),
+            attachments: new Map(),
+          }),
+        ).toThrow(
+          "Failed to instantiate extension 'app/test', input 'singleton' is required but was not received",
+        );
+      });
+
+      it('should warn when creating an instance with undeclared inputs', () => {
+        const { warn } = withLogCollector(['warn'], () =>
+          createAppNodeInstance({
+            attachments: new Map([
+              [
+                'declared',
+                [
+                  makeInstanceWithId(simpleExtension, {
+                    output: 'many1',
+                  }),
+                ],
+              ],
+              [
+                'undeclared',
+                [
+                  makeInstanceWithId(simpleExtension, {
+                    output: 'many1',
+                  }),
+                ],
+              ],
+            ]),
+            node: makeNode(
+              resolveExtensionDefinition(
+                createExtension({
+                  namespace: 'app',
+                  name: 'parent',
+                  attachTo: { id: 'ignored', input: 'ignored' },
+                  inputs: {
+                    declared: createExtensionInput({
+                      test: testDataRef,
+                    }),
+                  },
+                  output: {},
+                  factory: () => ({}),
+                }),
+              ),
+            ),
+          }),
+        );
+
+        expect(warn).toEqual([
+          "The extension 'app/test' is attached to the input 'undeclared' of the extension 'app/parent', but it has no such input (candidates are 'declared')",
+        ]);
+      });
+
+      it('should refuse to create an instance with multiple undeclared inputs', () => {
+        const { warn } = withLogCollector(['warn'], () =>
+          createAppNodeInstance({
+            attachments: new Map([
+              [
+                'undeclared1',
+                [makeInstanceWithId(simpleExtension, { output: 'many1' })],
+              ],
+              [
+                'undeclared2',
+                [
+                  makeInstanceWithId(simpleExtension, { output: 'many1' }),
+                  makeInstanceWithId(simpleExtension, { output: 'many1' }),
+                ],
+              ],
+            ]),
+            node: makeNode(
+              resolveExtensionDefinition(
+                createExtension({
+                  namespace: 'app',
+                  name: 'parent',
+                  attachTo: { id: 'ignored', input: 'ignored' },
+                  output: {},
+                  factory: () => ({}),
+                }),
+              ),
+            ),
+          }),
+        );
+
+        expect(warn).toEqual([
+          "The extension 'app/test' is attached to the input 'undeclared1' of the extension 'app/parent', but it has no inputs",
+          "The extensions 'app/test', 'app/test' are attached to the input 'undeclared2' of the extension 'app/parent', but it has no inputs",
+        ]);
+      });
+
+      it('should refuse to create an instance with multiple inputs for required singleton', () => {
+        expect(() =>
+          createAppNodeInstance({
+            attachments: new Map([
+              [
+                'singleton',
+                [
+                  makeInstanceWithId(simpleExtension, { output: 'many1' }),
+                  makeInstanceWithId(simpleExtension, { output: 'many2' }),
+                ],
+              ],
+            ]),
+            node: makeNode(
+              resolveExtensionDefinition(
+                createExtension({
+                  namespace: 'app',
+                  name: 'test',
+                  attachTo: { id: 'ignored', input: 'ignored' },
+                  inputs: {
+                    singleton: createExtensionInput(
+                      {
+                        test: testDataRef,
+                      },
+                      { singleton: true },
+                    ),
+                  },
+                  output: {},
+                  factory: () => ({}),
+                }),
+              ),
+            ),
+          }),
+        ).toThrow(
+          "Failed to instantiate extension 'app/test', expected exactly one 'singleton' input but received multiple: 'app/test', 'app/test'",
+        );
+      });
+
+      it('should refuse to create an instance with multiple inputs for optional singleton', () => {
+        expect(() =>
+          createAppNodeInstance({
+            attachments: new Map([
+              [
+                'singleton',
+                [
+                  makeInstanceWithId(simpleExtension, { output: 'many1' }),
+                  makeInstanceWithId(simpleExtension, { output: 'many2' }),
+                ],
+              ],
+            ]),
+            node: makeNode(
+              resolveExtensionDefinition(
+                createExtension({
+                  namespace: 'app',
+                  name: 'test',
+                  attachTo: { id: 'ignored', input: 'ignored' },
+                  inputs: {
+                    singleton: createExtensionInput(
+                      {
+                        test: testDataRef,
+                      },
+                      { singleton: true, optional: true },
+                    ),
+                  },
+                  output: {},
+                  factory: () => ({}),
+                }),
+              ),
+            ),
+          }),
+        ).toThrow(
+          "Failed to instantiate extension 'app/test', expected at most one 'singleton' input but received multiple: 'app/test', 'app/test'",
+        );
+      });
+
+      it('should refuse to create an instance with multiple inputs that did not provide required data', () => {
+        expect(() =>
+          createAppNodeInstance({
+            attachments: new Map([
+              ['singleton', [makeInstanceWithId(simpleExtension, undefined)]],
+            ]),
+            node: makeNode(
+              resolveExtensionDefinition(
+                createExtension({
+                  namespace: 'app',
+                  name: 'test',
+                  attachTo: { id: 'ignored', input: 'ignored' },
+                  inputs: {
+                    singleton: createExtensionInput(
+                      {
+                        other: otherDataRef,
+                      },
+                      { singleton: true },
+                    ),
+                  },
+                  output: {},
+                  factory: () => ({}),
+                }),
+              ),
+            ),
+          }),
+        ).toThrowErrorMatchingInlineSnapshot(
+          `"Failed to instantiate extension 'app/test', extension 'app/test' could not be attached because its output data ('test', 'other') does not match what the input 'singleton' requires ('other')"`,
+        );
+      });
     });
   });
 
-  it('should refuse to create an extension with invalid config', () => {
-    expect(() =>
-      createAppNodeInstance({
-        node: makeNode(simpleExtension, { config: { other: 'not-a-number' } }),
-        attachments: new Map(),
-      }),
-    ).toThrow(
-      "Invalid configuration for extension 'app/test'; caused by Error: Expected number, received string at 'other'",
-    );
-  });
-
-  it('should forward extension factory errors', () => {
-    expect(() =>
-      createAppNodeInstance({
-        node: makeNode(
-          resolveExtensionDefinition(
-            createExtension({
-              namespace: 'app',
-              name: 'test',
-              attachTo: { id: 'ignored', input: 'ignored' },
-              output: {},
-              factory() {
-                const error = new Error('NOPE');
-                error.name = 'NopeError';
-                throw error;
-              },
-            }),
-          ),
+  describe('v2', () => {
+    const simpleExtension = resolveExtensionDefinition(
+      createExtension({
+        namespace: 'app',
+        name: 'test',
+        attachTo: { id: 'ignored', input: 'ignored' },
+        output: [testDataRef, otherDataRef.optional()],
+        configSchema: createSchemaFromZod(z =>
+          z.object({
+            output: z.string().default('test'),
+            other: z.number().optional(),
+          }),
         ),
-        attachments: new Map(),
+        factory({ config }) {
+          return [
+            testDataRef(config.output),
+            ...(config.other ? [otherDataRef(config.other)] : []),
+          ];
+        },
       }),
-    ).toThrow(
-      "Failed to instantiate extension 'app/test'; caused by NopeError: NOPE",
     );
-  });
 
-  it('should refuse to create an instance with duplicate output', () => {
-    expect(() =>
-      createAppNodeInstance({
-        node: makeNode(
-          resolveExtensionDefinition(
-            createExtension({
-              namespace: 'app',
-              name: 'test',
-              attachTo: { id: 'ignored', input: 'ignored' },
-              output: {
-                test1: testDataRef,
-                test2: testDataRef,
-              },
-              factory({}) {
-                return { test1: 'test', test2: 'test2' };
-              },
-            }),
-          ),
-        ),
-        attachments: new Map(),
-      }),
-    ).toThrow(
-      "Failed to instantiate extension 'app/test', duplicate extension data 'test' received via output 'test2'",
-    );
-  });
-
-  it('should refuse to create an instance with disconnected output data', () => {
-    expect(() =>
-      createAppNodeInstance({
-        node: makeNode(
-          resolveExtensionDefinition(
-            createExtension({
-              namespace: 'app',
-              name: 'test',
-              attachTo: { id: 'ignored', input: 'ignored' },
-              output: {
-                test: testDataRef,
-              },
-              factory({}) {
-                return { nonexistent: 'test' } as any;
-              },
-            }),
-          ),
-        ),
-        attachments: new Map(),
-      }),
-    ).toThrow(
-      "Failed to instantiate extension 'app/test', unknown output provided via 'nonexistent'",
-    );
-  });
-
-  it('should refuse to create an instance with missing required input', () => {
-    expect(() =>
-      createAppNodeInstance({
-        node: makeNode(
-          resolveExtensionDefinition(
-            createExtension({
-              namespace: 'app',
-              name: 'test',
-              attachTo: { id: 'ignored', input: 'ignored' },
-              inputs: {
-                singleton: createExtensionInput(
-                  {
-                    test: testDataRef,
+    function mirrorInputs(ctx: {
+      inputs: {
+        [name in string]:
+          | undefined
+          | ResolvedExtensionInput<
+              ExtensionInput<any, { singleton: boolean; optional: boolean }>
+            >
+          | Array<
+              ResolvedExtensionInput<
+                ExtensionInput<any, { singleton: boolean; optional: boolean }>
+              >
+            >;
+      };
+    }) {
+      return [
+        inputMirrorDataRef(
+          Object.fromEntries(
+            Object.entries(ctx.inputs).map(([k, v]) => [
+              k,
+              Array.isArray(v)
+                ? v.map(vi => ({
+                    node: vi.node,
+                    test: vi.get(testDataRef),
+                    other: vi.get(otherDataRef),
+                  }))
+                : {
+                    node: v?.node,
+                    test: v?.get(testDataRef),
+                    other: v?.get(otherDataRef),
                   },
-                  { singleton: true },
-                ),
+            ]),
+          ),
+        ),
+      ];
+    }
+
+    it('should instantiate a single node', () => {
+      const tree = resolveAppTree('root-node', [
+        makeSpec(simpleExtension, { id: 'root-node' }),
+      ]);
+      expect(tree.root.instance).not.toBeDefined();
+      instantiateAppNodeTree(tree.root);
+      expect(tree.root.instance).toBeDefined();
+      expect(tree.root.instance?.getData(testDataRef)).toBe('test');
+
+      // Multiple calls should have no effect
+      instantiateAppNodeTree(tree.root);
+      expect(tree.root.instance).toBeDefined();
+    });
+
+    it('should not instantiate disabled nodes', () => {
+      const tree = resolveAppTree('root-node', [
+        makeSpec(simpleExtension, { id: 'root-node', disabled: true }),
+      ]);
+      expect(tree.root.instance).not.toBeDefined();
+      instantiateAppNodeTree(tree.root);
+      expect(tree.root.instance).not.toBeDefined();
+    });
+
+    it('should instantiate a node with attachments', () => {
+      const tree = resolveAppTree('root-node', [
+        makeSpec(
+          resolveExtensionDefinition(
+            createExtension({
+              namespace: 'root-node',
+              attachTo: { id: 'ignored', input: 'ignored' },
+              inputs: {
+                test: createExtensionInput([testDataRef]),
               },
-              output: {},
-              factory: () => ({}),
+              output: [inputMirrorDataRef],
+              factory: mirrorInputs,
             }),
           ),
         ),
-        attachments: new Map(),
-      }),
-    ).toThrow(
-      "Failed to instantiate extension 'app/test', input 'singleton' is required but was not received",
-    );
-  });
+        makeSpec(simpleExtension, {
+          id: 'child-node',
+          attachTo: { id: 'root-node', input: 'test' },
+        }),
+      ]);
 
-  it('should warn when creating an instance with undeclared inputs', () => {
-    const { warn } = withLogCollector(['warn'], () =>
-      createAppNodeInstance({
-        attachments: new Map([
+      const childNode = tree.nodes.get('child-node');
+      expect(childNode).toBeDefined();
+
+      expect(tree.root.instance).not.toBeDefined();
+      expect(childNode?.instance).not.toBeDefined();
+      instantiateAppNodeTree(tree.root);
+      expect(tree.root.instance).toBeDefined();
+      expect(childNode?.instance).toBeDefined();
+      expect(tree.root.instance?.getData(inputMirrorDataRef)).toMatchObject({
+        test: [{ node: { spec: { id: 'child-node' } }, test: 'test' }],
+      });
+
+      // Multiple calls should have no effect
+      instantiateAppNodeTree(tree.root);
+      expect(tree.root.instance).toBeDefined();
+      expect(childNode?.instance).toBeDefined();
+    });
+
+    it('should not instantiate disabled attachments', () => {
+      const tree = resolveAppTree('root-node', [
+        {
+          ...makeSpec(
+            resolveExtensionDefinition(
+              createExtension({
+                namespace: 'root-node',
+                attachTo: { id: 'ignored', input: 'ignored' },
+                inputs: {
+                  test: createExtensionInput([testDataRef]),
+                },
+                output: [inputMirrorDataRef],
+                factory: mirrorInputs,
+              }),
+            ),
+          ),
+        },
+        {
+          ...makeSpec(simpleExtension),
+          id: 'child-node',
+          // Using an invalid input should not be an error when disabled
+          attachTo: { id: 'root-node', input: 'invalid' },
+          disabled: true,
+        },
+      ]);
+
+      const childNode = tree.nodes.get('child-node');
+      expect(childNode).toBeDefined();
+
+      expect(tree.root.instance).not.toBeDefined();
+      expect(childNode?.instance).not.toBeDefined();
+      instantiateAppNodeTree(tree.root);
+      expect(tree.root.instance).toBeDefined();
+      expect(childNode?.instance).not.toBeDefined();
+      expect(tree.root.instance?.getData(inputMirrorDataRef)).toEqual({
+        test: [],
+      });
+    });
+
+    describe('createAppNodeInstance', () => {
+      it('should create a simple extension instance', () => {
+        const attachments = new Map();
+        const instance = createAppNodeInstance({
+          node: makeNode(simpleExtension),
+          attachments,
+        });
+
+        expect(Array.from(instance.getDataRefs())).toEqual([testDataRef]);
+        expect(instance.getData(testDataRef)).toEqual('test');
+      });
+
+      it('should create an extension with different kind of inputs', () => {
+        const attachments = new Map([
           [
-            'declared',
+            'optionalSingletonPresent',
             [
               makeInstanceWithId(simpleExtension, {
-                output: 'many1',
+                output: 'optionalSingletonPresent',
               }),
             ],
           ],
           [
-            'undeclared',
+            'singleton',
             [
               makeInstanceWithId(simpleExtension, {
-                output: 'many1',
+                output: 'singleton',
+                other: 2,
               }),
             ],
           ],
-        ]),
-        node: makeNode(
-          resolveExtensionDefinition(
-            createExtension({
-              namespace: 'app',
-              name: 'parent',
-              attachTo: { id: 'ignored', input: 'ignored' },
-              inputs: {
-                declared: createExtensionInput({
-                  test: testDataRef,
+          [
+            'many',
+            [
+              makeInstanceWithId(simpleExtension, { output: 'many1' }),
+              makeInstanceWithId(simpleExtension, {
+                output: 'many2',
+                other: 3,
+              }),
+            ],
+          ],
+        ]);
+
+        const instance = createAppNodeInstance({
+          attachments,
+          node: makeNode(
+            resolveExtensionDefinition(
+              createExtension({
+                namespace: 'app',
+                name: 'test',
+                attachTo: { id: 'ignored', input: 'ignored' },
+                inputs: {
+                  optionalSingletonPresent: createExtensionInput(
+                    [testDataRef, otherDataRef.optional()],
+                    { singleton: true, optional: true },
+                  ),
+                  optionalSingletonMissing: createExtensionInput(
+                    [testDataRef, otherDataRef.optional()],
+                    { singleton: true, optional: true },
+                  ),
+                  singleton: createExtensionInput(
+                    [testDataRef, otherDataRef.optional()],
+                    { singleton: true },
+                  ),
+                  many: createExtensionInput([
+                    testDataRef,
+                    otherDataRef.optional(),
+                  ]),
+                },
+                output: [inputMirrorDataRef],
+                factory: mirrorInputs,
+              }),
+            ),
+          ),
+        });
+
+        expect(Array.from(instance.getDataRefs())).toEqual([
+          inputMirrorDataRef,
+        ]);
+        expect(instance.getData(inputMirrorDataRef)).toMatchObject({
+          optionalSingletonPresent: {
+            node: { spec: { id: 'app/test' } },
+            test: 'optionalSingletonPresent',
+          },
+          singleton: {
+            node: { spec: { id: 'app/test' } },
+            test: 'singleton',
+            other: 2,
+          },
+          many: [
+            { node: { spec: { id: 'app/test' } }, test: 'many1' },
+            {
+              node: { spec: { id: 'app/test' } },
+              test: 'many2',
+              other: 3,
+            },
+          ],
+        });
+      });
+
+      it('should refuse to create an extension with invalid config', () => {
+        expect(() =>
+          createAppNodeInstance({
+            node: makeNode(simpleExtension, {
+              config: { other: 'not-a-number' },
+            }),
+            attachments: new Map(),
+          }),
+        ).toThrow(
+          "Invalid configuration for extension 'app/test'; caused by Error: Expected number, received string at 'other'",
+        );
+      });
+
+      it('should forward extension factory errors', () => {
+        expect(() =>
+          createAppNodeInstance({
+            node: makeNode(
+              resolveExtensionDefinition(
+                createExtension({
+                  namespace: 'app',
+                  name: 'test',
+                  attachTo: { id: 'ignored', input: 'ignored' },
+                  output: [],
+                  factory() {
+                    const error = new Error('NOPE');
+                    error.name = 'NopeError';
+                    throw error;
+                  },
                 }),
-              },
-              output: {},
-              factory: () => ({}),
-            }),
-          ),
-        ),
-      }),
-    );
+              ),
+            ),
+            attachments: new Map(),
+          }),
+        ).toThrow(
+          "Failed to instantiate extension 'app/test'; caused by NopeError: NOPE",
+        );
+      });
 
-    expect(warn).toEqual([
-      "The extension 'app/test' is attached to the input 'undeclared' of the extension 'app/parent', but it has no such input (candidates are 'declared')",
-    ]);
-  });
-
-  it('should refuse to create an instance with multiple undeclared inputs', () => {
-    const { warn } = withLogCollector(['warn'], () =>
-      createAppNodeInstance({
-        attachments: new Map([
-          [
-            'undeclared1',
-            [makeInstanceWithId(simpleExtension, { output: 'many1' })],
-          ],
-          [
-            'undeclared2',
-            [
-              makeInstanceWithId(simpleExtension, { output: 'many1' }),
-              makeInstanceWithId(simpleExtension, { output: 'many1' }),
-            ],
-          ],
-        ]),
-        node: makeNode(
-          resolveExtensionDefinition(
-            createExtension({
-              namespace: 'app',
-              name: 'parent',
-              attachTo: { id: 'ignored', input: 'ignored' },
-              output: {},
-              factory: () => ({}),
-            }),
-          ),
-        ),
-      }),
-    );
-
-    expect(warn).toEqual([
-      "The extension 'app/test' is attached to the input 'undeclared1' of the extension 'app/parent', but it has no inputs",
-      "The extensions 'app/test', 'app/test' are attached to the input 'undeclared2' of the extension 'app/parent', but it has no inputs",
-    ]);
-  });
-
-  it('should refuse to create an instance with multiple inputs for required singleton', () => {
-    expect(() =>
-      createAppNodeInstance({
-        attachments: new Map([
-          [
-            'singleton',
-            [
-              makeInstanceWithId(simpleExtension, { output: 'many1' }),
-              makeInstanceWithId(simpleExtension, { output: 'many2' }),
-            ],
-          ],
-        ]),
-        node: makeNode(
-          resolveExtensionDefinition(
-            createExtension({
-              namespace: 'app',
-              name: 'test',
-              attachTo: { id: 'ignored', input: 'ignored' },
-              inputs: {
-                singleton: createExtensionInput(
-                  {
-                    test: testDataRef,
+      it('should refuse to create an instance with duplicate output', () => {
+        expect(() =>
+          createAppNodeInstance({
+            node: makeNode(
+              resolveExtensionDefinition(
+                createExtension({
+                  namespace: 'app',
+                  name: 'test',
+                  attachTo: { id: 'ignored', input: 'ignored' },
+                  output: [testDataRef, testDataRef],
+                  factory({}) {
+                    return [testDataRef('test'), testDataRef('test2')];
                   },
-                  { singleton: true },
-                ),
-              },
-              output: {},
-              factory: () => ({}),
-            }),
-          ),
-        ),
-      }),
-    ).toThrow(
-      "Failed to instantiate extension 'app/test', expected exactly one 'singleton' input but received multiple: 'app/test', 'app/test'",
-    );
-  });
+                }),
+              ),
+            ),
+            attachments: new Map(),
+          }),
+        ).toThrow(
+          "Failed to instantiate extension 'app/test', duplicate extension data output 'test'",
+        );
+      });
 
-  it('should refuse to create an instance with multiple inputs for optional singleton', () => {
-    expect(() =>
-      createAppNodeInstance({
-        attachments: new Map([
-          [
-            'singleton',
-            [
-              makeInstanceWithId(simpleExtension, { output: 'many1' }),
-              makeInstanceWithId(simpleExtension, { output: 'many2' }),
-            ],
-          ],
-        ]),
-        node: makeNode(
-          resolveExtensionDefinition(
-            createExtension({
-              namespace: 'app',
-              name: 'test',
-              attachTo: { id: 'ignored', input: 'ignored' },
-              inputs: {
-                singleton: createExtensionInput(
-                  {
-                    test: testDataRef,
+      it('should refuse to create an instance without required', () => {
+        expect(() =>
+          createAppNodeInstance({
+            node: makeNode(
+              resolveExtensionDefinition(
+                createExtension({
+                  namespace: 'app',
+                  name: 'test',
+                  attachTo: { id: 'ignored', input: 'ignored' },
+                  output: [testDataRef],
+                  factory({}) {
+                    return [] as any;
                   },
-                  { singleton: true, optional: true },
-                ),
-              },
-              output: {},
-              factory: () => ({}),
-            }),
-          ),
-        ),
-      }),
-    ).toThrow(
-      "Failed to instantiate extension 'app/test', expected at most one 'singleton' input but received multiple: 'app/test', 'app/test'",
-    );
-  });
+                }),
+              ),
+            ),
+            attachments: new Map(),
+          }),
+        ).toThrow(
+          "Failed to instantiate extension 'app/test', missing required extension data output 'test'",
+        );
+      });
 
-  it('should refuse to create an instance with multiple inputs that did not provide required data', () => {
-    expect(() =>
-      createAppNodeInstance({
-        attachments: new Map([
-          ['singleton', [makeInstanceWithId(simpleExtension, undefined)]],
-        ]),
-        node: makeNode(
-          resolveExtensionDefinition(
-            createExtension({
-              namespace: 'app',
-              name: 'test',
-              attachTo: { id: 'ignored', input: 'ignored' },
-              inputs: {
-                singleton: createExtensionInput(
-                  {
-                    other: otherDataRef,
+      it('should refuse to create an instance with unknown output data', () => {
+        expect(() =>
+          createAppNodeInstance({
+            node: makeNode(
+              resolveExtensionDefinition(
+                createExtension({
+                  namespace: 'app',
+                  name: 'test',
+                  attachTo: { id: 'ignored', input: 'ignored' },
+                  output: [],
+                  factory({}) {
+                    return [testDataRef('test')] as any;
                   },
-                  { singleton: true },
-                ),
-              },
-              output: {},
-              factory: () => ({}),
-            }),
-          ),
-        ),
-      }),
-    ).toThrowErrorMatchingInlineSnapshot(
-      `"Failed to instantiate extension 'app/test', extension 'app/test' could not be attached because its output data ('test', 'other') does not match what the input 'singleton' requires ('other')"`,
-    );
+                }),
+              ),
+            ),
+            attachments: new Map(),
+          }),
+        ).toThrow(
+          "Failed to instantiate extension 'app/test', unexpected output 'test'",
+        );
+      });
+
+      it('should refuse to create an instance with missing required input', () => {
+        expect(() =>
+          createAppNodeInstance({
+            node: makeNode(
+              resolveExtensionDefinition(
+                createExtension({
+                  namespace: 'app',
+                  name: 'test',
+                  attachTo: { id: 'ignored', input: 'ignored' },
+                  inputs: {
+                    singleton: createExtensionInput([testDataRef], {
+                      singleton: true,
+                    }),
+                  },
+                  output: [],
+                  factory: () => [],
+                }),
+              ),
+            ),
+            attachments: new Map(),
+          }),
+        ).toThrow(
+          "Failed to instantiate extension 'app/test', input 'singleton' is required but was not received",
+        );
+      });
+
+      it('should warn when creating an instance with undeclared inputs', () => {
+        const { warn } = withLogCollector(['warn'], () =>
+          createAppNodeInstance({
+            attachments: new Map([
+              [
+                'declared',
+                [
+                  makeInstanceWithId(simpleExtension, {
+                    output: 'many1',
+                  }),
+                ],
+              ],
+              [
+                'undeclared',
+                [
+                  makeInstanceWithId(simpleExtension, {
+                    output: 'many1',
+                  }),
+                ],
+              ],
+            ]),
+            node: makeNode(
+              resolveExtensionDefinition(
+                createExtension({
+                  namespace: 'app',
+                  name: 'parent',
+                  attachTo: { id: 'ignored', input: 'ignored' },
+                  inputs: {
+                    declared: createExtensionInput([testDataRef]),
+                  },
+                  output: [],
+                  factory: () => [],
+                }),
+              ),
+            ),
+          }),
+        );
+
+        expect(warn).toEqual([
+          "The extension 'app/test' is attached to the input 'undeclared' of the extension 'app/parent', but it has no such input (candidates are 'declared')",
+        ]);
+      });
+
+      it('should refuse to create an instance with multiple undeclared inputs', () => {
+        const { warn } = withLogCollector(['warn'], () =>
+          createAppNodeInstance({
+            attachments: new Map([
+              [
+                'undeclared1',
+                [makeInstanceWithId(simpleExtension, { output: 'many1' })],
+              ],
+              [
+                'undeclared2',
+                [
+                  makeInstanceWithId(simpleExtension, { output: 'many1' }),
+                  makeInstanceWithId(simpleExtension, { output: 'many1' }),
+                ],
+              ],
+            ]),
+            node: makeNode(
+              resolveExtensionDefinition(
+                createExtension({
+                  namespace: 'app',
+                  name: 'parent',
+                  attachTo: { id: 'ignored', input: 'ignored' },
+                  output: [],
+                  factory: () => [],
+                }),
+              ),
+            ),
+          }),
+        );
+
+        expect(warn).toEqual([
+          "The extension 'app/test' is attached to the input 'undeclared1' of the extension 'app/parent', but it has no inputs",
+          "The extensions 'app/test', 'app/test' are attached to the input 'undeclared2' of the extension 'app/parent', but it has no inputs",
+        ]);
+      });
+
+      it('should refuse to create an instance with multiple inputs for required singleton', () => {
+        expect(() =>
+          createAppNodeInstance({
+            attachments: new Map([
+              [
+                'singleton',
+                [
+                  makeInstanceWithId(simpleExtension, { output: 'many1' }),
+                  makeInstanceWithId(simpleExtension, { output: 'many2' }),
+                ],
+              ],
+            ]),
+            node: makeNode(
+              resolveExtensionDefinition(
+                createExtension({
+                  namespace: 'app',
+                  name: 'test',
+                  attachTo: { id: 'ignored', input: 'ignored' },
+                  inputs: {
+                    singleton: createExtensionInput([testDataRef], {
+                      singleton: true,
+                    }),
+                  },
+                  output: [],
+                  factory: () => [],
+                }),
+              ),
+            ),
+          }),
+        ).toThrow(
+          "Failed to instantiate extension 'app/test', expected exactly one 'singleton' input but received multiple: 'app/test', 'app/test'",
+        );
+      });
+
+      it('should refuse to create an instance with multiple inputs for optional singleton', () => {
+        expect(() =>
+          createAppNodeInstance({
+            attachments: new Map([
+              [
+                'singleton',
+                [
+                  makeInstanceWithId(simpleExtension, { output: 'many1' }),
+                  makeInstanceWithId(simpleExtension, { output: 'many2' }),
+                ],
+              ],
+            ]),
+            node: makeNode(
+              resolveExtensionDefinition(
+                createExtension({
+                  namespace: 'app',
+                  name: 'test',
+                  attachTo: { id: 'ignored', input: 'ignored' },
+                  inputs: {
+                    singleton: createExtensionInput([testDataRef], {
+                      singleton: true,
+                      optional: true,
+                    }),
+                  },
+                  output: [],
+                  factory: () => [],
+                }),
+              ),
+            ),
+          }),
+        ).toThrow(
+          "Failed to instantiate extension 'app/test', expected at most one 'singleton' input but received multiple: 'app/test', 'app/test'",
+        );
+      });
+
+      it('should refuse to create an instance with multiple inputs that did not provide required data', () => {
+        expect(() =>
+          createAppNodeInstance({
+            attachments: new Map([
+              ['singleton', [makeInstanceWithId(simpleExtension, undefined)]],
+            ]),
+            node: makeNode(
+              resolveExtensionDefinition(
+                createExtension({
+                  namespace: 'app',
+                  name: 'test',
+                  attachTo: { id: 'ignored', input: 'ignored' },
+                  inputs: {
+                    singleton: createExtensionInput([otherDataRef], {
+                      singleton: true,
+                    }),
+                  },
+                  output: [],
+                  factory: () => [],
+                }),
+              ),
+            ),
+          }),
+        ).toThrowErrorMatchingInlineSnapshot(
+          `"Failed to instantiate extension 'app/test', extension 'app/test' could not be attached because its output data ('test') does not match what the input 'singleton' requires ('other')"`,
+        );
+      });
+    });
   });
 });

--- a/packages/frontend-plugin-api/src/extensions/IconBundleBlueprint.ts
+++ b/packages/frontend-plugin-api/src/extensions/IconBundleBlueprint.ts
@@ -25,16 +25,16 @@ export const IconBundleBlueprint = createExtensionBlueprint({
   kind: 'icon-bundle',
   namespace: 'app',
   attachTo: { id: 'app', input: 'icons' },
-  output: {
-    icons: iconsDataRef,
-  },
+  output: [iconsDataRef],
   config: {
     schema: {
       icons: z => z.string().default('blob'),
       test: z => z.string(),
     },
   },
-  factory: (params: { icons: { [key in string]: IconComponent } }) => params,
+  factory: (params: { icons: { [key in string]: IconComponent } }) => [
+    iconsDataRef(params.icons),
+  ],
   dataRefs: {
     icons: iconsDataRef,
   },

--- a/packages/frontend-plugin-api/src/wiring/createExtension.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.test.ts
@@ -40,7 +40,7 @@ describe('createExtension', () => {
         };
       },
     });
-    expect(extension.namespace).toBe('test');
+    expect(extension).toMatchObject({ version: 'v1', namespace: 'test' });
 
     // When declared as an error function without a block the TypeScript errors
     // are a more specific and will often point at the property that is problematic.
@@ -177,7 +177,7 @@ describe('createExtension', () => {
         foo: 'bar',
       }),
     });
-    expect(extension.namespace).toBe('test');
+    expect(extension).toMatchObject({ version: 'v1', namespace: 'test' });
 
     createExtension({
       ...baseConfig,
@@ -287,7 +287,7 @@ describe('createExtension', () => {
         };
       },
     });
-    expect(extension.namespace).toBe('test');
+    expect(extension).toMatchObject({ version: 'v1', namespace: 'test' });
     expect(String(extension)).toBe(
       'ExtensionDefinition{namespace=test,attachTo=root@default}',
     );
@@ -325,7 +325,7 @@ describe('createExtension', () => {
         };
       },
     });
-    expect(extension.namespace).toBe('test');
+    expect(extension).toMatchObject({ version: 'v1', namespace: 'test' });
     expect(String(extension)).toBe(
       'ExtensionDefinition{namespace=test,attachTo=root@default}',
     );
@@ -358,98 +358,108 @@ describe('createExtension', () => {
   });
 
   it('should support new form of outputs', () => {
-    // @ts-expect-error
-    createExtension({
-      namespace: 'test',
-      attachTo: { id: 'root', input: 'default' },
-      output: [stringDataRef, numberDataRef],
-      factory() {
-        return []; // Missing all outputs
-      },
-    });
+    expect(
+      // @ts-expect-error
+      createExtension({
+        namespace: 'test',
+        attachTo: { id: 'root', input: 'default' },
+        output: [stringDataRef, numberDataRef],
+        factory() {
+          return []; // Missing all outputs
+        },
+      }),
+    ).toMatchObject({ version: 'v2' });
 
-    // @ts-expect-error
-    createExtension({
-      namespace: 'test',
-      attachTo: { id: 'root', input: 'default' },
-      output: [stringDataRef, numberDataRef],
-      factory() {
-        return [stringDataRef('hello')]; // Missing number output
-      },
-    });
+    expect(
+      // @ts-expect-error
+      createExtension({
+        namespace: 'test',
+        attachTo: { id: 'root', input: 'default' },
+        output: [stringDataRef, numberDataRef],
+        factory() {
+          return [stringDataRef('hello')]; // Missing number output
+        },
+      }),
+    ).toMatchObject({ version: 'v2' });
 
     // Duplicate output, we won't attempt to handle this a compile time and instead error out at runtime
-    createExtension({
-      namespace: 'test',
-      attachTo: { id: 'root', input: 'default' },
-      output: [stringDataRef],
-      factory() {
-        return [stringDataRef('hello'), stringDataRef('hello')];
-      },
-    });
+    expect(
+      createExtension({
+        namespace: 'test',
+        attachTo: { id: 'root', input: 'default' },
+        output: [stringDataRef],
+        factory() {
+          return [stringDataRef('hello'), stringDataRef('hello')];
+        },
+      }),
+    ).toMatchObject({ version: 'v2' });
 
-    createExtension({
-      namespace: 'test',
-      attachTo: { id: 'root', input: 'default' },
-      output: [stringDataRef, numberDataRef],
-      factory() {
-        return [stringDataRef('hello'), numberDataRef(4)];
-      },
-    });
+    expect(
+      createExtension({
+        namespace: 'test',
+        attachTo: { id: 'root', input: 'default' },
+        output: [stringDataRef, numberDataRef],
+        factory() {
+          return [stringDataRef('hello'), numberDataRef(4)];
+        },
+      }),
+    ).toMatchObject({ version: 'v2' });
 
-    createExtension({
-      namespace: 'test',
-      attachTo: { id: 'root', input: 'default' },
-      output: [stringDataRef, numberDataRef.optional()],
-      factory() {
-        return [stringDataRef('hello'), numberDataRef(4)];
-      },
-    });
+    expect(
+      createExtension({
+        namespace: 'test',
+        attachTo: { id: 'root', input: 'default' },
+        output: [stringDataRef, numberDataRef.optional()],
+        factory() {
+          return [stringDataRef('hello'), numberDataRef(4)];
+        },
+      }),
+    ).toMatchObject({ version: 'v2' });
 
-    createExtension({
-      namespace: 'test',
-      attachTo: { id: 'root', input: 'default' },
-      output: [stringDataRef, numberDataRef.optional()],
-      factory() {
-        return [stringDataRef('hello')]; // Missing number output, but it's optional so that's allowed
-      },
-    });
-
-    expect(true).toBe(true);
+    expect(
+      createExtension({
+        namespace: 'test',
+        attachTo: { id: 'root', input: 'default' },
+        output: [stringDataRef, numberDataRef.optional()],
+        factory() {
+          return [stringDataRef('hello')]; // Missing number output, but it's optional so that's allowed
+        },
+      }),
+    ).toMatchObject({ version: 'v2' });
   });
 
   it('should support new form of inputs', () => {
-    createExtension({
-      namespace: 'test',
-      attachTo: { id: 'root', input: 'default' },
-      inputs: {
-        header: createExtensionInput([stringDataRef.optional()], {
-          optional: true,
-          singleton: true,
-        }),
-        content: createExtensionInput([stringDataRef, numberDataRef], {
-          optional: false,
-          singleton: true,
-        }),
-      },
-      output: [stringDataRef],
-      factory({ inputs }) {
-        const headerStr = inputs.header?.get(stringDataRef);
-        const contentStr = inputs.content.get(stringDataRef);
-        const contentNum = inputs.content.get(numberDataRef);
+    expect(
+      createExtension({
+        namespace: 'test',
+        attachTo: { id: 'root', input: 'default' },
+        inputs: {
+          header: createExtensionInput([stringDataRef.optional()], {
+            optional: true,
+            singleton: true,
+          }),
+          content: createExtensionInput([stringDataRef, numberDataRef], {
+            optional: false,
+            singleton: true,
+          }),
+        },
+        output: [stringDataRef],
+        factory({ inputs }) {
+          const headerStr = inputs.header?.get(stringDataRef);
+          const contentStr = inputs.content.get(stringDataRef);
+          const contentNum = inputs.content.get(numberDataRef);
 
-        // @ts-expect-error
-        inputs.header?.get(numberDataRef);
+          // @ts-expect-error
+          inputs.header?.get(numberDataRef);
 
-        // @ts-expect-error
-        const x1: string = headerStr; // string | undefined
+          // @ts-expect-error
+          const x1: string = headerStr; // string | undefined
 
-        unused(x1);
+          unused(x1);
 
-        return [stringDataRef(contentStr.repeat(contentNum))];
-      },
-    });
-
-    expect(true).toBe(true);
+          return [stringDataRef(contentStr.repeat(contentNum))];
+        },
+      }),
+    ).toMatchObject({ version: 'v2' });
   });
 });

--- a/packages/frontend-plugin-api/src/wiring/createExtension.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.test.ts
@@ -18,7 +18,8 @@ import { createExtension } from './createExtension';
 import { createExtensionDataRef } from './createExtensionDataRef';
 import { createExtensionInput } from './createExtensionInput';
 
-const stringData = createExtensionDataRef<string>().with({ id: 'string' });
+const stringDataRef = createExtensionDataRef<string>().with({ id: 'string' });
+const numberDataRef = createExtensionDataRef<number>().with({ id: 'number' });
 
 function unused(..._any: any[]) {}
 
@@ -28,7 +29,7 @@ describe('createExtension', () => {
       namespace: 'test',
       attachTo: { id: 'root', input: 'default' },
       output: {
-        foo: stringData,
+        foo: stringDataRef,
       },
     };
     const extension = createExtension({
@@ -42,11 +43,11 @@ describe('createExtension', () => {
     expect(extension.namespace).toBe('test');
 
     // When declared as an error function without a block the TypeScript errors
-    // are a more specific and will point at the property that is problematic.
+    // are a more specific and will often point at the property that is problematic.
+    // @ts-expect-error
     createExtension({
       ...baseConfig,
       factory: () => ({
-        // @ts-expect-error
         foo: 3,
       }),
     });
@@ -166,8 +167,8 @@ describe('createExtension', () => {
       namespace: 'test',
       attachTo: { id: 'root', input: 'default' },
       output: {
-        foo: stringData,
-        bar: stringData.optional(),
+        foo: stringDataRef,
+        bar: stringDataRef.optional(),
       },
     };
     const extension = createExtension({
@@ -185,18 +186,18 @@ describe('createExtension', () => {
         bar: 'baz',
       }),
     });
+    // @ts-expect-error
     createExtension({
       ...baseConfig,
       factory: () => ({
-        // @ts-expect-error
         foo: 3,
       }),
     });
+    // @ts-expect-error
     createExtension({
       ...baseConfig,
       factory: () => ({
         foo: 'bar',
-        // @ts-expect-error
         bar: 3,
       }),
     });
@@ -237,18 +238,18 @@ describe('createExtension', () => {
       attachTo: { id: 'root', input: 'default' },
       inputs: {
         mixed: createExtensionInput({
-          required: stringData,
-          optional: stringData.optional(),
+          required: stringDataRef,
+          optional: stringDataRef.optional(),
         }),
         onlyRequired: createExtensionInput({
-          required: stringData,
+          required: stringDataRef,
         }),
         onlyOptional: createExtensionInput({
-          optional: stringData.optional(),
+          optional: stringDataRef.optional(),
         }),
       },
       output: {
-        foo: stringData,
+        foo: stringDataRef,
       },
       factory({ inputs }) {
         const a1: string = inputs.mixed?.[0].output.required;
@@ -304,7 +305,7 @@ describe('createExtension', () => {
         },
       },
       output: {
-        foo: stringData,
+        foo: stringDataRef,
       },
       factory({ config }) {
         const a1: string = config.foo;
@@ -354,5 +355,89 @@ describe('createExtension', () => {
       // @ts-expect-error
       return extension.configSchema?.parse({});
     }).toThrow("Missing required value at 'foo'");
+  });
+
+  it('should new form of inputs and outputs', () => {
+    createExtension({
+      namespace: 'test',
+      attachTo: { id: 'root', input: 'default' },
+      inputs: {
+        header: createExtensionInput([stringDataRef.optional()], {
+          optional: true,
+          singleton: true,
+        }),
+        content: createExtensionInput([stringDataRef, numberDataRef], {
+          optional: false,
+          singleton: true,
+        }),
+      },
+      output: [stringDataRef],
+      factory({ inputs }) {
+        const headerStr = inputs.header?.get(stringDataRef);
+        const contentStr = inputs.content.get(stringDataRef);
+        const contentNum = inputs.content.get(numberDataRef);
+
+        // @ts-expect-error
+        inputs.header?.get(numberDataRef);
+
+        // @ts-expect-error
+        const x1: string = headerStr; // string | undefined
+
+        unused(x1);
+
+        return [stringDataRef(contentStr.repeat(contentNum))];
+      },
+    });
+
+    // Double output
+    createExtension({
+      namespace: 'test',
+      attachTo: { id: 'root', input: 'default' },
+      output: [stringDataRef],
+      // @ts-expect-error
+      factory() {
+        return [stringDataRef('hello'), stringDataRef('hello')];
+      },
+    });
+
+    // Missing output
+    createExtension({
+      namespace: 'test',
+      attachTo: { id: 'root', input: 'default' },
+      output: [stringDataRef, numberDataRef],
+      // @ts-expect-error
+      factory() {
+        return [stringDataRef('hello')];
+      },
+    });
+
+    createExtension({
+      namespace: 'test',
+      attachTo: { id: 'root', input: 'default' },
+      output: [stringDataRef, numberDataRef],
+      factory() {
+        return [stringDataRef('hello'), numberDataRef(4)];
+      },
+    });
+
+    createExtension({
+      namespace: 'test',
+      attachTo: { id: 'root', input: 'default' },
+      output: [stringDataRef, numberDataRef.optional()],
+      factory() {
+        return [stringDataRef('hello'), numberDataRef(4)];
+      },
+    });
+
+    createExtension({
+      namespace: 'test',
+      attachTo: { id: 'root', input: 'default' },
+      output: [stringDataRef, numberDataRef.optional()],
+      factory() {
+        return [stringDataRef('hello')];
+      },
+    });
+
+    expect(true).toBe(true);
   });
 });

--- a/packages/frontend-plugin-api/src/wiring/createExtension.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.test.ts
@@ -357,7 +357,68 @@ describe('createExtension', () => {
     }).toThrow("Missing required value at 'foo'");
   });
 
-  it('should new form of inputs and outputs', () => {
+  it('should support new form of outputs', () => {
+    // @ts-expect-error
+    createExtension({
+      namespace: 'test',
+      attachTo: { id: 'root', input: 'default' },
+      output: [stringDataRef, numberDataRef],
+      factory() {
+        return []; // Missing all outputs
+      },
+    });
+
+    // @ts-expect-error
+    createExtension({
+      namespace: 'test',
+      attachTo: { id: 'root', input: 'default' },
+      output: [stringDataRef, numberDataRef],
+      factory() {
+        return [stringDataRef('hello')]; // Missing number output
+      },
+    });
+
+    // Duplicate output, we won't attempt to handle this a compile time and instead error out at runtime
+    createExtension({
+      namespace: 'test',
+      attachTo: { id: 'root', input: 'default' },
+      output: [stringDataRef],
+      factory() {
+        return [stringDataRef('hello'), stringDataRef('hello')];
+      },
+    });
+
+    createExtension({
+      namespace: 'test',
+      attachTo: { id: 'root', input: 'default' },
+      output: [stringDataRef, numberDataRef],
+      factory() {
+        return [stringDataRef('hello'), numberDataRef(4)];
+      },
+    });
+
+    createExtension({
+      namespace: 'test',
+      attachTo: { id: 'root', input: 'default' },
+      output: [stringDataRef, numberDataRef.optional()],
+      factory() {
+        return [stringDataRef('hello'), numberDataRef(4)];
+      },
+    });
+
+    createExtension({
+      namespace: 'test',
+      attachTo: { id: 'root', input: 'default' },
+      output: [stringDataRef, numberDataRef.optional()],
+      factory() {
+        return [stringDataRef('hello')]; // Missing number output, but it's optional so that's allowed
+      },
+    });
+
+    expect(true).toBe(true);
+  });
+
+  it('should support new form of inputs', () => {
     createExtension({
       namespace: 'test',
       attachTo: { id: 'root', input: 'default' },
@@ -386,55 +447,6 @@ describe('createExtension', () => {
         unused(x1);
 
         return [stringDataRef(contentStr.repeat(contentNum))];
-      },
-    });
-
-    // Double output
-    createExtension({
-      namespace: 'test',
-      attachTo: { id: 'root', input: 'default' },
-      output: [stringDataRef],
-      // @ts-expect-error
-      factory() {
-        return [stringDataRef('hello'), stringDataRef('hello')];
-      },
-    });
-
-    // Missing output
-    createExtension({
-      namespace: 'test',
-      attachTo: { id: 'root', input: 'default' },
-      output: [stringDataRef, numberDataRef],
-      // @ts-expect-error
-      factory() {
-        return [stringDataRef('hello')];
-      },
-    });
-
-    createExtension({
-      namespace: 'test',
-      attachTo: { id: 'root', input: 'default' },
-      output: [stringDataRef, numberDataRef],
-      factory() {
-        return [stringDataRef('hello'), numberDataRef(4)];
-      },
-    });
-
-    createExtension({
-      namespace: 'test',
-      attachTo: { id: 'root', input: 'default' },
-      output: [stringDataRef, numberDataRef.optional()],
-      factory() {
-        return [stringDataRef('hello'), numberDataRef(4)];
-      },
-    });
-
-    createExtension({
-      namespace: 'test',
-      attachTo: { id: 'root', input: 'default' },
-      output: [stringDataRef, numberDataRef.optional()],
-      factory() {
-        return [stringDataRef('hello')];
       },
     });
 

--- a/packages/frontend-plugin-api/src/wiring/createExtension.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.ts
@@ -80,15 +80,15 @@ export type ExtensionDataContainer<UExtensionData extends AnyExtensionDataRef> =
  * @public
  */
 export type ResolvedExtensionInput<
-  TExtensionData extends AnyExtensionDataMap | AnyExtensionDataRef,
-> = [TExtensionData] extends [AnyExtensionDataRef]
+  TExtensionInput extends ExtensionInput<any, any>,
+> = TExtensionInput['extensionData'] extends Array<AnyExtensionDataRef>
   ? {
       node: AppNode;
-    } & ExtensionDataContainer<TExtensionData>
-  : TExtensionData extends AnyExtensionDataMap
+    } & ExtensionDataContainer<TExtensionInput['extensionData'][number]>
+  : TExtensionInput['extensionData'] extends AnyExtensionDataMap
   ? {
       node: AppNode;
-      output: ExtensionDataValues<TExtensionData>;
+      output: ExtensionDataValues<TExtensionInput['extensionData']>;
     }
   : never;
 
@@ -97,15 +97,15 @@ export type ResolvedExtensionInput<
  * @public
  */
 export type ResolvedExtensionInputs<
-  TInputs extends { [name in string]: ExtensionInput<any, any> },
+  TInputs extends {
+    [name in string]: ExtensionInput<any, any> | LegacyExtensionInput<any, any>;
+  },
 > = {
   [InputName in keyof TInputs]: false extends TInputs[InputName]['config']['singleton']
-    ? Array<Expand<ResolvedExtensionInput<TInputs[InputName]['extensionData']>>>
+    ? Array<Expand<ResolvedExtensionInput<TInputs[InputName]>>>
     : false extends TInputs[InputName]['config']['optional']
-    ? Expand<ResolvedExtensionInput<TInputs[InputName]['extensionData']>>
-    : Expand<
-        ResolvedExtensionInput<TInputs[InputName]['extensionData']> | undefined
-      >;
+    ? Expand<ResolvedExtensionInput<TInputs[InputName]>>
+    : Expand<ResolvedExtensionInput<TInputs[InputName]> | undefined>;
 };
 
 /**

--- a/packages/frontend-plugin-api/src/wiring/createExtension.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.ts
@@ -145,6 +145,27 @@ export interface LegacyCreateExtensionOptions<
   }): Expand<ExtensionDataValues<TOutput>>;
 }
 
+/** @ignore */
+export type VerifyExtensionFactoryOutput<
+  UDeclaredOutput extends AnyExtensionDataRef,
+  UFactoryOutput extends ExtensionDataValue<any, any>,
+> = (
+  UDeclaredOutput extends any
+    ? UDeclaredOutput['config']['optional'] extends true
+      ? never
+      : UDeclaredOutput['id']
+    : never
+) extends infer IRequiredOutputIds
+  ? [IRequiredOutputIds] extends [UFactoryOutput['id']]
+    ? {}
+    : {
+        'Error: The extension factory is missing the following outputs': Exclude<
+          IRequiredOutputIds,
+          UFactoryOutput['id']
+        >;
+      }
+  : never;
+
 /** @public */
 export type CreateExtensionOptions<
   UOutput extends AnyExtensionDataRef,
@@ -183,22 +204,7 @@ export type CreateExtensionOptions<
           });
     inputs: Expand<ResolvedExtensionInputs<TInputs>>;
   }): Iterable<UFactoryOutput>;
-} & ((
-  UOutput extends any
-    ? UOutput['config']['optional'] extends true
-      ? never
-      : UOutput['id']
-    : never
-) extends infer IRequiredOutputIds
-  ? [IRequiredOutputIds] extends [UFactoryOutput['id']]
-    ? {}
-    : {
-        'Error: The extension factory is missing the following outputs': Exclude<
-          IRequiredOutputIds,
-          UFactoryOutput['id']
-        >;
-      }
-  : never);
+} & VerifyExtensionFactoryOutput<UOutput, UFactoryOutput>;
 
 /** @public */
 export interface ExtensionDefinition<TConfig, TConfigInput = TConfig> {

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.test.tsx
@@ -57,13 +57,7 @@ describe('createExtensionBlueprint', () => {
       name: 'my-extension',
       namespace: undefined,
       output: {
-        element: {
-          $$type: '@backstage/ExtensionDataRef',
-          config: {},
-          id: 'core.reactElement',
-          optional: expect.any(Function),
-          toString: expect.any(Function),
-        },
+        element: coreExtensionData.reactElement,
       },
       factory: expect.any(Function),
       toString: expect.any(Function),

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.test.tsx
@@ -27,13 +27,9 @@ describe('createExtensionBlueprint', () => {
     const TestExtensionBlueprint = createExtensionBlueprint({
       kind: 'test-extension',
       attachTo: { id: 'test', input: 'default' },
-      output: {
-        element: coreExtensionData.reactElement,
-      },
+      output: [coreExtensionData.reactElement],
       factory(params: { text: string }) {
-        return {
-          element: <h1>{params.text}</h1>,
-        };
+        return [coreExtensionData.reactElement(<h1>{params.text}</h1>)];
       },
     });
 
@@ -56,12 +52,10 @@ describe('createExtensionBlueprint', () => {
       kind: 'test-extension',
       name: 'my-extension',
       namespace: undefined,
-      output: {
-        element: coreExtensionData.reactElement,
-      },
+      output: [coreExtensionData.reactElement],
       factory: expect.any(Function),
       toString: expect.any(Function),
-      version: 'v1',
+      version: 'v2',
     });
 
     const { container } = createExtensionTester(extension).render();
@@ -72,13 +66,9 @@ describe('createExtensionBlueprint', () => {
     const TestExtensionBlueprint = createExtensionBlueprint({
       kind: 'test-extension',
       attachTo: { id: 'test', input: 'default' },
-      output: {
-        element: coreExtensionData.reactElement,
-      },
+      output: [coreExtensionData.reactElement],
       factory(params: { text: string }) {
-        return {
-          element: <h1>{params.text}</h1>,
-        };
+        return [coreExtensionData.reactElement(<h1>{params.text}</h1>)];
       },
     });
 
@@ -103,16 +93,12 @@ describe('createExtensionBlueprint', () => {
     const TestExtensionBlueprint = createExtensionBlueprint({
       kind: 'test-extension',
       attachTo: { id: 'test', input: 'default' },
-      output: {
-        element: coreExtensionData.reactElement,
-      },
+      output: [coreExtensionData.reactElement],
       dataRefs: {
         data: dataRef,
       },
       factory(params: { text: string }) {
-        return {
-          element: <h1>{params.text}</h1>,
-        };
+        return [coreExtensionData.reactElement(<h1>{params.text}</h1>)];
       },
     });
 
@@ -125,9 +111,7 @@ describe('createExtensionBlueprint', () => {
     const TestExtensionBlueprint = createExtensionBlueprint({
       kind: 'test-extension',
       attachTo: { id: 'test', input: 'default' },
-      output: {
-        element: coreExtensionData.reactElement,
-      },
+      output: [coreExtensionData.reactElement],
       config: {
         schema: {
           text: z => z.string(),
@@ -142,9 +126,7 @@ describe('createExtensionBlueprint', () => {
 
         expect(config.text).toBe('Hello, world!');
 
-        return {
-          element: <h1>{config.text}</h1>,
-        };
+        return [coreExtensionData.reactElement(<h1>{config.text}</h1>)];
       },
     });
 
@@ -188,18 +170,14 @@ describe('createExtensionBlueprint', () => {
     const TestExtensionBlueprint = createExtensionBlueprint({
       kind: 'test-extension',
       attachTo: { id: 'test', input: 'default' },
-      output: {
-        element: coreExtensionData.reactElement,
-      },
+      output: [coreExtensionData.reactElement],
       config: {
         schema: {
           text: z => z.string(),
         },
       },
       factory(params: { text: string }) {
-        return {
-          element: <div>{params.text}</div>,
-        };
+        return [coreExtensionData.reactElement(<div>{params.text}</div>)];
       },
     });
 
@@ -224,16 +202,12 @@ describe('createExtensionBlueprint', () => {
     const TestExtensionBlueprint = createExtensionBlueprint({
       kind: 'test-extension',
       attachTo: { id: 'test', input: 'default' },
-      output: {
-        element: coreExtensionData.reactElement,
-      },
+      output: [coreExtensionData.reactElement],
       factory(_, { config }) {
         // @ts-expect-error
         const b = config.something;
 
-        return {
-          element: <div />,
-        };
+        return [coreExtensionData.reactElement(<div />)];
       },
     });
 

--- a/packages/frontend-plugin-api/src/wiring/createExtensionDataRef.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionDataRef.test.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { createExtensionDataRef } from './createExtensionDataRef';
+import {
+  ExtensionDataValue,
+  createExtensionDataRef,
+} from './createExtensionDataRef';
 
 describe('createExtensionDataRef', () => {
   it('can be created and read', () => {
@@ -33,5 +36,19 @@ describe('createExtensionDataRef', () => {
     const refOptional = ref.optional();
     expect(refOptional.id).toBe('foo');
     expect(String(refOptional)).toBe('ExtensionDataRef{id=foo,optional=true}');
+  });
+
+  it('can be used to encapsulate a value', () => {
+    const ref = createExtensionDataRef<string>().with({ id: 'foo' });
+    const val: ExtensionDataValue<string, 'foo'> = ref('hello');
+    expect(val).toEqual({
+      $$type: '@backstage/ExtensionDataValue',
+      id: 'foo',
+      value: 'hello',
+    });
+    // @ts-expect-error
+    ref(3);
+    // @ts-expect-error
+    ref();
   });
 });

--- a/packages/frontend-plugin-api/src/wiring/createExtensionDataRef.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionDataRef.ts
@@ -34,6 +34,12 @@ export type ExtensionDataRef<
 };
 
 /** @public */
+export type ExtensionDataRefToValue<TDataRef extends AnyExtensionDataRef> =
+  TDataRef extends ExtensionDataRef<infer IData, infer IId, any>
+    ? ExtensionDataValue<IData, IId>
+    : never;
+
+/** @public */
 export type AnyExtensionDataRef = ExtensionDataRef<
   unknown,
   string,

--- a/packages/frontend-plugin-api/src/wiring/createExtensionDataRef.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionDataRef.ts
@@ -34,6 +34,13 @@ export type ExtensionDataRef<
 };
 
 /** @public */
+export type AnyExtensionDataRef = ExtensionDataRef<
+  unknown,
+  string,
+  { optional?: true }
+>;
+
+/** @public */
 export interface ConfigurableExtensionDataRef<
   TData,
   TId extends string,

--- a/packages/frontend-plugin-api/src/wiring/createExtensionDataRef.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionDataRef.ts
@@ -15,28 +15,36 @@
  */
 
 /** @public */
+export type ExtensionDataValue<TData, TId extends string> = {
+  readonly $$type: '@backstage/ExtensionDataValue';
+  readonly id: TId;
+  readonly value: TData;
+};
+
+/** @public */
 export type ExtensionDataRef<
   TData,
   TId extends string = string,
   TConfig extends { optional?: true } = {},
 > = {
-  id: TId;
-  T: TData;
-  config: TConfig;
-  $$type: '@backstage/ExtensionDataRef';
+  readonly $$type: '@backstage/ExtensionDataRef';
+  readonly id: TId;
+  readonly T: TData;
+  readonly config: TConfig;
 };
 
 /** @public */
 export interface ConfigurableExtensionDataRef<
-  TId extends string,
   TData,
+  TId extends string,
   TConfig extends { optional?: true } = {},
 > extends ExtensionDataRef<TData, TId, TConfig> {
   optional(): ConfigurableExtensionDataRef<
-    TId,
     TData,
+    TId,
     TData & { optional: true }
   >;
+  (t: TData): ExtensionDataValue<TData, TId>;
 }
 
 /**
@@ -45,36 +53,43 @@ export interface ConfigurableExtensionDataRef<
  */
 export function createExtensionDataRef<TData>(
   id: string,
-): ConfigurableExtensionDataRef<string, TData>;
+): ConfigurableExtensionDataRef<TData, string>;
 /** @public */
 export function createExtensionDataRef<TData>(): {
   with<TId extends string>(options: {
     id: TId;
-  }): ConfigurableExtensionDataRef<TId, TData>;
+  }): ConfigurableExtensionDataRef<TData, TId>;
 };
 export function createExtensionDataRef<TData>(id?: string):
-  | ConfigurableExtensionDataRef<string, TData>
+  | ConfigurableExtensionDataRef<TData, string>
   | {
       with<TId extends string>(options: {
         id: TId;
-      }): ConfigurableExtensionDataRef<TId, TData>;
+      }): ConfigurableExtensionDataRef<TData, TId>;
     } {
   const createRef = <TId extends string>(refId: TId) =>
-    ({
-      id: refId,
-      $$type: '@backstage/ExtensionDataRef',
-      config: {},
-      optional() {
-        return {
-          ...this,
-          config: { ...this.config, optional: true },
-        };
-      },
-      toString() {
-        const optional = Boolean(this.config.optional);
-        return `ExtensionDataRef{id=${refId},optional=${optional}}`;
-      },
-    } as ConfigurableExtensionDataRef<TId, TData, { optional?: true }>);
+    Object.assign(
+      (value: TData): ExtensionDataValue<TData, TId> => ({
+        $$type: '@backstage/ExtensionDataValue',
+        id: refId,
+        value,
+      }),
+      {
+        id: refId,
+        $$type: '@backstage/ExtensionDataRef',
+        config: {},
+        optional() {
+          return {
+            ...this,
+            config: { ...this.config, optional: true },
+          };
+        },
+        toString() {
+          const optional = Boolean(this.config.optional);
+          return `ExtensionDataRef{id=${refId},optional=${optional}}`;
+        },
+      } as ConfigurableExtensionDataRef<TData, TId, { optional?: true }>,
+    );
   if (id) {
     return createRef(id);
   }

--- a/packages/frontend-plugin-api/src/wiring/createExtensionInput.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionInput.test.ts
@@ -15,7 +15,11 @@
  */
 
 import { createExtensionDataRef } from './createExtensionDataRef';
-import { ExtensionInput, createExtensionInput } from './createExtensionInput';
+import {
+  ExtensionInput,
+  LegacyExtensionInput,
+  createExtensionInput,
+} from './createExtensionInput';
 
 const stringDataRef = createExtensionDataRef<string>().with({ id: 'str' });
 const numberDataRef = createExtensionDataRef<number>().with({ id: 'num' });
@@ -33,25 +37,21 @@ describe('createExtensionInput', () => {
 
     const x1: ExtensionInput<
       typeof stringDataRef | typeof numberDataRef,
-      never,
       { singleton: false; optional: false }
     > = input;
     // @ts-expect-error
     const x2: ExtensionInput<
       typeof stringDataRef,
-      never,
       { singleton: false; optional: false }
     > = input;
     // @ts-expect-error
     const x3: ExtensionInput<
       typeof stringDataRef | typeof numberDataRef,
-      never,
       { singleton: true; optional: false }
     > = input;
     // @ts-expect-error
     const x4: ExtensionInput<
       typeof stringDataRef | typeof numberDataRef,
-      never,
       { singleton: false; optional: true }
     > = input;
 
@@ -70,25 +70,21 @@ describe('createExtensionInput', () => {
 
     const x1: ExtensionInput<
       typeof stringDataRef | typeof numberDataRef,
-      never,
       { singleton: true; optional: false }
     > = input;
     // @ts-expect-error
     const x2: ExtensionInput<
       typeof stringDataRef,
-      never,
       { singleton: true; optional: false }
     > = input;
     // @ts-expect-error
     const x3: ExtensionInput<
       typeof stringDataRef | typeof numberDataRef,
-      never,
       { singleton: false; optional: false }
     > = input;
     // @ts-expect-error
     const x4: ExtensionInput<
       typeof stringDataRef | typeof numberDataRef,
-      never,
       { singleton: false; optional: true }
     > = input;
 
@@ -108,25 +104,21 @@ describe('createExtensionInput', () => {
 
     const x1: ExtensionInput<
       typeof stringDataRef | typeof numberDataRef,
-      never,
       { singleton: true; optional: true }
     > = input;
     // @ts-expect-error
     const x2: ExtensionInput<
       typeof stringDataRef,
-      never,
       { singleton: true; optional: true }
     > = input;
     // @ts-expect-error
     const x3: ExtensionInput<
       typeof stringDataRef | typeof numberDataRef,
-      never,
       { singleton: false; optional: false }
     > = input;
     // @ts-expect-error
     const x4: ExtensionInput<
       typeof stringDataRef | typeof numberDataRef,
-      never,
       { singleton: false; optional: true }
     > = input;
 
@@ -151,26 +143,22 @@ describe('createExtensionInput', () => {
         config: { singleton: false, optional: false },
       });
 
-      const x1: ExtensionInput<
-        never,
+      const x1: LegacyExtensionInput<
         { str: typeof stringDataRef; num: typeof numberDataRef },
         { singleton: false; optional: false }
       > = input;
       // @ts-expect-error
-      const x2: ExtensionInput<
-        never,
+      const x2: LegacyExtensionInput<
         { str: typeof numberDataRef; num: typeof stringDataRef }, // switched
         { singleton: false; optional: false }
       > = input;
       // @ts-expect-error
-      const x3: ExtensionInput<
-        never,
+      const x3: LegacyExtensionInput<
         { str: typeof stringDataRef; num: typeof numberDataRef },
         { singleton: true; optional: false }
       > = input;
       // @ts-expect-error
-      const x4: ExtensionInput<
-        never,
+      const x4: LegacyExtensionInput<
         { str: typeof stringDataRef; num: typeof numberDataRef },
         { singleton: false; optional: true }
       > = input;

--- a/packages/frontend-plugin-api/src/wiring/createExtensionInput.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionInput.test.ts
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createExtensionDataRef } from './createExtensionDataRef';
+import { ExtensionInput, createExtensionInput } from './createExtensionInput';
+
+const stringDataRef = createExtensionDataRef<string>().with({ id: 'str' });
+const numberDataRef = createExtensionDataRef<number>().with({ id: 'num' });
+
+function unused(..._any: any[]) {}
+
+describe('createExtensionInput', () => {
+  it('should create a regular input', () => {
+    const input = createExtensionInput([stringDataRef, numberDataRef]);
+    expect(input).toEqual({
+      $$type: '@backstage/ExtensionInput',
+      extensionData: [stringDataRef, numberDataRef],
+      config: { singleton: false, optional: false },
+    });
+
+    const x1: ExtensionInput<
+      typeof stringDataRef | typeof numberDataRef,
+      never,
+      { singleton: false; optional: false }
+    > = input;
+    // @ts-expect-error
+    const x2: ExtensionInput<
+      typeof stringDataRef,
+      never,
+      { singleton: false; optional: false }
+    > = input;
+    // @ts-expect-error
+    const x3: ExtensionInput<
+      typeof stringDataRef | typeof numberDataRef,
+      never,
+      { singleton: true; optional: false }
+    > = input;
+    // @ts-expect-error
+    const x4: ExtensionInput<
+      typeof stringDataRef | typeof numberDataRef,
+      never,
+      { singleton: false; optional: true }
+    > = input;
+
+    unused(x1, x2, x3, x4);
+  });
+
+  it('should create a singleton input', () => {
+    const input = createExtensionInput([stringDataRef, numberDataRef], {
+      singleton: true,
+    });
+    expect(input).toEqual({
+      $$type: '@backstage/ExtensionInput',
+      extensionData: [stringDataRef, numberDataRef],
+      config: { singleton: true, optional: false },
+    });
+
+    const x1: ExtensionInput<
+      typeof stringDataRef | typeof numberDataRef,
+      never,
+      { singleton: true; optional: false }
+    > = input;
+    // @ts-expect-error
+    const x2: ExtensionInput<
+      typeof stringDataRef,
+      never,
+      { singleton: true; optional: false }
+    > = input;
+    // @ts-expect-error
+    const x3: ExtensionInput<
+      typeof stringDataRef | typeof numberDataRef,
+      never,
+      { singleton: false; optional: false }
+    > = input;
+    // @ts-expect-error
+    const x4: ExtensionInput<
+      typeof stringDataRef | typeof numberDataRef,
+      never,
+      { singleton: false; optional: true }
+    > = input;
+
+    unused(x1, x2, x3, x4);
+  });
+
+  it('should create an optional singleton input', () => {
+    const input = createExtensionInput([stringDataRef, numberDataRef], {
+      singleton: true,
+      optional: true,
+    });
+    expect(input).toEqual({
+      $$type: '@backstage/ExtensionInput',
+      extensionData: [stringDataRef, numberDataRef],
+      config: { singleton: true, optional: true },
+    });
+
+    const x1: ExtensionInput<
+      typeof stringDataRef | typeof numberDataRef,
+      never,
+      { singleton: true; optional: true }
+    > = input;
+    // @ts-expect-error
+    const x2: ExtensionInput<
+      typeof stringDataRef,
+      never,
+      { singleton: true; optional: true }
+    > = input;
+    // @ts-expect-error
+    const x3: ExtensionInput<
+      typeof stringDataRef | typeof numberDataRef,
+      never,
+      { singleton: false; optional: false }
+    > = input;
+    // @ts-expect-error
+    const x4: ExtensionInput<
+      typeof stringDataRef | typeof numberDataRef,
+      never,
+      { singleton: false; optional: true }
+    > = input;
+
+    unused(x1, x2, x3, x4);
+  });
+
+  it('should not allow duplicate data refs', () => {
+    expect(() =>
+      createExtensionInput([stringDataRef, stringDataRef], { singleton: true }),
+    ).toThrow("ExtensionInput may not have duplicate data refs: 'str'");
+  });
+
+  describe('old api', () => {
+    it('should create a regular input', () => {
+      const input = createExtensionInput({
+        str: stringDataRef,
+        num: numberDataRef,
+      });
+      expect(input).toEqual({
+        $$type: '@backstage/ExtensionInput',
+        extensionData: { str: stringDataRef, num: numberDataRef },
+        config: { singleton: false, optional: false },
+      });
+
+      const x1: ExtensionInput<
+        never,
+        { str: typeof stringDataRef; num: typeof numberDataRef },
+        { singleton: false; optional: false }
+      > = input;
+      // @ts-expect-error
+      const x2: ExtensionInput<
+        never,
+        { str: typeof numberDataRef; num: typeof stringDataRef }, // switched
+        { singleton: false; optional: false }
+      > = input;
+      // @ts-expect-error
+      const x3: ExtensionInput<
+        never,
+        { str: typeof stringDataRef; num: typeof numberDataRef },
+        { singleton: true; optional: false }
+      > = input;
+      // @ts-expect-error
+      const x4: ExtensionInput<
+        never,
+        { str: typeof stringDataRef; num: typeof numberDataRef },
+        { singleton: false; optional: true }
+      > = input;
+
+      unused(x1, x2, x3, x4);
+    });
+  });
+});

--- a/packages/frontend-plugin-api/src/wiring/createExtensionInput.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionInput.ts
@@ -20,11 +20,23 @@ import { ExtensionDataRef } from './createExtensionDataRef';
 /** @public */
 export interface ExtensionInput<
   TExtensionData extends ExtensionDataRef<unknown, string, { optional?: true }>,
+  TConfig extends { singleton: boolean; optional: boolean },
+> {
+  $$type: '@backstage/ExtensionInput';
+  extensionData: TExtensionData;
+  config: TConfig;
+}
+
+/**
+ * @public
+ * @deprecated This type will be removed. Use `ExtensionInput` instead.
+ */
+export interface LegacyExtensionInput<
   TExtensionDataMap extends AnyExtensionDataMap,
   TConfig extends { singleton: boolean; optional: boolean },
 > {
   $$type: '@backstage/ExtensionInput';
-  extensionData: TExtensionData | TExtensionDataMap;
+  extensionData: TExtensionDataMap;
   config: TConfig;
 }
 
@@ -38,8 +50,7 @@ export function createExtensionInput<
 >(
   extensionData: TExtensionDataMap,
   config?: TConfig,
-): ExtensionInput<
-  never,
+): LegacyExtensionInput<
   TExtensionDataMap,
   {
     singleton: TConfig['singleton'] extends true ? true : false;
@@ -55,7 +66,6 @@ export function createExtensionInput<
   config?: TConfig,
 ): ExtensionInput<
   UExtensionData,
-  never,
   {
     singleton: TConfig['singleton'] extends true ? true : false;
     optional: TConfig['optional'] extends true ? true : false;
@@ -68,14 +78,21 @@ export function createExtensionInput<
 >(
   extensionData: TExtensionData,
   config?: TConfig,
-): ExtensionInput<
-  TExtensionData,
-  TExtensionDataMap,
-  {
-    singleton: TConfig['singleton'] extends true ? true : false;
-    optional: TConfig['optional'] extends true ? true : false;
-  }
-> {
+):
+  | LegacyExtensionInput<
+      TExtensionDataMap,
+      {
+        singleton: TConfig['singleton'] extends true ? true : false;
+        optional: TConfig['optional'] extends true ? true : false;
+      }
+    >
+  | ExtensionInput<
+      TExtensionData,
+      {
+        singleton: TConfig['singleton'] extends true ? true : false;
+        optional: TConfig['optional'] extends true ? true : false;
+      }
+    > {
   if (Array.isArray(extensionData)) {
     const seen = new Set();
     const duplicates = [];

--- a/packages/frontend-plugin-api/src/wiring/index.ts
+++ b/packages/frontend-plugin-api/src/wiring/index.ts
@@ -23,6 +23,7 @@ export {
   type ExtensionDataValues,
   type ResolvedExtensionInput,
   type ResolvedExtensionInputs,
+  type LegacyCreateExtensionOptions,
   type AnyExtensionInputMap,
   type AnyExtensionDataMap,
 } from './createExtension';

--- a/packages/frontend-plugin-api/src/wiring/index.ts
+++ b/packages/frontend-plugin-api/src/wiring/index.ts
@@ -36,6 +36,7 @@ export {
   createExtensionDataRef,
   type AnyExtensionDataRef,
   type ExtensionDataRef,
+  type ExtensionDataRefToValue,
   type ExtensionDataValue,
   type ConfigurableExtensionDataRef,
 } from './createExtensionDataRef';

--- a/packages/frontend-plugin-api/src/wiring/index.ts
+++ b/packages/frontend-plugin-api/src/wiring/index.ts
@@ -17,6 +17,7 @@
 export { coreExtensionData } from './coreExtensionData';
 export {
   createExtension,
+  type ExtensionDataContainer,
   type ExtensionDefinition,
   type CreateExtensionOptions,
   type ExtensionDataValues,
@@ -28,10 +29,13 @@ export {
 export {
   createExtensionInput,
   type ExtensionInput,
+  type LegacyExtensionInput,
 } from './createExtensionInput';
 export {
   createExtensionDataRef,
+  type AnyExtensionDataRef,
   type ExtensionDataRef,
+  type ExtensionDataValue,
   type ConfigurableExtensionDataRef,
 } from './createExtensionDataRef';
 export { createPlugin, type PluginOptions } from './createPlugin';

--- a/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.test.ts
@@ -17,14 +17,54 @@
 import { ExtensionDefinition } from './createExtension';
 import { resolveExtensionDefinition } from './resolveExtensionDefinition';
 
-const baseDef = {
-  $$type: '@backstage/ExtensionDefinition',
-  version: 'v1',
-  attachTo: { id: '', input: '' },
-  disabled: false,
-};
-
 describe('resolveExtensionDefinition', () => {
+  const baseDef = {
+    $$type: '@backstage/ExtensionDefinition',
+    version: 'v2',
+    attachTo: { id: '', input: '' },
+    disabled: false,
+  };
+
+  it.each([
+    [{ namespace: 'ns' }, 'ns'],
+    [{ namespace: 'n' }, 'n'],
+    [{ namespace: 'ns', name: 'n' }, 'ns/n'],
+    [{ kind: 'k', namespace: 'ns' }, 'k:ns'],
+    [{ kind: 'k', namespace: 'ns', name: 'n' }, 'k:ns/n'],
+  ])(`should resolve extension IDs %s`, (definition, expected) => {
+    const resolved = resolveExtensionDefinition({
+      ...baseDef,
+      ...definition,
+    } as ExtensionDefinition<unknown>);
+    expect(resolved.id).toBe(expected);
+    expect(String(resolved)).toBe(`Extension{id=${expected}}`);
+  });
+
+  it('should fail to resolve extension ID without namespace', () => {
+    expect(() =>
+      resolveExtensionDefinition({
+        ...baseDef,
+        kind: 'k',
+      } as ExtensionDefinition<unknown>),
+    ).toThrow(
+      'Extension must declare an explicit namespace or name as it could not be resolved from context, kind=k namespace=undefined name=undefined',
+    );
+    expect(() =>
+      resolveExtensionDefinition(baseDef as ExtensionDefinition<unknown>),
+    ).toThrow(
+      'Extension must declare an explicit namespace or name as it could not be resolved from context, kind=undefined namespace=undefined name=undefined',
+    );
+  });
+});
+
+describe('old resolveExtensionDefinition', () => {
+  const baseDef = {
+    $$type: '@backstage/ExtensionDefinition',
+    version: 'v1',
+    attachTo: { id: '', input: '' },
+    disabled: false,
+  };
+
   it.each([
     [{ namespace: 'ns' }, 'ns'],
     [{ namespace: 'n' }, 'n'],

--- a/plugins/catalog-react/api-report-alpha.md
+++ b/plugins/catalog-react/api-report-alpha.md
@@ -18,18 +18,18 @@ import { TranslationRef } from '@backstage/core-plugin-api/alpha';
 // @alpha (undocumented)
 export const catalogExtensionData: {
   entityContentTitle: ConfigurableExtensionDataRef<
-    'catalog.entity-content-title',
     string,
+    'catalog.entity-content-title',
     {}
   >;
   entityFilterFunction: ConfigurableExtensionDataRef<
-    'catalog.entity-filter-function',
     (entity: Entity) => boolean,
+    'catalog.entity-filter-function',
     {}
   >;
   entityFilterExpression: ConfigurableExtensionDataRef<
-    'catalog.entity-filter-expression',
     string,
+    'catalog.entity-filter-expression',
     {}
   >;
 };

--- a/plugins/home/api-report-alpha.md
+++ b/plugins/home/api-report-alpha.md
@@ -12,8 +12,8 @@ export default _default;
 
 // @alpha (undocumented)
 export const titleExtensionDataRef: ConfigurableExtensionDataRef<
-  'title',
   string,
+  'title',
   {}
 >;
 

--- a/plugins/search-react/api-report-alpha.md
+++ b/plugins/search-react/api-report-alpha.md
@@ -31,11 +31,11 @@ export function createSearchResultListItemExtension<
 export namespace createSearchResultListItemExtension {
   const // (undocumented)
     itemDataRef: ConfigurableExtensionDataRef<
-      'search.search-result-list-item.item',
       {
         predicate?: SearchResultItemExtensionPredicate | undefined;
         component: SearchResultItemExtensionComponent;
       },
+      'search.search-result-list-item.item',
       {}
     >;
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

We've been considering this refactor for a good while, and what made us take a stab at it was that it'll be very messy to implement #25210 unless we're able to encapsulate input and outputs in a way that is agnostic to the extension implementation.

Still WIP

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
