### PR TITLE
permissions: move `MetadataResponseSerializedRule` to common package

### DIFF
--- a/.changeset/nine-seahorses-relate.md
+++ b/.changeset/nine-seahorses-relate.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-permission-common': patch
+---
+
+Add the MetadataResponseSerializedRule type from @backstage/plugin-permission-node, since this type might be used in frontend code.

--- a/.changeset/olive-books-sort.md
+++ b/.changeset/olive-books-sort.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-permission-node': patch
+---
+
+The MetadataResponseSerializedRule type has been moved to @backstage/plugin-permission-common, and should be imported from there going forward. To avoid an immediate breaking change, this type is still re-exported from this package, but is marked as deprecated and will be removed in a future release.

--- a/plugins/permission-common/api-report.md
+++ b/plugins/permission-common/api-report.md
@@ -5,6 +5,7 @@
 ```ts
 import { Config } from '@backstage/config';
 import { JsonPrimitive } from '@backstage/types';
+import zodToJsonSchema from 'zod-to-json-schema';
 
 // @public
 export type AllOfCriteria<TQuery> = {
@@ -124,6 +125,14 @@ export function isResourcePermission<T extends string = string>(
 
 // @public
 export function isUpdatePermission(permission: Permission): boolean;
+
+// @public
+export type MetadataResponseSerializedRule = {
+  name: string;
+  description: string;
+  resourceType: string;
+  paramsSchema?: ReturnType<typeof zodToJsonSchema>;
+};
 
 // @public
 export type NotCriteria<TQuery> = {

--- a/plugins/permission-common/package.json
+++ b/plugins/permission-common/package.json
@@ -53,7 +53,8 @@
     "@backstage/types": "workspace:^",
     "cross-fetch": "^4.0.0",
     "uuid": "^9.0.0",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "zod-to-json-schema": "^3.20.4"
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",

--- a/plugins/permission-common/src/types/index.ts
+++ b/plugins/permission-common/src/types/index.ts
@@ -40,6 +40,7 @@ export type {
   NotCriteria,
 } from './api';
 export type { DiscoveryApi } from './discovery';
+export type { MetadataResponseSerializedRule } from './integration';
 export type {
   BasicPermission,
   PermissionAttributes,

--- a/plugins/permission-common/src/types/integration.ts
+++ b/plugins/permission-common/src/types/integration.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import zodToJsonSchema from 'zod-to-json-schema';
+
+/**
+ * Serialized permission rules, with the paramsSchema
+ * converted from a ZodSchema to a JsonSchema.
+ *
+ * @public
+ */
+export type MetadataResponseSerializedRule = {
+  name: string;
+  description: string;
+  resourceType: string;
+  paramsSchema?: ReturnType<typeof zodToJsonSchema>;
+};

--- a/plugins/permission-node/api-report.md
+++ b/plugins/permission-node/api-report.md
@@ -17,6 +17,7 @@ import { DefinitivePolicyDecision } from '@backstage/plugin-permission-common';
 import { DiscoveryService } from '@backstage/backend-plugin-api';
 import express from 'express';
 import { IdentifiedPermissionMessage } from '@backstage/plugin-permission-common';
+import { MetadataResponseSerializedRule as MetadataResponseSerializedRule_2 } from '@backstage/plugin-permission-common';
 import { NotCriteria } from '@backstage/plugin-permission-common';
 import { Permission } from '@backstage/plugin-permission-common';
 import { PermissionCondition } from '@backstage/plugin-permission-common';
@@ -29,7 +30,6 @@ import { QueryPermissionRequest } from '@backstage/plugin-permission-common';
 import { ResourcePermission } from '@backstage/plugin-permission-common';
 import { TokenManagerService } from '@backstage/backend-plugin-api';
 import { z } from 'zod';
-import zodToJsonSchema from 'zod-to-json-schema';
 
 // @public
 export type ApplyConditionsRequest = {
@@ -194,13 +194,8 @@ export type MetadataResponse = {
   rules: MetadataResponseSerializedRule[];
 };
 
-// @public
-export type MetadataResponseSerializedRule = {
-  name: string;
-  description: string;
-  resourceType: string;
-  paramsSchema?: ReturnType<typeof zodToJsonSchema>;
-};
+// @public @deprecated
+export type MetadataResponseSerializedRule = MetadataResponseSerializedRule_2;
 
 // @public
 export type PermissionIntegrationRouterOptions<

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
@@ -24,6 +24,7 @@ import {
   AuthorizeResult,
   DefinitivePolicyDecision,
   IdentifiedPermissionMessage,
+  MetadataResponseSerializedRule as CommonMetadataResponseSerializedRule,
   Permission,
   PermissionCondition,
   PermissionCriteria,
@@ -109,13 +110,10 @@ export type ApplyConditionsResponse = {
  * converted from a ZodSchema to a JsonSchema.
  *
  * @public
+ * @deprecated Please import from `@backstage/plugin-permission-common` instead.
  */
-export type MetadataResponseSerializedRule = {
-  name: string;
-  description: string;
-  resourceType: string;
-  paramsSchema?: ReturnType<typeof zodToJsonSchema>;
-};
+export type MetadataResponseSerializedRule =
+  CommonMetadataResponseSerializedRule;
 
 /**
  * Response type for the .metadata endpoint.

--- a/yarn.lock
+++ b/yarn.lock
@@ -6723,6 +6723,7 @@ __metadata:
     msw: ^1.0.0
     uuid: ^9.0.0
     zod: ^3.22.4
+    zod-to-json-schema: ^3.20.4
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This type can be used when working with frontends that manage permissions - as such, it's helpful to provide it in an isomorphic package. This PR moves the type into `permission-common`, and re-exports it (marked as deprecated) in `permission-node` from the new location.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
