### PR TITLE
catalog: Allow transforming entity namespace in UrlReaderProcessor

### DIFF
--- a/.changeset/spicy-wombats-mate.md
+++ b/.changeset/spicy-wombats-mate.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-catalog-backend': minor
+'@backstage/plugin-catalog-node': minor
+---
+
+Modify `UrlReaderProcessor` to accept a callback function for transforming an entity's namespace before being written to the catalog. expose the `replaceDefaultProcessors` method in the `CatalogProcessingExtenstionPoint`

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -361,6 +361,16 @@ export class FileReaderProcessor implements CatalogProcessor_2 {
   ): Promise<boolean>;
 }
 
+// @public
+export function getDefaultProcessors(
+  deps: Pick<CatalogEnvironment, 'logger' | 'config' | 'reader'>,
+): (
+  | CodeOwnersProcessor
+  | AnnotateLocationEntityProcessor
+  | FileReaderProcessor
+  | UrlReaderProcessor
+)[];
+
 // @public @deprecated (undocumented)
 export type LocationAnalyzer = LocationAnalyzer_2;
 
@@ -390,6 +400,11 @@ export const locationSpecToLocationEntity: typeof locationSpecToLocationEntity_2
 
 // @public @deprecated (undocumented)
 export const locationSpecToMetadataName: typeof locationSpecToMetadataName_2;
+
+// @public (undocumented)
+export type NamespaceTransformer = (
+  processingResult: CatalogProcessorEntityResult_2,
+) => string;
 
 // @public (undocumented)
 export function parseEntityYaml(
@@ -465,9 +480,15 @@ export function transformLegacyPolicyToProcessor(
 
 // @public (undocumented)
 export class UrlReaderProcessor implements CatalogProcessor_2 {
-  constructor(options: { reader: UrlReader; logger: LoggerService });
+  constructor(options: {
+    reader: UrlReader;
+    logger: LoggerService;
+    namespaceTransformer?: NamespaceTransformer;
+  });
   // (undocumented)
   getProcessorName(): string;
+  // (undocumented)
+  namespaceTransformer: NamespaceTransformer;
   // (undocumented)
   readLocation(
     location: LocationSpec_2,

--- a/plugins/catalog-backend/src/modules/core/index.ts
+++ b/plugins/catalog-backend/src/modules/core/index.ts
@@ -23,5 +23,6 @@ export type { LocationEntityProcessorOptions } from './LocationEntityProcessor';
 export { PlaceholderProcessor } from './PlaceholderProcessor';
 export type { PlaceholderProcessorOptions } from './PlaceholderProcessor';
 export { UrlReaderProcessor } from './UrlReaderProcessor';
+export type { NamespaceTransformer } from './UrlReaderProcessor';
 export { parseEntityYaml } from '../util/parse';
 export { transformLegacyPolicyToProcessor } from './transformLegacyPolicyToProcessor';

--- a/plugins/catalog-backend/src/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.ts
@@ -142,7 +142,7 @@ export type CatalogEnvironment = {
 * parsing, and processing entities before they are persisted in the catalog. Changing
 * the order of processing can give more control to custom processors.
  */
-export function defaultProcessors(
+export function getDefaultProcessors(
   deps: Pick<CatalogEnvironment, 'logger' | 'config' | 'reader'>,
 ) {
   const { config, logger, reader } = deps;
@@ -384,7 +384,7 @@ export class CatalogBuilder {
    *
    */
   getDefaultProcessors(): CatalogProcessor[] {
-    return defaultProcessors(this.env);
+    return getDefaultProcessors(this.env);
   }
 
   /**

--- a/plugins/catalog-backend/src/service/index.ts
+++ b/plugins/catalog-backend/src/service/index.ts
@@ -18,4 +18,4 @@ export type {
   CatalogEnvironment,
   CatalogPermissionRuleInput,
 } from './CatalogBuilder';
-export { CatalogBuilder, defaultProcessors } from './CatalogBuilder';
+export { CatalogBuilder, getDefaultProcessors } from './CatalogBuilder';

--- a/plugins/catalog-backend/src/service/index.ts
+++ b/plugins/catalog-backend/src/service/index.ts
@@ -18,4 +18,4 @@ export type {
   CatalogEnvironment,
   CatalogPermissionRuleInput,
 } from './CatalogBuilder';
-export { CatalogBuilder } from './CatalogBuilder';
+export { CatalogBuilder, defaultProcessors } from './CatalogBuilder';

--- a/plugins/catalog-node/api-report-alpha.md
+++ b/plugins/catalog-node/api-report-alpha.md
@@ -83,6 +83,7 @@ export interface CatalogProcessingExtensionPoint {
   addProcessor(
     ...processors: Array<CatalogProcessor | Array<CatalogProcessor>>
   ): void;
+  replaceDefaultProcessors(processors: CatalogProcessor[]): void;
   // (undocumented)
   setOnProcessingErrorHandler(
     handler: (event: {

--- a/plugins/catalog-node/src/extensions.ts
+++ b/plugins/catalog-node/src/extensions.ts
@@ -54,6 +54,16 @@ export const catalogLocationsExtensionPoint =
  * @alpha
  */
 export interface CatalogProcessingExtensionPoint {
+  /**
+   * Sets what entity processors to use. These are responsible for reading,
+   * parsing, and processing entities before they are persisted in the catalog.
+   *
+   * This function replaces the default set of processors, consider using with
+   * {@link CatalogBuilder#getDefaultProcessors}; use with care.
+   *
+   * @param processors - One or more processors
+   */
+  replaceDefaultProcessors(processors: CatalogProcessor[]): void;
   addProcessor(
     ...processors: Array<CatalogProcessor | Array<CatalogProcessor>>
   ): void;

--- a/plugins/catalog-node/src/extensions.ts
+++ b/plugins/catalog-node/src/extensions.ts
@@ -55,9 +55,6 @@ export const catalogLocationsExtensionPoint =
  */
 export interface CatalogProcessingExtensionPoint {
   /**
-   * Sets what entity processors to use. These are responsible for reading,
-   * parsing, and processing entities before they are persisted in the catalog.
-   *
    * This function replaces the default set of processors, consider using with
    * {@link CatalogBuilder#getDefaultProcessors}; use with care.
    *


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR modifies the configuration for `UrlReaderProcessor` and defines a new method on the `CatalogProcessingExtensionPoint`.  It allows an operator to define a mapping function for modifying an entity's `namespace` before it is written to the entity database.

### Sample Usecase
Your company has acquired another company (hooray!).  This company has a github org you'd like to add to backstage.  However, several repositories between the organizations have the exact same name.  This will result in the `conflictingEntityRef` message if `orgA/Repo` and `orgB/Repo` are both added to the `default` namespace.  This PR aims to solve that


### Example usage
```ts
import {
  coreServices,
  createBackendModule,
} from '@backstage/backend-plugin-api';
import {
  catalogProcessingExtensionPoint,
} from '@backstage/plugin-catalog-node/alpha';
import { getDefaultProcessors, NamespaceTransformer, UrlReaderProcessor } from '@backstage/plugin-catalog-backend';
import { parseGithubOrgUrl } from '../lib';

export const exampleCatalogModule = createBackendModule({
  pluginId: 'catalog',
  moduleId: 'example',
  register(env) {
    env.registerInit({
      deps: {
        catalog: catalogProcessingExtensionPoint,
        config: coreServices.rootConfig,
        logger: coreServices.logger,
        reader: coreServices.urlReader,
      },
      async init({
        catalog,
        config,
        logger,
        reader,
      }) {
        const namespaceTransformer: NamespaceTransformer = result => parseGithubOrgUrl(result.location.target).org;
        const customUrlReader = new UrlReaderProcessor({logger, reader, namespaceTransformer});  
        const defaultProcessors = getDefaultProcessors({ logger, config, reader })
          .map(p => {
            if (p.getProcessorName() === customUrlReader.getProcessorName()) {
              return customUrlReader;
            }
            return p
          })

        catalog.replaceDefaultProcessors(defaultProcessors);
      },
    });
  },
});
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] (N/A) Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
