### PR TITLE
feat: add status filtering and pagination support for scaffolder

### DIFF
--- a/.changeset/chatty-colts-search.md
+++ b/.changeset/chatty-colts-search.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+'@backstage/plugin-scaffolder-node': patch
+---
+
+Add status filtering and pagination support for scaffolder tasks endpoint

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -49,6 +49,8 @@ import { SerializedTaskEvent as SerializedTaskEvent_2 } from '@backstage/plugin-
 import { TaskBroker as TaskBroker_2 } from '@backstage/plugin-scaffolder-node';
 import { TaskBrokerDispatchOptions as TaskBrokerDispatchOptions_2 } from '@backstage/plugin-scaffolder-node';
 import { TaskBrokerDispatchResult as TaskBrokerDispatchResult_2 } from '@backstage/plugin-scaffolder-node';
+import { TaskBrokerListOptions } from '@backstage/plugin-scaffolder-node';
+import { TaskBrokerListResult } from '@backstage/plugin-scaffolder-node';
 import { TaskCompletionState as TaskCompletionState_2 } from '@backstage/plugin-scaffolder-node';
 import { TaskContext as TaskContext_2 } from '@backstage/plugin-scaffolder-node';
 import { TaskEventType as TaskEventType_2 } from '@backstage/plugin-scaffolder-node';
@@ -427,8 +429,16 @@ export class DatabaseTaskStore implements TaskStore {
   // (undocumented)
   heartbeatTask(taskId: string): Promise<void>;
   // (undocumented)
-  list(options: { createdBy?: string }): Promise<{
+  list(options: {
+    createdBy?: string;
+    limit?: number;
+    offset?: number;
+    orderBy?: 'created_at' | 'last_heartbeat_at' | 'status';
+    order?: 'asc' | 'desc';
+    status?: 'cancelled' | 'completed' | 'failed' | 'open' | 'processing';
+  }): Promise<{
     tasks: SerializedTask_2[];
+    total: number;
   }>;
   // (undocumented)
   listEvents(options: TaskStoreListEventsOptions): Promise<{
@@ -646,9 +656,7 @@ export interface TaskStore {
   // (undocumented)
   heartbeatTask(taskId: string): Promise<void>;
   // (undocumented)
-  list?(options: { createdBy?: string }): Promise<{
-    tasks: SerializedTask[];
-  }>;
+  list?(options: TaskBrokerListOptions): Promise<TaskBrokerListResult>;
   // (undocumented)
   listEvents(options: TaskStoreListEventsOptions): Promise<{
     events: SerializedTaskEvent[];

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.test.ts
@@ -95,6 +95,37 @@ describe('DatabaseTaskStore', () => {
     expect(tasks[0].id).toBeDefined();
   });
 
+  it('should list tasks with limit and offset', async () => {
+    const { store } = await createStore();
+
+    await store.createTask({
+      spec: {} as TaskSpec,
+      createdBy: 'me',
+    });
+
+    await store.createTask({
+      spec: {} as TaskSpec,
+      createdBy: 'him',
+    });
+
+    const { tasks, total } = await store.list({ limit: 1, offset: 0 });
+    expect(tasks.length).toBe(1);
+    expect(total).toBe(2);
+    expect(tasks[0].createdBy).toBe('me');
+    expect(tasks[0].status).toBe('open');
+    expect(tasks[0].id).toBeDefined();
+
+    const { tasks: tasks2, total: total2 } = await store.list({
+      limit: 1,
+      offset: 1,
+    });
+    expect(tasks2.length).toBe(1);
+    expect(total2).toBe(2);
+    expect(tasks2[0].createdBy).toBe('him');
+    expect(tasks2[0].status).toBe('open');
+    expect(tasks2[0].id).toBeDefined();
+  });
+
   it('should sent an event to start cancelling the task', async () => {
     const { store } = await createStore();
 

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/StorageTaskBroker.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/StorageTaskBroker.test.ts
@@ -21,8 +21,8 @@ import {
 import { ConfigReader } from '@backstage/config';
 import { TaskSpec } from '@backstage/plugin-scaffolder-common';
 import {
-  TaskSecrets,
   SerializedTaskEvent,
+  TaskSecrets,
 } from '@backstage/plugin-scaffolder-node';
 import { DatabaseTaskStore } from './DatabaseTaskStore';
 import { StorageTaskBroker, TaskManager } from './StorageTaskBroker';
@@ -231,6 +231,7 @@ describe('StorageTaskBroker', () => {
           id: taskId,
         }),
       ]),
+      total: 13,
     });
   });
 
@@ -244,7 +245,22 @@ describe('StorageTaskBroker', () => {
     const task = await storage.getTask(taskId);
 
     const promise = broker.list({ createdBy: 'user:default/foo' });
-    await expect(promise).resolves.toEqual({ tasks: [task] });
+    await expect(promise).resolves.toEqual({ tasks: [task], total: 1 });
+  });
+
+  it('should list tasks with limit and offset', async () => {
+    const broker = new StorageTaskBroker(storage, logger);
+    const { taskId } = await broker.dispatch(emptyTaskSpec);
+
+    const promise = broker.list({ limit: 100, offset: 10 });
+    await expect(promise).resolves.toEqual({
+      tasks: expect.arrayContaining([
+        expect.objectContaining({
+          id: taskId,
+        }),
+      ]),
+      total: 15,
+    });
   });
 
   it('should handle checkpoints in task state', async () => {

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/StorageTaskBroker.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/StorageTaskBroker.ts
@@ -20,13 +20,15 @@ import { JsonObject, JsonValue, Observable } from '@backstage/types';
 import { Logger } from 'winston';
 import ObservableImpl from 'zen-observable';
 import {
-  TaskSecrets,
   SerializedTask,
   SerializedTaskEvent,
   TaskBroker,
   TaskBrokerDispatchOptions,
+  TaskBrokerListOptions,
+  TaskBrokerListResult,
   TaskCompletionState,
   TaskContext,
+  TaskSecrets,
 } from '@backstage/plugin-scaffolder-node';
 import { InternalTaskSecrets, TaskStore } from './types';
 import { readDuration } from './helper';
@@ -277,15 +279,13 @@ export class StorageTaskBroker implements TaskBroker {
     >,
   ) {}
 
-  async list(options?: {
-    createdBy?: string;
-  }): Promise<{ tasks: SerializedTask[] }> {
+  async list(options?: TaskBrokerListOptions): Promise<TaskBrokerListResult> {
     if (!this.storage.list) {
       throw new Error(
         'TaskStore does not implement the list method. Please implement the list method to be able to list tasks',
       );
     }
-    return await this.storage.list({ createdBy: options?.createdBy });
+    return await this.storage.list(options ?? {});
   }
 
   private deferredDispatch = defer();

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/types.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/types.ts
@@ -14,20 +14,22 @@
  * limitations under the License.
  */
 
-import { JsonValue, JsonObject, HumanDuration } from '@backstage/types';
+import { HumanDuration, JsonObject, JsonValue } from '@backstage/types';
 import { TaskSpec, TaskStep } from '@backstage/plugin-scaffolder-common';
-import { TaskSecrets } from '@backstage/plugin-scaffolder-node';
 import {
-  TemplateAction,
-  TaskStatus as _TaskStatus,
-  TaskCompletionState as _TaskCompletionState,
   SerializedTask as _SerializedTask,
-  TaskEventType as _TaskEventType,
   SerializedTaskEvent as _SerializedTaskEvent,
-  TaskBrokerDispatchResult as _TaskBrokerDispatchResult,
-  TaskBrokerDispatchOptions as _TaskBrokerDispatchOptions,
-  TaskContext as _TaskContext,
   TaskBroker as _TaskBroker,
+  TaskBrokerDispatchOptions as _TaskBrokerDispatchOptions,
+  TaskBrokerDispatchResult as _TaskBrokerDispatchResult,
+  TaskBrokerListOptions,
+  TaskBrokerListResult,
+  TaskCompletionState as _TaskCompletionState,
+  TaskContext as _TaskContext,
+  TaskEventType as _TaskEventType,
+  TaskSecrets,
+  TaskStatus as _TaskStatus,
+  TemplateAction,
 } from '@backstage/plugin-scaffolder-node';
 
 /**
@@ -190,7 +192,7 @@ export interface TaskStore {
     tasks: { taskId: string }[];
   }>;
 
-  list?(options: { createdBy?: string }): Promise<{ tasks: SerializedTask[] }>;
+  list?(options: TaskBrokerListOptions): Promise<TaskBrokerListResult>;
 
   emitLogEvent(options: TaskStoreEmitOptions): Promise<void>;
 

--- a/plugins/scaffolder-backend/src/service/router.test.ts
+++ b/plugins/scaffolder-backend/src/service/router.test.ts
@@ -396,6 +396,7 @@ describe('createRouter', () => {
               createdBy: '',
             },
           ],
+          total: 1,
         });
 
         const response = await request(app).get(`/v2/tasks`);
@@ -413,6 +414,7 @@ describe('createRouter', () => {
               createdBy: '',
             },
           ],
+          total: 1,
         });
       });
 
@@ -429,13 +431,18 @@ describe('createRouter', () => {
               createdBy: 'user:default/foo',
             },
           ],
+          total: 1,
         });
 
         const response = await request(app).get(
-          `/v2/tasks?createdBy=user:default/foo`,
+          `/v2/tasks?createdBy=user:default/foo&limit=1&offset=0&order=asc&orderBy=status`,
         );
         expect(taskBroker.list).toHaveBeenCalledWith({
           createdBy: 'user:default/foo',
+          limit: 1,
+          offset: 0,
+          order: 'asc',
+          orderBy: 'status',
         });
 
         expect(response.status).toEqual(200);
@@ -449,7 +456,28 @@ describe('createRouter', () => {
               createdBy: 'user:default/foo',
             },
           ],
+          total: 1,
         });
+      });
+
+      it('should throw an error on invalid limit', async () => {
+        const response = await request(app).get(`/v2/tasks?limit=0`);
+        expect(response.status).toEqual(500);
+      });
+
+      it('should throw an error on invalid offset', async () => {
+        const response = await request(app).get(`/v2/tasks?offset=invalid`);
+        expect(response.status).toEqual(500);
+      });
+
+      it('should throw an error on invalid orderBy', async () => {
+        const response = await request(app).get(`/v2/tasks?orderBy=0`);
+        expect(response.status).toEqual(500);
+      });
+
+      it('should throw an error on invalid order', async () => {
+        const response = await request(app).get(`/v2/tasks?order=0`);
+        expect(response.status).toEqual(500);
       });
     });
 
@@ -1194,6 +1222,7 @@ data: {"id":1,"taskId":"a-random-id","type":"completion","createdAt":"","body":{
               createdBy: '',
             },
           ],
+          total: 1,
         });
 
         const response = await request(app).get(`/v2/tasks`);
@@ -1211,6 +1240,7 @@ data: {"id":1,"taskId":"a-random-id","type":"completion","createdAt":"","body":{
               createdBy: '',
             },
           ],
+          total: 1,
         });
       });
 
@@ -1227,6 +1257,7 @@ data: {"id":1,"taskId":"a-random-id","type":"completion","createdAt":"","body":{
               createdBy: 'user:default/foo',
             },
           ],
+          total: 1,
         });
 
         const response = await request(app).get(
@@ -1247,6 +1278,7 @@ data: {"id":1,"taskId":"a-random-id","type":"completion","createdAt":"","body":{
               createdBy: 'user:default/foo',
             },
           ],
+          total: 1,
         });
       });
     });

--- a/plugins/scaffolder-node/api-report.md
+++ b/plugins/scaffolder-node/api-report.md
@@ -315,9 +315,7 @@ export interface TaskBroker {
   // (undocumented)
   get(taskId: string): Promise<SerializedTask>;
   // (undocumented)
-  list?(options?: { createdBy?: string }): Promise<{
-    tasks: SerializedTask[];
-  }>;
+  list?(options?: TaskBrokerListOptions): Promise<TaskBrokerListResult>;
   // (undocumented)
   recoverTasks?(): Promise<void>;
   // (undocumented)
@@ -334,6 +332,22 @@ export type TaskBrokerDispatchOptions = {
 // @public
 export type TaskBrokerDispatchResult = {
   taskId: string;
+};
+
+// @public
+export type TaskBrokerListOptions = {
+  createdBy?: string;
+  status?: TaskStatus;
+  limit?: number;
+  offset?: number;
+  orderBy?: 'created_at' | 'last_heartbeat_at' | 'status';
+  order?: 'asc' | 'desc';
+};
+
+// @public
+export type TaskBrokerListResult = {
+  tasks: SerializedTask[];
+  total: number;
 };
 
 // @public

--- a/plugins/scaffolder-node/src/tasks/index.ts
+++ b/plugins/scaffolder-node/src/tasks/index.ts
@@ -21,6 +21,8 @@ export type {
   TaskBroker,
   TaskBrokerDispatchOptions,
   TaskBrokerDispatchResult,
+  TaskBrokerListOptions,
+  TaskBrokerListResult,
   TaskCompletionState,
   TaskContext,
   TaskEventType,

--- a/plugins/scaffolder-node/src/tasks/types.ts
+++ b/plugins/scaffolder-node/src/tasks/types.ts
@@ -104,6 +104,27 @@ export type TaskBrokerDispatchOptions = {
 };
 
 /**
+ * The options passed to {@link TaskBroker.list}
+ *
+ * @public
+ */
+export type TaskBrokerListOptions = {
+  createdBy?: string;
+  status?: TaskStatus;
+  limit?: number;
+  offset?: number;
+  orderBy?: 'created_at' | 'last_heartbeat_at' | 'status';
+  order?: 'asc' | 'desc';
+};
+
+/**
+ * The result of {@link TaskBroker.list}
+ *
+ * @public
+ */
+export type TaskBrokerListResult = { tasks: SerializedTask[]; total: number };
+
+/**
  * Task
  *
  * @public
@@ -180,5 +201,5 @@ export interface TaskBroker {
 
   get(taskId: string): Promise<SerializedTask>;
 
-  list?(options?: { createdBy?: string }): Promise<{ tasks: SerializedTask[] }>;
+  list?(options?: TaskBrokerListOptions): Promise<TaskBrokerListResult>;
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds possibility to paginate and order tasks from the scaffolder tasks endpoint and additionally filter by task status

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
