### PR TITLE
Fix config loading of multiple files with new `ConfigSources`

### DIFF
--- a/.changeset/cool-schools-vanish.md
+++ b/.changeset/cool-schools-vanish.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Fixing loading of additional config files with new `ConfigSources`

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -70,7 +70,7 @@ export async function loadCliConfig(options: Options) {
       : undefined,
     watch: Boolean(options.watch),
     rootDir: paths.targetRoot,
-    argv: options.args,
+    argv: options.args.flatMap(t => ['--config', paths.resolveTarget(t)]),
   });
 
   const appConfigs = await new Promise<AppConfig[]>((resolve, reject) => {


### PR DESCRIPTION
https://github.com/backstage/backstage/commit/239dffc970b4b040ffdf9aee24f6937c4994f5ba refactored to use the new `ConfigSources.default` but I think we missed some logic that we need.

Previously it was possible to have multiple configs merged. This is no longer the case, and the config does not get parsed correctly as options to `argv`. 
