### PR TITLE
fix(search-backend-module-elasticsearch): align config.d.ts with the actual behavior

### DIFF
--- a/.changeset/big-rules-nail.md
+++ b/.changeset/big-rules-nail.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend-module-elasticsearch': patch
+---
+
+Align the configuration schema with the docs and actual behavior of the code

--- a/plugins/search-backend-module-elasticsearch/config.d.ts
+++ b/plugins/search-backend-module-elasticsearch/config.d.ts
@@ -80,165 +80,127 @@ export interface Config {
            */
           rejectUnauthorized?: boolean;
         };
-      } & (
-        | {
-            // elastic = Elastic.co ElasticSearch provider
-            provider: 'elastic';
+      };
+    } & (
+      | {
+          // elastic = Elastic.co ElasticSearch provider
+          provider: 'elastic';
 
-            /**
-             * Elastic.co CloudID
-             * See: https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/client-connecting.html#authentication
-             */
-            cloudId: string;
+          /**
+           * Elastic.co CloudID
+           * See: https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/client-connecting.html#authentication
+           */
+          cloudId: string;
 
-            auth: {
-              username: string;
-
-              /**
-               * @visibility secret
-               */
-              password: string;
-            };
-          }
-
-        /**
-         *  AWS = Amazon Elasticsearch Service provider
-         *
-         *  Authentication is handled using the default AWS credentials provider chain
-         */
-        | {
-            provider: 'aws';
-
-            /**
-             * Node configuration.
-             * URL AWS ES endpoint to connect to.
-             * Eg. https://my-es-cluster.eu-west-1.es.amazonaws.com
-             */
-            node: string;
-
-            /**
-             * The AWS region.
-             * Only needed if using a custom DNS record.
-             */
-            region?: string;
-
-            /**
-             * The AWS service used for request signature.
-             * Either 'es' for "Managed Clusters" or 'aoss' for "Serverless".
-             * Only needed if using a custom DNS record.
-             */
-            service?: 'es' | 'aoss';
-          }
-
-        /**
-         * Standard ElasticSearch
-         *
-         * Includes self-hosted clusters and others that provide direct connection via an endpoint
-         * and authentication method (see possible authentication options below)
-         */
-        | {
-            /**
-             * Node configuration.
-             * URL/URLS to ElasticSearch node to connect to.
-             * Either direct URL like 'https://localhost:9200' or with credentials like 'https://username:password@localhost:9200'
-             */
-            node: string | string[];
-
-            /**
-             * Authentication credentials for ElasticSearch
-             * If both ApiKey/Bearer token and username+password is provided, tokens take precedence
-             */
-            auth?:
-              | {
-                  username: string;
-
-                  /**
-                   * @visibility secret
-                   */
-                  password: string;
-                }
-              | {
-                  /**
-                   * Base64 Encoded API key to be used to connect to the cluster.
-                   * See: https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html
-                   *
-                   * @visibility secret
-                   */
-                  apiKey: string;
-                };
-            /* TODO(kuangp): unsupported until @elastic/elasticsearch@7.14 is released
-    | {
-
-      /**
-       * Bearer authentication token to connect to the cluster.
-       * See: https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-service-token.html
-       *
-       * @visibility secret
-       *
-      bearer: string;
-    };*/
-          }
-
-        /**
-         *  AWS = In house hosting Open Search
-         */
-        | {
-            provider: 'opensearch';
-            /**
-             * Node configuration.
-             * URL/URLS to OpenSearch node to connect to.
-             * Either direct URL like 'https://localhost:9200' or with credentials like 'https://username:password@localhost:9200'
-             */
-            node: string | string[];
-
-            /**
-             * Authentication credentials for OpenSearch
-             * If both ApiKey/Bearer token and username+password is provided, tokens take precedence
-             */
-            auth?:
-              | {
-                  username: string;
-
-                  /**
-                   * @visibility secret
-                   */
-                  password: string;
-                }
-              | {
-                  /**
-                   * @visibility secret
-                   */
-                  apiKey: string;
-                };
-          }
-      );
-
-      /**
-       * Authentication credentials for ElasticSearch. These are fallback
-       * credentials - in most cases, for known specific ES implementations, the
-       * respective auth block inside the clientOptions above will be used.
-       *
-       * If both ApiKey/Bearer token and username+password is provided, tokens
-       * take precedence
-       */
-      auth?:
-        | {
+          auth: {
             username: string;
 
             /**
              * @visibility secret
              */
             password: string;
-          }
-        | {
-            /**
-             * Base64 Encoded API key to be used to connect to the cluster.
-             * See: https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html
-             *
-             * @visibility secret
-             */
-            apiKey: string;
           };
-    };
+        }
+
+      /**
+       *  AWS = Amazon Elasticsearch Service provider
+       *
+       *  Authentication is handled using the default AWS credentials provider chain
+       */
+      | {
+          provider: 'aws';
+
+          /**
+           * Node configuration.
+           * URL AWS ES endpoint to connect to.
+           * Eg. https://my-es-cluster.eu-west-1.es.amazonaws.com
+           */
+          node: string;
+
+          /**
+           * The AWS region.
+           * Only needed if using a custom DNS record.
+           */
+          region?: string;
+
+          /**
+           * The AWS service used for request signature.
+           * Either 'es' for "Managed Clusters" or 'aoss' for "Serverless".
+           * Only needed if using a custom DNS record.
+           */
+          service?: 'es' | 'aoss';
+        }
+
+      /**
+       * Standard ElasticSearch
+       *
+       * Includes self-hosted clusters and others that provide direct connection via an endpoint
+       * and authentication method (see possible authentication options below)
+       */
+      | {
+          /**
+           * Node configuration.
+           * URL/URLS to ElasticSearch node to connect to.
+           * Either direct URL like 'https://localhost:9200' or with credentials like 'https://username:password@localhost:9200'
+           */
+          node: string | string[];
+
+          /**
+           * Authentication credentials for ElasticSearch
+           * If both ApiKey/Bearer token and username+password is provided, tokens take precedence
+           */
+          auth?:
+            | {
+                username: string;
+
+                /**
+                 * @visibility secret
+                 */
+                password: string;
+              }
+            | {
+                /**
+                 * Base64 Encoded API key to be used to connect to the cluster.
+                 * See: https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html
+                 *
+                 * @visibility secret
+                 */
+                apiKey: string;
+              };
+        }
+
+      /**
+       *  AWS = In house hosting Open Search
+       */
+      | {
+          provider: 'opensearch';
+          /**
+           * Node configuration.
+           * URL/URLS to OpenSearch node to connect to.
+           * Either direct URL like 'https://localhost:9200' or with credentials like 'https://username:password@localhost:9200'
+           */
+          node: string | string[];
+
+          /**
+           * Authentication credentials for OpenSearch
+           * If both ApiKey/Bearer token and username+password is provided, tokens take precedence
+           */
+          auth?:
+            | {
+                username: string;
+
+                /**
+                 * @visibility secret
+                 */
+                password: string;
+              }
+            | {
+                /**
+                 * @visibility secret
+                 */
+                apiKey: string;
+              };
+        }
+    );
   };
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR aligns the `config.d.ts` schema with the actual behavior of the code and the docs.

Before the schema expected something like:

```yaml
search:
  elasticsearch:
    clientOptions:
      provider: opensearch
      node: https://${OPENSEARCH_CLUSTER_URL}
      auth:
        username: ${OPENSEARCH_USERNAME_ADMIN}
        password: ${OPENSEARCH_PASSWORD_ADMIN}
      ssl:
        rejectUnauthorized: false
```

whereas the docs and the code expect:

```yaml
search:
  elasticsearch:
    provider: opensearch
    node: https://${OPENSEARCH_CLUSTER_URL}
    auth:
      username: ${OPENSEARCH_USERNAME_ADMIN}
      password: ${OPENSEARCH_PASSWORD_ADMIN}
    clientOptions:
      ssl:
        rejectUnauthorized: false
```

It seems this was introduced by mistake in https://github.com/backstage/backstage/pull/7101.

This issue was discussed in https://github.com/backstage/backstage/issues/21430 with a partial fix on the `auth`.

I've removed the `auth` section added by @freben in https://github.com/backstage/backstage/pull/23332 as it's now included by each provider option (with the correct `@visibility secret`).
Also I've removed a TODO on an unsupported feature that made reading the config a bit difficult.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] ~Added or updated documentation~
- [x] ~Tests for new functionality and regression tests for bug fixes~
- [x] ~Screenshots attached (for UI changes)~
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
