### PR TITLE
feat: add config.d.ts in tsconfig included files

### DIFF
--- a/.changeset/afraid-fans-cross.md
+++ b/.changeset/afraid-fans-cross.md
@@ -1,0 +1,8 @@
+---
+'@backstage/create-app': patch
+'@backstage/cli': patch
+---
+
+Add `config.d.ts` files to the list of included file in `tsconfig.json`.
+
+This allows ESLint to detect issues or deprecations in those files.

--- a/packages/cli/src/commands/repo/list-deprecations.ts
+++ b/packages/cli/src/commands/repo/list-deprecations.ts
@@ -17,7 +17,7 @@
 import chalk from 'chalk';
 import { ESLint } from 'eslint';
 import { OptionValues } from 'commander';
-import { join as joinPath, relative as relativePath } from 'path';
+import { relative as relativePath } from 'path';
 import { PackageGraph } from '@backstage/cli-node';
 import { paths } from '../../lib/paths';
 
@@ -45,7 +45,7 @@ export async function command(opts: OptionValues) {
 
   const deprecations = [];
   for (const [index, pkg] of packages.entries()) {
-    const results = await eslint.lintFiles(joinPath(pkg.dir, 'src'));
+    const results = await eslint.lintFiles(pkg.dir);
     for (const result of results) {
       for (const message of result.messages) {
         if (message.ruleId !== 'deprecation/deprecation') {

--- a/packages/create-app/templates/default-app/tsconfig.json
+++ b/packages/create-app/templates/default-app/tsconfig.json
@@ -2,7 +2,9 @@
   "extends": "@backstage/cli/config/tsconfig.json",
   "include": [
     "packages/*/src",
+    "packages/*/config.d.ts",
     "plugins/*/src",
+    "plugins/*/config.d.ts",
     "plugins/*/dev",
     "plugins/*/migrations"
   ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,9 @@
   "extends": "@backstage/cli/config/tsconfig.json",
   "include": [
     "packages/*/src",
+    "packages/*/config.d.ts",
     "plugins/*/src",
+    "plugins/*/config.d.ts",
     "plugins/*/dev",
     "plugins/*/migrations"
   ],


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #25058.

The `config.d.ts` patterns were not included in `tsconfig.json` and the `list-deprecations` CLI only ran on `src/` files.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] ~Added or updated documentation~
- [x] ~Tests for new functionality and regression tests for bug fixes~
- [x] ~Screenshots attached (for UI changes)~
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
