### PR TITLE
fix(techdocs-backend): update config.d.ts

### DIFF
--- a/.changeset/shaggy-mugs-return.md
+++ b/.changeset/shaggy-mugs-return.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-backend': patch
+---
+
+Update configuration schema to match actual behavior

--- a/plugins/techdocs-backend/config.d.ts
+++ b/plugins/techdocs-backend/config.d.ts
@@ -68,22 +68,14 @@ export interface Config {
     /**
      * Techdocs publisher information
      */
-    publisher?:
-      | {
-          type:
-            | 'local'
-            | 'googleGcs'
-            | 'awsS3'
-            | 'azureBlobStorage'
-            | 'openStackSwift';
-
-          local?: {
-            /**
-             * Directory to store generated static files.
-             */
-            publishDirectory?: string;
-          };
-        }
+    publisher?: {
+      local?: {
+        /**
+         * Directory to store generated static files.
+         */
+        publishDirectory?: string;
+      };
+    } & (
       | {
           type: 'awsS3';
 
@@ -132,6 +124,11 @@ export interface Config {
              * (Required) Cloud Storage Bucket Name
              */
             bucketName: string;
+            /**
+             * (Optional) Location in storage bucket to save files
+             * If not set, the default location will be the root of the storage bucket
+             */
+            bucketRootPath?: string;
             /**
              * (Optional) AWS Region.
              * If not set, AWS_REGION environment variable or aws config file will be used.
@@ -261,7 +258,8 @@ export interface Config {
              */
             projectId?: string;
           };
-        };
+        }
+    );
 
     /**
      * @example http://localhost:7007/api/techdocs


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Update the TechDocs backend `config.d.ts` to match the actual behavior and fix issues reported by the config check.

The `techdocs.publisher` config schema was wrongly declared: the type selection based on the `publisher.type` always matched the first case.

I also added `bucketRootPath` for AWS S3 and GCS since it's documented and supported, but not declared here.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] ~Added or updated documentation~
- [ ] ~Tests for new functionality and regression tests for bug fixes~
- [ ] ~Screenshots attached (for UI changes)~
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
