### PR TITLE
feat: add possibility to allow and deny specific email addresses

### DIFF
--- a/.changeset/witty-queens-run.md
+++ b/.changeset/witty-queens-run.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications-backend-module-email': patch
+---
+
+Notification email processor supports allowing or denying specific email addresses from receiving notifications

--- a/plugins/notifications-backend-module-email/config.d.ts
+++ b/plugins/notifications-backend-module-email/config.d.ts
@@ -132,6 +132,14 @@ export interface Config {
            */
           excludedTopics?: string[];
         };
+        /**
+         * White list of addresses to send email to
+         */
+        allowlistEmailAddresses?: string[];
+        /**
+         * Black list of addresses to not send email to
+         */
+        denylistEmailAddresses?: string[];
       };
     };
   };

--- a/plugins/notifications-backend-module-email/src/processor/NotificationsEmailProcessor.ts
+++ b/plugins/notifications-backend-module-email/src/processor/NotificationsEmailProcessor.ts
@@ -56,6 +56,8 @@ export class NotificationsEmailProcessor implements NotificationProcessor {
   private readonly throttleInterval: number;
   private readonly frontendBaseUrl: string;
   private readonly filter: NotificationProcessorFilters;
+  private readonly allowlistEmailAddresses?: string[];
+  private readonly denylistEmailAddresses?: string[];
 
   constructor(
     private readonly logger: LoggerService,
@@ -85,6 +87,12 @@ export class NotificationsEmailProcessor implements NotificationProcessor {
       ? durationToMilliseconds(readDurationFromConfig(cacheConfig))
       : 3_600_000;
     this.frontendBaseUrl = config.getString('app.baseUrl');
+    this.allowlistEmailAddresses = emailProcessorConfig.getOptionalStringArray(
+      'allowlistEmailAddresses',
+    );
+    this.denylistEmailAddresses = emailProcessorConfig.getOptionalStringArray(
+      'denylistEmailAddresses',
+    );
     this.filter = getProcessorFiltersFromConfig(emailProcessorConfig);
   }
 
@@ -197,10 +205,25 @@ export class NotificationsEmailProcessor implements NotificationProcessor {
     notification: Notification,
     options: NotificationSendOptions,
   ) {
+    let emails: string[];
     if (options.recipients.type === 'broadcast' || notification.user === null) {
-      return await this.getBroadcastEmails();
+      emails = await this.getBroadcastEmails();
+    } else {
+      emails = await this.getUserEmail(notification.user);
     }
-    return await this.getUserEmail(notification.user);
+
+    if (this.allowlistEmailAddresses) {
+      emails = emails.filter(email =>
+        this.allowlistEmailAddresses?.includes(email),
+      );
+    }
+
+    if (this.denylistEmailAddresses) {
+      emails = emails.filter(
+        email => !this.denylistEmailAddresses?.includes(email),
+      );
+    }
+    return emails;
   }
 
   private async sendMail(options: Mail.Options) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Notification email processor config to support allowing and denying specifinc email addresses who can receive notifications in email. This is required to be able to test this in test environments with real production data and not send unnecessary notifications.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
