### PR TITLE
feat(cli): allow setting license for new command

### DIFF
--- a/.changeset/two-emus-work.md
+++ b/.changeset/two-emus-work.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+New command now supports setting package license

--- a/packages/cli/cli-report.md
+++ b/packages/cli/cli-report.md
@@ -194,6 +194,7 @@ Options:
   --scope <scope>
   --npm-registry <URL>
   --baseVersion <version>
+  --license <license>
   --no-private
   -h, --help
 ```

--- a/packages/cli/src/commands/create-plugin/createPlugin.ts
+++ b/packages/cli/src/commands/create-plugin/createPlugin.ts
@@ -19,16 +19,16 @@ import { promisify } from 'util';
 import chalk from 'chalk';
 import inquirer, { Answers, Question } from 'inquirer';
 import { exec as execCb } from 'child_process';
-import { resolve as resolvePath, join as joinPath } from 'path';
+import { join as joinPath, resolve as resolvePath } from 'path';
 import camelCase from 'lodash/camelCase';
 import upperFirst from 'lodash/upperFirst';
 import os from 'os';
 import { OptionValues } from 'commander';
 import { assertError } from '@backstage/errors';
 import {
-  parseOwnerIds,
   addCodeownersEntry,
   getCodeownersFilePath,
+  parseOwnerIds,
 } from '../../lib/codeowners';
 import { paths } from '../../lib/paths';
 import { Task, templatingTask } from '../../lib/tasks';
@@ -266,6 +266,7 @@ export default async (opts: OptionValues) => {
   const { version: pluginVersion } = isMonoRepo
     ? await fs.readJson(paths.resolveTargetRoot('lerna.json'))
     : { version: '0.1.0' };
+  const license = opts.license ?? 'Apache-2.0';
 
   let lockfile: Lockfile | undefined;
   try {
@@ -299,6 +300,7 @@ export default async (opts: OptionValues) => {
         name,
         privatePackage,
         npmRegistry,
+        license,
       },
       createPackageVersionProvider(lockfile),
       isMonoRepo,

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -254,6 +254,10 @@ export function registerCommands(program: Command) {
       '--baseVersion <version>',
       'The version to use for any new packages (default: 0.1.0)',
     )
+    .option(
+      '--license <license>',
+      'The license to use for any new packages (default: Apache-2.0)',
+    )
     .option('--no-private', 'Do not mark new packages as private')
     .action(lazy(() => import('./new/new').then(m => m.default)));
 

--- a/packages/cli/src/commands/new/new.ts
+++ b/packages/cli/src/commands/new/new.ts
@@ -70,11 +70,14 @@ export default async (opts: OptionValues) => {
     return dir;
   }
 
+  const license = opts.license ?? 'Apache-2.0';
+
   let modified = false;
   try {
     await factory.create(options, {
       isMonoRepo: await isMonoRepo(),
       defaultVersion,
+      license,
       scope: opts.scope?.replace(/^@/, ''),
       npmRegistry: opts.npmRegistry,
       private: Boolean(opts.private),

--- a/packages/cli/src/lib/new/factories/backendModule.test.ts
+++ b/packages/cli/src/lib/new/factories/backendModule.test.ts
@@ -79,6 +79,7 @@ describe('backendModule factory', () => {
         modified = true;
       },
       createTemporaryDirectory: () => fs.mkdtemp('test'),
+      license: 'Apache-2.0',
     });
 
     expect(modified).toBe(true);

--- a/packages/cli/src/lib/new/factories/backendModule.ts
+++ b/packages/cli/src/lib/new/factories/backendModule.ts
@@ -75,6 +75,7 @@ export const backendModule = createFactory<Options>({
         packageVersion: ctx.defaultVersion,
         privatePackage: ctx.private,
         npmRegistry: ctx.npmRegistry,
+        license: ctx.license,
       },
     });
 

--- a/packages/cli/src/lib/new/factories/backendPlugin.test.ts
+++ b/packages/cli/src/lib/new/factories/backendPlugin.test.ts
@@ -78,6 +78,7 @@ describe('backendPlugin factory', () => {
         modified = true;
       },
       createTemporaryDirectory: () => fs.mkdtemp('test'),
+      license: 'Apache-2.0',
     });
 
     expect(modified).toBe(true);

--- a/packages/cli/src/lib/new/factories/backendPlugin.ts
+++ b/packages/cli/src/lib/new/factories/backendPlugin.ts
@@ -64,6 +64,7 @@ export const backendPlugin = createFactory<Options>({
         pluginVersion: ctx.defaultVersion,
         privatePackage: ctx.private,
         npmRegistry: ctx.npmRegistry,
+        license: ctx.license,
       },
     });
 

--- a/packages/cli/src/lib/new/factories/frontendPlugin.test.ts
+++ b/packages/cli/src/lib/new/factories/frontendPlugin.test.ts
@@ -80,6 +80,7 @@ describe('frontendPlugin factory', () => {
         modified = true;
       },
       createTemporaryDirectory: () => fs.mkdtemp('test'),
+      license: 'Apache-2.0',
     });
 
     expect(modified).toBe(true);
@@ -174,6 +175,7 @@ const router = (
       defaultVersion: '1.0.0',
       markAsModified: () => {},
       createTemporaryDirectory: () => fs.mkdtemp('test'),
+      license: 'Apache-2.0',
     });
 
     await expect(

--- a/packages/cli/src/lib/new/factories/frontendPlugin.ts
+++ b/packages/cli/src/lib/new/factories/frontendPlugin.ts
@@ -67,6 +67,7 @@ export const frontendPlugin = createFactory<Options>({
         pluginVersion: ctx.defaultVersion,
         privatePackage: ctx.private,
         npmRegistry: ctx.npmRegistry,
+        license: ctx.license,
       },
     });
 

--- a/packages/cli/src/lib/new/factories/nodeLibraryPackage.test.ts
+++ b/packages/cli/src/lib/new/factories/nodeLibraryPackage.test.ts
@@ -64,6 +64,7 @@ describe('nodeLibraryPackage factory', () => {
         modified = true;
       },
       createTemporaryDirectory: () => fs.mkdtemp('test'),
+      license: 'Apache-2.0',
     });
 
     expect(modified).toBe(true);
@@ -134,6 +135,7 @@ describe('nodeLibraryPackage factory', () => {
       defaultVersion: '1.0.0',
       markAsModified: () => {},
       createTemporaryDirectory: () => fs.mkdtemp('test'),
+      license: 'Apache-2.0',
     });
 
     expect(Task.forCommand).toHaveBeenCalledTimes(2);

--- a/packages/cli/src/lib/new/factories/nodeLibraryPackage.ts
+++ b/packages/cli/src/lib/new/factories/nodeLibraryPackage.ts
@@ -61,6 +61,7 @@ export const nodeLibraryPackage = createFactory<Options>({
         pluginVersion: ctx.defaultVersion,
         privatePackage: ctx.private,
         npmRegistry: ctx.npmRegistry,
+        license: ctx.license,
       },
     });
 

--- a/packages/cli/src/lib/new/factories/pluginCommon.test.ts
+++ b/packages/cli/src/lib/new/factories/pluginCommon.test.ts
@@ -62,6 +62,7 @@ describe('pluginCommon factory', () => {
         modified = true;
       },
       createTemporaryDirectory: () => fs.mkdtemp('test'),
+      license: 'Apache-2.0',
     });
 
     expect(modified).toBe(true);

--- a/packages/cli/src/lib/new/factories/pluginCommon.ts
+++ b/packages/cli/src/lib/new/factories/pluginCommon.ts
@@ -61,6 +61,7 @@ export const pluginCommon = createFactory<Options>({
         privatePackage: ctx.private,
         npmRegistry: ctx.npmRegistry,
         pluginVersion: ctx.defaultVersion,
+        license: ctx.license,
       },
     });
 

--- a/packages/cli/src/lib/new/factories/pluginNode.test.ts
+++ b/packages/cli/src/lib/new/factories/pluginNode.test.ts
@@ -62,6 +62,7 @@ describe('pluginNode factory', () => {
         modified = true;
       },
       createTemporaryDirectory: () => fs.mkdtemp('test'),
+      license: 'Apache-2.0',
     });
 
     expect(modified).toBe(true);

--- a/packages/cli/src/lib/new/factories/pluginNode.ts
+++ b/packages/cli/src/lib/new/factories/pluginNode.ts
@@ -61,6 +61,7 @@ export const pluginNode = createFactory<Options>({
         privatePackage: ctx.private,
         npmRegistry: ctx.npmRegistry,
         pluginVersion: ctx.defaultVersion,
+        license: ctx.license,
       },
     });
 

--- a/packages/cli/src/lib/new/factories/pluginWeb.test.ts
+++ b/packages/cli/src/lib/new/factories/pluginWeb.test.ts
@@ -62,6 +62,7 @@ describe('pluginWeb factory', () => {
         modified = true;
       },
       createTemporaryDirectory: () => fs.mkdtemp('test'),
+      license: 'Apache-2.0',
     });
 
     expect(modified).toBe(true);

--- a/packages/cli/src/lib/new/factories/pluginWeb.ts
+++ b/packages/cli/src/lib/new/factories/pluginWeb.ts
@@ -61,6 +61,7 @@ export const pluginWeb = createFactory<Options>({
         privatePackage: ctx.private,
         npmRegistry: ctx.npmRegistry,
         pluginVersion: ctx.defaultVersion,
+        license: ctx.license,
       },
     });
 

--- a/packages/cli/src/lib/new/factories/scaffolderModule.test.ts
+++ b/packages/cli/src/lib/new/factories/scaffolderModule.test.ts
@@ -62,6 +62,7 @@ describe('scaffolderModule factory', () => {
         modified = true;
       },
       createTemporaryDirectory: (name: string) => fs.mkdtemp(name),
+      license: 'Apache-2.0',
     });
 
     expect(modified).toBe(true);

--- a/packages/cli/src/lib/new/factories/scaffolderModule.ts
+++ b/packages/cli/src/lib/new/factories/scaffolderModule.ts
@@ -78,6 +78,7 @@ export const scaffolderModule = createFactory<Options>({
         privatePackage: ctx.private,
         npmRegistry: ctx.npmRegistry,
         pluginVersion: ctx.defaultVersion,
+        license: ctx.license,
       },
     });
 

--- a/packages/cli/src/lib/new/factories/webLibraryPackage.test.ts
+++ b/packages/cli/src/lib/new/factories/webLibraryPackage.test.ts
@@ -64,6 +64,7 @@ describe('webLibraryPackage factory', () => {
         modified = true;
       },
       createTemporaryDirectory: () => fs.mkdtemp('test'),
+      license: 'Apache-2.0',
     });
 
     expect(modified).toBe(true);
@@ -134,6 +135,7 @@ describe('webLibraryPackage factory', () => {
       defaultVersion: '1.0.0',
       markAsModified: () => {},
       createTemporaryDirectory: () => fs.mkdtemp('test'),
+      license: 'Apache-2.0',
     });
 
     expect(Task.forCommand).toHaveBeenCalledTimes(2);

--- a/packages/cli/src/lib/new/factories/webLibraryPackage.ts
+++ b/packages/cli/src/lib/new/factories/webLibraryPackage.ts
@@ -61,6 +61,7 @@ export const webLibraryPackage = createFactory<Options>({
         pluginVersion: ctx.defaultVersion,
         privatePackage: ctx.private,
         npmRegistry: ctx.npmRegistry,
+        license: ctx.license,
       },
     });
 

--- a/packages/cli/src/lib/new/types.ts
+++ b/packages/cli/src/lib/new/types.ts
@@ -27,6 +27,8 @@ export interface CreateContext {
   isMonoRepo: boolean;
   /** The default version to use for new packages */
   defaultVersion: string;
+  /** License to use for new packages */
+  license: string;
 
   /** Creates a temporary directory. This will always be deleted after creation is done. */
   createTemporaryDirectory(name: string): Promise<string>;

--- a/packages/cli/templates/default-backend-module/package.json.hbs
+++ b/packages/cli/templates/default-backend-module/package.json.hbs
@@ -4,7 +4,7 @@
   "version": "{{packageVersion}}",
   "main": "src/index.ts",
   "types": "src/index.ts",
-  "license": "Apache-2.0",
+  "license": "{{license}}",
 {{#if privatePackage}}
   "private": {{privatePackage}},
 {{/if}}

--- a/packages/cli/templates/default-backend-plugin/package.json.hbs
+++ b/packages/cli/templates/default-backend-plugin/package.json.hbs
@@ -3,7 +3,7 @@
   "version": "{{pluginVersion}}",
   "main": "src/index.ts",
   "types": "src/index.ts",
-  "license": "Apache-2.0",
+  "license": "{{license}}",
 {{#if privatePackage}}
   "private": {{privatePackage}},
 {{/if}}

--- a/packages/cli/templates/default-common-plugin-package/package.json.hbs
+++ b/packages/cli/templates/default-common-plugin-package/package.json.hbs
@@ -4,7 +4,7 @@
   "version": "{{pluginVersion}}",
   "main": "src/index.ts",
   "types": "src/index.ts",
-  "license": "Apache-2.0",
+  "license": "{{license}}",
 {{#if privatePackage}}
   "private": {{privatePackage}},
 {{/if}}

--- a/packages/cli/templates/default-node-plugin-package/package.json.hbs
+++ b/packages/cli/templates/default-node-plugin-package/package.json.hbs
@@ -4,7 +4,7 @@
   "version": "{{pluginVersion}}",
   "main": "src/index.ts",
   "types": "src/index.ts",
-  "license": "Apache-2.0",
+  "license": "{{license}}",
 {{#if privatePackage}}
   "private": {{privatePackage}},
 {{/if}}

--- a/packages/cli/templates/default-plugin/package.json.hbs
+++ b/packages/cli/templates/default-plugin/package.json.hbs
@@ -3,7 +3,7 @@
   "version": "{{pluginVersion}}",
   "main": "src/index.ts",
   "types": "src/index.ts",
-  "license": "Apache-2.0",
+  "license": "{{license}}",
 {{#if privatePackage}}
   "private": {{privatePackage}},
 {{/if}}

--- a/packages/cli/templates/default-react-plugin-package/package.json.hbs
+++ b/packages/cli/templates/default-react-plugin-package/package.json.hbs
@@ -4,7 +4,7 @@
   "version": "{{pluginVersion}}",
   "main": "src/index.ts",
   "types": "src/index.ts",
-  "license": "Apache-2.0",
+  "license": "{{license}}",
 {{#if privatePackage}}
   "private": {{privatePackage}},
 {{/if}}

--- a/packages/cli/templates/node-library-package/package.json.hbs
+++ b/packages/cli/templates/node-library-package/package.json.hbs
@@ -3,7 +3,7 @@
   "version": "{{pluginVersion}}",
   "main": "src/index.ts",
   "types": "src/index.ts",
-  "license": "Apache-2.0",
+  "license": "{{license}}",
 {{#if privatePackage}}
   "private": {{privatePackage}},
 {{/if}}

--- a/packages/cli/templates/scaffolder-module/package.json.hbs
+++ b/packages/cli/templates/scaffolder-module/package.json.hbs
@@ -4,7 +4,7 @@
   "version": "{{pluginVersion}}",
   "main": "src/index.ts",
   "types": "src/index.ts",
-  "license": "Apache-2.0",
+  "license": "{{license}}",
 {{#if privatePackage}}
   "private": {{privatePackage}},
 {{/if}}

--- a/packages/cli/templates/web-library-package/package.json.hbs
+++ b/packages/cli/templates/web-library-package/package.json.hbs
@@ -3,7 +3,7 @@
   "version": "{{pluginVersion}}",
   "main": "src/index.ts",
   "types": "src/index.ts",
-  "license": "Apache-2.0",
+  "license": "{{license}}",
 {{#if privatePackage}}
   "private": {{privatePackage}},
 {{/if}}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This allows using custom licenses for new plugins when using the backstage-cli new command

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
