### PR TITLE
fix(kubernetes-backend): add customResources to the config.d.ts

### DIFF
--- a/.changeset/silly-cycles-tan.md
+++ b/.changeset/silly-cycles-tan.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Add `kubernetes.clusterLocatorMethods[].clusters[].customResources` to the configuration schema.
+This was already documented and supported by the plugin.

--- a/plugins/kubernetes-backend/config.d.ts
+++ b/plugins/kubernetes-backend/config.d.ts
@@ -68,6 +68,11 @@ export interface Config {
             caData?: string;
             /** @visibility secret  */
             caFile?: string;
+            customResources?: Array<{
+              group: string;
+              apiVersion: string;
+              plural: string;
+            }>;
           }>;
         }
       | {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add `kubernetes.clusterLocatorMethods[].clusters[].customResources` to the configuration schema.
This was already documented and supported by the plugin.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] ~Added or updated documentation~
- [ ] ~Tests for new functionality and regression tests for bug fixes~
- [ ] ~Screenshots attached (for UI changes)~
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
