### PR TITLE
permissions: move MetadataResponse type to permission-common

### DIFF
--- a/.changeset/fair-hairs-mix.md
+++ b/.changeset/fair-hairs-mix.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-permission-common': patch
+---
+
+Add the MetadataResponse type from @backstage/plugin-permission-node, since this
+type might be used in frontend code.

--- a/.changeset/friendly-cherries-applaud.md
+++ b/.changeset/friendly-cherries-applaud.md
@@ -1,0 +1,9 @@
+---
+'@backstage/plugin-permission-node': patch
+---
+
+The MetadataResponse type has been moved to @backstage/plugin-permission-common
+to match the recent move of MetadataResponseSerializedRule, and should be
+imported from there going forward. To avoid an immediate breaking change, this
+type is still re-exported from this package, but is marked as deprecated and
+will be removed in a future release.

--- a/plugins/permission-common/api-report.md
+++ b/plugins/permission-common/api-report.md
@@ -127,6 +127,12 @@ export function isResourcePermission<T extends string = string>(
 export function isUpdatePermission(permission: Permission): boolean;
 
 // @public
+export type MetadataResponse = {
+  permissions?: Permission[];
+  rules: MetadataResponseSerializedRule[];
+};
+
+// @public
 export type MetadataResponseSerializedRule = {
   name: string;
   description: string;

--- a/plugins/permission-common/src/types/index.ts
+++ b/plugins/permission-common/src/types/index.ts
@@ -40,7 +40,10 @@ export type {
   NotCriteria,
 } from './api';
 export type { DiscoveryApi } from './discovery';
-export type { MetadataResponseSerializedRule } from './integration';
+export type {
+  MetadataResponse,
+  MetadataResponseSerializedRule,
+} from './integration';
 export type {
   BasicPermission,
   PermissionAttributes,

--- a/plugins/permission-common/src/types/integration.ts
+++ b/plugins/permission-common/src/types/integration.ts
@@ -15,6 +15,7 @@
  */
 
 import zodToJsonSchema from 'zod-to-json-schema';
+import { Permission } from './permission';
 
 /**
  * Serialized permission rules, with the paramsSchema
@@ -27,4 +28,15 @@ export type MetadataResponseSerializedRule = {
   description: string;
   resourceType: string;
   paramsSchema?: ReturnType<typeof zodToJsonSchema>;
+};
+
+/**
+ * Response type for the .metadata endpoint in
+ * {@link @backstage/plugin-permission-node#createPermissionIntegrationRouter}
+ *
+ * @public
+ */
+export type MetadataResponse = {
+  permissions?: Permission[];
+  rules: MetadataResponseSerializedRule[];
 };

--- a/plugins/permission-node/api-report.md
+++ b/plugins/permission-node/api-report.md
@@ -17,6 +17,7 @@ import { DefinitivePolicyDecision } from '@backstage/plugin-permission-common';
 import { DiscoveryService } from '@backstage/backend-plugin-api';
 import express from 'express';
 import { IdentifiedPermissionMessage } from '@backstage/plugin-permission-common';
+import { MetadataResponse as MetadataResponse_2 } from '@backstage/plugin-permission-common';
 import { MetadataResponseSerializedRule as MetadataResponseSerializedRule_2 } from '@backstage/plugin-permission-common';
 import { NotCriteria } from '@backstage/plugin-permission-common';
 import { Permission } from '@backstage/plugin-permission-common';
@@ -188,11 +189,8 @@ export const makeCreatePermissionRule: <
   rule: PermissionRule<TResource, TQuery, TResourceType, TParams>,
 ) => PermissionRule<TResource, TQuery, TResourceType, TParams>;
 
-// @public
-export type MetadataResponse = {
-  permissions?: Permission[];
-  rules: MetadataResponseSerializedRule[];
-};
+// @public @deprecated
+export type MetadataResponse = MetadataResponse_2;
 
 // @public @deprecated
 export type MetadataResponseSerializedRule = MetadataResponseSerializedRule_2;

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
@@ -24,6 +24,7 @@ import {
   AuthorizeResult,
   DefinitivePolicyDecision,
   IdentifiedPermissionMessage,
+  MetadataResponse as CommonMetadataResponse,
   MetadataResponseSerializedRule as CommonMetadataResponseSerializedRule,
   Permission,
   PermissionCondition,
@@ -119,11 +120,9 @@ export type MetadataResponseSerializedRule =
  * Response type for the .metadata endpoint.
  *
  * @public
+ * @deprecated Please import from `@backstage/plugin-permission-common` instead.
  */
-export type MetadataResponse = {
-  permissions?: Permission[];
-  rules: MetadataResponseSerializedRule[];
-};
+export type MetadataResponse = CommonMetadataResponse;
 
 const applyConditions = <TResourceType extends string, TResource>(
   criteria: PermissionCriteria<PermissionCondition<TResourceType>>,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This was missed when moving MetadataResponseSerializedRule in 137fa342b4bf43c91e91d3b0b947b8d37c9e233e - seems useful to keep these two types together.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
