### PR TITLE
fix: Add null check for review state utility function

### DIFF
--- a/.changeset/slow-ligers-drum.md
+++ b/.changeset/slow-ligers-drum.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+Fix null check in `isJsonObject` utility function for scaffolder review state component

--- a/plugins/scaffolder-react/src/next/components/ReviewState/util.test.ts
+++ b/plugins/scaffolder-react/src/next/components/ReviewState/util.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Backstage Authors
+ * Copyright 2024 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,10 @@ describe('isJsonObject', () => {
     expect(isJsonObject(123)).toBe(false);
     expect(isJsonObject(true)).toBe(false);
     expect(isJsonObject(undefined)).toBe(false);
+  });
+
+  it('should return false for null values', () => {
+    expect(isJsonObject(null)).toBe(false);
   });
 });
 

--- a/plugins/scaffolder-react/src/next/components/ReviewState/util.ts
+++ b/plugins/scaffolder-react/src/next/components/ReviewState/util.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Backstage Authors
+ * Copyright 2024 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 import { JsonObject, JsonValue } from '@backstage/types';
 
 export function isJsonObject(value?: JsonValue): value is JsonObject {
-  return typeof value === 'object' && !Array.isArray(value);
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 // Helper function to get the last part of the key


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#25346 added utility function `isJsonObject` but I missed adding null check (in typescript null is still an object). This fixes any potential edge cases with null values.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
