### PR TITLE
search: fix incorrect metadata due to inconsistent package name

### DIFF
--- a/.changeset/healthy-timers-divide.md
+++ b/.changeset/healthy-timers-divide.md
@@ -1,0 +1,9 @@
+---
+'@backstage/plugin-search-backend-node': patch
+'@backstage/plugin-search-backend': patch
+'@backstage/plugin-search-common': patch
+'@backstage/plugin-search-react': patch
+'@backstage/plugin-search': patch
+---
+
+Fix package metadata

--- a/plugins/search-backend-node/package.json
+++ b/plugins/search-backend-node/package.json
@@ -6,11 +6,11 @@
     "role": "node-library",
     "pluginId": "search",
     "pluginPackages": [
-      "@backstage/plugin-search-backend-node",
+      "@backstage/plugin-search",
       "@backstage/plugin-search-backend",
+      "@backstage/plugin-search-backend-node",
       "@backstage/plugin-search-common",
-      "@backstage/plugin-search-react",
-      "@backstage/plugin-search"
+      "@backstage/plugin-search-react"
     ]
   },
   "publishConfig": {

--- a/plugins/search-backend-node/package.json
+++ b/plugins/search-backend-node/package.json
@@ -4,9 +4,13 @@
   "description": "A library for Backstage backend plugins that want to interact with the search backend plugin",
   "backstage": {
     "role": "node-library",
-    "pluginId": "search-backend",
+    "pluginId": "search",
     "pluginPackages": [
-      "@backstage/plugin-search-backend-node"
+      "@backstage/plugin-search-backend-node",
+      "@backstage/plugin-search-backend",
+      "@backstage/plugin-search-common",
+      "@backstage/plugin-search-react",
+      "@backstage/plugin-search"
     ]
   },
   "publishConfig": {

--- a/plugins/search-backend/package.json
+++ b/plugins/search-backend/package.json
@@ -6,11 +6,11 @@
     "role": "backend-plugin",
     "pluginId": "search",
     "pluginPackages": [
-      "@backstage/plugin-search-backend-node",
+      "@backstage/plugin-search",
       "@backstage/plugin-search-backend",
+      "@backstage/plugin-search-backend-node",
       "@backstage/plugin-search-common",
-      "@backstage/plugin-search-react",
-      "@backstage/plugin-search"
+      "@backstage/plugin-search-react"
     ]
   },
   "publishConfig": {

--- a/plugins/search-backend/package.json
+++ b/plugins/search-backend/package.json
@@ -6,10 +6,11 @@
     "role": "backend-plugin",
     "pluginId": "search",
     "pluginPackages": [
-      "@backstage/plugin-search",
+      "@backstage/plugin-search-backend-node",
       "@backstage/plugin-search-backend",
       "@backstage/plugin-search-common",
-      "@backstage/plugin-search-react"
+      "@backstage/plugin-search-react",
+      "@backstage/plugin-search"
     ]
   },
   "publishConfig": {

--- a/plugins/search-common/package.json
+++ b/plugins/search-common/package.json
@@ -6,10 +6,11 @@
     "role": "common-library",
     "pluginId": "search",
     "pluginPackages": [
-      "@backstage/plugin-search",
+      "@backstage/plugin-search-backend-node",
       "@backstage/plugin-search-backend",
       "@backstage/plugin-search-common",
-      "@backstage/plugin-search-react"
+      "@backstage/plugin-search-react",
+      "@backstage/plugin-search"
     ]
   },
   "publishConfig": {

--- a/plugins/search-common/package.json
+++ b/plugins/search-common/package.json
@@ -6,11 +6,11 @@
     "role": "common-library",
     "pluginId": "search",
     "pluginPackages": [
-      "@backstage/plugin-search-backend-node",
+      "@backstage/plugin-search",
       "@backstage/plugin-search-backend",
+      "@backstage/plugin-search-backend-node",
       "@backstage/plugin-search-common",
-      "@backstage/plugin-search-react",
-      "@backstage/plugin-search"
+      "@backstage/plugin-search-react"
     ]
   },
   "publishConfig": {

--- a/plugins/search-react/package.json
+++ b/plugins/search-react/package.json
@@ -5,10 +5,11 @@
     "role": "web-library",
     "pluginId": "search",
     "pluginPackages": [
-      "@backstage/plugin-search",
+      "@backstage/plugin-search-backend-node",
       "@backstage/plugin-search-backend",
       "@backstage/plugin-search-common",
-      "@backstage/plugin-search-react"
+      "@backstage/plugin-search-react",
+      "@backstage/plugin-search"
     ]
   },
   "publishConfig": {

--- a/plugins/search-react/package.json
+++ b/plugins/search-react/package.json
@@ -5,11 +5,11 @@
     "role": "web-library",
     "pluginId": "search",
     "pluginPackages": [
-      "@backstage/plugin-search-backend-node",
+      "@backstage/plugin-search",
       "@backstage/plugin-search-backend",
+      "@backstage/plugin-search-backend-node",
       "@backstage/plugin-search-common",
-      "@backstage/plugin-search-react",
-      "@backstage/plugin-search"
+      "@backstage/plugin-search-react"
     ]
   },
   "publishConfig": {

--- a/plugins/search/package.json
+++ b/plugins/search/package.json
@@ -6,11 +6,11 @@
     "role": "frontend-plugin",
     "pluginId": "search",
     "pluginPackages": [
-      "@backstage/plugin-search-backend-node",
+      "@backstage/plugin-search",
       "@backstage/plugin-search-backend",
+      "@backstage/plugin-search-backend-node",
       "@backstage/plugin-search-common",
-      "@backstage/plugin-search-react",
-      "@backstage/plugin-search"
+      "@backstage/plugin-search-react"
     ]
   },
   "publishConfig": {

--- a/plugins/search/package.json
+++ b/plugins/search/package.json
@@ -6,10 +6,11 @@
     "role": "frontend-plugin",
     "pluginId": "search",
     "pluginPackages": [
-      "@backstage/plugin-search",
+      "@backstage/plugin-search-backend-node",
       "@backstage/plugin-search-backend",
       "@backstage/plugin-search-common",
-      "@backstage/plugin-search-react"
+      "@backstage/plugin-search-react",
+      "@backstage/plugin-search"
     ]
   },
   "publishConfig": {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

According to the usual Backstage package naming
conventions, @backstage/plugin-search-backend-node should be called @backstage/plugin-search-node.
Because of this mismatch, metadata was generated
incorrectly.

Adjust the metadata in all search packages to
include the node package, and fix the pluginId in
the node package itself.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
