### PR TITLE
feat: introduce subdomains card

### DIFF
--- a/.changeset/metal-rice-call.md
+++ b/.changeset/metal-rice-call.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': minor
+---
+
+Introduces the HasSubdomainsCard component that displays the subdomains of a given domain

--- a/plugins/catalog/api-report-alpha.md
+++ b/plugins/catalog/api-report-alpha.md
@@ -85,6 +85,8 @@ export const catalogTranslationRef: TranslationRef<
     readonly 'hasResourcesCard.emptyMessage': 'No resource is part of this system';
     readonly 'hasSubcomponentsCard.title': 'Has subcomponents';
     readonly 'hasSubcomponentsCard.emptyMessage': 'No subcomponent is part of this component';
+    readonly 'hasSubdomainsCard.title': 'Has subdomains';
+    readonly 'hasSubdomainsCard.emptyMessage': 'No subdomain is part of this domain';
     readonly 'hasSystemsCard.title': 'Has systems';
     readonly 'hasSystemsCard.emptyMessage': 'No system is part of this domain';
     readonly 'relatedEntitiesCard.emptyHelpLinkTitle': 'Learn how to change this.';

--- a/plugins/catalog/api-report.md
+++ b/plugins/catalog/api-report.md
@@ -371,6 +371,11 @@ export const EntityHasSubcomponentsCard: (
 ) => JSX.Element;
 
 // @public (undocumented)
+export const EntityHasSubdomainsCard: (
+  props: HasSubdomainsCardProps,
+) => JSX.Element;
+
+// @public (undocumented)
 export const EntityHasSystemsCard: (props: HasSystemsCardProps) => JSX.Element;
 
 // @public (undocumented)
@@ -543,6 +548,16 @@ export interface HasResourcesCardProps {
 
 // @public (undocumented)
 export interface HasSubcomponentsCardProps {
+  // (undocumented)
+  tableOptions?: TableOptions;
+  // (undocumented)
+  title?: string;
+  // (undocumented)
+  variant?: InfoCardVariants;
+}
+
+// @public (undocumented)
+export interface HasSubdomainsCardProps {
   // (undocumented)
   tableOptions?: TableOptions;
   // (undocumented)

--- a/plugins/catalog/src/alpha/entityCards.tsx
+++ b/plugins/catalog/src/alpha/entityCards.tsx
@@ -84,6 +84,14 @@ export const catalogHasSubcomponentsEntityCard = createEntityCardExtension({
     ),
 });
 
+export const catalogHasSubdomainsEntityCard = createEntityCardExtension({
+  name: 'has-subdomains',
+  loader: async () =>
+    import('../components/HasSubdomainsCard').then(m =>
+      compatWrapper(<m.HasSubdomainsCard variant="gridItem" />),
+    ),
+});
+
 export const catalogHasSystemsEntityCard = createEntityCardExtension({
   name: 'has-systems',
   loader: async () =>
@@ -101,5 +109,6 @@ export default [
   catalogHasComponentsEntityCard,
   catalogHasResourcesEntityCard,
   catalogHasSubcomponentsEntityCard,
+  catalogHasSubdomainsEntityCard,
   catalogHasSystemsEntityCard,
 ];

--- a/plugins/catalog/src/components/HasSubdomainsCard/HasSubdomainsCard.test.tsx
+++ b/plugins/catalog/src/components/HasSubdomainsCard/HasSubdomainsCard.test.tsx
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity, RELATION_HAS_PART } from '@backstage/catalog-model';
+import {
+  CatalogApi,
+  catalogApiRef,
+  EntityProvider,
+  entityRouteRef,
+} from '@backstage/plugin-catalog-react';
+import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
+import { waitFor, screen } from '@testing-library/react';
+import React from 'react';
+import { HasSubdomainsCard } from './HasSubdomainsCard';
+
+describe('<HasSubdomainsCard />', () => {
+  const getEntitiesByRefs: jest.MockedFunction<
+    CatalogApi['getEntitiesByRefs']
+  > = jest.fn();
+  let Wrapper: React.ComponentType<React.PropsWithChildren<{}>>;
+
+  beforeEach(() => {
+    Wrapper = ({ children }: { children?: React.ReactNode }) => (
+      <TestApiProvider apis={[[catalogApiRef, { getEntitiesByRefs }]]}>
+        {children}
+      </TestApiProvider>
+    );
+  });
+
+  afterEach(() => jest.resetAllMocks());
+
+  it('shows empty list if no relations', async () => {
+    const entity: Entity = {
+      apiVersion: 'v1',
+      kind: 'Domain',
+      metadata: {
+        name: 'my-domain',
+        namespace: 'my-namespace',
+      },
+      relations: [],
+    };
+
+    await renderInTestApp(
+      <Wrapper>
+        <EntityProvider entity={entity}>
+          <HasSubdomainsCard />
+        </EntityProvider>
+      </Wrapper>,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': entityRouteRef,
+        },
+      },
+    );
+
+    expect(screen.getByText('Has subdomains')).toBeInTheDocument();
+    expect(
+      screen.getByText(/No subdomain is part of this domain/i),
+    ).toBeInTheDocument();
+  });
+
+  it('shows related subdomains', async () => {
+    const entity: Entity = {
+      apiVersion: 'v1',
+      kind: 'Domain',
+      metadata: {
+        name: 'my-domain',
+        namespace: 'my-namespace',
+      },
+      relations: [
+        {
+          targetRef: 'domain:my-namespace/target-name',
+          type: RELATION_HAS_PART,
+        },
+      ],
+    };
+    getEntitiesByRefs.mockResolvedValue({
+      items: [
+        {
+          apiVersion: 'v1',
+          kind: 'Domain',
+          metadata: {
+            name: 'target-name',
+            namespace: 'my-namespace',
+          },
+          spec: {},
+        },
+      ],
+    });
+
+    await renderInTestApp(
+      <Wrapper>
+        <EntityProvider entity={entity}>
+          <HasSubdomainsCard />
+        </EntityProvider>
+      </Wrapper>,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': entityRouteRef,
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Has subdomains')).toBeInTheDocument();
+      expect(screen.getByText(/target-name/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/plugins/catalog/src/components/HasSubdomainsCard/HasSubdomainsCard.tsx
+++ b/plugins/catalog/src/components/HasSubdomainsCard/HasSubdomainsCard.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RELATION_HAS_PART } from '@backstage/catalog-model';
+import { InfoCardVariants, TableOptions } from '@backstage/core-components';
+import React from 'react';
+import {
+  asComponentEntities,
+  componentEntityColumns,
+  RelatedEntitiesCard,
+} from '../RelatedEntitiesCard';
+import { catalogTranslationRef } from '../../translation';
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+
+/** @public */
+export interface HasSubdomainsCardProps {
+  variant?: InfoCardVariants;
+  tableOptions?: TableOptions;
+  title?: string;
+}
+
+export function HasSubdomainsCard(props: HasSubdomainsCardProps) {
+  const { t } = useTranslationRef(catalogTranslationRef);
+  const {
+    variant = 'gridItem',
+    tableOptions = {},
+    title = t('hasSubdomainsCard.title'),
+  } = props;
+  return (
+    <RelatedEntitiesCard
+      variant={variant}
+      title={title}
+      entityKind="Domain"
+      relationType={RELATION_HAS_PART}
+      columns={componentEntityColumns}
+      asRenderableEntities={asComponentEntities}
+      emptyMessage={t('hasSubdomainsCard.emptyMessage')}
+      emptyHelpLink="https://backstage.io/docs/features/software-catalog/descriptor-format/#specsubdomainof-optional"
+      tableOptions={tableOptions}
+    />
+  );
+}

--- a/plugins/catalog/src/components/HasSubdomainsCard/index.ts
+++ b/plugins/catalog/src/components/HasSubdomainsCard/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { HasSubdomainsCard } from './HasSubdomainsCard';
+export type { HasSubdomainsCardProps } from './HasSubdomainsCard';

--- a/plugins/catalog/src/index.ts
+++ b/plugins/catalog/src/index.ts
@@ -49,6 +49,7 @@ export {
   EntityHasComponentsCard,
   EntityHasResourcesCard,
   EntityHasSubcomponentsCard,
+  EntityHasSubdomainsCard,
   EntityHasSystemsCard,
   EntityLinksCard,
   EntityLabelsCard,
@@ -71,6 +72,7 @@ export type { EntityContextMenuClassKey } from './components/EntityContextMenu';
 export type { HasComponentsCardProps } from './components/HasComponentsCard';
 export type { HasResourcesCardProps } from './components/HasResourcesCard';
 export type { HasSubcomponentsCardProps } from './components/HasSubcomponentsCard';
+export type { HasSubdomainsCardProps } from './components/HasSubdomainsCard';
 export type { HasSystemsCardProps } from './components/HasSystemsCard';
 export type { RelatedEntitiesCardProps } from './components/RelatedEntitiesCard';
 export type { CatalogSearchResultListItemProps } from './components/CatalogSearchResultListItem';

--- a/plugins/catalog/src/plugin.ts
+++ b/plugins/catalog/src/plugin.ts
@@ -50,6 +50,7 @@ import { DependsOnResourcesCardProps } from './components/DependsOnResourcesCard
 import { HasComponentsCardProps } from './components/HasComponentsCard';
 import { HasResourcesCardProps } from './components/HasResourcesCard';
 import { HasSubcomponentsCardProps } from './components/HasSubcomponentsCard';
+import { HasSubdomainsCardProps } from './components/HasSubdomainsCard';
 import { HasSystemsCardProps } from './components/HasSystemsCard';
 import { RelatedEntitiesCardProps } from './components/RelatedEntitiesCard';
 import { CatalogSearchResultListItemProps } from './components/CatalogSearchResultListItem';
@@ -195,6 +196,19 @@ export const EntityHasSubcomponentsCard: (
         import('./components/HasSubcomponentsCard').then(
           m => m.HasSubcomponentsCard,
         ),
+    },
+  }),
+);
+
+/** @public */
+export const EntityHasSubdomainsCard: (
+  props: HasSubdomainsCardProps,
+) => JSX.Element = catalogPlugin.provide(
+  createComponentExtension({
+    name: 'EntityHasSubdomainsCard',
+    component: {
+      lazy: () =>
+        import('./components/HasSubdomainsCard').then(m => m.HasSubdomainsCard),
     },
   }),
 );

--- a/plugins/catalog/src/translation.ts
+++ b/plugins/catalog/src/translation.ts
@@ -143,6 +143,10 @@ export const catalogTranslationRef = createTranslationRef({
       title: 'Has subcomponents',
       emptyMessage: 'No subcomponent is part of this component',
     },
+    hasSubdomainsCard: {
+      title: 'Has subdomains',
+      emptyMessage: 'No subdomain is part of this domain',
+    },
     hasSystemsCard: {
       title: 'Has systems',
       emptyMessage: 'No system is part of this domain',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Subdomains were introduced in https://github.com/backstage/backstage/pull/17125. This PR introduces the `HasSubdomainsCard` component to display to the subdomains of a given domain. It works in a similar fashion to other related entities cards like `HasSubcomponentsCard` and `HasSystemsCard`.

It can be added to catalog pages with the `EntityHasSubdomainsCard` component.

#### Images

- No subdomains
<img width="840" alt="Screenshot 2024-08-02 at 16 37 55" src="https://github.com/user-attachments/assets/10ee3525-d745-4535-9f7f-9f07048f458f">

- 2 subdomains, one with a `title` attribute and one without it
<img width="840" alt="Screenshot 2024-08-02 at 16 37 46" src="https://github.com/user-attachments/assets/d88349c6-79a8-4f4a-8f07-db1a58a8d4db">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
