### PR TITLE
avoid excessive error listeners

### DIFF
--- a/.changeset/tasty-ads-rescue.md
+++ b/.changeset/tasty-ads-rescue.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Avoid excessive numbers of error listeners on cache clients


### PR DESCRIPTION
Fixes #25901

Even if we only had one listener per Keyv instance, _those_ in turn immediately subscribed to the underlying store.