### PR TITLE
fix output element overlappig w/ flex-wrap

### DIFF
--- a/.changeset/breezy-rings-fly.md
+++ b/.changeset/breezy-rings-fly.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+Fixed bug in DefaultTableOutputs where output elements overlapped in below approx. 800 px wide screens

--- a/.changeset/breezy-rings-fly.md
+++ b/.changeset/breezy-rings-fly.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-react': patch
 ---
 
-Fixed bug in DefaultTableOutputs where output elements overlapped in below approx. 800 px wide screens
+Fixed a bug in `DefaultTableOutputs` where output elements overlapped on smaller screen sizes

--- a/plugins/scaffolder-react/src/next/components/TemplateOutputs/DefaultTemplateOutputs.tsx
+++ b/plugins/scaffolder-react/src/next/components/TemplateOutputs/DefaultTemplateOutputs.tsx
@@ -68,6 +68,7 @@ export const DefaultTemplateOutputs = (props: {
               justifyContent="center"
               display="flex"
               gridGap={16}
+              flexWrap="wrap"
             >
               <TextOutputs
                 output={output}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When there are multiple text outputs in the template output page and the screen is narrowed, the text outputs are overlapping their box and stacking in a messy way. I added a flex-wrap in the textput box to make the text outputs stack nicely.

Before:
![Näyttökuva2 2024-08-05 141541](https://github.com/user-attachments/assets/6a482df4-9af7-42ba-9a45-58a0acd4d90a)

After: 
![Näyttökuva2 2024-08-05 141623](https://github.com/user-attachments/assets/3fc1478d-deb0-40d7-8f16-a0df658b3f2c)

     

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
