### PR TITLE
catalog: enable entity page extensions by default in the new frontend system

### DIFF
--- a/.changeset/bright-donkeys-buy.md
+++ b/.changeset/bright-donkeys-buy.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+The entity relation cards available for the new frontend system via `/alpha` now have more accurate and granular default filters.

--- a/.changeset/witty-geese-battle.md
+++ b/.changeset/witty-geese-battle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Entity page extensions created for the new frontend system via the `/alpha` exports will now be enabled by default.

--- a/plugins/catalog-react/src/alpha.tsx
+++ b/plugins/catalog-react/src/alpha.tsx
@@ -83,7 +83,7 @@ export function createEntityCardExtension<
       id: 'entity-content:catalog/overview',
       input: 'cards',
     },
-    disabled: options.disabled ?? true,
+    disabled: options.disabled,
     output: {
       element: coreExtensionData.reactElement,
       filterFunction: catalogExtensionData.entityFilterFunction.optional(),
@@ -137,7 +137,7 @@ export function createEntityContentExtension<
       id: 'page:catalog/entity',
       input: 'contents',
     },
-    disabled: options.disabled ?? true,
+    disabled: options.disabled,
     output: {
       element: coreExtensionData.reactElement,
       path: coreExtensionData.routePath,

--- a/plugins/catalog/src/alpha/entityCards.tsx
+++ b/plugins/catalog/src/alpha/entityCards.tsx
@@ -46,6 +46,7 @@ export const catalogLabelsEntityCard = createEntityCardExtension({
 
 export const catalogDependsOnComponentsEntityCard = createEntityCardExtension({
   name: 'depends-on-components',
+  filter: 'kind:component',
   loader: async () =>
     import('../components/DependsOnComponentsCard').then(m =>
       compatWrapper(<m.DependsOnComponentsCard variant="gridItem" />),
@@ -54,6 +55,7 @@ export const catalogDependsOnComponentsEntityCard = createEntityCardExtension({
 
 export const catalogDependsOnResourcesEntityCard = createEntityCardExtension({
   name: 'depends-on-resources',
+  filter: 'kind:component',
   loader: async () =>
     import('../components/DependsOnResourcesCard').then(m =>
       compatWrapper(<m.DependsOnResourcesCard variant="gridItem" />),
@@ -62,6 +64,7 @@ export const catalogDependsOnResourcesEntityCard = createEntityCardExtension({
 
 export const catalogHasComponentsEntityCard = createEntityCardExtension({
   name: 'has-components',
+  filter: 'kind:system',
   loader: async () =>
     import('../components/HasComponentsCard').then(m =>
       compatWrapper(<m.HasComponentsCard variant="gridItem" />),
@@ -70,6 +73,7 @@ export const catalogHasComponentsEntityCard = createEntityCardExtension({
 
 export const catalogHasResourcesEntityCard = createEntityCardExtension({
   name: 'has-resources',
+  filter: 'kind:system',
   loader: async () =>
     import('../components/HasResourcesCard').then(m =>
       compatWrapper(<m.HasResourcesCard variant="gridItem" />),
@@ -78,6 +82,7 @@ export const catalogHasResourcesEntityCard = createEntityCardExtension({
 
 export const catalogHasSubcomponentsEntityCard = createEntityCardExtension({
   name: 'has-subcomponents',
+  filter: 'kind:component',
   loader: async () =>
     import('../components/HasSubcomponentsCard').then(m =>
       compatWrapper(<m.HasSubcomponentsCard variant="gridItem" />),
@@ -86,6 +91,7 @@ export const catalogHasSubcomponentsEntityCard = createEntityCardExtension({
 
 export const catalogHasSubdomainsEntityCard = createEntityCardExtension({
   name: 'has-subdomains',
+  filter: 'kind:domain',
   loader: async () =>
     import('../components/HasSubdomainsCard').then(m =>
       compatWrapper(<m.HasSubdomainsCard variant="gridItem" />),
@@ -94,6 +100,7 @@ export const catalogHasSubdomainsEntityCard = createEntityCardExtension({
 
 export const catalogHasSystemsEntityCard = createEntityCardExtension({
   name: 'has-systems',
+  filter: 'kind:domain',
   loader: async () =>
     import('../components/HasSystemsCard').then(m =>
       compatWrapper(<m.HasSystemsCard variant="gridItem" />),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is a followup to #24654, and improves the experience of installing new plugins for the catalog. The effect this has is that extensions for newly installed plugins will appear towards the end, depending on what order features happen to be installed in. It select an order for the extensions one still needs to add them in an explicit order in config.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
