### PR TITLE
Fix TechDocs Edit URL link when trailing slash not present

### DIFF
--- a/.changeset/tricky-rules-destroy.md
+++ b/.changeset/tricky-rules-destroy.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-node': patch
+---
+
+Fix TechDocs Edit URL for nexted docs

--- a/.changeset/tricky-rules-destroy.md
+++ b/.changeset/tricky-rules-destroy.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-techdocs-node': patch
 ---
 
-Fix TechDocs Edit URL for nexted docs
+Fix TechDocs Edit URL for nested docs

--- a/plugins/techdocs-node/src/stages/generate/helpers.test.ts
+++ b/plugins/techdocs-node/src/stages/generate/helpers.test.ts
@@ -115,6 +115,7 @@ describe('helpers', () => {
       url                                                                        | repo_url                                                                   | edit_uri
       ${'https://github.com/backstage/backstage'}                                | ${'https://github.com/backstage/backstage'}                                | ${undefined}
       ${'https://github.com/backstage/backstage/tree/main/examples/techdocs/'}   | ${'https://github.com/backstage/backstage/tree/main/examples/techdocs/'}   | ${'https://github.com/backstage/backstage/edit/main/examples/techdocs/docs'}
+      ${'https://github.com/backstage/backstage/tree/main/examples/techdocs'}    | ${'https://github.com/backstage/backstage/tree/main/examples/techdocs'}    | ${'https://github.com/backstage/backstage/edit/main/examples/techdocs/docs'}
       ${'https://github.com/backstage/backstage/tree/main/'}                     | ${'https://github.com/backstage/backstage/tree/main/'}                     | ${'https://github.com/backstage/backstage/edit/main/docs'}
       ${'https://gitlab.com/backstage/backstage'}                                | ${'https://gitlab.com/backstage/backstage'}                                | ${undefined}
       ${'https://gitlab.com/backstage/backstage/-/blob/main/examples/techdocs/'} | ${'https://gitlab.com/backstage/backstage/-/blob/main/examples/techdocs/'} | ${'https://gitlab.com/backstage/backstage/-/edit/main/examples/techdocs/docs'}

--- a/plugins/techdocs-node/src/stages/generate/helpers.ts
+++ b/plugins/techdocs-node/src/stages/generate/helpers.ts
@@ -117,7 +117,7 @@ export const getRepoUrlFromLocationAnnotation = (
 
       const sourceFolder = integration.resolveUrl({
         url: `./${docsFolder}`,
-        base: target,
+        base: target.endsWith('/') ? target : `${target}/`,
       });
       return {
         repo_url: target,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Given a nested techDocs structure like below the `Edit URL` link is incorrect as it points to the root of the repo instead of the nested structure.

`catalog-info.yaml`

```yaml
apiVersion: backstage.io/v1alpha1
kind: Component
metadata:
  name: "my-component"
  description: The best tutorial component
  tags:
   - kamil
  annotations:
    backstage.io/techdocs-ref: dir:./techDocs  # <------- NOTE the missing trailing slash
spec:
  type: api
  owner: user:kmarkow
  lifecycle: unknown
```

`techDocs/mkdocs.yaml`

```yaml
site_name: Test 
site_description: Test

nav:
  - Index: index.md

plugins:
  - techdocs-core
``` 

`techDocs/docs/index.md`
```md
hiiii there

you are viewing techDocs/docs/index.md
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Tests for new functionality and regression tests for bug fixes
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
