### PR TITLE
docs: Update rootLogger customisation link and add NBS health check

### DIFF
--- a/docs/plugins/observability.md
+++ b/docs/plugins/observability.md
@@ -17,7 +17,12 @@ See how to install Datadog Events in your app
 
 ### New Backend
 
-The backend supplies a central logging service, [`rootLogger`](../backend-system/core-services/root-logger.md), as well as a plugin based logger, [`logger`](../backend-system/core-services/logger.md) from `coreServices`. To add additional granularity to your logs, you can create children from the plugin based logger, using the `.child()` method and provide is with JSON data. For example, if you wanted to log items for a specific span in your plugin, you could do
+The backend supplies a central logging service,
+[`rootLogger`](../backend-system/core-services/root-logger.md), as well as a plugin
+based logger, [`logger`](../backend-system/core-services/logger.md) from `coreServices`.
+To add additional granularity to your logs, you can create children from the plugin
+based logger, using the `.child()` method and provide is with JSON data. For example,
+if you wanted to log items for a specific span in your plugin, you could do
 
 ```ts
 export function createRouter({ logger }) {
@@ -37,7 +42,9 @@ export function createRouter({ logger }) {
 }
 ```
 
-You can also add additional metadata to all logs for your Backstage instance by overriding the `rootLogger` implementation, you can see an example in [the `logger` docs](../backend-system/core-services/logger.md#configuring-the-service).
+You can also add additional metadata to all logs for your Backstage instance by
+overriding the `rootLogger` implementation, you can see an example in
+[the `rootLogger` docs](../backend-system/core-services/root-logger#configuring-the-service).
 
 ### Old Backend
 
@@ -63,9 +70,19 @@ An example log line could look as follows:
 
 ## Health Checks
 
-### New Backend
+### New Backend (post 1.29.0)
 
-The new backend is moving towards health checks being plugin-based, as such there is no current plugin for providing a health check route. You can add this yourself easily though,
+The new backend provides a `RootHealthService` which implements
+`/.backstage/health/v1/readiness` and `/.backstage/health/v1/liveness` endpoints
+to provide health checks for the entire backend instance.
+
+You can read more about this new service and how to customize it in the
+[Root Health Service documentation](../backend-system/core-services/root-health/).
+
+### New Backend (pre 1.29.0)
+
+The new backend is moving towards health checks being plugin-based, as such there is no
+current plugin for providing a health check route. You can add this yourself easily though,
 
 ```ts
 import {

--- a/docs/plugins/observability.md
+++ b/docs/plugins/observability.md
@@ -44,7 +44,7 @@ export function createRouter({ logger }) {
 
 You can also add additional metadata to all logs for your Backstage instance by
 overriding the `rootLogger` implementation, you can see an example in
-[the `rootLogger` docs](../backend-system/core-services/root-logger#configuring-the-service).
+[the `rootLogger` docs](../backend-system/core-services/root-logger.md#configuring-the-service).
 
 ### Old Backend
 
@@ -77,7 +77,7 @@ The new backend provides a `RootHealthService` which implements
 to provide health checks for the entire backend instance.
 
 You can read more about this new service and how to customize it in the
-[Root Health Service documentation](../backend-system/core-services/root-health/).
+[Root Health Service documentation](../backend-system/core-services/root-health.md).
 
 ### New Backend (pre 1.29.0)
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Documentation update for https://backstage.io/docs/plugins/observability/

This PR fixes the link for adding additional metadata to the backstage instance, by linking to the `rootLogger` documentation instead of `logger`. It also adds a section for the new `RootHealthService` that was released in version 1.29.0 while leaving the older NBS health check documentation in place for older installs.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
