### PR TITLE
tech insights has been moved

### DIFF
--- a/microsite/data/plugins/tech-insights.yaml
+++ b/microsite/data/plugins/tech-insights.yaml
@@ -6,7 +6,7 @@ category: Discovery
 description: Visualize, understand and optimize your team's tech health.
 documentation: https://roadie.io/backstage/plugins/tech-insights/
 iconUrl: https://roadie.io/images/logos/tech-insights.png
-npmPackageName: '@backstage/plugin-tech-insights'
+npmPackageName: '@backstage-community/plugin-tech-insights'
 tags:
   - tech-insights
   - reporting


### PR DESCRIPTION
The docs and icon are still in their old place, and the author is still roadie originally - leaving the other fields unchanged.

This replaces https://github.com/backstage/backstage/pull/25500