### PR TITLE
feat(catalog): only fetch needed fields for entity presentation

### DIFF
--- a/.changeset/tasty-pigs-vanish.md
+++ b/.changeset/tasty-pigs-vanish.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Entity presentation api now only fetches fields that are required to display entity title

--- a/plugins/catalog/src/apis/EntityPresentationApi/DefaultEntityPresentationApi.test.ts
+++ b/plugins/catalog/src/apis/EntityPresentationApi/DefaultEntityPresentationApi.test.ts
@@ -161,6 +161,15 @@ describe('DefaultEntityPresentationApi', () => {
     expect(catalogApi.getEntitiesByRefs).toHaveBeenCalledWith(
       expect.objectContaining({
         entityRefs: ['component:default/test'],
+        fields: [
+          'kind',
+          'metadata.name',
+          'metadata.namespace',
+          'metadata.title',
+          'metadata.description',
+          'spec.profile.displayName',
+          'spec.type',
+        ],
       }),
     );
   });

--- a/plugins/catalog/src/apis/EntityPresentationApi/DefaultEntityPresentationApi.ts
+++ b/plugins/catalog/src/apis/EntityPresentationApi/DefaultEntityPresentationApi.ts
@@ -26,15 +26,15 @@ import {
   EntityRefPresentation,
   EntityRefPresentationSnapshot,
 } from '@backstage/plugin-catalog-react';
-import { HumanDuration, durationToMilliseconds } from '@backstage/types';
+import { durationToMilliseconds, HumanDuration } from '@backstage/types';
 import DataLoader from 'dataloader';
 import ExpiryMap from 'expiry-map';
 import ObservableImpl from 'zen-observable';
 import {
+  createDefaultRenderer,
   DEFAULT_BATCH_DELAY,
   DEFAULT_CACHE_TTL,
   DEFAULT_ICONS,
-  createDefaultRenderer,
 } from './defaults';
 
 /**
@@ -371,6 +371,15 @@ export class DefaultEntityPresentationApi implements EntityPresentationApi {
       async (entityRefs: readonly string[]) => {
         const { items } = await options.catalogApi!.getEntitiesByRefs({
           entityRefs: entityRefs as string[],
+          fields: [
+            'kind',
+            'metadata.name',
+            'metadata.namespace',
+            'metadata.title',
+            'metadata.description',
+            'spec.profile.displayName',
+            'spec.type',
+          ],
         });
 
         const now = Date.now();


### PR DESCRIPTION
## Hey, I just made a Pull Request!

To save bandwidth, only fetch the necessary fields for the entity presentation API for displaying the entity title.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
