### PR TITLE
NFS: Fixing `inputs` merging in `Blueprints`

### DIFF
--- a/.changeset/breezy-cats-kiss.md
+++ b/.changeset/breezy-cats-kiss.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': patch
+---
+
+Fixing issue with `Blueprints` `inputs` merging

--- a/.changeset/breezy-cats-kiss.md
+++ b/.changeset/breezy-cats-kiss.md
@@ -2,4 +2,4 @@
 '@backstage/frontend-plugin-api': patch
 ---
 
-Fixing issue with `Blueprints` `inputs` merging
+Fixing issue with extension blueprints `inputs` merging.

--- a/packages/frontend-plugin-api/api-report.md
+++ b/packages/frontend-plugin-api/api-report.md
@@ -622,7 +622,7 @@ export function createExtensionBlueprint<
 ): ExtensionBlueprint<
   TParams,
   UOutput,
-  TInputs,
+  string extends keyof TInputs ? {} : TInputs,
   string extends keyof TConfigSchema
     ? {}
     : {
@@ -1367,15 +1367,7 @@ export const IconBundleBlueprint: ExtensionBlueprint<
     'core.icons',
     {}
   >,
-  {
-    [x: string]: ExtensionInput<
-      AnyExtensionDataRef,
-      {
-        optional: boolean;
-        singleton: boolean;
-      }
-    >;
-  },
+  {},
   {
     icons: string;
     test: string;

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
@@ -420,7 +420,7 @@ export function createExtensionBlueprint<
 ): ExtensionBlueprint<
   TParams,
   UOutput,
-  TInputs,
+  string extends keyof TInputs ? {} : TInputs,
   string extends keyof TConfigSchema
     ? {}
     : { [key in keyof TConfigSchema]: z.infer<ReturnType<TConfigSchema[key]>> },
@@ -436,7 +436,7 @@ export function createExtensionBlueprint<
   return new ExtensionBlueprintImpl(options) as ExtensionBlueprint<
     TParams,
     UOutput,
-    TInputs,
+    string extends keyof TInputs ? {} : TInputs,
     string extends keyof TConfigSchema
       ? {}
       : {


### PR DESCRIPTION
If there was no inputs defined in the `Blueprint` would cause typescript issues when trying to provide some in `.make`