### PR TITLE
backend-plugin-api: fix for plugins and modules depending on multion services

### DIFF
--- a/.changeset/seven-days-film.md
+++ b/.changeset/seven-days-film.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-plugin-api': patch
+---
+
+Fixed a type issue where plugin and modules depending on multiton services would not receive the correct type.

--- a/.changeset/silver-pillows-begin.md
+++ b/.changeset/silver-pillows-begin.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Internal type refactor.

--- a/.github/vale/config/vocabularies/Backstage/accept.txt
+++ b/.github/vale/config/vocabularies/Backstage/accept.txt
@@ -245,6 +245,7 @@ Monorepo
 monorepos
 msgraph
 msw
+multiton
 mutex
 mutexes
 mysql

--- a/packages/backend-common/src/compat/legacy/legacy.ts
+++ b/packages/backend-common/src/compat/legacy/legacy.ts
@@ -18,6 +18,7 @@ import {
   AuthService,
   coreServices,
   createBackendPlugin,
+  HttpRouterService,
   ServiceRef,
 } from '@backstage/backend-plugin-api';
 import { RequestHandler } from 'express';
@@ -107,7 +108,10 @@ export function makeLegacyPlugin<
                   return [key, transform(dep)];
                 }
                 if (key === 'tokenManager') {
-                  return [key, wrapTokenManager(dep as TokenManager, _auth)];
+                  return [
+                    key,
+                    wrapTokenManager(dep as TokenManager, _auth as AuthService),
+                  ];
                 }
                 return [key, dep];
               }),
@@ -115,7 +119,7 @@ export function makeLegacyPlugin<
             const router = await createRouter(
               pluginEnv as TransformedEnv<TEnv, TEnvTransforms>,
             );
-            _router.use(router);
+            (_router as HttpRouterService).use(router);
           },
         });
       },

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -82,14 +82,12 @@ export interface BackendModuleRegistrationPoints {
   ): void;
   // (undocumented)
   registerInit<
-    Deps extends {
-      [name in string]: unknown;
+    TDeps extends {
+      [name in string]: ServiceRef<unknown> | ExtensionPoint<unknown>;
     },
   >(options: {
-    deps: {
-      [name in keyof Deps]: ServiceRef<Deps[name]> | ExtensionPoint<Deps[name]>;
-    };
-    init(deps: Deps): Promise<void>;
+    deps: TDeps;
+    init(deps: DepsToInstances<TDeps>): Promise<void>;
   }): void;
 }
 
@@ -105,14 +103,12 @@ export interface BackendPluginRegistrationPoints {
   ): void;
   // (undocumented)
   registerInit<
-    Deps extends {
-      [name in string]: unknown;
+    TDeps extends {
+      [name in string]: ServiceRef<unknown>;
     },
   >(options: {
-    deps: {
-      [name in keyof Deps]: ServiceRef<Deps[name]>;
-    };
-    init(deps: Deps): Promise<void>;
+    deps: TDeps;
+    init(deps: DepsToInstances<TDeps>): Promise<void>;
   }): void;
 }
 

--- a/packages/backend-plugin-api/src/wiring/types.ts
+++ b/packages/backend-plugin-api/src/wiring/types.ts
@@ -36,6 +36,17 @@ export type ExtensionPoint<T> = {
   $$type: '@backstage/ExtensionPoint';
 };
 
+/** @ignore */
+type DepsToInstances<
+  TDeps extends {
+    [key in string]: ServiceRef<unknown> | ExtensionPoint<unknown>;
+  },
+> = {
+  [key in keyof TDeps]: TDeps[key] extends ServiceRef<unknown, any, 'multiton'>
+    ? Array<TDeps[key]['T']>
+    : TDeps[key]['T'];
+};
+
 /**
  * The callbacks passed to the `register` method of a backend plugin.
  *
@@ -46,11 +57,13 @@ export interface BackendPluginRegistrationPoints {
     ref: ExtensionPoint<TExtensionPoint>,
     impl: TExtensionPoint,
   ): void;
-  registerInit<Deps extends { [name in string]: unknown }>(options: {
-    deps: {
-      [name in keyof Deps]: ServiceRef<Deps[name]>;
-    };
-    init(deps: Deps): Promise<void>;
+  registerInit<
+    TDeps extends {
+      [name in string]: ServiceRef<unknown>;
+    },
+  >(options: {
+    deps: TDeps;
+    init(deps: DepsToInstances<TDeps>): Promise<void>;
   }): void;
 }
 
@@ -64,11 +77,13 @@ export interface BackendModuleRegistrationPoints {
     ref: ExtensionPoint<TExtensionPoint>,
     impl: TExtensionPoint,
   ): void;
-  registerInit<Deps extends { [name in string]: unknown }>(options: {
-    deps: {
-      [name in keyof Deps]: ServiceRef<Deps[name]> | ExtensionPoint<Deps[name]>;
-    };
-    init(deps: Deps): Promise<void>;
+  registerInit<
+    TDeps extends {
+      [name in string]: ServiceRef<unknown> | ExtensionPoint<unknown>;
+    },
+  >(options: {
+    deps: TDeps;
+    init(deps: DepsToInstances<TDeps>): Promise<void>;
   }): void;
 }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Followup fix for #24547, we forgot to properly handle multiton services for plugins and modules 😁. Our intention was for multiton services to mostly be dependencies of other services, but I see no reason to not have them work for plugins and modules too.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
