### PR TITLE
adds ability to configure the commit message when initializating a repo

### DIFF
--- a/.changeset/five-mangos-agree.md
+++ b/.changeset/five-mangos-agree.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-backend-module-bitbucket-cloud': patch
 ---
 
-Add abilty to set the initial commit message when initializing a repository using the scaffolder action.
+Add ability to set the initial commit message when initializing a repository using the scaffolder action.

--- a/.changeset/five-mangos-agree.md
+++ b/.changeset/five-mangos-agree.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-bitbucket-cloud': patch
+---
+
+Add abilty to set the initial commit message when initializing a repository using the scaffolder action.

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/api-report.md
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/api-report.md
@@ -36,6 +36,7 @@ export function createPublishBitbucketCloudAction(options: {
     description?: string | undefined;
     defaultBranch?: string | undefined;
     repoVisibility?: 'private' | 'public' | undefined;
+    gitCommitMessage?: string | undefined;
     sourcePath?: string | undefined;
     token?: string | undefined;
   },

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloud.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloud.ts
@@ -111,6 +111,7 @@ export function createPublishBitbucketCloudAction(options: {
     description?: string;
     defaultBranch?: string;
     repoVisibility?: 'private' | 'public';
+    gitCommitMessage?: string;
     sourcePath?: string;
     token?: string;
   }>({
@@ -140,6 +141,11 @@ export function createPublishBitbucketCloudAction(options: {
             title: 'Default Branch',
             type: 'string',
             description: `Sets the default branch on the repository. The default value is 'master'`,
+          },
+          gitCommitMessage: {
+            title: 'Git Commit Message',
+            type: 'string',
+            description: `Sets the commit message on the repository. The default value is 'initial commit'`,
           },
           sourcePath: {
             title: 'Source Path',
@@ -178,6 +184,7 @@ export function createPublishBitbucketCloudAction(options: {
         repoUrl,
         description,
         defaultBranch = 'master',
+        gitCommitMessage,
         repoVisibility = 'private',
       } = ctx.input;
 
@@ -256,9 +263,9 @@ export function createPublishBitbucketCloudAction(options: {
         auth,
         defaultBranch,
         logger: ctx.logger,
-        commitMessage: config.getOptionalString(
-          'scaffolder.defaultCommitMessage',
-        ),
+        commitMessage:
+          gitCommitMessage ||
+          config.getOptionalString('scaffolder.defaultCommitMessage'),
         gitAuthorInfo,
       });
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

adds ability to configure the commit message when initializating a repo

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
