### PR TITLE
frontend-plugin-api: add support for accessing extensions from plugin instance

### DIFF
--- a/.changeset/old-tools-smell.md
+++ b/.changeset/old-tools-smell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': patch
+---
+
+Add support for accessing extensions definitions provided by a plugin via `plugin.getExtension(...)`. For this to work the extensions must be defined using the v2 format, typically using an extension blueprint.

--- a/packages/app-next-example-plugin/api-report.md
+++ b/packages/app-next-example-plugin/api-report.md
@@ -7,7 +7,7 @@ import { BackstagePlugin } from '@backstage/frontend-plugin-api';
 import { default as React_2 } from 'react';
 
 // @public (undocumented)
-const examplePlugin: BackstagePlugin<{}, {}>;
+const examplePlugin: BackstagePlugin<{}, {}, {}>;
 export default examplePlugin;
 
 // @public (undocumented)

--- a/packages/frontend-plugin-api/api-report.md
+++ b/packages/frontend-plugin-api/api-report.md
@@ -275,17 +275,22 @@ export { BackstageIdentityResponse };
 
 // @public (undocumented)
 export interface BackstagePlugin<
-  Routes extends AnyRoutes = AnyRoutes,
-  ExternalRoutes extends AnyExternalRoutes = AnyExternalRoutes,
+  TRoutes extends AnyRoutes = AnyRoutes,
+  TExternalRoutes extends AnyExternalRoutes = AnyExternalRoutes,
+  TExtensionMap extends {
+    [id in string]: ExtensionDefinition<any, any>;
+  } = {},
 > {
   // (undocumented)
   readonly $$type: '@backstage/BackstagePlugin';
   // (undocumented)
-  readonly externalRoutes: ExternalRoutes;
+  readonly externalRoutes: TExternalRoutes;
+  // (undocumented)
+  getExtension<TId extends keyof TExtensionMap>(id: TId): TExtensionMap[TId];
   // (undocumented)
   readonly id: string;
   // (undocumented)
-  readonly routes: Routes;
+  readonly routes: TRoutes;
 }
 
 export { BackstageUserIdentity };
@@ -396,7 +401,15 @@ export function createApiExtension<
     configSchema?: PortableSchema<TConfig>;
     inputs?: TInputs;
   },
-): ExtensionDefinition<TConfig, TConfig, never, never>;
+): ExtensionDefinition<
+  TConfig,
+  TConfig,
+  never,
+  never,
+  string | undefined,
+  string | undefined,
+  string | undefined
+>;
 
 // @public (undocumented)
 export namespace createApiExtension {
@@ -492,7 +505,15 @@ export function createComponentExtension<
           inputs: Expand<ResolvedExtensionInputs<TInputs>>;
         }) => ComponentType<TProps>;
       };
-}): ExtensionDefinition<TConfig, TConfig, never, never>;
+}): ExtensionDefinition<
+  TConfig,
+  TConfig,
+  never,
+  never,
+  string | undefined,
+  string | undefined,
+  string | undefined
+>;
 
 // @public (undocumented)
 export namespace createComponentExtension {
@@ -528,8 +549,14 @@ export function createExtension<
     [key: string]: (zImpl: typeof z) => z.ZodType;
   },
   UFactoryOutput extends ExtensionDataValue<any, any>,
+  const TKind extends string | undefined = undefined,
+  const TNamespace extends string | undefined = undefined,
+  const TName extends string | undefined = undefined,
 >(
   options: CreateExtensionOptions<
+    TKind,
+    TNamespace,
+    TName,
     UOutput,
     TInputs,
     TConfigSchema,
@@ -545,7 +572,10 @@ export function createExtension<
     }>
   >,
   UOutput,
-  TInputs
+  TInputs,
+  string | undefined extends TKind ? undefined : TKind,
+  string | undefined extends TNamespace ? undefined : TNamespace,
+  string | undefined extends TName ? undefined : TName
 >;
 
 // @public @deprecated (undocumented)
@@ -580,11 +610,17 @@ export function createExtensionBlueprint<
     [key in string]: (zImpl: typeof z) => z.ZodType;
   },
   UFactoryOutput extends ExtensionDataValue<any, any>,
+  TKind extends string,
+  TNamespace extends string | undefined = undefined,
+  TName extends string | undefined = undefined,
   TDataRefs extends {
     [name in string]: AnyExtensionDataRef;
   } = never,
 >(
   options: CreateExtensionBlueprintOptions<
+    TKind,
+    TNamespace,
+    TName,
     TParams,
     UOutput,
     TInputs,
@@ -593,6 +629,9 @@ export function createExtensionBlueprint<
     TDataRefs
   >,
 ): ExtensionBlueprint<
+  TKind,
+  TNamespace,
+  TName,
   TParams,
   UOutput,
   string extends keyof TInputs ? {} : TInputs,
@@ -613,6 +652,9 @@ export function createExtensionBlueprint<
 
 // @public (undocumented)
 export type CreateExtensionBlueprintOptions<
+  TKind extends string,
+  TNamespace extends string | undefined,
+  TName extends string | undefined,
   TParams,
   UOutput extends AnyExtensionDataRef,
   TInputs extends {
@@ -632,8 +674,8 @@ export type CreateExtensionBlueprintOptions<
     [name in string]: AnyExtensionDataRef;
   },
 > = {
-  kind: string;
-  namespace?: string | ((params: TParams) => string);
+  kind: TKind;
+  namespace?: TNamespace | ((params: TParams) => TNamespace);
   attachTo: {
     id: string;
     input: string;
@@ -641,7 +683,7 @@ export type CreateExtensionBlueprintOptions<
   disabled?: boolean;
   inputs?: TInputs;
   output: Array<UOutput>;
-  name?: string | ((params: TParams) => string);
+  name?: TName | ((params: TParams) => TName);
   config?: {
     schema: TConfigSchema | ((params: TParams) => TConfigSchema);
   };
@@ -714,6 +756,9 @@ export function createExtensionInput<
 
 // @public (undocumented)
 export type CreateExtensionOptions<
+  TKind extends string | undefined,
+  TNamespace extends string | undefined,
+  TName extends string | undefined,
   UOutput extends AnyExtensionDataRef,
   TInputs extends {
     [inputName in string]: ExtensionInput<
@@ -729,9 +774,9 @@ export type CreateExtensionOptions<
   },
   UFactoryOutput extends ExtensionDataValue<any, any>,
 > = {
-  kind?: string;
-  namespace?: string;
-  name?: string;
+  kind?: TKind;
+  namespace?: TNamespace;
+  name?: TName;
   attachTo: {
     id: string;
     input: string;
@@ -794,7 +839,10 @@ export function createNavItemExtension(options: {
     title?: string | undefined;
   },
   never,
-  never
+  never,
+  string | undefined,
+  string | undefined,
+  string | undefined
 >;
 
 // @public (undocumented)
@@ -817,7 +865,15 @@ export function createNavLogoExtension(options: {
   namespace?: string;
   logoIcon: JSX.Element;
   logoFull: JSX.Element;
-}): ExtensionDefinition<unknown, unknown, never, never>;
+}): ExtensionDefinition<
+  unknown,
+  unknown,
+  never,
+  never,
+  string | undefined,
+  string | undefined,
+  string | undefined
+>;
 
 // @public (undocumented)
 export namespace createNavLogoExtension {
@@ -865,11 +921,22 @@ export function createPageExtension<
 
 // @public (undocumented)
 export function createPlugin<
-  Routes extends AnyRoutes = {},
-  ExternalRoutes extends AnyExternalRoutes = {},
+  TId extends string,
+  TRoutes extends AnyRoutes = {},
+  TExternalRoutes extends AnyExternalRoutes = {},
+  TExtensions extends readonly ExtensionDefinition<any, any>[] = [],
 >(
-  options: PluginOptions<Routes, ExternalRoutes>,
-): BackstagePlugin<Routes, ExternalRoutes>;
+  options: PluginOptions<TId, TRoutes, TExternalRoutes, TExtensions>,
+): BackstagePlugin<
+  TRoutes,
+  TExternalRoutes,
+  {
+    [KExtension in TExtensions[number] as ResolveExtensionId<
+      KExtension,
+      TId
+    >]: KExtension;
+  }
+>;
 
 // @public
 export function createRouteRef<
@@ -972,7 +1039,15 @@ export function createSubRouteRef<
 // @public (undocumented)
 export function createThemeExtension(
   theme: AppTheme,
-): ExtensionDefinition<unknown, unknown, never, never>;
+): ExtensionDefinition<
+  unknown,
+  unknown,
+  never,
+  never,
+  string | undefined,
+  string | undefined,
+  string | undefined
+>;
 
 // @public (undocumented)
 export namespace createThemeExtension {
@@ -988,7 +1063,15 @@ export namespace createThemeExtension {
 export function createTranslationExtension(options: {
   name?: string;
   resource: TranslationResource | TranslationMessages;
-}): ExtensionDefinition<unknown, unknown, never, never>;
+}): ExtensionDefinition<
+  unknown,
+  unknown,
+  never,
+  never,
+  string | undefined,
+  string | undefined,
+  string | undefined
+>;
 
 // @public (undocumented)
 export namespace createTranslationExtension {
@@ -1044,6 +1127,9 @@ export interface Extension<TConfig, TConfigInput = TConfig> {
 
 // @public (undocumented)
 export interface ExtensionBlueprint<
+  TKind extends string,
+  TNamespace extends string | undefined,
+  TName extends string | undefined,
   TParams,
   UOutput extends AnyExtensionDataRef,
   TInputs extends {
@@ -1068,6 +1154,8 @@ export interface ExtensionBlueprint<
   // (undocumented)
   dataRefs: TDataRefs;
   make<
+    TNewNamespace extends string | undefined,
+    TNewName extends string | undefined,
     TExtensionConfigSchema extends {
       [key in string]: (zImpl: typeof z) => z.ZodType;
     },
@@ -1084,8 +1172,8 @@ export interface ExtensionBlueprint<
     },
   >(
     args: {
-      namespace?: string;
-      name?: string;
+      namespace?: TNewNamespace;
+      name?: TNewName;
       attachTo?: {
         id: string;
         input: string;
@@ -1143,7 +1231,12 @@ export interface ExtensionBlueprint<
         >;
       }>
     > &
-      TConfigInput
+      TConfigInput,
+    AnyExtensionDataRef extends UNewOutput ? UOutput : UNewOutput,
+    TInputs & TExtraInputs,
+    TKind,
+    string | undefined extends TNewNamespace ? TNamespace : TNewNamespace,
+    string | undefined extends TNewName ? TName : TNewName
   >;
 }
 
@@ -1239,6 +1332,9 @@ export interface ExtensionDefinition<
       }
     >;
   } = {},
+  TKind extends string | undefined = string | undefined,
+  TNamespace extends string | undefined = string | undefined,
+  TName extends string | undefined = string | undefined,
 > {
   // (undocumented)
   $$type: '@backstage/ExtensionDefinition';
@@ -1252,11 +1348,11 @@ export interface ExtensionDefinition<
   // (undocumented)
   readonly disabled: boolean;
   // (undocumented)
-  readonly kind?: string;
+  readonly kind?: TKind;
   // (undocumented)
-  readonly name?: string;
+  readonly name?: TName;
   // (undocumented)
-  readonly namespace?: string;
+  readonly namespace?: TNamespace;
   // (undocumented)
   override<
     TExtensionConfigSchema extends {
@@ -1325,7 +1421,10 @@ export interface ExtensionDefinition<
     > &
       TConfigInput,
     AnyExtensionDataRef extends UNewOutput ? UOutput : UNewOutput,
-    TInputs & TExtraInputs
+    TInputs & TExtraInputs,
+    TKind,
+    TNamespace,
+    TName
   >;
 }
 
@@ -1405,6 +1504,9 @@ export { googleAuthApiRef };
 
 // @public (undocumented)
 export const IconBundleBlueprint: ExtensionBlueprint<
+  'icon-bundle',
+  'app',
+  undefined,
   {
     icons: {
       [x: string]: IconComponent;
@@ -1536,19 +1638,21 @@ export { PendingOAuthRequest };
 
 // @public (undocumented)
 export interface PluginOptions<
-  Routes extends AnyRoutes,
-  ExternalRoutes extends AnyExternalRoutes,
+  TId extends string,
+  TRoutes extends AnyRoutes,
+  TExternalRoutes extends AnyExternalRoutes,
+  TExtensions extends readonly ExtensionDefinition<any, any>[],
 > {
   // (undocumented)
-  extensions?: ExtensionDefinition<any, any>[];
+  extensions?: TExtensions;
   // (undocumented)
-  externalRoutes?: ExternalRoutes;
+  externalRoutes?: TExternalRoutes;
   // (undocumented)
   featureFlags?: FeatureFlagConfig[];
   // (undocumented)
-  id: string;
+  id: TId;
   // (undocumented)
-  routes?: Routes;
+  routes?: TRoutes;
 }
 
 // @public (undocumented)

--- a/packages/frontend-plugin-api/src/wiring/createPlugin.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createPlugin.test.ts
@@ -34,11 +34,9 @@ const nameExtensionDataRef = createExtensionDataRef<string>().with({
 const Extension1 = createExtension({
   name: '1',
   attachTo: { id: 'test/output', input: 'names' },
-  output: {
-    name: nameExtensionDataRef,
-  },
+  output: [nameExtensionDataRef],
   factory() {
-    return { name: 'extension-1' };
+    return [nameExtensionDataRef('extension-1')];
   },
 });
 
@@ -149,6 +147,8 @@ describe('createPlugin', () => {
       extensions: [Extension1, Extension2, outputExtension],
     });
     expect(plugin).toBeDefined();
+
+    expect(plugin.getExtension('test/1')).toBe(Extension1);
 
     await renderWithEffects(
       createTestAppRoot({

--- a/packages/frontend-plugin-api/src/wiring/createPlugin.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createPlugin.test.ts
@@ -149,6 +149,8 @@ describe('createPlugin', () => {
     expect(plugin).toBeDefined();
 
     expect(plugin.getExtension('test/1')).toBe(Extension1);
+    // @ts-expect-error
+    expect(plugin.getExtension('nonexistent')).toBeUndefined();
 
     await renderWithEffects(
       createTestAppRoot({

--- a/packages/frontend-plugin-api/src/wiring/createPlugin.ts
+++ b/packages/frontend-plugin-api/src/wiring/createPlugin.ts
@@ -17,6 +17,7 @@
 import { ExtensionDefinition } from './createExtension';
 import {
   Extension,
+  ResolveExtensionId,
   resolveExtensionDefinition,
 } from './resolveExtensionDefinition';
 import {
@@ -28,21 +29,23 @@ import {
 
 /** @public */
 export interface PluginOptions<
-  Routes extends AnyRoutes,
-  ExternalRoutes extends AnyExternalRoutes,
+  TId extends string,
+  TRoutes extends AnyRoutes,
+  TExternalRoutes extends AnyExternalRoutes,
+  TExtensions extends readonly ExtensionDefinition<any, any>[],
 > {
-  id: string;
-  routes?: Routes;
-  externalRoutes?: ExternalRoutes;
-  extensions?: ExtensionDefinition<any, any>[];
+  id: TId;
+  routes?: TRoutes;
+  externalRoutes?: TExternalRoutes;
+  extensions?: TExtensions;
   featureFlags?: FeatureFlagConfig[];
 }
 
 /** @public */
 export interface InternalBackstagePlugin<
-  Routes extends AnyRoutes = AnyRoutes,
-  ExternalRoutes extends AnyExternalRoutes = AnyExternalRoutes,
-> extends BackstagePlugin<Routes, ExternalRoutes> {
+  TRoutes extends AnyRoutes = AnyRoutes,
+  TExternalRoutes extends AnyExternalRoutes = AnyExternalRoutes,
+> extends BackstagePlugin<TRoutes, TExternalRoutes> {
   readonly version: 'v1';
   readonly extensions: Extension<unknown>[];
   readonly featureFlags: FeatureFlagConfig[];
@@ -50,17 +53,36 @@ export interface InternalBackstagePlugin<
 
 /** @public */
 export function createPlugin<
-  Routes extends AnyRoutes = {},
-  ExternalRoutes extends AnyExternalRoutes = {},
+  TId extends string,
+  TRoutes extends AnyRoutes = {},
+  TExternalRoutes extends AnyExternalRoutes = {},
+  TExtensions extends readonly ExtensionDefinition<any, any>[] = [],
 >(
-  options: PluginOptions<Routes, ExternalRoutes>,
-): BackstagePlugin<Routes, ExternalRoutes> {
-  const extensions = (options.extensions ?? []).map(def =>
-    resolveExtensionDefinition(def, { namespace: options.id }),
-  );
+  options: PluginOptions<TId, TRoutes, TExternalRoutes, TExtensions>,
+): BackstagePlugin<
+  TRoutes,
+  TExternalRoutes,
+  {
+    [KExtension in TExtensions[number] as ResolveExtensionId<
+      KExtension,
+      TId
+    >]: KExtension;
+  }
+> {
+  const extensions = new Array<Extension<unknown>>();
+  const extensionDefinitionsById = new Map<
+    string,
+    ExtensionDefinition<unknown>
+  >();
 
-  const extensionIds = extensions.map(e => e.id);
-  if (extensionIds.length !== new Set(extensionIds).size) {
+  for (const def of options.extensions ?? []) {
+    const ext = resolveExtensionDefinition(def, { namespace: options.id });
+    extensions.push(ext);
+    extensionDefinitionsById.set(ext.id, def);
+  }
+
+  if (extensions.length !== extensionDefinitionsById.size) {
+    const extensionIds = extensions.map(e => e.id);
     const duplicates = Array.from(
       new Set(
         extensionIds.filter((id, index) => extensionIds.indexOf(id) !== index),
@@ -78,14 +100,17 @@ export function createPlugin<
     $$type: '@backstage/BackstagePlugin',
     version: 'v1',
     id: options.id,
-    routes: options.routes ?? ({} as Routes),
-    externalRoutes: options.externalRoutes ?? ({} as ExternalRoutes),
+    routes: options.routes ?? ({} as TRoutes),
+    externalRoutes: options.externalRoutes ?? ({} as TExternalRoutes),
     featureFlags: options.featureFlags ?? [],
     extensions,
+    getExtension(id) {
+      return extensionDefinitionsById.get(id);
+    },
     toString() {
       return `Plugin{id=${options.id}}`;
     },
-  } as InternalBackstagePlugin<Routes, ExternalRoutes>;
+  } as InternalBackstagePlugin<TRoutes, TExternalRoutes>;
 }
 
 /** @internal */

--- a/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.test.ts
@@ -15,7 +15,10 @@
  */
 
 import { ExtensionDefinition } from './createExtension';
-import { resolveExtensionDefinition } from './resolveExtensionDefinition';
+import {
+  ResolveExtensionId,
+  resolveExtensionDefinition,
+} from './resolveExtensionDefinition';
 
 describe('resolveExtensionDefinition', () => {
   const baseDef = {
@@ -96,5 +99,105 @@ describe('old resolveExtensionDefinition', () => {
     ).toThrow(
       'Extension must declare an explicit namespace or name as it could not be resolved from context, kind=undefined namespace=undefined name=undefined',
     );
+  });
+});
+
+describe('ResolveExtensionId', () => {
+  it('should resolve extension IDs correctly', () => {
+    type NamedExtension<
+      TKind extends string | undefined,
+      TNamespace extends string | undefined,
+      TName extends string | undefined,
+    > = ExtensionDefinition<any, any, any, any, TKind, TNamespace, TName>;
+
+    const id1: 'k:ns' = {} as ResolveExtensionId<
+      NamedExtension<'k', 'ns', undefined>,
+      undefined
+    >;
+    const id2: 'k:n' = {} as ResolveExtensionId<
+      NamedExtension<'k', undefined, 'n'>,
+      undefined
+    >;
+    const id3: 'ns/n' = {} as ResolveExtensionId<
+      NamedExtension<undefined, 'ns', 'n'>,
+      undefined
+    >;
+    const id4: never = {} as ResolveExtensionId<
+      NamedExtension<'k', undefined, undefined>,
+      undefined
+    >;
+    const id5: 'ns' = {} as ResolveExtensionId<
+      NamedExtension<undefined, 'ns', undefined>,
+      undefined
+    >;
+    const id6: 'n' = {} as ResolveExtensionId<
+      NamedExtension<undefined, undefined, 'n'>,
+      undefined
+    >;
+    const id7: 'k:ns/n' = {} as ResolveExtensionId<
+      NamedExtension<'k', 'ns', 'n'>,
+      undefined
+    >;
+    const id8: 'k:ns2' = {} as ResolveExtensionId<
+      NamedExtension<'k', 'ns', undefined>,
+      'ns2'
+    >;
+    const id9: 'k:ns2/n' = {} as ResolveExtensionId<
+      NamedExtension<'k', undefined, 'n'>,
+      'ns2'
+    >;
+    const ida: 'ns2/n' = {} as ResolveExtensionId<
+      NamedExtension<undefined, 'ns', 'n'>,
+      'ns2'
+    >;
+    const idb: 'k:ns2' = {} as ResolveExtensionId<
+      NamedExtension<'k', undefined, undefined>,
+      'ns2'
+    >;
+    const idc: 'ns2' = {} as ResolveExtensionId<
+      NamedExtension<undefined, 'ns', undefined>,
+      'ns2'
+    >;
+    const idd: 'ns2/n' = {} as ResolveExtensionId<
+      NamedExtension<undefined, undefined, 'n'>,
+      'ns2'
+    >;
+    const ide: 'k:ns2/n' = {} as ResolveExtensionId<
+      NamedExtension<'k', 'ns', 'n'>,
+      'ns2'
+    >;
+
+    const invalid1: never = {} as ResolveExtensionId<
+      NamedExtension<string | undefined, 'ns', 'n'>,
+      undefined
+    >;
+    const invalid2: never = {} as ResolveExtensionId<
+      NamedExtension<'k', string | undefined, 'n'>,
+      undefined
+    >;
+    const invalid3: never = {} as ResolveExtensionId<
+      NamedExtension<'k', 'ns', string | undefined>,
+      undefined
+    >;
+
+    expect([
+      id1,
+      id2,
+      id3,
+      id4,
+      id5,
+      id6,
+      id7,
+      id8,
+      id9,
+      ida,
+      idb,
+      idc,
+      idd,
+      ide,
+      invalid1,
+      invalid2,
+      invalid3,
+    ]).toBeDefined();
   });
 });

--- a/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.ts
+++ b/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.ts
@@ -94,6 +94,36 @@ export function toInternalExtension<TConfig, TConfigInput>(
   return internal;
 }
 
+/** @ignore */
+export type ResolveExtensionId<
+  TExtension extends ExtensionDefinition<any>,
+  TDefaultNamespace extends string | undefined,
+> = TExtension extends ExtensionDefinition<
+  any,
+  any,
+  any,
+  any,
+  infer IKind,
+  infer INamespace,
+  infer IName
+>
+  ? [string | undefined] extends [IKind | INamespace | IName]
+    ? never
+    : (
+        (
+          undefined extends TDefaultNamespace ? INamespace : TDefaultNamespace
+        ) extends infer ISelectedNamespace extends string
+          ? undefined extends IName
+            ? ISelectedNamespace
+            : `${ISelectedNamespace}/${IName}`
+          : IName
+      ) extends infer INamePart extends string
+    ? IKind extends string
+      ? `${IKind}:${INamePart}`
+      : INamePart
+    : never
+  : never;
+
 /** @internal */
 export function resolveExtensionDefinition<TConfig, TConfigInput>(
   definition: ExtensionDefinition<TConfig, TConfigInput>,

--- a/packages/frontend-plugin-api/src/wiring/types.ts
+++ b/packages/frontend-plugin-api/src/wiring/types.ts
@@ -15,6 +15,7 @@
  */
 
 import { ExternalRouteRef, RouteRef, SubRouteRef } from '../routing';
+import { ExtensionDefinition } from './createExtension';
 
 /**
  * Feature flag configuration.
@@ -33,14 +34,23 @@ export type AnyRoutes = { [name in string]: RouteRef | SubRouteRef };
 export type AnyExternalRoutes = { [name in string]: ExternalRouteRef };
 
 /** @public */
+export type ExtensionMap<
+  TExtensionMap extends { [id in string]: ExtensionDefinition<any, any> },
+> = {
+  get<TId extends keyof TExtensionMap>(id: TId): TExtensionMap[TId];
+};
+
+/** @public */
 export interface BackstagePlugin<
-  Routes extends AnyRoutes = AnyRoutes,
-  ExternalRoutes extends AnyExternalRoutes = AnyExternalRoutes,
+  TRoutes extends AnyRoutes = AnyRoutes,
+  TExternalRoutes extends AnyExternalRoutes = AnyExternalRoutes,
+  TExtensionMap extends { [id in string]: ExtensionDefinition<any, any> } = {},
 > {
   readonly $$type: '@backstage/BackstagePlugin';
   readonly id: string;
-  readonly routes: Routes;
-  readonly externalRoutes: ExternalRoutes;
+  readonly routes: TRoutes;
+  readonly externalRoutes: TExternalRoutes;
+  getExtension<TId extends keyof TExtensionMap>(id: TId): TExtensionMap[TId];
 }
 
 /** @public */

--- a/plugins/api-docs/api-report-alpha.md
+++ b/plugins/api-docs/api-report-alpha.md
@@ -14,7 +14,8 @@ const _default: BackstagePlugin<
   },
   {
     registerApi: ExternalRouteRef<undefined>;
-  }
+  },
+  {}
 >;
 export default _default;
 

--- a/plugins/app-visualizer/api-report.md
+++ b/plugins/app-visualizer/api-report.md
@@ -6,7 +6,7 @@
 import { BackstagePlugin } from '@backstage/frontend-plugin-api';
 
 // @public (undocumented)
-const visualizerPlugin: BackstagePlugin<{}, {}>;
+const visualizerPlugin: BackstagePlugin<{}, {}, {}>;
 export default visualizerPlugin;
 
 // (No @packageDocumentation comment for this package)

--- a/plugins/catalog-graph/api-report-alpha.md
+++ b/plugins/catalog-graph/api-report-alpha.md
@@ -18,7 +18,8 @@ const _default: BackstagePlugin<
       kind: string;
       namespace: string;
     }>;
-  }
+  },
+  {}
 >;
 export default _default;
 

--- a/plugins/catalog-import/api-report-alpha.md
+++ b/plugins/catalog-import/api-report-alpha.md
@@ -11,6 +11,7 @@ const _default: BackstagePlugin<
   {
     importPage: RouteRef<undefined>;
   },
+  {},
   {}
 >;
 export default _default;

--- a/plugins/catalog-react/api-report-alpha.md
+++ b/plugins/catalog-react/api-report-alpha.md
@@ -115,7 +115,15 @@ export function createEntityCardExtension<
     config: TConfig;
     inputs: Expand<ResolvedExtensionInputs<TInputs>>;
   }) => Promise<JSX.Element>;
-}): ExtensionDefinition<TConfig, TConfig, never, never>;
+}): ExtensionDefinition<
+  TConfig,
+  TConfig,
+  never,
+  never,
+  string | undefined,
+  string | undefined,
+  string | undefined
+>;
 
 // @alpha (undocumented)
 export function createEntityContentExtension<
@@ -150,7 +158,10 @@ export function createEntityContentExtension<
     path?: string | undefined;
   },
   never,
-  never
+  never,
+  string | undefined,
+  string | undefined,
+  string | undefined
 >;
 
 // @alpha

--- a/plugins/catalog/api-report-alpha.md
+++ b/plugins/catalog/api-report-alpha.md
@@ -108,7 +108,15 @@ export function createCatalogFilterExtension<
   inputs?: TInputs;
   configSchema?: PortableSchema<TConfig>;
   loader: (options: { config: TConfig }) => Promise<JSX.Element>;
-}): ExtensionDefinition<TConfig, TConfig, never, never>;
+}): ExtensionDefinition<
+  TConfig,
+  TConfig,
+  never,
+  never,
+  string | undefined,
+  string | undefined,
+  string | undefined
+>;
 
 // @alpha (undocumented)
 const _default: BackstagePlugin<
@@ -132,7 +140,8 @@ const _default: BackstagePlugin<
       templateName: string;
     }>;
     unregisterRedirect: ExternalRouteRef<undefined>;
-  }
+  },
+  {}
 >;
 export default _default;
 

--- a/plugins/devtools/api-report-alpha.md
+++ b/plugins/devtools/api-report-alpha.md
@@ -11,6 +11,7 @@ const _default: BackstagePlugin<
   {
     root: RouteRef<undefined>;
   },
+  {},
   {}
 >;
 export default _default;

--- a/plugins/home/api-report-alpha.md
+++ b/plugins/home/api-report-alpha.md
@@ -7,7 +7,7 @@ import { BackstagePlugin } from '@backstage/frontend-plugin-api';
 import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
 
 // @alpha (undocumented)
-const _default: BackstagePlugin<{}, {}>;
+const _default: BackstagePlugin<{}, {}, {}>;
 export default _default;
 
 // @alpha (undocumented)

--- a/plugins/kubernetes/api-report-alpha.md
+++ b/plugins/kubernetes/api-report-alpha.md
@@ -11,6 +11,7 @@ const _default: BackstagePlugin<
   {
     kubernetes: RouteRef<undefined>;
   },
+  {},
   {}
 >;
 export default _default;

--- a/plugins/org/api-report-alpha.md
+++ b/plugins/org/api-report-alpha.md
@@ -11,7 +11,8 @@ const _default: BackstagePlugin<
   {},
   {
     catalogIndex: ExternalRouteRef<undefined>;
-  }
+  },
+  {}
 >;
 export default _default;
 

--- a/plugins/scaffolder/api-report-alpha.md
+++ b/plugins/scaffolder/api-report-alpha.md
@@ -36,7 +36,8 @@ const _default: BackstagePlugin<
       kind: string;
       namespace: string;
     }>;
-  }
+  },
+  {}
 >;
 export default _default;
 

--- a/plugins/search-react/api-report-alpha.md
+++ b/plugins/search-react/api-report-alpha.md
@@ -25,7 +25,15 @@ export function createSearchResultListItemExtension<
   },
 >(
   options: SearchResultItemExtensionOptions<TConfig>,
-): ExtensionDefinition<TConfig, TConfig, never, never>;
+): ExtensionDefinition<
+  TConfig,
+  TConfig,
+  never,
+  never,
+  string | undefined,
+  string | undefined,
+  string | undefined
+>;
 
 // @alpha (undocumented)
 export namespace createSearchResultListItemExtension {

--- a/plugins/search/api-report-alpha.md
+++ b/plugins/search/api-report-alpha.md
@@ -13,12 +13,21 @@ const _default: BackstagePlugin<
   {
     root: RouteRef<undefined>;
   },
+  {},
   {}
 >;
 export default _default;
 
 // @alpha (undocumented)
-export const searchApi: ExtensionDefinition<{}, {}, never, never>;
+export const searchApi: ExtensionDefinition<
+  {},
+  {},
+  never,
+  never,
+  string | undefined,
+  string | undefined,
+  string | undefined
+>;
 
 // @alpha (undocumented)
 export const searchNavItem: ExtensionDefinition<
@@ -29,7 +38,10 @@ export const searchNavItem: ExtensionDefinition<
     title?: string | undefined;
   },
   never,
-  never
+  never,
+  string | undefined,
+  string | undefined,
+  string | undefined
 >;
 
 // @alpha (undocumented)
@@ -43,7 +55,10 @@ export const searchPage: ExtensionDefinition<
     noTrack: boolean;
   },
   AnyExtensionDataRef,
-  {}
+  {},
+  string | undefined,
+  string | undefined,
+  string | undefined
 >;
 
 // (No @packageDocumentation comment for this package)

--- a/plugins/techdocs/api-report-alpha.md
+++ b/plugins/techdocs/api-report-alpha.md
@@ -18,6 +18,7 @@ const _default: BackstagePlugin<
     }>;
     entityContent: RouteRef<undefined>;
   },
+  {},
   {}
 >;
 export default _default;
@@ -39,7 +40,10 @@ export const techDocsSearchResultListItemExtension: ExtensionDefinition<
     title?: string | undefined;
   },
   never,
-  never
+  never,
+  string | undefined,
+  string | undefined,
+  string | undefined
 >;
 
 // (No @packageDocumentation comment for this package)

--- a/plugins/user-settings/api-report-alpha.md
+++ b/plugins/user-settings/api-report-alpha.md
@@ -13,6 +13,7 @@ const _default: BackstagePlugin<
   {
     root: RouteRef<undefined>;
   },
+  {},
   {}
 >;
 export default _default;
@@ -26,7 +27,10 @@ export const settingsNavItem: ExtensionDefinition<
     title?: string | undefined;
   },
   never,
-  never
+  never,
+  string | undefined,
+  string | undefined,
+  string | undefined
 >;
 
 // @alpha (undocumented)


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is a step towards simplifying the process of overriding plugin extensions. It makes all extension definitions that a plugin providers available via `plugin.getExtension(id)`. The extensions need to be defined with the v2 format, so until we've moved things to use blueprints the extensions won't be available anywhere just yet.

I opted for `.getExtension(id)`, but happy to discuss other options. Using `.extensions.get` had a collision with the existing `.extensions` property on the internal type, so figured it was best not to mess with that unless needed.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
