### PR TITLE
Switch process polyfill to require.resolve

### DIFF
--- a/.changeset/funny-bears-sort.md
+++ b/.changeset/funny-bears-sort.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Switched the `process` polyfill to use `require.resolve` for greater compatability.

--- a/packages/cli/src/lib/bundler/config.ts
+++ b/packages/cli/src/lib/bundler/config.ts
@@ -180,7 +180,7 @@ export async function createConfig(
   // to remove this eventually!
   plugins.push(
     new ProvidePlugin({
-      process: 'process/browser',
+      process: require.resolve('process/browser'),
       Buffer: ['buffer', 'Buffer'],
     }),
   );


### PR DESCRIPTION
The `process` polyfill added with ProvidePlugin in Webpack is not resolving when building packages using Yarn's PnP nodeLinker. This switches to `require.resolve`, which should be more reliable.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
