### PR TITLE
frontend-plugin-api: add support for overriding inputs values

### DIFF
--- a/packages/frontend-app-api/src/tree/instantiateAppNodeTree.ts
+++ b/packages/frontend-app-api/src/tree/instantiateAppNodeTree.ts
@@ -92,6 +92,16 @@ function resolveInputDataContainer(
     get(ref) {
       return dataMap.get(ref.id);
     },
+    *[Symbol.iterator]() {
+      for (const [id, value] of dataMap) {
+        // TODO: Would be better to be able to create a new instance using the ref here instead
+        yield {
+          $$type: '@backstage/ExtensionDataValue',
+          id,
+          value,
+        };
+      }
+    },
   } as { node: AppNode } & ExtensionDataContainer<AnyExtensionDataRef>;
 }
 

--- a/packages/frontend-plugin-api/api-report.md
+++ b/packages/frontend-plugin-api/api-report.md
@@ -1281,7 +1281,7 @@ export interface ExtensionBlueprint<
         params: TParams,
         context?: {
           config?: TConfig;
-          inputs?: Expand<ResolvedExtensionInputs<TInputs>>;
+          inputs?: ResolveInputValueOverrides<TInputs>;
         },
       ) => ExtensionDataContainer<UOutput>,
       context: {
@@ -1470,7 +1470,7 @@ export interface ExtensionDefinition<
       factory(
         originalFactory: (context?: {
           config?: TConfig;
-          inputs?: Expand<ResolvedExtensionInputs<TInputs>>;
+          inputs?: ResolveInputValueOverrides<TInputs>;
         }) => ExtensionDataContainer<UOutput>,
         context: {
           node: AppNode;
@@ -1867,6 +1867,73 @@ export type ResolvedExtensionInputs<
     ? Expand<ResolvedExtensionInput<TInputs[InputName]>>
     : Expand<ResolvedExtensionInput<TInputs[InputName]> | undefined>;
 };
+
+// @public (undocumented)
+export type ResolveInputValueOverrides<
+  TInputs extends {
+    [inputName in string]: ExtensionInput<
+      AnyExtensionDataRef,
+      {
+        optional: boolean;
+        singleton: boolean;
+      }
+    >;
+  } = {
+    [inputName in string]: ExtensionInput<
+      AnyExtensionDataRef,
+      {
+        optional: boolean;
+        singleton: boolean;
+      }
+    >;
+  },
+> = Expand<
+  {
+    [KName in keyof TInputs as TInputs[KName] extends ExtensionInput<
+      any,
+      {
+        optional: infer IOptional extends boolean;
+        singleton: boolean;
+      }
+    >
+      ? IOptional extends true
+        ? never
+        : KName
+      : never]: TInputs[KName] extends ExtensionInput<
+      infer IDataRefs,
+      {
+        optional: boolean;
+        singleton: infer ISingleton extends boolean;
+      }
+    >
+      ? ISingleton extends true
+        ? Iterable<ExtensionDataRefToValue<IDataRefs>>
+        : Array<Iterable<ExtensionDataRefToValue<IDataRefs>>>
+      : never;
+  } & {
+    [KName in keyof TInputs as TInputs[KName] extends ExtensionInput<
+      any,
+      {
+        optional: infer IOptional extends boolean;
+        singleton: boolean;
+      }
+    >
+      ? IOptional extends true
+        ? KName
+        : never
+      : never]?: TInputs[KName] extends ExtensionInput<
+      infer IDataRefs,
+      {
+        optional: boolean;
+        singleton: infer ISingleton extends boolean;
+      }
+    >
+      ? ISingleton extends true
+        ? Iterable<ExtensionDataRefToValue<IDataRefs>>
+        : Array<Iterable<ExtensionDataRefToValue<IDataRefs>>>
+      : never;
+  }
+>;
 
 // @public
 export type RouteFunc<TParams extends AnyRouteRefParams> = (

--- a/packages/frontend-plugin-api/src/wiring/createExtension.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.test.ts
@@ -850,7 +850,7 @@ describe('createExtension', () => {
               return originalFactory({
                 inputs: {
                   single: [testDataRef1('single')],
-                  multi: [[testDataRef1('multi1')], [testDataRef1('multi2')]],
+                  multi: [],
                 },
               });
             },
@@ -865,7 +865,7 @@ describe('createExtension', () => {
         opt: 'none',
         single: 'single',
         singleOpt: 'none',
-        multi: 'multi1,multi2',
+        multi: '',
       });
 
       // Forward inputs directly

--- a/packages/frontend-plugin-api/src/wiring/createExtension.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.test.ts
@@ -969,7 +969,7 @@ describe('createExtension', () => {
           .add(multi2Ext)
           .data(outputRef),
       ).toThrowErrorMatchingInlineSnapshot(
-        `"Failed to instantiate extension 'subject', Invalid override provided for input 'multi', when overriding the input data the length must match the original input data"`,
+        `"Failed to instantiate extension 'subject', override data provided for input 'multi' must match the length of the original inputs"`,
       );
 
       // Required input not provided
@@ -992,7 +992,7 @@ describe('createExtension', () => {
           .add(multi2Ext)
           .data(outputRef),
       ).toThrowErrorMatchingInlineSnapshot(
-        `"Failed to instantiate extension 'subject', Missing required data values for 'test1'"`,
+        `"Failed to instantiate extension 'subject', missing required extension data value(s) 'test1'"`,
       );
 
       // Wrong value provided
@@ -1021,7 +1021,7 @@ describe('createExtension', () => {
           .add(multi2Ext)
           .data(outputRef),
       ).toThrowErrorMatchingInlineSnapshot(
-        `"Failed to instantiate extension 'subject', Invalid data value provided, 'test2' was not declared"`,
+        `"Failed to instantiate extension 'subject', extension data 'test2' was provided but not declared"`,
       );
     });
   });

--- a/packages/frontend-plugin-api/src/wiring/createExtension.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.test.ts
@@ -732,5 +732,297 @@ describe('createExtension', () => {
         }).data(stringDataRef),
       ).toBe('foo-hello-override-world');
     });
+
+    it('should be able to override input values', () => {
+      const outputRef = createExtensionDataRef<unknown>().with({
+        id: 'output',
+      });
+      const testDataRef1 = createExtensionDataRef<string>().with({
+        id: 'test1',
+      });
+      const testDataRef2 = createExtensionDataRef<string>().with({
+        id: 'test2',
+      });
+
+      const subject = createExtension({
+        name: 'subject',
+        attachTo: { id: 'ignored', input: 'ignored' },
+        inputs: {
+          opt: createExtensionInput([testDataRef1.optional()], {
+            singleton: true,
+            optional: true,
+          }),
+          single: createExtensionInput(
+            [testDataRef1, testDataRef2.optional()],
+            {
+              singleton: true,
+            },
+          ),
+          multi: createExtensionInput([testDataRef1]),
+        },
+        output: [outputRef],
+        factory({ inputs }) {
+          return [
+            outputRef({
+              opt: inputs.opt?.get(testDataRef1) ?? 'none',
+              single: inputs.single.get(testDataRef1),
+              singleOpt: inputs.single.get(testDataRef2) ?? 'none',
+              multi: inputs.multi.map(i => i.get(testDataRef1)).join(','),
+            }),
+          ];
+        },
+      });
+
+      const optExt = createExtension({
+        name: 'opt',
+        attachTo: { id: 'subject', input: 'opt' },
+        output: [testDataRef1],
+        factory: () => [testDataRef1('orig-opt')],
+      });
+
+      const singleExt = createExtension({
+        name: 'single',
+        attachTo: { id: 'subject', input: 'single' },
+        output: [testDataRef1, testDataRef2.optional()],
+        factory: () => [testDataRef1('orig-single')],
+      });
+
+      const multi1Ext = createExtension({
+        name: 'multi1',
+        attachTo: { id: 'subject', input: 'multi' },
+        output: [testDataRef1],
+        factory: () => [testDataRef1('orig-multi1')],
+      });
+
+      const multi2Ext = createExtension({
+        name: 'multi2',
+        attachTo: { id: 'subject', input: 'multi' },
+        output: [testDataRef1],
+        factory: () => [testDataRef1('orig-multi2')],
+      });
+
+      expect(
+        createExtensionTester(subject)
+          .add(optExt)
+          .add(singleExt)
+          .add(multi1Ext)
+          .add(multi2Ext)
+          .data(outputRef),
+      ).toEqual({
+        opt: 'orig-opt',
+        single: 'orig-single',
+        singleOpt: 'none',
+        multi: 'orig-multi1,orig-multi2',
+      });
+
+      // All values provided
+      expect(
+        createExtensionTester(
+          subject.override({
+            factory(originalFactory) {
+              return originalFactory({
+                inputs: {
+                  opt: [testDataRef1('opt')],
+                  single: [testDataRef1('single'), testDataRef2('singleOpt')],
+                  multi: [[testDataRef1('multi1')], [testDataRef1('multi2')]],
+                },
+              });
+            },
+          }),
+        )
+          .add(optExt)
+          .add(singleExt)
+          .add(multi1Ext)
+          .add(multi2Ext)
+          .data(outputRef),
+      ).toEqual({
+        opt: 'opt',
+        single: 'single',
+        singleOpt: 'singleOpt',
+        multi: 'multi1,multi2',
+      });
+
+      // Minimal values provided
+      expect(
+        createExtensionTester(
+          subject.override({
+            factory(originalFactory) {
+              return originalFactory({
+                inputs: {
+                  single: [testDataRef1('single')],
+                  multi: [[testDataRef1('multi1')], [testDataRef1('multi2')]],
+                },
+              });
+            },
+          }),
+        )
+          .add(optExt)
+          .add(singleExt)
+          .add(multi1Ext)
+          .add(multi2Ext)
+          .data(outputRef),
+      ).toEqual({
+        opt: 'none',
+        single: 'single',
+        singleOpt: 'none',
+        multi: 'multi1,multi2',
+      });
+
+      // Forward inputs directly
+      expect(
+        createExtensionTester(
+          subject.override({
+            factory(originalFactory, { inputs }) {
+              return originalFactory({
+                inputs,
+              });
+            },
+          }),
+        )
+          .add(optExt)
+          .add(singleExt)
+          .add(multi1Ext)
+          .add(multi2Ext)
+          .data(outputRef),
+      ).toEqual({
+        opt: 'orig-opt',
+        single: 'orig-single',
+        singleOpt: 'none',
+        multi: 'orig-multi1,orig-multi2',
+      });
+
+      // Forward inputs separately
+      expect(
+        createExtensionTester(
+          subject.override({
+            factory(originalFactory, { inputs }) {
+              return originalFactory({
+                inputs: {
+                  opt: inputs.opt,
+                  single: inputs.single,
+                  multi: inputs.multi,
+                },
+              });
+            },
+          }),
+        )
+          .add(optExt)
+          .add(singleExt)
+          .add(multi1Ext)
+          .add(multi2Ext)
+          .data(outputRef),
+      ).toEqual({
+        opt: 'orig-opt',
+        single: 'orig-single',
+        singleOpt: 'none',
+        multi: 'orig-multi1,orig-multi2',
+      });
+
+      // Overriding based on original input
+      expect(
+        createExtensionTester(
+          subject.override({
+            factory(originalFactory, { inputs }) {
+              return originalFactory({
+                inputs: {
+                  single: [
+                    testDataRef1(`override-${inputs.single.get(testDataRef1)}`),
+                    testDataRef2('new-singleOpt'),
+                  ],
+                  multi: inputs.multi.map(i => [
+                    testDataRef1(`override-${i.get(testDataRef1)}`),
+                  ]),
+                },
+              });
+            },
+          }),
+        )
+          .add(optExt)
+          .add(singleExt)
+          .add(multi1Ext)
+          .add(multi2Ext)
+          .data(outputRef),
+      ).toEqual({
+        opt: 'none',
+        single: 'override-orig-single',
+        singleOpt: 'new-singleOpt',
+        multi: 'override-orig-multi1,override-orig-multi2',
+      });
+
+      // Mismatched input override length
+      expect(() =>
+        createExtensionTester(
+          subject.override({
+            factory(originalFactory, { inputs }) {
+              return originalFactory({
+                inputs: {
+                  ...inputs,
+                  multi: [[testDataRef1('multi1')]],
+                },
+              });
+            },
+          }),
+        )
+          .add(optExt)
+          .add(singleExt)
+          .add(multi1Ext)
+          .add(multi2Ext)
+          .data(outputRef),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"Failed to instantiate extension 'subject', Invalid override provided for input 'multi', when overriding the input data the length must match the original input data"`,
+      );
+
+      // Required input not provided
+      expect(() =>
+        createExtensionTester(
+          subject.override({
+            factory(originalFactory, { inputs }) {
+              return originalFactory({
+                inputs: {
+                  ...inputs,
+                  single: [testDataRef2('singleOpt')],
+                },
+              });
+            },
+          }),
+        )
+          .add(optExt)
+          .add(singleExt)
+          .add(multi1Ext)
+          .add(multi2Ext)
+          .data(outputRef),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"Failed to instantiate extension 'subject', Missing required data values for 'test1'"`,
+      );
+
+      // Wrong value provided
+      expect(() =>
+        createExtensionTester(
+          subject.override({
+            factory(originalFactory) {
+              return originalFactory({
+                inputs: {
+                  // @ts-expect-error
+                  opt: [testDataRef2('opt')],
+                  // @ts-expect-error
+                  single: [testDataRef1('single'), outputRef({})],
+                  multi: [
+                    // @ts-expect-error
+                    [testDataRef2('multi1')],
+                  ],
+                },
+              });
+            },
+          }),
+        )
+          .add(optExt)
+          .add(singleExt)
+          .add(multi1Ext)
+          .add(multi2Ext)
+          .data(outputRef),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"Failed to instantiate extension 'subject', Invalid data value provided, 'test2' was not declared"`,
+      );
+    });
   });
 });

--- a/packages/frontend-plugin-api/src/wiring/createExtension.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.ts
@@ -17,7 +17,11 @@
 import { AppNode } from '../apis';
 import { PortableSchema, createSchemaFromZod } from '../schema';
 import { Expand } from '../types';
-import { createDataContainer } from './createExtensionBlueprint';
+import {
+  ResolveInputValueOverrides,
+  createDataContainer,
+  resolveInputOverrides,
+} from './createExtensionBlueprint';
 import {
   AnyExtensionDataRef,
   ExtensionDataRef,
@@ -259,7 +263,7 @@ export interface ExtensionDefinition<
       factory(
         originalFactory: (context?: {
           config?: TConfig;
-          inputs?: Expand<ResolvedExtensionInputs<TInputs>>;
+          inputs?: ResolveInputValueOverrides<TInputs>;
         }) => ExtensionDataContainer<UOutput>,
         context: {
           node: AppNode;
@@ -558,7 +562,7 @@ export function createExtension<
               ReturnType<TConfigSchema[key]>
             >;
           };
-          inputs?: Expand<ResolvedExtensionInputs<TInputs>>;
+          inputs?: ResolveInputValueOverrides<TInputs>;
         }) => ExtensionDataContainer<UOutput>,
         context: {
           node: AppNode;
@@ -646,14 +650,19 @@ export function createExtension<
                   ReturnType<TConfigSchema[key]>
                 >;
               };
-              inputs?: Expand<ResolvedExtensionInputs<TInputs>>;
+              inputs?: ResolveInputValueOverrides<TInputs>;
             }): ExtensionDataContainer<UOutput> => {
               return createDataContainer<UOutput>(
                 newOptions.factory({
                   node,
                   config: innerContext?.config ?? config,
-                  inputs: (innerContext?.inputs ?? inputs) as any, // TODO: Fix the way input values are overridden
+                  inputs: resolveInputOverrides(
+                    newOptions.inputs,
+                    inputs,
+                    innerContext?.inputs,
+                  ) as any, // TODO: Might be able to improve this once legacy inputs are gone
                 }) as Iterable<any>,
+                newOptions.output,
               );
             },
             {

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.test.tsx
@@ -443,17 +443,17 @@ describe('createExtensionBlueprint', () => {
       }),
     ]);
 
-    // Not enough values provided, checked at runtime
+    // Mismatched input override length
     expect(() =>
       factoryOutput(
         Blueprint.makeWithOverrides({
-          factory(origFactory) {
+          factory(origFactory, { inputs }) {
             return origFactory(
               {},
               {
                 inputs: {
-                  single: [],
-                  multi: [],
+                  ...inputs,
+                  multi: [[testDataRef1('multi1')]],
                 },
               },
             );
@@ -463,6 +463,28 @@ describe('createExtensionBlueprint', () => {
       ),
     ).toThrowErrorMatchingInlineSnapshot(
       `"Invalid override provided for input 'multi', when overriding the input data the length must match the original input data"`,
+    );
+
+    // Required input not provided
+    expect(() =>
+      factoryOutput(
+        Blueprint.makeWithOverrides({
+          factory(origFactory, { inputs }) {
+            return origFactory(
+              {},
+              {
+                inputs: {
+                  ...inputs,
+                  single: [testDataRef2('singleOpt')],
+                },
+              },
+            );
+          },
+        }),
+        mockParentInputs,
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Missing required data values for 'test1'"`,
     );
 
     // Wrong value provided
@@ -490,7 +512,7 @@ describe('createExtensionBlueprint', () => {
         mockParentInputs,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `"Invalid override provided for input 'multi', when overriding the input data the length must match the original input data"`,
+      `"Invalid data value provided, 'test2' was not declared"`,
     );
 
     // Forwarding entire inputs object

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.test.tsx
@@ -462,7 +462,7 @@ describe('createExtensionBlueprint', () => {
         mockParentInputs,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `"Invalid override provided for input 'multi', when overriding the input data the length must match the original input data"`,
+      `"override data provided for input 'multi' must match the length of the original inputs"`,
     );
 
     // Required input not provided
@@ -484,7 +484,7 @@ describe('createExtensionBlueprint', () => {
         mockParentInputs,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `"Missing required data values for 'test1'"`,
+      `"missing required extension data value(s) 'test1'"`,
     );
 
     // Wrong value provided
@@ -512,7 +512,7 @@ describe('createExtensionBlueprint', () => {
         mockParentInputs,
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `"Invalid data value provided, 'test2' was not declared"`,
+      `"extension data 'test2' was provided but not declared"`,
     );
 
     // Forwarding entire inputs object
@@ -706,7 +706,7 @@ describe('createExtensionBlueprint', () => {
         }).makeWithOverrides({ factory: orig => orig({}) }),
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `"Invalid data value provided, 'test2' was not declared"`,
+      `"extension data 'test2' was provided but not declared"`,
     );
 
     expect(() =>
@@ -722,7 +722,7 @@ describe('createExtensionBlueprint', () => {
         }).makeWithOverrides({ factory: orig => orig({}) }),
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `"Missing required data values for 'test1'"`,
+      `"missing required extension data value(s) 'test1'"`,
     );
   });
 

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.test.tsx
@@ -16,9 +16,15 @@
 
 import React from 'react';
 import { coreExtensionData } from './coreExtensionData';
-import { createExtensionBlueprint } from './createExtensionBlueprint';
+import {
+  createDataContainer,
+  createExtensionBlueprint,
+} from './createExtensionBlueprint';
 import { createExtensionTester } from '@backstage/frontend-test-utils';
-import { createExtensionDataRef } from './createExtensionDataRef';
+import {
+  ExtensionDataValue,
+  createExtensionDataRef,
+} from './createExtensionDataRef';
 import { createExtensionInput } from './createExtensionInput';
 import { RouteRef } from '../routing';
 import {
@@ -28,12 +34,15 @@ import {
 
 function unused(..._any: any[]) {}
 
-function factoryOutput(ext: ExtensionDefinition<any, any>) {
+function factoryOutput(
+  ext: ExtensionDefinition<any, any>,
+  inputs: unknown = undefined,
+) {
   const int = toInternalExtensionDefinition(ext);
   if (int.version !== 'v2') {
     throw new Error('Expected v2 extension');
   }
-  return Array.from(int.factory({} as any));
+  return Array.from(int.factory({ inputs } as any));
 }
 
 describe('createExtensionBlueprint', () => {
@@ -333,6 +342,235 @@ describe('createExtensionBlueprint', () => {
     });
 
     expect(true).toBe(true);
+  });
+
+  it('should be able to override inputs when calling original factory', () => {
+    const outputRef = createExtensionDataRef<unknown>().with({ id: 'output' });
+    const testDataRef1 = createExtensionDataRef<string>().with({ id: 'test1' });
+    const testDataRef2 = createExtensionDataRef<string>().with({ id: 'test2' });
+
+    const Blueprint = createExtensionBlueprint({
+      kind: 'test-extension',
+      attachTo: { id: 'test', input: 'default' },
+      inputs: {
+        opt: createExtensionInput([testDataRef1.optional()], {
+          singleton: true,
+          optional: true,
+        }),
+        single: createExtensionInput([testDataRef1, testDataRef2.optional()], {
+          singleton: true,
+        }),
+        multi: createExtensionInput([testDataRef1]),
+      },
+      output: [outputRef],
+      factory(_, { inputs }) {
+        return [
+          outputRef({
+            opt: inputs.opt?.get(testDataRef1) ?? 'none',
+            single: inputs.single.get(testDataRef1),
+            singleOpt: inputs.single.get(testDataRef2) ?? 'none',
+            multi: inputs.multi.map(i => i.get(testDataRef1)).join(','),
+          }),
+        ];
+      },
+    });
+
+    const mockInput = (node: string, ...data: ExtensionDataValue<any, any>[]) =>
+      Object.assign(createDataContainer(data), {
+        node,
+      });
+    const mockParentInputs = {
+      opt: mockInput('node-opt', testDataRef1('orig-opt')),
+      single: mockInput('node-single', testDataRef1('orig-single')),
+      multi: [
+        mockInput('node-multi1', testDataRef1('orig-multi1')),
+        mockInput('node-multi2', testDataRef1('orig-multi2')),
+      ],
+    };
+
+    // All values provided
+    expect(
+      factoryOutput(
+        Blueprint.makeWithOverrides({
+          factory(origFactory) {
+            return origFactory(
+              {},
+              {
+                inputs: {
+                  opt: [testDataRef1('opt')],
+                  single: [testDataRef1('single'), testDataRef2('singleOpt')],
+                  multi: [[testDataRef1('multi1')], [testDataRef1('multi2')]],
+                },
+              },
+            );
+          },
+        }),
+        mockParentInputs,
+      ),
+    ).toEqual([
+      outputRef({
+        opt: 'opt',
+        single: 'single',
+        singleOpt: 'singleOpt',
+        multi: 'multi1,multi2',
+      }),
+    ]);
+
+    // Minimal values provided
+    expect(
+      factoryOutput(
+        Blueprint.makeWithOverrides({
+          factory(origFactory) {
+            return origFactory(
+              {},
+              {
+                inputs: {
+                  single: [testDataRef1('single')],
+                  multi: [[testDataRef1('multi1')], [testDataRef1('multi2')]],
+                },
+              },
+            );
+          },
+        }),
+        mockParentInputs,
+      ),
+    ).toEqual([
+      outputRef({
+        opt: 'none',
+        single: 'single',
+        singleOpt: 'none',
+        multi: 'multi1,multi2',
+      }),
+    ]);
+
+    // Not enough values provided, checked at runtime
+    expect(() =>
+      factoryOutput(
+        Blueprint.makeWithOverrides({
+          factory(origFactory) {
+            return origFactory(
+              {},
+              {
+                inputs: {
+                  single: [],
+                  multi: [],
+                },
+              },
+            );
+          },
+        }),
+        mockParentInputs,
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Invalid override provided for input 'multi', when overriding the input data the length must match the original input data"`,
+    );
+
+    // Wrong value provided
+    expect(() =>
+      factoryOutput(
+        Blueprint.makeWithOverrides({
+          factory(origFactory) {
+            return origFactory(
+              {},
+              {
+                inputs: {
+                  // @ts-expect-error
+                  opt: [testDataRef2('opt')],
+                  // @ts-expect-error
+                  single: [testDataRef1('single'), outputRef({})],
+                  multi: [
+                    // @ts-expect-error
+                    [testDataRef2('multi1')],
+                  ],
+                },
+              },
+            );
+          },
+        }),
+        mockParentInputs,
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Invalid override provided for input 'multi', when overriding the input data the length must match the original input data"`,
+    );
+
+    // Forwarding entire inputs object
+    expect(
+      factoryOutput(
+        Blueprint.makeWithOverrides({
+          factory(origFactory, { inputs }) {
+            return origFactory({}, { inputs });
+          },
+        }),
+        mockParentInputs,
+      ),
+    ).toEqual([
+      outputRef({
+        opt: 'orig-opt',
+        single: 'orig-single',
+        singleOpt: 'none',
+        multi: 'orig-multi1,orig-multi2',
+      }),
+    ]);
+
+    // Forwarding individual outputs
+    expect(
+      factoryOutput(
+        Blueprint.makeWithOverrides({
+          factory(origFactory, { inputs }) {
+            return origFactory(
+              {},
+              {
+                inputs: {
+                  opt: inputs.opt,
+                  single: inputs.single,
+                  multi: inputs.multi,
+                },
+              },
+            );
+          },
+        }),
+        mockParentInputs,
+      ),
+    ).toEqual([
+      outputRef({
+        opt: 'orig-opt',
+        single: 'orig-single',
+        singleOpt: 'none',
+        multi: 'orig-multi1,orig-multi2',
+      }),
+    ]);
+
+    // Overriding based on original input
+    expect(
+      factoryOutput(
+        Blueprint.makeWithOverrides({
+          factory(origFactory, { inputs }) {
+            return origFactory(
+              {},
+              {
+                inputs: {
+                  single: [
+                    testDataRef1(`override-${inputs.single.get(testDataRef1)}`),
+                    testDataRef2('new-singleOpt'),
+                  ],
+                  multi: inputs.multi.map(i => [
+                    testDataRef1(`override-${i.get(testDataRef1)}`),
+                  ]),
+                },
+              },
+            );
+          },
+        }),
+        mockParentInputs,
+      ),
+    ).toEqual([
+      outputRef({
+        opt: 'none',
+        single: 'override-orig-single',
+        singleOpt: 'new-singleOpt',
+        multi: 'override-orig-multi1,override-orig-multi2',
+      }),
+    ]);
   });
 
   it('should allow merging of inputs', () => {

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.test.tsx
@@ -426,7 +426,7 @@ describe('createExtensionBlueprint', () => {
               {
                 inputs: {
                   single: [testDataRef1('single')],
-                  multi: [[testDataRef1('multi1')], [testDataRef1('multi2')]],
+                  multi: [],
                 },
               },
             );
@@ -439,7 +439,7 @@ describe('createExtensionBlueprint', () => {
         opt: 'none',
         single: 'single',
         singleOpt: 'none',
-        multi: 'multi1,multi2',
+        multi: '',
       }),
     ]);
 

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.test.tsx
@@ -689,6 +689,43 @@ describe('createExtensionBlueprint', () => {
     expect(factoryOutput(ext)).toEqual([testDataRef2('foobar')]);
   });
 
+  it('should reject invalid output from original factory', () => {
+    const testDataRef1 = createExtensionDataRef<string>().with({ id: 'test1' });
+    const testDataRef2 = createExtensionDataRef<string>().with({ id: 'test2' });
+
+    expect(() =>
+      factoryOutput(
+        // @ts-expect-error
+        createExtensionBlueprint({
+          kind: 'test-extension',
+          attachTo: { id: 'test', input: 'default' },
+          output: [testDataRef1],
+          factory() {
+            return [testDataRef2('foo')];
+          },
+        }).makeWithOverrides({ factory: orig => orig({}) }),
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Invalid data value provided, 'test2' was not declared"`,
+    );
+
+    expect(() =>
+      factoryOutput(
+        // @ts-expect-error
+        createExtensionBlueprint({
+          kind: 'test-extension',
+          attachTo: { id: 'test', input: 'default' },
+          output: [testDataRef1],
+          factory() {
+            return [];
+          },
+        }).makeWithOverrides({ factory: orig => orig({}) }),
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Missing required data values for 'test1'"`,
+    );
+  });
+
   it('should allow returning of the parent data container', () => {
     const testDataRef1 = createExtensionDataRef<string>().with({ id: 'test1' });
     const testDataRef2 = createExtensionDataRef<string>().with({ id: 'test2' });

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
@@ -269,7 +269,7 @@ export function createDataContainer<UData extends AnyExtensionDataRef>(
     if (verifyRefs) {
       if (!verifyRefs.delete(output.id)) {
         throw new Error(
-          `Invalid data value provided, '${output.id}' was not declared`,
+          `extension data '${output.id}' was provided but not declared`,
         );
       }
     }
@@ -281,7 +281,7 @@ export function createDataContainer<UData extends AnyExtensionDataRef>(
     Array.from(verifyRefs.values()).filter(ref => !ref.config.optional);
   if (remainingRefs && remainingRefs.length > 0) {
     throw new Error(
-      `Missing required data values for '${remainingRefs
+      `missing required extension data value(s) '${remainingRefs
         .map(ref => ref.id)
         .join(', ')}'`,
     );
@@ -339,7 +339,7 @@ export function resolveInputOverrides(
         );
         if (!originalInput) {
           throw new Error(
-            `A data override was provided for input '${name}', but no original input was present.`,
+            `attempted to override data of input '${name}' but it is not present in the original inputs`,
           );
         }
         newInputs[name] = Object.assign(providedContainer, {
@@ -350,12 +350,12 @@ export function resolveInputOverrides(
       const originalInput = expectArray(inputs[name]);
       if (!Array.isArray(providedData)) {
         throw new Error(
-          `Invalid override provided for input '${name}', expected an array`,
+          `override data provided for input '${name}' must be an array`,
         );
       }
       if (originalInput.length !== providedData.length) {
         throw new Error(
-          `Invalid override provided for input '${name}', when overriding the input data the length must match the original input data`,
+          `override data provided for input '${name}' must match the length of the original inputs`,
         );
       }
       newInputs[name] = providedData.map((data, i) => {

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
@@ -77,7 +77,7 @@ export type CreateExtensionBlueprintOptions<
   dataRefs?: TDataRefs;
 } & VerifyExtensionFactoryOutput<UOutput, UFactoryOutput>;
 
-/** @ignore */
+/** @public */
 export type ResolveInputValueOverrides<
   TInputs extends {
     [inputName in string]: ExtensionInput<

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
@@ -78,7 +78,7 @@ export type CreateExtensionBlueprintOptions<
 } & VerifyExtensionFactoryOutput<UOutput, UFactoryOutput>;
 
 /** @ignore */
-type ResolveInputValueOverrides<
+export type ResolveInputValueOverrides<
   TInputs extends {
     [inputName in string]: ExtensionInput<
       AnyExtensionDataRef,

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
@@ -353,7 +353,10 @@ export function resolveInputOverrides(
           `override data provided for input '${name}' must be an array`,
         );
       }
-      if (originalInput.length !== providedData.length) {
+      if (
+        originalInput.length !== providedData.length &&
+        providedData.length > 0
+      ) {
         throw new Error(
           `override data provided for input '${name}' must match the length of the original inputs`,
         );

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
@@ -505,6 +505,7 @@ class ExtensionBlueprintImpl<
                 config: innerContext?.config ?? config,
                 inputs: forwardedInputs as any, // TODO: Might be able to improve this once legacy inputs are gone
               }),
+              this.options.output,
             );
           },
           {

--- a/packages/frontend-plugin-api/src/wiring/index.ts
+++ b/packages/frontend-plugin-api/src/wiring/index.ts
@@ -56,6 +56,7 @@ export {
 } from './types';
 export {
   type CreateExtensionBlueprintOptions,
+  type ResolveInputValueOverrides,
   type ExtensionBlueprint,
   createExtensionBlueprint,
 } from './createExtensionBlueprint';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds support for overriding the inputs values when calling the original factory for both blueprints and when overriding an extension. Since you need to original `node` information in the inputs, you're a bit limited in the types of overrides you can do. You can not provide an input value for an input that didn't already exist, and when overriding multiple inputs the lengths of the arrays must match.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
