### PR TITLE
doc(docs.features.softwareCatalog.systemModel): fix typo

### DIFF
--- a/docs/features/software-catalog/system-model.md
+++ b/docs/features/software-catalog/system-model.md
@@ -50,7 +50,7 @@ components need to be in a known machine-readable format so we can build further
 tooling and analysis on top.
 
 APIs have a visibility: they are either public (making them available for any
-other component to consume), restricted (only available to an allowlisted set of
+other component to consume), restricted (only available to an allowed set of
 consumers), or private (only available within their system). As public APIs are
 going to be the primary way interaction between components, Backstage supports
 documenting, indexing and searching all APIs so we can browse them as


### PR DESCRIPTION
## Description
* Fix small typo in the page https://backstage.io/docs/features/software-catalog/system-model

## How to review?
* Check in the section https://backstage.io/docs/features/software-catalog/system-model/#api, that you find a small typo

> an allowlisted set of consumers

* Suggested a proposal to fix that typo, checking that it makes sense

## Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes -- ❌  NOT apply here --
- [ ] Screenshots attached (for UI changes) -- ❌  NOT apply here --
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
