### PR TITLE
catalog: Make header customizable in EntityLayout

### DIFF
--- a/.changeset/quick-eagles-smell.md
+++ b/.changeset/quick-eagles-smell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': minor
+---
+
+Allow customizing the header of Entity pages by providing your own element.

--- a/plugins/catalog/api-report.md
+++ b/plugins/catalog/api-report.md
@@ -338,7 +338,24 @@ export interface DependsOnResourcesCardProps {
 export const EntityAboutCard: (props: AboutCardProps) => JSX.Element;
 
 // @public (undocumented)
+export function EntityContextMenu(
+  props: EntityContextMenuProps,
+): React_2.JSX.Element;
+
+// @public (undocumented)
 export type EntityContextMenuClassKey = 'button';
+
+// @public (undocumented)
+export interface EntityContextMenuProps {
+  // Warning: (ae-forgotten-export) The symbol "UnregisterEntityOptions" needs to be exported by the entry point index.d.ts
+  //
+  // (undocumented)
+  UNSTABLE_contextMenuOptions?: UnregisterEntityOptions;
+  // Warning: (ae-forgotten-export) The symbol "ExtraContextMenuItem" needs to be exported by the entry point index.d.ts
+  //
+  // (undocumented)
+  UNSTABLE_extraContextMenuItems?: ExtraContextMenuItem[];
+}
 
 // @public (undocumented)
 export const EntityDependencyOfComponentsCard: (
@@ -379,6 +396,9 @@ export const EntityHasSubdomainsCard: (
 export const EntityHasSystemsCard: (props: HasSystemsCardProps) => JSX.Element;
 
 // @public (undocumented)
+export function EntityLabels(props: { entity: Entity }): React_2.JSX.Element;
+
+// @public (undocumented)
 export const EntityLabelsCard: (props: EntityLabelsCardProps) => JSX_2.Element;
 
 // @public (undocumented)
@@ -400,15 +420,17 @@ export interface EntityLayoutProps {
   // (undocumented)
   children?: React_2.ReactNode;
   // (undocumented)
+  header?: JSX.Element;
+  // (undocumented)
   NotFoundComponent?: React_2.ReactNode;
   // Warning: (ae-forgotten-export) The symbol "EntityContextMenuOptions" needs to be exported by the entry point index.d.ts
   //
   // (undocumented)
   UNSTABLE_contextMenuOptions?: EntityContextMenuOptions;
-  // Warning: (ae-forgotten-export) The symbol "ExtraContextMenuItem" needs to be exported by the entry point index.d.ts
+  // Warning: (ae-forgotten-export) The symbol "ExtraContextMenuItem_2" needs to be exported by the entry point index.d.ts
   //
   // (undocumented)
-  UNSTABLE_extraContextMenuItems?: ExtraContextMenuItem[];
+  UNSTABLE_extraContextMenuItems?: ExtraContextMenuItem_2[];
 }
 
 // @public (undocumented)
@@ -424,6 +446,12 @@ export type EntityLayoutRouteProps = {
     }
   >;
 };
+
+// @public (undocumented)
+export function EntityLayoutTitle(props: {
+  title: string;
+  entity: Entity | undefined;
+}): React_2.JSX.Element;
 
 // @public (undocumented)
 export const EntityLinksCard: (props: EntityLinksCardProps) => JSX_2.Element;
@@ -573,6 +601,17 @@ export interface HasSystemsCardProps {
   // (undocumented)
   variant?: InfoCardVariants;
 }
+
+// @public (undocumented)
+export function headerProps(
+  paramKind: string | undefined,
+  paramNamespace: string | undefined,
+  paramName: string | undefined,
+  entity: Entity | undefined,
+): {
+  headerTitle: string;
+  headerType: string;
+};
 
 // @public
 export function isApiType(

--- a/plugins/catalog/src/components/EntityContextMenu/EntityContextMenu.tsx
+++ b/plugins/catalog/src/components/EntityContextMenu/EntityContextMenu.tsx
@@ -65,11 +65,13 @@ interface ExtraContextMenuItem {
   onClick: () => void;
 }
 
-interface EntityContextMenuProps {
+/** @public */
+export interface EntityContextMenuProps {
   UNSTABLE_extraContextMenuItems?: ExtraContextMenuItem[];
   UNSTABLE_contextMenuOptions?: UnregisterEntityOptions;
 }
 
+/** @public */
 export function EntityContextMenu(props: EntityContextMenuProps) {
   const { UNSTABLE_extraContextMenuItems, UNSTABLE_contextMenuOptions } = props;
   const { t } = useTranslationRef(catalogTranslationRef);

--- a/plugins/catalog/src/components/EntityContextMenu/index.ts
+++ b/plugins/catalog/src/components/EntityContextMenu/index.ts
@@ -15,4 +15,7 @@
  */
 
 export { EntityContextMenu } from './EntityContextMenu';
-export type { EntityContextMenuClassKey } from './EntityContextMenu';
+export type {
+  EntityContextMenuClassKey,
+  EntityContextMenuProps,
+} from './EntityContextMenu';

--- a/plugins/catalog/src/components/EntityLayout/EntityLayout.test.tsx
+++ b/plugins/catalog/src/components/EntityLayout/EntityLayout.test.tsx
@@ -272,4 +272,26 @@ describe('EntityLayout', () => {
     expect(linkParent).toBeInTheDocument();
     expect(linkParent?.tagName).toBe('P');
   });
+
+  it('renders given header when provided', async () => {
+    await renderInTestApp(
+      <ApiProvider apis={mockApis}>
+        <EntityProvider entity={mockEntity}>
+          <EntityLayout header={<div>custom-header</div>}>
+            <EntityLayout.Route path="/" title="tabbed-test-title">
+              <div>tabbed-test-content</div>
+            </EntityLayout.Route>
+          </EntityLayout>
+        </EntityProvider>
+      </ApiProvider>,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
+        },
+      },
+    );
+
+    expect(screen.getByText('custom-header')).toBeInTheDocument();
+  });
 });

--- a/plugins/catalog/src/components/EntityLayout/EntityLayout.test.tsx
+++ b/plugins/catalog/src/components/EntityLayout/EntityLayout.test.tsx
@@ -15,11 +15,7 @@
  */
 
 import { CatalogApi } from '@backstage/catalog-client';
-import {
-  ANNOTATION_ORIGIN_LOCATION,
-  Entity,
-  RELATION_OWNED_BY,
-} from '@backstage/catalog-model';
+import { Entity } from '@backstage/catalog-model';
 import { ApiProvider } from '@backstage/core-app-api';
 import { AlertApi, alertApiRef } from '@backstage/core-plugin-api';
 import {
@@ -34,14 +30,12 @@ import { permissionApiRef } from '@backstage/plugin-permission-react';
 import {
   MockPermissionApi,
   renderInTestApp,
-  TestApiProvider,
   TestApiRegistry,
 } from '@backstage/test-utils';
-import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen } from '@testing-library/react';
 import React from 'react';
 import { EntityLayout } from './EntityLayout';
-import { rootRouteRef, unregisterRedirectRouteRef } from '../../routes';
-import { Route, Routes } from 'react-router-dom';
+import { rootRouteRef } from '../../routes';
 
 describe('EntityLayout', () => {
   const mockEntity = {
@@ -277,170 +271,5 @@ describe('EntityLayout', () => {
     const linkParent = ownerLink?.parentElement;
     expect(linkParent).toBeInTheDocument();
     expect(linkParent?.tagName).toBe('P');
-  });
-});
-
-describe('EntityLayout - CleanUpAfterRemoval', () => {
-  const entity = {
-    apiVersion: 'backstage.io/v1alpha1',
-    kind: 'Component',
-    metadata: {
-      name: 'n',
-      namespace: 'ns',
-      annotations: {
-        [ANNOTATION_ORIGIN_LOCATION]: 'url:http://example.com',
-      },
-    },
-    spec: {
-      owner: 'tools',
-      type: 'service',
-    },
-    relations: [
-      {
-        type: RELATION_OWNED_BY,
-        targetRef: 'group:default/tools',
-      },
-    ],
-  };
-  const getLocationByRef: jest.MockedFunction<CatalogApi['getLocationByRef']> =
-    jest.fn();
-  const getEntities: jest.MockedFunction<CatalogApi['getEntities']> = jest.fn();
-  const removeEntityByUid: jest.MockedFunction<
-    CatalogApi['removeEntityByUid']
-  > = jest.fn();
-  const getEntityFacets: jest.MockedFunction<CatalogApi['getEntityFacets']> =
-    jest.fn();
-  getLocationByRef.mockResolvedValue(undefined);
-  getEntities.mockResolvedValue({ items: [{ ...entity }] });
-  getEntityFacets.mockResolvedValue({
-    facets: {
-      'relations.ownedBy': [{ count: 1, value: 'group:default/tools' }],
-    },
-  });
-
-  const alertApi: AlertApi = {
-    post() {
-      return undefined;
-    },
-    alert$() {
-      throw new Error('not implemented');
-    },
-  };
-
-  it('redirects to externalRouteRef when unregisterRedirectRouteRef is bound', async () => {
-    await renderInTestApp(
-      <TestApiProvider
-        apis={[
-          [
-            catalogApiRef,
-            {
-              getLocationByRef,
-              getEntities,
-              removeEntityByUid,
-              getEntityFacets,
-            },
-          ],
-          [alertApiRef, alertApi],
-          [starredEntitiesApiRef, new MockStarredEntitiesApi()],
-          [permissionApiRef, new MockPermissionApi()],
-        ]}
-      >
-        <EntityProvider entity={entity}>
-          <EntityLayout>
-            <EntityLayout.Route path="/" title="tabbed-test-title">
-              <div>tabbed-test-content</div>
-            </EntityLayout.Route>
-          </EntityLayout>
-        </EntityProvider>
-        <Routes>
-          <Route path="/catalog" element={<p>catalog-page</p>} />
-          <Route path="/testRoute" element={<p>external-page</p>} />
-        </Routes>
-      </TestApiProvider>,
-      {
-        mountedRoutes: {
-          '/catalog/:namespace/:kind/:name': entityRouteRef,
-          '/catalog': rootRouteRef,
-          '/testRoute': unregisterRedirectRouteRef,
-        },
-      },
-    );
-
-    const menuButton = screen.queryAllByTestId('menu-button')[0];
-    fireEvent.click(menuButton);
-    const listItemUnregister = screen.queryAllByRole('menuitem', {
-      name: /Unregister entity/i,
-    })[0];
-    fireEvent.click(listItemUnregister);
-    await waitFor(() => {
-      const deleteEntityButton = screen.getByRole('button', {
-        name: /Delete Entity/i,
-      });
-      act(() => {
-        fireEvent.click(deleteEntityButton);
-      });
-    });
-
-    await waitFor(() => {
-      expect(screen.getByText('external-page')).toBeInTheDocument();
-    });
-  });
-
-  it('redirects to rootRouteRef when unregisterRedirectRouteRef is not bound', async () => {
-    await renderInTestApp(
-      <TestApiProvider
-        apis={[
-          [
-            catalogApiRef,
-            {
-              getLocationByRef,
-              getEntities,
-              removeEntityByUid,
-              getEntityFacets,
-            },
-          ],
-          [alertApiRef, alertApi],
-          [starredEntitiesApiRef, new MockStarredEntitiesApi()],
-          [permissionApiRef, new MockPermissionApi()],
-        ]}
-      >
-        <EntityProvider entity={entity}>
-          <EntityLayout>
-            <EntityLayout.Route path="/" title="tabbed-test-title">
-              <div>tabbed-test-content</div>
-            </EntityLayout.Route>
-          </EntityLayout>
-        </EntityProvider>
-        <Routes>
-          <Route path="/catalog" element={<p>catalog-page</p>} />
-          <Route path="/testRoute" element={<p>external-page</p>} />
-        </Routes>
-      </TestApiProvider>,
-      {
-        mountedRoutes: {
-          '/catalog/:namespace/:kind/:name': entityRouteRef,
-          '/catalog': rootRouteRef,
-        },
-      },
-    );
-
-    const menuButton = screen.queryAllByTestId('menu-button')[0];
-    fireEvent.click(menuButton);
-    const listItemUnregister = screen.queryAllByRole('menuitem', {
-      name: /Unregister entity/i,
-    })[0];
-    fireEvent.click(listItemUnregister);
-    await waitFor(() => {
-      const deleteEntityButton = screen.getByRole('button', {
-        name: /Delete Entity/i,
-      });
-      act(() => {
-        fireEvent.click(deleteEntityButton);
-      });
-    });
-
-    await waitFor(() => {
-      expect(screen.getByText('catalog-page')).toBeInTheDocument();
-    });
   });
 });

--- a/plugins/catalog/src/components/EntityLayout/EntityLayout.tsx
+++ b/plugins/catalog/src/components/EntityLayout/EntityLayout.tsx
@@ -33,7 +33,6 @@ import {
   attachComponentData,
   IconComponent,
   useElementFilter,
-  useRouteRef,
   useRouteRefParams,
 } from '@backstage/core-plugin-api';
 import {
@@ -42,17 +41,13 @@ import {
   entityRouteRef,
   FavoriteEntity,
   getEntityRelations,
-  InspectEntityDialog,
-  UnregisterEntityDialog,
   useAsyncEntity,
 } from '@backstage/plugin-catalog-react';
 import Box from '@material-ui/core/Box';
 import { TabProps } from '@material-ui/core/Tab';
 import Alert from '@material-ui/lab/Alert';
-import React, { useEffect, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import React from 'react';
 import { EntityContextMenu } from '../EntityContextMenu/EntityContextMenu';
-import { rootRouteRef, unregisterRedirectRouteRef } from '../../routes';
 import { catalogTranslationRef } from '../../translation';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 
@@ -195,7 +190,6 @@ export const EntityLayout = (props: EntityLayoutProps) => {
   } = props;
   const { kind, namespace, name } = useRouteRefParams(entityRouteRef);
   const { entity, loading, error } = useAsyncEntity();
-  const location = useLocation();
   const routes = useElementFilter(
     children,
     elements =>
@@ -232,28 +226,7 @@ export const EntityLayout = (props: EntityLayoutProps) => {
     entity,
   );
 
-  const [confirmationDialogOpen, setConfirmationDialogOpen] = useState(false);
-  const [inspectionDialogOpen, setInspectionDialogOpen] = useState(false);
-  const navigate = useNavigate();
-  const catalogRoute = useRouteRef(rootRouteRef);
-  const unregisterRedirectRoute = useRouteRef(unregisterRedirectRouteRef);
   const { t } = useTranslationRef(catalogTranslationRef);
-
-  const cleanUpAfterRemoval = async () => {
-    setConfirmationDialogOpen(false);
-    setInspectionDialogOpen(false);
-    navigate(
-      unregisterRedirectRoute ? unregisterRedirectRoute() : catalogRoute(),
-    );
-  };
-
-  // Make sure to close the dialog if the user clicks links in it that navigate
-  // to another entity.
-  useEffect(() => {
-    setConfirmationDialogOpen(false);
-    setInspectionDialogOpen(false);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [location.pathname]);
 
   return (
     <Page themeId={entity?.spec?.type?.toString() ?? 'home'}>
@@ -268,8 +241,6 @@ export const EntityLayout = (props: EntityLayoutProps) => {
             <EntityContextMenu
               UNSTABLE_extraContextMenuItems={UNSTABLE_extraContextMenuItems}
               UNSTABLE_contextMenuOptions={UNSTABLE_contextMenuOptions}
-              onUnregisterEntity={() => setConfirmationDialogOpen(true)}
-              onInspectEntity={() => setInspectionDialogOpen(true)}
             />
           </>
         )}
@@ -300,18 +271,6 @@ export const EntityLayout = (props: EntityLayoutProps) => {
           )}
         </Content>
       )}
-
-      <UnregisterEntityDialog
-        open={confirmationDialogOpen}
-        entity={entity!}
-        onConfirm={cleanUpAfterRemoval}
-        onClose={() => setConfirmationDialogOpen(false)}
-      />
-      <InspectEntityDialog
-        open={inspectionDialogOpen}
-        entity={entity!}
-        onClose={() => setInspectionDialogOpen(false)}
-      />
     </Page>
   );
 };

--- a/plugins/catalog/src/components/EntityLayout/EntityLayout.tsx
+++ b/plugins/catalog/src/components/EntityLayout/EntityLayout.tsx
@@ -66,7 +66,8 @@ const Route: (props: EntityLayoutRouteProps) => null = () => null;
 attachComponentData(Route, dataKey, true);
 attachComponentData(Route, 'core.gatherMountPoints', true); // This causes all mount points that are discovered within this route to use the path of the route itself
 
-function EntityLayoutTitle(props: {
+/** @public */
+export function EntityLayoutTitle(props: {
   title: string;
   entity: Entity | undefined;
 }) {
@@ -86,7 +87,8 @@ function EntityLayoutTitle(props: {
   );
 }
 
-function headerProps(
+/** @public */
+export function headerProps(
   paramKind: string | undefined,
   paramNamespace: string | undefined,
   paramName: string | undefined,
@@ -111,7 +113,8 @@ function headerProps(
   };
 }
 
-function EntityLabels(props: { entity: Entity }) {
+/** @public */
+export function EntityLabels(props: { entity: Entity }) {
   const { entity } = props;
   const ownedByRelations = getEntityRelations(entity, RELATION_OWNED_BY);
   const { t } = useTranslationRef(catalogTranslationRef);
@@ -162,6 +165,7 @@ export interface EntityLayoutProps {
   UNSTABLE_contextMenuOptions?: EntityContextMenuOptions;
   children?: React.ReactNode;
   NotFoundComponent?: React.ReactNode;
+  header?: JSX.Element;
 }
 
 /**
@@ -187,6 +191,7 @@ export const EntityLayout = (props: EntityLayoutProps) => {
     UNSTABLE_contextMenuOptions,
     children,
     NotFoundComponent,
+    header,
   } = props;
   const { kind, namespace, name } = useRouteRefParams(entityRouteRef);
   const { entity, loading, error } = useAsyncEntity();
@@ -230,21 +235,23 @@ export const EntityLayout = (props: EntityLayoutProps) => {
 
   return (
     <Page themeId={entity?.spec?.type?.toString() ?? 'home'}>
-      <Header
-        title={<EntityLayoutTitle title={headerTitle} entity={entity!} />}
-        pageTitleOverride={headerTitle}
-        type={headerType}
-      >
-        {entity && (
-          <>
-            <EntityLabels entity={entity} />
-            <EntityContextMenu
-              UNSTABLE_extraContextMenuItems={UNSTABLE_extraContextMenuItems}
-              UNSTABLE_contextMenuOptions={UNSTABLE_contextMenuOptions}
-            />
-          </>
-        )}
-      </Header>
+      {header || (
+        <Header
+          title={<EntityLayoutTitle title={headerTitle} entity={entity!} />}
+          pageTitleOverride={headerTitle}
+          type={headerType}
+        >
+          {entity && (
+            <>
+              <EntityLabels entity={entity} />
+              <EntityContextMenu
+                UNSTABLE_extraContextMenuItems={UNSTABLE_extraContextMenuItems}
+                UNSTABLE_contextMenuOptions={UNSTABLE_contextMenuOptions}
+              />
+            </>
+          )}
+        </Header>
+      )}
 
       {loading && <Progress />}
 

--- a/plugins/catalog/src/components/EntityLayout/index.ts
+++ b/plugins/catalog/src/components/EntityLayout/index.ts
@@ -14,5 +14,10 @@
  * limitations under the License.
  */
 
-export { EntityLayout } from './EntityLayout';
+export {
+  EntityLabels,
+  EntityLayout,
+  EntityLayoutTitle,
+  headerProps,
+} from './EntityLayout';
 export type { EntityLayoutProps, EntityLayoutRouteProps } from './EntityLayout';

--- a/plugins/catalog/src/index.ts
+++ b/plugins/catalog/src/index.ts
@@ -30,6 +30,7 @@ export type {
 export { AboutContent, AboutField } from './components/AboutCard';
 export * from './components/CatalogKindHeader';
 export * from './components/CatalogTable';
+export * from './components/EntityContextMenu';
 export * from './components/EntityLayout';
 export * from './components/EntityOrphanWarning';
 export * from './components/EntityRelationWarning';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The header was pretty much hard-coded in the EntityLayout before and couldn't be easily changed. This change exposes a new property to overwrite the default implementation and makes a bunch of the internal components public in order to make them reusable in a custom header implementation.

The other internal change was to move the Inspect and Unregister dialogs to be controlled by the `EntityContextMenu` directly. This removes the need for state of those dialogs to be managed by `EntityLayout` and makes creation of a custom header easier since that state doesn't need to be passed down through it or managed through a separate context.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
