### PR TITLE
Add the abilty to style the tabbed card

### DIFF
--- a/.changeset/big-emus-add.md
+++ b/.changeset/big-emus-add.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': minor
+---
+
+Added the ability to style the TabbedCard component

--- a/packages/core-components/src/layout/TabbedCard/TabbedCard.test.tsx
+++ b/packages/core-components/src/layout/TabbedCard/TabbedCard.test.tsx
@@ -118,4 +118,14 @@ describe('<TabbedCard />', () => {
     await user.click(rendered.getByText('Test 2'));
     expect(mockOnChange).toHaveBeenCalledTimes(1);
   });
+
+  it('renders with a passed in style', async () => {
+    const tabbedCard = render(
+      <TabbedCard style={{ height: '50px' }} title={minProps.title}>
+        <CardTab label="Test 1">Test Content</CardTab>
+        <CardTab label="Test 2">Test Content</CardTab>
+      </TabbedCard>,
+    );
+    expect(tabbedCard.getByRole('presentation').style.height).toBe('50px');
+  });
 });

--- a/packages/core-components/src/layout/TabbedCard/TabbedCard.tsx
+++ b/packages/core-components/src/layout/TabbedCard/TabbedCard.tsx
@@ -22,6 +22,7 @@ import { makeStyles, withStyles } from '@material-ui/core/styles';
 import Tab, { TabProps } from '@material-ui/core/Tab';
 import Tabs from '@material-ui/core/Tabs';
 import React, {
+  CSSProperties,
   PropsWithChildren,
   ReactElement,
   ReactNode,
@@ -61,6 +62,7 @@ const BoldHeader = withStyles(
 type Props = {
   /** @deprecated Use errorBoundaryProps instead */
   slackChannel?: string;
+  style?: CSSProperties;
   errorBoundaryProps?: ErrorBoundaryProps;
   children?: ReactElement<TabProps>[];
   onChange?: (event: React.ChangeEvent<{}>, value: number | string) => void;
@@ -78,6 +80,7 @@ export function TabbedCard(props: PropsWithChildren<Props>) {
     deepLink,
     value,
     onChange,
+    style,
   } = props;
   const tabsClasses = useTabsStyles();
   const [selectedIndex, selectIndex] = useState(0);
@@ -110,7 +113,7 @@ export function TabbedCard(props: PropsWithChildren<Props>) {
     errorBoundaryProps || (slackChannel ? { slackChannel } : {});
 
   return (
-    <Card>
+    <Card role="presentation" style={style}>
       <ErrorBoundary {...errProps}>
         {title && <BoldHeader title={title} />}
         <Tabs


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added the ability to style the tabbedcard component.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
