### PR TITLE
NFS: Deprecate `.render()` of `createExtensionTester`

### DIFF
--- a/.changeset/three-kiwis-turn.md
+++ b/.changeset/three-kiwis-turn.md
@@ -5,12 +5,15 @@
 Deprecate the `.render` method of the `createExtensionTester` in favour of using `renderInTestApp` directly.
 
 ```tsx
-import { renderInTestApp, createExtensionTester } from '@backstage/frontend-test-utils';
+import {
+  renderInTestApp,
+  createExtensionTester,
+} from '@backstage/frontend-test-utils';
 
 const tester = createExtensionTester(extension);
 
 const { getByTestId } = renderInTestApp(tester.element());
 
 // or if you're not using `coreExtensionData.reactElement` as the output ref
-const { getByTestId } = renderInTestApp(tester.data(myComponentRef))'
+const { getByTestId } = renderInTestApp(tester.data(myComponentRef));
 ```

--- a/.changeset/three-kiwis-turn.md
+++ b/.changeset/three-kiwis-turn.md
@@ -1,0 +1,17 @@
+---
+'@backstage/frontend-plugin-api': patch
+'@backstage/frontend-test-utils': patch
+---
+
+Deprecate the `.render` method of the `createExtensionTester` in favour of using `renderInTestApp` directly.
+
+```tsx
+import { renderInTestApp, createExtensionTester } from '@backstage/frontend-test-utils';
+
+const tester = createExtensionTester(extension);
+
+const { getByTestId } = renderInTestApp(tester.element());
+
+// or if you're not using `coreExtensionData.reactElement` as the output ref
+const { getByTestId } = renderInTestApp(tester.data(myComponentRef))'
+```

--- a/.changeset/three-kiwis-turn.md
+++ b/.changeset/three-kiwis-turn.md
@@ -1,5 +1,4 @@
 ---
-'@backstage/frontend-plugin-api': patch
 '@backstage/frontend-test-utils': patch
 ---
 

--- a/.changeset/three-kiwis-turn.md
+++ b/.changeset/three-kiwis-turn.md
@@ -12,8 +12,8 @@ import {
 
 const tester = createExtensionTester(extension);
 
-const { getByTestId } = renderInTestApp(tester.element());
+const { getByTestId } = renderInTestApp(tester.reactElement());
 
 // or if you're not using `coreExtensionData.reactElement` as the output ref
-const { getByTestId } = renderInTestApp(tester.data(myComponentRef));
+const { getByTestId } = renderInTestApp(tester.get(myComponentRef));
 ```

--- a/packages/frontend-plugin-api/src/blueprints/NavItemBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/NavItemBlueprint.test.tsx
@@ -77,7 +77,7 @@ describe('NavItemBlueprint', () => {
 
     const tester = createExtensionTester(extension);
 
-    expect(tester.data(NavItemBlueprint.dataRefs.target)).toEqual({
+    expect(tester.get(NavItemBlueprint.dataRefs.target)).toEqual({
       title: 'TEST',
       icon: MockIcon,
       routeRef: mockRouteRef,
@@ -97,7 +97,7 @@ describe('NavItemBlueprint', () => {
       config: { title: 'OVERRIDDEN' },
     });
 
-    expect(tester.data(NavItemBlueprint.dataRefs.target)).toEqual({
+    expect(tester.get(NavItemBlueprint.dataRefs.target)).toEqual({
       title: 'OVERRIDDEN',
       icon: MockIcon,
       routeRef: mockRouteRef,

--- a/packages/frontend-plugin-api/src/blueprints/NavLogoBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/NavLogoBlueprint.test.tsx
@@ -64,7 +64,7 @@ describe('NavLogoBlueprint', () => {
 
     const tester = createExtensionTester(extension);
 
-    expect(tester.data(NavLogoBlueprint.dataRefs.logoElements)).toEqual({
+    expect(tester.get(NavLogoBlueprint.dataRefs.logoElements)).toEqual({
       logoFull,
       logoIcon,
     });

--- a/packages/frontend-plugin-api/src/blueprints/PageBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/PageBlueprint.test.tsx
@@ -16,7 +16,10 @@
 import React from 'react';
 import { createRouteRef } from '../routing';
 import { PageBlueprint } from './PageBlueprint';
-import { createExtensionTester } from '@backstage/frontend-test-utils';
+import {
+  createExtensionTester,
+  renderInTestApp,
+} from '@backstage/frontend-test-utils';
 import {
   coreExtensionData,
   createExtensionBlueprint,
@@ -144,7 +147,7 @@ describe('PageBlueprint', () => {
       CardBlueprint.make({ name: 'card', params: {} }),
     );
 
-    const { getByTestId, getByText } = tester.render();
+    const { getByTestId, getByText } = renderInTestApp(tester.element());
 
     await waitFor(() => expect(getByTestId('card')).toBeInTheDocument());
     await waitFor(() =>

--- a/packages/frontend-plugin-api/src/blueprints/PageBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/PageBlueprint.test.tsx
@@ -101,7 +101,7 @@ describe('PageBlueprint', () => {
     // TODO(blam): test for the routePath output doesn't work, due to the the way the test harness works
     // expect(tester.data(coreExtensionData.routePath)).toBe('/test');
 
-    expect(tester.data(coreExtensionData.routeRef)).toBe(mockRouteRef);
+    expect(tester.get(coreExtensionData.routeRef)).toBe(mockRouteRef);
 
     const { getByTestId } = tester.render();
 
@@ -147,7 +147,7 @@ describe('PageBlueprint', () => {
       CardBlueprint.make({ name: 'card', params: {} }),
     );
 
-    const { getByTestId, getByText } = renderInTestApp(tester.element());
+    const { getByTestId, getByText } = renderInTestApp(tester.reactElement());
 
     await waitFor(() => expect(getByTestId('card')).toBeInTheDocument());
     await waitFor(() =>

--- a/packages/frontend-plugin-api/src/blueprints/SignInPageBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/SignInPageBlueprint.test.tsx
@@ -16,9 +16,11 @@
 
 import React from 'react';
 import { SignInPageBlueprint } from './SignInPageBlueprint';
-import { createExtensionTester } from '@backstage/frontend-test-utils';
+import {
+  createExtensionTester,
+  renderInTestApp,
+} from '@backstage/frontend-test-utils';
 import { screen, waitFor } from '@testing-library/react';
-import { coreExtensionData, createExtension } from '../wiring';
 
 describe('SignInPageBlueprint', () => {
   it('should create an extension with sensible defaults', () => {
@@ -60,20 +62,11 @@ describe('SignInPageBlueprint', () => {
 
     const tester = createExtensionTester(extension);
 
-    expect(tester.data(SignInPageBlueprint.dataRefs.component)).toBeDefined();
+    const Element = tester.data(SignInPageBlueprint.dataRefs.component)!;
 
-    createExtensionTester(
-      createExtension({
-        name: 'dummy',
-        attachTo: { id: 'ignored', input: 'ignored' },
-        output: {
-          element: coreExtensionData.reactElement,
-        },
-        factory: () => ({ element: <div /> }),
-      }),
-    )
-      .add(extension)
-      .render();
+    expect(Element).toBeDefined();
+
+    renderInTestApp(<Element onSignInSuccess={() => {}} />);
 
     await waitFor(() => {
       expect(screen.getByTestId('mock-sign-in')).toBeInTheDocument();

--- a/packages/frontend-plugin-api/src/blueprints/SignInPageBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/SignInPageBlueprint.test.tsx
@@ -62,7 +62,7 @@ describe('SignInPageBlueprint', () => {
 
     const tester = createExtensionTester(extension);
 
-    const Element = tester.data(SignInPageBlueprint.dataRefs.component)!;
+    const Element = tester.get(SignInPageBlueprint.dataRefs.component)!;
 
     expect(Element).toBeDefined();
 

--- a/packages/frontend-plugin-api/src/blueprints/SignInPageBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/SignInPageBlueprint.test.tsx
@@ -62,11 +62,9 @@ describe('SignInPageBlueprint', () => {
 
     const tester = createExtensionTester(extension);
 
-    const Element = tester.get(SignInPageBlueprint.dataRefs.component);
+    const Component = tester.get(SignInPageBlueprint.dataRefs.component);
 
-    expect(Element).toBeDefined();
-
-    renderInTestApp(<Element onSignInSuccess={() => {}} />);
+    renderInTestApp(<Component onSignInSuccess={() => {}} />);
 
     await waitFor(() => {
       expect(screen.getByTestId('mock-sign-in')).toBeInTheDocument();

--- a/packages/frontend-plugin-api/src/blueprints/SignInPageBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/SignInPageBlueprint.test.tsx
@@ -62,7 +62,7 @@ describe('SignInPageBlueprint', () => {
 
     const tester = createExtensionTester(extension);
 
-    const Element = tester.get(SignInPageBlueprint.dataRefs.component)!;
+    const Element = tester.get(SignInPageBlueprint.dataRefs.component);
 
     expect(Element).toBeDefined();
 

--- a/packages/frontend-plugin-api/src/blueprints/ThemeBlueprint.test.ts
+++ b/packages/frontend-plugin-api/src/blueprints/ThemeBlueprint.test.ts
@@ -56,7 +56,7 @@ describe('ThemeBlueprint', () => {
     const extension = ThemeBlueprint.make({ params: { theme } });
 
     expect(
-      createExtensionTester(extension).data(ThemeBlueprint.dataRefs.theme),
+      createExtensionTester(extension).get(ThemeBlueprint.dataRefs.theme),
     ).toEqual(theme);
   });
 });

--- a/packages/frontend-plugin-api/src/blueprints/TranslationBlueprint.test.ts
+++ b/packages/frontend-plugin-api/src/blueprints/TranslationBlueprint.test.ts
@@ -76,7 +76,7 @@ describe('TranslationBlueprint', () => {
     });
 
     expect(
-      createExtensionTester(extension).data(
+      createExtensionTester(extension).get(
         TranslationBlueprint.dataRefs.translation,
       ),
     ).toBe(messages);

--- a/packages/frontend-plugin-api/src/wiring/createExtension.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.test.ts
@@ -688,7 +688,7 @@ describe('createExtension', () => {
 
       const tester = createExtensionTester(overridden);
 
-      expect(tester.data(numberDataRef)).toBe(43);
+      expect(tester.get(numberDataRef)).toBe(43);
     });
 
     it('should work functionally with overrides', () => {
@@ -722,14 +722,14 @@ describe('createExtension', () => {
         },
       });
 
-      expect(createExtensionTester(overriden).data(stringDataRef)).toBe(
+      expect(createExtensionTester(overriden).get(stringDataRef)).toBe(
         'foo-boom-override-hello',
       );
 
       expect(
         createExtensionTester(overriden, {
           config: { foo: 'hello', bar: 'world' },
-        }).data(stringDataRef),
+        }).get(stringDataRef),
       ).toBe('foo-hello-override-world');
     });
 
@@ -809,7 +809,7 @@ describe('createExtension', () => {
           .add(singleExt)
           .add(multi1Ext)
           .add(multi2Ext)
-          .data(outputRef),
+          .get(outputRef),
       ).toEqual({
         opt: 'orig-opt',
         single: 'orig-single',
@@ -836,7 +836,7 @@ describe('createExtension', () => {
           .add(singleExt)
           .add(multi1Ext)
           .add(multi2Ext)
-          .data(outputRef),
+          .get(outputRef),
       ).toEqual({
         opt: 'opt',
         single: 'single',
@@ -862,7 +862,7 @@ describe('createExtension', () => {
           .add(singleExt)
           .add(multi1Ext)
           .add(multi2Ext)
-          .data(outputRef),
+          .get(outputRef),
       ).toEqual({
         opt: 'none',
         single: 'single',
@@ -885,7 +885,7 @@ describe('createExtension', () => {
           .add(singleExt)
           .add(multi1Ext)
           .add(multi2Ext)
-          .data(outputRef),
+          .get(outputRef),
       ).toEqual({
         opt: 'orig-opt',
         single: 'orig-single',
@@ -912,7 +912,7 @@ describe('createExtension', () => {
           .add(singleExt)
           .add(multi1Ext)
           .add(multi2Ext)
-          .data(outputRef),
+          .get(outputRef),
       ).toEqual({
         opt: 'orig-opt',
         single: 'orig-single',
@@ -939,7 +939,7 @@ describe('createExtension', () => {
           .add(singleExt)
           .add(multi1Ext)
           .add(multi2Ext)
-          .data(outputRef),
+          .get(outputRef),
       ).toEqual({
         opt: 'orig-opt',
         single: 'orig-single',
@@ -966,7 +966,7 @@ describe('createExtension', () => {
           .add(singleExt)
           .add(multi1Ext)
           .add(multi2Ext)
-          .data(outputRef),
+          .get(outputRef),
       ).toEqual({
         opt: 'orig-opt',
         single: 'orig-single',
@@ -997,7 +997,7 @@ describe('createExtension', () => {
           .add(singleExt)
           .add(multi1Ext)
           .add(multi2Ext)
-          .data(outputRef),
+          .get(outputRef),
       ).toEqual({
         opt: 'none',
         single: 'override-orig-single',
@@ -1023,7 +1023,7 @@ describe('createExtension', () => {
           .add(singleExt)
           .add(multi1Ext)
           .add(multi2Ext)
-          .data(outputRef),
+          .get(outputRef),
       ).toThrowErrorMatchingInlineSnapshot(
         `"Failed to instantiate extension 'subject', override data provided for input 'multi' must match the length of the original inputs"`,
       );
@@ -1046,7 +1046,7 @@ describe('createExtension', () => {
           .add(singleExt)
           .add(multi1Ext)
           .add(multi2Ext)
-          .data(outputRef),
+          .get(outputRef),
       ).toThrowErrorMatchingInlineSnapshot(
         `"Failed to instantiate extension 'subject', override data for input 'multi' may not mix forwarded inputs with data overrides"`,
       );
@@ -1069,7 +1069,7 @@ describe('createExtension', () => {
           .add(singleExt)
           .add(multi1Ext)
           .add(multi2Ext)
-          .data(outputRef),
+          .get(outputRef),
       ).toThrowErrorMatchingInlineSnapshot(
         `"Failed to instantiate extension 'subject', missing required extension data value(s) 'test1'"`,
       );
@@ -1098,7 +1098,7 @@ describe('createExtension', () => {
           .add(singleExt)
           .add(multi1Ext)
           .add(multi2Ext)
-          .data(outputRef),
+          .get(outputRef),
       ).toThrowErrorMatchingInlineSnapshot(
         `"Failed to instantiate extension 'subject', extension data 'test2' was provided but not declared"`,
       );

--- a/packages/frontend-test-utils/api-report.md
+++ b/packages/frontend-test-utils/api-report.md
@@ -27,7 +27,6 @@ import { RouteRef } from '@backstage/frontend-plugin-api';
 import { TestApiProvider } from '@backstage/test-utils';
 import { TestApiProviderProps } from '@backstage/test-utils';
 import { TestApiRegistry } from '@backstage/test-utils';
-import { testingLibraryDomTypesQueries } from '@testing-library/dom/types/queries';
 import { withLogCollector } from '@backstage/test-utils';
 
 // @public (undocumented)
@@ -100,7 +99,7 @@ export { registerMswTestHooks };
 export function renderInTestApp(
   element: JSX.Element,
   options?: TestAppOptions,
-): RenderResult<testingLibraryDomTypesQueries, HTMLElement, HTMLElement>;
+): RenderResult;
 
 // @public @deprecated (undocumented)
 export function setupRequestMockHandlers(worker: {

--- a/packages/frontend-test-utils/api-report.md
+++ b/packages/frontend-test-utils/api-report.md
@@ -27,6 +27,7 @@ import { RouteRef } from '@backstage/frontend-plugin-api';
 import { TestApiProvider } from '@backstage/test-utils';
 import { TestApiProviderProps } from '@backstage/test-utils';
 import { TestApiRegistry } from '@backstage/test-utils';
+import { testingLibraryDomTypesQueries } from '@testing-library/dom/types/queries';
 import { withLogCollector } from '@backstage/test-utils';
 
 // @public (undocumented)
@@ -62,8 +63,10 @@ export class ExtensionTester {
   // (undocumented)
   data<T>(ref: ExtensionDataRef<T>): T | undefined;
   // (undocumented)
-  query(id: string | ExtensionDefinition<any, any>): ExtensionQuery;
+  element(): JSX.Element;
   // (undocumented)
+  query(id: string | ExtensionDefinition<any, any>): ExtensionQuery;
+  // @deprecated (undocumented)
   render(options?: { config?: JsonObject }): RenderResult;
 }
 
@@ -97,7 +100,7 @@ export { registerMswTestHooks };
 export function renderInTestApp(
   element: JSX.Element,
   options?: TestAppOptions,
-): RenderResult;
+): RenderResult<testingLibraryDomTypesQueries, HTMLElement, HTMLElement>;
 
 // @public @deprecated (undocumented)
 export function setupRequestMockHandlers(worker: {
@@ -117,6 +120,7 @@ export type TestAppOptions = {
   mountedRoutes?: {
     [path: string]: RouteRef;
   };
+  config?: JsonObject;
 };
 
 export { withLogCollector };

--- a/packages/frontend-test-utils/api-report.md
+++ b/packages/frontend-test-utils/api-report.md
@@ -43,7 +43,7 @@ export { ErrorWithContext };
 export class ExtensionQuery {
   constructor(node: AppNode);
   // (undocumented)
-  data<T>(ref: ExtensionDataRef<T>): T | undefined;
+  get<T>(ref: ExtensionDataRef<T>): T | undefined;
   // (undocumented)
   get instance(): AppNodeInstance;
   // (undocumented)
@@ -60,11 +60,11 @@ export class ExtensionTester {
     },
   ): ExtensionTester;
   // (undocumented)
-  data<T>(ref: ExtensionDataRef<T>): T | undefined;
-  // (undocumented)
-  element(): JSX.Element;
+  get<T>(ref: ExtensionDataRef<T>): T | undefined;
   // (undocumented)
   query(id: string | ExtensionDefinition<any, any>): ExtensionQuery;
+  // (undocumented)
+  reactElement(): JSX.Element;
   // @deprecated (undocumented)
   render(options?: { config?: JsonObject }): RenderResult;
 }

--- a/packages/frontend-test-utils/api-report.md
+++ b/packages/frontend-test-utils/api-report.md
@@ -7,6 +7,7 @@
 
 import { AnalyticsApi } from '@backstage/frontend-plugin-api';
 import { AnalyticsEvent } from '@backstage/frontend-plugin-api';
+import { AnyExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { AppNode } from '@backstage/frontend-plugin-api';
 import { AppNodeInstance } from '@backstage/frontend-plugin-api';
 import { ErrorWithContext } from '@backstage/test-utils';
@@ -30,20 +31,30 @@ import { TestApiRegistry } from '@backstage/test-utils';
 import { withLogCollector } from '@backstage/test-utils';
 
 // @public (undocumented)
-export function createExtensionTester<TConfig>(
-  subject: ExtensionDefinition<TConfig>,
+export function createExtensionTester<
+  TConfig,
+  TConfigInput,
+  UOutput extends AnyExtensionDataRef,
+>(
+  subject: ExtensionDefinition<TConfig, TConfigInput, UOutput>,
   options?: {
-    config?: TConfig;
+    config?: TConfigInput;
   },
-): ExtensionTester;
+): ExtensionTester<UOutput>;
 
 export { ErrorWithContext };
 
 // @public (undocumented)
-export class ExtensionQuery {
+export class ExtensionQuery<UOutput extends AnyExtensionDataRef> {
   constructor(node: AppNode);
   // (undocumented)
-  get<T>(ref: ExtensionDataRef<T>): T | undefined;
+  get<TId extends UOutput['id']>(
+    ref: ExtensionDataRef<any, TId, any>,
+  ): UOutput extends ExtensionDataRef<infer IData, TId, infer IConfig>
+    ? IConfig['optional'] extends true
+      ? IData | undefined
+      : IData
+    : never;
   // (undocumented)
   get instance(): AppNodeInstance;
   // (undocumented)
@@ -51,18 +62,26 @@ export class ExtensionQuery {
 }
 
 // @public (undocumented)
-export class ExtensionTester {
+export class ExtensionTester<UOutput extends AnyExtensionDataRef> {
   // (undocumented)
   add<TConfig, TConfigInput>(
     extension: ExtensionDefinition<TConfig, TConfigInput>,
     options?: {
       config?: TConfigInput;
     },
-  ): ExtensionTester;
+  ): ExtensionTester<UOutput>;
   // (undocumented)
-  get<T>(ref: ExtensionDataRef<T>): T | undefined;
+  get<TId extends UOutput['id']>(
+    ref: ExtensionDataRef<any, TId, any>,
+  ): UOutput extends ExtensionDataRef<infer IData, TId, infer IConfig>
+    ? IConfig['optional'] extends true
+      ? IData | undefined
+      : IData
+    : never;
   // (undocumented)
-  query(id: string | ExtensionDefinition<any, any>): ExtensionQuery;
+  query<UQueryExtensionOutput extends AnyExtensionDataRef>(
+    extension: ExtensionDefinition<any, any, UQueryExtensionOutput>,
+  ): ExtensionQuery<UQueryExtensionOutput>;
   // (undocumented)
   reactElement(): JSX.Element;
   // @deprecated (undocumented)

--- a/packages/frontend-test-utils/src/app/createExtensionTester.test.tsx
+++ b/packages/frontend-test-utils/src/app/createExtensionTester.test.tsx
@@ -246,7 +246,7 @@ describe('createExtensionTester', () => {
 
     const tester = createExtensionTester(extension);
 
-    expect(tester.data(stringDataRef)).toBe('test-text');
+    expect(tester.get(stringDataRef)).toBe('test-text');
   });
 
   it('should throw an error if trying to access an instance not provided to the tester', () => {
@@ -328,8 +328,8 @@ describe('createExtensionTester', () => {
 
     const tester = createExtensionTester(extension).add(extension2);
 
-    expect(tester.query(extension).data(stringDataRef)).toBe('nest-test-text');
-    expect(tester.query(extension2).data(stringDataRef)).toBe('test-text');
+    expect(tester.query(extension).get(stringDataRef)).toBe('nest-test-text');
+    expect(tester.query(extension2).get(stringDataRef)).toBe('test-text');
     // @ts-expect-error
     expect(tester.query(extension).input('input').data(stringDataRef)).toBe(
       'nest-test-text',
@@ -362,6 +362,6 @@ describe('createExtensionTester', () => {
       inputs: { input: 'test-text' },
     });
 
-    expect(tester.query(extension).data(stringDataRef)).toBe('nest-test-text');
+    expect(tester.query(extension).get(stringDataRef)).toBe('nest-test-text');
   });
 });

--- a/packages/frontend-test-utils/src/app/createExtensionTester.test.tsx
+++ b/packages/frontend-test-utils/src/app/createExtensionTester.test.tsx
@@ -240,8 +240,8 @@ describe('createExtensionTester', () => {
     const extension = createExtension({
       namespace: 'test',
       attachTo: { id: 'ignored', input: 'ignored' },
-      output: { text: stringDataRef },
-      factory: () => ({ text: 'test-text' }),
+      output: [stringDataRef],
+      factory: () => [stringDataRef('test-text')],
     });
 
     const tester = createExtensionTester(extension);
@@ -297,6 +297,76 @@ describe('createExtensionTester', () => {
     );
   });
 
+  it('should not allow getting extension data for an output that was not defined in the extension', () => {
+    const internalRef = createExtensionDataRef<number>().with({
+      id: 'test.internal',
+    });
+
+    const internalRef2 = createExtensionDataRef<number>().with({
+      id: 'test.internal2',
+    });
+
+    const extension = createExtension({
+      namespace: 'test',
+      name: 'e1',
+      attachTo: { id: 'ignored', input: 'ignored' },
+      output: [stringDataRef, internalRef.optional()],
+      factory: () => [stringDataRef('test-text')],
+    });
+
+    const tester = createExtensionTester(extension);
+
+    const test: string = tester.get(stringDataRef);
+
+    // @ts-expect-error - internalRef is optional
+    const test2: number = tester.get(internalRef);
+
+    // @ts-expect-error - internalRef2 is not defined in the extension
+    const test3: number = tester.get(internalRef2);
+
+    expect([test, test2, test3]).toBeDefined();
+  });
+
+  it('should support getting outputs from a query response', () => {
+    const internalRef = createExtensionDataRef<number>().with({
+      id: 'test.internal',
+    });
+
+    const internalRef2 = createExtensionDataRef<number>().with({
+      id: 'test.internal2',
+    });
+
+    const extension = createExtension({
+      namespace: 'test',
+      name: 'e1',
+      attachTo: { id: 'ignored', input: 'ignored' },
+      output: [coreExtensionData.reactElement],
+      factory: () => [coreExtensionData.reactElement(<div>bob</div>)],
+    });
+
+    const extraExtension = createExtension({
+      namespace: 'test',
+      name: 'e1',
+      attachTo: { id: 'ignored', input: 'ignored' },
+      output: [stringDataRef, internalRef.optional()],
+      factory: () => [stringDataRef('test-text')],
+    });
+
+    const tester = createExtensionTester(extension)
+      .add(extraExtension)
+      .query(extraExtension);
+
+    const test: string = tester.get(stringDataRef);
+
+    // @ts-expect-error - internalRef is optional
+    const test2: number = tester.get(internalRef);
+
+    // @ts-expect-error - internalRef2 is not defined in the extension
+    const test3: number = tester.get(internalRef2);
+
+    expect([test, test2, test3]).toBeDefined();
+  });
+
   // TODO: this should be implemented
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip('should allow querying an extension and getting outputs', () => {
@@ -328,7 +398,9 @@ describe('createExtensionTester', () => {
 
     const tester = createExtensionTester(extension).add(extension2);
 
+    // @ts-expect-error
     expect(tester.query(extension).get(stringDataRef)).toBe('nest-test-text');
+    // @ts-expect-error
     expect(tester.query(extension2).get(stringDataRef)).toBe('test-text');
     // @ts-expect-error
     expect(tester.query(extension).input('input').data(stringDataRef)).toBe(
@@ -362,6 +434,7 @@ describe('createExtensionTester', () => {
       inputs: { input: 'test-text' },
     });
 
+    // @ts-expect-error
     expect(tester.query(extension).get(stringDataRef)).toBe('nest-test-text');
   });
 });

--- a/packages/frontend-test-utils/src/app/createExtensionTester.test.tsx
+++ b/packages/frontend-test-utils/src/app/createExtensionTester.test.tsx
@@ -339,6 +339,9 @@ describe('createExtensionTester', () => {
     const extension = createExtension({
       namespace: 'test',
       name: 'e1',
+      inputs: {
+        ignored: createExtensionInput([stringDataRef]),
+      },
       attachTo: { id: 'ignored', input: 'ignored' },
       output: [coreExtensionData.reactElement],
       factory: () => [coreExtensionData.reactElement(<div>bob</div>)],
@@ -346,8 +349,8 @@ describe('createExtensionTester', () => {
 
     const extraExtension = createExtension({
       namespace: 'test',
-      name: 'e1',
-      attachTo: { id: 'ignored', input: 'ignored' },
+      name: 'e2',
+      attachTo: { id: 'test/e1', input: 'ignored' },
       output: [stringDataRef, internalRef.optional()],
       factory: () => [stringDataRef('test-text')],
     });

--- a/packages/frontend-test-utils/src/app/createExtensionTester.tsx
+++ b/packages/frontend-test-utils/src/app/createExtensionTester.tsx
@@ -43,6 +43,7 @@ import { resolveAppNodeSpecs } from '../../../frontend-app-api/src/tree/resolveA
 import { instantiateAppNodeTree } from '../../../frontend-app-api/src/tree/instantiateAppNodeTree';
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
 import { readAppExtensionsConfig } from '../../../frontend-app-api/src/tree/readAppExtensionsConfig';
+import { TestAppNavExtension } from './renderInTestApp';
 
 /** @public */
 export class ExtensionQuery {
@@ -227,6 +228,7 @@ export class ExtensionTester {
                 <MemoryRouter>{children}</MemoryRouter>
               ),
             }),
+            TestAppNavExtension,
           ],
         }),
       ],

--- a/packages/frontend-test-utils/src/app/createExtensionTester.tsx
+++ b/packages/frontend-test-utils/src/app/createExtensionTester.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-import { MemoryRouter, Link } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 import { RenderResult, render } from '@testing-library/react';
 import { createSpecializedApp } from '@backstage/frontend-app-api';
 import {
@@ -24,15 +24,10 @@ import {
   Extension,
   ExtensionDataRef,
   ExtensionDefinition,
-  IconComponent,
-  RouteRef,
   coreExtensionData,
   createExtension,
-  createExtensionInput,
   createExtensionOverrides,
-  createNavItemExtension,
   createRouterExtension,
-  useRouteRef,
 } from '@backstage/frontend-plugin-api';
 import { Config, ConfigReader } from '@backstage/config';
 import { JsonArray, JsonObject, JsonValue } from '@backstage/types';
@@ -215,14 +210,12 @@ export class ExtensionTester {
    */
   render(options?: { config?: JsonObject }): RenderResult {
     const { config = {} } = options ?? {};
-
     const [subject] = this.#extensions;
     if (!subject) {
       throw new Error(
         'No subject found. At least one extension should be added to the tester.',
       );
     }
-
     const app = createSpecializedApp({
       features: [
         createExtensionOverrides({
@@ -239,7 +232,6 @@ export class ExtensionTester {
       ],
       config: this.#getConfig(config),
     });
-
     return render(app.createRoot());
   }
 

--- a/packages/frontend-test-utils/src/app/renderInTestApp.tsx
+++ b/packages/frontend-test-utils/src/app/renderInTestApp.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import { Link, MemoryRouter } from 'react-router-dom';
 import { createSpecializedApp } from '@backstage/frontend-app-api';
-import { render } from '@testing-library/react';
+import { RenderResult, render } from '@testing-library/react';
 import { ConfigReader } from '@backstage/config';
 import { JsonObject } from '@backstage/types';
 import {
@@ -81,7 +81,7 @@ const NavItem = (props: {
   );
 };
 
-const TestAppNavExtension = createExtension({
+export const TestAppNavExtension = createExtension({
   namespace: 'app',
   name: 'nav',
   attachTo: { id: 'app/layout', input: 'nav' },
@@ -122,7 +122,7 @@ const TestAppNavExtension = createExtension({
 export function renderInTestApp(
   element: JSX.Element,
   options?: TestAppOptions,
-) {
+): RenderResult {
   const extensions: Array<ExtensionDefinition<any, any>> = [
     createExtension({
       namespace: 'test',

--- a/plugins/catalog-react/src/alpha/blueprints/EntityCardBlueprint.test.tsx
+++ b/plugins/catalog-react/src/alpha/blueprints/EntityCardBlueprint.test.tsx
@@ -100,7 +100,7 @@ describe('EntityCardBlueprint', () => {
             filter: 'test',
           },
         }),
-      ).data(EntityCardBlueprint.dataRefs.filterExpression),
+      ).get(EntityCardBlueprint.dataRefs.filterExpression),
     ).toBe('test');
 
     expect(
@@ -112,7 +112,7 @@ describe('EntityCardBlueprint', () => {
           },
         }),
         { config: { filter: 'test' } },
-      ).data(EntityCardBlueprint.dataRefs.filterExpression),
+      ).get(EntityCardBlueprint.dataRefs.filterExpression),
     ).toBe('test');
 
     expect(
@@ -124,7 +124,7 @@ describe('EntityCardBlueprint', () => {
             loader: async () => <div>Test!</div>,
           },
         }),
-      ).data(EntityCardBlueprint.dataRefs.filterFunction),
+      ).get(EntityCardBlueprint.dataRefs.filterFunction),
     ).toBe(mockFilter);
   });
 

--- a/plugins/catalog-react/src/alpha/blueprints/EntityContentBlueprint.test.tsx
+++ b/plugins/catalog-react/src/alpha/blueprints/EntityContentBlueprint.test.tsx
@@ -122,10 +122,10 @@ describe('EntityContentBlueprint', () => {
     const tester = createExtensionTester(extension);
 
     // todo(blam): route paths are always set to / in the createExtensionTester. This will work eventually.
-    // expect(tester.data(coreExtensionData.routePath)).toBe('/test');
+    // expect(tester.get(coreExtensionData.routePath)).toBe('/test');
 
-    expect(tester.data(coreExtensionData.routeRef)).toBe(mockRouteRef);
-    expect(tester.data(EntityContentBlueprint.dataRefs.title)).toBe('Test');
+    expect(tester.get(coreExtensionData.routeRef)).toBe(mockRouteRef);
+    expect(tester.get(EntityContentBlueprint.dataRefs.title)).toBe('Test');
   });
 
   it('should emit the correct filter output', () => {
@@ -142,7 +142,7 @@ describe('EntityContentBlueprint', () => {
             filter: 'test',
           },
         }),
-      ).data(EntityContentBlueprint.dataRefs.filterExpression),
+      ).get(EntityContentBlueprint.dataRefs.filterExpression),
     ).toBe('test');
 
     expect(
@@ -156,7 +156,7 @@ describe('EntityContentBlueprint', () => {
           },
         }),
         { config: { filter: 'test' } },
-      ).data(EntityContentBlueprint.dataRefs.filterExpression),
+      ).get(EntityContentBlueprint.dataRefs.filterExpression),
     ).toBe('test');
 
     expect(
@@ -170,7 +170,7 @@ describe('EntityContentBlueprint', () => {
             loader: async () => <div>Test!</div>,
           },
         }),
-      ).data(EntityContentBlueprint.dataRefs.filterFunction),
+      ).get(EntityContentBlueprint.dataRefs.filterFunction),
     ).toBe(mockFilter);
   });
 


### PR DESCRIPTION
- chore: wip
- feat: some more work on splitting out the render method
- feat: added api-reports
- chore: added changeset

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
