### PR TITLE
Fix: GCP IAP Config and Docs

### DIFF
--- a/.changeset/rare-maps-wave.md
+++ b/.changeset/rare-maps-wave.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-auth-backend-module-gcp-iap-provider': patch
+'@backstage/core-components': patch
+---
+
+Corrected the documentation for the GCP IAP auth module and updated the configuration to follow proxy configuration conventions by ignoring authEnv

--- a/docs/auth/google/gcp-iap-auth.md
+++ b/docs/auth/google/gcp-iap-auth.md
@@ -77,6 +77,6 @@ backend.add(import('@backstage/plugin-auth-backend-module-gcp-iap-provider'));
 
 ## Adding the provider to the Backstage frontend
 
-See [Sign-In with Proxy Providers](../index.md#sign-in-with-proxy-providers) for pointers on how to set up the sign-in page, and to also make it work smoothly for local development. You'll use `gcpiap` as the provider name.
+See [Sign-In with Proxy Providers](../index.md#sign-in-with-proxy-providers) for pointers on how to set up the sign-in page, and to also make it work smoothly for local development. You'll use `gcpIap` as the provider name.
 
 If you [provide a custom sign in resolver](https://backstage.io/docs/auth/identity-resolver#building-custom-resolvers), you can skip the `signIn` block entirely.

--- a/docs/auth/google/gcp-iap-auth.md
+++ b/docs/auth/google/gcp-iap-auth.md
@@ -24,7 +24,7 @@ Let's start by adding the following `auth` configuration in your
 ```yaml
 auth:
   providers:
-    gcp-iap:
+    gcpIap:
       audience: '/projects/<project number>/global/backendServices/<backend service id>'
       jwtHeader: x-custom-header # Optional: Only if you are using a custom header for the IAP JWT
       signIn:
@@ -77,6 +77,6 @@ backend.add(import('@backstage/plugin-auth-backend-module-gcp-iap-provider'));
 
 ## Adding the provider to the Backstage frontend
 
-See [Sign-In with Proxy Providers](../index.md#sign-in-with-proxy-providers) for pointers on how to set up the sign-in page, and to also make it work smoothly for local development. You'll use `gcp-iap` as the provider name.
+See [Sign-In with Proxy Providers](../index.md#sign-in-with-proxy-providers) for pointers on how to set up the sign-in page, and to also make it work smoothly for local development. You'll use `gcpiap` as the provider name.
 
 If you [provide a custom sign in resolver](https://backstage.io/docs/auth/identity-resolver#building-custom-resolvers), you can skip the `signIn` block entirely.

--- a/packages/core-components/src/layout/ProxiedSignInPage/ProxiedSignInPage.tsx
+++ b/packages/core-components/src/layout/ProxiedSignInPage/ProxiedSignInPage.tsx
@@ -34,7 +34,7 @@ import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
  */
 export type ProxiedSignInPageProps = SignInPageProps & {
   /**
-   * The provider to use, e.g. "gcpiap" or "awsalb". This must correspond to
+   * The provider to use, e.g. "gcpIap" or "awsalb". This must correspond to
    * a properly configured auth provider ID in the auth backend.
    */
   provider: string;

--- a/packages/core-components/src/layout/ProxiedSignInPage/ProxiedSignInPage.tsx
+++ b/packages/core-components/src/layout/ProxiedSignInPage/ProxiedSignInPage.tsx
@@ -34,7 +34,7 @@ import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
  */
 export type ProxiedSignInPageProps = SignInPageProps & {
   /**
-   * The provider to use, e.g. "gcp-iap" or "awsalb". This must correspond to
+   * The provider to use, e.g. "gcpiap" or "awsalb". This must correspond to
    * a properly configured auth provider ID in the auth backend.
    */
   provider: string;

--- a/plugins/auth-backend-module-gcp-iap-provider/config.d.ts
+++ b/plugins/auth-backend-module-gcp-iap-provider/config.d.ts
@@ -21,26 +21,24 @@ export interface Config {
        * Configuration for the Google Cloud Platform Identity-Aware Proxy (IAP) auth provider.
        */
       gcpIap?: {
-        [authEnv: string]: {
-          /**
-           * The audience to use when validating incoming JWT tokens.
-           * See https://backstage.io/docs/auth/google/gcp-iap-auth
-           */
-          audience: string;
+        /**
+         * The audience to use when validating incoming JWT tokens.
+         * See https://backstage.io/docs/auth/google/gcp-iap-auth
+         */
+        audience: string;
 
-          /**
-           * The name of the header to read the JWT token from, defaults to `'x-goog-iap-jwt-assertion'`.
-           */
-          jwtHeader?: string;
+        /**
+         * The name of the header to read the JWT token from, defaults to `'x-goog-iap-jwt-assertion'`.
+         */
+        jwtHeader?: string;
 
-          signIn?: {
-            resolvers: Array<
-              | { resolver: 'emailMatchingUserEntityAnnotation' }
-              | { resolver: 'idMatchingUserEntityAnnotation' }
-              | { resolver: 'emailLocalPartMatchingUserEntityName' }
-              | { resolver: 'emailMatchingUserEntityProfileEmail' }
-            >;
-          };
+        signIn?: {
+          resolvers: Array<
+            | { resolver: 'emailMatchingUserEntityAnnotation' }
+            | { resolver: 'idMatchingUserEntityAnnotation' }
+            | { resolver: 'emailLocalPartMatchingUserEntityName' }
+            | { resolver: 'emailMatchingUserEntityProfileEmail' }
+          >;
         };
       };
     };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is a fix for #25087. The IAP configuration documentation and `ProxiedSignInPage` doc comment were wrong, but the configuration also needed to be duplicated when using `auth.environment`. According to Patrik's comment on the issue, this is expected for proxy auth providers. I double-checked and confirmed that this now aligns with the AWS ALB provider.

I don't think this is a breaking change since the workaround for the issue creates a forwards-compatible configuration file.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
