### PR TITLE
Do not fallback to broadcast when user is missing for entity-types notifications

### DIFF
--- a/.changeset/flat-guests-behave.md
+++ b/.changeset/flat-guests-behave.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-notifications-backend-module-email': patch
+'@backstage/plugin-notifications-backend': patch
+---
+
+Avoid sending broadcast emails as a fallback in case the entity-typed notification user can not be resolved.

--- a/plugins/notifications-backend/src/service/getUsersForEntityRef.ts
+++ b/plugins/notifications-backend/src/service/getUsersForEntityRef.ts
@@ -157,5 +157,5 @@ export const getUsersForEntityRef = async (
     users.push(...u);
   }
 
-  return [...new Set(users)];
+  return [...new Set(users)].filter(Boolean);
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

With this patch, emails are not sent for entity-typed notifications without provided user.
Prior this patch, such unexpected data caused a broadcast email to be sent, which is confusing.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
