### PR TITLE
Added back `type: 'local'` to TechDocs config schema

### DIFF
--- a/.changeset/modern-apes-join.md
+++ b/.changeset/modern-apes-join.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-backend': patch
+---
+
+Added back `type: 'local'` to TechDocs config schema for `publisher`

--- a/plugins/techdocs-backend/config.d.ts
+++ b/plugins/techdocs-backend/config.d.ts
@@ -68,14 +68,20 @@ export interface Config {
     /**
      * Techdocs publisher information
      */
-    publisher?: {
-      local?: {
-        /**
-         * Directory to store generated static files.
-         */
-        publishDirectory?: string;
-      };
-    } & (
+    publisher?:
+      | {
+          type: 'local';
+
+          /**
+           *  Optional when 'type' is set to local
+           */
+          local?: {
+            /**
+             * (Optional) Directory to store generated static files.
+             */
+            publishDirectory?: string;
+          };
+        }
       | {
           type: 'awsS3';
 
@@ -258,8 +264,7 @@ export interface Config {
              */
             projectId?: string;
           };
-        }
-    );
+        };
 
     /**
      * @example http://localhost:7007/api/techdocs


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added back `type: 'local'` to TechDocs config schema for `publisher`.

Tested this change using the `app-config.yaml` in this repo as it has the config that would fail:

https://github.com/backstage/backstage/blob/eada5c4f2279e062027c7a6e6fabcfdf9398b35d/app-config.yaml#L151-L158'

Using this command: `yarn backstage-cli config:check --lax --strict --config app-config.yaml`

Closes #26014

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
