### PR TITLE
fix GitHub repository events

### DIFF
--- a/.changeset/warm-moles-appear.md
+++ b/.changeset/warm-moles-appear.md
@@ -4,4 +4,5 @@
 
 Fix GitHub `repository` event support.
 
-`$.repository.organization` is only provided for `push` events. Switched to `$.organization.login` instead.
+- `$.repository.organization` is only provided for `push` events. Switched to `$.organization.login` instead.
+- `$.repository.url` is not always returning the expected and required value. Use `$.repository.html_url` instead.

--- a/.changeset/warm-moles-appear.md
+++ b/.changeset/warm-moles-appear.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+Fix GitHub `repository` event support.
+
+`$.repository.organization` is only provided for `push` events. Switched to `$.organization.login` instead.

--- a/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.test.ts
@@ -665,7 +665,7 @@ describe('GithubEntityProvider', () => {
       event: EventParams<PushEvent | RepositoryEvent>,
       options?: { branch?: string; catalogFilePath?: string },
     ): DeferredEntity[] => {
-      const url = `${event.eventPayload.repository.url}/blob/${
+      const url = `${event.eventPayload.repository.html_url}/blob/${
         options?.branch ?? 'main'
       }/${options?.catalogFilePath ?? 'catalog-info.yaml'}`;
       return createExpectedEntitiesForUrl(url);
@@ -687,6 +687,7 @@ describe('GithubEntityProvider', () => {
           name: 'test-repo',
           organization,
           topics: [],
+          html_url: `https://github.com/${organization}/test-repo`,
           url: `https://github.com/${organization}/test-repo`,
         } as Partial<PushEvent['repository']>;
 
@@ -963,7 +964,8 @@ describe('GithubEntityProvider', () => {
       ): EventParams<RepositoryEvent> => {
         const repo = {
           name: 'test-repo',
-          url: 'https://github.com/test-org/test-repo',
+          html_url: 'https://github.com/test-org/test-repo',
+          url: 'https://api.github.com/repos/test-org/test-repo',
           default_branch: 'main',
           master_branch: 'main',
           topics: [],

--- a/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.test.ts
@@ -702,6 +702,9 @@ describe('GithubEntityProvider', () => {
         const event = {
           ref: options?.ref ?? 'refs/heads/main',
           repository: repo as PushEvent['repository'],
+          organization: {
+            login: organization,
+          },
           created: true,
           deleted: false,
           forced: false,
@@ -963,7 +966,6 @@ describe('GithubEntityProvider', () => {
           url: 'https://github.com/test-org/test-repo',
           default_branch: 'main',
           master_branch: 'main',
-          organization: 'test-org',
           topics: [],
           archived: action === 'archived',
           private: action !== 'publicized',
@@ -972,6 +974,9 @@ describe('GithubEntityProvider', () => {
         const event = {
           action,
           repository: repo as RepositoryEvent['repository'],
+          organization: {
+            login: 'test-org',
+          },
         } as RepositoryEvent;
 
         if (action === 'renamed') {
@@ -1285,7 +1290,7 @@ describe('GithubEntityProvider', () => {
           const event = createRepoEvent(
             'renamed',
           ) as EventParams<RepositoryRenamedEvent>;
-          const urlOldRepo = `https://github.com/${event.eventPayload.repository.organization}/${event.eventPayload.changes.repository.name.from}/blob/main/catalog-info.yaml`;
+          const urlOldRepo = `https://github.com/${event.eventPayload.organization?.login}/${event.eventPayload.changes.repository.name.from}/blob/main/catalog-info.yaml`;
           const expectedEntitiesRemoved =
             createExpectedEntitiesForUrl(urlOldRepo);
 
@@ -1314,7 +1319,7 @@ describe('GithubEntityProvider', () => {
           const event = createRepoEvent(
             'renamed',
           ) as EventParams<RepositoryRenamedEvent>;
-          const urlOldRepo = `https://github.com/${event.eventPayload.repository.organization}/${event.eventPayload.changes.repository.name.from}/blob/main/catalog-info.yaml`;
+          const urlOldRepo = `https://github.com/${event.eventPayload.organization?.login}/${event.eventPayload.changes.repository.name.from}/blob/main/catalog-info.yaml`;
           const expectedEntitiesRemoved =
             createExpectedEntitiesForUrl(urlOldRepo);
           const expectedEntitiesAdded = createExpectedEntitiesForEvent(event);

--- a/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.ts
@@ -294,7 +294,7 @@ export class GithubEntityProvider implements EntityProvider, EventSubscriber {
 
   /** {@inheritdoc @backstage/plugin-events-node#EventSubscriber.onEvent} */
   async onEvent(params: EventParams): Promise<void> {
-    this.logger.debug(`Received event from ${params.topic}`);
+    this.logger.debug(`Received event for topic ${params.topic}`);
     if (EVENT_TOPICS.some(topic => topic === params.topic)) {
       if (!this.connection) {
         throw new Error('Not initialized');

--- a/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.ts
@@ -540,7 +540,7 @@ export class GithubEntityProvider implements EntityProvider, EventSubscriber {
     const matchingTargets = this.matchesFilters([repository]);
     if (matchingTargets.length === 0) {
       this.logger.debug(
-        `skipping repository transferred event for repository ${repository.name} because it didn't match provider filters`,
+        `skipping repository renamed event for repository ${repository.name} because it didn't match provider filters`,
       );
       return;
     }
@@ -587,7 +587,7 @@ export class GithubEntityProvider implements EntityProvider, EventSubscriber {
     const matchingTargets = this.matchesFilters([repository]);
     if (matchingTargets.length === 0) {
       this.logger.debug(
-        `skipping repository transferred event for repository ${repository.name} because it didn't match provider filters`,
+        `skipping repository unarchived event for repository ${repository.name} because it didn't match provider filters`,
       );
       return;
     }

--- a/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.ts
@@ -323,9 +323,9 @@ export class GithubEntityProvider implements EntityProvider, EventSubscriber {
   }
 
   private async onPush(event: PushEvent) {
-    if (this.config.organization !== event.repository.organization) {
+    if (this.config.organization !== event.organization?.login) {
       this.logger.debug(
-        `skipping push event from organization ${event.repository.organization}`,
+        `skipping push event from organization ${event.organization?.login}`,
       );
       return;
     }
@@ -408,9 +408,9 @@ export class GithubEntityProvider implements EntityProvider, EventSubscriber {
   }
 
   private async onRepoChange(event: RepositoryEvent) {
-    if (this.config.organization !== event.repository.organization) {
+    if (this.config.organization !== event.organization?.login) {
       this.logger.debug(
-        `skipping repository event from organization ${event.repository.organization}`,
+        `skipping repository event from organization ${event.organization?.login}`,
       );
       return;
     }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Fix GitHub `repository` event support.

- `$.repository.organization` is only provided for `push` events. Switched to `$.organization.login` instead.
- `$.repository.url` is not always returning the expected and required value. Use `$.repository.html_url` instead.

Fixes: #25951

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
