### PR TITLE
fix: validate notification link when posting

### DIFF
--- a/.changeset/rotten-crabs-hear.md
+++ b/.changeset/rotten-crabs-hear.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications-backend': patch
+---
+
+Validate notification link when new notification is created

--- a/plugins/notifications-backend/src/plugin.ts
+++ b/plugins/notifications-backend/src/plugin.ts
@@ -67,6 +67,7 @@ export const notificationsPlugin = createBackendPlugin({
         database: coreServices.database,
         discovery: coreServices.discovery,
         signals: signalsServiceRef,
+        config: coreServices.rootConfig,
       },
       async init({
         auth,
@@ -77,6 +78,7 @@ export const notificationsPlugin = createBackendPlugin({
         database,
         discovery,
         signals,
+        config,
       }) {
         httpRouter.use(
           await createRouter({
@@ -84,6 +86,7 @@ export const notificationsPlugin = createBackendPlugin({
             httpAuth,
             userInfo,
             logger,
+            config,
             database,
             discovery,
             signals,

--- a/plugins/notifications-backend/src/service/router.test.ts
+++ b/plugins/notifications-backend/src/service/router.test.ts
@@ -23,7 +23,8 @@ import request from 'supertest';
 import { createRouter } from './router';
 import { ConfigReader } from '@backstage/config';
 import { SignalsService } from '@backstage/plugin-signals-node';
-import { mockServices } from '@backstage/backend-test-utils';
+import { mockCredentials, mockServices } from '@backstage/backend-test-utils';
+import { NotificationSendOptions } from '@backstage/plugin-notifications-node';
 
 function createDatabase(): PluginDatabaseManager {
   return DatabaseManager.fromConfig(
@@ -47,8 +48,13 @@ describe('createRouter', () => {
 
   const discovery = mockServices.discovery();
   const userInfo = mockServices.userInfo();
-  const httpAuth = mockServices.httpAuth();
+  const httpAuth = mockServices.httpAuth({
+    defaultCredentials: mockCredentials.service(),
+  });
   const auth = mockServices.auth();
+  const config = mockServices.rootConfig({
+    data: { app: { baseUrl: 'http://localhost' } },
+  });
 
   beforeAll(async () => {
     const router = await createRouter({
@@ -57,6 +63,7 @@ describe('createRouter', () => {
       discovery,
       signals: signalService,
       userInfo,
+      config,
       httpAuth,
       auth,
     });
@@ -73,6 +80,82 @@ describe('createRouter', () => {
 
       expect(response.status).toEqual(200);
       expect(response.body).toEqual({ status: 'ok' });
+    });
+  });
+
+  describe('POST /', () => {
+    const sendNotification = async (data: NotificationSendOptions) =>
+      request(app)
+        .post('/')
+        .send(data)
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json');
+
+    it('returns error on invalid link', async () => {
+      const javascriptXSS = await sendNotification({
+        recipients: {
+          type: 'broadcast',
+        },
+        payload: {
+          title: 'test notification',
+          // eslint-disable-next-line no-script-url
+          link: 'javascript:alert(document.domain)',
+        },
+      });
+
+      expect(javascriptXSS.status).toEqual(400);
+
+      const ftpLink = await sendNotification({
+        recipients: {
+          type: 'broadcast',
+        },
+        payload: {
+          title: 'test notification',
+          link: 'ftp://example.com',
+        },
+      });
+
+      expect(ftpLink.status).toEqual(400);
+    });
+
+    it('should accept absolute http links', async () => {
+      const httpLink = await sendNotification({
+        recipients: {
+          type: 'broadcast',
+        },
+        payload: {
+          title: 'test notification',
+          link: 'http://localhost/test',
+        },
+      });
+
+      expect(httpLink.status).toEqual(200);
+
+      const httpsLink = await sendNotification({
+        recipients: {
+          type: 'broadcast',
+        },
+        payload: {
+          title: 'test notification',
+          link: 'https://example.com',
+        },
+      });
+
+      expect(httpsLink.status).toEqual(200);
+    });
+
+    it('should accept relative links', async () => {
+      const catalogLink = await sendNotification({
+        recipients: {
+          type: 'broadcast',
+        },
+        payload: {
+          title: 'test notification',
+          link: '/catalog',
+        },
+      });
+
+      expect(catalogLink.status).toEqual(200);
     });
   });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

fixes an issue that allows posting notifications containing links with cross-site scripting attack

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
