### PR TITLE
Added OpenTelemetry support to Scaffolder metrics

### DIFF
--- a/.changeset/large-monkeys-dress.md
+++ b/.changeset/large-monkeys-dress.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+Added OpenTelemetry support to Scaffolder metrics

--- a/plugins/scaffolder-backend/package.json
+++ b/plugins/scaffolder-backend/package.json
@@ -86,6 +86,7 @@
     "@backstage/plugin-scaffolder-common": "workspace:^",
     "@backstage/plugin-scaffolder-node": "workspace:^",
     "@backstage/types": "workspace:^",
+    "@opentelemetry/api": "^1.3.0",
     "@types/express": "^4.17.6",
     "@types/luxon": "^3.0.0",
     "concat-stream": "^2.0.0",

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
@@ -26,6 +26,7 @@ import { PassThrough } from 'stream';
 import { generateExampleOutput, isTruthy } from './helper';
 import { validate as validateJsonSchema } from 'jsonschema';
 import { TemplateActionRegistry } from '../actions';
+import { metrics } from '@opentelemetry/api';
 import {
   SecureTemplater,
   SecureTemplateRenderer,
@@ -520,25 +521,45 @@ export class NunjucksWorkflowRunner implements WorkflowRunner {
 }
 
 function scaffoldingTracker() {
-  const taskCount = createCounterMetric({
+  // prom-client metrics are deprecated in favour of OpenTelemetry metrics.
+  const promTaskCount = createCounterMetric({
     name: 'scaffolder_task_count',
     help: 'Count of task runs',
     labelNames: ['template', 'user', 'result'],
   });
-  const taskDuration = createHistogramMetric({
+  const promTaskDuration = createHistogramMetric({
     name: 'scaffolder_task_duration',
     help: 'Duration of a task run',
     labelNames: ['template', 'result'],
   });
-  const stepCount = createCounterMetric({
+  const promtStepCount = createCounterMetric({
     name: 'scaffolder_step_count',
     help: 'Count of step runs',
     labelNames: ['template', 'step', 'result'],
   });
-  const stepDuration = createHistogramMetric({
+  const promStepDuration = createHistogramMetric({
     name: 'scaffolder_step_duration',
     help: 'Duration of a step runs',
     labelNames: ['template', 'step', 'result'],
+  });
+
+  const meter = metrics.getMeter('default');
+  const taskCount = meter.createCounter('scaffolder.task.count', {
+    description: 'Count of task runs',
+  });
+
+  const taskDuration = meter.createHistogram('scaffolder.task.duration', {
+    description: 'Duration of a task run',
+    unit: 'seconds',
+  });
+
+  const stepCount = meter.createCounter('scaffolder.step.count', {
+    description: 'Count of step runs',
+  });
+
+  const stepDuration = meter.createHistogram('scaffolder.step.duration', {
+    description: 'Duration of a step runs',
+    unit: 'seconds',
   });
 
   async function taskStart(task: TaskContext) {
@@ -546,9 +567,15 @@ function scaffoldingTracker() {
     const template = task.spec.templateInfo?.entityRef || '';
     const user = task.spec.user?.ref || '';
 
-    const taskTimer = taskDuration.startTimer({
+    const startTime = process.hrtime();
+    const taskTimer = promTaskDuration.startTimer({
       template,
     });
+
+    function endTime() {
+      const delta = process.hrtime(startTime);
+      return delta[0] + delta[1] / 1e9;
+    }
 
     async function skipDryRun(
       step: TaskStep,
@@ -561,12 +588,17 @@ function scaffoldingTracker() {
     }
 
     async function markSuccessful() {
-      taskCount.inc({
+      promTaskCount.inc({
         template,
         user,
         result: 'ok',
       });
       taskTimer({ result: 'ok' });
+
+      taskCount.add(1, { template, user, result: 'ok' });
+      taskDuration.record(endTime(), {
+        result: 'ok',
+      });
     }
 
     async function markFailed(step: TaskStep, err: Error) {
@@ -574,12 +606,17 @@ function scaffoldingTracker() {
         stepId: step.id,
         status: 'failed',
       });
-      taskCount.inc({
+      promTaskCount.inc({
         template,
         user,
         result: 'failed',
       });
       taskTimer({ result: 'failed' });
+
+      taskCount.add(1, { template, user, result: 'failed' });
+      taskDuration.record(endTime(), {
+        result: 'failed',
+      });
     }
 
     async function markCancelled(step: TaskStep) {
@@ -587,12 +624,17 @@ function scaffoldingTracker() {
         stepId: step.id,
         status: 'cancelled',
       });
-      taskCount.inc({
+      promTaskCount.inc({
         template,
         user,
         result: 'cancelled',
       });
       taskTimer({ result: 'cancelled' });
+
+      taskCount.add(1, { template, user, result: 'cancelled' });
+      taskDuration.record(endTime(), {
+        result: 'cancelled',
+      });
     }
 
     return {
@@ -610,40 +652,61 @@ function scaffoldingTracker() {
     });
     const template = task.spec.templateInfo?.entityRef || '';
 
-    const stepTimer = stepDuration.startTimer({
+    const startTime = process.hrtime();
+    const stepTimer = promStepDuration.startTimer({
       template,
       step: step.name,
     });
+
+    function endTime() {
+      const delta = process.hrtime(startTime);
+      return delta[0] + delta[1] / 1e9;
+    }
 
     async function markSuccessful() {
       await task.emitLog(`Finished step ${step.name}`, {
         stepId: step.id,
         status: 'completed',
       });
-      stepCount.inc({
+      promtStepCount.inc({
         template,
         step: step.name,
         result: 'ok',
       });
       stepTimer({ result: 'ok' });
+
+      stepCount.add(1, { template, step: step.name, result: 'ok' });
+      stepDuration.record(endTime(), {
+        result: 'ok',
+      });
     }
 
     async function markCancelled() {
-      stepCount.inc({
+      promtStepCount.inc({
         template,
         step: step.name,
         result: 'cancelled',
       });
       stepTimer({ result: 'cancelled' });
+
+      stepCount.add(1, { template, step: step.name, result: 'cancelled' });
+      stepDuration.record(endTime(), {
+        result: 'cancelled',
+      });
     }
 
     async function markFailed() {
-      stepCount.inc({
+      promtStepCount.inc({
         template,
         step: step.name,
         result: 'failed',
       });
       stepTimer({ result: 'failed' });
+
+      stepCount.add(1, { template, step: step.name, result: 'failed' });
+      stepDuration.record(endTime(), {
+        result: 'failed',
+      });
     }
 
     async function skipFalsy() {
@@ -652,6 +715,11 @@ function scaffoldingTracker() {
         { stepId: step.id, status: 'skipped' },
       );
       stepTimer({ result: 'skipped' });
+
+      stepCount.add(1, { template, step: step.name, result: 'skipped' });
+      stepDuration.record(endTime(), {
+        result: 'skipped',
+      });
     }
 
     return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7205,6 +7205,7 @@ __metadata:
     "@backstage/plugin-scaffolder-node": "workspace:^"
     "@backstage/plugin-scaffolder-node-test-utils": "workspace:^"
     "@backstage/types": "workspace:^"
+    "@opentelemetry/api": ^1.3.0
     "@types/express": ^4.17.6
     "@types/fs-extra": ^11.0.0
     "@types/luxon": ^3.0.0


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This add OpenTelemetry support on of the `prom-client` support for scaffolder metrics - the metrics exposed are identical.

I have implemented it in the same way that the `plugins/catalog-backend/src/processing/DefaultCatalogProcessingEngine.ts` implements the dual-support.

Example output where i ran a single task that failed and three steps where two succeeded and one failed which were all captured successfully:

```
# HELP scaffolder_task_count_total Count of task runs
# TYPE scaffolder_task_count_total counter
scaffolder_task_count_total{template="template:default/pull-request",user="user:development/guest",result="failed"} 1
# HELP scaffolder_task_duration Duration of a task run
# UNIT scaffolder_task_duration seconds
# TYPE scaffolder_task_duration histogram
scaffolder_task_duration_count{result="failed"} 1
scaffolder_task_duration_sum{result="failed"} 1.394662532
scaffolder_task_duration_bucket{result="failed",le="0"} 0
scaffolder_task_duration_bucket{result="failed",le="5"} 1
scaffolder_task_duration_bucket{result="failed",le="10"} 1
scaffolder_task_duration_bucket{result="failed",le="25"} 1
scaffolder_task_duration_bucket{result="failed",le="50"} 1
scaffolder_task_duration_bucket{result="failed",le="75"} 1
scaffolder_task_duration_bucket{result="failed",le="100"} 1
scaffolder_task_duration_bucket{result="failed",le="250"} 1
scaffolder_task_duration_bucket{result="failed",le="500"} 1
scaffolder_task_duration_bucket{result="failed",le="750"} 1
scaffolder_task_duration_bucket{result="failed",le="1000"} 1
scaffolder_task_duration_bucket{result="failed",le="2500"} 1
scaffolder_task_duration_bucket{result="failed",le="5000"} 1
scaffolder_task_duration_bucket{result="failed",le="7500"} 1
scaffolder_task_duration_bucket{result="failed",le="10000"} 1
scaffolder_task_duration_bucket{result="failed",le="+Inf"} 1
# HELP scaffolder_step_count_total Count of step runs
# TYPE scaffolder_step_count_total counter
scaffolder_step_count_total{template="template:default/pull-request",step="Fetch Base",result="ok"} 1
scaffolder_step_count_total{template="template:default/pull-request",step="Fetch Docs",result="ok"} 1
scaffolder_step_count_total{template="template:default/pull-request",step="Publish",result="failed"} 1
# HELP scaffolder_step_duration Duration of a step runs
# UNIT scaffolder_step_duration seconds
# TYPE scaffolder_step_duration histogram
scaffolder_step_duration_count{result="ok"} 2
scaffolder_step_duration_sum{result="ok"} 1.363769099
scaffolder_step_duration_bucket{result="ok",le="0"} 0
scaffolder_step_duration_bucket{result="ok",le="5"} 2
scaffolder_step_duration_bucket{result="ok",le="10"} 2
scaffolder_step_duration_bucket{result="ok",le="25"} 2
scaffolder_step_duration_bucket{result="ok",le="50"} 2
scaffolder_step_duration_bucket{result="ok",le="75"} 2
scaffolder_step_duration_bucket{result="ok",le="100"} 2
scaffolder_step_duration_bucket{result="ok",le="250"} 2
scaffolder_step_duration_bucket{result="ok",le="500"} 2
scaffolder_step_duration_bucket{result="ok",le="750"} 2
scaffolder_step_duration_bucket{result="ok",le="1000"} 2
scaffolder_step_duration_bucket{result="ok",le="2500"} 2
scaffolder_step_duration_bucket{result="ok",le="5000"} 2
scaffolder_step_duration_bucket{result="ok",le="7500"} 2
scaffolder_step_duration_bucket{result="ok",le="10000"} 2
scaffolder_step_duration_bucket{result="ok",le="+Inf"} 2
scaffolder_step_duration_count{result="failed"} 1
scaffolder_step_duration_sum{result="failed"} 0.005802923
scaffolder_step_duration_bucket{result="failed",le="0"} 0
scaffolder_step_duration_bucket{result="failed",le="5"} 1
scaffolder_step_duration_bucket{result="failed",le="10"} 1
scaffolder_step_duration_bucket{result="failed",le="25"} 1
scaffolder_step_duration_bucket{result="failed",le="50"} 1
scaffolder_step_duration_bucket{result="failed",le="75"} 1
scaffolder_step_duration_bucket{result="failed",le="100"} 1
scaffolder_step_duration_bucket{result="failed",le="250"} 1
scaffolder_step_duration_bucket{result="failed",le="500"} 1
scaffolder_step_duration_bucket{result="failed",le="750"} 1
scaffolder_step_duration_bucket{result="failed",le="1000"} 1
scaffolder_step_duration_bucket{result="failed",le="2500"} 1
scaffolder_step_duration_bucket{result="failed",le="5000"} 1
scaffolder_step_duration_bucket{result="failed",le="7500"} 1
scaffolder_step_duration_bucket{result="failed",le="10000"} 1
scaffolder_step_duration_bucket{result="failed",le="+Inf"} 1
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
