### PR TITLE
Scaffolder action: Replace logStream with winston logger in the executeShellCommand

### DIFF
--- a/.changeset/pretty-ducks-compete.md
+++ b/.changeset/pretty-ducks-compete.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-scaffolder-node': minor
+'@backstage/plugin-scaffolder-backend-module-cookiecutter': patch
+'@backstage/plugin-scaffolder-backend-module-rails': patch
+---
+
+Deprecate the `logStream` option in `executeShellCommand`, replacing it with a logger instance and log level.

--- a/.changeset/seven-timers-fetch.md
+++ b/.changeset/seven-timers-fetch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-node': minor
+---
+
+Deprecate the `logStream` option in `executeShellCommand`, replacing it with a logger instance and log level.

--- a/package.json
+++ b/package.json
@@ -95,7 +95,8 @@
     "@backstage/errors": "workspace:^",
     "@manypkg/get-packages": "^1.1.3",
     "@types/global-agent": "^2.1.3",
-    "@useoptic/optic": "^0.50.10"
+    "@useoptic/optic": "^0.50.10",
+    "winston": "^3.14.2"
   },
   "devDependencies": {
     "@backstage/cli": "workspace:*",

--- a/plugins/scaffolder-backend-module-cookiecutter/src/actions/fetch/cookiecutter.test.ts
+++ b/plugins/scaffolder-backend-module-cookiecutter/src/actions/fetch/cookiecutter.test.ts
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-import { UrlReader, ContainerRunner } from '@backstage/backend-common';
-import { ConfigReader } from '@backstage/config';
-import { JsonObject } from '@backstage/types';
-import { ScmIntegrations } from '@backstage/integration';
+import { ContainerRunner, UrlReader } from '@backstage/backend-common';
 import { createMockDirectory } from '@backstage/backend-test-utils';
-import { createFetchCookiecutterAction } from './cookiecutter';
-import { join } from 'path';
+import { ConfigReader } from '@backstage/config';
+import { ScmIntegrations } from '@backstage/integration';
 import type { ActionContext } from '@backstage/plugin-scaffolder-node';
 import { createMockActionContext } from '@backstage/plugin-scaffolder-node-test-utils';
+import { JsonObject } from '@backstage/types';
+import { join } from 'path';
 import { Writable } from 'stream';
+import { createFetchCookiecutterAction } from './cookiecutter';
 
 const executeShellCommand = jest.fn();
 const commandExists = jest.fn();
@@ -167,7 +167,6 @@ describe('fetch:cookiecutter', () => {
           join(mockTmpDir, 'template'),
           '--verbose',
         ],
-        logStream: expect.any(Writable),
       }),
     );
   });

--- a/plugins/scaffolder-backend-module-rails/package.json
+++ b/plugins/scaffolder-backend-module-rails/package.json
@@ -52,6 +52,7 @@
     "@backstage/types": "workspace:^",
     "command-exists": "^1.2.9",
     "fs-extra": "^11.0.0",
+    "winston": "^3.2.1",
     "yaml": "^2.0.0"
   },
   "devDependencies": {

--- a/plugins/scaffolder-backend-module-rails/src/actions/fetch/rails/index.test.ts
+++ b/plugins/scaffolder-backend-module-rails/src/actions/fetch/rails/index.test.ts
@@ -28,14 +28,14 @@ jest.mock('./railsNewRunner', () => {
 });
 
 import { ContainerRunner, UrlReader } from '@backstage/backend-common';
+import { createMockDirectory } from '@backstage/backend-test-utils';
 import { ConfigReader } from '@backstage/config';
 import { ScmIntegrations } from '@backstage/integration';
-import { resolve as resolvePath } from 'path';
-import { createFetchRailsAction } from './index';
 import { fetchContents } from '@backstage/plugin-scaffolder-node';
-import { createMockDirectory } from '@backstage/backend-test-utils';
 import { createMockActionContext } from '@backstage/plugin-scaffolder-node-test-utils';
+import { resolve as resolvePath } from 'path';
 import { Writable } from 'stream';
+import { createFetchRailsAction } from './index';
 
 describe('fetch:rails', () => {
   const mockDir = createMockDirectory();
@@ -102,10 +102,12 @@ describe('fetch:rails', () => {
 
   it('should execute the rails templater with the correct values', async () => {
     await action.handler(mockContext);
-
     expect(mockRailsTemplater.run).toHaveBeenCalledWith({
       workspacePath: mockContext.workspacePath,
       logStream: expect.any(Writable),
+      logger: expect.objectContaining({
+        verbose: expect.any(Function),
+      }),
       values: mockContext.input.values,
     });
   });
@@ -122,6 +124,9 @@ describe('fetch:rails', () => {
     expect(mockRailsTemplater.run).toHaveBeenCalledWith({
       workspacePath: mockContext.workspacePath,
       logStream: expect.any(Writable),
+      logger: expect.objectContaining({
+        verbose: expect.any(Function),
+      }),
       values: {
         ...mockContext.input.values,
         imageName: 'foo/rails-custom-image',

--- a/plugins/scaffolder-backend-module-rails/src/actions/fetch/rails/index.ts
+++ b/plugins/scaffolder-backend-module-rails/src/actions/fetch/rails/index.ts
@@ -15,19 +15,19 @@
  */
 
 import { ContainerRunner, UrlReader } from '@backstage/backend-common';
-import { JsonObject } from '@backstage/types';
 import { InputError } from '@backstage/errors';
 import { ScmIntegrations } from '@backstage/integration';
-import fs from 'fs-extra';
 import {
   createTemplateAction,
   fetchContents,
 } from '@backstage/plugin-scaffolder-node';
+import { JsonObject } from '@backstage/types';
+import fs from 'fs-extra';
 
 import { resolve as resolvePath } from 'path';
-import { RailsNewRunner } from './railsNewRunner';
 import { PassThrough } from 'stream';
 import { examples } from './index.examples';
+import { RailsNewRunner } from './railsNewRunner';
 
 /**
  * Creates the `fetch:rails` Scaffolder action.
@@ -227,6 +227,7 @@ export function createFetchRailsAction(options: {
       await templateRunner.run({
         workspacePath: workDir,
         logStream,
+        logger: ctx.logger,
         values: { ...ctx.input.values, imageName },
       });
 

--- a/plugins/scaffolder-backend-module-rails/src/actions/fetch/rails/railsNewRunner.ts
+++ b/plugins/scaffolder-backend-module-rails/src/actions/fetch/rails/railsNewRunner.ts
@@ -15,16 +15,17 @@
  */
 
 import { ContainerRunner } from '@backstage/backend-common';
+import { executeShellCommand } from '@backstage/plugin-scaffolder-node';
+import { JsonObject } from '@backstage/types';
+import commandExists from 'command-exists';
 import fs from 'fs-extra';
 import path from 'path';
-import { executeShellCommand } from '@backstage/plugin-scaffolder-node';
-import commandExists from 'command-exists';
+import { Writable } from 'stream';
+import { LeveledLogMethod, Logger } from 'winston';
 import {
   railsArgumentResolver,
   RailsRunOptions,
 } from './railsArgumentResolver';
-import { JsonObject } from '@backstage/types';
-import { Writable } from 'stream';
 
 export class RailsNewRunner {
   private readonly containerRunner?: ContainerRunner;
@@ -37,10 +38,14 @@ export class RailsNewRunner {
     workspacePath,
     values,
     logStream,
+    logger,
+    logLevel = logger.verbose,
   }: {
     workspacePath: string;
     values: JsonObject;
     logStream: Writable;
+    logger: Logger;
+    logLevel?: LeveledLogMethod;
   }): Promise<void> {
     const intermediateDir = path.join(workspacePath, 'intermediate');
     await fs.ensureDir(intermediateDir);
@@ -71,7 +76,8 @@ export class RailsNewRunner {
           `${intermediateDir}${path.sep}${name}`,
           ...arrayExtraArguments,
         ],
-        logStream,
+        logger,
+        logLevel,
       });
     } else {
       if (!imageName) {

--- a/plugins/scaffolder-node/api-report.md
+++ b/plugins/scaffolder-node/api-report.md
@@ -8,6 +8,7 @@
 import { BackstageCredentials } from '@backstage/backend-plugin-api';
 import { JsonObject } from '@backstage/types';
 import { JsonValue } from '@backstage/types';
+import { LeveledLogMethod } from 'winston';
 import { Logger } from 'winston';
 import { Observable } from '@backstage/types';
 import { Schema } from 'jsonschema';
@@ -191,7 +192,8 @@ export type ExecuteShellCommandOptions = {
   command: string;
   args: string[];
   options?: SpawnOptionsWithoutStdio;
-  logStream?: Writable;
+  logger?: Logger;
+  logLevel?: LeveledLogMethod;
 };
 
 // @public

--- a/yarn.lock
+++ b/yarn.lock
@@ -7108,6 +7108,7 @@ __metadata:
     command-exists: ^1.2.9
     fs-extra: ^11.0.0
     jest-when: ^3.1.0
+    winston: ^3.2.1
     yaml: ^2.0.0
   languageName: unknown
   linkType: soft
@@ -33228,9 +33229,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"logform@npm:^2.3.2, logform@npm:^2.4.0":
-  version: 2.6.0
-  resolution: "logform@npm:2.6.0"
+"logform@npm:^2.3.2, logform@npm:^2.6.0":
+  version: 2.6.1
+  resolution: "logform@npm:2.6.1"
   dependencies:
     "@colors/colors": 1.6.0
     "@types/triple-beam": ^1.3.2
@@ -33238,7 +33239,7 @@ __metadata:
     ms: ^2.1.1
     safe-stable-stringify: ^2.3.1
     triple-beam: ^1.3.0
-  checksum: b9ea74bb75e55379ad0eb3e4d65ae6e8d02bc45b431c218162878bf663997ab9258a73104c2b30e09dd2db288bb83c8bf8748e46689d75f5e7e34cf69378d6df
+  checksum: 0c6b95fa8350ccc33c7c33d77de2a9920205399706fc1b125151c857b61eb90873f4670d9e0e58e58c165b68a363206ae670d6da8b714527c838da3c84449605
   languageName: node
   linkType: hard
 
@@ -40276,6 +40277,7 @@ __metadata:
     sloc: ^0.3.1
     sort-package-json: ^2.8.0
     typescript: ~5.2.0
+    winston: ^3.14.2
   languageName: unknown
   linkType: soft
 
@@ -44911,22 +44913,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"winston@npm:^3.13.0, winston@npm:^3.2.1":
-  version: 3.13.0
-  resolution: "winston@npm:3.13.0"
+"winston@npm:^3.13.0, winston@npm:^3.14.2, winston@npm:^3.2.1":
+  version: 3.14.2
+  resolution: "winston@npm:3.14.2"
   dependencies:
     "@colors/colors": ^1.6.0
     "@dabh/diagnostics": ^2.0.2
     async: ^3.2.3
     is-stream: ^2.0.0
-    logform: ^2.4.0
+    logform: ^2.6.0
     one-time: ^1.0.0
     readable-stream: ^3.4.0
     safe-stable-stringify: ^2.3.1
     stack-trace: 0.0.x
     triple-beam: ^1.3.0
     winston-transport: ^4.7.0
-  checksum: 66f9fbbadb58e1632701e9c89391f217310c9455462148e163e060dcd25aed21351b0413bdbbf90e5c5fe9bc945fc5de6f53875ac7c7ef3061133a354fc678c0
+  checksum: 9021637d3ab1d1e639d64e7217ed5ae63fb0e5325defdbce439f708e9b4e26c7a31eb4a731106790aa8ac6f80a3a89242de18d1991ab3838f9d84e55101f4607
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR relates to https://github.com/backstage/backstage/issues/25732

It fixes the issue caused by the deprecation of `logStream` in the Action context. Users calling `executeShellCommand` in their Scaffolder custom actions were getting deprecation warnings, but the suggested fix wasn't quite right.

Now, `executeShellCommand` works with a Winston logger instance and a log level, with the Writable stream being created inside the function.

Please note that this would be a breaking change: 

Before: 
```typescript
await executeShellCommand({
  ...
  logStream: ctx.logStream,
});
```
after:
```typescript
await executeShellCommand({
  ...
  logger: ctx.logger,
  logLevel: 'verbose',
});
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
