### PR TITLE
Updated Prometheus and OpenTelemetry Guides

### DIFF
--- a/contrib/docs/tutorials/prometheus-metrics.md
+++ b/contrib/docs/tutorials/prometheus-metrics.md
@@ -1,5 +1,8 @@
 # Prometheus
 
+> [!NOTE]
+> The Prometheus metrics have been marked as deprecated and will be removed at a later point. The recommendation is to use the OpenTelemetry metrics by following the [Setup OpenTelemetry](https://backstage.io/docs/tutorials/setup-opentelemetry) documentation
+
 ## Overview
 
 This is a small tutorial that goes over how to setup your Backstage instance to output metrics in a format that can be pulled in by Prometheus.

--- a/docs/tutorials/setup-opentelemetry.md
+++ b/docs/tutorials/setup-opentelemetry.md
@@ -83,6 +83,28 @@ CMD ["node", "--require", "./instrumentation.js", "packages/backend", "--config"
 
 If you need to disable/configure some OpenTelemetry feature there are lots of [environment variables](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/) which you can tweak.
 
+### Available Metrics
+
+The following metrics are available:
+
+- `catalog_entities_count`: Total amount of entities in the catalog
+- `catalog_registered_locations_count`: Total amount of registered locations in the catalog
+- `catalog_relations_count`: Total amount of relations between entities
+- `catalog.processed.entities.count`: Amount of entities processed
+- `catalog.processing.duration`: Time spent executing the full processing flow
+- `catalog.processors.duration`: Time spent executing catalog processors
+- `catalog.processing.queue.delay`: The amount of delay between being scheduled for processing, and the start of actually being processed
+- `catalog.stitched.entities.count`: Amount of entities stitched
+- `catalog.stitching.duration`: Time spent executing the full stitching flow
+- `catalog.stitching.queue.length`: Number of entities currently in the stitching queue
+- `catalog.stitching.queue.delay`: The amount of delay between being scheduled for stitching, and the start of actually being stitched
+- `scaffolder.task.count`: Count of task runs
+- `scaffolder.task.duration`: Duration of a task run
+- `scaffolder.step.count`: Count of step runs
+- `scaffolder.step.duration`: Duration of a step runs
+- `backend_tasks.task.runs.count`: Total number of times a task has been run
+- `backend_tasks.task.runs.duration`: Histogram of task run durations
+
 ## References
 
 - [Getting started with OpenTelemetry Node.js](https://opentelemetry.io/docs/instrumentation/js/getting-started/nodejs/)


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updated Prometheus guide to note the metrics have been deprecated and to use the OpenTelemetry guide instead.

Updated the OpenTelemetry guide to list all the currently available metrics.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
