### PR TITLE
Redirect: Add documentation. Cleanup

### DIFF
--- a/.changeset/pink-bobcats-explain.md
+++ b/.changeset/pink-bobcats-explain.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Refactor TechDocs' mkdocs-redirects support.

--- a/docs/features/techdocs/how-to-guides.md
+++ b/docs/features/techdocs/how-to-guides.md
@@ -841,3 +841,8 @@ metadata:
   annotations:
     backstage.io/techdocs-entity: system:default/example
 ```
+
+## How to resolve broken links in your documentation site
+
+TechDocs supports using the [mkdocs-redirects](https://github.com/mkdocs/mkdocs-redirects/tree/master) plugin to create a redirect map for any TechDoc site. This allows broken links from renamed or deleted pages in your site to be redirected to their specified replacement.
+TechDocs will notify the user that the page they are trying to access is no longer maintained. Then, they will be redirected. External site redirects are not supported. If an external redirect is provided, the user will instead be redirected to the index page of the documentation site.

--- a/docs/features/techdocs/how-to-guides.md
+++ b/docs/features/techdocs/how-to-guides.md
@@ -842,7 +842,7 @@ metadata:
     backstage.io/techdocs-entity: system:default/example
 ```
 
-## How to resolve broken links in your documentation site
+## How to resolve broken links from moved or renamed pages in your documentation site
 
-TechDocs supports using the [mkdocs-redirects](https://github.com/mkdocs/mkdocs-redirects/tree/master) plugin to create a redirect map for any TechDoc site. This allows broken links from renamed or deleted pages in your site to be redirected to their specified replacement.
+TechDocs supports using the [mkdocs-redirects](https://github.com/mkdocs/mkdocs-redirects/tree/master) plugin to create a redirect map for any TechDocs site. This allows broken links from renamed or moved pages in your site to be redirected to their specified replacement.
 TechDocs will notify the user that the page they are trying to access is no longer maintained. Then, they will be redirected. External site redirects are not supported. If an external redirect is provided, the user will instead be redirected to the index page of the documentation site.

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx
@@ -44,9 +44,9 @@ import {
   copyToClipboard,
   useSanitizerTransformer,
   useStylesTransformer,
+  handleMetaRedirects,
 } from '../../transformers';
 import { useNavigateUrl } from './useNavigateUrl';
-import { handleMetaRedirects } from '../../transformers/handleMetaRedirects';
 
 const MOBILE_MEDIA_QUERY = 'screen and (max-width: 76.1875em)';
 

--- a/plugins/techdocs/src/reader/components/TechDocsRedirectNotification/TechDocsRedirectNotification.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsRedirectNotification/TechDocsRedirectNotification.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { makeStyles } from '@material-ui/core/styles';
+import React, { useState } from 'react';
+import Snackbar from '@material-ui/core/Snackbar';
+import Button from '@material-ui/core/Button';
+
+type TechDocsRedirectNotificationProps = {
+  handleButtonClick: () => void;
+  message: string;
+  autoHideDuration: number;
+};
+
+const useStyles = makeStyles(theme => ({
+  button: {
+    color: theme.palette.primary.light,
+    textDecoration: 'underline',
+  },
+}));
+
+export const TechDocsRedirectNotification = ({
+  message,
+  handleButtonClick,
+  autoHideDuration,
+}: TechDocsRedirectNotificationProps) => {
+  const classes = useStyles();
+  const [open, setOpen] = useState(true);
+
+  const handleClose = () => setOpen(false);
+
+  return (
+    <Snackbar
+      open={open}
+      anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+      autoHideDuration={autoHideDuration}
+      color="primary"
+      onClose={handleClose}
+      message={message}
+      action={
+        <Button
+          classes={{ root: classes.button }}
+          size="small"
+          onClick={() => {
+            handleClose();
+            handleButtonClick();
+          }}
+        >
+          Redirect now
+        </Button>
+      }
+    />
+  );
+};

--- a/plugins/techdocs/src/reader/components/TechDocsRedirectNotification/index.ts
+++ b/plugins/techdocs/src/reader/components/TechDocsRedirectNotification/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { TechDocsRedirectNotification } from './TechDocsRedirectNotification';

--- a/plugins/techdocs/src/reader/transformers/handleMetaRedirects.test.ts
+++ b/plugins/techdocs/src/reader/transformers/handleMetaRedirects.test.ts
@@ -82,7 +82,9 @@ describe('handleMetaRedirects', () => {
       ),
     ).toBeInTheDocument();
     jest.runAllTimers();
-    expect(navigate).toHaveBeenCalledWith('/docs/default/component/testEntity');
+    expect(navigate).toHaveBeenCalledWith(
+      'http://localhost/docs/default/component/testEntity',
+    );
   });
 
   it('should navigate to absolute URL if meta redirect tag is present and not external', async () => {

--- a/plugins/techdocs/src/reader/transformers/index.ts
+++ b/plugins/techdocs/src/reader/transformers/index.ts
@@ -27,3 +27,4 @@ export * from './simplifyMkdocsFooter';
 export * from './onCssReady';
 export * from './scrollIntoNavigation';
 export * from './transformer';
+export * from './handleMetaRedirects';


### PR DESCRIPTION
- Add documentation. 
- Cleanup and move the `TechDocsRedirectNotification` component to the components folder.
- The `handleMetaRedirects` function gets called an extra time when the url has changed, but the dom has not updated to the new page. This causes an extra redirect. Added in the guardrail to not proceed with redirect if the current url matches the redirect url.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
