### PR TITLE
docs/frontend-system: document extension override

### DIFF
--- a/docs/frontend-system/architecture/25-extension-overrides.md
+++ b/docs/frontend-system/architecture/25-extension-overrides.md
@@ -102,6 +102,40 @@ const overrideExtension = exampleExtension.override({
 
 When overriding the output declaration you don't need to include the original outputs. Just remember that you will no longer be able to directly forward the output from the original factory, and will still need to adhere to the contract of the input that the extension is attached to.
 
+## Overriding declared inputs
+
+When overriding an extension you can also provide new input declarations. You can define any number of new inputs, but you are **not** able to override the existing inputs declared by the original extension. The new inputs will be merged with the existing ones, giving the override factory access to both. The following example shows how to override an extension and add a new input declaration:
+
+```tsx
+const myOverrideExtension = myExtension.override({
+  inputs: {
+    myOverrideInput: createExtensionInput([coreExtensionData.reactElement]),
+  },
+  factory(originalFactory, { inputs }) {
+    const originalOutput = originalFactory();
+    const originalElement = originalOutput.get(coreExtensionData.reactElement);
+
+    return [
+      ...originalOutput,
+      coreExtensionData.reactElement(
+        <div>
+          <h1>Original element</h1>
+          {originalElement}
+          <h1>Additional inputs</h1>
+          <ul>
+            {inputs.myOverrideInput.map(i => (
+              <li key={i.node.spec.id}>
+                {i.get(coreExtensionData.reactElement)}
+              </li>
+            ))}
+          </ul>
+        </div>,
+      ),
+    ];
+  },
+});
+```
+
 ## Override App Extensions
 
 In order to override an app extension, you must create a new extension and add it to the list of overridden features. The steps are: create your extension overrides and use them in Backstage.

--- a/docs/frontend-system/architecture/25-extension-overrides.md
+++ b/docs/frontend-system/architecture/25-extension-overrides.md
@@ -81,7 +81,7 @@ Note the `yield*` expression, which forwards all values from the provided iterab
 
 ## Overriding declared outputs
 
-When overriding an extension out can provide a new output declaration. This **replaces** any existing output declaration, which means that you want to forward any of the original output you will need to declare it again. The following example shows how to override an extension and replace the output declaration:
+When overriding an extension you can provide a new output declaration. This **replaces** any existing output declaration, which means that you want to forward any of the original output you will need to declare it again. The following example shows how to override an extension and replace the output declaration:
 
 ```tsx
 // Original extension

--- a/docs/frontend-system/architecture/25-extension-overrides.md
+++ b/docs/frontend-system/architecture/25-extension-overrides.md
@@ -16,7 +16,7 @@ In general, most features should have a good level of customization built into 
 
 ## Overriding an extension
 
-Every extension created with `createExtension` comes with an `override` method, including those created from an [extension blueprint](./23-extension-blueprints.md). The `override` method **creates a new extension**, it does not mutate the existing extensions. This new extension in created in such a way that if it is installed adjacent to the existing extension, it will take precedence and override the existing extension. While the `override` method does create new extension instances, it is not intended to be used as a way to create multiple new extensions from a base template, for that use-case you will want to use an [extension blueprint](./23-extension-blueprints.md) instead.
+Every extension created with `createExtension` comes with an `override` method, including those created from an [extension blueprint](./23-extension-blueprints.md). The `override` method **creates a new extension**, it does not mutate the existing extension. This new extension in created in such a way that if it is installed adjacent to the existing extension, it will take precedence and override the existing extension. While the `override` method does create new extension instances, it is not intended to be used as a way to create multiple new extensions from a base template, for that use-case you will want to use an [extension blueprint](./23-extension-blueprints.md) instead.
 
 The following is an example of calling the `.override(...)` method on an extension:
 
@@ -81,7 +81,7 @@ Note the `yield*` expression, which forwards all values from the provided iterab
 
 ## Overriding declared outputs
 
-When overriding an extension you can provide a new output declaration. This **replaces** any existing output declaration, which means that you want to forward any of the original output you will need to declare it again. The following example shows how to override an extension and replace the output declaration:
+When overriding an extension you can provide a new output declaration. This **replaces** any existing output declaration, which means that if you want to forward any of the original output you will need to declare it again. The following example shows how to override an extension and replace the output declaration:
 
 ```tsx
 // Original extension
@@ -138,7 +138,7 @@ const myOverrideExtension = myExtension.override({
 
 ## Overriding configuration schema
 
-Overriding the configuration schema works very similar to overriding the declared inputs. You can define new configuration fields that will be merged with the existing ones, but you can not re-declare existing fields. The following example shows how to override an extension and add a new configuration field:
+Overriding the configuration schema works very similarly to overriding the declared inputs. You can define new configuration fields that will be merged with the existing ones, but you can not re-declare existing fields. The following example shows how to override an extension and add a new configuration field:
 
 ```tsx
 const exampleExtension = createExtension({
@@ -251,7 +251,7 @@ const overrideExtension = exampleExtension.override({
         content: inputs.content,
         // Sort items input by their extension ID
         items: inputs.items.toSorted((a, b) =>
-          a.node.spec.id.localCompare(b.node.spec.id),
+          a.node.spec.id.localeCompare(b.node.spec.id),
         ),
       },
     });
@@ -261,7 +261,7 @@ const overrideExtension = exampleExtension.override({
 
 ## Installing override extension in an app
 
-To install extension overrides in a Backstage app you should use `plugin.withOverrides` whenever you are overriding or adding extensions to for a plugin. See the section on [overriding a plugin](./15-plugins.md#overriding-a-plugin) for more information.
+To install extension overrides in a Backstage app you should use `plugin.withOverrides` whenever you are overriding or adding extensions for a plugin. See the section on [overriding a plugin](./15-plugins.md#overriding-a-plugin) for more information.
 
 There is also a `createExtensionOverrides` function that can be used to install a collection of standalone extensions in an app. This method will be replaced with a different mechanism in the future, but for now remains the only way to override the built-in extensions in the app or to package extensions for a plugin package separate from the plugin itself.
 

--- a/docs/frontend-system/architecture/25-extension-overrides.md
+++ b/docs/frontend-system/architecture/25-extension-overrides.md
@@ -79,6 +79,29 @@ const myOverrideExtension = myExtension.override({
 
 Note the `yield*` expression, which forwards all values from the provided iterable to the generator, in this case the original factory output.
 
+## Overriding declared outputs
+
+When overriding an extension out can provide a new output declaration. This **replaces** any existing output declaration, which means that you want to forward any of the original output you will need to declare it again. The following example shows how to override an extension and replace the output declaration:
+
+```tsx
+// Original extension
+const exampleExtension = createExtension({
+  name: 'example',
+  output: [coreExtensionData.reactElement],
+  factory: () => [coreExtensionData.reactElement(<h1>Example</h1>)],
+});
+
+// Override extension, with additional outputs
+const overrideExtension = exampleExtension.override({
+  output: [coreExtensionData.reactElement, coreExtensionData.routePath],
+  factory(originalFactory) {
+    return [...originalFactory(), coreExtensionData.routePath('/example')];
+  },
+});
+```
+
+When overriding the output declaration you don't need to include the original outputs. Just remember that you will no longer be able to directly forward the output from the original factory, and will still need to adhere to the contract of the input that the extension is attached to.
+
 ## Override App Extensions
 
 In order to override an app extension, you must create a new extension and add it to the list of overridden features. The steps are: create your extension overrides and use them in Backstage.

--- a/docs/frontend-system/architecture/25-extension-overrides.md
+++ b/docs/frontend-system/architecture/25-extension-overrides.md
@@ -277,7 +277,7 @@ import {
   createExtensionOverrides,
 } from '@backstage/frontend-plugin-api';
 
-const customSearchPage = PageBlueprint({
+const customSearchPage = PageBlueprint.make({
   // Since this is a standalone extension we need to provide the namespace to match the search plugin
   namespace: 'search',
   params: {

--- a/docs/frontend-system/architecture/25-extension-overrides.md
+++ b/docs/frontend-system/architecture/25-extension-overrides.md
@@ -10,9 +10,25 @@ description: Frontend extension overrides
 
 ## Introduction
 
-An extension override is a building block of the frontend system that allows you to programmatically override app or plugin extensions anywhere in your application. Since the entire application is built mostly out of extensions from the bottom up, this is a powerful feature. You can use it for example to provide your own app root layout, to replace the implementation of a Utility API with a custom one, to override how the catalog page renders itself, and much more.
+An important customization point in the frontend system is the ability to override existing extensions. It can be used for anything from slight tweaks to the extension logic, to completely replacing an extension with a custom implementation. While extensions are encouraged to make themselves configurable, there are many situations where you need to override an extension to achieve the desired behavior. The ability to override extensions should be kept in mind when building plugins, and can be a powerful tool to allow for deeper customizations without the need to re-implement large parts of the plugin.
 
-In general, most features should have a good level of customization built into them, so that users do not have to leverage extension overrides to achieve common goals. A well written feature often has [configuration](../../conf/) settings, or uses extension inputs for extensibility where applicable. An example of this is the search plugin, which allows you to provide result renderers as inputs rather than replacing the result page wholesale just to tweak how results are shown. Adopters should take advantage of those when possible, and only use extension overrides when it's necessary to entirely replace the extension. Check the respective extension documentation for guidance.
+In general, most features should have a good level of customization built into them, so that users do not have to leverage extension overrides to achieve common goals. A well written feature often has [configuration](../../conf/) settings, or uses extension inputs for extensibility where applicable. An example of this is the search plugin, which allows you to provide result renderers as inputs rather than replacing the result page wholesale just to tweak how results are shown. Adopters should take advantage of those when possible in order to reduce the need and size of extension overrides.
+
+## Overriding an extension
+
+Every extension created with `createExtension` comes with an `override` method, including those created from an [extension blueprint](./23-extension-blueprints.md). The `override` method **creates a new extension**, it does not mutate the existing extensions. This new extension in created in such a way that if it is installed adjacent to the existing extension, it will take precedence and override the existing extension. While the `override` method does create new extension instances, it is not intended to be used as a way to create multiple new extensions from a base template, for that use-case you will want to use an [extension blueprint](./23-extension-blueprints.md) instead.
+
+The following is an example of calling the `.override(...)` method on an extension:
+
+```tsx
+const myOverrideExtension = myExtension.override({
+  factory(originalFactory) {
+    return originalFactory();
+  },
+});
+```
+
+This override is a no-op, it does not change the behavior of the extension, but simply forwards the outputs from the original extension factory. If you are familiar with [extension blueprints](./23-extension-blueprints.md), you will recognize this factory override pattern where we get access to the original factory function. In fact the only difference is that we do not need to pass any parameters to the original factory. The first parameter is now instead the optional factory context overrides, more on that as we dive into each override pattern in the following sections.
 
 ## Override App Extensions
 

--- a/docs/frontend-system/architecture/25-extension-overrides.md
+++ b/docs/frontend-system/architecture/25-extension-overrides.md
@@ -136,6 +136,40 @@ const myOverrideExtension = myExtension.override({
 });
 ```
 
+## Overriding configuration schema
+
+Overriding the configuration schema works very similar to overriding the declared inputs. You can define new configuration fields that will be merged with the existing ones, but you can not re-declare existing fields. The following example shows how to override an extension and add a new configuration field:
+
+```tsx
+// Original extension
+const exampleExtension = createExtension({
+  name: 'example',
+  config: {
+    schema: {
+      layout: z => z.enum(['grid', 'list']).optional(),
+    },
+  },
+  output: [coreExtensionData.reactElement],
+  factory: ({ config }) => [
+    coreExtensionData.reactElement(<MyExtension layout={config.layout} />),
+  ],
+});
+
+const overrideExtension = exampleExtension.override({
+  config: {
+    schema: {
+      additionalField: z => z.string().optional(),
+    },
+  },
+  factory(originalFactory, { config }) {
+    console.log(
+      `additionalField=${config.additionalField} layout=${config.layout}`,
+    );
+    return originalFactory();
+  },
+});
+```
+
 ## Override App Extensions
 
 In order to override an app extension, you must create a new extension and add it to the list of overridden features. The steps are: create your extension overrides and use them in Backstage.

--- a/docs/frontend-system/architecture/25-extension-overrides.md
+++ b/docs/frontend-system/architecture/25-extension-overrides.md
@@ -30,6 +30,55 @@ const myOverrideExtension = myExtension.override({
 
 This override is a no-op, it does not change the behavior of the extension, but simply forwards the outputs from the original extension factory. If you are familiar with [extension blueprints](./23-extension-blueprints.md), you will recognize this factory override pattern where we get access to the original factory function. In fact the only difference is that we do not need to pass any parameters to the original factory. The first parameter is now instead the optional factory context overrides, more on that as we dive into each override pattern in the following sections.
 
+## Overriding original factory outputs
+
+When overriding an extension you can choose to forward the existing outputs, or replace them with your own. The override factory has an exception to the rule that extension factories can only return a single value for each declared output. It will instead always use the **last** value provided for each extension data reference. This makes it possible to forward the outputs from the original factory, but also provide your own, for example:
+
+```tsx
+const myOverrideExtension = myExtension.override({
+  factory(originalFactory) {
+    return [
+      ...originalFactory(),
+      coreExtensionData.reactElement(<h1>Hello Override</h1>),
+    ];
+  },
+});
+```
+
+You can also access individual data values from the original factory, in order to decorate the output:
+
+```tsx
+const myOverrideExtension = myExtension.override({
+  factory(originalFactory) {
+    const originalOutput = originalFactory();
+    const originalElement = originalOutput.get(coreExtensionData.reactElement);
+
+    return [
+      ...originalOutput,
+      coreExtensionData.reactElement(
+        <details>
+          <summary>Show original element</summary>
+          {originalElement}
+        </details>,
+      ),
+    ];
+  },
+});
+```
+
+Just as [extension factories can be declared as a generator function](./20-extensions.md#extension-factory-as-a-generator-function), so can the override factory. Using a generator function, the first example above can be written as follows:
+
+```tsx
+const myOverrideExtension = myExtension.override({
+  *factory(originalFactory) {
+    yield* originalFactory();
+    yield coreExtensionData.reactElement(<h1>Hello Override</h1>);
+  },
+});
+```
+
+Note the `yield*` expression, which forwards all values from the provided iterable to the generator, in this case the original factory output.
+
 ## Override App Extensions
 
 In order to override an app extension, you must create a new extension and add it to the list of overridden features. The steps are: create your extension overrides and use them in Backstage.


### PR DESCRIPTION
This repurposes the extension overrides doc which was primarily about how to create extensions that matched existing ones and install them with `createExtensionOverrides`, to instead be about the new `extension.override(...)` method its options.

I kept a section at the end with an example `createExtensionOverrides`, but the goal is of course to remove this in the future too once we've replaced that.