### PR TITLE
frontend-plugin-api: store extension ID parts in an object type parameter

### DIFF
--- a/packages/app-next-example-plugin/api-report.md
+++ b/packages/app-next-example-plugin/api-report.md
@@ -36,9 +36,11 @@ const examplePlugin: BackstagePlugin<
           }
         >,
       {},
-      'page',
-      undefined,
-      undefined
+      {
+        kind: 'page';
+        namespace: undefined;
+        name: undefined;
+      }
     >;
   }
 >;

--- a/packages/frontend-plugin-api/api-report.md
+++ b/packages/frontend-plugin-api/api-report.md
@@ -191,9 +191,11 @@ export type AnyRoutes = {
 
 // @public
 export const ApiBlueprint: ExtensionBlueprint<
-  'api',
-  undefined,
-  undefined,
+  {
+    kind: 'api';
+    namespace: undefined;
+    name: undefined;
+  },
   {
     factory: AnyApiFactory;
   },
@@ -263,9 +265,11 @@ export interface AppNodeSpec {
 
 // @public
 export const AppRootElementBlueprint: ExtensionBlueprint<
-  'app-root-element',
-  undefined,
-  undefined,
+  {
+    kind: 'app-root-element';
+    namespace: undefined;
+    name: undefined;
+  },
   {
     element: JSX.Element | (() => JSX.Element);
   },
@@ -278,9 +282,11 @@ export const AppRootElementBlueprint: ExtensionBlueprint<
 
 // @public
 export const AppRootWrapperBlueprint: ExtensionBlueprint<
-  'app-root-wrapper',
-  undefined,
-  undefined,
+  {
+    kind: 'app-root-wrapper';
+    namespace: undefined;
+    name: undefined;
+  },
   {
     Component: ComponentType<PropsWithChildren<{}>>;
   },
@@ -475,9 +481,11 @@ export function createApiExtension<
   TConfig,
   never,
   never,
-  string | undefined,
-  string | undefined,
-  string | undefined
+  {
+    kind?: string | undefined;
+    namespace?: string | undefined;
+    name?: string | undefined;
+  }
 >;
 
 // @public (undocumented)
@@ -579,9 +587,11 @@ export function createComponentExtension<
   TConfig,
   never,
   never,
-  string | undefined,
-  string | undefined,
-  string | undefined
+  {
+    kind?: string | undefined;
+    namespace?: string | undefined;
+    name?: string | undefined;
+  }
 >;
 
 // @public (undocumented)
@@ -642,9 +652,11 @@ export function createExtension<
   >,
   UOutput,
   TInputs,
-  string | undefined extends TKind ? undefined : TKind,
-  string | undefined extends TNamespace ? undefined : TNamespace,
-  string | undefined extends TName ? undefined : TName
+  {
+    kind: string | undefined extends TKind ? undefined : TKind;
+    namespace: string | undefined extends TNamespace ? undefined : TNamespace;
+    name: string | undefined extends TName ? undefined : TName;
+  }
 >;
 
 // @public @deprecated (undocumented)
@@ -698,9 +710,11 @@ export function createExtensionBlueprint<
     TDataRefs
   >,
 ): ExtensionBlueprint<
-  TKind,
-  TNamespace,
-  TName,
+  {
+    kind: TKind;
+    namespace: TNamespace;
+    name: TName;
+  },
   TParams,
   UOutput,
   string extends keyof TInputs ? {} : TInputs,
@@ -928,9 +942,11 @@ export function createNavItemExtension(options: {
   },
   never,
   never,
-  string | undefined,
-  string | undefined,
-  string | undefined
+  {
+    kind?: string | undefined;
+    namespace?: string | undefined;
+    name?: string | undefined;
+  }
 >;
 
 // @public (undocumented)
@@ -958,9 +974,11 @@ export function createNavLogoExtension(options: {
   unknown,
   never,
   never,
-  string | undefined,
-  string | undefined,
-  string | undefined
+  {
+    kind?: string | undefined;
+    namespace?: string | undefined;
+    name?: string | undefined;
+  }
 >;
 
 // @public (undocumented)
@@ -1109,16 +1127,16 @@ export function createSubRouteRef<
 }): MakeSubRouteRef<PathParams<Path>, ParentParams>;
 
 // @public @deprecated (undocumented)
-export function createThemeExtension(
-  theme: AppTheme,
-): ExtensionDefinition<
+export function createThemeExtension(theme: AppTheme): ExtensionDefinition<
   unknown,
   unknown,
   never,
   never,
-  string | undefined,
-  string | undefined,
-  string | undefined
+  {
+    kind?: string | undefined;
+    namespace?: string | undefined;
+    name?: string | undefined;
+  }
 >;
 
 // @public @deprecated (undocumented)
@@ -1140,9 +1158,11 @@ export function createTranslationExtension(options: {
   unknown,
   never,
   never,
-  string | undefined,
-  string | undefined,
-  string | undefined
+  {
+    kind?: string | undefined;
+    namespace?: string | undefined;
+    name?: string | undefined;
+  }
 >;
 
 // @public @deprecated (undocumented)
@@ -1199,9 +1219,11 @@ export interface Extension<TConfig, TConfigInput = TConfig> {
 
 // @public (undocumented)
 export interface ExtensionBlueprint<
-  TKind extends string,
-  TNamespace extends string | undefined,
-  TName extends string | undefined,
+  TIdParts extends {
+    kind: string;
+    namespace?: string;
+    name?: string;
+  },
   TParams,
   UOutput extends AnyExtensionDataRef,
   TInputs extends {
@@ -1243,9 +1265,13 @@ export interface ExtensionBlueprint<
     TConfigInput,
     UOutput,
     TInputs,
-    TKind,
-    string | undefined extends TNewNamespace ? TNamespace : TNewNamespace,
-    string | undefined extends TNewName ? TName : TNewName
+    {
+      kind: TIdParts['kind'];
+      namespace: string | undefined extends TNewNamespace
+        ? TIdParts['namespace']
+        : TNewNamespace;
+      name: string | undefined extends TNewName ? TIdParts['name'] : TNewName;
+    }
   >;
   makeWithOverrides<
     TNewNamespace extends string | undefined,
@@ -1321,9 +1347,13 @@ export interface ExtensionBlueprint<
       TConfigInput,
     AnyExtensionDataRef extends UNewOutput ? UOutput : UNewOutput,
     TInputs & TExtraInputs,
-    TKind,
-    string | undefined extends TNewNamespace ? TNamespace : TNewNamespace,
-    string | undefined extends TNewName ? TName : TNewName
+    {
+      kind: TIdParts['kind'];
+      namespace: string | undefined extends TNewNamespace
+        ? TIdParts['namespace']
+        : TNewNamespace;
+      name: string | undefined extends TNewName ? TIdParts['name'] : TNewName;
+    }
   >;
 }
 
@@ -1419,9 +1449,15 @@ export interface ExtensionDefinition<
       }
     >;
   } = {},
-  TKind extends string | undefined = string | undefined,
-  TNamespace extends string | undefined = string | undefined,
-  TName extends string | undefined = string | undefined,
+  TIdParts extends {
+    kind?: string;
+    namespace?: string;
+    name?: string;
+  } = {
+    kind?: string;
+    namespace?: string;
+    name?: string;
+  },
 > {
   // (undocumented)
   $$type: '@backstage/ExtensionDefinition';
@@ -1435,11 +1471,11 @@ export interface ExtensionDefinition<
   // (undocumented)
   readonly disabled: boolean;
   // (undocumented)
-  readonly kind?: TKind;
+  readonly kind?: TIdParts['kind'];
   // (undocumented)
-  readonly name?: TName;
+  readonly name?: TIdParts['name'];
   // (undocumented)
-  readonly namespace?: TNamespace;
+  readonly namespace?: TIdParts['namespace'];
   // (undocumented)
   override<
     TExtensionConfigSchema extends {
@@ -1509,9 +1545,7 @@ export interface ExtensionDefinition<
       TConfigInput,
     AnyExtensionDataRef extends UNewOutput ? UOutput : UNewOutput,
     TInputs & TExtraInputs,
-    TKind,
-    TNamespace,
-    TName
+    TIdParts
   >;
 }
 
@@ -1591,9 +1625,11 @@ export { googleAuthApiRef };
 
 // @public (undocumented)
 export const IconBundleBlueprint: ExtensionBlueprint<
-  'icon-bundle',
-  'app',
-  undefined,
+  {
+    kind: 'icon-bundle';
+    namespace: 'app';
+    name: undefined;
+  },
   {
     icons: {
       [x: string]: IconComponent;
@@ -1705,9 +1741,11 @@ export { microsoftAuthApiRef };
 
 // @public
 export const NavItemBlueprint: ExtensionBlueprint<
-  'nav-item',
-  undefined,
-  undefined,
+  {
+    kind: 'nav-item';
+    namespace: undefined;
+    name: undefined;
+  },
   {
     title: string;
     icon: IconComponent_2;
@@ -1740,9 +1778,11 @@ export const NavItemBlueprint: ExtensionBlueprint<
 
 // @public
 export const NavLogoBlueprint: ExtensionBlueprint<
-  'nav-logo',
-  undefined,
-  undefined,
+  {
+    kind: 'nav-logo';
+    namespace: undefined;
+    name: undefined;
+  },
   {
     logoIcon: JSX.Element;
     logoFull: JSX.Element;
@@ -1790,9 +1830,11 @@ export { OpenIdConnectApi };
 
 // @public
 export const PageBlueprint: ExtensionBlueprint<
-  'page',
-  undefined,
-  undefined,
+  {
+    kind: 'page';
+    namespace: undefined;
+    name: undefined;
+  },
   {
     defaultPath: string;
     loader: () => Promise<JSX.Element>;
@@ -1951,9 +1993,11 @@ export type RouteFunc<TParams extends AnyRouteRefParams> = (
 
 // @public (undocumented)
 export const RouterBlueprint: ExtensionBlueprint<
-  'app-router-component',
-  undefined,
-  undefined,
+  {
+    kind: 'app-router-component';
+    namespace: undefined;
+    name: undefined;
+  },
   {
     Component: ComponentType<PropsWithChildren<{}>>;
   },
@@ -2014,9 +2058,11 @@ export { SessionState };
 
 // @public
 export const SignInPageBlueprint: ExtensionBlueprint<
-  'sign-in-page',
-  undefined,
-  undefined,
+  {
+    kind: 'sign-in-page';
+    namespace: undefined;
+    name: undefined;
+  },
   {
     loader: () => Promise<ComponentType<SignInPageProps>>;
   },
@@ -2057,9 +2103,11 @@ export interface SubRouteRef<
 
 // @public
 export const ThemeBlueprint: ExtensionBlueprint<
-  'theme',
-  'app',
-  undefined,
+  {
+    kind: 'theme';
+    namespace: 'app';
+    name: undefined;
+  },
   {
     theme: AppTheme;
   },
@@ -2074,9 +2122,11 @@ export const ThemeBlueprint: ExtensionBlueprint<
 
 // @public
 export const TranslationBlueprint: ExtensionBlueprint<
-  'translation',
-  undefined,
-  undefined,
+  {
+    kind: 'translation';
+    namespace: undefined;
+    name: undefined;
+  },
   {
     resource: TranslationResource | TranslationMessages;
   },

--- a/packages/frontend-plugin-api/src/wiring/createExtension.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.ts
@@ -218,14 +218,20 @@ export interface ExtensionDefinition<
       { optional: boolean; singleton: boolean }
     >;
   } = {},
-  TKind extends string | undefined = string | undefined,
-  TNamespace extends string | undefined = string | undefined,
-  TName extends string | undefined = string | undefined,
+  TIdParts extends {
+    kind?: string;
+    namespace?: string;
+    name?: string;
+  } = {
+    kind?: string;
+    namespace?: string;
+    name?: string;
+  },
 > {
   $$type: '@backstage/ExtensionDefinition';
-  readonly kind?: TKind;
-  readonly namespace?: TNamespace;
-  readonly name?: TName;
+  readonly kind?: TIdParts['kind'];
+  readonly namespace?: TIdParts['namespace'];
+  readonly name?: TIdParts['name'];
   readonly attachTo: { id: string; input: string };
   readonly disabled: boolean;
   readonly configSchema?: PortableSchema<TConfig, TConfigInput>;
@@ -292,9 +298,7 @@ export interface ExtensionDefinition<
       TConfigInput,
     AnyExtensionDataRef extends UNewOutput ? UOutput : UNewOutput,
     TInputs & TExtraInputs,
-    TKind,
-    TNamespace,
-    TName
+    TIdParts
   >;
 }
 
@@ -309,18 +313,16 @@ export type InternalExtensionDefinition<
       { optional: boolean; singleton: boolean }
     >;
   } = {},
-  TKind extends string | undefined = string | undefined,
-  TNamespace extends string | undefined = string | undefined,
-  TName extends string | undefined = string | undefined,
-> = ExtensionDefinition<
-  TConfig,
-  TConfigInput,
-  UOutput,
-  TInputs,
-  TKind,
-  TNamespace,
-  TName
-> &
+  TIdParts extends {
+    kind?: string;
+    namespace?: string;
+    name?: string;
+  } = {
+    kind?: string;
+    namespace?: string;
+    name?: string;
+  },
+> = ExtensionDefinition<TConfig, TConfigInput, UOutput, TInputs, TIdParts> &
   (
     | {
         readonly version: 'v1';
@@ -411,9 +413,11 @@ export function createExtension<
   >,
   UOutput,
   TInputs,
-  string | undefined extends TKind ? undefined : TKind,
-  string | undefined extends TNamespace ? undefined : TNamespace,
-  string | undefined extends TName ? undefined : TName
+  {
+    kind: string | undefined extends TKind ? undefined : TKind;
+    namespace: string | undefined extends TNamespace ? undefined : TNamespace;
+    name: string | undefined extends TName ? undefined : TName;
+  }
 >;
 /**
  * @public
@@ -482,9 +486,11 @@ export function createExtension<
         >),
   UOutput,
   TInputs,
-  TKind,
-  TNamespace,
-  TName
+  {
+    kind: TKind;
+    namespace: TNamespace;
+    name: TName;
+  }
 > {
   if ('configSchema' in options && 'config' in options) {
     throw new Error(`Cannot provide both configSchema and config.schema`);
@@ -596,9 +602,11 @@ export function createExtension<
       >,
       AnyExtensionDataRef extends UNewOutput ? UOutput : UNewOutput,
       TInputs & TExtraInputs,
-      TKind,
-      TNamespace,
-      TName
+      {
+        kind: TKind;
+        namespace: TNamespace;
+        name: TName;
+      }
     > => {
       if (!Array.isArray(options.output)) {
         throw new Error(
@@ -697,8 +705,10 @@ export function createExtension<
           >),
     UOutput,
     TInputs,
-    TKind,
-    TNamespace,
-    TName
+    {
+      kind: TKind;
+      namespace: TNamespace;
+      name: TName;
+    }
   >;
 }

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
@@ -85,9 +85,11 @@ export type CreateExtensionBlueprintOptions<
  * @public
  */
 export interface ExtensionBlueprint<
-  TKind extends string,
-  TNamespace extends string | undefined,
-  TName extends string | undefined,
+  TIdParts extends {
+    kind: string;
+    namespace?: string;
+    name?: string;
+  },
   TParams,
   UOutput extends AnyExtensionDataRef,
   TInputs extends {
@@ -116,9 +118,13 @@ export interface ExtensionBlueprint<
     TConfigInput,
     UOutput,
     TInputs,
-    TKind,
-    string | undefined extends TNewNamespace ? TNamespace : TNewNamespace,
-    string | undefined extends TNewName ? TName : TNewName
+    {
+      kind: TIdParts['kind'];
+      namespace: string | undefined extends TNewNamespace
+        ? TIdParts['namespace']
+        : TNewNamespace;
+      name: string | undefined extends TNewName ? TIdParts['name'] : TNewName;
+    }
   >;
 
   /**
@@ -195,9 +201,13 @@ export interface ExtensionBlueprint<
       TConfigInput,
     AnyExtensionDataRef extends UNewOutput ? UOutput : UNewOutput,
     TInputs & TExtraInputs,
-    TKind,
-    string | undefined extends TNewNamespace ? TNamespace : TNewNamespace,
-    string | undefined extends TNewName ? TName : TNewName
+    {
+      kind: TIdParts['kind'];
+      namespace: string | undefined extends TNewNamespace
+        ? TIdParts['namespace']
+        : TNewNamespace;
+      name: string | undefined extends TNewName ? TIdParts['name'] : TNewName;
+    }
   >;
 }
 
@@ -422,9 +432,11 @@ export function createExtensionBlueprint<
     TDataRefs
   >,
 ): ExtensionBlueprint<
-  TKind,
-  TNamespace,
-  TName,
+  {
+    kind: TKind;
+    namespace: TNamespace;
+    name: TName;
+  },
   TParams,
   UOutput,
   string extends keyof TInputs ? {} : TInputs,
@@ -441,9 +453,11 @@ export function createExtensionBlueprint<
   TDataRefs
 > {
   return new ExtensionBlueprintImpl(options) as ExtensionBlueprint<
-    TKind,
-    TNamespace,
-    TName,
+    {
+      kind: TKind;
+      namespace: TNamespace;
+      name: TName;
+    },
     TParams,
     UOutput,
     string extends keyof TInputs ? {} : TInputs,

--- a/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.test.ts
@@ -108,7 +108,13 @@ describe('ResolveExtensionId', () => {
       TKind extends string | undefined,
       TNamespace extends string | undefined,
       TName extends string | undefined,
-    > = ExtensionDefinition<any, any, any, any, TKind, TNamespace, TName>;
+    > = ExtensionDefinition<
+      any,
+      any,
+      any,
+      any,
+      { kind: TKind; namespace: TNamespace; name: TName }
+    >;
 
     const id1: 'k:ns' = {} as ResolveExtensionId<
       NamedExtension<'k', 'ns', undefined>,

--- a/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.ts
+++ b/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.ts
@@ -103,9 +103,11 @@ export type ResolveExtensionId<
   any,
   any,
   any,
-  infer IKind,
-  infer INamespace,
-  infer IName
+  {
+    kind: infer IKind extends string | undefined;
+    namespace: infer INamespace extends string | undefined;
+    name: infer IName extends string | undefined;
+  }
 >
   ? [string | undefined] extends [IKind | INamespace | IName]
     ? never

--- a/plugins/api-docs/api-report-alpha.md
+++ b/plugins/api-docs/api-report-alpha.md
@@ -38,18 +38,22 @@ const _default: BackstagePlugin<
         {}
       >,
       {},
-      'nav-item',
-      undefined,
-      undefined
+      {
+        kind: 'nav-item';
+        namespace: undefined;
+        name: undefined;
+      }
     >;
     'api:api-docs/config': ExtensionDefinition<
       {},
       {},
       ConfigurableExtensionDataRef<AnyApiFactory, 'core.api.factory', {}>,
       {},
-      'api',
-      undefined,
-      'config'
+      {
+        kind: 'api';
+        namespace: undefined;
+        name: 'config';
+      }
     >;
     'page:api-docs': ExtensionDefinition<
       {
@@ -84,9 +88,11 @@ const _default: BackstagePlugin<
           }
         >;
       },
-      'page',
-      undefined,
-      undefined
+      {
+        kind: 'page';
+        namespace: undefined;
+        name: undefined;
+      }
     >;
     'entity-card:api-docs/has-apis': ExtensionDefinition<
       {
@@ -115,9 +121,11 @@ const _default: BackstagePlugin<
           }
         >,
       {},
-      'entity-card',
-      undefined,
-      'has-apis'
+      {
+        kind: 'entity-card';
+        namespace: undefined;
+        name: 'has-apis';
+      }
     >;
     'entity-card:api-docs/definition': ExtensionDefinition<
       {
@@ -146,9 +154,11 @@ const _default: BackstagePlugin<
           }
         >,
       {},
-      'entity-card',
-      undefined,
-      'definition'
+      {
+        kind: 'entity-card';
+        namespace: undefined;
+        name: 'definition';
+      }
     >;
     'entity-card:api-docs/consumed-apis': ExtensionDefinition<
       {
@@ -177,9 +187,11 @@ const _default: BackstagePlugin<
           }
         >,
       {},
-      'entity-card',
-      undefined,
-      'consumed-apis'
+      {
+        kind: 'entity-card';
+        namespace: undefined;
+        name: 'consumed-apis';
+      }
     >;
     'entity-card:api-docs/provided-apis': ExtensionDefinition<
       {
@@ -208,9 +220,11 @@ const _default: BackstagePlugin<
           }
         >,
       {},
-      'entity-card',
-      undefined,
-      'provided-apis'
+      {
+        kind: 'entity-card';
+        namespace: undefined;
+        name: 'provided-apis';
+      }
     >;
     'entity-card:api-docs/consuming-components': ExtensionDefinition<
       {
@@ -239,9 +253,11 @@ const _default: BackstagePlugin<
           }
         >,
       {},
-      'entity-card',
-      undefined,
-      'consuming-components'
+      {
+        kind: 'entity-card';
+        namespace: undefined;
+        name: 'consuming-components';
+      }
     >;
     'entity-card:api-docs/providing-components': ExtensionDefinition<
       {
@@ -270,9 +286,11 @@ const _default: BackstagePlugin<
           }
         >,
       {},
-      'entity-card',
-      undefined,
-      'providing-components'
+      {
+        kind: 'entity-card';
+        namespace: undefined;
+        name: 'providing-components';
+      }
     >;
     'entity-content:api-docs/definition': ExtensionDefinition<
       {
@@ -314,9 +332,11 @@ const _default: BackstagePlugin<
           }
         >,
       {},
-      'entity-content',
-      undefined,
-      'definition'
+      {
+        kind: 'entity-content';
+        namespace: undefined;
+        name: 'definition';
+      }
     >;
     'entity-content:api-docs/apis': ExtensionDefinition<
       {
@@ -358,9 +378,11 @@ const _default: BackstagePlugin<
           }
         >,
       {},
-      'entity-content',
-      undefined,
-      'apis'
+      {
+        kind: 'entity-content';
+        namespace: undefined;
+        name: 'apis';
+      }
     >;
   }
 >;

--- a/plugins/app-visualizer/api-report.md
+++ b/plugins/app-visualizer/api-report.md
@@ -37,9 +37,11 @@ const visualizerPlugin: BackstagePlugin<
           }
         >,
       {},
-      'page',
-      undefined,
-      undefined
+      {
+        kind: 'page';
+        namespace: undefined;
+        name: undefined;
+      }
     >;
     'nav-item:app-visualizer': ExtensionDefinition<
       {},
@@ -54,9 +56,11 @@ const visualizerPlugin: BackstagePlugin<
         {}
       >,
       {},
-      'nav-item',
-      undefined,
-      undefined
+      {
+        kind: 'nav-item';
+        namespace: undefined;
+        name: undefined;
+      }
     >;
   }
 >;

--- a/plugins/catalog-graph/api-report-alpha.md
+++ b/plugins/catalog-graph/api-report-alpha.md
@@ -87,9 +87,11 @@ const _default: BackstagePlugin<
           }
         >;
       },
-      'entity-card',
-      undefined,
-      'relations'
+      {
+        kind: 'entity-card';
+        namespace: undefined;
+        name: 'relations';
+      }
     >;
     'page:catalog-graph': ExtensionDefinition<
       {
@@ -148,9 +150,11 @@ const _default: BackstagePlugin<
           }
         >;
       },
-      'page',
-      undefined,
-      undefined
+      {
+        kind: 'page';
+        namespace: undefined;
+        name: undefined;
+      }
     >;
   }
 >;

--- a/plugins/catalog-import/api-report-alpha.md
+++ b/plugins/catalog-import/api-report-alpha.md
@@ -23,9 +23,11 @@ const _default: BackstagePlugin<
       {},
       ConfigurableExtensionDataRef<AnyApiFactory, 'core.api.factory', {}>,
       {},
-      'api',
-      undefined,
-      undefined
+      {
+        kind: 'api';
+        namespace: undefined;
+        name: undefined;
+      }
     >;
     'page:catalog-import': ExtensionDefinition<
       {
@@ -48,9 +50,11 @@ const _default: BackstagePlugin<
           }
         >,
       {},
-      'page',
-      undefined,
-      undefined
+      {
+        kind: 'page';
+        namespace: undefined;
+        name: undefined;
+      }
     >;
   }
 >;

--- a/plugins/catalog-react/api-report-alpha.md
+++ b/plugins/catalog-react/api-report-alpha.md
@@ -123,9 +123,11 @@ export function createEntityCardExtension<
   TConfig,
   never,
   never,
-  string | undefined,
-  string | undefined,
-  string | undefined
+  {
+    kind?: string | undefined;
+    namespace?: string | undefined;
+    name?: string | undefined;
+  }
 >;
 
 // @alpha @deprecated (undocumented)
@@ -162,16 +164,20 @@ export function createEntityContentExtension<
   },
   never,
   never,
-  string | undefined,
-  string | undefined,
-  string | undefined
+  {
+    kind?: string | undefined;
+    namespace?: string | undefined;
+    name?: string | undefined;
+  }
 >;
 
 // @alpha
 export const EntityCardBlueprint: ExtensionBlueprint<
-  'entity-card',
-  undefined,
-  undefined,
+  {
+    kind: 'entity-card';
+    namespace: undefined;
+    name: undefined;
+  },
   {
     loader: () => Promise<JSX.Element>;
     filter?: string | ((entity: Entity) => boolean) | undefined;
@@ -214,9 +220,11 @@ export const EntityCardBlueprint: ExtensionBlueprint<
 
 // @alpha
 export const EntityContentBlueprint: ExtensionBlueprint<
-  'entity-content',
-  undefined,
-  undefined,
+  {
+    kind: 'entity-content';
+    namespace: undefined;
+    name: undefined;
+  },
   {
     loader: () => Promise<JSX.Element>;
     defaultPath: string;

--- a/plugins/catalog/api-report-alpha.md
+++ b/plugins/catalog/api-report-alpha.md
@@ -27,9 +27,11 @@ import { TranslationRef } from '@backstage/core-plugin-api/alpha';
 
 // @alpha
 export const CatalogFilterBlueprint: ExtensionBlueprint<
-  'catalog-filter',
-  undefined,
-  undefined,
+  {
+    kind: 'catalog-filter';
+    namespace: undefined;
+    name: undefined;
+  },
   {
     loader: () => Promise<JSX.Element>;
   },
@@ -140,9 +142,11 @@ export function createCatalogFilterExtension<
   TConfig,
   never,
   never,
-  string | undefined,
-  string | undefined,
-  string | undefined
+  {
+    kind?: string | undefined;
+    namespace?: string | undefined;
+    name?: string | undefined;
+  }
 >;
 
 // @alpha (undocumented)
@@ -182,27 +186,33 @@ const _default: BackstagePlugin<
         {}
       >,
       {},
-      'nav-item',
-      undefined,
-      undefined
+      {
+        kind: 'nav-item';
+        namespace: undefined;
+        name: undefined;
+      }
     >;
     'api:catalog/starred-entities': ExtensionDefinition<
       {},
       {},
       ConfigurableExtensionDataRef<AnyApiFactory, 'core.api.factory', {}>,
       {},
-      'api',
-      undefined,
-      'starred-entities'
+      {
+        kind: 'api';
+        namespace: undefined;
+        name: 'starred-entities';
+      }
     >;
     'api:catalog/entity-presentation': ExtensionDefinition<
       {},
       {},
       ConfigurableExtensionDataRef<AnyApiFactory, 'core.api.factory', {}>,
       {},
-      'api',
-      undefined,
-      'entity-presentation'
+      {
+        kind: 'api';
+        namespace: undefined;
+        name: 'entity-presentation';
+      }
     >;
     'entity-card:catalog/about': ExtensionDefinition<
       {
@@ -227,9 +237,11 @@ const _default: BackstagePlugin<
           }
         >,
       {},
-      'entity-card',
-      undefined,
-      'about'
+      {
+        kind: 'entity-card';
+        namespace: undefined;
+        name: 'about';
+      }
     >;
     'entity-card:catalog/links': ExtensionDefinition<
       {
@@ -254,9 +266,11 @@ const _default: BackstagePlugin<
           }
         >,
       {},
-      'entity-card',
-      undefined,
-      'links'
+      {
+        kind: 'entity-card';
+        namespace: undefined;
+        name: 'links';
+      }
     >;
     'entity-card:catalog/labels': ExtensionDefinition<
       {
@@ -281,9 +295,11 @@ const _default: BackstagePlugin<
           }
         >,
       {},
-      'entity-card',
-      undefined,
-      'labels'
+      {
+        kind: 'entity-card';
+        namespace: undefined;
+        name: 'labels';
+      }
     >;
     'entity-card:catalog/depends-on-components': ExtensionDefinition<
       {
@@ -308,9 +324,11 @@ const _default: BackstagePlugin<
           }
         >,
       {},
-      'entity-card',
-      undefined,
-      'depends-on-components'
+      {
+        kind: 'entity-card';
+        namespace: undefined;
+        name: 'depends-on-components';
+      }
     >;
     'entity-card:catalog/depends-on-resources': ExtensionDefinition<
       {
@@ -335,9 +353,11 @@ const _default: BackstagePlugin<
           }
         >,
       {},
-      'entity-card',
-      undefined,
-      'depends-on-resources'
+      {
+        kind: 'entity-card';
+        namespace: undefined;
+        name: 'depends-on-resources';
+      }
     >;
     'entity-card:catalog/has-components': ExtensionDefinition<
       {
@@ -362,9 +382,11 @@ const _default: BackstagePlugin<
           }
         >,
       {},
-      'entity-card',
-      undefined,
-      'has-components'
+      {
+        kind: 'entity-card';
+        namespace: undefined;
+        name: 'has-components';
+      }
     >;
     'entity-card:catalog/has-resources': ExtensionDefinition<
       {
@@ -389,9 +411,11 @@ const _default: BackstagePlugin<
           }
         >,
       {},
-      'entity-card',
-      undefined,
-      'has-resources'
+      {
+        kind: 'entity-card';
+        namespace: undefined;
+        name: 'has-resources';
+      }
     >;
     'entity-card:catalog/has-subcomponents': ExtensionDefinition<
       {
@@ -416,9 +440,11 @@ const _default: BackstagePlugin<
           }
         >,
       {},
-      'entity-card',
-      undefined,
-      'has-subcomponents'
+      {
+        kind: 'entity-card';
+        namespace: undefined;
+        name: 'has-subcomponents';
+      }
     >;
     'entity-card:catalog/has-subdomains': ExtensionDefinition<
       {
@@ -443,9 +469,11 @@ const _default: BackstagePlugin<
           }
         >,
       {},
-      'entity-card',
-      undefined,
-      'has-subdomains'
+      {
+        kind: 'entity-card';
+        namespace: undefined;
+        name: 'has-subdomains';
+      }
     >;
     'entity-card:catalog/has-systems': ExtensionDefinition<
       {
@@ -470,9 +498,11 @@ const _default: BackstagePlugin<
           }
         >,
       {},
-      'entity-card',
-      undefined,
-      'has-systems'
+      {
+        kind: 'entity-card';
+        namespace: undefined;
+        name: 'has-systems';
+      }
     >;
     'entity-content:catalog/overview': ExtensionDefinition<
       {
@@ -536,18 +566,22 @@ const _default: BackstagePlugin<
           }
         >;
       },
-      'entity-content',
-      undefined,
-      'overview'
+      {
+        kind: 'entity-content';
+        namespace: undefined;
+        name: 'overview';
+      }
     >;
     'catalog-filter:catalog/tag': ExtensionDefinition<
       {},
       {},
       ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>,
       {},
-      'catalog-filter',
-      undefined,
-      'tag'
+      {
+        kind: 'catalog-filter';
+        namespace: undefined;
+        name: 'tag';
+      }
     >;
     'catalog-filter:catalog/kind': ExtensionDefinition<
       {
@@ -566,18 +600,22 @@ const _default: BackstagePlugin<
           }
         >;
       },
-      'catalog-filter',
-      undefined,
-      'kind'
+      {
+        kind: 'catalog-filter';
+        namespace: undefined;
+        name: 'kind';
+      }
     >;
     'catalog-filter:catalog/type': ExtensionDefinition<
       {},
       {},
       ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>,
       {},
-      'catalog-filter',
-      undefined,
-      'type'
+      {
+        kind: 'catalog-filter';
+        namespace: undefined;
+        name: 'type';
+      }
     >;
     'catalog-filter:catalog/mode': ExtensionDefinition<
       {
@@ -596,36 +634,44 @@ const _default: BackstagePlugin<
           }
         >;
       },
-      'catalog-filter',
-      undefined,
-      'mode'
+      {
+        kind: 'catalog-filter';
+        namespace: undefined;
+        name: 'mode';
+      }
     >;
     'catalog-filter:catalog/namespace': ExtensionDefinition<
       {},
       {},
       ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>,
       {},
-      'catalog-filter',
-      undefined,
-      'namespace'
+      {
+        kind: 'catalog-filter';
+        namespace: undefined;
+        name: 'namespace';
+      }
     >;
     'catalog-filter:catalog/lifecycle': ExtensionDefinition<
       {},
       {},
       ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>,
       {},
-      'catalog-filter',
-      undefined,
-      'lifecycle'
+      {
+        kind: 'catalog-filter';
+        namespace: undefined;
+        name: 'lifecycle';
+      }
     >;
     'catalog-filter:catalog/processing-status': ExtensionDefinition<
       {},
       {},
       ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>,
       {},
-      'catalog-filter',
-      undefined,
-      'processing-status'
+      {
+        kind: 'catalog-filter';
+        namespace: undefined;
+        name: 'processing-status';
+      }
     >;
     'catalog-filter:catalog/list': ExtensionDefinition<
       {
@@ -644,9 +690,11 @@ const _default: BackstagePlugin<
           }
         >;
       },
-      'catalog-filter',
-      undefined,
-      'list'
+      {
+        kind: 'catalog-filter';
+        namespace: undefined;
+        name: 'list';
+      }
     >;
     'page:catalog': ExtensionDefinition<
       {
@@ -677,9 +725,11 @@ const _default: BackstagePlugin<
           }
         >;
       },
-      'page',
-      undefined,
-      undefined
+      {
+        kind: 'page';
+        namespace: undefined;
+        name: undefined;
+      }
     >;
     'page:catalog/entity': ExtensionDefinition<
       {
@@ -737,9 +787,11 @@ const _default: BackstagePlugin<
           }
         >;
       },
-      'page',
-      undefined,
-      'entity'
+      {
+        kind: 'page';
+        namespace: undefined;
+        name: 'entity';
+      }
     >;
     'search-result-list-item:catalog': ExtensionDefinition<
       {
@@ -757,9 +809,11 @@ const _default: BackstagePlugin<
         {}
       >,
       {},
-      'search-result-list-item',
-      undefined,
-      undefined
+      {
+        kind: 'search-result-list-item';
+        namespace: undefined;
+        name: undefined;
+      }
     >;
   }
 >;

--- a/plugins/devtools/api-report-alpha.md
+++ b/plugins/devtools/api-report-alpha.md
@@ -24,9 +24,11 @@ const _default: BackstagePlugin<
       {},
       ConfigurableExtensionDataRef<AnyApiFactory, 'core.api.factory', {}>,
       {},
-      'api',
-      undefined,
-      undefined
+      {
+        kind: 'api';
+        namespace: undefined;
+        name: undefined;
+      }
     >;
     'page:devtools': ExtensionDefinition<
       {
@@ -49,9 +51,11 @@ const _default: BackstagePlugin<
           }
         >,
       {},
-      'page',
-      undefined,
-      undefined
+      {
+        kind: 'page';
+        namespace: undefined;
+        name: undefined;
+      }
     >;
     'nav-item:devtools': ExtensionDefinition<
       {},
@@ -66,9 +70,11 @@ const _default: BackstagePlugin<
         {}
       >,
       {},
-      'nav-item',
-      undefined,
-      undefined
+      {
+        kind: 'nav-item';
+        namespace: undefined;
+        name: undefined;
+      }
     >;
   }
 >;

--- a/plugins/home/api-report-alpha.md
+++ b/plugins/home/api-report-alpha.md
@@ -62,9 +62,11 @@ const _default: BackstagePlugin<
           }
         >;
       },
-      'page',
-      undefined,
-      undefined
+      {
+        kind: 'page';
+        namespace: undefined;
+        name: undefined;
+      }
     >;
   }
 >;

--- a/plugins/kubernetes/api-report-alpha.md
+++ b/plugins/kubernetes/api-report-alpha.md
@@ -38,9 +38,11 @@ const _default: BackstagePlugin<
           }
         >,
       {},
-      'page',
-      undefined,
-      undefined
+      {
+        kind: 'page';
+        namespace: undefined;
+        name: undefined;
+      }
     >;
     'entity-content:kubernetes/kubernetes': ExtensionDefinition<
       {
@@ -78,36 +80,44 @@ const _default: BackstagePlugin<
           }
         >,
       {},
-      'entity-content',
-      undefined,
-      'kubernetes'
+      {
+        kind: 'entity-content';
+        namespace: undefined;
+        name: 'kubernetes';
+      }
     >;
     'api:kubernetes/proxy': ExtensionDefinition<
       {},
       {},
       ConfigurableExtensionDataRef<AnyApiFactory, 'core.api.factory', {}>,
       {},
-      'api',
-      undefined,
-      'proxy'
+      {
+        kind: 'api';
+        namespace: undefined;
+        name: 'proxy';
+      }
     >;
     'api:kubernetes/auth-providers': ExtensionDefinition<
       {},
       {},
       ConfigurableExtensionDataRef<AnyApiFactory, 'core.api.factory', {}>,
       {},
-      'api',
-      undefined,
-      'auth-providers'
+      {
+        kind: 'api';
+        namespace: undefined;
+        name: 'auth-providers';
+      }
     >;
     'api:kubernetes/cluster-link-formatter': ExtensionDefinition<
       {},
       {},
       ConfigurableExtensionDataRef<AnyApiFactory, 'core.api.factory', {}>,
       {},
-      'api',
-      undefined,
-      'cluster-link-formatter'
+      {
+        kind: 'api';
+        namespace: undefined;
+        name: 'cluster-link-formatter';
+      }
     >;
   }
 >;

--- a/plugins/org/api-report-alpha.md
+++ b/plugins/org/api-report-alpha.md
@@ -44,9 +44,11 @@ const _default: BackstagePlugin<
           }
         >,
       {},
-      'entity-card',
-      undefined,
-      'group-profile'
+      {
+        kind: 'entity-card';
+        namespace: undefined;
+        name: 'group-profile';
+      }
     >;
     'entity-card:org/members-list': ExtensionDefinition<
       {
@@ -75,9 +77,11 @@ const _default: BackstagePlugin<
           }
         >,
       {},
-      'entity-card',
-      undefined,
-      'members-list'
+      {
+        kind: 'entity-card';
+        namespace: undefined;
+        name: 'members-list';
+      }
     >;
     'entity-card:org/ownership': ExtensionDefinition<
       {
@@ -106,9 +110,11 @@ const _default: BackstagePlugin<
           }
         >,
       {},
-      'entity-card',
-      undefined,
-      'ownership'
+      {
+        kind: 'entity-card';
+        namespace: undefined;
+        name: 'ownership';
+      }
     >;
     'entity-card:org/user-profile': ExtensionDefinition<
       {
@@ -137,9 +143,11 @@ const _default: BackstagePlugin<
           }
         >,
       {},
-      'entity-card',
-      undefined,
-      'user-profile'
+      {
+        kind: 'entity-card';
+        namespace: undefined;
+        name: 'user-profile';
+      }
     >;
   }
 >;

--- a/plugins/scaffolder/api-report-alpha.md
+++ b/plugins/scaffolder/api-report-alpha.md
@@ -48,9 +48,11 @@ const _default: BackstagePlugin<
       {},
       ConfigurableExtensionDataRef<AnyApiFactory, 'core.api.factory', {}>,
       {},
-      'api',
-      undefined,
-      undefined
+      {
+        kind: 'api';
+        namespace: undefined;
+        name: undefined;
+      }
     >;
     'page:scaffolder': ExtensionDefinition<
       {
@@ -73,9 +75,11 @@ const _default: BackstagePlugin<
           }
         >,
       {},
-      'page',
-      undefined,
-      undefined
+      {
+        kind: 'page';
+        namespace: undefined;
+        name: undefined;
+      }
     >;
     'nav-item:scaffolder': ExtensionDefinition<
       {},
@@ -90,9 +94,11 @@ const _default: BackstagePlugin<
         {}
       >,
       {},
-      'nav-item',
-      undefined,
-      undefined
+      {
+        kind: 'nav-item';
+        namespace: undefined;
+        name: undefined;
+      }
     >;
   }
 >;

--- a/plugins/search-react/api-report-alpha.md
+++ b/plugins/search-react/api-report-alpha.md
@@ -31,9 +31,11 @@ export function createSearchResultListItemExtension<
   TConfig,
   never,
   never,
-  string | undefined,
-  string | undefined,
-  string | undefined
+  {
+    kind?: string | undefined;
+    namespace?: string | undefined;
+    name?: string | undefined;
+  }
 >;
 
 // @alpha @deprecated (undocumented)
@@ -82,9 +84,11 @@ export type SearchResultItemExtensionPredicate = (
 
 // @alpha
 export const SearchResultListItemBlueprint: ExtensionBlueprint<
-  'search-result-list-item',
-  undefined,
-  undefined,
+  {
+    kind: 'search-result-list-item';
+    namespace: undefined;
+    name: undefined;
+  },
   SearchResultListItemBlueprintParams,
   ConfigurableExtensionDataRef<
     {

--- a/plugins/search/api-report-alpha.md
+++ b/plugins/search/api-report-alpha.md
@@ -27,9 +27,11 @@ const _default: BackstagePlugin<
       {},
       ConfigurableExtensionDataRef<AnyApiFactory, 'core.api.factory', {}>,
       {},
-      'api',
-      undefined,
-      undefined
+      {
+        kind: 'api';
+        namespace: undefined;
+        name: undefined;
+      }
     >;
     'nav-item:search': ExtensionDefinition<
       {},
@@ -44,9 +46,11 @@ const _default: BackstagePlugin<
         {}
       >,
       {},
-      'nav-item',
-      undefined,
-      undefined
+      {
+        kind: 'nav-item';
+        namespace: undefined;
+        name: undefined;
+      }
     >;
     'page:search': ExtensionDefinition<
       {
@@ -88,9 +92,11 @@ const _default: BackstagePlugin<
           }
         >;
       },
-      'page',
-      undefined,
-      undefined
+      {
+        kind: 'page';
+        namespace: undefined;
+        name: undefined;
+      }
     >;
   }
 >;
@@ -102,9 +108,11 @@ export const searchApi: ExtensionDefinition<
   {},
   ConfigurableExtensionDataRef<AnyApiFactory, 'core.api.factory', {}>,
   {},
-  'api',
-  undefined,
-  undefined
+  {
+    kind: 'api';
+    namespace: undefined;
+    name: undefined;
+  }
 >;
 
 // @alpha (undocumented)
@@ -121,9 +129,11 @@ export const searchNavItem: ExtensionDefinition<
     {}
   >,
   {},
-  'nav-item',
-  undefined,
-  undefined
+  {
+    kind: 'nav-item';
+    namespace: undefined;
+    name: undefined;
+  }
 >;
 
 // @alpha (undocumented)
@@ -163,9 +173,11 @@ export const searchPage: ExtensionDefinition<
       }
     >;
   },
-  'page',
-  undefined,
-  undefined
+  {
+    kind: 'page';
+    namespace: undefined;
+    name: undefined;
+  }
 >;
 
 // (No @packageDocumentation comment for this package)

--- a/plugins/techdocs/api-report-alpha.md
+++ b/plugins/techdocs/api-report-alpha.md
@@ -43,18 +43,22 @@ const _default: BackstagePlugin<
         {}
       >,
       {},
-      'nav-item',
-      undefined,
-      undefined
+      {
+        kind: 'nav-item';
+        namespace: undefined;
+        name: undefined;
+      }
     >;
     'api:techdocs/storage': ExtensionDefinition<
       {},
       {},
       ConfigurableExtensionDataRef<AnyApiFactory, 'core.api.factory', {}>,
       {},
-      'api',
-      undefined,
-      'storage'
+      {
+        kind: 'api';
+        namespace: undefined;
+        name: 'storage';
+      }
     >;
     'search-result-list-item:techdocs': ExtensionDefinition<
       {
@@ -90,9 +94,11 @@ const _default: BackstagePlugin<
           }
         >;
       },
-      'search-result-list-item',
-      undefined,
-      undefined
+      {
+        kind: 'search-result-list-item';
+        namespace: undefined;
+        name: undefined;
+      }
     >;
     'page:techdocs/reader': ExtensionDefinition<
       {
@@ -115,9 +121,11 @@ const _default: BackstagePlugin<
           }
         >,
       {},
-      'page',
-      undefined,
-      'reader'
+      {
+        kind: 'page';
+        namespace: undefined;
+        name: 'reader';
+      }
     >;
     'entity-content:techdocs': ExtensionDefinition<
       {
@@ -159,9 +167,11 @@ const _default: BackstagePlugin<
           }
         >,
       {},
-      'entity-content',
-      undefined,
-      undefined
+      {
+        kind: 'entity-content';
+        namespace: undefined;
+        name: undefined;
+      }
     >;
   }
 >;
@@ -202,9 +212,11 @@ export const techDocsSearchResultListItemExtension: ExtensionDefinition<
       }
     >;
   },
-  'search-result-list-item',
-  undefined,
-  undefined
+  {
+    kind: 'search-result-list-item';
+    namespace: undefined;
+    name: undefined;
+  }
 >;
 
 // (No @packageDocumentation comment for this package)

--- a/plugins/user-settings/api-report-alpha.md
+++ b/plugins/user-settings/api-report-alpha.md
@@ -33,9 +33,11 @@ const _default: BackstagePlugin<
         {}
       >,
       {},
-      'nav-item',
-      undefined,
-      undefined
+      {
+        kind: 'nav-item';
+        namespace: undefined;
+        name: undefined;
+      }
     >;
     'page:user-settings': ExtensionDefinition<
       {
@@ -74,9 +76,11 @@ const _default: BackstagePlugin<
           }
         >;
       },
-      'page',
-      undefined,
-      undefined
+      {
+        kind: 'page';
+        namespace: undefined;
+        name: undefined;
+      }
     >;
   }
 >;
@@ -96,9 +100,11 @@ export const settingsNavItem: ExtensionDefinition<
     {}
   >,
   {},
-  'nav-item',
-  undefined,
-  undefined
+  {
+    kind: 'nav-item';
+    namespace: undefined;
+    name: undefined;
+  }
 >;
 
 // @alpha (undocumented)


### PR DESCRIPTION
This consolidates the separate kind/namespace/name type parameters into a single parameter for both extension definitions and extension blueprints. The primary purpose of this change is no make the API report and API reference more readable.

Skipping changesets as these are all in-flight changes anyway and doesn't change the API.