### PR TITLE
Fix: UI Issue with Sidebar Submenu Overlapping When Sidebar is Pinned

### DIFF
--- a/.changeset/honest-impalas-rescue.md
+++ b/.changeset/honest-impalas-rescue.md
@@ -2,4 +2,4 @@
 '@backstage/core-components': patch
 ---
 
-Fixed a bug in the SidebarSubmenu core component that caused the submenu to overlap with the sidebar when the user hovers over the pinned sidebar.
+Fixed a bug in the `SidebarSubmenu` core component that caused the nested menu to overlap with the sidebar when the user hovers over the pinned sidebar.

--- a/.changeset/honest-impalas-rescue.md
+++ b/.changeset/honest-impalas-rescue.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Fixed a bug in the SidebarSubmenu core component that caused the submenu to overlap with the sidebar when the user hovers over the pinned sidebar.

--- a/packages/core-components/src/layout/Sidebar/SidebarSubmenu.tsx
+++ b/packages/core-components/src/layout/Sidebar/SidebarSubmenu.tsx
@@ -43,11 +43,12 @@ const useStyles = makeStyles<
       flexFlow: 'column nowrap',
       alignItems: 'flex-start',
       position: 'fixed',
+      opacity: 0,
       [theme.breakpoints.up('sm')]: {
         marginLeft: props.left,
-        transition: theme.transitions.create('margin-left', {
+        transition: theme.transitions.create(['margin-left', 'opacity'], {
           easing: theme.transitions.easing.sharp,
-          duration: theme.transitions.duration.shortest,
+          duration: props.submenuConfig.defaultOpenDelayMs,
         }),
       },
       top: 0,
@@ -68,6 +69,8 @@ const useStyles = makeStyles<
       },
     }),
     drawerOpen: props => ({
+      marginLeft: props.left,
+      opacity: 1,
       width: props.submenuConfig.drawerWidthOpen,
       [theme.breakpoints.down('xs')]: {
         width: '100%',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Fixed a bug where the submenu in the sidebar would overlap with the pinned sidebar when hovering over the any grouped tab from sidebar.

Along with that added fade-in animation to the submenu which looks smooth.

closes: #25888

## Screenshots

## Before

https://github.com/user-attachments/assets/7700d7e4-df99-438e-b4be-2871e260cda7

## After

https://github.com/user-attachments/assets/90a56100-c575-4679-97e8-7f1b380ddeac

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
