### PR TITLE
declare data refs in the blueprints instead of extension creators

### DIFF
--- a/packages/frontend-plugin-api/api-report.md
+++ b/packages/frontend-plugin-api/api-report.md
@@ -488,9 +488,9 @@ export function createApiExtension<
   }
 >;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export namespace createApiExtension {
-  const // (undocumented)
+  const // @deprecated (undocumented)
     factoryDataRef: ConfigurableExtensionDataRef<
       AnyApiFactory,
       'core.api.factory',
@@ -546,9 +546,9 @@ export function createAppRootWrapperExtension<
   >;
 }): ExtensionDefinition<TConfig>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export namespace createAppRootWrapperExtension {
-  const // (undocumented)
+  const // @deprecated (undocumented)
     componentDataRef: ConfigurableExtensionDataRef<
       React_2.ComponentType<{
         children?: React_2.ReactNode;
@@ -949,9 +949,9 @@ export function createNavItemExtension(options: {
   }
 >;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export namespace createNavItemExtension {
-  const // (undocumented)
+  const // @deprecated (undocumented)
     targetDataRef: ConfigurableExtensionDataRef<
       {
         title: string;
@@ -981,9 +981,9 @@ export function createNavLogoExtension(options: {
   }
 >;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export namespace createNavLogoExtension {
-  const // (undocumented)
+  const // @deprecated (undocumented)
     logoElementsDataRef: ConfigurableExtensionDataRef<
       {
         logoIcon?: JSX.Element | undefined;
@@ -1070,9 +1070,9 @@ export function createRouterExtension<
   >;
 }): ExtensionDefinition<TConfig>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export namespace createRouterExtension {
-  const // (undocumented)
+  const // @deprecated (undocumented)
     componentDataRef: ConfigurableExtensionDataRef<
       React_2.ComponentType<{
         children?: React_2.ReactNode;
@@ -1107,9 +1107,9 @@ export function createSignInPageExtension<
   }) => Promise<ComponentType<SignInPageProps>>;
 }): ExtensionDefinition<TConfig>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export namespace createSignInPageExtension {
-  const // (undocumented)
+  const // @deprecated (undocumented)
     componentDataRef: ConfigurableExtensionDataRef<
       React_2.ComponentType<SignInPageProps>,
       'core.sign-in-page.component',

--- a/packages/frontend-plugin-api/src/blueprints/ApiBlueprint.test.ts
+++ b/packages/frontend-plugin-api/src/blueprints/ApiBlueprint.test.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { createExtensionInput } from '../wiring';
 import { ApiBlueprint } from './ApiBlueprint';
 import { createApiFactory, createApiRef } from '@backstage/core-plugin-api';

--- a/packages/frontend-plugin-api/src/blueprints/ApiBlueprint.ts
+++ b/packages/frontend-plugin-api/src/blueprints/ApiBlueprint.ts
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
-import { createExtensionBlueprint } from '../wiring';
-import { createApiExtension } from '../extensions/createApiExtension';
+import { createExtensionBlueprint, createExtensionDataRef } from '../wiring';
 import { AnyApiFactory } from '@backstage/core-plugin-api';
+
+const factoryDataRef = createExtensionDataRef<AnyApiFactory>().with({
+  id: 'core.api.factory',
+});
 
 /**
  * Creates utility API extensions.
@@ -26,11 +29,11 @@ import { AnyApiFactory } from '@backstage/core-plugin-api';
 export const ApiBlueprint = createExtensionBlueprint({
   kind: 'api',
   attachTo: { id: 'app', input: 'apis' },
-  output: [createApiExtension.factoryDataRef],
+  output: [factoryDataRef],
   dataRefs: {
-    factory: createApiExtension.factoryDataRef,
+    factory: factoryDataRef,
   },
   *factory(params: { factory: AnyApiFactory }) {
-    yield createApiExtension.factoryDataRef(params.factory);
+    yield factoryDataRef(params.factory);
   },
 });

--- a/packages/frontend-plugin-api/src/blueprints/AppRootElementBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/AppRootElementBlueprint.test.tsx
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { AppRootElementBlueprint } from './AppRootElementBlueprint';
 

--- a/packages/frontend-plugin-api/src/blueprints/AppRootElementBlueprint.ts
+++ b/packages/frontend-plugin-api/src/blueprints/AppRootElementBlueprint.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { coreExtensionData, createExtensionBlueprint } from '../wiring';
 
 /**

--- a/packages/frontend-plugin-api/src/blueprints/AppRootWrapperBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/AppRootWrapperBlueprint.test.tsx
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { AppRootWrapperBlueprint } from './AppRootWrapperBlueprint';
 import { createExtensionTester } from '@backstage/frontend-test-utils';

--- a/packages/frontend-plugin-api/src/blueprints/AppRootWrapperBlueprint.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/AppRootWrapperBlueprint.tsx
@@ -16,8 +16,11 @@
 
 import React from 'react';
 import { ComponentType, PropsWithChildren } from 'react';
-import { createExtensionBlueprint } from '../wiring';
-import { createAppRootWrapperExtension } from '../extensions/createAppRootWrapperExtension';
+import { createExtensionBlueprint, createExtensionDataRef } from '../wiring';
+
+const componentDataRef = createExtensionDataRef<
+  ComponentType<PropsWithChildren<{}>>
+>().with({ id: 'app.root.wrapper' });
 
 /**
  * Creates a extensions that render a React wrapper at the app root, enclosing
@@ -29,9 +32,9 @@ import { createAppRootWrapperExtension } from '../extensions/createAppRootWrappe
 export const AppRootWrapperBlueprint = createExtensionBlueprint({
   kind: 'app-root-wrapper',
   attachTo: { id: 'app/root', input: 'wrappers' },
-  output: [createAppRootWrapperExtension.componentDataRef],
+  output: [componentDataRef],
   dataRefs: {
-    component: createAppRootWrapperExtension.componentDataRef,
+    component: componentDataRef,
   },
   *factory(params: { Component: ComponentType<PropsWithChildren<{}>> }) {
     // todo(blam): not sure that this wrapping is even necessary anymore.
@@ -39,6 +42,6 @@ export const AppRootWrapperBlueprint = createExtensionBlueprint({
       return <params.Component>{props.children}</params.Component>;
     };
 
-    yield createAppRootWrapperExtension.componentDataRef(Component);
+    yield componentDataRef(Component);
   },
 });

--- a/packages/frontend-plugin-api/src/blueprints/IconBundleBlueprint.ts
+++ b/packages/frontend-plugin-api/src/blueprints/IconBundleBlueprint.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { IconComponent } from '../icons';
 import { createExtensionBlueprint, createExtensionDataRef } from '../wiring';
 

--- a/packages/frontend-plugin-api/src/blueprints/NavItemBlueprint.ts
+++ b/packages/frontend-plugin-api/src/blueprints/NavItemBlueprint.ts
@@ -16,8 +16,14 @@
 
 import { IconComponent } from '@backstage/core-plugin-api';
 import { RouteRef } from '../routing';
-import { createExtensionBlueprint } from '../wiring';
-import { createNavItemExtension } from '../extensions/createNavItemExtension';
+import { createExtensionBlueprint, createExtensionDataRef } from '../wiring';
+
+// TODO(Rugvip): Should this be broken apart into separate refs? title/icon/routeRef
+const targetDataRef = createExtensionDataRef<{
+  title: string;
+  icon: IconComponent;
+  routeRef: RouteRef<undefined>;
+}>().with({ id: 'core.nav-item.target' });
 
 /**
  * Creates extensions that make up the items of the nav bar.
@@ -27,9 +33,9 @@ import { createNavItemExtension } from '../extensions/createNavItemExtension';
 export const NavItemBlueprint = createExtensionBlueprint({
   kind: 'nav-item',
   attachTo: { id: 'app/nav', input: 'items' },
-  output: [createNavItemExtension.targetDataRef],
+  output: [targetDataRef],
   dataRefs: {
-    target: createNavItemExtension.targetDataRef,
+    target: targetDataRef,
   },
   factory: (
     {
@@ -43,7 +49,7 @@ export const NavItemBlueprint = createExtensionBlueprint({
     },
     { config },
   ) => [
-    createNavItemExtension.targetDataRef({
+    targetDataRef({
       title: config.title ?? title,
       icon,
       routeRef,

--- a/packages/frontend-plugin-api/src/blueprints/NavLogoBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/NavLogoBlueprint.test.tsx
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { NavLogoBlueprint } from './NavLogoBlueprint';
 import { createExtensionTester } from '@backstage/frontend-test-utils';

--- a/packages/frontend-plugin-api/src/blueprints/NavLogoBlueprint.ts
+++ b/packages/frontend-plugin-api/src/blueprints/NavLogoBlueprint.ts
@@ -14,8 +14,12 @@
  * limitations under the License.
  */
 
-import { createExtensionBlueprint } from '../wiring';
-import { createNavLogoExtension } from '../extensions/createNavLogoExtension';
+import { createExtensionBlueprint, createExtensionDataRef } from '../wiring';
+
+const logoElementsDataRef = createExtensionDataRef<{
+  logoIcon?: JSX.Element;
+  logoFull?: JSX.Element;
+}>().with({ id: 'core.nav-logo.logo-elements' });
 
 /**
  * Creates an extension that replaces the logo in the nav bar with your own.
@@ -25,9 +29,9 @@ import { createNavLogoExtension } from '../extensions/createNavLogoExtension';
 export const NavLogoBlueprint = createExtensionBlueprint({
   kind: 'nav-logo',
   attachTo: { id: 'app/nav', input: 'logos' },
-  output: [createNavLogoExtension.logoElementsDataRef],
+  output: [logoElementsDataRef],
   dataRefs: {
-    logoElements: createNavLogoExtension.logoElementsDataRef,
+    logoElements: logoElementsDataRef,
   },
   *factory({
     logoIcon,
@@ -36,7 +40,7 @@ export const NavLogoBlueprint = createExtensionBlueprint({
     logoIcon: JSX.Element;
     logoFull: JSX.Element;
   }) {
-    yield createNavLogoExtension.logoElementsDataRef({
+    yield logoElementsDataRef({
       logoIcon,
       logoFull,
     });

--- a/packages/frontend-plugin-api/src/blueprints/RouterBlueprint.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/RouterBlueprint.tsx
@@ -13,19 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { ComponentType, PropsWithChildren } from 'react';
-import { createExtensionBlueprint } from '../wiring';
-import { createRouterExtension } from '../extensions/createRouterExtension';
+import { createExtensionBlueprint, createExtensionDataRef } from '../wiring';
+
+const componentDataRef = createExtensionDataRef<
+  ComponentType<PropsWithChildren<{}>>
+>().with({ id: 'app.router.wrapper' });
 
 /** @public */
 export const RouterBlueprint = createExtensionBlueprint({
   kind: 'app-router-component',
   attachTo: { id: 'app/root', input: 'router' },
-  output: [createRouterExtension.componentDataRef],
+  output: [componentDataRef],
   dataRefs: {
-    component: createRouterExtension.componentDataRef,
+    component: componentDataRef,
   },
   *factory({ Component }: { Component: ComponentType<PropsWithChildren<{}>> }) {
-    yield createRouterExtension.componentDataRef(Component);
+    yield componentDataRef(Component);
   },
 });

--- a/packages/frontend-plugin-api/src/blueprints/SignInPageBlueprint.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/SignInPageBlueprint.tsx
@@ -13,11 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React, { ComponentType, lazy } from 'react';
-import { createExtensionBlueprint } from '../wiring';
-import { createSignInPageExtension } from '../extensions/createSignInPageExtension';
+import { createExtensionBlueprint, createExtensionDataRef } from '../wiring';
 import { SignInPageProps } from '@backstage/core-plugin-api';
 import { ExtensionBoundary } from '../components';
+
+const componentDataRef = createExtensionDataRef<
+  ComponentType<SignInPageProps>
+>().with({ id: 'core.sign-in-page.component' });
 
 /**
  * Creates an extension that replaces the sign in page.
@@ -27,9 +31,9 @@ import { ExtensionBoundary } from '../components';
 export const SignInPageBlueprint = createExtensionBlueprint({
   kind: 'sign-in-page',
   attachTo: { id: 'app/root', input: 'signInPage' },
-  output: [createSignInPageExtension.componentDataRef],
+  output: [componentDataRef],
   dataRefs: {
-    component: createSignInPageExtension.componentDataRef,
+    component: componentDataRef,
   },
   *factory(
     {
@@ -43,7 +47,7 @@ export const SignInPageBlueprint = createExtensionBlueprint({
       loader().then(component => ({ default: component })),
     );
 
-    yield createSignInPageExtension.componentDataRef(props => (
+    yield componentDataRef(props => (
       <ExtensionBoundary node={node} routable>
         <ExtensionComponent {...props} />
       </ExtensionBoundary>

--- a/packages/frontend-plugin-api/src/blueprints/ThemeBlueprint.ts
+++ b/packages/frontend-plugin-api/src/blueprints/ThemeBlueprint.ts
@@ -15,8 +15,11 @@
  */
 
 import { AppTheme } from '@backstage/core-plugin-api';
-import { createExtensionBlueprint } from '../wiring';
-import { createThemeExtension } from '../extensions/createThemeExtension';
+import { createExtensionBlueprint, createExtensionDataRef } from '../wiring';
+
+const themeDataRef = createExtensionDataRef<AppTheme>().with({
+  id: 'core.theme.theme',
+});
 
 /**
  * Creates an extension that adds/replaces an app theme.
@@ -27,11 +30,9 @@ export const ThemeBlueprint = createExtensionBlueprint({
   kind: 'theme',
   namespace: 'app',
   attachTo: { id: 'app', input: 'themes' },
-  output: [createThemeExtension.themeDataRef],
+  output: [themeDataRef],
   dataRefs: {
-    theme: createThemeExtension.themeDataRef,
+    theme: themeDataRef,
   },
-  factory: ({ theme }: { theme: AppTheme }) => [
-    createThemeExtension.themeDataRef(theme),
-  ],
+  factory: ({ theme }: { theme: AppTheme }) => [themeDataRef(theme)],
 });

--- a/packages/frontend-plugin-api/src/blueprints/TranslationBlueprint.ts
+++ b/packages/frontend-plugin-api/src/blueprints/TranslationBlueprint.ts
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
-import { createExtensionBlueprint } from '../wiring';
-import { createTranslationExtension } from '../extensions/createTranslationExtension';
+import { createExtensionBlueprint, createExtensionDataRef } from '../wiring';
 import { TranslationMessages, TranslationResource } from '../translation';
+
+const translationDataRef = createExtensionDataRef<
+  TranslationResource | TranslationMessages
+>().with({ id: 'core.translation.translation' });
 
 /**
  * Creates an extension that adds translations to your app.
@@ -26,13 +29,13 @@ import { TranslationMessages, TranslationResource } from '../translation';
 export const TranslationBlueprint = createExtensionBlueprint({
   kind: 'translation',
   attachTo: { id: 'app', input: 'translations' },
-  output: [createTranslationExtension.translationDataRef],
+  output: [translationDataRef],
   dataRefs: {
-    translation: createTranslationExtension.translationDataRef,
+    translation: translationDataRef,
   },
   factory: ({
     resource,
   }: {
     resource: TranslationResource | TranslationMessages;
-  }) => [createTranslationExtension.translationDataRef(resource)],
+  }) => [translationDataRef(resource)],
 });

--- a/packages/frontend-plugin-api/src/extensions/createApiExtension.ts
+++ b/packages/frontend-plugin-api/src/extensions/createApiExtension.ts
@@ -16,13 +16,10 @@
 
 import { AnyApiFactory, AnyApiRef } from '@backstage/core-plugin-api';
 import { PortableSchema } from '../schema';
-import {
-  ResolvedExtensionInputs,
-  createExtension,
-  createExtensionDataRef,
-} from '../wiring';
+import { ResolvedExtensionInputs, createExtension } from '../wiring';
 import { AnyExtensionInputMap } from '../wiring/createExtension';
 import { Expand } from '../types';
+import { ApiBlueprint } from '../blueprints/ApiBlueprint';
 
 /**
  * @public
@@ -62,7 +59,7 @@ export function createApiExtension<
     inputs: extensionInputs,
     configSchema,
     output: {
-      api: createApiExtension.factoryDataRef,
+      api: ApiBlueprint.dataRefs.factory,
     },
     factory({ config, inputs }) {
       if (typeof factory === 'function') {
@@ -73,9 +70,13 @@ export function createApiExtension<
   });
 }
 
-/** @public */
+/**
+ * @public
+ * @deprecated Use {@link ApiBlueprint} instead.
+ */
 export namespace createApiExtension {
-  export const factoryDataRef = createExtensionDataRef<AnyApiFactory>().with({
-    id: 'core.api.factory',
-  });
+  /**
+   * @deprecated Use {@link ApiBlueprint} instead.
+   */
+  export const factoryDataRef = ApiBlueprint.dataRefs.factory;
 }

--- a/packages/frontend-plugin-api/src/extensions/createAppRootWrapperExtension.tsx
+++ b/packages/frontend-plugin-api/src/extensions/createAppRootWrapperExtension.tsx
@@ -22,8 +22,8 @@ import {
   ResolvedExtensionInputs,
   createExtension,
 } from '../wiring/createExtension';
-import { createExtensionDataRef } from '../wiring/createExtensionDataRef';
 import { Expand } from '../types';
+import { AppRootWrapperBlueprint } from '../blueprints/AppRootWrapperBlueprint';
 
 /**
  * Creates an extension that renders a React wrapper at the app root, enclosing
@@ -59,7 +59,7 @@ export function createAppRootWrapperExtension<
     disabled: options.disabled,
     inputs: options.inputs,
     output: {
-      component: createAppRootWrapperExtension.componentDataRef,
+      component: AppRootWrapperBlueprint.dataRefs.component,
     },
     factory({ inputs, config }) {
       const Component = (props: PropsWithChildren<{}>) => {
@@ -76,9 +76,13 @@ export function createAppRootWrapperExtension<
   });
 }
 
-/** @public */
+/**
+ * @public
+ * @deprecated Use {@link AppRootWrapperBlueprint} instead.
+ */
 export namespace createAppRootWrapperExtension {
-  export const componentDataRef = createExtensionDataRef<
-    ComponentType<PropsWithChildren<{}>>
-  >().with({ id: 'app.root.wrapper' });
+  /**
+   * @deprecated Use {@link AppRootWrapperBlueprint} instead.
+   */
+  export const componentDataRef = AppRootWrapperBlueprint.dataRefs.component;
 }

--- a/packages/frontend-plugin-api/src/extensions/createNavItemExtension.tsx
+++ b/packages/frontend-plugin-api/src/extensions/createNavItemExtension.tsx
@@ -16,8 +16,9 @@
 
 import { IconComponent } from '@backstage/core-plugin-api';
 import { createSchemaFromZod } from '../schema/createSchemaFromZod';
-import { createExtension, createExtensionDataRef } from '../wiring';
+import { createExtension } from '../wiring';
 import { RouteRef } from '../routing';
+import { NavItemBlueprint } from '../blueprints/NavItemBlueprint';
 
 /**
  * Helper for creating extensions for a nav item.
@@ -44,7 +45,7 @@ export function createNavItemExtension(options: {
       }),
     ),
     output: {
-      navTarget: createNavItemExtension.targetDataRef,
+      navTarget: NavItemBlueprint.dataRefs.target,
     },
     factory: ({ config }) => ({
       navTarget: {
@@ -56,12 +57,13 @@ export function createNavItemExtension(options: {
   });
 }
 
-/** @public */
+/**
+ * @public
+ * @deprecated Use {@link NavItemBlueprint} instead.
+ */
 export namespace createNavItemExtension {
-  // TODO(Rugvip): Should this be broken apart into separate refs? title/icon/routeRef
-  export const targetDataRef = createExtensionDataRef<{
-    title: string;
-    icon: IconComponent;
-    routeRef: RouteRef<undefined>;
-  }>().with({ id: 'core.nav-item.target' });
+  /**
+   * @deprecated Use {@link NavItemBlueprint} instead.
+   */
+  export const targetDataRef = NavItemBlueprint.dataRefs.target;
 }

--- a/packages/frontend-plugin-api/src/extensions/createNavLogoExtension.tsx
+++ b/packages/frontend-plugin-api/src/extensions/createNavLogoExtension.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { createExtension, createExtensionDataRef } from '../wiring';
+import { createExtension } from '../wiring';
+import { NavLogoBlueprint } from '../blueprints/NavLogoBlueprint';
 
 /**
  * Helper for creating extensions for a nav logos.
@@ -35,7 +36,7 @@ export function createNavLogoExtension(options: {
     namespace: options?.namespace,
     attachTo: { id: 'app/nav', input: 'logos' },
     output: {
-      logos: createNavLogoExtension.logoElementsDataRef,
+      logos: NavLogoBlueprint.dataRefs.logoElements,
     },
     factory: () => {
       return {
@@ -48,10 +49,13 @@ export function createNavLogoExtension(options: {
   });
 }
 
-/** @public */
+/**
+ * @public
+ * @deprecated Use {@link NavLogoBlueprint} instead.
+ */
 export namespace createNavLogoExtension {
-  export const logoElementsDataRef = createExtensionDataRef<{
-    logoIcon?: JSX.Element;
-    logoFull?: JSX.Element;
-  }>().with({ id: 'core.nav-logo.logo-elements' });
+  /**
+   * @deprecated Use {@link NavLogoBlueprint} instead.
+   */
+  export const logoElementsDataRef = NavLogoBlueprint.dataRefs.logoElements;
 }

--- a/packages/frontend-plugin-api/src/extensions/createRouterExtension.tsx
+++ b/packages/frontend-plugin-api/src/extensions/createRouterExtension.tsx
@@ -22,8 +22,8 @@ import {
   ResolvedExtensionInputs,
   createExtension,
 } from '../wiring/createExtension';
-import { createExtensionDataRef } from '../wiring/createExtensionDataRef';
 import { Expand } from '../types';
+import { RouterBlueprint } from '../blueprints/RouterBlueprint';
 
 /**
  * Creates an extension that replaces the router implementation at the app root.
@@ -59,7 +59,7 @@ export function createRouterExtension<
     disabled: options.disabled,
     inputs: options.inputs,
     output: {
-      component: createRouterExtension.componentDataRef,
+      component: RouterBlueprint.dataRefs.component,
     },
     factory({ inputs, config }) {
       const Component = (props: PropsWithChildren<{}>) => {
@@ -76,9 +76,13 @@ export function createRouterExtension<
   });
 }
 
-/** @public */
+/**
+ * @public
+ * @deprecated Use {@link RouterBlueprint} instead.
+ */
 export namespace createRouterExtension {
-  export const componentDataRef = createExtensionDataRef<
-    ComponentType<PropsWithChildren<{}>>
-  >().with({ id: 'app.router.wrapper' });
+  /**
+   * @deprecated Use {@link RouterBlueprint} instead.
+   */
+  export const componentDataRef = RouterBlueprint.dataRefs.component;
 }

--- a/packages/frontend-plugin-api/src/extensions/createSignInPageExtension.tsx
+++ b/packages/frontend-plugin-api/src/extensions/createSignInPageExtension.tsx
@@ -21,11 +21,11 @@ import {
   createExtension,
   ResolvedExtensionInputs,
   AnyExtensionInputMap,
-  createExtensionDataRef,
   ExtensionDefinition,
 } from '../wiring';
 import { Expand } from '../types';
 import { SignInPageProps } from '@backstage/core-plugin-api';
+import { SignInPageBlueprint } from '../blueprints';
 
 /**
  *
@@ -76,9 +76,13 @@ export function createSignInPageExtension<
   });
 }
 
-/** @public */
+/**
+ * @public
+ * @deprecated Use {@link SignInPageBlueprint} instead.
+ */
 export namespace createSignInPageExtension {
-  export const componentDataRef = createExtensionDataRef<
-    ComponentType<SignInPageProps>
-  >().with({ id: 'core.sign-in-page.component' });
+  /**
+   * @deprecated Use {@link SignInPageBlueprint} instead.
+   */
+  export const componentDataRef = SignInPageBlueprint.dataRefs.component;
 }

--- a/packages/frontend-plugin-api/src/extensions/createThemeExtension.ts
+++ b/packages/frontend-plugin-api/src/extensions/createThemeExtension.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { createExtension, createExtensionDataRef } from '../wiring';
+import { ThemeBlueprint } from '../blueprints/ThemeBlueprint';
+import { createExtension } from '../wiring';
 import { AppTheme } from '@backstage/core-plugin-api';
 
 /**
@@ -28,7 +29,7 @@ export function createThemeExtension(theme: AppTheme) {
     name: theme.id,
     attachTo: { id: 'app', input: 'themes' },
     output: {
-      theme: createThemeExtension.themeDataRef,
+      theme: ThemeBlueprint.dataRefs.theme,
     },
     factory: () => ({ theme }),
   });
@@ -39,7 +40,5 @@ export function createThemeExtension(theme: AppTheme) {
  * @deprecated Use {@link ThemeBlueprint} instead.
  */
 export namespace createThemeExtension {
-  export const themeDataRef = createExtensionDataRef<AppTheme>().with({
-    id: 'core.theme.theme',
-  });
+  export const themeDataRef = ThemeBlueprint.dataRefs.theme;
 }

--- a/packages/frontend-plugin-api/src/extensions/createTranslationExtension.ts
+++ b/packages/frontend-plugin-api/src/extensions/createTranslationExtension.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
+import { TranslationBlueprint } from '../blueprints/TranslationBlueprint';
 import { TranslationMessages, TranslationResource } from '../translation';
-import { createExtension, createExtensionDataRef } from '../wiring';
+import { createExtension } from '../wiring';
 
 /**
  * @public
@@ -31,7 +32,7 @@ export function createTranslationExtension(options: {
     name: options.name,
     attachTo: { id: 'app', input: 'translations' },
     output: {
-      resource: createTranslationExtension.translationDataRef,
+      resource: TranslationBlueprint.dataRefs.translation,
     },
     factory: () => ({ resource: options.resource }),
   });
@@ -42,7 +43,5 @@ export function createTranslationExtension(options: {
  * @deprecated Use {@link TranslationBlueprint} instead.
  */
 export namespace createTranslationExtension {
-  export const translationDataRef = createExtensionDataRef<
-    TranslationResource | TranslationMessages
-  >().with({ id: 'core.translation.translation' });
+  export const translationDataRef = TranslationBlueprint.dataRefs.translation;
 }


### PR DESCRIPTION
Fixes #26055

This basically just moves the declarations of these refs closer to the blueprints themselves, making it easier to just remove the deprecated extension creators in a later release. Functionally no changes. Skipping changesets since this is already well covered by the creation of the blueprints, and just an internal move