### PR TITLE
app-backend: Deprecate createRouter

### DIFF
--- a/.changeset/spicy-jars-hear.md
+++ b/.changeset/spicy-jars-hear.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-app-backend': patch
+---
+
+Deprecate `createRouter` and its options in favour of the new backend system.

--- a/plugins/app-backend/api-report.md
+++ b/plugins/app-backend/api-report.md
@@ -6,22 +6,22 @@
 import { AuthService } from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
 import { ConfigSchema } from '@backstage/config-loader';
+import { DatabaseService } from '@backstage/backend-plugin-api';
 import express from 'express';
 import { HttpAuthService } from '@backstage/backend-plugin-api';
 import { LoggerService } from '@backstage/backend-plugin-api';
-import { PluginDatabaseManager } from '@backstage/backend-common';
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export function createRouter(options: RouterOptions): Promise<express.Router>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export interface RouterOptions {
   appPackageName: string;
   // (undocumented)
   auth?: AuthService;
   // (undocumented)
   config: Config;
-  database?: PluginDatabaseManager;
+  database?: DatabaseService;
   disableConfigInjection?: boolean;
   // (undocumented)
   httpAuth?: HttpAuthService;

--- a/plugins/app-backend/api-report.md
+++ b/plugins/app-backend/api-report.md
@@ -4,12 +4,12 @@
 
 ```ts
 import { AuthService } from '@backstage/backend-plugin-api';
-import { Config } from '@backstage/config';
 import { ConfigSchema } from '@backstage/config-loader';
 import { DatabaseService } from '@backstage/backend-plugin-api';
 import express from 'express';
 import { HttpAuthService } from '@backstage/backend-plugin-api';
 import { LoggerService } from '@backstage/backend-plugin-api';
+import { RootConfigService } from '@backstage/backend-plugin-api';
 
 // @public @deprecated (undocumented)
 export function createRouter(options: RouterOptions): Promise<express.Router>;
@@ -20,7 +20,7 @@ export interface RouterOptions {
   // (undocumented)
   auth?: AuthService;
   // (undocumented)
-  config: Config;
+  config: RootConfigService;
   database?: DatabaseService;
   disableConfigInjection?: boolean;
   // (undocumented)

--- a/plugins/app-backend/src/service/router.ts
+++ b/plugins/app-backend/src/service/router.ts
@@ -18,8 +18,9 @@ import { notFoundHandler } from '@backstage/backend-common';
 import {
   DatabaseService,
   resolvePackagePath,
+  RootConfigService,
 } from '@backstage/backend-plugin-api';
-import { AppConfig, Config } from '@backstage/config';
+import { AppConfig } from '@backstage/config';
 import helmet from 'helmet';
 import express from 'express';
 import Router from 'express-promise-router';
@@ -52,7 +53,7 @@ type Mime = { lookup(arg0: string): string };
  * @deprecated Please migrate to the new backend system as this will be removed in the future.
  */
 export interface RouterOptions {
-  config: Config;
+  config: RootConfigService;
   logger: LoggerService;
   auth?: AuthService;
   httpAuth?: HttpAuthService;

--- a/plugins/app-backend/src/service/router.ts
+++ b/plugins/app-backend/src/service/router.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+import { notFoundHandler } from '@backstage/backend-common';
 import {
-  notFoundHandler,
-  PluginDatabaseManager,
-} from '@backstage/backend-common';
-import { resolvePackagePath } from '@backstage/backend-plugin-api';
+  DatabaseService,
+  resolvePackagePath,
+} from '@backstage/backend-plugin-api';
 import { AppConfig, Config } from '@backstage/config';
 import helmet from 'helmet';
 import express from 'express';
@@ -47,7 +47,10 @@ import { AuthenticationError } from '@backstage/errors';
 // express uses mime v1 while we only have types for mime v2
 type Mime = { lookup(arg0: string): string };
 
-/** @public */
+/**
+ * @public
+ * @deprecated Please migrate to the new backend system as this will be removed in the future.
+ */
 export interface RouterOptions {
   config: Config;
   logger: LoggerService;
@@ -59,7 +62,7 @@ export interface RouterOptions {
    *
    * This is a built-in alternative to using a `staticFallbackHandler`.
    */
-  database?: PluginDatabaseManager;
+  database?: DatabaseService;
 
   /**
    * The name of the app package that content should be served from. The same app package should be
@@ -102,7 +105,10 @@ export interface RouterOptions {
   schema?: ConfigSchema;
 }
 
-/** @public */
+/**
+ * @public
+ * @deprecated Please migrate to the new backend system as this will be removed in the future.
+ */
 export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {


### PR DESCRIPTION
Deprecate `createRouter` and its options in favour of the new backend system.
