### PR TITLE
Adding ability to throttle Gitlab discovery via sleepBetweenMs

### DIFF
--- a/.changeset/little-peas-lie.md
+++ b/.changeset/little-peas-lie.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-gitlab': patch
+---
+
+Adding ability to throttle the Gitlab Discovery network requests while searching for repositories to import into Backstage

--- a/docs/integrations/gitlab/discovery.md
+++ b/docs/integrations/gitlab/discovery.md
@@ -153,6 +153,7 @@ catalog:
         group: example-group # Optional. Group and subgroup (if needed) to look for repositories. If not present the whole instance will be scanned
         entityFilename: catalog-info.yaml # Optional. Defaults to `catalog-info.yaml`
         projectPattern: '[\s\S]*' # Optional. Filters found projects based on provided patter. Defaults to `[\s\S]*`, which means to not filter anything
+        sleepBetweenMs: 500 # Optional. Discovery will make a request to Gitlab for every repository. By providing this you can throttle how often those requests occur, in milliseconds.
         excludeRepos: [] # Optional. A list of project paths that should be excluded from discovery, e.g. group/subgroup/repo. Should not start or end with a slash.
         schedule: # Same options as in TaskScheduleDefinition. Optional for the Legacy Backend System
           # supports cron, ISO duration, "human duration" as used in code

--- a/plugins/catalog-backend-module-gitlab/config.d.ts
+++ b/plugins/catalog-backend-module-gitlab/config.d.ts
@@ -68,6 +68,11 @@ export interface Config {
            * Should be in the format group/subgroup/repo, with no leading or trailing slashes.
            */
           excludeRepos?: string[];
+
+          /**
+           * Sleep in milliseconds between each call to Gitlab to reduce load
+           */
+          sleepBetweenMs?: number;
         };
       };
     };

--- a/plugins/catalog-backend-module-gitlab/package.json
+++ b/plugins/catalog-backend-module-gitlab/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "@backstage/backend-common": "workspace:^",
+    "@backstage/backend-defaults": "workspace:^",
     "@backstage/backend-plugin-api": "workspace:^",
     "@backstage/backend-tasks": "workspace:^",
     "@backstage/catalog-model": "workspace:^",
@@ -61,6 +62,8 @@
     "@backstage/plugin-catalog-node": "workspace:^",
     "@backstage/plugin-events-node": "workspace:^",
     "@gitbeaker/rest": "^40.0.3",
+    "express": "^4.17.1",
+    "express-promise-router": "^4.1.1",
     "lodash": "^4.17.21",
     "node-fetch": "^2.7.0",
     "uuid": "^9.0.0"

--- a/plugins/catalog-backend-module-gitlab/src/lib/types.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/types.ts
@@ -206,6 +206,11 @@ export type GitlabProviderConfig = {
    * Paths should not start or end with a slash.
    */
   excludeRepos?: string[];
+
+  /**
+   * Sleep in milliseconds between each call to Gitlab to reduce load
+   */
+  sleepBetweenMs?: number;
 };
 
 /**

--- a/plugins/catalog-backend-module-gitlab/src/module/catalogModuleGitlabDiscoveryEntityProvider.ts
+++ b/plugins/catalog-backend-module-gitlab/src/module/catalogModuleGitlabDiscoveryEntityProvider.ts
@@ -21,6 +21,7 @@ import {
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
 import { eventsServiceRef } from '@backstage/plugin-events-node';
 import { GitlabDiscoveryEntityProvider } from '../providers';
+import { createRouter } from '../service/router';
 
 /**
  * Registers the GitlabDiscoveryEntityProvider with the catalog processing extension point.
@@ -39,15 +40,19 @@ export const catalogModuleGitlabDiscoveryEntityProvider = createBackendModule({
         logger: coreServices.logger,
         scheduler: coreServices.scheduler,
         events: eventsServiceRef,
+        httpRouter: coreServices.httpRouter,
       },
-      async init({ config, catalog, logger, scheduler, events }) {
-        const gitlabDiscoveryEntityProvider =
+      async init({ config, catalog, logger, scheduler, events, httpRouter }) {
+        const providers: GitlabDiscoveryEntityProvider[] =
           GitlabDiscoveryEntityProvider.fromConfig(config, {
             logger,
             events,
             scheduler,
           });
-        catalog.addEntityProvider(gitlabDiscoveryEntityProvider);
+
+        catalog.addEntityProvider(providers);
+
+        await createRouter({ httpRouter, logger, config, providers });
       },
     });
   },

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.ts
@@ -179,7 +179,7 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
 
           try {
             await this.refresh(logger);
-          } catch (error) {
+          } catch (error: any) {
             logger.error(
               `${this.getProviderName()} refresh failed, ${error}`,
               error,
@@ -221,6 +221,15 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
       if (await this.shouldProcessProject(project, this.gitLabClient)) {
         res.scanned++;
         res.matches.push(project);
+      }
+
+      if (
+        this.config.sleepBetweenMs !== undefined &&
+        this.config.sleepBetweenMs > 0
+      ) {
+        await new Promise(resolve =>
+          setTimeout(resolve, this.config.sleepBetweenMs),
+        );
       }
     }
 

--- a/plugins/catalog-backend-module-gitlab/src/providers/config.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/config.ts
@@ -31,6 +31,7 @@ function readGitlabConfig(id: string, config: Config): GitlabProviderConfig {
   const host = config.getString('host');
   const branch = config.getOptionalString('branch');
   const fallbackBranch = config.getOptionalString('fallbackBranch') ?? 'master';
+  const sleepBetweenMs = config.getOptionalNumber('sleepBetweenMs');
   const catalogFile =
     config.getOptionalString('entityFilename') ?? 'catalog-info.yaml';
   const projectPattern = new RegExp(
@@ -72,6 +73,7 @@ function readGitlabConfig(id: string, config: Config): GitlabProviderConfig {
     skipForkedRepos,
     excludeRepos,
     restrictUsersToGroup,
+    sleepBetweenMs,
   };
 }
 

--- a/plugins/catalog-backend-module-gitlab/src/service/router.ts
+++ b/plugins/catalog-backend-module-gitlab/src/service/router.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { MiddlewareFactory } from '@backstage/backend-defaults/rootHttpRouter';
+import {
+  HttpRouterService,
+  LoggerService,
+} from '@backstage/backend-plugin-api';
+import { Config } from '@backstage/config';
+import express, { Request, Response } from 'express';
+import Router from 'express-promise-router';
+import { GitlabDiscoveryEntityProvider } from '../providers';
+import * as uuid from 'uuid';
+
+export interface RouterOptions {
+  httpRouter: HttpRouterService;
+  logger: LoggerService;
+  config: Config;
+  providers: GitlabDiscoveryEntityProvider[];
+}
+
+export async function createRouter(
+  options: RouterOptions,
+): Promise<express.Router> {
+  const { logger, config } = options;
+
+  const router = Router();
+  router.use(express.json());
+
+  const middleware = MiddlewareFactory.create({ logger, config });
+
+  router.use(middleware.error());
+
+  /**
+   * This route provided primarily to enable testing of your Gitlab instance to manage load. If you are having issues
+   * with Gitlab going down, you may need to adjust the throttle of how often and how quickly you hit Gitlab and this
+   * can be used to manually trigger a discovery.
+   *
+   * You can run this by hitting /api/catalog/gitlab/discover and passing an Authorization header.
+   */
+  router.get(
+    '/gitlab/discover',
+    async function (_req: Request, res: Response): Promise<any> {
+      options.logger.info(
+        'START running manually triggered Gitlab catalog indexing',
+      );
+
+      const log = logger.child({
+        class: GitlabDiscoveryEntityProvider.prototype.constructor.name,
+        taskId: 'manual-trigger-gitlab-discover',
+        taskInstanceId: uuid.v4(),
+      });
+
+      options.providers[0].refresh(log).then(() => {
+        options.logger.info(
+          'FINISH running manually triggered Gitlab catalog indexing',
+        );
+      });
+
+      return res.json({ running: true });
+    },
+  );
+
+  options.httpRouter.use(router);
+
+  return router;
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

We had an issue where Gitlab Discovery was causing so many 404 requests in a short time period that it was spiking our Gitlab CPUs through the roof, and we were asked to somehow reduce this load. By adding a throttle property we were able to get this working.

This PR adds the new `sleepBetweenMs` Gitlab Discovery property which allows you to add a short sleep between each
request to Gitlab to reduce the overall load.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
