### PR TITLE
fix: change scaffolder widgets to use textfield

### DIFF
--- a/.changeset/clever-laws-raise.md
+++ b/.changeset/clever-laws-raise.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+Change scaffolder secret widget to use `TextField` component for more flexibility in theme overrides.

--- a/.changeset/clever-laws-raise.md
+++ b/.changeset/clever-laws-raise.md
@@ -1,5 +1,6 @@
 ---
+'@backstage/plugin-scaffolder': patch
 '@backstage/plugin-scaffolder-react': patch
 ---
 
-Change scaffolder secret widget to use `TextField` component for more flexibility in theme overrides.
+Change scaffolder widgets to use `TextField` component for more flexibility in theme overrides.

--- a/plugins/scaffolder-react/src/next/components/PasswordWidget/PasswordWidget.tsx
+++ b/plugins/scaffolder-react/src/next/components/PasswordWidget/PasswordWidget.tsx
@@ -15,8 +15,7 @@
  */
 
 import { WidgetProps } from '@rjsf/utils';
-import InputLabel from '@material-ui/core/InputLabel';
-import Input from '@material-ui/core/Input';
+import TextField from '@material-ui/core/TextField';
 import React from 'react';
 import FormHelperText from '@material-ui/core/FormHelperText';
 import { MarkdownContent } from '@backstage/core-components';
@@ -32,9 +31,9 @@ export const PasswordWidget = (
 
   return (
     <>
-      <InputLabel htmlFor={title}>{title}</InputLabel>
-      <Input
+      <TextField
         id={title}
+        label={title}
         aria-describedby={title}
         onChange={e => {
           onChange(e.target.value);

--- a/plugins/scaffolder-react/src/next/components/SecretWidget/SecretWidget.tsx
+++ b/plugins/scaffolder-react/src/next/components/SecretWidget/SecretWidget.tsx
@@ -16,8 +16,7 @@
 
 import { WidgetProps } from '@rjsf/utils';
 import { useTemplateSecrets } from '@backstage/plugin-scaffolder-react';
-import InputLabel from '@material-ui/core/InputLabel';
-import Input from '@material-ui/core/Input';
+import TextField from '@material-ui/core/TextField';
 import React from 'react';
 
 /**
@@ -35,19 +34,17 @@ export const SecretWidget = (
   } = props;
 
   return (
-    <>
-      <InputLabel htmlFor={title}>{title}</InputLabel>
-      <Input
-        id={title}
-        aria-describedby={title}
-        onChange={e => {
-          onChange(Array(e.target?.value.length).fill('*').join(''));
-          setSecrets({ [name]: e.target?.value });
-        }}
-        value={secrets[name] ?? ''}
-        type="password"
-        autoComplete="off"
-      />
-    </>
+    <TextField
+      id={title}
+      label={title}
+      aria-describedby={title}
+      onChange={e => {
+        onChange(Array(e.target.value.length).fill('*').join(''));
+        setSecrets({ [name]: e.target.value });
+      }}
+      value={secrets[name] ?? ''}
+      type="password"
+      autoComplete="off"
+    />
   );
 };

--- a/plugins/scaffolder/src/components/fields/RepoBranchPicker/DefaultRepoBranchPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoBranchPicker/DefaultRepoBranchPicker.tsx
@@ -17,8 +17,7 @@
 import FormControl from '@material-ui/core/FormControl';
 import React from 'react';
 import FormHelperText from '@material-ui/core/FormHelperText';
-import Input from '@material-ui/core/Input';
-import InputLabel from '@material-ui/core/InputLabel';
+import TextField from '@material-ui/core/TextField';
 
 import { BaseRepoBranchPickerProps } from './types';
 
@@ -43,9 +42,9 @@ export const DefaultRepoBranchPicker = ({
       required={required}
       error={rawErrors?.length > 0 && !branch}
     >
-      <InputLabel htmlFor="branchInput">Branch</InputLabel>
-      <Input
+      <TextField
         id="branchInput"
+        label="Branch"
         onChange={e => onChange({ branch: e.target.value })}
         value={branch}
       />

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/AzureRepoPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/AzureRepoPicker.tsx
@@ -17,8 +17,7 @@
 import React from 'react';
 import FormControl from '@material-ui/core/FormControl';
 import FormHelperText from '@material-ui/core/FormHelperText';
-import Input from '@material-ui/core/Input';
-import InputLabel from '@material-ui/core/InputLabel';
+import TextField from '@material-ui/core/TextField';
 import { BaseRepoUrlPickerProps } from './types';
 import { Select, SelectItem } from '@backstage/core-components';
 
@@ -65,14 +64,12 @@ export const AzureRepoPicker = (
             items={organizationItems}
           />
         ) : (
-          <>
-            <InputLabel htmlFor="orgInput">Organization</InputLabel>
-            <Input
-              id="orgInput"
-              onChange={e => onChange({ organization: e.target.value })}
-              value={organization}
-            />
-          </>
+          <TextField
+            id="orgInput"
+            label="Organization"
+            onChange={e => onChange({ organization: e.target.value })}
+            value={organization}
+          />
         )}
         <FormHelperText>
           The Organization that this repo will belong to
@@ -95,14 +92,12 @@ export const AzureRepoPicker = (
             items={projectItems}
           />
         ) : (
-          <>
-            <InputLabel htmlFor="projectInput">Project</InputLabel>
-            <Input
-              id="projectInput"
-              onChange={e => onChange({ project: e.target.value })}
-              value={project}
-            />
-          </>
+          <TextField
+            id="projectInput"
+            label="Project"
+            onChange={e => onChange({ project: e.target.value })}
+            value={project}
+          />
         )}
         <FormHelperText>
           The Project that this repo will belong to

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/GerritRepoPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/GerritRepoPicker.tsx
@@ -16,8 +16,7 @@
 import React from 'react';
 import FormControl from '@material-ui/core/FormControl';
 import FormHelperText from '@material-ui/core/FormHelperText';
-import Input from '@material-ui/core/Input';
-import InputLabel from '@material-ui/core/InputLabel';
+import TextField from '@material-ui/core/TextField';
 import { BaseRepoUrlPickerProps } from './types';
 
 export const GerritRepoPicker = (props: BaseRepoUrlPickerProps) => {
@@ -26,9 +25,9 @@ export const GerritRepoPicker = (props: BaseRepoUrlPickerProps) => {
   return (
     <>
       <FormControl margin="normal" error={rawErrors?.length > 0 && !workspace}>
-        <InputLabel htmlFor="ownerInput">Owner</InputLabel>
-        <Input
+        <TextField
           id="ownerInput"
+          label="Owner"
           onChange={e => onChange({ owner: e.target.value })}
           value={owner}
         />
@@ -39,9 +38,9 @@ export const GerritRepoPicker = (props: BaseRepoUrlPickerProps) => {
         required
         error={rawErrors?.length > 0 && !workspace}
       >
-        <InputLabel htmlFor="parentInput">Parent</InputLabel>
-        <Input
+        <TextField
           id="parentInput"
+          label="Parent"
           onChange={e => onChange({ workspace: e.target.value })}
           value={workspace}
         />

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/GiteaRepoPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/GiteaRepoPicker.tsx
@@ -16,8 +16,7 @@
 import React from 'react';
 import FormControl from '@material-ui/core/FormControl';
 import FormHelperText from '@material-ui/core/FormHelperText';
-import Input from '@material-ui/core/Input';
-import InputLabel from '@material-ui/core/InputLabel';
+import TextField from '@material-ui/core/TextField';
 import { Select, SelectItem } from '@backstage/core-components';
 import { BaseRepoUrlPickerProps } from './types';
 
@@ -56,9 +55,9 @@ export const GiteaRepoPicker = (
           />
         ) : (
           <>
-            <InputLabel htmlFor="ownerInput">Owner</InputLabel>
-            <Input
+            <TextField
               id="ownerInput"
+              label="Owner"
               onChange={e => onChange({ owner: e.target.value })}
               value={owner}
             />

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/GithubRepoPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/GithubRepoPicker.tsx
@@ -16,8 +16,7 @@
 import React from 'react';
 import FormControl from '@material-ui/core/FormControl';
 import FormHelperText from '@material-ui/core/FormHelperText';
-import Input from '@material-ui/core/Input';
-import InputLabel from '@material-ui/core/InputLabel';
+import TextField from '@material-ui/core/TextField';
 import { Select, SelectItem } from '@backstage/core-components';
 import { BaseRepoUrlPickerProps } from './types';
 
@@ -52,14 +51,12 @@ export const GithubRepoPicker = (
             items={ownerItems}
           />
         ) : (
-          <>
-            <InputLabel htmlFor="ownerInput">Owner</InputLabel>
-            <Input
-              id="ownerInput"
-              onChange={e => onChange({ owner: e.target.value })}
-              value={owner}
-            />
-          </>
+          <TextField
+            id="ownerInput"
+            label="Owner"
+            onChange={e => onChange({ owner: e.target.value })}
+            value={owner}
+          />
         )}
         <FormHelperText>
           The organization, user or project that this repo will belong to

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/GitlabRepoPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/GitlabRepoPicker.tsx
@@ -16,8 +16,7 @@
 import React from 'react';
 import FormControl from '@material-ui/core/FormControl';
 import FormHelperText from '@material-ui/core/FormHelperText';
-import Input from '@material-ui/core/Input';
-import InputLabel from '@material-ui/core/InputLabel';
+import TextField from '@material-ui/core/TextField';
 import { Select, SelectItem } from '@backstage/core-components';
 import { BaseRepoUrlPickerProps } from './types';
 
@@ -55,14 +54,12 @@ export const GitlabRepoPicker = (
             items={ownerItems}
           />
         ) : (
-          <>
-            <InputLabel htmlFor="ownerInput">Owner</InputLabel>
-            <Input
-              id="ownerInput"
-              onChange={e => onChange({ owner: e.target.value })}
-              value={owner}
-            />
-          </>
+          <TextField
+            id="ownerInput"
+            label="Owner"
+            onChange={e => onChange({ owner: e.target.value })}
+            value={owner}
+          />
         )}
         <FormHelperText>
           GitLab namespace where this repository will belong to. It can be the


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR changes the scaffolder secret widget to use `TextField` instead of `Input`. There is no visual or functional change but it does allow more flexibility to override using custom themes.

MUI documented way to create a password text field is to use the `TextField` component: See: https://v4.mui.com/components/text-fields/#form-props

Currently in our custom theme we set default variant for text fields to `outlined` to align with our style guidelines. However the scaffolder secret widget is not affected by this as it uses the `Input` component with seemingly no simple way to override for the same look.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
