### PR TITLE
feat(notifications): render description as Markdown

### DIFF
--- a/.changeset/moody-planets-know.md
+++ b/.changeset/moody-planets-know.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications': patch
+---
+
+Render notification's description as Markdown.

--- a/plugins/notifications/src/components/NotificationsTable/NotificationsTable.tsx
+++ b/plugins/notifications/src/components/NotificationsTable/NotificationsTable.tsx
@@ -27,6 +27,7 @@ import { useConfirm } from 'material-ui-confirm';
 import { alertApiRef, useApi } from '@backstage/core-plugin-api';
 import {
   Link,
+  MarkdownContent,
   Table,
   TableColumn,
   TableProps,
@@ -232,9 +233,10 @@ export const NotificationsTable = ({
                     )}
                   </Typography>
                   {notification.payload.description ? (
-                    <Typography variant="body2" className={classes.description}>
-                      {notification.payload.description}
-                    </Typography>
+                    <MarkdownContent
+                      className={classes.description}
+                      content={notification.payload.description}
+                    />
                   ) : null}
                   <Typography variant="caption">
                     {notification.origin && (


### PR DESCRIPTION
Add support for Markdown at notification's description field.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
