### PR TITLE
fix: verify target plugin as aud instead of source plugin

### DIFF
--- a/.changeset/flat-falcons-kneel.md
+++ b/.changeset/flat-falcons-kneel.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Fixed bug in verification of jwt aud where source plugin audience was verified instead of target

--- a/packages/backend-defaults/src/entrypoints/auth/authServiceFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/authServiceFactory.ts
@@ -67,7 +67,6 @@ export const authServiceFactory = createServiceFactory({
     });
 
     const pluginTokens = PluginTokenHandler.create({
-      ownPluginId: plugin.getId(),
       logger,
       keySource,
       keyDuration,

--- a/packages/backend-defaults/src/entrypoints/auth/plugin/PluginTokenHandler.test.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/plugin/PluginTokenHandler.test.ts
@@ -46,7 +46,6 @@ describe('PluginTokenHandler', () => {
       discovery: mockServices.discovery(),
       keyDuration: { seconds: 10 },
       logger: mockServices.logger.mock(),
-      ownPluginId: 'test',
       keySource: {
         getPrivateSigningKey: getKeyMock,
         listKeys: jest.fn(),

--- a/packages/backend-defaults/src/entrypoints/auth/plugin/PluginTokenHandler.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/plugin/PluginTokenHandler.ts
@@ -84,6 +84,7 @@ export class PluginTokenHandler {
     }
 
     const pluginId = String(decodeJwt(token).sub);
+    const targetPluginId = String(decodeJwt(token).aud);
     if (!pluginId) {
       throw new AuthenticationError('Invalid plugin token: missing subject');
     }
@@ -101,7 +102,7 @@ export class PluginTokenHandler {
       jwksClient.getKey,
       {
         typ: tokenTypes.plugin.typParam,
-        audience: this.ownPluginId,
+        audience: targetPluginId,
         requiredClaims: ['iat', 'exp', 'sub', 'aud'],
       },
     ).catch(e => {

--- a/packages/backend-defaults/src/entrypoints/auth/plugin/PluginTokenHandler.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/plugin/PluginTokenHandler.ts
@@ -28,7 +28,6 @@ const SECONDS_IN_MS = 1000;
 const ALLOWED_PLUGIN_ID_PATTERN = /^[a-z0-9_-]+$/i;
 
 type Options = {
-  ownPluginId: string;
   keyDuration: HumanDuration;
   keySource: PluginKeySource;
   discovery: DiscoveryService;
@@ -54,7 +53,6 @@ export class PluginTokenHandler {
   static create(options: Options) {
     return new PluginTokenHandler(
       options.logger,
-      options.ownPluginId,
       options.keySource,
       options.algorithm ?? 'ES256',
       Math.round(durationToMilliseconds(options.keyDuration) / 1000),
@@ -64,7 +62,6 @@ export class PluginTokenHandler {
 
   private constructor(
     private readonly logger: LoggerService,
-    private readonly ownPluginId: string,
     private readonly keySource: PluginKeySource,
     private readonly algorithm: string,
     private readonly keyDurationSeconds: number,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

For verification JWT, verify that the audience matches the one of the target plugin id instead of the current plugin's id.
Solves https://github.com/backstage/backstage/issues/26037

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
