### PR TITLE
[NBS 1.0] Mark `backend-common` as deprecated

### DIFF
--- a/.changeset/famous-cougars-walk.md
+++ b/.changeset/famous-cougars-walk.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+This package is marked as `deprecated` and will be removed in a near future, please follow the deprecated instructions for the exports you still use.

--- a/packages/backend-common/README.md
+++ b/packages/backend-common/README.md
@@ -1,5 +1,8 @@
 # @backstage/backend-common
 
+> [!CAUTION]
+> This package is deprecated and will be removed in a near future, so please follow the deprecated instructions for the exports you still use.
+
 Common functionality library for Backstage backends, implementing logging,
 error handling and similar.
 

--- a/packages/backend-common/src/index.ts
+++ b/packages/backend-common/src/index.ts
@@ -17,6 +17,9 @@
 /**
  * Common functionality library for Backstage backends
  *
+ * @remarks
+ * This package is deprecated and will be removed in a near future, so please follow the deprecated instructions for the exports you still use.
+ *
  * @packageDocumentation
  */
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Mark `@backstage/backend-common` as deprecated.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
