### PR TITLE
catalog-backend: Deprecate createRouter and CatalogBuilder

### DIFF
--- a/.changeset/flat-bugs-drive.md
+++ b/.changeset/flat-bugs-drive.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend': minor
 ---
 
-Deprecated `createRouter`, `RouterOptions`, `CatalogBuilder` and `CatalogEnvironment`. Please make sure to upgrade to the new backend system.
+Deprecated `RouterOptions`, `CatalogBuilder`, and `CatalogEnvironment`. Please make sure to upgrade to the new backend system.

--- a/.changeset/flat-bugs-drive.md
+++ b/.changeset/flat-bugs-drive.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': minor
+---
+
+Deprecated `createRouter`, `RouterOptions`, `CatalogBuilder` and `CatalogEnvironment`. Please make sure to upgrade to the new backend system.

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -26,6 +26,7 @@ import { CatalogProcessorRefreshKeysResult as CatalogProcessorRefreshKeysResult_
 import { CatalogProcessorRelationResult as CatalogProcessorRelationResult_2 } from '@backstage/plugin-catalog-node';
 import { CatalogProcessorResult as CatalogProcessorResult_2 } from '@backstage/plugin-catalog-node';
 import { Config } from '@backstage/config';
+import { DatabaseService } from '@backstage/backend-plugin-api';
 import { DefaultCatalogCollatorFactory as DefaultCatalogCollatorFactory_2 } from '@backstage/plugin-search-backend-module-catalog';
 import { DefaultCatalogCollatorFactoryOptions as DefaultCatalogCollatorFactoryOptions_2 } from '@backstage/plugin-search-backend-module-catalog';
 import { DeferredEntity as DeferredEntity_2 } from '@backstage/plugin-catalog-node';
@@ -56,9 +57,9 @@ import { PlaceholderResolver as PlaceholderResolver_2 } from '@backstage/plugin-
 import { PlaceholderResolverParams as PlaceholderResolverParams_2 } from '@backstage/plugin-catalog-node';
 import { PlaceholderResolverRead as PlaceholderResolverRead_2 } from '@backstage/plugin-catalog-node';
 import { PlaceholderResolverResolveUrl as PlaceholderResolverResolveUrl_2 } from '@backstage/plugin-catalog-node';
-import { PluginDatabaseManager } from '@backstage/backend-common';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
 import { PluginTaskScheduler } from '@backstage/backend-tasks';
+import { RootConfigService } from '@backstage/backend-plugin-api';
 import { Router } from 'express';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import { ScmLocationAnalyzer as ScmLocationAnalyzer_2 } from '@backstage/plugin-catalog-node';
@@ -137,7 +138,7 @@ export const CATALOG_CONFLICTS_TOPIC = 'experimental.catalog.conflict';
 // @public (undocumented)
 export const CATALOG_ERRORS_TOPIC = 'experimental.catalog.errors';
 
-// @public
+// @public @deprecated
 export class CatalogBuilder {
   addEntityPolicy(
     ...policies: Array<EntityPolicy | Array<EntityPolicy>>
@@ -192,11 +193,11 @@ export class CatalogBuilder {
 export type CatalogCollatorEntityTransformer =
   CatalogCollatorEntityTransformer_2;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type CatalogEnvironment = {
   logger: LoggerService;
-  database: PluginDatabaseManager;
-  config: Config;
+  database: DatabaseService;
+  config: RootConfigService;
   reader: UrlReaderService;
   permissions: PermissionsService | PermissionAuthorizer;
   scheduler?: PluginTaskScheduler;

--- a/plugins/catalog-backend/src/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.ts
@@ -17,7 +17,6 @@
 import {
   createLegacyAuthAdapters,
   HostDiscovery,
-  PluginDatabaseManager,
 } from '@backstage/backend-common';
 import { PluginTaskScheduler } from '@backstage/backend-tasks';
 import {
@@ -107,10 +106,12 @@ import { EventBroker, EventsService } from '@backstage/plugin-events-node';
 import { durationToMilliseconds } from '@backstage/types';
 import {
   AuthService,
+  DatabaseService,
   DiscoveryService,
   HttpAuthService,
   LoggerService,
   PermissionsService,
+  RootConfigService,
   UrlReaderService,
 } from '@backstage/backend-plugin-api';
 
@@ -123,11 +124,13 @@ export type CatalogPermissionRuleInput<
   TParams extends PermissionRuleParams = PermissionRuleParams,
 > = PermissionRule<Entity, EntitiesSearchFilter, 'catalog-entity', TParams>;
 
-/** @public */
+/**
+ * @deprecated Please migrate to the new backend system as this will be removed in the future.
+ * @public */
 export type CatalogEnvironment = {
   logger: LoggerService;
-  database: PluginDatabaseManager;
-  config: Config;
+  database: DatabaseService;
+  config: RootConfigService;
   reader: UrlReaderService;
   permissions: PermissionsService | PermissionAuthorizer;
   scheduler?: PluginTaskScheduler;
@@ -160,6 +163,7 @@ export type CatalogEnvironment = {
  *   persisted in the catalog.
  *
  * @public
+ * @deprecated Please migrate to the new backend system as this will be removed in the future.
  */
 export class CatalogBuilder {
   private readonly env: CatalogEnvironment;

--- a/plugins/catalog-backend/src/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.ts
@@ -126,7 +126,8 @@ export type CatalogPermissionRuleInput<
 
 /**
  * @deprecated Please migrate to the new backend system as this will be removed in the future.
- * @public */
+ * @public
+ */
 export type CatalogEnvironment = {
   logger: LoggerService;
   database: DatabaseService;

--- a/plugins/catalog-backend/src/service/createRouter.ts
+++ b/plugins/catalog-backend/src/service/createRouter.ts
@@ -78,9 +78,6 @@ export interface RouterOptions {
 
 /**
  * Creates a catalog router.
- *
- * @public
- * @deprecated Please migrate to the new backend system as this will be removed in the future.
  */
 export async function createRouter(
   options: RouterOptions,

--- a/plugins/catalog-backend/src/service/createRouter.ts
+++ b/plugins/catalog-backend/src/service/createRouter.ts
@@ -60,6 +60,7 @@ import { LocationAnalyzer } from '@backstage/plugin-catalog-node';
  * Options used by {@link createRouter}.
  *
  * @public
+ * @deprecated Please migrate to the new backend system as this will be removed in the future.
  */
 export interface RouterOptions {
   entitiesCatalog?: EntitiesCatalog;
@@ -79,6 +80,7 @@ export interface RouterOptions {
  * Creates a catalog router.
  *
  * @public
+ * @deprecated Please migrate to the new backend system as this will be removed in the future.
  */
 export async function createRouter(
   options: RouterOptions,


### PR DESCRIPTION
Deprecated `createRouter`, `RouterOptions`, `CatalogBuilder` and `CatalogEnvironment`.