### PR TITLE
NFS: Small fixes

### DIFF
--- a/.changeset/eight-days-sin.md
+++ b/.changeset/eight-days-sin.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': patch
+---
+
+Deprecated `inputs` and `configSchema` options for `createComponentExtenion`, these will be removed in a future release

--- a/.changeset/swift-dragons-know.md
+++ b/.changeset/swift-dragons-know.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-app-visualizer': patch
+---
+
+Fixing issue with the visualizer crashing when clicking on the detailed view because of `routeRef` parameters

--- a/packages/frontend-plugin-api/src/extensions/createComponentExtension.tsx
+++ b/packages/frontend-plugin-api/src/extensions/createComponentExtension.tsx
@@ -34,7 +34,9 @@ export function createComponentExtension<
   ref: ComponentRef<TProps>;
   name?: string;
   disabled?: boolean;
+  /** @deprecated these will be removed in the future */
   inputs?: TInputs;
+  /** @deprecated these will be removed in the future */
   configSchema?: PortableSchema<TConfig>;
   loader:
     | {

--- a/plugins/app-visualizer/src/components/AppVisualizerPage/DetailedVisualizer.tsx
+++ b/plugins/app-visualizer/src/components/AppVisualizerPage/DetailedVisualizer.tsx
@@ -189,15 +189,26 @@ function OutputLink(props: {
 }) {
   const routeRef = props.node?.instance?.getData(coreExtensionData.routeRef);
 
-  const link = useRouteRef(routeRef as RouteRef<undefined>);
+  try {
+    const link = useRouteRef(routeRef as RouteRef<undefined>);
 
-  return (
-    <Tooltip title={<Typography>{props.dataRef.id}</Typography>}>
-      <Box className={props.className}>
-        {link ? <Link to={link()}>link</Link> : null}
-      </Box>
-    </Tooltip>
-  );
+    return (
+      <Tooltip title={<Typography>{props.dataRef.id}</Typography>}>
+        <Box className={props.className}>
+          {link ? <Link to={link()}>link</Link> : null}
+        </Box>
+      </Tooltip>
+    );
+  } catch (ex) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      props.node?.spec.id
+        ? `Unable to generate output link for ${props.node.spec.id}`
+        : 'Unable to generate output link',
+      ex,
+    );
+    return null;
+  }
 }
 
 function Output(props: { dataRef: ExtensionDataRef<unknown>; node?: AppNode }) {

--- a/plugins/kubernetes/src/alpha/entityContents.tsx
+++ b/plugins/kubernetes/src/alpha/entityContents.tsx
@@ -15,19 +15,14 @@
  */
 
 import React from 'react';
-import {
-  compatWrapper,
-  convertLegacyRouteRef,
-} from '@backstage/core-compat-api';
-import { rootCatalogKubernetesRouteRef } from '../plugin';
+import { compatWrapper } from '@backstage/core-compat-api';
 import { EntityContentBlueprint } from '@backstage/plugin-catalog-react/alpha';
 
 export const entityKubernetesContent = EntityContentBlueprint.make({
   name: 'kubernetes',
   params: {
-    defaultPath: 'kubernetes',
+    defaultPath: '/kubernetes',
     defaultTitle: 'Kubernetes',
-    routeRef: convertLegacyRouteRef(rootCatalogKubernetesRouteRef),
     loader: () =>
       import('./KubernetesContentPage').then(m =>
         compatWrapper(<m.KubernetesContentPage />),


### PR DESCRIPTION
- Deprecate some options in `createComponentExtension`
- Fixing the visualizer to stop throwing errors with `routeRefs`
- Remove the `routeRef` for the `content` page of k8s plugin. Also skipping changeset here as it's already covered by the blueprint migration 