### PR TITLE
Fix typo and unify TechDocs casing in doc strings

### DIFF
--- a/.changeset/hip-pandas-think.md
+++ b/.changeset/hip-pandas-think.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-node': patch
+---
+
+Fix typo and unify TechDocs casing in doc strings

--- a/plugins/techdocs-node/src/extensions.ts
+++ b/plugins/techdocs-node/src/extensions.ts
@@ -25,7 +25,7 @@ import {
 import * as winston from 'winston';
 
 /**
- * Extension point type for configuring Techdocs builds.
+ * Extension point type for configuring TechDocs builds.
  *
  * @public
  */
@@ -35,7 +35,7 @@ export interface TechdocsBuildsExtensionPoint {
 }
 
 /**
- * Extension point for configuring Techdocs builds.
+ * Extension point for configuring TechDocs builds.
  *
  * @public
  */
@@ -45,7 +45,7 @@ export const techdocsBuildsExtensionPoint =
   });
 
 /**
- * Extension point type for configuring a custom Techdocs generator
+ * Extension point type for configuring a custom TechDocs generator
  *
  * @public
  */
@@ -54,7 +54,7 @@ export interface TechdocsGeneratorExtensionPoint {
 }
 
 /**
- * Extension point for configuring a custom Techdocs generator
+ * Extension point for configuring a custom TechDocs generator
  *
  * @public
  */
@@ -64,7 +64,7 @@ export const techdocsGeneratorExtensionPoint =
   });
 
 /**
- * Extension point type for configuring a custom Techdocs preparer
+ * Extension point type for configuring a custom TechDocs preparer
  *
  * @public
  */
@@ -73,7 +73,7 @@ export interface TechdocsPreparerExtensionPoint {
 }
 
 /**
- * Extension point for configuring a custom Techdocs preparer
+ * Extension point for configuring a custom TechDocs preparer
  *
  * @public
  */
@@ -83,7 +83,7 @@ export const techdocsPreparerExtensionPoint =
   });
 
 /**
- * Extension point type for configuring a custom Techdocs publisher
+ * Extension point type for configuring a custom TechDocs publisher
  *
  * @public
  */
@@ -92,7 +92,7 @@ export interface TechdocsPublisherExtensionPoint {
 }
 
 /**
- * Extension point for configuring a custom Techdocs publisher
+ * Extension point for configuring a custom TechDocs publisher
  *
  * @public
  */

--- a/plugins/techdocs-node/src/helpers.ts
+++ b/plugins/techdocs-node/src/helpers.ts
@@ -38,7 +38,7 @@ export type ParsedLocationAnnotation = {
 };
 
 /**
- * Returns a parset locations annotation
+ * Returns a parsed locations annotation
  * @public
  * @param annotationName - The name of the annotation in the entity metadata
  * @param entity - A TechDocs entity instance
@@ -114,7 +114,7 @@ export const transformDirLocation = (
 };
 
 /**
- * Returns a entity reference based on the TechDocs annotation type
+ * Returns an entity reference based on the TechDocs annotation type
  * @public
  * @param entity - A TechDocs instance
  * @param scmIntegration - An implementation for  SCM integration API


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix one typo and unify `TechDocs` letter casing in doc strings.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
