### PR TITLE
feat(scaffolder): Added EntityOwnerPicker to TemplateListPage filters

### DIFF
--- a/.changeset/twenty-queens-grow.md
+++ b/.changeset/twenty-queens-grow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': minor
+---
+
+Added EntityOwnerPicker component to the TemplateListPage to allow filtering on owner

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/useFacetsEntities.test.ts
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/useFacetsEntities.test.ts
@@ -70,6 +70,21 @@ describe('useFacetsEntities', () => {
     expect(result.current[0]).toEqual({ value: { items: [] }, loading: true });
   });
 
+  it(`should return empty response when facet is not present`, async () => {
+    mockedGetEntityFacets.mockResolvedValueOnce({
+      facets: { 'metadata.tags': [{ value: 'tag', count: 1 }] },
+    });
+    mockedGetEntitiesByRefs.mockResolvedValueOnce({ items: [] });
+    const { result } = renderHook(() => useFacetsEntities({ enabled: true }));
+    result.current[1]({ text: '' });
+    await waitFor(() => {
+      expect(result.current[0]).toEqual({
+        value: { items: [] },
+        loading: false,
+      });
+    });
+  });
+
   it(`should return the owners`, async () => {
     const entityRefs = ['component:default/e1', 'component:default/e2'];
     mockedGetEntityFacets.mockResolvedValue(facetsFromEntityRefs(entityRefs));

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/useFacetsEntities.ts
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/useFacetsEntities.ts
@@ -52,7 +52,7 @@ export function useFacetsEntities({ enabled }: { enabled: boolean }) {
     const facetsResponse = await catalogApi.getEntityFacets({
       facets: [facet],
     });
-    const entityRefs = facetsResponse.facets[facet].map(e => e.value);
+    const entityRefs = facetsResponse.facets[facet]?.map(e => e.value) ?? [];
 
     return catalogApi
       .getEntitiesByRefs({ entityRefs })

--- a/plugins/scaffolder/src/next/TemplateListPage/TemplateListPage.test.tsx
+++ b/plugins/scaffolder/src/next/TemplateListPage/TemplateListPage.test.tsx
@@ -45,6 +45,9 @@ describe('TemplateListPage', () => {
     getEntityFacets: async () => ({
       facets: { 'spec.type': [{ value: 'service', count: 1 }] },
     }),
+    getEntitiesByRefs: async () => ({
+      items: [],
+    }),
   };
 
   it('should render the search bar for templates', async () => {

--- a/plugins/scaffolder/src/next/TemplateListPage/TemplateListPage.test.tsx
+++ b/plugins/scaffolder/src/next/TemplateListPage/TemplateListPage.test.tsx
@@ -114,6 +114,28 @@ describe('TemplateListPage', () => {
     expect(getByText('Categories')).toBeInTheDocument();
   });
 
+  it('should render the EntityOwnerPicker', async () => {
+    const { getByText } = await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [catalogApiRef, mockCatalogApi],
+          [
+            starredEntitiesApiRef,
+            new DefaultStarredEntitiesApi({
+              storageApi: MockStorageApi.create(),
+            }),
+          ],
+          [permissionApiRef, {}],
+        ]}
+      >
+        <TemplateListPage />
+      </TestApiProvider>,
+      { mountedRoutes: { '/': rootRouteRef } },
+    );
+
+    expect(getByText('Owner')).toBeInTheDocument();
+  });
+
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip('should render the EntityTag picker', async () => {
     const { getByText } = await renderInTestApp(

--- a/plugins/scaffolder/src/next/TemplateListPage/TemplateListPage.tsx
+++ b/plugins/scaffolder/src/next/TemplateListPage/TemplateListPage.tsx
@@ -34,6 +34,7 @@ import {
   EntityTagPicker,
   CatalogFilterLayout,
   UserListPicker,
+  EntityOwnerPicker,
 } from '@backstage/plugin-catalog-react';
 import {
   ScaffolderPageContextMenu,
@@ -189,6 +190,7 @@ export const TemplateListPage = (props: TemplateListPageProps) => {
               />
               <TemplateCategoryPicker />
               <EntityTagPicker />
+              <EntityOwnerPicker />
             </CatalogFilterLayout.Filters>
             <CatalogFilterLayout.Content>
               <TemplateGroups


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I have added the `EntityOwnerPicker` component to the filters on the TemplateListPage to allow filtering on owners.

<img width="577" alt="Screenshot 2024-08-19 at 16 59 17" src="https://github.com/user-attachments/assets/8bb6523d-4e3c-4578-bb68-8c79060805b0">

We have this feature requested by our users. If this is unwanted please let me know what a better way of extending the filters on the default page would be.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
