### PR TITLE
techdocs-backend: separate request token for cache sync

### DIFF
--- a/.changeset/big-spies-stare.md
+++ b/.changeset/big-spies-stare.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-backend': patch
+---
+
+Dedicated token for techdocs cache sync

--- a/plugins/techdocs-backend/src/service/router.ts
+++ b/plugins/techdocs-backend/src/service/router.ts
@@ -252,10 +252,14 @@ export async function createRouter(
       // However, if caching is enabled, take the opportunity to check and
       // invalidate stale cache entries.
       if (cache) {
+        const { token: techDocsToken } = await auth.getPluginRequestToken({
+          onBehalfOf: await auth.getOwnServiceCredentials(),
+          targetPluginId: 'techdocs',
+        });
         await docsSynchronizer.doCacheSync({
           responseHandler,
           discovery,
-          token,
+          token: techDocsToken,
           entity,
         });
         return;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Solves https://github.com/backstage/backstage/issues/26037

Dedicated token with `sub: techdocs` and `aud: techdocs` should be used for cache sync instead of the token used for fetching entity which has `sub: techdocs` `aud: catalog`. The token verification fails which leads to cache not being accessible. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
