### PR TITLE
kubernetes-backend: Deprecate KubernetesBuilder

### DIFF
--- a/.changeset/dry-monkeys-mate.md
+++ b/.changeset/dry-monkeys-mate.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+The `KubernetesBuilder` and its related types has been marked as deprecared. This backend should instead be initialized using the new backend system.

--- a/plugins/kubernetes-backend/api-report.md
+++ b/plugins/kubernetes-backend/api-report.md
@@ -28,8 +28,8 @@ import { LoggerService } from '@backstage/backend-plugin-api';
 import { ObjectToFetch as ObjectToFetch_2 } from '@backstage/plugin-kubernetes-node';
 import { PermissionEvaluator } from '@backstage/plugin-permission-common';
 import { PermissionsService } from '@backstage/backend-plugin-api';
-import { PluginEndpointDiscovery } from '@backstage/backend-common';
 import { RequestHandler } from 'http-proxy-middleware';
+import { RootConfigService } from '@backstage/backend-plugin-api';
 import { TokenCredential } from '@azure/identity';
 
 // @public (undocumented)
@@ -153,7 +153,7 @@ export const HEADER_KUBERNETES_AUTH: string;
 // @public
 export const HEADER_KUBERNETES_CLUSTER: string;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export class KubernetesBuilder {
   constructor(env: KubernetesEnvironment);
   // (undocumented)
@@ -268,7 +268,7 @@ export class KubernetesBuilder {
   setServiceLocator(serviceLocator?: KubernetesServiceLocator_2): this;
 }
 
-// @public
+// @public @deprecated
 export type KubernetesBuilderReturn = Promise<{
   router: express.Router;
   clusterSupplier: KubernetesClustersSupplier_2;
@@ -289,7 +289,7 @@ export type KubernetesClustersSupplier =
 // @public @deprecated (undocumented)
 export type KubernetesCredential = k8sAuthTypes.KubernetesCredential;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export interface KubernetesEnvironment {
   // (undocumented)
   auth?: AuthService;
@@ -380,16 +380,16 @@ export class OidcStrategy implements AuthenticationStrategy_2 {
   validateCluster(authMetadata: AuthMetadata_2): Error[];
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export interface RouterOptions {
   // (undocumented)
   catalogApi: CatalogApi;
   // (undocumented)
   clusterSupplier?: KubernetesClustersSupplier;
   // (undocumented)
-  config: Config;
+  config: RootConfigService;
   // (undocumented)
-  discovery: PluginEndpointDiscovery;
+  discovery: DiscoveryService;
   // (undocumented)
   logger: Logger;
   // (undocumented)

--- a/plugins/kubernetes-backend/src/service/KubernetesBuilder.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesBuilder.ts
@@ -76,7 +76,7 @@ import { KubernetesProxy } from './KubernetesProxy';
 /**
  * @deprecated Please migrate to the new backend system as this will be removed in the future.
  * @public
- * */
+ */
 export interface KubernetesEnvironment {
   logger: LoggerService;
   config: Config;

--- a/plugins/kubernetes-backend/src/service/KubernetesBuilder.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesBuilder.ts
@@ -74,9 +74,9 @@ import { KubernetesClientBasedFetcher } from './KubernetesFetcher';
 import { KubernetesProxy } from './KubernetesProxy';
 
 /**
- *
+ * @deprecated Please migrate to the new backend system as this will be removed in the future.
  * @public
- */
+ * */
 export interface KubernetesEnvironment {
   logger: LoggerService;
   config: Config;
@@ -89,7 +89,7 @@ export interface KubernetesEnvironment {
 
 /**
  * The return type of the `KubernetesBuilder.build` method
- *
+ * @deprecated Please migrate to the new backend system as this will be removed in the future.
  * @public
  */
 export type KubernetesBuilderReturn = Promise<{
@@ -104,9 +104,9 @@ export type KubernetesBuilderReturn = Promise<{
 }>;
 
 /**
- *
+ * @deprecated Please migrate to the new backend system as this will be removed in the future.
  * @public
- */
+ * */
 export class KubernetesBuilder {
   private clusterSupplier?: KubernetesClustersSupplier;
   private defaultClusterRefreshInterval: Duration = Duration.fromObject({

--- a/plugins/kubernetes-backend/src/service/router.ts
+++ b/plugins/kubernetes-backend/src/service/router.ts
@@ -14,25 +14,27 @@
  * limitations under the License.
  */
 
-import { Config } from '@backstage/config';
 import { Logger } from 'winston';
 import { KubernetesClustersSupplier } from '../types/types';
 import express from 'express';
 import { KubernetesBuilder } from './KubernetesBuilder';
-import { PluginEndpointDiscovery } from '@backstage/backend-common';
 import { CatalogApi } from '@backstage/catalog-client';
 import { PermissionEvaluator } from '@backstage/plugin-permission-common';
+import {
+  DiscoveryService,
+  RootConfigService,
+} from '@backstage/backend-plugin-api';
 
 /**
- *
+ * @deprecated Please migrate to the new backend system as this will be removed in the future.
  * @public
  */
 export interface RouterOptions {
   logger: Logger;
-  config: Config;
+  config: RootConfigService;
   catalogApi: CatalogApi;
   clusterSupplier?: KubernetesClustersSupplier;
-  discovery: PluginEndpointDiscovery;
+  discovery: DiscoveryService;
   permissions: PermissionEvaluator;
 }
 
@@ -40,7 +42,7 @@ export interface RouterOptions {
  * creates and configure a new router for handling the kubernetes backend APIs
  * @param options - specifies the options required by this plugin
  * @returns a new router
- * @deprecated Please use the new KubernetesBuilder instead like this
+ * @deprecated Please migrate to the new backend system as this will be removed in the future.
  * ```
  * import { KubernetesBuilder } from '@backstage/plugin-kubernetes-backend';
  * const { router } = await KubernetesBuilder.createBuilder({


### PR DESCRIPTION
The `KubernetesBuilder` and its related types has been marked as deprecared. This backend should instead be initialized using the new backend system.
