### PR TITLE
permission-backend: Deprecate createRouter

### DIFF
--- a/.changeset/witty-years-cry.md
+++ b/.changeset/witty-years-cry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-permission-backend': patch
+---
+
+Deprecated `createRouter` and its router options in favour of the new backend system.

--- a/plugins/permission-backend/api-report.md
+++ b/plugins/permission-backend/api-report.md
@@ -4,24 +4,24 @@
 
 ```ts
 import { AuthService } from '@backstage/backend-plugin-api';
-import { Config } from '@backstage/config';
 import { DiscoveryService } from '@backstage/backend-plugin-api';
 import express from 'express';
 import { HttpAuthService } from '@backstage/backend-plugin-api';
 import { IdentityApi } from '@backstage/plugin-auth-node';
 import { LoggerService } from '@backstage/backend-plugin-api';
 import { PermissionPolicy } from '@backstage/plugin-permission-node';
+import { RootConfigService } from '@backstage/backend-plugin-api';
 import { UserInfoService } from '@backstage/backend-plugin-api';
 
-// @public
+// @public @deprecated
 export function createRouter(options: RouterOptions): Promise<express.Router>;
 
-// @public
+// @public @deprecated
 export interface RouterOptions {
   // (undocumented)
   auth?: AuthService;
   // (undocumented)
-  config: Config;
+  config: RootConfigService;
   // (undocumented)
   discovery: DiscoveryService;
   // (undocumented)

--- a/plugins/permission-backend/src/service/router.ts
+++ b/plugins/permission-backend/src/service/router.ts
@@ -42,7 +42,6 @@ import {
 import { PermissionIntegrationClient } from './PermissionIntegrationClient';
 import { memoize } from 'lodash';
 import DataLoader from 'dataloader';
-import { Config } from '@backstage/config';
 import {
   AuthService,
   BackstageCredentials,
@@ -51,6 +50,7 @@ import {
   DiscoveryService,
   HttpAuthService,
   LoggerService,
+  RootConfigService,
   UserInfoService,
 } from '@backstage/backend-plugin-api';
 
@@ -97,13 +97,14 @@ const evaluatePermissionRequestBatchSchema: z.ZodSchema<EvaluatePermissionReques
  * {@link createRouter}.
  *
  * @public
+ * @deprecated Please migrate to the new backend system as this will be removed in the future.
  */
 export interface RouterOptions {
   logger: LoggerService;
   discovery: DiscoveryService;
   policy: PermissionPolicy;
   identity?: IdentityApi;
-  config: Config;
+  config: RootConfigService;
   auth?: AuthService;
   httpAuth?: HttpAuthService;
   userInfo?: UserInfoService;
@@ -190,6 +191,7 @@ const handleRequest = async (
  * Creates a new {@link express#Router} which provides the backend API
  * for the permission system.
  *
+ * @deprecated Please migrate to the new backend system as this will be removed in the future.
  * @public
  */
 export async function createRouter(


### PR DESCRIPTION
Deprecated `createRouter` and its router options in favour of the new backend system.
