### PR TITLE
scaffolder-backend: Deprecate createRouter

### DIFF
--- a/.changeset/short-moles-brush.md
+++ b/.changeset/short-moles-brush.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+`createRouter` and its related types has been marked as deprecared. This backend should instead be initialized using the new backend system.

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -15,6 +15,7 @@ import * as bitbucketCloud from '@backstage/plugin-scaffolder-backend-module-bit
 import * as bitbucketServer from '@backstage/plugin-scaffolder-backend-module-bitbucket-server';
 import { CatalogApi } from '@backstage/catalog-client';
 import { Config } from '@backstage/config';
+import { DatabaseService } from '@backstage/backend-plugin-api';
 import { DiscoveryService } from '@backstage/backend-plugin-api';
 import { Duration } from 'luxon';
 import { executeShellCommand as executeShellCommand_2 } from '@backstage/plugin-scaffolder-node';
@@ -320,7 +321,7 @@ export const createPublishGitlabMergeRequestAction: (options: {
   JsonObject
 >;
 
-// @public
+// @public @deprecated
 export function createRouter(options: RouterOptions): Promise<express.Router>;
 
 // @public @deprecated (undocumented)
@@ -469,7 +470,7 @@ export const executeShellCommand: typeof executeShellCommand_2;
 // @public @deprecated
 export const fetchContents: typeof fetchContents_2;
 
-// @public
+// @public @deprecated
 export interface RouterOptions {
   // (undocumented)
   actions?: TemplateAction_2<any, any>[];
@@ -489,7 +490,7 @@ export interface RouterOptions {
   // (undocumented)
   config: Config;
   // (undocumented)
-  database: PluginDatabaseManager;
+  database: DatabaseService;
   // (undocumented)
   discovery?: DiscoveryService;
   // (undocumented)

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -17,7 +17,6 @@
 import {
   createLegacyAuthAdapters,
   HostDiscovery,
-  PluginDatabaseManager,
 } from '@backstage/backend-common';
 import { CatalogApi } from '@backstage/catalog-client';
 import {
@@ -88,6 +87,7 @@ import {
   PermissionsService,
   UrlReaderService,
   SchedulerService,
+  DatabaseService,
 } from '@backstage/backend-plugin-api';
 import {
   IdentityApi,
@@ -140,13 +140,14 @@ function isActionPermissionRuleInput(
  * RouterOptions
  *
  * @public
+ * @deprecated Please migrate to the new backend system as this will be removed in the future.
  */
 export interface RouterOptions {
   logger: Logger;
   config: Config;
   reader: UrlReaderService;
   lifecycle?: LifecycleService;
-  database: PluginDatabaseManager;
+  database: DatabaseService;
   catalogClient: CatalogApi;
   scheduler?: SchedulerService;
   actions?: TemplateAction<any, any>[];
@@ -258,6 +259,7 @@ const readDuration = (
 /**
  * A method to create a router for the scaffolder backend plugin.
  * @public
+ * @deprecated Please migrate to the new backend system as this will be removed in the future.
  */
 export async function createRouter(
   options: RouterOptions,


### PR DESCRIPTION
`createRouter` and its related types has been marked as deprecared. This backend should instead be initialized using the new backend system.
