### PR TITLE
backend-dynamic-feature-service: expand type check

### DIFF
--- a/.changeset/cold-ways-protect.md
+++ b/.changeset/cold-ways-protect.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-dynamic-feature-service': patch
+---
+
+Relax type check for a plugin's default export to also accept a BackendFeature defined as a function instead of an object

--- a/packages/backend-dynamic-feature-service/src/manager/plugin-manager.test.ts
+++ b/packages/backend-dynamic-feature-service/src/manager/plugin-manager.test.ts
@@ -247,6 +247,59 @@ describe('backend-dynamic-feature-service', () => {
         },
       },
       {
+        name: 'should successfully load a backend plugin wrapped in a BackendFeatureCompatWrapper function',
+        packageManifest: {
+          name: 'backend-dynamic-plugin-test',
+          version: '0.0.0',
+          backstage: {
+            role: 'backend-plugin',
+          },
+          main: 'dist/index.cjs.js',
+        },
+        indexFile: {
+          relativePath: ['dist', 'index.cjs.js'],
+          content: `
+          function backendFeatureCompatWrapper() {
+            return backendFeatureCompatWrapper;
+          }
+          Object.assign(backendFeatureCompatWrapper, {
+            $$type: "@backstage/BackendFeature",
+            version: "v1",
+          });
+          const alpha = backendFeatureCompatWrapper;
+          exports.default = alpha;
+          `,
+        },
+        expectedLogs(location) {
+          return {
+            infos: [
+              {
+                message: `loaded dynamic backend plugin 'backend-dynamic-plugin-test' from '${location}'`,
+              },
+            ],
+          };
+        },
+        checkLoadedPlugins(plugins) {
+          expect(plugins).toMatchObject([
+            {
+              name: 'backend-dynamic-plugin-test',
+              version: '0.0.0',
+              role: 'backend-plugin',
+              platform: 'node',
+              installer: {
+                kind: 'new',
+              },
+            },
+          ]);
+          const installer: NewBackendPluginInstaller = (
+            plugins[0] as BackendDynamicPlugin
+          ).installer as NewBackendPluginInstaller;
+          expect((installer.install() as BackendFeature).$$type).toEqual(
+            '@backstage/BackendFeature',
+          );
+        },
+      },
+      {
         name: 'should fail when no index file',
         packageManifest: {
           name: 'backend-dynamic-plugin-test',

--- a/packages/backend-dynamic-feature-service/src/manager/plugin-manager.ts
+++ b/packages/backend-dynamic-feature-service/src/manager/plugin-manager.ts
@@ -301,7 +301,7 @@ export const dynamicPluginsFeatureDiscoveryServiceFactory =
 function isBackendFeature(value: unknown): value is BackendFeature {
   return (
     !!value &&
-    typeof value === 'object' &&
+    (typeof value === 'object' || typeof value === 'function') &&
     (value as BackendFeature).$$type === '@backstage/BackendFeature'
   );
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This change caters for backend dynamic plugins that have been wrapped by BackendFeatureCompatWrapper by expanding the allowed types for the default export of a dynamic plugin to also be a function.

Without this change on more recent Backstage versions a valid dynamic plugin will fail to load with the message:

```
backend plugin 'backstage-plugin-scaffolder-backend-module-github-dynamic' could not be loaded from 'file:///opt/app-root/src/dynamic-plugins-root/backstage-plugin-scaffolder-backend-module-github-dynamic-0.4.0': the module should either export a 'BackendFeature' or 'BackendFeatureFactory' as default export, or export a 'const dynamicPluginInstaller: BackendDynamicPluginInstaller' field as dynamic loading entrypoint.
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
