### PR TITLE
secrets on scaffolder review page show constant asterisks value

### DIFF
--- a/.changeset/unlucky-cycles-clean.md
+++ b/.changeset/unlucky-cycles-clean.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+Scaffolder review page shows static amount of asterisks for secret fields.

--- a/plugins/scaffolder-react/src/next/components/ReviewState/ReviewState.tsx
+++ b/plugins/scaffolder-react/src/next/components/ReviewState/ReviewState.tsx
@@ -52,7 +52,10 @@ function processSchema(
       }
     }
 
-    if (definitionInSchema['ui:widget'] === 'password') {
+    if (
+      definitionInSchema['ui:widget'] === 'password' ||
+      definitionInSchema['ui:field']?.toLocaleLowerCase('en-us') === 'secret'
+    ) {
       return [[getLastKey(key), '******']];
     }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR updates review page to show static amount of asterisks for secrets instead of showing the length of the secret. UX wise it doesn't matter if I see 100x asterisks or 6x asterisks as the value is masked either way.

Input: `test-secret1234567890`
Before: `*********************`
After: `******`

Input: `abc`
Before: `***`
After: `******`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
