### PR TITLE
fix loaders in production builds

### DIFF
--- a/.changeset/spicy-vans-eat.md
+++ b/.changeset/spicy-vans-eat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+Fix feature loaders in CJS double-default nested builds

--- a/packages/backend-app-api/src/wiring/BackendInitializer.ts
+++ b/packages/backend-app-api/src/wiring/BackendInitializer.ts
@@ -38,6 +38,7 @@ import { featureDiscoveryServiceRef } from '@backstage/backend-plugin-api/alpha'
 import { DependencyGraph } from '../lib/DependencyGraph';
 import { ServiceRegistry } from './ServiceRegistry';
 import { createInitializationLogger } from './createInitializationLogger';
+import { unwrapFeature } from './helpers';
 
 export interface BackendRegisterInit {
   consumes: Set<ServiceOrExtensionPoint>;
@@ -163,7 +164,7 @@ export class BackendInitializer {
     if (featureDiscovery) {
       const { features } = await featureDiscovery.getBackendFeatures();
       for (const feature of features) {
-        this.#addFeature(feature);
+        this.#addFeature(unwrapFeature(feature));
       }
       this.#serviceRegistry.checkForCircularDeps();
     }
@@ -417,6 +418,7 @@ export class BackendInitializer {
 
       const result = await loader
         .loader(Object.fromEntries(deps))
+        .then(features => features.map(unwrapFeature))
         .catch(error => {
           throw new ForwardedError(
             `Feature loader ${loader.description} failed`,

--- a/packages/backend-app-api/src/wiring/BackstageBackend.ts
+++ b/packages/backend-app-api/src/wiring/BackstageBackend.ts
@@ -16,6 +16,7 @@
 
 import { BackendFeature, ServiceFactory } from '@backstage/backend-plugin-api';
 import { BackendInitializer } from './BackendInitializer';
+import { unwrapFeature } from './helpers';
 import { Backend } from './types';
 
 export class BackstageBackend implements Backend {
@@ -49,22 +50,4 @@ function isPromise<T>(value: unknown | Promise<T>): value is Promise<T> {
     'then' in value &&
     typeof value.then === 'function'
   );
-}
-
-function unwrapFeature(
-  feature: BackendFeature | { default: BackendFeature },
-): BackendFeature {
-  if ('$$type' in feature) {
-    return feature;
-  }
-
-  // This is a workaround where default exports get transpiled to `exports['default'] = ...`
-  // in CommonJS modules, which in turn results in a double `{ default: { default: ... } }` nesting
-  // when importing using a dynamic import.
-  // TODO: This is a broader issue than just this piece of code, and should move away from CommonJS.
-  if ('default' in feature) {
-    return feature.default;
-  }
-
-  return feature;
 }

--- a/packages/backend-app-api/src/wiring/helpers.ts
+++ b/packages/backend-app-api/src/wiring/helpers.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { BackendFeature } from '@backstage/backend-plugin-api';
+
+/** @internal */
+export function unwrapFeature(
+  feature: BackendFeature | { default: BackendFeature },
+): BackendFeature {
+  if ('$$type' in feature) {
+    return feature;
+  }
+
+  // This is a workaround where default exports get transpiled to `exports['default'] = ...`
+  // in CommonJS modules, which in turn results in a double `{ default: { default: ... } }` nesting
+  // when importing using a dynamic import.
+  // TODO: This is a broader issue than just this piece of code, and should move away from CommonJS.
+  if ('default' in feature) {
+    return feature.default;
+  }
+
+  return feature;
+}


### PR DESCRIPTION
The double-default nesting can also interfere with loaders, leading to errors like the following, only in production builds, because the loader returns essentially `{default: { default: { $$type: ... } }}`

```
/app/packages/backend-app-api/dist/index.cjs.js:781
    throw new Error(`Invalid BackendFeature, bad type '${feature.$$type}'`);
          ^

Error: Invalid BackendFeature, bad type 'undefined'
    at toInternalBackendFeature (/app/packages/backend-app-api/dist/index.cjs.js:781:11)
    at isBackendFeatureLoader (/app/packages/backend-app-api/dist/index.cjs.js:806:10)
    at #applyBackendFeatureLoaders (/app/packages/backend-app-api/dist/index.cjs.js:763:13)
    at async #doStart (/app/packages/backend-app-api/dist/index.cjs.js:564:5)
    at async BackendInitializer.start (/app/packages/backend-app-api/dist/index.cjs.js:546:5)
    at async BackstageBackend.start (/app/packages/backend-app-api/dist/index.cjs.js:822:5)
```
