### PR TITLE
backend-common: add shims for token manager and identity services

### DIFF
--- a/.changeset/lucky-sheep-cover.md
+++ b/.changeset/lucky-sheep-cover.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+The `legacyPlugin` and `makeLeagcyPlugin` helpers now provide their own shim implementation of the identity and token manager services, as these services are being removed from the new backend system.

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -35,6 +35,7 @@ import { PermissionsService } from '@backstage/backend-plugin-api';
 import { PluginMetadataService } from '@backstage/backend-plugin-api';
 import { PushResult } from 'isomorphic-git';
 import { ReadCommitResult } from 'isomorphic-git';
+import { Request as Request_2 } from 'express';
 import { RequestHandler } from 'express';
 import { resolvePackagePath as resolvePackagePath_2 } from '@backstage/backend-plugin-api';
 import { resolveSafeChildPath as resolveSafeChildPath_2 } from '@backstage/backend-plugin-api';
@@ -322,6 +323,23 @@ export type KubernetesContainerRunnerOptions = {
 export type LegacyCreateRouter<TEnv> = (deps: TEnv) => Promise<RequestHandler>;
 
 // @public @deprecated
+export interface LegacyIdentityService {
+  // (undocumented)
+  getIdentity(options: { request: Request_2<unknown> }): Promise<
+    | {
+        expiresInSeconds?: number;
+        token: string;
+        identity: {
+          type: 'user';
+          userEntityRef: string;
+          ownershipEntityRefs: string[];
+        };
+      }
+    | undefined
+  >;
+}
+
+// @public @deprecated
 export const legacyPlugin: (
   name: string,
   createRouterImport: Promise<{
@@ -335,9 +353,7 @@ export const legacyPlugin: (
           logger: LoggerService;
           permissions: PermissionsService;
           scheduler: SchedulerService;
-          tokenManager: TokenManagerService;
           reader: UrlReaderService;
-          identity: IdentityService;
         },
         {
           logger: (log: LoggerService) => Logger;
@@ -345,7 +361,10 @@ export const legacyPlugin: (
             getClient(options?: CacheServiceOptions | undefined): CacheService;
           };
         }
-      >
+      > & {
+        tokenManager: ServerTokenManager;
+        identity: LegacyIdentityService;
+      }
     >;
   }>,
 ) => BackendFeatureCompat;
@@ -384,7 +403,12 @@ export function makeLegacyPlugin<
 ): (
   name: string,
   createRouterImport: Promise<{
-    default: LegacyCreateRouter<TransformedEnv<TEnv, TEnvTransforms>>;
+    default: LegacyCreateRouter<
+      TransformedEnv<TEnv, TEnvTransforms> & {
+        tokenManager: ServerTokenManager;
+        identity: LegacyIdentityService;
+      }
+    >;
   }>,
 ) => BackendFeatureCompat;
 

--- a/packages/backend-common/src/compat/legacy/index.ts
+++ b/packages/backend-common/src/compat/legacy/index.ts
@@ -15,4 +15,4 @@
  */
 
 export { legacyPlugin, makeLegacyPlugin } from './legacy';
-export type { LegacyCreateRouter } from './legacy';
+export type { LegacyCreateRouter, LegacyIdentityService } from './legacy';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

These services are about to be removed from the new backend system, but in order to keep backwards compatibility in `legacyPlugin` we introduce shims that implement then using the new auth services instead. This makes it possible to use legacy plugins that depend on these services, but does not allow for customization of the services themselves.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
