### PR TITLE
Fix wrong secret saving behaviour in SecretWidget

### DIFF
--- a/.changeset/fifty-maps-drive.md
+++ b/.changeset/fifty-maps-drive.md
@@ -1,0 +1,36 @@
+---
+'@backstage/plugin-scaffolder-react': major
+---
+
+**BREAKING**: Fixed a [wrong behaviour in `SecretWidget`](https://github.com/backstage/backstage/issues/25966) where secrets are saved using the field name instead of the proper path in the formData.
+The previous behaviour caused problems when using nested formData or array fields.
+
+Example:
+
+```
+spec:
+  type: service
+  parameters:
+    - title: Normal
+      properties:
+        nested:
+          type: object
+          properties:
+            name:
+              type: string
+              ui:field: Secret
+```
+
+Before this change the secret would be accessible via `secrets.name` instead of `secrets.nested.name`.
+
+Migration:
+
+```diff
+ steps:
+   - id: debug
+     name: debug
+     action: debug:log
+     input:
+-      message: "Creating foo with name: ${{ secrets.name }}"
++      message: "Creating foo with name: ${{ secrets.nested.name }}"
+```

--- a/docs/features/software-templates/writing-templates.md
+++ b/docs/features/software-templates/writing-templates.md
@@ -264,14 +264,23 @@ spec:
         password:
           type: string
           ui:field: Secret
+        api:
+          type: object
+          properties:
+            host:
+              type: string
+            key:
+              type: string
+              ui:field: Secret
 
   steps:
     - id: setupAuthentication
       action: auth:create
       input:
-        # make sure to use ${{ secrets.parameterName }} to reference these values
+        # make sure to use ${{ secrets.parameterPath }} to reference these values
         username: ${{ secrets.username }}
         password: ${{ secrets.password }}
+        apiKey: ${{ secrets.api.key }}
 ```
 
 ### Custom step layouts

--- a/plugins/scaffolder-react/src/next/components/SecretWidget/SecretWidget.test.tsx
+++ b/plugins/scaffolder-react/src/next/components/SecretWidget/SecretWidget.test.tsx
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useTemplateSecrets } from '@backstage/plugin-scaffolder-react';
+import { SecretWidget } from './SecretWidget';
+
+jest.mock('@backstage/plugin-scaffolder-react', () => ({
+  useTemplateSecrets: jest.fn(),
+}));
+
+describe('SecretWidget', () => {
+  const mockUseTemplateSecrets = useTemplateSecrets as jest.MockedFunction<
+    typeof useTemplateSecrets
+  >;
+
+  beforeEach(() => {
+    mockUseTemplateSecrets.mockReturnValue({
+      setSecrets: jest.fn(),
+      secrets: {},
+    });
+  });
+
+  it('should render the label correctly', () => {
+    const props = {
+      name: 'password',
+      onChange: jest.fn(),
+      schema: { title: 'Password' },
+      idSchema: {
+        $id: 'root_password',
+      },
+      idSeperator: '',
+    };
+
+    render(<SecretWidget {...props} />);
+
+    expect(screen.getByLabelText('Password')).toBeInTheDocument();
+  });
+
+  it('should render the input field correctly', () => {
+    const props = {
+      name: 'password',
+      onChange: jest.fn(),
+      schema: { title: 'Password' },
+      idSchema: {
+        $id: 'root_password',
+      },
+      idSeperator: '',
+    };
+    mockUseTemplateSecrets.mockReturnValueOnce({
+      setSecrets: jest.fn(),
+      secrets: {
+        password: 'mySecretPassword',
+      },
+    });
+
+    render(<SecretWidget {...props} />);
+
+    const input = screen.getByLabelText('Password') as HTMLInputElement;
+
+    expect(input).toBeInTheDocument();
+    expect(input.type).toBe('password');
+    expect(input).toHaveValue('mySecretPassword');
+  });
+
+  it('should render the input field correctly for nested fields', () => {
+    const props = {
+      name: 'password',
+      onChange: jest.fn(),
+      schema: { title: 'Password' },
+      idSchema: {
+        $id: 'root_api_password',
+      },
+      idSeperator: undefined,
+    };
+    mockUseTemplateSecrets.mockReturnValueOnce({
+      setSecrets: jest.fn(),
+      secrets: {
+        api: {
+          password: 'mySecretPassword',
+        },
+      },
+    });
+
+    render(<SecretWidget {...props} />);
+
+    const input = screen.getByLabelText('Password') as HTMLInputElement;
+
+    expect(input).toBeInTheDocument();
+    expect(input.type).toBe('password');
+    expect(input).toHaveValue('mySecretPassword');
+  });
+
+  it('should render the input field correctly for array fields', () => {
+    const props = {
+      name: 'password',
+      onChange: jest.fn(),
+      schema: { title: 'Password' },
+      idSchema: {
+        $id: 'root_apis_1_password',
+      },
+      idSeperator: undefined,
+    };
+    mockUseTemplateSecrets.mockReturnValueOnce({
+      setSecrets: jest.fn(),
+      secrets: {
+        apis: [
+          undefined,
+          {
+            password: 'mySecretPassword',
+          },
+        ],
+      } as any,
+    });
+
+    render(<SecretWidget {...props} />);
+
+    const input = screen.getByLabelText('Password') as HTMLInputElement;
+
+    expect(input).toBeInTheDocument();
+    expect(input.type).toBe('password');
+    expect(input).toHaveValue('mySecretPassword');
+  });
+
+  it('should update the value and secrets when input value changes', () => {
+    const setSecrets = jest.fn();
+    const props = {
+      name: 'password',
+      onChange: jest.fn(),
+      schema: { title: 'Password' },
+      idSchema: { $id: 'root_password' },
+      idSeperator: '',
+    };
+    mockUseTemplateSecrets.mockReturnValueOnce({
+      setSecrets,
+      secrets: {},
+    });
+
+    render(<SecretWidget {...props} />);
+
+    const input = screen.getByLabelText('Password') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'mySecretPassword' } });
+
+    expect(props.onChange).toHaveBeenCalledWith('****************');
+    expect(setSecrets).toHaveBeenCalledWith({
+      password: 'mySecretPassword',
+    });
+  });
+
+  it('should update the value correctly for nested fields', () => {
+    const setSecrets = jest.fn();
+    const props = {
+      name: 'password',
+      onChange: jest.fn(),
+      schema: { title: 'Password' },
+      idSchema: { $id: 'root_api_password' },
+      idSeperator: undefined,
+    };
+    mockUseTemplateSecrets.mockReturnValueOnce({
+      setSecrets,
+      secrets: {},
+    });
+
+    render(<SecretWidget {...props} />);
+
+    const input = screen.getByLabelText('Password');
+    fireEvent.change(input, { target: { value: 'mySecretPassword' } });
+
+    expect(props.onChange).toHaveBeenCalledWith('****************');
+    expect(setSecrets).toHaveBeenCalledWith({
+      api: {
+        password: 'mySecretPassword',
+      },
+    });
+  });
+
+  it('should update the value correctly for array fields', () => {
+    const setSecrets = jest.fn();
+    const props = {
+      name: 'password',
+      onChange: jest.fn(),
+      schema: { title: 'Password' },
+      idSchema: { $id: 'root_apis_0_password' },
+      idSeperator: undefined,
+    };
+    mockUseTemplateSecrets.mockReturnValueOnce({
+      setSecrets,
+      secrets: {},
+    });
+
+    render(<SecretWidget {...props} />);
+    const input = screen.getByLabelText('Password');
+    fireEvent.change(input, { target: { value: 'mySecretPassword' } });
+
+    expect(props.onChange).toHaveBeenCalledWith('****************');
+    expect(setSecrets).toHaveBeenCalledWith({
+      apis: [
+        {
+          password: 'mySecretPassword',
+        },
+      ],
+    });
+  });
+
+  it('should update the value correctly for array fields at not zero index', () => {
+    const setSecrets = jest.fn();
+    const props = {
+      name: 'password',
+      onChange: jest.fn(),
+      schema: { title: 'Password' },
+      idSchema: { $id: 'root_apis_2_password' },
+      idSeperator: undefined,
+    };
+    mockUseTemplateSecrets.mockReturnValueOnce({
+      setSecrets,
+      secrets: {
+        apis: [
+          {
+            password: 'mySecretPassword',
+          },
+        ],
+      } as any,
+    });
+
+    render(<SecretWidget {...props} />);
+    const input = screen.getByLabelText('Password');
+    fireEvent.change(input, { target: { value: 'mySecretPassword' } });
+
+    expect(props.onChange).toHaveBeenCalledWith('****************');
+    expect(setSecrets).toHaveBeenCalledWith({
+      apis: [
+        undefined,
+        undefined,
+        {
+          password: 'mySecretPassword',
+        },
+      ],
+    });
+  });
+
+  it('should display the current secret value', () => {
+    const props = {
+      name: 'password',
+      onChange: jest.fn(),
+      schema: { title: 'Password' },
+      idSchema: {
+        $id: 'root_password',
+      },
+      idSeperator: '',
+    };
+    mockUseTemplateSecrets.mockReturnValueOnce({
+      setSecrets: jest.fn(),
+      secrets: { password: 'mySecretPassword' },
+    });
+
+    render(<SecretWidget {...props} />);
+
+    const input = screen.getByLabelText('Password');
+    expect(input).toHaveValue('mySecretPassword');
+  });
+});

--- a/plugins/scaffolder-react/src/next/components/SecretWidget/SecretWidget.tsx
+++ b/plugins/scaffolder-react/src/next/components/SecretWidget/SecretWidget.tsx
@@ -14,35 +14,54 @@
  * limitations under the License.
  */
 
+import React from 'react';
 import { WidgetProps } from '@rjsf/utils';
 import { useTemplateSecrets } from '@backstage/plugin-scaffolder-react';
 import TextField from '@material-ui/core/TextField';
-import React from 'react';
+import get from 'lodash/get';
+import set from 'lodash/set';
+
+const getPath = (id: any, idSeperator: string) => {
+  if (typeof id !== 'string') return '';
+
+  const [_root, ...parts] = id.split(idSeperator || '_');
+  return parts.join('.');
+};
 
 /**
  * Secret Widget for overriding the default password input widget
  * @alpha
  */
 export const SecretWidget = (
-  props: Pick<WidgetProps, 'name' | 'onChange' | 'schema'>,
+  props: Pick<WidgetProps, 'onChange' | 'schema' | 'idSchema' | 'idSeperator'>,
 ) => {
   const { setSecrets, secrets } = useTemplateSecrets();
+
   const {
-    name,
     onChange,
     schema: { title },
+    idSchema: { $id },
+    idSeperator,
   } = props;
+
+  const onChangeText = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    const redactedValue = Array(value.length).fill('*').join('');
+    onChange(redactedValue);
+
+    const path = getPath($id, idSeperator);
+    setSecrets(set({}, path, value));
+  };
+
+  const value = get(secrets, getPath($id, idSeperator), '');
 
   return (
     <TextField
       id={title}
       label={title}
       aria-describedby={title}
-      onChange={e => {
-        onChange(Array(e.target.value.length).fill('*').join(''));
-        setSecrets({ [name]: e.target.value });
-      }}
-      value={secrets[name] ?? ''}
+      onChange={onChangeText}
+      value={value}
       type="password"
       autoComplete="off"
     />

--- a/plugins/scaffolder-react/src/secrets/SecretsContext.test.tsx
+++ b/plugins/scaffolder-react/src/secrets/SecretsContext.test.tsx
@@ -36,6 +36,48 @@ describe('SecretsContext', () => {
     expect(result.current.hook?.secrets.foo).toEqual('bar');
   });
 
+  it('should allow setting nested secrets in the context', async () => {
+    const { result } = renderHook(
+      () => ({
+        hook: useTemplateSecrets(),
+      }),
+      {
+        wrapper: ({ children }: React.PropsWithChildren<{}>) => (
+          <SecretsContextProvider>{children}</SecretsContextProvider>
+        ),
+      },
+    );
+
+    expect(result.current.hook?.secrets).toEqual({});
+
+    act(() => result.current.hook.setSecrets({ foo: { bar: 'baz' } }));
+
+    expect(result.current.hook?.secrets).toEqual({ foo: { bar: 'baz' } });
+  });
+
+  it('should allow setting secrets in arrays in the context', async () => {
+    const { result } = renderHook(
+      () => ({
+        hook: useTemplateSecrets(),
+      }),
+      {
+        wrapper: ({ children }: React.PropsWithChildren<{}>) => (
+          <SecretsContextProvider>{children}</SecretsContextProvider>
+        ),
+      },
+    );
+
+    expect(result.current.hook?.secrets).toEqual({});
+
+    act(() => result.current.hook.setSecrets({ foo: ['one'] }));
+
+    expect(result.current.hook?.secrets).toEqual({ foo: ['one'] });
+
+    act(() => result.current.hook.setSecrets({ foo: [undefined, 'two'] }));
+
+    expect(result.current.hook?.secrets).toEqual({ foo: ['one', 'two'] });
+  });
+
   it('should create SecretsContextProvider with initial secrets', async () => {
     const { result } = renderHook(
       () => ({

--- a/plugins/scaffolder-react/src/secrets/SecretsContext.tsx
+++ b/plugins/scaffolder-react/src/secrets/SecretsContext.tsx
@@ -23,6 +23,7 @@ import React, {
   useContext,
   PropsWithChildren,
 } from 'react';
+import merge from 'lodash/merge';
 
 /**
  * The contents of the `SecretsContext`
@@ -60,13 +61,21 @@ export const SecretsContextProvider = (
   );
 };
 
+type SetSecretsInput = {
+  [key: string]: string | Secrets | (string | Secrets | undefined)[];
+};
+
+type Secrets = {
+  [key: string]: string | Secrets | (string | Secrets)[];
+};
+
 /**
  * The return type from the useTemplateSecrets hook.
  * @public
  */
 export interface ScaffolderUseTemplateSecrets {
-  setSecrets: (input: Record<string, string>) => void;
-  secrets: Record<string, string>;
+  setSecrets: (input: SetSecretsInput) => void;
+  secrets: Secrets;
 }
 
 /**
@@ -86,8 +95,11 @@ export const useTemplateSecrets = (): ScaffolderUseTemplateSecrets => {
   const { setSecrets: updateSecrets, secrets = {} } = value;
 
   const setSecrets = useCallback(
-    (input: Record<string, string>) => {
-      updateSecrets(currentSecrets => ({ ...currentSecrets, ...input }));
+    (input: Secrets) => {
+      updateSecrets(currentSecrets => {
+        const newSecrets = merge({}, currentSecrets, input);
+        return newSecrets;
+      });
     },
     [updateSecrets],
   );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

**BREAKING**: Fixed a [wrong behaviour in `SecretWidget`](https://github.com/backstage/backstage/issues/25966) where secrets are saved using the field name instead of the proper path in the formData.
The previous behaviour caused problems when using nested formData or array fields.

Example:

```
spec:
  type: service
  parameters:
    - title: Normal
      properties:
        nested:
          type: object
          properties:
            name:
              type: string
              ui:field: Secret
```

Before this change the secret would be accessible via `secrets.name` instead of `secrets.nested.name`.

Migration:

```diff
 steps:
   - id: debug
     name: debug
     action: debug:log
     input:
-      message: "Creating foo with name: ${{ secrets.name }}"
+      message: "Creating foo with name: ${{ secrets.nested.name }}"
```


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
