### PR TITLE
Patch release of #26114

### DIFF
--- a/.changeset/spicy-vans-eat.md
+++ b/.changeset/spicy-vans-eat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+Fix feature loaders in CJS double-default nested builds

--- a/.changeset/spicy-vans-eat.md
+++ b/.changeset/spicy-vans-eat.md
@@ -1,5 +1,0 @@
----
-'@backstage/backend-app-api': patch
----
-
-Fix feature loaders in CJS double-default nested builds

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.30.1",
+  "version": "1.30.2",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/backend-app-api/CHANGELOG.md
+++ b/packages/backend-app-api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/backend-app-api
 
+## 0.9.2
+
+### Patch Changes
+
+- af62df8: Fix feature loaders in CJS double-default nested builds
+
 ## 0.9.1
 
 ### Patch Changes

--- a/packages/backend-app-api/package.json
+++ b/packages/backend-app-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/backend-app-api",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Core API used by Backstage backend apps",
   "backstage": {
     "role": "node-library"

--- a/packages/backend-app-api/src/wiring/BackendInitializer.ts
+++ b/packages/backend-app-api/src/wiring/BackendInitializer.ts
@@ -38,6 +38,7 @@ import { featureDiscoveryServiceRef } from '@backstage/backend-plugin-api/alpha'
 import { DependencyGraph } from '../lib/DependencyGraph';
 import { ServiceRegistry } from './ServiceRegistry';
 import { createInitializationLogger } from './createInitializationLogger';
+import { unwrapFeature } from './helpers';
 
 export interface BackendRegisterInit {
   consumes: Set<ServiceOrExtensionPoint>;
@@ -163,7 +164,7 @@ export class BackendInitializer {
     if (featureDiscovery) {
       const { features } = await featureDiscovery.getBackendFeatures();
       for (const feature of features) {
-        this.#addFeature(feature);
+        this.#addFeature(unwrapFeature(feature));
       }
       this.#serviceRegistry.checkForCircularDeps();
     }
@@ -417,6 +418,7 @@ export class BackendInitializer {
 
       const result = await loader
         .loader(Object.fromEntries(deps))
+        .then(features => features.map(unwrapFeature))
         .catch(error => {
           throw new ForwardedError(
             `Feature loader ${loader.description} failed`,

--- a/packages/backend-app-api/src/wiring/BackstageBackend.ts
+++ b/packages/backend-app-api/src/wiring/BackstageBackend.ts
@@ -16,6 +16,7 @@
 
 import { BackendFeature, ServiceFactory } from '@backstage/backend-plugin-api';
 import { BackendInitializer } from './BackendInitializer';
+import { unwrapFeature } from './helpers';
 import { Backend } from './types';
 
 export class BackstageBackend implements Backend {
@@ -49,22 +50,4 @@ function isPromise<T>(value: unknown | Promise<T>): value is Promise<T> {
     'then' in value &&
     typeof value.then === 'function'
   );
-}
-
-function unwrapFeature(
-  feature: BackendFeature | { default: BackendFeature },
-): BackendFeature {
-  if ('$$type' in feature) {
-    return feature;
-  }
-
-  // This is a workaround where default exports get transpiled to `exports['default'] = ...`
-  // in CommonJS modules, which in turn results in a double `{ default: { default: ... } }` nesting
-  // when importing using a dynamic import.
-  // TODO: This is a broader issue than just this piece of code, and should move away from CommonJS.
-  if ('default' in feature) {
-    return feature.default;
-  }
-
-  return feature;
 }

--- a/packages/backend-app-api/src/wiring/helpers.ts
+++ b/packages/backend-app-api/src/wiring/helpers.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { BackendFeature } from '@backstage/backend-plugin-api';
+
+/** @internal */
+export function unwrapFeature(
+  feature: BackendFeature | { default: BackendFeature },
+): BackendFeature {
+  if ('$$type' in feature) {
+    return feature;
+  }
+
+  // This is a workaround where default exports get transpiled to `exports['default'] = ...`
+  // in CommonJS modules, which in turn results in a double `{ default: { default: ... } }` nesting
+  // when importing using a dynamic import.
+  // TODO: This is a broader issue than just this piece of code, and should move away from CommonJS.
+  if ('default' in feature) {
+    return feature.default;
+  }
+
+  return feature;
+}


### PR DESCRIPTION
This release fixes an issue where feature loaders don't unwrap the `double-default` when using `common-js`