### PR TITLE
feat(i18n): allow plugins to add translations

### DIFF
--- a/.changeset/calm-files-sleep.md
+++ b/.changeset/calm-files-sleep.md
@@ -1,0 +1,10 @@
+---
+'@backstage/frontend-plugin-api': patch
+'@backstage/frontend-app-api': patch
+'@backstage/core-compat-api': patch
+'@backstage/core-plugin-api': patch
+'@backstage/core-app-api': patch
+'@backstage/plugin-user-settings': patch
+---
+
+Allow plugins to define their translations in plugin creation

--- a/packages/core-app-api/src/app/AppManager.test.tsx
+++ b/packages/core-app-api/src/app/AppManager.test.tsx
@@ -17,32 +17,32 @@
 import { LocalStorageFeatureFlags, NoOpAnalyticsApi } from '../apis';
 import {
   MockAnalyticsApi,
+  registerMswTestHooks,
   renderWithEffects,
   withLogCollector,
-  registerMswTestHooks,
 } from '@backstage/test-utils';
-import { screen, act } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { setupServer } from 'msw/node';
 import { rest } from 'msw';
 import React, { PropsWithChildren, ReactNode } from 'react';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import {
+  analyticsApiRef,
   configApiRef,
   createApiFactory,
-  featureFlagsApiRef,
-  createPlugin,
-  useRouteRef,
   createExternalRouteRef,
+  createPlugin,
+  createRoutableExtension,
   createRouteRef,
   createSubRouteRef,
-  createRoutableExtension,
-  analyticsApiRef,
-  useApi,
-  errorApiRef,
-  fetchApiRef,
   discoveryApiRef,
+  errorApiRef,
+  featureFlagsApiRef,
+  fetchApiRef,
   identityApiRef,
+  useApi,
+  useRouteRef,
 } from '@backstage/core-plugin-api';
 import { AppRouter } from './AppRouter';
 import { AppManager } from './AppManager';
@@ -439,6 +439,9 @@ describe('Integration Test', () => {
           },
           getApis() {
             return [];
+          },
+          getTranslations() {
+            return undefined;
           },
           output() {
             return [

--- a/packages/core-compat-api/src/compatWrapper/BackwardsCompatProvider.tsx
+++ b/packages/core-compat-api/src/compatWrapper/BackwardsCompatProvider.tsx
@@ -14,33 +14,32 @@
  * limitations under the License.
  */
 
-import React, { useMemo } from 'react';
-import { ReactNode } from 'react';
+import React, { ReactNode, useMemo } from 'react';
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
 import { AppContextProvider } from '../../../core-app-api/src/app/AppContext';
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
 import { RouteResolver } from '../../../core-plugin-api/src/routing/useRouteRef';
 import {
-  createFrontendPlugin as createNewPlugin,
-  FrontendPlugin as NewFrontendPlugin,
   appTreeApiRef,
   componentsApiRef,
   coreComponentRefs,
+  createFrontendPlugin as createNewPlugin,
+  FrontendPlugin as NewFrontendPlugin,
   iconsApiRef,
-  useApi,
   routeResolutionApiRef,
+  useApi,
 } from '@backstage/frontend-plugin-api';
 import {
   AppComponents,
-  IconComponent,
   BackstagePlugin as LegacyBackstagePlugin,
+  IconComponent,
   RouteRef,
 } from '@backstage/core-plugin-api';
 import {
-  VersionedValue,
   createVersionedContext,
   createVersionedValueMap,
   getOrCreateGlobalSingleton,
+  VersionedValue,
 } from '@backstage/version-bridge';
 import { convertLegacyRouteRef } from '../convertLegacyRouteRef';
 
@@ -76,6 +75,9 @@ export function toLegacyPlugin(
     getApis: notImplemented,
     getFeatureFlags: notImplemented,
     provide: notImplemented,
+    getTranslations() {
+      return plugin.translations;
+    },
   };
 
   legacyPluginStore.set(plugin, legacy);
@@ -86,6 +88,7 @@ export function toLegacyPlugin(
 function toNewPlugin(plugin: LegacyBackstagePlugin): NewFrontendPlugin {
   return createNewPlugin({
     id: plugin.getId(),
+    translations: plugin.getTranslations(),
   });
 }
 

--- a/packages/core-compat-api/src/convertLegacyPlugin.test.tsx
+++ b/packages/core-compat-api/src/convertLegacyPlugin.test.tsx
@@ -15,11 +15,11 @@
  */
 
 import {
-  createPlugin as createLegacyPlugin,
-  createRouteRef as createLegacyRouteRef,
-  createExternalRouteRef as createLegacyExternalRouteRef,
   createApiFactory,
   createApiRef,
+  createExternalRouteRef as createLegacyExternalRouteRef,
+  createPlugin as createLegacyPlugin,
+  createRouteRef as createLegacyRouteRef,
 } from '@backstage/core-plugin-api';
 import { convertLegacyPlugin } from './convertLegacyPlugin';
 import { PageBlueprint } from '@backstage/frontend-plugin-api';
@@ -42,6 +42,7 @@ describe('convertLegacyPlugin', () => {
         "id": "test",
         "routes": {},
         "toString": [Function],
+        "translations": undefined,
         "version": "v1",
         "withOverrides": [Function],
       }

--- a/packages/core-compat-api/src/convertLegacyPlugin.ts
+++ b/packages/core-compat-api/src/convertLegacyPlugin.ts
@@ -17,9 +17,9 @@
 import { BackstagePlugin as LegacyBackstagePlugin } from '@backstage/core-plugin-api';
 import {
   ApiBlueprint,
-  ExtensionDefinition,
   BackstagePlugin as NewBackstagePlugin,
   createFrontendPlugin,
+  ExtensionDefinition,
 } from '@backstage/frontend-plugin-api';
 import { convertLegacyRouteRefs } from './convertLegacyRouteRef';
 
@@ -37,5 +37,6 @@ export function convertLegacyPlugin(
     routes: convertLegacyRouteRefs(legacyPlugin.routes ?? {}),
     externalRoutes: convertLegacyRouteRefs(legacyPlugin.externalRoutes ?? {}),
     extensions: [...apiExtensions, ...options.extensions],
+    translations: legacyPlugin.getTranslations(),
   });
 }

--- a/packages/core-plugin-api/api-report-alpha.md
+++ b/packages/core-plugin-api/api-report-alpha.md
@@ -184,7 +184,7 @@ export interface TranslationRefOptions<
   translations?: TTranslations;
 }
 
-// @alpha (undocumented)
+// @public (undocumented)
 export interface TranslationResource<TId extends string = string> {
   // (undocumented)
   $$type: '@backstage/TranslationResource';

--- a/packages/core-plugin-api/api-report.md
+++ b/packages/core-plugin-api/api-report.md
@@ -230,6 +230,7 @@ export type BackstagePlugin<
   getId(): string;
   getApis(): Iterable<AnyApiFactory>;
   getFeatureFlags(): Iterable<PluginFeatureFlagConfig>;
+  getTranslations(): TranslationResource | undefined;
   provide<T>(extension: Extension<T>): T;
   routes: Routes;
   externalRoutes: ExternalRoutes;
@@ -655,6 +656,7 @@ export type PluginConfig<
   routes?: Routes;
   externalRoutes?: ExternalRoutes;
   featureFlags?: PluginFeatureFlagConfig[];
+  translations?: TranslationResource;
 };
 
 // @public
@@ -737,6 +739,14 @@ export type SubRouteRef<Params extends AnyParams = any> = {
   path: string;
   params: ParamKeys<Params>;
 };
+
+// @public (undocumented)
+export interface TranslationResource<TId extends string = string> {
+  // (undocumented)
+  $$type: '@backstage/TranslationResource';
+  // (undocumented)
+  id: TId;
+}
 
 // @public
 export type TypesToApiRefs<T> = {

--- a/packages/core-plugin-api/src/index.ts
+++ b/packages/core-plugin-api/src/index.ts
@@ -27,3 +27,4 @@ export * from './extensions';
 export * from './icons';
 export * from './plugin';
 export * from './routing';
+export type { TranslationResource } from './translation';

--- a/packages/core-plugin-api/src/plugin/Plugin.tsx
+++ b/packages/core-plugin-api/src/plugin/Plugin.tsx
@@ -15,14 +15,15 @@
  */
 
 import {
-  PluginConfig,
+  AnyExternalRoutes,
+  AnyRoutes,
   BackstagePlugin,
   Extension,
-  AnyRoutes,
-  AnyExternalRoutes,
+  PluginConfig,
   PluginFeatureFlagConfig,
 } from './types';
 import { AnyApiFactory } from '../apis';
+import { TranslationResource } from '../alpha';
 
 /**
  * @internal
@@ -60,6 +61,10 @@ export class PluginImpl<
 
   toString() {
     return `plugin{${this.config.id}}`;
+  }
+
+  getTranslations(): TranslationResource | undefined {
+    return this.config.translations;
   }
 }
 

--- a/packages/core-plugin-api/src/plugin/types.ts
+++ b/packages/core-plugin-api/src/plugin/types.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import { RouteRef, SubRouteRef, ExternalRouteRef } from '../routing';
+import { ExternalRouteRef, RouteRef, SubRouteRef } from '../routing';
 import { AnyApiFactory } from '../apis';
+import { TranslationResource } from '../alpha';
 
 /**
  * Plugin extension type.
@@ -60,6 +61,10 @@ export type BackstagePlugin<
    * Returns all registered feature flags for this plugin.
    */
   getFeatureFlags(): Iterable<PluginFeatureFlagConfig>;
+  /**
+   * @alpha
+   */
+  getTranslations(): TranslationResource | undefined;
   provide<T>(extension: Extension<T>): T;
   routes: Routes;
   externalRoutes: ExternalRoutes;
@@ -89,6 +94,10 @@ export type PluginConfig<
   routes?: Routes;
   externalRoutes?: ExternalRoutes;
   featureFlags?: PluginFeatureFlagConfig[];
+  /**
+   * @alpha
+   */
+  translations?: TranslationResource;
 };
 
 /**

--- a/packages/core-plugin-api/src/translation/TranslationResource.ts
+++ b/packages/core-plugin-api/src/translation/TranslationResource.ts
@@ -19,7 +19,7 @@ import {
   TranslationRef,
 } from '@backstage/core-plugin-api/alpha';
 
-/** @alpha */
+/** @public */
 export interface TranslationResource<TId extends string = string> {
   $$type: '@backstage/TranslationResource';
   id: TId;

--- a/packages/frontend-app-api/src/routing/toLegacyPlugin.ts
+++ b/packages/frontend-app-api/src/routing/toLegacyPlugin.ts
@@ -48,6 +48,7 @@ export function toLegacyPlugin(plugin: BackstagePlugin): LegacyBackstagePlugin {
     getApis: notImplemented,
     getFeatureFlags: notImplemented,
     provide: notImplemented,
+    getTranslations: notImplemented,
   };
 
   legacyPluginStore.set(plugin, legacy);

--- a/packages/frontend-plugin-api/api-report.md
+++ b/packages/frontend-plugin-api/api-report.md
@@ -1274,6 +1274,8 @@ export interface FrontendPlugin<
   readonly id: string;
   // (undocumented)
   readonly routes: TRoutes;
+  // @alpha (undocumented)
+  translations?: TranslationResource;
   // (undocumented)
   withOverrides(options: {
     extensions: Array<ExtensionDefinition>;
@@ -1484,6 +1486,8 @@ export interface PluginOptions<
   id: TId;
   // (undocumented)
   routes?: TRoutes;
+  // @alpha (undocumented)
+  translations?: TranslationResource;
 }
 
 // @public (undocumented)

--- a/packages/frontend-plugin-api/src/wiring/createFrontendPlugin.ts
+++ b/packages/frontend-plugin-api/src/wiring/createFrontendPlugin.ts
@@ -21,10 +21,11 @@ import {
 } from './createExtension';
 import {
   Extension,
-  ResolveExtensionId,
   resolveExtensionDefinition,
+  ResolveExtensionId,
 } from './resolveExtensionDefinition';
 import { AnyExternalRoutes, AnyRoutes, FeatureFlagConfig } from './types';
+import { TranslationResource } from '@backstage/core-plugin-api/alpha';
 
 /** @public */
 export interface FrontendPlugin<
@@ -40,6 +41,11 @@ export interface FrontendPlugin<
   withOverrides(options: {
     extensions: Array<ExtensionDefinition>;
   }): FrontendPlugin<TRoutes, TExternalRoutes, TExtensionMap>;
+
+  /**
+   * @alpha
+   */
+  translations?: TranslationResource;
 }
 
 /**
@@ -63,6 +69,10 @@ export interface PluginOptions<
   externalRoutes?: TExternalRoutes;
   extensions?: TExtensions;
   featureFlags?: FeatureFlagConfig[];
+  /**
+   * @alpha
+   */
+  translations?: TranslationResource;
 }
 
 /** @public */
@@ -131,6 +141,7 @@ export function createFrontendPlugin<
     routes: options.routes ?? ({} as TRoutes),
     externalRoutes: options.externalRoutes ?? ({} as TExternalRoutes),
     featureFlags: options.featureFlags ?? [],
+    translations: options.translations,
     extensions,
     getExtension(id) {
       return extensionDefinitionsById.get(id);

--- a/plugins/user-settings/api-report-alpha.md
+++ b/plugins/user-settings/api-report-alpha.md
@@ -12,6 +12,7 @@ import { IconComponent } from '@backstage/core-plugin-api';
 import { default as React_2 } from 'react';
 import { RouteRef } from '@backstage/frontend-plugin-api';
 import { TranslationRef } from '@backstage/core-plugin-api/alpha';
+import { TranslationResource } from '@backstage/core-plugin-api/alpha';
 
 // @alpha (undocumented)
 const _default: FrontendPlugin<
@@ -114,6 +115,9 @@ export const userSettingsTranslationRef: TranslationRef<
     readonly 'themeToggle.selectAuto': 'Select Auto Theme';
   }
 >;
+
+// @alpha (undocumented)
+export const userSettingsTranslations: TranslationResource<'user-settings'>;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/user-settings/src/plugin.ts
+++ b/plugins/user-settings/src/plugin.ts
@@ -19,6 +19,7 @@ import {
   createRoutableExtension,
   createRouteRef,
 } from '@backstage/core-plugin-api';
+import { userSettingsTranslations } from './translation';
 
 export const settingsRouteRef = createRouteRef({
   id: 'user-settings',
@@ -30,6 +31,7 @@ export const userSettingsPlugin = createPlugin({
   routes: {
     settingsPage: settingsRouteRef,
   },
+  translations: userSettingsTranslations,
 });
 
 /** @public */

--- a/plugins/user-settings/src/translation.ts
+++ b/plugins/user-settings/src/translation.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { createTranslationRef } from '@backstage/core-plugin-api/alpha';
+import {
+  createTranslationRef,
+  createTranslationResource,
+} from '@backstage/core-plugin-api/alpha';
 
 /** @alpha */
 export const userSettingsTranslationRef = createTranslationRef({
@@ -36,5 +39,13 @@ export const userSettingsTranslationRef = createTranslationRef({
         auto: 'Auto',
       },
     },
+  },
+});
+
+/** @alpha */
+export const userSettingsTranslations = createTranslationResource({
+  ref: userSettingsTranslationRef,
+  translations: {
+    fi: () => import('./translations/fi'),
   },
 });

--- a/plugins/user-settings/src/translations/fi.ts
+++ b/plugins/user-settings/src/translations/fi.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { createTranslationMessages } from '@backstage/core-plugin-api/alpha';
+import { userSettingsTranslationRef } from '../translation';
+
+const fi = createTranslationMessages({
+  ref: userSettingsTranslationRef,
+  full: false,
+  messages: {
+    'languageToggle.title': 'Kieli',
+    'languageToggle.description': 'Vaihda kieli',
+    'languageToggle.select': 'Valitse kieli {{language}}',
+    'themeToggle.title': 'Teema',
+    'themeToggle.description': 'Vaihda teemaa',
+    'themeToggle.select': 'Valitse teema {{theme}}',
+    'themeToggle.selectAuto': 'Valitse teema automaattisesti',
+    'themeToggle.names.light': 'Vaalea',
+    'themeToggle.names.dark': 'Tumma',
+    'themeToggle.names.auto': 'Automaattinen',
+  },
+});
+
+export default fi;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

NOTE: Maybe not mergeable as is, just proof of concept.

this allows plugins to add their own translations in the plugin creation. app developer translation resources override the ones coming from plugin. also this requires the application devleoper to define the available languages (which could come automatically too from plugins).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
