### PR TITLE
backend-defaults: remove support for legacy auth

### DIFF
--- a/.changeset/kind-walls-speak.md
+++ b/.changeset/kind-walls-speak.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': minor
+---
+
+**BREAKING**: The backwards compatibility with plugins using legacy auth through the token manage service has been removed. This means that instead of falling back to using the old token manager, requests towards plugins that don't support the new auth system will simply fail. Please make sure that all plugins in your deployment are hosted within a backend instance from the new backend system.

--- a/packages/backend-defaults/src/entrypoints/auth/DefaultAuthService.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/DefaultAuthService.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { TokenManager } from '@backstage/backend-common';
 import {
   AuthService,
   BackstageCredentials,
@@ -22,9 +21,8 @@ import {
   BackstagePrincipalTypes,
   BackstageServicePrincipal,
   BackstageUserPrincipal,
-  LoggerService,
 } from '@backstage/backend-plugin-api';
-import { AuthenticationError, ForwardedError } from '@backstage/errors';
+import { AuthenticationError } from '@backstage/errors';
 import { JsonObject } from '@backstage/types';
 import { decodeJwt } from 'jose';
 import { ExternalTokenHandler } from './external/ExternalTokenHandler';
@@ -44,11 +42,9 @@ export class DefaultAuthService implements AuthService {
     private readonly userTokenHandler: UserTokenHandler,
     private readonly pluginTokenHandler: PluginTokenHandler,
     private readonly externalTokenHandler: ExternalTokenHandler,
-    private readonly tokenManager: TokenManager,
     private readonly pluginId: string,
     private readonly disableDefaultAuthPolicy: boolean,
     private readonly pluginKeySource: PluginKeySource,
-    private readonly logger: LoggerService,
   ) {}
 
   async authenticate(
@@ -153,55 +149,28 @@ export class DefaultAuthService implements AuthService {
       return { token: '' };
     }
 
-    const targetSupportsNewAuth =
-      await this.pluginTokenHandler.isTargetPluginSupported(targetPluginId);
-
     // check whether a plugin support the new auth system
     // by checking the public keys endpoint existance.
     switch (type) {
       // TODO: Check whether the principal is ourselves
       case 'service':
-        if (targetSupportsNewAuth) {
-          return this.pluginTokenHandler.issueToken({
-            pluginId: this.pluginId,
-            targetPluginId,
-          });
-        }
-        // If the target plugin does not support the new auth service, fall back to using old token format
-        this.logger.warn(
-          `DEPRECATION WARNING: A call to the '${targetPluginId}' plugin had to fall back to using deprecated auth via the token manager service. Please migrate all plugins to the new auth service, see https://backstage.io/docs/tutorials/auth-service-migration for more information`,
-        );
-        return this.tokenManager.getToken().catch(error => {
-          throw new ForwardedError(
-            `Unable to generate legacy token for communication with the '${targetPluginId}' plugin. ` +
-              `You will typically encounter this error when attempting to call a plugin that does not exist, or is deployed with an old version of Backstage`,
-            error,
-          );
+        return this.pluginTokenHandler.issueToken({
+          pluginId: this.pluginId,
+          targetPluginId,
         });
       case 'user': {
         const { token } = internalForward;
         if (!token) {
           throw new Error('User credentials is unexpectedly missing token');
         }
-        // If the target plugin supports the new auth service we issue a service
-        // on-behalf-of token rather than forwarding the user token
-        if (targetSupportsNewAuth) {
-          const onBehalfOf = await this.userTokenHandler.createLimitedUserToken(
-            token,
-          );
-          return this.pluginTokenHandler.issueToken({
-            pluginId: this.pluginId,
-            targetPluginId,
-            onBehalfOf,
-          });
-        }
-
-        if (this.userTokenHandler.isLimitedUserToken(token)) {
-          throw new AuthenticationError(
-            `Unable to call '${targetPluginId}' plugin on behalf of user, because the target plugin does not support on-behalf-of tokens or the plugin doesn't exist`,
-          );
-        }
-        return { token };
+        const onBehalfOf = await this.userTokenHandler.createLimitedUserToken(
+          token,
+        );
+        return this.pluginTokenHandler.issueToken({
+          pluginId: this.pluginId,
+          targetPluginId,
+          onBehalfOf,
+        });
       }
       default:
         throw new AuthenticationError(

--- a/packages/backend-defaults/src/entrypoints/auth/authServiceFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/authServiceFactory.ts
@@ -41,13 +41,8 @@ export const authServiceFactory = createServiceFactory({
     discovery: coreServices.discovery,
     plugin: coreServices.pluginMetadata,
     database: coreServices.database,
-    // Re-using the token manager makes sure that we use the same generated keys for
-    // development as plugins that have not yet been migrated. It's important that this
-    // keeps working as long as there are plugins that have not been migrated to the
-    // new auth services in the new backend system.
-    tokenManager: coreServices.tokenManager,
   },
-  async factory({ config, discovery, plugin, tokenManager, logger, database }) {
+  async factory({ config, discovery, plugin, logger, database }) {
     const disableDefaultAuthPolicy =
       config.getOptionalBoolean(
         'backend.auth.dangerouslyDisableDefaultAuthPolicy',
@@ -84,11 +79,9 @@ export const authServiceFactory = createServiceFactory({
       userTokens,
       pluginTokens,
       externalTokens,
-      tokenManager,
       plugin.getId(),
       disableDefaultAuthPolicy,
       keySource,
-      logger,
     );
   },
 });

--- a/packages/backend-defaults/src/entrypoints/auth/plugin/PluginTokenHandler.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/plugin/PluginTokenHandler.ts
@@ -146,7 +146,9 @@ export class PluginTokenHandler {
     return { token };
   }
 
-  async isTargetPluginSupported(targetPluginId: string): Promise<boolean> {
+  private async isTargetPluginSupported(
+    targetPluginId: string,
+  ): Promise<boolean> {
     if (this.supportedTargetPlugins.has(targetPluginId)) {
       return true;
     }
@@ -199,7 +201,8 @@ export class PluginTokenHandler {
     // Double check that the target plugin has a valid JWKS endpoint, otherwise avoid creating a remote key set
     if (!(await this.isTargetPluginSupported(pluginId))) {
       throw new AuthenticationError(
-        `Received a plugin token where the source '${pluginId}' plugin unexpectedly does not have a JWKS endpoint`,
+        `Received a plugin token where the source '${pluginId}' plugin unexpectedly does not have a JWKS endpoint. ` +
+          'The target plugin needs to be migrated to be installed in an app using the new backend system.',
       );
     }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This removes support for the detection and automatic backwards compatibility of auth towards plugins deployed using the old backend system. Since we are removing the identity and token manager services we will no longer be able to support this compatibility layer. The changes in #26115 does still allow for legacy plugins using the token manager to be deployed in the new backend system however, which makes them support the new auth services.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
