### PR TITLE
fix:(techdocs): Unnecessary updates in `useShadowRootElements`

### DIFF
--- a/.changeset/brown-worms-sneeze.md
+++ b/.changeset/brown-worms-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-react': patch
+---
+
+Fixed issue in useShadowRootElements which could lead to unlimited render loops

--- a/plugins/techdocs-module-addons-contrib/src/TextSize/TextSize.test.tsx
+++ b/plugins/techdocs-module-addons-contrib/src/TextSize/TextSize.test.tsx
@@ -16,10 +16,22 @@
 
 import { TechDocsAddonTester } from '@backstage/plugin-techdocs-addons-test-utils';
 import React from 'react';
-import { fireEvent, waitFor, act } from '@testing-library/react';
+import { act, fireEvent, waitFor } from '@testing-library/react';
 import { TextSize } from '../plugin';
+import { useShadowRootElements } from '@backstage/plugin-techdocs-react';
+
+jest.mock('@backstage/plugin-techdocs-react', () => ({
+  ...jest.requireActual('@backstage/plugin-techdocs-react'),
+  useShadowRootElements: jest.fn(),
+}));
 
 describe('TextSize', () => {
+  const useShadowRootElementsMock = useShadowRootElements as jest.Mock;
+
+  beforeEach(() => {
+    useShadowRootElementsMock.mockReturnValue([]);
+  });
+
   it('renders without exploding', async () => {
     const { getByText } = await TechDocsAddonTester.buildAddonsInTechDocs([
       <TextSize />,
@@ -35,6 +47,9 @@ describe('TextSize', () => {
       await TechDocsAddonTester.buildAddonsInTechDocs([<TextSize />])
         .withDom(<body>TEST_CONTENT</body>)
         .renderWithEffects();
+
+    const content = getByText('TEST_CONTENT');
+    useShadowRootElementsMock.mockReturnValue([content]);
 
     fireEvent.click(getByTitle('Settings'));
 
@@ -60,7 +75,9 @@ describe('TextSize', () => {
 
     let style = window.getComputedStyle(getByText('TEST_CONTENT'));
 
-    expect(style.getPropertyValue('--md-typeset-font-size')).toBe('18.4px');
+    await waitFor(() => {
+      expect(style.getPropertyValue('--md-typeset-font-size')).toBe('18.4px');
+    });
 
     fireEvent.keyDown(slider, {
       key: 'ArrowLeft',
@@ -87,6 +104,9 @@ describe('TextSize', () => {
     } = await TechDocsAddonTester.buildAddonsInTechDocs([<TextSize />])
       .withDom(<body>TEST_CONTENT</body>)
       .renderWithEffects();
+
+    const content = getByText('TEST_CONTENT');
+    useShadowRootElementsMock.mockReturnValue([content]);
 
     fireEvent.click(getByTitle('Settings'));
 

--- a/plugins/techdocs-react/src/hooks.ts
+++ b/plugins/techdocs-react/src/hooks.ts
@@ -39,13 +39,13 @@ export const useShadowRootElements = <
   selectors: string[],
 ): TReturnedElement[] => {
   const shadowRoot = useShadowRoot();
-  const [render, rerender] = useState(false);
+  const [root, setRootNode] = useState(shadowRoot?.firstChild);
 
   useEffect(() => {
     let observer: MutationObserver;
     if (shadowRoot) {
       observer = new MutationObserver(() => {
-        rerender(!render);
+        setRootNode(shadowRoot?.firstChild);
       });
       observer.observe(shadowRoot, {
         attributes: true,
@@ -55,12 +55,12 @@ export const useShadowRootElements = <
       });
     }
     return () => observer?.disconnect();
-  }, [shadowRoot, render, rerender]);
+  }, [shadowRoot]);
 
-  if (!shadowRoot) return [];
+  if (!root || !(root instanceof HTMLElement)) return [];
 
   return selectors
-    .map(selector => shadowRoot.querySelectorAll<TReturnedElement>(selector))
+    .map(selector => root.querySelectorAll<TReturnedElement>(selector))
     .filter(nodeList => nodeList.length)
     .map(nodeList => Array.from(nodeList))
     .flat();


### PR DESCRIPTION


## Hey, I just made a Pull Request!

Updated `useShadowRootElements` to use the shadow root first child instead of flipping booleans to help with unnecessary updates when the DOM doesn't change. It was also possible that if the side-effects from the elements touched the DOM, but didn't change it, this hook could possible get into a infinite loop

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
