### PR TITLE
Fix secret saving behaviour in SecretWidget

### DIFF
--- a/.changeset/fifty-maps-drive.md
+++ b/.changeset/fifty-maps-drive.md
@@ -1,0 +1,35 @@
+---
+'@backstage/plugin-scaffolder-react': major
+---
+
+**BREAKING:** Fixed a [wrong behaviour in `SecretWidget`](https://github.com/backstage/backstage/issues/25966) where secrets are saved using the field name instead of the proper path in the `formData`. If you were using nested `SecretFields` they will now be on the correct nested value.
+
+Example:
+
+```
+spec:
+  type: service
+  parameters:
+    - title: Normal
+      properties:
+        nested:
+          type: object
+          properties:
+            name:
+              type: string
+              ui:field: Secret
+```
+
+Before this change the secret would be accessible via `secrets.name` instead of `secrets.nested.name`.
+
+Migration:
+
+```diff
+ steps:
+   - id: debug
+     name: debug
+     action: debug:log
+     input:
+-      message: "Creating foo with name: ${{ secrets.name }}"
++      message: "Creating foo with name: ${{ secrets.nested.name }}"
+```

--- a/.changeset/smooth-moles-drive.md
+++ b/.changeset/smooth-moles-drive.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+The new version of scaffolder-react requires a change in the handling of secrets for the BitbucketRepoPicker.

--- a/docs/features/software-templates/writing-templates.md
+++ b/docs/features/software-templates/writing-templates.md
@@ -264,14 +264,23 @@ spec:
         password:
           type: string
           ui:field: Secret
+        api:
+          type: object
+          properties:
+            host:
+              type: string
+            key:
+              type: string
+              ui:field: Secret
 
   steps:
     - id: setupAuthentication
       action: auth:create
       input:
-        # make sure to use ${{ secrets.parameterName }} to reference these values
+        # make sure to use ${{ secrets.parameterPath }} to reference these values
         username: ${{ secrets.username }}
         password: ${{ secrets.password }}
+        apiKey: ${{ secrets.api.key }}
 ```
 
 ### Custom step layouts

--- a/plugins/scaffolder-react/api-report-alpha.md
+++ b/plugins/scaffolder-react/api-report-alpha.md
@@ -154,8 +154,10 @@ export type ScaffolderReactTemplateCategoryPickerClassKey = 'root' | 'label';
 export const SecretWidget: (
   props: Pick<
     WidgetProps,
-    'name' | 'onChange' | 'schema' | 'required' | 'disabled'
-  >,
+    'onChange' | 'schema' | 'required' | 'disabled' | 'idSchema'
+  > & {
+    idSeparator?: string;
+  },
 ) => React_2.JSX.Element;
 
 // @alpha

--- a/plugins/scaffolder-react/api-report.md
+++ b/plugins/scaffolder-react/api-report.md
@@ -401,7 +401,7 @@ export type ScaffolderRJSFRegistryFieldsType<
 // @public
 export interface ScaffolderScaffoldOptions {
   // (undocumented)
-  secrets?: Record<string, string>;
+  secrets?: JsonObject;
   // (undocumented)
   templateRef: string;
   // (undocumented)
@@ -459,9 +459,9 @@ export type ScaffolderTaskStatus =
 // @public
 export interface ScaffolderUseTemplateSecrets {
   // (undocumented)
-  secrets: Record<string, string>;
+  secrets: JsonObject;
   // (undocumented)
-  setSecrets: (input: Record<string, string>) => void;
+  setSecrets: (input: JsonObject) => void;
 }
 
 // @public

--- a/plugins/scaffolder-react/src/api/types.ts
+++ b/plugins/scaffolder-react/src/api/types.ts
@@ -125,7 +125,7 @@ export type LogEvent = {
 export interface ScaffolderScaffoldOptions {
   templateRef: string;
   values: Record<string, JsonValue>;
-  secrets?: Record<string, string>;
+  secrets?: JsonObject;
 }
 
 /**

--- a/plugins/scaffolder-react/src/next/components/Form/Form.tsx
+++ b/plugins/scaffolder-react/src/next/components/Form/Form.tsx
@@ -64,6 +64,11 @@ export const Form = (props: PropsWithChildren<ScaffolderRJSFFormProps>) => {
   );
 
   return (
-    <WrappedForm {...props} templates={templates} fields={wrappedFields} />
+    <WrappedForm
+      {...props}
+      templates={templates}
+      fields={wrappedFields}
+      idSeparator="/"
+    />
   );
 };

--- a/plugins/scaffolder-react/src/next/components/SecretWidget/SecretWidget.test.tsx
+++ b/plugins/scaffolder-react/src/next/components/SecretWidget/SecretWidget.test.tsx
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useTemplateSecrets } from '@backstage/plugin-scaffolder-react';
+import { SecretWidget } from './SecretWidget';
+
+jest.mock('@backstage/plugin-scaffolder-react', () => ({
+  useTemplateSecrets: jest.fn(),
+}));
+
+describe('SecretWidget', () => {
+  const mockUseTemplateSecrets = useTemplateSecrets as jest.MockedFunction<
+    typeof useTemplateSecrets
+  >;
+
+  beforeEach(() => {
+    mockUseTemplateSecrets.mockReturnValue({
+      setSecrets: jest.fn(),
+      secrets: {},
+    });
+  });
+
+  it('should render the label correctly', () => {
+    const props = {
+      name: 'password',
+      onChange: jest.fn(),
+      schema: { title: 'Password' },
+      idSchema: {
+        $id: 'root_password',
+      },
+      idSeparator: '',
+    };
+
+    render(<SecretWidget {...props} />);
+
+    expect(screen.getByLabelText('Password')).toBeInTheDocument();
+  });
+
+  it('should render the input field correctly', () => {
+    const props = {
+      name: 'password',
+      onChange: jest.fn(),
+      schema: { title: 'Password' },
+      idSchema: {
+        $id: 'root_password',
+      },
+      idSeparator: '',
+    };
+    mockUseTemplateSecrets.mockReturnValueOnce({
+      setSecrets: jest.fn(),
+      secrets: {
+        password: 'mySecretPassword',
+      },
+    });
+
+    render(<SecretWidget {...props} />);
+
+    const input = screen.getByLabelText('Password') as HTMLInputElement;
+
+    expect(input).toBeInTheDocument();
+    expect(input.type).toBe('password');
+    expect(input).toHaveValue('mySecretPassword');
+  });
+
+  it('should render the input field correctly for nested fields', () => {
+    const props = {
+      name: 'password',
+      onChange: jest.fn(),
+      schema: { title: 'Password' },
+      idSchema: {
+        $id: 'root_api_password',
+      },
+      idSeparator: undefined,
+    };
+    mockUseTemplateSecrets.mockReturnValueOnce({
+      setSecrets: jest.fn(),
+      secrets: {
+        api: {
+          password: 'mySecretPassword',
+        },
+      },
+    });
+
+    render(<SecretWidget {...props} />);
+
+    const input = screen.getByLabelText('Password') as HTMLInputElement;
+
+    expect(input).toBeInTheDocument();
+    expect(input.type).toBe('password');
+    expect(input).toHaveValue('mySecretPassword');
+  });
+
+  it('should render the input field correctly for array fields', () => {
+    const props = {
+      name: 'password',
+      onChange: jest.fn(),
+      schema: { title: 'Password' },
+      idSchema: {
+        $id: 'root_apis_1_password',
+      },
+      idSeparator: undefined,
+    };
+    mockUseTemplateSecrets.mockReturnValueOnce({
+      setSecrets: jest.fn(),
+      secrets: {
+        apis: [
+          undefined,
+          {
+            password: 'mySecretPassword',
+          },
+        ],
+      } as any,
+    });
+
+    render(<SecretWidget {...props} />);
+
+    const input = screen.getByLabelText('Password') as HTMLInputElement;
+
+    expect(input).toBeInTheDocument();
+    expect(input.type).toBe('password');
+    expect(input).toHaveValue('mySecretPassword');
+  });
+
+  it('should update the value and secrets when input value changes', () => {
+    const setSecrets = jest.fn();
+    const props = {
+      name: 'password',
+      onChange: jest.fn(),
+      schema: { title: 'Password' },
+      idSchema: { $id: 'root_password' },
+      idSeparator: '',
+    };
+    mockUseTemplateSecrets.mockReturnValueOnce({
+      setSecrets,
+      secrets: {},
+    });
+
+    render(<SecretWidget {...props} />);
+
+    const input = screen.getByLabelText('Password') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'mySecretPassword' } });
+
+    expect(props.onChange).toHaveBeenCalledWith('****************');
+    expect(setSecrets).toHaveBeenCalledWith({
+      password: 'mySecretPassword',
+    });
+  });
+
+  it('should update the value correctly for nested fields', () => {
+    const setSecrets = jest.fn();
+    const props = {
+      name: 'password',
+      onChange: jest.fn(),
+      schema: { title: 'Password' },
+      idSchema: { $id: 'root_api_password' },
+      idSeparator: undefined,
+    };
+    mockUseTemplateSecrets.mockReturnValueOnce({
+      setSecrets,
+      secrets: {},
+    });
+
+    render(<SecretWidget {...props} />);
+
+    const input = screen.getByLabelText('Password');
+    fireEvent.change(input, { target: { value: 'mySecretPassword' } });
+
+    expect(props.onChange).toHaveBeenCalledWith('****************');
+    expect(setSecrets).toHaveBeenCalledWith({
+      api: {
+        password: 'mySecretPassword',
+      },
+    });
+  });
+
+  it('should update the value correctly for array fields', () => {
+    const setSecrets = jest.fn();
+    const props = {
+      name: 'password',
+      onChange: jest.fn(),
+      schema: { title: 'Password' },
+      idSchema: { $id: 'root_apis_0_password' },
+      idSeparator: undefined,
+    };
+    mockUseTemplateSecrets.mockReturnValueOnce({
+      setSecrets,
+      secrets: {},
+    });
+
+    render(<SecretWidget {...props} />);
+    const input = screen.getByLabelText('Password');
+    fireEvent.change(input, { target: { value: 'mySecretPassword' } });
+
+    expect(props.onChange).toHaveBeenCalledWith('****************');
+    expect(setSecrets).toHaveBeenCalledWith({
+      apis: [
+        {
+          password: 'mySecretPassword',
+        },
+      ],
+    });
+  });
+
+  it('should update the value correctly for array fields at not zero index', () => {
+    const setSecrets = jest.fn();
+    const props = {
+      name: 'password',
+      onChange: jest.fn(),
+      schema: { title: 'Password' },
+      idSchema: { $id: 'root_apis_2_password' },
+      idSeparator: undefined,
+    };
+    mockUseTemplateSecrets.mockReturnValueOnce({
+      setSecrets,
+      secrets: {
+        apis: [
+          {
+            password: 'mySecretPassword',
+          },
+        ],
+      } as any,
+    });
+
+    render(<SecretWidget {...props} />);
+    const input = screen.getByLabelText('Password');
+    fireEvent.change(input, { target: { value: 'mySecretPassword' } });
+
+    expect(props.onChange).toHaveBeenCalledWith('****************');
+    expect(setSecrets).toHaveBeenCalledWith({
+      apis: [
+        undefined,
+        undefined,
+        {
+          password: 'mySecretPassword',
+        },
+      ],
+    });
+  });
+
+  it('should display the current secret value', () => {
+    const props = {
+      name: 'password',
+      onChange: jest.fn(),
+      schema: { title: 'Password' },
+      idSchema: {
+        $id: 'root_password',
+      },
+      idSeparator: '',
+    };
+    mockUseTemplateSecrets.mockReturnValueOnce({
+      setSecrets: jest.fn(),
+      secrets: { password: 'mySecretPassword' },
+    });
+
+    render(<SecretWidget {...props} />);
+
+    const input = screen.getByLabelText('Password');
+    expect(input).toHaveValue('mySecretPassword');
+  });
+});

--- a/plugins/scaffolder-react/src/secrets/SecretsContext.test.tsx
+++ b/plugins/scaffolder-react/src/secrets/SecretsContext.test.tsx
@@ -36,6 +36,51 @@ describe('SecretsContext', () => {
     expect(result.current.hook?.secrets.foo).toEqual('bar');
   });
 
+  it('should allow setting nested secrets in the context', async () => {
+    const { result } = renderHook(
+      () => ({
+        hook: useTemplateSecrets(),
+      }),
+      {
+        wrapper: ({ children }: React.PropsWithChildren<{}>) => (
+          <SecretsContextProvider>{children}</SecretsContextProvider>
+        ),
+      },
+    );
+
+    expect(result.current.hook?.secrets).toEqual({});
+
+    act(() => result.current.hook.setSecrets({ foo: { bar: 'baz' } }));
+
+    expect(result.current.hook?.secrets).toEqual({ foo: { bar: 'baz' } });
+  });
+
+  it('should allow setting secrets in arrays in the context', async () => {
+    const { result } = renderHook(
+      () => ({
+        hook: useTemplateSecrets(),
+      }),
+      {
+        wrapper: ({ children }: React.PropsWithChildren<{}>) => (
+          <SecretsContextProvider>{children}</SecretsContextProvider>
+        ),
+      },
+    );
+
+    expect(result.current.hook?.secrets).toEqual({});
+
+    act(() => result.current.hook.setSecrets({ foo: ['one'] }));
+
+    expect(result.current.hook?.secrets).toEqual({ foo: ['one'] });
+
+    const otherFoo: string[] = [];
+    otherFoo[1] = 'two';
+
+    act(() => result.current.hook.setSecrets({ foo: otherFoo }));
+
+    expect(result.current.hook?.secrets).toEqual({ foo: ['one', 'two'] });
+  });
+
   it('should create SecretsContextProvider with initial secrets', async () => {
     const { result } = renderHook(
       () => ({

--- a/plugins/scaffolder-react/src/secrets/SecretsContext.tsx
+++ b/plugins/scaffolder-react/src/secrets/SecretsContext.tsx
@@ -23,6 +23,8 @@ import React, {
   useContext,
   PropsWithChildren,
 } from 'react';
+import merge from 'lodash/merge';
+import { JsonObject } from '@backstage/types';
 
 /**
  * The contents of the `SecretsContext`
@@ -65,8 +67,8 @@ export const SecretsContextProvider = (
  * @public
  */
 export interface ScaffolderUseTemplateSecrets {
-  setSecrets: (input: Record<string, string>) => void;
-  secrets: Record<string, string>;
+  setSecrets: (input: JsonObject) => void;
+  secrets: JsonObject;
 }
 
 /**
@@ -86,8 +88,11 @@ export const useTemplateSecrets = (): ScaffolderUseTemplateSecrets => {
   const { setSecrets: updateSecrets, secrets = {} } = value;
 
   const setSecrets = useCallback(
-    (input: Record<string, string>) => {
-      updateSecrets(currentSecrets => ({ ...currentSecrets, ...input }));
+    (input: JsonObject) => {
+      updateSecrets(currentSecrets => {
+        const newSecrets = merge({}, currentSecrets, input);
+        return newSecrets;
+      });
     },
     [updateSecrets],
   );

--- a/plugins/scaffolder/src/components/fields/RepoBranchPicker/RepoBranchPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoBranchPicker/RepoBranchPicker.test.tsx
@@ -137,7 +137,7 @@ describe('RepoBranchPicker', () => {
 
       const SecretsComponent = () => {
         const { secrets } = useTemplateSecrets();
-        const secret = secrets[secretsKey];
+        const secret = secrets[secretsKey] as string;
         return secret ? <div>{secret}</div> : null;
       };
 
@@ -249,7 +249,7 @@ describe('RepoBranchPicker', () => {
 
       const SecretsComponent = () => {
         const { secrets } = useTemplateSecrets();
-        const secret = secrets[secretsKey];
+        const secret = secrets[secretsKey] as string;
         return secret ? <div>{secret}</div> : null;
       };
 

--- a/plugins/scaffolder/src/components/fields/RepoBranchPicker/RepoBranchPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoBranchPicker/RepoBranchPicker.tsx
@@ -119,6 +119,17 @@ export const RepoBranchPicker = (props: RepoBranchPickerProps) => {
 
   const hostType = (host && integrationApi.byHost(host)?.type) ?? null;
 
+  const getAccessToken = (): string | undefined => {
+    const secretsKey =
+      uiSchema?.['ui:options']?.requestUserCredentials?.secretsKey;
+    if (!secretsKey) return undefined;
+
+    const secret = secrets[secretsKey];
+    if (typeof secret !== 'string') return undefined;
+
+    return secret;
+  };
+
   const renderRepoBranchPicker = () => {
     switch (hostType) {
       case 'bitbucket':
@@ -127,10 +138,7 @@ export const RepoBranchPicker = (props: RepoBranchPickerProps) => {
             onChange={updateLocalState}
             state={state}
             rawErrors={rawErrors}
-            accessToken={
-              uiSchema?.['ui:options']?.requestUserCredentials?.secretsKey &&
-              secrets[uiSchema['ui:options'].requestUserCredentials.secretsKey]
-            }
+            accessToken={getAccessToken()}
             required={required}
           />
         );

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.test.tsx
@@ -219,7 +219,7 @@ describe('RepoUrlPicker', () => {
 
       const SecretsComponent = () => {
         const { secrets } = useTemplateSecrets();
-        const secret = secrets[secretsKey];
+        const secret = secrets[secretsKey] as string;
         return secret ? <div>{secret}</div> : null;
       };
       const { getByText } = await renderInTestApp(
@@ -317,7 +317,7 @@ describe('RepoUrlPicker', () => {
 
       const SecretsComponent = () => {
         const { secrets } = useTemplateSecrets();
-        const secret = secrets[secretsKey];
+        const secret = secrets[secretsKey] as string;
         return secret ? <div>{secret}</div> : null;
       };
       const allowedHosts = ['github.com', 'gitlab.example.com'];

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
@@ -161,6 +161,18 @@ export const RepoUrlPicker = (props: RepoUrlPickerProps) => {
 
   const hostType =
     (state.host && integrationApi.byHost(state.host)?.type) ?? null;
+
+  const getAccessToken = (): string | undefined => {
+    const secretsKey =
+      uiSchema?.['ui:options']?.requestUserCredentials?.secretsKey;
+    if (!secretsKey) return undefined;
+
+    const secret = secrets[secretsKey];
+    if (typeof secret !== 'string') return undefined;
+
+    return secret;
+  };
+
   return (
     <>
       {schema.title && (
@@ -210,10 +222,7 @@ export const RepoUrlPicker = (props: RepoUrlPickerProps) => {
           rawErrors={rawErrors}
           state={state}
           onChange={updateLocalState}
-          accessToken={
-            uiSchema?.['ui:options']?.requestUserCredentials?.secretsKey &&
-            secrets[uiSchema['ui:options'].requestUserCredentials.secretsKey]
-          }
+          accessToken={getAccessToken()}
         />
       )}
       {hostType === 'azure' && (


### PR DESCRIPTION
## Hey, I just made a Pull Request!

**BREAKING**: Fixed a [wrong behaviour in `SecretWidget`](https://github.com/backstage/backstage/issues/25966) where secrets are saved using the field name instead of the proper path in the formData.
The previous behaviour caused problems when using nested formData or array fields.

Example:

```
spec:
  type: service
  parameters:
    - title: Normal
      properties:
        nested:
          type: object
          properties:
            name:
              type: string
              ui:field: Secret
```

Before this change the secret would be accessible via `secrets.name` instead of `secrets.nested.name`.

Migration:

```diff
 steps:
   - id: debug
     name: debug
     action: debug:log
     input:
-      message: "Creating foo with name: ${{ secrets.name }}"
+      message: "Creating foo with name: ${{ secrets.nested.name }}"
```


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
