### PR TITLE
frontend-plugin-api: clean up internal createExtension{,Input,Blueprint} types

### DIFF
--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
@@ -17,7 +17,6 @@
 import { AppNode } from '../apis';
 import { Expand } from '../types';
 import {
-  CreateExtensionOptions,
   ExtensionDefinition,
   ResolvedExtensionInputs,
   VerifyExtensionFactoryOutput,
@@ -212,193 +211,6 @@ export interface ExtensionBlueprint<
 }
 
 /**
- * @internal
- */
-class ExtensionBlueprintImpl<
-  TKind extends string,
-  TNamespace extends string | undefined,
-  TName extends string | undefined,
-  TParams,
-  UOutput extends AnyExtensionDataRef,
-  TInputs extends {
-    [inputName in string]: ExtensionInput<
-      AnyExtensionDataRef,
-      { optional: boolean; singleton: boolean }
-    >;
-  },
-  TConfigSchema extends { [key in string]: (zImpl: typeof z) => z.ZodType },
-  TDataRefs extends { [name in string]: AnyExtensionDataRef },
-> {
-  constructor(
-    private readonly options: CreateExtensionBlueprintOptions<
-      TKind,
-      TNamespace,
-      TName,
-      TParams,
-      UOutput,
-      TInputs,
-      TConfigSchema,
-      any,
-      TDataRefs
-    >,
-  ) {
-    this.dataRefs = options.dataRefs!;
-  }
-
-  dataRefs: TDataRefs;
-
-  public makeWithOverrides<
-    TExtensionConfigSchema extends {
-      [key in string]: (zImpl: typeof z) => z.ZodType;
-    },
-    UFactoryOutput extends ExtensionDataValue<any, any>,
-    UNewOutput extends AnyExtensionDataRef,
-    TExtraInputs extends {
-      [inputName in string]: ExtensionInput<
-        AnyExtensionDataRef,
-        { optional: boolean; singleton: boolean }
-      >;
-    },
-    TNewNamespace extends string | undefined = undefined,
-    TNewName extends string | undefined = undefined,
-  >(args: {
-    namespace?: TNewNamespace;
-    name?: TNewName;
-    attachTo?: { id: string; input: string };
-    disabled?: boolean;
-    inputs?: TExtraInputs;
-    output?: Array<UNewOutput>;
-    config?: {
-      schema: TExtensionConfigSchema;
-    };
-    factory(
-      originalFactory: (
-        params: TParams,
-        context?: {
-          config?: {
-            [key in keyof TConfigSchema]: z.infer<
-              ReturnType<TConfigSchema[key]>
-            >;
-          };
-          inputs?: ResolveInputValueOverrides<TInputs>;
-        },
-      ) => ExtensionDataContainer<UOutput>,
-      context: {
-        node: AppNode;
-        config: {
-          [key in keyof TExtensionConfigSchema]: z.infer<
-            ReturnType<TExtensionConfigSchema[key]>
-          >;
-        } & {
-          [key in keyof TConfigSchema]: z.infer<ReturnType<TConfigSchema[key]>>;
-        };
-        inputs: Expand<ResolvedExtensionInputs<TInputs & TExtraInputs>>;
-      },
-    ): Iterable<UFactoryOutput>;
-  }): ExtensionDefinition<
-    {
-      [key in keyof TExtensionConfigSchema]: z.infer<
-        ReturnType<TExtensionConfigSchema[key]>
-      >;
-    } & {
-      [key in keyof TConfigSchema]: z.infer<ReturnType<TConfigSchema[key]>>;
-    },
-    z.input<
-      z.ZodObject<
-        {
-          [key in keyof TExtensionConfigSchema]: ReturnType<
-            TExtensionConfigSchema[key]
-          >;
-        } & {
-          [key in keyof TConfigSchema]: ReturnType<TConfigSchema[key]>;
-        }
-      >
-    >
-  > {
-    const schema = {
-      ...this.options.config?.schema,
-      ...args.config?.schema,
-    } as TConfigSchema & TExtensionConfigSchema;
-
-    return createExtension({
-      kind: this.options.kind,
-      namespace: args.namespace ?? this.options.namespace,
-      name: args.name ?? this.options.name,
-      attachTo: args.attachTo ?? this.options.attachTo,
-      disabled: args.disabled ?? this.options.disabled,
-      inputs: { ...args.inputs, ...this.options.inputs },
-      output: args.output ?? this.options.output,
-      config: Object.keys(schema).length === 0 ? undefined : { schema },
-      factory: ({ node, config, inputs }) => {
-        return args.factory(
-          (
-            innerParams: TParams,
-            innerContext?: {
-              config?: {
-                [key in keyof TConfigSchema]: z.infer<
-                  ReturnType<TConfigSchema[key]>
-                >;
-              };
-              inputs?: ResolveInputValueOverrides;
-            },
-          ): ExtensionDataContainer<UOutput> => {
-            return createExtensionDataContainer<UOutput>(
-              this.options.factory(innerParams, {
-                node,
-                config: innerContext?.config ?? config,
-                inputs: resolveInputOverrides(
-                  this.options.inputs,
-                  inputs,
-                  innerContext?.inputs,
-                ) as any, // TODO: Might be able to improve this once legacy inputs are gone
-              }),
-              this.options.output,
-            );
-          },
-          {
-            node,
-            config,
-            inputs,
-          },
-        );
-      },
-    } as CreateExtensionOptions<TKind, string | undefined extends TNewNamespace ? TNamespace : TNewNamespace, string | undefined extends TNewName ? TName : TNewName, AnyExtensionDataRef extends UNewOutput ? UOutput : UNewOutput, TInputs & TExtraInputs, TConfigSchema & TExtensionConfigSchema, UFactoryOutput>);
-  }
-
-  public make<
-    TNewNamespace extends string | undefined = undefined,
-    TNewName extends string | undefined = undefined,
-  >(args: {
-    namespace?: TNewNamespace;
-    name?: TNewName;
-    attachTo?: { id: string; input: string };
-    disabled?: boolean;
-    params: TParams;
-  }): ExtensionDefinition<
-    {
-      [key in keyof TConfigSchema]: z.infer<ReturnType<TConfigSchema[key]>>;
-    },
-    z.input<
-      z.ZodObject<{
-        [key in keyof TConfigSchema]: ReturnType<TConfigSchema[key]>;
-      }>
-    >
-  > {
-    return createExtension({
-      kind: this.options.kind,
-      namespace: args.namespace ?? this.options.namespace,
-      name: args.name ?? this.options.name,
-      attachTo: args.attachTo ?? this.options.attachTo,
-      disabled: args.disabled ?? this.options.disabled,
-      inputs: this.options.inputs,
-      output: this.options.output,
-      config: this.options.config,
-      factory: ctx => this.options.factory(args.params, ctx),
-    } as CreateExtensionOptions<TKind, string | undefined extends TNewNamespace ? TNamespace : TNewNamespace, string | undefined extends TNewName ? TName : TNewName, UOutput, TInputs, TConfigSchema, any>);
-  }
-}
-
-/**
  * A simpler replacement for wrapping up `createExtension` inside a kind or type. This allows for a cleaner API for creating
  * types and instances of those types.
  *
@@ -452,7 +264,68 @@ export function createExtensionBlueprint<
       >,
   TDataRefs
 > {
-  return new ExtensionBlueprintImpl(options) as ExtensionBlueprint<
+  return {
+    dataRefs: options.dataRefs,
+    make(args) {
+      return createExtension({
+        kind: options.kind,
+        namespace: args.namespace ?? options.namespace,
+        name: args.name ?? options.name,
+        attachTo: args.attachTo ?? options.attachTo,
+        disabled: args.disabled ?? options.disabled,
+        inputs: options.inputs,
+        output: options.output as AnyExtensionDataRef[],
+        config: options.config,
+        factory: ctx =>
+          options.factory(args.params, ctx) as Iterable<
+            ExtensionDataValue<any, any>
+          >,
+      });
+    },
+    makeWithOverrides(args) {
+      return createExtension({
+        kind: options.kind,
+        namespace: args.namespace ?? options.namespace,
+        name: args.name ?? options.name,
+        attachTo: args.attachTo ?? options.attachTo,
+        disabled: args.disabled ?? options.disabled,
+        inputs: { ...args.inputs, ...options.inputs },
+        output: (args.output ?? options.output) as AnyExtensionDataRef[],
+        config:
+          options.config || args.config
+            ? {
+                schema: {
+                  ...options.config?.schema,
+                  ...args.config?.schema,
+                },
+              }
+            : undefined,
+        factory: ({ node, config, inputs }) => {
+          return args.factory(
+            (innerParams, innerContext) => {
+              return createExtensionDataContainer<UOutput>(
+                options.factory(innerParams, {
+                  node,
+                  config: (innerContext?.config ?? config) as any,
+                  inputs: resolveInputOverrides(
+                    options.inputs,
+                    inputs,
+                    innerContext?.inputs,
+                  ) as any,
+                }) as Iterable<any>,
+                options.output,
+              );
+            },
+            {
+              node,
+              config: config as any,
+              inputs: inputs as any,
+            },
+          ) as Iterable<ExtensionDataValue<any, any>>;
+        },
+      }) as ExtensionDefinition<any>;
+    },
+  } as ExtensionBlueprint<
     {
       kind: TKind;
       namespace: TNamespace;

--- a/packages/frontend-plugin-api/src/wiring/createExtensionInput.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionInput.ts
@@ -39,19 +39,6 @@ export function createExtensionInput<
     singleton: TConfig['singleton'] extends true ? true : false;
     optional: TConfig['optional'] extends true ? true : false;
   }
->;
-export function createExtensionInput<
-  TExtensionData extends ExtensionDataRef<unknown, string, { optional?: true }>,
-  TConfig extends { singleton?: boolean; optional?: boolean },
->(
-  extensionData: Array<TExtensionData>,
-  config?: TConfig,
-): ExtensionInput<
-  TExtensionData,
-  {
-    singleton: TConfig['singleton'] extends true ? true : false;
-    optional: TConfig['optional'] extends true ? true : false;
-  }
 > {
   if (process.env.NODE_ENV !== 'production') {
     if (Array.isArray(extensionData)) {
@@ -85,7 +72,7 @@ export function createExtensionInput<
         : false,
     },
   } as ExtensionInput<
-    TExtensionData,
+    UExtensionData,
     {
       singleton: TConfig['singleton'] extends true ? true : false;
       optional: TConfig['optional'] extends true ? true : false;


### PR DESCRIPTION
🧹, just cleaning up internal types, piggybacking on changeset from #26076

There are a couple of `as any` in there, but it's in places where I don't think TypeScript is gonna help us verify the logic anyway, and we need to rely on unit tests.