### PR TITLE
fix microsoft auth and ingestion for users without defined email

### DIFF
--- a/.changeset/real-pants-rule.md
+++ b/.changeset/real-pants-rule.md
@@ -1,5 +1,6 @@
 ---
-'@backstage/plugin-auth-backend-module-microsoft-provider': minor
+'@backstage/plugin-auth-backend-module-microsoft-provider': patch
+'@backstage/plugin-auth-backend': patch
 '@backstage/plugin-catalog-backend-module-msgraph': patch
 ---
 

--- a/.changeset/real-pants-rule.md
+++ b/.changeset/real-pants-rule.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-auth-backend-module-microsoft-provider': minor
+'@backstage/plugin-catalog-backend-module-msgraph': patch
+---
+
+Allow users without defined email to be ingested by the `msgraph` catalog plugin and add `userIdMatchingUserEntityAnnotation` sign-in resolver for the Microsoft auth provider to support sign-in for users without defined email.

--- a/plugins/auth-backend-module-microsoft-provider/api-report.md
+++ b/plugins/auth-backend-module-microsoft-provider/api-report.md
@@ -32,5 +32,9 @@ export namespace microsoftSignInResolvers {
     OAuthAuthenticatorResult<PassportProfile>,
     unknown
   >;
+  const userIdMatchingUserEntityAnnotation: SignInResolverFactory<
+    OAuthAuthenticatorResult<PassportProfile>,
+    unknown
+  >;
 }
 ```

--- a/plugins/auth-backend-module-microsoft-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-microsoft-provider/src/resolvers.ts
@@ -28,7 +28,7 @@ import {
  */
 export namespace microsoftSignInResolvers {
   /**
-   * Looks up the user by matching their Microsoft username to the entity name.
+   * Looks up the user by matching their Microsoft email to the email entity annotation.
    */
   export const emailMatchingUserEntityAnnotation = createSignInResolverFactory({
     create() {
@@ -50,4 +50,31 @@ export namespace microsoftSignInResolvers {
       };
     },
   });
+  /**
+   * Looks up the user by matching their Microsoft user id to the user id entity annotation.
+   */
+  export const userIdMatchingUserEntityAnnotation = createSignInResolverFactory(
+    {
+      create() {
+        return async (
+          info: SignInInfo<OAuthAuthenticatorResult<PassportProfile>>,
+          ctx,
+        ) => {
+          const { result } = info;
+
+          const id = result.fullProfile.id;
+
+          if (!id) {
+            throw new Error('Microsoft profile contained no id');
+          }
+
+          return ctx.signInWithCatalogUser({
+            annotations: {
+              'graph.microsoft.com/user-id': id,
+            },
+          });
+        };
+      },
+    },
+  );
 }

--- a/plugins/auth-backend/api-report.md
+++ b/plugins/auth-backend/api-report.md
@@ -533,6 +533,7 @@ export const providers: Readonly<{
     resolvers: Readonly<{
       emailMatchingUserEntityProfileEmail: () => SignInResolver_2<OAuthResult>;
       emailLocalPartMatchingUserEntityName: () => SignInResolver_2<OAuthResult>;
+      userIdMatchingUserEntityAnnotation: () => SignInResolver_2<OAuthResult>;
       emailMatchingUserEntityAnnotation: () => SignInResolver_2<OAuthResult>;
     }>;
   }>;

--- a/plugins/auth-backend/src/providers/microsoft/provider.ts
+++ b/plugins/auth-backend/src/providers/microsoft/provider.ts
@@ -65,5 +65,7 @@ export const microsoft = createAuthProviderIntegration({
       commonSignInResolvers.emailMatchingUserEntityProfileEmail(),
     emailMatchingUserEntityAnnotation:
       microsoftSignInResolvers.emailMatchingUserEntityAnnotation(),
+    userIdMatchingUserEntityAnnotation:
+      microsoftSignInResolvers.userIdMatchingUserEntityAnnotation(),
   }),
 });

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/defaultTransformers.test.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/defaultTransformers.test.ts
@@ -90,4 +90,31 @@ describe('defaultTransformers', () => {
       },
     });
   });
+
+  it('tests defaultUserTransformer with no email', async () => {
+    const user: MicrosoftGraph.User = {
+      id: 'foo',
+      displayName: 'BAR',
+      userPrincipalName: 'test@upn',
+    };
+    const userPhoto = 'test_photo';
+    const result = await defaultUserTransformer(user, userPhoto);
+    expect(result).toEqual({
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'User',
+      metadata: {
+        annotations: {
+          'graph.microsoft.com/user-id': 'foo',
+        },
+        name: 'test_upn',
+      },
+      spec: {
+        memberOf: [],
+        profile: {
+          displayName: 'BAR',
+          picture: 'test_photo',
+        },
+      },
+    });
+  });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!
This PR is to address the issue with users not being ingested into the catalog when they don't have an email defined in their profile.
* `metadata.name` is set to the `user.userPrincipalName` when `user.mail` is undefined
* the email annotation (`user.metadata.annotations[MICROSOFT_EMAIL_ANNOTATION]`) and user spec (`user.spec.profile.email`) is left blank when `user.mail` is undefined

To address the concern with the sign in resolver using email to match, I've added a new resolver that uses the user Id to do the matching to fall back on when the email field does not exist. Please let me know how this looks and I'll update the documentation if this is the approach we want to go with.

Fixes https://github.com/backstage/backstage/issues/26137

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
