### PR TITLE
[NBS 1.0] Deprecate the legacy  `signals` create router

### DIFF
--- a/.changeset/fuzzy-spies-share.md
+++ b/.changeset/fuzzy-spies-share.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-signals-backend': patch
+---
+
+The `createRouter` and its related types has been marked as deprecared. This backend should instead be initialized using the new backend system.

--- a/plugins/signals-backend/api-report.md
+++ b/plugins/signals-backend/api-report.md
@@ -6,25 +6,25 @@
 import { AuthService } from '@backstage/backend-plugin-api';
 import { BackendFeature } from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
+import { DiscoveryService } from '@backstage/backend-plugin-api';
 import { EventsService } from '@backstage/plugin-events-node';
 import express from 'express';
 import { IdentityApi } from '@backstage/plugin-auth-node';
 import { LifecycleService } from '@backstage/backend-plugin-api';
 import { LoggerService } from '@backstage/backend-plugin-api';
-import { PluginEndpointDiscovery } from '@backstage/backend-common';
 import { UserInfoService } from '@backstage/backend-plugin-api';
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export function createRouter(options: RouterOptions): Promise<express.Router>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export interface RouterOptions {
   // (undocumented)
   auth?: AuthService;
   // (undocumented)
   config: Config;
   // (undocumented)
-  discovery: PluginEndpointDiscovery;
+  discovery: DiscoveryService;
   // (undocumented)
   events: EventsService;
   // (undocumented)

--- a/plugins/signals-backend/src/deprecated.ts
+++ b/plugins/signals-backend/src/deprecated.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import express from 'express';
+
+import { Config } from '@backstage/config';
+import {
+  AuthService,
+  DiscoveryService,
+  LifecycleService,
+  LoggerService,
+  UserInfoService,
+} from '@backstage/backend-plugin-api';
+import { createLegacyAuthAdapters } from '@backstage/backend-common';
+
+import { IdentityApi } from '@backstage/plugin-auth-node';
+import { EventsService } from '@backstage/plugin-events-node';
+
+import { createRouter as _createRouter } from './service/router';
+
+/**
+ * @public
+ * @deprecated Please migrate to the new backend system as this will be removed in the future.
+ */
+export interface RouterOptions {
+  logger: LoggerService;
+  events: EventsService;
+  identity?: IdentityApi;
+  discovery: DiscoveryService;
+  config: Config;
+  lifecycle?: LifecycleService;
+  auth?: AuthService;
+  userInfo?: UserInfoService;
+}
+
+/**
+ * @public
+ * @deprecated Please migrate to the new backend system as this will be removed in the future.
+ */
+export async function createRouter(
+  options: RouterOptions,
+): Promise<express.Router> {
+  return _createRouter({
+    ...options,
+    ...createLegacyAuthAdapters(options),
+  });
+}

--- a/plugins/signals-backend/src/index.ts
+++ b/plugins/signals-backend/src/index.ts
@@ -13,5 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './service/router';
+
+export * from './deprecated';
 export { signalsPlugin as default } from './plugin';

--- a/plugins/signals-backend/src/plugin.ts
+++ b/plugins/signals-backend/src/plugin.ts
@@ -17,7 +17,7 @@ import {
   coreServices,
   createBackendPlugin,
 } from '@backstage/backend-plugin-api';
-import { createRouter } from './service/router';
+import { createRouter } from './deprecated';
 import { eventsServiceRef } from '@backstage/plugin-events-node';
 
 /**

--- a/plugins/signals-backend/src/service/router.test.ts
+++ b/plugins/signals-backend/src/service/router.test.ts
@@ -13,27 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { PluginEndpointDiscovery } from '@backstage/backend-common';
+
 import express from 'express';
 import request from 'supertest';
 
 import { createRouter } from './router';
 import { EventsService } from '@backstage/plugin-events-node';
-import { IdentityApi } from '@backstage/plugin-auth-node';
-import { UserInfoService } from '@backstage/backend-plugin-api';
+import {
+  DiscoveryService,
+  UserInfoService,
+} from '@backstage/backend-plugin-api';
 import { ConfigReader } from '@backstage/config';
 import { mockServices } from '@backstage/backend-test-utils';
+import { MiddlewareFactory } from '@backstage/backend-defaults/rootHttpRouter';
 
 const eventsServiceMock: jest.Mocked<EventsService> = {
   subscribe: jest.fn(),
   publish: jest.fn(),
 };
 
-const identityApiMock: jest.Mocked<IdentityApi> = {
-  getIdentity: jest.fn(),
-};
-
-const discovery: jest.Mocked<PluginEndpointDiscovery> = {
+const discovery: jest.Mocked<DiscoveryService> = {
   getBaseUrl: jest.fn().mockResolvedValue('/api/signals'),
   getExternalBaseUrl: jest.fn(),
 };
@@ -48,13 +47,17 @@ describe('createRouter', () => {
   beforeAll(async () => {
     const router = await createRouter({
       logger: mockServices.logger.mock(),
-      identity: identityApiMock,
       events: eventsServiceMock,
       discovery,
       userInfo,
       config: new ConfigReader({}),
+      auth: mockServices.auth(),
     });
-    app = express().use(router);
+    const errorHandler = MiddlewareFactory.create({
+      config: mockServices.rootConfig(),
+      logger: mockServices.rootLogger(),
+    }).error();
+    app = express().use(router).use(errorHandler);
   });
 
   beforeEach(() => {

--- a/plugins/signals-backend/src/service/router.ts
+++ b/plugins/signals-backend/src/service/router.ts
@@ -13,16 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-  createLegacyAuthAdapters,
-  errorHandler,
-  PluginEndpointDiscovery,
-} from '@backstage/backend-common';
 import express, { NextFunction, Request, Response } from 'express';
 import Router from 'express-promise-router';
 import {
   AuthService,
   BackstageUserInfo,
+  DiscoveryService,
   LifecycleService,
   LoggerService,
   UserInfoService,
@@ -30,30 +26,25 @@ import {
 import * as https from 'https';
 import http, { IncomingMessage } from 'http';
 import { SignalManager } from './SignalManager';
-import { IdentityApi } from '@backstage/plugin-auth-node';
 import { EventsService } from '@backstage/plugin-events-node';
 import { WebSocket, WebSocketServer } from 'ws';
 import { Duplex } from 'stream';
 import { Config } from '@backstage/config';
 
-/** @public */
 export interface RouterOptions {
   logger: LoggerService;
   events: EventsService;
-  identity?: IdentityApi;
-  discovery: PluginEndpointDiscovery;
+  discovery: DiscoveryService;
   config: Config;
   lifecycle?: LifecycleService;
-  auth?: AuthService;
-  userInfo?: UserInfoService;
+  userInfo: UserInfoService;
+  auth: AuthService;
 }
 
-/** @public */
 export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {
-  const { logger, discovery } = options;
-  const { auth, userInfo } = createLegacyAuthAdapters(options);
+  const { logger, discovery, auth, userInfo } = options;
 
   const manager = SignalManager.create(options);
   let subscribedToUpgradeRequests = false;
@@ -155,6 +146,5 @@ export async function createRouter(
     response.json({ status: 'ok' });
   });
 
-  router.use(errorHandler());
   return router;
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `createRouter` and its related types has been marked as deprecared. This backend should instead be initialized using the new backend system.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
