### PR TITLE
fix secret widgets not able to be required or disabled

### DIFF
--- a/.changeset/sharp-fans-tan.md
+++ b/.changeset/sharp-fans-tan.md
@@ -2,6 +2,7 @@
 '@backstage/plugin-scaffolder-react': patch
 ---
 
-- Fix scaffolder secret widget field not displaying as required when it's listed as required.
-- Fix scaffolder secret widget not able to be required inside nested objects.
-- Fix scaffolder secret widget not able to be disabled.
+- Fix secret widget field not displaying as required.
+- Fix secret widget not able to be required inside nested objects.
+- Fix secret widget not able to be disabled.
+- Support `minLength` and `maxLength` properties for secret widget.

--- a/.changeset/sharp-fans-tan.md
+++ b/.changeset/sharp-fans-tan.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+- Fix scaffolder secret widget field not displaying as required when it's listed as required.
+- Fix scaffolder secret widget not able to be required inside nested objects.
+- Fix scaffolder secret widget not able to be disabled.

--- a/plugins/scaffolder-react/api-report-alpha.md
+++ b/plugins/scaffolder-react/api-report-alpha.md
@@ -152,7 +152,10 @@ export type ScaffolderReactTemplateCategoryPickerClassKey = 'root' | 'label';
 
 // @alpha
 export const SecretWidget: (
-  props: Pick<WidgetProps, 'name' | 'onChange' | 'schema'>,
+  props: Pick<
+    WidgetProps,
+    'name' | 'onChange' | 'schema' | 'required' | 'disabled'
+  >,
 ) => React_2.JSX.Element;
 
 // @alpha

--- a/plugins/scaffolder-react/src/next/components/SecretWidget/SecretWidget.tsx
+++ b/plugins/scaffolder-react/src/next/components/SecretWidget/SecretWidget.tsx
@@ -33,7 +33,7 @@ export const SecretWidget = (
   const {
     name,
     onChange,
-    schema: { title },
+    schema: { title, minLength, maxLength },
     required,
     disabled,
   } = props;
@@ -52,6 +52,10 @@ export const SecretWidget = (
       autoComplete="off"
       required={required}
       disabled={disabled}
+      inputProps={{
+        minLength,
+        maxLength,
+      }}
     />
   );
 };

--- a/plugins/scaffolder-react/src/next/components/SecretWidget/SecretWidget.tsx
+++ b/plugins/scaffolder-react/src/next/components/SecretWidget/SecretWidget.tsx
@@ -24,13 +24,18 @@ import React from 'react';
  * @alpha
  */
 export const SecretWidget = (
-  props: Pick<WidgetProps, 'name' | 'onChange' | 'schema'>,
+  props: Pick<
+    WidgetProps,
+    'name' | 'onChange' | 'schema' | 'required' | 'disabled'
+  >,
 ) => {
   const { setSecrets, secrets } = useTemplateSecrets();
   const {
     name,
     onChange,
     schema: { title },
+    required,
+    disabled,
   } = props;
 
   return (
@@ -45,6 +50,8 @@ export const SecretWidget = (
       value={secrets[name] ?? ''}
       type="password"
       autoComplete="off"
+      required={required}
+      disabled={disabled}
     />
   );
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #26156 where scaffolder secret widgets cannot be set required if they are in an object. If the field is not in an object, it won't let the user proceed due to validation but it still doesn't properly show the field as required. This also fixes not being able to set the field as disabled using `ui:disabled` property.

This PR passes down the `required` and `disabled` props from `SecretInput` to the `SecretWidget` text field.
Also, while I was in here also added support of `minLength` and `maxLength` properties for the secret widget.

Test schema:
```yaml
parameters:
  - title: Choose a location
    required:
      - world
    properties:
      hello:
        title: hello
        type: string
      world:
        title: world
        type: string
        ui:field: Secret
        ui:disabled: true
      nest:
        title: Nest
        type: object
        required:
          - foo
        properties:
          foo:
            title: Test 1
            type: string
            ui:field: Secret
          bar:
            title: Test 2
            type: string
            ui:field: Secret
```

Before:

<img width="594" alt="image" src="https://github.com/user-attachments/assets/84615a71-3c35-4383-9f4f-d2dcd95182e2">



After:

<img width="594" alt="image" src="https://github.com/user-attachments/assets/8c1c285c-6f11-4e62-8831-78ccc6ea7e01">



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
