### PR TITLE
Docs: Correct reference to legacy plugin code reference in the NFS migration guide

### DIFF
--- a/docs/frontend-system/building-plugins/05-migrating.md
+++ b/docs/frontend-system/building-plugins/05-migrating.md
@@ -15,9 +15,9 @@ The main concept is that routes, components, apis are now extensions. You can us
 In the legacy frontend system a plugin was defined in its own `plugin.ts` file as following:
 
 ```ts title="my-plugin/src/plugin.ts"
-  import { createFrontendPlugin } from '@backstage/core-plugin-api';
+  import { createPlugin } from '@backstage/core-plugin-api';
 
-  export const myPlugin = createFrontendPlugin({
+  export const myPlugin = createPlugin({
     id: 'my-plugin',
     apis: [],
     routes: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I was reviewing the new frontend system [migration guide](https://backstage.io/docs/frontend-system/building-plugins/migrating) and noticed that the code referencing the legacy plugin system seems to be incorrect, as the new and legacy system code looks similar. Therefore, I am raising a PR.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
