### PR TITLE
Add default component & resource entity filter to k8s plugin (new FE system only)

### DIFF
--- a/.changeset/new-poets-unite.md
+++ b/.changeset/new-poets-unite.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes': patch
+---
+
+Make k8s entity content appear on components & resources only by default in new FE system

--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -52,7 +52,7 @@ export const app = createApp({
 });
 ```
 
-2. Next, enable your desired extensions in `app-config.yaml`
+2. Next, enable your desired extensions in `app-config.yaml`.
 
 ```yaml
 app:
@@ -60,4 +60,14 @@ app:
     - entity-content:kubernetes/kubernetes
 ```
 
-Now, the extension appears on your entity page as one of the tabs, which is called `KUBERNETES`
+Now, the extension appears on your entity page as one of the tabs, which is called `KUBERNETES`.
+By default, the tab will only appear on entities that are Components or Resources. You can override
+that behavior by providing a config block to the extension, like so:
+
+```yaml
+app:
+  extensions:
+    - entity-content:kubernetes/kubernetes:
+        config:
+          filter: kind:component,api,resource,system
+```

--- a/plugins/kubernetes/src/alpha/entityContents.tsx
+++ b/plugins/kubernetes/src/alpha/entityContents.tsx
@@ -23,6 +23,7 @@ export const entityKubernetesContent = EntityContentBlueprint.make({
   params: {
     defaultPath: '/kubernetes',
     defaultTitle: 'Kubernetes',
+    filter: 'kind:component,resource',
     loader: () =>
       import('./KubernetesContentPage').then(m =>
         compatWrapper(<m.KubernetesContentPage />),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Follow up from portal compatibility work, ensure the kubernetes plugin, when using the [new FE system](https://backstage.io/docs/frontend-system/), includes a filter to publish the entity content to components & resources only by default. This can be overridden.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
