### PR TITLE
add scaffolder review step custom name option

### DIFF
--- a/.changeset/four-ties-raise.md
+++ b/.changeset/four-ties-raise.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-react': minor
 ---
 
-Add `ui:backstage.review.name` option for custom item names on scaffolder review page
+Add `ui:backstage.review.name` option for custom item names on scaffolder review page, and also add support for rendering the `title` property instead of the key name.

--- a/.changeset/four-ties-raise.md
+++ b/.changeset/four-ties-raise.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+Add `ui:backstage.review.name` option for custom item names on scaffolder review page

--- a/.changeset/four-ties-raise.md
+++ b/.changeset/four-ties-raise.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-scaffolder-react': patch
+'@backstage/plugin-scaffolder-react': minor
 ---
 
 Add `ui:backstage.review.name` option for custom item names on scaffolder review page

--- a/plugins/scaffolder-react/src/next/components/ReviewState/ReviewState.test.tsx
+++ b/plugins/scaffolder-react/src/next/components/ReviewState/ReviewState.test.tsx
@@ -435,6 +435,35 @@ describe('ReviewState', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('should allow using the title property', async () => {
+    const formState = {
+      foo: 'test',
+    };
+
+    const schemas: ParsedTemplateSchema[] = [
+      {
+        mergedSchema: {
+          type: 'object',
+          properties: {
+            foo: {
+              type: 'string',
+              title: 'Test Thing',
+            },
+          },
+        },
+        schema: {},
+        title: 'test',
+        uiSchema: {},
+      },
+    ];
+
+    const { queryByRole } = render(
+      <ReviewState formState={formState} schemas={schemas} />,
+    );
+
+    expect(queryByRole('row', { name: 'Test Thing test' })).toBeInTheDocument();
+  });
+
   it('should allow custom review name', async () => {
     const formState = {
       foo: 'test',

--- a/plugins/scaffolder-react/src/next/components/ReviewState/ReviewState.test.tsx
+++ b/plugins/scaffolder-react/src/next/components/ReviewState/ReviewState.test.tsx
@@ -434,4 +434,38 @@ describe('ReviewState', () => {
       queryByRole('row', { name: 'Name > Example > Test type6' }),
     ).not.toBeInTheDocument();
   });
+
+  it('should allow custom review name', async () => {
+    const formState = {
+      foo: 'test',
+    };
+
+    const schemas: ParsedTemplateSchema[] = [
+      {
+        mergedSchema: {
+          type: 'object',
+          properties: {
+            foo: {
+              type: 'string',
+              'ui:backstage': {
+                review: {
+                  name: 'bar',
+                },
+              },
+            },
+          },
+        },
+        schema: {},
+        title: 'test',
+        uiSchema: {},
+      },
+    ];
+
+    const { queryByRole } = render(
+      <ReviewState formState={formState} schemas={schemas} />,
+    );
+
+    expect(queryByRole('row', { name: 'Bar test' })).toBeInTheDocument();
+    expect(queryByRole('row', { name: 'Foo test' })).not.toBeInTheDocument();
+  });
 });

--- a/plugins/scaffolder-react/src/next/components/ReviewState/ReviewState.tsx
+++ b/plugins/scaffolder-react/src/next/components/ReviewState/ReviewState.tsx
@@ -41,11 +41,13 @@ function processSchema(
     data: formState,
   });
 
+  const name = definitionInSchema?.['ui:backstage']?.review?.name ?? key;
+
   if (definitionInSchema) {
     const backstageReviewOptions = definitionInSchema['ui:backstage']?.review;
     if (backstageReviewOptions) {
       if (backstageReviewOptions.mask) {
-        return [[key, backstageReviewOptions.mask]];
+        return [[name, backstageReviewOptions.mask]];
       }
       if (backstageReviewOptions.show === false) {
         return [];
@@ -56,13 +58,13 @@ function processSchema(
       definitionInSchema['ui:widget'] === 'password' ||
       definitionInSchema['ui:field']?.toLocaleLowerCase('en-us') === 'secret'
     ) {
-      return [[key, '******']];
+      return [[name, '******']];
     }
 
     if (definitionInSchema.enum && definitionInSchema.enumNames) {
       return [
         [
-          key,
+          name,
           definitionInSchema.enumNames[
             definitionInSchema.enum.indexOf(value)
           ] || value,
@@ -78,7 +80,7 @@ function processSchema(
     }
   }
 
-  return [[key, value]];
+  return [[name, value]];
 }
 
 /**

--- a/plugins/scaffolder-react/src/next/components/ReviewState/ReviewState.tsx
+++ b/plugins/scaffolder-react/src/next/components/ReviewState/ReviewState.tsx
@@ -41,7 +41,10 @@ function processSchema(
     data: formState,
   });
 
-  const name = definitionInSchema?.['ui:backstage']?.review?.name ?? key;
+  const name =
+    definitionInSchema?.['ui:backstage']?.review?.name ??
+    definitionInSchema?.title ??
+    key;
 
   if (definitionInSchema) {
     const backstageReviewOptions = definitionInSchema['ui:backstage']?.review;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Follow-up to #26140

#26140 addressed an issue with duplicate final keys in review step page by formatting object items with the fully qualified path of the item. While this is a fine solution it kind of subtracts from the UX improvements I aimed to achieve with #25346 where I wanted to display an item that was in a nested object as just a regular row in the review page table. 

This PR allows for an optional `ui:backstage.review.name` to provide a custom name for the item on the review step page. Benefits are that users are no longer restrained to the property name and for nested objects it provides the user a way to "opt-out" of displaying the fully qualified path on the review page for UX purposes.

Example:

```yaml
  parameters:
    - title: Fill in some steps
      properties:
        configuration:
          title: Configuration
          type: object
          properties:
            firstName:
              title: First Name
              type: string
              ui:backstage:
                review:
                  name: First Name
            lastName:
              title: LastName
              type: string
              ui:backstage:
                review:
                  name: Last Name
```

Before:
<img width="612" alt="image" src="https://github.com/user-attachments/assets/7a3d7646-d067-48a4-9fd5-a7af9cbbe483">


After:
<img width="612" alt="image" src="https://github.com/user-attachments/assets/e33b4799-f4ab-400f-8c83-b6c3f11af69d">

P.S. all the review options should be noted in the backstage documentation and I can add those docs in a separate PR, including this one if it's accepted

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
