### PR TITLE
frontend-plugin-api: consolidate type parameters for extension definitions and blueprints

### DIFF
--- a/.changeset/cool-melons-check.md
+++ b/.changeset/cool-melons-check.md
@@ -1,0 +1,21 @@
+---
+'@backstage/frontend-test-utils': patch
+'@backstage/frontend-app-api': patch
+'@backstage/core-compat-api': patch
+'@backstage/plugin-catalog-import': patch
+'@backstage/plugin-catalog-graph': patch
+'@backstage/plugin-catalog-react': patch
+'@backstage/plugin-user-settings': patch
+'@backstage/plugin-search-react': patch
+'@backstage/plugin-kubernetes': patch
+'@backstage/plugin-scaffolder': patch
+'@backstage/plugin-api-docs': patch
+'@backstage/plugin-devtools': patch
+'@backstage/plugin-techdocs': patch
+'@backstage/plugin-catalog': patch
+'@backstage/plugin-search': patch
+'@backstage/plugin-home': patch
+'@backstage/plugin-org': patch
+---
+
+Updated exports to use the new type parameters for extensions and extension blueprints.

--- a/.changeset/flat-kangaroos-push.md
+++ b/.changeset/flat-kangaroos-push.md
@@ -1,0 +1,31 @@
+---
+'@backstage/frontend-plugin-api': minor
+---
+
+**BREAKING**: Updated the type parameters for `ExtensionDefinition` and `ExtensionBlueprint` to only have a single object parameter. The base type parameter is exported as `ExtensionDefinitionParameters` and `ExtensionBlueprintParameters` respectively. This is shipped as an immediate breaking change as we expect usage of these types to be rare, and it does not affect the runtime behavior of the API.
+
+This is a breaking change as it changes the type parameters. Existing usage can generally be updated as follows:
+
+- `ExtensionDefinition<any>` -> `ExtensionDefinition`
+- `ExtensionDefinition<any, any>` -> `ExtensionDefinition`
+- `ExtensionDefinition<TConfig>` -> `ExtensionDefinition<{ config: TConfig }>`
+- `ExtensionDefinition<TConfig, TConfigInput>` -> `ExtensionDefinition<{ config: TConfig, configInput: TConfigInput }>`
+
+If you need to infer the parameter you can use `ExtensionDefinitionParameters`, for example:
+
+```ts
+import {
+  ExtensionDefinition,
+  ExtensionDefinitionParameters,
+} from '@backstage/frontend-plugin-api';
+
+function myUtility<T extends ExtensionDefinitionParameters>(
+  ext: ExtensionDefinition<T>,
+): T['config'] {
+  // ...
+}
+```
+
+The same patterns apply to `ExtensionBlueprint`.
+
+This change is made to improve the readability of API references and ability to evolve the type parameters in the future.

--- a/packages/app-next-example-plugin/api-report.md
+++ b/packages/app-next-example-plugin/api-report.md
@@ -15,33 +15,32 @@ const examplePlugin: BackstagePlugin<
   {},
   {},
   {
-    'page:example': ExtensionDefinition<
-      {
+    'page:example': ExtensionDefinition<{
+      kind: 'page';
+      namespace: undefined;
+      name: undefined;
+      config: {
         path: string | undefined;
-      },
-      {
+      };
+      configInput: {
         path?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<
-          React_2.JSX.Element,
-          'core.reactElement',
-          {}
-        >
-      | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
-      | ConfigurableExtensionDataRef<
-          RouteRef<AnyRouteRefParams>,
-          'core.routing.ref',
-          {
-            optional: true;
-          }
-        >,
-      {},
-      {
-        kind: 'page';
-        namespace: undefined;
-        name: undefined;
-      }
-    >;
+      };
+      output:
+        | ConfigurableExtensionDataRef<
+            React_2.JSX.Element,
+            'core.reactElement',
+            {}
+          >
+        | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
+        | ConfigurableExtensionDataRef<
+            RouteRef<AnyRouteRefParams>,
+            'core.routing.ref',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+    }>;
   }
 >;
 export default examplePlugin;

--- a/packages/core-compat-api/api-report.md
+++ b/packages/core-compat-api/api-report.md
@@ -37,13 +37,13 @@ export function convertLegacyPageExtension(
     name?: string;
     defaultPath?: string;
   },
-): ExtensionDefinition<any>;
+): ExtensionDefinition;
 
 // @public (undocumented)
 export function convertLegacyPlugin(
   legacyPlugin: BackstagePlugin,
   options: {
-    extensions: ExtensionDefinition<any, any>[];
+    extensions: ExtensionDefinition[];
   },
 ): BackstagePlugin_2;
 

--- a/packages/core-compat-api/src/collectLegacyRoutes.tsx
+++ b/packages/core-compat-api/src/collectLegacyRoutes.tsx
@@ -106,7 +106,7 @@ function visitRouteChildren(options: {
   parentExtensionId: string;
   context: {
     pluginId: string;
-    extensions: ExtensionDefinition<any, any>[];
+    extensions: ExtensionDefinition[];
     getUniqueName: () => string;
     discoverPlugin: (plugin: LegacyBackstagePlugin) => void;
   };
@@ -159,7 +159,7 @@ export function collectLegacyRoutes(
 ): BackstagePlugin[] {
   const pluginExtensions = new Map<
     LegacyBackstagePlugin,
-    ExtensionDefinition<any, any>[]
+    ExtensionDefinition[]
   >();
 
   const getUniqueName = (() => {

--- a/packages/core-compat-api/src/convertLegacyPageExtension.test.tsx
+++ b/packages/core-compat-api/src/convertLegacyPageExtension.test.tsx
@@ -48,11 +48,10 @@ describe('convertLegacyPageExtension', () => {
     );
 
     const converted = convertLegacyPageExtension(LegacyExtension);
-    expect(converted.kind).toBe('page');
-    expect(converted.namespace).toBe(undefined);
-    expect(converted.name).toBe('example');
 
     const tester = createExtensionTester(converted);
+
+    expect(tester.query(converted).node.spec.id).toBe('page:example');
 
     await renderInTestApp(tester.reactElement(), {
       mountedRoutes: {
@@ -79,11 +78,10 @@ describe('convertLegacyPageExtension', () => {
       name: 'other',
       defaultPath: '/other',
     });
-    expect(converted.kind).toBe('page');
-    expect(converted.namespace).toBe(undefined);
-    expect(converted.name).toBe('other');
 
     const tester = createExtensionTester(converted);
+
+    expect(tester.query(converted).node.spec.id).toBe('page:other');
 
     await renderInTestApp(tester.reactElement(), {
       mountedRoutes: {

--- a/packages/core-compat-api/src/convertLegacyPageExtension.tsx
+++ b/packages/core-compat-api/src/convertLegacyPageExtension.tsx
@@ -35,7 +35,7 @@ export function convertLegacyPageExtension(
     name?: string;
     defaultPath?: string;
   },
-): ExtensionDefinition<any> {
+): ExtensionDefinition {
   const element = <LegacyExtension />;
 
   const extName = getComponentData<string>(element, 'core.extensionName');

--- a/packages/core-compat-api/src/convertLegacyPlugin.ts
+++ b/packages/core-compat-api/src/convertLegacyPlugin.ts
@@ -26,7 +26,7 @@ import { convertLegacyRouteRefs } from './convertLegacyRouteRef';
 /** @public */
 export function convertLegacyPlugin(
   legacyPlugin: LegacyBackstagePlugin,
-  options: { extensions: ExtensionDefinition<any, any>[] },
+  options: { extensions: ExtensionDefinition[] },
 ): NewBackstagePlugin {
   const apiExtensions = Array.from(legacyPlugin.getApis()).map(factory =>
     ApiBlueprint.make({ namespace: factory.api.id, params: { factory } }),

--- a/packages/frontend-app-api/src/routing/extractRouteInfoFromAppNode.test.ts
+++ b/packages/frontend-app-api/src/routing/extractRouteInfoFromAppNode.test.ts
@@ -76,7 +76,7 @@ function createTestExtension(options: {
   });
 }
 
-function routeInfoFromExtensions(extensions: ExtensionDefinition<any, any>[]) {
+function routeInfoFromExtensions(extensions: ExtensionDefinition[]) {
   const plugin = createFrontendPlugin({
     id: 'test',
     extensions,

--- a/packages/frontend-app-api/src/tree/resolveAppNodeSpecs.test.ts
+++ b/packages/frontend-app-api/src/tree/resolveAppNodeSpecs.test.ts
@@ -44,7 +44,7 @@ function makeExtDef(
 ) {
   return {
     $$type: '@backstage/ExtensionDefinition',
-    T: null as any,
+    T: undefined as any,
     version: 'v1',
     name,
     attachTo: { id: attachId, input: 'default' },

--- a/packages/frontend-app-api/src/tree/resolveAppNodeSpecs.test.ts
+++ b/packages/frontend-app-api/src/tree/resolveAppNodeSpecs.test.ts
@@ -44,12 +44,13 @@ function makeExtDef(
 ) {
   return {
     $$type: '@backstage/ExtensionDefinition',
+    T: null as any,
     version: 'v1',
     name,
     attachTo: { id: attachId, input: 'default' },
     disabled: status === 'disabled',
-    override: () => ({} as ExtensionDefinition<unknown>),
-  } as ExtensionDefinition<unknown>;
+    override: () => ({} as ExtensionDefinition),
+  } as ExtensionDefinition;
 }
 
 describe('resolveAppNodeSpecs', () => {

--- a/packages/frontend-app-api/src/wiring/createApp.tsx
+++ b/packages/frontend-app-api/src/wiring/createApp.tsx
@@ -22,6 +22,7 @@ import {
   AppTreeApi,
   appTreeApiRef,
   coreExtensionData,
+  ExtensionDefinition,
   FrontendFeature,
   RouteRef,
   ExternalRouteRef,
@@ -112,28 +113,30 @@ const DefaultApis = defaultApis.map(factory =>
   ApiBlueprint.make({ namespace: factory.api.id, params: { factory } }),
 );
 
-export const builtinExtensions = [
-  Root,
-  App,
-  AppRoot,
-  AppRoutes,
-  AppNav,
-  AppLayout,
-  DefaultProgressComponent,
-  DefaultErrorBoundaryComponent,
-  DefaultNotFoundErrorPageComponent,
-  LightTheme,
-  DarkTheme,
-  oauthRequestDialogAppRootElement,
-  alertDisplayAppRootElement,
-  AppThemeApi,
-  AppLanguageApi,
-  IconsApi,
-  TranslationsApi,
-  ComponentsApi,
-  FeatureFlagsApi,
-  ...DefaultApis,
-].map(def => resolveExtensionDefinition(def));
+export const builtinExtensions = (
+  [
+    Root,
+    App,
+    AppRoot,
+    AppRoutes,
+    AppNav,
+    AppLayout,
+    DefaultProgressComponent,
+    DefaultErrorBoundaryComponent,
+    DefaultNotFoundErrorPageComponent,
+    LightTheme,
+    DarkTheme,
+    oauthRequestDialogAppRootElement,
+    alertDisplayAppRootElement,
+    AppThemeApi,
+    AppLanguageApi,
+    IconsApi,
+    TranslationsApi,
+    ComponentsApi,
+    FeatureFlagsApi,
+    ...DefaultApis,
+  ] as ExtensionDefinition[]
+).map(def => resolveExtensionDefinition(def));
 
 function deduplicateFeatures(
   allFeatures: FrontendFeature[],

--- a/packages/frontend-plugin-api/api-report.md
+++ b/packages/frontend-plugin-api/api-report.md
@@ -919,7 +919,7 @@ export interface ExtensionBlueprint<
           config?: T['config'];
           inputs?: ResolveInputValueOverrides<NonNullable<T['inputs']>>;
         },
-      ) => ExtensionDataContainer<T['output']>,
+      ) => ExtensionDataContainer<NonNullable<T['output']>>,
       context: {
         node: AppNode;
         apis: ApiHolder;
@@ -932,7 +932,9 @@ export interface ExtensionBlueprint<
       },
     ): Iterable<UFactoryOutput> &
       VerifyExtensionFactoryOutput<
-        AnyExtensionDataRef extends UNewOutput ? T['output'] : UNewOutput,
+        AnyExtensionDataRef extends UNewOutput
+          ? NonNullable<T['output']>
+          : UNewOutput,
         UFactoryOutput
       >;
   }): ExtensionDefinition<{
@@ -969,14 +971,14 @@ export type ExtensionBlueprintParameters = {
   kind: string;
   namespace?: string;
   name?: string;
-  params: object;
+  params?: object;
   configInput?: {
     [K in string]: any;
   };
   config?: {
     [K in string]: any;
   };
-  output: AnyExtensionDataRef;
+  output?: AnyExtensionDataRef;
   inputs?: {
     [KName in string]: ExtensionInput<
       AnyExtensionDataRef,
@@ -1157,7 +1159,7 @@ export type ExtensionDefinitionParameters = {
   config?: {
     [K in string]: any;
   };
-  output: AnyExtensionDataRef;
+  output?: AnyExtensionDataRef;
   inputs?: {
     [KName in string]: ExtensionInput<
       AnyExtensionDataRef,

--- a/packages/frontend-plugin-api/api-report.md
+++ b/packages/frontend-plugin-api/api-report.md
@@ -172,27 +172,25 @@ export type AnyRoutes = {
 };
 
 // @public
-export const ApiBlueprint: ExtensionBlueprint<
-  {
-    kind: 'api';
-    namespace: undefined;
-    name: undefined;
-  },
-  {
+export const ApiBlueprint: ExtensionBlueprint<{
+  kind: 'api';
+  namespace: undefined;
+  name: undefined;
+  params: {
     factory: AnyApiFactory;
-  },
-  ConfigurableExtensionDataRef<AnyApiFactory, 'core.api.factory', {}>,
-  {},
-  {},
-  {},
-  {
+  };
+  output: ConfigurableExtensionDataRef<AnyApiFactory, 'core.api.factory', {}>;
+  inputs: {};
+  config: {};
+  configInput: {};
+  dataRefs: {
     factory: ConfigurableExtensionDataRef<
       AnyApiFactory,
       'core.api.factory',
       {}
     >;
-  }
->;
+  };
+}>;
 
 export { ApiFactory };
 
@@ -246,43 +244,39 @@ export interface AppNodeSpec {
 }
 
 // @public
-export const AppRootElementBlueprint: ExtensionBlueprint<
-  {
-    kind: 'app-root-element';
-    namespace: undefined;
-    name: undefined;
-  },
-  {
+export const AppRootElementBlueprint: ExtensionBlueprint<{
+  kind: 'app-root-element';
+  namespace: undefined;
+  name: undefined;
+  params: {
     element: JSX.Element | (() => JSX.Element);
-  },
-  ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>,
-  {},
-  {},
-  {},
-  never
->;
+  };
+  output: ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>;
+  inputs: {};
+  config: {};
+  configInput: {};
+  dataRefs: never;
+}>;
 
 // @public
-export const AppRootWrapperBlueprint: ExtensionBlueprint<
-  {
-    kind: 'app-root-wrapper';
-    namespace: undefined;
-    name: undefined;
-  },
-  {
+export const AppRootWrapperBlueprint: ExtensionBlueprint<{
+  kind: 'app-root-wrapper';
+  namespace: undefined;
+  name: undefined;
+  params: {
     Component: ComponentType<PropsWithChildren<{}>>;
-  },
-  ConfigurableExtensionDataRef<
+  };
+  output: ConfigurableExtensionDataRef<
     React_2.ComponentType<{
       children?: React_2.ReactNode;
     }>,
     'app.root.wrapper',
     {}
-  >,
-  {},
-  {},
-  {},
-  {
+  >;
+  inputs: {};
+  config: {};
+  configInput: {};
+  dataRefs: {
     component: ConfigurableExtensionDataRef<
       React_2.ComponentType<{
         children?: React_2.ReactNode;
@@ -290,8 +284,8 @@ export const AppRootWrapperBlueprint: ExtensionBlueprint<
       'app.root.wrapper',
       {}
     >;
-  }
->;
+  };
+}>;
 
 export { AppTheme };
 
@@ -331,7 +325,7 @@ export interface BackstagePlugin<
   TRoutes extends AnyRoutes = AnyRoutes,
   TExternalRoutes extends AnyExternalRoutes = AnyExternalRoutes,
   TExtensionMap extends {
-    [id in string]: ExtensionDefinition<any, any>;
+    [id in string]: ExtensionDefinition;
   } = {},
 > {
   // (undocumented)
@@ -346,7 +340,7 @@ export interface BackstagePlugin<
   readonly routes: TRoutes;
   // (undocumented)
   withOverrides(options: {
-    extensions: Array<ExtensionDefinition<any, any>>;
+    extensions: Array<ExtensionDefinition>;
   }): BackstagePlugin<TRoutes, TExternalRoutes, TExtensionMap>;
 }
 
@@ -454,22 +448,18 @@ export function createComponentExtension<TProps extends {}>(options: {
     | {
         sync: () => ComponentType<TProps>;
       };
-}): ExtensionDefinition<
-  {
-    [x: string]: any;
-  },
-  {
-    [x: string]: any;
-  },
-  ConfigurableExtensionDataRef<
+}): ExtensionDefinition<{
+  config: {};
+  configInput: {};
+  output: ConfigurableExtensionDataRef<
     {
       ref: ComponentRef;
       impl: ComponentType;
     },
     'core.component.component',
     {}
-  >,
-  {
+  >;
+  inputs: {
     [x: string]: ExtensionInput<
       AnyExtensionDataRef,
       {
@@ -477,13 +467,11 @@ export function createComponentExtension<TProps extends {}>(options: {
         singleton: boolean;
       }
     >;
-  },
-  {
-    kind: 'component';
-    namespace: string;
-    name: string;
-  }
->;
+  };
+  kind: 'component';
+  namespace: string;
+  name: string;
+}>;
 
 // @public (undocumented)
 export namespace createComponentExtension {
@@ -532,27 +520,29 @@ export function createExtension<
     TConfigSchema,
     UFactoryOutput
   >,
-): ExtensionDefinition<
-  {
-    [key in keyof TConfigSchema]: z.infer<ReturnType<TConfigSchema[key]>>;
-  },
-  z.input<
-    z.ZodObject<{
-      [key in keyof TConfigSchema]: ReturnType<TConfigSchema[key]>;
-    }>
-  >,
-  UOutput,
-  TInputs,
-  {
-    kind: string | undefined extends TKind ? undefined : TKind;
-    namespace: string | undefined extends TNamespace ? undefined : TNamespace;
-    name: string | undefined extends TName ? undefined : TName;
-  }
->;
+): ExtensionDefinition<{
+  config: string extends keyof TConfigSchema
+    ? {}
+    : {
+        [key in keyof TConfigSchema]: z.infer<ReturnType<TConfigSchema[key]>>;
+      };
+  configInput: string extends keyof TConfigSchema
+    ? {}
+    : z.input<
+        z.ZodObject<{
+          [key in keyof TConfigSchema]: ReturnType<TConfigSchema[key]>;
+        }>
+      >;
+  output: UOutput;
+  inputs: TInputs;
+  kind: string | undefined extends TKind ? undefined : TKind;
+  namespace: string | undefined extends TNamespace ? undefined : TNamespace;
+  name: string | undefined extends TName ? undefined : TName;
+}>;
 
 // @public
 export function createExtensionBlueprint<
-  TParams,
+  TParams extends object,
   UOutput extends AnyExtensionDataRef,
   TInputs extends {
     [inputName in string]: ExtensionInput<
@@ -585,29 +575,27 @@ export function createExtensionBlueprint<
     UFactoryOutput,
     TDataRefs
   >,
-): ExtensionBlueprint<
-  {
-    kind: TKind;
-    namespace: TNamespace;
-    name: TName;
-  },
-  TParams,
-  UOutput,
-  string extends keyof TInputs ? {} : TInputs,
-  string extends keyof TConfigSchema
+): ExtensionBlueprint<{
+  kind: TKind;
+  namespace: TNamespace;
+  name: TName;
+  params: TParams;
+  output: UOutput;
+  inputs: string extends keyof TInputs ? {} : TInputs;
+  config: string extends keyof TConfigSchema
     ? {}
     : {
         [key in keyof TConfigSchema]: z.infer<ReturnType<TConfigSchema[key]>>;
-      },
-  string extends keyof TConfigSchema
+      };
+  configInput: string extends keyof TConfigSchema
     ? {}
     : z.input<
         z.ZodObject<{
           [key in keyof TConfigSchema]: ReturnType<TConfigSchema[key]>;
         }>
-      >,
-  TDataRefs
->;
+      >;
+  dataRefs: TDataRefs;
+}>;
 
 // @public (undocumented)
 export type CreateExtensionBlueprintOptions<
@@ -777,7 +765,7 @@ export function createFrontendPlugin<
   TId extends string,
   TRoutes extends AnyRoutes = {},
   TExternalRoutes extends AnyExternalRoutes = {},
-  TExtensions extends readonly ExtensionDefinition<any, any>[] = [],
+  TExtensions extends readonly ExtensionDefinition[] = [],
 >(
   options: PluginOptions<TId, TRoutes, TExternalRoutes, TExtensions>,
 ): BackstagePlugin<
@@ -860,34 +848,10 @@ export interface Extension<TConfig, TConfigInput = TConfig> {
 
 // @public (undocumented)
 export interface ExtensionBlueprint<
-  TIdParts extends {
-    kind: string;
-    namespace?: string;
-    name?: string;
-  },
-  TParams,
-  UOutput extends AnyExtensionDataRef,
-  TInputs extends {
-    [inputName in string]: ExtensionInput<
-      AnyExtensionDataRef,
-      {
-        optional: boolean;
-        singleton: boolean;
-      }
-    >;
-  },
-  TConfig extends {
-    [key in string]: unknown;
-  },
-  TConfigInput extends {
-    [key in string]: unknown;
-  },
-  TDataRefs extends {
-    [name in string]: AnyExtensionDataRef;
-  },
+  T extends ExtensionBlueprintParameters = ExtensionBlueprintParameters,
 > {
   // (undocumented)
-  dataRefs: TDataRefs;
+  dataRefs: T['dataRefs'];
   // (undocumented)
   make<
     TNewNamespace extends string | undefined,
@@ -900,20 +864,18 @@ export interface ExtensionBlueprint<
       input: string;
     };
     disabled?: boolean;
-    params: TParams;
-  }): ExtensionDefinition<
-    TConfig,
-    TConfigInput,
-    UOutput,
-    TInputs,
-    {
-      kind: TIdParts['kind'];
-      namespace: string | undefined extends TNewNamespace
-        ? TIdParts['namespace']
-        : TNewNamespace;
-      name: string | undefined extends TNewName ? TIdParts['name'] : TNewName;
-    }
-  >;
+    params: T['params'];
+  }): ExtensionDefinition<{
+    kind: T['kind'];
+    namespace: string | undefined extends TNewNamespace
+      ? T['namespace']
+      : TNewNamespace;
+    name: string | undefined extends TNewName ? T['name'] : TNewName;
+    config: T['config'];
+    configInput: T['configInput'];
+    output: T['output'];
+    inputs: T['inputs'];
+  }>;
   makeWithOverrides<
     TNewNamespace extends string | undefined,
     TNewName extends string | undefined,
@@ -940,64 +902,94 @@ export interface ExtensionBlueprint<
     };
     disabled?: boolean;
     inputs?: TExtraInputs & {
-      [KName in keyof TInputs]?: `Error: Input '${KName &
+      [KName in keyof T['inputs']]?: `Error: Input '${KName &
         string}' is already defined in parent definition`;
     };
     output?: Array<UNewOutput>;
     config?: {
       schema: TExtensionConfigSchema & {
-        [KName in keyof TConfig]?: `Error: Config key '${KName &
+        [KName in keyof T['config']]?: `Error: Config key '${KName &
           string}' is already defined in parent schema`;
       };
     };
     factory(
       originalFactory: (
-        params: TParams,
+        params: T['params'],
         context?: {
-          config?: TConfig;
-          inputs?: ResolveInputValueOverrides<TInputs>;
+          config?: T['config'];
+          inputs?: ResolveInputValueOverrides<NonNullable<T['inputs']>>;
         },
-      ) => ExtensionDataContainer<UOutput>,
+      ) => ExtensionDataContainer<T['output']>,
       context: {
         node: AppNode;
         apis: ApiHolder;
-        config: TConfig & {
+        config: T['config'] & {
           [key in keyof TExtensionConfigSchema]: z.infer<
             ReturnType<TExtensionConfigSchema[key]>
           >;
         };
-        inputs: Expand<ResolvedExtensionInputs<TInputs & TExtraInputs>>;
+        inputs: Expand<ResolvedExtensionInputs<T['inputs'] & TExtraInputs>>;
       },
     ): Iterable<UFactoryOutput> &
       VerifyExtensionFactoryOutput<
-        AnyExtensionDataRef extends UNewOutput ? UOutput : UNewOutput,
+        AnyExtensionDataRef extends UNewOutput ? T['output'] : UNewOutput,
         UFactoryOutput
       >;
-  }): ExtensionDefinition<
-    {
-      [key in keyof TExtensionConfigSchema]: z.infer<
-        ReturnType<TExtensionConfigSchema[key]>
-      >;
-    } & TConfig,
-    z.input<
-      z.ZodObject<{
-        [key in keyof TExtensionConfigSchema]: ReturnType<
-          TExtensionConfigSchema[key]
-        >;
-      }>
-    > &
-      TConfigInput,
-    AnyExtensionDataRef extends UNewOutput ? UOutput : UNewOutput,
-    TInputs & TExtraInputs,
-    {
-      kind: TIdParts['kind'];
-      namespace: string | undefined extends TNewNamespace
-        ? TIdParts['namespace']
-        : TNewNamespace;
-      name: string | undefined extends TNewName ? TIdParts['name'] : TNewName;
-    }
-  >;
+  }): ExtensionDefinition<{
+    config: (string extends keyof TExtensionConfigSchema
+      ? {}
+      : {
+          [key in keyof TExtensionConfigSchema]: z.infer<
+            ReturnType<TExtensionConfigSchema[key]>
+          >;
+        }) &
+      T['config'];
+    configInput: (string extends keyof TExtensionConfigSchema
+      ? {}
+      : z.input<
+          z.ZodObject<{
+            [key in keyof TExtensionConfigSchema]: ReturnType<
+              TExtensionConfigSchema[key]
+            >;
+          }>
+        >) &
+      T['configInput'];
+    output: AnyExtensionDataRef extends UNewOutput ? T['output'] : UNewOutput;
+    inputs: T['inputs'] & TExtraInputs;
+    kind: T['kind'];
+    namespace: string | undefined extends TNewNamespace
+      ? T['namespace']
+      : TNewNamespace;
+    name: string | undefined extends TNewName ? T['name'] : TNewName;
+  }>;
 }
+
+// @public (undocumented)
+export type ExtensionBlueprintParameters = {
+  kind: string;
+  namespace?: string;
+  name?: string;
+  params: object;
+  configInput?: {
+    [K in string]: any;
+  };
+  config?: {
+    [K in string]: any;
+  };
+  output: AnyExtensionDataRef;
+  inputs?: {
+    [KName in string]: ExtensionInput<
+      AnyExtensionDataRef,
+      {
+        optional: boolean;
+        singleton: boolean;
+      }
+    >;
+  };
+  dataRefs?: {
+    [name in string]: AnyExtensionDataRef;
+  };
+};
 
 // @public (undocumented)
 export function ExtensionBoundary(
@@ -1072,47 +1064,11 @@ export type ExtensionDataValue<TData, TId extends string> = {
 };
 
 // @public (undocumented)
-export interface ExtensionDefinition<
-  TConfig,
-  TConfigInput = TConfig,
-  UOutput extends AnyExtensionDataRef = AnyExtensionDataRef,
-  TInputs extends {
-    [inputName in string]: ExtensionInput<
-      AnyExtensionDataRef,
-      {
-        optional: boolean;
-        singleton: boolean;
-      }
-    >;
-  } = {},
-  TIdParts extends {
-    kind?: string;
-    namespace?: string;
-    name?: string;
-  } = {
-    kind?: string;
-    namespace?: string;
-    name?: string;
-  },
-> {
-  // (undocumented)
+export type ExtensionDefinition<
+  T extends ExtensionDefinitionParameters = ExtensionDefinitionParameters,
+> = {
   $$type: '@backstage/ExtensionDefinition';
-  // (undocumented)
-  readonly attachTo: {
-    id: string;
-    input: string;
-  };
-  // (undocumented)
-  readonly configSchema?: PortableSchema<TConfig, TConfigInput>;
-  // (undocumented)
-  readonly disabled: boolean;
-  // (undocumented)
-  readonly kind?: TIdParts['kind'];
-  // (undocumented)
-  readonly name?: TIdParts['name'];
-  // (undocumented)
-  readonly namespace?: TIdParts['namespace'];
-  // (undocumented)
+  readonly T: T;
   override<
     TExtensionConfigSchema extends {
       [key in string]: (zImpl: typeof z) => z.ZodType;
@@ -1136,55 +1092,82 @@ export interface ExtensionDefinition<
       };
       disabled?: boolean;
       inputs?: TExtraInputs & {
-        [KName in keyof TInputs]?: `Error: Input '${KName &
+        [KName in keyof T['inputs']]?: `Error: Input '${KName &
           string}' is already defined in parent definition`;
       };
       output?: Array<UNewOutput>;
       config?: {
         schema: TExtensionConfigSchema & {
-          [KName in keyof TConfig]?: `Error: Config key '${KName &
+          [KName in keyof T['config']]?: `Error: Config key '${KName &
             string}' is already defined in parent schema`;
         };
       };
       factory(
         originalFactory: (context?: {
-          config?: TConfig;
-          inputs?: ResolveInputValueOverrides<TInputs>;
-        }) => ExtensionDataContainer<UOutput>,
+          config?: T['config'];
+          inputs?: ResolveInputValueOverrides<NonNullable<T['inputs']>>;
+        }) => ExtensionDataContainer<NonNullable<T['output']>>,
         context: {
           node: AppNode;
           apis: ApiHolder;
-          config: TConfig & {
+          config: T['config'] & {
             [key in keyof TExtensionConfigSchema]: z.infer<
               ReturnType<TExtensionConfigSchema[key]>
             >;
           };
-          inputs: Expand<ResolvedExtensionInputs<TInputs & TExtraInputs>>;
+          inputs: Expand<ResolvedExtensionInputs<T['inputs'] & TExtraInputs>>;
         },
       ): Iterable<UFactoryOutput>;
     } & VerifyExtensionFactoryOutput<
-      AnyExtensionDataRef extends UNewOutput ? UOutput : UNewOutput,
+      AnyExtensionDataRef extends UNewOutput
+        ? NonNullable<T['output']>
+        : UNewOutput,
       UFactoryOutput
     >,
-  ): ExtensionDefinition<
-    {
+  ): ExtensionDefinition<{
+    kind: T['kind'];
+    namespace: T['namespace'];
+    name: T['name'];
+    output: AnyExtensionDataRef extends UNewOutput ? T['output'] : UNewOutput;
+    inputs: T['inputs'] & TExtraInputs;
+    config: T['config'] & {
       [key in keyof TExtensionConfigSchema]: z.infer<
         ReturnType<TExtensionConfigSchema[key]>
       >;
-    } & TConfig,
-    z.input<
-      z.ZodObject<{
-        [key in keyof TExtensionConfigSchema]: ReturnType<
-          TExtensionConfigSchema[key]
-        >;
-      }>
-    > &
-      TConfigInput,
-    AnyExtensionDataRef extends UNewOutput ? UOutput : UNewOutput,
-    TInputs & TExtraInputs,
-    TIdParts
-  >;
-}
+    };
+    configInput: T['configInput'] &
+      z.input<
+        z.ZodObject<{
+          [key in keyof TExtensionConfigSchema]: ReturnType<
+            TExtensionConfigSchema[key]
+          >;
+        }>
+      >;
+  }>;
+};
+
+// @public (undocumented)
+export type ExtensionDefinitionParameters = {
+  kind?: string;
+  namespace?: string;
+  name?: string;
+  configInput?: {
+    [K in string]: any;
+  };
+  config?: {
+    [K in string]: any;
+  };
+  output: AnyExtensionDataRef;
+  inputs?: {
+    [KName in string]: ExtensionInput<
+      AnyExtensionDataRef,
+      {
+        optional: boolean;
+        singleton: boolean;
+      }
+    >;
+  };
+};
 
 // @public (undocumented)
 export interface ExtensionInput<
@@ -1222,7 +1205,7 @@ export interface ExtensionOverrides {
 // @public (undocumented)
 export interface ExtensionOverridesOptions {
   // (undocumented)
-  extensions: ExtensionDefinition<any, any>[];
+  extensions: ExtensionDefinition[];
   // (undocumented)
   featureFlags?: FeatureFlagConfig[];
 }
@@ -1266,34 +1249,32 @@ export { gitlabAuthApiRef };
 export { googleAuthApiRef };
 
 // @public (undocumented)
-export const IconBundleBlueprint: ExtensionBlueprint<
-  {
-    kind: 'icon-bundle';
-    namespace: 'app';
-    name: undefined;
-  },
-  {
+export const IconBundleBlueprint: ExtensionBlueprint<{
+  kind: 'icon-bundle';
+  namespace: 'app';
+  name: undefined;
+  params: {
     icons: {
       [x: string]: IconComponent;
     };
-  },
-  ConfigurableExtensionDataRef<
+  };
+  output: ConfigurableExtensionDataRef<
     {
       [x: string]: IconComponent;
     },
     'core.icons',
     {}
-  >,
-  {},
-  {
+  >;
+  inputs: {};
+  config: {
     icons: string;
     test: string;
-  },
-  {
+  };
+  configInput: {
     test: string;
     icons?: string | undefined;
-  },
-  {
+  };
+  dataRefs: {
     icons: ConfigurableExtensionDataRef<
       {
         [x: string]: IconComponent;
@@ -1301,8 +1282,8 @@ export const IconBundleBlueprint: ExtensionBlueprint<
       'core.icons',
       {}
     >;
-  }
->;
+  };
+}>;
 
 // @public
 export type IconComponent = ComponentType<
@@ -1332,18 +1313,16 @@ export { identityApiRef };
 export { microsoftAuthApiRef };
 
 // @public
-export const NavItemBlueprint: ExtensionBlueprint<
-  {
-    kind: 'nav-item';
-    namespace: undefined;
-    name: undefined;
-  },
-  {
+export const NavItemBlueprint: ExtensionBlueprint<{
+  kind: 'nav-item';
+  namespace: undefined;
+  name: undefined;
+  params: {
     title: string;
     icon: IconComponent_2;
     routeRef: RouteRef<undefined>;
-  },
-  ConfigurableExtensionDataRef<
+  };
+  output: ConfigurableExtensionDataRef<
     {
       title: string;
       icon: IconComponent_2;
@@ -1351,11 +1330,11 @@ export const NavItemBlueprint: ExtensionBlueprint<
     },
     'core.nav-item.target',
     {}
-  >,
-  {},
-  {},
-  {},
-  {
+  >;
+  inputs: {};
+  config: {};
+  configInput: {};
+  dataRefs: {
     target: ConfigurableExtensionDataRef<
       {
         title: string;
@@ -1365,32 +1344,30 @@ export const NavItemBlueprint: ExtensionBlueprint<
       'core.nav-item.target',
       {}
     >;
-  }
->;
+  };
+}>;
 
 // @public
-export const NavLogoBlueprint: ExtensionBlueprint<
-  {
-    kind: 'nav-logo';
-    namespace: undefined;
-    name: undefined;
-  },
-  {
+export const NavLogoBlueprint: ExtensionBlueprint<{
+  kind: 'nav-logo';
+  namespace: undefined;
+  name: undefined;
+  params: {
     logoIcon: JSX.Element;
     logoFull: JSX.Element;
-  },
-  ConfigurableExtensionDataRef<
+  };
+  output: ConfigurableExtensionDataRef<
     {
       logoIcon?: JSX.Element | undefined;
       logoFull?: JSX.Element | undefined;
     },
     'core.nav-logo.logo-elements',
     {}
-  >,
-  {},
-  {},
-  {},
-  {
+  >;
+  inputs: {};
+  config: {};
+  configInput: {};
+  dataRefs: {
     logoElements: ConfigurableExtensionDataRef<
       {
         logoIcon?: JSX.Element | undefined;
@@ -1399,8 +1376,8 @@ export const NavLogoBlueprint: ExtensionBlueprint<
       'core.nav-logo.logo-elements',
       {}
     >;
-  }
->;
+  };
+}>;
 
 export { OAuthApi };
 
@@ -1421,35 +1398,34 @@ export { oneloginAuthApiRef };
 export { OpenIdConnectApi };
 
 // @public
-export const PageBlueprint: ExtensionBlueprint<
-  {
-    kind: 'page';
-    namespace: undefined;
-    name: undefined;
-  },
-  {
+export const PageBlueprint: ExtensionBlueprint<{
+  kind: 'page';
+  namespace: undefined;
+  name: undefined;
+  params: {
     defaultPath: string;
     loader: () => Promise<JSX.Element>;
     routeRef?: RouteRef<AnyRouteRefParams> | undefined;
-  },
-  | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
-  | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
-  | ConfigurableExtensionDataRef<
-      RouteRef<AnyRouteRefParams>,
-      'core.routing.ref',
-      {
-        optional: true;
-      }
-    >,
-  {},
-  {
+  };
+  output:
+    | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
+    | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
+    | ConfigurableExtensionDataRef<
+        RouteRef<AnyRouteRefParams>,
+        'core.routing.ref',
+        {
+          optional: true;
+        }
+      >;
+  inputs: {};
+  config: {
     path: string | undefined;
-  },
-  {
+  };
+  configInput: {
     path?: string | undefined;
-  },
-  never
->;
+  };
+  dataRefs: never;
+}>;
 
 export { PendingOAuthRequest };
 
@@ -1458,7 +1434,7 @@ export interface PluginOptions<
   TId extends string,
   TRoutes extends AnyRoutes,
   TExternalRoutes extends AnyExternalRoutes,
-  TExtensions extends readonly ExtensionDefinition<any, any>[],
+  TExtensions extends readonly ExtensionDefinition[],
 > {
   // (undocumented)
   extensions?: TExtensions;
@@ -1579,26 +1555,24 @@ export type RouteFunc<TParams extends AnyRouteRefParams> = (
 ) => string;
 
 // @public (undocumented)
-export const RouterBlueprint: ExtensionBlueprint<
-  {
-    kind: 'app-router-component';
-    namespace: undefined;
-    name: undefined;
-  },
-  {
+export const RouterBlueprint: ExtensionBlueprint<{
+  kind: 'app-router-component';
+  namespace: undefined;
+  name: undefined;
+  params: {
     Component: ComponentType<PropsWithChildren<{}>>;
-  },
-  ConfigurableExtensionDataRef<
+  };
+  output: ConfigurableExtensionDataRef<
     ComponentType<{
       children?: ReactNode;
     }>,
     'app.router.wrapper',
     {}
-  >,
-  {},
-  {},
-  {},
-  {
+  >;
+  inputs: {};
+  config: {};
+  configInput: {};
+  dataRefs: {
     component: ConfigurableExtensionDataRef<
       ComponentType<{
         children?: ReactNode;
@@ -1606,8 +1580,8 @@ export const RouterBlueprint: ExtensionBlueprint<
       'app.router.wrapper',
       {}
     >;
-  }
->;
+  };
+}>;
 
 // @public
 export interface RouteRef<
@@ -1644,31 +1618,29 @@ export { SessionApi };
 export { SessionState };
 
 // @public
-export const SignInPageBlueprint: ExtensionBlueprint<
-  {
-    kind: 'sign-in-page';
-    namespace: undefined;
-    name: undefined;
-  },
-  {
+export const SignInPageBlueprint: ExtensionBlueprint<{
+  kind: 'sign-in-page';
+  namespace: undefined;
+  name: undefined;
+  params: {
     loader: () => Promise<ComponentType<SignInPageProps>>;
-  },
-  ConfigurableExtensionDataRef<
+  };
+  output: ConfigurableExtensionDataRef<
     React_2.ComponentType<SignInPageProps>,
     'core.sign-in-page.component',
     {}
-  >,
-  {},
-  {},
-  {},
-  {
+  >;
+  inputs: {};
+  config: {};
+  configInput: {};
+  dataRefs: {
     component: ConfigurableExtensionDataRef<
       React_2.ComponentType<SignInPageProps>,
       'core.sign-in-page.component',
       {}
     >;
-  }
->;
+  };
+}>;
 
 export { StorageApi };
 
@@ -1689,35 +1661,31 @@ export interface SubRouteRef<
 }
 
 // @public
-export const ThemeBlueprint: ExtensionBlueprint<
-  {
-    kind: 'theme';
-    namespace: 'app';
-    name: undefined;
-  },
-  {
+export const ThemeBlueprint: ExtensionBlueprint<{
+  kind: 'theme';
+  namespace: 'app';
+  name: undefined;
+  params: {
     theme: AppTheme;
-  },
-  ConfigurableExtensionDataRef<AppTheme, 'core.theme.theme', {}>,
-  {},
-  {},
-  {},
-  {
+  };
+  output: ConfigurableExtensionDataRef<AppTheme, 'core.theme.theme', {}>;
+  inputs: {};
+  config: {};
+  configInput: {};
+  dataRefs: {
     theme: ConfigurableExtensionDataRef<AppTheme, 'core.theme.theme', {}>;
-  }
->;
+  };
+}>;
 
 // @public
-export const TranslationBlueprint: ExtensionBlueprint<
-  {
-    kind: 'translation';
-    namespace: undefined;
-    name: undefined;
-  },
-  {
+export const TranslationBlueprint: ExtensionBlueprint<{
+  kind: 'translation';
+  namespace: undefined;
+  name: undefined;
+  params: {
     resource: TranslationResource | TranslationMessages;
-  },
-  ConfigurableExtensionDataRef<
+  };
+  output: ConfigurableExtensionDataRef<
     | TranslationResource<string>
     | TranslationMessages<
         string,
@@ -1728,11 +1696,11 @@ export const TranslationBlueprint: ExtensionBlueprint<
       >,
     'core.translation.translation',
     {}
-  >,
-  {},
-  {},
-  {},
-  {
+  >;
+  inputs: {};
+  config: {};
+  configInput: {};
+  dataRefs: {
     translation: ConfigurableExtensionDataRef<
       | TranslationResource<string>
       | TranslationMessages<
@@ -1745,8 +1713,8 @@ export const TranslationBlueprint: ExtensionBlueprint<
       'core.translation.translation',
       {}
     >;
-  }
->;
+  };
+}>;
 
 export { TranslationMessages };
 

--- a/packages/frontend-plugin-api/src/blueprints/ApiBlueprint.test.ts
+++ b/packages/frontend-plugin-api/src/blueprints/ApiBlueprint.test.ts
@@ -37,6 +37,7 @@ describe('ApiBlueprint', () => {
     expect(extension).toMatchInlineSnapshot(`
       {
         "$$type": "@backstage/ExtensionDefinition",
+        "T": undefined,
         "attachTo": {
           "id": "root",
           "input": "apis",
@@ -86,6 +87,7 @@ describe('ApiBlueprint', () => {
     expect(extension).toMatchInlineSnapshot(`
       {
         "$$type": "@backstage/ExtensionDefinition",
+        "T": undefined,
         "attachTo": {
           "id": "root",
           "input": "apis",

--- a/packages/frontend-plugin-api/src/blueprints/AppRootElementBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/AppRootElementBlueprint.test.tsx
@@ -27,6 +27,7 @@ describe('AppRootElementBlueprint', () => {
     expect(extension).toMatchInlineSnapshot(`
       {
         "$$type": "@backstage/ExtensionDefinition",
+        "T": undefined,
         "attachTo": {
           "id": "app/root",
           "input": "elements",

--- a/packages/frontend-plugin-api/src/blueprints/AppRootWrapperBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/AppRootWrapperBlueprint.test.tsx
@@ -37,6 +37,7 @@ describe('AppRootWrapperBlueprint', () => {
     expect(extension).toMatchInlineSnapshot(`
       {
         "$$type": "@backstage/ExtensionDefinition",
+        "T": undefined,
         "attachTo": {
           "id": "app/root",
           "input": "wrappers",

--- a/packages/frontend-plugin-api/src/blueprints/NavItemBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/NavItemBlueprint.test.tsx
@@ -33,6 +33,7 @@ describe('NavItemBlueprint', () => {
     expect(extension).toMatchInlineSnapshot(`
       {
         "$$type": "@backstage/ExtensionDefinition",
+        "T": undefined,
         "attachTo": {
           "id": "app/nav",
           "input": "items",

--- a/packages/frontend-plugin-api/src/blueprints/NavLogoBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/NavLogoBlueprint.test.tsx
@@ -30,6 +30,7 @@ describe('NavLogoBlueprint', () => {
     expect(extension).toMatchInlineSnapshot(`
       {
         "$$type": "@backstage/ExtensionDefinition",
+        "T": undefined,
         "attachTo": {
           "id": "app/nav",
           "input": "logos",

--- a/packages/frontend-plugin-api/src/blueprints/PageBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/PageBlueprint.test.tsx
@@ -43,6 +43,7 @@ describe('PageBlueprint', () => {
     expect(myPage).toMatchInlineSnapshot(`
       {
         "$$type": "@backstage/ExtensionDefinition",
+        "T": undefined,
         "attachTo": {
           "id": "app/routes",
           "input": "routes",

--- a/packages/frontend-plugin-api/src/blueprints/RouterBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/RouterBlueprint.test.tsx
@@ -38,6 +38,7 @@ describe('RouterBlueprint', () => {
     expect(extension).toMatchInlineSnapshot(`
       {
         "$$type": "@backstage/ExtensionDefinition",
+        "T": undefined,
         "attachTo": {
           "id": "app/root",
           "input": "router",

--- a/packages/frontend-plugin-api/src/blueprints/SignInPageBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/SignInPageBlueprint.test.tsx
@@ -31,6 +31,7 @@ describe('SignInPageBlueprint', () => {
     ).toMatchInlineSnapshot(`
       {
         "$$type": "@backstage/ExtensionDefinition",
+        "T": undefined,
         "attachTo": {
           "id": "app/root",
           "input": "signInPage",

--- a/packages/frontend-plugin-api/src/blueprints/ThemeBlueprint.test.ts
+++ b/packages/frontend-plugin-api/src/blueprints/ThemeBlueprint.test.ts
@@ -31,6 +31,7 @@ describe('ThemeBlueprint', () => {
       .toMatchInlineSnapshot(`
       {
         "$$type": "@backstage/ExtensionDefinition",
+        "T": undefined,
         "attachTo": {
           "id": "api:app-theme",
           "input": "themes",

--- a/packages/frontend-plugin-api/src/blueprints/TranslationBlueprint.test.ts
+++ b/packages/frontend-plugin-api/src/blueprints/TranslationBlueprint.test.ts
@@ -46,6 +46,7 @@ describe('TranslationBlueprint', () => {
     ).toMatchInlineSnapshot(`
       {
         "$$type": "@backstage/ExtensionDefinition",
+        "T": undefined,
         "attachTo": {
           "id": "api:translations",
           "input": "translations",

--- a/packages/frontend-plugin-api/src/wiring/createExtension.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.test.ts
@@ -18,6 +18,7 @@ import { createExtensionTester } from '@backstage/frontend-test-utils';
 import { createExtension } from './createExtension';
 import { createExtensionDataRef } from './createExtensionDataRef';
 import { createExtensionInput } from './createExtensionInput';
+import { PortableSchema } from '../schema';
 
 const stringDataRef = createExtensionDataRef<string>().with({ id: 'string' });
 const numberDataRef = createExtensionDataRef<number>().with({ id: 'number' });
@@ -289,7 +290,12 @@ describe('createExtension', () => {
     );
 
     expect(
-      extension.configSchema?.parse({
+      (
+        (extension as any).configSchema as PortableSchema<
+          (typeof extension.T)['config'],
+          (typeof extension.T)['configInput']
+        >
+      )?.parse({
         foo: 'x',
         bar: 'y',
         baz: 'z',
@@ -302,7 +308,12 @@ describe('createExtension', () => {
       baz: 'z',
     });
     expect(
-      extension.configSchema?.parse({
+      (
+        (extension as any).configSchema as PortableSchema<
+          (typeof extension.T)['config'],
+          (typeof extension.T)['configInput']
+        >
+      )?.parse({
         foo: 'x',
       }),
     ).toEqual({

--- a/packages/frontend-plugin-api/src/wiring/createExtension.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.ts
@@ -390,7 +390,7 @@ export function createExtension<
   return {
     $$type: '@backstage/ExtensionDefinition',
     version: 'v2',
-    T: null as unknown as T,
+    T: undefined as unknown as T,
     kind: options.kind,
     namespace: options.namespace,
     name: options.name,

--- a/packages/frontend-plugin-api/src/wiring/createExtension.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.ts
@@ -148,7 +148,7 @@ export type ExtensionDefinitionParameters = {
   name?: string;
   configInput?: { [K in string]: any };
   config?: { [K in string]: any };
-  output: AnyExtensionDataRef;
+  output?: AnyExtensionDataRef;
   inputs?: {
     [KName in string]: ExtensionInput<
       AnyExtensionDataRef,

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.test.tsx
@@ -35,10 +35,7 @@ import { createExtensionDataContainer } from './createExtensionDataContainer';
 
 function unused(..._any: any[]) {}
 
-function factoryOutput(
-  ext: ExtensionDefinition<any, any>,
-  inputs: unknown = undefined,
-) {
+function factoryOutput(ext: ExtensionDefinition, inputs: unknown = undefined) {
   const int = toInternalExtensionDefinition(ext);
   if (int.version !== 'v2') {
     throw new Error('Expected v2 extension');

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
@@ -86,10 +86,10 @@ export type ExtensionBlueprintParameters = {
   kind: string;
   namespace?: string;
   name?: string;
-  params: object;
+  params?: object;
   configInput?: { [K in string]: any };
   config?: { [K in string]: any };
-  output: AnyExtensionDataRef;
+  output?: AnyExtensionDataRef;
   inputs?: {
     [KName in string]: ExtensionInput<
       AnyExtensionDataRef,
@@ -171,7 +171,7 @@ export interface ExtensionBlueprint<
           config?: T['config'];
           inputs?: ResolveInputValueOverrides<NonNullable<T['inputs']>>;
         },
-      ) => ExtensionDataContainer<T['output']>,
+      ) => ExtensionDataContainer<NonNullable<T['output']>>,
       context: {
         node: AppNode;
         apis: ApiHolder;
@@ -184,7 +184,9 @@ export interface ExtensionBlueprint<
       },
     ): Iterable<UFactoryOutput> &
       VerifyExtensionFactoryOutput<
-        AnyExtensionDataRef extends UNewOutput ? T['output'] : UNewOutput,
+        AnyExtensionDataRef extends UNewOutput
+          ? NonNullable<T['output']>
+          : UNewOutput,
         UFactoryOutput
       >;
   }): ExtensionDefinition<{

--- a/packages/frontend-plugin-api/src/wiring/createExtensionOverrides.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionOverrides.test.ts
@@ -65,6 +65,7 @@ describe('createExtensionOverrides', () => {
         "extensions": [
           {
             "$$type": "@backstage/Extension",
+            "T": undefined,
             "attachTo": {
               "id": "app",
               "input": "apis",
@@ -80,6 +81,7 @@ describe('createExtensionOverrides', () => {
           },
           {
             "$$type": "@backstage/Extension",
+            "T": undefined,
             "attachTo": {
               "id": "app",
               "input": "apis",
@@ -95,6 +97,7 @@ describe('createExtensionOverrides', () => {
           },
           {
             "$$type": "@backstage/Extension",
+            "T": undefined,
             "attachTo": {
               "id": "app",
               "input": "apis",

--- a/packages/frontend-plugin-api/src/wiring/createExtensionOverrides.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionOverrides.ts
@@ -23,7 +23,7 @@ import { ExtensionOverrides, FeatureFlagConfig } from './types';
 
 /** @public */
 export interface ExtensionOverridesOptions {
-  extensions: ExtensionDefinition<any, any>[];
+  extensions: ExtensionDefinition[];
   featureFlags?: FeatureFlagConfig[];
 }
 

--- a/packages/frontend-plugin-api/src/wiring/createFrontendPlugin.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createFrontendPlugin.test.ts
@@ -150,6 +150,7 @@ describe('createFrontendPlugin', () => {
     expect(plugin.getExtension('test/1')).toMatchInlineSnapshot(`
       {
         "$$type": "@backstage/ExtensionDefinition",
+        "T": undefined,
         "attachTo": {
           "id": "test/output",
           "input": "names",
@@ -281,6 +282,7 @@ describe('createFrontendPlugin', () => {
       expect(plugin.getExtension('test/1')).toMatchInlineSnapshot(`
         {
           "$$type": "@backstage/ExtensionDefinition",
+          "T": undefined,
           "attachTo": {
             "id": "test/output",
             "input": "names",

--- a/packages/frontend-plugin-api/src/wiring/createFrontendPlugin.ts
+++ b/packages/frontend-plugin-api/src/wiring/createFrontendPlugin.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { ExtensionDefinition } from './createExtension';
+import {
+  ExtensionDefinition,
+  InternalExtensionDefinition,
+  toInternalExtensionDefinition,
+} from './createExtension';
 import {
   Extension,
   ResolveExtensionId,
@@ -32,7 +36,7 @@ export interface PluginOptions<
   TId extends string,
   TRoutes extends AnyRoutes,
   TExternalRoutes extends AnyExternalRoutes,
-  TExtensions extends readonly ExtensionDefinition<any, any>[],
+  TExtensions extends readonly ExtensionDefinition[],
 > {
   id: TId;
   routes?: TRoutes;
@@ -56,7 +60,7 @@ export function createFrontendPlugin<
   TId extends string,
   TRoutes extends AnyRoutes = {},
   TExternalRoutes extends AnyExternalRoutes = {},
-  TExtensions extends readonly ExtensionDefinition<any, any>[] = [],
+  TExtensions extends readonly ExtensionDefinition[] = [],
 >(
   options: PluginOptions<TId, TRoutes, TExternalRoutes, TExtensions>,
 ): BackstagePlugin<
@@ -69,16 +73,20 @@ export function createFrontendPlugin<
     >]: KExtension;
   }
 > {
-  const extensions = new Array<Extension<unknown>>();
+  const extensions = new Array<Extension<any>>();
   const extensionDefinitionsById = new Map<
     string,
-    ExtensionDefinition<unknown>
+    InternalExtensionDefinition
   >();
 
   for (const def of options.extensions ?? []) {
+    const internal = toInternalExtensionDefinition(def);
     const ext = resolveExtensionDefinition(def, { namespace: options.id });
     extensions.push(ext);
-    extensionDefinitionsById.set(ext.id, { ...def, namespace: options.id });
+    extensionDefinitionsById.set(ext.id, {
+      ...internal,
+      namespace: options.id,
+    });
   }
 
   if (extensions.length !== extensionDefinitionsById.size) {

--- a/packages/frontend-plugin-api/src/wiring/index.ts
+++ b/packages/frontend-plugin-api/src/wiring/index.ts
@@ -18,6 +18,7 @@ export { coreExtensionData } from './coreExtensionData';
 export {
   createExtension,
   type ExtensionDefinition,
+  type ExtensionDefinitionParameters,
   type CreateExtensionOptions,
   type ResolvedExtensionInput,
   type ResolvedExtensionInputs,
@@ -56,6 +57,7 @@ export {
 export {
   type CreateExtensionBlueprintOptions,
   type ExtensionBlueprint,
+  type ExtensionBlueprintParameters,
   createExtensionBlueprint,
 } from './createExtensionBlueprint';
 export { type ResolveInputValueOverrides } from './resolveInputOverrides';

--- a/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.test.ts
@@ -23,10 +23,11 @@ import {
 describe('resolveExtensionDefinition', () => {
   const baseDef = {
     $$type: '@backstage/ExtensionDefinition',
+    T: null as any,
     version: 'v2',
     attachTo: { id: '', input: '' },
     disabled: false,
-    override: () => ({} as ExtensionDefinition<unknown>),
+    override: () => ({} as ExtensionDefinition),
   };
 
   it.each([
@@ -39,7 +40,7 @@ describe('resolveExtensionDefinition', () => {
     const resolved = resolveExtensionDefinition({
       ...baseDef,
       ...definition,
-    } as ExtensionDefinition<unknown>);
+    } as ExtensionDefinition);
     expect(resolved.id).toBe(expected);
     expect(String(resolved)).toBe(`Extension{id=${expected}}`);
   });
@@ -49,12 +50,12 @@ describe('resolveExtensionDefinition', () => {
       resolveExtensionDefinition({
         ...baseDef,
         kind: 'k',
-      } as ExtensionDefinition<unknown>),
+      } as ExtensionDefinition),
     ).toThrow(
       'Extension must declare an explicit namespace or name as it could not be resolved from context, kind=k namespace=undefined name=undefined',
     );
     expect(() =>
-      resolveExtensionDefinition(baseDef as ExtensionDefinition<unknown>),
+      resolveExtensionDefinition(baseDef as ExtensionDefinition),
     ).toThrow(
       'Extension must declare an explicit namespace or name as it could not be resolved from context, kind=undefined namespace=undefined name=undefined',
     );
@@ -64,10 +65,11 @@ describe('resolveExtensionDefinition', () => {
 describe('old resolveExtensionDefinition', () => {
   const baseDef = {
     $$type: '@backstage/ExtensionDefinition',
+    T: null as any,
     version: 'v1',
     attachTo: { id: '', input: '' },
     disabled: false,
-    override: () => ({} as ExtensionDefinition<unknown>),
+    override: () => ({} as ExtensionDefinition),
   };
 
   it.each([
@@ -80,7 +82,7 @@ describe('old resolveExtensionDefinition', () => {
     const resolved = resolveExtensionDefinition({
       ...baseDef,
       ...definition,
-    } as ExtensionDefinition<unknown>);
+    } as ExtensionDefinition);
     expect(resolved.id).toBe(expected);
     expect(String(resolved)).toBe(`Extension{id=${expected}}`);
   });
@@ -90,12 +92,12 @@ describe('old resolveExtensionDefinition', () => {
       resolveExtensionDefinition({
         ...baseDef,
         kind: 'k',
-      } as ExtensionDefinition<unknown>),
+      } as ExtensionDefinition),
     ).toThrow(
       'Extension must declare an explicit namespace or name as it could not be resolved from context, kind=k namespace=undefined name=undefined',
     );
     expect(() =>
-      resolveExtensionDefinition(baseDef as ExtensionDefinition<unknown>),
+      resolveExtensionDefinition(baseDef as ExtensionDefinition),
     ).toThrow(
       'Extension must declare an explicit namespace or name as it could not be resolved from context, kind=undefined namespace=undefined name=undefined',
     );
@@ -108,13 +110,12 @@ describe('ResolveExtensionId', () => {
       TKind extends string | undefined,
       TNamespace extends string | undefined,
       TName extends string | undefined,
-    > = ExtensionDefinition<
-      any,
-      any,
-      any,
-      any,
-      { kind: TKind; namespace: TNamespace; name: TName }
-    >;
+    > = ExtensionDefinition<{
+      kind: TKind;
+      namespace: TNamespace;
+      name: TName;
+      output: any;
+    }>;
 
     const id1: 'k:ns' = {} as ResolveExtensionId<
       NamedExtension<'k', 'ns', undefined>,

--- a/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.test.ts
@@ -23,7 +23,7 @@ import {
 describe('resolveExtensionDefinition', () => {
   const baseDef = {
     $$type: '@backstage/ExtensionDefinition',
-    T: null as any,
+    T: undefined as any,
     version: 'v2',
     attachTo: { id: '', input: '' },
     disabled: false,
@@ -65,7 +65,7 @@ describe('resolveExtensionDefinition', () => {
 describe('old resolveExtensionDefinition', () => {
   const baseDef = {
     $$type: '@backstage/ExtensionDefinition',
-    T: null as any,
+    T: undefined as any,
     version: 'v1',
     attachTo: { id: '', input: '' },
     disabled: false,

--- a/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.ts
+++ b/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.ts
@@ -116,7 +116,6 @@ export type ResolveExtensionId<
   kind: infer IKind extends string | undefined;
   namespace: infer INamespace extends string | undefined;
   name: infer IName extends string | undefined;
-  output: any;
 }>
   ? [string | undefined] extends [IKind | INamespace | IName]
     ? never

--- a/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.ts
+++ b/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.ts
@@ -17,6 +17,7 @@
 import { ApiHolder, AppNode } from '../apis';
 import {
   ExtensionDefinition,
+  ExtensionDefinitionParameters,
   ResolvedExtensionInputs,
   toInternalExtensionDefinition,
 } from './createExtension';
@@ -109,19 +110,14 @@ export function toInternalExtension<TConfig, TConfigInput>(
 
 /** @ignore */
 export type ResolveExtensionId<
-  TExtension extends ExtensionDefinition<any>,
+  TExtension extends ExtensionDefinition,
   TDefaultNamespace extends string | undefined,
-> = TExtension extends ExtensionDefinition<
-  any,
-  any,
-  any,
-  any,
-  {
-    kind: infer IKind extends string | undefined;
-    namespace: infer INamespace extends string | undefined;
-    name: infer IName extends string | undefined;
-  }
->
+> = TExtension extends ExtensionDefinition<{
+  kind: infer IKind extends string | undefined;
+  namespace: infer INamespace extends string | undefined;
+  name: infer IName extends string | undefined;
+  output: any;
+}>
   ? [string | undefined] extends [IKind | INamespace | IName]
     ? never
     : (
@@ -140,10 +136,12 @@ export type ResolveExtensionId<
   : never;
 
 /** @internal */
-export function resolveExtensionDefinition<TConfig, TConfigInput>(
-  definition: ExtensionDefinition<TConfig, TConfigInput>,
+export function resolveExtensionDefinition<
+  T extends ExtensionDefinitionParameters,
+>(
+  definition: ExtensionDefinition<T>,
   context?: { namespace?: string },
-): Extension<TConfig, TConfigInput> {
+): Extension<T['config'], T['configInput']> {
   const internalDefinition = toInternalExtensionDefinition(definition);
   const {
     name,
@@ -172,5 +170,5 @@ export function resolveExtensionDefinition<TConfig, TConfigInput>(
     toString() {
       return `Extension{id=${id}}`;
     },
-  } as InternalExtension<TConfig, TConfigInput>;
+  } as InternalExtension<T['config'], T['configInput']> & Object;
 }

--- a/packages/frontend-plugin-api/src/wiring/types.ts
+++ b/packages/frontend-plugin-api/src/wiring/types.ts
@@ -35,7 +35,7 @@ export type AnyExternalRoutes = { [name in string]: ExternalRouteRef };
 
 /** @public */
 export type ExtensionMap<
-  TExtensionMap extends { [id in string]: ExtensionDefinition<any, any> },
+  TExtensionMap extends { [id in string]: ExtensionDefinition },
 > = {
   get<TId extends keyof TExtensionMap>(id: TId): TExtensionMap[TId];
 };
@@ -44,7 +44,7 @@ export type ExtensionMap<
 export interface BackstagePlugin<
   TRoutes extends AnyRoutes = AnyRoutes,
   TExternalRoutes extends AnyExternalRoutes = AnyExternalRoutes,
-  TExtensionMap extends { [id in string]: ExtensionDefinition<any, any> } = {},
+  TExtensionMap extends { [id in string]: ExtensionDefinition } = {},
 > {
   readonly $$type: '@backstage/BackstagePlugin';
   readonly id: string;
@@ -52,7 +52,7 @@ export interface BackstagePlugin<
   readonly externalRoutes: TExternalRoutes;
   getExtension<TId extends keyof TExtensionMap>(id: TId): TExtensionMap[TId];
   withOverrides(options: {
-    extensions: Array<ExtensionDefinition<any, any>>;
+    extensions: Array<ExtensionDefinition>;
   }): BackstagePlugin<TRoutes, TExternalRoutes, TExtensionMap>;
 }
 

--- a/packages/frontend-test-utils/api-report.md
+++ b/packages/frontend-test-utils/api-report.md
@@ -13,6 +13,7 @@ import { AppNodeInstance } from '@backstage/frontend-plugin-api';
 import { ErrorWithContext } from '@backstage/test-utils';
 import { ExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { ExtensionDefinition } from '@backstage/frontend-plugin-api';
+import { ExtensionDefinitionParameters } from '@backstage/frontend-plugin-api';
 import { JsonObject } from '@backstage/types';
 import { MockConfigApi } from '@backstage/test-utils';
 import { MockErrorApi } from '@backstage/test-utils';
@@ -31,16 +32,12 @@ import { TestApiRegistry } from '@backstage/test-utils';
 import { withLogCollector } from '@backstage/test-utils';
 
 // @public (undocumented)
-export function createExtensionTester<
-  TConfig,
-  TConfigInput,
-  UOutput extends AnyExtensionDataRef,
->(
-  subject: ExtensionDefinition<TConfig, TConfigInput, UOutput>,
+export function createExtensionTester<T extends ExtensionDefinitionParameters>(
+  subject: ExtensionDefinition<T>,
   options?: {
-    config?: TConfigInput;
+    config?: T['configInput'];
   },
-): ExtensionTester<UOutput>;
+): ExtensionTester<T['output']>;
 
 export { ErrorWithContext };
 
@@ -64,10 +61,10 @@ export class ExtensionQuery<UOutput extends AnyExtensionDataRef> {
 // @public (undocumented)
 export class ExtensionTester<UOutput extends AnyExtensionDataRef> {
   // (undocumented)
-  add<TConfig, TConfigInput>(
-    extension: ExtensionDefinition<TConfig, TConfigInput>,
+  add<T extends ExtensionDefinitionParameters>(
+    extension: ExtensionDefinition<T>,
     options?: {
-      config?: TConfigInput;
+      config?: T['configInput'];
     },
   ): ExtensionTester<UOutput>;
   // (undocumented)
@@ -79,9 +76,9 @@ export class ExtensionTester<UOutput extends AnyExtensionDataRef> {
       : IData
     : never;
   // (undocumented)
-  query<UQueryExtensionOutput extends AnyExtensionDataRef>(
-    extension: ExtensionDefinition<any, any, UQueryExtensionOutput>,
-  ): ExtensionQuery<UQueryExtensionOutput>;
+  query<T extends ExtensionDefinitionParameters>(
+    extension: ExtensionDefinition<T>,
+  ): ExtensionQuery<T['output']>;
   // (undocumented)
   reactElement(): JSX.Element;
 }

--- a/packages/frontend-test-utils/api-report.md
+++ b/packages/frontend-test-utils/api-report.md
@@ -37,7 +37,7 @@ export function createExtensionTester<T extends ExtensionDefinitionParameters>(
   options?: {
     config?: T['configInput'];
   },
-): ExtensionTester<T['output']>;
+): ExtensionTester<NonNullable<T['output']>>;
 
 export { ErrorWithContext };
 
@@ -78,7 +78,7 @@ export class ExtensionTester<UOutput extends AnyExtensionDataRef> {
   // (undocumented)
   query<T extends ExtensionDefinitionParameters>(
     extension: ExtensionDefinition<T>,
-  ): ExtensionQuery<T['output']>;
+  ): ExtensionQuery<NonNullable<T['output']>>;
   // (undocumented)
   reactElement(): JSX.Element;
 }

--- a/packages/frontend-test-utils/src/app/createExtensionTester.tsx
+++ b/packages/frontend-test-utils/src/app/createExtensionTester.tsx
@@ -143,7 +143,13 @@ export class ExtensionTester<UOutput extends AnyExtensionDataRef> {
   ): ExtensionQuery<NonNullable<T['output']>> {
     const tree = this.#resolveTree();
 
-    const actualId = resolveExtensionDefinition(extension).id;
+    // Same fallback logic as in .add
+    const { name, namespace } = toInternalExtensionDefinition(extension);
+    const definition = {
+      ...extension,
+      name: !namespace && !name ? 'test' : name,
+    };
+    const actualId = resolveExtensionDefinition(definition).id;
 
     const node = tree.nodes.get(actualId);
 

--- a/packages/frontend-test-utils/src/app/createExtensionTester.tsx
+++ b/packages/frontend-test-utils/src/app/createExtensionTester.tsx
@@ -79,7 +79,7 @@ export class ExtensionTester<UOutput extends AnyExtensionDataRef> {
   static forSubject<T extends ExtensionDefinitionParameters>(
     subject: ExtensionDefinition<T>,
     options?: { config?: T['configInput'] },
-  ): ExtensionTester<T['output']> {
+  ): ExtensionTester<NonNullable<T['output']>> {
     const tester = new ExtensionTester();
     tester.add(subject, options as T['configInput'] & {});
     return tester;
@@ -137,7 +137,7 @@ export class ExtensionTester<UOutput extends AnyExtensionDataRef> {
 
   query<T extends ExtensionDefinitionParameters>(
     extension: ExtensionDefinition<T>,
-  ): ExtensionQuery<T['output']> {
+  ): ExtensionQuery<NonNullable<T['output']>> {
     const tree = this.#resolveTree();
 
     const actualId = this.#extensions.find(e => e.definition === extension)?.id;
@@ -240,6 +240,6 @@ export class ExtensionTester<UOutput extends AnyExtensionDataRef> {
 export function createExtensionTester<T extends ExtensionDefinitionParameters>(
   subject: ExtensionDefinition<T>,
   options?: { config?: T['configInput'] },
-): ExtensionTester<T['output']> {
+): ExtensionTester<NonNullable<T['output']>> {
   return ExtensionTester.forSubject(subject, options);
 }

--- a/packages/frontend-test-utils/src/app/renderInTestApp.tsx
+++ b/packages/frontend-test-utils/src/app/renderInTestApp.tsx
@@ -123,7 +123,7 @@ export function renderInTestApp(
   element: JSX.Element,
   options?: TestAppOptions,
 ): RenderResult {
-  const extensions: Array<ExtensionDefinition<any, any>> = [
+  const extensions: Array<ExtensionDefinition> = [
     createExtension({
       namespace: 'test',
       attachTo: { id: 'app/routes', input: 'routes' },

--- a/plugins/api-docs/api-report-alpha.md
+++ b/plugins/api-docs/api-report-alpha.md
@@ -25,10 +25,13 @@ const _default: BackstagePlugin<
     registerApi: ExternalRouteRef<undefined>;
   },
   {
-    'nav-item:api-docs': ExtensionDefinition<
-      {},
-      {},
-      ConfigurableExtensionDataRef<
+    'nav-item:api-docs': ExtensionDefinition<{
+      kind: 'nav-item';
+      namespace: undefined;
+      name: undefined;
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
         {
           title: string;
           icon: IconComponent;
@@ -36,50 +39,48 @@ const _default: BackstagePlugin<
         },
         'core.nav-item.target',
         {}
-      >,
-      {},
-      {
-        kind: 'nav-item';
-        namespace: undefined;
-        name: undefined;
-      }
-    >;
-    'api:api-docs/config': ExtensionDefinition<
-      {},
-      {},
-      ConfigurableExtensionDataRef<AnyApiFactory, 'core.api.factory', {}>,
-      {},
-      {
-        kind: 'api';
-        namespace: undefined;
-        name: 'config';
-      }
-    >;
-    'page:api-docs': ExtensionDefinition<
-      {
+      >;
+      inputs: {};
+    }>;
+    'api:api-docs/config': ExtensionDefinition<{
+      kind: 'api';
+      namespace: undefined;
+      name: 'config';
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {};
+    }>;
+    'page:api-docs': ExtensionDefinition<{
+      config: {
         initiallySelectedFilter: 'all' | 'owned' | 'starred' | undefined;
       } & {
         path: string | undefined;
-      },
-      {
+      };
+      configInput: {
         initiallySelectedFilter?: 'all' | 'owned' | 'starred' | undefined;
       } & {
         path?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<
-          React_2.JSX.Element,
-          'core.reactElement',
-          {}
-        >
-      | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
-      | ConfigurableExtensionDataRef<
-          RouteRef<AnyRouteRefParams>,
-          'core.routing.ref',
-          {
-            optional: true;
-          }
-        >,
-      {
+      };
+      output:
+        | ConfigurableExtensionDataRef<
+            React_2.JSX.Element,
+            'core.reactElement',
+            {}
+          >
+        | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
+        | ConfigurableExtensionDataRef<
+            RouteRef<AnyRouteRefParams>,
+            'core.routing.ref',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {
         [x: string]: ExtensionInput<
           AnyExtensionDataRef,
           {
@@ -87,303 +88,301 @@ const _default: BackstagePlugin<
             singleton: boolean;
           }
         >;
-      },
-      {
-        kind: 'page';
-        namespace: undefined;
-        name: undefined;
-      }
-    >;
-    'entity-card:api-docs/has-apis': ExtensionDefinition<
-      {
+      };
+      kind: 'page';
+      namespace: undefined;
+      name: undefined;
+    }>;
+    'entity-card:api-docs/has-apis': ExtensionDefinition<{
+      kind: 'entity-card';
+      namespace: undefined;
+      name: 'has-apis';
+      config: {
         filter: string | undefined;
-      },
-      {
+      };
+      configInput: {
         filter?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<
-          React_2.JSX.Element,
-          'core.reactElement',
-          {}
-        >
-      | ConfigurableExtensionDataRef<
-          (entity: Entity) => boolean,
-          'catalog.entity-filter-function',
-          {
-            optional: true;
-          }
-        >
-      | ConfigurableExtensionDataRef<
-          string,
-          'catalog.entity-filter-expression',
-          {
-            optional: true;
-          }
-        >,
-      {},
-      {
-        kind: 'entity-card';
-        namespace: undefined;
-        name: 'has-apis';
-      }
-    >;
-    'entity-card:api-docs/definition': ExtensionDefinition<
-      {
+      };
+      output:
+        | ConfigurableExtensionDataRef<
+            React_2.JSX.Element,
+            'core.reactElement',
+            {}
+          >
+        | ConfigurableExtensionDataRef<
+            (entity: Entity) => boolean,
+            'catalog.entity-filter-function',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-filter-expression',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+    }>;
+    'entity-card:api-docs/definition': ExtensionDefinition<{
+      kind: 'entity-card';
+      namespace: undefined;
+      name: 'definition';
+      config: {
         filter: string | undefined;
-      },
-      {
+      };
+      configInput: {
         filter?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<
-          React_2.JSX.Element,
-          'core.reactElement',
-          {}
-        >
-      | ConfigurableExtensionDataRef<
-          (entity: Entity) => boolean,
-          'catalog.entity-filter-function',
-          {
-            optional: true;
-          }
-        >
-      | ConfigurableExtensionDataRef<
-          string,
-          'catalog.entity-filter-expression',
-          {
-            optional: true;
-          }
-        >,
-      {},
-      {
-        kind: 'entity-card';
-        namespace: undefined;
-        name: 'definition';
-      }
-    >;
-    'entity-card:api-docs/consumed-apis': ExtensionDefinition<
-      {
+      };
+      output:
+        | ConfigurableExtensionDataRef<
+            React_2.JSX.Element,
+            'core.reactElement',
+            {}
+          >
+        | ConfigurableExtensionDataRef<
+            (entity: Entity) => boolean,
+            'catalog.entity-filter-function',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-filter-expression',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+    }>;
+    'entity-card:api-docs/consumed-apis': ExtensionDefinition<{
+      kind: 'entity-card';
+      namespace: undefined;
+      name: 'consumed-apis';
+      config: {
         filter: string | undefined;
-      },
-      {
+      };
+      configInput: {
         filter?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<
-          React_2.JSX.Element,
-          'core.reactElement',
-          {}
-        >
-      | ConfigurableExtensionDataRef<
-          (entity: Entity) => boolean,
-          'catalog.entity-filter-function',
-          {
-            optional: true;
-          }
-        >
-      | ConfigurableExtensionDataRef<
-          string,
-          'catalog.entity-filter-expression',
-          {
-            optional: true;
-          }
-        >,
-      {},
-      {
-        kind: 'entity-card';
-        namespace: undefined;
-        name: 'consumed-apis';
-      }
-    >;
-    'entity-card:api-docs/provided-apis': ExtensionDefinition<
-      {
+      };
+      output:
+        | ConfigurableExtensionDataRef<
+            React_2.JSX.Element,
+            'core.reactElement',
+            {}
+          >
+        | ConfigurableExtensionDataRef<
+            (entity: Entity) => boolean,
+            'catalog.entity-filter-function',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-filter-expression',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+    }>;
+    'entity-card:api-docs/provided-apis': ExtensionDefinition<{
+      kind: 'entity-card';
+      namespace: undefined;
+      name: 'provided-apis';
+      config: {
         filter: string | undefined;
-      },
-      {
+      };
+      configInput: {
         filter?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<
-          React_2.JSX.Element,
-          'core.reactElement',
-          {}
-        >
-      | ConfigurableExtensionDataRef<
-          (entity: Entity) => boolean,
-          'catalog.entity-filter-function',
-          {
-            optional: true;
-          }
-        >
-      | ConfigurableExtensionDataRef<
-          string,
-          'catalog.entity-filter-expression',
-          {
-            optional: true;
-          }
-        >,
-      {},
-      {
-        kind: 'entity-card';
-        namespace: undefined;
-        name: 'provided-apis';
-      }
-    >;
-    'entity-card:api-docs/consuming-components': ExtensionDefinition<
-      {
+      };
+      output:
+        | ConfigurableExtensionDataRef<
+            React_2.JSX.Element,
+            'core.reactElement',
+            {}
+          >
+        | ConfigurableExtensionDataRef<
+            (entity: Entity) => boolean,
+            'catalog.entity-filter-function',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-filter-expression',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+    }>;
+    'entity-card:api-docs/consuming-components': ExtensionDefinition<{
+      kind: 'entity-card';
+      namespace: undefined;
+      name: 'consuming-components';
+      config: {
         filter: string | undefined;
-      },
-      {
+      };
+      configInput: {
         filter?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<
-          React_2.JSX.Element,
-          'core.reactElement',
-          {}
-        >
-      | ConfigurableExtensionDataRef<
-          (entity: Entity) => boolean,
-          'catalog.entity-filter-function',
-          {
-            optional: true;
-          }
-        >
-      | ConfigurableExtensionDataRef<
-          string,
-          'catalog.entity-filter-expression',
-          {
-            optional: true;
-          }
-        >,
-      {},
-      {
-        kind: 'entity-card';
-        namespace: undefined;
-        name: 'consuming-components';
-      }
-    >;
-    'entity-card:api-docs/providing-components': ExtensionDefinition<
-      {
+      };
+      output:
+        | ConfigurableExtensionDataRef<
+            React_2.JSX.Element,
+            'core.reactElement',
+            {}
+          >
+        | ConfigurableExtensionDataRef<
+            (entity: Entity) => boolean,
+            'catalog.entity-filter-function',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-filter-expression',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+    }>;
+    'entity-card:api-docs/providing-components': ExtensionDefinition<{
+      kind: 'entity-card';
+      namespace: undefined;
+      name: 'providing-components';
+      config: {
         filter: string | undefined;
-      },
-      {
+      };
+      configInput: {
         filter?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<
-          React_2.JSX.Element,
-          'core.reactElement',
-          {}
-        >
-      | ConfigurableExtensionDataRef<
-          (entity: Entity) => boolean,
-          'catalog.entity-filter-function',
-          {
-            optional: true;
-          }
-        >
-      | ConfigurableExtensionDataRef<
-          string,
-          'catalog.entity-filter-expression',
-          {
-            optional: true;
-          }
-        >,
-      {},
-      {
-        kind: 'entity-card';
-        namespace: undefined;
-        name: 'providing-components';
-      }
-    >;
-    'entity-content:api-docs/definition': ExtensionDefinition<
-      {
+      };
+      output:
+        | ConfigurableExtensionDataRef<
+            React_2.JSX.Element,
+            'core.reactElement',
+            {}
+          >
+        | ConfigurableExtensionDataRef<
+            (entity: Entity) => boolean,
+            'catalog.entity-filter-function',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-filter-expression',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+    }>;
+    'entity-content:api-docs/definition': ExtensionDefinition<{
+      kind: 'entity-content';
+      namespace: undefined;
+      name: 'definition';
+      config: {
         path: string | undefined;
         title: string | undefined;
         filter: string | undefined;
-      },
-      {
+      };
+      configInput: {
         filter?: string | undefined;
         title?: string | undefined;
         path?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<
-          React_2.JSX.Element,
-          'core.reactElement',
-          {}
-        >
-      | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
-      | ConfigurableExtensionDataRef<
-          RouteRef<AnyRouteRefParams>,
-          'core.routing.ref',
-          {
-            optional: true;
-          }
-        >
-      | ConfigurableExtensionDataRef<string, 'catalog.entity-content-title', {}>
-      | ConfigurableExtensionDataRef<
-          (entity: Entity) => boolean,
-          'catalog.entity-filter-function',
-          {
-            optional: true;
-          }
-        >
-      | ConfigurableExtensionDataRef<
-          string,
-          'catalog.entity-filter-expression',
-          {
-            optional: true;
-          }
-        >,
-      {},
-      {
-        kind: 'entity-content';
-        namespace: undefined;
-        name: 'definition';
-      }
-    >;
-    'entity-content:api-docs/apis': ExtensionDefinition<
-      {
+      };
+      output:
+        | ConfigurableExtensionDataRef<
+            React_2.JSX.Element,
+            'core.reactElement',
+            {}
+          >
+        | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
+        | ConfigurableExtensionDataRef<
+            RouteRef<AnyRouteRefParams>,
+            'core.routing.ref',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-content-title',
+            {}
+          >
+        | ConfigurableExtensionDataRef<
+            (entity: Entity) => boolean,
+            'catalog.entity-filter-function',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-filter-expression',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+    }>;
+    'entity-content:api-docs/apis': ExtensionDefinition<{
+      kind: 'entity-content';
+      namespace: undefined;
+      name: 'apis';
+      config: {
         path: string | undefined;
         title: string | undefined;
         filter: string | undefined;
-      },
-      {
+      };
+      configInput: {
         filter?: string | undefined;
         title?: string | undefined;
         path?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<
-          React_2.JSX.Element,
-          'core.reactElement',
-          {}
-        >
-      | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
-      | ConfigurableExtensionDataRef<
-          RouteRef<AnyRouteRefParams>,
-          'core.routing.ref',
-          {
-            optional: true;
-          }
-        >
-      | ConfigurableExtensionDataRef<string, 'catalog.entity-content-title', {}>
-      | ConfigurableExtensionDataRef<
-          (entity: Entity) => boolean,
-          'catalog.entity-filter-function',
-          {
-            optional: true;
-          }
-        >
-      | ConfigurableExtensionDataRef<
-          string,
-          'catalog.entity-filter-expression',
-          {
-            optional: true;
-          }
-        >,
-      {},
-      {
-        kind: 'entity-content';
-        namespace: undefined;
-        name: 'apis';
-      }
-    >;
+      };
+      output:
+        | ConfigurableExtensionDataRef<
+            React_2.JSX.Element,
+            'core.reactElement',
+            {}
+          >
+        | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
+        | ConfigurableExtensionDataRef<
+            RouteRef<AnyRouteRefParams>,
+            'core.routing.ref',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-content-title',
+            {}
+          >
+        | ConfigurableExtensionDataRef<
+            (entity: Entity) => boolean,
+            'catalog.entity-filter-function',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-filter-expression',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+    }>;
   }
 >;
 export default _default;

--- a/plugins/app-visualizer/api-report.md
+++ b/plugins/app-visualizer/api-report.md
@@ -16,37 +16,39 @@ const visualizerPlugin: BackstagePlugin<
   {},
   {},
   {
-    'page:app-visualizer': ExtensionDefinition<
-      {
+    'page:app-visualizer': ExtensionDefinition<{
+      kind: 'page';
+      namespace: undefined;
+      name: undefined;
+      config: {
         path: string | undefined;
-      },
-      {
+      };
+      configInput: {
         path?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<
-          React_2.JSX.Element,
-          'core.reactElement',
-          {}
-        >
-      | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
-      | ConfigurableExtensionDataRef<
-          RouteRef<AnyRouteRefParams>,
-          'core.routing.ref',
-          {
-            optional: true;
-          }
-        >,
-      {},
-      {
-        kind: 'page';
-        namespace: undefined;
-        name: undefined;
-      }
-    >;
-    'nav-item:app-visualizer': ExtensionDefinition<
-      {},
-      {},
-      ConfigurableExtensionDataRef<
+      };
+      output:
+        | ConfigurableExtensionDataRef<
+            React_2.JSX.Element,
+            'core.reactElement',
+            {}
+          >
+        | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
+        | ConfigurableExtensionDataRef<
+            RouteRef<AnyRouteRefParams>,
+            'core.routing.ref',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+    }>;
+    'nav-item:app-visualizer': ExtensionDefinition<{
+      kind: 'nav-item';
+      namespace: undefined;
+      name: undefined;
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
         {
           title: string;
           icon: IconComponent;
@@ -54,14 +56,9 @@ const visualizerPlugin: BackstagePlugin<
         },
         'core.nav-item.target',
         {}
-      >,
-      {},
-      {
-        kind: 'nav-item';
-        namespace: undefined;
-        name: undefined;
-      }
-    >;
+      >;
+      inputs: {};
+    }>;
   }
 >;
 export default visualizerPlugin;

--- a/plugins/catalog-graph/api-report-alpha.md
+++ b/plugins/catalog-graph/api-report-alpha.md
@@ -28,8 +28,8 @@ const _default: BackstagePlugin<
     }>;
   },
   {
-    'entity-card:catalog-graph/relations': ExtensionDefinition<
-      {
+    'entity-card:catalog-graph/relations': ExtensionDefinition<{
+      config: {
         kinds: string[] | undefined;
         relations: string[] | undefined;
         maxDepth: number | undefined;
@@ -43,8 +43,8 @@ const _default: BackstagePlugin<
         height: number | undefined;
       } & {
         filter: string | undefined;
-      },
-      {
+      };
+      configInput: {
         height?: number | undefined;
         curve?: 'curveStepBefore' | 'curveMonotoneX' | undefined;
         direction?: Direction | undefined;
@@ -58,27 +58,28 @@ const _default: BackstagePlugin<
         relationPairs?: [string, string][] | undefined;
       } & {
         filter?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<
-          React_2.JSX.Element,
-          'core.reactElement',
-          {}
-        >
-      | ConfigurableExtensionDataRef<
-          (entity: Entity) => boolean,
-          'catalog.entity-filter-function',
-          {
-            optional: true;
-          }
-        >
-      | ConfigurableExtensionDataRef<
-          string,
-          'catalog.entity-filter-expression',
-          {
-            optional: true;
-          }
-        >,
-      {
+      };
+      output:
+        | ConfigurableExtensionDataRef<
+            React_2.JSX.Element,
+            'core.reactElement',
+            {}
+          >
+        | ConfigurableExtensionDataRef<
+            (entity: Entity) => boolean,
+            'catalog.entity-filter-function',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-filter-expression',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {
         [x: string]: ExtensionInput<
           AnyExtensionDataRef,
           {
@@ -86,15 +87,13 @@ const _default: BackstagePlugin<
             singleton: boolean;
           }
         >;
-      },
-      {
-        kind: 'entity-card';
-        namespace: undefined;
-        name: 'relations';
-      }
-    >;
-    'page:catalog-graph': ExtensionDefinition<
-      {
+      };
+      kind: 'entity-card';
+      namespace: undefined;
+      name: 'relations';
+    }>;
+    'page:catalog-graph': ExtensionDefinition<{
+      config: {
         selectedKinds: string[] | undefined;
         selectedRelations: string[] | undefined;
         rootEntityRefs: string[] | undefined;
@@ -110,8 +109,8 @@ const _default: BackstagePlugin<
         zoom: 'disabled' | 'enabled' | 'enable-on-click' | undefined;
       } & {
         path: string | undefined;
-      },
-      {
+      };
+      configInput: {
         curve?: 'curveStepBefore' | 'curveMonotoneX' | undefined;
         direction?: Direction | undefined;
         zoom?: 'disabled' | 'enabled' | 'enable-on-click' | undefined;
@@ -127,21 +126,22 @@ const _default: BackstagePlugin<
         showFilters?: boolean | undefined;
       } & {
         path?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<
-          React_2.JSX.Element,
-          'core.reactElement',
-          {}
-        >
-      | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
-      | ConfigurableExtensionDataRef<
-          RouteRef<AnyRouteRefParams>,
-          'core.routing.ref',
-          {
-            optional: true;
-          }
-        >,
-      {
+      };
+      output:
+        | ConfigurableExtensionDataRef<
+            React_2.JSX.Element,
+            'core.reactElement',
+            {}
+          >
+        | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
+        | ConfigurableExtensionDataRef<
+            RouteRef<AnyRouteRefParams>,
+            'core.routing.ref',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {
         [x: string]: ExtensionInput<
           AnyExtensionDataRef,
           {
@@ -149,13 +149,11 @@ const _default: BackstagePlugin<
             singleton: boolean;
           }
         >;
-      },
-      {
-        kind: 'page';
-        namespace: undefined;
-        name: undefined;
-      }
-    >;
+      };
+      kind: 'page';
+      namespace: undefined;
+      name: undefined;
+    }>;
   }
 >;
 export default _default;

--- a/plugins/catalog-import/api-report-alpha.md
+++ b/plugins/catalog-import/api-report-alpha.md
@@ -18,44 +18,45 @@ const _default: BackstagePlugin<
   },
   {},
   {
-    'api:catalog-import': ExtensionDefinition<
-      {},
-      {},
-      ConfigurableExtensionDataRef<AnyApiFactory, 'core.api.factory', {}>,
-      {},
-      {
-        kind: 'api';
-        namespace: undefined;
-        name: undefined;
-      }
-    >;
-    'page:catalog-import': ExtensionDefinition<
-      {
+    'api:catalog-import': ExtensionDefinition<{
+      kind: 'api';
+      namespace: undefined;
+      name: undefined;
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {};
+    }>;
+    'page:catalog-import': ExtensionDefinition<{
+      kind: 'page';
+      namespace: undefined;
+      name: undefined;
+      config: {
         path: string | undefined;
-      },
-      {
+      };
+      configInput: {
         path?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<
-          React_2.JSX.Element,
-          'core.reactElement',
-          {}
-        >
-      | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
-      | ConfigurableExtensionDataRef<
-          RouteRef<AnyRouteRefParams>,
-          'core.routing.ref',
-          {
-            optional: true;
-          }
-        >,
-      {},
-      {
-        kind: 'page';
-        namespace: undefined;
-        name: undefined;
-      }
-    >;
+      };
+      output:
+        | ConfigurableExtensionDataRef<
+            React_2.JSX.Element,
+            'core.reactElement',
+            {}
+          >
+        | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
+        | ConfigurableExtensionDataRef<
+            RouteRef<AnyRouteRefParams>,
+            'core.routing.ref',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+    }>;
   }
 >;
 export default _default;

--- a/plugins/catalog-react/api-report-alpha.md
+++ b/plugins/catalog-react/api-report-alpha.md
@@ -83,7 +83,7 @@ export function convertLegacyEntityCardExtension(
       | typeof EntityCardBlueprint.dataRefs.filterFunction.T
       | typeof EntityCardBlueprint.dataRefs.filterExpression.T;
   },
-): ExtensionDefinition<any>;
+): ExtensionDefinition;
 
 // @alpha (undocumented)
 export function convertLegacyEntityContentExtension(
@@ -96,42 +96,41 @@ export function convertLegacyEntityContentExtension(
     defaultPath?: string;
     defaultTitle?: string;
   },
-): ExtensionDefinition<any>;
+): ExtensionDefinition;
 
 // @alpha
-export const EntityCardBlueprint: ExtensionBlueprint<
-  {
-    kind: 'entity-card';
-    namespace: undefined;
-    name: undefined;
-  },
-  {
+export const EntityCardBlueprint: ExtensionBlueprint<{
+  kind: 'entity-card';
+  namespace: undefined;
+  name: undefined;
+  params: {
     loader: () => Promise<JSX.Element>;
     filter?: string | ((entity: Entity) => boolean) | undefined;
-  },
-  | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
-  | ConfigurableExtensionDataRef<
-      (entity: Entity) => boolean,
-      'catalog.entity-filter-function',
-      {
-        optional: true;
-      }
-    >
-  | ConfigurableExtensionDataRef<
-      string,
-      'catalog.entity-filter-expression',
-      {
-        optional: true;
-      }
-    >,
-  {},
-  {
+  };
+  output:
+    | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
+    | ConfigurableExtensionDataRef<
+        (entity: Entity) => boolean,
+        'catalog.entity-filter-function',
+        {
+          optional: true;
+        }
+      >
+    | ConfigurableExtensionDataRef<
+        string,
+        'catalog.entity-filter-expression',
+        {
+          optional: true;
+        }
+      >;
+  inputs: {};
+  config: {
     filter: string | undefined;
-  },
-  {
+  };
+  configInput: {
     filter?: string | undefined;
-  },
-  {
+  };
+  dataRefs: {
     filterFunction: ConfigurableExtensionDataRef<
       (entity: Entity) => boolean,
       'catalog.entity-filter-function',
@@ -142,59 +141,58 @@ export const EntityCardBlueprint: ExtensionBlueprint<
       'catalog.entity-filter-expression',
       {}
     >;
-  }
->;
+  };
+}>;
 
 // @alpha
-export const EntityContentBlueprint: ExtensionBlueprint<
-  {
-    kind: 'entity-content';
-    namespace: undefined;
-    name: undefined;
-  },
-  {
+export const EntityContentBlueprint: ExtensionBlueprint<{
+  kind: 'entity-content';
+  namespace: undefined;
+  name: undefined;
+  params: {
     loader: () => Promise<JSX.Element>;
     defaultPath: string;
     defaultTitle: string;
     routeRef?: RouteRef<AnyRouteRefParams> | undefined;
     filter?: string | ((entity: Entity) => boolean) | undefined;
-  },
-  | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
-  | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
-  | ConfigurableExtensionDataRef<
-      RouteRef<AnyRouteRefParams>,
-      'core.routing.ref',
-      {
-        optional: true;
-      }
-    >
-  | ConfigurableExtensionDataRef<string, 'catalog.entity-content-title', {}>
-  | ConfigurableExtensionDataRef<
-      (entity: Entity) => boolean,
-      'catalog.entity-filter-function',
-      {
-        optional: true;
-      }
-    >
-  | ConfigurableExtensionDataRef<
-      string,
-      'catalog.entity-filter-expression',
-      {
-        optional: true;
-      }
-    >,
-  {},
-  {
+  };
+  output:
+    | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
+    | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
+    | ConfigurableExtensionDataRef<
+        RouteRef<AnyRouteRefParams>,
+        'core.routing.ref',
+        {
+          optional: true;
+        }
+      >
+    | ConfigurableExtensionDataRef<string, 'catalog.entity-content-title', {}>
+    | ConfigurableExtensionDataRef<
+        (entity: Entity) => boolean,
+        'catalog.entity-filter-function',
+        {
+          optional: true;
+        }
+      >
+    | ConfigurableExtensionDataRef<
+        string,
+        'catalog.entity-filter-expression',
+        {
+          optional: true;
+        }
+      >;
+  inputs: {};
+  config: {
     path: string | undefined;
     title: string | undefined;
     filter: string | undefined;
-  },
-  {
+  };
+  configInput: {
     filter?: string | undefined;
     title?: string | undefined;
     path?: string | undefined;
-  },
-  {
+  };
+  dataRefs: {
     title: ConfigurableExtensionDataRef<
       string,
       'catalog.entity-content-title',
@@ -210,8 +208,8 @@ export const EntityContentBlueprint: ExtensionBlueprint<
       'catalog.entity-filter-expression',
       {}
     >;
-  }
->;
+  };
+}>;
 
 // @alpha
 export function isOwnerOf(owner: Entity, entity: Entity): boolean;

--- a/plugins/catalog-react/src/alpha/blueprints/EntityCardBlueprint.test.tsx
+++ b/plugins/catalog-react/src/alpha/blueprints/EntityCardBlueprint.test.tsx
@@ -40,6 +40,7 @@ describe('EntityCardBlueprint', () => {
     expect(extension).toMatchInlineSnapshot(`
       {
         "$$type": "@backstage/ExtensionDefinition",
+        "T": undefined,
         "attachTo": {
           "id": "entity-content:catalog/overview",
           "input": "cards",

--- a/plugins/catalog-react/src/alpha/blueprints/EntityContentBlueprint.test.tsx
+++ b/plugins/catalog-react/src/alpha/blueprints/EntityContentBlueprint.test.tsx
@@ -42,6 +42,7 @@ describe('EntityContentBlueprint', () => {
     expect(extension).toMatchInlineSnapshot(`
       {
         "$$type": "@backstage/ExtensionDefinition",
+        "T": undefined,
         "attachTo": {
           "id": "page:catalog/entity",
           "input": "contents",

--- a/plugins/catalog-react/src/alpha/converters/convertLegacyEntityCardExtension.test.tsx
+++ b/plugins/catalog-react/src/alpha/converters/convertLegacyEntityCardExtension.test.tsx
@@ -48,11 +48,10 @@ describe('convertLegacyEntityCardExtension', () => {
     );
 
     const converted = convertLegacyEntityCardExtension(LegacyExtension);
-    expect(converted.kind).toBe('entity-card');
-    expect(converted.namespace).toBe(undefined);
-    expect(converted.name).toBe('example');
 
     const tester = createExtensionTester(converted);
+
+    expect(tester.query(converted).node.spec.id).toBe('entity-card:example');
 
     await renderInTestApp(tester.reactElement(), {
       mountedRoutes: {
@@ -83,11 +82,10 @@ describe('convertLegacyEntityCardExtension', () => {
       name: 'other',
       filter: 'my-filter',
     });
-    expect(converted.kind).toBe('entity-card');
-    expect(converted.namespace).toBe(undefined);
-    expect(converted.name).toBe('other');
 
     const tester = createExtensionTester(converted);
+
+    expect(tester.query(converted).node.spec.id).toBe('entity-card:other');
 
     await renderInTestApp(tester.reactElement(), {
       mountedRoutes: {
@@ -106,7 +104,7 @@ describe('convertLegacyEntityCardExtension', () => {
   });
 
   it('should support various naming patterns for entity card extensions', async () => {
-    const withName = (name: string) => {
+    const getDiscoveredId = (name: string) => {
       const converted = convertLegacyEntityCardExtension(
         legacyPlugin.provide(
           createRoutableExtension({
@@ -116,14 +114,14 @@ describe('convertLegacyEntityCardExtension', () => {
           }),
         ),
       );
-      return converted.name;
+      return createExtensionTester(converted).query(converted).node.spec.id;
     };
 
-    expect(withName('EntityTestCard')).toBe(undefined);
-    expect(withName('EntityTestTrimCard')).toBe('trim');
-    expect(withName('EntityTeStTrimCard')).toBe('trim');
-    expect(withName('EntityExampleCard')).toBe('example');
-    expect(withName('EntityExAmpleCard')).toBe('ex-ample');
-    expect(withName('ExampleCard')).toBe('example-card');
+    expect(getDiscoveredId('EntityTestCard')).toBe('entity-card:test'); // falls back to test namespace
+    expect(getDiscoveredId('EntityTestTrimCard')).toBe('entity-card:trim');
+    expect(getDiscoveredId('EntityTeStTrimCard')).toBe('entity-card:trim');
+    expect(getDiscoveredId('EntityExampleCard')).toBe('entity-card:example');
+    expect(getDiscoveredId('EntityExAmpleCard')).toBe('entity-card:ex-ample');
+    expect(getDiscoveredId('ExampleCard')).toBe('entity-card:example-card');
   });
 });

--- a/plugins/catalog-react/src/alpha/converters/convertLegacyEntityCardExtension.tsx
+++ b/plugins/catalog-react/src/alpha/converters/convertLegacyEntityCardExtension.tsx
@@ -30,7 +30,7 @@ export function convertLegacyEntityCardExtension(
       | typeof EntityCardBlueprint.dataRefs.filterFunction.T
       | typeof EntityCardBlueprint.dataRefs.filterExpression.T;
   },
-): ExtensionDefinition<any> {
+): ExtensionDefinition {
   const element = <LegacyExtension />;
 
   const extName = getComponentData<string>(element, 'core.extensionName');

--- a/plugins/catalog-react/src/alpha/converters/convertLegacyEntityContentExtension.test.tsx
+++ b/plugins/catalog-react/src/alpha/converters/convertLegacyEntityContentExtension.test.tsx
@@ -49,11 +49,10 @@ describe('convertLegacyEntityContentExtension', () => {
     );
 
     const converted = convertLegacyEntityContentExtension(LegacyExtension);
-    expect(converted.kind).toBe('entity-content');
-    expect(converted.namespace).toBe(undefined);
-    expect(converted.name).toBe('example');
 
     const tester = createExtensionTester(converted);
+
+    expect(tester.query(converted).node.spec.id).toBe('entity-content:example');
 
     await renderInTestApp(tester.reactElement(), {
       mountedRoutes: {
@@ -88,11 +87,10 @@ describe('convertLegacyEntityContentExtension', () => {
       defaultTitle: 'Other',
       filter: 'my-filter',
     });
-    expect(converted.kind).toBe('entity-content');
-    expect(converted.namespace).toBe(undefined);
-    expect(converted.name).toBe('other');
 
     const tester = createExtensionTester(converted);
+
+    expect(tester.query(converted).node.spec.id).toBe('entity-content:other');
 
     await renderInTestApp(tester.reactElement(), {
       mountedRoutes: {
@@ -123,14 +121,14 @@ describe('convertLegacyEntityContentExtension', () => {
           }),
         ),
       );
-      return converted.name;
+      return createExtensionTester(converted).query(converted).node.spec.id;
     };
 
-    expect(withName('EntityTestContent')).toBe(undefined);
-    expect(withName('EntityTestTrimContent')).toBe('trim');
-    expect(withName('EntityTeStTrimContent')).toBe('trim');
-    expect(withName('EntityExampleContent')).toBe('example');
-    expect(withName('EntityExAmpleContent')).toBe('ex-ample');
-    expect(withName('ExampleContent')).toBe('example-content');
+    expect(withName('EntityTestContent')).toBe('entity-content:test'); // falls back to test namespace
+    expect(withName('EntityTestTrimContent')).toBe('entity-content:trim');
+    expect(withName('EntityTeStTrimContent')).toBe('entity-content:trim');
+    expect(withName('EntityExampleContent')).toBe('entity-content:example');
+    expect(withName('EntityExAmpleContent')).toBe('entity-content:ex-ample');
+    expect(withName('ExampleContent')).toBe('entity-content:example-content');
   });
 });

--- a/plugins/catalog-react/src/alpha/converters/convertLegacyEntityContentExtension.tsx
+++ b/plugins/catalog-react/src/alpha/converters/convertLegacyEntityContentExtension.tsx
@@ -40,7 +40,7 @@ export function convertLegacyEntityContentExtension(
     defaultPath?: string;
     defaultTitle?: string;
   },
-): ExtensionDefinition<any> {
+): ExtensionDefinition {
   const element = <LegacyExtension />;
 
   const extName = getComponentData<string>(element, 'core.extensionName');

--- a/plugins/catalog/api-report-alpha.md
+++ b/plugins/catalog/api-report-alpha.md
@@ -23,21 +23,19 @@ import { SearchResultItemExtensionPredicate } from '@backstage/plugin-search-rea
 import { TranslationRef } from '@backstage/core-plugin-api/alpha';
 
 // @alpha
-export const CatalogFilterBlueprint: ExtensionBlueprint<
-  {
-    kind: 'catalog-filter';
-    namespace: undefined;
-    name: undefined;
-  },
-  {
+export const CatalogFilterBlueprint: ExtensionBlueprint<{
+  kind: 'catalog-filter';
+  namespace: undefined;
+  name: undefined;
+  params: {
     loader: () => Promise<JSX.Element>;
-  },
-  ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>,
-  {},
-  {},
-  {},
-  never
->;
+  };
+  output: ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>;
+  inputs: {};
+  config: {};
+  configInput: {};
+  dataRefs: never;
+}>;
 
 // @alpha (undocumented)
 export const catalogTranslationRef: TranslationRef<
@@ -148,10 +146,26 @@ const _default: BackstagePlugin<
     unregisterRedirect: ExternalRouteRef<undefined>;
   },
   {
-    'nav-item:catalog': ExtensionDefinition<
-      {},
-      {},
-      ConfigurableExtensionDataRef<
+    'api:catalog': ExtensionDefinition<{
+      kind: 'api';
+      namespace: undefined;
+      name: undefined;
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {};
+    }>;
+    'nav-item:catalog': ExtensionDefinition<{
+      kind: 'nav-item';
+      namespace: undefined;
+      name: undefined;
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
         {
           title: string;
           icon: IconComponent;
@@ -159,366 +173,356 @@ const _default: BackstagePlugin<
         },
         'core.nav-item.target',
         {}
-      >,
-      {},
-      {
-        kind: 'nav-item';
-        namespace: undefined;
-        name: undefined;
-      }
-    >;
-    'api:catalog/starred-entities': ExtensionDefinition<
-      {},
-      {},
-      ConfigurableExtensionDataRef<AnyApiFactory, 'core.api.factory', {}>,
-      {},
-      {
-        kind: 'api';
-        namespace: undefined;
-        name: 'starred-entities';
-      }
-    >;
-    'api:catalog/entity-presentation': ExtensionDefinition<
-      {},
-      {},
-      ConfigurableExtensionDataRef<AnyApiFactory, 'core.api.factory', {}>,
-      {},
-      {
-        kind: 'api';
-        namespace: undefined;
-        name: 'entity-presentation';
-      }
-    >;
-    'entity-card:catalog/about': ExtensionDefinition<
-      {
+      >;
+      inputs: {};
+    }>;
+    'api:catalog/starred-entities': ExtensionDefinition<{
+      kind: 'api';
+      namespace: undefined;
+      name: 'starred-entities';
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {};
+    }>;
+    'api:catalog/entity-presentation': ExtensionDefinition<{
+      kind: 'api';
+      namespace: undefined;
+      name: 'entity-presentation';
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {};
+    }>;
+    'entity-card:catalog/about': ExtensionDefinition<{
+      kind: 'entity-card';
+      namespace: undefined;
+      name: 'about';
+      config: {
         filter: string | undefined;
-      },
-      {
+      };
+      configInput: {
         filter?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
-      | ConfigurableExtensionDataRef<
-          (entity: Entity) => boolean,
-          'catalog.entity-filter-function',
-          {
-            optional: true;
-          }
-        >
-      | ConfigurableExtensionDataRef<
-          string,
-          'catalog.entity-filter-expression',
-          {
-            optional: true;
-          }
-        >,
-      {},
-      {
-        kind: 'entity-card';
-        namespace: undefined;
-        name: 'about';
-      }
-    >;
-    'entity-card:catalog/links': ExtensionDefinition<
-      {
+      };
+      output:
+        | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
+        | ConfigurableExtensionDataRef<
+            (entity: Entity) => boolean,
+            'catalog.entity-filter-function',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-filter-expression',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+    }>;
+    'entity-card:catalog/links': ExtensionDefinition<{
+      kind: 'entity-card';
+      namespace: undefined;
+      name: 'links';
+      config: {
         filter: string | undefined;
-      },
-      {
+      };
+      configInput: {
         filter?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
-      | ConfigurableExtensionDataRef<
-          (entity: Entity) => boolean,
-          'catalog.entity-filter-function',
-          {
-            optional: true;
-          }
-        >
-      | ConfigurableExtensionDataRef<
-          string,
-          'catalog.entity-filter-expression',
-          {
-            optional: true;
-          }
-        >,
-      {},
-      {
-        kind: 'entity-card';
-        namespace: undefined;
-        name: 'links';
-      }
-    >;
-    'entity-card:catalog/labels': ExtensionDefinition<
-      {
+      };
+      output:
+        | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
+        | ConfigurableExtensionDataRef<
+            (entity: Entity) => boolean,
+            'catalog.entity-filter-function',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-filter-expression',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+    }>;
+    'entity-card:catalog/labels': ExtensionDefinition<{
+      kind: 'entity-card';
+      namespace: undefined;
+      name: 'labels';
+      config: {
         filter: string | undefined;
-      },
-      {
+      };
+      configInput: {
         filter?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
-      | ConfigurableExtensionDataRef<
-          (entity: Entity) => boolean,
-          'catalog.entity-filter-function',
-          {
-            optional: true;
-          }
-        >
-      | ConfigurableExtensionDataRef<
-          string,
-          'catalog.entity-filter-expression',
-          {
-            optional: true;
-          }
-        >,
-      {},
-      {
-        kind: 'entity-card';
-        namespace: undefined;
-        name: 'labels';
-      }
-    >;
-    'entity-card:catalog/depends-on-components': ExtensionDefinition<
-      {
+      };
+      output:
+        | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
+        | ConfigurableExtensionDataRef<
+            (entity: Entity) => boolean,
+            'catalog.entity-filter-function',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-filter-expression',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+    }>;
+    'entity-card:catalog/depends-on-components': ExtensionDefinition<{
+      kind: 'entity-card';
+      namespace: undefined;
+      name: 'depends-on-components';
+      config: {
         filter: string | undefined;
-      },
-      {
+      };
+      configInput: {
         filter?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
-      | ConfigurableExtensionDataRef<
-          (entity: Entity) => boolean,
-          'catalog.entity-filter-function',
-          {
-            optional: true;
-          }
-        >
-      | ConfigurableExtensionDataRef<
-          string,
-          'catalog.entity-filter-expression',
-          {
-            optional: true;
-          }
-        >,
-      {},
-      {
-        kind: 'entity-card';
-        namespace: undefined;
-        name: 'depends-on-components';
-      }
-    >;
-    'entity-card:catalog/depends-on-resources': ExtensionDefinition<
-      {
+      };
+      output:
+        | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
+        | ConfigurableExtensionDataRef<
+            (entity: Entity) => boolean,
+            'catalog.entity-filter-function',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-filter-expression',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+    }>;
+    'entity-card:catalog/depends-on-resources': ExtensionDefinition<{
+      kind: 'entity-card';
+      namespace: undefined;
+      name: 'depends-on-resources';
+      config: {
         filter: string | undefined;
-      },
-      {
+      };
+      configInput: {
         filter?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
-      | ConfigurableExtensionDataRef<
-          (entity: Entity) => boolean,
-          'catalog.entity-filter-function',
-          {
-            optional: true;
-          }
-        >
-      | ConfigurableExtensionDataRef<
-          string,
-          'catalog.entity-filter-expression',
-          {
-            optional: true;
-          }
-        >,
-      {},
-      {
-        kind: 'entity-card';
-        namespace: undefined;
-        name: 'depends-on-resources';
-      }
-    >;
-    'entity-card:catalog/has-components': ExtensionDefinition<
-      {
+      };
+      output:
+        | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
+        | ConfigurableExtensionDataRef<
+            (entity: Entity) => boolean,
+            'catalog.entity-filter-function',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-filter-expression',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+    }>;
+    'entity-card:catalog/has-components': ExtensionDefinition<{
+      kind: 'entity-card';
+      namespace: undefined;
+      name: 'has-components';
+      config: {
         filter: string | undefined;
-      },
-      {
+      };
+      configInput: {
         filter?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
-      | ConfigurableExtensionDataRef<
-          (entity: Entity) => boolean,
-          'catalog.entity-filter-function',
-          {
-            optional: true;
-          }
-        >
-      | ConfigurableExtensionDataRef<
-          string,
-          'catalog.entity-filter-expression',
-          {
-            optional: true;
-          }
-        >,
-      {},
-      {
-        kind: 'entity-card';
-        namespace: undefined;
-        name: 'has-components';
-      }
-    >;
-    'entity-card:catalog/has-resources': ExtensionDefinition<
-      {
+      };
+      output:
+        | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
+        | ConfigurableExtensionDataRef<
+            (entity: Entity) => boolean,
+            'catalog.entity-filter-function',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-filter-expression',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+    }>;
+    'entity-card:catalog/has-resources': ExtensionDefinition<{
+      kind: 'entity-card';
+      namespace: undefined;
+      name: 'has-resources';
+      config: {
         filter: string | undefined;
-      },
-      {
+      };
+      configInput: {
         filter?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
-      | ConfigurableExtensionDataRef<
-          (entity: Entity) => boolean,
-          'catalog.entity-filter-function',
-          {
-            optional: true;
-          }
-        >
-      | ConfigurableExtensionDataRef<
-          string,
-          'catalog.entity-filter-expression',
-          {
-            optional: true;
-          }
-        >,
-      {},
-      {
-        kind: 'entity-card';
-        namespace: undefined;
-        name: 'has-resources';
-      }
-    >;
-    'entity-card:catalog/has-subcomponents': ExtensionDefinition<
-      {
+      };
+      output:
+        | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
+        | ConfigurableExtensionDataRef<
+            (entity: Entity) => boolean,
+            'catalog.entity-filter-function',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-filter-expression',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+    }>;
+    'entity-card:catalog/has-subcomponents': ExtensionDefinition<{
+      kind: 'entity-card';
+      namespace: undefined;
+      name: 'has-subcomponents';
+      config: {
         filter: string | undefined;
-      },
-      {
+      };
+      configInput: {
         filter?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
-      | ConfigurableExtensionDataRef<
-          (entity: Entity) => boolean,
-          'catalog.entity-filter-function',
-          {
-            optional: true;
-          }
-        >
-      | ConfigurableExtensionDataRef<
-          string,
-          'catalog.entity-filter-expression',
-          {
-            optional: true;
-          }
-        >,
-      {},
-      {
-        kind: 'entity-card';
-        namespace: undefined;
-        name: 'has-subcomponents';
-      }
-    >;
-    'entity-card:catalog/has-subdomains': ExtensionDefinition<
-      {
+      };
+      output:
+        | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
+        | ConfigurableExtensionDataRef<
+            (entity: Entity) => boolean,
+            'catalog.entity-filter-function',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-filter-expression',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+    }>;
+    'entity-card:catalog/has-subdomains': ExtensionDefinition<{
+      kind: 'entity-card';
+      namespace: undefined;
+      name: 'has-subdomains';
+      config: {
         filter: string | undefined;
-      },
-      {
+      };
+      configInput: {
         filter?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
-      | ConfigurableExtensionDataRef<
-          (entity: Entity) => boolean,
-          'catalog.entity-filter-function',
-          {
-            optional: true;
-          }
-        >
-      | ConfigurableExtensionDataRef<
-          string,
-          'catalog.entity-filter-expression',
-          {
-            optional: true;
-          }
-        >,
-      {},
-      {
-        kind: 'entity-card';
-        namespace: undefined;
-        name: 'has-subdomains';
-      }
-    >;
-    'entity-card:catalog/has-systems': ExtensionDefinition<
-      {
+      };
+      output:
+        | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
+        | ConfigurableExtensionDataRef<
+            (entity: Entity) => boolean,
+            'catalog.entity-filter-function',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-filter-expression',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+    }>;
+    'entity-card:catalog/has-systems': ExtensionDefinition<{
+      kind: 'entity-card';
+      namespace: undefined;
+      name: 'has-systems';
+      config: {
         filter: string | undefined;
-      },
-      {
+      };
+      configInput: {
         filter?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
-      | ConfigurableExtensionDataRef<
-          (entity: Entity) => boolean,
-          'catalog.entity-filter-function',
-          {
-            optional: true;
-          }
-        >
-      | ConfigurableExtensionDataRef<
-          string,
-          'catalog.entity-filter-expression',
-          {
-            optional: true;
-          }
-        >,
-      {},
-      {
-        kind: 'entity-card';
-        namespace: undefined;
-        name: 'has-systems';
-      }
-    >;
-    'entity-content:catalog/overview': ExtensionDefinition<
-      {
-        [x: string]: any;
-      } & {
+      };
+      output:
+        | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
+        | ConfigurableExtensionDataRef<
+            (entity: Entity) => boolean,
+            'catalog.entity-filter-function',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-filter-expression',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+    }>;
+    'entity-content:catalog/overview': ExtensionDefinition<{
+      config: {
         path: string | undefined;
         title: string | undefined;
         filter: string | undefined;
-      },
-      {
-        [x: string]: any;
-      } & {
+      };
+      configInput: {
         filter?: string | undefined;
         title?: string | undefined;
         path?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
-      | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
-      | ConfigurableExtensionDataRef<
-          RouteRef<AnyRouteRefParams>,
-          'core.routing.ref',
-          {
-            optional: true;
-          }
-        >
-      | ConfigurableExtensionDataRef<string, 'catalog.entity-content-title', {}>
-      | ConfigurableExtensionDataRef<
-          (entity: Entity) => boolean,
-          'catalog.entity-filter-function',
-          {
-            optional: true;
-          }
-        >
-      | ConfigurableExtensionDataRef<
-          string,
-          'catalog.entity-filter-expression',
-          {
-            optional: true;
-          }
-        >,
-      {
+      };
+      output:
+        | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
+        | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
+        | ConfigurableExtensionDataRef<
+            RouteRef<AnyRouteRefParams>,
+            'core.routing.ref',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-content-title',
+            {}
+          >
+        | ConfigurableExtensionDataRef<
+            (entity: Entity) => boolean,
+            'catalog.entity-filter-function',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-filter-expression',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {
         cards: ExtensionInput<
           | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
           | ConfigurableExtensionDataRef<
@@ -540,33 +544,37 @@ const _default: BackstagePlugin<
             optional: false;
           }
         >;
-      },
-      {
-        kind: 'entity-content';
-        namespace: undefined;
-        name: 'overview';
-      }
-    >;
-    'catalog-filter:catalog/tag': ExtensionDefinition<
-      {},
-      {},
-      ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>,
-      {},
-      {
-        kind: 'catalog-filter';
-        namespace: undefined;
-        name: 'tag';
-      }
-    >;
-    'catalog-filter:catalog/kind': ExtensionDefinition<
-      {
+      };
+      kind: 'entity-content';
+      namespace: undefined;
+      name: 'overview';
+    }>;
+    'catalog-filter:catalog/tag': ExtensionDefinition<{
+      kind: 'catalog-filter';
+      namespace: undefined;
+      name: 'tag';
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        JSX_2.Element,
+        'core.reactElement',
+        {}
+      >;
+      inputs: {};
+    }>;
+    'catalog-filter:catalog/kind': ExtensionDefinition<{
+      config: {
         initialFilter: string;
-      },
-      {
+      };
+      configInput: {
         initialFilter?: string | undefined;
-      },
-      ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>,
-      {
+      };
+      output: ConfigurableExtensionDataRef<
+        JSX_2.Element,
+        'core.reactElement',
+        {}
+      >;
+      inputs: {
         [x: string]: ExtensionInput<
           AnyExtensionDataRef,
           {
@@ -574,33 +582,37 @@ const _default: BackstagePlugin<
             singleton: boolean;
           }
         >;
-      },
-      {
-        kind: 'catalog-filter';
-        namespace: undefined;
-        name: 'kind';
-      }
-    >;
-    'catalog-filter:catalog/type': ExtensionDefinition<
-      {},
-      {},
-      ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>,
-      {},
-      {
-        kind: 'catalog-filter';
-        namespace: undefined;
-        name: 'type';
-      }
-    >;
-    'catalog-filter:catalog/mode': ExtensionDefinition<
-      {
+      };
+      kind: 'catalog-filter';
+      namespace: undefined;
+      name: 'kind';
+    }>;
+    'catalog-filter:catalog/type': ExtensionDefinition<{
+      kind: 'catalog-filter';
+      namespace: undefined;
+      name: 'type';
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        JSX_2.Element,
+        'core.reactElement',
+        {}
+      >;
+      inputs: {};
+    }>;
+    'catalog-filter:catalog/mode': ExtensionDefinition<{
+      config: {
         mode: 'all' | 'owners-only' | undefined;
-      },
-      {
+      };
+      configInput: {
         mode?: 'all' | 'owners-only' | undefined;
-      },
-      ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>,
-      {
+      };
+      output: ConfigurableExtensionDataRef<
+        JSX_2.Element,
+        'core.reactElement',
+        {}
+      >;
+      inputs: {
         [x: string]: ExtensionInput<
           AnyExtensionDataRef,
           {
@@ -608,55 +620,63 @@ const _default: BackstagePlugin<
             singleton: boolean;
           }
         >;
-      },
-      {
-        kind: 'catalog-filter';
-        namespace: undefined;
-        name: 'mode';
-      }
-    >;
-    'catalog-filter:catalog/namespace': ExtensionDefinition<
-      {},
-      {},
-      ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>,
-      {},
-      {
-        kind: 'catalog-filter';
-        namespace: undefined;
-        name: 'namespace';
-      }
-    >;
-    'catalog-filter:catalog/lifecycle': ExtensionDefinition<
-      {},
-      {},
-      ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>,
-      {},
-      {
-        kind: 'catalog-filter';
-        namespace: undefined;
-        name: 'lifecycle';
-      }
-    >;
-    'catalog-filter:catalog/processing-status': ExtensionDefinition<
-      {},
-      {},
-      ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>,
-      {},
-      {
-        kind: 'catalog-filter';
-        namespace: undefined;
-        name: 'processing-status';
-      }
-    >;
-    'catalog-filter:catalog/list': ExtensionDefinition<
-      {
+      };
+      kind: 'catalog-filter';
+      namespace: undefined;
+      name: 'mode';
+    }>;
+    'catalog-filter:catalog/namespace': ExtensionDefinition<{
+      kind: 'catalog-filter';
+      namespace: undefined;
+      name: 'namespace';
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        JSX_2.Element,
+        'core.reactElement',
+        {}
+      >;
+      inputs: {};
+    }>;
+    'catalog-filter:catalog/lifecycle': ExtensionDefinition<{
+      kind: 'catalog-filter';
+      namespace: undefined;
+      name: 'lifecycle';
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        JSX_2.Element,
+        'core.reactElement',
+        {}
+      >;
+      inputs: {};
+    }>;
+    'catalog-filter:catalog/processing-status': ExtensionDefinition<{
+      kind: 'catalog-filter';
+      namespace: undefined;
+      name: 'processing-status';
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        JSX_2.Element,
+        'core.reactElement',
+        {}
+      >;
+      inputs: {};
+    }>;
+    'catalog-filter:catalog/list': ExtensionDefinition<{
+      config: {
         initialFilter: 'all' | 'owned' | 'starred';
-      },
-      {
+      };
+      configInput: {
         initialFilter?: 'all' | 'owned' | 'starred' | undefined;
-      },
-      ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>,
-      {
+      };
+      output: ConfigurableExtensionDataRef<
+        JSX_2.Element,
+        'core.reactElement',
+        {}
+      >;
+      inputs: {
         [x: string]: ExtensionInput<
           AnyExtensionDataRef,
           {
@@ -664,34 +684,29 @@ const _default: BackstagePlugin<
             singleton: boolean;
           }
         >;
-      },
-      {
-        kind: 'catalog-filter';
-        namespace: undefined;
-        name: 'list';
-      }
-    >;
-    'page:catalog': ExtensionDefinition<
-      {
-        [x: string]: any;
-      } & {
+      };
+      kind: 'catalog-filter';
+      namespace: undefined;
+      name: 'list';
+    }>;
+    'page:catalog': ExtensionDefinition<{
+      config: {
         path: string | undefined;
-      },
-      {
-        [x: string]: any;
-      } & {
+      };
+      configInput: {
         path?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
-      | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
-      | ConfigurableExtensionDataRef<
-          RouteRef<AnyRouteRefParams>,
-          'core.routing.ref',
-          {
-            optional: true;
-          }
-        >,
-      {
+      };
+      output:
+        | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
+        | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
+        | ConfigurableExtensionDataRef<
+            RouteRef<AnyRouteRefParams>,
+            'core.routing.ref',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {
         filters: ExtensionInput<
           ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>,
           {
@@ -699,34 +714,29 @@ const _default: BackstagePlugin<
             optional: false;
           }
         >;
-      },
-      {
-        kind: 'page';
-        namespace: undefined;
-        name: undefined;
-      }
-    >;
-    'page:catalog/entity': ExtensionDefinition<
-      {
-        [x: string]: any;
-      } & {
+      };
+      kind: 'page';
+      namespace: undefined;
+      name: undefined;
+    }>;
+    'page:catalog/entity': ExtensionDefinition<{
+      config: {
         path: string | undefined;
-      },
-      {
-        [x: string]: any;
-      } & {
+      };
+      configInput: {
         path?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
-      | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
-      | ConfigurableExtensionDataRef<
-          RouteRef<AnyRouteRefParams>,
-          'core.routing.ref',
-          {
-            optional: true;
-          }
-        >,
-      {
+      };
+      output:
+        | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
+        | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
+        | ConfigurableExtensionDataRef<
+            RouteRef<AnyRouteRefParams>,
+            'core.routing.ref',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {
         contents: ExtensionInput<
           | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
           | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
@@ -761,35 +771,31 @@ const _default: BackstagePlugin<
             optional: false;
           }
         >;
-      },
-      {
-        kind: 'page';
-        namespace: undefined;
-        name: 'entity';
-      }
-    >;
-    'search-result-list-item:catalog': ExtensionDefinition<
-      {
+      };
+      kind: 'page';
+      namespace: undefined;
+      name: 'entity';
+    }>;
+    'search-result-list-item:catalog': ExtensionDefinition<{
+      kind: 'search-result-list-item';
+      namespace: undefined;
+      name: undefined;
+      config: {
         noTrack: boolean;
-      },
-      {
+      };
+      configInput: {
         noTrack?: boolean | undefined;
-      },
-      ConfigurableExtensionDataRef<
+      };
+      output: ConfigurableExtensionDataRef<
         {
           predicate?: SearchResultItemExtensionPredicate | undefined;
           component: SearchResultItemExtensionComponent;
         },
         'search.search-result-list-item.item',
         {}
-      >,
-      {},
-      {
-        kind: 'search-result-list-item';
-        namespace: undefined;
-        name: undefined;
-      }
-    >;
+      >;
+      inputs: {};
+    }>;
   }
 >;
 export default _default;

--- a/plugins/catalog/src/alpha/blueprints/CatalogFilterBlueprint.test.tsx
+++ b/plugins/catalog/src/alpha/blueprints/CatalogFilterBlueprint.test.tsx
@@ -36,6 +36,7 @@ describe('CatalogFilterBlueprint', () => {
     expect(extension).toMatchInlineSnapshot(`
       {
         "$$type": "@backstage/ExtensionDefinition",
+        "T": undefined,
         "attachTo": {
           "id": "page:catalog",
           "input": "filters",

--- a/plugins/devtools/api-report-alpha.md
+++ b/plugins/devtools/api-report-alpha.md
@@ -19,48 +19,52 @@ const _default: BackstagePlugin<
   },
   {},
   {
-    'api:devtools': ExtensionDefinition<
-      {},
-      {},
-      ConfigurableExtensionDataRef<AnyApiFactory, 'core.api.factory', {}>,
-      {},
-      {
-        kind: 'api';
-        namespace: undefined;
-        name: undefined;
-      }
-    >;
-    'page:devtools': ExtensionDefinition<
-      {
+    'api:devtools': ExtensionDefinition<{
+      kind: 'api';
+      namespace: undefined;
+      name: undefined;
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {};
+    }>;
+    'page:devtools': ExtensionDefinition<{
+      kind: 'page';
+      namespace: undefined;
+      name: undefined;
+      config: {
         path: string | undefined;
-      },
-      {
+      };
+      configInput: {
         path?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<
-          React_2.JSX.Element,
-          'core.reactElement',
-          {}
-        >
-      | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
-      | ConfigurableExtensionDataRef<
-          RouteRef<AnyRouteRefParams>,
-          'core.routing.ref',
-          {
-            optional: true;
-          }
-        >,
-      {},
-      {
-        kind: 'page';
-        namespace: undefined;
-        name: undefined;
-      }
-    >;
-    'nav-item:devtools': ExtensionDefinition<
-      {},
-      {},
-      ConfigurableExtensionDataRef<
+      };
+      output:
+        | ConfigurableExtensionDataRef<
+            React_2.JSX.Element,
+            'core.reactElement',
+            {}
+          >
+        | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
+        | ConfigurableExtensionDataRef<
+            RouteRef<AnyRouteRefParams>,
+            'core.routing.ref',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+    }>;
+    'nav-item:devtools': ExtensionDefinition<{
+      kind: 'nav-item';
+      namespace: undefined;
+      name: undefined;
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
         {
           title: string;
           icon: IconComponent;
@@ -68,14 +72,9 @@ const _default: BackstagePlugin<
         },
         'core.nav-item.target',
         {}
-      >,
-      {},
-      {
-        kind: 'nav-item';
-        namespace: undefined;
-        name: undefined;
-      }
-    >;
+      >;
+      inputs: {};
+    }>;
   }
 >;
 export default _default;

--- a/plugins/home/api-report-alpha.md
+++ b/plugins/home/api-report-alpha.md
@@ -16,31 +16,28 @@ const _default: BackstagePlugin<
   {},
   {},
   {
-    'page:home': ExtensionDefinition<
-      {
-        [x: string]: any;
-      } & {
+    'page:home': ExtensionDefinition<{
+      config: {
         path: string | undefined;
-      },
-      {
-        [x: string]: any;
-      } & {
+      };
+      configInput: {
         path?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<
-          React_2.JSX.Element,
-          'core.reactElement',
-          {}
-        >
-      | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
-      | ConfigurableExtensionDataRef<
-          RouteRef<AnyRouteRefParams>,
-          'core.routing.ref',
-          {
-            optional: true;
-          }
-        >,
-      {
+      };
+      output:
+        | ConfigurableExtensionDataRef<
+            React_2.JSX.Element,
+            'core.reactElement',
+            {}
+          >
+        | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
+        | ConfigurableExtensionDataRef<
+            RouteRef<AnyRouteRefParams>,
+            'core.routing.ref',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {
         props: ExtensionInput<
           | ConfigurableExtensionDataRef<
               React_2.JSX.Element,
@@ -61,13 +58,11 @@ const _default: BackstagePlugin<
             optional: true;
           }
         >;
-      },
-      {
-        kind: 'page';
-        namespace: undefined;
-        name: undefined;
-      }
-    >;
+      };
+      kind: 'page';
+      namespace: undefined;
+      name: undefined;
+    }>;
   }
 >;
 export default _default;

--- a/plugins/kubernetes/api-report-alpha.md
+++ b/plugins/kubernetes/api-report-alpha.md
@@ -21,104 +21,125 @@ const _default: BackstagePlugin<
   },
   {},
   {
-    'page:kubernetes': ExtensionDefinition<
-      {
+    'api:kubernetes': ExtensionDefinition<{
+      kind: 'api';
+      namespace: undefined;
+      name: undefined;
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {};
+    }>;
+    'page:kubernetes': ExtensionDefinition<{
+      kind: 'page';
+      namespace: undefined;
+      name: undefined;
+      config: {
         path: string | undefined;
-      },
-      {
+      };
+      configInput: {
         path?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
-      | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
-      | ConfigurableExtensionDataRef<
-          RouteRef<AnyRouteRefParams>,
-          'core.routing.ref',
-          {
-            optional: true;
-          }
-        >,
-      {},
-      {
-        kind: 'page';
-        namespace: undefined;
-        name: undefined;
-      }
-    >;
-    'entity-content:kubernetes/kubernetes': ExtensionDefinition<
-      {
+      };
+      output:
+        | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
+        | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
+        | ConfigurableExtensionDataRef<
+            RouteRef<AnyRouteRefParams>,
+            'core.routing.ref',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+    }>;
+    'entity-content:kubernetes/kubernetes': ExtensionDefinition<{
+      kind: 'entity-content';
+      namespace: undefined;
+      name: 'kubernetes';
+      config: {
         path: string | undefined;
         title: string | undefined;
         filter: string | undefined;
-      },
-      {
+      };
+      configInput: {
         filter?: string | undefined;
         title?: string | undefined;
         path?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
-      | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
-      | ConfigurableExtensionDataRef<
-          RouteRef<AnyRouteRefParams>,
-          'core.routing.ref',
-          {
-            optional: true;
-          }
-        >
-      | ConfigurableExtensionDataRef<string, 'catalog.entity-content-title', {}>
-      | ConfigurableExtensionDataRef<
-          (entity: Entity) => boolean,
-          'catalog.entity-filter-function',
-          {
-            optional: true;
-          }
-        >
-      | ConfigurableExtensionDataRef<
-          string,
-          'catalog.entity-filter-expression',
-          {
-            optional: true;
-          }
-        >,
-      {},
-      {
-        kind: 'entity-content';
-        namespace: undefined;
-        name: 'kubernetes';
-      }
-    >;
-    'api:kubernetes/proxy': ExtensionDefinition<
-      {},
-      {},
-      ConfigurableExtensionDataRef<AnyApiFactory, 'core.api.factory', {}>,
-      {},
-      {
-        kind: 'api';
-        namespace: undefined;
-        name: 'proxy';
-      }
-    >;
-    'api:kubernetes/auth-providers': ExtensionDefinition<
-      {},
-      {},
-      ConfigurableExtensionDataRef<AnyApiFactory, 'core.api.factory', {}>,
-      {},
-      {
-        kind: 'api';
-        namespace: undefined;
-        name: 'auth-providers';
-      }
-    >;
-    'api:kubernetes/cluster-link-formatter': ExtensionDefinition<
-      {},
-      {},
-      ConfigurableExtensionDataRef<AnyApiFactory, 'core.api.factory', {}>,
-      {},
-      {
-        kind: 'api';
-        namespace: undefined;
-        name: 'cluster-link-formatter';
-      }
-    >;
+      };
+      output:
+        | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
+        | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
+        | ConfigurableExtensionDataRef<
+            RouteRef<AnyRouteRefParams>,
+            'core.routing.ref',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-content-title',
+            {}
+          >
+        | ConfigurableExtensionDataRef<
+            (entity: Entity) => boolean,
+            'catalog.entity-filter-function',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-filter-expression',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+    }>;
+    'api:kubernetes/proxy': ExtensionDefinition<{
+      kind: 'api';
+      namespace: undefined;
+      name: 'proxy';
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {};
+    }>;
+    'api:kubernetes/auth-providers': ExtensionDefinition<{
+      kind: 'api';
+      namespace: undefined;
+      name: 'auth-providers';
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {};
+    }>;
+    'api:kubernetes/cluster-link-formatter': ExtensionDefinition<{
+      kind: 'api';
+      namespace: undefined;
+      name: 'cluster-link-formatter';
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {};
+    }>;
   }
 >;
 export default _default;

--- a/plugins/org/api-report-alpha.md
+++ b/plugins/org/api-report-alpha.md
@@ -17,138 +17,134 @@ const _default: BackstagePlugin<
     catalogIndex: ExternalRouteRef<undefined>;
   },
   {
-    'entity-card:org/group-profile': ExtensionDefinition<
-      {
+    'entity-card:org/group-profile': ExtensionDefinition<{
+      kind: 'entity-card';
+      namespace: undefined;
+      name: 'group-profile';
+      config: {
         filter: string | undefined;
-      },
-      {
+      };
+      configInput: {
         filter?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<
-          React_2.JSX.Element,
-          'core.reactElement',
-          {}
-        >
-      | ConfigurableExtensionDataRef<
-          (entity: Entity) => boolean,
-          'catalog.entity-filter-function',
-          {
-            optional: true;
-          }
-        >
-      | ConfigurableExtensionDataRef<
-          string,
-          'catalog.entity-filter-expression',
-          {
-            optional: true;
-          }
-        >,
-      {},
-      {
-        kind: 'entity-card';
-        namespace: undefined;
-        name: 'group-profile';
-      }
-    >;
-    'entity-card:org/members-list': ExtensionDefinition<
-      {
+      };
+      output:
+        | ConfigurableExtensionDataRef<
+            React_2.JSX.Element,
+            'core.reactElement',
+            {}
+          >
+        | ConfigurableExtensionDataRef<
+            (entity: Entity) => boolean,
+            'catalog.entity-filter-function',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-filter-expression',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+    }>;
+    'entity-card:org/members-list': ExtensionDefinition<{
+      kind: 'entity-card';
+      namespace: undefined;
+      name: 'members-list';
+      config: {
         filter: string | undefined;
-      },
-      {
+      };
+      configInput: {
         filter?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<
-          React_2.JSX.Element,
-          'core.reactElement',
-          {}
-        >
-      | ConfigurableExtensionDataRef<
-          (entity: Entity) => boolean,
-          'catalog.entity-filter-function',
-          {
-            optional: true;
-          }
-        >
-      | ConfigurableExtensionDataRef<
-          string,
-          'catalog.entity-filter-expression',
-          {
-            optional: true;
-          }
-        >,
-      {},
-      {
-        kind: 'entity-card';
-        namespace: undefined;
-        name: 'members-list';
-      }
-    >;
-    'entity-card:org/ownership': ExtensionDefinition<
-      {
+      };
+      output:
+        | ConfigurableExtensionDataRef<
+            React_2.JSX.Element,
+            'core.reactElement',
+            {}
+          >
+        | ConfigurableExtensionDataRef<
+            (entity: Entity) => boolean,
+            'catalog.entity-filter-function',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-filter-expression',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+    }>;
+    'entity-card:org/ownership': ExtensionDefinition<{
+      kind: 'entity-card';
+      namespace: undefined;
+      name: 'ownership';
+      config: {
         filter: string | undefined;
-      },
-      {
+      };
+      configInput: {
         filter?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<
-          React_2.JSX.Element,
-          'core.reactElement',
-          {}
-        >
-      | ConfigurableExtensionDataRef<
-          (entity: Entity) => boolean,
-          'catalog.entity-filter-function',
-          {
-            optional: true;
-          }
-        >
-      | ConfigurableExtensionDataRef<
-          string,
-          'catalog.entity-filter-expression',
-          {
-            optional: true;
-          }
-        >,
-      {},
-      {
-        kind: 'entity-card';
-        namespace: undefined;
-        name: 'ownership';
-      }
-    >;
-    'entity-card:org/user-profile': ExtensionDefinition<
-      {
+      };
+      output:
+        | ConfigurableExtensionDataRef<
+            React_2.JSX.Element,
+            'core.reactElement',
+            {}
+          >
+        | ConfigurableExtensionDataRef<
+            (entity: Entity) => boolean,
+            'catalog.entity-filter-function',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-filter-expression',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+    }>;
+    'entity-card:org/user-profile': ExtensionDefinition<{
+      kind: 'entity-card';
+      namespace: undefined;
+      name: 'user-profile';
+      config: {
         filter: string | undefined;
-      },
-      {
+      };
+      configInput: {
         filter?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<
-          React_2.JSX.Element,
-          'core.reactElement',
-          {}
-        >
-      | ConfigurableExtensionDataRef<
-          (entity: Entity) => boolean,
-          'catalog.entity-filter-function',
-          {
-            optional: true;
-          }
-        >
-      | ConfigurableExtensionDataRef<
-          string,
-          'catalog.entity-filter-expression',
-          {
-            optional: true;
-          }
-        >,
-      {},
-      {
-        kind: 'entity-card';
-        namespace: undefined;
-        name: 'user-profile';
-      }
-    >;
+      };
+      output:
+        | ConfigurableExtensionDataRef<
+            React_2.JSX.Element,
+            'core.reactElement',
+            {}
+          >
+        | ConfigurableExtensionDataRef<
+            (entity: Entity) => boolean,
+            'catalog.entity-filter-function',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-filter-expression',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+    }>;
   }
 >;
 export default _default;

--- a/plugins/scaffolder/api-report-alpha.md
+++ b/plugins/scaffolder/api-report-alpha.md
@@ -44,48 +44,52 @@ const _default: BackstagePlugin<
     }>;
   },
   {
-    'api:scaffolder': ExtensionDefinition<
-      {},
-      {},
-      ConfigurableExtensionDataRef<AnyApiFactory, 'core.api.factory', {}>,
-      {},
-      {
-        kind: 'api';
-        namespace: undefined;
-        name: undefined;
-      }
-    >;
-    'page:scaffolder': ExtensionDefinition<
-      {
+    'api:scaffolder': ExtensionDefinition<{
+      kind: 'api';
+      namespace: undefined;
+      name: undefined;
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {};
+    }>;
+    'page:scaffolder': ExtensionDefinition<{
+      kind: 'page';
+      namespace: undefined;
+      name: undefined;
+      config: {
         path: string | undefined;
-      },
-      {
+      };
+      configInput: {
         path?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<
-          React_2.JSX.Element,
-          'core.reactElement',
-          {}
-        >
-      | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
-      | ConfigurableExtensionDataRef<
-          RouteRef<AnyRouteRefParams>,
-          'core.routing.ref',
-          {
-            optional: true;
-          }
-        >,
-      {},
-      {
-        kind: 'page';
-        namespace: undefined;
-        name: undefined;
-      }
-    >;
-    'nav-item:scaffolder': ExtensionDefinition<
-      {},
-      {},
-      ConfigurableExtensionDataRef<
+      };
+      output:
+        | ConfigurableExtensionDataRef<
+            React_2.JSX.Element,
+            'core.reactElement',
+            {}
+          >
+        | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
+        | ConfigurableExtensionDataRef<
+            RouteRef<AnyRouteRefParams>,
+            'core.routing.ref',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+    }>;
+    'nav-item:scaffolder': ExtensionDefinition<{
+      kind: 'nav-item';
+      namespace: undefined;
+      name: undefined;
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
         {
           title: string;
           icon: IconComponent;
@@ -93,14 +97,9 @@ const _default: BackstagePlugin<
         },
         'core.nav-item.target',
         {}
-      >,
-      {},
-      {
-        kind: 'nav-item';
-        namespace: undefined;
-        name: undefined;
-      }
-    >;
+      >;
+      inputs: {};
+    }>;
   }
 >;
 export default _default;

--- a/plugins/search-react/api-report-alpha.md
+++ b/plugins/search-react/api-report-alpha.md
@@ -30,29 +30,27 @@ export type SearchResultItemExtensionPredicate = (
 ) => boolean;
 
 // @alpha
-export const SearchResultListItemBlueprint: ExtensionBlueprint<
-  {
-    kind: 'search-result-list-item';
-    namespace: undefined;
-    name: undefined;
-  },
-  SearchResultListItemBlueprintParams,
-  ConfigurableExtensionDataRef<
+export const SearchResultListItemBlueprint: ExtensionBlueprint<{
+  kind: 'search-result-list-item';
+  namespace: undefined;
+  name: undefined;
+  params: SearchResultListItemBlueprintParams;
+  output: ConfigurableExtensionDataRef<
     {
       predicate?: SearchResultItemExtensionPredicate | undefined;
       component: SearchResultItemExtensionComponent;
     },
     'search.search-result-list-item.item',
     {}
-  >,
-  {},
-  {
+  >;
+  inputs: {};
+  config: {
     noTrack: boolean;
-  },
-  {
+  };
+  configInput: {
     noTrack?: boolean | undefined;
-  },
-  {
+  };
+  dataRefs: {
     item: ConfigurableExtensionDataRef<
       {
         predicate?: SearchResultItemExtensionPredicate | undefined;
@@ -61,8 +59,8 @@ export const SearchResultListItemBlueprint: ExtensionBlueprint<
       'search.search-result-list-item.item',
       {}
     >;
-  }
->;
+  };
+}>;
 
 // @alpha (undocumented)
 export interface SearchResultListItemBlueprintParams {

--- a/plugins/search-react/src/alpha/blueprints/SearchResultListItemBlueprint.test.tsx
+++ b/plugins/search-react/src/alpha/blueprints/SearchResultListItemBlueprint.test.tsx
@@ -40,6 +40,7 @@ describe('SearchResultListItemBlueprint', () => {
     expect(extension).toMatchInlineSnapshot(`
       {
         "$$type": "@backstage/ExtensionDefinition",
+        "T": undefined,
         "attachTo": {
           "id": "page:search",
           "input": "items",

--- a/plugins/search/api-report-alpha.md
+++ b/plugins/search/api-report-alpha.md
@@ -22,21 +22,26 @@ const _default: BackstagePlugin<
   },
   {},
   {
-    'api:search': ExtensionDefinition<
-      {},
-      {},
-      ConfigurableExtensionDataRef<AnyApiFactory, 'core.api.factory', {}>,
-      {},
-      {
-        kind: 'api';
-        namespace: undefined;
-        name: undefined;
-      }
-    >;
-    'nav-item:search': ExtensionDefinition<
-      {},
-      {},
-      ConfigurableExtensionDataRef<
+    'api:search': ExtensionDefinition<{
+      kind: 'api';
+      namespace: undefined;
+      name: undefined;
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {};
+    }>;
+    'nav-item:search': ExtensionDefinition<{
+      kind: 'nav-item';
+      namespace: undefined;
+      name: undefined;
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
         {
           title: string;
           icon: IconComponent;
@@ -44,39 +49,35 @@ const _default: BackstagePlugin<
         },
         'core.nav-item.target',
         {}
-      >,
-      {},
-      {
-        kind: 'nav-item';
-        namespace: undefined;
-        name: undefined;
-      }
-    >;
-    'page:search': ExtensionDefinition<
-      {
+      >;
+      inputs: {};
+    }>;
+    'page:search': ExtensionDefinition<{
+      config: {
         noTrack: boolean;
       } & {
         path: string | undefined;
-      },
-      {
+      };
+      configInput: {
         noTrack?: boolean | undefined;
       } & {
         path?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<
-          React_2.JSX.Element,
-          'core.reactElement',
-          {}
-        >
-      | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
-      | ConfigurableExtensionDataRef<
-          RouteRef<AnyRouteRefParams>,
-          'core.routing.ref',
-          {
-            optional: true;
-          }
-        >,
-      {
+      };
+      output:
+        | ConfigurableExtensionDataRef<
+            React_2.JSX.Element,
+            'core.reactElement',
+            {}
+          >
+        | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
+        | ConfigurableExtensionDataRef<
+            RouteRef<AnyRouteRefParams>,
+            'core.routing.ref',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {
         items: ExtensionInput<
           ConfigurableExtensionDataRef<
             {
@@ -91,35 +92,34 @@ const _default: BackstagePlugin<
             optional: false;
           }
         >;
-      },
-      {
-        kind: 'page';
-        namespace: undefined;
-        name: undefined;
-      }
-    >;
+      };
+      kind: 'page';
+      namespace: undefined;
+      name: undefined;
+    }>;
   }
 >;
 export default _default;
 
 // @alpha (undocumented)
-export const searchApi: ExtensionDefinition<
-  {},
-  {},
-  ConfigurableExtensionDataRef<AnyApiFactory, 'core.api.factory', {}>,
-  {},
-  {
-    kind: 'api';
-    namespace: undefined;
-    name: undefined;
-  }
->;
+export const searchApi: ExtensionDefinition<{
+  kind: 'api';
+  namespace: undefined;
+  name: undefined;
+  config: {};
+  configInput: {};
+  output: ConfigurableExtensionDataRef<AnyApiFactory, 'core.api.factory', {}>;
+  inputs: {};
+}>;
 
 // @alpha (undocumented)
-export const searchNavItem: ExtensionDefinition<
-  {},
-  {},
-  ConfigurableExtensionDataRef<
+export const searchNavItem: ExtensionDefinition<{
+  kind: 'nav-item';
+  namespace: undefined;
+  name: undefined;
+  config: {};
+  configInput: {};
+  output: ConfigurableExtensionDataRef<
     {
       title: string;
       icon: IconComponent;
@@ -127,37 +127,33 @@ export const searchNavItem: ExtensionDefinition<
     },
     'core.nav-item.target',
     {}
-  >,
-  {},
-  {
-    kind: 'nav-item';
-    namespace: undefined;
-    name: undefined;
-  }
->;
+  >;
+  inputs: {};
+}>;
 
 // @alpha (undocumented)
-export const searchPage: ExtensionDefinition<
-  {
+export const searchPage: ExtensionDefinition<{
+  config: {
     noTrack: boolean;
   } & {
     path: string | undefined;
-  },
-  {
+  };
+  configInput: {
     noTrack?: boolean | undefined;
   } & {
     path?: string | undefined;
-  },
-  | ConfigurableExtensionDataRef<React_2.JSX.Element, 'core.reactElement', {}>
-  | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
-  | ConfigurableExtensionDataRef<
-      RouteRef<AnyRouteRefParams>,
-      'core.routing.ref',
-      {
-        optional: true;
-      }
-    >,
-  {
+  };
+  output:
+    | ConfigurableExtensionDataRef<React_2.JSX.Element, 'core.reactElement', {}>
+    | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
+    | ConfigurableExtensionDataRef<
+        RouteRef<AnyRouteRefParams>,
+        'core.routing.ref',
+        {
+          optional: true;
+        }
+      >;
+  inputs: {
     items: ExtensionInput<
       ConfigurableExtensionDataRef<
         {
@@ -172,13 +168,11 @@ export const searchPage: ExtensionDefinition<
         optional: false;
       }
     >;
-  },
-  {
-    kind: 'page';
-    namespace: undefined;
-    name: undefined;
-  }
->;
+  };
+  kind: 'page';
+  namespace: undefined;
+  name: undefined;
+}>;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/techdocs/api-report-alpha.md
+++ b/plugins/techdocs/api-report-alpha.md
@@ -30,10 +30,52 @@ const _default: BackstagePlugin<
   },
   {},
   {
-    'nav-item:techdocs': ExtensionDefinition<
-      {},
-      {},
-      ConfigurableExtensionDataRef<
+    'api:techdocs': ExtensionDefinition<{
+      kind: 'api';
+      namespace: undefined;
+      name: undefined;
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {};
+    }>;
+    'page:techdocs': ExtensionDefinition<{
+      kind: 'page';
+      namespace: undefined;
+      name: undefined;
+      config: {
+        path: string | undefined;
+      };
+      configInput: {
+        path?: string | undefined;
+      };
+      output:
+        | ConfigurableExtensionDataRef<
+            React_2.JSX.Element,
+            'core.reactElement',
+            {}
+          >
+        | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
+        | ConfigurableExtensionDataRef<
+            RouteRef<AnyRouteRefParams>,
+            'core.routing.ref',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+    }>;
+    'nav-item:techdocs': ExtensionDefinition<{
+      kind: 'nav-item';
+      namespace: undefined;
+      name: undefined;
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
         {
           title: string;
           icon: IconComponent;
@@ -41,51 +83,48 @@ const _default: BackstagePlugin<
         },
         'core.nav-item.target',
         {}
-      >,
-      {},
-      {
-        kind: 'nav-item';
-        namespace: undefined;
-        name: undefined;
-      }
-    >;
-    'api:techdocs/storage': ExtensionDefinition<
-      {},
-      {},
-      ConfigurableExtensionDataRef<AnyApiFactory, 'core.api.factory', {}>,
-      {},
-      {
-        kind: 'api';
-        namespace: undefined;
-        name: 'storage';
-      }
-    >;
-    'search-result-list-item:techdocs': ExtensionDefinition<
-      {
+      >;
+      inputs: {};
+    }>;
+    'api:techdocs/storage': ExtensionDefinition<{
+      kind: 'api';
+      namespace: undefined;
+      name: 'storage';
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {};
+    }>;
+    'search-result-list-item:techdocs': ExtensionDefinition<{
+      config: {
         title: string | undefined;
         lineClamp: number;
         asLink: boolean;
         asListItem: boolean;
       } & {
         noTrack: boolean;
-      },
-      {
+      };
+      configInput: {
         title?: string | undefined;
         lineClamp?: number | undefined;
         asListItem?: boolean | undefined;
         asLink?: boolean | undefined;
       } & {
         noTrack?: boolean | undefined;
-      },
-      ConfigurableExtensionDataRef<
+      };
+      output: ConfigurableExtensionDataRef<
         {
           predicate?: SearchResultItemExtensionPredicate | undefined;
           component: SearchResultItemExtensionComponent;
         },
         'search.search-result-list-item.item',
         {}
-      >,
-      {
+      >;
+      inputs: {
         [x: string]: ExtensionInput<
           AnyExtensionDataRef,
           {
@@ -93,117 +132,117 @@ const _default: BackstagePlugin<
             singleton: boolean;
           }
         >;
-      },
-      {
-        kind: 'search-result-list-item';
-        namespace: undefined;
-        name: undefined;
-      }
-    >;
-    'page:techdocs/reader': ExtensionDefinition<
-      {
+      };
+      kind: 'search-result-list-item';
+      namespace: undefined;
+      name: undefined;
+    }>;
+    'page:techdocs/reader': ExtensionDefinition<{
+      kind: 'page';
+      namespace: undefined;
+      name: 'reader';
+      config: {
         path: string | undefined;
-      },
-      {
+      };
+      configInput: {
         path?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<
-          React_2.JSX.Element,
-          'core.reactElement',
-          {}
-        >
-      | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
-      | ConfigurableExtensionDataRef<
-          RouteRef<AnyRouteRefParams>,
-          'core.routing.ref',
-          {
-            optional: true;
-          }
-        >,
-      {},
-      {
-        kind: 'page';
-        namespace: undefined;
-        name: 'reader';
-      }
-    >;
-    'entity-content:techdocs': ExtensionDefinition<
-      {
+      };
+      output:
+        | ConfigurableExtensionDataRef<
+            React_2.JSX.Element,
+            'core.reactElement',
+            {}
+          >
+        | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
+        | ConfigurableExtensionDataRef<
+            RouteRef<AnyRouteRefParams>,
+            'core.routing.ref',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+    }>;
+    'entity-content:techdocs': ExtensionDefinition<{
+      kind: 'entity-content';
+      namespace: undefined;
+      name: undefined;
+      config: {
         path: string | undefined;
         title: string | undefined;
         filter: string | undefined;
-      },
-      {
+      };
+      configInput: {
         filter?: string | undefined;
         title?: string | undefined;
         path?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<
-          React_2.JSX.Element,
-          'core.reactElement',
-          {}
-        >
-      | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
-      | ConfigurableExtensionDataRef<
-          RouteRef<AnyRouteRefParams>,
-          'core.routing.ref',
-          {
-            optional: true;
-          }
-        >
-      | ConfigurableExtensionDataRef<string, 'catalog.entity-content-title', {}>
-      | ConfigurableExtensionDataRef<
-          (entity: Entity) => boolean,
-          'catalog.entity-filter-function',
-          {
-            optional: true;
-          }
-        >
-      | ConfigurableExtensionDataRef<
-          string,
-          'catalog.entity-filter-expression',
-          {
-            optional: true;
-          }
-        >,
-      {},
-      {
-        kind: 'entity-content';
-        namespace: undefined;
-        name: undefined;
-      }
-    >;
+      };
+      output:
+        | ConfigurableExtensionDataRef<
+            React_2.JSX.Element,
+            'core.reactElement',
+            {}
+          >
+        | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
+        | ConfigurableExtensionDataRef<
+            RouteRef<AnyRouteRefParams>,
+            'core.routing.ref',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-content-title',
+            {}
+          >
+        | ConfigurableExtensionDataRef<
+            (entity: Entity) => boolean,
+            'catalog.entity-filter-function',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-filter-expression',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+    }>;
   }
 >;
 export default _default;
 
 // @alpha (undocumented)
-export const techDocsSearchResultListItemExtension: ExtensionDefinition<
-  {
+export const techDocsSearchResultListItemExtension: ExtensionDefinition<{
+  config: {
     title: string | undefined;
     lineClamp: number;
     asLink: boolean;
     asListItem: boolean;
   } & {
     noTrack: boolean;
-  },
-  {
+  };
+  configInput: {
     title?: string | undefined;
     lineClamp?: number | undefined;
     asListItem?: boolean | undefined;
     asLink?: boolean | undefined;
   } & {
     noTrack?: boolean | undefined;
-  },
-  ConfigurableExtensionDataRef<
+  };
+  output: ConfigurableExtensionDataRef<
     {
       predicate?: SearchResultItemExtensionPredicate | undefined;
       component: SearchResultItemExtensionComponent;
     },
     'search.search-result-list-item.item',
     {}
-  >,
-  {
+  >;
+  inputs: {
     [x: string]: ExtensionInput<
       AnyExtensionDataRef,
       {
@@ -211,13 +250,11 @@ export const techDocsSearchResultListItemExtension: ExtensionDefinition<
         singleton: boolean;
       }
     >;
-  },
-  {
-    kind: 'search-result-list-item';
-    namespace: undefined;
-    name: undefined;
-  }
->;
+  };
+  kind: 'search-result-list-item';
+  namespace: undefined;
+  name: undefined;
+}>;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/user-settings/api-report-alpha.md
+++ b/plugins/user-settings/api-report-alpha.md
@@ -20,10 +20,13 @@ const _default: BackstagePlugin<
   },
   {},
   {
-    'nav-item:user-settings': ExtensionDefinition<
-      {},
-      {},
-      ConfigurableExtensionDataRef<
+    'nav-item:user-settings': ExtensionDefinition<{
+      kind: 'nav-item';
+      namespace: undefined;
+      name: undefined;
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
         {
           title: string;
           icon: IconComponent;
@@ -31,39 +34,31 @@ const _default: BackstagePlugin<
         },
         'core.nav-item.target',
         {}
-      >,
-      {},
-      {
-        kind: 'nav-item';
-        namespace: undefined;
-        name: undefined;
-      }
-    >;
-    'page:user-settings': ExtensionDefinition<
-      {
-        [x: string]: any;
-      } & {
+      >;
+      inputs: {};
+    }>;
+    'page:user-settings': ExtensionDefinition<{
+      config: {
         path: string | undefined;
-      },
-      {
-        [x: string]: any;
-      } & {
+      };
+      configInput: {
         path?: string | undefined;
-      },
-      | ConfigurableExtensionDataRef<
-          React_2.JSX.Element,
-          'core.reactElement',
-          {}
-        >
-      | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
-      | ConfigurableExtensionDataRef<
-          RouteRef<AnyRouteRefParams>,
-          'core.routing.ref',
-          {
-            optional: true;
-          }
-        >,
-      {
+      };
+      output:
+        | ConfigurableExtensionDataRef<
+            React_2.JSX.Element,
+            'core.reactElement',
+            {}
+          >
+        | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
+        | ConfigurableExtensionDataRef<
+            RouteRef<AnyRouteRefParams>,
+            'core.routing.ref',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {
         providerSettings: ExtensionInput<
           ConfigurableExtensionDataRef<
             React_2.JSX.Element,
@@ -75,22 +70,23 @@ const _default: BackstagePlugin<
             optional: true;
           }
         >;
-      },
-      {
-        kind: 'page';
-        namespace: undefined;
-        name: undefined;
-      }
-    >;
+      };
+      kind: 'page';
+      namespace: undefined;
+      name: undefined;
+    }>;
   }
 >;
 export default _default;
 
 // @alpha (undocumented)
-export const settingsNavItem: ExtensionDefinition<
-  {},
-  {},
-  ConfigurableExtensionDataRef<
+export const settingsNavItem: ExtensionDefinition<{
+  kind: 'nav-item';
+  namespace: undefined;
+  name: undefined;
+  config: {};
+  configInput: {};
+  output: ConfigurableExtensionDataRef<
     {
       title: string;
       icon: IconComponent;
@@ -98,14 +94,9 @@ export const settingsNavItem: ExtensionDefinition<
     },
     'core.nav-item.target',
     {}
-  >,
-  {},
-  {
-    kind: 'nav-item';
-    namespace: undefined;
-    name: undefined;
-  }
->;
+  >;
+  inputs: {};
+}>;
 
 // @alpha (undocumented)
 export const userSettingsTranslationRef: TranslationRef<


### PR DESCRIPTION
## Hey, I just made a Pull Request!

More info in the changeset, but the idea here is to make it easier to change these types over time, and in particular improving the readability of API references/report. You can see the changes to the API reports in this PR.

All fields in the parameter types are optional since that provides the best compatibility, but it does require a few extra `NonNullable`.

I also experimented with an `ExtensionDefinition.Parameters` pattern. The namespacing is nice, but it requires the definition to be an interface. I ran into some issues with that and API Extractor not being able to handle the `T` value if `ExtensionDefinition` was an interface, and figure that it would be unfortunate to never be able to use a type alias instead anyway.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
