### PR TITLE
Patch release of #26151, #26206

### DIFF
--- a/.changeset/blue-forks-cry.md
+++ b/.changeset/blue-forks-cry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-aws-alb-provider': patch
+---
+
+Fix a bug where the signer was checked from the payload instead of the header

--- a/.changeset/blue-forks-cry.md
+++ b/.changeset/blue-forks-cry.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-auth-backend-module-aws-alb-provider': patch
----
-
-Fix a bug where the signer was checked from the payload instead of the header

--- a/.changeset/tough-peaches-kneel.md
+++ b/.changeset/tough-peaches-kneel.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Fixed an issue with the by-query call, where ordering by a field that does not exist on all entities led to not all results being returned

--- a/.changeset/tough-peaches-kneel.md
+++ b/.changeset/tough-peaches-kneel.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-catalog-backend': patch
----
-
-Fixed an issue with the by-query call, where ordering by a field that does not exist on all entities led to not all results being returned

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.30.2",
+  "version": "1.30.3",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/backend-dynamic-feature-service/CHANGELOG.md
+++ b/packages/backend-dynamic-feature-service/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/backend-dynamic-feature-service
 
+## 0.3.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-backend@1.25.1
+
 ## 0.3.0
 
 ### Minor Changes

--- a/packages/backend-dynamic-feature-service/package.json
+++ b/packages/backend-dynamic-feature-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/backend-dynamic-feature-service",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Backstage dynamic feature service",
   "backstage": {
     "role": "node-library"

--- a/packages/backend-legacy/CHANGELOG.md
+++ b/packages/backend-legacy/CHANGELOG.md
@@ -1,5 +1,14 @@
 # example-backend-legacy
 
+## 0.2.102
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-backend@1.25.1
+  - @backstage/plugin-auth-backend@0.22.11
+  - @backstage/plugin-signals-backend@0.1.9
+
 ## 0.2.101
 
 ### Patch Changes

--- a/packages/backend-legacy/package.json
+++ b/packages/backend-legacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-backend-legacy",
-  "version": "0.2.101",
+  "version": "0.2.102",
   "backstage": {
     "role": "backend"
   },

--- a/packages/backend/CHANGELOG.md
+++ b/packages/backend/CHANGELOG.md
@@ -1,5 +1,17 @@
 # example-backend
 
+## 0.0.30
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-backend@1.25.1
+  - @backstage/plugin-auth-backend@0.22.11
+  - @backstage/plugin-catalog-backend-module-openapi@0.1.42
+  - @backstage/plugin-auth-backend-module-github-provider@0.1.20
+  - @backstage/plugin-notifications-backend@0.3.4
+  - @backstage/plugin-signals-backend@0.1.9
+
 ## 0.0.29
 
 ### Patch Changes

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-backend",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/auth-backend-module-aws-alb-provider/CHANGELOG.md
+++ b/plugins/auth-backend-module-aws-alb-provider/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-auth-backend-module-aws-alb-provider
 
+## 0.1.16
+
+### Patch Changes
+
+- 17c9d35: Fix a bug where the signer was checked from the payload instead of the header
+- Updated dependencies
+  - @backstage/plugin-auth-backend@0.22.11
+
 ## 0.1.15
 
 ### Patch Changes

--- a/plugins/auth-backend-module-aws-alb-provider/package.json
+++ b/plugins/auth-backend-module-aws-alb-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-auth-backend-module-aws-alb-provider",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "The aws-alb provider module for the Backstage auth backend.",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/auth-backend-module-aws-alb-provider/src/authenticator.test.ts
+++ b/plugins/auth-backend-module-aws-alb-provider/src/authenticator.test.ts
@@ -35,7 +35,6 @@ describe('AwsAlbProvider', () => {
     email: 'user.name@email.test',
     exp: Date.now() + 10000,
     iss: 'ISSUER_URL',
-    signer: 'SIGNER_ARN',
   };
   const signingKey = new TextEncoder().encode('signingKey');
   let mockJwt: string;
@@ -78,7 +77,7 @@ describe('AwsAlbProvider', () => {
 
   beforeEach(async () => {
     mockJwt = await new SignJWT(mockClaims)
-      .setProtectedHeader({ alg: 'HS256' })
+      .setProtectedHeader({ alg: 'HS256', signer: 'SIGNER_ARN' })
       .sign(signingKey);
   });
 
@@ -206,8 +205,8 @@ describe('AwsAlbProvider', () => {
     });
 
     it('signer is invalid', async () => {
-      const jwt = await new SignJWT({ signer: 'INVALID_SIGNER_ARN' })
-        .setProtectedHeader({ alg: 'HS256' })
+      const jwt = await new SignJWT({})
+        .setProtectedHeader({ alg: 'HS256', signer: 'INVALID_SIGNER_ARN' })
         .sign(signingKey);
       const req = {
         header: jest.fn(name => {

--- a/plugins/auth-backend-module-aws-alb-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-aws-alb-provider/src/authenticator.ts
@@ -15,7 +15,7 @@
  */
 
 import { AuthenticationError } from '@backstage/errors';
-import { AwsAlbClaims, AwsAlbResult } from './types';
+import { AwsAlbClaims, AwsAlbResult, AwsAlbProtectedHeader } from './types';
 import { jwtVerify } from 'jose';
 import {
   PassportProfile,
@@ -60,11 +60,12 @@ export const awsAlbAuthenticator = createProxyAuthenticator({
 
     try {
       const verifyResult = await jwtVerify(jwt, getKey);
+      const header = verifyResult.protectedHeader as AwsAlbProtectedHeader;
       const claims = verifyResult.payload as AwsAlbClaims;
 
       if (claims?.iss !== issuer) {
         throw new AuthenticationError('Issuer mismatch on JWT token');
-      } else if (signer && claims?.signer !== signer) {
+      } else if (signer && header?.signer !== signer) {
         throw new AuthenticationError('Signer mismatch on JWT token');
       }
 

--- a/plugins/auth-backend-module-aws-alb-provider/src/types.ts
+++ b/plugins/auth-backend-module-aws-alb-provider/src/types.ts
@@ -38,5 +38,10 @@ export type AwsAlbClaims = {
   email: string;
   exp: number;
   iss: string;
-  signer: string;
+};
+/**
+ * @internal
+ */
+export type AwsAlbProtectedHeader = {
+  signer?: string;
 };

--- a/plugins/auth-backend-module-oidc-provider/CHANGELOG.md
+++ b/plugins/auth-backend-module-oidc-provider/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-auth-backend-module-oidc-provider
 
+## 0.2.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-auth-backend@0.22.11
+
 ## 0.2.4
 
 ### Patch Changes

--- a/plugins/auth-backend-module-oidc-provider/package.json
+++ b/plugins/auth-backend-module-oidc-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-auth-backend-module-oidc-provider",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "The oidc-provider backend module for the auth plugin.",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/auth-backend/CHANGELOG.md
+++ b/plugins/auth-backend/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @backstage/plugin-auth-backend
 
+## 0.22.11
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-auth-backend-module-aws-alb-provider@0.1.16
+  - @backstage/plugin-auth-backend-module-atlassian-provider@0.2.4
+  - @backstage/plugin-auth-backend-module-azure-easyauth-provider@0.1.6
+  - @backstage/plugin-auth-backend-module-bitbucket-provider@0.1.6
+  - @backstage/plugin-auth-backend-module-cloudflare-access-provider@0.2.0
+  - @backstage/plugin-auth-backend-module-github-provider@0.1.20
+  - @backstage/plugin-auth-backend-module-gitlab-provider@0.1.20
+  - @backstage/plugin-auth-backend-module-google-provider@0.1.20
+  - @backstage/plugin-auth-backend-module-microsoft-provider@0.1.18
+  - @backstage/plugin-auth-backend-module-oauth2-provider@0.2.4
+  - @backstage/plugin-auth-backend-module-oidc-provider@0.2.5
+  - @backstage/plugin-auth-backend-module-okta-provider@0.0.16
+  - @backstage/plugin-auth-backend-module-onelogin-provider@0.1.4
+
 ## 0.22.10
 
 ### Patch Changes

--- a/plugins/auth-backend/package.json
+++ b/plugins/auth-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-auth-backend",
-  "version": "0.22.10",
+  "version": "0.22.11",
   "description": "A Backstage backend plugin that handles authentication",
   "backstage": {
     "role": "backend-plugin",

--- a/plugins/catalog-backend-module-github-org/CHANGELOG.md
+++ b/plugins/catalog-backend-module-github-org/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-catalog-backend-module-github-org
 
+## 0.2.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-backend-module-github@0.7.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/plugins/catalog-backend-module-github-org/package.json
+++ b/plugins/catalog-backend-module-github-org/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-github-org",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "The github-org backend module for the catalog plugin.",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/catalog-backend-module-github/CHANGELOG.md
+++ b/plugins/catalog-backend-module-github/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-catalog-backend-module-github
 
+## 0.7.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-backend@1.25.1
+
 ## 0.7.0
 
 ### Minor Changes

--- a/plugins/catalog-backend-module-github/package.json
+++ b/plugins/catalog-backend-module-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-github",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "A Backstage catalog backend module that helps integrate towards GitHub",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/catalog-backend-module-incremental-ingestion/CHANGELOG.md
+++ b/plugins/catalog-backend-module-incremental-ingestion/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-catalog-backend-module-incremental-ingestion
 
+## 0.5.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-backend@1.25.1
+
 ## 0.5.0
 
 ### Minor Changes

--- a/plugins/catalog-backend-module-incremental-ingestion/package.json
+++ b/plugins/catalog-backend-module-incremental-ingestion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-incremental-ingestion",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "An entity provider for streaming large asset sources into the catalog",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/catalog-backend-module-logs/CHANGELOG.md
+++ b/plugins/catalog-backend-module-logs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-catalog-backend-module-logs
 
+## 0.0.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-backend@1.25.1
+
 ## 0.0.2
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-logs/package.json
+++ b/plugins/catalog-backend-module-logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-logs",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A module that subscribes to catalog releated events and logs them.",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/catalog-backend-module-openapi/CHANGELOG.md
+++ b/plugins/catalog-backend-module-openapi/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-catalog-backend-module-openapi
 
+## 0.1.42
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-backend@1.25.1
+
 ## 0.1.41
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-openapi/package.json
+++ b/plugins/catalog-backend-module-openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-openapi",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "description": "A Backstage catalog backend module that helps with OpenAPI specifications",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/catalog-backend/CHANGELOG.md
+++ b/plugins/catalog-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/plugin-catalog-backend
 
+## 1.25.1
+
+### Patch Changes
+
+- 2fb4670: Fixed an issue with the by-query call, where ordering by a field that does not exist on all entities led to not all results being returned
+
 ## 1.25.0
 
 ### Minor Changes

--- a/plugins/catalog-backend/package.json
+++ b/plugins/catalog-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "description": "The Backstage backend plugin that provides the Backstage catalog",
   "backstage": {
     "role": "backend-plugin",

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -379,12 +379,20 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
     const [prevItemOrderFieldValue, prevItemUid] =
       cursor.orderFieldValues || [];
 
-    const dbQuery = db('search')
-      .join('final_entities', 'search.entity_id', 'final_entities.entity_id')
-      .where('search.key', sortField.field);
+    const dbQuery = db('final_entities').leftOuterJoin('search', qb =>
+      qb
+        .on('search.entity_id', 'final_entities.entity_id')
+        .andOnVal('search.key', sortField.field),
+    );
 
     if (cursor.filter) {
-      parseFilter(cursor.filter, dbQuery, db, false, 'search.entity_id');
+      parseFilter(
+        cursor.filter,
+        dbQuery,
+        db,
+        false,
+        'final_entities.entity_id',
+      );
     }
 
     const normalizedFullTextFilterTerm = cursor.fullTextFilter?.term?.trim();
@@ -410,7 +418,7 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
               `%${normalizedFullTextFilterTerm.toLocaleLowerCase('en-US')}%`,
             );
           });
-        dbQuery.andWhere('search.entity_id', 'in', matchQuery);
+        dbQuery.andWhere('final_entities.entity_id', 'in', matchQuery);
       }
     }
 
@@ -427,32 +435,59 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
         )
           .orWhere('value', '=', prevItemOrderFieldValue)
           .andWhere(
-            'search.entity_id',
+            'final_entities.entity_id',
             isFetchingBackwards !== isOrderingDescending ? '<' : '>',
             prevItemUid,
           );
       });
     }
 
-    dbQuery
-      .orderBy([
+    if (db.client.config.client === 'pg') {
+      // pg correctly orders by the column value and handling nulls in one go
+      dbQuery.orderBy([
         {
-          column: 'value',
+          column: 'search.value',
+          order: isFetchingBackwards
+            ? invertOrder(sortField.order)
+            : sortField.order,
+          nulls: 'last',
+        },
+        {
+          column: 'final_entities.entity_id',
+          order: isFetchingBackwards
+            ? invertOrder(sortField.order)
+            : sortField.order,
+        },
+      ]);
+    } else {
+      // sqlite and mysql translate the above statement ONLY into "order by (value is null) asc"
+      // no matter what the order is, for some reason, so we have to manually add back the statement
+      // that translates to "order by value <order>" while avoiding to give an order
+      dbQuery.orderBy([
+        {
+          column: 'search.value',
+          order: undefined,
+          nulls: 'last',
+        },
+        {
+          column: 'search.value',
           order: isFetchingBackwards
             ? invertOrder(sortField.order)
             : sortField.order,
         },
         {
-          column: 'search.entity_id',
+          column: 'final_entities.entity_id',
           order: isFetchingBackwards
             ? invertOrder(sortField.order)
             : sortField.order,
         },
-      ])
-      // fetch an extra item to check if there are more items.
-      .limit(isFetchingBackwards ? limit : limit + 1);
+      ]);
+    }
 
-    countQuery.count('search.entity_id', { as: 'count' });
+    // fetch an extra item to check if there are more items.
+    dbQuery.limit(isFetchingBackwards ? limit : limit + 1);
+
+    countQuery.count('final_entities.entity_id', { as: 'count' });
 
     const [rows, [{ count }]] = await Promise.all([
       limit > 0 ? dbQuery : [],


### PR DESCRIPTION
This release fixes two issues:

* The catalog by-query endpoint sorts properly on fields that do not exist for all entities in the result set
* The AWS ALB `signer` validation properly checks the signed header portion of the token
