### PR TITLE
add check reads among the default github app permissions

### DIFF
--- a/.changeset/green-worms-rescue.md
+++ b/.changeset/green-worms-rescue.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Add `checks: 'read'` for default GitHub app permissions

--- a/packages/cli/src/commands/create-github-app/GithubCreateAppServer.ts
+++ b/packages/cli/src/commands/create-github-app/GithubCreateAppServer.ts
@@ -114,10 +114,16 @@ export class GithubCreateAppServer {
       default_events: ['create', 'delete', 'push', 'repository'],
       default_permissions: {
         metadata: 'read',
-        ...(this.permissions.includes('members') && { members: 'read' }),
-        ...(this.permissions.includes('read') && { contents: 'read' }),
+        ...(this.permissions.includes('members') && {
+          members: 'read',
+        }),
+        ...(this.permissions.includes('read') && {
+          contents: 'read',
+          checks: 'read',
+        }),
         ...(this.permissions.includes('write') && {
           contents: 'write',
+          checks: 'read',
           actions: 'write',
         }),
       },

--- a/packages/cli/src/commands/create-github-app/index.ts
+++ b/packages/cli/src/commands/create-github-app/index.ts
@@ -22,6 +22,7 @@ import { paths } from '../../lib/paths';
 import { GithubCreateAppServer } from './GithubCreateAppServer';
 import fetch from 'node-fetch';
 import openBrowser from 'react-dev-utils/openBrowser';
+
 // This is an experimental command that at this point does not support GitHub Enterprise
 // due to lacking support for creating apps from manifests.
 // https://docs.github.com/en/free-pro-team@latest/developers/apps/creating-a-github-app-from-a-manifest


### PR DESCRIPTION
Fixes #24441

In all honesty I was a bit confused by the docs. Do you agree that this should be the correct default permission?