### PR TITLE
[Kubernetes] Skip start without config

### DIFF
--- a/.changeset/serious-spies-knock.md
+++ b/.changeset/serious-spies-knock.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Skip start without proper config

--- a/plugins/kubernetes-backend/src/plugin.ts
+++ b/plugins/kubernetes-backend/src/plugin.ts
@@ -40,6 +40,8 @@ import {
   type KubernetesServiceLocatorExtensionPoint,
 } from '@backstage/plugin-kubernetes-node';
 
+import Router from 'express-promise-router';
+
 class ObjectsProvider implements KubernetesObjectsProviderExtensionPoint {
   private objectsProvider: KubernetesObjectsProvider | undefined;
 
@@ -193,27 +195,33 @@ export const kubernetesPlugin = createBackendPlugin({
         auth,
         httpAuth,
       }) {
-        // TODO: expose all of the customization & extension points of the builder here
-        const builder: KubernetesBuilder = KubernetesBuilder.createBuilder({
-          logger,
-          config,
-          catalogApi,
-          permissions,
-          discovery,
-          auth,
-          httpAuth,
-        })
-          .setObjectsProvider(extPointObjectsProvider.getObjectsProvider())
-          .setClusterSupplier(extPointClusterSuplier.getClusterSupplier())
-          .setFetcher(extPointFetcher.getFetcher())
-          .setServiceLocator(extPointServiceLocator.getServiceLocator());
+        if (config.has('kubernetes')) {
+          // TODO: expose all of the customization & extension points of the builder here
+          const builder: KubernetesBuilder = KubernetesBuilder.createBuilder({
+            logger,
+            config,
+            catalogApi,
+            permissions,
+            discovery,
+            auth,
+            httpAuth,
+          })
+            .setObjectsProvider(extPointObjectsProvider.getObjectsProvider())
+            .setClusterSupplier(extPointClusterSuplier.getClusterSupplier())
+            .setFetcher(extPointFetcher.getFetcher())
+            .setServiceLocator(extPointServiceLocator.getServiceLocator());
 
-        AuthStrategy.addAuthStrategiesFromArray(
-          extPointAuthStrategy.getAuthenticationStrategies(),
-          builder,
-        );
-        const { router } = await builder.build();
-        http.use(router);
+          AuthStrategy.addAuthStrategiesFromArray(
+            extPointAuthStrategy.getAuthenticationStrategies(),
+            builder,
+          );
+          const { router } = await builder.build();
+          http.use(router);
+        } else {
+          logger.warn(
+            'Failed to initialize kubernetes backend: valid kubernetes config is missing',
+          );
+        }
       },
     });
   },

--- a/plugins/kubernetes-backend/src/plugin.ts
+++ b/plugins/kubernetes-backend/src/plugin.ts
@@ -40,8 +40,6 @@ import {
   type KubernetesServiceLocatorExtensionPoint,
 } from '@backstage/plugin-kubernetes-node';
 
-import Router from 'express-promise-router';
-
 class ObjectsProvider implements KubernetesObjectsProviderExtensionPoint {
   private objectsProvider: KubernetesObjectsProvider | undefined;
 

--- a/plugins/kubernetes-backend/src/service/KubernetesBuilder.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesBuilder.test.ts
@@ -728,6 +728,19 @@ metadata:
     const throwError = () =>
       startTestBackend({
         features: [
+          mockServices.rootConfig.factory({
+            data: {
+              kubernetes: {
+                serviceLocatorMethod: { type: 'multiTenant' },
+                clusterLocatorMethods: [
+                  {
+                    type: 'config',
+                    clusters: [],
+                  },
+                ],
+              },
+            },
+          }),
           import('@backstage/plugin-kubernetes-backend/alpha'),
           createBackendModule({
             pluginId: 'kubernetes',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This will skip starting up the Kubernetes plugin if the config is missing. This follows a similar pattern used by `search-backend-module-pg` and `search-backend-module-elasticsearch` for when expected config is not in place.

If you provide just `kubernetes:` in your `app-config.yaml` it won't start and logs the warning, if you provide a proper config such as this:

```yaml
kubernetes:
  serviceLocatorMethod:
    type: 'multiTenant'
  clusterLocatorMethods:
    - type: 'config'
      clusters: []
```

If will start up as expected.

Closes #26216

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
