### PR TITLE
[NBS 1.0] Use `mockErrorHandler` instead of `MiddlewareFactory` in tests

### DIFF
--- a/packages/backend-defaults/src/entrypoints/httpRouter/createCredentialsBarrier.test.ts
+++ b/packages/backend-defaults/src/entrypoints/httpRouter/createCredentialsBarrier.test.ts
@@ -19,13 +19,11 @@
 import express from 'express';
 import request from 'supertest';
 import { createCredentialsBarrier } from './createCredentialsBarrier';
-import { mockCredentials, mockServices } from '@backstage/backend-test-utils';
-import { MiddlewareFactory } from '../rootHttpRouter/http';
-
-const errorMiddleware = MiddlewareFactory.create({
-  config: mockServices.rootConfig(),
-  logger: mockServices.rootLogger(),
-}).error();
+import {
+  mockCredentials,
+  mockErrorHandler,
+  mockServices,
+} from '@backstage/backend-test-utils';
 
 function setup() {
   const barrier = createCredentialsBarrier({
@@ -37,7 +35,7 @@ function setup() {
 
   const app = express();
   app.use(barrier.middleware);
-  app.use(errorMiddleware);
+  app.use(mockErrorHandler());
   app.get('*', (_req, res) => res.status(200).end());
 
   return { app, barrier };

--- a/plugins/scaffolder-backend/src/service/router.test.ts
+++ b/plugins/scaffolder-backend/src/service/router.test.ts
@@ -44,9 +44,12 @@ import {
   AuthorizeResult,
   PermissionEvaluator,
 } from '@backstage/plugin-permission-common';
-import { mockCredentials, mockServices } from '@backstage/backend-test-utils';
+import {
+  mockCredentials,
+  mockErrorHandler,
+  mockServices,
+} from '@backstage/backend-test-utils';
 import { AutocompleteHandler } from '@backstage/plugin-scaffolder-node/alpha';
-import { MiddlewareFactory } from '@backstage/backend-defaults/rootHttpRouter';
 import { UrlReaders } from '@backstage/backend-defaults/urlReader';
 
 const mockAccess = jest.fn();
@@ -1501,8 +1504,6 @@ data: {"id":1,"taskId":"a-random-id","type":"completion","createdAt":"","body":{
           results: [{ title: 'blob' }],
         });
 
-        const logger = mockServices.logger.mock();
-        const middleware = MiddlewareFactory.create({ config, logger });
         const router = await createRouter({
           logger: loggerToWinstonLogger(mockServices.logger.mock()),
           config: new ConfigReader({}),
@@ -1519,7 +1520,7 @@ data: {"id":1,"taskId":"a-random-id","type":"completion","createdAt":"","body":{
           },
         });
 
-        app = express().use(router).use(middleware.error());
+        app = express().use(router).use(mockErrorHandler());
       });
 
       it('should throw an error when the provider is not registered', async () => {

--- a/plugins/search-backend/src/service/router.test.ts
+++ b/plugins/search-backend/src/service/router.test.ts
@@ -25,9 +25,12 @@ import request from 'supertest';
 import { createRouter } from './router';
 import { wrapInOpenApiTestServer } from '@backstage/backend-openapi-utils';
 import { Server } from 'http';
-import { mockCredentials, mockServices } from '@backstage/backend-test-utils';
+import {
+  mockCredentials,
+  mockErrorHandler,
+  mockServices,
+} from '@backstage/backend-test-utils';
 import { DiscoveryService } from '@backstage/backend-plugin-api';
-import { MiddlewareFactory } from '@backstage/backend-defaults/rootHttpRouter';
 
 const mockPermissionEvaluator: PermissionEvaluator = {
   authorize: () => {
@@ -84,11 +87,9 @@ describe('createRouter', () => {
       auth: mockServices.auth(),
       httpAuth: mockServices.httpAuth(),
     });
-    const errorHandler = MiddlewareFactory.create({
-      config: mockServices.rootConfig(),
-      logger: mockServices.rootLogger(),
-    }).error();
-    app = wrapInOpenApiTestServer(express().use(router).use(errorHandler));
+    app = wrapInOpenApiTestServer(
+      express().use(router).use(mockErrorHandler()),
+    );
   });
 
   beforeEach(() => {

--- a/plugins/signals-backend/src/service/router.test.ts
+++ b/plugins/signals-backend/src/service/router.test.ts
@@ -24,8 +24,7 @@ import {
   UserInfoService,
 } from '@backstage/backend-plugin-api';
 import { ConfigReader } from '@backstage/config';
-import { mockServices } from '@backstage/backend-test-utils';
-import { MiddlewareFactory } from '@backstage/backend-defaults/rootHttpRouter';
+import { mockErrorHandler, mockServices } from '@backstage/backend-test-utils';
 
 const eventsServiceMock: jest.Mocked<EventsService> = {
   subscribe: jest.fn(),
@@ -53,11 +52,7 @@ describe('createRouter', () => {
       config: new ConfigReader({}),
       auth: mockServices.auth(),
     });
-    const errorHandler = MiddlewareFactory.create({
-      config: mockServices.rootConfig(),
-      logger: mockServices.rootLogger(),
-    }).error();
-    app = express().use(router).use(errorHandler);
+    app = express().use(router).use(mockErrorHandler());
   });
 
   beforeEach(() => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

🧹 Use `mockErrorHandler` instead of `MiddlewareFactory` in tests.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
