### PR TITLE
add pg-format

### DIFF
--- a/.changeset/olive-phones-sniff.md
+++ b/.changeset/olive-phones-sniff.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Add `pg-format` as a dependency

--- a/packages/backend-common/package.json
+++ b/packages/backend-common/package.json
@@ -107,6 +107,7 @@
     "p-limit": "^3.1.0",
     "path-to-regexp": "^6.2.1",
     "pg": "^8.11.3",
+    "pg-format": "^1.0.4",
     "raw-body": "^2.4.1",
     "selfsigned": "^2.0.0",
     "stoppable": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3590,6 +3590,7 @@ __metadata:
     p-limit: ^3.1.0
     path-to-regexp: ^6.2.1
     pg: ^8.11.3
+    pg-format: ^1.0.4
     raw-body: ^2.4.1
     selfsigned: ^2.0.0
     stoppable: ^1.1.0


### PR DESCRIPTION
This fixes a problem where sometimes when you depend exclusively on backend-common, this dependency was not pulled in since the code lives in backend-defaults. Please migrate to [the new backend system](https://backstage.io/docs/backend-system/) if this happens to you.