### PR TITLE
Patch release of #26232

### DIFF
--- a/.changeset/olive-phones-sniff.md
+++ b/.changeset/olive-phones-sniff.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Add `pg-format` as a dependency

--- a/.changeset/olive-phones-sniff.md
+++ b/.changeset/olive-phones-sniff.md
@@ -1,5 +1,0 @@
----
-'@backstage/backend-common': patch
----
-
-Add `pg-format` as a dependency

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.30.3",
+  "version": "1.30.4",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/backend-app-api/CHANGELOG.md
+++ b/packages/backend-app-api/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage/backend-app-api
 
+## 0.9.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/plugin-permission-node@0.8.2
+  - @backstage/backend-plugin-api@0.8.1
+  - @backstage/cli-node@0.2.7
+  - @backstage/config-loader@1.9.0
+
 ## 0.9.2
 
 ### Patch Changes

--- a/packages/backend-app-api/package.json
+++ b/packages/backend-app-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/backend-app-api",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Core API used by Backstage backend apps",
   "backstage": {
     "role": "node-library"

--- a/packages/backend-common/CHANGELOG.md
+++ b/packages/backend-common/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/backend-common
 
+## 0.24.1
+
+### Patch Changes
+
+- a8f7034: Add `pg-format` as a dependency
+- Updated dependencies
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/backend-plugin-api@0.8.1
+  - @backstage/config-loader@1.9.0
+
 ## 0.24.0
 
 ### Minor Changes

--- a/packages/backend-common/package.json
+++ b/packages/backend-common/package.json
@@ -107,6 +107,7 @@
     "p-limit": "^3.1.0",
     "path-to-regexp": "^6.2.1",
     "pg": "^8.11.3",
+    "pg-format": "^1.0.4",
     "raw-body": "^2.4.1",
     "selfsigned": "^2.0.0",
     "stoppable": "^1.1.0",

--- a/packages/backend-common/package.json
+++ b/packages/backend-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/backend-common",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Common functionality library for Backstage backends",
   "backstage": {
     "role": "node-library"

--- a/packages/backend-defaults/CHANGELOG.md
+++ b/packages/backend-defaults/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage/backend-defaults
 
+## 0.4.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/backend-app-api@0.9.3
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/plugin-events-node@0.3.10
+  - @backstage/plugin-permission-node@0.8.2
+  - @backstage/backend-plugin-api@0.8.1
+  - @backstage/config-loader@1.9.0
+
 ## 0.4.3
 
 ### Patch Changes

--- a/packages/backend-defaults/package.json
+++ b/packages/backend-defaults/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/backend-defaults",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Backend defaults used by Backstage backend apps",
   "backstage": {
     "role": "node-library"

--- a/packages/backend-dynamic-feature-service/CHANGELOG.md
+++ b/packages/backend-dynamic-feature-service/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @backstage/backend-dynamic-feature-service
 
+## 0.3.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/backend-app-api@0.9.3
+  - @backstage/backend-defaults@0.4.4
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/plugin-catalog-backend@1.25.2
+  - @backstage/plugin-events-backend@0.3.11
+  - @backstage/plugin-events-node@0.3.10
+  - @backstage/plugin-permission-node@0.8.2
+  - @backstage/plugin-scaffolder-node@0.4.10
+  - @backstage/plugin-search-backend-node@1.3.1
+  - @backstage/backend-plugin-api@0.8.1
+  - @backstage/cli-node@0.2.7
+  - @backstage/config-loader@1.9.0
+  - @backstage/plugin-app-node@0.1.24
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/backend-dynamic-feature-service/package.json
+++ b/packages/backend-dynamic-feature-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/backend-dynamic-feature-service",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Backstage dynamic feature service",
   "backstage": {
     "role": "node-library"

--- a/packages/backend-legacy/CHANGELOG.md
+++ b/packages/backend-legacy/CHANGELOG.md
@@ -1,5 +1,42 @@
 # example-backend-legacy
 
+## 0.2.103
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/backend-defaults@0.4.4
+  - @backstage/plugin-app-backend@0.3.73
+  - @backstage/plugin-auth-backend@0.22.12
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/plugin-catalog-backend@1.25.2
+  - @backstage/plugin-catalog-backend-module-unprocessed@0.4.11
+  - @backstage/plugin-devtools-backend@0.3.10
+  - @backstage/plugin-events-backend@0.3.11
+  - @backstage/plugin-events-node@0.3.10
+  - @backstage/plugin-kubernetes-backend@0.18.5
+  - @backstage/plugin-permission-backend@0.5.48
+  - @backstage/plugin-permission-node@0.8.2
+  - @backstage/plugin-proxy-backend@0.5.5
+  - @backstage/plugin-scaffolder-backend@1.24.1
+  - @backstage/plugin-scaffolder-backend-module-confluence-to-markdown@0.2.25
+  - @backstage/plugin-scaffolder-backend-module-gitlab@0.4.6
+  - @backstage/plugin-scaffolder-backend-module-rails@0.4.41
+  - @backstage/plugin-search-backend@1.5.16
+  - @backstage/plugin-search-backend-module-catalog@0.2.1
+  - @backstage/plugin-search-backend-module-elasticsearch@1.5.5
+  - @backstage/plugin-search-backend-module-explore@0.2.1
+  - @backstage/plugin-search-backend-module-pg@0.5.34
+  - @backstage/plugin-search-backend-module-techdocs@0.2.1
+  - @backstage/plugin-search-backend-node@1.3.1
+  - @backstage/plugin-signals-backend@0.1.10
+  - @backstage/plugin-signals-node@0.1.10
+  - @backstage/plugin-techdocs-backend@1.10.12
+  - @backstage/backend-plugin-api@0.8.1
+  - @backstage/plugin-catalog-node@1.12.6
+  - @backstage/plugin-catalog-backend-module-scaffolder-entity-model@0.1.22
+
 ## 0.2.102
 
 ### Patch Changes

--- a/packages/backend-legacy/package.json
+++ b/packages/backend-legacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-backend-legacy",
-  "version": "0.2.102",
+  "version": "0.2.103",
   "backstage": {
     "role": "backend"
   },

--- a/packages/backend-openapi-utils/CHANGELOG.md
+++ b/packages/backend-openapi-utils/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/backend-openapi-utils
 
+## 0.1.17
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.1.16
 
 ### Patch Changes

--- a/packages/backend-openapi-utils/package.json
+++ b/packages/backend-openapi-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/backend-openapi-utils",
   "description": "OpenAPI typescript support.",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/packages/backend-plugin-api/CHANGELOG.md
+++ b/packages/backend-plugin-api/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/backend-plugin-api
 
+## 0.8.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-auth-node@0.5.1
+
 ## 0.8.0
 
 ### Minor Changes

--- a/packages/backend-plugin-api/package.json
+++ b/packages/backend-plugin-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/backend-plugin-api",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Core API used by Backstage backend plugins",
   "backstage": {
     "role": "node-library"

--- a/packages/backend-tasks/CHANGELOG.md
+++ b/packages/backend-tasks/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/backend-tasks
 
+## 0.6.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/backend-tasks/package.json
+++ b/packages/backend-tasks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/backend-tasks",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Common distributed task management library for Backstage backends",
   "backstage": {
     "role": "node-library"

--- a/packages/backend-test-utils/CHANGELOG.md
+++ b/packages/backend-test-utils/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage/backend-test-utils
 
+## 0.5.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-app-api@0.9.3
+  - @backstage/backend-defaults@0.4.4
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/plugin-events-node@0.3.10
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/backend-test-utils/package.json
+++ b/packages/backend-test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/backend-test-utils",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Test helpers library for Backstage backends",
   "backstage": {
     "role": "node-library"

--- a/packages/backend/CHANGELOG.md
+++ b/packages/backend/CHANGELOG.md
@@ -1,5 +1,39 @@
 # example-backend
 
+## 0.0.31
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-defaults@0.4.4
+  - @backstage/plugin-app-backend@0.3.73
+  - @backstage/plugin-auth-backend@0.22.12
+  - @backstage/plugin-auth-backend-module-guest-provider@0.1.10
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/plugin-catalog-backend@1.25.2
+  - @backstage/plugin-catalog-backend-module-openapi@0.1.43
+  - @backstage/plugin-catalog-backend-module-unprocessed@0.4.11
+  - @backstage/plugin-devtools-backend@0.3.10
+  - @backstage/plugin-kubernetes-backend@0.18.5
+  - @backstage/plugin-notifications-backend@0.3.5
+  - @backstage/plugin-permission-backend@0.5.48
+  - @backstage/plugin-permission-node@0.8.2
+  - @backstage/plugin-proxy-backend@0.5.5
+  - @backstage/plugin-scaffolder-backend@1.24.1
+  - @backstage/plugin-scaffolder-backend-module-github@0.4.2
+  - @backstage/plugin-search-backend@1.5.16
+  - @backstage/plugin-search-backend-module-catalog@0.2.1
+  - @backstage/plugin-search-backend-module-explore@0.2.1
+  - @backstage/plugin-search-backend-module-techdocs@0.2.1
+  - @backstage/plugin-search-backend-node@1.3.1
+  - @backstage/plugin-signals-backend@0.1.10
+  - @backstage/plugin-techdocs-backend@1.10.12
+  - @backstage/plugin-auth-backend-module-github-provider@0.1.21
+  - @backstage/backend-plugin-api@0.8.1
+  - @backstage/plugin-permission-backend-module-allow-all-policy@0.1.21
+  - @backstage/plugin-catalog-backend-module-scaffolder-entity-model@0.1.22
+  - @backstage/plugin-catalog-backend-module-backstage-openapi@0.3.1
+
 ## 0.0.30
 
 ### Patch Changes

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-backend",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/packages/repo-tools/CHANGELOG.md
+++ b/packages/repo-tools/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/repo-tools
 
+## 0.9.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-plugin-api@0.8.1
+  - @backstage/cli-node@0.2.7
+  - @backstage/config-loader@1.9.0
+
 ## 0.9.5
 
 ### Patch Changes

--- a/packages/repo-tools/package.json
+++ b/packages/repo-tools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/repo-tools",
   "description": "CLI for Backstage repo tooling ",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/techdocs-cli/CHANGELOG.md
+++ b/packages/techdocs-cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @techdocs/cli
 
+## 1.8.18
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-defaults@0.4.4
+  - @backstage/plugin-techdocs-node@1.12.10
+
 ## 1.8.17
 
 ### Patch Changes

--- a/packages/techdocs-cli/package.json
+++ b/packages/techdocs-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@techdocs/cli",
   "description": "Utility CLI for managing TechDocs sites in Backstage.",
-  "version": "1.8.17",
+  "version": "1.8.18",
   "publishConfig": {
     "access": "public"
   },

--- a/plugins/app-backend/CHANGELOG.md
+++ b/plugins/app-backend/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage/plugin-app-backend
 
+## 0.3.73
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/backend-plugin-api@0.8.1
+  - @backstage/config-loader@1.9.0
+  - @backstage/plugin-app-node@0.1.24
+
 ## 0.3.72
 
 ### Patch Changes

--- a/plugins/app-backend/package.json
+++ b/plugins/app-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-app-backend",
-  "version": "0.3.72",
+  "version": "0.3.73",
   "description": "A Backstage backend plugin that serves the Backstage frontend app",
   "backstage": {
     "role": "backend-plugin",

--- a/plugins/app-node/CHANGELOG.md
+++ b/plugins/app-node/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-app-node
 
+## 0.1.24
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-plugin-api@0.8.1
+  - @backstage/config-loader@1.9.0
+
 ## 0.1.23
 
 ### Patch Changes

--- a/plugins/app-node/package.json
+++ b/plugins/app-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-app-node",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "Node.js library for the app plugin",
   "backstage": {
     "role": "node-library",

--- a/plugins/auth-backend-module-atlassian-provider/CHANGELOG.md
+++ b/plugins/auth-backend-module-atlassian-provider/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-auth-backend-module-atlassian-provider
 
+## 0.2.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.2.4
 
 ### Patch Changes

--- a/plugins/auth-backend-module-atlassian-provider/package.json
+++ b/plugins/auth-backend-module-atlassian-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-auth-backend-module-atlassian-provider",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "The atlassian-provider backend module for the auth plugin.",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/auth-backend-module-aws-alb-provider/CHANGELOG.md
+++ b/plugins/auth-backend-module-aws-alb-provider/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/plugin-auth-backend-module-aws-alb-provider
 
+## 0.1.17
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-auth-backend@0.22.12
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.1.16
 
 ### Patch Changes

--- a/plugins/auth-backend-module-aws-alb-provider/package.json
+++ b/plugins/auth-backend-module-aws-alb-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-auth-backend-module-aws-alb-provider",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "The aws-alb provider module for the Backstage auth backend.",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/auth-backend-module-azure-easyauth-provider/CHANGELOG.md
+++ b/plugins/auth-backend-module-azure-easyauth-provider/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-auth-backend-module-azure-easyauth-provider
 
+## 0.1.7
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.1.6
 
 ### Patch Changes

--- a/plugins/auth-backend-module-azure-easyauth-provider/package.json
+++ b/plugins/auth-backend-module-azure-easyauth-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-auth-backend-module-azure-easyauth-provider",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "The azure-easyauth-provider backend module for the auth plugin.",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/auth-backend-module-bitbucket-provider/CHANGELOG.md
+++ b/plugins/auth-backend-module-bitbucket-provider/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-auth-backend-module-bitbucket-provider
 
+## 0.1.7
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.1.6
 
 ### Patch Changes

--- a/plugins/auth-backend-module-bitbucket-provider/package.json
+++ b/plugins/auth-backend-module-bitbucket-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-auth-backend-module-bitbucket-provider",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "The bitbucket-provider backend module for the auth plugin.",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/auth-backend-module-cloudflare-access-provider/CHANGELOG.md
+++ b/plugins/auth-backend-module-cloudflare-access-provider/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-auth-backend-module-cloudflare-access-provider
 
+## 0.2.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/plugins/auth-backend-module-cloudflare-access-provider/package.json
+++ b/plugins/auth-backend-module-cloudflare-access-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-auth-backend-module-cloudflare-access-provider",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "The cloudflare-access-provider backend module for the auth plugin.",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/auth-backend-module-gcp-iap-provider/CHANGELOG.md
+++ b/plugins/auth-backend-module-gcp-iap-provider/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-auth-backend-module-gcp-iap-provider
 
+## 0.2.19
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.2.18
 
 ### Patch Changes

--- a/plugins/auth-backend-module-gcp-iap-provider/package.json
+++ b/plugins/auth-backend-module-gcp-iap-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-auth-backend-module-gcp-iap-provider",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "description": "A GCP IAP auth provider module for the Backstage auth backend",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/auth-backend-module-github-provider/CHANGELOG.md
+++ b/plugins/auth-backend-module-github-provider/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-auth-backend-module-github-provider
 
+## 0.1.21
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.1.20
 
 ### Patch Changes

--- a/plugins/auth-backend-module-github-provider/package.json
+++ b/plugins/auth-backend-module-github-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-auth-backend-module-github-provider",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "The github-provider backend module for the auth plugin.",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/auth-backend-module-gitlab-provider/CHANGELOG.md
+++ b/plugins/auth-backend-module-gitlab-provider/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-auth-backend-module-gitlab-provider
 
+## 0.1.21
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.1.20
 
 ### Patch Changes

--- a/plugins/auth-backend-module-gitlab-provider/package.json
+++ b/plugins/auth-backend-module-gitlab-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-auth-backend-module-gitlab-provider",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "The gitlab-provider backend module for the auth plugin.",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/auth-backend-module-google-provider/CHANGELOG.md
+++ b/plugins/auth-backend-module-google-provider/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-auth-backend-module-google-provider
 
+## 0.1.21
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.1.20
 
 ### Patch Changes

--- a/plugins/auth-backend-module-google-provider/package.json
+++ b/plugins/auth-backend-module-google-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-auth-backend-module-google-provider",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "A Google auth provider module for the Backstage auth backend",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/auth-backend-module-guest-provider/CHANGELOG.md
+++ b/plugins/auth-backend-module-guest-provider/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-auth-backend-module-guest-provider
 
+## 0.1.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.1.9
 
 ### Patch Changes

--- a/plugins/auth-backend-module-guest-provider/package.json
+++ b/plugins/auth-backend-module-guest-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-auth-backend-module-guest-provider",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "The guest-provider backend module for the auth plugin.",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/auth-backend-module-microsoft-provider/CHANGELOG.md
+++ b/plugins/auth-backend-module-microsoft-provider/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-auth-backend-module-microsoft-provider
 
+## 0.1.19
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.1.18
 
 ### Patch Changes

--- a/plugins/auth-backend-module-microsoft-provider/package.json
+++ b/plugins/auth-backend-module-microsoft-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-auth-backend-module-microsoft-provider",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "The microsoft-provider backend module for the auth plugin.",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/auth-backend-module-oauth2-provider/CHANGELOG.md
+++ b/plugins/auth-backend-module-oauth2-provider/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-auth-backend-module-oauth2-provider
 
+## 0.2.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.2.4
 
 ### Patch Changes

--- a/plugins/auth-backend-module-oauth2-provider/package.json
+++ b/plugins/auth-backend-module-oauth2-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-auth-backend-module-oauth2-provider",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "The oauth2-provider backend module for the auth plugin.",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/auth-backend-module-oauth2-proxy-provider/CHANGELOG.md
+++ b/plugins/auth-backend-module-oauth2-proxy-provider/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-auth-backend-module-oauth2-proxy-provider
 
+## 0.1.17
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.1.16
 
 ### Patch Changes

--- a/plugins/auth-backend-module-oauth2-proxy-provider/package.json
+++ b/plugins/auth-backend-module-oauth2-proxy-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-auth-backend-module-oauth2-proxy-provider",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "The oauth2-proxy-provider backend module for the auth plugin.",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/auth-backend-module-oidc-provider/CHANGELOG.md
+++ b/plugins/auth-backend-module-oidc-provider/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/plugin-auth-backend-module-oidc-provider
 
+## 0.2.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-auth-backend@0.22.12
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.2.5
 
 ### Patch Changes

--- a/plugins/auth-backend-module-oidc-provider/package.json
+++ b/plugins/auth-backend-module-oidc-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-auth-backend-module-oidc-provider",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "The oidc-provider backend module for the auth plugin.",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/auth-backend-module-okta-provider/CHANGELOG.md
+++ b/plugins/auth-backend-module-okta-provider/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-auth-backend-module-okta-provider
 
+## 0.0.17
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.0.16
 
 ### Patch Changes

--- a/plugins/auth-backend-module-okta-provider/package.json
+++ b/plugins/auth-backend-module-okta-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-auth-backend-module-okta-provider",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "The okta-provider backend module for the auth plugin.",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/auth-backend-module-onelogin-provider/CHANGELOG.md
+++ b/plugins/auth-backend-module-onelogin-provider/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-auth-backend-module-onelogin-provider
 
+## 0.1.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.1.4
 
 ### Patch Changes

--- a/plugins/auth-backend-module-onelogin-provider/package.json
+++ b/plugins/auth-backend-module-onelogin-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-auth-backend-module-onelogin-provider",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "The onelogin-provider backend module for the auth plugin.",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/auth-backend-module-pinniped-provider/CHANGELOG.md
+++ b/plugins/auth-backend-module-pinniped-provider/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-auth-backend-module-pinniped-provider
 
+## 0.1.18
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.1.17
 
 ### Patch Changes

--- a/plugins/auth-backend-module-pinniped-provider/package.json
+++ b/plugins/auth-backend-module-pinniped-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-auth-backend-module-pinniped-provider",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "The pinniped-provider backend module for the auth plugin.",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/auth-backend-module-vmware-cloud-provider/CHANGELOG.md
+++ b/plugins/auth-backend-module-vmware-cloud-provider/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-auth-backend-module-vmware-cloud-provider
 
+## 0.2.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.2.4
 
 ### Patch Changes

--- a/plugins/auth-backend-module-vmware-cloud-provider/package.json
+++ b/plugins/auth-backend-module-vmware-cloud-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-auth-backend-module-vmware-cloud-provider",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "The vmware-cloud-provider backend module for the auth plugin.",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/auth-backend/CHANGELOG.md
+++ b/plugins/auth-backend/CHANGELOG.md
@@ -1,5 +1,30 @@
 # @backstage/plugin-auth-backend
 
+## 0.22.12
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-auth-backend-module-aws-alb-provider@0.1.17
+  - @backstage/plugin-auth-backend-module-oidc-provider@0.2.6
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/plugin-auth-backend-module-atlassian-provider@0.2.5
+  - @backstage/plugin-auth-backend-module-bitbucket-provider@0.1.7
+  - @backstage/plugin-auth-backend-module-cloudflare-access-provider@0.2.1
+  - @backstage/plugin-auth-backend-module-github-provider@0.1.21
+  - @backstage/plugin-auth-backend-module-gitlab-provider@0.1.21
+  - @backstage/plugin-auth-backend-module-microsoft-provider@0.1.19
+  - @backstage/plugin-auth-backend-module-oauth2-provider@0.2.5
+  - @backstage/plugin-auth-backend-module-okta-provider@0.0.17
+  - @backstage/plugin-auth-backend-module-onelogin-provider@0.1.5
+  - @backstage/plugin-auth-backend-module-azure-easyauth-provider@0.1.7
+  - @backstage/plugin-auth-backend-module-google-provider@0.1.21
+  - @backstage/backend-plugin-api@0.8.1
+  - @backstage/plugin-auth-backend-module-gcp-iap-provider@0.2.19
+  - @backstage/plugin-auth-backend-module-oauth2-proxy-provider@0.1.17
+  - @backstage/plugin-catalog-node@1.12.6
+
 ## 0.22.11
 
 ### Patch Changes

--- a/plugins/auth-backend/package.json
+++ b/plugins/auth-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-auth-backend",
-  "version": "0.22.11",
+  "version": "0.22.12",
   "description": "A Backstage backend plugin that handles authentication",
   "backstage": {
     "role": "backend-plugin",

--- a/plugins/auth-node/CHANGELOG.md
+++ b/plugins/auth-node/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-auth-node
 
+## 0.5.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.5.0
 
 ### Minor Changes

--- a/plugins/auth-node/package.json
+++ b/plugins/auth-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-auth-node",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "backstage": {
     "role": "node-library",
     "pluginId": "auth",

--- a/plugins/catalog-backend-module-aws/CHANGELOG.md
+++ b/plugins/catalog-backend-module-aws/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-catalog-backend-module-aws
 
+## 0.4.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-defaults@0.4.4
+  - @backstage/backend-plugin-api@0.8.1
+  - @backstage/plugin-catalog-node@1.12.6
+
 ## 0.4.0
 
 ### Minor Changes

--- a/plugins/catalog-backend-module-aws/package.json
+++ b/plugins/catalog-backend-module-aws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-aws",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A Backstage catalog backend module that helps integrate towards AWS",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/catalog-backend-module-azure/CHANGELOG.md
+++ b/plugins/catalog-backend-module-azure/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-catalog-backend-module-azure
 
+## 0.2.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-plugin-api@0.8.1
+  - @backstage/plugin-catalog-node@1.12.6
+
 ## 0.2.0
 
 ### Minor Changes

--- a/plugins/catalog-backend-module-azure/package.json
+++ b/plugins/catalog-backend-module-azure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-azure",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A Backstage catalog backend module that helps integrate towards Azure",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/catalog-backend-module-backstage-openapi/CHANGELOG.md
+++ b/plugins/catalog-backend-module-backstage-openapi/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-catalog-backend-module-backstage-openapi
 
+## 0.3.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-plugin-api@0.8.1
+  - @backstage/plugin-catalog-node@1.12.6
+  - @backstage/backend-openapi-utils@0.1.17
+
 ## 0.3.0
 
 ### Minor Changes

--- a/plugins/catalog-backend-module-backstage-openapi/package.json
+++ b/plugins/catalog-backend-module-backstage-openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-backstage-openapi",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "backstage": {
     "role": "backend-plugin-module",
     "pluginId": "catalog",

--- a/plugins/catalog-backend-module-bitbucket-cloud/CHANGELOG.md
+++ b/plugins/catalog-backend-module-bitbucket-cloud/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/plugin-catalog-backend-module-bitbucket-cloud
 
+## 0.3.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-events-node@0.3.10
+  - @backstage/backend-plugin-api@0.8.1
+  - @backstage/plugin-catalog-node@1.12.6
+
 ## 0.3.0
 
 ### Minor Changes

--- a/plugins/catalog-backend-module-bitbucket-cloud/package.json
+++ b/plugins/catalog-backend-module-bitbucket-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-bitbucket-cloud",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A Backstage catalog backend module that helps integrate towards Bitbucket Cloud",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/catalog-backend-module-bitbucket-server/CHANGELOG.md
+++ b/plugins/catalog-backend-module-bitbucket-server/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-catalog-backend-module-bitbucket-server
 
+## 0.2.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-plugin-api@0.8.1
+  - @backstage/plugin-catalog-node@1.12.6
+
 ## 0.2.0
 
 ### Minor Changes

--- a/plugins/catalog-backend-module-bitbucket-server/package.json
+++ b/plugins/catalog-backend-module-bitbucket-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-bitbucket-server",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "backstage": {
     "role": "backend-plugin-module",
     "pluginId": "catalog",

--- a/plugins/catalog-backend-module-gcp/CHANGELOG.md
+++ b/plugins/catalog-backend-module-gcp/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-catalog-backend-module-gcp
 
+## 0.2.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-plugin-api@0.8.1
+  - @backstage/plugin-catalog-node@1.12.6
+
 ## 0.2.0
 
 ### Minor Changes

--- a/plugins/catalog-backend-module-gcp/package.json
+++ b/plugins/catalog-backend-module-gcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-gcp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A Backstage catalog backend module that helps integrate towards GCP",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/catalog-backend-module-gerrit/CHANGELOG.md
+++ b/plugins/catalog-backend-module-gerrit/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-catalog-backend-module-gerrit
 
+## 0.2.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-plugin-api@0.8.1
+  - @backstage/plugin-catalog-node@1.12.6
+
 ## 0.2.0
 
 ### Minor Changes

--- a/plugins/catalog-backend-module-gerrit/package.json
+++ b/plugins/catalog-backend-module-gerrit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-gerrit",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "backstage": {
     "role": "backend-plugin-module",
     "pluginId": "catalog",

--- a/plugins/catalog-backend-module-github-org/CHANGELOG.md
+++ b/plugins/catalog-backend-module-github-org/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/plugin-catalog-backend-module-github-org
 
+## 0.2.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-backend-module-github@0.7.2
+  - @backstage/plugin-events-node@0.3.10
+  - @backstage/backend-plugin-api@0.8.1
+  - @backstage/plugin-catalog-node@1.12.6
+
 ## 0.2.1
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-github-org/package.json
+++ b/plugins/catalog-backend-module-github-org/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-github-org",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "The github-org backend module for the catalog plugin.",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/catalog-backend-module-github/CHANGELOG.md
+++ b/plugins/catalog-backend-module-github/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage/plugin-catalog-backend-module-github
 
+## 0.7.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-catalog-backend@1.25.2
+  - @backstage/plugin-events-node@0.3.10
+  - @backstage/backend-plugin-api@0.8.1
+  - @backstage/plugin-catalog-node@1.12.6
+
 ## 0.7.1
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-github/package.json
+++ b/plugins/catalog-backend-module-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-github",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "A Backstage catalog backend module that helps integrate towards GitHub",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/catalog-backend-module-gitlab-org/CHANGELOG.md
+++ b/plugins/catalog-backend-module-gitlab-org/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage/plugin-catalog-backend-module-gitlab-org
 
+## 0.1.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-catalog-backend-module-gitlab@0.4.1
+  - @backstage/plugin-events-node@0.3.10
+  - @backstage/backend-plugin-api@0.8.1
+  - @backstage/plugin-catalog-node@1.12.6
+
 ## 0.1.0
 
 ### Minor Changes

--- a/plugins/catalog-backend-module-gitlab-org/package.json
+++ b/plugins/catalog-backend-module-gitlab-org/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-gitlab-org",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "The gitlab-org backend module for the catalog plugin.",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/catalog-backend-module-gitlab/CHANGELOG.md
+++ b/plugins/catalog-backend-module-gitlab/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/plugin-catalog-backend-module-gitlab
 
+## 0.4.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-events-node@0.3.10
+  - @backstage/backend-plugin-api@0.8.1
+  - @backstage/plugin-catalog-node@1.12.6
+
 ## 0.4.0
 
 ### Minor Changes

--- a/plugins/catalog-backend-module-gitlab/package.json
+++ b/plugins/catalog-backend-module-gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-gitlab",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A Backstage catalog backend module that helps integrate towards GitLab",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/catalog-backend-module-incremental-ingestion/CHANGELOG.md
+++ b/plugins/catalog-backend-module-incremental-ingestion/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage/plugin-catalog-backend-module-incremental-ingestion
 
+## 0.5.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-catalog-backend@1.25.2
+  - @backstage/plugin-events-node@0.3.10
+  - @backstage/backend-plugin-api@0.8.1
+  - @backstage/plugin-catalog-node@1.12.6
+
 ## 0.5.1
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-incremental-ingestion/package.json
+++ b/plugins/catalog-backend-module-incremental-ingestion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-incremental-ingestion",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "An entity provider for streaming large asset sources into the catalog",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/catalog-backend-module-ldap/CHANGELOG.md
+++ b/plugins/catalog-backend-module-ldap/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-catalog-backend-module-ldap
 
+## 0.8.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-plugin-api@0.8.1
+  - @backstage/plugin-catalog-node@1.12.6
+
 ## 0.8.0
 
 ### Minor Changes

--- a/plugins/catalog-backend-module-ldap/package.json
+++ b/plugins/catalog-backend-module-ldap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-ldap",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "A Backstage catalog backend module that helps integrate towards LDAP",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/catalog-backend-module-logs/CHANGELOG.md
+++ b/plugins/catalog-backend-module-logs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-catalog-backend-module-logs
 
+## 0.0.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-backend@1.25.2
+  - @backstage/plugin-events-node@0.3.10
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.0.3
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-logs/package.json
+++ b/plugins/catalog-backend-module-logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-logs",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A module that subscribes to catalog releated events and logs them.",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/catalog-backend-module-msgraph/CHANGELOG.md
+++ b/plugins/catalog-backend-module-msgraph/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-catalog-backend-module-msgraph
 
+## 0.6.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-plugin-api@0.8.1
+  - @backstage/plugin-catalog-node@1.12.6
+
 ## 0.6.0
 
 ### Minor Changes

--- a/plugins/catalog-backend-module-msgraph/package.json
+++ b/plugins/catalog-backend-module-msgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-msgraph",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A Backstage catalog backend module that helps integrate towards Microsoft Graph",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/catalog-backend-module-openapi/CHANGELOG.md
+++ b/plugins/catalog-backend-module-openapi/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/plugin-catalog-backend-module-openapi
 
+## 0.1.43
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-catalog-backend@1.25.2
+  - @backstage/backend-plugin-api@0.8.1
+  - @backstage/plugin-catalog-node@1.12.6
+
 ## 0.1.42
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-openapi/package.json
+++ b/plugins/catalog-backend-module-openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-openapi",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "description": "A Backstage catalog backend module that helps with OpenAPI specifications",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/catalog-backend-module-puppetdb/CHANGELOG.md
+++ b/plugins/catalog-backend-module-puppetdb/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-catalog-backend-module-puppetdb
 
+## 0.2.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-plugin-api@0.8.1
+  - @backstage/plugin-catalog-node@1.12.6
+
 ## 0.2.0
 
 ### Minor Changes

--- a/plugins/catalog-backend-module-puppetdb/package.json
+++ b/plugins/catalog-backend-module-puppetdb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-puppetdb",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A Backstage catalog backend module that helps integrate towards PuppetDB",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/catalog-backend-module-scaffolder-entity-model/CHANGELOG.md
+++ b/plugins/catalog-backend-module-scaffolder-entity-model/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-catalog-backend-module-scaffolder-entity-model
 
+## 0.1.22
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-plugin-api@0.8.1
+  - @backstage/plugin-catalog-node@1.12.6
+
 ## 0.1.21
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-scaffolder-entity-model/package.json
+++ b/plugins/catalog-backend-module-scaffolder-entity-model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-scaffolder-entity-model",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "Adds support for the scaffolder specific entity model (e.g. the Template kind) to the catalog backend plugin.",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/catalog-backend-module-unprocessed/CHANGELOG.md
+++ b/plugins/catalog-backend-module-unprocessed/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/plugin-catalog-backend-module-unprocessed
 
+## 0.4.11
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/backend-plugin-api@0.8.1
+  - @backstage/plugin-catalog-node@1.12.6
+
 ## 0.4.10
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-unprocessed/package.json
+++ b/plugins/catalog-backend-module-unprocessed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-unprocessed",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "description": "Backstage Catalog module to view unprocessed entities",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/catalog-backend/CHANGELOG.md
+++ b/plugins/catalog-backend/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage/plugin-catalog-backend
 
+## 1.25.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-events-node@0.3.10
+  - @backstage/plugin-permission-node@0.8.2
+  - @backstage/plugin-search-backend-module-catalog@0.2.1
+  - @backstage/backend-plugin-api@0.8.1
+  - @backstage/plugin-catalog-node@1.12.6
+  - @backstage/backend-openapi-utils@0.1.17
+
 ## 1.25.1
 
 ### Patch Changes

--- a/plugins/catalog-backend/package.json
+++ b/plugins/catalog-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend",
-  "version": "1.25.1",
+  "version": "1.25.2",
   "description": "The Backstage backend plugin that provides the Backstage catalog",
   "backstage": {
     "role": "backend-plugin",

--- a/plugins/catalog-node/CHANGELOG.md
+++ b/plugins/catalog-node/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-catalog-node
 
+## 1.12.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-permission-node@0.8.2
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 1.12.5
 
 ### Patch Changes

--- a/plugins/catalog-node/package.json
+++ b/plugins/catalog-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-node",
-  "version": "1.12.5",
+  "version": "1.12.6",
   "description": "The plugin-catalog-node module for @backstage/plugin-catalog-backend",
   "backstage": {
     "role": "node-library",

--- a/plugins/devtools-backend/CHANGELOG.md
+++ b/plugins/devtools-backend/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/plugin-devtools-backend
 
+## 0.3.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-permission-node@0.8.2
+  - @backstage/backend-plugin-api@0.8.1
+  - @backstage/config-loader@1.9.0
+
 ## 0.3.9
 
 ### Patch Changes

--- a/plugins/devtools-backend/package.json
+++ b/plugins/devtools-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-devtools-backend",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "devtools",

--- a/plugins/events-backend-module-aws-sqs/CHANGELOG.md
+++ b/plugins/events-backend-module-aws-sqs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-events-backend-module-aws-sqs
 
+## 0.4.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-events-node@0.3.10
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.4.0
 
 ### Minor Changes

--- a/plugins/events-backend-module-aws-sqs/package.json
+++ b/plugins/events-backend-module-aws-sqs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-events-backend-module-aws-sqs",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "backstage": {
     "role": "backend-plugin-module",
     "pluginId": "events",

--- a/plugins/events-backend-module-azure/CHANGELOG.md
+++ b/plugins/events-backend-module-azure/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-events-backend-module-azure
 
+## 0.2.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-events-node@0.3.10
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.2.9
 
 ### Patch Changes

--- a/plugins/events-backend-module-azure/package.json
+++ b/plugins/events-backend-module-azure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-events-backend-module-azure",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "backstage": {
     "role": "backend-plugin-module",
     "pluginId": "events",

--- a/plugins/events-backend-module-bitbucket-cloud/CHANGELOG.md
+++ b/plugins/events-backend-module-bitbucket-cloud/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-events-backend-module-bitbucket-cloud
 
+## 0.2.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-events-node@0.3.10
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.2.9
 
 ### Patch Changes

--- a/plugins/events-backend-module-bitbucket-cloud/package.json
+++ b/plugins/events-backend-module-bitbucket-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-events-backend-module-bitbucket-cloud",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "backstage": {
     "role": "backend-plugin-module",
     "pluginId": "events",

--- a/plugins/events-backend-module-gerrit/CHANGELOG.md
+++ b/plugins/events-backend-module-gerrit/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-events-backend-module-gerrit
 
+## 0.2.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-events-node@0.3.10
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.2.9
 
 ### Patch Changes

--- a/plugins/events-backend-module-gerrit/package.json
+++ b/plugins/events-backend-module-gerrit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-events-backend-module-gerrit",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "backstage": {
     "role": "backend-plugin-module",
     "pluginId": "events",

--- a/plugins/events-backend-module-github/CHANGELOG.md
+++ b/plugins/events-backend-module-github/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-events-backend-module-github
 
+## 0.2.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-events-node@0.3.10
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.2.9
 
 ### Patch Changes

--- a/plugins/events-backend-module-github/package.json
+++ b/plugins/events-backend-module-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-events-backend-module-github",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "backstage": {
     "role": "backend-plugin-module",
     "pluginId": "events",

--- a/plugins/events-backend-module-gitlab/CHANGELOG.md
+++ b/plugins/events-backend-module-gitlab/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-events-backend-module-gitlab
 
+## 0.2.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-events-node@0.3.10
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.2.9
 
 ### Patch Changes

--- a/plugins/events-backend-module-gitlab/package.json
+++ b/plugins/events-backend-module-gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-events-backend-module-gitlab",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "backstage": {
     "role": "backend-plugin-module",
     "pluginId": "events",

--- a/plugins/events-backend-test-utils/CHANGELOG.md
+++ b/plugins/events-backend-test-utils/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-events-backend-test-utils
 
+## 0.1.34
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-events-node@0.3.10
+
 ## 0.1.33
 
 ### Patch Changes

--- a/plugins/events-backend-test-utils/package.json
+++ b/plugins/events-backend-test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-events-backend-test-utils",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "description": "The plugin-events-backend-test-utils for @backstage/plugin-events-node",
   "backstage": {
     "role": "node-library",

--- a/plugins/events-backend/CHANGELOG.md
+++ b/plugins/events-backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-events-backend
 
+## 0.3.11
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-events-node@0.3.10
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.3.10
 
 ### Patch Changes

--- a/plugins/events-backend/package.json
+++ b/plugins/events-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-events-backend",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "events",

--- a/plugins/events-node/CHANGELOG.md
+++ b/plugins/events-node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-events-node
 
+## 0.3.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.3.9
 
 ### Patch Changes

--- a/plugins/events-node/package.json
+++ b/plugins/events-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-events-node",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "The plugin-events-node module for @backstage/plugin-events-backend",
   "backstage": {
     "role": "node-library",

--- a/plugins/example-todo-list-backend/CHANGELOG.md
+++ b/plugins/example-todo-list-backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @internal/plugin-todo-list-backend
 
+## 1.0.31
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 1.0.30
 
 ### Patch Changes

--- a/plugins/example-todo-list-backend/package.json
+++ b/plugins/example-todo-list-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internal/plugin-todo-list-backend",
-  "version": "1.0.30",
+  "version": "1.0.31",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "todo-list",

--- a/plugins/kubernetes-backend/CHANGELOG.md
+++ b/plugins/kubernetes-backend/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage/plugin-kubernetes-backend
 
+## 0.18.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/plugin-kubernetes-node@0.1.18
+  - @backstage/plugin-permission-node@0.8.2
+  - @backstage/backend-plugin-api@0.8.1
+  - @backstage/plugin-catalog-node@1.12.6
+
 ## 0.18.4
 
 ### Patch Changes

--- a/plugins/kubernetes-backend/package.json
+++ b/plugins/kubernetes-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-kubernetes-backend",
-  "version": "0.18.4",
+  "version": "0.18.5",
   "description": "A Backstage backend plugin that integrates towards Kubernetes",
   "backstage": {
     "role": "backend-plugin",

--- a/plugins/kubernetes-node/CHANGELOG.md
+++ b/plugins/kubernetes-node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-kubernetes-node
 
+## 0.1.18
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.1.17
 
 ### Patch Changes

--- a/plugins/kubernetes-node/package.json
+++ b/plugins/kubernetes-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-kubernetes-node",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Node.js library for the kubernetes plugin",
   "backstage": {
     "role": "node-library",

--- a/plugins/notifications-backend-module-email/CHANGELOG.md
+++ b/plugins/notifications-backend-module-email/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-notifications-backend-module-email
 
+## 0.2.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-notifications-node@0.2.5
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/plugins/notifications-backend-module-email/package.json
+++ b/plugins/notifications-backend-module-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-notifications-backend-module-email",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "The email backend module for the notifications plugin.",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/notifications-backend/CHANGELOG.md
+++ b/plugins/notifications-backend/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage/plugin-notifications-backend
 
+## 0.3.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/plugin-events-node@0.3.10
+  - @backstage/plugin-notifications-node@0.2.5
+  - @backstage/plugin-signals-node@0.1.10
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.3.4
 
 ### Patch Changes

--- a/plugins/notifications-backend/package.json
+++ b/plugins/notifications-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-notifications-backend",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "notifications",

--- a/plugins/notifications-node/CHANGELOG.md
+++ b/plugins/notifications-node/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-notifications-node
 
+## 0.2.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-signals-node@0.1.10
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.2.4
 
 ### Patch Changes

--- a/plugins/notifications-node/package.json
+++ b/plugins/notifications-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-notifications-node",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Node.js library for the notifications plugin",
   "backstage": {
     "role": "node-library",

--- a/plugins/permission-backend-module-policy-allow-all/CHANGELOG.md
+++ b/plugins/permission-backend-module-policy-allow-all/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-permission-backend-module-allow-all-policy
 
+## 0.1.21
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/plugin-permission-node@0.8.2
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.1.20
 
 ### Patch Changes

--- a/plugins/permission-backend-module-policy-allow-all/package.json
+++ b/plugins/permission-backend-module-policy-allow-all/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-permission-backend-module-allow-all-policy",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "Allow all policy backend module for the permission plugin.",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/permission-backend/CHANGELOG.md
+++ b/plugins/permission-backend/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/plugin-permission-backend
 
+## 0.5.48
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/plugin-permission-node@0.8.2
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.5.47
 
 ### Patch Changes

--- a/plugins/permission-backend/package.json
+++ b/plugins/permission-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-permission-backend",
-  "version": "0.5.47",
+  "version": "0.5.48",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "permission",

--- a/plugins/permission-node/CHANGELOG.md
+++ b/plugins/permission-node/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-permission-node
 
+## 0.8.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.8.1
 
 ### Patch Changes

--- a/plugins/permission-node/package.json
+++ b/plugins/permission-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-permission-node",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Common permission and authorization utilities for backend plugins",
   "backstage": {
     "role": "node-library",

--- a/plugins/proxy-backend/CHANGELOG.md
+++ b/plugins/proxy-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-proxy-backend
 
+## 0.5.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.5.4
 
 ### Patch Changes

--- a/plugins/proxy-backend/package.json
+++ b/plugins/proxy-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-proxy-backend",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "A Backstage backend plugin that helps you set up proxy endpoints in the backend",
   "backstage": {
     "role": "backend-plugin",

--- a/plugins/scaffolder-backend-module-azure/CHANGELOG.md
+++ b/plugins/scaffolder-backend-module-azure/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-scaffolder-backend-module-azure
 
+## 0.1.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-scaffolder-node@0.4.10
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.1.15
 
 ### Patch Changes

--- a/plugins/scaffolder-backend-module-azure/package.json
+++ b/plugins/scaffolder-backend-module-azure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-scaffolder-backend-module-azure",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "The azure module for @backstage/plugin-scaffolder-backend",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/CHANGELOG.md
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-scaffolder-backend-module-bitbucket-cloud
 
+## 0.1.14
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-scaffolder-node@0.4.10
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.1.13
 
 ### Patch Changes

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/package.json
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "The Bitbucket Cloud module for @backstage/plugin-scaffolder-backend",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/scaffolder-backend-module-bitbucket-server/CHANGELOG.md
+++ b/plugins/scaffolder-backend-module-bitbucket-server/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-scaffolder-backend-module-bitbucket-server
 
+## 0.1.14
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-scaffolder-node@0.4.10
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.1.13
 
 ### Patch Changes

--- a/plugins/scaffolder-backend-module-bitbucket-server/package.json
+++ b/plugins/scaffolder-backend-module-bitbucket-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-scaffolder-backend-module-bitbucket-server",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "The Bitbucket Server module for @backstage/plugin-scaffolder-backend",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/scaffolder-backend-module-bitbucket/CHANGELOG.md
+++ b/plugins/scaffolder-backend-module-bitbucket/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/plugin-scaffolder-backend-module-bitbucket
 
+## 0.2.14
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-scaffolder-node@0.4.10
+  - @backstage/backend-plugin-api@0.8.1
+  - @backstage/plugin-scaffolder-backend-module-bitbucket-cloud@0.1.14
+  - @backstage/plugin-scaffolder-backend-module-bitbucket-server@0.1.14
+
 ## 0.2.13
 
 ### Patch Changes

--- a/plugins/scaffolder-backend-module-bitbucket/package.json
+++ b/plugins/scaffolder-backend-module-bitbucket/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-scaffolder-backend-module-bitbucket",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "The bitbucket module for @backstage/plugin-scaffolder-backend",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/scaffolder-backend-module-confluence-to-markdown/CHANGELOG.md
+++ b/plugins/scaffolder-backend-module-confluence-to-markdown/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-scaffolder-backend-module-confluence-to-markdown
 
+## 0.2.25
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-scaffolder-node@0.4.10
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.2.24
 
 ### Patch Changes

--- a/plugins/scaffolder-backend-module-confluence-to-markdown/package.json
+++ b/plugins/scaffolder-backend-module-confluence-to-markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-scaffolder-backend-module-confluence-to-markdown",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "description": "The confluence-to-markdown module for @backstage/plugin-scaffolder-backend",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/scaffolder-backend-module-cookiecutter/CHANGELOG.md
+++ b/plugins/scaffolder-backend-module-cookiecutter/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/plugin-scaffolder-backend-module-cookiecutter
 
+## 0.2.48
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/backend-defaults@0.4.4
+  - @backstage/plugin-scaffolder-node@0.4.10
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.2.47
 
 ### Patch Changes

--- a/plugins/scaffolder-backend-module-cookiecutter/package.json
+++ b/plugins/scaffolder-backend-module-cookiecutter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-scaffolder-backend-module-cookiecutter",
-  "version": "0.2.47",
+  "version": "0.2.48",
   "description": "A module for the scaffolder backend that lets you template projects using cookiecutter",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/scaffolder-backend-module-gcp/CHANGELOG.md
+++ b/plugins/scaffolder-backend-module-gcp/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-scaffolder-backend-module-gcp
 
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-scaffolder-node@0.4.10
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.1.1
 
 ### Patch Changes

--- a/plugins/scaffolder-backend-module-gcp/package.json
+++ b/plugins/scaffolder-backend-module-gcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-scaffolder-backend-module-gcp",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "The GCP Bucket module for @backstage/plugin-scaffolder-backend",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/scaffolder-backend-module-gerrit/CHANGELOG.md
+++ b/plugins/scaffolder-backend-module-gerrit/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-scaffolder-backend-module-gerrit
 
+## 0.1.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-scaffolder-node@0.4.10
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.1.15
 
 ### Patch Changes

--- a/plugins/scaffolder-backend-module-gerrit/package.json
+++ b/plugins/scaffolder-backend-module-gerrit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-scaffolder-backend-module-gerrit",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "The gerrit module for @backstage/plugin-scaffolder-backend",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/scaffolder-backend-module-gitea/CHANGELOG.md
+++ b/plugins/scaffolder-backend-module-gitea/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-scaffolder-backend-module-gitea
 
+## 0.1.14
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-scaffolder-node@0.4.10
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.1.13
 
 ### Patch Changes

--- a/plugins/scaffolder-backend-module-gitea/package.json
+++ b/plugins/scaffolder-backend-module-gitea/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-scaffolder-backend-module-gitea",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "The gitea module for @backstage/plugin-scaffolder-backend",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/scaffolder-backend-module-github/CHANGELOG.md
+++ b/plugins/scaffolder-backend-module-github/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-scaffolder-backend-module-github
 
+## 0.4.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-scaffolder-node@0.4.10
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.4.1
 
 ### Patch Changes

--- a/plugins/scaffolder-backend-module-github/package.json
+++ b/plugins/scaffolder-backend-module-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-scaffolder-backend-module-github",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "The github module for @backstage/plugin-scaffolder-backend",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/scaffolder-backend-module-gitlab/CHANGELOG.md
+++ b/plugins/scaffolder-backend-module-gitlab/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-scaffolder-backend-module-gitlab
 
+## 0.4.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-scaffolder-node@0.4.10
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.4.5
 
 ### Patch Changes

--- a/plugins/scaffolder-backend-module-gitlab/package.json
+++ b/plugins/scaffolder-backend-module-gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-scaffolder-backend-module-gitlab",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "backstage": {
     "role": "backend-plugin-module",
     "pluginId": "scaffolder",

--- a/plugins/scaffolder-backend-module-notifications/CHANGELOG.md
+++ b/plugins/scaffolder-backend-module-notifications/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/plugin-scaffolder-backend-module-notifications
 
+## 0.0.7
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-notifications-node@0.2.5
+  - @backstage/plugin-scaffolder-node@0.4.10
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.0.6
 
 ### Patch Changes

--- a/plugins/scaffolder-backend-module-notifications/package.json
+++ b/plugins/scaffolder-backend-module-notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-scaffolder-backend-module-notifications",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "The notifications backend module for the scaffolder plugin.",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/scaffolder-backend-module-rails/CHANGELOG.md
+++ b/plugins/scaffolder-backend-module-rails/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-scaffolder-backend-module-rails
 
+## 0.4.41
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-scaffolder-node@0.4.10
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.4.40
 
 ### Patch Changes

--- a/plugins/scaffolder-backend-module-rails/package.json
+++ b/plugins/scaffolder-backend-module-rails/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-scaffolder-backend-module-rails",
-  "version": "0.4.40",
+  "version": "0.4.41",
   "description": "A module for the scaffolder backend that lets you template projects using Rails",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/scaffolder-backend-module-sentry/CHANGELOG.md
+++ b/plugins/scaffolder-backend-module-sentry/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-scaffolder-backend-module-sentry
 
+## 0.1.32
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-scaffolder-node@0.4.10
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.1.31
 
 ### Patch Changes

--- a/plugins/scaffolder-backend-module-sentry/package.json
+++ b/plugins/scaffolder-backend-module-sentry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-scaffolder-backend-module-sentry",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "backstage": {
     "role": "backend-plugin-module",
     "pluginId": "scaffolder",

--- a/plugins/scaffolder-backend-module-yeoman/CHANGELOG.md
+++ b/plugins/scaffolder-backend-module-yeoman/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-scaffolder-backend-module-yeoman
 
+## 0.3.8
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-scaffolder-node@0.4.10
+  - @backstage/plugin-scaffolder-node-test-utils@0.1.11
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.3.7
 
 ### Patch Changes

--- a/plugins/scaffolder-backend-module-yeoman/package.json
+++ b/plugins/scaffolder-backend-module-yeoman/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-scaffolder-backend-module-yeoman",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "backstage": {
     "role": "backend-plugin-module",
     "pluginId": "scaffolder",

--- a/plugins/scaffolder-backend/CHANGELOG.md
+++ b/plugins/scaffolder-backend/CHANGELOG.md
@@ -1,5 +1,27 @@
 # @backstage/plugin-scaffolder-backend
 
+## 1.24.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/backend-defaults@0.4.4
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/plugin-permission-node@0.8.2
+  - @backstage/plugin-scaffolder-backend-module-github@0.4.2
+  - @backstage/plugin-scaffolder-backend-module-gitlab@0.4.6
+  - @backstage/plugin-scaffolder-node@0.4.10
+  - @backstage/backend-plugin-api@0.8.1
+  - @backstage/plugin-catalog-node@1.12.6
+  - @backstage/plugin-scaffolder-backend-module-azure@0.1.16
+  - @backstage/plugin-scaffolder-backend-module-bitbucket@0.2.14
+  - @backstage/plugin-scaffolder-backend-module-bitbucket-cloud@0.1.14
+  - @backstage/plugin-scaffolder-backend-module-bitbucket-server@0.1.14
+  - @backstage/plugin-scaffolder-backend-module-gerrit@0.1.16
+  - @backstage/plugin-scaffolder-backend-module-gitea@0.1.14
+  - @backstage/plugin-catalog-backend-module-scaffolder-entity-model@0.1.22
+
 ## 1.24.0
 
 ### Minor Changes

--- a/plugins/scaffolder-backend/package.json
+++ b/plugins/scaffolder-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-scaffolder-backend",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "description": "The Backstage backend plugin that helps you create new things",
   "backstage": {
     "role": "backend-plugin",

--- a/plugins/scaffolder-node-test-utils/CHANGELOG.md
+++ b/plugins/scaffolder-node-test-utils/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-scaffolder-node-test-utils
 
+## 0.1.11
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-scaffolder-node@0.4.10
+  - @backstage/backend-test-utils@0.5.1
+
 ## 0.1.10
 
 ### Patch Changes

--- a/plugins/scaffolder-node-test-utils/package.json
+++ b/plugins/scaffolder-node-test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-scaffolder-node-test-utils",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "backstage": {
     "role": "node-library",
     "pluginId": "scaffolder",

--- a/plugins/scaffolder-node/CHANGELOG.md
+++ b/plugins/scaffolder-node/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-scaffolder-node
 
+## 0.4.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.4.9
 
 ### Patch Changes

--- a/plugins/scaffolder-node/package.json
+++ b/plugins/scaffolder-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-scaffolder-node",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "The plugin-scaffolder-node module for @backstage/plugin-scaffolder-backend",
   "backstage": {
     "role": "node-library",

--- a/plugins/search-backend-module-catalog/CHANGELOG.md
+++ b/plugins/search-backend-module-catalog/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/plugin-search-backend-module-catalog
 
+## 0.2.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-search-backend-node@1.3.1
+  - @backstage/backend-plugin-api@0.8.1
+  - @backstage/plugin-catalog-node@1.12.6
+
 ## 0.2.0
 
 ### Minor Changes

--- a/plugins/search-backend-module-catalog/package.json
+++ b/plugins/search-backend-module-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-search-backend-module-catalog",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A module for the search backend that exports catalog modules",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/search-backend-module-elasticsearch/CHANGELOG.md
+++ b/plugins/search-backend-module-elasticsearch/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-search-backend-module-elasticsearch
 
+## 1.5.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-search-backend-node@1.3.1
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 1.5.4
 
 ### Patch Changes

--- a/plugins/search-backend-module-elasticsearch/package.json
+++ b/plugins/search-backend-module-elasticsearch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-search-backend-module-elasticsearch",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "A module for the search backend that implements search using ElasticSearch",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/search-backend-module-explore/CHANGELOG.md
+++ b/plugins/search-backend-module-explore/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-search-backend-module-explore
 
+## 0.2.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-search-backend-node@1.3.1
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/plugins/search-backend-module-explore/package.json
+++ b/plugins/search-backend-module-explore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-search-backend-module-explore",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A module for the search backend that exports explore modules",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/search-backend-module-pg/CHANGELOG.md
+++ b/plugins/search-backend-module-pg/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-search-backend-module-pg
 
+## 0.5.34
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-search-backend-node@1.3.1
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.5.33
 
 ### Patch Changes

--- a/plugins/search-backend-module-pg/package.json
+++ b/plugins/search-backend-module-pg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-search-backend-module-pg",
-  "version": "0.5.33",
+  "version": "0.5.34",
   "description": "A module for the search backend that implements search using PostgreSQL",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/search-backend-module-stack-overflow-collator/CHANGELOG.md
+++ b/plugins/search-backend-module-stack-overflow-collator/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-search-backend-module-stack-overflow-collator
 
+## 0.2.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-search-backend-node@1.3.1
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/plugins/search-backend-module-stack-overflow-collator/package.json
+++ b/plugins/search-backend-module-stack-overflow-collator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-search-backend-module-stack-overflow-collator",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A module for the search backend that exports stack overflow modules",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/search-backend-module-techdocs/CHANGELOG.md
+++ b/plugins/search-backend-module-techdocs/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage/plugin-search-backend-module-techdocs
 
+## 0.2.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-search-backend-node@1.3.1
+  - @backstage/plugin-techdocs-node@1.12.10
+  - @backstage/backend-plugin-api@0.8.1
+  - @backstage/plugin-catalog-node@1.12.6
+
 ## 0.2.0
 
 ### Minor Changes

--- a/plugins/search-backend-module-techdocs/package.json
+++ b/plugins/search-backend-module-techdocs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-search-backend-module-techdocs",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A module for the search backend that exports techdocs modules",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/search-backend-node/CHANGELOG.md
+++ b/plugins/search-backend-node/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-search-backend-node
 
+## 1.3.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-defaults@0.4.4
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 1.3.0
 
 ### Minor Changes

--- a/plugins/search-backend-node/package.json
+++ b/plugins/search-backend-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-search-backend-node",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A library for Backstage backend plugins that want to interact with the search backend plugin",
   "backstage": {
     "role": "node-library",

--- a/plugins/search-backend/CHANGELOG.md
+++ b/plugins/search-backend/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage/plugin-search-backend
 
+## 1.5.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/backend-defaults@0.4.4
+  - @backstage/plugin-permission-node@0.8.2
+  - @backstage/plugin-search-backend-node@1.3.1
+  - @backstage/backend-plugin-api@0.8.1
+  - @backstage/backend-openapi-utils@0.1.17
+
 ## 1.5.15
 
 ### Patch Changes

--- a/plugins/search-backend/package.json
+++ b/plugins/search-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-search-backend",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "description": "The Backstage backend plugin that provides your backstage app with search",
   "backstage": {
     "role": "backend-plugin",

--- a/plugins/signals-backend/CHANGELOG.md
+++ b/plugins/signals-backend/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage/plugin-signals-backend
 
+## 0.1.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/plugin-events-node@0.3.10
+  - @backstage/plugin-signals-node@0.1.10
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.1.9
 
 ### Patch Changes

--- a/plugins/signals-backend/package.json
+++ b/plugins/signals-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-signals-backend",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "signals",

--- a/plugins/signals-node/CHANGELOG.md
+++ b/plugins/signals-node/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/plugin-signals-node
 
+## 0.1.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/plugin-events-node@0.3.10
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.1.9
 
 ### Patch Changes

--- a/plugins/signals-node/package.json
+++ b/plugins/signals-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-signals-node",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Node.js library for the signals plugin",
   "backstage": {
     "role": "node-library",

--- a/plugins/techdocs-backend/CHANGELOG.md
+++ b/plugins/techdocs-backend/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/plugin-techdocs-backend
 
+## 1.10.12
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-search-backend-module-techdocs@0.2.1
+  - @backstage/plugin-techdocs-node@1.12.10
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 1.10.11
 
 ### Patch Changes

--- a/plugins/techdocs-backend/package.json
+++ b/plugins/techdocs-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-techdocs-backend",
-  "version": "1.10.11",
+  "version": "1.10.12",
   "description": "The Backstage backend plugin that renders technical documentation for your components",
   "backstage": {
     "role": "backend-plugin",

--- a/plugins/techdocs-node/CHANGELOG.md
+++ b/plugins/techdocs-node/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-techdocs-node
 
+## 1.12.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 1.12.9
 
 ### Patch Changes

--- a/plugins/techdocs-node/package.json
+++ b/plugins/techdocs-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-techdocs-node",
-  "version": "1.12.9",
+  "version": "1.12.10",
   "description": "Common node.js functionalities for TechDocs, to be shared between techdocs-backend plugin and techdocs-cli",
   "backstage": {
     "role": "node-library",

--- a/plugins/user-settings-backend/CHANGELOG.md
+++ b/plugins/user-settings-backend/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/plugin-user-settings-backend
 
+## 0.2.23
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-common@0.24.1
+  - @backstage/plugin-auth-node@0.5.1
+  - @backstage/plugin-signals-node@0.1.10
+  - @backstage/backend-plugin-api@0.8.1
+
 ## 0.2.22
 
 ### Patch Changes

--- a/plugins/user-settings-backend/package.json
+++ b/plugins/user-settings-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-user-settings-backend",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "description": "The Backstage backend plugin to manage user settings",
   "backstage": {
     "role": "backend-plugin",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3590,6 +3590,7 @@ __metadata:
     p-limit: ^3.1.0
     path-to-regexp: ^6.2.1
     pg: ^8.11.3
+    pg-format: ^1.0.4
     raw-body: ^2.4.1
     selfsigned: ^2.0.0
     stoppable: ^1.1.0


### PR DESCRIPTION
This release fixes an issue where backend startup could throw an error about a missing `pg-format` dependency. Note that this only happens when the deprecated `@backstage/backend-common` library is used. Please migrate to the new backend system as soon as possible.