### PR TITLE
Set 0001-notifications BEP to "implemented"

### DIFF
--- a/beps/0001-notifications-system/README.md
+++ b/beps/0001-notifications-system/README.md
@@ -1,6 +1,6 @@
 ---
 title: Backstage Notifications System
-status: implementable
+status: implemented
 authors:
   - '@Rugvip'
   - '@drodil'


### PR DESCRIPTION
Moving `0001-notifications` to **implemented**.
Future changes can be done via new BEPs.

Let's list potential gaps to this transition.
- [x] https://github.com/backstage/backstage/pull/25941


Past this PR:
- https://github.com/backstage/backstage/pull/24963