### PR TITLE
fix: change severity filter label to "Min severity"

### DIFF
--- a/.changeset/five-walls-carry.md
+++ b/.changeset/five-walls-carry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications': patch
+---
+
+Severity filter label newly contains "Min severity" to better describe range instead of exact value.

--- a/plugins/notifications/src/components/NotificationsFilters/NotificationsFilters.tsx
+++ b/plugins/notifications/src/components/NotificationsFilters/NotificationsFilters.tsx
@@ -249,10 +249,12 @@ export const NotificationsFilters = ({
 
         <Grid item xs={12}>
           <FormControl fullWidth variant="outlined" size="small">
-            <InputLabel id="notifications-filter-severity">Severity</InputLabel>
+            <InputLabel id="notifications-filter-severity">
+              Min severity
+            </InputLabel>
 
             <Select
-              label="Severity"
+              label="Min severity"
               labelId="notifications-filter-severity"
               value={severity}
               onChange={handleOnSeverityChanged}


### PR DESCRIPTION
The filter is newly called "Min severity" to better match the behavior.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
