### PR TITLE
feat: move `getEntities` ordering to database

### DIFF
--- a/.changeset/loud-brooms-pull.md
+++ b/.changeset/loud-brooms-pull.md
@@ -1,0 +1,8 @@
+---
+'@backstage/catalog-client': patch
+'@backstage/plugin-catalog-backend': patch
+---
+
+Moved `getEntities` ordering to utilize database instead of having it inside catalog client
+
+Please note that the latest version of `@backstage/catalog-client` will not order the entities in the same way as before. This is because the ordering is now done in the database query instead of in the client. If you rely on the ordering of the entities, you may need to update your backend plugin or code to handle this change.

--- a/packages/catalog-client/src/CatalogClient.ts
+++ b/packages/catalog-client/src/CatalogClient.ts
@@ -18,7 +18,6 @@ import {
   CompoundEntityRef,
   Entity,
   parseEntityRef,
-  stringifyEntityRef,
   stringifyLocationRef,
 } from '@backstage/catalog-model';
 import { ResponseError } from '@backstage/errors';
@@ -142,35 +141,7 @@ export class CatalogClient implements CatalogApi {
         options,
       ),
     );
-
-    // do not sort entities, if order is provided
-    if (encodedOrder.length) {
-      return { items: entities };
-    }
-
-    const refCompare = (a: Entity, b: Entity) => {
-      // in case field filtering is used, these fields might not be part of the response
-      if (
-        a.metadata?.name === undefined ||
-        a.kind === undefined ||
-        b.metadata?.name === undefined ||
-        b.kind === undefined
-      ) {
-        return 0;
-      }
-
-      const aRef = stringifyEntityRef(a);
-      const bRef = stringifyEntityRef(b);
-      if (aRef < bRef) {
-        return -1;
-      }
-      if (aRef > bRef) {
-        return 1;
-      }
-      return 0;
-    };
-
-    return { items: entities.sort(refCompare) };
+    return { items: entities };
   }
 
   /**

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -249,7 +249,18 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
         ]);
       }
     });
-    entitiesQuery = entitiesQuery.orderBy('final_entities.entity_id', 'asc'); // stable sort
+
+    if (!request?.order) {
+      entitiesQuery = entitiesQuery
+        .leftOuterJoin(
+          'refresh_state',
+          'refresh_state.entity_id',
+          'final_entities.entity_id',
+        )
+        .orderBy('refresh_state.entity_ref', 'asc'); // default sort
+    } else {
+      entitiesQuery.orderBy('final_entities.entity_id', 'asc'); // stable sort
+    }
 
     const { limit, offset } = parsePagination(request?.pagination);
     if (limit !== undefined) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

instead sorting the entities in the client on demand, use default ordering parameters for entities when calling `getEntities`. having thousands of entities causes this function to pop up as the sorting method is not very lightweight thus moving it to database to handle.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
