### PR TITLE
scripts/create-release-tag: make it possible to override target sha

### DIFF
--- a/scripts/create-release-tag.js
+++ b/scripts/create-release-tag.js
@@ -59,8 +59,9 @@ async function createGitTag(octokit, commitSha, tagName) {
 }
 
 async function main() {
-  if (!process.env.GITHUB_SHA) {
-    throw new Error('GITHUB_SHA is not set');
+  const commitSha = process.env.RELEASE_SHA ?? process.env.GITHUB_SHA;
+  if (!commitSha) {
+    throw new Error('RELEASE_SHA or GITHUB_SHA is not set');
   }
   if (!process.env.GITHUB_TOKEN) {
     throw new Error('GITHUB_TOKEN is not set');
@@ -69,7 +70,6 @@ async function main() {
     throw new Error('GITHUB_OUTPUT environment variable not set');
   }
 
-  const commitSha = process.env.GITHUB_SHA;
   const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
 
   const releaseVersion = await getCurrentReleaseTag();


### PR DESCRIPTION
🧹, releases are now triggered from outside this repo but they still run this script, so we need a way to override the target sha