### PR TITLE
feat: allow signing git commits from scaffolder

### DIFF
--- a/.changeset/silver-camels-brake.md
+++ b/.changeset/silver-camels-brake.md
@@ -1,0 +1,15 @@
+---
+'@backstage/plugin-scaffolder-backend-module-bitbucket-server': patch
+'@backstage/plugin-scaffolder-backend-module-bitbucket-cloud': patch
+'@backstage/plugin-scaffolder-backend-module-bitbucket': patch
+'@backstage/plugin-scaffolder-backend-module-gerrit': patch
+'@backstage/plugin-scaffolder-backend-module-github': patch
+'@backstage/plugin-scaffolder-backend-module-gitlab': patch
+'@backstage/plugin-scaffolder-backend-module-azure': patch
+'@backstage/plugin-scaffolder-backend-module-gitea': patch
+'@backstage/plugin-scaffolder-backend': patch
+'@backstage/plugin-scaffolder-node': patch
+'@backstage/integration': patch
+---
+
+Allow signing git commits using configured private PGP key in scaffolder

--- a/packages/integration/api-report.md
+++ b/packages/integration/api-report.md
@@ -151,6 +151,7 @@ export type AzureIntegrationConfig = {
   token?: string;
   credential?: AzureDevOpsCredential;
   credentials?: AzureDevOpsCredential[];
+  signingKey?: string;
 };
 
 // @public
@@ -187,6 +188,7 @@ export type BitbucketCloudIntegrationConfig = {
   username?: string;
   appPassword?: string;
   token?: string;
+  signingKey?: string;
 };
 
 // @public @deprecated
@@ -217,6 +219,7 @@ export type BitbucketIntegrationConfig = {
   token?: string;
   username?: string;
   appPassword?: string;
+  signingKey?: string;
 };
 
 // @public
@@ -247,6 +250,7 @@ export type BitbucketServerIntegrationConfig = {
   token?: string;
   username?: string;
   password?: string;
+  signingKey?: string;
 };
 
 // @public
@@ -330,6 +334,7 @@ export type GerritIntegrationConfig = {
   gitilesBaseUrl: string;
   username?: string;
   password?: string;
+  signingKey?: string;
 };
 
 // @public
@@ -565,6 +570,7 @@ export type GiteaIntegrationConfig = {
   baseUrl?: string;
   username?: string;
   password?: string;
+  signingKey?: string;
 };
 
 // @public
@@ -636,6 +642,7 @@ export type GithubIntegrationConfig = {
   rawBaseUrl?: string;
   token?: string;
   apps?: GithubAppConfig[];
+  signingKey?: string;
 };
 
 // @public (undocumented)
@@ -679,6 +686,7 @@ export type GitLabIntegrationConfig = {
   apiBaseUrl: string;
   token?: string;
   baseUrl: string;
+  signingKey?: string;
 };
 
 // @public

--- a/packages/integration/config.d.ts
+++ b/packages/integration/config.d.ts
@@ -62,6 +62,10 @@ export interface Config {
         tenantId?: string;
         personalAccessToken?: string;
       }[];
+      /**
+       * PGP signing key for signing commits.
+       */
+      signingKey?: string;
     }>;
 
     /**
@@ -94,6 +98,10 @@ export interface Config {
        * @visibility secret
        */
       appPassword?: string;
+      /**
+       * PGP signing key for signing commits.
+       */
+      signingKey?: string;
     }>;
 
     /** Integration configuration for Bitbucket Cloud */
@@ -108,6 +116,10 @@ export interface Config {
        * @visibility secret
        */
       appPassword: string;
+      /**
+       * PGP signing key for signing commits.
+       */
+      signingKey?: string;
     }>;
 
     /** Integration configuration for Bitbucket Server */
@@ -137,6 +149,10 @@ export interface Config {
        * @visibility frontend
        */
       apiBaseUrl?: string;
+      /**
+       * PGP signing key for signing commits.
+       */
+      signingKey?: string;
     }>;
 
     /** Integration configuration for Gerrit */
@@ -172,6 +188,10 @@ export interface Config {
        * @visibility secret
        */
       password?: string;
+      /**
+       * PGP signing key for signing commits.
+       */
+      signingKey?: string;
     }>;
 
     /** Integration configuration for GitHub */
@@ -233,6 +253,10 @@ export interface Config {
          */
         allowedInstallationOwners?: string[];
       }>;
+      /**
+       * PGP signing key for signing commits.
+       */
+      signingKey?: string;
     }>;
 
     /** Integration configuration for GitLab */
@@ -269,6 +293,10 @@ export interface Config {
        * @visibility frontend
        */
       baseUrl?: string;
+      /**
+       * PGP signing key for signing commits.
+       */
+      signingKey?: string;
     }>;
 
     /** Integration configuration for Google Cloud Storage */
@@ -349,6 +377,10 @@ export interface Config {
        * @visibility secret
        */
       password?: string;
+      /**
+       * PGP signing key for signing commits.
+       */
+      signingKey?: string;
     }>;
     /** Integration configuration for Harness Code */
     harness?: Array<{

--- a/packages/integration/src/azure/config.ts
+++ b/packages/integration/src/azure/config.ts
@@ -57,6 +57,11 @@ export type AzureIntegrationConfig = {
    * If no credentials are specified at all, either a default credential (for Azure DevOps) or anonymous access (for Azure DevOps Server) is used.
    */
   credentials?: AzureDevOpsCredential[];
+
+  /**
+   * Signing key for commits
+   */
+  signingKey?: string;
 };
 
 /**
@@ -349,6 +354,7 @@ export function readAzureIntegrationConfig(
   return {
     host,
     credentials,
+    signingKey: config.getOptionalString('signingKey'),
   };
 }
 

--- a/packages/integration/src/bitbucket/config.ts
+++ b/packages/integration/src/bitbucket/config.ts
@@ -62,6 +62,11 @@ export type BitbucketIntegrationConfig = {
    * See https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/
    */
   appPassword?: string;
+
+  /**
+   * Signing key for commits
+   */
+  signingKey?: string;
 };
 
 /**
@@ -100,6 +105,7 @@ export function readBitbucketIntegrationConfig(
     token,
     username,
     appPassword,
+    signingKey: config.getOptionalString('signingKey'),
   };
 }
 

--- a/packages/integration/src/bitbucketCloud/config.ts
+++ b/packages/integration/src/bitbucketCloud/config.ts
@@ -51,6 +51,9 @@ export type BitbucketCloudIntegrationConfig = {
    * The access token to use for requests to Bitbucket Cloud (bitbucket.org).
    */
   token?: string;
+
+  /** PGP private key for signing commits. */
+  signingKey?: string;
 };
 
 /**
@@ -74,6 +77,7 @@ export function readBitbucketCloudIntegrationConfig(
     apiBaseUrl,
     username,
     appPassword,
+    signingKey: config.getOptionalString('signingKey'),
   };
 }
 

--- a/packages/integration/src/bitbucketServer/config.ts
+++ b/packages/integration/src/bitbucketServer/config.ts
@@ -64,6 +64,11 @@ export type BitbucketServerIntegrationConfig = {
    * See https://developer.atlassian.com/server/bitbucket/how-tos/command-line-rest/#authentication
    */
   password?: string;
+
+  /**
+   * Signing key for commits
+   */
+  signingKey?: string;
 };
 
 /**
@@ -99,6 +104,7 @@ export function readBitbucketServerIntegrationConfig(
     token,
     username,
     password,
+    signingKey: config.getOptionalString('signingKey'),
   };
 }
 

--- a/packages/integration/src/gerrit/config.ts
+++ b/packages/integration/src/gerrit/config.ts
@@ -60,6 +60,11 @@ export type GerritIntegrationConfig = {
    * The password or http token to use for authentication.
    */
   password?: string;
+
+  /**
+   * The signing key to use for signing commits.
+   */
+  signingKey?: string;
 };
 
 /**
@@ -119,6 +124,7 @@ export function readGerritIntegrationConfig(
     gitilesBaseUrl,
     username,
     password,
+    signingKey: config.getOptionalString('signingKey'),
   };
 }
 

--- a/packages/integration/src/gitea/config.ts
+++ b/packages/integration/src/gitea/config.ts
@@ -45,6 +45,11 @@ export type GiteaIntegrationConfig = {
    * The password or http token to use for authentication.
    */
   password?: string;
+
+  /**
+   * Signing key to to sign commits
+   */
+  signingKey?: string;
 };
 
 /**
@@ -79,5 +84,6 @@ export function readGiteaConfig(config: Config): GiteaIntegrationConfig {
     baseUrl,
     username,
     password,
+    signingKey: config.getOptionalString('signingKey'),
   };
 }

--- a/packages/integration/src/github/config.ts
+++ b/packages/integration/src/github/config.ts
@@ -68,6 +68,11 @@ export type GithubIntegrationConfig = {
    * If no apps are specified, token or anonymous is used.
    */
   apps?: GithubAppConfig[];
+
+  /**
+   * Signing key for signing commits
+   */
+  signingKey?: string;
 };
 
 /**
@@ -153,7 +158,14 @@ export function readGithubIntegrationConfig(
     rawBaseUrl = GITHUB_RAW_BASE_URL;
   }
 
-  return { host, apiBaseUrl, rawBaseUrl, token, apps };
+  return {
+    host,
+    apiBaseUrl,
+    rawBaseUrl,
+    token,
+    apps,
+    signingKey: config.getOptionalString('signingKey'),
+  };
 }
 
 /**

--- a/packages/integration/src/gitlab/config.ts
+++ b/packages/integration/src/gitlab/config.ts
@@ -54,6 +54,11 @@ export type GitLabIntegrationConfig = {
    * If no baseUrl is provided, it will default to `https://${host}`
    */
   baseUrl: string;
+
+  /**
+   * Signing key to sign commits
+   */
+  signingKey?: string;
 };
 
 /**
@@ -95,7 +100,13 @@ export function readGitLabIntegrationConfig(
     );
   }
 
-  return { host, token, apiBaseUrl, baseUrl };
+  return {
+    host,
+    token,
+    apiBaseUrl,
+    baseUrl,
+    signingKey: config.getOptionalString('signingKey'),
+  };
 }
 
 /**

--- a/plugins/scaffolder-backend-module-azure/api-report.md
+++ b/plugins/scaffolder-backend-module-azure/api-report.md
@@ -27,6 +27,7 @@ export function createPublishAzureAction(options: {
     gitCommitMessage?: string | undefined;
     gitAuthorName?: string | undefined;
     gitAuthorEmail?: string | undefined;
+    signCommit?: boolean | undefined;
   },
   JsonObject
 >;

--- a/plugins/scaffolder-backend-module-azure/src/actions/azure.ts
+++ b/plugins/scaffolder-backend-module-azure/src/actions/azure.ts
@@ -20,10 +20,10 @@ import {
   ScmIntegrationRegistry,
 } from '@backstage/integration';
 import {
-  initRepoAndPush,
-  getRepoSourceDirectory,
-  parseRepoUrl,
   createTemplateAction,
+  getRepoSourceDirectory,
+  initRepoAndPush,
+  parseRepoUrl,
 } from '@backstage/plugin-scaffolder-node';
 import { GitRepositoryCreateOptions } from 'azure-devops-node-api/interfaces/GitInterfaces';
 import {
@@ -54,6 +54,7 @@ export function createPublishAzureAction(options: {
     gitCommitMessage?: string;
     gitAuthorName?: string;
     gitAuthorEmail?: string;
+    signCommit?: boolean;
   }>({
     id: 'publish:azure',
     examples,
@@ -103,6 +104,11 @@ export function createPublishAzureAction(options: {
             type: 'string',
             description: 'The token to use for authorization to Azure',
           },
+          signCommit: {
+            title: 'Sign commit',
+            type: 'boolean',
+            description: 'Sign commit with configured PGP private key',
+          },
         },
       },
       output: {
@@ -134,6 +140,7 @@ export function createPublishAzureAction(options: {
         gitCommitMessage = 'initial commit',
         gitAuthorName,
         gitAuthorEmail,
+        signCommit,
       } = ctx.input;
 
       const { project, repo, host, organization } = parseRepoUrl(
@@ -151,6 +158,7 @@ export function createPublishAzureAction(options: {
       const credentialProvider =
         DefaultAzureDevOpsCredentialsProvider.fromIntegrations(integrations);
       const credentials = await credentialProvider.getCredentials({ url: url });
+      const integrationConfig = integrations.azure.byHost(host);
 
       if (credentials === undefined && ctx.input.token === undefined) {
         throw new InputError(
@@ -215,6 +223,15 @@ export function createPublishAzureAction(options: {
             }
           : { token: credentials!.token };
 
+      const signingKey =
+        integrationConfig?.config.signingKey ??
+        config.getOptionalString('scaffolder.defaultSigningKey');
+      if (signCommit && !signingKey) {
+        throw new Error(
+          'Signing commits is enabled but no signing key is provided in the configuration',
+        );
+      }
+
       const commitResult = await initRepoAndPush({
         dir: getRepoSourceDirectory(ctx.workspacePath, ctx.input.sourcePath),
         remoteUrl,
@@ -225,6 +242,7 @@ export function createPublishAzureAction(options: {
           ? gitCommitMessage
           : config.getOptionalString('scaffolder.defaultCommitMessage'),
         gitAuthorInfo,
+        signingKey: signCommit ? signingKey : undefined,
       });
 
       ctx.output('commitHash', commitResult?.commitHash);

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/api-report.md
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/api-report.md
@@ -39,6 +39,7 @@ export function createPublishBitbucketCloudAction(options: {
     gitCommitMessage?: string | undefined;
     sourcePath?: string | undefined;
     token?: string | undefined;
+    signCommit?: boolean | undefined;
   },
   JsonObject
 >;

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloud.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloud.ts
@@ -18,11 +18,11 @@ import { InputError } from '@backstage/errors';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import {
   createTemplateAction,
-  initRepoAndPush,
   getRepoSourceDirectory,
+  initRepoAndPush,
   parseRepoUrl,
 } from '@backstage/plugin-scaffolder-node';
-import fetch, { Response, RequestInit } from 'node-fetch';
+import fetch, { RequestInit, Response } from 'node-fetch';
 
 import { Config } from '@backstage/config';
 import { getAuthorizationHeader } from './helpers';
@@ -114,6 +114,7 @@ export function createPublishBitbucketCloudAction(options: {
     gitCommitMessage?: string;
     sourcePath?: string;
     token?: string;
+    signCommit?: boolean;
   }>({
     id: 'publish:bitbucketCloud',
     examples,
@@ -159,6 +160,11 @@ export function createPublishBitbucketCloudAction(options: {
             description:
               'The token to use for authorization to BitBucket Cloud',
           },
+          signCommit: {
+            title: 'Sign commit',
+            type: 'boolean',
+            description: 'Sign commit with configured PGP private key',
+          },
         },
       },
       output: {
@@ -186,6 +192,7 @@ export function createPublishBitbucketCloudAction(options: {
         defaultBranch = 'master',
         gitCommitMessage,
         repoVisibility = 'private',
+        signCommit,
       } = ctx.input;
 
       const { workspace, project, repo, host } = parseRepoUrl(
@@ -257,6 +264,15 @@ export function createPublishBitbucketCloudAction(options: {
         };
       }
 
+      const signingKey =
+        integrationConfig.config.signingKey ??
+        config.getOptionalString('scaffolder.defaultSigningKey');
+      if (signCommit && !signingKey) {
+        throw new Error(
+          'Signing commits is enabled but no signing key is provided in the configuration',
+        );
+      }
+
       const commitResult = await initRepoAndPush({
         dir: getRepoSourceDirectory(ctx.workspacePath, ctx.input.sourcePath),
         remoteUrl,
@@ -267,6 +283,7 @@ export function createPublishBitbucketCloudAction(options: {
           gitCommitMessage ||
           config.getOptionalString('scaffolder.defaultCommitMessage'),
         gitAuthorInfo,
+        signingKey: signCommit ? signingKey : undefined,
       });
 
       ctx.output('commitHash', commitResult?.commitHash);

--- a/plugins/scaffolder-backend-module-bitbucket-server/api-report.md
+++ b/plugins/scaffolder-backend-module-bitbucket-server/api-report.md
@@ -29,6 +29,7 @@ export function createPublishBitbucketServerAction(options: {
     gitCommitMessage?: string | undefined;
     gitAuthorName?: string | undefined;
     gitAuthorEmail?: string | undefined;
+    signCommit?: boolean | undefined;
   },
   JsonObject
 >;

--- a/plugins/scaffolder-backend-module-bitbucket/api-report.md
+++ b/plugins/scaffolder-backend-module-bitbucket/api-report.md
@@ -44,6 +44,7 @@ export function createPublishBitbucketAction(options: {
     gitCommitMessage?: string | undefined;
     gitAuthorName?: string | undefined;
     gitAuthorEmail?: string | undefined;
+    signCommit?: boolean | undefined;
   },
   JsonObject
 >;

--- a/plugins/scaffolder-backend-module-gerrit/api-report.md
+++ b/plugins/scaffolder-backend-module-gerrit/api-report.md
@@ -22,6 +22,7 @@ export function createPublishGerritAction(options: {
     gitAuthorName?: string | undefined;
     gitAuthorEmail?: string | undefined;
     sourcePath?: string | undefined;
+    signCommit?: boolean | undefined;
   },
   JsonObject
 >;
@@ -38,6 +39,7 @@ export function createPublishGerritReviewAction(options: {
     gitCommitMessage?: string | undefined;
     gitAuthorName?: string | undefined;
     gitAuthorEmail?: string | undefined;
+    signCommit?: boolean | undefined;
   },
   JsonObject
 >;

--- a/plugins/scaffolder-backend-module-gerrit/src/actions/gerrit.ts
+++ b/plugins/scaffolder-backend-module-gerrit/src/actions/gerrit.ts
@@ -24,11 +24,11 @@ import {
 } from '@backstage/integration';
 import {
   createTemplateAction,
-  initRepoAndPush,
   getRepoSourceDirectory,
+  initRepoAndPush,
   parseRepoUrl,
 } from '@backstage/plugin-scaffolder-node';
-import fetch, { Response, RequestInit } from 'node-fetch';
+import fetch, { RequestInit, Response } from 'node-fetch';
 import { examples } from './gerrit.examples';
 
 const createGerritProject = async (
@@ -100,6 +100,7 @@ export function createPublishGerritAction(options: {
     gitAuthorName?: string;
     gitAuthorEmail?: string;
     sourcePath?: string;
+    signCommit?: boolean;
   }>({
     id: 'publish:gerrit',
     supportsDryRun: true,
@@ -144,6 +145,11 @@ export function createPublishGerritAction(options: {
             type: 'string',
             description: `Path within the workspace that will be used as the repository root. If omitted, the entire workspace will be published as the repository.`,
           },
+          signCommit: {
+            title: 'Sign commit',
+            type: 'boolean',
+            description: 'Sign commit with configured PGP private key',
+          },
         },
       },
       output: {
@@ -173,6 +179,7 @@ export function createPublishGerritAction(options: {
         gitAuthorEmail,
         gitCommitMessage = 'initial commit',
         sourcePath,
+        signCommit,
       } = ctx.input;
       const { repo, host, owner, workspace } = parseRepoUrl(
         repoUrl,
@@ -234,6 +241,15 @@ export function createPublishGerritAction(options: {
         email: gitEmail,
       };
 
+      const signingKey =
+        integrationConfig.config.signingKey ??
+        config.getOptionalString('scaffolder.defaultSigningKey');
+      if (signCommit && !signingKey) {
+        throw new Error(
+          'Signing commits is enabled but no signing key is provided in the configuration',
+        );
+      }
+
       const commitResult = await initRepoAndPush({
         dir: getRepoSourceDirectory(ctx.workspacePath, sourcePath),
         remoteUrl,
@@ -242,6 +258,7 @@ export function createPublishGerritAction(options: {
         logger: ctx.logger,
         commitMessage: generateCommitMessage(config, gitCommitMessage),
         gitAuthorInfo,
+        signingKey: signCommit ? signingKey : undefined,
       });
 
       ctx.output('remoteUrl', remoteUrl);

--- a/plugins/scaffolder-backend-module-gerrit/src/actions/gerritReview.ts
+++ b/plugins/scaffolder-backend-module-gerrit/src/actions/gerritReview.ts
@@ -19,8 +19,8 @@ import { InputError } from '@backstage/errors';
 import { Config } from '@backstage/config';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import {
-  createTemplateAction,
   commitAndPushRepo,
+  createTemplateAction,
   getRepoSourceDirectory,
   parseRepoUrl,
 } from '@backstage/plugin-scaffolder-node';
@@ -48,6 +48,7 @@ export function createPublishGerritReviewAction(options: {
     gitCommitMessage?: string;
     gitAuthorName?: string;
     gitAuthorEmail?: string;
+    signCommit?: boolean;
   }>({
     id: 'publish:gerrit:review',
     description: 'Creates a new Gerrit review.',
@@ -88,6 +89,11 @@ export function createPublishGerritReviewAction(options: {
             type: 'string',
             description: `Sets the default author email for the commit.`,
           },
+          signCommit: {
+            title: 'Sign commit',
+            type: 'boolean',
+            description: 'Sign commit with configured PGP private key',
+          },
         },
       },
       output: {
@@ -112,6 +118,7 @@ export function createPublishGerritReviewAction(options: {
         gitAuthorName,
         gitAuthorEmail,
         gitCommitMessage,
+        signCommit,
       } = ctx.input;
       const { host, repo } = parseRepoUrl(repoUrl, integrations);
 
@@ -139,6 +146,14 @@ export function createPublishGerritReviewAction(options: {
           ? gitAuthorEmail
           : config.getOptionalString('scaffolder.defaultAuthor.email'),
       };
+      const signingKey =
+        integrationConfig.config.signingKey ??
+        config.getOptionalString('scaffolder.defaultSigningKey');
+      if (signCommit && !signingKey) {
+        throw new Error(
+          'Signing commits is enabled but no signing key is provided in the configuration',
+        );
+      }
       const changeId = generateGerritChangeId();
       const commitMessage = `${gitCommitMessage}\n\nChange-Id: ${changeId}`;
 
@@ -150,6 +165,7 @@ export function createPublishGerritReviewAction(options: {
         gitAuthorInfo,
         branch,
         remoteRef: `refs/for/${branch}`,
+        signingKey: signCommit ? signingKey : undefined,
       });
 
       const repoContentsUrl = `${integrationConfig.config.gitilesBaseUrl}/${repo}/+/refs/heads/${branch}`;

--- a/plugins/scaffolder-backend-module-gitea/api-report.md
+++ b/plugins/scaffolder-backend-module-gitea/api-report.md
@@ -23,6 +23,7 @@ export function createPublishGiteaAction(options: {
     gitAuthorName?: string | undefined;
     gitAuthorEmail?: string | undefined;
     sourcePath?: string | undefined;
+    signCommit?: boolean | undefined;
   },
   JsonObject
 >;

--- a/plugins/scaffolder-backend-module-gitea/src/actions/gitea.ts
+++ b/plugins/scaffolder-backend-module-gitea/src/actions/gitea.ts
@@ -30,7 +30,7 @@ import {
 } from '@backstage/plugin-scaffolder-node';
 import { examples } from './gitea.examples';
 import crypto from 'crypto';
-import fetch, { Response, RequestInit } from 'node-fetch';
+import fetch, { RequestInit, Response } from 'node-fetch';
 
 const checkGiteaContentUrl = async (
   config: GiteaIntegrationConfig,
@@ -220,6 +220,7 @@ export function createPublishGiteaAction(options: {
     gitAuthorName?: string;
     gitAuthorEmail?: string;
     sourcePath?: string;
+    signCommit?: boolean;
   }>({
     id: 'publish:gitea',
     description:
@@ -269,6 +270,11 @@ export function createPublishGiteaAction(options: {
             type: 'string',
             description: `Path within the workspace that will be used as the repository root. If omitted, the entire workspace will be published as the repository.`,
           },
+          signCommit: {
+            title: 'Sign commit',
+            type: 'boolean',
+            description: 'Sign commit with configured PGP private key',
+          },
         },
       },
       output: {
@@ -299,6 +305,7 @@ export function createPublishGiteaAction(options: {
         gitAuthorEmail,
         gitCommitMessage = 'initial commit',
         sourcePath,
+        signCommit,
       } = ctx.input;
 
       const { repo, host, owner } = parseRepoUrl(repoUrl, integrations);
@@ -339,6 +346,16 @@ export function createPublishGiteaAction(options: {
           ? gitAuthorEmail
           : config.getOptionalString('scaffolder.defaultAuthor.email'),
       };
+
+      const signingKey =
+        integrationConfig.config.signingKey ??
+        config.getOptionalString('scaffolder.defaultSigningKey');
+      if (signCommit && !signingKey) {
+        throw new Error(
+          'Signing commits is enabled but no signing key is provided in the configuration',
+        );
+      }
+
       // The owner to be used should be either the org name or user authenticated with the gitea server
       const remoteUrl = `${integrationConfig.config.baseUrl}/${owner}/${repo}.git`;
       const commitResult = await initRepoAndPush({

--- a/plugins/scaffolder-backend-module-github/api-report.md
+++ b/plugins/scaffolder-backend-module-github/api-report.md
@@ -249,6 +249,7 @@ export function createGithubRepoPushAction(options: {
     gitCommitMessage?: string | undefined;
     gitAuthorName?: string | undefined;
     gitAuthorEmail?: string | undefined;
+    signCommit?: boolean | undefined;
     requireCodeOwnerReviews?: boolean | undefined;
     dismissStaleReviews?: boolean | undefined;
     bypassPullRequestAllowances?:
@@ -314,6 +315,7 @@ export function createPublishGithubAction(options: {
     gitCommitMessage?: string | undefined;
     gitAuthorName?: string | undefined;
     gitAuthorEmail?: string | undefined;
+    signCommit?: boolean | undefined;
     allowRebaseMerge?: boolean | undefined;
     allowSquashMerge?: boolean | undefined;
     squashMergeCommitTitle?: 'PR_TITLE' | 'COMMIT_OR_PR_TITLE' | undefined;

--- a/plugins/scaffolder-backend-module-github/src/actions/githubRepoPush.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubRepoPush.ts
@@ -52,6 +52,7 @@ export function createGithubRepoPushAction(options: {
     gitCommitMessage?: string;
     gitAuthorName?: string;
     gitAuthorEmail?: string;
+    signCommit?: boolean;
     requireCodeOwnerReviews?: boolean;
     dismissStaleReviews?: boolean;
     bypassPullRequestAllowances?:
@@ -103,6 +104,7 @@ export function createGithubRepoPushAction(options: {
           gitCommitMessage: inputProps.gitCommitMessage,
           gitAuthorName: inputProps.gitAuthorName,
           gitAuthorEmail: inputProps.gitAuthorEmail,
+          signCommit: inputProps.signCommit,
           sourcePath: inputProps.sourcePath,
           token: inputProps.token,
           requiredCommitSigning: inputProps.requiredCommitSigning,
@@ -126,6 +128,7 @@ export function createGithubRepoPushAction(options: {
         gitCommitMessage = 'initial commit',
         gitAuthorName,
         gitAuthorEmail,
+        signCommit = false,
         requireCodeOwnerReviews = false,
         dismissStaleReviews = false,
         bypassPullRequestAllowances,
@@ -139,7 +142,7 @@ export function createGithubRepoPushAction(options: {
         requiredCommitSigning = false,
       } = ctx.input;
 
-      const { owner, repo } = parseRepoUrl(repoUrl, integrations);
+      const { owner, repo, host } = parseRepoUrl(repoUrl, integrations);
 
       if (!owner) {
         throw new InputError('Invalid repository owner provided in repoUrl');
@@ -151,6 +154,13 @@ export function createGithubRepoPushAction(options: {
         token: providedToken,
         repoUrl,
       });
+      const integrationConfig = integrations.github.byHost(host);
+
+      if (!integrationConfig) {
+        throw new InputError(
+          `No matching integration configuration for host ${host}, please check your integrations config`,
+        );
+      }
 
       const client = new Octokit(octokitOptions);
 
@@ -180,9 +190,11 @@ export function createGithubRepoPushAction(options: {
         requireLastPushApproval,
         config,
         ctx.logger,
+        integrationConfig,
         gitCommitMessage,
         gitAuthorName,
         gitAuthorEmail,
+        signCommit,
         dismissStaleReviews,
         requiredCommitSigning,
       );

--- a/plugins/scaffolder-backend-module-github/src/actions/inputProperties.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/inputProperties.ts
@@ -89,6 +89,11 @@ const gitAuthorEmail = {
   type: 'string',
   description: `Sets the default author email for the commit.`,
 };
+const signCommit = {
+  title: 'Sign commit',
+  type: 'boolean',
+  description: 'Sign commit with configured PGP private key',
+};
 const allowMergeCommit = {
   title: 'Allow Merge Commits',
   type: 'boolean',
@@ -317,6 +322,7 @@ export { deleteBranchOnMerge };
 export { description };
 export { gitAuthorEmail };
 export { gitAuthorName };
+export { signCommit };
 export { gitCommitMessage };
 export { homepage };
 export { protectDefaultBranch };

--- a/plugins/scaffolder-backend-module-gitlab/api-report.md
+++ b/plugins/scaffolder-backend-module-gitlab/api-report.md
@@ -137,6 +137,7 @@ export function createPublishGitlabAction(options: {
     gitCommitMessage?: string | undefined;
     gitAuthorName?: string | undefined;
     gitAuthorEmail?: string | undefined;
+    signCommit?: boolean | undefined;
     setUserAsOwner?: boolean | undefined;
     topics?: string[] | undefined;
     settings?:

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlab.test.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlab.test.ts
@@ -71,6 +71,7 @@ describe('publish:gitlab', () => {
           host: 'gitlab.com',
           token: 'tokenlols',
           apiBaseUrl: 'https://api.gitlab.com',
+          signingKey: 'test-signing-key',
         },
         {
           host: 'hosted.gitlab.com',
@@ -357,6 +358,30 @@ describe('publish:gitlab', () => {
       logger: mockContext.logger,
       commitMessage: 'initial commit',
       gitAuthorInfo: {},
+    });
+  });
+
+  it('should call initRepoAndPush with the signing key', async () => {
+    mockGitlabClient.Users.current.mockResolvedValue({ id: 12345 });
+    mockGitlabClient.Namespaces.show.mockResolvedValue({ id: 1234 });
+    mockGitlabClient.Projects.create.mockResolvedValue({
+      http_url_to_repo: 'http://mockurl.git',
+    });
+
+    await action.handler({
+      ...mockContext,
+      input: { ...mockContext.input, signCommit: true },
+    });
+
+    expect(initRepoAndPush).toHaveBeenCalledWith({
+      dir: mockContext.workspacePath,
+      defaultBranch: 'master',
+      remoteUrl: 'http://mockurl.git',
+      auth: { username: 'oauth2', password: 'tokenlols' },
+      logger: mockContext.logger,
+      commitMessage: 'initial commit',
+      gitAuthorInfo: {},
+      signingKey: 'test-signing-key',
     });
   });
 

--- a/plugins/scaffolder-backend/config.d.ts
+++ b/plugins/scaffolder-backend/config.d.ts
@@ -27,6 +27,10 @@ export interface Config {
       email?: string;
     };
     /**
+     * Default PGP signing key for signing commits.
+     */
+    defaultSigningKey?: string;
+    /**
      * The commit message used when new components are created.
      */
     defaultCommitMessage?: string;

--- a/plugins/scaffolder-node/api-report.md
+++ b/plugins/scaffolder-node/api-report.md
@@ -104,6 +104,7 @@ export function commitAndPushBranch(options: {
   branch?: string;
   remoteRef?: string;
   remote?: string;
+  signingKey?: string;
 }): Promise<{
   commitHash: string;
 }>;
@@ -127,6 +128,7 @@ export function commitAndPushRepo(input: {
   };
   branch?: string;
   remoteRef?: string;
+  signingKey?: string;
 }): Promise<{
   commitHash: string;
 }>;
@@ -239,6 +241,7 @@ export function initRepoAndPush(input: {
     name?: string;
     email?: string;
   };
+  signingKey?: string;
 }): Promise<{
   commitHash: string;
 }>;

--- a/plugins/scaffolder-node/package.json
+++ b/plugins/scaffolder-node/package.json
@@ -61,6 +61,7 @@
     "@backstage/integration": "workspace:^",
     "@backstage/plugin-scaffolder-common": "workspace:^",
     "@backstage/types": "workspace:^",
+    "@isomorphic-git/pgp-plugin": "^0.0.7",
     "concat-stream": "^2.0.0",
     "fs-extra": "^11.2.0",
     "globby": "^11.0.0",

--- a/plugins/scaffolder-node/src/actions/gitHelpers.test.ts
+++ b/plugins/scaffolder-node/src/actions/gitHelpers.test.ts
@@ -17,12 +17,12 @@
 import { loggerToWinstonLogger } from '@backstage/backend-common';
 import { Git } from '../scm';
 import {
-  commitAndPushRepo,
-  initRepoAndPush,
-  commitAndPushBranch,
   addFiles,
-  createBranch,
   cloneRepo,
+  commitAndPushBranch,
+  commitAndPushRepo,
+  createBranch,
+  initRepoAndPush,
 } from './gitHelpers';
 import { mockServices } from '@backstage/backend-test-utils';
 
@@ -227,6 +227,32 @@ describe('commitAndPushRepo', () => {
           name: 'Scaffolder',
           email: 'scaffolder@backstage.io',
         },
+      });
+    });
+
+    it('creates commit with signing key', async () => {
+      await commitAndPushRepo({
+        dir: '/test/repo/dir/',
+        auth: {
+          username: 'test-user',
+          password: 'test-password',
+        },
+        logger: loggerToWinstonLogger(mockServices.logger.mock()),
+        commitMessage: 'commit message',
+        signingKey: 'test-signing-key',
+      });
+      expect(mockedGit.commit).toHaveBeenCalledWith({
+        dir: '/test/repo/dir/',
+        message: 'commit message',
+        author: {
+          name: 'Scaffolder',
+          email: 'scaffolder@backstage.io',
+        },
+        committer: {
+          name: 'Scaffolder',
+          email: 'scaffolder@backstage.io',
+        },
+        signingKey: 'test-signing-key',
       });
     });
 

--- a/plugins/scaffolder-node/src/actions/gitHelpers.ts
+++ b/plugins/scaffolder-node/src/actions/gitHelpers.ts
@@ -31,6 +31,7 @@ export async function initRepoAndPush(input: {
   defaultBranch?: string;
   commitMessage?: string;
   gitAuthorInfo?: { name?: string; email?: string };
+  signingKey?: string;
 }): Promise<{ commitHash: string }> {
   const {
     dir,
@@ -40,6 +41,7 @@ export async function initRepoAndPush(input: {
     defaultBranch = 'master',
     commitMessage = 'Initial commit',
     gitAuthorInfo,
+    signingKey,
   } = input;
   const git = Git.fromAuth({
     ...auth,
@@ -64,6 +66,7 @@ export async function initRepoAndPush(input: {
     message: commitMessage,
     author: authorInfo,
     committer: authorInfo,
+    signingKey,
   });
   await git.addRemote({
     dir,
@@ -93,6 +96,7 @@ export async function commitAndPushRepo(input: {
   gitAuthorInfo?: { name?: string; email?: string };
   branch?: string;
   remoteRef?: string;
+  signingKey?: string;
 }): Promise<{ commitHash: string }> {
   const {
     dir,
@@ -102,6 +106,7 @@ export async function commitAndPushRepo(input: {
     gitAuthorInfo,
     branch = 'master',
     remoteRef,
+    signingKey,
   } = input;
 
   const git = Git.fromAuth({
@@ -124,6 +129,7 @@ export async function commitAndPushRepo(input: {
     message: commitMessage,
     author: authorInfo,
     committer: authorInfo,
+    signingKey,
   });
 
   await git.push({
@@ -217,6 +223,7 @@ export async function commitAndPushBranch(options: {
   branch?: string;
   remoteRef?: string;
   remote?: string;
+  signingKey?: string;
 }): Promise<{ commitHash: string }> {
   const {
     dir,
@@ -227,6 +234,7 @@ export async function commitAndPushBranch(options: {
     branch = 'master',
     remoteRef,
     remote = 'origin',
+    signingKey,
   } = options;
   const git = Git.fromAuth({
     ...auth,
@@ -244,6 +252,7 @@ export async function commitAndPushBranch(options: {
     message: commitMessage,
     author: authorInfo,
     committer: authorInfo,
+    signingKey,
   });
 
   await git.push({

--- a/plugins/scaffolder-node/src/scm/git.test.ts
+++ b/plugins/scaffolder-node/src/scm/git.test.ts
@@ -16,6 +16,12 @@
 jest.mock('isomorphic-git');
 jest.mock('isomorphic-git/http/node');
 jest.mock('fs-extra');
+jest.mock('@isomorphic-git/pgp-plugin', () => ({
+  ...jest.requireActual('@isomorphic-git/pgp-plugin'),
+  pgp: {
+    sign: jest.fn().mockResolvedValue({ signature: 'sign' }),
+  },
+}));
 
 import * as isomorphic from 'isomorphic-git';
 import { Git } from './git';
@@ -140,8 +146,9 @@ describe('Git', () => {
         name: 'comitter',
         email: 'test@backstage.io',
       };
+      const signingKey = 'test-signing-key';
 
-      await git.commit({ dir, message, author, committer });
+      await git.commit({ dir, message, author, committer, signingKey });
 
       expect(isomorphic.commit).toHaveBeenCalledWith({
         fs,
@@ -149,6 +156,8 @@ describe('Git', () => {
         message,
         author,
         committer,
+        signingKey,
+        onSign: expect.any(Function),
       });
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7193,6 +7193,7 @@ __metadata:
     "@backstage/integration": "workspace:^"
     "@backstage/plugin-scaffolder-common": "workspace:^"
     "@backstage/types": "workspace:^"
+    "@isomorphic-git/pgp-plugin": ^0.0.7
     concat-stream: ^2.0.0
     fs-extra: ^11.2.0
     globby: ^11.0.0
@@ -9960,6 +9961,59 @@ __metadata:
   version: 1.1.0
   resolution: "@isaacs/string-locale-compare@npm:1.1.0"
   checksum: 7287da5d11497b82c542d3c2abe534808015be4f4883e71c26853277b5456f6bbe4108535db847a29f385ad6dc9318ffb0f55ee79bb5f39993233d7dccf8751d
+  languageName: node
+  linkType: hard
+
+"@isomorphic-git/pgp-plugin@npm:^0.0.7":
+  version: 0.0.7
+  resolution: "@isomorphic-git/pgp-plugin@npm:0.0.7"
+  dependencies:
+    "@isomorphic-pgp/sign-and-verify": ^0.0.10
+    "@isomorphic-pgp/util": ^0.0.6
+  checksum: 5361b4e58933f87747607b4bcfdf7ce2e4d75f591d5839ecd313fba55196020ee0e867c307fbfa2cd0aa85442942a5efca40653dfac0acabe8043e80f1dbebc1
+  languageName: node
+  linkType: hard
+
+"@isomorphic-pgp/parser@npm:^0.0.3":
+  version: 0.0.3
+  resolution: "@isomorphic-pgp/parser@npm:0.0.3"
+  dependencies:
+    array-buffer-to-hex: ^1.0.0
+    base64-js: ^1.3.0
+    bn.js: ^4.11.8
+    clz-buffer: ^1.0.0
+    concat-buffers: ^1.0.0
+    crc: ^3.8.0
+    isomorphic-textencoder: ^1.0.1
+    select-case: ^1.0.0
+  checksum: 3ddfb1d39e7a9c0da98940c95bf2a9b7a59819a1ee0a4839fcbf3152c386aa974a16854043e6cd5f987db2f9475b480c10f3ef5686f0da1495675cb399cdd22f
+  languageName: node
+  linkType: hard
+
+"@isomorphic-pgp/sign-and-verify@npm:^0.0.10":
+  version: 0.0.10
+  resolution: "@isomorphic-pgp/sign-and-verify@npm:0.0.10"
+  dependencies:
+    "@isomorphic-pgp/parser": ^0.0.3
+    "@isomorphic-pgp/util": ^0.0.6
+    "@wmhilton/crypto-hash": ^1.0.2
+    array-buffer-to-hex: ^1.0.0
+    isomorphic-textencoder: ^1.0.1
+    jsbn: ^1.1.0
+    sha.js: ^2.4.11
+  checksum: 3d43408abdb0d53c4514797ef47ec1d8f634e4a6b4a80f0df9ac826b9ba51df1a9cedcb26f7ddbee4594827de9676d7cda57549d321ea87bc95facfaa7127146
+  languageName: node
+  linkType: hard
+
+"@isomorphic-pgp/util@npm:^0.0.6":
+  version: 0.0.6
+  resolution: "@isomorphic-pgp/util@npm:0.0.6"
+  dependencies:
+    "@isomorphic-pgp/parser": ^0.0.3
+    array-buffer-to-hex: ^1.0.0
+    concat-buffers: ^1.0.0
+    sha.js: ^2.4.11
+  checksum: 721a15ddb4597f90b7b897b2d18a5819e86988ac44510f9aee9dc6a7823a62c3f1ba5b12eb35792c803b3b1c6d4af924ae0bc31123f21fbc6f5a8e8e7962a412
   languageName: node
   linkType: hard
 
@@ -19174,6 +19228,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wmhilton/crypto-hash@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@wmhilton/crypto-hash@npm:1.0.2"
+  checksum: 99c7e46856d75dbd828922ed8088dcd85ac405d58976f785e3d3062e3e4044b11073ef43a6c74976d42abd2c320820993afcd6a1d41db22f19bf7a9fe5557140
+  languageName: node
+  linkType: hard
+
 "@xmldom/xmldom@npm:^0.8.3, @xmldom/xmldom@npm:^0.8.5, @xmldom/xmldom@npm:^0.8.6, @xmldom/xmldom@npm:^0.8.8":
   version: 0.8.10
   resolution: "@xmldom/xmldom@npm:0.8.10"
@@ -20429,6 +20490,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"array-buffer-to-hex@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "array-buffer-to-hex@npm:1.0.0"
+  checksum: 8de16fbb42fc79c839e5579e3e7dbf9a36dfa52cfcb4c0576a0e9cc6eeb5bf3f066b671858a292c97fcf9bd117c6eebc121085325e836dfb62b2737babd29264
+  languageName: node
+  linkType: hard
+
 "array-differ@npm:^3.0.0":
   version: 3.0.0
   resolution: "array-differ@npm:3.0.0"
@@ -21310,7 +21378,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bn.js@npm:^4.0.0, bn.js@npm:^4.1.0, bn.js@npm:^4.11.9":
+"bn.js@npm:^4.0.0, bn.js@npm:^4.1.0, bn.js@npm:^4.11.8, bn.js@npm:^4.11.9":
   version: 4.12.0
   resolution: "bn.js@npm:4.12.0"
   checksum: 39afb4f15f4ea537b55eaf1446c896af28ac948fdcf47171961475724d1bb65118cca49fa6e3d67706e4790955ec0e74de584e45c8f1ef89f46c812bee5b5a12
@@ -21622,7 +21690,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer@npm:^5.5.0":
+"buffer@npm:^5.1.0, buffer@npm:^5.5.0":
   version: 5.7.1
   resolution: "buffer@npm:5.7.1"
   dependencies:
@@ -22401,6 +22469,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"clz-buffer@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "clz-buffer@npm:1.0.0"
+  checksum: 00a177ec2e7732e2c6393e3825de5f9d4a530d77fefb1797cdf1782a3d72407c43941e0c30d4511dd6c0536ed0652cf17d356ce8408e4c3234e80e1d5c88e980
+  languageName: node
+  linkType: hard
+
 "cmd-extension@npm:^1.0.2":
   version: 1.0.2
   resolution: "cmd-extension@npm:1.0.2"
@@ -22805,6 +22880,13 @@ __metadata:
     validate.io-function: ^1.0.2
     validate.io-integer-array: ^1.0.0
   checksum: d499ab57dcb48e8d0fd233b99844a06d1cc56115602c920c586e998ebba60293731f5b6976e8a1e83ae6cbfe86716f62d9432e8d94913fed8bd8352f447dc917
+  languageName: node
+  linkType: hard
+
+"concat-buffers@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "concat-buffers@npm:1.0.0"
+  checksum: 5b1d0215687a1ab27d9181d9a5036664e0f86f7da5bda5a9e446962572736e5c345eb3ca40b7d276198efad703754f8870fd216e70a36990d231b0b27c5fe9d7
   languageName: node
   linkType: hard
 
@@ -23240,6 +23322,15 @@ __metadata:
     crc-32: ^1.2.0
     readable-stream: ^4.0.0
   checksum: e6edc2f81bc387daef6d18b2ac18c2ffcb01b554d3b5c7d8d29b177505aafffba574658fdd23922767e8dab1183d1962026c98c17e17fb272794c33293ef607c
+  languageName: node
+  linkType: hard
+
+"crc@npm:^3.8.0":
+  version: 3.8.0
+  resolution: "crc@npm:3.8.0"
+  dependencies:
+    buffer: ^5.1.0
+  checksum: dabbc4eba223b206068b92ca82bb471d583eb6be2384a87f5c3712730cfd6ba4b13a45e8ba3ef62174d5a781a2c5ac5c20bf36cf37bba73926899bd0aa19186f
   languageName: node
   linkType: hard
 
@@ -26695,6 +26786,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-text-encoding@npm:^1.0.0":
+  version: 1.0.6
+  resolution: "fast-text-encoding@npm:1.0.6"
+  checksum: 9d58f694314b3283e785bf61954902536da228607ad246905e30256f9ab8331f780ac987e7222c9f5eafd04168d07e12b8054c85cedb76a2c05af0e82387a903
+  languageName: node
+  linkType: hard
+
 "fast-uri@npm:^3.0.1":
   version: 3.0.1
   resolution: "fast-uri@npm:3.0.1"
@@ -30136,6 +30234,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"isomorphic-textencoder@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "isomorphic-textencoder@npm:1.0.1"
+  dependencies:
+    fast-text-encoding: ^1.0.0
+  checksum: 9bd0c04bff7b1dc9e410d2f9a2705ca4cc288872929d88fbb7758f06b5147de8dbaea5f95ce6cf4d314f064643f3d42d69a07bbb68df0261e81153d2d56f77f3
+  languageName: node
+  linkType: hard
+
 "isomorphic-ws@npm:5.0.0, isomorphic-ws@npm:^5.0.0":
   version: 5.0.0
   resolution: "isomorphic-ws@npm:5.0.0"
@@ -30913,6 +31020,13 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: 7511b764abb66d8aa963379f7d2a404f078457d106552d05a7b556d204f7932384e8477513c124749fa2de52eb328961834562bd09924902c6432e40daa408bc
+  languageName: node
+  linkType: hard
+
+"jsbn@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "jsbn@npm:1.1.0"
+  checksum: 944f924f2bd67ad533b3850eee47603eed0f6ae425fd1ee8c760f477e8c34a05f144c1bd4f5a5dd1963141dc79a2c55f89ccc5ab77d039e7077f3ad196b64965
   languageName: node
   linkType: hard
 
@@ -39568,6 +39682,13 @@ __metadata:
   version: 2.4.0
   resolution: "secure-json-parse@npm:2.4.0"
   checksum: efaafcaa08a4646ca829b29168474f57fb289a0ca7a1d77b66b55a0292785bc6eb9143b21cfc50b37dd12a823c25b12aa1771f18314ed5a616a1f8f12a318533
+  languageName: node
+  linkType: hard
+
+"select-case@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "select-case@npm:1.0.0"
+  checksum: 19cf1c8fd16ae4b811dea9fc4a11860dc764b9f7d2e6f7c8910814d91617e0d0d508ce2186aa9f99a3708834caf261e963769fed3a313552e1dae3d28d64042a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

adds support to sign git commits with configured PGP key in scaffolder actions. configuration can be done either by integration or by using the default signing key in the scaffolder config. note that this pgp-plugin is used for signing and that it is limited to using RSA keys and signatures made with SHA1 hashing algorithm.

closes #25934

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
