### PR TITLE
feat: allow listing file contents with `debug:log`

### DIFF
--- a/.changeset/fair-peaches-learn.md
+++ b/.changeset/fair-peaches-learn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Allow listing file contents with `debug:log` scaffolder action

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -130,7 +130,7 @@ export function createCatalogWriteAction(): TemplateAction_2<
 export function createDebugLogAction(): TemplateAction_2<
   {
     message?: string | undefined;
-    listWorkspace?: boolean | undefined;
+    listWorkspace?: boolean | 'with-contents' | 'with-filenames' | undefined;
   },
   JsonObject
 >;

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/debug/log.examples.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/debug/log.examples.ts
@@ -48,4 +48,19 @@ export const examples: TemplateExample[] = [
       ],
     }),
   },
+  {
+    description: 'List the workspace directory with file contents',
+    example: yaml.stringify({
+      steps: [
+        {
+          action: 'debug:log',
+          id: 'write-workspace-directory',
+          name: 'List the workspace directory with file contents',
+          input: {
+            listWorkspace: 'with-contents',
+          },
+        },
+      ],
+    }),
+  },
 ];

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/debug/log.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/debug/log.test.ts
@@ -35,8 +35,9 @@ describe('debug:log', () => {
 
   beforeEach(() => {
     mockDir.setContent({
-      [`${mockContext.workspacePath}/README.md`]: '',
-      [`${mockContext.workspacePath}/a-directory/index.md`]: '',
+      [`${mockContext.workspacePath}/README.md`]: 'This is a README file',
+      [`${mockContext.workspacePath}/a-directory/index.md`]:
+        'This is a markdown file',
     });
     jest.resetAllMocks();
   });
@@ -91,6 +92,34 @@ describe('debug:log', () => {
     );
     expect(logger.info).toHaveBeenCalledWith(
       expect.stringContaining(join('a-directory', 'index.md')),
+    );
+  });
+
+  it('should log the workspace content with file contents from an example, if active', async () => {
+    const example = action.examples?.find(
+      sample =>
+        sample.description ===
+        'List the workspace directory with file contents',
+    )?.example as string;
+    expect(typeof example).toEqual('string');
+    const context = {
+      ...mockContext,
+      ...yaml.parse(example).steps[0],
+    };
+
+    await action.handler(context);
+
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('README.md'),
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining(join('a-directory', 'index.md')),
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('This is a README file'),
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('This is a markdown file'),
     );
   });
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This further improves the debug functionality to be able to actually see what is the content of the files generated by the template

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
