### PR TITLE
Update GitHub scaffolder plugin - grant ability to add custom properties to organization repos

### DIFF
--- a/.changeset/plenty-hounds-poke.md
+++ b/.changeset/plenty-hounds-poke.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-github': patch
+---
+
+Added the ability for the actions `publish:github` and `github:repo:create` to take inputs for 'custom properties' for organization repositories.

--- a/plugins/scaffolder-backend-module-github/api-report.md
+++ b/plugins/scaffolder-backend-module-github/api-report.md
@@ -230,6 +230,11 @@ export function createGithubRepoCreateAction(options: {
         }
       | undefined;
     requireCommitSigning?: boolean | undefined;
+    customProperties?:
+      | {
+          [key: string]: string;
+        }
+      | undefined;
   },
   JsonObject
 >;
@@ -385,6 +390,11 @@ export function createPublishGithubAction(options: {
         }
       | undefined;
     requiredCommitSigning?: boolean | undefined;
+    customProperties?:
+      | {
+          [key: string]: string;
+        }
+      | undefined;
   },
   JsonObject
 >;

--- a/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
@@ -287,6 +287,36 @@ describe('publish:github', () => {
       has_projects: false,
       has_issues: false,
     });
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        customProperties: {
+          foo: 'bar',
+          foo2: 'bar2',
+        },
+      },
+    });
+
+    expect(mockOctokit.rest.repos.createInOrg).toHaveBeenCalledWith({
+      description: 'description',
+      name: 'repo',
+      org: 'owner',
+      private: true,
+      delete_branch_on_merge: false,
+      allow_squash_merge: true,
+      squash_merge_commit_title: 'COMMIT_OR_PR_TITLE',
+      squash_merge_commit_message: 'COMMIT_MESSAGES',
+      allow_merge_commit: true,
+      allow_rebase_merge: true,
+      allow_auto_merge: false,
+      visibility: 'private',
+      custom_properties: {
+        foo: 'bar',
+        foo2: 'bar2',
+      },
+    });
   });
 
   it('should call the githubApis with the correct values for createForAuthenticatedUser', async () => {
@@ -411,6 +441,33 @@ describe('publish:github', () => {
       has_wiki: false,
       has_projects: false,
       has_issues: false,
+    });
+
+    // Custom properties on user repos should be ignored
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        customProperties: {
+          foo: 'bar',
+          foo2: 'bar2',
+        },
+      },
+    });
+
+    expect(
+      mockOctokit.rest.repos.createForAuthenticatedUser,
+    ).toHaveBeenCalledWith({
+      description: 'description',
+      name: 'repo',
+      private: true,
+      delete_branch_on_merge: false,
+      allow_squash_merge: true,
+      squash_merge_commit_title: 'COMMIT_OR_PR_TITLE',
+      squash_merge_commit_message: 'COMMIT_MESSAGES',
+      allow_merge_commit: true,
+      allow_rebase_merge: true,
+      allow_auto_merge: false,
     });
   });
 

--- a/plugins/scaffolder-backend-module-github/src/actions/github.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/github.ts
@@ -115,6 +115,7 @@ export function createPublishGithubAction(options: {
       includeClaimKeys?: string[];
     };
     requiredCommitSigning?: boolean;
+    customProperties?: { [key: string]: string };
   }>({
     id: 'publish:github',
     description:
@@ -164,6 +165,7 @@ export function createPublishGithubAction(options: {
           secrets: inputProps.secrets,
           oidcCustomization: inputProps.oidcCustomization,
           requiredCommitSigning: inputProps.requiredCommitSigning,
+          customProperties: inputProps.customProperties,
         },
       },
       output: {
@@ -213,6 +215,7 @@ export function createPublishGithubAction(options: {
         secrets,
         oidcCustomization,
         token: providedToken,
+        customProperties,
         requiredCommitSigning = false,
       } = ctx.input;
 
@@ -253,6 +256,7 @@ export function createPublishGithubAction(options: {
         repoVariables,
         secrets,
         oidcCustomization,
+        customProperties,
         ctx.logger,
       );
 

--- a/plugins/scaffolder-backend-module-github/src/actions/githubRepoCreate.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubRepoCreate.test.ts
@@ -235,6 +235,36 @@ describe('github:repo:create', () => {
       has_projects: false,
       has_issues: false,
     });
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        customProperties: {
+          foo: 'bar',
+          foo2: 'bar2',
+        },
+      },
+    });
+
+    expect(mockOctokit.rest.repos.createInOrg).toHaveBeenCalledWith({
+      description: 'description',
+      name: 'repo',
+      org: 'owner',
+      private: true,
+      delete_branch_on_merge: false,
+      allow_squash_merge: true,
+      squash_merge_commit_title: 'COMMIT_OR_PR_TITLE',
+      squash_merge_commit_message: 'COMMIT_MESSAGES',
+      allow_merge_commit: true,
+      allow_rebase_merge: true,
+      allow_auto_merge: false,
+      visibility: 'private',
+      custom_properties: {
+        foo: 'bar',
+        foo2: 'bar2',
+      },
+    });
   });
 
   it('should call the githubApis with the correct values for createForAuthenticatedUser', async () => {
@@ -359,6 +389,33 @@ describe('github:repo:create', () => {
       has_wiki: false,
       has_projects: false,
       has_issues: false,
+    });
+
+    // Custom properties on user repos should be ignored
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        customProperties: {
+          foo: 'bar',
+          foo2: 'bar2',
+        },
+      },
+    });
+
+    expect(
+      mockOctokit.rest.repos.createForAuthenticatedUser,
+    ).toHaveBeenCalledWith({
+      description: 'description',
+      name: 'repo',
+      private: true,
+      delete_branch_on_merge: false,
+      allow_squash_merge: true,
+      squash_merge_commit_title: 'COMMIT_OR_PR_TITLE',
+      squash_merge_commit_message: 'COMMIT_MESSAGES',
+      allow_merge_commit: true,
+      allow_rebase_merge: true,
+      allow_auto_merge: false,
     });
   });
 

--- a/plugins/scaffolder-backend-module-github/src/actions/githubRepoCreate.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubRepoCreate.ts
@@ -100,6 +100,7 @@ export function createGithubRepoCreateAction(options: {
       includeClaimKeys?: string[];
     };
     requireCommitSigning?: boolean;
+    customProperties?: { [key: string]: string };
   }>({
     id: 'github:repo:create',
     description: 'Creates a GitHub repository.',
@@ -139,6 +140,7 @@ export function createGithubRepoCreateAction(options: {
           secrets: inputProps.secrets,
           oidcCustomization: inputProps.oidcCustomization,
           requiredCommitSigning: inputProps.requiredCommitSigning,
+          customProperties: inputProps.customProperties,
         },
       },
       output: {
@@ -171,6 +173,7 @@ export function createGithubRepoCreateAction(options: {
         repoVariables,
         secrets,
         oidcCustomization,
+        customProperties,
         token: providedToken,
       } = ctx.input;
 
@@ -211,6 +214,7 @@ export function createGithubRepoCreateAction(options: {
         repoVariables,
         secrets,
         oidcCustomization,
+        customProperties,
         ctx.logger,
       );
 

--- a/plugins/scaffolder-backend-module-github/src/actions/helpers.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/helpers.ts
@@ -148,6 +148,7 @@ export async function createGithubRepoWithCollaboratorsAndTopics(
         includeClaimKeys?: string[];
       }
     | undefined,
+  customProperties: { [key: string]: string } | undefined,
   logger: LoggerService,
 ) {
   // eslint-disable-next-line testing-library/no-await-sync-queries
@@ -179,6 +180,8 @@ export async function createGithubRepoWithCollaboratorsAndTopics(
           has_projects: hasProjects,
           has_wiki: hasWiki,
           has_issues: hasIssues,
+          // Custom properties only available on org repos
+          custom_properties: customProperties,
         })
       : client.rest.repos.createForAuthenticatedUser({
           name: repo,

--- a/plugins/scaffolder-backend-module-github/src/actions/inputProperties.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/inputProperties.ts
@@ -304,6 +304,13 @@ const oidcCustomization = {
   },
 };
 
+const customProperties = {
+  title: 'Custom Repository Properties',
+  description:
+    'Custom properties to be added to the repository (note, this only works for organization repositories)',
+  type: 'object',
+};
+
 export { access };
 export { allowMergeCommit };
 export { allowRebaseMerge };
@@ -342,3 +349,4 @@ export { requiredCommitSigning };
 export { repoVariables };
 export { secrets };
 export { oidcCustomization };
+export { customProperties };


### PR DESCRIPTION
## Update GitHub scaffolder plugin - grant the ability to add custom properties to organization repos

Upon merging this PR, the GitHub scaffolder plugin will have updates made to both the `publish:github` and `github:repo:create` actions. Both of these actions will now be able to add custom properties when a repo is created.

This functionality is only available to organization repos as custom properties are unavailable to other repos. As a result this new input is ignored in user repositories.

Note: This is my first PR to this project, please let me know if there are any mistakes here :)

### Changeset
A Changeset has been made to **patch** the `@backstage/plugin-scaffolder-backend-module-github` package. All changes made by this PR will have no effect on any live code as the new feature has been created as an optional parameter.

This can be found at `.changeset/plenty-hounds-poke.md`

### Testing
New tests have been made for this feature on both the `github.test.ts` and `githubRepoCreate.test.ts` files. These tests have been added as new steps within existing checks and have been run successfully.

<img width="419" alt="Screen Shot 2024-08-29 at 3 40 32 PM" src="https://github.com/user-attachments/assets/116e9665-b9ef-445e-bd29-85844890413c">
