### PR TITLE
frontend-plugin-api: no longer require factory for extension overrides

### DIFF
--- a/.changeset/breezy-guests-scream.md
+++ b/.changeset/breezy-guests-scream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-test-utils': patch
+---
+
+The extension tester will no longer unconditionally enable any additional extensions that have been added.

--- a/.changeset/three-socks-call.md
+++ b/.changeset/three-socks-call.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': patch
+---
+
+The `factory` option is no longer required when overriding an extension.

--- a/packages/frontend-plugin-api/api-report.md
+++ b/packages/frontend-plugin-api/api-report.md
@@ -1108,7 +1108,7 @@ export type ExtensionDefinition<
             string}' is already defined in parent schema`;
         };
       };
-      factory(
+      factory?(
         originalFactory: (context?: {
           config?: T['config'];
           inputs?: ResolveInputValueOverrides<NonNullable<T['inputs']>>;

--- a/packages/frontend-plugin-api/src/wiring/createExtension.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.test.ts
@@ -705,6 +705,41 @@ describe('createExtension', () => {
       ).toBe('foo-hello-override-world');
     });
 
+    it('should be able to disable extension with override', () => {
+      const subject = createExtension({
+        name: 'root',
+        attachTo: { id: 'ignored', input: 'ignored' },
+        inputs: {
+          input: createExtensionInput([stringDataRef], {
+            singleton: true,
+            optional: true,
+          }),
+        },
+        output: [stringDataRef.optional()],
+        factory({ inputs }) {
+          return inputs.input ?? [];
+        },
+      });
+
+      const attached = createExtension({
+        attachTo: { id: 'root', input: 'input' },
+        output: [stringDataRef],
+        factory() {
+          return [stringDataRef('test')];
+        },
+      });
+
+      expect(
+        createExtensionTester(subject).add(attached).get(stringDataRef),
+      ).toBe('test');
+
+      expect(
+        createExtensionTester(subject)
+          .add(attached.override({ disabled: true }))
+          .get(stringDataRef),
+      ).toBe(undefined);
+    });
+
     it('should be able to override input values', () => {
       const outputRef = createExtensionDataRef<unknown>().with({
         id: 'output',

--- a/packages/frontend-plugin-api/src/wiring/createExtension.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.test.ts
@@ -588,7 +588,7 @@ describe('createExtension', () => {
         },
       });
 
-      // @ts-expect-error - this should fail because string output should be merged?
+      // @ts-expect-error
       const override2 = testExtension.override({
         output: [numberDataRef],
         factory(_, { inputs }) {
@@ -738,6 +738,34 @@ describe('createExtension', () => {
           .add(attached.override({ disabled: true }))
           .get(stringDataRef),
       ).toBe(undefined);
+    });
+
+    it('should complain when overriding with incompatible output', () => {
+      const testExtension = createExtension({
+        namespace: 'test',
+        attachTo: { id: 'root', input: 'blob' },
+        output: [stringDataRef],
+        factory() {
+          return [stringDataRef('0')];
+        },
+      });
+
+      // @ts-expect-error - override output is incompatible with factory
+      const override = testExtension.override({
+        output: [numberDataRef],
+        factory() {
+          return [stringDataRef('1')];
+        },
+      });
+      expect(override).toBeDefined();
+
+      expect(() =>
+        testExtension.override({
+          output: [numberDataRef],
+        }),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"Refused to override output without also overriding factory"`,
+      );
     });
 
     it('should be able to override input values', () => {

--- a/packages/frontend-plugin-api/src/wiring/createExtension.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.ts
@@ -191,7 +191,7 @@ export type ExtensionDefinition<
             string}' is already defined in parent schema`;
         };
       };
-      factory(
+      factory?(
         originalFactory: (context?: {
           config?: T['config'];
           inputs?: ResolveInputValueOverrides<NonNullable<T['inputs']>>;

--- a/packages/frontend-plugin-api/src/wiring/createExtension.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.ts
@@ -430,6 +430,15 @@ export function createExtension<
         UFactoryOutput
       >;
 
+      // TODO(Rugvip): Making this a type check would be optimal, but it seems
+      //               like it's tricky to add that and still have the type
+      //               inference work correctly for the factory output.
+      if (overrideOptions.output && !overrideOptions.factory) {
+        throw new Error(
+          'Refused to override output without also overriding factory',
+        );
+      }
+
       return createExtension({
         kind: newOptions.kind,
         namespace: newOptions.namespace,

--- a/packages/frontend-test-utils/src/app/createExtensionTester.tsx
+++ b/packages/frontend-test-utils/src/app/createExtensionTester.tsx
@@ -213,11 +213,17 @@ export class ExtensionTester<UOutput extends AnyExtensionDataRef> {
     const [subject, ...rest] = this.#extensions;
 
     const extensionsConfig: JsonArray = [
-      ...rest.map(extension => ({
-        [extension.id]: {
-          config: extension.config,
-        },
-      })),
+      ...rest.flatMap(extension =>
+        extension.config
+          ? [
+              {
+                [extension.id]: {
+                  config: extension.config,
+                },
+              },
+            ]
+          : [],
+      ),
       {
         [subject.id]: {
           config: subject.config,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Had a couple of cases now where I just wanted to disable an extension with an override. I think it makes sense to support that without the need to define a factory.

Also snuck in a fix for the tester which was unintentionally enabling extensions.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
