### PR TITLE
Clean up the backend-defaults cache report

### DIFF
--- a/.changeset/chilled-cameras-change.md
+++ b/.changeset/chilled-cameras-change.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-gitlab': patch
+---
+
+Internal update to use the new cache manager

--- a/.changeset/wise-forks-play.md
+++ b/.changeset/wise-forks-play.md
@@ -4,7 +4,14 @@
 
 **BREAKING**: Simplifications and cleanup as part of the Backend System 1.0 work.
 
+For the `/database` subpath exports:
+
 - The deprecated `dropDatabase` function has now been removed, without replacement.
 - The deprecated `LegacyRootDatabaseService` type has now been removed.
 - The return type from `DatabaseManager.forPlugin` is now directly a `DatabaseService`, as arguably expected.
 - `DatabaseManager.forPlugin` now requires the `deps` argument, with the logger and lifecycle services.
+
+For the `/cache` subpath exports:
+
+- The `PluginCacheManager` type has been removed. You can still import it from `@backstage/backend-common`, but it's deprecated there, and you should move off of that package by migrating fully to the new backend system.
+- Accordingly, `CacheManager.forPlugin` immediately returns a `CacheService` instead of a `PluginCacheManager`. The outcome of this is that you no longer need to make the extra `.getClient()` call. The old `CacheManager` with the old behavior still exists on `@backstage/backend-common`, but the above recommendations apply.

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -65,10 +65,15 @@ export type CacheClientOptions = CacheServiceOptions;
 // @public @deprecated (undocumented)
 export type CacheClientSetOptions = CacheServiceSetOptions;
 
-// Warning: (ae-forgotten-export) The symbol "CacheManager_2" needs to be exported by the entry point index.d.ts
-//
 // @public @deprecated (undocumented)
-export class CacheManager extends CacheManager_2 {}
+export class CacheManager {
+  // (undocumented)
+  forPlugin(pluginId: string): PluginCacheManager;
+  static fromConfig(
+    config: RootConfigService,
+    options?: CacheManagerOptions,
+  ): CacheManager;
+}
 
 // Warning: (ae-forgotten-export) The symbol "CacheManagerOptions_2" needs to be exported by the entry point index.d.ts
 //
@@ -411,10 +416,10 @@ export function makeLegacyPlugin<
 // @public @deprecated
 export function notFoundHandler(): RequestHandler;
 
-// Warning: (ae-forgotten-export) The symbol "PluginCacheManager_2" needs to be exported by the entry point index.d.ts
-//
 // @public @deprecated (undocumented)
-export type PluginCacheManager = PluginCacheManager_2;
+export type PluginCacheManager = {
+  getClient(options?: CacheServiceOptions): CacheService;
+};
 
 // @public @deprecated (undocumented)
 export type PluginDatabaseManager = DatabaseService;

--- a/packages/backend-defaults/api-report-cache.md
+++ b/packages/backend-defaults/api-report-cache.md
@@ -4,14 +4,13 @@
 
 ```ts
 import { CacheService } from '@backstage/backend-plugin-api';
-import { CacheServiceOptions } from '@backstage/backend-plugin-api';
 import { LoggerService } from '@backstage/backend-plugin-api';
 import { RootConfigService } from '@backstage/backend-plugin-api';
 import { ServiceFactory } from '@backstage/backend-plugin-api';
 
 // @public
 export class CacheManager {
-  forPlugin(pluginId: string): PluginCacheManager;
+  forPlugin(pluginId: string): CacheService;
   static fromConfig(
     config: RootConfigService,
     options?: CacheManagerOptions,
@@ -30,12 +29,6 @@ export const cacheServiceFactory: ServiceFactory<
   'plugin',
   'singleton'
 >;
-
-// @public (undocumented)
-export interface PluginCacheManager {
-  // (undocumented)
-  getClient(options?: CacheServiceOptions): CacheService;
-}
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/packages/backend-defaults/src/entrypoints/cache/CacheManager.test.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/CacheManager.test.ts
@@ -52,10 +52,10 @@ describe('CacheManager integration', () => {
         }),
       );
 
-      manager.forPlugin('p1').getClient();
-      manager.forPlugin('p1').getClient({ defaultTtl: 200 });
-      manager.forPlugin('p2').getClient();
-      manager.forPlugin('p3').getClient({});
+      manager.forPlugin('p1');
+      manager.forPlugin('p1').withOptions({ defaultTtl: 200 });
+      manager.forPlugin('p2');
+      manager.forPlugin('p3').withOptions({});
 
       if (store === 'redis') {
         // eslint-disable-next-line jest/no-conditional-expect
@@ -80,9 +80,11 @@ describe('CacheManager integration', () => {
         }),
       );
 
-      const plugin1 = manager.forPlugin('p1').getClient();
-      const plugin2a = manager.forPlugin('p2').getClient();
-      const plugin2b = manager.forPlugin('p2').getClient({ defaultTtl: 2000 });
+      const plugin1 = manager.forPlugin('p1');
+      const plugin2a = manager.forPlugin('p2');
+      const plugin2b = manager
+        .forPlugin('p2')
+        .withOptions({ defaultTtl: 2000 });
 
       await plugin1.set('a', 'plugin1');
       await plugin2a.set('a', 'plugin2a');
@@ -114,9 +116,9 @@ describe('CacheManager integration', () => {
           }),
         ).forPlugin('p');
 
-        const defaultClient = manager.getClient();
-        const numberOverrideClient = manager.getClient({ defaultTtl: 400 });
-        const durationOverrideClient = manager.getClient({
+        const defaultClient = manager;
+        const numberOverrideClient = manager.withOptions({ defaultTtl: 400 });
+        const durationOverrideClient = manager.withOptions({
           defaultTtl: { milliseconds: 400 },
         });
 

--- a/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
@@ -15,17 +15,14 @@
  */
 
 import {
+  CacheService,
   CacheServiceOptions,
   LoggerService,
   RootConfigService,
 } from '@backstage/backend-plugin-api';
 import Keyv from 'keyv';
 import { DefaultCacheClient } from './CacheClient';
-import {
-  CacheManagerOptions,
-  PluginCacheManager,
-  ttlToMilliseconds,
-} from './types';
+import { CacheManagerOptions, ttlToMilliseconds } from './types';
 import { durationToMilliseconds } from '@backstage/types';
 
 type StoreFactory = (pluginId: string, defaultTtl: number | undefined) => Keyv;
@@ -129,24 +126,16 @@ export class CacheManager {
    * @param pluginId - The plugin that the cache manager should be created for.
    *        Plugin names should be unique.
    */
-  forPlugin(pluginId: string): PluginCacheManager {
-    return {
-      getClient: (defaultOptions = {}) => {
-        const clientFactory = (options: CacheServiceOptions) => {
-          const ttl = options.defaultTtl ?? this.defaultTtl;
-          return this.getClientWithTtl(
-            pluginId,
-            ttl !== undefined ? ttlToMilliseconds(ttl) : undefined,
-          );
-        };
-
-        return new DefaultCacheClient(
-          clientFactory(defaultOptions),
-          clientFactory,
-          defaultOptions,
-        );
-      },
+  forPlugin(pluginId: string): CacheService {
+    const clientFactory = (options: CacheServiceOptions) => {
+      const ttl = options.defaultTtl ?? this.defaultTtl;
+      return this.getClientWithTtl(
+        pluginId,
+        ttl !== undefined ? ttlToMilliseconds(ttl) : undefined,
+      );
     };
+
+    return new DefaultCacheClient(clientFactory({}), clientFactory, {});
   }
 
   private getClientWithTtl(pluginId: string, ttl: number | undefined): Keyv {

--- a/packages/backend-defaults/src/entrypoints/cache/cacheServiceFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/cacheServiceFactory.ts
@@ -40,6 +40,6 @@ export const cacheServiceFactory = createServiceFactory({
     return CacheManager.fromConfig(config, { logger });
   },
   async factory({ plugin }, manager) {
-    return manager.forPlugin(plugin.getId()).getClient();
+    return manager.forPlugin(plugin.getId());
   },
 });

--- a/packages/backend-defaults/src/entrypoints/cache/index.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/index.ts
@@ -16,4 +16,4 @@
 
 export { cacheServiceFactory } from './cacheServiceFactory';
 export { CacheManager } from './CacheManager';
-export type { CacheManagerOptions, PluginCacheManager } from './types';
+export type { CacheManagerOptions } from './types';

--- a/packages/backend-defaults/src/entrypoints/cache/types.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/types.ts
@@ -15,10 +15,6 @@
  */
 
 import { LoggerService } from '@backstage/backend-plugin-api';
-import {
-  CacheService,
-  CacheServiceOptions,
-} from '@backstage/backend-plugin-api';
 import { HumanDuration, durationToMilliseconds } from '@backstage/types';
 
 /**
@@ -38,13 +34,6 @@ export type CacheManagerOptions = {
    */
   onError?: (err: Error) => void;
 };
-
-/**
- * @public
- */
-export interface PluginCacheManager {
-  getClient(options?: CacheServiceOptions): CacheService;
-}
 
 export function ttlToMilliseconds(ttl: number | HumanDuration): number {
   return typeof ttl === 'number' ? ttl : durationToMilliseconds(ttl);

--- a/plugins/catalog-backend-module-gitlab/src/GitLabDiscoveryProcessor.ts
+++ b/plugins/catalog-backend-module-gitlab/src/GitLabDiscoveryProcessor.ts
@@ -27,10 +27,7 @@ import {
 } from '@backstage/plugin-catalog-node';
 import { GitLabClient, GitLabProject, paginated } from './lib';
 import { CacheService, LoggerService } from '@backstage/backend-plugin-api';
-import {
-  CacheManager,
-  PluginCacheManager,
-} from '@backstage/backend-defaults/cache';
+import { CacheManager } from '@backstage/backend-defaults/cache';
 
 /**
  * Extracts repositories out of an GitLab instance.
@@ -64,13 +61,13 @@ export class GitLabDiscoveryProcessor implements CatalogProcessor {
 
   private constructor(options: {
     integrations: ScmIntegrationRegistry;
-    pluginCache: PluginCacheManager;
+    pluginCache: CacheService;
     logger: LoggerService;
     skipReposWithoutExactFileMatch?: boolean;
     skipForkedRepos?: boolean;
   }) {
     this.integrations = options.integrations;
-    this.cache = options.pluginCache.getClient();
+    this.cache = options.pluginCache;
     this.logger = options.logger;
     this.skipReposWithoutExactFileMatch =
       options.skipReposWithoutExactFileMatch || false;

--- a/plugins/techdocs-backend/src/service/router.test.ts
+++ b/plugins/techdocs-backend/src/service/router.test.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { loggerToWinstonLogger } from '@backstage/backend-common';
+import {
+  PluginCacheManager,
+  loggerToWinstonLogger,
+} from '@backstage/backend-common';
 import { ConfigReader } from '@backstage/config';
 import {
   DocsBuildStrategy,
@@ -30,7 +33,6 @@ import { createEventStream, createRouter, RouterOptions } from './router';
 import { TechDocsCache } from '../cache';
 import { mockErrorHandler, mockServices } from '@backstage/backend-test-utils';
 import { DiscoveryService } from '@backstage/backend-plugin-api';
-import { PluginCacheManager } from '@backstage/backend-defaults/cache';
 
 jest.mock('@backstage/catalog-client');
 jest.mock('@backstage/config');


### PR DESCRIPTION
Closes #26356

Now `CacheManager.forPlugin` returns a `CacheService` right away.

Reuses the previous backend-defaults changeset to reduce the amount of noise in the release. Skipping backend-common changeset since it's intended to be transparent to users and that package already has other changesets that makes it ship.