### PR TITLE
core-components: Add titleComponent prop to SignInPage to allow title customization with ReactNode

### DIFF
--- a/.changeset/odd-goats-kiss.md
+++ b/.changeset/odd-goats-kiss.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Added `titleComponent` prop to `SignInPage` component to allow further customization of the title using `ReactNode`

--- a/packages/core-components/src/layout/SignInPage/SignInPage.tsx
+++ b/packages/core-components/src/layout/SignInPage/SignInPage.tsx
@@ -24,7 +24,7 @@ import { UserIdentity } from './UserIdentity';
 import Button from '@material-ui/core/Button';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
-import React, { useState } from 'react';
+import React, { ReactNode, useState } from 'react';
 import { useMountEffect } from '@react-hookz/web';
 import { Progress } from '../../components/Progress';
 import { Content } from '../Content/Content';
@@ -41,6 +41,7 @@ import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 type MultiSignInPageProps = SignInPageProps & {
   providers: IdentityProviders;
   title?: string;
+  titleComponent?: ReactNode;
   align?: 'center' | 'left';
 };
 
@@ -55,6 +56,7 @@ export const MultiSignInPage = ({
   onSignInSuccess,
   providers = [],
   title,
+  titleComponent,
   align = 'left',
 }: MultiSignInPageProps) => {
   const configApi = useApi(configApiRef);
@@ -74,7 +76,13 @@ export const MultiSignInPage = ({
     <Page themeId="home">
       <Header title={configApi.getString('app.title')} />
       <Content>
-        {title && <ContentHeader title={title} textAlign={align} />}
+        {(title || titleComponent) && (
+          <ContentHeader
+            title={title}
+            titleComponent={titleComponent}
+            textAlign={align}
+          />
+        )}
         <Grid
           container
           justifyContent={align === 'center' ? align : 'flex-start'}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added `titleComponent` prop to `SignInPage` component besides the `title` prop. It makes possible to pass a `ReactNode` as title. It allows more customization of the title, like placing there icons and logos.

The original proposal is described [here](https://github.com/backstage/backstage/issues/26304). The `title` prop type could not be changed, because the `Helmet` component requires a `string`. Instead, the `titleComponent` prop of `ContentHeader` is exposed to Backstage users in the current PR.
https://github.com/backstage/backstage/blob/09f24bd0c240d9629d099e26794c043042a80497/packages/core-components/src/layout/ContentHeader/ContentHeader.tsx#L122

### Example
Modified login page, added an icon to the title.
```JavaScript
<SignInPage
  ...
  title="Select a sign-in method"
  titleComponent={
    <Typography variant="h3">
      <AssignmentIndIcon />{' '}
      Sign in
    </Typography>
  }
/>
```
![image](https://github.com/user-attachments/assets/6e9b4b10-8b11-48d2-9de3-b86cd5927253)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
