### PR TITLE
cli: fix css + svg import conflict

### DIFF
--- a/.changeset/swift-fishes-rush.md
+++ b/.changeset/swift-fishes-rush.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Fixed an issue where published frontend packages would end up with an invalid import structure if a single module imported both `.css` and `.svg` files.

--- a/packages/cli/src/lib/builder/config.ts
+++ b/packages/cli/src/lib/builder/config.ts
@@ -118,6 +118,7 @@ export async function makeRollupConfigs(
       ),
       output,
       onwarn,
+      makeAbsoluteExternalsRelative: false,
       preserveEntrySignatures: 'strict',
       // All module imports are always marked as external
       external: (source, importer, isResolved) =>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #25954

This sets [makeAbsoluteExternalsRelative](https://rollupjs.org/configuration-options/#makeabsoluteexternalsrelative) to `false`. I expect what's going on in #25954 is that the absolute path that's used by the css plugin is causing the "common root" file resolution logic mentioned in the `makeAbsoluteExternalsRelative` to be used. I don't know why that would be, but it seems to be the behavior we're seeing. Other than that I don't expect this change to have any impact on builds in other ways, since we never treat absolute imports as external.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
