### PR TITLE
Extend the "unable to resolve user identity" message

### DIFF
--- a/.changeset/dry-glasses-push.md
+++ b/.changeset/dry-glasses-push.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-node': patch
+---
+
+Extend the "unable to resolve user identity" message

--- a/plugins/auth-node/src/sign-in/readDeclarativeSignInResolver.ts
+++ b/plugins/auth-node/src/sign-in/readDeclarativeSignInResolver.ts
@@ -66,6 +66,8 @@ export function readDeclarativeSignInResolver<TAuthResult>(
       }
     }
 
-    throw new Error('Failed to sign-in, unable to resolve user identity');
+    throw new Error(
+      'Failed to sign-in, unable to resolve user identity. Please verify that your catalog contains the expected User entities that would match your configured sign-in resolver.',
+    );
   };
 }


### PR DESCRIPTION
Try to help adopters to easier understand why sign-in is not working for them. This particular error often comes up in support asks.

There's a tricky balance to strike here. This message is shown to end users as well - but hopefully only in corner cases where ingestion is not fully set up yet or so. So my hope is that it's not TOO technical, but at the same time can guide an adopter better during the setup phase.

We could go all the way to showing the query that didn't match etc, but I thought it's best to try this first.