### PR TITLE
backend-defaults: deprecate createLifecycleMiddleware

### DIFF
--- a/packages/backend-defaults/api-report-httpRouter.md
+++ b/packages/backend-defaults/api-report-httpRouter.md
@@ -9,7 +9,7 @@ import { LifecycleService } from '@backstage/backend-plugin-api';
 import { RequestHandler } from 'express';
 import { ServiceFactory } from '@backstage/backend-plugin-api';
 
-// @public
+// @public @deprecated
 export function createLifecycleMiddleware(
   options: LifecycleMiddlewareOptions,
 ): RequestHandler;

--- a/packages/backend-defaults/src/entrypoints/httpRouter/createLifecycleMiddleware.ts
+++ b/packages/backend-defaults/src/entrypoints/httpRouter/createLifecycleMiddleware.ts
@@ -48,6 +48,8 @@ export interface LifecycleMiddlewareOptions {
  * {@link @backstage/errors#ServiceUnavailableError}.
  *
  * @public
+ * @deprecated This function export will be removed in a future release.
+ * If rely on this function then please reach out to the Backstage maintainers.
  */
 export function createLifecycleMiddleware(
   options: LifecycleMiddlewareOptions,


### PR DESCRIPTION
Reduce API surface by deprecating export with no external usage. Fixes #26359