### PR TITLE
Upate url docs - changes in slug. 

### DIFF
--- a/.changeset/fuzzy-feet-exist.md
+++ b/.changeset/fuzzy-feet-exist.md
@@ -1,0 +1,6 @@
+---
+'@backstage/frontend-plugin-api': patch
+'@backstage/plugin-app': patch
+---
+
+Deprecated the `namespace` option for `createExtensionBlueprint` and `createExtension`, these are no longer required and will default to the `pluginId` instead

--- a/microsite/data/plugins/github-workflows.yaml
+++ b/microsite/data/plugins/github-workflows.yaml
@@ -4,7 +4,7 @@ author: VeeCode Platform
 authorUrl: https://platform.vee.codes/
 category: CI/CD
 description: The Github Workflows plugin provides an alternative for manually triggering GitHub workflows from within your Backstage component.
-documentation: https://platform.vee.codes/plugin/Github%20workflows/
+documentation: https://platform.vee.codes/plugin/github-workflows/
 iconUrl: https://veecode-platform.github.io/support/imgs/logo_2.svg
 npmPackageName: '@veecode-platform/backstage-plugin-github-workflows'
 tags:

--- a/microsite/data/plugins/gitlab-pipelines.yaml
+++ b/microsite/data/plugins/gitlab-pipelines.yaml
@@ -4,7 +4,7 @@ author: VeeCode Platform
 authorUrl: https://platform.vee.codes
 category: CI/CD
 description: The Gitlab pipelines plugin integrates GitlabCi with its backstage component in a simple way.
-documentation: https://platform.vee.codes/plugin/Gitlab%20Pipelines/
+documentation: https://platform.vee.codes/plugin/gitlab-pipelines/
 iconUrl: https://veecode-platform.github.io/support/imgs/logo_1.svg
 npmPackageName: '@veecode-platform/backstage-plugin-gitlab-pipelines'
 tags:

--- a/microsite/data/plugins/infracost.yaml
+++ b/microsite/data/plugins/infracost.yaml
@@ -4,7 +4,7 @@ author: VeeCode Platform
 authorUrl: https://platform.vee.codes/
 category: FinOps
 description: The Infracost plug-in works in conjunction with terraform and provides a graphical representation and cost estimate data for your entity at your respective provider.
-documentation: https://platform.vee.codes/plugin/Infracost
+documentation: https://platform.vee.codes/plugin/infracost
 iconUrl: https://veecode-platform.github.io/support/imgs/logo_5.svg
 npmPackageName: '@veecode-platform/backstage-plugin-infracost'
 tags:

--- a/microsite/data/plugins/kong-service-manager.yaml
+++ b/microsite/data/plugins/kong-service-manager.yaml
@@ -4,7 +4,7 @@ author: VeeCode Platform
 authorUrl: https://platform.vee.codes/
 category: api-manager
 description: The Kong Service Manager plugin provides information about the kong service, a list of the routes it has and also offers the possibility of manipulating plugins without leaving the backstage.
-documentation: https://platform.vee.codes/plugin/Kong%20Service%20Manager/
+documentation: https://platform.vee.codes/plugin/kong-service-manager/
 iconUrl: https://veecode-platform.github.io/support/imgs/logo_3.svg
 npmPackageName: '@veecode-platform/plugin-kong-service-manager'
 tags:

--- a/microsite/data/plugins/kubernetes-gpt-analyzer.yaml
+++ b/microsite/data/plugins/kubernetes-gpt-analyzer.yaml
@@ -4,7 +4,7 @@ author: VeeCode Platform
 authorUrl: https://platform.vee.codes/
 category: Monitoring
 description: The Kubernetes GPT Analyzer plug-in uses artificial intelligence with the help of k8s-operator to analyze and optimize your Kubernetes entities, improving the management and performance of your cluster. It makes it easier to detect anomalies and suggest best practices.
-documentation: https://platform.vee.codes/plugin/Kubernetes%20GPT%20Analyzer/
+documentation: https://platform.vee.codes/plugin/kubernetes-gpt-analyzer/
 iconUrl: https://veecode-platform.github.io/support/imgs/logo_4.svg
 npmPackageName: '@veecode-platform/backstage-plugin-kubernetes-gpt-analyzer'
 tags:

--- a/packages/frontend-plugin-api/api-report.md
+++ b/packages/frontend-plugin-api/api-report.md
@@ -1289,7 +1289,7 @@ export { googleAuthApiRef };
 // @public (undocumented)
 export const IconBundleBlueprint: ExtensionBlueprint<{
   kind: 'icon-bundle';
-  namespace: 'app';
+  namespace: undefined;
   name: undefined;
   params: {
     icons: {
@@ -1701,7 +1701,7 @@ export interface SubRouteRef<
 // @public
 export const ThemeBlueprint: ExtensionBlueprint<{
   kind: 'theme';
-  namespace: 'app';
+  namespace: undefined;
   name: undefined;
   params: {
     theme: AppTheme;

--- a/packages/frontend-plugin-api/api-report.md
+++ b/packages/frontend-plugin-api/api-report.md
@@ -631,6 +631,63 @@ export function createExtensionBlueprint<
   dataRefs: TDataRefs;
 }>;
 
+// @public @deprecated (undocumented)
+export function createExtensionBlueprint<
+  TParams extends object,
+  UOutput extends AnyExtensionDataRef,
+  TInputs extends {
+    [inputName in string]: ExtensionInput<
+      AnyExtensionDataRef,
+      {
+        optional: boolean;
+        singleton: boolean;
+      }
+    >;
+  },
+  TConfigSchema extends {
+    [key in string]: (zImpl: typeof z) => z.ZodType;
+  },
+  UFactoryOutput extends ExtensionDataValue<any, any>,
+  TKind extends string,
+  TNamespace extends string | undefined = undefined,
+  TName extends string | undefined = undefined,
+  TDataRefs extends {
+    [name in string]: AnyExtensionDataRef;
+  } = never,
+>(
+  options: CreateExtensionBlueprintOptions<
+    TKind,
+    TNamespace,
+    TName,
+    TParams,
+    UOutput,
+    TInputs,
+    TConfigSchema,
+    UFactoryOutput,
+    TDataRefs
+  >,
+): ExtensionBlueprint<{
+  kind: TKind;
+  namespace: TNamespace;
+  name: TName;
+  params: TParams;
+  output: UOutput;
+  inputs: string extends keyof TInputs ? {} : TInputs;
+  config: string extends keyof TConfigSchema
+    ? {}
+    : {
+        [key in keyof TConfigSchema]: z.infer<ReturnType<TConfigSchema[key]>>;
+      };
+  configInput: string extends keyof TConfigSchema
+    ? {}
+    : z.input<
+        z.ZodObject<{
+          [key in keyof TConfigSchema]: ReturnType<TConfigSchema[key]>;
+        }>
+      >;
+  dataRefs: TDataRefs;
+}>;
+
 // @public (undocumented)
 export type CreateExtensionBlueprintOptions<
   TKind extends string,

--- a/packages/frontend-plugin-api/src/blueprints/IconBundleBlueprint.ts
+++ b/packages/frontend-plugin-api/src/blueprints/IconBundleBlueprint.ts
@@ -24,7 +24,6 @@ const iconsDataRef = createExtensionDataRef<{
 /** @public */
 export const IconBundleBlueprint = createExtensionBlueprint({
   kind: 'icon-bundle',
-  namespace: 'app',
   attachTo: { id: 'api:app/icons', input: 'icons' },
   output: [iconsDataRef],
   config: {

--- a/packages/frontend-plugin-api/src/blueprints/ThemeBlueprint.test.ts
+++ b/packages/frontend-plugin-api/src/blueprints/ThemeBlueprint.test.ts
@@ -42,7 +42,7 @@ describe('ThemeBlueprint', () => {
         "inputs": {},
         "kind": "theme",
         "name": "light",
-        "namespace": "app",
+        "namespace": undefined,
         "output": [
           [Function],
         ],

--- a/packages/frontend-plugin-api/src/blueprints/ThemeBlueprint.ts
+++ b/packages/frontend-plugin-api/src/blueprints/ThemeBlueprint.ts
@@ -28,7 +28,6 @@ const themeDataRef = createExtensionDataRef<AppTheme>().with({
  */
 export const ThemeBlueprint = createExtensionBlueprint({
   kind: 'theme',
-  namespace: 'app',
   attachTo: { id: 'api:app/app-theme', input: 'themes' },
   output: [themeDataRef],
   dataRefs: {

--- a/packages/frontend-plugin-api/src/wiring/createExtension.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.ts
@@ -122,6 +122,7 @@ export type CreateExtensionOptions<
   UFactoryOutput extends ExtensionDataValue<any, any>,
 > = {
   kind?: TKind;
+  /** @deprecated namespace is no longer required, you can safely remove this option and it will default to the `pluginId`. It will be removed in a future release. */
   namespace?: TNamespace;
   name?: TName;
   attachTo: { id: string; input: string };

--- a/packages/frontend-plugin-api/src/wiring/createExtension.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.ts
@@ -122,7 +122,6 @@ export type CreateExtensionOptions<
   UFactoryOutput extends ExtensionDataValue<any, any>,
 > = {
   kind?: TKind;
-  /** @deprecated namespace is no longer required, you can safely remove this option and it will default to the `pluginId`. It will be removed in a future release. */
   namespace?: TNamespace;
   name?: TName;
   attachTo: { id: string; input: string };
@@ -315,6 +314,94 @@ export function toInternalExtensionDefinition<
 }
 
 /** @public */
+export function createExtension<
+  UOutput extends AnyExtensionDataRef,
+  TInputs extends {
+    [inputName in string]: ExtensionInput<
+      AnyExtensionDataRef,
+      { optional: boolean; singleton: boolean }
+    >;
+  },
+  TConfigSchema extends { [key: string]: (zImpl: typeof z) => z.ZodType },
+  UFactoryOutput extends ExtensionDataValue<any, any>,
+  const TKind extends string | undefined = undefined,
+  const TNamespace extends string | undefined = undefined,
+  const TName extends string | undefined = undefined,
+>(
+  options: CreateExtensionOptions<
+    TKind,
+    undefined,
+    TName,
+    UOutput,
+    TInputs,
+    TConfigSchema,
+    UFactoryOutput
+  >,
+): ExtensionDefinition<{
+  config: string extends keyof TConfigSchema
+    ? {}
+    : {
+        [key in keyof TConfigSchema]: z.infer<ReturnType<TConfigSchema[key]>>;
+      };
+  configInput: string extends keyof TConfigSchema
+    ? {}
+    : z.input<
+        z.ZodObject<{
+          [key in keyof TConfigSchema]: ReturnType<TConfigSchema[key]>;
+        }>
+      >;
+  output: UOutput;
+  inputs: TInputs;
+  kind: string | undefined extends TKind ? undefined : TKind;
+  namespace: string | undefined extends TNamespace ? undefined : TNamespace;
+  name: string | undefined extends TName ? undefined : TName;
+}>;
+/**
+ * @public
+ * @deprecated namespace is no longer required, you can safely remove this option and it will default to the `pluginId`. It will be removed in a future release.
+ */
+export function createExtension<
+  UOutput extends AnyExtensionDataRef,
+  TInputs extends {
+    [inputName in string]: ExtensionInput<
+      AnyExtensionDataRef,
+      { optional: boolean; singleton: boolean }
+    >;
+  },
+  TConfigSchema extends { [key: string]: (zImpl: typeof z) => z.ZodType },
+  UFactoryOutput extends ExtensionDataValue<any, any>,
+  const TKind extends string | undefined = undefined,
+  const TNamespace extends string | undefined = undefined,
+  const TName extends string | undefined = undefined,
+>(
+  options: CreateExtensionOptions<
+    TKind,
+    TNamespace,
+    TName,
+    UOutput,
+    TInputs,
+    TConfigSchema,
+    UFactoryOutput
+  >,
+): ExtensionDefinition<{
+  config: string extends keyof TConfigSchema
+    ? {}
+    : {
+        [key in keyof TConfigSchema]: z.infer<ReturnType<TConfigSchema[key]>>;
+      };
+  configInput: string extends keyof TConfigSchema
+    ? {}
+    : z.input<
+        z.ZodObject<{
+          [key in keyof TConfigSchema]: ReturnType<TConfigSchema[key]>;
+        }>
+      >;
+  output: UOutput;
+  inputs: TInputs;
+  kind: string | undefined extends TKind ? undefined : TKind;
+  namespace: string | undefined extends TNamespace ? undefined : TNamespace;
+  name: string | undefined extends TName ? undefined : TName;
+}>;
 export function createExtension<
   UOutput extends AnyExtensionDataRef,
   TInputs extends {

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
@@ -57,7 +57,6 @@ export type CreateExtensionBlueprintOptions<
   TDataRefs extends { [name in string]: AnyExtensionDataRef },
 > = {
   kind: TKind;
-  /** @deprecated namespace is no longer required, you can safely remove this option and it will default to the `pluginId`. It will be removed in a future release. */
   namespace?: TNamespace;
   attachTo: { id: string; input: string };
   disabled?: boolean;
@@ -112,7 +111,25 @@ export interface ExtensionBlueprint<
     TNewNamespace extends string | undefined,
     TNewName extends string | undefined,
   >(args: {
-    /** @deprecated namespace is no longer required, you can safely remove this option and it will default to the `pluginId`. It will be removed in a future release. */
+    namespace?: undefined;
+    name?: TNewName;
+    attachTo?: { id: string; input: string };
+    disabled?: boolean;
+    params: T['params'];
+  }): ExtensionDefinition<{
+    kind: T['kind'];
+    namespace: undefined;
+    name: string | undefined extends TNewName ? T['name'] : TNewName;
+    config: T['config'];
+    configInput: T['configInput'];
+    output: T['output'];
+    inputs: T['inputs'];
+  }>;
+  /** @deprecated namespace is no longer required, you can safely remove this option and it will default to the `pluginId`. It will be removed in a future release. */
+  make<
+    TNewNamespace extends string | undefined,
+    TNewName extends string | undefined,
+  >(args: {
     namespace?: TNewNamespace;
     name?: TNewName;
     attachTo?: { id: string; input: string };
@@ -151,8 +168,88 @@ export interface ExtensionBlueprint<
       >;
     },
   >(args: {
-    /** @deprecated namespace is no longer required, you can safely remove this option and it will default to the `pluginId`. It will be removed in a future release. */
-    namespace?: TNewNamespace;
+    namespace?: undefined;
+    name?: TNewName;
+    attachTo?: { id: string; input: string };
+    disabled?: boolean;
+    inputs?: TExtraInputs & {
+      [KName in keyof T['inputs']]?: `Error: Input '${KName &
+        string}' is already defined in parent definition`;
+    };
+    output?: Array<UNewOutput>;
+    config?: {
+      schema: TExtensionConfigSchema & {
+        [KName in keyof T['config']]?: `Error: Config key '${KName &
+          string}' is already defined in parent schema`;
+      };
+    };
+    factory(
+      originalFactory: (
+        params: T['params'],
+        context?: {
+          config?: T['config'];
+          inputs?: ResolveInputValueOverrides<NonNullable<T['inputs']>>;
+        },
+      ) => ExtensionDataContainer<NonNullable<T['output']>>,
+      context: {
+        node: AppNode;
+        apis: ApiHolder;
+        config: T['config'] & {
+          [key in keyof TExtensionConfigSchema]: z.infer<
+            ReturnType<TExtensionConfigSchema[key]>
+          >;
+        };
+        inputs: Expand<ResolvedExtensionInputs<T['inputs'] & TExtraInputs>>;
+      },
+    ): Iterable<UFactoryOutput> &
+      VerifyExtensionFactoryOutput<
+        AnyExtensionDataRef extends UNewOutput
+          ? NonNullable<T['output']>
+          : UNewOutput,
+        UFactoryOutput
+      >;
+  }): ExtensionDefinition<{
+    config: (string extends keyof TExtensionConfigSchema
+      ? {}
+      : {
+          [key in keyof TExtensionConfigSchema]: z.infer<
+            ReturnType<TExtensionConfigSchema[key]>
+          >;
+        }) &
+      T['config'];
+    configInput: (string extends keyof TExtensionConfigSchema
+      ? {}
+      : z.input<
+          z.ZodObject<{
+            [key in keyof TExtensionConfigSchema]: ReturnType<
+              TExtensionConfigSchema[key]
+            >;
+          }>
+        >) &
+      T['configInput'];
+    output: AnyExtensionDataRef extends UNewOutput ? T['output'] : UNewOutput;
+    inputs: T['inputs'] & TExtraInputs;
+    kind: T['kind'];
+    namespace: undefined;
+    name: string | undefined extends TNewName ? T['name'] : TNewName;
+  }>;
+  /** @deprecated namespace is no longer required, you can safely remove this option and it will default to the `pluginId`. It will be removed in a future release. */
+  makeWithOverrides<
+    TNewNamespace extends string | undefined,
+    TNewName extends string | undefined,
+    TExtensionConfigSchema extends {
+      [key in string]: (zImpl: typeof z) => z.ZodType;
+    },
+    UFactoryOutput extends ExtensionDataValue<any, any>,
+    UNewOutput extends AnyExtensionDataRef,
+    TExtraInputs extends {
+      [inputName in string]: ExtensionInput<
+        AnyExtensionDataRef,
+        { optional: boolean; singleton: boolean }
+      >;
+    },
+  >(args: {
+    namespace: TNewNamespace;
     name?: TNewName;
     attachTo?: { id: string; input: string };
     disabled?: boolean;
@@ -226,6 +323,56 @@ export interface ExtensionBlueprint<
  * types and instances of those types.
  *
  * @public
+ */
+export function createExtensionBlueprint<
+  TParams extends object,
+  UOutput extends AnyExtensionDataRef,
+  TInputs extends {
+    [inputName in string]: ExtensionInput<
+      AnyExtensionDataRef,
+      { optional: boolean; singleton: boolean }
+    >;
+  },
+  TConfigSchema extends { [key in string]: (zImpl: typeof z) => z.ZodType },
+  UFactoryOutput extends ExtensionDataValue<any, any>,
+  TKind extends string,
+  TNamespace extends undefined = undefined,
+  TName extends string | undefined = undefined,
+  TDataRefs extends { [name in string]: AnyExtensionDataRef } = never,
+>(
+  options: CreateExtensionBlueprintOptions<
+    TKind,
+    undefined,
+    TName,
+    TParams,
+    UOutput,
+    TInputs,
+    TConfigSchema,
+    UFactoryOutput,
+    TDataRefs
+  >,
+): ExtensionBlueprint<{
+  kind: TKind;
+  namespace: undefined;
+  name: TName;
+  params: TParams;
+  output: UOutput;
+  inputs: string extends keyof TInputs ? {} : TInputs;
+  config: string extends keyof TConfigSchema
+    ? {}
+    : { [key in keyof TConfigSchema]: z.infer<ReturnType<TConfigSchema[key]>> };
+  configInput: string extends keyof TConfigSchema
+    ? {}
+    : z.input<
+        z.ZodObject<{
+          [key in keyof TConfigSchema]: ReturnType<TConfigSchema[key]>;
+        }>
+      >;
+  dataRefs: TDataRefs;
+}>;
+/**
+ * @public
+ * @deprcated the namespace is no longer required, you can safely remove this option and it will default to the `pluginId`. It will be removed in a future release.
  */
 export function createExtensionBlueprint<
   TParams extends object,

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
@@ -57,6 +57,7 @@ export type CreateExtensionBlueprintOptions<
   TDataRefs extends { [name in string]: AnyExtensionDataRef },
 > = {
   kind: TKind;
+  /** @deprecated namespace is no longer required, you can safely remove this option and it will default to the `pluginId`. It will be removed in a future release. */
   namespace?: TNamespace;
   attachTo: { id: string; input: string };
   disabled?: boolean;
@@ -111,6 +112,7 @@ export interface ExtensionBlueprint<
     TNewNamespace extends string | undefined,
     TNewName extends string | undefined,
   >(args: {
+    /** @deprecated namespace is no longer required, you can safely remove this option and it will default to the `pluginId`. It will be removed in a future release. */
     namespace?: TNewNamespace;
     name?: TNewName;
     attachTo?: { id: string; input: string };
@@ -149,6 +151,7 @@ export interface ExtensionBlueprint<
       >;
     },
   >(args: {
+    /** @deprecated namespace is no longer required, you can safely remove this option and it will default to the `pluginId`. It will be removed in a future release. */
     namespace?: TNewNamespace;
     name?: TNewName;
     attachTo?: { id: string; input: string };

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
@@ -372,8 +372,54 @@ export function createExtensionBlueprint<
 }>;
 /**
  * @public
- * @deprcated the namespace is no longer required, you can safely remove this option and it will default to the `pluginId`. It will be removed in a future release.
+ * @deprecated the namespace is no longer required, you can safely remove this option and it will default to the `pluginId`. It will be removed in a future release.
  */
+export function createExtensionBlueprint<
+  TParams extends object,
+  UOutput extends AnyExtensionDataRef,
+  TInputs extends {
+    [inputName in string]: ExtensionInput<
+      AnyExtensionDataRef,
+      { optional: boolean; singleton: boolean }
+    >;
+  },
+  TConfigSchema extends { [key in string]: (zImpl: typeof z) => z.ZodType },
+  UFactoryOutput extends ExtensionDataValue<any, any>,
+  TKind extends string,
+  TNamespace extends string | undefined = undefined,
+  TName extends string | undefined = undefined,
+  TDataRefs extends { [name in string]: AnyExtensionDataRef } = never,
+>(
+  options: CreateExtensionBlueprintOptions<
+    TKind,
+    TNamespace,
+    TName,
+    TParams,
+    UOutput,
+    TInputs,
+    TConfigSchema,
+    UFactoryOutput,
+    TDataRefs
+  >,
+): ExtensionBlueprint<{
+  kind: TKind;
+  namespace: TNamespace;
+  name: TName;
+  params: TParams;
+  output: UOutput;
+  inputs: string extends keyof TInputs ? {} : TInputs;
+  config: string extends keyof TConfigSchema
+    ? {}
+    : { [key in keyof TConfigSchema]: z.infer<ReturnType<TConfigSchema[key]>> };
+  configInput: string extends keyof TConfigSchema
+    ? {}
+    : z.input<
+        z.ZodObject<{
+          [key in keyof TConfigSchema]: ReturnType<TConfigSchema[key]>;
+        }>
+      >;
+  dataRefs: TDataRefs;
+}>;
 export function createExtensionBlueprint<
   TParams extends object,
   UOutput extends AnyExtensionDataRef,

--- a/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.ts
+++ b/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.ts
@@ -149,6 +149,7 @@ export function resolveExtensionDefinition<
     override: _skip2,
     ...rest
   } = internalDefinition;
+
   const namespace = internalDefinition.namespace ?? context?.namespace;
 
   const namePart =
@@ -160,6 +161,13 @@ export function resolveExtensionDefinition<
   }
 
   const id = kind ? `${kind}:${namePart}` : namePart;
+
+  if (internalDefinition.namespace) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `Extension ${id} has a deprecated namespace set, this option is no longer required, and should be removed from createExtensionBlueprint or createExtension. It will be automatically set from the pluginId when installing extensions using createFrontendModule and createFrontendPlugin`,
+    );
+  }
 
   return {
     ...rest,

--- a/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.ts
+++ b/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.ts
@@ -162,13 +162,6 @@ export function resolveExtensionDefinition<
 
   const id = kind ? `${kind}:${namePart}` : namePart;
 
-  if (internalDefinition.namespace) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      `Extension ${id} has a deprecated namespace set, this option is no longer required, and should be removed from createExtensionBlueprint or createExtension. It will be automatically set from the pluginId when installing extensions using createFrontendModule and createFrontendPlugin`,
-    );
-  }
-
   return {
     ...rest,
     $$type: '@backstage/Extension',

--- a/plugins/app/api-report.md
+++ b/plugins/app/api-report.md
@@ -71,7 +71,7 @@ const appPlugin: FrontendPlugin<
         >;
       };
       kind: undefined;
-      namespace: 'app';
+      namespace: undefined;
       name: undefined;
     }>;
     'api:app/app-language': ExtensionDefinition<{
@@ -112,7 +112,7 @@ const appPlugin: FrontendPlugin<
         >;
       };
       kind: undefined;
-      namespace: 'app';
+      namespace: undefined;
       name: 'layout';
     }>;
     'app/nav': ExtensionDefinition<{
@@ -155,7 +155,7 @@ const appPlugin: FrontendPlugin<
         >;
       };
       kind: undefined;
-      namespace: 'app';
+      namespace: undefined;
       name: 'nav';
     }>;
     'app/root': ExtensionDefinition<{
@@ -220,7 +220,7 @@ const appPlugin: FrontendPlugin<
         >;
       };
       kind: undefined;
-      namespace: 'app';
+      namespace: undefined;
       name: 'root';
     }>;
     'app/routes': ExtensionDefinition<{
@@ -249,7 +249,7 @@ const appPlugin: FrontendPlugin<
         >;
       };
       kind: undefined;
-      namespace: 'app';
+      namespace: undefined;
       name: 'routes';
     }>;
     'api:app/app-theme': ExtensionDefinition<{
@@ -275,7 +275,7 @@ const appPlugin: FrontendPlugin<
     }>;
     'theme:app/light': ExtensionDefinition<{
       kind: 'theme';
-      namespace: 'app';
+      namespace: undefined;
       name: 'light';
       config: {};
       configInput: {};
@@ -284,7 +284,7 @@ const appPlugin: FrontendPlugin<
     }>;
     'theme:app/dark': ExtensionDefinition<{
       kind: 'theme';
-      namespace: 'app';
+      namespace: undefined;
       name: 'dark';
       config: {};
       configInput: {};
@@ -393,7 +393,7 @@ const appPlugin: FrontendPlugin<
     }>;
     'app-root-element:app/oauth-request-dialog': ExtensionDefinition<{
       kind: 'app-root-element';
-      namespace: 'app';
+      namespace: undefined;
       name: 'oauth-request-dialog';
       config: {};
       configInput: {};
@@ -436,7 +436,7 @@ const appPlugin: FrontendPlugin<
         >;
       };
       kind: 'app-root-element';
-      namespace: 'app';
+      namespace: undefined;
       name: 'alert-display';
     }>;
     'api:app/discovery': ExtensionDefinition<{

--- a/plugins/app/src/extensions/App.tsx
+++ b/plugins/app/src/extensions/App.tsx
@@ -27,7 +27,6 @@ import { ApiProvider } from '../../../../packages/core-app-api/src';
 import { AppThemeProvider } from '../../../../packages/core-app-api/src/app/AppThemeProvider';
 
 export const App = createExtension({
-  namespace: 'app',
   attachTo: { id: 'root', input: 'app' },
   inputs: {
     root: createExtensionInput([coreExtensionData.reactElement], {

--- a/plugins/app/src/extensions/AppLayout.tsx
+++ b/plugins/app/src/extensions/AppLayout.tsx
@@ -23,7 +23,6 @@ import {
 import { SidebarPage } from '@backstage/core-components';
 
 export const AppLayout = createExtension({
-  namespace: 'app',
   name: 'layout',
   attachTo: { id: 'app/root', input: 'children' },
   inputs: {

--- a/plugins/app/src/extensions/AppNav.tsx
+++ b/plugins/app/src/extensions/AppNav.tsx
@@ -82,7 +82,6 @@ const SidebarNavItem = (
 };
 
 export const AppNav = createExtension({
-  namespace: 'app',
   name: 'nav',
   attachTo: { id: 'app/layout', input: 'nav' },
   inputs: {

--- a/plugins/app/src/extensions/AppRoot.tsx
+++ b/plugins/app/src/extensions/AppRoot.tsx
@@ -53,7 +53,6 @@ import { RouteTracker } from '../../../../packages/frontend-app-api/src/routing/
 import { getBasePath } from '../../../../packages/frontend-app-api/src/routing/getBasePath';
 
 export const AppRoot = createExtension({
-  namespace: 'app',
   name: 'root',
   attachTo: { id: 'app', input: 'root' },
   inputs: {

--- a/plugins/app/src/extensions/AppRoutes.tsx
+++ b/plugins/app/src/extensions/AppRoutes.tsx
@@ -25,7 +25,6 @@ import {
 import { useRoutes } from 'react-router-dom';
 
 export const AppRoutes = createExtension({
-  namespace: 'app',
   name: 'routes',
   attachTo: { id: 'app/layout', input: 'content' },
   inputs: {

--- a/plugins/app/src/extensions/elements.tsx
+++ b/plugins/app/src/extensions/elements.tsx
@@ -19,7 +19,6 @@ import { AppRootElementBlueprint } from '@backstage/frontend-plugin-api';
 import React from 'react';
 
 export const oauthRequestDialogAppRootElement = AppRootElementBlueprint.make({
-  namespace: 'app',
   name: 'oauth-request-dialog',
   params: {
     element: <OAuthRequestDialog />,
@@ -28,7 +27,6 @@ export const oauthRequestDialogAppRootElement = AppRootElementBlueprint.make({
 
 export const alertDisplayAppRootElement =
   AppRootElementBlueprint.makeWithOverrides({
-    namespace: 'app',
     name: 'alert-display',
     config: {
       schema: {


### PR DESCRIPTION
## Fix Url Docs

I changed the slug of the documentation links, because they had spaces in them and were therefore interpreted as different characters, but now we've added a slug separated by “-”.

#### :heavy_check_mark: Checklist

- [x] Documentation added or updated
- [x] All your commits have a `Signed-off-by` line in the message. 