### PR TITLE
Removed broad Gitlab permission from ScmAuth

### DIFF
--- a/.changeset/cuddly-glasses-battle.md
+++ b/.changeset/cuddly-glasses-battle.md
@@ -1,0 +1,7 @@
+---
+'@backstage/integration-react': patch
+---
+
+Remove unnecessary broad permissions from Gitlab SCMAuth
+
+Newer versions of Gitlab (after 2019) do not require the broad api permissions to write to repos.

--- a/.changeset/cuddly-glasses-battle.md
+++ b/.changeset/cuddly-glasses-battle.md
@@ -2,6 +2,6 @@
 '@backstage/integration-react': patch
 ---
 
-Remove unnecessary broad permissions from Gitlab SCMAuth
+Remove unnecessary broad permissions from Gitlab `SCMAuth`
 
 Newer versions of Gitlab (after 2019) do not require the broad api permissions to write to repos.

--- a/packages/integration-react/src/api/ScmAuth.test.ts
+++ b/packages/integration-react/src/api/ScmAuth.test.ts
@@ -105,7 +105,7 @@ describe('ScmAuth', () => {
         additionalScope: { repoWrite: true },
       }),
     ).resolves.toMatchObject({
-      token: 'read_user read_api read_repository write_repository api',
+      token: 'read_user read_api read_repository write_repository',
     });
 
     const azureAuth = ScmAuth.forAzure(mockAuthApi);

--- a/packages/integration-react/src/api/ScmAuth.ts
+++ b/packages/integration-react/src/api/ScmAuth.ts
@@ -162,7 +162,7 @@ export class ScmAuth implements ScmAuthApi {
    *
    * If the additional `repoWrite` permission is requested, these scopes are added:
    *
-   * `write_repository api`
+   * `write_repository`
    */
   static forGitlab(
     gitlabAuthApi: OAuthApi,
@@ -173,7 +173,7 @@ export class ScmAuth implements ScmAuthApi {
     const host = options?.host ?? 'gitlab.com';
     return new ScmAuth('gitlab', gitlabAuthApi, host, {
       default: ['read_user', 'read_api', 'read_repository'],
-      repoWrite: ['write_repository', 'api'],
+      repoWrite: ['write_repository'],
     });
   }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

To write repositories the `api` permission is not needed anymore.

Addresses #26413

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
