### PR TITLE
fix(techdocs-node): Allow mapping custom tags in mkdocs validator

### DIFF
--- a/.changeset/long-peas-repeat.md
+++ b/.changeset/long-peas-repeat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-node': patch
+---
+
+Add support for mapping custom tags in the techdocs yaml parser that validates the mkdocs.yaml file

--- a/plugins/techdocs-node/src/stages/generate/__fixtures__/mkdocs_with_extensions.yml
+++ b/plugins/techdocs-node/src/stages/generate/__fixtures__/mkdocs_with_extensions.yml
@@ -4,4 +4,9 @@ site_description: Test site description
 markdown_extensions:
   - pymdownx.emoji:
       emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_generator: !!python/object.apply:materialx.emoji.to_svg
+  - pymdownx.tabbed:
+      alternate_style: true
+      slugify: !!python/object/apply:pymdownx.slugs.slugify
+        kwds:
+          case: lower

--- a/plugins/techdocs-node/src/stages/generate/helpers.test.ts
+++ b/plugins/techdocs-node/src/stages/generate/helpers.test.ts
@@ -247,6 +247,10 @@ describe('helpers', () => {
       expect(updatedMkdocsYml.toString()).toContain(
         "emoji_index: !!python/name:materialx.emoji.twemoji ''",
       );
+      expect(updatedMkdocsYml.toString()).toContain(
+        'slugify: !!python/object/apply:pymdownx.slugs.slugify',
+      );
+      expect(updatedMkdocsYml.toString()).toContain('case: lower');
     });
 
     it('should not override existing repo_url in mkdocs.yml', async () => {

--- a/plugins/techdocs-node/src/stages/generate/helpers.ts
+++ b/plugins/techdocs-node/src/stages/generate/helpers.ts
@@ -141,6 +141,14 @@ export const MKDOCS_SCHEMA = DEFAULT_SCHEMA.extend([
     instanceOf: UnknownTag,
     construct: (data: string, type?: string) => new UnknownTag(data, type),
   }),
+  new Type('tag:', {
+    kind: 'mapping',
+    multi: true,
+    representName: o => (o as UnknownTag).type,
+    represent: o => (o as UnknownTag).data ?? '',
+    instanceOf: UnknownTag,
+    construct: (data: string, type?: string) => new UnknownTag(data, type),
+  }),
   new Type('', {
     kind: 'sequence',
     multi: true,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR tries to fix this techdocs error while parsing an mkdocs.yaml file that contains custom yaml tags of type mapping like:

```
info: Step 1 of 3: Preparing docs for entity component:default/example-api {"timestamp":"2024-09-03T10:02:12.769Z"}
info: Prepare step completed for entity component:default/example-api, stored at /tmp/backstage-SmADMG {"timestamp":"2024-09-03T10:02:13.530Z"}
info: Step 2 of 3: Generating docs for entity component:default/example-api {"timestamp":"2024-09-03T10:02:13.530Z"}
error: Failed to build the docs page for entity component:default/example-api: unknown tag !<tag:yaml.org,2002:python/object/apply:pymdownx.slugs.slugify> (75:1)
 
  72 |       slugify: !!python/object/ ...
  73 |         kwds:
  74 |           case: lower
  75 |
------^ {"timestamp":"2024-09-03T10:02:13.533Z"}
```

This happens because the validator can understand the scalar and sequence typed custom tags but not the ones of type mapping like this example:

```yaml
markdown_extensions:
  - pymdownx.tabbed:
      alternate_style: true
      slugify: !!python/object/apply:pymdownx.slugs.slugify
        kwds:
          case: lower
```

See [this conversation](https://discord.com/channels/687207715902193673/714754240933003266/1268520660091535451) where another user experiencing the same issue.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] ~Added or updated documentation~ 
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] ~Screenshots attached (for UI changes)~
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
