### PR TITLE
removed the `basePath` of discovery

### DIFF
--- a/.changeset/angry-hotels-warn.md
+++ b/.changeset/angry-hotels-warn.md
@@ -1,0 +1,6 @@
+---
+'@backstage/backend-defaults': minor
+'@backstage/backend-common': minor
+---
+
+**BREAKING**: You can no longer supply a `basePath` option to the host discovery implementation. In the new backend system, the ability to choose this path has been removed anyway at the plugin router level.

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -277,12 +277,7 @@ export class Git {
 
 // @public @deprecated
 class HostDiscovery implements DiscoveryService {
-  static fromConfig(
-    config: Config,
-    options?: {
-      basePath?: string;
-    },
-  ): HostDiscovery;
+  static fromConfig(config: Config): HostDiscovery;
   // (undocumented)
   getBaseUrl(pluginId: string): Promise<string>;
   // (undocumented)

--- a/packages/backend-common/src/deprecated/index.ts
+++ b/packages/backend-common/src/deprecated/index.ts
@@ -96,11 +96,11 @@ export class HostDiscovery implements DiscoveryService {
    *      plugins: [search]
    * ```
    *
-   * The basePath defaults to `/api`, meaning the default full internal
+   * The fixed base path is `/api`, meaning the default full internal
    * path for the `catalog` plugin will be `http://localhost:7007/api/catalog`.
    */
-  static fromConfig(config: Config, options?: { basePath?: string }) {
-    return new HostDiscovery(_HostDiscovery.fromConfig(config, options));
+  static fromConfig(config: Config) {
+    return new HostDiscovery(_HostDiscovery.fromConfig(config));
   }
 
   private constructor(private readonly impl: _HostDiscovery) {}

--- a/packages/backend-defaults/api-report-discovery.md
+++ b/packages/backend-defaults/api-report-discovery.md
@@ -16,12 +16,7 @@ export const discoveryServiceFactory: ServiceFactory<
 
 // @public
 export class HostDiscovery implements DiscoveryService {
-  static fromConfig(
-    config: RootConfigService,
-    options?: {
-      basePath?: string;
-    },
-  ): HostDiscovery;
+  static fromConfig(config: RootConfigService): HostDiscovery;
   // (undocumented)
   getBaseUrl(pluginId: string): Promise<string>;
   // (undocumented)

--- a/packages/backend-defaults/src/entrypoints/discovery/HostDiscovery.test.ts
+++ b/packages/backend-defaults/src/entrypoints/discovery/HostDiscovery.test.ts
@@ -54,25 +54,6 @@ describe('HostDiscovery', () => {
     );
   });
 
-  it('can configure the base path', async () => {
-    const discovery = HostDiscovery.fromConfig(
-      new ConfigReader({
-        backend: {
-          baseUrl: 'http://localhost:40',
-          listen: { port: 80, host: 'localhost' },
-        },
-      }),
-      { basePath: '/service' },
-    );
-
-    await expect(discovery.getBaseUrl('catalog')).resolves.toBe(
-      'http://localhost:80/service/catalog',
-    );
-    await expect(discovery.getExternalBaseUrl('catalog')).resolves.toBe(
-      'http://localhost:40/service/catalog',
-    );
-  });
-
   it.each([
     [{ listen: ':80' }, 'http://localhost:80'],
     [{ listen: ':40', https: true }, 'https://localhost:40'],

--- a/packages/backend-defaults/src/entrypoints/discovery/HostDiscovery.ts
+++ b/packages/backend-defaults/src/entrypoints/discovery/HostDiscovery.ts
@@ -42,6 +42,7 @@ export class HostDiscovery implements DiscoveryService {
    *
    * Can be overridden in config by providing a target and corresponding plugins in `discovery.endpoints`.
    * eg.
+   *
    * ```yaml
    * discovery:
    *  endpoints:
@@ -55,14 +56,11 @@ export class HostDiscovery implements DiscoveryService {
    *      plugins: [search]
    * ```
    *
-   * The basePath defaults to `/api`, meaning the default full internal
+   * The fixed base path is `/api`, meaning the default full internal
    * path for the `catalog` plugin will be `http://localhost:7007/api/catalog`.
    */
-  static fromConfig(
-    config: RootConfigService,
-    options?: { basePath?: string },
-  ) {
-    const basePath = options?.basePath ?? '/api';
+  static fromConfig(config: RootConfigService) {
+    const basePath = '/api';
     const externalBaseUrl = config
       .getString('backend.baseUrl')
       .replace(/\/+$/, '');


### PR DESCRIPTION
Closes #26358

This isn't supported in the new system anyway.