### PR TITLE
fix: use primary theme color for entity star icon

### DIFF
--- a/.changeset/small-papayas-roll.md
+++ b/.changeset/small-papayas-roll.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-catalog-react': patch
+'@backstage/plugin-techdocs': patch
+'@backstage/plugin-catalog': patch
+'@backstage/plugin-home': patch
+---
+
+Use primary theme color for entity star icon

--- a/plugins/catalog-react/src/components/FavoriteEntity/FavoriteEntity.tsx
+++ b/plugins/catalog-react/src/components/FavoriteEntity/FavoriteEntity.tsx
@@ -17,7 +17,6 @@
 import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
 import IconButton from '@material-ui/core/IconButton';
 import Tooltip from '@material-ui/core/Tooltip';
-import { withStyles } from '@material-ui/core/styles';
 import Star from '@material-ui/icons/Star';
 import StarBorder from '@material-ui/icons/StarBorder';
 import React, { ComponentProps } from 'react';
@@ -29,12 +28,6 @@ import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 export type FavoriteEntityProps = ComponentProps<typeof IconButton> & {
   entity: Entity;
 };
-
-const YellowStar = withStyles({
-  root: {
-    color: '#f3ba37',
-  },
-})(Star);
 
 /**
  * IconButton for showing if a current entity is starred and adding/removing it from the favorite entities
@@ -64,7 +57,7 @@ export const FavoriteEntity = (props: FavoriteEntityProps) => {
       onClick={() => toggleStarredEntity()}
     >
       <Tooltip id={id} title={title}>
-        {isStarredEntity ? <YellowStar /> : <StarBorder />}
+        {isStarredEntity ? <Star /> : <StarBorder />}
       </Tooltip>
     </IconButton>
   );

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -35,7 +35,6 @@ import {
   useStarredEntities,
 } from '@backstage/plugin-catalog-react';
 import Typography from '@material-ui/core/Typography';
-import { withStyles } from '@material-ui/core/styles';
 import { visuallyHidden } from '@mui/utils';
 import Edit from '@material-ui/icons/Edit';
 import OpenInNew from '@material-ui/icons/OpenInNew';
@@ -63,12 +62,6 @@ export interface CatalogTableProps {
   emptyContent?: ReactNode;
   subtitle?: string;
 }
-
-const YellowStar = withStyles({
-  root: {
-    color: '#f3ba37',
-  },
-})(Star);
 
 const refCompare = (a: Entity, b: Entity) => {
   const toRef = (entity: Entity) =>
@@ -163,7 +156,7 @@ export const CatalogTable = (props: CatalogTableProps) => {
         icon: () => (
           <>
             <Typography style={visuallyHidden}>{title}</Typography>
-            {isStarred ? <YellowStar /> : <StarBorder />}
+            {isStarred ? <Star /> : <StarBorder />}
           </>
         ),
         tooltip: title,

--- a/plugins/home/src/components/StarredEntityListItem/StarredEntityListItem.tsx
+++ b/plugins/home/src/components/StarredEntityListItem/StarredEntityListItem.tsx
@@ -46,7 +46,7 @@ export const StarredEntityListItem = ({
             aria-label="unstar"
             onClick={() => onToggleStarredEntity(entity)}
           >
-            <StarIcon style={{ color: '#f3ba37' }} />
+            <StarIcon />
           </IconButton>
         </Tooltip>
       </ListItemIcon>

--- a/plugins/techdocs/src/home/components/Tables/actions.tsx
+++ b/plugins/techdocs/src/home/components/Tables/actions.tsx
@@ -17,15 +17,8 @@
 import React from 'react';
 import ShareIcon from '@material-ui/icons/Share';
 import { DocsTableRow } from './types';
-import { withStyles } from '@material-ui/core/styles';
 import Star from '@material-ui/icons/Star';
 import StarBorder from '@material-ui/icons/StarBorder';
-
-const YellowStar = withStyles({
-  root: {
-    color: '#f3ba37',
-  },
-})(Star);
 
 /**
  * Not directly exported, but through DocsTable.actions and EntityListDocsTable.actions
@@ -52,7 +45,7 @@ export const actionFactories = {
       const isStarred = isStarredEntity(entity);
       return {
         cellStyle: { paddingLeft: '1em' },
-        icon: () => (isStarred ? <YellowStar /> : <StarBorder />),
+        icon: () => (isStarred ? <Star /> : <StarBorder />),
         tooltip: isStarred ? 'Remove from favorites' : 'Add to favorites',
         onClick: () => toggleStarredEntity(entity),
       };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### Background
TLDR; we should use primary theme color for the entity star (favorite) icon. See https://github.com/backstage/backstage/issues/26385.  

### Changes
- Remove all occurrences of `#f3ba37` as color for `Star`

### Screenshots 
![image](https://github.com/user-attachments/assets/d0249a9d-c50b-4150-99f6-be09cd211a17)

![image](https://github.com/user-attachments/assets/28963075-c178-41ae-800e-3be417796b08)

![image](https://github.com/user-attachments/assets/bb8d49e8-5ba2-4d78-99ff-a1f5ee9650a9)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
