### PR TITLE
feat: Allow for proxied auth provider logout

### DIFF
--- a/packages/core-app-api/src/apis/implementations/IdentityApi/AppIdentityProxy.test.ts
+++ b/packages/core-app-api/src/apis/implementations/IdentityApi/AppIdentityProxy.test.ts
@@ -91,4 +91,22 @@ describe('AppIdentityProxy', () => {
     await proxy.signOut();
     expect(window.location.href).toBe('/foo');
   });
+
+  it('should navigate to redirect URL on sign out', async () => {
+    const proxy = new AppIdentityProxy();
+    const mockRedirectingIdentityApi = {
+      getBackstageIdentity: jest.fn(),
+      getProfileInfo: jest.fn(),
+      getCredentials: jest.fn(),
+      signOut: jest.fn().mockResolvedValue({ redirectUrl: '/bar' }),
+    };
+    proxy.setTarget(mockRedirectingIdentityApi, { signOutTargetUrl: '/foo' });
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: {},
+    });
+
+    await proxy.signOut();
+    expect(window.location.href).toBe('/bar');
+  });
 });

--- a/packages/core-app-api/src/apis/implementations/IdentityApi/AppIdentityProxy.ts
+++ b/packages/core-app-api/src/apis/implementations/IdentityApi/AppIdentityProxy.ts
@@ -128,8 +128,14 @@ export class AppIdentityProxy implements IdentityApi {
     });
   }
 
-  async signOut(): Promise<void> {
-    await this.waitForTarget.then(target => target.signOut());
+  async signOut(): Promise<any> {
+    await this.waitForTarget.then(async target => {
+      if (target.signOut) {
+        const res = await target.signOut();
+        this.signOutTargetUrl =
+          res && res.redirectUrl ? res.redirectUrl : this.signOutTargetUrl;
+      }
+    });
 
     await this.#cookieAuthSignOut?.();
 

--- a/packages/core-components/src/layout/ProxiedSignInPage/ProxiedSignInIdentity.ts
+++ b/packages/core-components/src/layout/ProxiedSignInPage/ProxiedSignInIdentity.ts
@@ -21,7 +21,12 @@ import {
   ProfileInfo,
 } from '@backstage/core-plugin-api';
 import { ResponseError } from '@backstage/errors';
-import { ProxiedSession, proxiedSessionSchema } from './types';
+import {
+  LogoutResponse,
+  logoutResponseSchema,
+  ProxiedSession,
+  proxiedSessionSchema,
+} from './types';
 
 export const DEFAULTS = {
   // The amount of time between token refreshes, if we fail to get an actual
@@ -52,6 +57,7 @@ type ProxiedSignInIdentityOptions = {
   provider: string;
   discoveryApi: typeof discoveryApiRef.T;
   headers?: HeadersInit | (() => HeadersInit) | (() => Promise<HeadersInit>);
+  logoutRedirectUrl?: string;
 };
 
 type State =
@@ -138,8 +144,11 @@ export class ProxiedSignInIdentity implements IdentityApi {
   }
 
   /** {@inheritdoc @backstage/core-plugin-api#IdentityApi.signOut} */
-  async signOut(): Promise<void> {
-    this.abortController.abort();
+  async signOut(): Promise<LogoutResponse> {
+    const response = await this.postLogout();
+    return {
+      redirectUrl: response.redirectUrl ?? '/',
+    };
   }
 
   getSessionSync(): ProxiedSession {
@@ -189,6 +198,30 @@ export class ProxiedSignInIdentity implements IdentityApi {
     };
 
     return promise;
+  }
+
+  async postLogout(): Promise<LogoutResponse> {
+    const baseUrl = await this.options.discoveryApi.getBaseUrl('auth');
+
+    const headers =
+      typeof this.options.headers === 'function'
+        ? await this.options.headers()
+        : this.options.headers;
+    const mergedHeaders = new Headers(headers);
+    mergedHeaders.set('X-Requested-With', 'XMLHttpRequest');
+
+    const response = await fetch(`${baseUrl}/${this.options.provider}/logout`, {
+      method: 'POST',
+      signal: this.abortController.signal,
+      headers: mergedHeaders,
+      credentials: 'include',
+    });
+
+    if (!response.ok) {
+      throw await ResponseError.fromResponse(response);
+    }
+
+    return logoutResponseSchema.parse(await response.json());
   }
 
   async fetchSession(): Promise<ProxiedSession> {

--- a/packages/core-components/src/layout/ProxiedSignInPage/ProxiedSignInPage.tsx
+++ b/packages/core-components/src/layout/ProxiedSignInPage/ProxiedSignInPage.tsx
@@ -46,6 +46,11 @@ export type ProxiedSignInPageProps = SignInPageProps & {
   headers?: HeadersInit | (() => HeadersInit) | (() => Promise<HeadersInit>);
 
   /**
+   * Optional url to redirect to upon logout.
+   */
+  logoutRedirectUrl?: string;
+
+  /**
    * Error component to be rendered instead of the default error panel in case
    * sign in fails.
    */

--- a/packages/core-components/src/layout/ProxiedSignInPage/types.ts
+++ b/packages/core-components/src/layout/ProxiedSignInPage/types.ts
@@ -48,3 +48,11 @@ export type ProxiedSession = {
   profile: ProfileInfo;
   backstageIdentity: Omit<BackstageIdentityResponse, 'id'>;
 };
+
+export const logoutResponseSchema = z.object({
+  redirectUrl: z.string().optional(),
+});
+
+export type LogoutResponse = {
+  redirectUrl?: string;
+};

--- a/packages/core-components/src/layout/SignInPage/IdentityApiSignOutProxy.ts
+++ b/packages/core-components/src/layout/SignInPage/IdentityApiSignOutProxy.ts
@@ -17,6 +17,7 @@
 import {
   BackstageUserIdentity,
   IdentityApi,
+  LogoutResponse,
   ProfileInfo,
 } from '@backstage/core-plugin-api';
 
@@ -75,7 +76,7 @@ export class IdentityApiSignOutProxy implements IdentityApi {
     return this.config.identityApi.getCredentials();
   }
 
-  signOut(): Promise<void> {
+  signOut(): Promise<LogoutResponse> | Promise<void> {
     return this.config.signOut();
   }
 }

--- a/packages/core-components/src/layout/SignInPage/LegacyUserIdentity.ts
+++ b/packages/core-components/src/layout/SignInPage/LegacyUserIdentity.ts
@@ -18,6 +18,7 @@ import {
   IdentityApi,
   ProfileInfo,
   BackstageUserIdentity,
+  LogoutResponse,
 } from '@backstage/core-plugin-api';
 
 function parseJwtPayload(token: string) {
@@ -29,7 +30,7 @@ type LegacySignInResult = {
   userId: string;
   profile: ProfileInfo;
   getIdToken?: () => Promise<string>;
-  signOut?: () => Promise<void>;
+  signOut?: () => Promise<LogoutResponse> | Promise<void>;
 };
 
 /** @internal */
@@ -82,6 +83,6 @@ export class LegacyUserIdentity implements IdentityApi {
   }
 
   async signOut(): Promise<void> {
-    return this.result.signOut?.();
+    this.result.signOut?.();
   }
 }

--- a/packages/core-components/src/layout/SignInPage/UserIdentity.ts
+++ b/packages/core-components/src/layout/SignInPage/UserIdentity.ts
@@ -21,6 +21,7 @@ import {
   BackstageUserIdentity,
   BackstageIdentityApi,
   SessionApi,
+  LogoutResponse,
 } from '@backstage/core-plugin-api';
 
 import { GuestUserIdentity } from './GuestUserIdentity';
@@ -70,7 +71,7 @@ export class UserIdentity implements IdentityApi {
     /**
      * Sign out handler that will be called if the user requests to sign out.
      */
-    signOut?: () => Promise<void>;
+    signOut?: () => Promise<LogoutResponse> | Promise<void>;
   }): IdentityApi {
     return LegacyUserIdentity.fromResult(result);
   }
@@ -159,6 +160,6 @@ export class UserIdentity implements IdentityApi {
 
   /** {@inheritdoc @backstage/core-plugin-api#IdentityApi.signOut} */
   async signOut(): Promise<void> {
-    return this.authApi.signOut();
+    this.authApi.signOut();
   }
 }

--- a/packages/core-plugin-api/report.api.md
+++ b/packages/core-plugin-api/report.api.md
@@ -516,11 +516,18 @@ export type IdentityApi = {
   getCredentials(): Promise<{
     token?: string;
   }>;
-  signOut(): Promise<void>;
+  signOut(): Promise<LogoutResponse> | Promise<void>;
 };
 
 // @public
 export const identityApiRef: ApiRef<IdentityApi>;
+
+// Warning: (ae-missing-release-tag) "LogoutResponse" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type LogoutResponse = {
+  redirectUrl?: string;
+};
 
 // @public @deprecated
 export type MakeSubRouteRef<
@@ -687,7 +694,7 @@ export type RouteRef<Params extends AnyParams = any> = {
 // @public
 export type SessionApi = {
   signIn(): Promise<void>;
-  signOut(): Promise<void>;
+  signOut(): Promise<LogoutResponse> | Promise<void>;
   sessionState$(): Observable<SessionState>;
 };
 

--- a/packages/core-plugin-api/src/apis/definitions/IdentityApi.ts
+++ b/packages/core-plugin-api/src/apis/definitions/IdentityApi.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { ApiRef, createApiRef } from '../system';
-import { BackstageUserIdentity, ProfileInfo } from './auth';
+import { BackstageUserIdentity, LogoutResponse, ProfileInfo } from './auth';
 
 /**
  * The Identity API used to identify and get information about the signed in user.
@@ -43,7 +43,7 @@ export type IdentityApi = {
   /**
    * Sign out the current user
    */
-  signOut(): Promise<void>;
+  signOut(): Promise<LogoutResponse> | Promise<void>;
 };
 
 /**

--- a/packages/core-plugin-api/src/apis/definitions/auth.ts
+++ b/packages/core-plugin-api/src/apis/definitions/auth.ts
@@ -259,6 +259,13 @@ export type ProfileInfo = {
   picture?: string;
 };
 
+export type LogoutResponse = {
+  /**
+   * The url to redirect to upon logout.
+   */
+  redirectUrl?: string;
+};
+
 /**
  * Session state values passed to subscribers of the SessionApi.
  *
@@ -289,7 +296,7 @@ export type SessionApi = {
   /**
    * Sign out from the current session. This will reload the page.
    */
-  signOut(): Promise<void>;
+  signOut(): Promise<LogoutResponse> | Promise<void>;
 
   /**
    * Observe the current state of the auth session. Emits the current state on subscription.

--- a/plugins/auth-backend-module-oauth2-proxy-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-oauth2-proxy-provider/src/authenticator.ts
@@ -39,7 +39,10 @@ export const oauth2ProxyAuthenticator = createProxyAuthenticator({
       },
     };
   },
-  async initialize() {},
+  async initialize({ config }) {
+    const logoutRedirectUrl = config.getOptionalString('logoutRedirectUrl');
+    return { logoutRedirectUrl };
+  },
   async authenticate({ req }) {
     try {
       // This unpacking of the JWT is just a utility provided by the
@@ -76,5 +79,16 @@ export const oauth2ProxyAuthenticator = createProxyAuthenticator({
     } catch (e) {
       throw new AuthenticationError('Authentication failed', e);
     }
+  },
+  logout({ res }, { logoutRedirectUrl }) {
+    if (logoutRedirectUrl && res) {
+      return res
+        .status(200)
+        .json({
+          redirectUrl: logoutRedirectUrl,
+        })
+        .send();
+    }
+    return res.status(204).send();
   },
 });

--- a/plugins/auth-node/report.api.md
+++ b/plugins/auth-node/report.api.md
@@ -191,13 +191,23 @@ export function createOAuthRouteHandlers<TProfile>(
 ): AuthProviderRouteHandlers;
 
 // @public (undocumented)
-export function createProxyAuthenticator<TContext, TResult, TProviderInfo>(
-  authenticator: ProxyAuthenticator<TContext, TResult, TProviderInfo>,
-): ProxyAuthenticator<TContext, TResult, TProviderInfo>;
+export function createProxyAuthenticator<
+  TContext,
+  TResult,
+  TProviderInfo,
+  TLogoutResult,
+>(
+  authenticator: ProxyAuthenticator<
+    TContext,
+    TResult,
+    TProviderInfo,
+    TLogoutResult
+  >,
+): ProxyAuthenticator<TContext, TResult, TProviderInfo, TLogoutResult>;
 
 // @public (undocumented)
 export function createProxyAuthProviderFactory<TResult>(options: {
-  authenticator: ProxyAuthenticator<unknown, TResult, unknown>;
+  authenticator: ProxyAuthenticator<unknown, TResult, unknown, unknown>;
   profileTransform?: ProfileTransform<TResult>;
   signInResolver?: SignInResolver<TResult>;
   signInResolverFactories?: Record<string, SignInResolverFactory>;
@@ -578,7 +588,8 @@ export type ProfileTransform<TResult> = (
 export interface ProxyAuthenticator<
   TContext,
   TResult,
-  TProviderInfo = undefined,
+  TProviderInfo,
+  TLogoutResult = undefined,
 > {
   // (undocumented)
   authenticate(
@@ -594,12 +605,22 @@ export interface ProxyAuthenticator<
   defaultProfileTransform: ProfileTransform<TResult>;
   // (undocumented)
   initialize(ctx: { config: Config }): TContext;
+  // (undocumented)
+  logout?(
+    options: {
+      req: Request_2;
+      res: Response_2;
+    },
+    ctx: {
+      logoutRedirectUrl?: string;
+    },
+  ): TLogoutResult;
 }
 
 // @public (undocumented)
 export interface ProxyAuthRouteHandlersOptions<TResult> {
   // (undocumented)
-  authenticator: ProxyAuthenticator<any, TResult, unknown>;
+  authenticator: ProxyAuthenticator<any, TResult, unknown, unknown>;
   // (undocumented)
   config: Config;
   // (undocumented)

--- a/plugins/auth-node/src/proxy/createProxyAuthProviderFactory.ts
+++ b/plugins/auth-node/src/proxy/createProxyAuthProviderFactory.ts
@@ -28,7 +28,7 @@ import { ProxyAuthenticator } from './types';
 
 /** @public */
 export function createProxyAuthProviderFactory<TResult>(options: {
-  authenticator: ProxyAuthenticator<unknown, TResult, unknown>;
+  authenticator: ProxyAuthenticator<unknown, TResult, unknown, unknown>;
   profileTransform?: ProfileTransform<TResult>;
   signInResolver?: SignInResolver<TResult>;
   signInResolverFactories?: Record<string, SignInResolverFactory>;

--- a/plugins/auth-node/src/proxy/createProxyRouteHandlers.ts
+++ b/plugins/auth-node/src/proxy/createProxyRouteHandlers.ts
@@ -29,7 +29,7 @@ import { NotImplementedError } from '@backstage/errors';
 
 /** @public */
 export interface ProxyAuthRouteHandlersOptions<TResult> {
-  authenticator: ProxyAuthenticator<any, TResult, unknown>;
+  authenticator: ProxyAuthenticator<any, TResult, unknown, unknown>;
   config: Config;
   resolverContext: AuthResolverContext;
   signInResolver: SignInResolver<TResult>;
@@ -45,6 +45,12 @@ export function createProxyAuthRouteHandlers<TResult>(
   const profileTransform =
     options.profileTransform ?? authenticator.defaultProfileTransform;
   const authenticatorCtx = authenticator.initialize({ config });
+
+  const logoutCallback = authenticator.logout
+    ? async (req: Request, res: Response): Promise<void> => {
+        authenticator.logout?.({ req, res }, await authenticatorCtx);
+      }
+    : undefined;
 
   return {
     async start(): Promise<void> {
@@ -76,5 +82,7 @@ export function createProxyAuthRouteHandlers<TResult>(
 
       res.status(200).json(response);
     },
+
+    logout: logoutCallback,
   };
 }

--- a/plugins/auth-node/src/proxy/types.ts
+++ b/plugins/auth-node/src/proxy/types.ts
@@ -15,14 +15,15 @@
  */
 
 import { Config } from '@backstage/config';
-import { Request } from 'express';
+import { Request, Response } from 'express';
 import { ProfileTransform } from '../types';
 
 /** @public */
 export interface ProxyAuthenticator<
   TContext,
   TResult,
-  TProviderInfo = undefined,
+  TProviderInfo,
+  TLogoutResult = undefined,
 > {
   defaultProfileTransform: ProfileTransform<TResult>;
   initialize(ctx: { config: Config }): TContext;
@@ -30,11 +31,25 @@ export interface ProxyAuthenticator<
     options: { req: Request },
     ctx: TContext,
   ): Promise<{ result: TResult; providerInfo?: TProviderInfo }>;
+  logout?(
+    options: { req: Request; res: Response },
+    ctx: { logoutRedirectUrl?: string },
+  ): TLogoutResult;
 }
 
 /** @public */
-export function createProxyAuthenticator<TContext, TResult, TProviderInfo>(
-  authenticator: ProxyAuthenticator<TContext, TResult, TProviderInfo>,
-): ProxyAuthenticator<TContext, TResult, TProviderInfo> {
+export function createProxyAuthenticator<
+  TContext,
+  TResult,
+  TProviderInfo,
+  TLogoutResult,
+>(
+  authenticator: ProxyAuthenticator<
+    TContext,
+    TResult,
+    TProviderInfo,
+    TLogoutResult
+  >,
+): ProxyAuthenticator<TContext, TResult, TProviderInfo, TLogoutResult> {
   return authenticator;
 }

--- a/plugins/user-settings/report-alpha.api.md
+++ b/plugins/user-settings/report-alpha.api.md
@@ -20,27 +20,6 @@ const _default: FrontendPlugin<
   },
   {},
   {
-    'nav-item:user-settings': ExtensionDefinition<{
-      kind: 'nav-item';
-      name: undefined;
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        {
-          title: string;
-          icon: IconComponent;
-          routeRef: RouteRef<undefined>;
-        },
-        'core.nav-item.target',
-        {}
-      >;
-      inputs: {};
-      params: {
-        title: string;
-        icon: IconComponent;
-        routeRef: RouteRef<undefined>;
-      };
-    }>;
     'page:user-settings': ExtensionDefinition<{
       config: {
         path: string | undefined;
@@ -81,6 +60,27 @@ const _default: FrontendPlugin<
         defaultPath: string;
         loader: () => Promise<JSX.Element>;
         routeRef?: RouteRef<AnyRouteRefParams> | undefined;
+      };
+    }>;
+    'nav-item:user-settings': ExtensionDefinition<{
+      kind: 'nav-item';
+      name: undefined;
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        {
+          title: string;
+          icon: IconComponent;
+          routeRef: RouteRef<undefined>;
+        },
+        'core.nav-item.target',
+        {}
+      >;
+      inputs: {};
+      params: {
+        title: string;
+        icon: IconComponent;
+        routeRef: RouteRef<undefined>;
       };
     }>;
   }

--- a/plugins/user-settings/src/components/General/UserSettingsMenu.test.tsx
+++ b/plugins/user-settings/src/components/General/UserSettingsMenu.test.tsx
@@ -37,7 +37,7 @@ describe('<UserSettingsMenu />', () => {
 
   it('handles errors that occur when signing out', async () => {
     const failingIdentityApi = mockApis.identity.mock({
-      signOut: () => Promise.reject(new Error('Logout error')),
+      signOut: () => Promise.reject<void>(new Error('Logout error')),
     });
     const mockErrorApi = new MockErrorApi({ collect: true });
     await renderInTestApp(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adding an `app.signOutUrl` configuration attribute to enable signout workflows that require a redirect to a specific URL.

Upon logout, if `app.signOutUrl` is specified, the application will redirect to the configured URL. Alternatively, the application will maintain the current behavior: redirect to `baseUrl` or the root path /.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
