### PR TITLE
Update wording in user-settings README to clarify example location

### DIFF
--- a/.changeset/seven-beds-deliver.md
+++ b/.changeset/seven-beds-deliver.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-user-settings': patch
+---
+
+Update README to clarify location of additional tabs example

--- a/plugins/user-settings/README.md
+++ b/plugins/user-settings/README.md
@@ -91,7 +91,7 @@ To standardize the UI of all setting tabs,
 make sure you use a similar component structure as the other tabs.
 You can take a look at
 [the example extra tab](https://github.com/backstage/backstage/blob/master/packages/app/src/components/advancedSettings/AdvancedSettings.tsx)
-we have created in Backstage's demo app.
+we have created in Backstage's example app.
 
 To change the layout altogether, create a custom page in `packages/app/src/components/user-settings/SettingsPage.tsx`:
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The README for the `user-settings` plugin referenced an example screen in the Demo app, where it was linking to the example app in the main Backstage repository.

Discord link for more details: https://discord.com/channels/687207715902193673/1279569368875008176/1280616399256948971 

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
