### PR TITLE
fix(techdocs-node): Allow for dictionaries in pymdx plugin settings

### DIFF
--- a/.changeset/happy-numbers-press.md
+++ b/.changeset/happy-numbers-press.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-node': minor
+---
+
+Fixed issue in techdocs yaml parser which didn't allow for dictionaries/mappings in pymdx plugin configuration.

--- a/plugins/techdocs-node/src/stages/generate/__fixtures__/mkdocs_with_extensions.yml
+++ b/plugins/techdocs-node/src/stages/generate/__fixtures__/mkdocs_with_extensions.yml
@@ -5,3 +5,9 @@ markdown_extensions:
   - pymdownx.emoji:
       emoji_index: !!python/name:materialx.emoji.twemoji
       emoji_generator: !!python/name:materialx.emoji.to_svg
+  - pymdownx.tabbed:
+      alternate_style: true
+      combine_header_slug: true
+      slugify: !!python/object/apply:pymdownx.slugs.slugify
+        kwds:
+          case: lower

--- a/plugins/techdocs-node/src/stages/generate/helpers.ts
+++ b/plugins/techdocs-node/src/stages/generate/helpers.ts
@@ -149,6 +149,14 @@ export const MKDOCS_SCHEMA = DEFAULT_SCHEMA.extend([
     instanceOf: UnknownTag,
     construct: (data: string, type?: string) => new UnknownTag(data, type),
   }),
+  new Type('', {
+    kind: 'mapping',
+    multi: true,
+    representName: o => (o as UnknownTag).type,
+    represent: o => (o as UnknownTag).data ?? '',
+    instanceOf: UnknownTag,
+    construct: (data: string, type?: string) => new UnknownTag(data, type),
+  }),
 ]);
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixed issue in techdocs yaml parser which didn't allow for dictionaries/mappings in pymdx plugin configuration.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
