### PR TITLE
NFS: Support defining multiple attachment points

### DIFF
--- a/packages/app-next/src/App.tsx
+++ b/packages/app-next/src/App.tsx
@@ -28,6 +28,8 @@ import {
   createExtension,
   ApiBlueprint,
   createFrontendModule,
+  PageBlueprint,
+  createExtensionInput,
 } from '@backstage/frontend-plugin-api';
 import {
   techdocsPlugin,
@@ -52,6 +54,7 @@ import { signInPageModule } from './overrides/SignInPage';
 import { convertLegacyPlugin } from '@backstage/core-compat-api';
 import { convertLegacyPageExtension } from '@backstage/core-compat-api';
 import { convertLegacyEntityContentExtension } from '@backstage/plugin-catalog-react/alpha';
+import { Link } from 'react-router-dom';
 
 /*
 
@@ -108,6 +111,54 @@ const customHomePageModule = createFrontendModule({
           coreExtensionData.reactElement(homePage),
           titleExtensionDataRef('just a title'),
         ];
+      },
+    }),
+    PageBlueprint.makeWithOverrides({
+      name: 'test-1',
+      inputs: {
+        test: createExtensionInput([coreExtensionData.reactElement]),
+      },
+      factory(o, { inputs }) {
+        return o({
+          defaultPath: '/lols-1',
+          loader: async () => (
+            <div>
+              <Link to="/lols-2">Go to lols 2</Link>
+              {inputs.test.map(t => t.get(coreExtensionData.reactElement))}
+            </div>
+          ),
+        });
+      },
+    }),
+    PageBlueprint.makeWithOverrides({
+      name: 'test-2',
+      inputs: {
+        test: createExtensionInput([coreExtensionData.reactElement]),
+      },
+      factory(o, { inputs }) {
+        return o({
+          defaultPath: '/lols-2',
+          loader: async () => (
+            <div>
+              <Link to="/lols-1">Go to lols 1</Link>
+              {inputs.test.map(t => t.get(coreExtensionData.reactElement))}
+            </div>
+          ),
+        });
+      },
+    }),
+    createExtension({
+      kind: 'testy',
+      name: 'thing',
+      attachTo: [
+        { id: 'page:home/test-1', input: 'test' },
+        { id: 'page:home/test-2', input: 'test' },
+      ],
+      output: [coreExtensionData.reactElement],
+      *factory() {
+        yield coreExtensionData.reactElement(
+          <div>ITS WORKING {Date.now()}</div>,
+        );
       },
     }),
   ],

--- a/packages/frontend-app-api/src/tree/resolveAppTree.test.ts
+++ b/packages/frontend-app-api/src/tree/resolveAppTree.test.ts
@@ -307,7 +307,7 @@ describe('buildAppTree', () => {
         { attachTo: e3.attachTo, id: e3.id, extension: e3, disabled: false },
       ]);
 
-      expect(tree.nodes.get('test-3')?.edges.attachedTo?.node).toBe(
+      expect(tree.nodes.get('test-3')?.edges.attachedTo?.[0].node).toBe(
         tree.nodes.get('test-2'),
       );
     });

--- a/packages/frontend-plugin-api/src/apis/definitions/AppTreeApi.ts
+++ b/packages/frontend-plugin-api/src/apis/definitions/AppTreeApi.ts
@@ -28,7 +28,9 @@ import { BackstagePlugin, Extension, ExtensionDataRef } from '../../wiring';
  */
 export interface AppNodeSpec {
   readonly id: string;
-  readonly attachTo: { id: string; input: string };
+  readonly attachTo:
+    | { id: string; input: string }
+    | { id: string; input: string }[];
   readonly extension: Extension<unknown, unknown>;
   readonly disabled: boolean;
   readonly config?: unknown;
@@ -45,7 +47,7 @@ export interface AppNodeSpec {
  * adjacent nodes are disabled or not. If no parent attachment is present or
  */
 export interface AppNodeEdges {
-  readonly attachedTo?: { node: AppNode; input: string };
+  readonly attachedTo?: { node: AppNode; input: string }[];
   readonly attachments: ReadonlyMap<string, AppNode[]>;
 }
 

--- a/packages/frontend-plugin-api/src/wiring/createExtension.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.ts
@@ -124,7 +124,7 @@ export type CreateExtensionOptions<
   kind?: TKind;
   namespace?: TNamespace;
   name?: TName;
-  attachTo: { id: string; input: string };
+  attachTo: { id: string; input: string } | { id: string; input: string }[];
   disabled?: boolean;
   inputs?: TInputs;
   output: Array<UOutput>;
@@ -178,7 +178,9 @@ export type ExtensionDefinition<
     },
   >(
     args: {
-      attachTo?: { id: string; input: string };
+      attachTo?:
+        | { id: string; input: string }
+        | { id: string; input: string }[];
       disabled?: boolean;
       inputs?: TExtraInputs & {
         [KName in keyof T['inputs']]?: `Error: Input '${KName &
@@ -242,7 +244,9 @@ export type InternalExtensionDefinition<
   readonly kind?: string;
   readonly namespace?: string;
   readonly name?: string;
-  readonly attachTo: { id: string; input: string };
+  readonly attachTo:
+    | { id: string; input: string }
+    | { id: string; input: string }[];
   readonly disabled: boolean;
   readonly configSchema?: PortableSchema<T['config'], T['configInput']>;
 } & (
@@ -499,7 +503,14 @@ export function createExtension<
       if (options.name) {
         parts.push(`name=${options.name}`);
       }
-      parts.push(`attachTo=${options.attachTo.id}@${options.attachTo.input}`);
+
+      if (Array.isArray(options.attachTo)) {
+        for (const attachmentPoint of options.attachTo) {
+          parts.push(`attachTo=${attachmentPoint.id}@${attachmentPoint.input}`);
+        }
+      } else {
+        parts.push(`attachTo=${options.attachTo.id}@${options.attachTo.input}`);
+      }
       return `ExtensionDefinition{${parts.join(',')}}`;
     },
     override(overrideOptions) {

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
@@ -58,7 +58,7 @@ export type CreateExtensionBlueprintOptions<
 > = {
   kind: TKind;
   namespace?: TNamespace;
-  attachTo: { id: string; input: string };
+  attachTo: { id: string; input: string } | { id: string; input: string }[];
   disabled?: boolean;
   inputs?: TInputs;
   output: Array<UOutput>;
@@ -113,7 +113,7 @@ export interface ExtensionBlueprint<
   >(args: {
     namespace?: undefined;
     name?: TNewName;
-    attachTo?: { id: string; input: string };
+    attachTo?: { id: string; input: string } | { id: string; input: string }[];
     disabled?: boolean;
     params: T['params'];
   }): ExtensionDefinition<{
@@ -132,7 +132,7 @@ export interface ExtensionBlueprint<
   >(args: {
     namespace?: TNewNamespace;
     name?: TNewName;
-    attachTo?: { id: string; input: string };
+    attachTo?: { id: string; input: string } | { id: string; input: string }[];
     disabled?: boolean;
     params: T['params'];
   }): ExtensionDefinition<{
@@ -170,7 +170,7 @@ export interface ExtensionBlueprint<
   >(args: {
     namespace?: undefined;
     name?: TNewName;
-    attachTo?: { id: string; input: string };
+    attachTo?: { id: string; input: string } | { id: string; input: string }[];
     disabled?: boolean;
     inputs?: TExtraInputs & {
       [KName in keyof T['inputs']]?: `Error: Input '${KName &
@@ -251,7 +251,7 @@ export interface ExtensionBlueprint<
   >(args: {
     namespace: TNewNamespace;
     name?: TNewName;
-    attachTo?: { id: string; input: string };
+    attachTo?: { id: string; input: string } | { id: string; input: string }[];
     disabled?: boolean;
     inputs?: TExtraInputs & {
       [KName in keyof T['inputs']]?: `Error: Input '${KName &

--- a/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.ts
+++ b/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.ts
@@ -32,7 +32,9 @@ import {
 export interface Extension<TConfig, TConfigInput = TConfig> {
   $$type: '@backstage/Extension';
   readonly id: string;
-  readonly attachTo: { id: string; input: string };
+  readonly attachTo:
+    | { id: string; input: string }
+    | { id: string; input: string }[];
   readonly disabled: boolean;
   readonly configSchema?: PortableSchema<TConfig, TConfigInput>;
 }

--- a/plugins/app-visualizer/src/components/AppVisualizerPage/DetailedVisualizer.tsx
+++ b/plugins/app-visualizer/src/components/AppVisualizerPage/DetailedVisualizer.tsx
@@ -174,7 +174,7 @@ function getFullPath(node?: AppNode): string {
   if (!node) {
     return '';
   }
-  const parent = node.edges.attachedTo?.node;
+  const parent = node.edges.attachedTo?.[0]?.node;
   const part = node.instance?.getData(coreExtensionData.routePath);
   if (!part) {
     return getFullPath(parent);
@@ -284,13 +284,15 @@ function Attachments(props: {
 
 function ExtensionTooltip(props: { node: AppNode }) {
   const parts = [];
-  let node = props.node;
+  const node = props.node;
   parts.push(node.spec.id);
-  while (node.edges.attachedTo) {
-    const input = node.edges.attachedTo.input;
-    node = node.edges.attachedTo.node;
-    parts.push(`${node.spec.id} [${input}]`);
-  }
+
+  // todo(blam): need to fix this somehow?
+  // while (node.edges.attachedTo) {
+  //   const input = node.edges.attachedTo.input;
+  //   node = node.edges.attachedTo.node;
+  //   parts.push(`${node.spec.id} [${input}]`);
+  // }
   parts.reverse();
 
   return (

--- a/plugins/app-visualizer/src/components/AppVisualizerPage/TreeVisualizer.tsx
+++ b/plugins/app-visualizer/src/components/AppVisualizerPage/TreeVisualizer.tsx
@@ -71,10 +71,12 @@ function resolveGraphData(tree: AppTree): {
     edges: [
       ...nodes
         .filter(node => node.edges.attachedTo)
-        .map(node => ({
-          from: inputId(node.edges.attachedTo!),
-          to: node.spec.id,
-        })),
+        .flatMap(node =>
+          [node.edges.attachedTo].flat().map(attachedTo => ({
+            from: inputId(attachedTo!),
+            to: node.spec.id,
+          })),
+        ),
       ...nodes.flatMap(node =>
         [...node.edges.attachments.keys()].map(input => ({
           from: node.spec.id,


### PR DESCRIPTION
This has been on the backlog for a bit, but it came up when thinking about migrating the Scaffolder to the New Frontend System. Field Extensions are an example where these extensions can be used in multiple places and therefore potentially many `PageExtensions` or even just any other extensions.

There's one way around this, which is to use a `Context` and just have one page extension, or prop drilling but those both feel a little limiting when you might want these things outside of the React context.

We tried implementing this without touching the `AppNode` and just have `resolveAppTree` return multiple extensions, but then ran into the issue that there would be duplicate extensions, which also then lead to potentials of factory functions being called more than once, therefore this appeared like the better fix.

@Rugvip thoughts here?