### PR TITLE
feat(scaffolder): port Bitbucket Server PR action to Bitbucket Cloud

### DIFF
--- a/.changeset/fuzzy-fireants-crash.md
+++ b/.changeset/fuzzy-fireants-crash.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+'@backstage/plugin-scaffolder-backend-module-bitbucket-cloud': patch
+---
+
+Added scaffolder action publish:bitbucketCloud:pull-request

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/README.md
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/README.md
@@ -7,5 +7,6 @@ _This plugin was created through the Backstage CLI_
 
 ## Actions
 
-- `publish:bitbucketCloud`
-- `bitbucket:pipelines:run`
+* `publish:bitbucketCloud`
+* `bitbucket:pipelines:run`
+* `publish:bitbucketCloud:pull-request`

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/README.md
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/README.md
@@ -7,6 +7,6 @@ _This plugin was created through the Backstage CLI_
 
 ## Actions
 
-* `publish:bitbucketCloud`
-* `bitbucket:pipelines:run`
-* `publish:bitbucketCloud:pull-request`
+- `publish:bitbucketCloud`
+- `bitbucket:pipelines:run`
+- `publish:bitbucketCloud:pull-request`

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/api-report.md
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/api-report.md
@@ -42,4 +42,22 @@ export function createPublishBitbucketCloudAction(options: {
   },
   JsonObject
 >;
+
+// @public
+export function createPublishBitbucketCloudPullRequestAction(options: {
+  integrations: ScmIntegrationRegistry;
+  config: Config;
+}): TemplateAction<
+  {
+    repoUrl: string;
+    title: string;
+    description?: string | undefined;
+    targetBranch?: string | undefined;
+    sourceBranch: string;
+    token?: string | undefined;
+    gitAuthorName?: string | undefined;
+    gitAuthorEmail?: string | undefined;
+  },
+  JsonObject
+>;
 ```

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPullRequest.examples.test.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPullRequest.examples.test.ts
@@ -1,0 +1,431 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+jest.mock('@backstage/plugin-scaffolder-node', () => {
+  return {
+    ...jest.requireActual('@backstage/plugin-scaffolder-node'),
+    initRepoAndPush: jest.fn().mockResolvedValue({
+      commitHash: '220f19cc36b551763d157f1b5e4a4b446165dbd6',
+    }),
+    commitAndPushRepo: jest.fn().mockResolvedValue({
+      commitHash: '220f19cc36b551763d157f1b5e4a4b446165dbd6',
+    }),
+  };
+});
+
+import { createPublishBitbucketCloudPullRequestAction } from './bitbucketCloudPullRequest';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { registerMswTestHooks } from '@backstage/backend-test-utils';
+import { ScmIntegrations } from '@backstage/integration';
+import { ConfigReader } from '@backstage/config';
+import yaml from 'yaml';
+import { examples } from './bitbucketCloudPullRequest.examples';
+import { createMockActionContext } from '@backstage/plugin-scaffolder-node-test-utils';
+
+describe('publish:bitbucketCloud:pull-request', () => {
+  const config = new ConfigReader({
+    integrations: {
+      bitbucketCloud: [
+        {
+          username: 'test-user',
+          appPassword: 'test-password',
+        },
+      ],
+    },
+  });
+
+  const integrations = ScmIntegrations.fromConfig(config);
+  const action = createPublishBitbucketCloudPullRequestAction({
+    integrations,
+    config,
+  });
+  const mockContext = createMockActionContext({
+    input: {
+      repoUrl: 'bitbucket.org?workspace=workspace&project=project&repo=repo',
+      title: 'Add Scaffolder actions for Bitbucket Cloud',
+      description:
+        'I just made a Pull Request that Add Scaffolder actions for Bitbucket Cloud',
+      targetBranch: 'master',
+      sourceBranch: 'develop',
+    },
+  });
+  const responseOfBranches = {
+    pagelen: 1,
+    size: 187,
+    values: [
+      {
+        name: 'issue-9.3/AUI-5343-assistive-class',
+        links: {
+          commits: {
+            href: 'https://api.bitbucket.org/2.0/repositories/atlassian/aui/commits/issue-9.3/AUI-5343-assistive-class',
+          },
+          self: {
+            href: 'https://api.bitbucket.org/2.0/repositories/atlassian/aui/refs/branches/issue-9.3/AUI-5343-assistive-class',
+          },
+          html: {
+            href: 'https://bitbucket.org/atlassian/aui/branch/issue-9.3/AUI-5343-assistive-class',
+          },
+        },
+        default_merge_strategy: 'squash',
+        merge_strategies: ['merge_commit', 'squash', 'fast_forward'],
+        type: 'branch',
+        target: {
+          hash: 'e5d1cde9069fcb9f0af90403a4de2150c125a148',
+          repository: {
+            links: {
+              self: {
+                href: 'https://api.bitbucket.org/2.0/repositories/atlassian/aui',
+              },
+              html: { href: 'https://bitbucket.org/atlassian/aui' },
+              avatar: {
+                href: 'https://bytebucket.org/ravatar/%7B585074de-7b60-4fd1-81ed-e0bc7fafbda5%7D?ts=86317',
+              },
+            },
+            type: 'repository',
+            name: 'aui',
+            full_name: 'atlassian/aui',
+            uuid: '{585074de-7b60-4fd1-81ed-e0bc7fafbda5}',
+          },
+          links: {
+            self: {
+              href: 'https://api.bitbucket.org/2.0/repositories/atlassian/aui/commit/e5d1cde9069fcb9f0af90403a4de2150c125a148',
+            },
+            comments: {
+              href: 'https://api.bitbucket.org/2.0/repositories/atlassian/aui/commit/e5d1cde9069fcb9f0af90403a4de2150c125a148/comments',
+            },
+            patch: {
+              href: 'https://api.bitbucket.org/2.0/repositories/atlassian/aui/patch/e5d1cde9069fcb9f0af90403a4de2150c125a148',
+            },
+            html: {
+              href: 'https://bitbucket.org/atlassian/aui/commits/e5d1cde9069fcb9f0af90403a4de2150c125a148',
+            },
+            diff: {
+              href: 'https://api.bitbucket.org/2.0/repositories/atlassian/aui/diff/e5d1cde9069fcb9f0af90403a4de2150c125a148',
+            },
+            approve: {
+              href: 'https://api.bitbucket.org/2.0/repositories/atlassian/aui/commit/e5d1cde9069fcb9f0af90403a4de2150c125a148/approve',
+            },
+            statuses: {
+              href: 'https://api.bitbucket.org/2.0/repositories/atlassian/aui/commit/e5d1cde9069fcb9f0af90403a4de2150c125a148/statuses',
+            },
+          },
+          author: {
+            raw: 'Marcin Konopka <mkonopka@atlassian.com>',
+            type: 'author',
+            user: {
+              display_name: 'Marcin Konopka',
+              uuid: '{47cc24f4-2a05-4420-88fe-0417535a110a}',
+              links: {
+                self: {
+                  href: 'https://api.bitbucket.org/2.0/users/%7B47cc24f4-2a05-4420-88fe-0417535a110a%7D',
+                },
+                html: {
+                  href: 'https://bitbucket.org/%7B47cc24f4-2a05-4420-88fe-0417535a110a%7D/',
+                },
+                avatar: {
+                  href: 'https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/initials/MK-1.png',
+                },
+              },
+              nickname: 'Marcin Konopka',
+              type: 'user',
+              account_id: '60113d2b47a9540069f4de03',
+            },
+          },
+          parents: [
+            {
+              hash: '87f7fc92b00464ae47b13ef65c91884e4ac9be51',
+              type: 'commit',
+              links: {
+                self: {
+                  href: 'https://api.bitbucket.org/2.0/repositories/atlassian/aui/commit/87f7fc92b00464ae47b13ef65c91884e4ac9be51',
+                },
+                html: {
+                  href: 'https://bitbucket.org/atlassian/aui/commits/87f7fc92b00464ae47b13ef65c91884e4ac9be51',
+                },
+              },
+            },
+          ],
+          date: '2021-04-13T13:44:49+00:00',
+          message: 'wip\n',
+          type: 'commit',
+        },
+      },
+    ],
+    page: 1,
+    next: 'https://api.bitbucket.org/2.0/repositories/atlassian/aui/refs/branches?pagelen=1&page=2',
+  };
+  const responseOfPullRequests = {
+    type: '<string>',
+    links: {
+      self: { href: '<string>', name: '<string>' },
+      html: { href: '<string>', name: '<string>' },
+      commits: { href: '<string>', name: '<string>' },
+      approve: { href: '<string>', name: '<string>' },
+      diff: { href: '<string>', name: '<string>' },
+      diffstat: { href: '<string>', name: '<string>' },
+      comments: { href: '<string>', name: '<string>' },
+      activity: { href: '<string>', name: '<string>' },
+      merge: { href: '<string>', name: '<string>' },
+      decline: { href: '<string>', name: '<string>' },
+    },
+    id: 108,
+    title: '<string>',
+    rendered: {
+      title: { raw: '<string>', markup: 'markdown', html: '<string>' },
+      description: { raw: '<string>', markup: 'markdown', html: '<string>' },
+      reason: { raw: '<string>', markup: 'markdown', html: '<string>' },
+    },
+    summary: { raw: '<string>', markup: 'markdown', html: '<string>' },
+    state: 'OPEN',
+    author: { type: '<string>' },
+    source: {
+      repository: { type: '<string>' },
+      branch: {
+        name: '<string>',
+        merge_strategies: ['merge_commit'],
+        default_merge_strategy: '<string>',
+      },
+      commit: { hash: '<string>' },
+    },
+    destination: {
+      repository: { type: '<string>' },
+      branch: {
+        name: '<string>',
+        merge_strategies: ['merge_commit'],
+        default_merge_strategy: '<string>',
+      },
+      commit: { hash: '<string>' },
+    },
+    merge_commit: { hash: '<string>' },
+    comment_count: 51,
+    task_count: 53,
+    close_source_branch: true,
+    closed_by: { type: '<string>' },
+    reason: '<string>',
+    created_on: '<string>',
+    updated_on: '<string>',
+    reviewers: [{ type: '<string>' }],
+    participants: [{ type: '<string>' }],
+  };
+
+  const server = setupServer();
+  registerMswTestHooks(server);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it(`should ${examples[0].description}`, async () => {
+    expect.assertions(2);
+    server.use(
+      rest.get(
+        'https://api.bitbucket.org/2.0/repositories/workspace/repo/refs/branches',
+        (req, res, ctx) => {
+          expect(req.headers.get('Authorization')).toBe(
+            `Basic ${btoa('test-user:test-password')}`,
+          );
+          return res(
+            ctx.status(200),
+            ctx.set('Content-Type', 'application/json'),
+            ctx.json(responseOfBranches),
+          );
+        },
+      ),
+      rest.post(
+        'https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests',
+        (req, res, ctx) => {
+          expect(req.headers.get('Authorization')).toBe(
+            `Basic ${btoa('test-user:test-password')}`,
+          );
+          return res(
+            ctx.status(201),
+            ctx.set('Content-Type', 'application/json'),
+            ctx.json(responseOfPullRequests),
+          );
+        },
+      ),
+    );
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        ...yaml.parse(examples[0].example).steps[0].input,
+      },
+    });
+  });
+
+  it(`should ${examples[1].description}`, async () => {
+    expect.assertions(2);
+    server.use(
+      rest.get(
+        'https://api.bitbucket.org/2.0/repositories/workspace/repo/refs/branches',
+        (req, res, ctx) => {
+          expect(req.headers.get('Authorization')).toBe(
+            `Basic ${btoa('test-user:test-password')}`,
+          );
+          return res(
+            ctx.status(200),
+            ctx.set('Content-Type', 'application/json'),
+            ctx.json(responseOfBranches),
+          );
+        },
+      ),
+      rest.post(
+        'https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests',
+        (req, res, ctx) => {
+          expect(req.headers.get('Authorization')).toBe(
+            `Basic ${btoa('test-user:test-password')}`,
+          );
+          return res(
+            ctx.status(201),
+            ctx.set('Content-Type', 'application/json'),
+            ctx.json(responseOfPullRequests),
+          );
+        },
+      ),
+    );
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        ...yaml.parse(examples[1].example).steps[0].input,
+      },
+    });
+  });
+
+  it(`should ${examples[2].description}`, async () => {
+    expect.assertions(2);
+    server.use(
+      rest.get(
+        'https://api.bitbucket.org/2.0/repositories/workspace/repo/refs/branches',
+        (req, res, ctx) => {
+          expect(req.headers.get('Authorization')).toBe(
+            `Basic ${btoa('test-user:test-password')}`,
+          );
+          return res(
+            ctx.status(200),
+            ctx.set('Content-Type', 'application/json'),
+            ctx.json(responseOfBranches),
+          );
+        },
+      ),
+      rest.post(
+        'https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests',
+        (req, res, ctx) => {
+          expect(req.headers.get('Authorization')).toBe(
+            `Basic ${btoa('test-user:test-password')}`,
+          );
+          return res(
+            ctx.status(201),
+            ctx.set('Content-Type', 'application/json'),
+            ctx.json(responseOfPullRequests),
+          );
+        },
+      ),
+    );
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        ...yaml.parse(examples[2].example).steps[0].input,
+      },
+    });
+  });
+
+  it(`should ${examples[3].description}`, async () => {
+    expect.assertions(2);
+    server.use(
+      rest.get(
+        'https://api.bitbucket.org/2.0/repositories/workspace/repo/refs/branches',
+        (req, res, ctx) => {
+          expect(req.headers.get('Authorization')).toBe(
+            `Bearer ${yaml.parse(examples[3].example).steps[0].input.token}`,
+          );
+          return res(
+            ctx.status(200),
+            ctx.set('Content-Type', 'application/json'),
+            ctx.json(responseOfBranches),
+          );
+        },
+      ),
+      rest.post(
+        'https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests',
+        (req, res, ctx) => {
+          expect(req.headers.get('Authorization')).toBe(
+            `Bearer ${yaml.parse(examples[3].example).steps[0].input.token}`,
+          );
+          return res(
+            ctx.status(201),
+            ctx.set('Content-Type', 'application/json'),
+            ctx.json(responseOfPullRequests),
+          );
+        },
+      ),
+    );
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        ...yaml.parse(examples[3].example).steps[0].input,
+      },
+    });
+  });
+
+  it(`should ${examples[4].description}`, async () => {
+    expect.assertions(2);
+    server.use(
+      rest.get(
+        'https://api.bitbucket.org/2.0/repositories/workspace/repo/refs/branches',
+        (req, res, ctx) => {
+          expect(req.headers.get('Authorization')).toBe(
+            `Bearer ${yaml.parse(examples[4].example).steps[0].input.token}`,
+          );
+          return res(
+            ctx.status(200),
+            ctx.set('Content-Type', 'application/json'),
+            ctx.json(responseOfBranches),
+          );
+        },
+      ),
+      rest.post(
+        'https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests',
+        (req, res, ctx) => {
+          expect(req.headers.get('Authorization')).toBe(
+            `Bearer ${yaml.parse(examples[4].example).steps[0].input.token}`,
+          );
+          return res(
+            ctx.status(201),
+            ctx.set('Content-Type', 'application/json'),
+            ctx.json(responseOfPullRequests),
+          );
+        },
+      ),
+    );
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        ...yaml.parse(examples[4].example).steps[0].input,
+      },
+    });
+  });
+});

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPullRequest.examples.test.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPullRequest.examples.test.ts
@@ -239,7 +239,7 @@ describe('publish:bitbucketCloud:pull-request', () => {
         'https://api.bitbucket.org/2.0/repositories/workspace/repo/refs/branches',
         (req, res, ctx) => {
           expect(req.headers.get('Authorization')).toBe(
-            `Basic ${btoa('test-user:test-password')}`,
+            'Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ=',
           );
           return res(
             ctx.status(200),
@@ -252,7 +252,7 @@ describe('publish:bitbucketCloud:pull-request', () => {
         'https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests',
         (req, res, ctx) => {
           expect(req.headers.get('Authorization')).toBe(
-            `Basic ${btoa('test-user:test-password')}`,
+            'Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ=',
           );
           return res(
             ctx.status(201),
@@ -279,7 +279,7 @@ describe('publish:bitbucketCloud:pull-request', () => {
         'https://api.bitbucket.org/2.0/repositories/workspace/repo/refs/branches',
         (req, res, ctx) => {
           expect(req.headers.get('Authorization')).toBe(
-            `Basic ${btoa('test-user:test-password')}`,
+            'Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ=',
           );
           return res(
             ctx.status(200),
@@ -292,7 +292,7 @@ describe('publish:bitbucketCloud:pull-request', () => {
         'https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests',
         (req, res, ctx) => {
           expect(req.headers.get('Authorization')).toBe(
-            `Basic ${btoa('test-user:test-password')}`,
+            'Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ=',
           );
           return res(
             ctx.status(201),
@@ -319,7 +319,7 @@ describe('publish:bitbucketCloud:pull-request', () => {
         'https://api.bitbucket.org/2.0/repositories/workspace/repo/refs/branches',
         (req, res, ctx) => {
           expect(req.headers.get('Authorization')).toBe(
-            `Basic ${btoa('test-user:test-password')}`,
+            'Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ=',
           );
           return res(
             ctx.status(200),
@@ -332,7 +332,7 @@ describe('publish:bitbucketCloud:pull-request', () => {
         'https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests',
         (req, res, ctx) => {
           expect(req.headers.get('Authorization')).toBe(
-            `Basic ${btoa('test-user:test-password')}`,
+            'Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ=',
           );
           return res(
             ctx.status(201),

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPullRequest.examples.test.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPullRequest.examples.test.ts
@@ -171,11 +171,11 @@ describe('publish:bitbucketCloud:pull-request', () => {
   const responseOfPullRequests = {
     type: '<string>',
     links: {
-      self: {
+      self: { href: '<string>', name: '<string>' },
+      html: {
         href: 'https://bitbucket.org/workspace/repo/pull-requests/1',
         name: '<string>',
       },
-      html: { href: '<string>', name: '<string>' },
       commits: { href: '<string>', name: '<string>' },
       approve: { href: '<string>', name: '<string>' },
       diff: { href: '<string>', name: '<string>' },

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPullRequest.examples.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPullRequest.examples.ts
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TemplateExample } from '@backstage/plugin-scaffolder-node';
+import yaml from 'yaml';
+
+export const examples: TemplateExample[] = [
+  {
+    description:
+      'Creating pull request on bitbucket cloud with required fields',
+    example: yaml.stringify({
+      steps: [
+        {
+          action: 'publish:bitbucketCloud:pull-request',
+          id: 'publish-bitbucket-cloud-pull-request-minimal',
+          name: 'Creating pull request on bitbucket cloud',
+          input: {
+            repoUrl:
+              'bitbucket.org?workspace=workspace&project=project&repo=repo',
+            title: 'My pull request',
+            sourceBranch: 'my-feature-branch',
+          },
+        },
+      ],
+    }),
+  },
+  {
+    description:
+      'Creating pull request on bitbucket cloud with custom descriptions',
+    example: yaml.stringify({
+      steps: [
+        {
+          action: 'publish:bitbucketCloud:pull-request',
+          id: 'publish-bitbucket-cloud-pull-request-minimal',
+          name: 'Creating pull request on bitbucket cloud',
+          input: {
+            repoUrl:
+              'bitbucket.org?workspace=workspace&project=project&repo=repo',
+            title: 'My pull request',
+            sourceBranch: 'my-feature-branch',
+            description: 'This is a detailed description of my pull request',
+          },
+        },
+      ],
+    }),
+  },
+  {
+    description:
+      'Creating pull request on bitbucket cloud with different target branch',
+    example: yaml.stringify({
+      steps: [
+        {
+          action: 'publish:bitbucketCloud:pull-request',
+          id: 'publish-bitbucket-cloud-pull-request-target-branch',
+          name: 'Creating pull request on bitbucket cloud',
+          input: {
+            repoUrl:
+              'bitbucket.org?workspace=workspace&project=project&repo=repo',
+            title: 'My pull request',
+            sourceBranch: 'my-feature-branch',
+            targetBranch: 'development',
+          },
+        },
+      ],
+    }),
+  },
+  {
+    description:
+      'Creating pull request on bitbucket cloud with authorization token',
+    example: yaml.stringify({
+      steps: [
+        {
+          action: 'publish:bitbucketCloud:pull-request',
+          id: 'publish-bitbucket-cloud-pull-request-minimal',
+          name: 'Creating pull request on bitbucket cloud',
+          input: {
+            repoUrl:
+              'bitbucket.org?workspace=workspace&project=project&repo=repo',
+            title: 'My pull request',
+            sourceBranch: 'my-feature-branch',
+            token: 'my-auth-token',
+          },
+        },
+      ],
+    }),
+  },
+  {
+    description: 'Creating pull request on bitbucket cloud with all fields',
+    example: yaml.stringify({
+      steps: [
+        {
+          action: 'publish:bitbucketCloud:pull-request',
+          id: 'publish-bitbucket-cloud-pull-request-minimal',
+          name: 'Creating pull request on bitbucket cloud',
+          input: {
+            repoUrl:
+              'bitbucket.org?workspace=workspace&project=project&repo=repo',
+            title: 'My pull request',
+            sourceBranch: 'my-feature-branch',
+            targetBranch: 'development',
+            description: 'This is a detailed description of my pull request',
+            token: 'my-auth-token',
+            gitAuthorName: 'test-user',
+            gitAuthorEmail: 'test-user@sample.com',
+          },
+        },
+      ],
+    }),
+  },
+];

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPullRequest.test.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPullRequest.test.ts
@@ -200,11 +200,11 @@ describe('publish:bitbucketCloud:pull-request', () => {
   const responseOfPullRequests = {
     type: '<string>',
     links: {
-      self: {
+      self: { href: '<string>', name: '<string>' },
+      html: {
         href: 'https://bitbucket.org/workspace/repo/pull-requests/1',
         name: '<string>',
       },
-      html: { href: '<string>', name: '<string>' },
       commits: { href: '<string>', name: '<string>' },
       approve: { href: '<string>', name: '<string>' },
       diff: { href: '<string>', name: '<string>' },

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPullRequest.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPullRequest.ts
@@ -323,12 +323,9 @@ export function createPublishBitbucketCloudPullRequestAction(options: {
         gitAuthorEmail,
       } = ctx.input;
 
-      const { project, repo, host, workspace } = parseRepoUrl(
-        repoUrl,
-        integrations,
-      );
+      const { workspace, repo, host } = parseRepoUrl(repoUrl, integrations);
 
-      if (!project) {
+      if (!workspace) {
         throw new InputError(
           `Invalid URL provider was included in the repo URL to create ${ctx.input.repoUrl}, missing project`,
         );
@@ -350,15 +347,17 @@ export function createPublishBitbucketCloudPullRequestAction(options: {
       let finalTargetBranch = targetBranch;
       if (!finalTargetBranch) {
         finalTargetBranch = await getDefaultBranch({
-          workspace: workspace!,
+          workspace,
           repo,
           authorization,
           apiBaseUrl,
         });
       }
 
+      // TODO: check if sourceBranch already exists and just create a pull request for it if so
+
       await createBranch({
-        workspace: workspace!,
+        workspace,
         repo,
         branchName: sourceBranch,
         authorization,
@@ -445,7 +444,7 @@ export function createPublishBitbucketCloudPullRequestAction(options: {
       });
 
       const pullRequestUrl = await createPullRequest({
-        workspace: workspace!,
+        workspace,
         repo,
         title,
         description,

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPullRequest.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPullRequest.ts
@@ -317,7 +317,7 @@ export function createPublishBitbucketCloudPullRequestAction(options: {
 
       if (!workspace) {
         throw new InputError(
-          `Invalid URL provider was included in the repo URL to create ${ctx.input.repoUrl}, missing project`,
+          `Invalid URL provider was included in the repo URL to create ${ctx.input.repoUrl}, missing workspace`,
         );
       }
 

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPullRequest.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPullRequest.ts
@@ -226,7 +226,6 @@ const getDefaultBranch = async (opts: {
   }
 
   const { mainbranch } = await response.json();
-  console.log(authorization);
   const defaultBranch = mainbranch.name;
   if (!defaultBranch) {
     throw new Error(`Could not fetch default branch for ${workspace}/${repo}`);

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPullRequest.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPullRequest.ts
@@ -1,0 +1,468 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { InputError } from '@backstage/errors';
+import {
+  getBitbucketServerRequestOptions,
+  ScmIntegrationRegistry,
+} from '@backstage/integration';
+import {
+  createTemplateAction,
+  getRepoSourceDirectory,
+  commitAndPushBranch,
+  addFiles,
+  createBranch as createGitBranch,
+  cloneRepo,
+  parseRepoUrl,
+} from '@backstage/plugin-scaffolder-node';
+import fetch, { RequestInit, Response } from 'node-fetch';
+import { Config } from '@backstage/config';
+import fs from 'fs-extra';
+import { getAuthorizationHeader } from './helpers';
+
+const createPullRequest = async (opts: {
+  workspace: string;
+  repo: string;
+  title: string;
+  description?: string;
+  targetBranch: string;
+  sourceBranch: string;
+  authorization: string;
+  apiBaseUrl: string;
+}) => {
+  const {
+    workspace,
+    repo,
+    title,
+    description,
+    targetBranch,
+    sourceBranch,
+    authorization,
+    apiBaseUrl,
+  } = opts;
+
+  let response: Response;
+  const data: RequestInit = {
+    method: 'POST',
+    body: JSON.stringify({
+      title: title,
+      summary: {
+        raw: description,
+      },
+      state: 'OPEN',
+      source: {
+        branch: {
+          name: sourceBranch,
+        },
+      },
+      destination: {
+        branch: {
+          name: targetBranch,
+        },
+      },
+    }),
+    headers: {
+      Authorization: authorization,
+      'Content-Type': 'application/json',
+    },
+  };
+
+  try {
+    response = await fetch(
+      `${apiBaseUrl}/repositories/${workspace}/${repo}/pullrequests`,
+      data,
+    );
+  } catch (e) {
+    throw new Error(`Unable to create pull-reqeusts, ${e}`);
+  }
+
+  if (response.status !== 201) {
+    throw new Error(
+      `Unable to create pull requests, ${response.status} ${
+        response.statusText
+      }, ${await response.text()}`,
+    );
+  }
+
+  const r = await response.json();
+  return r.links.self.href;
+};
+
+const findBranches = async (opts: {
+  project: string;
+  repo: string;
+  branchName: string;
+  authorization: string;
+  apiBaseUrl: string;
+}) => {
+  const { project, repo, branchName, authorization, apiBaseUrl } = opts;
+
+  let response: Response;
+  const options: RequestInit = {
+    method: 'GET',
+    headers: {
+      Authorization: authorization,
+      'Content-Type': 'application/json',
+    },
+  };
+
+  try {
+    response = await fetch(
+      `${apiBaseUrl}/projects/${encodeURIComponent(
+        project,
+      )}/repos/${encodeURIComponent(
+        repo,
+      )}/branches?boostMatches=true&filterText=${encodeURIComponent(
+        branchName,
+      )}`,
+      options,
+    );
+  } catch (e) {
+    throw new Error(`Unable to get branches, ${e}`);
+  }
+
+  if (response.status !== 200) {
+    throw new Error(
+      `Unable to get branches, ${response.status} ${
+        response.statusText
+      }, ${await response.text()}`,
+    );
+  }
+
+  const r = await response.json();
+  for (const object of r.values) {
+    if (object.displayId === branchName) {
+      return object;
+    }
+  }
+
+  return undefined;
+};
+const createBranch = async (opts: {
+  project: string;
+  repo: string;
+  branchName: string;
+  authorization: string;
+  apiBaseUrl: string;
+  startPoint: string;
+}) => {
+  const { project, repo, branchName, authorization, apiBaseUrl, startPoint } =
+    opts;
+
+  let response: Response;
+  const options: RequestInit = {
+    method: 'POST',
+    body: JSON.stringify({
+      name: branchName,
+      startPoint,
+    }),
+    headers: {
+      Authorization: authorization,
+      'Content-Type': 'application/json',
+    },
+  };
+
+  try {
+    response = await fetch(
+      `${apiBaseUrl}/projects/${encodeURIComponent(
+        project,
+      )}/repos/${encodeURIComponent(repo)}/branches`,
+      options,
+    );
+  } catch (e) {
+    throw new Error(`Unable to create branch, ${e}`);
+  }
+
+  if (response.status !== 200) {
+    throw new Error(
+      `Unable to create branch, ${response.status} ${
+        response.statusText
+      }, ${await response.text()}`,
+    );
+  }
+
+  return await response.json();
+};
+const getDefaultBranch = async (opts: {
+  workspace: string;
+  repo: string;
+  authorization: string;
+  apiBaseUrl: string;
+}): Promise<string> => {
+  const { workspace, repo, authorization, apiBaseUrl } = opts;
+  let response: Response;
+
+  const options: RequestInit = {
+    method: 'GET',
+    headers: {
+      Authorization: authorization,
+      'Content-Type': 'application/json',
+    },
+  };
+
+  try {
+    response = await fetch(
+      `${apiBaseUrl}/repositories/${workspace}/${repo}`,
+      options,
+    );
+  } catch (error) {
+    throw error;
+  }
+
+  const { mainbranch } = await response.json();
+  console.log(authorization);
+  const defaultBranch = mainbranch.name;
+  if (!defaultBranch) {
+    throw new Error(`Could not fetch default branch for ${workspace}/${repo}`);
+  }
+  return defaultBranch;
+};
+/**
+ * Creates a Bitbucket Cloud Pull Request action.
+ * @public
+ */
+export function createPublishBitbucketCloudPullRequestAction(options: {
+  integrations: ScmIntegrationRegistry;
+  config: Config;
+}) {
+  const { integrations, config } = options;
+
+  return createTemplateAction<{
+    repoUrl: string;
+    title: string;
+    description?: string;
+    targetBranch?: string;
+    sourceBranch: string;
+    token?: string;
+    gitAuthorName?: string;
+    gitAuthorEmail?: string;
+  }>({
+    id: 'publish:bitbucketCloud:pull-request',
+    // examples,
+    schema: {
+      input: {
+        type: 'object',
+        required: ['repoUrl', 'title', 'sourceBranch'],
+        properties: {
+          repoUrl: {
+            title: 'Repository Location',
+            type: 'string',
+          },
+          title: {
+            title: 'Pull Request title',
+            type: 'string',
+            description: 'The title for the pull request',
+          },
+          description: {
+            title: 'Pull Request Description',
+            type: 'string',
+            description: 'The description of the pull request',
+          },
+          targetBranch: {
+            title: 'Target Branch',
+            type: 'string',
+            description: `Branch of repository to apply changes to. The default value is 'master'`,
+          },
+          sourceBranch: {
+            title: 'Source Branch',
+            type: 'string',
+            description: 'Branch of repository to copy changes from',
+          },
+          token: {
+            title: 'Authorization Token',
+            type: 'string',
+            description:
+              'The token to use for authorization to BitBucket Cloud',
+          },
+          gitAuthorName: {
+            title: 'Author Name',
+            type: 'string',
+            description: `Sets the author name for the commit. The default value is 'Scaffolder'`,
+          },
+          gitAuthorEmail: {
+            title: 'Author Email',
+            type: 'string',
+            description: `Sets the author email for the commit.`,
+          },
+        },
+      },
+      output: {
+        type: 'object',
+        properties: {
+          pullRequestUrl: {
+            title: 'A URL to the pull request with the provider',
+            type: 'string',
+          },
+        },
+      },
+    },
+    async handler(ctx) {
+      const {
+        repoUrl,
+        title,
+        description,
+        targetBranch,
+        sourceBranch,
+        gitAuthorName,
+        gitAuthorEmail,
+      } = ctx.input;
+
+      const { project, repo, host, workspace } = parseRepoUrl(
+        repoUrl,
+        integrations,
+      );
+
+      if (!project) {
+        throw new InputError(
+          `Invalid URL provider was included in the repo URL to create ${ctx.input.repoUrl}, missing project`,
+        );
+      }
+
+      const integrationConfig = integrations.bitbucketCloud.byHost(host);
+      if (!integrationConfig) {
+        throw new InputError(
+          `No matching integration configuration for host ${host}, please check your integrations config`,
+        );
+      }
+
+      const authorization = getAuthorizationHeader(
+        ctx.input.token ? { token: ctx.input.token } : integrationConfig.config,
+      );
+
+      const apiBaseUrl = integrationConfig.config.apiBaseUrl;
+
+      let finalTargetBranch = targetBranch;
+      if (!finalTargetBranch) {
+        finalTargetBranch = await getDefaultBranch({
+          workspace: workspace!,
+          repo,
+          authorization,
+          apiBaseUrl,
+        });
+      }
+
+      // const toRef = await findBranches({
+      //   project,
+      //   repo,
+      //   branchName: finalTargetBranch!,
+      //   authorization,
+      //   apiBaseUrl,
+      // });
+
+      // let fromRef = await findBranches({
+      //   project,
+      //   repo,
+      //   branchName: sourceBranch,
+      //   authorization,
+      //   apiBaseUrl,
+      // });
+
+      // if (!fromRef) {
+      //   // create branch
+      //   ctx.logger.info(
+      //     `source branch not found -> creating branch named: ${sourceBranch} lastCommit: ${toRef.latestCommit}`,
+      //   );
+      //   const latestCommit = toRef.latestCommit;
+
+      //   fromRef = await createBranch({
+      //     project,
+      //     repo,
+      //     branchName: sourceBranch,
+      //     authorization,
+      //     apiBaseUrl,
+      //     startPoint: latestCommit,
+      //   });
+
+      //   const remoteUrl = `https://${host}/scm/${project}/${repo}.git`;
+
+      //   const auth = authConfig.token
+      //     ? {
+      //         token: token!,
+      //       }
+      //     : {
+      //         username: authConfig.username!,
+      //         password: authConfig.password!,
+      //       };
+
+      //   const gitAuthorInfo = {
+      //     name:
+      //       gitAuthorName ||
+      //       config.getOptionalString('scaffolder.defaultAuthor.name'),
+      //     email:
+      //       gitAuthorEmail ||
+      //       config.getOptionalString('scaffolder.defaultAuthor.email'),
+      //   };
+
+      //   const tempDir = await ctx.createTemporaryDirectory();
+      //   const sourceDir = getRepoSourceDirectory(ctx.workspacePath, undefined);
+      //   await cloneRepo({
+      //     url: remoteUrl,
+      //     dir: tempDir,
+      //     auth,
+      //     logger: ctx.logger,
+      //     ref: sourceBranch,
+      //   });
+
+      //   await createGitBranch({
+      //     dir: tempDir,
+      //     auth,
+      //     logger: ctx.logger,
+      //     ref: sourceBranch,
+      //   });
+
+      //   // copy files
+      //   fs.cpSync(sourceDir, tempDir, {
+      //     recursive: true,
+      //     filter: path => {
+      //       return !(path.indexOf('.git') > -1);
+      //     },
+      //   });
+
+      //   await addFiles({
+      //     dir: tempDir,
+      //     auth,
+      //     logger: ctx.logger,
+      //     filepath: '.',
+      //   });
+
+      //   await commitAndPushBranch({
+      //     dir: tempDir,
+      //     auth,
+      //     logger: ctx.logger,
+      //     commitMessage:
+      //       description ??
+      //       config.getOptionalString('scaffolder.defaultCommitMessage') ??
+      //       '',
+      //     gitAuthorInfo,
+      //     branch: sourceBranch,
+      //   });
+      // }
+
+      const pullRequestUrl = await createPullRequest({
+        workspace: workspace!,
+        repo,
+        title,
+        description,
+        targetBranch: finalTargetBranch,
+        sourceBranch,
+        authorization,
+        apiBaseUrl,
+      });
+
+      ctx.output('pullRequestUrl', pullRequestUrl);
+    },
+  });
+}

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPullRequest.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPullRequest.ts
@@ -96,7 +96,7 @@ const createPullRequest = async (opts: {
   }
 
   const r = await response.json();
-  return r.links.self.href;
+  return r.links.html.href;
 };
 
 const findBranches = async (opts: {

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPullRequest.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPullRequest.ts
@@ -29,6 +29,7 @@ import fetch, { RequestInit, Response } from 'node-fetch';
 import { Config } from '@backstage/config';
 import fs from 'fs-extra';
 import { getAuthorizationHeader } from './helpers';
+import { examples } from './bitbucketCloudPullRequest.examples';
 
 const createPullRequest = async (opts: {
   workspace: string;
@@ -244,7 +245,7 @@ export function createPublishBitbucketCloudPullRequestAction(options: {
     gitAuthorEmail?: string;
   }>({
     id: 'publish:bitbucketCloud:pull-request',
-    // examples,
+    examples,
     schema: {
       input: {
         type: 'object',

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/index.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/index.ts
@@ -15,3 +15,4 @@
  */
 export * from './bitbucketCloud';
 export { createBitbucketPipelinesRunAction } from './bitbucketCloudPipelinesRun';
+export * from './bitbucketCloudPullRequest';

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/src/module.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/src/module.ts
@@ -24,6 +24,7 @@ import {
 import {
   createBitbucketPipelinesRunAction,
   createPublishBitbucketCloudAction,
+  createPublishBitbucketCloudPullRequestAction,
 } from './actions';
 import { ScmIntegrations } from '@backstage/integration';
 import { handleAutocompleteRequest } from './autocomplete/autocomplete';
@@ -48,6 +49,10 @@ export const bitbucketCloudModule = createBackendModule({
         scaffolder.addActions(
           createPublishBitbucketCloudAction({ integrations, config }),
           createBitbucketPipelinesRunAction({ integrations }),
+          createPublishBitbucketCloudPullRequestAction({
+            integrations,
+            config,
+          }),
         );
 
         autocomplete.addAutocompleteProvider({

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/createBuiltinActions.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/createBuiltinActions.ts
@@ -62,6 +62,7 @@ import { createPublishBitbucketAction } from '@backstage/plugin-scaffolder-backe
 import {
   createPublishBitbucketCloudAction,
   createBitbucketPipelinesRunAction,
+  createPublishBitbucketCloudPullRequestAction,
 } from '@backstage/plugin-scaffolder-backend-module-bitbucket-cloud';
 
 import {
@@ -197,6 +198,7 @@ export const createBuiltinActions = (
       integrations,
       config,
     }),
+    createPublishBitbucketCloudPullRequestAction({ integrations, config }),
     createPublishBitbucketServerAction({
       integrations,
       config,


### PR DESCRIPTION
This PR ports the Bitbucket Server PR action to Bitbucket Cloud.

The goal was to stay as close to the original code as possible for consistency, so some parts of the code might not be the most elegant, but maybe that's something that should be cleaned up in both actions in another PR.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
