### PR TITLE
docs: 📚 fix slug in doc url

### DIFF
--- a/microsite/data/plugins/github-workflows.yaml
+++ b/microsite/data/plugins/github-workflows.yaml
@@ -4,7 +4,7 @@ author: VeeCode Platform
 authorUrl: https://platform.vee.codes/
 category: CI/CD
 description: The Github Workflows plugin provides an alternative for manually triggering GitHub workflows from within your Backstage component.
-documentation: https://platform.vee.codes/plugin/Github%20workflows/
+documentation: https://platform.vee.codes/plugin/github-workflows
 iconUrl: https://veecode-platform.github.io/support/imgs/logo_2.svg
 npmPackageName: '@veecode-platform/backstage-plugin-github-workflows'
 tags:

--- a/microsite/data/plugins/gitlab-pipelines.yaml
+++ b/microsite/data/plugins/gitlab-pipelines.yaml
@@ -4,7 +4,7 @@ author: VeeCode Platform
 authorUrl: https://platform.vee.codes
 category: CI/CD
 description: The Gitlab pipelines plugin integrates GitlabCi with its backstage component in a simple way.
-documentation: https://platform.vee.codes/plugin/Gitlab%20Pipelines/
+documentation: https://platform.vee.codes/plugin/gitlab-pipelines
 iconUrl: https://veecode-platform.github.io/support/imgs/logo_1.svg
 npmPackageName: '@veecode-platform/backstage-plugin-gitlab-pipelines'
 tags:

--- a/microsite/data/plugins/kong-service-manager.yaml
+++ b/microsite/data/plugins/kong-service-manager.yaml
@@ -4,7 +4,7 @@ author: VeeCode Platform
 authorUrl: https://platform.vee.codes/
 category: api-manager
 description: The Kong Service Manager plugin provides information about the kong service, a list of the routes it has and also offers the possibility of manipulating plugins without leaving the backstage.
-documentation: https://platform.vee.codes/plugin/Kong%20Service%20Manager/
+documentation: https://platform.vee.codes/plugin/kong-service-manager
 iconUrl: https://veecode-platform.github.io/support/imgs/logo_3.svg
 npmPackageName: '@veecode-platform/plugin-kong-service-manager'
 tags:

--- a/microsite/data/plugins/kubernetes-gpt-analyzer.yaml
+++ b/microsite/data/plugins/kubernetes-gpt-analyzer.yaml
@@ -4,7 +4,7 @@ author: VeeCode Platform
 authorUrl: https://platform.vee.codes/
 category: Monitoring
 description: The Kubernetes GPT Analyzer plug-in uses artificial intelligence with the help of k8s-operator to analyze and optimize your Kubernetes entities, improving the management and performance of your cluster. It makes it easier to detect anomalies and suggest best practices.
-documentation: https://platform.vee.codes/plugin/Kubernetes%20GPT%20Analyzer/
+documentation: https://platform.vee.codes/plugin/kubernetes-gpt-analyzer
 iconUrl: https://veecode-platform.github.io/support/imgs/logo_4.svg
 npmPackageName: '@veecode-platform/backstage-plugin-kubernetes-gpt-analyzer'
 tags:


### PR DESCRIPTION
## Fix Url Docs

I changed the slug of the documentation links, because they had spaces in them and were therefore interpreted as different characters, but now we've added a slug separated by “-”.

#### :heavy_check_mark: Checklist

- [x] Documentation added or updated
- [x] All your commits have a `Signed-off-by` line in the message. 