### PR TITLE
Update gitlab-pipelines.yaml

### DIFF
--- a/microsite/data/plugins/gitlab-pipelines.yaml
+++ b/microsite/data/plugins/gitlab-pipelines.yaml
@@ -4,7 +4,7 @@ author: VeeCode Platform
 authorUrl: https://platform.vee.codes
 category: CI/CD
 description: The Gitlab pipelines plugin integrates GitlabCi with its backstage component in a simple way.
-documentation: https://platform.vee.codes/plugin/Gitlab%20Pipelines/
+documentation: https://platform.vee.codes/plugin/gitlab-pipelines/
 iconUrl: https://veecode-platform.github.io/support/imgs/logo_1.svg
 npmPackageName: '@veecode-platform/backstage-plugin-gitlab-pipelines'
 tags:


### PR DESCRIPTION
Fix Url Docs

I changed the slug of the documentation links, because they had spaces in them and were therefore interpreted as different characters, but now we've added a slug separated by “-”.

✔️ Checklist
 [✔️]  Documentation added or updated
 [✔️] All your commits have a Signed-off-by line in the message.