### PR TITLE
Update kong-service-manager.yaml

### DIFF
--- a/microsite/data/plugins/kong-service-manager.yaml
+++ b/microsite/data/plugins/kong-service-manager.yaml
@@ -4,7 +4,7 @@ author: VeeCode Platform
 authorUrl: https://platform.vee.codes/
 category: api-manager
 description: The Kong Service Manager plugin provides information about the kong service, a list of the routes it has and also offers the possibility of manipulating plugins without leaving the backstage.
-documentation: https://platform.vee.codes/plugin/Kong%20Service%20Manager/
+documentation: https://platform.vee.codes/plugin/kong-service-manager/
 iconUrl: https://veecode-platform.github.io/support/imgs/logo_3.svg
 npmPackageName: '@veecode-platform/plugin-kong-service-manager'
 tags:


### PR DESCRIPTION
Fix Url Docs
I changed the slug of the documentation links, because they had spaces in them and were therefore interpreted as different characters, but now we've added a slug separated by “-”.

✔️ Checklist
 [✔️] Documentation added or updated
 [✔️] All your commits have a Signed-off-by line in the message.