### PR TITLE
fix: support `EntityPicker` ui options in `OwnedEntityPicker`

### DIFF
--- a/.changeset/proud-forks-buy.md
+++ b/.changeset/proud-forks-buy.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+The `ui:options` for `OwnedEntityPicker` field are now passed to `EntityPicker`. This allows you to use any `ui:options` which `EntityPicker` accepts in the `OwnedEntityPicker` field including `allowArbitraryValues` and `defaultNamespace`.

--- a/plugins/scaffolder/src/components/fields/OwnedEntityPicker/OwnedEntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/OwnedEntityPicker/OwnedEntityPicker.tsx
@@ -94,7 +94,7 @@ function buildEntityPickerUISchema(
   // Note: This is typed to avoid es-lint rule TS2698
   const uiOptions: EntityPickerProps['uiSchema']['ui:options'] =
     uiSchema?.['ui:options'] || {};
-  const allowedKinds = uiOptions.allowedKinds;
+  const { allowedKinds, ...extraOptions } = uiOptions;
 
   const catalogFilter = asArray(uiOptions.catalogFilter).map(e => ({
     ...e,
@@ -104,6 +104,7 @@ function buildEntityPickerUISchema(
 
   return {
     'ui:options': {
+      ...extraOptions,
       catalogFilter,
     },
   };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `OwnedEntityPicker` does not support the `allowArbitaryValues` or `defaultNamespace` option although this field is just a wrapper for `EntityPicker` component which does indeed support this. Currently, there is no way to disable arbitrary values using the `OwnedEntityPicker`.

The fix in this PR is to pass options from the `OwnedEntityPicker` to `EntityPicker` so it can utilize any option it supports.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
