### PR TITLE
Add watchOptions to frontend webpack config

### DIFF
--- a/.changeset/quick-dog-jump.md
+++ b/.changeset/quick-dog-jump.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Added `watchOptions` to frontend webpack config for compatibility with Yarn PnP

--- a/packages/cli/src/lib/bundler/config.ts
+++ b/packages/cli/src/lib/bundler/config.ts
@@ -350,7 +350,7 @@ export async function createConfig(
     ...(isDev
       ? {
           watchOptions: {
-            ignored: /node_modules\/(?!\@backstage)/,
+            ignored: /node_modules/,
           },
         }
       : {}),

--- a/packages/cli/src/lib/bundler/config.ts
+++ b/packages/cli/src/lib/bundler/config.ts
@@ -349,10 +349,10 @@ export async function createConfig(
     profile: false,
     ...(isDev
       ? {
-        watchOptions: {
-          ignored: /node_modules\/(?!\@backstage)/,
-        },
-      }
+          watchOptions: {
+            ignored: /node_modules\/(?!\@backstage)/,
+          },
+        }
       : {}),
     optimization,
     bail: false,

--- a/packages/cli/src/lib/bundler/config.ts
+++ b/packages/cli/src/lib/bundler/config.ts
@@ -347,6 +347,13 @@ export async function createConfig(
   return {
     mode,
     profile: false,
+    ...(isDev
+      ? {
+        watchOptions: {
+          ignored: /node_modules\/(?!\@backstage)/,
+        },
+      }
+      : {}),
     optimization,
     bail: false,
     performance: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The webpack configuration for the frontend was causing issues when running backstage locally with Yarn PnP.  The webpack dev server would take longer to compile and hot reloads weren't working for frontend plugins.  I worked through the issues locally by patching the @backstage/cli dependency and adding `watchOptions` to the `createConfig` function.

I initially copied the exact code from `createBackendConfig` and that worked, but I was met with a `DeprecationWarning` like the one mentioned in this issue thread: https://github.com/webpack/webpack-cli/issues/1918.

So, I didn't include the `watch: true`  in `createConfig` and it still works like a charm!  I've also tested it out locally with `nodeLinker: node-modules` and webpack is still working as expected.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
