### PR TITLE
fix: scaffolder review step doesn't process appropriate schema for multi step templates

### DIFF
--- a/.changeset/popular-pumpkins-rush.md
+++ b/.changeset/popular-pumpkins-rush.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+Fix scaffolder review step issue where schema options are not handled for fields on multi-step templates.

--- a/plugins/scaffolder-react/src/next/components/ReviewState/ReviewState.test.tsx
+++ b/plugins/scaffolder-react/src/next/components/ReviewState/ReviewState.test.tsx
@@ -497,4 +497,109 @@ describe('ReviewState', () => {
     expect(queryByRole('row', { name: 'Bar test' })).toBeInTheDocument();
     expect(queryByRole('row', { name: 'Foo test' })).not.toBeInTheDocument();
   });
+
+  it('should handle options in multiple schemas', async () => {
+    const formState = {
+      foo1: 'bar1',
+      foo2: 'bar2',
+      foo3: {
+        foo4: 'bar4',
+      },
+      foo5: 'bar5',
+    };
+
+    const schemas: ParsedTemplateSchema[] = [
+      {
+        mergedSchema: {
+          type: 'object',
+          properties: {
+            foo1: {
+              type: 'string',
+              'ui:backstage': {
+                review: {
+                  name: 'Test 1',
+                },
+              },
+            },
+          },
+        },
+        schema: {},
+        title: 'Schema 1',
+        uiSchema: {},
+      },
+      {
+        mergedSchema: {
+          type: 'object',
+          properties: {
+            foo2: {
+              type: 'string',
+              'ui:backstage': {
+                review: {
+                  name: 'Test 2',
+                },
+              },
+            },
+            foo3: {
+              type: 'object',
+              properties: {
+                foo4: {
+                  type: 'string',
+                  'ui:backstage': {
+                    review: {
+                      name: 'Test 4',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        schema: {},
+        title: 'Schema 2',
+        uiSchema: {},
+      },
+      {
+        mergedSchema: {
+          type: 'object',
+          dependencies: {
+            foo1: {
+              oneOf: [
+                {
+                  properties: {
+                    foo5: {
+                      type: 'string',
+                      'ui:backstage': {
+                        review: {
+                          name: 'Test 5',
+                        },
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+        schema: {},
+        title: 'Schema 3',
+        uiSchema: {},
+      },
+    ];
+
+    const { queryByRole } = render(
+      <ReviewState formState={formState} schemas={schemas} />,
+    );
+
+    // handles options in first schema
+    expect(queryByRole('row', { name: 'Test 1 bar1' })).toBeInTheDocument();
+
+    // handles options in second schema
+    expect(queryByRole('row', { name: 'Test 2 bar2' })).toBeInTheDocument();
+
+    // handles options for nested object in second schema
+    expect(queryByRole('row', { name: 'Test 4 bar4' })).toBeInTheDocument();
+
+    // handles options for property in dependencies in third schema
+    expect(queryByRole('row', { name: 'Test 5 bar5' })).toBeInTheDocument();
+  });
 });

--- a/plugins/scaffolder-react/src/next/components/ReviewState/ReviewState.tsx
+++ b/plugins/scaffolder-react/src/next/components/ReviewState/ReviewState.tsx
@@ -18,7 +18,7 @@ import { StructuredMetadataTable } from '@backstage/core-components';
 import { JsonObject, JsonValue } from '@backstage/types';
 import { Draft07 as JSONSchema } from 'json-schema-library';
 import { ParsedTemplateSchema } from '../../hooks/useTemplateSchema';
-import { isJsonObject, formatKey } from './util';
+import { isJsonObject, formatKey, findSchemaForKey } from './util';
 
 /**
  * The props for the {@link ReviewState} component.
@@ -94,10 +94,10 @@ export const ReviewState = (props: ReviewStateProps) => {
   const reviewData = Object.fromEntries(
     Object.entries(props.formState)
       .flatMap(([key, value]) => {
-        for (const step of props.schemas) {
-          return processSchema(key, value, step, props.formState);
-        }
-        return [[key, value]];
+        const schema = findSchemaForKey(key, props.schemas, props.formState);
+        return schema
+          ? processSchema(key, value, schema, props.formState)
+          : [[key, value]];
       })
       .filter(prop => prop.length > 0),
   );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #26508 . Introduced in #25346 

The flaw can be seen here: 
https://github.com/backstage/backstage/blob/7b8446a5e116157520b4e86435162c0b9d871254/plugins/scaffolder-react/src/next/components/ReviewState/ReviewState.tsx#L98

As a current behavior, the review state component iterates the form schemas and calls `processSchema` function. However, the result of `processSchema` is always immediately returned after the first iteration. The effect of this is that `processSchema` is always processed with the schema definition of the first step in a template. Therefore, any `ui:backstage`, `ui:field`, `ui:widget` processing in `processSchema` won't work for fields in a template except for the first step.

As a simple example:
```yaml

  - title: First
    properties:
      foo:
        type: string

  - title: Second
    properties:
      bar:
        type: string
        ui:backstage:
          review:
            # Even though we set it to false, it will still show in the review step page
            show: false
```

This PR fixes this adding a `findSchemaForKey` utility function that returns the schema where the key is defined. The review step component calls `findSchemaForKey` and uses the returned schema when calling `processSchema`.

- The `findSchemaForKey` supports dynamic forms using `dependencies` (https://react-jsonschema-form.readthedocs.io/en/v1.8.1/dependencies/#schema-dependencies)
- Adds test cases for `findSchemaForKey` and the `ReviewState` component

If there's any suggestions for a better way to tackle this (maybe refactoring the `ReviewState` component?) please let me know!

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
