### PR TITLE
Add dependencyOf property to Component catalog model

### DIFF
--- a/.changeset/flat-deers-raise.md
+++ b/.changeset/flat-deers-raise.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-model': minor
+---
+
+Add dependencyOf prop to catalog model for Component kind to enable building relationship graphs with both directions using dependsOn and dependencyOf.

--- a/.changeset/flat-deers-raise.md
+++ b/.changeset/flat-deers-raise.md
@@ -2,4 +2,4 @@
 '@backstage/catalog-model': minor
 ---
 
-Add dependencyOf prop to catalog model for Component kind to enable building relationship graphs with both directions using dependsOn and dependencyOf.
+Add `dependencyOf` prop to catalog model for Component kind to enable building relationship graphs with both directions using `dependsOn` and `dependencyOf`.

--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -527,6 +527,8 @@ spec:
   system: artist-engagement-portal
   dependsOn:
     - resource:default/artists-db
+  dependencyOf:
+    - component:default/artist-web-lookup
   providesApis:
     - artist-api
 ```
@@ -635,6 +637,17 @@ field is optional.
 | --------------------------------------- | ------------------------------------------ | --------------------------------------------------------------------------------------------- |
 | [`Component`](#kind-component)          | Same as this entity, typically `default`   | [`dependsOn`, and reverse `dependencyOf`](well-known-relations.md#dependson-and-dependencyof) |
 | [`Resource`](#kind-resource)            | Same as this entity, typically `default`   | [`dependsOn`, and reverse `dependencyOf`](well-known-relations.md#dependson-and-dependencyof) |
+
+### `spec.dependencyOf` [optional]
+
+An array of [entity references](references.md#string-references) to the
+components and resources that the component is a dependency of, e.g. `artist-web-lookup`.
+This field is optional.
+
+| [`kind`](#apiversion-and-kind-required) | Default [`namespace`](#namespace-optional) | Generated [relation](well-known-relations.md) type                                            |
+| --------------------------------------- | ------------------------------------------ | --------------------------------------------------------------------------------------------- |
+| [`Component`](#kind-component)          | Same as this entity, typically `default`   | [`dependencyOf`, and reverse `dependsOn`](well-known-relations.md#dependson-and-dependencyof) |
+| [`Resource`](#kind-resource)            | Same as this entity, typically `default`   | [`dependencyOf`, and reverse `dependsOn`](well-known-relations.md#dependson-and-dependencyof) |
 
 ## Kind: Template
 

--- a/packages/catalog-model/api-report.md
+++ b/packages/catalog-model/api-report.md
@@ -87,6 +87,7 @@ interface ComponentEntityV1alpha1 extends Entity {
     providesApis?: string[];
     consumesApis?: string[];
     dependsOn?: string[];
+    dependencyOf?: string[];
     system?: string;
   };
 }

--- a/packages/catalog-model/src/kinds/ComponentEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/ComponentEntityV1alpha1.ts
@@ -38,6 +38,7 @@ export interface ComponentEntityV1alpha1 extends Entity {
     providesApis?: string[];
     consumesApis?: string[];
     dependsOn?: string[];
+    dependencyOf?: string[];
     system?: string;
   };
 }

--- a/plugins/catalog-backend/src/modules/core/BuiltinKindsEntityProcessor.test.ts
+++ b/plugins/catalog-backend/src/modules/core/BuiltinKindsEntityProcessor.test.ts
@@ -46,13 +46,14 @@ describe('BuiltinKindsEntityProcessor', () => {
           providesApis: ['b'],
           consumesApis: ['c'],
           dependsOn: ['Resource:r', 'Component:d'],
+          dependencyOf: ['Resource:f', 'Component:g'],
           system: 's',
         },
       };
 
       await processor.postProcessEntity(entity, location, emit);
 
-      expect(emit).toHaveBeenCalledTimes(14);
+      expect(emit).toHaveBeenCalledTimes(18);
       expect(emit).toHaveBeenCalledWith({
         type: 'relation',
         relation: {
@@ -136,6 +137,38 @@ describe('BuiltinKindsEntityProcessor', () => {
       expect(emit).toHaveBeenCalledWith({
         type: 'relation',
         relation: {
+          source: { kind: 'Component', namespace: 'default', name: 'n' },
+          type: 'dependencyOf',
+          target: { kind: 'Resource', namespace: 'default', name: 'f' },
+        },
+      });
+      expect(emit).toHaveBeenCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'Resource', namespace: 'default', name: 'f' },
+          type: 'dependsOn',
+          target: { kind: 'Component', namespace: 'default', name: 'n' },
+        },
+      });
+      expect(emit).toHaveBeenCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'Component', namespace: 'default', name: 'n' },
+          type: 'dependencyOf',
+          target: { kind: 'Component', namespace: 'default', name: 'g' },
+        },
+      });
+      expect(emit).toHaveBeenCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'Component', namespace: 'default', name: 'g' },
+          type: 'dependsOn',
+          target: { kind: 'Component', namespace: 'default', name: 'n' },
+        },
+      });
+      expect(emit).toHaveBeenCalledWith({
+        type: 'relation',
+        relation: {
           source: { kind: 'Component', namespace: 'default', name: 's' },
           type: 'hasPart',
           target: { kind: 'Component', namespace: 'default', name: 'n' },
@@ -187,6 +220,29 @@ describe('BuiltinKindsEntityProcessor', () => {
         processor.postProcessEntity(entity, location, emit),
       ).rejects.toThrow(
         'Entity reference "r" had missing or empty kind (e.g. did not start with "component:" or similar)',
+      );
+    });
+
+    it('generates an error for component entities with unspecified dependencyOf entity reference kinds', async () => {
+      const entity: ComponentEntity = {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: { name: 'n' },
+        spec: {
+          type: 'service',
+          owner: 'o',
+          subcomponentOf: 's',
+          lifecycle: 'l',
+          providesApis: ['b'],
+          consumesApis: ['c'],
+          dependencyOf: ['m'],
+          system: 's',
+        },
+      };
+      await expect(
+        processor.postProcessEntity(entity, location, emit),
+      ).rejects.toThrow(
+        'Entity reference "m" had missing or empty kind (e.g. did not start with "component:" or similar)',
       );
     });
 

--- a/plugins/catalog-backend/src/modules/core/BuiltinKindsEntityProcessor.test.ts
+++ b/plugins/catalog-backend/src/modules/core/BuiltinKindsEntityProcessor.test.ts
@@ -235,14 +235,14 @@ describe('BuiltinKindsEntityProcessor', () => {
           lifecycle: 'l',
           providesApis: ['b'],
           consumesApis: ['c'],
-          dependencyOf: ['m'],
+          dependencyOf: ['y'],
           system: 's',
         },
       };
       await expect(
         processor.postProcessEntity(entity, location, emit),
       ).rejects.toThrow(
-        'Entity reference "m" had missing or empty kind (e.g. did not start with "component:" or similar)',
+        'Entity reference "y" had missing or empty kind (e.g. did not start with "component:" or similar)',
       );
     });
 

--- a/plugins/catalog-backend/src/modules/core/BuiltinKindsEntityProcessor.ts
+++ b/plugins/catalog-backend/src/modules/core/BuiltinKindsEntityProcessor.ts
@@ -167,6 +167,12 @@ export class BuiltinKindsEntityProcessor implements CatalogProcessor {
         RELATION_DEPENDENCY_OF,
       );
       doEmit(
+        component.spec.dependencyOf,
+        { defaultNamespace: selfRef.namespace },
+        RELATION_DEPENDENCY_OF,
+        RELATION_DEPENDS_ON,
+      );
+      doEmit(
         component.spec.system,
         { defaultKind: 'System', defaultNamespace: selfRef.namespace },
         RELATION_PART_OF,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Current implementation supports dependencyOf only for Resources, which means we can build entity relations graph for components only by using dependsOn direction and not dependencyOf. Adding dependencyOf prop to Component kind so that we can build relationships in both direction.

#### :heavy_check_mark: Checklist

- [X] A changeset describing the change and affected packages.
- [X] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message.
