### PR TITLE
Prevent 3 separate React elements from being created for each part of the support title

### DIFF
--- a/.changeset/odd-insects-behave.md
+++ b/.changeset/odd-insects-behave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-import': patch
+---
+
+Support button title should be contained in a single menu item

--- a/plugins/catalog-import/src/components/DefaultImportPage/DefaultImportPage.tsx
+++ b/plugins/catalog-import/src/components/DefaultImportPage/DefaultImportPage.tsx
@@ -40,6 +40,8 @@ export const DefaultImportPage = () => {
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const appTitle = configApi.getOptionalString('app.title') || 'Backstage';
 
+  const supportTitle = `Start tracking your component in ${appTitle} by adding it to the software catalog.`;
+
   const contentItems = [
     <Grid key={0} item xs={12} md={4} lg={6} xl={8}>
       <ImportInfoCard />
@@ -55,10 +57,7 @@ export const DefaultImportPage = () => {
       <Header title="Register an existing component" />
       <Content>
         <ContentHeader title={`Start tracking your component in ${appTitle}`}>
-          <SupportButton>
-            Start tracking your component in {appTitle} by adding it to the
-            software catalog.
-          </SupportButton>
+          <SupportButton>{supportTitle}</SupportButton>
         </ContentHeader>
 
         <Grid container spacing={2}>


### PR DESCRIPTION
### Background
The `DefaultCatalogImportPage` declares the support button title as the following:
``` 
React.createElement(SupportButton, null, "Start tracking your component in ", appTitle, " by adding it to the software catalog."))
```
rendering 3 support menu list items instead of one.

### Changes
- Ensure only a single child is passed to `SupportButton`

*Before*
![image](https://github.com/user-attachments/assets/1521862c-ec67-4182-914b-cc3e845859d5)

*After*
![image](https://github.com/user-attachments/assets/03aafc10-0594-4356-9a21-558ffe90cbe1)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
