### PR TITLE
fix: support menu items should not be buttons in favour of links

### DIFF
--- a/.changeset/early-cats-deliver.md
+++ b/.changeset/early-cats-deliver.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Support menu items should not be buttons in favour of links

--- a/packages/core-components/src/components/SupportButton/SupportButton.tsx
+++ b/packages/core-components/src/components/SupportButton/SupportButton.tsx
@@ -67,7 +67,7 @@ const SupportLink = ({ link }: { link: SupportItemLink }) => (
 
 const SupportListItem = ({ item }: { item: SupportItem }) => {
   return (
-    <MenuItem>
+    <MenuItem button={false}>
       <ListItemIcon>
         <SupportIcon icon={item.icon} />
       </ListItemIcon>
@@ -161,6 +161,7 @@ export function SupportButton(props: SupportButtonProps) {
           )}
           {React.Children.map(children, (child, i) => (
             <MenuItem
+              button={false}
               alignItems="flex-start"
               key={`child-${i}`}
               className={classes.menuItem}


### PR DESCRIPTION
### Background
When the Support button is clicked, a pop over with 2 menu items appears. However, these menu items are just messages that aren’t clickable.  That these messages are clickable “menu” or  “button” would be misleading for screen-reader users

### Changes
- Set `button={false}` for `SupportButton` children and fallback to accessible links
 
![image](https://github.com/user-attachments/assets/fd0a90a9-e984-4ba4-b542-dd20a817c311)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
