### PR TITLE
[Scaffolder] copy improvements

### DIFF
--- a/.changeset/bright-pillows-confess.md
+++ b/.changeset/bright-pillows-confess.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Removed default title set to Unknown page on `ContentHeaderTitle` component to support usage of component without title prop.

--- a/.changeset/slimy-hornets-explode.md
+++ b/.changeset/slimy-hornets-explode.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Removed duplicated titles on Scaffolder `TemplateListPage` component

--- a/packages/core-components/src/layout/ContentHeader/ContentHeader.test.tsx
+++ b/packages/core-components/src/layout/ContentHeader/ContentHeader.test.tsx
@@ -30,6 +30,13 @@ describe('<ContentHeader/>', () => {
     rendered.getByText('Title');
   });
 
+  it('should render without title', async () => {
+    const rendered = await renderInTestApp(
+      <ContentHeader>content</ContentHeader>,
+    );
+    rendered.getByText('content');
+  });
+
   it('should render with titleComponent', async () => {
     const title = 'Custom title';
     const titleComponent = <h1>{title}</h1>;

--- a/packages/core-components/src/layout/ContentHeader/ContentHeader.tsx
+++ b/packages/core-components/src/layout/ContentHeader/ContentHeader.tsx
@@ -73,10 +73,7 @@ type ContentHeaderTitleProps = {
   className?: string;
 };
 
-const ContentHeaderTitle = ({
-  title = 'Unknown page',
-  className,
-}: ContentHeaderTitleProps) => (
+const ContentHeaderTitle = ({ title, className }: ContentHeaderTitleProps) => (
   <Typography
     variant="h4"
     component="h2"

--- a/plugins/scaffolder/api-report-alpha.md
+++ b/plugins/scaffolder/api-report-alpha.md
@@ -230,7 +230,6 @@ export const scaffolderTranslationRef: TranslationRef<
     readonly 'templateListPage.pageTitle': 'Create a new component';
     readonly 'templateListPage.templateGroups.defaultTitle': 'Templates';
     readonly 'templateListPage.templateGroups.otherTitle': 'Other Templates';
-    readonly 'templateListPage.contentHeader.title': 'Available Templates';
     readonly 'templateListPage.contentHeader.registerExistingButtonTitle': 'Register Existing Component';
     readonly 'templateListPage.contentHeader.supportButtonTitle': 'Create new software components using standard templates. Different templates create different kinds of components (services, websites, documentation, ...).';
     readonly 'templateListPage.additionalLinksForEntity.viewTechDocsTitle': 'View TechDocs';

--- a/plugins/scaffolder/src/next/TemplateListPage/TemplateListPage.tsx
+++ b/plugins/scaffolder/src/next/TemplateListPage/TemplateListPage.tsx
@@ -177,7 +177,7 @@ export const TemplateListPage = (props: TemplateListPageProps) => {
           <ScaffolderPageContextMenu {...scaffolderPageContextMenuProps} />
         </Header>
         <Content>
-          <ContentHeader title={t('templateListPage.contentHeader.title')}>
+          <ContentHeader>
             <RegisterExistingButton
               title={t(
                 'templateListPage.contentHeader.registerExistingButtonTitle',

--- a/plugins/scaffolder/src/translation.ts
+++ b/plugins/scaffolder/src/translation.ts
@@ -261,7 +261,6 @@ export const scaffolderTranslationRef = createTranslationRef({
         otherTitle: 'Other Templates',
       },
       contentHeader: {
-        title: 'Available Templates',
         registerExistingButtonTitle: 'Register Existing Component',
         supportButtonTitle:
           'Create new software components using standard templates. Different templates create different kinds of components (services, websites, documentation, ...).',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

We have conducted a UX audit of certain pages in Backstage. This PR aims to reduce duplication of page titles in scaffolder. 
* Since the `ContentHeaderTitle` component set the title to `Unknown page` by default, I removed this so that you can use that component without providing a title. 

**Before**
![Screenshot 2024-09-09 at 14 27 27](https://github.com/user-attachments/assets/3774a777-36d8-42bc-8f96-a5104bda687e)

**After**
![Screenshot 2024-09-09 at 14 34 53](https://github.com/user-attachments/assets/cdbb3757-bb82-4d1f-b928-2097c3644a8a)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
