### PR TITLE
root: add GOVERNANCE.md with link to actual governance doc

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,1 +1,0 @@
-See the [GOVERNANCE.md](https://github.com/backstage/community/blob/main/GOVERNANCE.md) document in the [backstage/community](https://github.com/backstage/community) repository.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,1 @@
+See the [GOVERNANCE.md](https://github.com/backstage/community/blob/main/GOVERNANCE.md) document in the [backstage/community](https://github.com/backstage/community) repository.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ To engage with our community, you can use the following resources:
 - [Backstage Community Sessions](https://github.com/backstage/community) - Join monthly meetups and explore Backstage community
 - Give us a star ⭐️ - If you are using Backstage or think it is an interesting project, we would love a star ❤️
 
+## Governance
+
+See the [GOVERNANCE.md](https://github.com/backstage/community/blob/main/GOVERNANCE.md) document in the [backstage/community](https://github.com/backstage/community) repository.
+
 ## License
 
 Copyright 2020-2024 © The Backstage Authors. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our Trademark Usage page: https://www.linuxfoundation.org/trademark-usage


### PR DESCRIPTION
Figured it's good to have this in place to make it a bit easier to find, as I think it's very common to be landing at this repo.