### PR TITLE
oauth2-proxy: document lack of request authentication

### DIFF
--- a/docs/auth/oauth2-proxy/provider.md
+++ b/docs/auth/oauth2-proxy/provider.md
@@ -13,6 +13,12 @@ a cluster. In general the `oauth2-proxy` supports all OpenID Connect providers,
 for more details check this
 [list of supported providers](https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/oauth_provider).
 
+:::note Note
+
+OAuth2 Proxy does not provide a way to authenticate requests, you must instead ensure that your Backstage instance is only accessible through the OAuth2 Proxy. If you need more strict validation, consider using a different provider.
+
+:::
+
 ## Configuration
 
 The provider configuration can be added to your `app-config.yaml` under the root

--- a/plugins/auth-backend-module-oauth2-proxy-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-oauth2-proxy-provider/src/authenticator.ts
@@ -42,6 +42,15 @@ export const oauth2ProxyAuthenticator = createProxyAuthenticator({
   async initialize() {},
   async authenticate({ req }) {
     try {
+      // This unpacking of the JWT is just a utility provided by the
+      // authenticator to make the fields available to the profile transform and
+      // sign-in resolvers. The JWT is already validated by the upstream OAuth2
+      // Proxy, and since OAuth2 Proxy doesn't provide a way to authenticate
+      // forwarded requests, we don't do any additional validation here but
+      // instead trust that there is no way for attackers to bypass the OAuth2
+      // Proxy. We could validate these individual ID tokens for some of the
+      // upstream providers, but that is currently not in scope for this
+      // authenticator.
       const authHeader = req.header(OAUTH2_PROXY_JWT_HEADER);
       const jwt = authHeader?.match(/^Bearer[ ]+(\S+)$/i)?.[1];
       const decodedJWT = jwt && decodeJwt(jwt);


### PR DESCRIPTION
I realized we don't spell this out in our own documentation anywhere, so adding these two bits to reduce the risk of confusion.