### PR TITLE
Added `classic-dedupe` script to `create-app`

### DIFF
--- a/.changeset/serious-suns-jog.md
+++ b/.changeset/serious-suns-jog.md
@@ -1,0 +1,7 @@
+---
+'@backstage/create-app': patch
+---
+
+Added `classic-dedupe` script that uses `yarn-deduplicate` to deduplicate the `yarn.lock` file. Run it using `yarn classic-dedupe`
+
+Note: for those using Yarn 3+ this is not needed, please use the built in `yarn dedupe`

--- a/packages/create-app/templates/default-app/package.json.hbs
+++ b/packages/create-app/templates/default-app/package.json.hbs
@@ -22,7 +22,8 @@
     "lint": "backstage-cli repo lint --since origin/{{defaultBranch}}",
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",
-    "new": "backstage-cli new --scope internal"
+    "new": "backstage-cli new --scope internal",
+    "classic-dedupe": "yarn-deduplicate yarn.lock"
   },
   "workspaces": {
     "packages": [
@@ -39,7 +40,8 @@
     "lerna": "^7.3.0",
     "node-gyp": "^10.0.0",
     "prettier": "^2.3.2",
-    "typescript": "~5.4.0"
+    "typescript": "~5.4.0",
+    "yarn-deduplicate": "^6.0.2"
   },
   "resolutions": {
     "@types/react": "^18",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added `classic-dedupe` script that uses `yarn-deduplicate` to deduplicate the `yarn.lock` file. Run it using `yarn classic-dedupe`

Note: for those using Yarn 3+ this is not needed, please use the built in `yarn dedupe`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
