### PR TITLE
[Catalog] Enable loading state for paginated catalog table

### DIFF
--- a/.changeset/spotty-buses-drive.md
+++ b/.changeset/spotty-buses-drive.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog': patch
 ---
 
-Enable loading state for paginated catalog tables by passing isLoading prop
+Enable loading state for paginated catalog tables by passing `isLoading` prop

--- a/.changeset/spotty-buses-drive.md
+++ b/.changeset/spotty-buses-drive.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Enable loading state for paginated catalog tables by passing isLoading prop

--- a/plugins/catalog/src/components/CatalogTable/CursorPaginatedCatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CursorPaginatedCatalogTable.tsx
@@ -62,6 +62,7 @@ export function CursorPaginatedCatalogTable(props: PaginatedCatalogTableProps) {
       /* this will enable the next button accordingly */
       totalCount={next ? Number.MAX_VALUE : Number.MAX_SAFE_INTEGER}
       localization={{ pagination: { labelDisplayedRows: '' } }}
+      isLoading={isLoading}
       {...restProps}
     />
   );

--- a/plugins/catalog/src/components/CatalogTable/OffsetPaginatedCatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/OffsetPaginatedCatalogTable.tsx
@@ -29,7 +29,7 @@ import {
 export function OffsetPaginatedCatalogTable(
   props: TableProps<CatalogTableRow>,
 ) {
-  const { columns, data } = props;
+  const { columns, data, isLoading } = props;
   const { updateFilters, setLimit, setOffset, limit, totalItems, offset } =
     useEntityList();
   const [page, setPage] = React.useState(
@@ -68,6 +68,7 @@ export function OffsetPaginatedCatalogTable(
       }}
       totalCount={totalItems}
       localization={{ pagination: { labelDisplayedRows: '' } }}
+      isLoading={isLoading}
     />
   );
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This change is the response to the issue I created [here](https://github.com/backstage/backstage/issues/26569). Whenever you used a `paginated` catalog table, the loading state was not there since the `isLoading` prop was not passed to the `Table` component.

PR fixes that by adding `isLoading` in both `CursorPaginatedCatalogTable` and `OffsetPaginatedCatalogTable`.

- Not paginated catalog table has loading state

![image](https://github.com/user-attachments/assets/4b76198b-8818-426f-b1f4-4ab157dd6d2d)


- Paginated (cursor) catalog table **before** the change

![image](https://github.com/user-attachments/assets/9115f153-43a7-486d-b706-58c352bd6ca7)

- Paginated (offset) catalog table **before** the change

![image](https://github.com/user-attachments/assets/73c4caad-55dd-4e6c-82fc-857dcdba5059)

- Paginated (cursor) catalog table **after** the change

![image](https://github.com/user-attachments/assets/1aaf118d-a0b3-455f-8b83-574d09ac524e)

- Paginated (offset) catalog table **after** the change

![image](https://github.com/user-attachments/assets/6cf6dd31-d1c0-4c26-b48e-63c56eb1427c)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
