### PR TITLE
Expose catalog-graph styles as overrideableComponents

### DIFF
--- a/.changeset/eight-fireants-unite.md
+++ b/.changeset/eight-fireants-unite.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-graph': minor
+---
+
+Expose catalog-graph component overrides

--- a/plugins/catalog-graph/api-report.md
+++ b/plugins/catalog-graph/api-report.md
@@ -127,6 +127,28 @@ export type EntityRelationsGraphProps = {
   showArrowHeads?: boolean;
 };
 
+// @public (undocumented)
+export type PluginCatalogGraphCatalogGraphCardClassKey = 'card' | 'graph';
+
+// @public (undocumented)
+export type PluginCatalogGraphCatalogGraphPageClassKey =
+  | 'content'
+  | 'container'
+  | 'fullHeight'
+  | 'graphWrapper'
+  | 'graph'
+  | 'legend'
+  | 'filters';
+
+// @public (undocumented)
+export type PluginCatalogGraphCustomLabelClassKey = 'text' | 'secondary';
+
+// @public (undocumented)
+export type PluginCatalogGraphCustomNodeClassKey =
+  | 'node'
+  | 'text'
+  | 'clickable';
+
 // @public
 export type RelationPairs = [string, string][];
 ```

--- a/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.tsx
@@ -39,6 +39,9 @@ import {
 } from '../EntityRelationsGraph';
 import { EntityRelationsGraphProps } from '../EntityRelationsGraph';
 
+/** @public */
+export type PluginCatalogGraphCatalogGraphCardClassKey = 'card' | 'graph';
+
 const useStyles = makeStyles<Theme, { height: number | undefined }>(
   {
     card: ({ height }) => ({

--- a/plugins/catalog-graph/src/components/CatalogGraphCard/index.ts
+++ b/plugins/catalog-graph/src/components/CatalogGraphCard/index.ts
@@ -14,3 +14,4 @@
  * limitations under the License.
  */
 export { CatalogGraphCard } from './CatalogGraphCard';
+export type { PluginCatalogGraphCatalogGraphCardClassKey } from './CatalogGraphCard';

--- a/plugins/catalog-graph/src/components/CatalogGraphPage/CatalogGraphPage.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphPage/CatalogGraphPage.tsx
@@ -51,6 +51,16 @@ import { SelectedRelationsFilter } from './SelectedRelationsFilter';
 import { SwitchFilter } from './SwitchFilter';
 import { useCatalogGraphPage } from './useCatalogGraphPage';
 
+/** @public */
+export type PluginCatalogGraphCatalogGraphPageClassKey =
+  | 'content'
+  | 'container'
+  | 'fullHeight'
+  | 'graphWrapper'
+  | 'graph'
+  | 'legend'
+  | 'filters';
+
 const useStyles = makeStyles(
   theme => ({
     content: {

--- a/plugins/catalog-graph/src/components/CatalogGraphPage/index.ts
+++ b/plugins/catalog-graph/src/components/CatalogGraphPage/index.ts
@@ -14,3 +14,4 @@
  * limitations under the License.
  */
 export { CatalogGraphPage } from './CatalogGraphPage';
+export type { PluginCatalogGraphCatalogGraphPageClassKey } from './CatalogGraphPage';

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/DefaultRenderLabel.tsx
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/DefaultRenderLabel.tsx
@@ -19,6 +19,9 @@ import React from 'react';
 import { EntityEdgeData } from './types';
 import classNames from 'classnames';
 
+/** @public */
+export type PluginCatalogGraphCustomLabelClassKey = 'text' | 'secondary';
+
 const useStyles = makeStyles(
   theme => ({
     text: {

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/DefaultRenderNode.tsx
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/DefaultRenderNode.tsx
@@ -23,6 +23,12 @@ import { EntityIcon } from './EntityIcon';
 import { EntityNodeData } from './types';
 import { DEFAULT_NAMESPACE } from '@backstage/catalog-model';
 
+/** @public */
+export type PluginCatalogGraphCustomNodeClassKey =
+  | 'node'
+  | 'text'
+  | 'clickable';
+
 const useStyles = makeStyles(
   theme => ({
     node: {

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/index.ts
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/index.ts
@@ -24,3 +24,5 @@ export type {
   EntityNodeData,
   EntityNode,
 } from './types';
+export type { PluginCatalogGraphCustomNodeClassKey } from './DefaultRenderNode';
+export type { PluginCatalogGraphCustomLabelClassKey } from './DefaultRenderLabel';

--- a/plugins/catalog-graph/src/components/index.ts
+++ b/plugins/catalog-graph/src/components/index.ts
@@ -14,3 +14,5 @@
  * limitations under the License.
  */
 export * from './EntityRelationsGraph';
+export type { PluginCatalogGraphCatalogGraphCardClassKey } from './CatalogGraphCard';
+export type { PluginCatalogGraphCatalogGraphPageClassKey } from './CatalogGraphPage';

--- a/plugins/catalog-graph/src/overridableComponents.ts
+++ b/plugins/catalog-graph/src/overridableComponents.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Overrides } from '@material-ui/core/styles/overrides';
+import { StyleRules } from '@material-ui/core/styles/withStyles';
+import {
+  PluginCatalogGraphCustomLabelClassKey,
+  PluginCatalogGraphCustomNodeClassKey,
+} from './components';
+import { PluginCatalogGraphCatalogGraphPageClassKey } from './components/CatalogGraphPage';
+import { PluginCatalogGraphCatalogGraphCardClassKey } from './components/CatalogGraphCard';
+
+/** @public */
+export type CatalogReactComponentsNameToClassKey = {
+  PluginCatalogGraphCustomNode: PluginCatalogGraphCustomNodeClassKey;
+  PluginCatalogGraphCustomLabel: PluginCatalogGraphCustomLabelClassKey;
+  PluginCatalogGraphCatalogGraphPage: PluginCatalogGraphCatalogGraphPageClassKey;
+  PluginCatalogGraphCatalogGraphCard: PluginCatalogGraphCatalogGraphCardClassKey;
+};
+
+/** @public */
+export type BackstageOverrides = Overrides & {
+  [Name in keyof CatalogReactComponentsNameToClassKey]?: Partial<
+    StyleRules<CatalogReactComponentsNameToClassKey[Name]>
+  >;
+};
+
+declare module '@backstage/theme' {
+  interface OverrideComponentNameToClassKeys
+    extends CatalogReactComponentsNameToClassKey {}
+}


### PR DESCRIPTION
### Changes
- Expose `PluginCatalogGraphCustomNode`, `PluginCatalogGraphCustomLabel`, `PluginCatalogGraphCatalogGraphPage` and `PluginCatalogGraphCatalogGraphCard` in catalog-graph's `overrideableComponents`

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
