### PR TITLE
[UX / UI ] Empty states including learn link to descriptor format to include external link icon

### DIFF
--- a/.changeset/eleven-pugs-hear.md
+++ b/.changeset/eleven-pugs-hear.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-api-docs': patch
+'@backstage/plugin-catalog': patch
+---
+
+Empty states updated with external link icon for learn more links

--- a/.changeset/giant-kiwis-retire.md
+++ b/.changeset/giant-kiwis-retire.md
@@ -1,0 +1,5 @@
+---
+'@backstage/app-defaults': patch
+---
+
+Added `externalLink` to icon defaults

--- a/.changeset/strange-bees-attack.md
+++ b/.changeset/strange-bees-attack.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+`Link` component now accepts `externalLinkIcon` prop

--- a/packages/app-defaults/src/defaults/icons.tsx
+++ b/packages/app-defaults/src/defaults/icons.tsx
@@ -38,6 +38,7 @@ import MuiStorageIcon from '@material-ui/icons/Storage';
 import MuiFeaturedPlayListIcon from '@material-ui/icons/FeaturedPlayList';
 import Star from '@material-ui/icons/Star';
 import StarBorder from '@material-ui/icons/StarBorder';
+import OpenInNew from '@material-ui/icons/OpenInNew';
 
 export const icons = {
   brokenImage: MuiBrokenImageIcon as IconComponent,
@@ -66,4 +67,5 @@ export const icons = {
   warning: MuiWarningIcon as IconComponent,
   star: Star as IconComponent,
   unstarred: StarBorder as IconComponent,
+  externalLink: OpenInNew as IconComponent,
 };

--- a/packages/core-compat-api/src/compatWrapper/compatWrapper.test.tsx
+++ b/packages/core-compat-api/src/compatWrapper/compatWrapper.test.tsx
@@ -76,7 +76,7 @@ describe('BackwardsCompatProvider', () => {
     expect(screen.getByTestId('ctx').textContent).toMatchInlineSnapshot(`
       "plugins: test, app
       components: NotFoundErrorPage, BootErrorPage, Progress, Router, ErrorBoundaryFallback
-      icons: brokenImage, catalog, scaffolder, techdocs, search, chat, dashboard, docs, email, github, group, help, kind:api, kind:component, kind:domain, kind:group, kind:location, kind:system, kind:user, kind:resource, kind:template, user, warning, star, unstarred"
+      icons: brokenImage, catalog, scaffolder, techdocs, search, chat, dashboard, docs, email, github, group, help, kind:api, kind:component, kind:domain, kind:group, kind:location, kind:system, kind:user, kind:resource, kind:template, user, warning, star, unstarred, externalLink"
     `);
   });
 

--- a/packages/core-components/report.api.md
+++ b/packages/core-components/report.api.md
@@ -706,6 +706,7 @@ export type LinkProps = Omit<LinkProps_2, 'to'> &
     to: string;
     component?: ElementType<any>;
     noTrack?: boolean;
+    externalLinkIcon?: React_2.ReactNode;
   };
 
 // Warning: (ae-missing-release-tag) "LoginRequestListItemClassKey" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/packages/core-components/report.api.md
+++ b/packages/core-components/report.api.md
@@ -706,7 +706,7 @@ export type LinkProps = Omit<LinkProps_2, 'to'> &
     to: string;
     component?: ElementType<any>;
     noTrack?: boolean;
-    externalLinkIcon?: React_2.ReactNode;
+    externalLinkIcon?: boolean;
   };
 
 // Warning: (ae-missing-release-tag) "LoginRequestListItemClassKey" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/packages/core-components/src/components/Link/Link.test.tsx
+++ b/packages/core-components/src/components/Link/Link.test.tsx
@@ -25,6 +25,7 @@ import { analyticsApiRef, configApiRef } from '@backstage/core-plugin-api';
 import { isExternalUri, Link, useResolvedPath } from './Link';
 import { Route, Routes } from 'react-router-dom';
 import { ConfigReader } from '@backstage/config';
+import OpenInNew from '@material-ui/icons/OpenInNew';
 
 describe('<Link />', () => {
   it('navigates using react-router', async () => {
@@ -43,6 +44,30 @@ describe('<Link />', () => {
     await waitFor(() => {
       expect(screen.getByText(testString)).toBeInTheDocument();
     });
+  });
+
+  it('does not render external link icon if externalLinkIcon prop is not passed', async () => {
+    const { container } = await renderInTestApp(
+      <Link to="http://something.external">External Link</Link>,
+    );
+    const externalLink = screen.getByRole('link', {
+      name: 'External Link , Opens in a new window',
+    });
+    const externalLinkIcon = container.querySelector('svg');
+    expect(externalLink).not.toContainElement(externalLinkIcon);
+  });
+
+  it('renders external link icon if externalLinkIcon prop is passed', async () => {
+    const { container } = await renderInTestApp(
+      <Link to="http://something.external" externalLinkIcon={<OpenInNew />}>
+        External Link
+      </Link>,
+    );
+    const externalLink = screen.getByRole('link', {
+      name: 'External Link , Opens in a new window',
+    });
+    const externalLinkIcon = container.querySelector('svg');
+    expect(externalLink).toContainElement(externalLinkIcon);
   });
 
   it('captures click using analytics api', async () => {

--- a/packages/core-components/src/components/Link/Link.test.tsx
+++ b/packages/core-components/src/components/Link/Link.test.tsx
@@ -25,7 +25,6 @@ import { analyticsApiRef, configApiRef } from '@backstage/core-plugin-api';
 import { isExternalUri, Link, useResolvedPath } from './Link';
 import { Route, Routes } from 'react-router-dom';
 import { ConfigReader } from '@backstage/config';
-import OpenInNew from '@material-ui/icons/OpenInNew';
 
 describe('<Link />', () => {
   it('navigates using react-router', async () => {
@@ -59,7 +58,7 @@ describe('<Link />', () => {
 
   it('renders external link icon if externalLinkIcon prop is passed', async () => {
     const { container } = await renderInTestApp(
-      <Link to="http://something.external" externalLinkIcon={<OpenInNew />}>
+      <Link to="http://something.external" externalLinkIcon>
         External Link
       </Link>,
     );

--- a/packages/core-components/src/components/Link/Link.tsx
+++ b/packages/core-components/src/components/Link/Link.tsx
@@ -90,6 +90,7 @@ export type LinkProps = Omit<MaterialLinkProps, 'to'> &
     to: string;
     component?: ElementType<any>;
     noTrack?: boolean;
+    externalLinkIcon?: React.ReactNode;
   };
 
 /**
@@ -161,7 +162,7 @@ const getNodeText = (node: React.ReactNode): string => {
  * - Captures Link clicks as analytics events.
  */
 export const Link = React.forwardRef<any, LinkProps>(
-  ({ onClick, noTrack, ...props }, ref) => {
+  ({ onClick, noTrack, externalLinkIcon, ...props }, ref) => {
     const classes = useStyles();
     const analytics = useAnalytics();
 
@@ -201,6 +202,7 @@ export const Link = React.forwardRef<any, LinkProps>(
         className={classnames(classes.externalLink, props.className)}
       >
         {props.children}
+        {externalLinkIcon && externalLinkIcon}
         <Typography component="span" className={classes.visuallyHidden}>
           , Opens in a new window
         </Typography>

--- a/packages/core-components/src/components/Link/Link.tsx
+++ b/packages/core-components/src/components/Link/Link.tsx
@@ -29,6 +29,8 @@ import {
   LinkProps as RouterLinkProps,
   Route,
 } from 'react-router-dom';
+import OpenInNew from '@material-ui/icons/OpenInNew';
+import { useApp } from '@backstage/core-plugin-api';
 
 export function isReactRouterBeta(): boolean {
   const [obj] = createRoutesFromChildren(<Route index element={<div />} />);
@@ -39,7 +41,7 @@ export function isReactRouterBeta(): boolean {
 export type LinkClassKey = 'visuallyHidden' | 'externalLink';
 
 const useStyles = makeStyles(
-  {
+  theme => ({
     visuallyHidden: {
       clip: 'rect(0 0 0 0)',
       clipPath: 'inset(50%)',
@@ -53,9 +55,20 @@ const useStyles = makeStyles(
     externalLink: {
       position: 'relative',
     },
-  },
+    externalLinkIcon: {
+      verticalAlign: 'bottom',
+      marginLeft: theme.spacing(0.5),
+    },
+  }),
   { name: 'Link' },
 );
+
+const ExternalLinkIcon = () => {
+  const app = useApp();
+  const Icon = app.getSystemIcon('externalLink') || OpenInNew;
+  const classes = useStyles();
+  return <Icon className={classes.externalLinkIcon} />;
+};
 
 export const isExternalUri = (uri: string) => /^([a-z+.-]+):/.test(uri);
 
@@ -90,7 +103,7 @@ export type LinkProps = Omit<MaterialLinkProps, 'to'> &
     to: string;
     component?: ElementType<any>;
     noTrack?: boolean;
-    externalLinkIcon?: React.ReactNode;
+    externalLinkIcon?: boolean;
   };
 
 /**
@@ -202,7 +215,7 @@ export const Link = React.forwardRef<any, LinkProps>(
         className={classnames(classes.externalLink, props.className)}
       >
         {props.children}
-        {externalLinkIcon && externalLinkIcon}
+        {externalLinkIcon && <ExternalLinkIcon />}
         <Typography component="span" className={classes.visuallyHidden}>
           , Opens in a new window
         </Typography>

--- a/plugins/api-docs/src/components/ApisCards/ConsumedApisCard.test.tsx
+++ b/plugins/api-docs/src/components/ApisCards/ConsumedApisCard.test.tsx
@@ -62,7 +62,7 @@ describe('<ConsumedApisCard />', () => {
       relations: [],
     };
 
-    const { getByText } = await renderInTestApp(
+    const { getByText, getByRole, container } = await renderInTestApp(
       <Wrapper>
         <EntityProvider entity={entity}>
           <ConsumedApisCard />
@@ -77,6 +77,17 @@ describe('<ConsumedApisCard />', () => {
 
     expect(getByText(/Consumed APIs/i)).toBeInTheDocument();
     expect(getByText(/does not consume any APIs/i)).toBeInTheDocument();
+
+    // Also render external link icon
+    const externalLink = getByRole('link');
+    expect(externalLink).toHaveAttribute(
+      'href',
+      'https://backstage.io/docs/features/software-catalog/descriptor-format#specconsumesapis-optional',
+    );
+    const externalLinkIcon: HTMLElement | null = container.querySelector(
+      'svg[class*="externalLink"]',
+    );
+    expect(externalLink).toContainElement(externalLinkIcon);
   });
 
   it('shows consumed APIs', async () => {

--- a/plugins/api-docs/src/components/ApisCards/ConsumedApisCard.tsx
+++ b/plugins/api-docs/src/components/ApisCards/ConsumedApisCard.tsx
@@ -33,6 +33,16 @@ import {
   TableOptions,
   WarningPanel,
 } from '@backstage/core-components';
+import OpenInNew from '@material-ui/icons/OpenInNew';
+import { useApp } from '@backstage/core-plugin-api';
+import { makeStyles, Theme } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  externalLink: {
+    verticalAlign: 'bottom',
+    marginLeft: theme.spacing(0.5),
+  },
+}));
 
 /**
  * @public
@@ -53,6 +63,9 @@ export const ConsumedApisCard = (props: {
   const { entities, loading, error } = useRelatedEntities(entity, {
     type: RELATION_CONSUMES_API,
   });
+  const app = useApp();
+  const ExternalLinkIcon = app.getSystemIcon('externalLink') || OpenInNew;
+  const classes = useStyles();
 
   if (loading) {
     return (
@@ -85,8 +98,16 @@ export const ConsumedApisCard = (props: {
             APIs.
           </Typography>
           <Typography variant="body2">
-            <Link to="https://backstage.io/docs/features/software-catalog/descriptor-format#specconsumesapis-optional">
-              Learn how to change this.
+            <Link
+              to="https://backstage.io/docs/features/software-catalog/descriptor-format#specconsumesapis-optional"
+              externalLinkIcon={
+                <ExternalLinkIcon
+                  fontSize="small"
+                  className={classes.externalLink}
+                />
+              }
+            >
+              Learn how to change this
             </Link>
           </Typography>
         </div>

--- a/plugins/api-docs/src/components/ApisCards/ConsumedApisCard.tsx
+++ b/plugins/api-docs/src/components/ApisCards/ConsumedApisCard.tsx
@@ -33,16 +33,6 @@ import {
   TableOptions,
   WarningPanel,
 } from '@backstage/core-components';
-import OpenInNew from '@material-ui/icons/OpenInNew';
-import { useApp } from '@backstage/core-plugin-api';
-import { makeStyles, Theme } from '@material-ui/core/styles';
-
-const useStyles = makeStyles((theme: Theme) => ({
-  externalLink: {
-    verticalAlign: 'bottom',
-    marginLeft: theme.spacing(0.5),
-  },
-}));
 
 /**
  * @public
@@ -63,9 +53,6 @@ export const ConsumedApisCard = (props: {
   const { entities, loading, error } = useRelatedEntities(entity, {
     type: RELATION_CONSUMES_API,
   });
-  const app = useApp();
-  const ExternalLinkIcon = app.getSystemIcon('externalLink') || OpenInNew;
-  const classes = useStyles();
 
   if (loading) {
     return (
@@ -100,12 +87,7 @@ export const ConsumedApisCard = (props: {
           <Typography variant="body2">
             <Link
               to="https://backstage.io/docs/features/software-catalog/descriptor-format#specconsumesapis-optional"
-              externalLinkIcon={
-                <ExternalLinkIcon
-                  fontSize="small"
-                  className={classes.externalLink}
-                />
-              }
+              externalLinkIcon
             >
               Learn how to change this
             </Link>

--- a/plugins/api-docs/src/components/ApisCards/ProvidedApisCard.test.tsx
+++ b/plugins/api-docs/src/components/ApisCards/ProvidedApisCard.test.tsx
@@ -62,7 +62,7 @@ describe('<ProvidedApisCard />', () => {
       relations: [],
     };
 
-    const { getByText } = await renderInTestApp(
+    const { getByText, getByRole, container } = await renderInTestApp(
       <Wrapper>
         <EntityProvider entity={entity}>
           <ProvidedApisCard />
@@ -77,6 +77,18 @@ describe('<ProvidedApisCard />', () => {
 
     expect(getByText(/Provided APIs/i)).toBeInTheDocument();
     expect(getByText(/does not provide any APIs/i)).toBeInTheDocument();
+    expect(getByText(/Learn how to change this/)).toBeInTheDocument();
+
+    // Also render external link icon
+    const externalLink = getByRole('link');
+    expect(externalLink).toHaveAttribute(
+      'href',
+      'https://backstage.io/docs/features/software-catalog/descriptor-format#specprovidesapis-optional',
+    );
+    const externalLinkIcon: HTMLElement | null = container.querySelector(
+      'svg[class*="externalLink"]',
+    );
+    expect(externalLink).toContainElement(externalLinkIcon);
   });
 
   it('shows consumed APIs', async () => {

--- a/plugins/api-docs/src/components/ApisCards/ProvidedApisCard.tsx
+++ b/plugins/api-docs/src/components/ApisCards/ProvidedApisCard.tsx
@@ -33,16 +33,6 @@ import {
   TableOptions,
   WarningPanel,
 } from '@backstage/core-components';
-import { useApp } from '@backstage/core-plugin-api';
-import OpenInNew from '@material-ui/icons/OpenInNew';
-import { makeStyles, Theme } from '@material-ui/core/styles';
-
-const useStyles = makeStyles((theme: Theme) => ({
-  externalLink: {
-    verticalAlign: 'bottom',
-    marginLeft: theme.spacing(0.5),
-  },
-}));
 
 /**
  * @public
@@ -63,9 +53,6 @@ export const ProvidedApisCard = (props: {
   const { entities, loading, error } = useRelatedEntities(entity, {
     type: RELATION_PROVIDES_API,
   });
-  const app = useApp();
-  const ExternalLinkIcon = app.getSystemIcon('externalLink') || OpenInNew;
-  const classes = useStyles();
 
   if (loading) {
     return (
@@ -99,12 +86,7 @@ export const ProvidedApisCard = (props: {
           </Typography>
           <Link
             to="https://backstage.io/docs/features/software-catalog/descriptor-format#specprovidesapis-optional"
-            externalLinkIcon={
-              <ExternalLinkIcon
-                fontSize="small"
-                className={classes.externalLink}
-              />
-            }
+            externalLinkIcon
           >
             Learn how to change this
           </Link>

--- a/plugins/api-docs/src/components/ApisCards/ProvidedApisCard.tsx
+++ b/plugins/api-docs/src/components/ApisCards/ProvidedApisCard.tsx
@@ -33,6 +33,16 @@ import {
   TableOptions,
   WarningPanel,
 } from '@backstage/core-components';
+import { useApp } from '@backstage/core-plugin-api';
+import OpenInNew from '@material-ui/icons/OpenInNew';
+import { makeStyles, Theme } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  externalLink: {
+    verticalAlign: 'bottom',
+    marginLeft: theme.spacing(0.5),
+  },
+}));
 
 /**
  * @public
@@ -53,6 +63,9 @@ export const ProvidedApisCard = (props: {
   const { entities, loading, error } = useRelatedEntities(entity, {
     type: RELATION_PROVIDES_API,
   });
+  const app = useApp();
+  const ExternalLinkIcon = app.getSystemIcon('externalLink') || OpenInNew;
+  const classes = useStyles();
 
   if (loading) {
     return (
@@ -84,11 +97,17 @@ export const ProvidedApisCard = (props: {
             This {entity.kind.toLocaleLowerCase('en-US')} does not provide any
             APIs.
           </Typography>
-          <Typography variant="body2">
-            <Link to="https://backstage.io/docs/features/software-catalog/descriptor-format#specprovidesapis-optional">
-              Learn how to change this.
-            </Link>
-          </Typography>
+          <Link
+            to="https://backstage.io/docs/features/software-catalog/descriptor-format#specprovidesapis-optional"
+            externalLinkIcon={
+              <ExternalLinkIcon
+                fontSize="small"
+                className={classes.externalLink}
+              />
+            }
+          >
+            Learn how to change this
+          </Link>
         </div>
       }
       columns={columns}

--- a/plugins/catalog/report-alpha.api.md
+++ b/plugins/catalog/report-alpha.api.md
@@ -113,7 +113,7 @@ export const catalogTranslationRef: TranslationRef<
     readonly 'hasSubdomainsCard.emptyMessage': 'No subdomain is part of this domain';
     readonly 'hasSystemsCard.title': 'Has systems';
     readonly 'hasSystemsCard.emptyMessage': 'No system is part of this domain';
-    readonly 'relatedEntitiesCard.emptyHelpLinkTitle': 'Learn how to change this.';
+    readonly 'relatedEntitiesCard.emptyHelpLinkTitle': 'Learn how to change this';
     readonly 'systemDiagramCard.title': 'System Diagram';
     readonly 'systemDiagramCard.description': 'Use pinch & zoo to move around the diagram.';
     readonly 'systemDiagramCard.edgeLabels.dependsOn': 'depends on';

--- a/plugins/catalog/src/alpha/translation.ts
+++ b/plugins/catalog/src/alpha/translation.ts
@@ -152,7 +152,7 @@ export const catalogTranslationRef = createTranslationRef({
       emptyMessage: 'No system is part of this domain',
     },
     relatedEntitiesCard: {
-      emptyHelpLinkTitle: 'Learn how to change this.',
+      emptyHelpLinkTitle: 'Learn how to change this',
     },
     systemDiagramCard: {
       title: 'System Diagram',

--- a/plugins/catalog/src/components/RelatedEntitiesCard/RelatedEntitiesCard.tsx
+++ b/plugins/catalog/src/components/RelatedEntitiesCard/RelatedEntitiesCard.tsx
@@ -44,9 +44,6 @@ import {
 } from './presets';
 import { catalogTranslationRef } from '../../alpha/translation';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
-import { useApp } from '@backstage/core-plugin-api';
-import OpenInNew from '@material-ui/icons/OpenInNew';
-import { makeStyles, Theme } from '@material-ui/core/styles';
 
 /** @public */
 export type RelatedEntitiesCardProps<T extends Entity> = {
@@ -60,13 +57,6 @@ export type RelatedEntitiesCardProps<T extends Entity> = {
   asRenderableEntities: (entities: Entity[]) => T[];
   tableOptions?: TableOptions;
 };
-
-const useStyles = makeStyles((theme: Theme) => ({
-  externalLink: {
-    verticalAlign: 'bottom',
-    marginLeft: theme.spacing(0.5),
-  },
-}));
 
 /**
  * A low level card component that can be used as a building block for more
@@ -94,9 +84,6 @@ export const RelatedEntitiesCard = <T extends Entity>(
     asRenderableEntities,
     tableOptions = {},
   } = props;
-  const classes = useStyles();
-  const app = useApp();
-  const ExternalLinkIcon = app.getSystemIcon('externalLink') || OpenInNew;
   const { t } = useTranslationRef(catalogTranslationRef);
   const { entity } = useEntity();
   const { entities, loading, error } = useRelatedEntities(entity, {
@@ -128,16 +115,7 @@ export const RelatedEntitiesCard = <T extends Entity>(
         <div style={{ textAlign: 'center' }}>
           <Typography variant="body1">{emptyMessage}</Typography>
           <Typography variant="body2">
-            <Link
-              className={classes.externalLink}
-              to={emptyHelpLink}
-              externalLinkIcon={
-                <ExternalLinkIcon
-                  fontSize="small"
-                  className={classes.externalLink}
-                />
-              }
-            >
+            <Link to={emptyHelpLink} externalLinkIcon>
               {t('relatedEntitiesCard.emptyHelpLinkTitle')}
             </Link>
           </Typography>

--- a/plugins/catalog/src/components/RelatedEntitiesCard/RelatedEntitiesCard.tsx
+++ b/plugins/catalog/src/components/RelatedEntitiesCard/RelatedEntitiesCard.tsx
@@ -44,6 +44,9 @@ import {
 } from './presets';
 import { catalogTranslationRef } from '../../alpha/translation';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import { useApp } from '@backstage/core-plugin-api';
+import OpenInNew from '@material-ui/icons/OpenInNew';
+import { makeStyles, Theme } from '@material-ui/core/styles';
 
 /** @public */
 export type RelatedEntitiesCardProps<T extends Entity> = {
@@ -57,6 +60,13 @@ export type RelatedEntitiesCardProps<T extends Entity> = {
   asRenderableEntities: (entities: Entity[]) => T[];
   tableOptions?: TableOptions;
 };
+
+const useStyles = makeStyles((theme: Theme) => ({
+  externalLink: {
+    verticalAlign: 'bottom',
+    marginLeft: theme.spacing(0.5),
+  },
+}));
 
 /**
  * A low level card component that can be used as a building block for more
@@ -84,7 +94,9 @@ export const RelatedEntitiesCard = <T extends Entity>(
     asRenderableEntities,
     tableOptions = {},
   } = props;
-
+  const classes = useStyles();
+  const app = useApp();
+  const ExternalLinkIcon = app.getSystemIcon('externalLink') || OpenInNew;
   const { t } = useTranslationRef(catalogTranslationRef);
   const { entity } = useEntity();
   const { entities, loading, error } = useRelatedEntities(entity, {
@@ -116,7 +128,16 @@ export const RelatedEntitiesCard = <T extends Entity>(
         <div style={{ textAlign: 'center' }}>
           <Typography variant="body1">{emptyMessage}</Typography>
           <Typography variant="body2">
-            <Link to={emptyHelpLink}>
+            <Link
+              className={classes.externalLink}
+              to={emptyHelpLink}
+              externalLinkIcon={
+                <ExternalLinkIcon
+                  fontSize="small"
+                  className={classes.externalLink}
+                />
+              }
+            >
               {t('relatedEntitiesCard.emptyHelpLinkTitle')}
             </Link>
           </Typography>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

* Added external link icon to default icons
* Added a new prop to the `Link` component to let it accept an external link icon
* Updated api docs consume api / provide api entity cards to include external link icon
* Updated related entities card to include external link icon

<img width="717" alt="Screenshot 2024-09-11 at 15 08 21" src="https://github.com/user-attachments/assets/8754598c-0026-4bb8-bcbd-5d52a0f96c00">


The default external link icon can be changed in the new frontend system by using the following override (example)

```tsx
const iconOverrides = IconBundleBlueprint.make({
  name: 'icons',
  params: {
    icons: {
      externalLink: ArrowForwardIcon,
    },
  },
});
 
```



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
