### PR TITLE
auth-backend-module-guest-provider: avoid halting backend startup

### DIFF
--- a/.changeset/kind-hornets-sort.md
+++ b/.changeset/kind-hornets-sort.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-guest-provider': patch
+---
+
+This provider will now reject authentication attempts rather than halt backend startup when `dangerouslyAllowOutsideDevelopment` is not set in production.

--- a/plugins/auth-backend-module-guest-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-guest-provider/src/authenticator.ts
@@ -15,7 +15,7 @@
  */
 
 import { createProxyAuthenticator } from '@backstage/plugin-auth-node';
-import { NotImplementedError } from '@backstage/errors';
+import { NotAllowedError } from '@backstage/errors';
 
 export const guestAuthenticator = createProxyAuthenticator({
   defaultProfileTransform: async () => {
@@ -25,13 +25,14 @@ export const guestAuthenticator = createProxyAuthenticator({
     const allowOutsideDev = config.getOptionalBoolean(
       'dangerouslyAllowOutsideDevelopment',
     );
-    if (process.env.NODE_ENV !== 'development' && allowOutsideDev !== true) {
-      throw new NotImplementedError(
-        'The guest provider cannot be used outside of a development environment',
+    return process.env.NODE_ENV !== 'development' && allowOutsideDev !== true;
+  },
+  async authenticate(_, disabled) {
+    if (disabled) {
+      throw new NotAllowedError(
+        "The guest provider cannot be used outside of a development environment unless 'auth.providers.guest.dangerouslyAllowOutsideDevelopment' is enabled",
       );
     }
-  },
-  async authenticate() {
     return { result: {} };
   },
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Throwing on startup seems to be causing a lot of issues, #26546, #24284. In particular, see https://github.com/backstage/backstage/issues/24284#issuecomment-2170116113

Fixes #26546

I suggest that we don't re-introduce the warning either, but instead simply throw an error if anyone attempts sign-in with the provider when it's disabled.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
