### PR TITLE
fix(deps): update dependency @octokit/webhooks to 10.9.2 due to vulnerability

### DIFF
--- a/.changeset/six-icons-beam.md
+++ b/.changeset/six-icons-beam.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-github': patch
+---
+
+Update dependency @octokit/webhooks to 10.9.2 due to SNYK-JS-OCTOKITWEBHOOKS-6129527

--- a/plugins/scaffolder-backend-module-github/package.json
+++ b/plugins/scaffolder-backend-module-github/package.json
@@ -48,7 +48,7 @@
     "@backstage/errors": "workspace:^",
     "@backstage/integration": "workspace:^",
     "@backstage/plugin-scaffolder-node": "workspace:^",
-    "@octokit/webhooks": "^10.0.0",
+    "@octokit/webhooks": "^10.9.2",
     "libsodium-wrappers": "^0.7.11",
     "octokit": "^3.0.0",
     "octokit-plugin-create-pull-request": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7113,7 +7113,7 @@ __metadata:
     "@backstage/integration": "workspace:^"
     "@backstage/plugin-scaffolder-node": "workspace:^"
     "@backstage/plugin-scaffolder-node-test-utils": "workspace:^"
-    "@octokit/webhooks": ^10.0.0
+    "@octokit/webhooks": ^10.9.2
     "@types/libsodium-wrappers": ^0.7.10
     fs-extra: ^11.2.0
     jsonschema: ^1.2.6
@@ -12477,7 +12477,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/webhooks@npm:^10.0.0":
+"@octokit/webhooks@npm:^10.9.2":
   version: 10.9.2
   resolution: "@octokit/webhooks@npm:10.9.2"
   dependencies:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is a simple dependency bump in the` scaffolder-backend-module-github` plugin of the octokit/webhooks dependency.

This dependency is vulnerable according to Snyk: https://security.snyk.io/vuln/SNYK-JS-OCTOKITWEBHOOKS-6129527
As this is a non-major upgrade and I have not seen the vulnerability being mentioned anywhere in the repository I thought I'd open a PR for it.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
