### PR TITLE
NFS: Fix `apiRef` overriding

### DIFF
--- a/.changeset/ninety-brooms-fry.md
+++ b/.changeset/ninety-brooms-fry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-app-api': patch
+---
+
+Reverse the order of API factory initialization in order to make sure that overrides from modules take priority

--- a/packages/frontend-app-api/src/wiring/createSpecializedApp.tsx
+++ b/packages/frontend-app-api/src/wiring/createSpecializedApp.tsx
@@ -305,7 +305,7 @@ function createApiHolder(options: {
 }): ApiHolder {
   const factoryRegistry = new ApiFactoryRegistry();
 
-  for (const factory of options.factories) {
+  for (const factory of options.factories.slice().reverse()) {
     factoryRegistry.register('default', factory);
   }
 


### PR DESCRIPTION
`ApiRefs` should be allowed to be overridden without having to match the `kind/namespace/name` triplet and relying on the tree, they were currently setup so that the first takes priority, whereas it should be loaded in reverse order so that modules take precedence.