### PR TITLE
Fix azure scaffolder git push auth

### DIFF
--- a/.changeset/tricky-pigs-smoke.md
+++ b/.changeset/tricky-pigs-smoke.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-azure': patch
+---
+
+Publish Azure action now uses basic authentication to authenticate to Git when Azure integration is configured to use App Registration/Service Account or Managed Identity.

--- a/plugins/scaffolder-backend-module-azure/src/actions/azure.ts
+++ b/plugins/scaffolder-backend-module-azure/src/actions/azure.ts
@@ -207,13 +207,10 @@ export function createPublishAzureAction(options: {
           : config.getOptionalString('scaffolder.defaultAuthor.email'),
       };
 
-      const auth =
-        ctx.input.token || credentials?.type === 'pat'
-          ? {
-              username: 'notempty',
-              password: ctx.input.token ?? credentials!.token,
-            }
-          : { token: credentials!.token };
+      const auth = {
+        username: 'notempty',
+        password: ctx.input.token ?? credentials!.token,
+      };
 
       const commitResult = await initRepoAndPush({
         dir: getRepoSourceDirectory(ctx.workspacePath, ctx.input.sourcePath),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
     
Fixed issue https://github.com/backstage/backstage/issues/26368.
When Azure integration is configured to use App Registration or Managed Identity, the Azure:Publish action in Azure Devops Scaffolder module will be configured to authenticate to Git using basic authentication as opposed to Authorization header.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
