### PR TITLE
Add support for changing counters and subtitle

### DIFF
--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -61,6 +61,8 @@ export interface CatalogTableProps {
   tableOptions?: TableProps<CatalogTableRow>['options'];
   emptyContent?: ReactNode;
   subtitle?: string;
+  calculateCounterFunction?: Function,
+  buildSubtitleFunction?: Function
 }
 
 const refCompare = (a: Entity, b: Entity) => {
@@ -79,6 +81,8 @@ export const CatalogTable = (props: CatalogTableProps) => {
     columns = defaultCatalogTableColumnsFunc,
     tableOptions,
     subtitle,
+    calculateCounterFunction,
+    buildSubtitleFunction,
     emptyContent,
   } = props;
   const { isStarredEntity, toggleStarredEntity } = useStarredEntities();
@@ -170,7 +174,14 @@ export const CatalogTable = (props: CatalogTableProps) => {
 
   const currentKind = filters.kind?.value || '';
   const currentType = filters.type?.value || '';
-  const currentCount = typeof totalItems === 'number' ? `(${totalItems})` : '';
+  let currentCount = typeof totalItems === 'number' ? `(${totalItems})` : '';
+  if (calculateCounterFunction) {
+    currentCount = `(${calculateCounterFunction(entities)})`;
+  }
+  let finalSubtitle = subtitle
+  if (buildSubtitleFunction) {
+    finalSubtitle = buildSubtitleFunction(entities)
+  }
   // TODO(timbonicus): remove the title from the CatalogTable once using EntitySearchBar
   const titlePreamble = capitalize(filters.user?.value ?? 'all');
   const title = [
@@ -199,7 +210,7 @@ export const CatalogTable = (props: CatalogTableProps) => {
         isLoading={loading}
         title={title}
         actions={actions}
-        subtitle={subtitle}
+        subtitle={finalSubtitle}
         options={options}
         data={entities.map(toEntityRow)}
         next={pageInfo?.next}
@@ -214,7 +225,7 @@ export const CatalogTable = (props: CatalogTableProps) => {
         isLoading={loading}
         title={title}
         actions={actions}
-        subtitle={subtitle}
+        subtitle={finalSubtitle}
         options={options}
         data={entities.map(toEntityRow)}
       />
@@ -238,7 +249,7 @@ export const CatalogTable = (props: CatalogTableProps) => {
       title={title}
       data={rows}
       actions={actions}
-      subtitle={subtitle}
+      subtitle={finalSubtitle}
       emptyContent={emptyContent}
     />
   );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adding new functionality to the CatalogTable to make it possible to change the counters and prepare subtitles. 

```
<CatalogTable columns={columns} actions={actions} calculateCounterFunction={getEntityCounterForDefault} buildSubtitleFunction={getEntityCounterSubtitle}/>
```

where `getEntityCounterSubtitle` and `getEntityCounterForDefault` have array Entities[] in parameters

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
