### PR TITLE
app-backend: 500 -> 400 on unknown POST

### DIFF
--- a/.changeset/eight-carpets-yell.md
+++ b/.changeset/eight-carpets-yell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-app-backend': patch
+---
+
+Return HTTP status 400 rather than 500 when receiving an unknown POST request.

--- a/plugins/app-backend/src/service/router.ts
+++ b/plugins/app-backend/src/service/router.ts
@@ -220,7 +220,9 @@ export async function createRouter(
           req.method = 'GET';
           next('router');
         } else {
-          throw new InputError('Invalid POST request to /');
+          throw new InputError(
+            'Invalid POST request to app-backend wildcard endpoint',
+          );
         }
       },
     );

--- a/plugins/app-backend/src/service/router.ts
+++ b/plugins/app-backend/src/service/router.ts
@@ -42,7 +42,7 @@ import {
   HttpAuthService,
   LoggerService,
 } from '@backstage/backend-plugin-api';
-import { AuthenticationError } from '@backstage/errors';
+import { AuthenticationError, InputError } from '@backstage/errors';
 import { injectConfig, readFrontendConfig } from '../lib/config';
 
 // express uses mime v1 while we only have types for mime v2
@@ -220,7 +220,7 @@ export async function createRouter(
           req.method = 'GET';
           next('router');
         } else {
-          throw new Error('Invalid POST request to /');
+          throw new InputError('Invalid POST request to /');
         }
       },
     );


### PR DESCRIPTION
Reported by @timbonicus, this avoids 500 errors due to unknown POST requests.