### PR TITLE
feat(permission): allow requesting batch permissions

### DIFF
--- a/.changeset/shiny-emus-greet.md
+++ b/.changeset/shiny-emus-greet.md
@@ -1,0 +1,13 @@
+---
+'@backstage/backend-plugin-api': patch
+'@backstage/backend-test-utils': patch
+'@backstage/plugin-permission-common': patch
+'@backstage/plugin-permission-react': patch
+'@backstage/plugin-permission-node': patch
+'@backstage/test-utils': patch
+---
+
+Allow creating batch permission requests through client
+
+Sometimes it's necessary to check multiple permissions at once using the `permissionApiRef`.
+A new function `authorizeBatch` is now available publicly.

--- a/packages/backend-plugin-api/api-report.md
+++ b/packages/backend-plugin-api/api-report.md
@@ -9,6 +9,8 @@ import { AuthorizePermissionRequest } from '@backstage/plugin-permission-common'
 import { AuthorizePermissionResponse } from '@backstage/plugin-permission-common';
 import { Config } from '@backstage/config';
 import { Duration } from 'luxon';
+import { EvaluatePermissionRequestBatch } from '@backstage/plugin-permission-common';
+import { EvaluatePermissionResponseBatch } from '@backstage/plugin-permission-common';
 import { EvaluatorRequestOptions } from '@backstage/plugin-permission-common';
 import { Handler } from 'express';
 import { HumanDuration } from '@backstage/types';
@@ -431,6 +433,10 @@ export interface PermissionsService extends PermissionEvaluator {
     requests: AuthorizePermissionRequest[],
     options: PermissionsServiceRequestOptions,
   ): Promise<AuthorizePermissionResponse[]>;
+  authorizeBatch(
+    request: EvaluatePermissionRequestBatch,
+    options: PermissionsServiceRequestOptions,
+  ): Promise<EvaluatePermissionResponseBatch>;
   authorizeConditional(
     requests: QueryPermissionRequest[],
     options: PermissionsServiceRequestOptions,

--- a/packages/backend-plugin-api/src/services/definitions/PermissionsService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/PermissionsService.ts
@@ -17,6 +17,8 @@
 import {
   AuthorizePermissionRequest,
   AuthorizePermissionResponse,
+  EvaluatePermissionRequestBatch,
+  EvaluatePermissionResponseBatch,
   EvaluatorRequestOptions,
   PermissionEvaluator,
   QueryPermissionRequest,
@@ -58,6 +60,16 @@ export interface PermissionsService extends PermissionEvaluator {
     requests: AuthorizePermissionRequest[],
     options: PermissionsServiceRequestOptions,
   ): Promise<AuthorizePermissionResponse[]>;
+
+  /**
+   * Evaluates batch of
+   * {@link backstage/plugin-permission-common#Permission | Permissions} and
+   * returns a definitive decision for each.
+   */
+  authorizeBatch(
+    request: EvaluatePermissionRequestBatch,
+    options: PermissionsServiceRequestOptions,
+  ): Promise<EvaluatePermissionResponseBatch>;
 
   /**
    * Evaluates {@link @backstage/plugin-permission-common#ResourcePermission | ResourcePermissions} and returns both definitive and

--- a/packages/backend-test-utils/src/next/services/mockServices.ts
+++ b/packages/backend-test-utils/src/next/services/mockServices.ts
@@ -17,8 +17,8 @@
 import { cacheServiceFactory } from '@backstage/backend-defaults/cache';
 import { databaseServiceFactory } from '@backstage/backend-defaults/database';
 import {
-  HostDiscovery,
   discoveryServiceFactory,
+  HostDiscovery,
 } from '@backstage/backend-defaults/discovery';
 import { httpRouterServiceFactory } from '@backstage/backend-defaults/httpRouter';
 import { lifecycleServiceFactory } from '@backstage/backend-defaults/lifecycle';
@@ -33,6 +33,8 @@ import {
   AuthService,
   BackstageCredentials,
   BackstageUserInfo,
+  coreServices,
+  createServiceFactory,
   DiscoveryService,
   HttpAuthService,
   LoggerService,
@@ -40,8 +42,6 @@ import {
   ServiceFactory,
   ServiceRef,
   UserInfoService,
-  coreServices,
-  createServiceFactory,
 } from '@backstage/backend-plugin-api';
 import { ConfigReader } from '@backstage/config';
 import {
@@ -384,6 +384,7 @@ export namespace mockServices {
     export const factory = () => permissionsServiceFactory;
     export const mock = simpleMock(coreServices.permissions, () => ({
       authorize: jest.fn(),
+      authorizeBatch: jest.fn(),
       authorizeConditional: jest.fn(),
     }));
   }

--- a/packages/test-utils/api-report.md
+++ b/packages/test-utils/api-report.md
@@ -19,7 +19,9 @@ import { ErrorApi } from '@backstage/core-plugin-api';
 import { ErrorApiError } from '@backstage/core-plugin-api';
 import { ErrorApiErrorContext } from '@backstage/core-plugin-api';
 import { EvaluatePermissionRequest } from '@backstage/plugin-permission-common';
+import { EvaluatePermissionRequestBatch } from '@backstage/plugin-permission-common';
 import { EvaluatePermissionResponse } from '@backstage/plugin-permission-common';
+import { EvaluatePermissionResponseBatch } from '@backstage/plugin-permission-common';
 import { ExternalRouteRef } from '@backstage/core-plugin-api';
 import { FetchApi } from '@backstage/core-plugin-api';
 import { IconComponent } from '@backstage/core-plugin-api';
@@ -174,6 +176,10 @@ export class MockPermissionApi implements PermissionApi {
   authorize(
     request: EvaluatePermissionRequest,
   ): Promise<EvaluatePermissionResponse>;
+  // (undocumented)
+  authorizeBatch(
+    request: EvaluatePermissionRequestBatch,
+  ): Promise<EvaluatePermissionResponseBatch>;
 }
 
 // @public

--- a/packages/test-utils/src/testUtils/apis/PermissionApi/MockPermissionApi.ts
+++ b/packages/test-utils/src/testUtils/apis/PermissionApi/MockPermissionApi.ts
@@ -16,9 +16,11 @@
 
 import { PermissionApi } from '@backstage/plugin-permission-react';
 import {
-  EvaluatePermissionResponse,
-  EvaluatePermissionRequest,
   AuthorizeResult,
+  EvaluatePermissionRequest,
+  EvaluatePermissionRequestBatch,
+  EvaluatePermissionResponse,
+  EvaluatePermissionResponseBatch,
 } from '@backstage/plugin-permission-common';
 
 /**
@@ -40,5 +42,16 @@ export class MockPermissionApi implements PermissionApi {
     request: EvaluatePermissionRequest,
   ): Promise<EvaluatePermissionResponse> {
     return { result: this.requestHandler(request) };
+  }
+
+  async authorizeBatch(
+    request: EvaluatePermissionRequestBatch,
+  ): Promise<EvaluatePermissionResponseBatch> {
+    return {
+      items: request.items.map(permission => ({
+        id: permission.id,
+        result: this.requestHandler(permission),
+      })),
+    };
   }
 }

--- a/plugins/catalog-backend/src/service/AuthorizedEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/AuthorizedEntitiesCatalog.test.ts
@@ -38,6 +38,7 @@ describe('AuthorizedEntitiesCatalog', () => {
   };
   const fakePermissionApi = {
     authorize: jest.fn(),
+    authorizeBatch: jest.fn(),
     authorizeConditional: jest.fn(),
   };
 

--- a/plugins/catalog-backend/src/service/AuthorizedLocationService.test.ts
+++ b/plugins/catalog-backend/src/service/AuthorizedLocationService.test.ts
@@ -29,6 +29,7 @@ describe('AuthorizedLocationService', () => {
   };
   const fakePermissionApi = {
     authorize: jest.fn(),
+    authorizeBatch: jest.fn(),
     authorizeConditional: jest.fn(),
   };
 

--- a/plugins/catalog-backend/src/service/createRouter.test.ts
+++ b/plugins/catalog-backend/src/service/createRouter.test.ts
@@ -75,6 +75,7 @@ describe('createRouter readonly disabled', () => {
     };
     permissionsService = {
       authorize: jest.fn(),
+      authorizeBatch: jest.fn(),
       authorizeConditional: jest.fn(),
     };
 

--- a/plugins/devtools-backend/src/service/router.test.ts
+++ b/plugins/devtools-backend/src/service/router.test.ts
@@ -23,12 +23,16 @@ import { mockServices } from '@backstage/backend-test-utils';
 
 const mockedAuthorize: jest.MockedFunction<PermissionEvaluator['authorize']> =
   jest.fn();
+const mockedAuthorizeBatch: jest.MockedFunction<
+  PermissionEvaluator['authorizeBatch']
+> = jest.fn();
 const mockedPermissionQuery: jest.MockedFunction<
   PermissionEvaluator['authorizeConditional']
 > = jest.fn();
 
 const permissionEvaluator: PermissionEvaluator = {
   authorize: mockedAuthorize,
+  authorizeBatch: mockedAuthorizeBatch,
   authorizeConditional: mockedPermissionQuery,
 };
 

--- a/plugins/kubernetes-backend/src/service/KubernetesProxy.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesProxy.test.ts
@@ -32,6 +32,7 @@ import {
   KubernetesRequestAuth,
 } from '@backstage/plugin-kubernetes-common';
 import { getMockReq, getMockRes } from '@jest-mock/express';
+import type { Request } from 'express';
 import express from 'express';
 import Router from 'express-promise-router';
 import { Server } from 'http';
@@ -43,8 +44,8 @@ import { Config } from '@kubernetes/client-node';
 
 import { LocalKubectlProxyClusterLocator } from '../cluster-locator/LocalKubectlProxyLocator';
 import {
-  AuthenticationStrategy,
   AnonymousStrategy,
+  AuthenticationStrategy,
   KubernetesCredential,
 } from '../auth';
 import { ClusterDetails, KubernetesClustersSupplier } from '../types/types';
@@ -54,8 +55,6 @@ import {
   HEADER_KUBERNETES_CLUSTER,
   KubernetesProxy,
 } from './KubernetesProxy';
-
-import type { Request } from 'express';
 import {
   BackstageCredentials,
   DiscoveryService,
@@ -82,6 +81,7 @@ describe('KubernetesProxy', () => {
 
   const permissionApi: jest.Mocked<PermissionEvaluator> = {
     authorize: jest.fn(),
+    authorizeBatch: jest.fn(),
     authorizeConditional: jest.fn(),
   };
 

--- a/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.stories.tsx
+++ b/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.stories.tsx
@@ -64,6 +64,7 @@ const catalogApi: Partial<CatalogApi> = {
 
 const permissionApi: typeof permissionApiRef.T = {
   authorize: async () => ({ result: AuthorizeResult.ALLOW }),
+  authorizeBatch: jest.fn(),
 };
 
 export const Default = () => (

--- a/plugins/permission-common/api-report.md
+++ b/plugins/permission-common/api-report.md
@@ -177,6 +177,10 @@ export class PermissionClient implements PermissionEvaluator {
     requests: AuthorizePermissionRequest[],
     options?: PermissionClientRequestOptions,
   ): Promise<AuthorizePermissionResponse[]>;
+  authorizeBatch(
+    request: EvaluatePermissionRequestBatch,
+    options?: PermissionClientRequestOptions,
+  ): Promise<EvaluatePermissionResponseBatch>;
   authorizeConditional(
     queries: QueryPermissionRequest[],
     options?: PermissionClientRequestOptions,
@@ -213,6 +217,12 @@ export interface PermissionEvaluator {
       _ignored?: never;
     },
   ): Promise<AuthorizePermissionResponse[]>;
+  authorizeBatch(
+    request: EvaluatePermissionRequestBatch,
+    options?: EvaluatorRequestOptions & {
+      _ignored?: never;
+    },
+  ): Promise<EvaluatePermissionResponseBatch>;
   authorizeConditional(
     requests: QueryPermissionRequest[],
     options?: EvaluatorRequestOptions & {

--- a/plugins/permission-common/src/PermissionClient.test.ts
+++ b/plugins/permission-common/src/PermissionClient.test.ts
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-import { RestContext, rest } from 'msw';
+import { rest, RestContext } from 'msw';
 import { setupServer } from 'msw/node';
 import { ConfigReader } from '@backstage/config';
 import { PermissionClient } from './PermissionClient';
 import {
-  EvaluatePermissionRequest,
   AuthorizeResult,
-  IdentifiedPermissionMessage,
   ConditionalPolicyDecision,
+  EvaluatePermissionRequest,
+  IdentifiedPermissionMessage,
 } from './types/api';
 import { DiscoveryApi } from './types/discovery';
 import { createPermission } from './permissions';
@@ -95,6 +95,16 @@ describe('PermissionClient', () => {
           }),
         ],
       });
+    });
+
+    it('should allow batch authorize', async () => {
+      const id = '1';
+      const resp = await client.authorizeBatch({
+        items: [{ id, ...mockAuthorizeConditional }],
+      });
+      expect(mockAuthorizeHandler).toHaveBeenCalled();
+      expect(resp.items[0].id).toBe(id);
+      expect(resp.items[0].result).toBe(AuthorizeResult.ALLOW);
     });
 
     it('should return the response from the fetch request', async () => {

--- a/plugins/permission-common/src/permissions/util.ts
+++ b/plugins/permission-common/src/permissions/util.ts
@@ -18,6 +18,8 @@ import {
   AuthorizePermissionRequest,
   AuthorizePermissionResponse,
   DefinitivePolicyDecision,
+  EvaluatePermissionRequestBatch,
+  EvaluatePermissionResponseBatch,
   EvaluatorRequestOptions,
   Permission,
   PermissionAuthorizer,
@@ -103,6 +105,20 @@ export function toPermissionEvaluator(
       const response = await permissionAuthorizer.authorize(requests, options);
 
       return response as DefinitivePolicyDecision[];
+    },
+    async authorizeBatch(
+      request: EvaluatePermissionRequestBatch,
+      options?: EvaluatorRequestOptions, // Since the options are empty we add this placeholder to reject all options
+    ): Promise<EvaluatePermissionResponseBatch> {
+      const resp: EvaluatePermissionResponseBatch = { items: [] };
+      for (const item of request.items) {
+        const response = await permissionAuthorizer.authorize([item], options);
+        resp.items.push({
+          id: item.id,
+          ...(response[0] as DefinitivePolicyDecision),
+        });
+      }
+      return resp;
     },
     authorizeConditional(
       requests: QueryPermissionRequest[],

--- a/plugins/permission-common/src/types/api.ts
+++ b/plugins/permission-common/src/types/api.ts
@@ -248,6 +248,14 @@ export interface PermissionEvaluator {
   ): Promise<AuthorizePermissionResponse[]>;
 
   /**
+   * Evaluates batch of {@link Permission | Permissions} and returns a definitive decision for each.
+   */
+  authorizeBatch(
+    request: EvaluatePermissionRequestBatch,
+    options?: EvaluatorRequestOptions & { _ignored?: never }, // Since the options are empty we add this placeholder to reject all options
+  ): Promise<EvaluatePermissionResponseBatch>;
+
+  /**
    * Evaluates {@link ResourcePermission | ResourcePermissions} and returns both definitive and
    * conditional decisions, depending on the configured
    * {@link @backstage/plugin-permission-node#PermissionPolicy}. This method is useful when the

--- a/plugins/permission-node/api-report.md
+++ b/plugins/permission-node/api-report.md
@@ -15,6 +15,8 @@ import { ConditionalPolicyDecision } from '@backstage/plugin-permission-common';
 import { Config } from '@backstage/config';
 import { DefinitivePolicyDecision } from '@backstage/plugin-permission-common';
 import { DiscoveryService } from '@backstage/backend-plugin-api';
+import { EvaluatePermissionRequestBatch } from '@backstage/plugin-permission-common';
+import { EvaluatePermissionResponseBatch } from '@backstage/plugin-permission-common';
 import express from 'express';
 import { IdentifiedPermissionMessage } from '@backstage/plugin-permission-common';
 import { MetadataResponse as MetadataResponse_2 } from '@backstage/plugin-permission-common';
@@ -280,6 +282,11 @@ export class ServerPermissionClient implements PermissionsService {
     requests: AuthorizePermissionRequest[],
     options?: PermissionsServiceRequestOptions,
   ): Promise<AuthorizePermissionResponse[]>;
+  // (undocumented)
+  authorizeBatch(
+    request: EvaluatePermissionRequestBatch,
+    options: PermissionsServiceRequestOptions,
+  ): Promise<EvaluatePermissionResponseBatch>;
   // (undocumented)
   authorizeConditional(
     queries: QueryPermissionRequest[],

--- a/plugins/permission-react/api-report.md
+++ b/plugins/permission-react/api-report.md
@@ -9,7 +9,9 @@ import { AuthorizePermissionResponse } from '@backstage/plugin-permission-common
 import { Config } from '@backstage/config';
 import { DiscoveryApi } from '@backstage/core-plugin-api';
 import { EvaluatePermissionRequest } from '@backstage/plugin-permission-common';
+import { EvaluatePermissionRequestBatch } from '@backstage/plugin-permission-common';
 import { EvaluatePermissionResponse } from '@backstage/plugin-permission-common';
+import { EvaluatePermissionResponseBatch } from '@backstage/plugin-permission-common';
 import { IdentityApi } from '@backstage/core-plugin-api';
 import { Permission } from '@backstage/plugin-permission-common';
 import { default as React_2 } from 'react';
@@ -31,6 +33,10 @@ export class IdentityPermissionApi implements PermissionApi {
     request: AuthorizePermissionRequest,
   ): Promise<AuthorizePermissionResponse>;
   // (undocumented)
+  authorizeBatch(
+    request: EvaluatePermissionRequestBatch,
+  ): Promise<EvaluatePermissionResponseBatch>;
+  // (undocumented)
   static create(options: {
     config: Config;
     discovery: DiscoveryApi;
@@ -43,6 +49,9 @@ export type PermissionApi = {
   authorize(
     request: EvaluatePermissionRequest,
   ): Promise<EvaluatePermissionResponse>;
+  authorizeBatch(
+    request: EvaluatePermissionRequestBatch,
+  ): Promise<EvaluatePermissionResponseBatch>;
 };
 
 // @public

--- a/plugins/permission-react/src/apis/IdentityPermissionApi.ts
+++ b/plugins/permission-react/src/apis/IdentityPermissionApi.ts
@@ -19,6 +19,8 @@ import { PermissionApi } from './PermissionApi';
 import {
   AuthorizePermissionRequest,
   AuthorizePermissionResponse,
+  EvaluatePermissionRequestBatch,
+  EvaluatePermissionResponseBatch,
   PermissionClient,
 } from '@backstage/plugin-permission-common';
 import { Config } from '@backstage/config';
@@ -52,5 +54,14 @@ export class IdentityPermissionApi implements PermissionApi {
       await this.identityApi.getCredentials(),
     );
     return response[0];
+  }
+
+  async authorizeBatch(
+    request: EvaluatePermissionRequestBatch,
+  ): Promise<EvaluatePermissionResponseBatch> {
+    return this.permissionClient.authorizeBatch(
+      request,
+      await this.identityApi.getCredentials(),
+    );
   }
 }

--- a/plugins/permission-react/src/apis/PermissionApi.ts
+++ b/plugins/permission-react/src/apis/PermissionApi.ts
@@ -16,7 +16,9 @@
 
 import {
   EvaluatePermissionRequest,
+  EvaluatePermissionRequestBatch,
   EvaluatePermissionResponse,
+  EvaluatePermissionResponseBatch,
 } from '@backstage/plugin-permission-common';
 import { ApiRef, createApiRef } from '@backstage/core-plugin-api';
 
@@ -30,6 +32,9 @@ export type PermissionApi = {
   authorize(
     request: EvaluatePermissionRequest,
   ): Promise<EvaluatePermissionResponse>;
+  authorizeBatch(
+    request: EvaluatePermissionRequestBatch,
+  ): Promise<EvaluatePermissionResponseBatch>;
 };
 
 /**

--- a/plugins/permission-react/src/hooks/usePermission.test.tsx
+++ b/plugins/permission-react/src/hooks/usePermission.test.tsx
@@ -52,7 +52,10 @@ function renderComponent(mockApi: PermissionApi) {
 }
 
 describe('usePermission', () => {
-  const mockPermissionApi = { authorize: jest.fn() };
+  const mockPermissionApi = {
+    authorize: jest.fn(),
+    authorizeBatch: jest.fn(),
+  };
 
   it('Returns loading when permissionApi has not yet responded.', () => {
     mockPermissionApi.authorize.mockReturnValueOnce(new Promise(() => {}));

--- a/plugins/scaffolder/src/components/OngoingTask/OngoingTask.test.tsx
+++ b/plugins/scaffolder/src/components/OngoingTask/OngoingTask.test.tsx
@@ -17,9 +17,9 @@
 import { OngoingTask } from './OngoingTask';
 import React from 'react';
 import {
+  MockPermissionApi,
   renderInTestApp,
   TestApiProvider,
-  MockPermissionApi,
 } from '@backstage/test-utils';
 import { scaffolderApiRef } from '@backstage/plugin-scaffolder-react';
 import { act, fireEvent, waitFor, within } from '@testing-library/react';
@@ -149,7 +149,10 @@ describe('OngoingTask', () => {
     const mockAuthorize = jest
       .fn()
       .mockImplementation(async () => ({ result: AuthorizeResult.DENY }));
-    const permissionApi: PermissionApi = { authorize: mockAuthorize };
+    const permissionApi: PermissionApi = {
+      authorize: mockAuthorize,
+      authorizeBatch: jest.fn(),
+    };
     const rendered = await render(permissionApi);
 
     const { getByTestId } = rendered;

--- a/plugins/search-backend/src/service/AuthorizedSearchEngine.test.ts
+++ b/plugins/search-backend/src/service/AuthorizedSearchEngine.test.ts
@@ -16,11 +16,11 @@
 
 import { ConfigReader } from '@backstage/config';
 import {
-  EvaluatePermissionResponse,
   AuthorizeResult,
   createPermission,
-  PolicyDecision,
+  EvaluatePermissionResponse,
   PermissionEvaluator,
+  PolicyDecision,
 } from '@backstage/plugin-permission-common';
 import {
   DocumentTypeInfo,
@@ -28,9 +28,9 @@ import {
 } from '@backstage/plugin-search-common';
 import { SearchEngine } from '@backstage/plugin-search-backend-node';
 import {
-  encodePageCursor,
-  decodePageCursor,
   AuthorizedSearchEngine,
+  decodePageCursor,
+  encodePageCursor,
 } from './AuthorizedSearchEngine';
 import { mockCredentials, mockServices } from '@backstage/backend-test-utils';
 
@@ -74,12 +74,16 @@ describe('AuthorizedSearchEngine', () => {
 
   const mockedAuthorize: jest.MockedFunction<PermissionEvaluator['authorize']> =
     jest.fn();
+  const mockedAuthorizeBatch: jest.MockedFunction<
+    PermissionEvaluator['authorizeBatch']
+  > = jest.fn();
   const mockedPermissionQuery: jest.MockedFunction<
     PermissionEvaluator['authorizeConditional']
   > = jest.fn();
 
   const permissionEvaluator: PermissionEvaluator = {
     authorize: mockedAuthorize,
+    authorizeBatch: mockedAuthorizeBatch,
     authorizeConditional: mockedPermissionQuery,
   };
 

--- a/plugins/search-backend/src/service/router.test.ts
+++ b/plugins/search-backend/src/service/router.test.ts
@@ -36,6 +36,9 @@ const mockPermissionEvaluator: PermissionEvaluator = {
   authorize: () => {
     throw new Error('Not implemented');
   },
+  authorizeBatch: () => {
+    throw new Error('Not implemented');
+  },
   authorizeConditional: () => {
     throw new Error('Not implemented');
   },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

this allows to check multiple permissions with the same call using the PermissionClient. the client itself already does this underneath but the id mapping is done automatically by the client; a new function `authorizeBatch` allows the user to give ids themselves and request multiple permissions with one call.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
