### PR TITLE
[emailMatchingUserEntityProfileEmail] Try matching emails without plus addressing

### DIFF
--- a/.changeset/six-poems-press.md
+++ b/.changeset/six-poems-press.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-node': patch
+---
+
+[emailMatchingUserEntityProfileEmail resolver]: Try also matching emails with plus addressing removed.

--- a/.changeset/six-poems-press.md
+++ b/.changeset/six-poems-press.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-auth-node': patch
 ---
 
-[emailMatchingUserEntityProfileEmail resolver]: Try also matching emails with plus addressing removed.
+The `emailMatchingUserEntityProfileEmail` sign-in resolver will now also try matching emails with plus addressing removed.

--- a/plugins/auth-node/src/sign-in/commonSignInResolvers.ts
+++ b/plugins/auth-node/src/sign-in/commonSignInResolvers.ts
@@ -19,7 +19,7 @@ import { createSignInResolverFactory } from './createSignInResolverFactory';
 // This splits an email "joe+work@acme.com" into ["joe", "+work", "@acme.com"]
 // so that we can remove the plus addressing. May output a shorter array:
 // ["joe", "@acme.com"], if no plus addressing was found.
-const reEmail = /([^@+]+)(\+[^@]+)?(@.*)/;
+const reEmail = /^([^@+]+)(\+[^@]+)?(@.*)$/;
 
 /**
  * A collection of common sign-in resolvers that work with any auth provider.
@@ -50,17 +50,19 @@ export namespace commonSignInResolvers {
               },
             });
           } catch (err) {
-            // Try removing the plus addressing from the email address
-            const m = profile.email.match(reEmail);
-            if (m?.length === 4) {
-              const [_, name, _plus, domain] = m;
-              const noPlusEmail = `${name}${domain}`;
+            if (err?.name === 'NotFoundError') {
+              // Try removing the plus addressing from the email address
+              const m = profile.email.match(reEmail);
+              if (m?.length === 4) {
+                const [_, name, _plus, domain] = m;
+                const noPlusEmail = `${name}${domain}`;
 
-              return ctx.signInWithCatalogUser({
-                filter: {
-                  'spec.profile.email': noPlusEmail,
-                },
-              });
+                return ctx.signInWithCatalogUser({
+                  filter: {
+                    'spec.profile.email': noPlusEmail,
+                  },
+                });
+              }
             }
             // Email had no plus addressing or is missing in the catalog, forward failure
             throw err;

--- a/plugins/auth-node/src/sign-in/commonSignInResolvers.ts
+++ b/plugins/auth-node/src/sign-in/commonSignInResolvers.ts
@@ -16,6 +16,11 @@
 
 import { createSignInResolverFactory } from './createSignInResolverFactory';
 
+// This splits an email "joe+work@acme.com" into ["joe", "+work", "@acme.com"]
+// so that we can remove the plus addressing. May output a shorter array:
+// ["joe", "@acme.com"], if no plus addressing was found.
+const reEmail = /([^@+]+)(\+[^@]+)?(@.*)/;
+
 /**
  * A collection of common sign-in resolvers that work with any auth provider.
  *
@@ -38,11 +43,28 @@ export namespace commonSignInResolvers {
             );
           }
 
-          return ctx.signInWithCatalogUser({
-            filter: {
-              'spec.profile.email': profile.email,
-            },
-          });
+          try {
+            return await ctx.signInWithCatalogUser({
+              filter: {
+                'spec.profile.email': profile.email,
+              },
+            });
+          } catch (err) {
+            // Try removing the plus addressing from the email address
+            const m = profile.email.match(reEmail);
+            if (m?.length === 4) {
+              const [_, name, _plus, domain] = m;
+              const noPlusEmail = `${name}${domain}`;
+
+              return ctx.signInWithCatalogUser({
+                filter: {
+                  'spec.profile.email': noPlusEmail,
+                },
+              });
+            }
+            // Email had no plus addressing or is missing in the catalog, forward failure
+            throw err;
+          }
         };
       },
     });


### PR DESCRIPTION
## Detect and strip plus addressing from emailMatchingUserEntityProfileEmail sign-in resolver

We have recently seen sign-in with GitHub failing for some of our users. When debugging we see that the email we get from GitHub for these users have an added plus addressing of the company name. So for e.g. `john.doe@acme.com` (even being displayed in GitHub instead gets the added plus addressing of the company name (say, acme), i.e. `john.doe+acme@acme.com`. We're unsure why, it only happens to some users.

When using the `emailMatchingUserEntityProfileEmail` resolver, this fails, as it doesn't match any catalog user.

We can't depend on user names or any other resolver, so we need email matching.

This PR adds an extra check in the `emailMatchingUserEntityProfileEmail` if it fails, by detecting if the received email is plus addressed, and if so, removes the plus addressing and tries to `signInWithCatalogUser` again. This works well for us.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
