### PR TITLE
fix(cache): pass useRedisSets option to KeyvRedis cache storage adapter

### DIFF
--- a/.changeset/clever-numbers-impress.md
+++ b/.changeset/clever-numbers-impress.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Fixed an issue where the `useRedisSets` configuration for the cache service would have no effect.

--- a/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
@@ -147,7 +147,9 @@ export class CacheManager {
     let store: typeof KeyvRedis | undefined;
     return (pluginId, defaultTtl) => {
       if (!store) {
-        store = new KeyvRedis(this.connection);
+        store = new KeyvRedis(this.connection, {
+          useRedisSets: this.useRedisSets,
+        });
         // Always provide an error handler to avoid stopping the process
         store.on('error', (err: Error) => {
           this.logger?.error('Failed to create redis cache client', err);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I notices that `useRedisSets` option is not properly passed to Keyv's Redis adapter, so the option does nothing at all.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
