### PR TITLE
scaffolder-react: remove singleton wrapping of API ref

### DIFF
--- a/.changeset/seven-glasses-double.md
+++ b/.changeset/seven-glasses-double.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+Remove unnecessary singleton wrapping of `scaffolderApiRef`.

--- a/plugins/scaffolder-react/src/api/ref.ts
+++ b/plugins/scaffolder-react/src/api/ref.ts
@@ -16,13 +16,8 @@
 
 import { createApiRef } from '@backstage/core-plugin-api';
 import { ScaffolderApi } from './types';
-import { getOrCreateGlobalSingleton } from '@backstage/version-bridge';
 
 /** @public */
-export const scaffolderApiRef = getOrCreateGlobalSingleton(
-  'scaffolder:scaffolder-api-ref',
-  () =>
-    createApiRef<ScaffolderApi>({
-      id: 'plugin.scaffolder.service',
-    }),
-);
+export const scaffolderApiRef = createApiRef<ScaffolderApi>({
+  id: 'plugin.scaffolder.service',
+});


### PR DESCRIPTION
🧹 , no need to wrap API refs as a singleton