### PR TITLE
Add title prop to OwnershipCard

### DIFF
--- a/.changeset/moody-cherries-pay.md
+++ b/.changeset/moody-cherries-pay.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Add title prop to OwnershipCard

--- a/plugins/org/api-report.md
+++ b/plugins/org/api-report.md
@@ -36,6 +36,7 @@ export const EntityOwnershipCard: (props: {
   relationsType?: EntityRelationAggregation | undefined;
   relationAggregation?: EntityRelationAggregation | undefined;
   entityLimit?: number | undefined;
+  title?: string | undefined;
 }) => JSX_2.Element;
 
 // @public (undocumented)
@@ -95,6 +96,7 @@ export const OwnershipCard: (props: {
   relationsType?: EntityRelationAggregation;
   relationAggregation?: EntityRelationAggregation;
   entityLimit?: number;
+  title?: string;
 }) => React_2.JSX.Element;
 
 // @public (undocumented)

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
@@ -71,6 +71,7 @@ export const OwnershipCard = (props: {
   relationsType?: EntityRelationAggregation;
   relationAggregation?: EntityRelationAggregation;
   entityLimit?: number;
+  title?: string;
 }) => {
   const {
     variant,
@@ -98,7 +99,7 @@ export const OwnershipCard = (props: {
 
   return (
     <InfoCard
-      title="Ownership"
+      title={props.title ?? 'Ownership'}
       variant={variant}
       className={classes.card}
       cardClassName={classes.cardContent}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I would like to have 2 OwnershipCards on the GroupPage, 1 with defaults and another only Showing Resource Kinds, the cards would have different titles i.e "Resource Ownership" so users can understand the difference.
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
