### PR TITLE
Fix techdocs nav positioning when using blog plugin

### DIFF
--- a/.changeset/curvy-sheep-grab.md
+++ b/.changeset/curvy-sheep-grab.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Fixes left navigation positioning when using mkdocs blog plugin

--- a/plugins/techdocs/src/reader/transformers/styles/rules/layout.ts
+++ b/plugins/techdocs/src/reader/transformers/styles/rules/layout.ts
@@ -121,6 +121,10 @@ export default ({ theme, sidebar }: RuleOptions) => `
   margin-bottom: 50px;
 }
 
+.md-content > .md-sidebar {
+  left: 16rem;
+}
+
 .md-footer {
   position: fixed;
   bottom: 0px;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes https://github.com/backstage/backstage/issues/25581

When not viewing a blog:
![Screenshot 2024-09-13 at 4 11 16 PM](https://github.com/user-attachments/assets/bc707d96-3e3d-484e-b902-639c9712c38a)

Viewing a blog:
![Screenshot 2024-09-13 at 4 11 48 PM](https://github.com/user-attachments/assets/e6484a40-6966-4cb8-a7bb-cf1ef34ed8ca)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
