### PR TITLE
fix: table width overriden with custom styles

### DIFF
--- a/.changeset/giant-seas-smile.md
+++ b/.changeset/giant-seas-smile.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Fixed Table width being overriden by custom styling

--- a/.changeset/giant-seas-smile.md
+++ b/.changeset/giant-seas-smile.md
@@ -2,4 +2,4 @@
 '@backstage/core-components': patch
 ---
 
-Fixed Table width being overriden by custom styling
+Fixed `Table` width being overridden by custom `style` prop.

--- a/packages/core-components/src/components/Table/Table.tsx
+++ b/packages/core-components/src/components/Table/Table.tsx
@@ -350,6 +350,7 @@ export function Table<T extends object = {}>(props: TableProps<T>) {
     onStateChange,
     components,
     isLoading: loading,
+    style,
     ...restProps
   } = props;
   const tableClasses = useTableStyles();
@@ -483,7 +484,7 @@ export function Table<T extends object = {}>(props: TableProps<T>) {
           </>
         }
         data={tableData}
-        style={{ width: '100%' }}
+        style={{ width: '100%', ...style }}
         localization={{
           toolbar: { searchPlaceholder: 'Filter', searchTooltip: 'Filter' },
           ...localization,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

when custom styles are passed to Table component, they override the default width 100%. moving the style out of restProps fixes this issue while still allows customizing the width if wanted.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
