### PR TITLE
experiment with using joins for catalog filters

### DIFF
--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
@@ -575,6 +575,63 @@ describe('DefaultEntitiesCatalog', () => {
     );
 
     it.each(databases.eachSupportedId())(
+      'handles inversion both for existing and missing keys, %p',
+      async databaseId => {
+        await createDatabase(databaseId);
+
+        const entity1: Entity = {
+          apiVersion: 'a',
+          kind: 'k',
+          metadata: { name: 'n1' },
+          spec: { a: 'foo' },
+        };
+        const entity2: Entity = {
+          apiVersion: 'a',
+          kind: 'k',
+          metadata: { name: 'n2' },
+          spec: { a: 'bar', b: 'lonely' },
+        };
+        const entity3: Entity = {
+          apiVersion: 'a',
+          kind: 'k',
+          metadata: { name: 'n3' },
+          spec: { a: 'baz', b: 'only' },
+        };
+        await addEntityToSearch(entity1);
+        await addEntityToSearch(entity2);
+        await addEntityToSearch(entity3);
+
+        const catalog = new DefaultEntitiesCatalog({
+          database: knex,
+          logger: mockServices.logger.mock(),
+          stitcher,
+        });
+
+        function f(
+          request: Omit<EntitiesRequest, 'credentials'>,
+        ): Promise<string[]> {
+          return catalog
+            .entities({ ...request, credentials: mockCredentials.none() })
+            .then(response =>
+              response.entities.map(e => e.metadata.name).toSorted(),
+            );
+        }
+
+        await expect(
+          f({
+            filter: { key: 'spec.b', values: ['lonely'] },
+          }),
+        ).resolves.toEqual(['n2']);
+
+        await expect(
+          f({
+            filter: { not: { key: 'spec.b', values: ['lonely'] } },
+          }),
+        ).resolves.toEqual(['n1', 'n3']);
+      },
+    );
+
+    it.each(databases.eachSupportedId())(
       'can order and combine with filtering, %p',
       async databaseId => {
         await createDatabase(databaseId);

--- a/plugins/catalog-backend/src/tests/performance/getEntitiesPerformance.test.ts
+++ b/plugins/catalog-backend/src/tests/performance/getEntitiesPerformance.test.ts
@@ -22,7 +22,11 @@ import {
   SyntheticLoadEntitiesProvider,
   SyntheticLoadOptions,
 } from './lib/catalogModuleSyntheticLoadEntities';
-import { CatalogClient } from '@backstage/catalog-client';
+import {
+  CatalogApi,
+  CatalogClient,
+  GetEntitiesResponse,
+} from '@backstage/catalog-client';
 import {
   coreServices,
   createBackendModule,
@@ -31,116 +35,191 @@ import {
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
 import { Knex } from 'knex';
 
+// #region Helpers
+
 jest.setTimeout(600_000);
+
+const databases = TestDatabases.create({
+  ids: [/* 'MYSQL_8', */ 'POSTGRES_16' /* 'POSTGRES_12', 'SQLITE_3'*/],
+  disableDocker: false,
+});
 
 const traceLog: typeof console.log = performanceTraceEnabled
   ? console.log
   : () => {};
 
-const completionPolling = async (load: SyntheticLoadOptions, knex: Knex) => {
-  const { baseEntitiesCount, childrenCount } = load;
-  const expectedTotal = baseEntitiesCount + baseEntitiesCount * childrenCount;
+async function createBackend(
+  knex: Knex,
+  load: SyntheticLoadOptions,
+): Promise<{
+  client: CatalogApi;
+  numberOfEntities: number;
+  stop: () => Promise<void>;
+}> {
+  await applyDatabaseMigrations(knex);
 
-  return new Promise<void>((resolve, reject) => {
-    const interval = setInterval(async () => {
-      try {
-        const stitchedCount = await knex('final_entities')
-          .count({ count: '*' })
-          .whereNotNull('final_entity')
-          .then(rows => Number(rows[0].count));
+  const numberOfEntities =
+    load.baseEntitiesCount + load.baseEntitiesCount * load.childrenCount;
 
-        if (stitchedCount === expectedTotal) {
-          clearInterval(interval);
-          resolve();
-        }
-      } catch (error) {
-        clearInterval(interval);
-        reject(error);
-      }
-    }, 1000);
-  });
-};
+  traceLog(`Creating test backend with ${numberOfEntities} entities`);
 
-describePerformanceTest('getEntitiesPerformanceTest', () => {
-  const databases = TestDatabases.create({
-    ids: [/* 'MYSQL_8', */ 'POSTGRES_16', /* 'POSTGRES_12',*/ 'SQLITE_3'],
-    disableDocker: false,
-  });
-
-  it.each(databases.eachSupportedId())(
-    'fetch entities, %p',
-    async databaseId => {
-      const knex = await databases.init(databaseId);
-      await applyDatabaseMigrations(knex);
-
-      const load: SyntheticLoadOptions = {
-        baseEntitiesCount: 2000,
-        baseRelationsCount: 3,
-        baseRelationsSkew: 0.3,
-        childrenCount: 3,
-      };
-
-      traceLog('Starting test backend');
-
-      const backend = await startTestBackend({
-        features: [
-          import('@backstage/plugin-catalog-backend/alpha'),
-          createServiceFactory({
-            service: coreServices.database,
-            deps: {},
-            factory: () => ({ getClient: async () => knex }),
-          }),
-          createBackendModule({
-            pluginId: 'catalog',
-            moduleId: 'synthetic-load-entities',
-            register(reg) {
-              reg.registerInit({
-                deps: {
-                  catalog: catalogProcessingExtensionPoint,
-                },
-                async init({ catalog }) {
-                  catalog.addEntityProvider(
-                    new SyntheticLoadEntitiesProvider(load, {}),
-                  );
-                  catalog.addProcessor(
-                    new SyntheticLoadEntitiesProcessor(load),
-                  );
-                },
-              });
+  const backend = await startTestBackend({
+    features: [
+      import('@backstage/plugin-catalog-backend/alpha'),
+      createServiceFactory({
+        service: coreServices.database,
+        deps: {},
+        factory: () => ({ getClient: async () => knex }),
+      }),
+      createBackendModule({
+        pluginId: 'catalog',
+        moduleId: 'synthetic-load-entities',
+        register(reg) {
+          reg.registerInit({
+            deps: {
+              catalog: catalogProcessingExtensionPoint,
             },
-          }),
-        ],
-      });
-
-      const expectedTotal =
-        load.baseEntitiesCount + load.baseEntitiesCount * load.childrenCount;
-      traceLog(`Waiting for completion polling of ${expectedTotal} entities`);
-
-      await expect(completionPolling(load, knex)).resolves.toBeUndefined();
-
-      const client = new CatalogClient({
-        discoveryApi: {
-          getBaseUrl: jest
-            .fn()
-            .mockResolvedValue(
-              `http://localhost:${backend.server.port()}/api/catalog`,
-            ),
+            async init({ catalog }) {
+              catalog.addEntityProvider(
+                new SyntheticLoadEntitiesProvider(load, {}),
+              );
+              catalog.addProcessor(new SyntheticLoadEntitiesProcessor(load));
+            },
+          });
         },
+      }),
+    ],
+  });
+
+  while (
+    (await knex('final_entities')
+      .count({ count: '*' })
+      .whereNotNull('final_entity')
+      .then(rows => Number(rows[0].count))) !== numberOfEntities
+  ) {
+    await new Promise(resolve => setTimeout(resolve, 200));
+  }
+
+  const client = new CatalogClient({
+    discoveryApi: {
+      getBaseUrl: jest
+        .fn()
+        .mockResolvedValue(
+          `http://localhost:${backend.server.port()}/api/catalog`,
+        ),
+    },
+  });
+
+  return {
+    client,
+    numberOfEntities,
+    stop: backend.stop.bind(backend),
+  };
+}
+
+// #endregion
+// #region Tests
+
+describePerformanceTest('getEntities', () => {
+  let knex: Knex;
+  let backend: Awaited<ReturnType<typeof createBackend>>;
+
+  describe.skip.each(databases.eachSupportedId())(
+    'burst reads, %p',
+    databaseId => {
+      beforeAll(async () => {
+        knex = await databases.init(databaseId);
+        backend = await createBackend(knex, {
+          baseEntitiesCount: 2000,
+          baseRelationsCount: 3,
+          baseRelationsSkew: 0.3,
+          childrenCount: 3,
+        });
       });
-      const start = Date.now();
-      traceLog(`[${databaseId}] Starting to fetch ${expectedTotal} entities`);
 
-      // Fetch all entities
-      const response = await client.getEntities();
-      expect(response.items).toHaveLength(expectedTotal);
+      afterAll(async () => {
+        await backend.stop();
+        await knex.destroy();
+      });
 
-      const fetchDuration = Date.now() - start;
-      traceLog(
-        `[${databaseId}] Fetched ${expectedTotal} entities in ${fetchDuration}ms`,
-      );
-
-      await backend.stop();
-      await knex.destroy();
+      it('does a large burst read', async () => {
+        const response = await backend.client.getEntities();
+        expect(response.items).toHaveLength(backend.numberOfEntities);
+      });
     },
   );
+
+  describe.each(databases.eachSupportedId())('filtering, %p', databaseId => {
+    beforeAll(async () => {
+      knex = await databases.init(databaseId);
+      backend = await createBackend(knex, {
+        baseEntitiesCount: 20000,
+        baseRelationsCount: 0,
+        baseRelationsSkew: 0,
+        childrenCount: 0,
+      });
+    });
+
+    afterAll(async () => {
+      await backend.stop();
+      await knex.destroy();
+    });
+
+    it('single matching filter, all fields', async () => {
+      let response: GetEntitiesResponse;
+      for (let i = 0; i < 20; ++i) {
+        response = await backend.client.getEntities({
+          filter: { kind: 'Location' },
+        });
+      }
+      expect(response!.items).toHaveLength(backend.numberOfEntities);
+    });
+
+    it('single matching filter, one field', async () => {
+      let response: GetEntitiesResponse;
+      for (let i = 0; i < 20; ++i) {
+        response = await backend.client.getEntities({
+          filter: { kind: 'Location' },
+          fields: ['kind'],
+        });
+      }
+      expect(response!.items).toHaveLength(backend.numberOfEntities);
+    });
+
+    it('single non-matching filter', async () => {
+      let response: GetEntitiesResponse;
+      for (let i = 0; i < 20; ++i) {
+        response = await backend.client.getEntities({
+          filter: { kind: 'NotALocation' },
+        });
+      }
+      expect(response!.items).toHaveLength(0);
+    });
+
+    it('complex filter, all fields', async () => {
+      let response: GetEntitiesResponse;
+      for (let i = 0; i < 20; ++i) {
+        response = await backend.client.getEntities({
+          filter: [
+            {
+              kind: 'Location',
+            },
+            {
+              kind: 'Location',
+              'metadata.name': new Array(100)
+                .fill(0)
+                .map((_, j) => `synthetic-${j}`),
+            },
+            ...new Array(10).fill(0).map((_, j) => ({
+              kind: 'NotALocation',
+              'metadata.name': new Array(10)
+                .fill(0)
+                .map((__, k) => `no-match-${i}-${j}-${k}`),
+            })),
+          ],
+        });
+      }
+      expect(response!.items).toHaveLength(backend.numberOfEntities);
+    });
+  });
 });


### PR DESCRIPTION
Just trying out using joins instead of large INs.

## BEFORE

Example SQL:

```sql
select `final_entities`.* from `final_entities`
left outer join `refresh_state`
  on `refresh_state`.`entity_id` = `final_entities`.`entity_id`
where `final_entities`.`final_entity` is not null
and
(
  `final_entities`.`entity_id` in (
    # one big select like this per condition basically
    select `search`.`entity_id` from `search` where `key` = 'spec.test' and `value` = 'some value'
  )
)
order by `refresh_state`.`entity_ref` asc
```

Perf test before (with 20k entities):

![Screenshot 2024-09-15 at 11 31 41](https://github.com/user-attachments/assets/d711e64c-c26a-4a04-affe-25fd648dcf5a)

## AFTER:

Example SQL:

```sql
select `final_entities`.* from `final_entities`
# one block like this for each unique key filtered against
left outer join `search` as `filter_0`
  on `filter_0`.`entity_id` = `final_entities`.`entity_id`
  and `filter_0`.`key` = 'spec.test'
# this is pre-existing boilerplate
left outer join `refresh_state` 
  on `refresh_state`.`entity_id` = `final_entities`.`entity_id`
where `final_entities`.`final_entity` is not null
# and then a nested logic expression here, matching the filter
# and mapping against the per-key aliases made above
and `filter_0`.`value` = 'some value'
order by `refresh_state`.`entity_ref` asc
```

So it makes one OUTER JOIN with the search table per unique key matched against in the filter tree, and then builds the expressions targeting those table aliases.

Perf test after (still with 20k entities):

![Screenshot 2024-09-15 at 11 24 37](https://github.com/user-attachments/assets/a7ef796a-8c51-4d55-82ea-59e286b68c28)

Bit of a mixed bag. On pg and mysql it's a bit better for simple cases but worse for very complex cases - significantly worse on mysql. On sqlite the join code is so much worse for complex joins that it's almost impossible to run agains tens of thousands of entities. Hence not even posting any numbers for the 20k entity test, because I got tired of waiting.