### PR TITLE
Update bitbucketServerPullRequest.ts - protocol from apiBaseUrl

### DIFF
--- a/plugins/scaffolder-backend-module-bitbucket-server/src/actions/bitbucketServerPullRequest.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-server/src/actions/bitbucketServerPullRequest.ts
@@ -237,6 +237,10 @@ const getDefaultBranch = async (opts: {
   }
   return defaultBranch;
 };
+const parseProtocol = (apiBaseUrl: string) => {
+  const url = new Url(apiBaseUrl);
+  return url.protocol || 'https';
+};
 /**
  * Creates a BitbucketServer Pull Request action.
  * @public
@@ -401,7 +405,8 @@ export function createPublishBitbucketServerPullRequestAction(options: {
           startPoint: latestCommit,
         });
 
-        const remoteUrl = `https://${host}/scm/${project}/${repo}.git`;
+        const protocol = parseProtocol(apiBaseUrl);
+        const remoteUrl = `${protocol}://${host}/scm/${project}/${repo}.git`;
 
         const auth = authConfig.token
           ? {


### PR DESCRIPTION
Use the protocol from `apiBaseUrl` instead of hard-coded "https"

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
The Bitbucket Server scaffolder plugin accepts `apiBaseUrl`'s which use the "http" protocol, however some internal calls use a hard-coded "https". While "https" is ideal, our On-Premise Bitbucket Server is only exposed over "http" inside of the VPN.  

With this change the `publish:bitbucketServer:pull-request` will work with hosts not available over "https".

![image](https://github.com/user-attachments/assets/c3c80025-a203-483d-be2c-9a49f38bceef)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
