### PR TITLE
yarn-plugin: add additional check during pack to confirm that all backstage versions have been replaced

### DIFF
--- a/.changeset/seven-ladybugs-fetch.md
+++ b/.changeset/seven-ladybugs-fetch.md
@@ -1,0 +1,5 @@
+---
+'yarn-plugin-backstage': patch
+---
+
+Add additional check before packing workspace to verify that all backstage:^ versions have been removed.

--- a/packages/yarn-plugin/src/handlers/beforeWorkspacePacking.ts
+++ b/packages/yarn-plugin/src/handlers/beforeWorkspacePacking.ts
@@ -15,8 +15,12 @@
  */
 
 import { Descriptor, Workspace, structUtils } from '@yarnpkg/core';
+import { some } from 'lodash';
 import { getCurrentBackstageVersion, getPackageVersion } from '../util';
 import { PROTOCOL } from '../constants';
+
+const hasBackstageVersion = (range: string) =>
+  structUtils.parseRange(range).protocol === PROTOCOL;
 
 const getFinalDependencyType = (
   dependencyType: string,
@@ -68,5 +72,16 @@ export const beforeWorkspacePacking = async (
         ),
       )}`;
     }
+  }
+
+  if (
+    some(
+      ['dependencies', 'devDependencies', 'optionalDependencies'],
+      dependencyType => some(rawManifest[dependencyType], hasBackstageVersion),
+    )
+  ) {
+    throw new Error(
+      `Failed to replace all "backstage:" ranges in manifest for ${rawManifest.name}`,
+    );
   }
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds an additional check during pack which walks all the dependencies in the manifest, and verifies that there are no remaining `backstage:` versions. I'm not aware of any realistic cases where the code that does the replacement would be expected to fail, but since a `backstage:^` package in the manifest will break the release, it seems prudent to double check and fail fast to allow us to catch unexpected results.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
