### PR TITLE
doc: permission doc typo fix

### DIFF
--- a/docs/permissions/getting-started.md
+++ b/docs/permissions/getting-started.md
@@ -81,7 +81,7 @@ To help validate the permission framework is setup we'll create a Test Permissio
    });
    ```
 
-6. We now need to register this in the backend. We will do this by adding the follow line:
+6. We now need to register this in the backend. We will do this by adding the new module and remove the existing allow all policy module as we can't have two modules setting the policy:
 
    ```ts title="packages/backend/src/index.ts"
    // permission plugin

--- a/docs/permissions/getting-started.md
+++ b/docs/permissions/getting-started.md
@@ -86,8 +86,13 @@ To help validate the permission framework is setup we'll create a Test Permissio
    ```ts title="packages/backend/src/index.ts"
    // permission plugin
    backend.add(import('@backstage/plugin-permission-backend/alpha'));
+   /* highlight-remove-start */
+   backend.add(
+     import('@backstage/plugin-permission-backend-module-allow-all-policy'),
+   );
+   /* highlight-remove-end */
    /* highlight-add-next-line */
-   backend.add(import('./extensions/permissionPolicyExtension'));
+   backend.add(import('./extensions/permissionsPolicyExtension'));
    ```
 
 You now have a Test Permission Policy in place, this will help us test that the permission framework is working in the next section.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

small typo fix for permission doc.

I added the following code to remove the existing all-permission-policy module, which is added by default in new setups. I thought it would be helpful to include this in the documentation so people are aware of how to remove it. Otherwise, it throws the following error:

`Module 'permission-policy' for plugin 'permission' startup failed; caused by Error: Policy already set`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
