### PR TITLE
feat(scaffolder): add support for EventsService

### DIFF
--- a/.changeset/orange-moles-kick.md
+++ b/.changeset/orange-moles-kick.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+Emit scaffolder events using the optional `EventsService`

--- a/plugins/scaffolder-backend/package.json
+++ b/plugins/scaffolder-backend/package.json
@@ -73,6 +73,7 @@
     "@backstage/plugin-bitbucket-cloud-common": "workspace:^",
     "@backstage/plugin-catalog-backend-module-scaffolder-entity-model": "workspace:^",
     "@backstage/plugin-catalog-node": "workspace:^",
+    "@backstage/plugin-events-node": "workspace:^",
     "@backstage/plugin-permission-common": "workspace:^",
     "@backstage/plugin-permission-node": "workspace:^",
     "@backstage/plugin-scaffolder-backend-module-azure": "workspace:^",

--- a/plugins/scaffolder-backend/report.api.md
+++ b/plugins/scaffolder-backend/report.api.md
@@ -19,6 +19,7 @@ import { Config } from '@backstage/config';
 import { DatabaseService } from '@backstage/backend-plugin-api';
 import { DiscoveryService } from '@backstage/backend-plugin-api';
 import { Duration } from 'luxon';
+import { EventsService } from '@backstage/plugin-events-node';
 import { executeShellCommand as executeShellCommand_2 } from '@backstage/plugin-scaffolder-node';
 import { ExecuteShellCommandOptions } from '@backstage/plugin-scaffolder-node';
 import express from 'express';
@@ -520,6 +521,7 @@ export class DatabaseTaskStore implements TaskStore {
 // @public
 export type DatabaseTaskStoreOptions = {
   database: PluginDatabaseManager | Knex;
+  events?: EventsService;
 };
 
 // @public @deprecated
@@ -551,6 +553,8 @@ export interface RouterOptions {
   database: DatabaseService;
   // (undocumented)
   discovery?: DiscoveryService;
+  // (undocumented)
+  events?: EventsService;
   // (undocumented)
   httpAuth?: HttpAuthService;
   // (undocumented)

--- a/plugins/scaffolder-backend/src/ScaffolderPlugin.ts
+++ b/plugins/scaffolder-backend/src/ScaffolderPlugin.ts
@@ -15,8 +15,8 @@
  */
 
 import {
-  createBackendPlugin,
   coreServices,
+  createBackendPlugin,
 } from '@backstage/backend-plugin-api';
 import { loggerToWinstonLogger } from '@backstage/backend-common';
 import { ScmIntegrations } from '@backstage/integration';
@@ -50,6 +50,7 @@ import {
   createWaitAction,
 } from './scaffolder';
 import { createRouter } from './service/router';
+import { eventsServiceRef } from '@backstage/plugin-events-node';
 
 /**
  * Scaffolder plugin
@@ -114,6 +115,7 @@ export const scaffolderPlugin = createBackendPlugin({
         httpRouter: coreServices.httpRouter,
         httpAuth: coreServices.httpAuth,
         catalogClient: catalogServiceRef,
+        events: eventsServiceRef,
       },
       async init({
         logger,
@@ -127,6 +129,7 @@ export const scaffolderPlugin = createBackendPlugin({
         httpAuth,
         catalogClient,
         permissions,
+        events,
       }) {
         const log = loggerToWinstonLogger(logger);
         const integrations = ScmIntegrations.fromConfig(config);
@@ -189,6 +192,7 @@ export const scaffolderPlugin = createBackendPlugin({
           permissions,
           autocompleteHandlers,
           additionalWorkspaceProviders,
+          events,
         });
         httpRouter.use(router);
       },

--- a/plugins/scaffolder-backend/src/service/router.test.ts
+++ b/plugins/scaffolder-backend/src/service/router.test.ts
@@ -51,6 +51,7 @@ import {
 import { AutocompleteHandler } from '@backstage/plugin-scaffolder-node/alpha';
 import { UrlReaders } from '@backstage/backend-defaults/urlReader';
 import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
+import { EventsService } from '@backstage/plugin-events-node';
 
 const mockAccess = jest.fn();
 
@@ -99,6 +100,9 @@ describe('createRouter', () => {
   const auth = mockServices.auth();
   const httpAuth = mockServices.httpAuth();
   const discovery = mockServices.discovery();
+  const events = {
+    publish: jest.fn(),
+  } as unknown as EventsService;
 
   const credentials = mockCredentials.user();
   const token = mockCredentials.service.token({
@@ -211,6 +215,7 @@ describe('createRouter', () => {
         auth,
         httpAuth,
         discovery,
+        events,
       });
       app = express().use(router);
 

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -92,9 +92,9 @@ import {
   HttpAuthService,
   LifecycleService,
   PermissionsService,
+  resolveSafeChildPath,
   SchedulerService,
   UrlReaderService,
-  resolveSafeChildPath,
 } from '@backstage/backend-plugin-api';
 import {
   IdentityApi,
@@ -108,6 +108,7 @@ import {
 } from '@backstage/plugin-scaffolder-node/alpha';
 import { pathToFileURL } from 'url';
 import { v4 as uuid } from 'uuid';
+import { EventsService } from '@backstage/plugin-events-node';
 
 /**
  *
@@ -182,6 +183,7 @@ export interface RouterOptions {
   httpAuth?: HttpAuthService;
   identity?: IdentityApi;
   discovery?: DiscoveryService;
+  events?: EventsService;
 
   autocompleteHandlers?: Record<string, AutocompleteHandler>;
 }
@@ -294,6 +296,7 @@ export async function createRouter(
     discovery = HostDiscovery.fromConfig(config),
     identity = buildDefaultIdentityClient(options),
     autocompleteHandlers = {},
+    events: eventsService,
   } = options;
 
   const { auth, httpAuth } = createLegacyAuthAdapters({
@@ -313,7 +316,10 @@ export async function createRouter(
 
   let taskBroker: TaskBroker;
   if (!options.taskBroker) {
-    const databaseTaskStore = await DatabaseTaskStore.create({ database });
+    const databaseTaskStore = await DatabaseTaskStore.create({
+      database,
+      events: eventsService,
+    });
     taskBroker = new StorageTaskBroker(
       databaseTaskStore,
       logger,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7615,6 +7615,7 @@ __metadata:
     "@backstage/plugin-bitbucket-cloud-common": "workspace:^"
     "@backstage/plugin-catalog-backend-module-scaffolder-entity-model": "workspace:^"
     "@backstage/plugin-catalog-node": "workspace:^"
+    "@backstage/plugin-events-node": "workspace:^"
     "@backstage/plugin-permission-common": "workspace:^"
     "@backstage/plugin-permission-node": "workspace:^"
     "@backstage/plugin-scaffolder-backend-module-azure": "workspace:^"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

adds support to the default DatabaseTaskStore to emit events from scaffolder tasks using the EventsService

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
