### PR TITLE
app-backend: escape script tag endings in config

### DIFF
--- a/plugins/app-backend/src/lib/config/injectConfigIntoHtml.test.ts
+++ b/plugins/app-backend/src/lib/config/injectConfigIntoHtml.test.ts
@@ -70,4 +70,33 @@ describe('injectConfigIntoHtml', () => {
 </head></html>`,
     });
   });
+
+  it('should trim script tag endings from injected config', async () => {
+    mockDir.setContent({
+      'index.html.tmpl': '<html><head></head></html>',
+    });
+    await injectConfigIntoHtml({
+      ...baseOptions,
+      appConfigs: [
+        {
+          context: 'mock',
+          data: { x: "</script><script>alert('hi')</script><!-- Hi -->" },
+        },
+      ],
+    });
+    expect(mockDir.content()).toMatchObject({
+      'index.html': `<html><head>
+<script type="backstage.io/config">
+[
+  {
+    "context": "mock",
+    "data": {
+      "x": "><script>alert('hi')> Hi -->"
+    }
+  }
+]
+</script>
+</head></html>`,
+    });
+  });
 });

--- a/plugins/app-backend/src/lib/config/injectConfigIntoHtml.ts
+++ b/plugins/app-backend/src/lib/config/injectConfigIntoHtml.ts
@@ -55,7 +55,14 @@ export async function injectConfigIntoHtml(
     '</head>',
     `
 <script type="backstage.io/config">
-${JSON.stringify(appConfigs, null, 2)}
+${JSON.stringify(appConfigs, null, 2)
+  // Note on the security aspects of this: We generally trust the app config to
+  // be safe, since control of the app config effectively means full control of
+  // the app. These substitutions are here as an extra precaution to avoid
+  // unintentionally breaking the app, to avoid this being flagged, and in case
+  // someone decides to hook up user input to the app config in their own setup.
+  .replaceAll('</script', '')
+  .replaceAll('<!--', '')}
 </script>
 </head>`,
   );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Followup for #26389

As mentioned in the comment this isn't a security fix as such, just avoiding silly mistakes. I do still prefer to keep the app-config inline in JSON form rather than a base64 approach like we do in the auth backend, because I think there's a big benefit to having the config be readable.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
