### PR TITLE
clean up the todo-list-backend report

### DIFF
--- a/plugins/example-todo-list-backend/api-report.md
+++ b/plugins/example-todo-list-backend/api-report.md
@@ -4,24 +4,10 @@
 
 ```ts
 import { BackendFeature } from '@backstage/backend-plugin-api';
-import express from 'express';
-import { HttpAuthService } from '@backstage/backend-plugin-api';
-import { LoggerService } from '@backstage/backend-plugin-api';
-
-// @public
-export function createRouter(options: RouterOptions): Promise<express.Router>;
 
 // @public
 const exampleTodoListPlugin: BackendFeature;
 export default exampleTodoListPlugin;
-
-// @public
-export interface RouterOptions {
-  // (undocumented)
-  httpAuth: HttpAuthService;
-  // (undocumented)
-  logger: LoggerService;
-}
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/example-todo-list-backend/src/index.ts
+++ b/plugins/example-todo-list-backend/src/index.ts
@@ -14,5 +14,4 @@
  * limitations under the License.
  */
 
-export * from './service/router';
 export { exampleTodoListPlugin as default } from './plugin';

--- a/plugins/example-todo-list-backend/src/service/router.test.ts
+++ b/plugins/example-todo-list-backend/src/service/router.test.ts
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
+import { mockServices } from '@backstage/backend-test-utils';
 import express from 'express';
 import request from 'supertest';
-
 import { createRouter } from './router';
-import { mockServices } from '@backstage/backend-test-utils';
 
 describe('createRouter', () => {
   let app: express.Express;

--- a/plugins/example-todo-list-backend/src/service/router.ts
+++ b/plugins/example-todo-list-backend/src/service/router.ts
@@ -23,8 +23,6 @@ import { HttpAuthService, LoggerService } from '@backstage/backend-plugin-api';
 
 /**
  * Dependencies of the todo-list router
- *
- * @public
  */
 export interface RouterOptions {
   logger: LoggerService;
@@ -35,7 +33,6 @@ export interface RouterOptions {
  * Creates an express.Router with some endpoints
  * for creating, editing and deleting todo items.
  *
- * @public
  * @param options - the dependencies of the router
  * @returns an express.Router
  *

--- a/plugins/example-todo-list-backend/src/service/todos.ts
+++ b/plugins/example-todo-list-backend/src/service/todos.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { v4 as uuid } from 'uuid';
 import { NotFoundError } from '@backstage/errors';
 
@@ -29,9 +30,7 @@ export type TodoFilter = {
 };
 
 export type TodoFilters =
-  | {
-      anyOf: TodoFilters[];
-    }
+  | { anyOf: TodoFilters[] }
   | { allOf: TodoFilters[] }
   | { not: TodoFilters }
   | TodoFilter;


### PR DESCRIPTION
Yeah it's just an example, but it's nice if it's on the latest style and features. And it was the only non-deprecated createRouter so I thought, rather than marking it deprecated, let's just kick it out of the API.