### PR TITLE
CI: force yarn to override the lockfile

### DIFF
--- a/.github/workflows/deploy_docker-image.yml
+++ b/.github/workflows/deploy_docker-image.yml
@@ -45,6 +45,7 @@ jobs:
         run: npx @backstage/create-app
         env:
           BACKSTAGE_APP_NAME: example-app
+          YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
       - name: yarn build
         run: yarn build:backend


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR fixes an issue in the `Build and push Docker image` workflow preventing yarn to override the lockfile when creating a new Backstage app.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
