### PR TITLE
Static editUrl for 26563 when clicking 'edit this page'

### DIFF
--- a/microsite/docusaurus.config.ts
+++ b/microsite/docusaurus.config.ts
@@ -84,7 +84,10 @@ const config: Config = {
       /** @type {import('@docusaurus/preset-classic').Options} */
       {
         docs: {
-          editUrl: 'https://github.com/backstage/backstage/edit/master/docs/',
+          editUrl: ({ docPath }) => {
+            // Always point to the non-versioned directory when editing a doc page
+            return `https://github.com/backstage/backstage/edit/master/docs/${docPath}`;
+          },
           path: '../docs',
           sidebarPath: 'sidebars.js',
           ...(useVersionedDocs


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

When clicking on the `edit this page` in the docs site, it tries to point you to the versioned docs created when the github action runs:

https://github.com/backstage/backstage/blob/8c5c6b8c1ace5ce1a2e6f5e134b0111514ca0b44/.github/workflows/deploy_microsite.yml#L192-L194

I think this is more of an in-between fix until the versioned docs are fully live as it will always point to the static doc location (as it did before the versioned docs where generated) later I would assume, you want to edit that specific version of the docs and not the static one.

This relates to #26563 
