### PR TITLE
Registering Existing Component CTA should be a secondary action

### DIFF
--- a/.changeset/hungry-buckets-repair.md
+++ b/.changeset/hungry-buckets-repair.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Change "Register Existing Component" CTA to outlined as it's not a primary action on the scaffolder pages

--- a/plugins/scaffolder/src/alpha/components/TemplateListPage/RegisterExistingButton.tsx
+++ b/plugins/scaffolder/src/alpha/components/TemplateListPage/RegisterExistingButton.tsx
@@ -61,7 +61,7 @@ export const RegisterExistingButton = (props: RegisterExistingButtonProps) => {
       <AddCircleOutline />
     </IconButton>
   ) : (
-    <Button component={RouterLink} variant="contained" color="primary" to={to}>
+    <Button component={RouterLink} variant="outlined" color="primary" to={to}>
       {title}
     </Button>
   );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### Background
The "Register Existing Component" is simply a shortcut to a alternative flow and should not be presented as a primary action using a `primary` + `contained` button. 

### Changes
- Change "Register Existing Component" CTA to appear as a secondary action 

*Before*
![image](https://github.com/user-attachments/assets/93b130c2-af4a-4caa-8983-3431839800b8)

*After*
![image](https://github.com/user-attachments/assets/166a99ba-bece-457b-a01b-7648f321fb69)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
