### PR TITLE
frontend-plugin-api: add support for overriding blueprint parameters

### DIFF
--- a/.changeset/large-plants-rhyme.md
+++ b/.changeset/large-plants-rhyme.md
@@ -1,0 +1,30 @@
+---
+'@backstage/frontend-plugin-api': patch
+---
+
+It is now possible to override the blueprint parameters when overriding an extension created from a blueprint:
+
+```ts
+const myExtension = MyBlueprint.make({
+  params: {
+    myParam: 'myDefault',
+  },
+});
+
+const myOverride = myExtension.override({
+  params: {
+    myParam: 'myOverride',
+  },
+});
+const myFactoryOverride = myExtension.override({
+  factory(origFactory) {
+    return origFactory({
+      params: {
+        myParam: 'myOverride',
+      },
+    });
+  },
+});
+```
+
+The provided parameters will be merged with the original parameters of the extension.

--- a/docs/frontend-system/architecture/25-extension-overrides.md
+++ b/docs/frontend-system/architecture/25-extension-overrides.md
@@ -79,6 +79,48 @@ const myOverrideExtension = myExtension.override({
 
 Note the `yield*` expression, which forwards all values from the provided iterable to the generator, in this case the original factory output.
 
+## Overriding blueprint parameters
+
+If you are overriding an extension that was originally created from an [extension blueprint](./23-extension-blueprints.md), you are able to override the parameters that were originally provided for the blueprint. This can be done directly as an option to `.override`, or when calling the original factory in the override factory. The provided parameter overrides will be merged with the existing parameters that where provided when creating the extension from the blueprint.
+
+For example, consider the following extension created from the `PageBlueprint`:
+
+```tsx
+const exampleExtension = PageBlueprint.make({
+  params: {
+    loader: () =>
+      import('./components/ExamplePage').then(m => <m.ExamplePage />),
+    defaultPath: '/example',
+  },
+});
+```
+
+You can immediately override parameters through the `params` option:
+
+```tsx
+const overrideExtension = exampleExtension.override({
+  params: {
+    loader: () =>
+      import('./components/OverridePage').then(m => <m.OverridePage />),
+  },
+});
+```
+
+It is also possible to pass parameter overrides when calling the original factory in the override factory:
+
+```tsx
+const overrideExtension = exampleExtension.override({
+  factory(originalFactory) {
+    return originalFactory({
+      params: {
+        loader: () =>
+          import('./components/OverridePage').then(m => <m.OverridePage />),
+      },
+    });
+  },
+});
+```
+
 ## Overriding declared outputs
 
 When overriding an extension you can provide a new output declaration. This **replaces** any existing output declaration, which means that if you want to forward any of the original output you will need to declare it again. The following example shows how to override an extension and replace the output declaration:

--- a/packages/app-next-example-plugin/api-report.md
+++ b/packages/app-next-example-plugin/api-report.md
@@ -40,6 +40,11 @@ const examplePlugin: FrontendPlugin<
             }
           >;
       inputs: {};
+      params: {
+        defaultPath: string;
+        loader: () => Promise<JSX.Element>;
+        routeRef?: RouteRef<AnyRouteRefParams> | undefined;
+      };
     }>;
   }
 >;

--- a/packages/frontend-plugin-api/api-report.md
+++ b/packages/frontend-plugin-api/api-report.md
@@ -453,6 +453,7 @@ export function createComponentExtension<TProps extends {}>(options: {
       }
     >;
   };
+  params: never;
   kind: 'component';
   namespace: undefined;
   name: string;
@@ -520,6 +521,7 @@ export function createExtension<
       >;
   output: UOutput;
   inputs: TInputs;
+  params: never;
   kind: string | undefined extends TKind ? undefined : TKind;
   namespace: string | undefined extends TNamespace ? undefined : TNamespace;
   name: string | undefined extends TName ? undefined : TName;
@@ -569,6 +571,7 @@ export function createExtension<
       >;
   output: UOutput;
   inputs: TInputs;
+  params: never;
   kind: string | undefined extends TKind ? undefined : TKind;
   namespace: string | undefined extends TNamespace ? undefined : TNamespace;
   name: string | undefined extends TName ? undefined : TName;
@@ -983,6 +986,7 @@ export interface ExtensionBlueprint<
     configInput: T['configInput'];
     output: T['output'];
     inputs: T['inputs'];
+    params: T['params'];
   }>;
   // @deprecated (undocumented)
   make<
@@ -1093,6 +1097,7 @@ export interface ExtensionBlueprint<
     kind: T['kind'];
     namespace: undefined;
     name: string | undefined extends TNewName ? T['name'] : TNewName;
+    params: T['params'];
   }>;
   // @deprecated (undocumented)
   makeWithOverrides<
@@ -1306,45 +1311,60 @@ export type ExtensionDefinition<
       >;
     },
   >(
-    args: {
-      attachTo?: {
-        id: string;
-        input: string;
-      };
-      disabled?: boolean;
-      inputs?: TExtraInputs & {
-        [KName in keyof T['inputs']]?: `Error: Input '${KName &
-          string}' is already defined in parent definition`;
-      };
-      output?: Array<UNewOutput>;
-      config?: {
-        schema: TExtensionConfigSchema & {
-          [KName in keyof T['config']]?: `Error: Config key '${KName &
-            string}' is already defined in parent schema`;
+    args: Expand<
+      {
+        attachTo?: {
+          id: string;
+          input: string;
         };
-      };
-      factory?(
-        originalFactory: (context?: {
-          config?: T['config'];
-          inputs?: ResolveInputValueOverrides<NonNullable<T['inputs']>>;
-        }) => ExtensionDataContainer<NonNullable<T['output']>>,
-        context: {
-          node: AppNode;
-          apis: ApiHolder;
-          config: T['config'] & {
-            [key in keyof TExtensionConfigSchema]: z.infer<
-              ReturnType<TExtensionConfigSchema[key]>
-            >;
+        disabled?: boolean;
+        inputs?: TExtraInputs & {
+          [KName in keyof T['inputs']]?: `Error: Input '${KName &
+            string}' is already defined in parent definition`;
+        };
+        output?: Array<UNewOutput>;
+        config?: {
+          schema: TExtensionConfigSchema & {
+            [KName in keyof T['config']]?: `Error: Config key '${KName &
+              string}' is already defined in parent schema`;
           };
-          inputs: Expand<ResolvedExtensionInputs<T['inputs'] & TExtraInputs>>;
-        },
-      ): Iterable<UFactoryOutput>;
-    } & VerifyExtensionFactoryOutput<
-      AnyExtensionDataRef extends UNewOutput
-        ? NonNullable<T['output']>
-        : UNewOutput,
-      UFactoryOutput
-    >,
+        };
+        factory?(
+          originalFactory: (
+            context?: Expand<
+              {
+                config?: T['config'];
+                inputs?: ResolveInputValueOverrides<NonNullable<T['inputs']>>;
+              } & ([T['params']] extends [never]
+                ? {}
+                : {
+                    params?: Partial<T['params']>;
+                  })
+            >,
+          ) => ExtensionDataContainer<NonNullable<T['output']>>,
+          context: {
+            node: AppNode;
+            apis: ApiHolder;
+            config: T['config'] & {
+              [key in keyof TExtensionConfigSchema]: z.infer<
+                ReturnType<TExtensionConfigSchema[key]>
+              >;
+            };
+            inputs: Expand<ResolvedExtensionInputs<T['inputs'] & TExtraInputs>>;
+          },
+        ): Iterable<UFactoryOutput>;
+      } & ([T['params']] extends [never]
+        ? {}
+        : {
+            params?: Partial<T['params']>;
+          })
+    > &
+      VerifyExtensionFactoryOutput<
+        AnyExtensionDataRef extends UNewOutput
+          ? NonNullable<T['output']>
+          : UNewOutput,
+        UFactoryOutput
+      >,
   ): ExtensionDefinition<{
     kind: T['kind'];
     namespace: T['namespace'];
@@ -1388,6 +1408,7 @@ export type ExtensionDefinitionParameters = {
       }
     >;
   };
+  params?: object;
 };
 
 // @public (undocumented)

--- a/packages/frontend-plugin-api/src/wiring/createExtension.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.test.ts
@@ -744,6 +744,35 @@ describe('createExtension', () => {
       );
     });
 
+    it('should not have params unless explicitly defined', () => {
+      const ext = createExtension({
+        attachTo: { id: 'root', input: 'blob' },
+        output: [stringDataRef],
+        factory() {
+          return [stringDataRef('0')];
+        },
+      });
+
+      ext.override({
+        // @ts-expect-error - params are not allowed
+        params: {} as any,
+      });
+
+      ext.override({
+        // @ts-expect-error - params are not provided
+        factory(origFactory, { params }) {
+          return origFactory({
+            // @ts-expect-error - params are not allowed
+            params: {
+              ...params,
+            },
+          });
+        },
+      });
+
+      expect(ext).toBeDefined();
+    });
+
     it('should be able to override input values', () => {
       const outputRef = createExtensionDataRef<unknown>().with({
         id: 'output',

--- a/packages/frontend-plugin-api/src/wiring/createExtension.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.ts
@@ -34,6 +34,12 @@ import { createSchemaFromZod } from '../schema/createSchemaFromZod';
 import { OpaqueExtensionDefinition } from '@internal/frontend';
 
 /**
+ * This symbol is used to pass parameter overrides from the extension override to the blueprint factory
+ * @internal
+ */
+export const ctxParamsSymbol = Symbol('params');
+
+/**
  * Convert a single extension input into a matching resolved input.
  * @public
  */
@@ -484,11 +490,8 @@ export function createExtension<
               apis,
               config: config as any,
               inputs: inputs as any,
-              params: overrideOptions.params,
-              // TODO(Rugvip): This is a bit of a hack to send the params
-              // through to the blueprint factory, might be that there's a
-              // better way to do this
-            } as Parameters<typeof options.factory>[0]);
+              [ctxParamsSymbol as any]: overrideOptions.params,
+            });
           }
           const parentResult = overrideOptions.factory(
             (innerContext): ExtensionDataContainer<UOutput> => {
@@ -502,9 +505,8 @@ export function createExtension<
                     inputs,
                     innerContext?.inputs,
                   ) as any,
-                  params: innerContext?.params,
-                  // TODO(Rugvip): Same as above
-                } as Parameters<typeof options.factory>[0]) as Iterable<any>,
+                  [ctxParamsSymbol as any]: innerContext?.params,
+                }) as Iterable<any>,
                 options.output,
               );
             },

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.test.tsx
@@ -836,4 +836,117 @@ describe('createExtensionBlueprint', () => {
       ),
     ).toEqual([testDataRef1('foo'), testDataRef2('bar')]);
   });
+
+  it('should be possible to override extensions resulting from .make', () => {
+    const testDataRef1 = createExtensionDataRef<string>().with({ id: 'test1' });
+    const testDataRef2 = createExtensionDataRef<string>().with({ id: 'test2' });
+
+    function getOutputs(ext: ExtensionDefinition) {
+      const tester = createExtensionTester(ext);
+      return {
+        test1: tester.get(testDataRef1),
+        test2: tester.get(testDataRef2),
+      };
+    }
+
+    const blueprint = createExtensionBlueprint({
+      kind: 'test-extension',
+      attachTo: { id: 'test', input: 'default' },
+      output: [testDataRef1, testDataRef2],
+      *factory(params: { test1: string; test2: string }) {
+        yield testDataRef1(params.test1);
+        yield testDataRef2(params.test2);
+      },
+    });
+
+    const extension = blueprint.make({
+      params: {
+        test1: 'orig-1',
+        test2: 'orig-2',
+      },
+    });
+
+    expect(getOutputs(extension)).toEqual({
+      test1: 'orig-1',
+      test2: 'orig-2',
+    });
+
+    expect(
+      getOutputs(
+        extension.override({
+          params: {
+            test1: 'override-1',
+            test2: 'override-2',
+          },
+        }),
+      ),
+    ).toEqual({
+      test1: 'override-1',
+      test2: 'override-2',
+    });
+
+    // Partial override
+    expect(
+      getOutputs(
+        extension.override({
+          params: {
+            test2: 'override-2',
+          },
+        }),
+      ),
+    ).toEqual({
+      test1: 'orig-1',
+      test2: 'override-2',
+    });
+
+    expect(
+      getOutputs(
+        extension.override({
+          factory(origFactory) {
+            return origFactory({
+              params: {
+                test1: 'override-1',
+                test2: 'override-2',
+              },
+            });
+          },
+        }),
+      ),
+    ).toEqual({
+      test1: 'override-1',
+      test2: 'override-2',
+    });
+
+    // Partial override via factory
+    expect(
+      getOutputs(
+        extension.override({
+          factory(origFactory) {
+            return origFactory({
+              params: {
+                test2: 'override-2',
+              },
+            });
+          },
+        }),
+      ),
+    ).toEqual({
+      test1: 'orig-1',
+      test2: 'override-2',
+    });
+
+    expect(() =>
+      getOutputs(
+        extension.override({
+          params: {
+            test1: 'override-1',
+            test2: 'override-2',
+          },
+          factory(origFactory) {
+            return origFactory();
+          },
+        }),
+      ),
+    ).toThrow('Refused to override params and factory at the same time');
+  });
 });

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
@@ -124,6 +124,7 @@ export interface ExtensionBlueprint<
     configInput: T['configInput'];
     output: T['output'];
     inputs: T['inputs'];
+    params: T['params'];
   }>;
   /** @deprecated namespace is no longer required, you can safely remove this option and it will default to the `pluginId`. It will be removed in a future release. */
   make<
@@ -232,6 +233,7 @@ export interface ExtensionBlueprint<
     kind: T['kind'];
     namespace: undefined;
     name: string | undefined extends TNewName ? T['name'] : TNewName;
+    params: T['params'];
   }>;
   /** @deprecated namespace is no longer required, you can safely remove this option and it will default to the `pluginId`. It will be removed in a future release. */
   makeWithOverrides<
@@ -479,9 +481,13 @@ export function createExtensionBlueprint<
         output: options.output as AnyExtensionDataRef[],
         config: options.config,
         factory: ctx =>
-          options.factory(args.params, ctx) as Iterable<
-            ExtensionDataValue<any, any>
-          >,
+          options.factory(
+            // TODO(Rugvip): The `ctx` here might actually have a `params` key
+            // when the extension has been overridden. It's currently hidden in
+            // the types and there might be a better way to do this.
+            { ...args.params, ...(ctx as any).params },
+            ctx,
+          ) as Iterable<ExtensionDataValue<any, any>>,
       }) as ExtensionDefinition;
     },
     makeWithOverrides(args) {

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
@@ -21,6 +21,7 @@ import {
   ResolvedExtensionInputs,
   VerifyExtensionFactoryOutput,
   createExtension,
+  ctxParamsSymbol,
 } from './createExtension';
 import { z } from 'zod';
 import { ExtensionInput } from './createExtensionInput';
@@ -482,10 +483,7 @@ export function createExtensionBlueprint<
         config: options.config,
         factory: ctx =>
           options.factory(
-            // TODO(Rugvip): The `ctx` here might actually have a `params` key
-            // when the extension has been overridden. It's currently hidden in
-            // the types and there might be a better way to do this.
-            { ...args.params, ...(ctx as any).params },
+            { ...args.params, ...(ctx as any)[ctxParamsSymbol] },
             ctx,
           ) as Iterable<ExtensionDataValue<any, any>>,
       }) as ExtensionDefinition;
@@ -514,8 +512,7 @@ export function createExtensionBlueprint<
             (innerParams, innerContext) => {
               return createExtensionDataContainer<UOutput>(
                 options.factory(
-                  // TODO(Rugvip): Same as ctx.params from .make
-                  { ...innerParams, ...(ctx as any).params },
+                  { ...innerParams, ...(ctx as any)[ctxParamsSymbol] },
                   {
                     apis,
                     node,

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
@@ -508,20 +508,25 @@ export function createExtensionBlueprint<
                 },
               }
             : undefined,
-        factory: ({ node, config, inputs, apis }) => {
+        factory: ctx => {
+          const { node, config, inputs, apis } = ctx;
           return args.factory(
             (innerParams, innerContext) => {
               return createExtensionDataContainer<UOutput>(
-                options.factory(innerParams, {
-                  apis,
-                  node,
-                  config: (innerContext?.config ?? config) as any,
-                  inputs: resolveInputOverrides(
-                    options.inputs,
-                    inputs,
-                    innerContext?.inputs,
-                  ) as any,
-                }) as Iterable<any>,
+                options.factory(
+                  // TODO(Rugvip): Same as ctx.params from .make
+                  { ...innerParams, ...(ctx as any).params },
+                  {
+                    apis,
+                    node,
+                    config: (innerContext?.config ?? config) as any,
+                    inputs: resolveInputOverrides(
+                      options.inputs,
+                      inputs,
+                      innerContext?.inputs,
+                    ) as any,
+                  },
+                ) as Iterable<any>,
                 options.output,
               );
             },

--- a/plugins/api-docs/api-report-alpha.md
+++ b/plugins/api-docs/api-report-alpha.md
@@ -41,6 +41,11 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        title: string;
+        icon: IconComponent;
+        routeRef: RouteRef<undefined>;
+      };
     }>;
     'api:api-docs/config': ExtensionDefinition<{
       kind: 'api';
@@ -54,6 +59,9 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
     'page:api-docs': ExtensionDefinition<{
       config: {
@@ -92,6 +100,11 @@ const _default: FrontendPlugin<
       kind: 'page';
       namespace: undefined;
       name: undefined;
+      params: {
+        defaultPath: string;
+        loader: () => Promise<JSX.Element>;
+        routeRef?: RouteRef<AnyRouteRefParams> | undefined;
+      };
     }>;
     'entity-card:api-docs/has-apis': ExtensionDefinition<{
       kind: 'entity-card';
@@ -124,6 +137,10 @@ const _default: FrontendPlugin<
             }
           >;
       inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+        filter?: string | ((entity: Entity) => boolean) | undefined;
+      };
     }>;
     'entity-card:api-docs/definition': ExtensionDefinition<{
       kind: 'entity-card';
@@ -156,6 +173,10 @@ const _default: FrontendPlugin<
             }
           >;
       inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+        filter?: string | ((entity: Entity) => boolean) | undefined;
+      };
     }>;
     'entity-card:api-docs/consumed-apis': ExtensionDefinition<{
       kind: 'entity-card';
@@ -188,6 +209,10 @@ const _default: FrontendPlugin<
             }
           >;
       inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+        filter?: string | ((entity: Entity) => boolean) | undefined;
+      };
     }>;
     'entity-card:api-docs/provided-apis': ExtensionDefinition<{
       kind: 'entity-card';
@@ -220,6 +245,10 @@ const _default: FrontendPlugin<
             }
           >;
       inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+        filter?: string | ((entity: Entity) => boolean) | undefined;
+      };
     }>;
     'entity-card:api-docs/consuming-components': ExtensionDefinition<{
       kind: 'entity-card';
@@ -252,6 +281,10 @@ const _default: FrontendPlugin<
             }
           >;
       inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+        filter?: string | ((entity: Entity) => boolean) | undefined;
+      };
     }>;
     'entity-card:api-docs/providing-components': ExtensionDefinition<{
       kind: 'entity-card';
@@ -284,6 +317,10 @@ const _default: FrontendPlugin<
             }
           >;
       inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+        filter?: string | ((entity: Entity) => boolean) | undefined;
+      };
     }>;
     'entity-content:api-docs/definition': ExtensionDefinition<{
       kind: 'entity-content';
@@ -333,6 +370,13 @@ const _default: FrontendPlugin<
             }
           >;
       inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+        defaultPath: string;
+        defaultTitle: string;
+        routeRef?: RouteRef<AnyRouteRefParams> | undefined;
+        filter?: string | ((entity: Entity) => boolean) | undefined;
+      };
     }>;
     'entity-content:api-docs/apis': ExtensionDefinition<{
       kind: 'entity-content';
@@ -382,6 +426,13 @@ const _default: FrontendPlugin<
             }
           >;
       inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+        defaultPath: string;
+        defaultTitle: string;
+        routeRef?: RouteRef<AnyRouteRefParams> | undefined;
+        filter?: string | ((entity: Entity) => boolean) | undefined;
+      };
     }>;
   }
 >;

--- a/plugins/app-visualizer/api-report.md
+++ b/plugins/app-visualizer/api-report.md
@@ -41,6 +41,11 @@ const visualizerPlugin: FrontendPlugin<
             }
           >;
       inputs: {};
+      params: {
+        defaultPath: string;
+        loader: () => Promise<JSX.Element>;
+        routeRef?: RouteRef<AnyRouteRefParams> | undefined;
+      };
     }>;
     'nav-item:app-visualizer': ExtensionDefinition<{
       kind: 'nav-item';
@@ -58,6 +63,11 @@ const visualizerPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        title: string;
+        icon: IconComponent;
+        routeRef: RouteRef<undefined>;
+      };
     }>;
   }
 >;

--- a/plugins/app/api-report.md
+++ b/plugins/app/api-report.md
@@ -46,6 +46,7 @@ const appPlugin: FrontendPlugin<
           }
         >;
       };
+      params: never;
       kind: undefined;
       namespace: undefined;
       name: undefined;
@@ -62,6 +63,9 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
     'app/layout': ExtensionDefinition<{
       config: {};
@@ -87,6 +91,7 @@ const appPlugin: FrontendPlugin<
           }
         >;
       };
+      params: never;
       kind: undefined;
       namespace: undefined;
       name: 'layout';
@@ -130,6 +135,7 @@ const appPlugin: FrontendPlugin<
           }
         >;
       };
+      params: never;
       kind: undefined;
       namespace: undefined;
       name: 'nav';
@@ -195,6 +201,7 @@ const appPlugin: FrontendPlugin<
           }
         >;
       };
+      params: never;
       kind: undefined;
       namespace: undefined;
       name: 'root';
@@ -224,6 +231,7 @@ const appPlugin: FrontendPlugin<
           }
         >;
       };
+      params: never;
       kind: undefined;
       namespace: undefined;
       name: 'routes';
@@ -248,6 +256,9 @@ const appPlugin: FrontendPlugin<
       kind: 'api';
       namespace: undefined;
       name: 'app-theme';
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
     'theme:app/light': ExtensionDefinition<{
       kind: 'theme';
@@ -257,6 +268,9 @@ const appPlugin: FrontendPlugin<
       configInput: {};
       output: ConfigurableExtensionDataRef<AppTheme, 'core.theme.theme', {}>;
       inputs: {};
+      params: {
+        theme: AppTheme;
+      };
     }>;
     'theme:app/dark': ExtensionDefinition<{
       kind: 'theme';
@@ -266,6 +280,9 @@ const appPlugin: FrontendPlugin<
       configInput: {};
       output: ConfigurableExtensionDataRef<AppTheme, 'core.theme.theme', {}>;
       inputs: {};
+      params: {
+        theme: AppTheme;
+      };
     }>;
     'api:app/components': ExtensionDefinition<{
       config: {};
@@ -294,6 +311,9 @@ const appPlugin: FrontendPlugin<
       kind: 'api';
       namespace: undefined;
       name: 'components';
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
     'api:app/icons': ExtensionDefinition<{
       config: {};
@@ -321,6 +341,9 @@ const appPlugin: FrontendPlugin<
       kind: 'api';
       namespace: undefined;
       name: 'icons';
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
     'api:app/feature-flags': ExtensionDefinition<{
       kind: 'api';
@@ -334,6 +357,9 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
     'api:app/translations': ExtensionDefinition<{
       config: {};
@@ -366,6 +392,9 @@ const appPlugin: FrontendPlugin<
       kind: 'api';
       namespace: undefined;
       name: 'translations';
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
     'app-root-element:app/oauth-request-dialog': ExtensionDefinition<{
       kind: 'app-root-element';
@@ -379,6 +408,9 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        element: JSX.Element | (() => JSX.Element);
+      };
     }>;
     'app-root-element:app/alert-display': ExtensionDefinition<{
       config: {
@@ -414,6 +446,9 @@ const appPlugin: FrontendPlugin<
       kind: 'app-root-element';
       namespace: undefined;
       name: 'alert-display';
+      params: {
+        element: JSX.Element | (() => JSX.Element);
+      };
     }>;
     'api:app/discovery': ExtensionDefinition<{
       kind: 'api';
@@ -427,6 +462,9 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
     'api:app/alert': ExtensionDefinition<{
       kind: 'api';
@@ -440,6 +478,9 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
     'api:app/analytics': ExtensionDefinition<{
       kind: 'api';
@@ -453,6 +494,9 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
     'api:app/error': ExtensionDefinition<{
       kind: 'api';
@@ -466,6 +510,9 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
     'api:app/storage': ExtensionDefinition<{
       kind: 'api';
@@ -479,6 +526,9 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
     'api:app/fetch': ExtensionDefinition<{
       kind: 'api';
@@ -492,6 +542,9 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
     'api:app/oauth-request': ExtensionDefinition<{
       kind: 'api';
@@ -505,6 +558,9 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
     'api:app/google-auth': ExtensionDefinition<{
       kind: 'api';
@@ -518,6 +574,9 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
     'api:app/microsoft-auth': ExtensionDefinition<{
       kind: 'api';
@@ -531,6 +590,9 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
     'api:app/github-auth': ExtensionDefinition<{
       kind: 'api';
@@ -544,6 +606,9 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
     'api:app/okta-auth': ExtensionDefinition<{
       kind: 'api';
@@ -557,6 +622,9 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
     'api:app/gitlab-auth': ExtensionDefinition<{
       kind: 'api';
@@ -570,6 +638,9 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
     'api:app/onelogin-auth': ExtensionDefinition<{
       kind: 'api';
@@ -583,6 +654,9 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
     'api:app/bitbucket-auth': ExtensionDefinition<{
       kind: 'api';
@@ -596,6 +670,9 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
     'api:app/bitbucket-server-auth': ExtensionDefinition<{
       kind: 'api';
@@ -609,6 +686,9 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
     'api:app/atlassian-auth': ExtensionDefinition<{
       kind: 'api';
@@ -622,6 +702,9 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
     'api:app/vmware-cloud-auth': ExtensionDefinition<{
       kind: 'api';
@@ -635,6 +718,9 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
     'api:app/permission': ExtensionDefinition<{
       kind: 'api';
@@ -648,6 +734,9 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
   }
 >;

--- a/plugins/catalog-graph/api-report-alpha.md
+++ b/plugins/catalog-graph/api-report-alpha.md
@@ -91,6 +91,10 @@ const _default: FrontendPlugin<
       kind: 'entity-card';
       namespace: undefined;
       name: 'relations';
+      params: {
+        loader: () => Promise<JSX.Element>;
+        filter?: string | ((entity: Entity) => boolean) | undefined;
+      };
     }>;
     'page:catalog-graph': ExtensionDefinition<{
       config: {
@@ -153,6 +157,11 @@ const _default: FrontendPlugin<
       kind: 'page';
       namespace: undefined;
       name: undefined;
+      params: {
+        defaultPath: string;
+        loader: () => Promise<JSX.Element>;
+        routeRef?: RouteRef<AnyRouteRefParams> | undefined;
+      };
     }>;
   }
 >;

--- a/plugins/catalog-import/api-report-alpha.md
+++ b/plugins/catalog-import/api-report-alpha.md
@@ -30,6 +30,9 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
     'page:catalog-import': ExtensionDefinition<{
       kind: 'page';
@@ -56,6 +59,11 @@ const _default: FrontendPlugin<
             }
           >;
       inputs: {};
+      params: {
+        defaultPath: string;
+        loader: () => Promise<JSX.Element>;
+        routeRef?: RouteRef<AnyRouteRefParams> | undefined;
+      };
     }>;
   }
 >;

--- a/plugins/catalog/api-report-alpha.md
+++ b/plugins/catalog/api-report-alpha.md
@@ -20,6 +20,7 @@ import { JSX as JSX_2 } from 'react';
 import { RouteRef } from '@backstage/frontend-plugin-api';
 import { SearchResultItemExtensionComponent } from '@backstage/plugin-search-react/alpha';
 import { SearchResultItemExtensionPredicate } from '@backstage/plugin-search-react/alpha';
+import { SearchResultListItemBlueprintParams } from '@backstage/plugin-search-react/alpha';
 import { TranslationRef } from '@backstage/core-plugin-api/alpha';
 
 // @alpha
@@ -158,6 +159,9 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
     'nav-item:catalog': ExtensionDefinition<{
       kind: 'nav-item';
@@ -175,6 +179,11 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        title: string;
+        icon: IconComponent;
+        routeRef: RouteRef<undefined>;
+      };
     }>;
     'api:catalog/starred-entities': ExtensionDefinition<{
       kind: 'api';
@@ -188,6 +197,9 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
     'api:catalog/entity-presentation': ExtensionDefinition<{
       kind: 'api';
@@ -201,6 +213,9 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
     'entity-card:catalog/about': ExtensionDefinition<{
       kind: 'entity-card';
@@ -229,6 +244,10 @@ const _default: FrontendPlugin<
             }
           >;
       inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+        filter?: string | ((entity: Entity) => boolean) | undefined;
+      };
     }>;
     'entity-card:catalog/links': ExtensionDefinition<{
       kind: 'entity-card';
@@ -257,6 +276,10 @@ const _default: FrontendPlugin<
             }
           >;
       inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+        filter?: string | ((entity: Entity) => boolean) | undefined;
+      };
     }>;
     'entity-card:catalog/labels': ExtensionDefinition<{
       kind: 'entity-card';
@@ -285,6 +308,10 @@ const _default: FrontendPlugin<
             }
           >;
       inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+        filter?: string | ((entity: Entity) => boolean) | undefined;
+      };
     }>;
     'entity-card:catalog/depends-on-components': ExtensionDefinition<{
       kind: 'entity-card';
@@ -313,6 +340,10 @@ const _default: FrontendPlugin<
             }
           >;
       inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+        filter?: string | ((entity: Entity) => boolean) | undefined;
+      };
     }>;
     'entity-card:catalog/depends-on-resources': ExtensionDefinition<{
       kind: 'entity-card';
@@ -341,6 +372,10 @@ const _default: FrontendPlugin<
             }
           >;
       inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+        filter?: string | ((entity: Entity) => boolean) | undefined;
+      };
     }>;
     'entity-card:catalog/has-components': ExtensionDefinition<{
       kind: 'entity-card';
@@ -369,6 +404,10 @@ const _default: FrontendPlugin<
             }
           >;
       inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+        filter?: string | ((entity: Entity) => boolean) | undefined;
+      };
     }>;
     'entity-card:catalog/has-resources': ExtensionDefinition<{
       kind: 'entity-card';
@@ -397,6 +436,10 @@ const _default: FrontendPlugin<
             }
           >;
       inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+        filter?: string | ((entity: Entity) => boolean) | undefined;
+      };
     }>;
     'entity-card:catalog/has-subcomponents': ExtensionDefinition<{
       kind: 'entity-card';
@@ -425,6 +468,10 @@ const _default: FrontendPlugin<
             }
           >;
       inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+        filter?: string | ((entity: Entity) => boolean) | undefined;
+      };
     }>;
     'entity-card:catalog/has-subdomains': ExtensionDefinition<{
       kind: 'entity-card';
@@ -453,6 +500,10 @@ const _default: FrontendPlugin<
             }
           >;
       inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+        filter?: string | ((entity: Entity) => boolean) | undefined;
+      };
     }>;
     'entity-card:catalog/has-systems': ExtensionDefinition<{
       kind: 'entity-card';
@@ -481,6 +532,10 @@ const _default: FrontendPlugin<
             }
           >;
       inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+        filter?: string | ((entity: Entity) => boolean) | undefined;
+      };
     }>;
     'entity-content:catalog/overview': ExtensionDefinition<{
       config: {
@@ -548,6 +603,13 @@ const _default: FrontendPlugin<
       kind: 'entity-content';
       namespace: undefined;
       name: 'overview';
+      params: {
+        loader: () => Promise<JSX.Element>;
+        defaultPath: string;
+        defaultTitle: string;
+        routeRef?: RouteRef<AnyRouteRefParams> | undefined;
+        filter?: string | ((entity: Entity) => boolean) | undefined;
+      };
     }>;
     'catalog-filter:catalog/tag': ExtensionDefinition<{
       kind: 'catalog-filter';
@@ -561,6 +623,9 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+      };
     }>;
     'catalog-filter:catalog/kind': ExtensionDefinition<{
       config: {
@@ -586,6 +651,9 @@ const _default: FrontendPlugin<
       kind: 'catalog-filter';
       namespace: undefined;
       name: 'kind';
+      params: {
+        loader: () => Promise<JSX.Element>;
+      };
     }>;
     'catalog-filter:catalog/type': ExtensionDefinition<{
       kind: 'catalog-filter';
@@ -599,6 +667,9 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+      };
     }>;
     'catalog-filter:catalog/mode': ExtensionDefinition<{
       config: {
@@ -624,6 +695,9 @@ const _default: FrontendPlugin<
       kind: 'catalog-filter';
       namespace: undefined;
       name: 'mode';
+      params: {
+        loader: () => Promise<JSX.Element>;
+      };
     }>;
     'catalog-filter:catalog/namespace': ExtensionDefinition<{
       kind: 'catalog-filter';
@@ -637,6 +711,9 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+      };
     }>;
     'catalog-filter:catalog/lifecycle': ExtensionDefinition<{
       kind: 'catalog-filter';
@@ -650,6 +727,9 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+      };
     }>;
     'catalog-filter:catalog/processing-status': ExtensionDefinition<{
       kind: 'catalog-filter';
@@ -663,6 +743,9 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+      };
     }>;
     'catalog-filter:catalog/list': ExtensionDefinition<{
       config: {
@@ -688,6 +771,9 @@ const _default: FrontendPlugin<
       kind: 'catalog-filter';
       namespace: undefined;
       name: 'list';
+      params: {
+        loader: () => Promise<JSX.Element>;
+      };
     }>;
     'page:catalog': ExtensionDefinition<{
       config: {
@@ -718,6 +804,11 @@ const _default: FrontendPlugin<
       kind: 'page';
       namespace: undefined;
       name: undefined;
+      params: {
+        defaultPath: string;
+        loader: () => Promise<JSX.Element>;
+        routeRef?: RouteRef<AnyRouteRefParams> | undefined;
+      };
     }>;
     'page:catalog/entity': ExtensionDefinition<{
       config: {
@@ -775,6 +866,11 @@ const _default: FrontendPlugin<
       kind: 'page';
       namespace: undefined;
       name: 'entity';
+      params: {
+        defaultPath: string;
+        loader: () => Promise<JSX.Element>;
+        routeRef?: RouteRef<AnyRouteRefParams> | undefined;
+      };
     }>;
     'search-result-list-item:catalog': ExtensionDefinition<{
       kind: 'search-result-list-item';
@@ -795,6 +891,7 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: SearchResultListItemBlueprintParams;
     }>;
   }
 >;

--- a/plugins/devtools/api-report-alpha.md
+++ b/plugins/devtools/api-report-alpha.md
@@ -31,6 +31,9 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
     'page:devtools': ExtensionDefinition<{
       kind: 'page';
@@ -57,6 +60,11 @@ const _default: FrontendPlugin<
             }
           >;
       inputs: {};
+      params: {
+        defaultPath: string;
+        loader: () => Promise<JSX.Element>;
+        routeRef?: RouteRef<AnyRouteRefParams> | undefined;
+      };
     }>;
     'nav-item:devtools': ExtensionDefinition<{
       kind: 'nav-item';
@@ -74,6 +82,11 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        title: string;
+        icon: IconComponent;
+        routeRef: RouteRef<undefined>;
+      };
     }>;
   }
 >;

--- a/plugins/home/api-report-alpha.md
+++ b/plugins/home/api-report-alpha.md
@@ -62,6 +62,11 @@ const _default: FrontendPlugin<
       kind: 'page';
       namespace: undefined;
       name: undefined;
+      params: {
+        defaultPath: string;
+        loader: () => Promise<JSX.Element>;
+        routeRef?: RouteRef<AnyRouteRefParams> | undefined;
+      };
     }>;
   }
 >;

--- a/plugins/kubernetes/api-report-alpha.md
+++ b/plugins/kubernetes/api-report-alpha.md
@@ -33,6 +33,9 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
     'page:kubernetes': ExtensionDefinition<{
       kind: 'page';
@@ -55,6 +58,11 @@ const _default: FrontendPlugin<
             }
           >;
       inputs: {};
+      params: {
+        defaultPath: string;
+        loader: () => Promise<JSX.Element>;
+        routeRef?: RouteRef<AnyRouteRefParams> | undefined;
+      };
     }>;
     'entity-content:kubernetes/kubernetes': ExtensionDefinition<{
       kind: 'entity-content';
@@ -100,6 +108,13 @@ const _default: FrontendPlugin<
             }
           >;
       inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+        defaultPath: string;
+        defaultTitle: string;
+        routeRef?: RouteRef<AnyRouteRefParams> | undefined;
+        filter?: string | ((entity: Entity) => boolean) | undefined;
+      };
     }>;
     'api:kubernetes/proxy': ExtensionDefinition<{
       kind: 'api';
@@ -113,6 +128,9 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
     'api:kubernetes/auth-providers': ExtensionDefinition<{
       kind: 'api';
@@ -126,6 +144,9 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
     'api:kubernetes/cluster-link-formatter': ExtensionDefinition<{
       kind: 'api';
@@ -139,6 +160,9 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
   }
 >;

--- a/plugins/org/api-report-alpha.md
+++ b/plugins/org/api-report-alpha.md
@@ -48,6 +48,10 @@ const _default: FrontendPlugin<
             }
           >;
       inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+        filter?: string | ((entity: Entity) => boolean) | undefined;
+      };
     }>;
     'entity-card:org/members-list': ExtensionDefinition<{
       kind: 'entity-card';
@@ -80,6 +84,10 @@ const _default: FrontendPlugin<
             }
           >;
       inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+        filter?: string | ((entity: Entity) => boolean) | undefined;
+      };
     }>;
     'entity-card:org/ownership': ExtensionDefinition<{
       kind: 'entity-card';
@@ -112,6 +120,10 @@ const _default: FrontendPlugin<
             }
           >;
       inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+        filter?: string | ((entity: Entity) => boolean) | undefined;
+      };
     }>;
     'entity-card:org/user-profile': ExtensionDefinition<{
       kind: 'entity-card';
@@ -144,6 +156,10 @@ const _default: FrontendPlugin<
             }
           >;
       inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+        filter?: string | ((entity: Entity) => boolean) | undefined;
+      };
     }>;
   }
 >;

--- a/plugins/scaffolder/api-report-alpha.md
+++ b/plugins/scaffolder/api-report-alpha.md
@@ -56,6 +56,9 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
     'page:scaffolder': ExtensionDefinition<{
       kind: 'page';
@@ -82,6 +85,11 @@ const _default: FrontendPlugin<
             }
           >;
       inputs: {};
+      params: {
+        defaultPath: string;
+        loader: () => Promise<JSX.Element>;
+        routeRef?: RouteRef<AnyRouteRefParams> | undefined;
+      };
     }>;
     'nav-item:scaffolder': ExtensionDefinition<{
       kind: 'nav-item';
@@ -99,6 +107,11 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        title: string;
+        icon: IconComponent;
+        routeRef: RouteRef<undefined>;
+      };
     }>;
   }
 >;

--- a/plugins/search/api-report-alpha.md
+++ b/plugins/search/api-report-alpha.md
@@ -34,6 +34,9 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
     'nav-item:search': ExtensionDefinition<{
       kind: 'nav-item';
@@ -51,6 +54,11 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        title: string;
+        icon: IconComponent;
+        routeRef: RouteRef<undefined>;
+      };
     }>;
     'page:search': ExtensionDefinition<{
       config: {
@@ -96,6 +104,11 @@ const _default: FrontendPlugin<
       kind: 'page';
       namespace: undefined;
       name: undefined;
+      params: {
+        defaultPath: string;
+        loader: () => Promise<JSX.Element>;
+        routeRef?: RouteRef<AnyRouteRefParams> | undefined;
+      };
     }>;
   }
 >;
@@ -110,6 +123,9 @@ export const searchApi: ExtensionDefinition<{
   configInput: {};
   output: ConfigurableExtensionDataRef<AnyApiFactory, 'core.api.factory', {}>;
   inputs: {};
+  params: {
+    factory: AnyApiFactory;
+  };
 }>;
 
 // @alpha (undocumented)
@@ -129,6 +145,11 @@ export const searchNavItem: ExtensionDefinition<{
     {}
   >;
   inputs: {};
+  params: {
+    title: string;
+    icon: IconComponent;
+    routeRef: RouteRef<undefined>;
+  };
 }>;
 
 // @alpha (undocumented)
@@ -172,6 +193,11 @@ export const searchPage: ExtensionDefinition<{
   kind: 'page';
   namespace: undefined;
   name: undefined;
+  params: {
+    defaultPath: string;
+    loader: () => Promise<JSX.Element>;
+    routeRef?: RouteRef<AnyRouteRefParams> | undefined;
+  };
 }>;
 
 // (No @packageDocumentation comment for this package)

--- a/plugins/techdocs/api-report-alpha.md
+++ b/plugins/techdocs/api-report-alpha.md
@@ -16,6 +16,7 @@ import { default as React_2 } from 'react';
 import { RouteRef } from '@backstage/frontend-plugin-api';
 import { SearchResultItemExtensionComponent } from '@backstage/plugin-search-react/alpha';
 import { SearchResultItemExtensionPredicate } from '@backstage/plugin-search-react/alpha';
+import { SearchResultListItemBlueprintParams } from '@backstage/plugin-search-react/alpha';
 
 // @alpha (undocumented)
 const _default: FrontendPlugin<
@@ -42,6 +43,9 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
     'page:techdocs': ExtensionDefinition<{
       kind: 'page';
@@ -68,6 +72,11 @@ const _default: FrontendPlugin<
             }
           >;
       inputs: {};
+      params: {
+        defaultPath: string;
+        loader: () => Promise<JSX.Element>;
+        routeRef?: RouteRef<AnyRouteRefParams> | undefined;
+      };
     }>;
     'nav-item:techdocs': ExtensionDefinition<{
       kind: 'nav-item';
@@ -85,6 +94,11 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        title: string;
+        icon: IconComponent;
+        routeRef: RouteRef<undefined>;
+      };
     }>;
     'api:techdocs/storage': ExtensionDefinition<{
       kind: 'api';
@@ -98,6 +112,9 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
     }>;
     'search-result-list-item:techdocs': ExtensionDefinition<{
       config: {
@@ -136,6 +153,7 @@ const _default: FrontendPlugin<
       kind: 'search-result-list-item';
       namespace: undefined;
       name: undefined;
+      params: SearchResultListItemBlueprintParams;
     }>;
     'page:techdocs/reader': ExtensionDefinition<{
       kind: 'page';
@@ -162,6 +180,11 @@ const _default: FrontendPlugin<
             }
           >;
       inputs: {};
+      params: {
+        defaultPath: string;
+        loader: () => Promise<JSX.Element>;
+        routeRef?: RouteRef<AnyRouteRefParams> | undefined;
+      };
     }>;
     'entity-content:techdocs': ExtensionDefinition<{
       config: {
@@ -223,6 +246,13 @@ const _default: FrontendPlugin<
       kind: 'entity-content';
       namespace: undefined;
       name: undefined;
+      params: {
+        loader: () => Promise<JSX.Element>;
+        defaultPath: string;
+        defaultTitle: string;
+        routeRef?: RouteRef<AnyRouteRefParams> | undefined;
+        filter?: string | ((entity: Entity) => boolean) | undefined;
+      };
     }>;
     'empty-state:techdocs/entity-content': ExtensionDefinition<{
       config: {};
@@ -243,6 +273,7 @@ const _default: FrontendPlugin<
           }
         >;
       };
+      params: never;
       kind: 'empty-state';
       namespace: undefined;
       name: 'entity-content';
@@ -289,6 +320,7 @@ export const techDocsSearchResultListItemExtension: ExtensionDefinition<{
   kind: 'search-result-list-item';
   namespace: undefined;
   name: undefined;
+  params: SearchResultListItemBlueprintParams;
 }>;
 
 // (No @packageDocumentation comment for this package)

--- a/plugins/user-settings/api-report-alpha.md
+++ b/plugins/user-settings/api-report-alpha.md
@@ -36,6 +36,11 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
+      params: {
+        title: string;
+        icon: IconComponent;
+        routeRef: RouteRef<undefined>;
+      };
     }>;
     'page:user-settings': ExtensionDefinition<{
       config: {
@@ -74,6 +79,11 @@ const _default: FrontendPlugin<
       kind: 'page';
       namespace: undefined;
       name: undefined;
+      params: {
+        defaultPath: string;
+        loader: () => Promise<JSX.Element>;
+        routeRef?: RouteRef<AnyRouteRefParams> | undefined;
+      };
     }>;
   }
 >;
@@ -96,6 +106,11 @@ export const settingsNavItem: ExtensionDefinition<{
     {}
   >;
   inputs: {};
+  params: {
+    title: string;
+    icon: IconComponent;
+    routeRef: RouteRef<undefined>;
+  };
 }>;
 
 // @alpha (undocumented)


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds support for overriding blueprint parameters when overriding any extension that was originally created from a blueprint. It lifts the `.override` API up to the same level as the blueprints, making the majority of override use-cases much simpler to implement. It avoids the need to mess around with extension data, which was and is intended to be the lower level API that you don't need to touch unless you're implementing more advanced patterns.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
