### PR TITLE
fix(catalog-backend-module-gerrit): add schedule in config.d.ts

### DIFF
--- a/.changeset/cyan-cooks-sing.md
+++ b/.changeset/cyan-cooks-sing.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend-module-gerrit': patch
 ---
 
-Add missing `schedule` key in `config.d.ts`
+Fixed an issue preventing the provider's `schedule` config from being applied."

--- a/.changeset/cyan-cooks-sing.md
+++ b/.changeset/cyan-cooks-sing.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-gerrit': patch
+---
+
+Add missing `schedule` key in `config.d.ts`

--- a/plugins/catalog-backend-module-gerrit/config.d.ts
+++ b/plugins/catalog-backend-module-gerrit/config.d.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { SchedulerServiceTaskScheduleDefinition } from '@backstage/backend-plugin-api';
+
 export interface Config {
   catalog?: {
     /**
@@ -41,6 +43,10 @@ export interface Config {
            * The branch where the provider will try to find entities. Defaults to "master".
            */
           branch?: string;
+          /**
+           * (Optional) TaskScheduleDefinition for the discovery.
+           */
+          schedule?: SchedulerServiceTaskScheduleDefinition;
         };
       };
     };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add missing `schedule` key in `config.d.ts` for `catalog-backend-module-gerrit` plugin.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] ~Added or updated documentation~
- [X] ~Tests for new functionality and regression tests for bug fixes~
- [X] ~Screenshots attached (for UI changes)~
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
