### PR TITLE
fix extra divider in owner list picker on tasks list page

### DIFF
--- a/.changeset/angry-windows-decide.md
+++ b/.changeset/angry-windows-decide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Fix extra divider displayed in owner list picker on list tasks page

--- a/plugins/scaffolder/src/components/ListTasksPage/OwnerListPicker.tsx
+++ b/plugins/scaffolder/src/components/ListTasksPage/OwnerListPicker.tsx
@@ -113,10 +113,10 @@ export const OwnerListPicker = (props: {
           </Typography>
           <Card className={classes.groupWrapper}>
             <List disablePadding dense role="menu">
-              {group.items.map(item => (
+              {group.items.map((item, index) => (
                 <MenuItem
                   key={item.id}
-                  divider
+                  divider={index !== group.items.length - 1}
                   ContainerProps={{ role: 'menuitem' }}
                   onClick={() => onSelectOwner(item.id as 'owned' | 'all')}
                   selected={item.id === filter}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Similar fix as #25580 
Fixes extra divider showed on the owner list picker on the tasks list page

Before:
<img width="226" alt="image" src="https://github.com/user-attachments/assets/12896b86-af7c-4334-bc08-4a8546943276">


After:
<img width="259" alt="image" src="https://github.com/user-attachments/assets/a71a6311-83bd-48fc-b273-6f7ad4ffc82e">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
