### PR TITLE
change task lists created at column to use timestamp

### DIFF
--- a/.changeset/dry-frogs-drum.md
+++ b/.changeset/dry-frogs-drum.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Change task list created at column to show timestamp

--- a/plugins/scaffolder/src/components/ListTasksPage/columns/CreatedAtColumn.test.tsx
+++ b/plugins/scaffolder/src/components/ListTasksPage/columns/CreatedAtColumn.test.tsx
@@ -13,26 +13,48 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import { renderInTestApp } from '@backstage/test-utils';
-
 import React from 'react';
 import { CreatedAtColumn } from './CreatedAtColumn';
-import { DateTime } from 'luxon';
+import { renderInTestApp } from '@backstage/test-utils';
 
 describe('<CreatedAtColumn />', () => {
-  it('should render the column with the time', async () => {
-    const props = {
-      createdAt: DateTime.now().toISO(),
-    };
+  const testDate = '2024-09-22T13:30:00Z';
 
-    const formattedTime = DateTime.fromISO(props.createdAt).toLocaleString(
-      DateTime.DATETIME_SHORT_WITH_SECONDS,
+  const mockNavigatorLanguage = (language: string) => {
+    jest.spyOn(window.navigator, 'language', 'get').mockReturnValue(language);
+  };
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should render the column using mocked locale (de-DE)', async () => {
+    mockNavigatorLanguage('de-DE');
+    const { getByText } = await renderInTestApp(
+      <CreatedAtColumn createdAt={testDate} />,
     );
+    expect(getByText('22.9.2024, 13:30:00')).toBeDefined();
+  });
 
-    const { getByText } = await renderInTestApp(<CreatedAtColumn {...props} />);
+  it('should render the column with the default locale (en-US)', async () => {
+    mockNavigatorLanguage('');
+    const { getByText } = await renderInTestApp(
+      <CreatedAtColumn createdAt={testDate} />,
+    );
+    expect(getByText('9/22/2024, 1:30:00 PM')).toBeDefined();
+  });
 
-    const text = getByText(formattedTime);
-    expect(text).toBeDefined();
+  it('should render the column with a specified locale (fr-FR)', async () => {
+    const { getByText } = await renderInTestApp(
+      <CreatedAtColumn createdAt={testDate} locale="fr-FR" />,
+    );
+    expect(getByText('22/09/2024 13:30:00')).toBeDefined();
+  });
+
+  it('should render the column with a specified locale (en-DE)', async () => {
+    const { getByText } = await renderInTestApp(
+      <CreatedAtColumn createdAt={testDate} locale="en-DE" />,
+    );
+    expect(getByText('22/09/2024, 13:30:00')).toBeDefined();
   });
 });

--- a/plugins/scaffolder/src/components/ListTasksPage/columns/CreatedAtColumn.test.tsx
+++ b/plugins/scaffolder/src/components/ListTasksPage/columns/CreatedAtColumn.test.tsx
@@ -23,12 +23,16 @@ import { DateTime } from 'luxon';
 describe('<CreatedAtColumn />', () => {
   it('should render the column with the time', async () => {
     const props = {
-      createdAt: DateTime.now().toISO()!,
+      createdAt: DateTime.now().toISO(),
     };
+
+    const formattedTime = DateTime.fromISO(props.createdAt).toLocaleString(
+      DateTime.DATETIME_SHORT_WITH_SECONDS,
+    );
 
     const { getByText } = await renderInTestApp(<CreatedAtColumn {...props} />);
 
-    const text = getByText('0 seconds ago');
+    const text = getByText(formattedTime);
     expect(text).toBeDefined();
   });
 });

--- a/plugins/scaffolder/src/components/ListTasksPage/columns/CreatedAtColumn.tsx
+++ b/plugins/scaffolder/src/components/ListTasksPage/columns/CreatedAtColumn.tsx
@@ -17,11 +17,22 @@ import { DateTime } from 'luxon';
 import React from 'react';
 import Typography from '@material-ui/core/Typography';
 
-export const CreatedAtColumn = ({ createdAt }: { createdAt: string }) => {
+interface CreatedAtColumnProps {
+  createdAt: string;
+  locale?: string;
+}
+
+export const CreatedAtColumn: React.FC<CreatedAtColumnProps> = ({
+  createdAt,
+  locale,
+}) => {
   const createdAtTime = DateTime.fromISO(createdAt);
-  const formatted = createdAtTime.toLocaleString(
-    DateTime.DATETIME_SHORT_WITH_SECONDS,
-  );
+
+  const userLocale = locale || window.navigator.language || 'en-US';
+
+  const formatted = createdAtTime.setLocale(userLocale).toLocaleString({
+    ...DateTime.DATETIME_SHORT_WITH_SECONDS,
+  });
 
   return <Typography paragraph>{formatted}</Typography>;
 };

--- a/plugins/scaffolder/src/components/ListTasksPage/columns/CreatedAtColumn.tsx
+++ b/plugins/scaffolder/src/components/ListTasksPage/columns/CreatedAtColumn.tsx
@@ -13,20 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { DateTime, Interval } from 'luxon';
-import humanizeDuration from 'humanize-duration';
+import { DateTime } from 'luxon';
 import React from 'react';
 import Typography from '@material-ui/core/Typography';
 
 export const CreatedAtColumn = ({ createdAt }: { createdAt: string }) => {
   const createdAtTime = DateTime.fromISO(createdAt);
-  const formatted = Interval.fromDateTimes(createdAtTime, DateTime.local())
-    .toDuration()
-    .valueOf();
-
-  return (
-    <Typography paragraph>
-      {humanizeDuration(formatted, { round: true })} ago
-    </Typography>
+  const formatted = createdAtTime.toLocaleString(
+    DateTime.DATETIME_SHORT_WITH_SECONDS,
   );
+
+  return <Typography paragraph>{formatted}</Typography>;
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The tasks list created at column displays relative time in a format like:
`8 months, 1 week, 19 hours, 46 minutes, 40 seconds`

However, when you want to find a task that has ran near a date or time then rendering it this way makes this difficult since it is all relative to the current date.

This PR changes the created at column on tasks list page to show timestamp for easier visual searching. Example:
`9/18/2024, 9:51:37 PM`

Before:
<img width="1051" alt="Screenshot 2024-09-18 at 9 52 52 PM" src="https://github.com/user-attachments/assets/c27d4997-d605-4af4-a858-4858f94372e3">

After:
<img width="1051" alt="Screenshot 2024-09-18 at 9 53 47 PM" src="https://github.com/user-attachments/assets/50777b20-46f5-46f8-ac22-d444679d0ec4">

Feedback appreciated as always!

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
