### PR TITLE
perf: improve performance of scaffolder secret widget 

### DIFF
--- a/.changeset/silent-gifts-dream.md
+++ b/.changeset/silent-gifts-dream.md
@@ -1,5 +1,4 @@
 ---
-'@backstage/plugin-scaffolder': patch
 '@backstage/plugin-scaffolder-react': patch
 ---
 

--- a/.changeset/silent-gifts-dream.md
+++ b/.changeset/silent-gifts-dream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+Improve performance of typing into scaffolder secret widget

--- a/.changeset/silent-gifts-dream.md
+++ b/.changeset/silent-gifts-dream.md
@@ -1,4 +1,5 @@
 ---
+'@backstage/plugin-scaffolder': patch
 '@backstage/plugin-scaffolder-react': patch
 ---
 

--- a/plugins/scaffolder/src/components/fields/SecretInput/SecretInput.test.tsx
+++ b/plugins/scaffolder/src/components/fields/SecretInput/SecretInput.test.tsx
@@ -22,7 +22,7 @@ import { SecretInput } from './SecretInput';
 import { renderInTestApp } from '@backstage/test-utils';
 import { Form } from '@backstage/plugin-scaffolder-react/alpha';
 import validator from '@rjsf/validator-ajv8';
-import { fireEvent, act } from '@testing-library/react';
+import { fireEvent, act, waitFor } from '@testing-library/react';
 
 describe('<SecretInput />', () => {
   const SecretsComponent = () => {
@@ -63,8 +63,15 @@ describe('<SecretInput />', () => {
       fireEvent.change(secretInput, { target: { value: mockSecret } });
     });
 
-    const { secrets } = JSON.parse(getByTestId('current-secrets').textContent!);
-
-    expect(secrets.myKey).toBe(mockSecret);
+    // Wait for the debounced update to occur
+    await waitFor(
+      () => {
+        const { secrets } = JSON.parse(
+          getByTestId('current-secrets').textContent!,
+        );
+        expect(secrets.myKey).toBe(mockSecret);
+      },
+      { timeout: 500 },
+    );
   });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Typing into scaffolder secret widget is very slow on some machines. On my Windows laptop with an i5 processor its laggy but on my M2 pro macbook it's fine. However, using dev tools CPU throttler you can mock this for testing and notice the performance. 4x throttle on my M2 pro is similar to perf to the i5 windows laptop.

This PR adds debouncing to scaffolder secret widget inputs and updates state management to allow for immediate updates instead on waiting for global state updates.

Before improvements (with 4x throttle on M2 pro):

https://github.com/user-attachments/assets/d2ff9c47-6364-40bc-9b01-a8025c8d063d

After improvements (with 4x throttle on M2 pro):

https://github.com/user-attachments/assets/f85a6468-feaa-406f-a4d9-25ba663eb1ba



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
