### PR TITLE
backend-app-api: settle all inits before exiting on error

### DIFF
--- a/.changeset/rich-deers-attend.md
+++ b/.changeset/rich-deers-attend.md
@@ -1,0 +1,7 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+The backend will no longer exit immediately if any plugin or modules fails to initialize. Instead, the backend will wait for all plugins and modules to either start up successfully or throw, and then shut down the backend if there were any initialization errors.
+
+This fixes an issue where backend initialization errors in adjacent plugins during database schema migration could cause the database migrations to be stuck in a locked state.

--- a/packages/backend-app-api/src/wiring/BackendInitializer.ts
+++ b/packages/backend-app-api/src/wiring/BackendInitializer.ts
@@ -277,71 +277,76 @@ export class BackendInitializer {
     // All plugins are initialized in parallel
     const results = await Promise.allSettled(
       allPluginIds.map(async pluginId => {
-        // Initialize all eager services
-        await this.#serviceRegistry.initializeEagerServicesWithScope(
-          'plugin',
-          pluginId,
-        );
-
-        // Modules are initialized before plugins, so that they can provide extension to the plugin
-        const modules = moduleInits.get(pluginId);
-        if (modules) {
-          const tree = DependencyGraph.fromIterable(
-            Array.from(modules).map(([moduleId, moduleInit]) => ({
-              value: { moduleId, moduleInit },
-              // Relationships are reversed at this point since we're only interested in the extension points.
-              // If a modules provides extension point A we want it to be initialized AFTER all modules
-              // that depend on extension point A, so that they can provide their extensions.
-              consumes: Array.from(moduleInit.provides).map(p => p.id),
-              provides: Array.from(moduleInit.consumes).map(c => c.id),
-            })),
-          );
-          const circular = tree.detectCircularDependency();
-          if (circular) {
-            throw new ConflictError(
-              `Circular dependency detected for modules of plugin '${pluginId}', ${circular
-                .map(({ moduleId }) => `'${moduleId}'`)
-                .join(' -> ')}`,
-            );
-          }
-          await tree.parallelTopologicalTraversal(
-            async ({ moduleId, moduleInit }) => {
-              const moduleDeps = await this.#getInitDeps(
-                moduleInit.init.deps,
-                pluginId,
-                moduleId,
-              );
-              await moduleInit.init.func(moduleDeps).catch(error => {
-                throw new ForwardedError(
-                  `Module '${moduleId}' for plugin '${pluginId}' startup failed`,
-                  error,
-                );
-              });
-            },
-          );
-        }
-
-        // Once all modules have been initialized, we can initialize the plugin itself
-        const pluginInit = pluginInits.get(pluginId);
-        // We allow modules to be installed without the accompanying plugin, so the plugin may not exist
-        if (pluginInit) {
-          const pluginDeps = await this.#getInitDeps(
-            pluginInit.init.deps,
+        try {
+          // Initialize all eager services
+          await this.#serviceRegistry.initializeEagerServicesWithScope(
+            'plugin',
             pluginId,
           );
-          await pluginInit.init.func(pluginDeps).catch(error => {
-            throw new ForwardedError(
-              `Plugin '${pluginId}' startup failed`,
-              error,
+
+          // Modules are initialized before plugins, so that they can provide extension to the plugin
+          const modules = moduleInits.get(pluginId);
+          if (modules) {
+            const tree = DependencyGraph.fromIterable(
+              Array.from(modules).map(([moduleId, moduleInit]) => ({
+                value: { moduleId, moduleInit },
+                // Relationships are reversed at this point since we're only interested in the extension points.
+                // If a modules provides extension point A we want it to be initialized AFTER all modules
+                // that depend on extension point A, so that they can provide their extensions.
+                consumes: Array.from(moduleInit.provides).map(p => p.id),
+                provides: Array.from(moduleInit.consumes).map(c => c.id),
+              })),
             );
-          });
+            const circular = tree.detectCircularDependency();
+            if (circular) {
+              throw new ConflictError(
+                `Circular dependency detected for modules of plugin '${pluginId}', ${circular
+                  .map(({ moduleId }) => `'${moduleId}'`)
+                  .join(' -> ')}`,
+              );
+            }
+            await tree.parallelTopologicalTraversal(
+              async ({ moduleId, moduleInit }) => {
+                const moduleDeps = await this.#getInitDeps(
+                  moduleInit.init.deps,
+                  pluginId,
+                  moduleId,
+                );
+                await moduleInit.init.func(moduleDeps).catch(error => {
+                  throw new ForwardedError(
+                    `Module '${moduleId}' for plugin '${pluginId}' startup failed`,
+                    error,
+                  );
+                });
+              },
+            );
+          }
+
+          // Once all modules have been initialized, we can initialize the plugin itself
+          const pluginInit = pluginInits.get(pluginId);
+          // We allow modules to be installed without the accompanying plugin, so the plugin may not exist
+          if (pluginInit) {
+            const pluginDeps = await this.#getInitDeps(
+              pluginInit.init.deps,
+              pluginId,
+            );
+            await pluginInit.init.func(pluginDeps).catch(error => {
+              throw new ForwardedError(
+                `Plugin '${pluginId}' startup failed`,
+                error,
+              );
+            });
+          }
+
+          initLogger.onPluginStarted(pluginId);
+
+          // Once the plugin and all modules have been initialized, we can signal that the plugin has stared up successfully
+          const lifecycleService = await this.#getPluginLifecycleImpl(pluginId);
+          await lifecycleService.startup();
+        } catch (error) {
+          initLogger.onPluginFailed(pluginId);
+          throw error;
         }
-
-        initLogger.onPluginStarted(pluginId);
-
-        // Once the plugin and all modules have been initialized, we can signal that the plugin has stared up successfully
-        const lifecycleService = await this.#getPluginLifecycleImpl(pluginId);
-        await lifecycleService.startup();
       }),
     );
 

--- a/packages/backend-app-api/src/wiring/createInitializationLogger.ts
+++ b/packages/backend-app-api/src/wiring/createInitializationLogger.ts
@@ -27,6 +27,7 @@ export function createInitializationLogger(
   rootLogger?: RootLoggerService,
 ): {
   onPluginStarted(pluginId: string): void;
+  onPluginFailed(pluginId: string): void;
   onAllStarted(): void;
 } {
   const logger = rootLogger?.child({ type: 'initialization' });
@@ -66,6 +67,16 @@ export function createInitializationLogger(
     onPluginStarted(pluginId: string) {
       starting.delete(pluginId);
       started.add(pluginId);
+    },
+    onPluginFailed(pluginId: string) {
+      starting.delete(pluginId);
+      const status =
+        starting.size > 0
+          ? `, waiting for ${starting.size} other plugins to finish before shutting down the process`
+          : '';
+      logger?.error(
+        `Plugin '${pluginId}' thew an error during startup${status}`,
+      );
     },
     onAllStarted() {
       logger?.info(`Plugin initialization complete${getInitStatus()}`);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

We're expecting this to fix a lot of the DB migration lock errors that are being encountered. Shutting down the backend violently in the middle of plugin initalization doesn't seem like a good idea. Instead we wait for all plugins to either succeed or fail to initialize, and then react to any errors.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
