### PR TITLE
fix: propagate environment for bitbucket-server-auth

### DIFF
--- a/.changeset/happy-ligers-think.md
+++ b/.changeset/happy-ligers-think.md
@@ -1,0 +1,5 @@
+---
+'@backstage/app-defaults': patch
+---
+
+Updated the `bitbucket-server-auth` default API to set its environment based on the `auth.environment` config option instead of being hardcoded to `development`.

--- a/packages/app-defaults/src/defaults/apis.ts
+++ b/packages/app-defaults/src/defaults/apis.ts
@@ -243,6 +243,7 @@ export const apis = [
         discoveryApi,
         oauthRequestApi,
         defaultScopes: ['REPO_READ'],
+        environment: configApi.getOptionalString('auth.environment'),
       }),
   }),
   createApiFactory({

--- a/plugins/app/src/defaultApis.ts
+++ b/plugins/app/src/defaultApis.ts
@@ -318,6 +318,7 @@ export const apis = [
             discoveryApi,
             oauthRequestApi,
             defaultScopes: ['REPO_READ'],
+            environment: configApi.getOptionalString('auth.environment'),
           }),
       }),
     },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Unlike all other auth providers, the bitbucket-server-auth provider didn't get `environment` passed as a parameter from the config.
Because of this it *always* used the default value for the arg: `development`
https://github.com/backstage/backstage/blob/master/packages/core-app-api/src/apis/implementations/auth/bitbucketServer/BitbucketServerAuth.ts#L53

This caused a bug where if you tried to use it in a `production` environment, it would still redirect to `development` for logging in, and since no backend handler was registered for that, it resulted in an error.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
