### PR TITLE
[Scaffolder] Create a separate form route

### DIFF
--- a/.changeset/cyan-peaches-lay.md
+++ b/.changeset/cyan-peaches-lay.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Create a separate route for the template form editor so we refresh it without being redirected to scaffolder edit page.

--- a/plugins/scaffolder/api-report-alpha.md
+++ b/plugins/scaffolder/api-report-alpha.md
@@ -229,6 +229,8 @@ export const scaffolderTranslationRef: TranslationRef<
     readonly 'ongoingTask.showLogsButtonTitle': 'Show Logs';
     readonly 'templateEditorForm.stepper.emptyText': 'There are no spec parameters in the template to preview.';
     readonly 'templateTypePicker.title': 'Categories';
+    readonly 'templateFormPage.title': 'Template Form Playground';
+    readonly 'templateFormPage.subtitle': 'Edit, preview, and try out templates and template forms';
     readonly 'templateEditorPage.title': 'Template Editor';
     readonly 'templateEditorPage.subtitle': 'Edit, preview, and try out templates and template forms';
     readonly 'templateEditorPage.dryRunResults.title': 'Dry-run results';

--- a/plugins/scaffolder/api-report.md
+++ b/plugins/scaffolder/api-report.md
@@ -614,6 +614,7 @@ export const scaffolderPlugin: BackstagePlugin<
     edit: SubRouteRef<undefined>;
     editor: SubRouteRef<undefined>;
     customFields: SubRouteRef<undefined>;
+    templateForm: SubRouteRef<undefined>;
   },
   {
     registerComponent: ExternalRouteRef<undefined, true>;

--- a/plugins/scaffolder/src/components/Router/Router.tsx
+++ b/plugins/scaffolder/src/components/Router/Router.tsx
@@ -40,6 +40,7 @@ import {
   scaffolderListTaskRouteRef,
   scaffolderTaskRouteRef,
   selectedTemplateRouteRef,
+  templateFormRouteRef,
 } from '../../routes';
 import { ErrorPage } from '@backstage/core-components';
 
@@ -54,6 +55,7 @@ import { TemplateListPage, TemplateWizardPage } from '../../next';
 import { OngoingTask } from '../OngoingTask';
 import {
   TemplatePage,
+  TemplateFormPage,
   TemplateEditorPage,
   CustomFieldsPage,
 } from '../../next/TemplateEditorPage';
@@ -169,11 +171,7 @@ export const Router = (props: PropsWithChildren<RouterProps>) => {
         path={editRouteRef.path}
         element={
           <SecretsContextProvider>
-            <TemplateEditorPage
-              customFieldExtensions={fieldExtensions}
-              layouts={customLayouts}
-              formProps={props.formProps}
-            />
+            <TemplateEditorPage />
           </SecretsContextProvider>
         }
       />
@@ -182,6 +180,18 @@ export const Router = (props: PropsWithChildren<RouterProps>) => {
         element={
           <SecretsContextProvider>
             <CustomFieldsPage fieldExtensions={fieldExtensions} />
+          </SecretsContextProvider>
+        }
+      />
+      <Route
+        path={templateFormRouteRef.path}
+        element={
+          <SecretsContextProvider>
+            <TemplateFormPage
+              layouts={customLayouts}
+              formProps={props.formProps}
+              fieldExtensions={fieldExtensions}
+            />
           </SecretsContextProvider>
         }
       />

--- a/plugins/scaffolder/src/next/TemplateEditorPage/TemplateEditorPage.tsx
+++ b/plugins/scaffolder/src/next/TemplateEditorPage/TemplateEditorPage.tsx
@@ -13,18 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { useState } from 'react';
+import React from 'react';
 import { Content, Header, Page } from '@backstage/core-components';
-import {
-  TemplateDirectoryAccess,
-  WebFileSystemAccess,
-} from '../../lib/filesystem';
-import { TemplateFormPreviewer } from './TemplateFormPreviewer';
-import {
-  FieldExtensionOptions,
-  FormProps,
-  type LayoutOptions,
-} from '@backstage/plugin-scaffolder-react';
+import { WebFileSystemAccess } from '../../lib/filesystem';
 import { TemplateEditorIntro } from './TemplateEditorIntro';
 import { ScaffolderPageContextMenu } from '@backstage/plugin-scaffolder-react/alpha';
 import { useNavigate } from 'react-router-dom';
@@ -35,42 +26,21 @@ import {
   customFieldsRouteRef,
   rootRouteRef,
   scaffolderListTaskRouteRef,
+  templateFormRouteRef,
 } from '../../routes';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { scaffolderTranslationRef } from '../../translation';
 import { WebFileSystemStore } from '../../lib/filesystem/WebFileSystemAccess';
 import { createExampleTemplate } from '../../lib/filesystem/createExampleTemplate';
 
-type Selection =
-  | {
-      type: 'local';
-      directory: TemplateDirectoryAccess;
-    }
-  | {
-      type: 'create-template';
-    }
-  | {
-      type: 'form';
-    }
-  | {
-      type: 'field-explorer';
-    };
-
-interface TemplateEditorPageProps {
-  defaultPreviewTemplate?: string;
-  customFieldExtensions?: FieldExtensionOptions<any, any>[];
-  layouts?: LayoutOptions[];
-  formProps?: FormProps;
-}
-
-export function TemplateEditorPage(props: TemplateEditorPageProps) {
-  const [selection, setSelection] = useState<Selection>();
+export function TemplateEditorPage() {
   const navigate = useNavigate();
   const actionsLink = useRouteRef(actionsRouteRef);
   const tasksLink = useRouteRef(scaffolderListTaskRouteRef);
   const createLink = useRouteRef(rootRouteRef);
   const editorLink = useRouteRef(editorRouteRef);
   const customFieldsLink = useRouteRef(customFieldsRouteRef);
+  const templateFormLink = useRouteRef(templateFormRouteRef);
   const { t } = useTranslationRef(scaffolderTranslationRef);
 
   const scaffolderPageContextMenuProps = {
@@ -80,19 +50,14 @@ export function TemplateEditorPage(props: TemplateEditorPageProps) {
     onCreateClicked: () => navigate(createLink()),
   };
 
-  let content: JSX.Element | null = null;
-  if (selection?.type === 'form') {
-    content = (
-      <TemplateFormPreviewer
-        defaultPreviewTemplate={props.defaultPreviewTemplate}
-        customFieldExtensions={props.customFieldExtensions}
-        onClose={() => setSelection(undefined)}
-        layouts={props.layouts}
-        formProps={props.formProps}
-      />
-    );
-  } else {
-    content = (
+  return (
+    <Page themeId="home">
+      <Header
+        title={t('templateEditorPage.title')}
+        subtitle={t('templateEditorPage.subtitle')}
+      >
+        <ScaffolderPageContextMenu {...scaffolderPageContextMenuProps} />
+      </Header>
       <Content>
         <TemplateEditorIntro
           onSelect={option => {
@@ -111,25 +76,13 @@ export function TemplateEditorPage(props: TemplateEditorPageProps) {
                 })
                 .catch(() => {});
             } else if (option === 'form') {
-              setSelection({ type: 'form' });
+              navigate(templateFormLink());
             } else if (option === 'field-explorer') {
               navigate(customFieldsLink());
             }
           }}
         />
       </Content>
-    );
-  }
-
-  return (
-    <Page themeId="home">
-      <Header
-        title={t('templateEditorPage.title')}
-        subtitle={t('templateEditorPage.subtitle')}
-      >
-        <ScaffolderPageContextMenu {...scaffolderPageContextMenuProps} />
-      </Header>
-      {content}
     </Page>
   );
 }

--- a/plugins/scaffolder/src/next/TemplateEditorPage/TemplateEditorToolbar.tsx
+++ b/plugins/scaffolder/src/next/TemplateEditorPage/TemplateEditorToolbar.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useState } from 'react';
+import React, { ReactNode, useState } from 'react';
 
 import { makeStyles } from '@material-ui/core/styles';
 import AppBar from '@material-ui/core/AppBar';
@@ -49,18 +49,29 @@ const useStyles = makeStyles(
     },
     toolbar: {
       display: 'grid',
-      justifyItems: 'flex-end',
+      gridTemplateColumns: 'auto 1fr',
+      gridGap: theme.spacing(1),
       padding: theme.spacing(0, 1),
       backgroundColor: theme.palette.background.paper,
+    },
+    toolbarCustomActions: {
+      display: 'grid',
+      alignItems: 'center',
+      gridAutoFlow: 'Column',
+      gridGap: theme.spacing(1),
+    },
+    toolbarDefaultActions: {
+      justifySelf: 'end',
     },
   }),
   { name: 'ScaffolderTemplateEditorToolbar' },
 );
 
 export function TemplateEditorToolbar(props: {
+  children?: ReactNode;
   fieldExtensions?: FieldExtensionOptions<any, any>[];
 }) {
-  const { fieldExtensions } = props;
+  const { children, fieldExtensions } = props;
   const classes = useStyles();
   const [showFieldsDrawer, setShowFieldsDrawer] = useState(false);
   const [showActionsDrawer, setShowActionsDrawer] = useState(false);
@@ -69,14 +80,19 @@ export function TemplateEditorToolbar(props: {
   return (
     <AppBar className={classes.appbar} position="relative">
       <Toolbar className={classes.toolbar}>
-        <ButtonGroup variant="outlined" color="primary">
+        <div className={classes.toolbarCustomActions}>{children}</div>
+        <ButtonGroup
+          className={classes.toolbarDefaultActions}
+          variant="outlined"
+          color="primary"
+        >
           <Tooltip title="Custom Fields Explorer">
-            <Button size="small" onClick={() => setShowFieldsDrawer(true)}>
+            <Button onClick={() => setShowFieldsDrawer(true)}>
               <ExtensionIcon />
             </Button>
           </Tooltip>
           <Tooltip title="Installed Actions Documentation">
-            <Button size="small" onClick={() => setShowActionsDrawer(true)}>
+            <Button onClick={() => setShowActionsDrawer(true)}>
               <DescriptionIcon />
             </Button>
           </Tooltip>

--- a/plugins/scaffolder/src/next/TemplateEditorPage/TemplateFormPage.tsx
+++ b/plugins/scaffolder/src/next/TemplateEditorPage/TemplateFormPage.tsx
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { makeStyles } from '@material-ui/core/styles';
+
+import { Page, Header, Content } from '@backstage/core-components';
+import { useRouteRef } from '@backstage/core-plugin-api';
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import {
+  FormProps,
+  LayoutOptions,
+  FieldExtensionOptions,
+} from '@backstage/plugin-scaffolder-react';
+
+import { editRouteRef } from '../../routes';
+import { scaffolderTranslationRef } from '../../translation';
+
+import { TemplateFormPreviewer } from './TemplateFormPreviewer';
+
+const useStyles = makeStyles({
+  root: {
+    padding: 0,
+  },
+});
+
+interface TemplateFormPageProps {
+  layouts?: LayoutOptions[];
+  formProps?: FormProps;
+  fieldExtensions?: FieldExtensionOptions<any, any>[];
+  defaultPreviewTemplate?: string;
+}
+
+export function TemplateFormPage(props: TemplateFormPageProps) {
+  const classes = useStyles();
+  const navigate = useNavigate();
+  const editLink = useRouteRef(editRouteRef);
+  const { t } = useTranslationRef(scaffolderTranslationRef);
+
+  const handleClose = useCallback(() => {
+    navigate(editLink());
+  }, [navigate, editLink]);
+
+  return (
+    <Page themeId="home">
+      <Header
+        title={t('templateEditorPage.title')}
+        subtitle={t('templateEditorPage.subtitle')}
+      />
+      <Content className={classes.root}>
+        <TemplateFormPreviewer
+          layouts={props.layouts}
+          formProps={props.formProps}
+          customFieldExtensions={props.fieldExtensions}
+          defaultPreviewTemplate={props.defaultPreviewTemplate}
+          onClose={handleClose}
+        />
+      </Content>
+    </Page>
+  );
+}

--- a/plugins/scaffolder/src/next/TemplateEditorPage/TemplateFormPage.tsx
+++ b/plugins/scaffolder/src/next/TemplateEditorPage/TemplateFormPage.tsx
@@ -59,8 +59,8 @@ export function TemplateFormPage(props: TemplateFormPageProps) {
   return (
     <Page themeId="home">
       <Header
-        title={t('templateEditorPage.title')}
-        subtitle={t('templateEditorPage.subtitle')}
+        title={t('templateFormPage.title')}
+        subtitle={t('templateFormPage.subtitle')}
       />
       <Content className={classes.root}>
         <TemplateFormPreviewer

--- a/plugins/scaffolder/src/next/TemplateEditorPage/index.ts
+++ b/plugins/scaffolder/src/next/TemplateEditorPage/index.ts
@@ -15,6 +15,7 @@
  */
 
 export { TemplatePage } from './TemplatePage';
+export { TemplateFormPage } from './TemplateFormPage';
 export { TemplateEditorPage } from './TemplateEditorPage';
 export { CustomFieldsPage } from './CustomFieldsPage';
 export type { ScaffolderCustomFieldExplorerClassKey } from './CustomFieldExplorer';

--- a/plugins/scaffolder/src/plugin.tsx
+++ b/plugins/scaffolder/src/plugin.tsx
@@ -70,6 +70,7 @@ import {
   editRouteRef,
   editorRouteRef,
   customFieldsRouteRef,
+  templateFormRouteRef,
 } from './routes';
 import {
   MyGroupsPicker,
@@ -111,6 +112,7 @@ export const scaffolderPlugin = createPlugin({
     edit: editRouteRef,
     editor: editorRouteRef,
     customFields: customFieldsRouteRef,
+    templateForm: templateFormRouteRef,
   },
   externalRoutes: {
     registerComponent: registerComponentRouteRef,

--- a/plugins/scaffolder/src/routes.ts
+++ b/plugins/scaffolder/src/routes.ts
@@ -86,7 +86,13 @@ export const editorRouteRef = createSubRouteRef({
 });
 
 export const customFieldsRouteRef = createSubRouteRef({
-  id: 'scaffolder/edit',
+  id: 'scaffolder/customFields',
   parent: rootRouteRef,
   path: '/custom-fields',
+});
+
+export const templateFormRouteRef = createSubRouteRef({
+  id: 'scaffolder/editorForm',
+  parent: rootRouteRef,
+  path: '/template-form',
 });

--- a/plugins/scaffolder/src/translation.ts
+++ b/plugins/scaffolder/src/translation.ts
@@ -192,6 +192,10 @@ export const scaffolderTranslationRef = createTranslationRef({
     templateTypePicker: {
       title: 'Categories',
     },
+    templateFormPage: {
+      title: 'Template Form Playground',
+      subtitle: 'Edit, preview, and try out templates and template forms',
+    },
     templateEditorPage: {
       title: 'Template Editor',
       subtitle: 'Edit, preview, and try out templates and template forms',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Create a separate route for the template form editor so we refresh it without being redirected to scaffolder edit page.

https://github.com/user-attachments/assets/713a140f-3809-42c8-8cc4-7c398bc2325a

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
