### PR TITLE
techdocs: make emptyState input optional on entityContent extension

### DIFF
--- a/.changeset/fifty-trainers-watch.md
+++ b/.changeset/fifty-trainers-watch.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Make `emptyState` input optional on `entity-content:techdocs` extension so that
+the default empty state extension works correctly.

--- a/plugins/techdocs/api-report-alpha.md
+++ b/plugins/techdocs/api-report-alpha.md
@@ -229,7 +229,9 @@ const _default: FrontendPlugin<
           ConfigurableExtensionDataRef<
             React_2.JSX.Element,
             'core.reactElement',
-            {}
+            {
+              optional: true;
+            }
           >,
           {
             singleton: true;

--- a/plugins/techdocs/src/alpha.tsx
+++ b/plugins/techdocs/src/alpha.tsx
@@ -157,10 +157,13 @@ const techDocsReaderPage = PageBlueprint.make({
  */
 const techDocsEntityContent = EntityContentBlueprint.makeWithOverrides({
   inputs: {
-    emptyState: createExtensionInput([coreExtensionData.reactElement], {
-      singleton: true,
-      optional: true,
-    }),
+    emptyState: createExtensionInput(
+      [coreExtensionData.reactElement.optional()],
+      {
+        singleton: true,
+        optional: true,
+      },
+    ),
   },
   factory(originalFactory, context) {
     return originalFactory(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes a bug introduced late in the game in https://github.com/backstage/backstage/pull/25775. When addressing [this comment](https://github.com/backstage/backstage/pull/25775#discussion_r1760912135), I missed the need to make the corresponding input type optional, which means that when the default empty state extension is used, its output type doesn't match.

The reason we didn't catch this in testing is because we currently don't use the new frontend system TechDocs plugin in app-next - it happens to be the plugin we use to test the legacy wrappers system. Might be a good plan to introduce a dedicated example legacy plugin for that purpose.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
