### PR TITLE
feat(gerrit-urlreader): support fetching content for a commit SHA hash

### DIFF
--- a/.changeset/light-sloths-report.md
+++ b/.changeset/light-sloths-report.md
@@ -1,0 +1,6 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+The `GerritUrlReader` can now read content from a commit and not only from the top of a branch. The
+Gitiles URL must contain the full commit `SHA` hash like: `https://gerrit.com/gitiles/repo/+/2846e8dc327ae2f60249983b1c3b96f42f205bae/catalog-info.yaml`.

--- a/.changeset/old-waves-camp.md
+++ b/.changeset/old-waves-camp.md
@@ -1,0 +1,13 @@
+---
+'@backstage/integration': patch
+---
+
+A new Gerrit helper function (`buildGerritGitilesArchiveUrlFromLocation`) has been added. This
+constructs a Gitiles URL to download an archive. It is similar to the existing
+`buildGerritGitilesArchiveUrl` but also support content referenced by a full commit `SHA`.
+
+**DEPRECATIONS**: The function `buildGerritGitilesArchiveUrl` is deprecated, use the
+`buildGerritGitilesArchiveUrlFromLocation` function instead.
+
+**DEPRECATIONS**: The function `parseGerritGitilesUrl` is deprecated, use the
+`parseGitilesUrlRef` function instead.

--- a/packages/integration/report.api.md
+++ b/packages/integration/report.api.md
@@ -299,12 +299,18 @@ export type BitbucketServerIntegrationConfig = {
   password?: string;
 };
 
-// @public
+// @public @deprecated
 export function buildGerritGitilesArchiveUrl(
   config: GerritIntegrationConfig,
   project: string,
   branch: string,
   filePath: string,
+): string;
+
+// @public
+export function buildGerritGitilesArchiveUrlFromLocation(
+  config: GerritIntegrationConfig,
+  url: string,
 ): string;
 
 // @public
@@ -802,7 +808,7 @@ export interface IntegrationsByType {
   harness: ScmIntegrationsGroup<HarnessIntegration>;
 }
 
-// @public
+// @public @deprecated
 export function parseGerritGitilesUrl(
   config: GerritIntegrationConfig,
   url: string,

--- a/packages/integration/src/gerrit/core.ts
+++ b/packages/integration/src/gerrit/core.ts
@@ -41,8 +41,9 @@ const GERRIT_BODY_PREFIX = ")]}'";
  *
  * @param url - An URL pointing to a file stored in git.
  * @public
+ * @deprecated `parseGerritGitilesUrl` is deprecated. Use
+ *  {@link parseGitilesUrlRef} instead.
  */
-
 export function parseGerritGitilesUrl(
   config: GerritIntegrationConfig,
   url: string,
@@ -215,6 +216,8 @@ export function buildGerritGitilesUrl(
  * @param branch - The branch we will target.
  * @param filePath - The absolute file path.
  * @public
+ * @deprecated `buildGerritGitilesArchiveUrl` is deprecated. Use
+ *  {@link buildGerritGitilesArchiveUrlFromLocation} instead.
  */
 export function buildGerritGitilesArchiveUrl(
   config: GerritIntegrationConfig,
@@ -227,6 +230,38 @@ export function buildGerritGitilesArchiveUrl(
   return `${getGitilesAuthenticationUrl(
     config,
   )}/${project}/+archive/refs/heads/${branch}${archiveName}`;
+}
+
+/**
+ * Build a Gerrit Gitiles archive url from a Gitiles url.
+ *
+ * @param config - A Gerrit provider config.
+ * @param url - The gitiles url
+ * @public
+ */
+export function buildGerritGitilesArchiveUrlFromLocation(
+  config: GerritIntegrationConfig,
+  url: string,
+): string {
+  const {
+    path: filePath,
+    ref,
+    project,
+    refType,
+  } = parseGitilesUrlRef(config, url);
+  const archiveName =
+    filePath === '/' || filePath === '' ? '.tar.gz' : `/${filePath}.tar.gz`;
+  if (refType === 'branch') {
+    return `${getGitilesAuthenticationUrl(
+      config,
+    )}/${project}/+archive/refs/heads/${ref}${archiveName}`;
+  }
+  if (refType === 'sha') {
+    return `${getGitilesAuthenticationUrl(
+      config,
+    )}/${project}/+archive/${ref}${archiveName}`;
+  }
+  throw new Error(`Unsupported gitiles ref type: ${refType}`);
 }
 
 /**
@@ -324,13 +359,25 @@ export function getGerritFileContentsApiUrl(
   config: GerritIntegrationConfig,
   url: string,
 ) {
-  const { branch, filePath, project } = parseGerritGitilesUrl(config, url);
+  const { ref, refType, path, project } = parseGitilesUrlRef(config, url);
 
-  return `${config.baseUrl}${getAuthenticationPrefix(
-    config,
-  )}projects/${encodeURIComponent(
-    project,
-  )}/branches/${branch}/files/${encodeURIComponent(filePath)}/content`;
+  // https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#get-content
+  if (refType === 'branch') {
+    return `${config.baseUrl}${getAuthenticationPrefix(
+      config,
+    )}projects/${encodeURIComponent(
+      project,
+    )}/branches/${ref}/files/${encodeURIComponent(path)}/content`;
+  }
+  // https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#get-content-from-commit
+  if (refType === 'sha') {
+    return `${config.baseUrl}${getAuthenticationPrefix(
+      config,
+    )}projects/${encodeURIComponent(
+      project,
+    )}/commits/${ref}/files/${encodeURIComponent(path)}/content`;
+  }
+  throw new Error(`Unsupported gitiles ref type: ${refType}`);
 }
 
 /**

--- a/packages/integration/src/gerrit/index.ts
+++ b/packages/integration/src/gerrit/index.ts
@@ -20,6 +20,7 @@ export {
 } from './config';
 export {
   buildGerritGitilesArchiveUrl,
+  buildGerritGitilesArchiveUrlFromLocation,
   getGerritBranchApiUrl,
   getGerritCloneRepoUrl,
   getGerritFileContentsApiUrl,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

A follow up to #25202 that brings support to the GerritUrlReader to get content referenced by a full 
SHA hash. The intended use cases is auxiliary helpers to support users creating/updating catalog files.
One example is API validation as stated in #25733.

#### :heavy_check_mark: Checklist

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
