### PR TITLE
opaque-internal: support class implementations

### DIFF
--- a/packages/opaque-internal/src/OpaqueType.test.ts
+++ b/packages/opaque-internal/src/OpaqueType.test.ts
@@ -413,4 +413,40 @@ describe('OpaqueType', () => {
     expect(myInternal.$$type).toBe('my-type');
     expect(myInternal.version).toBe(undefined);
   });
+
+  it('should work with class implementations', () => {
+    type MyType = {
+      $$type: 'my-type';
+    };
+
+    const OpaqueMyType = OpaqueType.create<{
+      public: MyType;
+      versions: {
+        version: 'v1';
+        getX(): number;
+      };
+    }>({
+      type: 'my-type',
+      versions: ['v1'],
+    });
+
+    class MyTypeImpl {
+      getX() {
+        return 4;
+      }
+    }
+
+    const myInstance = OpaqueMyType.createInstance('v1', new MyTypeImpl());
+
+    expect(myInstance.$$type).toBe('my-type');
+
+    expect(OpaqueMyType.isType(myInstance)).toBe(true);
+
+    const myInternal = OpaqueMyType.toInternal(myInstance);
+    expect(myInternal).toBe(myInstance);
+
+    expect(myInternal.$$type).toBe('my-type');
+    expect(myInternal.version).toBe('v1');
+    expect(myInternal.getX()).toBe(4);
+  });
 });

--- a/packages/opaque-internal/src/OpaqueType.ts
+++ b/packages/opaque-internal/src/OpaqueType.ts
@@ -135,11 +135,10 @@ export class OpaqueType<
         : never) &
       Object, // & Object to allow for object properties too, e.g. toString()
   ): TPublic {
-    return {
-      ...(props as object),
+    return Object.assign(props as object, {
       $$type: this.#type,
       ...(version && { version }),
-    } as unknown as TPublic;
+    }) as unknown as TPublic;
   }
 
   #isThisInternalType(value: unknown): value is T['public'] & T['versions'] {


### PR DESCRIPTION
Tweak to the `OpaqueType` helper to support using objects with prototypes as the instance