### PR TITLE
frontend-plugin-api: extension attachments declaration by reference

### DIFF
--- a/packages/frontend-app-api/src/tree/resolveAppNodeSpecs.test.ts
+++ b/packages/frontend-app-api/src/tree/resolveAppNodeSpecs.test.ts
@@ -48,6 +48,7 @@ function makeExtDef(
     version: 'v1',
     name,
     attachTo: { id: attachId, input: 'default' },
+    inputs: {},
     disabled: status === 'disabled',
     override: () => ({} as ExtensionDefinition),
   } as ExtensionDefinition;

--- a/packages/frontend-internal/src/wiring/InternalExtensionDefinition.ts
+++ b/packages/frontend-internal/src/wiring/InternalExtensionDefinition.ts
@@ -66,7 +66,7 @@ export const OpaqueExtensionDefinition = OpaqueType.create<{
         readonly kind?: string;
         readonly namespace?: string;
         readonly name?: string;
-        readonly attachTo: { id: string; input: string };
+        readonly attachTo: { id: string; input: string } | ExtensionInput;
         readonly disabled: boolean;
         readonly configSchema?: PortableSchema<any, any>;
         readonly inputs: {

--- a/packages/frontend-internal/src/wiring/InternalExtensionInput.ts
+++ b/packages/frontend-internal/src/wiring/InternalExtensionInput.ts
@@ -14,9 +14,23 @@
  * limitations under the License.
  */
 
-export { OpaqueExtensionDefinition } from './InternalExtensionDefinition';
-export { OpaqueFrontendPlugin } from './InternalFrontendPlugin';
-export {
-  OpaqueExtensionInput,
-  type ExtensionInputMeta,
-} from './InternalExtensionInput';
+import { ExtensionInput } from '@backstage/frontend-plugin-api';
+import { OpaqueType } from '@internal/opaque';
+
+export type ExtensionInputMeta = {
+  kind?: string;
+  name?: string;
+  inputName: string;
+};
+
+export const OpaqueExtensionInput = OpaqueType.create<{
+  public: ExtensionInput;
+  versions: {
+    readonly version: 'v1';
+    getMeta(): ExtensionInputMeta;
+    withMeta(meta: ExtensionInputMeta): ExtensionInput;
+  };
+}>({
+  type: '@backstage/ExtensionInput',
+  versions: ['v1'],
+});

--- a/packages/frontend-plugin-api/src/wiring/createExtensionDataRef.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionDataRef.ts
@@ -23,7 +23,7 @@ export type ExtensionDataValue<TData, TId extends string> = {
 
 /** @public */
 export type ExtensionDataRef<
-  TData,
+  TData = unknown,
   TId extends string = string,
   TConfig extends { optional?: true } = {},
 > = {

--- a/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.test.ts
@@ -24,6 +24,7 @@ describe('resolveExtensionDefinition', () => {
   const baseDef = {
     $$type: '@backstage/ExtensionDefinition',
     T: undefined as any,
+    inputs: {},
     version: 'v2',
     attachTo: { id: '', input: '' },
     disabled: false,
@@ -51,14 +52,10 @@ describe('resolveExtensionDefinition', () => {
         ...baseDef,
         kind: 'k',
       } as ExtensionDefinition),
-    ).toThrow(
-      'Extension must declare an explicit namespace or name as it could not be resolved from context, kind=k namespace=undefined name=undefined',
-    );
+    ).toThrow('Extension resolution failed, missing both namespace and name');
     expect(() =>
       resolveExtensionDefinition(baseDef as ExtensionDefinition),
-    ).toThrow(
-      'Extension must declare an explicit namespace or name as it could not be resolved from context, kind=undefined namespace=undefined name=undefined',
-    );
+    ).toThrow('Extension resolution failed, missing both namespace and name');
   });
 });
 
@@ -66,6 +63,7 @@ describe('old resolveExtensionDefinition', () => {
   const baseDef = {
     $$type: '@backstage/ExtensionDefinition',
     T: undefined as any,
+    inputs: {},
     version: 'v1',
     attachTo: { id: '', input: '' },
     disabled: false,
@@ -93,14 +91,10 @@ describe('old resolveExtensionDefinition', () => {
         ...baseDef,
         kind: 'k',
       } as ExtensionDefinition),
-    ).toThrow(
-      'Extension must declare an explicit namespace or name as it could not be resolved from context, kind=k namespace=undefined name=undefined',
-    );
+    ).toThrow('Extension resolution failed, missing both namespace and name');
     expect(() =>
       resolveExtensionDefinition(baseDef as ExtensionDefinition),
-    ).toThrow(
-      'Extension must declare an explicit namespace or name as it could not be resolved from context, kind=undefined namespace=undefined name=undefined',
-    );
+    ).toThrow('Extension resolution failed, missing both namespace and name');
   });
 });
 

--- a/packages/frontend-test-utils/src/app/createExtensionTester.test.tsx
+++ b/packages/frontend-test-utils/src/app/createExtensionTester.test.tsx
@@ -134,7 +134,7 @@ describe('createExtensionTester', () => {
 
     const extraExtension = createExtension({
       name: 'e2',
-      attachTo: { id: 'e1', input: 'ignored' },
+      attachTo: extension.inputs.ignored,
       output: [stringDataRef, internalRef.optional()],
       factory: () => [stringDataRef('test-text')],
     });

--- a/plugins/app/api-report.md
+++ b/plugins/app/api-report.md
@@ -65,6 +65,71 @@ const appPlugin: FrontendPlugin<
         factory: AnyApiFactory;
       };
     }>;
+    'app/root': ExtensionDefinition<{
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        JSX_2.Element,
+        'core.reactElement',
+        {}
+      >;
+      inputs: {
+        router: ExtensionInput<
+          ConfigurableExtensionDataRef<
+            ComponentType<{
+              children?: ReactNode;
+            }>,
+            'app.router.wrapper',
+            {}
+          >,
+          {
+            singleton: true;
+            optional: true;
+          }
+        >;
+        signInPage: ExtensionInput<
+          ConfigurableExtensionDataRef<
+            ComponentType<SignInPageProps>,
+            'core.sign-in-page.component',
+            {}
+          >,
+          {
+            singleton: true;
+            optional: true;
+          }
+        >;
+        children: ExtensionInput<
+          ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>,
+          {
+            singleton: true;
+            optional: false;
+          }
+        >;
+        elements: ExtensionInput<
+          ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>,
+          {
+            singleton: false;
+            optional: false;
+          }
+        >;
+        wrappers: ExtensionInput<
+          ConfigurableExtensionDataRef<
+            ComponentType<{
+              children?: ReactNode;
+            }>,
+            'app.root.wrapper',
+            {}
+          >,
+          {
+            singleton: false;
+            optional: false;
+          }
+        >;
+      };
+      params: never;
+      kind: undefined;
+      name: 'root';
+    }>;
     'app/layout': ExtensionDefinition<{
       config: {};
       configInput: {};
@@ -135,71 +200,6 @@ const appPlugin: FrontendPlugin<
       params: never;
       kind: undefined;
       name: 'nav';
-    }>;
-    'app/root': ExtensionDefinition<{
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        JSX_2.Element,
-        'core.reactElement',
-        {}
-      >;
-      inputs: {
-        router: ExtensionInput<
-          ConfigurableExtensionDataRef<
-            ComponentType<{
-              children?: ReactNode;
-            }>,
-            'app.router.wrapper',
-            {}
-          >,
-          {
-            singleton: true;
-            optional: true;
-          }
-        >;
-        signInPage: ExtensionInput<
-          ConfigurableExtensionDataRef<
-            ComponentType<SignInPageProps>,
-            'core.sign-in-page.component',
-            {}
-          >,
-          {
-            singleton: true;
-            optional: true;
-          }
-        >;
-        children: ExtensionInput<
-          ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>,
-          {
-            singleton: true;
-            optional: false;
-          }
-        >;
-        elements: ExtensionInput<
-          ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>,
-          {
-            singleton: false;
-            optional: false;
-          }
-        >;
-        wrappers: ExtensionInput<
-          ConfigurableExtensionDataRef<
-            ComponentType<{
-              children?: ReactNode;
-            }>,
-            'app.root.wrapper',
-            {}
-          >,
-          {
-            singleton: false;
-            optional: false;
-          }
-        >;
-      };
-      params: never;
-      kind: undefined;
-      name: 'root';
     }>;
     'app/routes': ExtensionDefinition<{
       config: {};

--- a/plugins/app/src/extensions/AppLayout.tsx
+++ b/plugins/app/src/extensions/AppLayout.tsx
@@ -21,10 +21,11 @@ import {
   createExtensionInput,
 } from '@backstage/frontend-plugin-api';
 import { SidebarPage } from '@backstage/core-components';
+import { AppRoot } from './AppRoot';
 
 export const AppLayout = createExtension({
   name: 'layout',
-  attachTo: { id: 'app/root', input: 'children' },
+  attachTo: AppRoot.inputs.children,
   inputs: {
     nav: createExtensionInput([coreExtensionData.reactElement], {
       singleton: true,

--- a/plugins/app/src/extensions/AppNav.tsx
+++ b/plugins/app/src/extensions/AppNav.tsx
@@ -36,6 +36,7 @@ import {
 import LogoIcon from '../../../../packages/app/src/components/Root/LogoIcon';
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
 import LogoFull from '../../../../packages/app/src/components/Root/LogoFull';
+import { AppLayout } from './AppLayout';
 
 const useSidebarLogoStyles = makeStyles({
   root: {
@@ -83,7 +84,7 @@ const SidebarNavItem = (
 
 export const AppNav = createExtension({
   name: 'nav',
-  attachTo: { id: 'app/layout', input: 'nav' },
+  attachTo: AppLayout.inputs.nav,
   inputs: {
     items: createExtensionInput([NavItemBlueprint.dataRefs.target]),
     logos: createExtensionInput([NavLogoBlueprint.dataRefs.logoElements], {

--- a/plugins/app/src/extensions/AppRoot.tsx
+++ b/plugins/app/src/extensions/AppRoot.tsx
@@ -43,6 +43,7 @@ import {
   identityApiRef,
   useApi,
 } from '@backstage/core-plugin-api';
+import { App } from './App';
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
 import { isProtectedApp } from '../../../../packages/core-app-api/src/app/isProtectedApp';
 import { BrowserRouter } from 'react-router-dom';
@@ -53,7 +54,7 @@ import { getBasePath } from '../../../../packages/frontend-app-api/src/routing/g
 
 export const AppRoot = createExtension({
   name: 'root',
-  attachTo: { id: 'app', input: 'root' },
+  attachTo: App.inputs.root,
   inputs: {
     router: createExtensionInput([RouterBlueprint.dataRefs.component], {
       singleton: true,

--- a/plugins/app/src/extensions/AppRoutes.tsx
+++ b/plugins/app/src/extensions/AppRoutes.tsx
@@ -23,10 +23,11 @@ import {
   useComponentRef,
 } from '@backstage/frontend-plugin-api';
 import { useRoutes } from 'react-router-dom';
+import { AppLayout } from './AppLayout';
 
 export const AppRoutes = createExtension({
   name: 'routes',
-  attachTo: { id: 'app/layout', input: 'content' },
+  attachTo: AppLayout.inputs.content,
   inputs: {
     routes: createExtensionInput([
       coreExtensionData.routePath,

--- a/plugins/catalog-react/src/alpha/blueprints/EntityCardBlueprint.test.tsx
+++ b/plugins/catalog-react/src/alpha/blueprints/EntityCardBlueprint.test.tsx
@@ -159,7 +159,7 @@ describe('EntityCardBlueprint', () => {
     });
 
     const mockExtension = createExtension({
-      attachTo: { id: 'entity-card:test', input: 'mock' },
+      attachTo: extension.inputs.mock,
       output: [coreExtensionData.reactElement],
       factory() {
         return [coreExtensionData.reactElement(<div>im a mock</div>)];

--- a/plugins/catalog-react/src/alpha/blueprints/EntityContentBlueprint.test.tsx
+++ b/plugins/catalog-react/src/alpha/blueprints/EntityContentBlueprint.test.tsx
@@ -207,7 +207,7 @@ describe('EntityContentBlueprint', () => {
     });
 
     const mockExtension = createExtension({
-      attachTo: { id: 'entity-content:test', input: 'mock' },
+      attachTo: extension.inputs.mock,
       output: [coreExtensionData.reactElement],
       factory() {
         return [coreExtensionData.reactElement(<div>im a mock</div>)];

--- a/plugins/catalog/src/alpha/blueprints/CatalogFilterBlueprint.test.tsx
+++ b/plugins/catalog/src/alpha/blueprints/CatalogFilterBlueprint.test.tsx
@@ -85,7 +85,7 @@ describe('CatalogFilterBlueprint', () => {
     });
 
     const mockExtension = createExtension({
-      attachTo: { id: 'catalog-filter:test-name', input: 'mock' },
+      attachTo: extension.inputs.mock,
       output: [coreExtensionData.reactElement],
       factory() {
         return [coreExtensionData.reactElement(<div>im a mock</div>)];

--- a/plugins/techdocs/src/alpha.tsx
+++ b/plugins/techdocs/src/alpha.tsx
@@ -186,7 +186,7 @@ const techDocsEntityContent = EntityContentBlueprint.makeWithOverrides({
 const techDocsEntityContentEmptyState = createExtension({
   kind: 'empty-state',
   name: 'entity-content',
-  attachTo: { id: 'entity-content:techdocs', input: 'emptyState' },
+  attachTo: techDocsEntityContent.inputs.emptyState,
   output: [coreExtensionData.reactElement.optional()],
   factory: () => [],
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This enables extension attachment points to be declared via a reference to an extension input object rather than the hardcoded extension id + input name.

This approach is fairly limited in that it's fully implemented within `frontend-plugin-api` and resolved per plugin. This for example prevents us from using this for blueprint declarations, since we'd end up with the wrong namespace. I'm inclined to explore other options such as passing through the reference to the declaration all the way to the app tree resolution, but that's definitely gonna have some problem with using references rather than IDs.

Either way, I thought'd I'd get this up for now for early review and discussion. You can see a few updates in the plugins where this helps out a little bit.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
