### PR TITLE
Docs (Sign In): Ensure resolvers are not in app config when setting up custom sign in resolvers

### DIFF
--- a/docs/auth/identity-resolver.md
+++ b/docs/auth/identity-resolver.md
@@ -142,8 +142,28 @@ backend.add(import('@backstage/plugin-auth-backend-module-github-provider'));
 
 When you want to supply a custom sign-in resolver, as a general pattern you
 remove that last import and instead construct your own provider using the
-facilities from the same package. You can leave the config unchanged from
-before.
+facilities from the same package.
+
+Make sure that your `auth` config in your `app-config.yaml` does not contain
+any `resolvers` field.
+
+```yaml title="in e.g. app-config.yaml"
+auth:
+  environment: development
+  providers:
+    github:
+      development:
+        clientId: ${AUTH_GITHUB_CLIENT_ID}
+        clientSecret: ${AUTH_GITHUB_CLIENT_SECRET}
+        enterpriseInstanceUrl: ${AUTH_GITHUB_ENTERPRISE_INSTANCE_URL}
+/* highlight-remove-start */
+        signIn:
+          resolvers:
+            - resolver: usernameMatchingUserEntityName
+            - resolver: emailMatchingUserEntityProfileEmail
+            - resolver: emailLocalPartMatchingUserEntityName
+/* highlight-remove-end */
+```
 
 ```ts title="in packages/backend/src/index.ts"
 /* highlight-add-start */

--- a/docs/auth/identity-resolver.md
+++ b/docs/auth/identity-resolver.md
@@ -145,7 +145,7 @@ remove that last import and instead construct your own provider using the
 facilities from the same package.
 
 Make sure that your `auth` config in your `app-config.yaml` does not contain
-any `resolvers` field.
+any `resolvers` field - otherwise, they take priority.
 
 ```yaml title="in e.g. app-config.yaml"
 auth:


### PR DESCRIPTION
When we keep the resolvers in there, the custom sign in resolver does not pick up. Spent some time today on this when creating https://www.youtube.com/watch?v=r46uFbu9wOs :)

![2024-09-21 03_24_43-Sign-in Identities and Resolvers _ Backstage Software Catalog and Developer Plat](https://github.com/user-attachments/assets/cfb8308a-1829-462c-8946-716742a1db38)


## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
