### PR TITLE
Apply `defaultValue` props in `MultiEntityPicker`

### DIFF
--- a/.changeset/curly-foxes-brake.md
+++ b/.changeset/curly-foxes-brake.md
@@ -1,0 +1,14 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Apply `defaultValue` props in `MultiEntityPicker`
+
+```diff
+  <Autocomplete
+    multiple
+    filterSelectedOptions
+    disabled={entities?.entities?.length === 1}
+    id={idSchema?.$id}
++   defaultValue={formData}
+```

--- a/.changeset/curly-foxes-brake.md
+++ b/.changeset/curly-foxes-brake.md
@@ -3,12 +3,3 @@
 ---
 
 Apply `defaultValue` props in `MultiEntityPicker`
-
-```diff
-  <Autocomplete
-    multiple
-    filterSelectedOptions
-    disabled={entities?.entities?.length === 1}
-    id={idSchema?.$id}
-+   defaultValue={formData}
-```

--- a/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.tsx
@@ -152,6 +152,7 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
         filterSelectedOptions
         disabled={entities?.entities?.length === 1}
         id={idSchema?.$id}
+        defaultValue={formData}
         loading={loading}
         onChange={onSelect}
         options={entities?.entities || []}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Apply `defaultValue` props in `MultiEntityPicker` (plugin-scaffolder) 

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
