### PR TITLE
feat(techdocs): use more of the available space for navigation sidebar

### DIFF
--- a/.changeset/thirty-pianos-mix.md
+++ b/.changeset/thirty-pianos-mix.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-techdocs-module-addons-contrib': patch
+'@backstage/plugin-techdocs': patch
+---
+
+Use more of the available space for the navigation sidebar.

--- a/plugins/techdocs-module-addons-contrib/src/ExpandableNavigation/ExpandableNavigation.tsx
+++ b/plugins/techdocs-module-addons-contrib/src/ExpandableNavigation/ExpandableNavigation.tsx
@@ -30,8 +30,9 @@ const EXPANDABLE_NAVIGATION_LOCAL_STORAGE =
 const StyledButton = withStyles({
   root: {
     position: 'absolute',
-    left: '220px',
+    left: '13.7rem', // Sidebar inner width (15.1em) minus the different margins/paddings
     top: '19px',
+    zIndex: 2,
     padding: 0,
     minWidth: 0,
   },

--- a/plugins/techdocs/src/reader/transformers/styles/rules/layout.ts
+++ b/plugins/techdocs/src/reader/transformers/styles/rules/layout.ts
@@ -86,8 +86,13 @@ export default ({ theme, sidebar }: RuleOptions) => `
   scrollbar-width: thin;
 }
 .md-sidebar .md-sidebar__scrollwrap {
-  width: calc(12.1rem);
+  width: calc(16rem);
   overflow-y: hidden;
+}
+@supports selector(::-webkit-scrollbar) {
+  [dir=ltr] .md-sidebar__inner {
+      padding-right: calc(100% - 15.1rem);
+  }
 }
 .md-sidebar--secondary {
   right: ${theme.spacing(3)}px;
@@ -202,16 +207,20 @@ export default ({ theme, sidebar }: RuleOptions) => `
     height: 100%;
   }
   .md-sidebar--primary {
-    width: 12.1rem !important;
+    width: 16rem !important;
     z-index: 200;
     left: ${
       sidebar.isPinned
-        ? `calc(-12.1rem + ${SIDEBAR_WIDTH})`
-        : 'calc(-12.1rem + 72px)'
+        ? `calc(-16rem + ${SIDEBAR_WIDTH})`
+        : 'calc(-16rem + 72px)'
     } !important;
   }
   .md-sidebar--secondary:not([hidden]) {
     display: none;
+  }
+
+  [data-md-toggle=drawer]:checked~.md-container .md-sidebar--primary {
+    transform: translateX(16rem);
   }
 
   .md-content {
@@ -241,8 +250,8 @@ export default ({ theme, sidebar }: RuleOptions) => `
 
 @media screen and (max-width: 600px) {
   .md-sidebar--primary {
-    left: -12.1rem !important;
-    width: 12.1rem;
+    left: -16rem !important;
+    width: 16rem;
   }
 }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR makes the inner content of the navbar to use the full available width (16rem minus some margins for the scrollbar).

Some units weren't correctly updated for Backstage: in Backstage the sidebar's width is `16rem` but in Material for MkDocs it's `12.1rem`.

I also changed the position for the ExpandableNavigation button to match those changes.

**Before/After:**
 
![image](https://github.com/user-attachments/assets/8005ae21-0d13-4a21-9c3e-d0147eab450d)

![image](https://github.com/user-attachments/assets/c5097247-427b-4dbf-b7c2-cc3cca13db79)

**Before/After on smaller screens:**

![image](https://github.com/user-attachments/assets/1931d51c-163a-4d84-92f2-feb90e0c8f43)
![image](https://github.com/user-attachments/assets/54cdd6eb-873c-47b4-90cc-a8b568653d54)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] ~Added or updated documentation~
- [x] ~Tests for new functionality and regression tests for bug fixes~
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
