### PR TITLE
feat(techdocs): Add support for mkdocs palette conditional hashes

### DIFF
--- a/.changeset/rare-crabs-cheat.md
+++ b/.changeset/rare-crabs-cheat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Add support for mkdocs material palette conditional hashes.

--- a/plugins/techdocs/src/reader/transformers/styles/rules/palette.ts
+++ b/plugins/techdocs/src/reader/transformers/styles/rules/palette.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RuleOptions } from './types';
+import { Theme } from '@material-ui/core/styles';
+
+const themeHashes: Record<Theme['palette']['type'], ReadonlyArray<string>> = {
+  dark: ['#only-light', '#gh-light-mode-only'],
+  light: ['#only-dark', '#gh-dark-mode-only'],
+};
+
+export default ({ theme }: RuleOptions) => `
+/*==================  Palette  ==================*/
+/*
+  When color palette toggle is enabled in material theme for Mkdocs, there is a possibility to show conditionally 
+  images by adding #only-dark or #only-light to resource hash. Backstage doesn't use mkdocs color palette mechanism,
+  so there is a need to add css rules from palette*.css manually.
+*/
+
+${themeHashes[theme.palette.type]
+  .map(hash => `img[src$="${hash}"]`)
+  .join(', ')} {
+  display: none;
+}
+`;

--- a/plugins/techdocs/src/reader/transformers/styles/rules/rules.ts
+++ b/plugins/techdocs/src/reader/transformers/styles/rules/rules.ts
@@ -20,6 +20,7 @@ import { default as layout } from './layout';
 import { default as typeset } from './typeset';
 import { default as animations } from './animations';
 import { default as extensions } from './extensions';
+import palette from './palette';
 
 /**
  * A list of style rules that will be applied to an element in the order they were added.
@@ -35,4 +36,5 @@ export const rules = [
   typeset,
   animations,
   extensions,
+  palette,
 ];

--- a/plugins/techdocs/src/reader/transformers/styles/transformer.test.tsx
+++ b/plugins/techdocs/src/reader/transformers/styles/transformer.test.tsx
@@ -47,6 +47,9 @@ describe('Transformers > Styles', () => {
     expect(style).toHaveTextContent(
       '/*================== Extensions ==================*/',
     );
+    expect(style).toHaveTextContent(
+      '/*================== Palette ==================*/',
+    );
   });
 
   it('should use headers relative font-size value as the factor for the md-typeset variable', () => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add support for [mkdocs images in light/dark mode](https://squidfunk.github.io/mkdocs-material/reference/images/#light-and-dark-mode) - conditionally showing/hiding images with `#light-only` or `#dark-only` hash in `src` attribute.


#### Context
`Mkdocs` sets color palette using `data-md-color-scheme` attribute in body element. `palette.{hash}.css` has css rules that hide part of images when specific value of  `data-md-color-scheme` is set and the image has one of hashes described above.

#### Why the change is needed
Backstage filters out css file with palette, so some custom `css` rules have to be added.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
