### PR TITLE
cli: optimize ts-morph project for workspace build

### DIFF
--- a/packages/cli/src/lib/packager/createDistWorkspace.ts
+++ b/packages/cli/src/lib/packager/createDistWorkspace.ts
@@ -44,6 +44,7 @@ import {
   PackageGraphNode,
 } from '@backstage/cli-node';
 import { runParallelWorkers } from '../parallel';
+import { createTypeDistProject } from '../typeDistProject';
 
 // These packages aren't safe to pack in parallel since the CLI depends on them
 const UNSAFE_PACKAGES = [
@@ -287,6 +288,9 @@ async function moveToDistWorkspace(
       FAST_PACK_SCRIPTS.includes(pkg.packageJson.scripts?.prepack),
   );
 
+  const tsMorphProject =
+    fastPackPackages.length > 0 ? await createTypeDistProject() : undefined;
+
   // New an improved flow where we avoid calling `yarn pack`
   await Promise.all(
     fastPackPackages.map(async target => {
@@ -297,6 +301,7 @@ async function moveToDistWorkspace(
       await productionPack({
         packageDir: target.dir,
         targetDir: absoluteOutputPath,
+        project: tsMorphProject,
       });
     }),
   );

--- a/packages/cli/src/lib/packager/productionPack.ts
+++ b/packages/cli/src/lib/packager/productionPack.ts
@@ -23,6 +23,7 @@ import {
   createTypeDistProject,
   getEntryPointDefaultFeatureType,
 } from '../typeDistProject';
+import { Project } from 'ts-morph';
 
 const PKG_PATH = 'package.json';
 const PKG_BACKUP_PATH = 'package.json-prepack';
@@ -33,6 +34,10 @@ const SCRIPT_EXTS = ['.js', '.jsx', '.ts', '.tsx'];
 interface ProductionPackOptions {
   packageDir: string;
   targetDir?: string;
+  /**
+   * A ts-morph project to share across packages
+   */
+  project?: Project;
 }
 
 export async function productionPack(options: ProductionPackOptions) {
@@ -50,6 +55,7 @@ export async function productionPack(options: ProductionPackOptions) {
   const writeCompatibilityEntryPoints = await prepareExportsEntryPoints(
     pkg,
     packageDir,
+    options.project,
   );
 
   // TODO(Rugvip): Once exports are rolled out more broadly we should deprecate and remove this behavior
@@ -138,6 +144,7 @@ const EXPORT_MAP = {
 async function prepareExportsEntryPoints(
   pkg: BackstagePackageJson,
   packageDir: string,
+  commonProject?: Project,
 ) {
   const distPath = resolvePath(packageDir, 'dist');
   if (!(await fs.pathExists(distPath))) {
@@ -151,7 +158,7 @@ async function prepareExportsEntryPoints(
   >();
 
   const entryPoints = readEntryPoints(pkg);
-  const project = await createTypeDistProject();
+  const project = commonProject || (await createTypeDistProject());
 
   for (const entryPoint of entryPoints) {
     if (!SCRIPT_EXTS.includes(entryPoint.ext)) {


### PR DESCRIPTION
Tiny optimization on top of #26524, re-using the project across packages speeds up the backend build by quite a bit. 👀 @HHogg 