### PR TITLE
feat(techdocs): Allow to pass options to GCS publisher

### DIFF
--- a/.changeset/tough-fireants-itch.md
+++ b/.changeset/tough-fireants-itch.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-techdocs-backend': patch
+'@backstage/plugin-techdocs-node': patch
+---
+
+Allow to pass StorageOptions to GCS Publisher

--- a/docs/features/techdocs/using-cloud-storage.md
+++ b/docs/features/techdocs/using-cloud-storage.md
@@ -120,6 +120,36 @@ techdocs:
 Your Backstage app is now ready to use Google Cloud Storage for TechDocs, to
 store and read the static generated documentation files.
 
+### Extending default Storage configuration
+
+If you need a non-standard configuration of Google Cloud Storage client,
+`TechdocsPublisherExtensionPoint` is something you should look at.
+You can register custom `StorageOptions` that will be used to configure the client. To do so, you
+need to register publisher settings inside your module init, like in the following example:
+
+```typescript
+export const gcsPublisherCustomizer = createBackendModule({
+  pluginId: 'techdocs',
+  moduleId: 'gcs-publisher-customizer',
+  register(reg) {
+    reg.registerInit({
+      deps: {
+        techdocsExtensionPoint: techdocsPublisherExtensionPoint,
+      },
+      async init({ techdocsExtensionPoint }) {
+        const customOptions: StorageOptions = {
+          userAgent: 'my-custom-user-agent',
+        };
+        techdocsExtensionPoint.registerPublisherSettings(
+          'googleGcs',
+          customOptions,
+        );
+      },
+    });
+  },
+});
+```
+
 ## Configuring AWS S3 Bucket with TechDocs
 
 **1. Set `techdocs.publisher.type` config in your `app-config.yaml`**

--- a/plugins/techdocs-backend/src/plugin.ts
+++ b/plugins/techdocs-backend/src/plugin.ts
@@ -29,6 +29,7 @@ import {
   Preparers,
   Publisher,
   PublisherBase,
+  PublisherSettings,
   PublisherType,
   RemoteProtocol,
   techdocsBuildsExtensionPoint,
@@ -89,12 +90,19 @@ export const techdocsPlugin = createBackendPlugin({
     });
 
     let customTechdocsPublisher: PublisherBase | undefined;
+    const publisherSettings: PublisherSettings = {};
     env.registerExtensionPoint(techdocsPublisherExtensionPoint, {
       registerPublisher(type: PublisherType, publisher: PublisherBase) {
         if (customTechdocsPublisher) {
           throw new Error(`Publisher for type ${type} is already registered`);
         }
         customTechdocsPublisher = publisher;
+      },
+      registerPublisherSettings<T extends keyof PublisherSettings>(
+        publisher: T,
+        settings: PublisherSettings[T],
+      ) {
+        publisherSettings[publisher] = settings;
       },
     });
 
@@ -144,6 +152,7 @@ export const techdocsPlugin = createBackendPlugin({
           logger: winstonLogger,
           discovery: discovery,
           customPublisher: customTechdocsPublisher,
+          publisherSettings,
         });
 
         // checks if the publisher is working and logs the result

--- a/plugins/techdocs-node/report.api.md
+++ b/plugins/techdocs-node/report.api.md
@@ -381,13 +381,15 @@ export class UrlPreparer implements PreparerBase {
 
 // Warnings were encountered during analysis:
 //
-// src/extensions.d.ts:10:5 - (ae-undocumented) Missing documentation for "setBuildStrategy".
-// src/extensions.d.ts:11:5 - (ae-undocumented) Missing documentation for "setBuildLogTransport".
-// src/extensions.d.ts:25:5 - (ae-undocumented) Missing documentation for "setTechdocsGenerator".
-// src/extensions.d.ts:39:5 - (ae-undocumented) Missing documentation for "registerPreparer".
-// src/extensions.d.ts:53:5 - (ae-undocumented) Missing documentation for "registerPublisher".
+// src/extensions.d.ts:11:5 - (ae-undocumented) Missing documentation for "setBuildStrategy".
+// src/extensions.d.ts:12:5 - (ae-undocumented) Missing documentation for "setBuildLogTransport".
+// src/extensions.d.ts:26:5 - (ae-undocumented) Missing documentation for "setTechdocsGenerator".
+// src/extensions.d.ts:40:5 - (ae-undocumented) Missing documentation for "registerPreparer".
+// src/extensions.d.ts:54:5 - (ae-undocumented) Missing documentation for "registerPublisher".
+// src/extensions.d.ts:55:5 - (ae-undocumented) Missing documentation for "registerPublisherSettings".
 // src/stages/generate/index.d.ts:10:22 - (ae-undocumented) Missing documentation for "getMkDocsYml".
 // src/stages/publish/publish.d.ts:10:5 - (ae-undocumented) Missing documentation for "register".
 // src/stages/publish/publish.d.ts:11:5 - (ae-undocumented) Missing documentation for "get".
+// src/stages/publish/types.d.ts:21:5 - (ae-undocumented) Missing documentation for "googleGcs".
 // src/techdocsTypes.d.ts:39:5 - (ae-undocumented) Missing documentation for "shouldBuild".
 ```

--- a/plugins/techdocs-node/report.api.md
+++ b/plugins/techdocs-node/report.api.md
@@ -15,6 +15,7 @@ import { IndexableDocument } from '@backstage/plugin-search-common';
 import { Logger } from 'winston';
 import { LoggerService } from '@backstage/backend-plugin-api';
 import { ScmIntegrationRegistry } from '@backstage/integration';
+import { StorageOptions } from '@google-cloud/storage';
 import { UrlReaderService } from '@backstage/backend-plugin-api';
 import * as winston from 'winston';
 import { Writable } from 'stream';
@@ -217,7 +218,14 @@ export type PublisherFactory = {
   logger: LoggerService;
   discovery: DiscoveryService;
   customPublisher?: PublisherBase | undefined;
+  publisherSettings?: PublisherSettings;
 };
+
+// @public
+export interface PublisherSettings {
+  // (undocumented)
+  googleGcs?: StorageOptions;
+}
 
 // @public
 export type PublisherType =
@@ -344,6 +352,11 @@ export const techdocsPreparerExtensionPoint: ExtensionPoint<TechdocsPreparerExte
 export interface TechdocsPublisherExtensionPoint {
   // (undocumented)
   registerPublisher(type: PublisherType, publisher: PublisherBase): void;
+  // (undocumented)
+  registerPublisherSettings<T extends keyof PublisherSettings>(
+    publisher: T,
+    settings: PublisherSettings[T],
+  ): void;
 }
 
 // @public

--- a/plugins/techdocs-node/src/extensions.ts
+++ b/plugins/techdocs-node/src/extensions.ts
@@ -23,6 +23,7 @@ import {
   TechdocsGenerator,
 } from './stages';
 import * as winston from 'winston';
+import { PublisherSettings } from './stages/publish/types';
 
 /**
  * Extension point type for configuring TechDocs builds.
@@ -89,6 +90,10 @@ export const techdocsPreparerExtensionPoint =
  */
 export interface TechdocsPublisherExtensionPoint {
   registerPublisher(type: PublisherType, publisher: PublisherBase): void;
+  registerPublisherSettings<T extends keyof PublisherSettings>(
+    publisher: T,
+    settings: PublisherSettings[T],
+  ): void;
 }
 
 /**

--- a/plugins/techdocs-node/src/stages/publish/googleStorage.ts
+++ b/plugins/techdocs-node/src/stages/publish/googleStorage.ts
@@ -68,7 +68,11 @@ export class GoogleGCSPublish implements PublisherBase {
     this.bucketRootPath = options.bucketRootPath;
   }
 
-  static fromConfig(config: Config, logger: LoggerService): PublisherBase {
+  static fromConfig(
+    config: Config,
+    logger: LoggerService,
+    options?: StorageOptions,
+  ): PublisherBase {
     let bucketName = '';
     try {
       bucketName = config.getString('techdocs.publisher.googleGcs.bucketName');
@@ -103,7 +107,7 @@ export class GoogleGCSPublish implements PublisherBase {
       }
     }
 
-    const clientOpts: StorageOptions = {};
+    const clientOpts: StorageOptions = options ?? {};
     if (projectId) {
       clientOpts.projectId = projectId;
     }

--- a/plugins/techdocs-node/src/stages/publish/index.ts
+++ b/plugins/techdocs-node/src/stages/publish/index.ts
@@ -24,4 +24,5 @@ export type {
   MigrateRequest,
   ReadinessResponse,
   TechDocsMetadata,
+  PublisherSettings,
 } from './types';

--- a/plugins/techdocs-node/src/stages/publish/publish.ts
+++ b/plugins/techdocs-node/src/stages/publish/publish.ts
@@ -86,7 +86,11 @@ export class Publisher implements PublisherBuilder {
         logger.info('Creating Google Storage Bucket publisher for TechDocs');
         publishers.register(
           publisherType,
-          GoogleGCSPublish.fromConfig(config, logger),
+          GoogleGCSPublish.fromConfig(
+            config,
+            logger,
+            options.publisherSettings?.googleGcs,
+          ),
         );
         break;
       case 'awsS3':

--- a/plugins/techdocs-node/src/stages/publish/types.ts
+++ b/plugins/techdocs-node/src/stages/publish/types.ts
@@ -17,6 +17,7 @@ import express from 'express';
 import { Config } from '@backstage/config';
 import { DiscoveryService, LoggerService } from '@backstage/backend-plugin-api';
 import { Entity, CompoundEntityRef } from '@backstage/catalog-model';
+import { StorageOptions } from '@google-cloud/storage';
 
 /**
  * Options for building publishers
@@ -26,7 +27,12 @@ export type PublisherFactory = {
   logger: LoggerService;
   discovery: DiscoveryService;
   customPublisher?: PublisherBase | undefined;
+  publisherSettings?: PublisherSettings;
 };
+
+export interface PublisherSettings {
+  googleGcs?: StorageOptions;
+}
 
 /**
  * Key for all the different types of TechDocs publishers that are supported.

--- a/plugins/techdocs-node/src/stages/publish/types.ts
+++ b/plugins/techdocs-node/src/stages/publish/types.ts
@@ -30,6 +30,10 @@ export type PublisherFactory = {
   publisherSettings?: PublisherSettings;
 };
 
+/**
+ * Additional configurations for publishers.
+ * @public
+ */
 export interface PublisherSettings {
   googleGcs?: StorageOptions;
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!
It adds ability to configure Google Storage client by registering `StorageOptions` in techdocs extension point.

It's needed when you have i.e. non-standard `authClient` used in your organization and you need to pass it somehow to the `Storage` client.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
