### PR TITLE
Fix Bitbucket Cloud OAuth scopes being used for BitbucketServer in ScmAuth

### DIFF
--- a/.changeset/pretty-plants-hammer.md
+++ b/.changeset/pretty-plants-hammer.md
@@ -2,5 +2,4 @@
 '@backstage/integration-react': minor
 ---
 
-Add ScmAuth provider for Bitbucket Server that uses correct OAuth scopes by default.
-Also allows for overriding the default OAuth scopes.
+Added new ScmAuth method `forBitbucketServer` that uses correct OAuth scopes by default. Also updated `forBitbucket` method to allow overriding the default OAuth scopes.

--- a/.changeset/pretty-plants-hammer.md
+++ b/.changeset/pretty-plants-hammer.md
@@ -1,0 +1,6 @@
+---
+'@backstage/integration-react': minor
+---
+
+Add ScmAuth provider for Bitbucket Server that uses correct OAuth scopes by default.
+Also allows for overriding the default OAuth scopes.

--- a/docs/auth/bitbucketServer/provider.md
+++ b/docs/auth/bitbucketServer/provider.md
@@ -31,7 +31,7 @@ auth:
   providers:
     bitbucketServer:
       development:
-        host: bitbucket.org
+        host: bitbucket.example.org
         clientId: ${AUTH_BITBUCKET_SERVER_CLIENT_ID}
         clientSecret: ${AUTH_BITBUCKET_SERVER_CLIENT_SECRET}
 ```
@@ -77,7 +77,14 @@ backend.add(
 //...
 ```
 
-## Adding the provider to the Backstage frontend
+## Frontend Configuration
 
-To add the provider to the frontend, add the `bitbucketServerAuthApi` reference and `SignInPage` component as shown
-in [Adding the provider to the sign-in page](../index.md#sign-in-configuration).
+### Sign-in
+
+To add the provider to the frontend, add the `bitbucketServerAuthApiRef` reference and
+`SignInPage` component as shown in
+[Adding the provider to the sign-in page](../index.md#sign-in-configuration).
+
+### ScmAuth
+
+For backstage to be able to use the oauth token of the logged in user to access the Bitbucket Server API, you need to add it to list of ScmAuth providers as shown in [Custom ScmAuthApi Implementation](../index.md#custom-scmauthapi-implementation) using the `ScmAuth.forBitbucketServer` method.

--- a/packages/integration-react/report.api.md
+++ b/packages/integration-react/report.api.md
@@ -61,6 +61,16 @@ export class ScmAuth implements ScmAuthApi {
       };
     },
   ): ScmAuth;
+  static forBitbucketServer(
+    bitbucketAuthApi: OAuthApi,
+    options: {
+      host: string;
+      scopeMapping?: {
+        default?: string[];
+        repoWrite?: string[];
+      };
+    },
+  ): ScmAuth;
   static forGithub(
     githubAuthApi: OAuthApi,
     options?: {

--- a/packages/integration-react/report.api.md
+++ b/packages/integration-react/report.api.md
@@ -55,6 +55,10 @@ export class ScmAuth implements ScmAuthApi {
     bitbucketAuthApi: OAuthApi,
     options?: {
       host?: string;
+      scopeMapping?: {
+        default?: string[];
+        repoWrite?: string[];
+      };
     },
   ): ScmAuth;
   static forGithub(

--- a/packages/integration-react/src/api/ScmAuth.ts
+++ b/packages/integration-react/src/api/ScmAuth.ts
@@ -252,6 +252,41 @@ export class ScmAuth implements ScmAuthApi {
   }
 
   /**
+   * Creates a new ScmAuth instance that handles authentication towards Bitbucket Server.
+   *
+   * The host option determines which URLs that are handled by this instance.
+   *
+   * The default scopes are:
+   *
+   * `PUBLIC_REPOS REPOS_READ`
+   *
+   * If the additional `repoWrite` permission is requested, these scopes are added:
+   *
+   * `REPO_WRITE`
+   */
+  static forBitbucketServer(
+    bitbucketAuthApi: OAuthApi,
+    options: {
+      host: string;
+      scopeMapping?: {
+        default?: string[];
+        repoWrite?: string[];
+      };
+    },
+  ): ScmAuth {
+    return this.forBitbucket(bitbucketAuthApi, {
+      host: options.host,
+      scopeMapping: {
+        default: options.scopeMapping?.default ?? [
+          'PUBLIC_REPOS',
+          'REPOS_READ',
+        ],
+        repoWrite: options.scopeMapping?.repoWrite ?? ['REPO_WRITE'],
+      },
+    });
+  }
+
+  /**
    * Merges together multiple ScmAuth instances into one that
    * routes requests to the correct instance based on the URL.
    */

--- a/packages/integration-react/src/api/ScmAuth.ts
+++ b/packages/integration-react/src/api/ScmAuth.ts
@@ -226,12 +226,28 @@ export class ScmAuth implements ScmAuthApi {
     bitbucketAuthApi: OAuthApi,
     options?: {
       host?: string;
+      scopeMapping?: {
+        default?: string[];
+        repoWrite?: string[];
+      };
     },
   ): ScmAuth {
     const host = options?.host ?? 'bitbucket.org';
+    const defaultScopes = options?.scopeMapping?.default ?? [
+      'account',
+      'team',
+      'pullrequest',
+      'snippet',
+      'issue',
+    ];
+    const repoWriteScopes = options?.scopeMapping?.repoWrite ?? [
+      'pullrequest:write',
+      'snippet:write',
+      'issue:write',
+    ];
     return new ScmAuth('bitbucket', bitbucketAuthApi, host, {
-      default: ['account', 'team', 'pullrequest', 'snippet', 'issue'],
-      repoWrite: ['pullrequest:write', 'snippet:write', 'issue:write'],
+      default: defaultScopes,
+      repoWrite: repoWriteScopes,
     });
   }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #26803 and improves documentation for Bitbucket Server Setup to also include ScmAuth configuration.
This also follows my interpretation of the recommendations made by @camilaibs in the original issue.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
