### PR TITLE
fix(core-components): correct size and color of FavoriteToggle

### DIFF
--- a/.changeset/angry-mayflies-collect.md
+++ b/.changeset/angry-mayflies-collect.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Correct size of FavoriteToggle and inherit non-starred color from parent

--- a/packages/core-components/src/components/FavoriteToggle/FavoriteToggle.stories.tsx
+++ b/packages/core-components/src/components/FavoriteToggle/FavoriteToggle.stories.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
+import React, { ComponentType, PropsWithChildren } from 'react';
 import { FavoriteToggle } from './FavoriteToggle';
 import {
   UnifiedThemeProvider,
@@ -21,10 +21,14 @@ import {
   createUnifiedTheme,
   palettes,
 } from '@backstage/theme';
+import { wrapInTestApp } from '@backstage/test-utils';
 
 export default {
   title: 'Core/FavoriteToggle',
   component: FavoriteToggle,
+  decorators: [
+    (Story: ComponentType<PropsWithChildren<{}>>) => wrapInTestApp(<Story />),
+  ],
 };
 
 export const Default = () => {

--- a/packages/core-components/src/components/FavoriteToggle/FavoriteToggle.tsx
+++ b/packages/core-components/src/components/FavoriteToggle/FavoriteToggle.tsx
@@ -21,14 +21,16 @@ import { Theme, makeStyles } from '@material-ui/core/styles';
 import { StarIcon, UnstarredIcon } from '../../icons';
 
 const useStyles = makeStyles<Theme>(
-  theme => ({
+  () => ({
     icon: {
       color: '#f3ba37',
       cursor: 'pointer',
+      display: 'inline-flex',
     },
     iconBorder: {
-      color: theme.palette.text.primary,
+      color: 'inherit',
       cursor: 'pointer',
+      display: 'inline-flex',
     },
   }),
   { name: 'BackstageFavoriteToggleIcon' },
@@ -89,6 +91,7 @@ export function FavoriteToggle(
         aria-label={title}
         id={id}
         onClick={() => onChange(!value)}
+        color="inherit"
         {...iconButtonProps}
       >
         <FavoriteToggleIcon isFavorite={value} />


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes a regression introduced in #26484

- The icon is wrapped in a span which adds a little height instead of being exactly 24px like the icon.
Added `display: inline-flex;` to fix this.

Before / After
<img width="275" alt="image" src="https://github.com/user-attachments/assets/326a4a32-b91c-4b1f-8efe-a745e4322e2f">

<img width="275" alt="image" src="https://github.com/user-attachments/assets/c30ec86e-c40b-4f1c-8df0-70519dd1c76a">


- The un-starred color was set to `theme.palette.text.primary`. In most places the catalog inherited the color from the parent.

<img width="226" alt="image" src="https://github.com/user-attachments/assets/09d490fb-9008-4ec6-b446-31cba282c5f7">

<img width="226" alt="image" src="https://github.com/user-attachments/assets/47cec6ae-2cee-4d68-be3d-305873730884">

- Also fixed the Storybook CI


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] ~Added or updated documentation~
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
