### PR TITLE
feat(home): improve StarredEntities UI

### DIFF
--- a/.changeset/quick-cougars-fry.md
+++ b/.changeset/quick-cougars-fry.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-home': minor
+'@backstage/plugin-home': patch
 ---
 
 Improve Starred Entities UI to reduce whitespace and provide more context on the entities:

--- a/.changeset/quick-cougars-fry.md
+++ b/.changeset/quick-cougars-fry.md
@@ -1,0 +1,9 @@
+---
+'@backstage/plugin-home': minor
+---
+
+Improve Starred Entities UI to reduce whitespace and provide more context on the entities:
+
+- Use the Entity Presentation API (via `<EntityDisplayName>`) to display the entity's name
+- Component's `kind` and `spec.type` are displayed as a secondary text
+- List items are condensed to reduce unnecessary spacing

--- a/plugins/home/report.api.md
+++ b/plugins/home/report.api.md
@@ -198,7 +198,9 @@ export const SettingsModal: (props: {
   children: JSX.Element;
 }) => JSX_2.Element;
 
-// @public
+// Warning: (ae-missing-release-tag) "StarredEntitiesProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
 export type StarredEntitiesProps = {
   noStarredEntitiesMessage?: React_2.ReactNode | undefined;
   groupByKind?: boolean;
@@ -327,4 +329,38 @@ export const WelcomeTitle: ({
 export type WelcomeTitleLanguageProps = {
   language?: string[];
 };
+<<<<<<< HEAD
+=======
+
+// Warnings were encountered during analysis:
+//
+// src/api/VisitsApi.d.ts:106:22 - (ae-undocumented) Missing documentation for "visitsApiRef".
+// src/api/VisitsStorageApi.d.ts:4:1 - (ae-undocumented) Missing documentation for "VisitsStorageApiOptions".
+// src/api/VisitsStorageApi.d.ts:20:5 - (ae-undocumented) Missing documentation for "create".
+// src/api/VisitsWebStorageApi.d.ts:4:1 - (ae-undocumented) Missing documentation for "VisitsWebStorageApiOptions".
+// src/api/VisitsWebStorageApi.d.ts:14:5 - (ae-undocumented) Missing documentation for "create".
+// src/assets/TemplateBackstageLogo.d.ts:3:22 - (ae-undocumented) Missing documentation for "TemplateBackstageLogo".
+// src/assets/TemplateBackstageLogoIcon.d.ts:3:22 - (ae-undocumented) Missing documentation for "TemplateBackstageLogoIcon".
+// src/deprecated.d.ts:7:22 - (ae-undocumented) Missing documentation for "createCardExtension".
+// src/deprecated.d.ts:12:1 - (ae-undocumented) Missing documentation for "CardExtensionProps".
+// src/deprecated.d.ts:17:1 - (ae-undocumented) Missing documentation for "CardLayout".
+// src/deprecated.d.ts:22:1 - (ae-undocumented) Missing documentation for "CardSettings".
+// src/deprecated.d.ts:27:1 - (ae-undocumented) Missing documentation for "CardConfig".
+// src/deprecated.d.ts:32:1 - (ae-undocumented) Missing documentation for "ComponentParts".
+// src/deprecated.d.ts:37:1 - (ae-undocumented) Missing documentation for "ComponentRenderer".
+// src/deprecated.d.ts:42:1 - (ae-undocumented) Missing documentation for "RendererProps".
+// src/deprecated.d.ts:47:22 - (ae-undocumented) Missing documentation for "SettingsModal".
+// src/homePageComponents/HeaderWorldClock/HeaderWorldClock.d.ts:3:1 - (ae-undocumented) Missing documentation for "ClockConfig".
+// src/homePageComponents/StarredEntities/Content.d.ts:2:1 - (ae-undocumented) Missing documentation for "StarredEntitiesProps".
+// src/homePageComponents/Toolkit/Context.d.ts:3:1 - (ae-undocumented) Missing documentation for "Tool".
+// src/homePageComponents/VisitedByType/Content.d.ts:4:1 - (ae-undocumented) Missing documentation for "VisitedByTypeKind".
+// src/homePageComponents/VisitedByType/Content.d.ts:6:1 - (ae-undocumented) Missing documentation for "VisitedByTypeProps".
+// src/homePageComponents/WelcomeTitle/WelcomeTitle.d.ts:3:1 - (ae-undocumented) Missing documentation for "WelcomeTitleLanguageProps".
+// src/plugin.d.ts:5:22 - (ae-undocumented) Missing documentation for "homePlugin".
+// src/plugin.d.ts:9:22 - (ae-undocumented) Missing documentation for "HomepageCompositionRoot".
+// src/plugin.d.ts:14:22 - (ae-undocumented) Missing documentation for "ComponentAccordion".
+// src/plugin.d.ts:24:22 - (ae-undocumented) Missing documentation for "ComponentTabs".
+// src/plugin.d.ts:32:22 - (ae-undocumented) Missing documentation for "ComponentTab".
+// src/plugin.d.ts:53:22 - (ae-undocumented) Missing documentation for "HomePageRandomJoke".
+>>>>>>> c97341f047fd4 (feat(home): improve StarredEntities UI)
 ```

--- a/plugins/home/report.api.md
+++ b/plugins/home/report.api.md
@@ -198,9 +198,7 @@ export const SettingsModal: (props: {
   children: JSX.Element;
 }) => JSX_2.Element;
 
-// Warning: (ae-missing-release-tag) "StarredEntitiesProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export type StarredEntitiesProps = {
   noStarredEntitiesMessage?: React_2.ReactNode | undefined;
   groupByKind?: boolean;
@@ -329,38 +327,4 @@ export const WelcomeTitle: ({
 export type WelcomeTitleLanguageProps = {
   language?: string[];
 };
-<<<<<<< HEAD
-=======
-
-// Warnings were encountered during analysis:
-//
-// src/api/VisitsApi.d.ts:106:22 - (ae-undocumented) Missing documentation for "visitsApiRef".
-// src/api/VisitsStorageApi.d.ts:4:1 - (ae-undocumented) Missing documentation for "VisitsStorageApiOptions".
-// src/api/VisitsStorageApi.d.ts:20:5 - (ae-undocumented) Missing documentation for "create".
-// src/api/VisitsWebStorageApi.d.ts:4:1 - (ae-undocumented) Missing documentation for "VisitsWebStorageApiOptions".
-// src/api/VisitsWebStorageApi.d.ts:14:5 - (ae-undocumented) Missing documentation for "create".
-// src/assets/TemplateBackstageLogo.d.ts:3:22 - (ae-undocumented) Missing documentation for "TemplateBackstageLogo".
-// src/assets/TemplateBackstageLogoIcon.d.ts:3:22 - (ae-undocumented) Missing documentation for "TemplateBackstageLogoIcon".
-// src/deprecated.d.ts:7:22 - (ae-undocumented) Missing documentation for "createCardExtension".
-// src/deprecated.d.ts:12:1 - (ae-undocumented) Missing documentation for "CardExtensionProps".
-// src/deprecated.d.ts:17:1 - (ae-undocumented) Missing documentation for "CardLayout".
-// src/deprecated.d.ts:22:1 - (ae-undocumented) Missing documentation for "CardSettings".
-// src/deprecated.d.ts:27:1 - (ae-undocumented) Missing documentation for "CardConfig".
-// src/deprecated.d.ts:32:1 - (ae-undocumented) Missing documentation for "ComponentParts".
-// src/deprecated.d.ts:37:1 - (ae-undocumented) Missing documentation for "ComponentRenderer".
-// src/deprecated.d.ts:42:1 - (ae-undocumented) Missing documentation for "RendererProps".
-// src/deprecated.d.ts:47:22 - (ae-undocumented) Missing documentation for "SettingsModal".
-// src/homePageComponents/HeaderWorldClock/HeaderWorldClock.d.ts:3:1 - (ae-undocumented) Missing documentation for "ClockConfig".
-// src/homePageComponents/StarredEntities/Content.d.ts:2:1 - (ae-undocumented) Missing documentation for "StarredEntitiesProps".
-// src/homePageComponents/Toolkit/Context.d.ts:3:1 - (ae-undocumented) Missing documentation for "Tool".
-// src/homePageComponents/VisitedByType/Content.d.ts:4:1 - (ae-undocumented) Missing documentation for "VisitedByTypeKind".
-// src/homePageComponents/VisitedByType/Content.d.ts:6:1 - (ae-undocumented) Missing documentation for "VisitedByTypeProps".
-// src/homePageComponents/WelcomeTitle/WelcomeTitle.d.ts:3:1 - (ae-undocumented) Missing documentation for "WelcomeTitleLanguageProps".
-// src/plugin.d.ts:5:22 - (ae-undocumented) Missing documentation for "homePlugin".
-// src/plugin.d.ts:9:22 - (ae-undocumented) Missing documentation for "HomepageCompositionRoot".
-// src/plugin.d.ts:14:22 - (ae-undocumented) Missing documentation for "ComponentAccordion".
-// src/plugin.d.ts:24:22 - (ae-undocumented) Missing documentation for "ComponentTabs".
-// src/plugin.d.ts:32:22 - (ae-undocumented) Missing documentation for "ComponentTab".
-// src/plugin.d.ts:53:22 - (ae-undocumented) Missing documentation for "HomePageRandomJoke".
->>>>>>> c97341f047fd4 (feat(home): improve StarredEntities UI)
 ```

--- a/plugins/home/src/homePageComponents/StarredEntities/Content.tsx
+++ b/plugins/home/src/homePageComponents/StarredEntities/Content.tsx
@@ -30,12 +30,6 @@ import useAsync from 'react-use/esm/useAsync';
 import { StarredEntityListItem } from '../../components/StarredEntityListItem/StarredEntityListItem';
 import { makeStyles } from '@material-ui/core/styles';
 
-/**
- * A component to display a list of starred entities for the user.
- *
- * @public
- */
-
 const useStyles = makeStyles(theme => ({
   tabs: {
     marginBottom: theme.spacing(1),
@@ -46,11 +40,21 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
+/**
+ * Props for the StarredEntities component
+ *
+ * @public
+ */
 export type StarredEntitiesProps = {
   noStarredEntitiesMessage?: React.ReactNode | undefined;
   groupByKind?: boolean;
 };
 
+/**
+ * A component to display a list of starred entities for the user.
+ *
+ * @public
+ */
 export const Content = ({
   noStarredEntitiesMessage,
   groupByKind,

--- a/plugins/home/src/homePageComponents/StarredEntities/Content.tsx
+++ b/plugins/home/src/homePageComponents/StarredEntities/Content.tsx
@@ -28,12 +28,23 @@ import Tab from '@material-ui/core/Tab';
 import React from 'react';
 import useAsync from 'react-use/esm/useAsync';
 import { StarredEntityListItem } from '../../components/StarredEntityListItem/StarredEntityListItem';
+import { makeStyles } from '@material-ui/core/styles';
 
 /**
  * A component to display a list of starred entities for the user.
  *
  * @public
  */
+
+const useStyles = makeStyles(theme => ({
+  tabs: {
+    marginBottom: theme.spacing(1),
+  },
+  list: {
+    paddingTop: 0,
+    paddingBottom: 0,
+  },
+}));
 
 export type StarredEntitiesProps = {
   noStarredEntitiesMessage?: React.ReactNode | undefined;
@@ -44,6 +55,7 @@ export const Content = ({
   noStarredEntitiesMessage,
   groupByKind,
 }: StarredEntitiesProps) => {
+  const classes = useStyles();
   const catalogApi = useApi(catalogApiRef);
   const { starredEntities, toggleStarredEntity } = useStarredEntities();
   const [activeTab, setActiveTab] = React.useState(0);
@@ -57,12 +69,7 @@ export const Content = ({
     return (
       await catalogApi.getEntitiesByRefs({
         entityRefs: [...starredEntities],
-        fields: [
-          'kind',
-          'metadata.namespace',
-          'metadata.name',
-          'metadata.title',
-        ],
+        fields: ['kind', 'metadata.namespace', 'metadata.name', 'spec.type'],
       })
     ).items.filter((e): e is Entity => !!e);
   }, [catalogApi, starredEntities]);
@@ -95,7 +102,7 @@ export const Content = ({
   ) : (
     <div>
       {!groupByKind && (
-        <List>
+        <List className={classes.list}>
           {entities.value
             ?.sort((a, b) =>
               (a.metadata.title ?? a.metadata.name).localeCompare(
@@ -107,6 +114,7 @@ export const Content = ({
                 key={stringifyEntityRef(entity)}
                 entity={entity}
                 onToggleStarredEntity={toggleStarredEntity}
+                showKind
               />
             ))}
         </List>
@@ -114,6 +122,7 @@ export const Content = ({
 
       {groupByKind && (
         <Tabs
+          className={classes.tabs}
           value={activeTab}
           onChange={(_, newValue) => setActiveTab(newValue)}
           variant="scrollable"
@@ -129,7 +138,7 @@ export const Content = ({
       {groupByKind &&
         groupByKindEntries.map(([kind, entitiesByKind], index) => (
           <div key={kind} hidden={groupByKind && activeTab !== index}>
-            <List>
+            <List className={classes.list}>
               {entitiesByKind
                 ?.sort((a, b) =>
                   (a.metadata.title ?? a.metadata.name).localeCompare(
@@ -141,6 +150,7 @@ export const Content = ({
                     key={stringifyEntityRef(entity)}
                     entity={entity}
                     onToggleStarredEntity={toggleStarredEntity}
+                    showKind={false}
                   />
                 ))}
             </List>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Improve Starred Entities UI to reduce whitespace and provide more context on the entities:

- Use the Entity Presentation API (via `<EntityDisplayName>`) to display the entity's name
- Component's `kind` and `spec.type` are displayed as a secondary text
- List items are condensed to reduce unecessary spacing

**Default** (before/after):
<img width="767" alt="image" src="https://github.com/user-attachments/assets/6aa7da2a-4532-42db-8c44-844d508884b2">

<img width="767" alt="image" src="https://github.com/user-attachments/assets/436f5c9f-87ae-48ed-9f17-6d0e148d62fa">



**Grouped by kinds** (before/after):

<img width="767" alt="image" src="https://github.com/user-attachments/assets/a245f09c-36db-4353-8739-1abe8367ea42">

<img width="767" alt="image" src="https://github.com/user-attachments/assets/1a968f39-8605-403f-8e89-2aee34fcb84f">


This PR depends on #26842 to fix the icon alignment (but it's subtle here)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] ~Added or updated documentation~
- [X] ~Tests for new functionality and regression tests for bug fixes~
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
