### PR TITLE
feat(EntityRefLink): add disableTooltip prop to control tooltip visibility

### DIFF
--- a/.changeset/loud-hotels-tan.md
+++ b/.changeset/loud-hotels-tan.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': minor
+---
+
+Added a new prop, `disableTooltip` to the `EntityRefLink` component

--- a/plugins/catalog-react/report.api.md
+++ b/plugins/catalog-react/report.api.md
@@ -456,6 +456,7 @@ export type EntityRefLinkProps = {
   title?: string;
   children?: React_2.ReactNode;
   hideIcon?: boolean;
+  disableTooltip?: boolean;
 } & Omit<LinkProps, 'to'>;
 
 // @public

--- a/plugins/catalog-react/src/components/EntityRefLink/EntityRefLink.tsx
+++ b/plugins/catalog-react/src/components/EntityRefLink/EntityRefLink.tsx
@@ -39,6 +39,7 @@ export type EntityRefLinkProps = {
   title?: string;
   children?: React.ReactNode;
   hideIcon?: boolean;
+  disableTooltip?: boolean;
 } & Omit<LinkProps, 'to'>;
 
 /**
@@ -55,6 +56,7 @@ export const EntityRefLink = forwardRef<any, EntityRefLinkProps>(
       title,
       children,
       hideIcon,
+      disableTooltip,
       ...linkProps
     } = props;
     const entityRoute = useEntityRoute(props.entityRef);
@@ -65,6 +67,7 @@ export const EntityRefLink = forwardRef<any, EntityRefLinkProps>(
         defaultKind={defaultKind}
         defaultNamespace={defaultNamespace}
         hideIcon={hideIcon}
+        disableTooltip={disableTooltip}
       />
     );
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This MR introduces a new prop, `disableTooltip`, to the `EntityRefLink` component, allowing users to control the visibility of tooltips associated with the entity reference.


<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
