### PR TITLE
properly print instructions when the api reports don't match

### DIFF
--- a/.changeset/five-turkeys-taste.md
+++ b/.changeset/five-turkeys-taste.md
@@ -1,0 +1,5 @@
+---
+'@backstage/repo-tools': patch
+---
+
+Properly log instructions when APIs do not match

--- a/packages/repo-tools/src/commands/api-reports/api-extractor.ts
+++ b/packages/repo-tools/src/commands/api-reports/api-extractor.ts
@@ -519,14 +519,17 @@ export async function runApiExtraction({
           if (message.text.includes('The API report file is missing')) {
             shouldLogInstructions = true;
           }
+
+          // Detect messages like the following being output by the generator:
+          // Warning: You have changed the API signature for this project. Please copy the file "/home/runner/work/backstage/backstage/node_modules/.cache/api-extractor/backend-test-utils/report.api.md" to "report.api.md", or perform a local build (which does this automatically). See the Git repo documentation for more info.
           if (
             message.text.includes(
-              'You have changed the public API signature for this project.',
+              'You have changed the API signature for this project.',
             )
           ) {
             shouldLogInstructions = true;
             const match = message.text.match(
-              /Please copy the file "(.*)" to "api-report\.api\.md"/,
+              /Please copy the file "(.*)" to "report\.api\.md"/,
             );
             if (match) {
               conflictingFile = match[1];


### PR DESCRIPTION
When we upgraded the libraries underpinning this, the log messages also changed, so we weren't getting the nice output in CI anymore.

https://github.com/backstage/backstage/actions/runs/11039925478/job/30666829948?pr=26372#step:14:191

Before:

```
Warning: You have changed the API signature for this project. Please copy the file "/Users/freben/dev/github/backstage/node_modules/.cache/api-extractor/plugin-catalog-backend/report.api.md" to "report.api.md", or perform a local build (which does this automatically). See the Git repo documentation for more info.
```

After:

```
*************************************************************************************
* You have uncommitted changes to the public API or reports of a package.           *
* To solve this, run `yarn build:api-reports` and commit all md file changes.       *
*************************************************************************************
```
