### PR TITLE
Fix error message for getProjectId (GitLab)

### DIFF
--- a/.changeset/rude-apricots-eat.md
+++ b/.changeset/rude-apricots-eat.md
@@ -1,0 +1,6 @@
+---
+'@backstage/backend-defaults': patch
+'@backstage/integration': patch
+---
+
+Updating error message for getProjectId when fetching Gitlab project from its url to be more accurate

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/GitlabUrlReader.test.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/GitlabUrlReader.test.ts
@@ -697,7 +697,9 @@ describe('GitlabUrlReader', () => {
         (gitlabProcessor as any).getGitlabFetchUrl(
           'https://gitlab.com/some/random/endpoint',
         ),
-      ).rejects.toThrow('Please provide full path to yaml file from GitLab');
+      ).rejects.toThrow(
+        'Failed converting /some/random/endpoint to a project id. Url path must include /blob/.',
+      );
     });
   });
 

--- a/packages/integration/src/gitlab/core.ts
+++ b/packages/integration/src/gitlab/core.ts
@@ -116,7 +116,9 @@ export async function getProjectId(
   const url = new URL(target);
 
   if (!url.pathname.includes('/blob/')) {
-    throw new Error('Please provide full path to yaml file from GitLab');
+    throw new Error(
+      `Failed converting ${url.pathname} to a project id. Url path must include /blob/.`,
+    );
   }
 
   try {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

I ran into the error message:

```
[2](http://localhost:3000/create/tasks/f2733715-f469-430c-a3c7-bae1e2a2c751#line-2)2024-09-26T22:17:16.483Z info: Fetching plain content from remote URL[3]
(http://localhost:3000/create/tasks/f2733715-f469-430c-a3c7-bae1e2a2c751#line-3)2024-09-26T22:17:16.483Z Error: Please provide full path to yaml file from GitLab
```

This was while trying to use the scaffolder with the `fetch:plain:file` scaffolder action. The error message makes absolutely no sense since I'm not fetching a YAML file at all. I am guessing this error message originally was written when this utility function was only used for fetching a yaml file so I updated the error message to be much more accurate and provide some context.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
