### PR TITLE
fix(scaffolder): use entity title for selected entity in EntityPicker…

### DIFF
--- a/.changeset/large-hats-reply.md
+++ b/.changeset/large-hats-reply.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': minor
+---
+
+Text field content of the `EntityPicker` is now more readable as it uses entity title instead of entity reference.

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
@@ -190,7 +190,7 @@ export const EntityPicker = (props: EntityPickerProps) => {
           typeof option === 'string'
             ? option
             : entities?.entityRefToPresentation.get(stringifyEntityRef(option))
-                ?.entityRef!
+                ?.primaryTitle!
         }
         autoSelect
         freeSolo={allowArbitraryValues}


### PR DESCRIPTION
… field

## Hey, I just made a Pull Request!

We have a lot of entities in the Catalog. Some of the entities are quite human-readable such as repositories and users, when we have clear idea what can be used as identifier. But for some, that is not so clear. As we've added more and more integrations then some of them produces very cryptic entity names, for example: `group/default:my-group-t1234o234e345`.  Most of the entity providers are written by us, but for example group provider is one case where we end up having external id AND human readable name as identifier. This is required because group names are not unique in the external service that we're using. OTOH, using only group id would be even more confusing to the users as they might show up here and there is Backstage's UI.

As Backstage has evolved over time, we now have `EntityPresentationApi` and that's great. Some time ago there was an improvement made to the `EntityPicker`  scaffolder field to use `EntityPresentationApi` and that way it shows entity icon and title in the dropdown (using Material UI `<Autocomplete>` component to do so).

However, that improvement is a bit lacking as when the user selects an item from the dropdown then the selection turns into entity reference. This is expected as `TextField` component cannot really show an icon and title as nicely as the dropdown can. This PR modified the `EntityPicker` to use entity title instead of entity reference, as in our case, would really improve user experience as they don't need to see all those cryptic ids that we must carry in our Catalog.

### Screenshots:

![image](https://github.com/user-attachments/assets/b72dfb09-9816-4836-92e0-6f8f8bc57334)

After user selects from the dropdown:

![image](https://github.com/user-attachments/assets/9641ce48-0453-4a9a-b842-679753fc9287)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
