### PR TITLE
Patch release of #26841, #26862

### DIFF
--- a/.changeset/four-moons-watch.md
+++ b/.changeset/four-moons-watch.md
@@ -1,5 +1,0 @@
----
-'@backstage/integration-react': patch
----
-
-Revert of change #26430

--- a/.changeset/four-moons-watch.md
+++ b/.changeset/four-moons-watch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration-react': patch
+---
+
+Revert of change #26430

--- a/.changeset/weak-bottles-cross.md
+++ b/.changeset/weak-bottles-cross.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-catalog-backend': patch
----
-
-Fix a bug where etags were expiring too soon in the URL reader

--- a/.changeset/weak-bottles-cross.md
+++ b/.changeset/weak-bottles-cross.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Fix a bug where etags were expiring too soon in the URL reader

--- a/docs/auth/gitlab/provider.md
+++ b/docs/auth/gitlab/provider.md
@@ -19,6 +19,7 @@ should point to your Backstage backend auth handler.
    1. Set this to `http://localhost:7007/api/auth/gitlab/handler/frame` for local development.
    2. Set this to `http://{APP_FQDN}:{APP_BACKEND_PORT}/api/auth/gitlab/handler/frame` for non-local deployments.
    3. Select the following scopes from the list:
+      - [x] `api` Grants full read-write access to the api. This is only required if users need to be able to create merge requests with their own permissions.
       - [x] `read_user` Grants read-only access to the authenticated user's profile through the /user API endpoint, which includes username, public email, and full name. Also grants access to read-only API endpoints under /users.
       - [x] `read_repository` Grants read-only access to repositories on private projects using Git-over-HTTP (not using the API).
       - [x] `write_repository` Grants read-write access to repositories on private projects using Git-over-HTTP (not using the API).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.31.1",
+  "version": "1.31.2",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/app-next/CHANGELOG.md
+++ b/packages/app-next/CHANGELOG.md
@@ -1,5 +1,33 @@
 # example-app-next
 
+## 0.0.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration-react@1.1.32
+  - @backstage/plugin-catalog@1.23.1
+  - @backstage/plugin-catalog-import@0.12.4
+  - @backstage/plugin-catalog-react@1.13.1
+  - @backstage/plugin-scaffolder@1.25.1
+  - @backstage/plugin-techdocs@1.10.10
+  - @backstage/plugin-techdocs-module-addons-contrib@1.1.15
+  - @backstage/cli@0.27.1
+  - @backstage/plugin-api-docs@0.11.10
+  - @backstage/plugin-app@0.1.0
+  - @backstage/plugin-catalog-graph@0.4.10
+  - @backstage/plugin-catalog-unprocessed-entities@0.2.8
+  - @backstage/plugin-home@0.7.11
+  - @backstage/plugin-kubernetes@0.11.15
+  - @backstage/plugin-notifications@0.3.1
+  - @backstage/plugin-org@0.6.30
+  - @backstage/plugin-search@1.4.17
+  - @backstage/plugin-signals@0.0.10
+  - @backstage/plugin-user-settings@0.8.13
+  - @backstage/core-compat-api@0.3.0
+  - @backstage/plugin-scaffolder-react@1.12.1
+  - @backstage/plugin-kubernetes-cluster@0.0.16
+
 ## 0.0.15
 
 ### Patch Changes

--- a/packages/app-next/package.json
+++ b/packages/app-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-app-next",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -1,5 +1,32 @@
 # example-app
 
+## 0.2.102
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration-react@1.1.32
+  - @backstage/plugin-catalog@1.23.1
+  - @backstage/plugin-catalog-import@0.12.4
+  - @backstage/plugin-catalog-react@1.13.1
+  - @backstage/plugin-scaffolder@1.25.1
+  - @backstage/plugin-techdocs@1.10.10
+  - @backstage/plugin-techdocs-module-addons-contrib@1.1.15
+  - @backstage/cli@0.27.1
+  - @backstage/plugin-api-docs@0.11.10
+  - @backstage/plugin-catalog-graph@0.4.10
+  - @backstage/plugin-catalog-unprocessed-entities@0.2.8
+  - @backstage/plugin-devtools@0.1.18
+  - @backstage/plugin-home@0.7.11
+  - @backstage/plugin-kubernetes@0.11.15
+  - @backstage/plugin-notifications@0.3.1
+  - @backstage/plugin-org@0.6.30
+  - @backstage/plugin-search@1.4.17
+  - @backstage/plugin-signals@0.0.10
+  - @backstage/plugin-user-settings@0.8.13
+  - @backstage/plugin-scaffolder-react@1.12.1
+  - @backstage/plugin-kubernetes-cluster@0.0.16
+
 ## 0.2.101
 
 ### Patch Changes

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-app",
-  "version": "0.2.101",
+  "version": "0.2.102",
   "backstage": {
     "role": "frontend"
   },

--- a/packages/backend-dynamic-feature-service/CHANGELOG.md
+++ b/packages/backend-dynamic-feature-service/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/backend-dynamic-feature-service
 
+## 0.4.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-backend@1.26.1
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/backend-dynamic-feature-service/package.json
+++ b/packages/backend-dynamic-feature-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/backend-dynamic-feature-service",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Backstage dynamic feature service",
   "backstage": {
     "role": "node-library"

--- a/packages/backend-legacy/CHANGELOG.md
+++ b/packages/backend-legacy/CHANGELOG.md
@@ -1,5 +1,12 @@
 # example-backend-legacy
 
+## 0.2.103
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-backend@1.26.1
+
 ## 0.2.102
 
 ### Patch Changes

--- a/packages/backend-legacy/package.json
+++ b/packages/backend-legacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-backend-legacy",
-  "version": "0.2.102",
+  "version": "0.2.103",
   "backstage": {
     "role": "backend"
   },

--- a/packages/backend/CHANGELOG.md
+++ b/packages/backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # example-backend
 
+## 0.0.31
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-backend@1.26.1
+  - @backstage/plugin-catalog-backend-module-openapi@0.2.1
+
 ## 0.0.30
 
 ### Patch Changes

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-backend",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/packages/dev-utils/CHANGELOG.md
+++ b/packages/dev-utils/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/dev-utils
 
+## 1.1.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration-react@1.1.32
+  - @backstage/plugin-catalog-react@1.13.1
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/dev-utils/package.json
+++ b/packages/dev-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/dev-utils",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Utilities for developing Backstage plugins.",
   "backstage": {
     "role": "web-library"

--- a/packages/integration-react/CHANGELOG.md
+++ b/packages/integration-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/integration-react
 
+## 1.1.32
+
+### Patch Changes
+
+- e88c6cc: Revert of change #26430
+
 ## 1.1.31
 
 ### Patch Changes

--- a/packages/integration-react/package.json
+++ b/packages/integration-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/integration-react",
-  "version": "1.1.31",
+  "version": "1.1.32",
   "description": "Frontend package for managing integrations towards external systems",
   "backstage": {
     "role": "web-library"

--- a/packages/integration-react/src/api/ScmAuth.test.ts
+++ b/packages/integration-react/src/api/ScmAuth.test.ts
@@ -105,7 +105,7 @@ describe('ScmAuth', () => {
         additionalScope: { repoWrite: true },
       }),
     ).resolves.toMatchObject({
-      token: 'read_user read_api read_repository write_repository',
+      token: 'read_user read_api read_repository write_repository api',
     });
 
     const azureAuth = ScmAuth.forAzure(mockAuthApi);

--- a/packages/integration-react/src/api/ScmAuth.ts
+++ b/packages/integration-react/src/api/ScmAuth.ts
@@ -162,7 +162,7 @@ export class ScmAuth implements ScmAuthApi {
    *
    * If the additional `repoWrite` permission is requested, these scopes are added:
    *
-   * `write_repository`
+   * `write_repository api`
    */
   static forGitlab(
     gitlabAuthApi: OAuthApi,
@@ -173,7 +173,7 @@ export class ScmAuth implements ScmAuthApi {
     const host = options?.host ?? 'gitlab.com';
     return new ScmAuth('gitlab', gitlabAuthApi, host, {
       default: ['read_user', 'read_api', 'read_repository'],
-      repoWrite: ['write_repository'],
+      repoWrite: ['write_repository api'],
     });
   }
 

--- a/packages/techdocs-cli-embedded-app/CHANGELOG.md
+++ b/packages/techdocs-cli-embedded-app/CHANGELOG.md
@@ -1,5 +1,15 @@
 # techdocs-cli-embedded-app
 
+## 0.2.101
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration-react@1.1.32
+  - @backstage/plugin-catalog@1.23.1
+  - @backstage/plugin-techdocs@1.10.10
+  - @backstage/cli@0.27.1
+
 ## 0.2.100
 
 ### Patch Changes

--- a/packages/techdocs-cli-embedded-app/package.json
+++ b/packages/techdocs-cli-embedded-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "techdocs-cli-embedded-app",
-  "version": "0.2.100",
+  "version": "0.2.101",
   "private": true,
   "backstage": {
     "role": "frontend"

--- a/plugins/api-docs/CHANGELOG.md
+++ b/plugins/api-docs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-api-docs
 
+## 0.11.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog@1.23.1
+  - @backstage/plugin-catalog-react@1.13.1
+  - @backstage/core-compat-api@0.3.0
+
 ## 0.11.9
 
 ### Patch Changes

--- a/plugins/api-docs/package.json
+++ b/plugins/api-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-api-docs",
-  "version": "0.11.9",
+  "version": "0.11.10",
   "description": "A Backstage plugin that helps represent API entities in the frontend",
   "backstage": {
     "role": "frontend-plugin",

--- a/plugins/catalog-backend-module-github-org/CHANGELOG.md
+++ b/plugins/catalog-backend-module-github-org/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-catalog-backend-module-github-org
 
+## 0.3.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-backend-module-github@0.7.4
+
 ## 0.3.0
 
 ### Minor Changes

--- a/plugins/catalog-backend-module-github-org/package.json
+++ b/plugins/catalog-backend-module-github-org/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-github-org",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "The github-org backend module for the catalog plugin.",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/catalog-backend-module-github/CHANGELOG.md
+++ b/plugins/catalog-backend-module-github/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-catalog-backend-module-github
 
+## 0.7.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-backend@1.26.1
+
 ## 0.7.3
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-github/package.json
+++ b/plugins/catalog-backend-module-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-github",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "A Backstage catalog backend module that helps integrate towards GitHub",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/catalog-backend-module-incremental-ingestion/CHANGELOG.md
+++ b/plugins/catalog-backend-module-incremental-ingestion/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-catalog-backend-module-incremental-ingestion
 
+## 0.5.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-backend@1.26.1
+
 ## 0.5.3
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-incremental-ingestion/package.json
+++ b/plugins/catalog-backend-module-incremental-ingestion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-incremental-ingestion",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "An entity provider for streaming large asset sources into the catalog",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/catalog-backend-module-logs/CHANGELOG.md
+++ b/plugins/catalog-backend-module-logs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-catalog-backend-module-logs
 
+## 0.1.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-backend@1.26.1
+
 ## 0.1.0
 
 ### Minor Changes

--- a/plugins/catalog-backend-module-logs/package.json
+++ b/plugins/catalog-backend-module-logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-logs",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A module that subscribes to catalog releated events and logs them.",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/catalog-backend-module-openapi/CHANGELOG.md
+++ b/plugins/catalog-backend-module-openapi/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-catalog-backend-module-openapi
 
+## 0.2.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-backend@1.26.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/plugins/catalog-backend-module-openapi/package.json
+++ b/plugins/catalog-backend-module-openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-openapi",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A Backstage catalog backend module that helps with OpenAPI specifications",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/catalog-backend/CHANGELOG.md
+++ b/plugins/catalog-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/plugin-catalog-backend
 
+## 1.26.1
+
+### Patch Changes
+
+- 4c35456: Fix a bug where etags were expiring too soon in the URL reader
+
 ## 1.26.0
 
 ### Minor Changes

--- a/plugins/catalog-backend/package.json
+++ b/plugins/catalog-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "description": "The Backstage backend plugin that provides the Backstage catalog",
   "backstage": {
     "role": "backend-plugin",

--- a/plugins/catalog-backend/src/modules/core/UrlReaderProcessor.test.ts
+++ b/plugins/catalog-backend/src/modules/core/UrlReaderProcessor.test.ts
@@ -149,7 +149,7 @@ describe('UrlReaderProcessor', () => {
 
     expect(mockCache.get).toHaveBeenCalledWith('v1');
     expect(mockCache.get).toHaveBeenCalledTimes(1);
-    expect(mockCache.set).toHaveBeenCalledTimes(0);
+    expect(mockCache.set).toHaveBeenCalledTimes(1);
   });
 
   it('should fail load from url with error', async () => {

--- a/plugins/catalog-backend/src/modules/core/UrlReaderProcessor.ts
+++ b/plugins/catalog-backend/src/modules/core/UrlReaderProcessor.ts
@@ -105,6 +105,7 @@ export class UrlReaderProcessor implements CatalogProcessor {
           emit(parseResult);
         }
         emit(processingResult.refresh(`${location.type}:${location.target}`));
+        await cache.set(CACHE_KEY, cacheItem);
       } else if (error.name === 'NotFoundError') {
         if (!optional) {
           emit(processingResult.notFoundError(location, message));

--- a/plugins/catalog-graph/CHANGELOG.md
+++ b/plugins/catalog-graph/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-catalog-graph
 
+## 0.4.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.13.1
+  - @backstage/core-compat-api@0.3.0
+
 ## 0.4.9
 
 ### Patch Changes

--- a/plugins/catalog-graph/package.json
+++ b/plugins/catalog-graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-graph",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "catalog-graph",

--- a/plugins/catalog-import/CHANGELOG.md
+++ b/plugins/catalog-import/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-catalog-import
 
+## 0.12.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration-react@1.1.32
+  - @backstage/plugin-catalog-react@1.13.1
+  - @backstage/core-compat-api@0.3.0
+
 ## 0.12.3
 
 ### Patch Changes

--- a/plugins/catalog-import/package.json
+++ b/plugins/catalog-import/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-import",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "A Backstage plugin the helps you import entities into your catalog",
   "backstage": {
     "role": "frontend-plugin",

--- a/plugins/catalog-react/CHANGELOG.md
+++ b/plugins/catalog-react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-catalog-react
 
+## 1.13.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration-react@1.1.32
+  - @backstage/core-compat-api@0.3.0
+
 ## 1.13.0
 
 ### Minor Changes

--- a/plugins/catalog-react/package.json
+++ b/plugins/catalog-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-react",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "A frontend library that helps other Backstage plugins interact with the catalog",
   "backstage": {
     "role": "web-library",

--- a/plugins/catalog/CHANGELOG.md
+++ b/plugins/catalog/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-catalog
 
+## 1.23.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration-react@1.1.32
+  - @backstage/plugin-catalog-react@1.13.1
+  - @backstage/core-compat-api@0.3.0
+
 ## 1.23.0
 
 ### Minor Changes

--- a/plugins/catalog/package.json
+++ b/plugins/catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "description": "The Backstage plugin for browsing the Backstage catalog",
   "backstage": {
     "role": "frontend-plugin",

--- a/plugins/home/CHANGELOG.md
+++ b/plugins/home/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-home
 
+## 0.7.11
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.13.1
+  - @backstage/core-compat-api@0.3.0
+
 ## 0.7.10
 
 ### Patch Changes

--- a/plugins/home/package.json
+++ b/plugins/home/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-home",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "A Backstage plugin that helps you build a home page",
   "backstage": {
     "role": "frontend-plugin",

--- a/plugins/kubernetes-cluster/CHANGELOG.md
+++ b/plugins/kubernetes-cluster/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-kubernetes-cluster
 
+## 0.0.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.13.1
+
 ## 0.0.15
 
 ### Patch Changes

--- a/plugins/kubernetes-cluster/package.json
+++ b/plugins/kubernetes-cluster/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-kubernetes-cluster",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "A Backstage plugin that shows details of Kubernetes clusters",
   "backstage": {
     "role": "frontend-plugin",

--- a/plugins/kubernetes/CHANGELOG.md
+++ b/plugins/kubernetes/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-kubernetes
 
+## 0.11.15
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.13.1
+  - @backstage/core-compat-api@0.3.0
+
 ## 0.11.14
 
 ### Patch Changes

--- a/plugins/kubernetes/package.json
+++ b/plugins/kubernetes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-kubernetes",
-  "version": "0.11.14",
+  "version": "0.11.15",
   "description": "A Backstage plugin that integrates towards Kubernetes",
   "backstage": {
     "role": "frontend-plugin",

--- a/plugins/org-react/CHANGELOG.md
+++ b/plugins/org-react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-org-react
 
+## 0.1.29
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.13.1
+
 ## 0.1.28
 
 ### Patch Changes

--- a/plugins/org-react/package.json
+++ b/plugins/org-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-org-react",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "backstage": {
     "role": "web-library",
     "pluginId": "org",

--- a/plugins/org/CHANGELOG.md
+++ b/plugins/org/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-org
 
+## 0.6.30
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.13.1
+  - @backstage/core-compat-api@0.3.0
+
 ## 0.6.29
 
 ### Patch Changes

--- a/plugins/org/package.json
+++ b/plugins/org/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-org",
-  "version": "0.6.29",
+  "version": "0.6.30",
   "description": "A Backstage plugin that helps you create entity pages for your organization",
   "backstage": {
     "role": "frontend-plugin",

--- a/plugins/scaffolder-react/CHANGELOG.md
+++ b/plugins/scaffolder-react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-scaffolder-react
 
+## 1.12.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.13.1
+
 ## 1.12.0
 
 ### Minor Changes

--- a/plugins/scaffolder-react/package.json
+++ b/plugins/scaffolder-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-scaffolder-react",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "A frontend library that helps other Backstage plugins interact with the Scaffolder",
   "backstage": {
     "role": "web-library",

--- a/plugins/scaffolder/CHANGELOG.md
+++ b/plugins/scaffolder/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/plugin-scaffolder
 
+## 1.25.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration-react@1.1.32
+  - @backstage/plugin-catalog-react@1.13.1
+  - @backstage/core-compat-api@0.3.0
+  - @backstage/plugin-scaffolder-react@1.12.1
+
 ## 1.25.0
 
 ### Minor Changes

--- a/plugins/scaffolder/package.json
+++ b/plugins/scaffolder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-scaffolder",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "description": "The Backstage plugin that helps you create new things",
   "backstage": {
     "role": "frontend-plugin",

--- a/plugins/search/CHANGELOG.md
+++ b/plugins/search/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-search
 
+## 1.4.17
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.13.1
+  - @backstage/core-compat-api@0.3.0
+
 ## 1.4.16
 
 ### Patch Changes

--- a/plugins/search/package.json
+++ b/plugins/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-search",
-  "version": "1.4.16",
+  "version": "1.4.17",
   "description": "The Backstage plugin that provides your backstage app with search",
   "backstage": {
     "role": "frontend-plugin",

--- a/plugins/techdocs-addons-test-utils/CHANGELOG.md
+++ b/plugins/techdocs-addons-test-utils/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/plugin-techdocs-addons-test-utils
 
+## 1.0.39
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration-react@1.1.32
+  - @backstage/plugin-catalog@1.23.1
+  - @backstage/plugin-catalog-react@1.13.1
+  - @backstage/plugin-techdocs@1.10.10
+
 ## 1.0.38
 
 ### Patch Changes

--- a/plugins/techdocs-addons-test-utils/package.json
+++ b/plugins/techdocs-addons-test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-techdocs-addons-test-utils",
-  "version": "1.0.38",
+  "version": "1.0.39",
   "backstage": {
     "role": "web-library",
     "pluginId": "techdocs-addons",

--- a/plugins/techdocs-module-addons-contrib/CHANGELOG.md
+++ b/plugins/techdocs-module-addons-contrib/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-techdocs-module-addons-contrib
 
+## 1.1.15
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration-react@1.1.32
+
 ## 1.1.14
 
 ### Patch Changes

--- a/plugins/techdocs-module-addons-contrib/package.json
+++ b/plugins/techdocs-module-addons-contrib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-techdocs-module-addons-contrib",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "description": "Plugin module for contributed TechDocs Addons",
   "backstage": {
     "role": "frontend-plugin-module",

--- a/plugins/techdocs/CHANGELOG.md
+++ b/plugins/techdocs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-techdocs
 
+## 1.10.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/integration-react@1.1.32
+  - @backstage/plugin-catalog-react@1.13.1
+  - @backstage/core-compat-api@0.3.0
+
 ## 1.10.9
 
 ### Patch Changes

--- a/plugins/techdocs/package.json
+++ b/plugins/techdocs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-techdocs",
-  "version": "1.10.9",
+  "version": "1.10.10",
   "description": "The Backstage plugin that renders technical documentation for your components",
   "backstage": {
     "role": "frontend-plugin",

--- a/plugins/user-settings/CHANGELOG.md
+++ b/plugins/user-settings/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-user-settings
 
+## 0.8.13
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-react@1.13.1
+  - @backstage/core-compat-api@0.3.0
+
 ## 0.8.12
 
 ### Patch Changes

--- a/plugins/user-settings/package.json
+++ b/plugins/user-settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-user-settings",
-  "version": "0.8.12",
+  "version": "0.8.13",
   "description": "A Backstage plugin that provides a settings page",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
This release fixes an issue where the catalog would not refresh the TTL of the `ProcessorCache` when getting a `NotModifiedError`. Also reverts the removal of the `api` scope in GitLab SCM Auth, as it's required for a lot of existing use cases.