### PR TITLE
cli: rework jest configuration collection

### DIFF
--- a/.changeset/cold-nails-rescue.md
+++ b/.changeset/cold-nails-rescue.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': minor
+---
+
+**BREAKING**: The Jest configuration defined at `@backstage/cli/config/jest` no longer collects configuration defined in the `"jest"` field from all parent `package.json` files. Instead, it will only read and merge configuration from the `package.json` in the monorepo root if it exists, as well as the target package. In addition, configuration defined in the root `package.json` will now only be merged into each package configuration if it is a valid project-level configuration key.

--- a/.changeset/sour-grapes-trade.md
+++ b/.changeset/sour-grapes-trade.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+The Jest configuration will now search for a `src/setupTests.*` file with any valid script extension, not only `.ts`.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This switches out the strategy for collecting `"jest"` configuration from `package.json` files. Rather than traversing all parent `package.json` files, we now only check the target package as well as the monorepo root. I'm not expecting this change to affect any existing Backstage project, as this structure is enforced in many other places.

In addition the config is now a bit smarted in its handling of global vs project Jest config keys, where we now only forward config to the package level if it is valid project-level configuration. For example it is only possible to configure the `testTimeout` in the root and not for each project. Previously that meant that you would get warnings if you tried to use it at all, because it would be lifted to the project level even if that was invalid. Now we only apply it to the global config, which means that you can use it without warnings.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
