### PR TITLE
cli: add support for trimming next entry

### DIFF
--- a/.changeset/friendly-cougars-return.md
+++ b/.changeset/friendly-cougars-return.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Added support for a new experimental `EXPERIMENTAL_TRIM_NEXT_ENTRY` flag which removes any `./next` entry points present in packages when building and publishing.

--- a/packages/cli/src/lib/entryPoints.ts
+++ b/packages/cli/src/lib/entryPoints.ts
@@ -67,6 +67,11 @@ export function readEntryPoints(pkg: BackstagePackageJson): Array<EntryPoint> {
         );
       }
 
+      // Setting the EXPERIMENTAL_TRIM_NEXT_ENTRY flag will remove any `./next` entry points
+      if (process.env.EXPERIMENTAL_TRIM_NEXT_ENTRY && mount === './next') {
+        continue;
+      }
+
       entryPoints.push(parseEntryPoint(mount, path));
     }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

We've been looking for a good way to support compile-time feature flags in the project. In particular we want to be able to ship experimental features that are only present in `next` releases, avoiding the need for things like `__experimental` prefixes in APIs, etc.

We figured this is a very simply way to achieve that. When publishing main-line releases we'll set this new flag that removes any `./next` entry points from all packages. This applies both to the exports definitions, as well as the compiled code itself. We'll also for example get API reports for the next entry.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
