### PR TITLE
Fix: Prevent auto-login after sign-out when 'auto' prop is enabled on the SignInPage

### DIFF
--- a/.changeset/lucky-sheep-march.md
+++ b/.changeset/lucky-sheep-march.md
@@ -1,0 +1,7 @@
+---
+'@backstage/core-components': patch
+'@backstage/core-app-api': patch
+---
+
+Fix auto sign-in bug after logout for Okta auth provider.
+Added a query parameter to prevent auto-login flow from being triggered after redirecting to the home page following logout.

--- a/packages/core-app-api/src/apis/implementations/IdentityApi/AppIdentityProxy.test.ts
+++ b/packages/core-app-api/src/apis/implementations/IdentityApi/AppIdentityProxy.test.ts
@@ -89,6 +89,6 @@ describe('AppIdentityProxy', () => {
     });
 
     await proxy.signOut();
-    expect(window.location.href).toBe('/foo');
+    expect(window.location.href).toBe('/foo?signedOut=true');
   });
 });

--- a/packages/core-app-api/src/apis/implementations/IdentityApi/AppIdentityProxy.ts
+++ b/packages/core-app-api/src/apis/implementations/IdentityApi/AppIdentityProxy.ts
@@ -130,10 +130,9 @@ export class AppIdentityProxy implements IdentityApi {
 
   async signOut(): Promise<void> {
     await this.waitForTarget.then(target => target.signOut());
-
     await this.#cookieAuthSignOut?.();
 
-    window.location.href = this.signOutTargetUrl;
+    window.location.href = `${this.signOutTargetUrl}?signedOut=true`;
   }
 
   enableCookieAuth(ctx: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Fixed a bug where auto sign-in was triggered after logout when using the Okta auth provider.
Added a query parameter on sign-out to prevent the auto-login flow from being triggered upon redirect to the home page.

Closes: #26440

## Screenshots

### Before

https://github.com/user-attachments/assets/db349014-64da-4921-a347-7955086106f6

### After

https://github.com/user-attachments/assets/b694d630-8cd8-441d-950e-6024b6588176

- first I entered URL to check auto login.
- then signed out, to verify that user is not logged in back.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
