### PR TITLE
feat(catalog): Implement breadcrumbs for entity navigation

### DIFF
--- a/.changeset/afraid-carrots-greet.md
+++ b/.changeset/afraid-carrots-greet.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-catalog': minor
+---
+
+- Updated EntityLayout component to implement breadcrumb navigation based on the entity relations.
+
+- Added parentEntityRelations prop to EntityLayoutProps to specify relation types for parent entities.

--- a/packages/app/src/components/catalog/EntityPage.test.tsx
+++ b/packages/app/src/components/catalog/EntityPage.test.tsx
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import { EntityLayout, catalogPlugin } from '@backstage/plugin-catalog';
 import {
   EntityProvider,
   starredEntitiesApiRef,
   MockStarredEntitiesApi,
+  catalogApiRef,
 } from '@backstage/plugin-catalog-react';
 import { permissionApiRef } from '@backstage/plugin-permission-react';
 import {
@@ -28,6 +28,7 @@ import {
 } from '@backstage/test-utils';
 import React from 'react';
 import { cicdContent } from './EntityPage';
+import { catalogApiMock } from '@backstage/plugin-catalog-react/testUtils';
 
 describe('EntityPage Test', () => {
   const entity = {
@@ -55,6 +56,7 @@ describe('EntityPage Test', () => {
           apis={[
             [starredEntitiesApiRef, new MockStarredEntitiesApi()],
             [permissionApiRef, mockApis.permission()],
+            [catalogApiRef, catalogApiMock()],
           ]}
         >
           <EntityProvider entity={entity}>

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -85,15 +85,14 @@ const customEntityFilterKind = ['Component', 'API', 'System'];
 
 const EntityLayoutWrapper = (props: { children?: ReactNode }) => {
   return (
-    <>
-      <EntityLayout
-        UNSTABLE_contextMenuOptions={{
-          disableUnregister: 'visible',
-        }}
-      >
-        {props.children}
-      </EntityLayout>
-    </>
+    <EntityLayout
+      parentEntityRelations={['partOf', 'memberOf', 'childOf']}
+      UNSTABLE_contextMenuOptions={{
+        disableUnregister: 'visible',
+      }}
+    >
+      {props.children}
+    </EntityLayout>
   );
 };
 

--- a/plugins/catalog/report.api.md
+++ b/plugins/catalog/report.api.md
@@ -414,6 +414,7 @@ export interface EntityLayoutProps {
   children?: React_2.ReactNode;
   // (undocumented)
   NotFoundComponent?: React_2.ReactNode;
+  parentEntityRelations?: string[];
   // Warning: (ae-forgotten-export) The symbol "EntityContextMenuOptions" needs to be exported by the entry point index.d.ts
   //
   // (undocumented)

--- a/plugins/catalog/src/components/EntityLayout/EntityLayout.test.tsx
+++ b/plugins/catalog/src/components/EntityLayout/EntityLayout.test.tsx
@@ -169,6 +169,38 @@ describe('EntityLayout', () => {
     expect(screen.queryByText('tabbed-test-content')).not.toBeInTheDocument();
   });
 
+  it('renders the breadcrumbs if defined', async () => {
+    const mockEntityWithRelation = {
+      kind: 'MyKind',
+      metadata: {
+        name: 'my-entity',
+        namespace: 'default',
+        title: 'My Entity',
+      },
+      relations: [{ type: 'partOf', targetRef: 'system:default/my-system' }],
+    } as Entity;
+
+    await renderInTestApp(
+      <ApiProvider apis={apis}>
+        <EntityProvider entity={mockEntityWithRelation}>
+          <EntityLayout parentEntityRelations={['partOf']}>
+            <EntityLayout.Route path="/" title="tabbed-test-title">
+              <div>tabbed-test-content</div>
+            </EntityLayout.Route>
+          </EntityLayout>
+        </EntityProvider>
+      </ApiProvider>,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
+        },
+      },
+    );
+
+    expect(screen.getByText('my-system')).toBeInTheDocument();
+  });
+
   it('navigates when user clicks different tab', async () => {
     await renderInTestApp(
       <ApiProvider apis={apis}>

--- a/plugins/catalog/src/components/EntityLayout/EntityLayout.tsx
+++ b/plugins/catalog/src/components/EntityLayout/EntityLayout.tsx
@@ -15,11 +15,13 @@
  */
 
 import {
-  Entity,
   DEFAULT_NAMESPACE,
+  Entity,
+  EntityRelation,
   RELATION_OWNED_BY,
 } from '@backstage/catalog-model';
 import {
+  Breadcrumbs,
   Content,
   Header,
   HeaderLabel,
@@ -32,12 +34,16 @@ import {
 import {
   attachComponentData,
   IconComponent,
+  useApi,
   useElementFilter,
   useRouteRef,
   useRouteRefParams,
 } from '@backstage/core-plugin-api';
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import {
+  catalogApiRef,
   EntityDisplayName,
+  EntityRefLink,
   EntityRefLinks,
   entityRouteRef,
   FavoriteEntity,
@@ -47,14 +53,15 @@ import {
   useAsyncEntity,
 } from '@backstage/plugin-catalog-react';
 import Box from '@material-ui/core/Box';
+import { makeStyles } from '@material-ui/core/styles';
 import { TabProps } from '@material-ui/core/Tab';
 import Alert from '@material-ui/lab/Alert';
 import React, { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { EntityContextMenu } from '../EntityContextMenu/EntityContextMenu';
-import { rootRouteRef, unregisterRedirectRouteRef } from '../../routes';
+import useAsync from 'react-use/esm/useAsync';
 import { catalogTranslationRef } from '../../alpha/translation';
-import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import { rootRouteRef, unregisterRedirectRouteRef } from '../../routes';
+import { EntityContextMenu } from '../EntityContextMenu/EntityContextMenu';
 
 /** @public */
 export type EntityLayoutRouteProps = {
@@ -101,6 +108,7 @@ function headerProps(
   const namespace = paramNamespace ?? entity?.metadata.namespace ?? '';
   const name =
     entity?.metadata.title ?? paramName ?? entity?.metadata.name ?? '';
+
   return {
     headerTitle: `${name}${
       namespace && namespace !== DEFAULT_NAMESPACE ? ` in ${namespace}` : ''
@@ -167,7 +175,48 @@ export interface EntityLayoutProps {
   UNSTABLE_contextMenuOptions?: EntityContextMenuOptions;
   children?: React.ReactNode;
   NotFoundComponent?: React.ReactNode;
+  /**
+   * An array of relation types used to determine the parent entities in the hierarchy.
+   * These relations are prioritized in the order provided, allowing for flexible
+   * navigation through entity relationships.
+   *
+   * For example, use relation types like `["partOf", "memberOf", "ownedBy"]` to define how the entity is related to
+   * its parents in the Entity Catalog.
+   *
+   * It adds breadcrumbs in the Entity page to enhance user navigation and context awareness.
+   */
+  parentEntityRelations?: string[];
 }
+
+function findParentRelation(
+  entityRelations: EntityRelation[] = [],
+  relationTypes: string[] = [],
+) {
+  for (const type of relationTypes) {
+    const foundRelation = entityRelations.find(
+      relation => relation.type === type,
+    );
+    if (foundRelation) {
+      return foundRelation; // Return the first found relation and stop
+    }
+  }
+  return null;
+}
+
+const useStyles = makeStyles(theme => ({
+  breadcrumbs: {
+    color: theme.page.fontColor,
+    fontSize: theme.typography.caption.fontSize,
+    textTransform: 'uppercase',
+    marginTop: theme.spacing(1),
+    opacity: 0.8,
+    '& span ': {
+      color: theme.page.fontColor,
+      textDecoration: 'underline',
+      textUnderlineOffset: '3px',
+    },
+  },
+}));
 
 /**
  * EntityLayout is a compound component, which allows you to define a layout for
@@ -192,7 +241,9 @@ export const EntityLayout = (props: EntityLayoutProps) => {
     UNSTABLE_contextMenuOptions,
     children,
     NotFoundComponent,
+    parentEntityRelations,
   } = props;
+  const classes = useStyles();
   const { kind, namespace, name } = useRouteRefParams(entityRouteRef);
   const { entity, loading, error } = useAsyncEntity();
   const location = useLocation();
@@ -247,6 +298,22 @@ export const EntityLayout = (props: EntityLayoutProps) => {
     );
   };
 
+  const parentEntity = findParentRelation(
+    entity?.relations ?? [],
+    parentEntityRelations ?? [],
+  );
+
+  const catalogApi = useApi(catalogApiRef);
+  const { value: ancestorEntity } = useAsync(async () => {
+    if (parentEntity) {
+      return findParentRelation(
+        (await catalogApi.getEntityByRef(parentEntity?.targetRef))?.relations,
+        parentEntityRelations,
+      );
+    }
+    return null;
+  }, [parentEntity]);
+
   // Make sure to close the dialog if the user clicks links in it that navigate
   // to another entity.
   useEffect(() => {
@@ -261,6 +328,23 @@ export const EntityLayout = (props: EntityLayoutProps) => {
         title={<EntityLayoutTitle title={headerTitle} entity={entity!} />}
         pageTitleOverride={headerTitle}
         type={headerType}
+        subtitle={
+          parentEntity && (
+            <Breadcrumbs separator=">" className={classes.breadcrumbs}>
+              {ancestorEntity && (
+                <EntityRefLink
+                  entityRef={ancestorEntity.targetRef}
+                  disableTooltip
+                />
+              )}
+              <EntityRefLink
+                entityRef={parentEntity.targetRef}
+                disableTooltip
+              />
+              {name}
+            </Breadcrumbs>
+          )
+        }
       >
         {entity && (
           <>


### PR DESCRIPTION
## Hey, I just made a Pull Request!
This pull request introduces a breadcrumb navigation feature in the Entity Catalog page. The new `parentEntityRelations` prop allows users to specify relation types for fetching parent entities, enhancing context awareness and navigation. The **EntityLayout** component has been updated accordingly, This improvement aims to provide users with a clearer understanding of their current location within the entity hierarchy.

Please review the changes and provide feedback.

### Screenshots:
1. User example:
  ![image](https://github.com/user-attachments/assets/d2a00f21-3643-4bc6-98ea-f1bee2484268)

2. Component Example
  ![image](https://github.com/user-attachments/assets/fe446f9c-3817-4741-9799-9b555afa6d00)

3. demo recording:  

https://github.com/user-attachments/assets/24ea0081-477a-4997-aac0-4f806e0ab312
<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

### Closes
- #26898 
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [ ] Added or updated documentation
