### PR TITLE
Patch release for fixing cyclical dependency

### DIFF
--- a/packages/app-next/src/App.tsx
+++ b/packages/app-next/src/App.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-import { createApp } from '@backstage/frontend-app-api';
+import { createApp } from '@backstage/frontend-defaults';
 import { pagesPlugin } from './examples/pagesPlugin';
 import notFoundErrorPage from './examples/notFoundErrorPageExtension';
 import userSettingsPlugin from '@backstage/plugin-user-settings/alpha';

--- a/packages/frontend-app-api/api-report.md
+++ b/packages/frontend-app-api/api-report.md
@@ -4,18 +4,24 @@
 
 ```ts
 import { ConfigApi } from '@backstage/core-plugin-api';
-import { createApp as createApp_2 } from '@backstage/frontend-defaults';
-import { CreateAppFeatureLoader as CreateAppFeatureLoader_2 } from '@backstage/frontend-defaults';
+import { ConfigApi as ConfigApi_2 } from '@backstage/frontend-plugin-api';
+import { CreateAppRouteBinder as CreateAppRouteBinder_2 } from '@backstage/frontend-app-api';
 import { ExternalRouteRef } from '@backstage/frontend-plugin-api';
+import { FrontendFeature as FrontendFeature_2 } from '@backstage/frontend-app-api';
 import { FrontendModule } from '@backstage/frontend-plugin-api';
 import { FrontendPlugin } from '@backstage/frontend-plugin-api';
 import { JSX as JSX_2 } from 'react';
+import { ReactNode } from 'react';
 import { RouteRef } from '@backstage/frontend-plugin-api';
 import { SubRouteRef } from '@backstage/frontend-plugin-api';
 
+// Warning: (ae-forgotten-export) The symbol "createApp_2" needs to be exported by the entry point index.d.ts
+//
 // @public @deprecated (undocumented)
 export const createApp: typeof createApp_2;
 
+// Warning: (ae-forgotten-export) The symbol "CreateAppFeatureLoader_2" needs to be exported by the entry point index.d.ts
+//
 // @public @deprecated (undocumented)
 export type CreateAppFeatureLoader = CreateAppFeatureLoader_2;
 

--- a/packages/frontend-app-api/package.json
+++ b/packages/frontend-app-api/package.json
@@ -36,7 +36,6 @@
     "@backstage/core-app-api": "workspace:^",
     "@backstage/core-plugin-api": "workspace:^",
     "@backstage/errors": "workspace:^",
-    "@backstage/frontend-defaults": "workspace:^",
     "@backstage/frontend-plugin-api": "workspace:^",
     "@backstage/types": "workspace:^",
     "@backstage/version-bridge": "workspace:^",

--- a/packages/frontend-app-api/src/wiring/createSpecializedApp.tsx
+++ b/packages/frontend-app-api/src/wiring/createSpecializedApp.tsx
@@ -42,12 +42,6 @@ import {
 } from '@backstage/core-plugin-api';
 import { ApiFactoryRegistry, ApiResolver } from '@backstage/core-app-api';
 
-// TODO: Get rid of all of these
-
-import {
-  createApp as _createApp,
-  CreateAppFeatureLoader as _CreateAppFeatureLoader,
-} from '@backstage/frontend-defaults';
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
 import { resolveExtensionDefinition } from '../../../frontend-plugin-api/src/wiring/resolveExtensionDefinition';
 
@@ -174,18 +168,6 @@ class RouteResolutionApiProxy implements RouteResolutionApi {
     return this.#routeObjects;
   }
 }
-
-/**
- * @public
- * @deprecated Import from `@backstage/frontend-defaults` instead.
- */
-export const createApp = _createApp;
-
-/**
- * @public
- * @deprecated Import from `@backstage/frontend-defaults` instead.
- */
-export type CreateAppFeatureLoader = _CreateAppFeatureLoader;
 
 /**
  * Creates an empty app without any default features. This is a low-level API is

--- a/packages/frontend-app-api/src/wiring/deprecated.ts
+++ b/packages/frontend-app-api/src/wiring/deprecated.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 The Backstage Authors
+ * Copyright 2024 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,20 @@
  * limitations under the License.
  */
 
-export { createSpecializedApp } from './createSpecializedApp';
+// eslint-disable-next-line @backstage/no-relative-monorepo-imports
+import {
+  createApp as _createApp,
+  CreateAppFeatureLoader as _CreateAppFeatureLoader,
+} from '../../../frontend-defaults/src/createApp';
 
-export * from './deprecated';
-export * from './types';
+/**
+ * @public
+ * @deprecated Import from `@backstage/frontend-defaults` instead.
+ */
+export const createApp = _createApp;
+
+/**
+ * @public
+ * @deprecated Import from `@backstage/frontend-defaults` instead.
+ */
+export type CreateAppFeatureLoader = _CreateAppFeatureLoader;


### PR DESCRIPTION
This release fixes an issue where it was not possible to follow the deprecation notice for moving to `createApp` from `@backstage/frontend-defaults` due to cyclical dependencies.