### PR TITLE
feat: add reviewers input for bitbucket server pr

### DIFF
--- a/.changeset/healthy-shoes-judge.md
+++ b/.changeset/healthy-shoes-judge.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-bitbucket-server': minor
+---
+
+Add `reviewers` input parameter to `publish:bitbucketServer:pull-request`

--- a/.changeset/healthy-shoes-judge.md
+++ b/.changeset/healthy-shoes-judge.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-scaffolder-backend-module-bitbucket-server': minor
+'@backstage/plugin-scaffolder-backend-module-bitbucket-server': patch
 ---
 
 Add `reviewers` input parameter to `publish:bitbucketServer:pull-request`

--- a/plugins/scaffolder-backend-module-bitbucket-server/report.api.md
+++ b/plugins/scaffolder-backend-module-bitbucket-server/report.api.md
@@ -44,6 +44,7 @@ export function createPublishBitbucketServerPullRequestAction(options: {
     description?: string | undefined;
     targetBranch?: string | undefined;
     sourceBranch: string;
+    reviewers?: string[] | undefined;
     token?: string | undefined;
     gitAuthorName?: string | undefined;
     gitAuthorEmail?: string | undefined;

--- a/plugins/scaffolder-backend-module-bitbucket-server/src/actions/bitbucketServerPullRequest.examples.test.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-server/src/actions/bitbucketServerPullRequest.examples.test.ts
@@ -366,7 +366,7 @@ describe('publish:bitbucketServer:pull-request', () => {
   });
 
   it(`should ${examples[4].description}`, async () => {
-    expect.assertions(7);
+    expect.assertions(8);
     server.use(
       rest.get(
         'https://no-credentials.bitbucket.com/rest/api/1.0/projects/project/repos/repo/branches',
@@ -389,6 +389,7 @@ describe('publish:bitbucketServer:pull-request', () => {
             toRef: { displayId: string };
             fromRef: { displayId: string };
             description: string;
+            reviewers: [{ user: { name: string } }];
           };
           expect(requestBody.title).toBe('My pull request');
           expect(requestBody.fromRef.displayId).toBe('my-feature-branch');
@@ -396,6 +397,10 @@ describe('publish:bitbucketServer:pull-request', () => {
           expect(requestBody.description).toBe(
             'This is a detailed description of my pull request',
           );
+          expect(requestBody.reviewers).toEqual([
+            { user: { name: 'reviewer1' } },
+            { user: { name: 'reviewer2' } },
+          ]);
           expect(req.headers.get('Authorization')).toBe(
             `Bearer ${yaml.parse(examples[4].example).steps[0].input.token}`,
           );

--- a/plugins/scaffolder-backend-module-bitbucket-server/src/actions/bitbucketServerPullRequest.examples.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-server/src/actions/bitbucketServerPullRequest.examples.ts
@@ -107,6 +107,7 @@ export const examples: TemplateExample[] = [
             sourceBranch: 'my-feature-branch',
             targetBranch: 'development',
             description: 'This is a detailed description of my pull request',
+            reviewers: ['reviewer1', 'reviewer2'],
             token: 'my-auth-token',
             gitAuthorName: 'test-user',
             gitAuthorEmail: 'test-user@sample.com',

--- a/plugins/scaffolder-backend-module-bitbucket-server/src/actions/bitbucketServerPullRequest.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-server/src/actions/bitbucketServerPullRequest.ts
@@ -54,6 +54,7 @@ const createPullRequest = async (opts: {
     latestChangeset: string;
     isDefault: boolean;
   };
+  reviewers?: string[];
   authorization: string;
   apiBaseUrl: string;
 }) => {
@@ -64,6 +65,7 @@ const createPullRequest = async (opts: {
     description,
     toRef,
     fromRef,
+    reviewers,
     authorization,
     apiBaseUrl,
   } = opts;
@@ -80,6 +82,7 @@ const createPullRequest = async (opts: {
       locked: true,
       toRef: toRef,
       fromRef: fromRef,
+      reviewers: reviewers?.map(reviewer => ({ user: { name: reviewer } })),
     }),
     headers: {
       Authorization: authorization,
@@ -253,6 +256,7 @@ export function createPublishBitbucketServerPullRequestAction(options: {
     description?: string;
     targetBranch?: string;
     sourceBranch: string;
+    reviewers?: string[];
     token?: string;
     gitAuthorName?: string;
     gitAuthorEmail?: string;
@@ -287,6 +291,15 @@ export function createPublishBitbucketServerPullRequestAction(options: {
             title: 'Source Branch',
             type: 'string',
             description: 'Branch of repository to copy changes from',
+          },
+          reviewers: {
+            title: 'Pull Request Reviewers',
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+            description:
+              'The usernames of reviewers that will be added to the pull request',
           },
           token: {
             title: 'Authorization Token',
@@ -323,6 +336,7 @@ export function createPublishBitbucketServerPullRequestAction(options: {
         description,
         targetBranch,
         sourceBranch,
+        reviewers,
         gitAuthorName,
         gitAuthorEmail,
       } = ctx.input;
@@ -473,6 +487,7 @@ export function createPublishBitbucketServerPullRequestAction(options: {
         description,
         toRef,
         fromRef,
+        reviewers,
         authorization,
         apiBaseUrl,
       });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This allows for a reviewers for a PR to be added automatically from backstage.

This doesn't include default-reviewers because those require a separate semi-official API call to get, which I didn't want to implement for now.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
