### PR TITLE
SearchType.Accordion UX improvement

### DIFF
--- a/.changeset/shy-plants-retire.md
+++ b/.changeset/shy-plants-retire.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-search': patch
 ---
 
-Updated the default SearchType.Accordion behavior to remain open after result type selection. This is a UX improvement to reduce the number of clicks needed when toggling result type filters."
+Updated the default SearchType.Accordion behavior to remain open after result type selection. This is a UX improvement to reduce the number of clicks needed when toggling result type filters.

--- a/.changeset/shy-plants-retire.md
+++ b/.changeset/shy-plants-retire.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search': patch
+---
+
+Updated the default SearchType.Accordion behavior to remain open after result type selection. This is a UX improvement to reduce the number of clicks needed when toggling result type filters."

--- a/plugins/search/src/components/SearchType/SearchType.Accordion.test.tsx
+++ b/plugins/search/src/components/SearchType/SearchType.Accordion.test.tsx
@@ -140,18 +140,6 @@ describe('SearchType.Accordion', () => {
     expect(setPageCursorMock).toHaveBeenCalledWith(undefined);
   });
 
-  it('should collapse when a new type is selected', async () => {
-    const { getByText, queryByText } = render(
-      <Wrapper>
-        <SearchType.Accordion name={expectedLabel} types={[expectedType]} />
-      </Wrapper>,
-    );
-
-    await user.click(getByText(expectedType.name));
-
-    expect(queryByText('Collapse')).not.toBeInTheDocument();
-  });
-
   it('should show result counts if enabled', async () => {
     const { getAllByText } = render(
       <Wrapper>

--- a/plugins/search/src/components/SearchType/SearchType.Accordion.tsx
+++ b/plugins/search/src/components/SearchType/SearchType.Accordion.tsx
@@ -96,7 +96,6 @@ export const SearchTypeAccordion = (props: SearchTypeAccordionProps) => {
     return () => {
       setTypes(type !== '' ? [type] : []);
       setPageCursor(undefined);
-      setExpanded(false);
     };
   };
 


### PR DESCRIPTION
Updates default SearchType.Accordion behavior to NOT close accordion after selection. This is a UX improvement to reduce the number of clicks needed when toggling result type filters. Fixes https://github.com/backstage/backstage/issues/26818

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
