### PR TITLE
fix(techdocs): avoid rerender when clicking on anchor links in same page

### DIFF
--- a/.changeset/mighty-spoons-suffer.md
+++ b/.changeset/mighty-spoons-suffer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Avoid page re-rendering when clicking on anchor links in the same documentation page.

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx
@@ -208,7 +208,18 @@ export const useTechDocsReaderDom = (
               if (modifierActive) {
                 window.open(url, '_blank');
               } else {
-                navigate(url);
+                // If it's in a different page, we navigate to it
+                if (window.location.pathname !== parsedUrl.pathname) {
+                  navigate(url);
+                } else {
+                  // If it's in the same page we avoid using navigate that causes
+                  // the page to rerender.
+                  window.history.pushState(
+                    null,
+                    document.title,
+                    parsedUrl.hash,
+                  );
+                }
                 // Scroll to hash if it's on the current page
                 transformedElement
                   ?.querySelector(`[id="${parsedUrl.hash.slice(1)}"]`)


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix an issue that caused the page to re-render when clicking on anchor links (for example, in the Table of Content).

This PR checks if the link is towards an anchor in the same page and uses `window.history.pushState` instead of `navigate` (which calls `react-router-dom` and cause the page to re-render).

This should fix:
Bug Report: TechDocs page reloads when clicking anchor links #15804
[TechDocs] clicking on an anchor of TechDocs page result in full page reload #10803

I'm able to reproduce the issue on the [Backstage docs in the demo instance](https://demo.backstage.io/docs/default/component/backstage/getting-started/#general-folder-structure).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] ~Added or updated documentation~
- [X] ~Tests for new functionality and regression tests for bug fixes~
- [X] ~Screenshots attached (for UI changes)~
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
