### PR TITLE
fix(techdocs): avoid rerender current page when navigating

### DIFF
--- a/.changeset/slimy-jobs-scream.md
+++ b/.changeset/slimy-jobs-scream.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-techdocs-react': patch
+'@backstage/plugin-techdocs': patch
+---
+
+Fix an issue that caused the current documentation page to be re-rendered when navigating to
+another one.

--- a/plugins/techdocs-react/src/component.test.tsx
+++ b/plugins/techdocs-react/src/component.test.tsx
@@ -64,24 +64,6 @@ describe('TechDocsShadowDom', () => {
     expect(onAppend).toHaveBeenCalledTimes(2);
   });
 
-  it('Should show progress bar while styles are being loaded', async () => {
-    const dom = createDom(
-      '<head><link rel="stylesheet" src="styles.css"/></head><body><h1>Title</h1></body>',
-    );
-    const onAppend = jest.fn();
-    dom.querySelector('link[rel="stylesheet"]')!.addEventListener = () => {};
-
-    render(
-      <TechDocsShadowDom element={dom} onAppend={onAppend}>
-        Children
-      </TechDocsShadowDom>,
-    );
-
-    await await waitFor(() => {
-      expect(screen.getByRole('progressbar')).toBeInTheDocument();
-    });
-  });
-
   it('Should dispatch an event after all styles are loaded', async () => {
     const dom = createDom(
       '<head><link rel="stylesheet" src="styles.css"/></head><body><h1>Title</h1></body>',
@@ -98,15 +80,7 @@ describe('TechDocsShadowDom', () => {
 
     render(<TechDocsShadowDom element={dom}>Children</TechDocsShadowDom>);
 
-    await await waitFor(() => {
-      expect(screen.getByRole('progressbar')).toBeInTheDocument();
-    });
-
     listener({} as Event);
-
-    await waitFor(() => {
-      expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
-    });
 
     expect(handleStylesLoad).toHaveBeenCalledTimes(1);
   });

--- a/plugins/techdocs-react/src/component.tsx
+++ b/plugins/techdocs-react/src/component.tsx
@@ -25,8 +25,6 @@ import { create } from 'jss';
 import StylesProvider from '@material-ui/styles/StylesProvider';
 import jssPreset from '@material-ui/styles/jssPreset';
 
-import { Progress } from '@backstage/core-components';
-
 /**
  * Name for the event dispatched when ShadowRoot styles are loaded.
  * @public
@@ -216,7 +214,6 @@ export const TechDocsShadowDom = (props: TechDocsShadowDomProps) => {
   );
 
   useShadowDomStylesEvents(element);
-  const loading = useShadowDomStylesLoading(element);
 
   const ref = useCallback(
     (shadowHost: HTMLDivElement) => {
@@ -246,7 +243,6 @@ export const TechDocsShadowDom = (props: TechDocsShadowDomProps) => {
 
   return (
     <>
-      {loading && <Progress />}
       {/* The sheetsManager={new Map()} is needed in order to deduplicate the injection of CSS in the page. */}
       <StylesProvider jss={jss} sheetsManager={new Map()}>
         <div ref={ref} data-testid="techdocs-native-shadowroot" />

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/TechDocsReaderPageContent.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/TechDocsReaderPageContent.tsx
@@ -26,13 +26,16 @@ import {
   useTechDocsReaderPage,
 } from '@backstage/plugin-techdocs-react';
 import { CompoundEntityRef } from '@backstage/catalog-model';
-import { Content, ErrorPage } from '@backstage/core-components';
+import { Content, ErrorPage, Progress } from '@backstage/core-components';
 
 import { TechDocsSearch } from '../../../search';
 import { TechDocsStateIndicator } from '../TechDocsStateIndicator';
 
 import { useTechDocsReaderDom } from './dom';
-import { withTechDocsReaderProvider } from '../TechDocsReaderProvider';
+import {
+  useTechDocsReader,
+  withTechDocsReaderProvider,
+} from '../TechDocsReaderProvider';
 import { TechDocsReaderPageContentAddons } from './TechDocsReaderPageContentAddons';
 
 const useStyles = makeStyles({
@@ -81,6 +84,7 @@ export const TechDocsReaderPageContent = withTechDocsReaderProvider(
       entityRef,
       setShadowRoot,
     } = useTechDocsReaderPage();
+    const { state } = useTechDocsReader();
     const dom = useTechDocsReaderDom(entityRef);
     const path = window.location.pathname;
     const hash = window.location.hash;
@@ -143,6 +147,8 @@ export const TechDocsReaderPageContent = withTechDocsReaderProvider(
           )}
           <Grid xs={12} item>
             {/* Centers the styles loaded event to avoid having multiple locations setting the opacity style in Shadow Dom causing the screen to flash multiple times */}
+            {(state === 'CHECKING' || isStyleLoading) && <Progress />}
+
             <TechDocsShadowDom element={dom} onAppend={handleAppend}>
               <TechDocsReaderPageContentAddons />
             </TechDocsShadowDom>

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx
@@ -265,6 +265,12 @@ export const useTechDocsReaderDom = (
         return;
       }
 
+      // Skip this update if the location's path has changed but the state
+      // contains a page for another page that isn't loaded yet.
+      if (!window.location.pathname.endsWith(path)) {
+        return;
+      }
+
       // Scroll to top after render
       window.scroll({ top: 0 });
 
@@ -272,6 +278,7 @@ export const useTechDocsReaderDom = (
       const postTransformedDomElement = await postRender(
         preTransformedDomElement,
       );
+
       setDom(postTransformedDomElement as HTMLElement);
     });
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR fixes an issue that caused the current documentation page to be re-rendered when navigating to
another one.

Fixes #26751  (🐛 Bug Report: TechDocs reloads current page before changing to new page)

Similar to #25594 (TechDocs - Navigation page flicker)


**Before/After**

https://github.com/user-attachments/assets/76053401-025f-4cee-a426-75e7b1b23bc6

https://github.com/user-attachments/assets/6aac723b-c2f6-4973-b3d2-612e53e79dfc

**Before/After (with throttle to show the loading bar)**

https://github.com/user-attachments/assets/a1531dac-7021-4b4d-a9c6-4be9de033437

https://github.com/user-attachments/assets/113a13cc-0bae-4e78-a4ec-3fcd36fbc10d

**Note:** the progress bar is showing after a [small transition delay](https://github.com/backstage/backstage/blob/master/packages/core-components/src/components/Progress/Progress.tsx) (this is integrated in the `core-components` package).
This means that in most cases the progress bar won't be shown as the latency isn't noticeable by the user.

### What happens

When clicking on the navigation, there's [a call to `navigate`](https://github.com/backstage/backstage/blob/master/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx#L221).

This causes the shadow dom to be re-rendered immediately with the current page. If you add network throttling you can see that the styles are reloaded, even though the new page isn't fetched yet, which displays the first progress bar.

When the styles are loaded the bar disappear and the current page is shown. After the new content has been loaded, the DOM is replaced with the new page and starts the download of the styles again (the second progress bar).

This PR avoids the first DOM replacement by checking the path in the reader state and the actual browser path.
The progress bar is moved in the parent component to handle the two loading state (when the content is being retrieved from the storage API and when the styles are being loaded by the browser).


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] ~Added or updated documentation~
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
