### PR TITLE
feat(scaffolder): allow actions to return as 'skipped'

### DIFF
--- a/.changeset/fast-jars-repair.md
+++ b/.changeset/fast-jars-repair.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+'@backstage/plugin-scaffolder-node': patch
+---
+
+Add throwable `SkipTask` that can be used in actions to display task as being skipped rather than failed or success.

--- a/plugins/scaffolder-node/report.api.md
+++ b/plugins/scaffolder-node/report.api.md
@@ -300,6 +300,11 @@ export type SerializedTaskEvent = {
 };
 
 // @public
+export class SkipTask extends Error {
+  constructor();
+}
+
+// @public
 export interface TaskBroker {
   // (undocumented)
   cancel?(taskId: string): Promise<void>;

--- a/plugins/scaffolder-node/src/tasks/errors.ts
+++ b/plugins/scaffolder-node/src/tasks/errors.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 The Backstage Authors
+ * Copyright 2024 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,14 @@
  * limitations under the License.
  */
 
-export type {
-  TaskSecrets,
-  SerializedTask,
-  SerializedTaskEvent,
-  TaskBroker,
-  TaskBrokerDispatchOptions,
-  TaskBrokerDispatchResult,
-  TaskCompletionState,
-  TaskContext,
-  TaskEventType,
-  TaskStatus,
-} from './types';
-export { SkipTask } from './errors';
+/**
+ * Throwing allows an action to display the task as skipped
+ *
+ * @public
+ */
+export class SkipTask extends Error {
+  constructor() {
+    super();
+    this.name = 'SkipTask';
+  }
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Actions are able to return success or failed (by throwing an `Error`). However, there's no way to indicate via the UI that the action was skipped like it does when the `if` condition in your template is falsey. For example, if my action is creating a new resource but the resource already exists it would make more sense to show the action was skipped rather than success because the task didn't really perform any action. This PR allows actions to throw a `SkipTask` which will display the action as skipped rather than success.

I'm opening this as Draft because I want to get some feedback if the approach I'm taking here is OK or if this will break anything. Thanks!

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
