### PR TITLE
fix(scaffolder): only show task routes with permission

### DIFF
--- a/.changeset/quiet-lions-lie.md
+++ b/.changeset/quiet-lions-lie.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+'@backstage/plugin-scaffolder': patch
+---
+
+Scaffolder task routes require read permission to access. The tasks list option in the scaffolder page context menu only shows with permission.

--- a/plugins/scaffolder-react/src/next/components/ScaffolderPageContextMenu/ScaffolderPageContextMenu.tsx
+++ b/plugins/scaffolder-react/src/next/components/ScaffolderPageContextMenu/ScaffolderPageContextMenu.tsx
@@ -27,6 +27,8 @@ import Edit from '@material-ui/icons/Edit';
 import List from '@material-ui/icons/List';
 import MoreVert from '@material-ui/icons/MoreVert';
 import React, { useState } from 'react';
+import { usePermission } from '@backstage/plugin-permission-react';
+import { taskReadPermission } from '@backstage/plugin-scaffolder-common/alpha';
 
 const useStyles = makeStyles(theme => ({
   button: {
@@ -54,6 +56,10 @@ export function ScaffolderPageContextMenu(
     props;
   const classes = useStyles();
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement>();
+
+  const { allowed: canReadTasks } = usePermission({
+    permission: taskReadPermission,
+  });
 
   if (!onEditorClicked && !onActionsClicked) {
     return null;
@@ -116,7 +122,7 @@ export function ScaffolderPageContextMenu(
               <ListItemText primary="Installed Actions" />
             </MenuItem>
           )}
-          {onTasksClicked && (
+          {onTasksClicked && canReadTasks && (
             <MenuItem onClick={onTasksClicked}>
               <ListItemIcon>
                 <List fontSize="small" />

--- a/plugins/scaffolder/src/components/ActionsPage/ActionsPage.test.tsx
+++ b/plugins/scaffolder/src/components/ActionsPage/ActionsPage.test.tsx
@@ -23,6 +23,7 @@ import { renderInTestApp, TestApiRegistry } from '@backstage/test-utils';
 import { ApiProvider } from '@backstage/core-app-api';
 import { rootRouteRef } from '../../routes';
 import { userEvent } from '@testing-library/user-event';
+import { permissionApiRef } from '@backstage/plugin-permission-react';
 
 const scaffolderApiMock: jest.Mocked<ScaffolderApi> = {
   scaffold: jest.fn(),
@@ -36,7 +37,11 @@ const scaffolderApiMock: jest.Mocked<ScaffolderApi> = {
   autocomplete: jest.fn(),
 };
 
-const apis = TestApiRegistry.from([scaffolderApiRef, scaffolderApiMock]);
+const mockPermissionApi = { authorize: jest.fn() };
+const apis = TestApiRegistry.from(
+  [scaffolderApiRef, scaffolderApiMock],
+  [permissionApiRef, mockPermissionApi],
+);
 
 describe('TemplatePage', () => {
   beforeEach(() => jest.resetAllMocks());

--- a/plugins/scaffolder/src/components/ListTasksPage/ListTaskPage.test.tsx
+++ b/plugins/scaffolder/src/components/ListTasksPage/ListTaskPage.test.tsx
@@ -30,6 +30,7 @@ import {
 } from '@backstage/plugin-scaffolder-react';
 import { act, fireEvent } from '@testing-library/react';
 import { rootRouteRef } from '../../routes';
+import { permissionApiRef } from '@backstage/plugin-permission-react';
 
 describe('<ListTasksPage />', () => {
   const catalogApi: jest.Mocked<CatalogApi> = {
@@ -48,6 +49,8 @@ describe('<ListTasksPage />', () => {
     getTemplateParameterSchema: jest.fn(),
     listTasks: jest.fn(),
   } as any;
+
+  const mockPermissionApi = { authorize: jest.fn() };
 
   it('should render the page', async () => {
     const entity: Entity = {
@@ -72,6 +75,7 @@ describe('<ListTasksPage />', () => {
           [catalogApiRef, catalogApi],
           [identityApiRef, identityApi],
           [scaffolderApiRef, scaffolderApiMock],
+          [permissionApiRef, mockPermissionApi],
         ]}
       >
         <ListTasksPage />
@@ -132,6 +136,7 @@ describe('<ListTasksPage />', () => {
           [catalogApiRef, catalogApi],
           [identityApiRef, identityApi],
           [scaffolderApiRef, scaffolderApiMock],
+          [permissionApiRef, mockPermissionApi],
         ]}
       >
         <ListTasksPage />
@@ -230,6 +235,7 @@ describe('<ListTasksPage />', () => {
           [catalogApiRef, catalogApi],
           [identityApiRef, identityApi],
           [scaffolderApiRef, scaffolderApiMock],
+          [permissionApiRef, mockPermissionApi],
         ]}
       >
         <ListTasksPage />

--- a/plugins/scaffolder/src/components/Router/Router.tsx
+++ b/plugins/scaffolder/src/components/Router/Router.tsx
@@ -59,6 +59,8 @@ import {
   TemplateEditorPage,
   CustomFieldsPage,
 } from '../../alpha/components/TemplateEditorPage';
+import { RequirePermission } from '@backstage/plugin-permission-react';
+import { taskReadPermission } from '@backstage/plugin-scaffolder-common/alpha';
 
 /**
  * The Props for the Scaffolder Router
@@ -162,9 +164,11 @@ export const Router = (props: PropsWithChildren<RouterProps>) => {
       <Route
         path={scaffolderTaskRouteRef.path}
         element={
-          <TaskPageComponent
-            TemplateOutputsComponent={TemplateOutputsComponent}
-          />
+          <RequirePermission permission={taskReadPermission}>
+            <TaskPageComponent
+              TemplateOutputsComponent={TemplateOutputsComponent}
+            />
+          </RequirePermission>
         }
       />
       <Route
@@ -199,7 +203,11 @@ export const Router = (props: PropsWithChildren<RouterProps>) => {
       <Route path={actionsRouteRef.path} element={<ActionsPage />} />
       <Route
         path={scaffolderListTaskRouteRef.path}
-        element={<ListTasksPage />}
+        element={
+          <RequirePermission permission={taskReadPermission}>
+            <ListTasksPage />
+          </RequirePermission>
+        }
       />
       <Route
         path={editorRouteRef.path}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR addresses two issues:
1. The template page context menu shows "Tasks list" navigation option even if you are denied tasks read permission. Clicking this option under this condition will take you to the task lists page just to see some 403 errors and unrendered page. If user doesn't have read permission, we shouldn't show the option.
2. User can navigate to task routes without read permission and will see 403 errors and unrendered page. If the user doesn't have read permission, then it should show error page.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
