### PR TITLE
add customisable techdocs code bg color that defaults to background.paper

### DIFF
--- a/.changeset/slimy-ravens-end.md
+++ b/.changeset/slimy-ravens-end.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-techdocs': minor
+'@backstage/theme': minor
+---
+
+Adds support for custom background colors in code blocks and inline code within TechDocs.

--- a/packages/theme/report.api.md
+++ b/packages/theme/report.api.md
@@ -313,7 +313,6 @@ export const palettes: {
     tabbar: {
       indicator: string;
     };
-    code: {};
   };
   dark: {
     type: 'dark';
@@ -388,7 +387,6 @@ export const palettes: {
     tabbar: {
       indicator: string;
     };
-    code: {};
   };
 };
 

--- a/packages/theme/report.api.md
+++ b/packages/theme/report.api.md
@@ -81,6 +81,9 @@ export type BackstagePaletteAdditions = {
     closeButtonColor?: string;
     warning?: string;
   };
+  code: {
+    background?: string;
+  };
 };
 
 // @public @deprecated
@@ -310,6 +313,7 @@ export const palettes: {
     tabbar: {
       indicator: string;
     };
+    code: {};
   };
   dark: {
     type: 'dark';
@@ -384,6 +388,7 @@ export const palettes: {
     tabbar: {
       indicator: string;
     };
+    code: {};
   };
 };
 

--- a/packages/theme/src/base/palettes.ts
+++ b/packages/theme/src/base/palettes.ts
@@ -89,6 +89,7 @@ export const palettes = {
     tabbar: {
       indicator: '#9BF0E1',
     },
+    code: {},
   },
   dark: {
     type: 'dark' as const,
@@ -163,5 +164,6 @@ export const palettes = {
     tabbar: {
       indicator: '#9BF0E1',
     },
+    code: {},
   },
 };

--- a/packages/theme/src/base/palettes.ts
+++ b/packages/theme/src/base/palettes.ts
@@ -89,7 +89,6 @@ export const palettes = {
     tabbar: {
       indicator: '#9BF0E1',
     },
-    code: {},
   },
   dark: {
     type: 'dark' as const,
@@ -164,6 +163,5 @@ export const palettes = {
     tabbar: {
       indicator: '#9BF0E1',
     },
-    code: {},
   },
 };

--- a/packages/theme/src/base/types.ts
+++ b/packages/theme/src/base/types.ts
@@ -82,6 +82,9 @@ export type BackstagePaletteAdditions = {
     closeButtonColor?: string;
     warning?: string;
   };
+  code: {
+    background?: string;
+  };
 };
 
 /**

--- a/plugins/techdocs/src/reader/transformers/styles/rules/variables.ts
+++ b/plugins/techdocs/src/reader/transformers/styles/rules/variables.ts
@@ -109,7 +109,7 @@ export default ({ theme }: RuleOptions) => `
   /* CODE */
   --md-code-fg-color: ${theme.palette.text.primary};
   --md-code-bg-color: ${
-    theme.palette.code.background || theme.palette.background.paper
+    theme.palette.code?.background ?? theme.palette.background.paper
   };
   --md-code-hl-color: ${alpha(theme.palette.warning.main, 0.5)};
   --md-code-hl-color--light: var(--md-code-hl-color);

--- a/plugins/techdocs/src/reader/transformers/styles/rules/variables.ts
+++ b/plugins/techdocs/src/reader/transformers/styles/rules/variables.ts
@@ -108,7 +108,9 @@ export default ({ theme }: RuleOptions) => `
 :host > * {
   /* CODE */
   --md-code-fg-color: ${theme.palette.text.primary};
-  --md-code-bg-color: ${theme.palette.background.paper};
+  --md-code-bg-color: ${
+    theme.palette.code.background || theme.palette.background.paper
+  };
   --md-code-hl-color: ${alpha(theme.palette.warning.main, 0.5)};
   --md-code-hl-color--light: var(--md-code-hl-color);
   --md-code-hl-keyword-color: ${


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds a customisable TechDocs code-block and inline-code background color to the Theme palette. If no custom color is provided then `palette.background.paper` is used as is the current behaviour in main.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
