### PR TITLE
[scaffolder-react] Add an overridable className to template stepper

### DIFF
--- a/.changeset/breezy-berries-yawn.md
+++ b/.changeset/breezy-berries-yawn.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-react': patch
 ---
 
-Update template form buttons from `justifyContent` 'right' to `justifyContent` 'left'
+Add `overridableComponent` `BackstageTemplateStepperClassKey` to template stepper to enable custom styling

--- a/.changeset/breezy-berries-yawn.md
+++ b/.changeset/breezy-berries-yawn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+Update template form buttons from `justifyContent` 'right' to `justifyContent` 'left'

--- a/plugins/scaffolder-react/report-alpha.api.md
+++ b/plugins/scaffolder-react/report-alpha.api.md
@@ -200,10 +200,17 @@ export type ScaffolderPageContextMenuProps = {
 // @alpha (undocumented)
 export type ScaffolderReactComponentsNameToClassKey = {
   ScaffolderReactTemplateCategoryPicker: ScaffolderReactTemplateCategoryPickerClassKey;
+  BackstageTemplateStepper: BackstageTemplateStepperClassKey;
 };
 
 // @alpha (undocumented)
 export type ScaffolderReactTemplateCategoryPickerClassKey = 'root' | 'label';
+
+// @alpha (undocumented)
+export type BackstageTemplateStepperClassKey =
+  | 'backButton'
+  | 'footer'
+  | 'formWrapper';
 
 // @alpha
 export const SecretWidget: (
@@ -416,8 +423,9 @@ export type WorkflowProps = {
 // src/next/hooks/useTemplateSchema.d.ts:12:5 - (ae-undocumented) Missing documentation for "schema".
 // src/next/hooks/useTemplateSchema.d.ts:13:5 - (ae-undocumented) Missing documentation for "title".
 // src/next/hooks/useTemplateSchema.d.ts:14:5 - (ae-undocumented) Missing documentation for "description".
-// src/next/overridableComponents.d.ts:5:1 - (ae-undocumented) Missing documentation for "ScaffolderReactComponentsNameToClassKey".
-// src/next/overridableComponents.d.ts:9:1 - (ae-undocumented) Missing documentation for "BackstageOverrides".
+// src/next/overridableComponents.d.ts:6:1 - (ae-undocumented) Missing documentation for "ScaffolderReactComponentsNameToClassKey".
+// src/next/overridableComponents.d.ts:8:5 - (ae-forgotten-export) The symbol "BackstageTemplateStepperClassKey" needs to be exported by the entry point alpha.d.ts
+// src/next/overridableComponents.d.ts:11:1 - (ae-undocumented) Missing documentation for "BackstageOverrides".
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/scaffolder-react/report-alpha.api.md
+++ b/plugins/scaffolder-react/report-alpha.api.md
@@ -206,12 +206,6 @@ export type ScaffolderReactComponentsNameToClassKey = {
 // @alpha (undocumented)
 export type ScaffolderReactTemplateCategoryPickerClassKey = 'root' | 'label';
 
-// @alpha (undocumented)
-export type BackstageTemplateStepperClassKey =
-  | 'backButton'
-  | 'footer'
-  | 'formWrapper';
-
 // @alpha
 export const SecretWidget: (
   props: Pick<

--- a/plugins/scaffolder-react/src/next/components/Stepper/Stepper.tsx
+++ b/plugins/scaffolder-react/src/next/components/Stepper/Stepper.tsx
@@ -56,6 +56,7 @@ import { merge } from 'lodash';
 const validator = customizeValidator();
 ajvErrors(validator.ajv);
 
+/** @alpha */
 export type BackstageTemplateStepperClassKey =
   | 'backButton'
   | 'footer'

--- a/plugins/scaffolder-react/src/next/components/Stepper/Stepper.tsx
+++ b/plugins/scaffolder-react/src/next/components/Stepper/Stepper.tsx
@@ -56,20 +56,28 @@ import { merge } from 'lodash';
 const validator = customizeValidator();
 ajvErrors(validator.ajv);
 
-const useStyles = makeStyles(theme => ({
-  backButton: {
-    marginRight: theme.spacing(1),
-  },
-  footer: {
-    display: 'flex',
-    flexDirection: 'row',
-    justifyContent: 'left',
-    marginTop: theme.spacing(2),
-  },
-  formWrapper: {
-    padding: theme.spacing(2),
-  },
-}));
+export type BackstageTemplateStepperClassKey =
+  | 'backButton'
+  | 'footer'
+  | 'formWrapper';
+
+const useStyles = makeStyles(
+  theme => ({
+    backButton: {
+      marginRight: theme.spacing(1),
+    },
+    footer: {
+      display: 'flex',
+      flexDirection: 'row',
+      justifyContent: 'right',
+      marginTop: theme.spacing(2),
+    },
+    formWrapper: {
+      padding: theme.spacing(2),
+    },
+  }),
+  { name: 'BackstageTemplateStepper' },
+);
 
 /**
  * The Props for {@link Stepper} component

--- a/plugins/scaffolder-react/src/next/components/Stepper/Stepper.tsx
+++ b/plugins/scaffolder-react/src/next/components/Stepper/Stepper.tsx
@@ -63,7 +63,7 @@ const useStyles = makeStyles(theme => ({
   footer: {
     display: 'flex',
     flexDirection: 'row',
-    justifyContent: 'right',
+    justifyContent: 'left',
     marginTop: theme.spacing(2),
   },
   formWrapper: {

--- a/plugins/scaffolder-react/src/next/overridableComponents.ts
+++ b/plugins/scaffolder-react/src/next/overridableComponents.ts
@@ -17,10 +17,12 @@
 import { Overrides } from '@material-ui/core/styles/overrides';
 import { StyleRules } from '@material-ui/core/styles/withStyles';
 import { ScaffolderReactTemplateCategoryPickerClassKey } from './components/TemplateCategoryPicker/TemplateCategoryPicker';
+import { BackstageTemplateStepperClassKey } from './components/Stepper/Stepper';
 
 /** @alpha */
 export type ScaffolderReactComponentsNameToClassKey = {
   ScaffolderReactTemplateCategoryPicker: ScaffolderReactTemplateCategoryPickerClassKey;
+  BackstageTemplateStepper: BackstageTemplateStepperClassKey;
 };
 
 /** @alpha */


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist
Our design team has mentioned this to us developers on many instances:
"[There is research to support that left alignment is better](https://adamsilver.io/blog/where-to-put-buttons-on-forms/)" 
Though there are many opportunities to improve this through out, we saw Templates as an easy win 🤞 

Adding an overridable className `BackstageTemplateStepper`, so that teams can update the template stepper styling like this if they want to:
<img width="1389" alt="Screenshot 2024-10-03 at 2 24 12 PM" src="https://github.com/user-attachments/assets/8c0dcde0-175c-495b-ad99-ac0fc796e272">


<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
