### PR TITLE
Fix/createbranch githelper

### DIFF
--- a/.changeset/thick-tables-give.md
+++ b/.changeset/thick-tables-give.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-node': patch
 ---
 
-Use Git class' branch function instead of checkout function when creating branch
+Use `branch` function instead of `checkout` function when creating branch

--- a/.changeset/thick-tables-give.md
+++ b/.changeset/thick-tables-give.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-node': patch
+---
+
+Use Git class' branch function instead of checkout function when creating branch

--- a/plugins/scaffolder-node/src/actions/gitHelpers.test.ts
+++ b/plugins/scaffolder-node/src/actions/gitHelpers.test.ts
@@ -32,6 +32,7 @@ jest.mock('../scm', () => ({
       init: jest.fn(),
       add: jest.fn(),
       checkout: jest.fn(),
+      branch: jest.fn(),
       commit: jest
         .fn()
         .mockResolvedValue('220f19cc36b551763d157f1b5e4a4b446165dbd6'),
@@ -444,7 +445,7 @@ describe('createBranch', () => {
     });
 
     it('create the branch', () => {
-      expect(mockedGit.checkout).toHaveBeenCalledWith({
+      expect(mockedGit.branch).toHaveBeenCalledWith({
         ref: 'trunk',
         dir: '/tmp/repo/dir/',
       });
@@ -460,7 +461,7 @@ describe('createBranch', () => {
       },
     });
 
-    expect(mockedGit.checkout).toHaveBeenCalledWith({
+    expect(mockedGit.branch).toHaveBeenCalledWith({
       ref: 'trunk',
       dir: '/tmp/repo/dir/',
     });

--- a/plugins/scaffolder-node/src/actions/gitHelpers.ts
+++ b/plugins/scaffolder-node/src/actions/gitHelpers.ts
@@ -178,7 +178,7 @@ export async function createBranch(options: {
     logger,
   });
 
-  await git.checkout({ dir, ref });
+  await git.branch({ dir, ref });
 }
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

scaffolder-node plugin's createBranch function is using isomorphic-git `checkout` function instead of `branch` function, which results to an error when trying to createBranch.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
