### PR TITLE
Allow 'Resource' to declare relations 'partOf' and 'hasPart'

### DIFF
--- a/.changeset/clever-taxis-drop.md
+++ b/.changeset/clever-taxis-drop.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-model': minor
+---
+
+Add partOf and hasPart to entity type Resource model

--- a/.changeset/itchy-books-obey.md
+++ b/.changeset/itchy-books-obey.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': minor
+---
+
+Allow entity type Resource to declare partOf and hasPart relations

--- a/docs/features/software-catalog/well-known-relations.md
+++ b/docs/features/software-catalog/well-known-relations.md
@@ -95,9 +95,11 @@ This relation is commonly based on `spec.memberOf`.
 
 ### `partOf` and `hasPart`
 
-A relation with a [Domain](descriptor-format.md#kind-domain),
+A relation with a [Resource](descriptor-format.md#kind-resource),
+[Domain](descriptor-format.md#kind-domain),
 [System](descriptor-format.md#kind-system) or
-[Component](descriptor-format.md#kind-component) entity, typically from a
+[Component](descriptor-format.md#kind-component) entity, typically from another
+[Resource](descriptor-format.md#kind-resource),
 [Component](descriptor-format.md#kind-component),
 [API](descriptor-format.md#kind-api),
 [System](descriptor-format.md#kind-system), or

--- a/packages/catalog-model/report.api.md
+++ b/packages/catalog-model/report.api.md
@@ -414,6 +414,8 @@ interface ResourceEntityV1alpha1 extends Entity {
     owner: string;
     dependsOn?: string[];
     dependencyOf?: string[];
+    partOf?: string[];
+    hasPart?: string[];
     system?: string;
   };
 }

--- a/packages/catalog-model/src/kinds/ResourceEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/ResourceEntityV1alpha1.ts
@@ -35,6 +35,8 @@ export interface ResourceEntityV1alpha1 extends Entity {
     owner: string;
     dependsOn?: string[];
     dependencyOf?: string[];
+    partOf?: string[];
+    hasPart?: string[];
     system?: string;
   };
 }

--- a/packages/catalog-model/src/schema/kinds/Resource.v1alpha1.schema.json
+++ b/packages/catalog-model/src/schema/kinds/Resource.v1alpha1.schema.json
@@ -55,6 +55,30 @@
                 "minLength": 1
               }
             },
+            "dependencyOf": {
+              "type": "array",
+              "description": "An array of references to other entities that depend on this resource to function.",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "partOf": {
+              "type": "array",
+              "description": "An array of references to other entities that this resource is a part of.",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "hasPart": {
+              "type": "array",
+              "description": "An array of references to other entities that are part of this resource.",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
             "system": {
               "type": "string",
               "description": "An entity reference to the system that the resource belongs to.",

--- a/packages/catalog-model/src/schema/kinds/Resource.v1alpha1.schema.json
+++ b/packages/catalog-model/src/schema/kinds/Resource.v1alpha1.schema.json
@@ -47,6 +47,11 @@
               "examples": ["artist-relations-team", "user:john.johnson"],
               "minLength": 1
             },
+            "system": {
+              "type": "string",
+              "description": "An entity reference to the system that the resource belongs to.",
+              "minLength": 1
+            },
             "dependsOn": {
               "type": "array",
               "description": "An array of references to other entities that the resource depends on to function.",
@@ -78,11 +83,6 @@
                 "type": "string",
                 "minLength": 1
               }
-            },
-            "system": {
-              "type": "string",
-              "description": "An entity reference to the system that the resource belongs to.",
-              "minLength": 1
             }
           }
         }

--- a/plugins/catalog-backend/src/processors/BuiltinKindsEntityProcessor.test.ts
+++ b/plugins/catalog-backend/src/processors/BuiltinKindsEntityProcessor.test.ts
@@ -307,6 +307,8 @@ describe('BuiltinKindsEntityProcessor', () => {
           owner: 'o',
           dependsOn: ['Component:c', 'Resource:r'],
           dependencyOf: ['Component:d'],
+          partOf: ['Resource:r'],
+          hasPart: ['Resource:r'],
           system: 's',
         },
       };

--- a/plugins/catalog-backend/src/processors/BuiltinKindsEntityProcessor.test.ts
+++ b/plugins/catalog-backend/src/processors/BuiltinKindsEntityProcessor.test.ts
@@ -315,7 +315,7 @@ describe('BuiltinKindsEntityProcessor', () => {
 
       await processor.postProcessEntity(entity, location, emit);
 
-      expect(emit).toHaveBeenCalledTimes(10);
+      expect(emit).toHaveBeenCalledTimes(14);
       expect(emit).toHaveBeenCalledWith({
         type: 'relation',
         relation: {

--- a/plugins/catalog-backend/src/processors/BuiltinKindsEntityProcessor.test.ts
+++ b/plugins/catalog-backend/src/processors/BuiltinKindsEntityProcessor.test.ts
@@ -307,8 +307,8 @@ describe('BuiltinKindsEntityProcessor', () => {
           owner: 'o',
           dependsOn: ['Component:c', 'Resource:r'],
           dependencyOf: ['Component:d'],
-          partOf: ['Resource:r'],
-          hasPart: ['Resource:r'],
+          partOf: ['Resource:r1'],
+          hasPart: ['Resource:r2'],
           system: 's',
         },
       };
@@ -364,6 +364,40 @@ describe('BuiltinKindsEntityProcessor', () => {
           source: { kind: 'Resource', namespace: 'default', name: 'r' },
           type: 'dependencyOf',
           target: { kind: 'Resource', namespace: 'default', name: 'n' },
+        },
+      });
+
+      expect(emit).toHaveBeenCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'Resource', namespace: 'default', name: 'n' },
+          type: 'partOf',
+          target: { kind: 'Resource', namespace: 'default', name: 'r1' },
+        },
+      });
+      expect(emit).toHaveBeenCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'Resource', namespace: 'default', name: 'r1' },
+          type: 'hasPart',
+          target: { kind: 'Resource', namespace: 'default', name: 'n' },
+        },
+      });
+
+      expect(emit).toHaveBeenCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'Resource', namespace: 'default', name: 'r2' },
+          type: 'partOf',
+          target: { kind: 'Resource', namespace: 'default', name: 'n' },
+        },
+      });
+      expect(emit).toHaveBeenCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'Resource', namespace: 'default', name: 'n' },
+          type: 'hasPart',
+          target: { kind: 'Resource', namespace: 'default', name: 'r2' },
         },
       });
 

--- a/plugins/catalog-backend/src/processors/BuiltinKindsEntityProcessor.ts
+++ b/plugins/catalog-backend/src/processors/BuiltinKindsEntityProcessor.ts
@@ -225,6 +225,18 @@ export class BuiltinKindsEntityProcessor implements CatalogProcessor {
         RELATION_DEPENDS_ON,
       );
       doEmit(
+        resource.spec.partOf,
+        { defaultNamespace: selfRef.namespace },
+        RELATION_PART_OF,
+        RELATION_HAS_PART,
+      );
+      doEmit(
+        resource.spec.hasPart,
+        { defaultNamespace: selfRef.namespace },
+        RELATION_HAS_PART,
+        RELATION_PART_OF,
+      );
+      doEmit(
         resource.spec.system,
         { defaultKind: 'System', defaultNamespace: selfRef.namespace },
         RELATION_PART_OF,


### PR DESCRIPTION
## Description
Entity type `Resource` is quite restrictive in term of relationships currently allowed, while it is a very generic entity.

According to the documentation:
```
A resource describes the infrastructure a system needs to operate, like BigTable databases, Pub/Sub topics, S3 buckets or CDNs
```

But right now it is lacking a proper relation to describe for example:
- An `RDS instance` is `partOf` an `AWS Account`
- An `ECS Cluster`, `hasPart` an `ECS Service`
- .... the list goes on

You could hack the model and use `dependsOn`/`dependencyOf`, but this does not feel right, to say an `RDS Instance`, `dependsOn` an `AWS Account`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
