### PR TITLE
declare correct type (number) for publish:gitlab output.projectId

### DIFF
--- a/.changeset/quiet-needles-impress.md
+++ b/.changeset/quiet-needles-impress.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gitlab': minor
+---
+
+declare correct type (number) for publish:gitlab output.projectId

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlab.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlab.ts
@@ -294,7 +294,7 @@ export function createPublishGitlabAction(options: {
           },
           projectId: {
             title: 'The ID of the project',
-            type: 'string',
+            type: 'number',
           },
           commitHash: {
             title: 'The git commit hash of the initial commit',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Corrected output schema for `publish:gitlab`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
