### PR TITLE
Fix rootConfigServiceFactory import in rootConfig docs

### DIFF
--- a/docs/backend-system/core-services/root-config.md
+++ b/docs/backend-system/core-services/root-config.md
@@ -44,7 +44,7 @@ There's additional configuration that you can optionally pass to setup the `conf
 You can configure these additional options by adding an override for the core service when calling `createBackend` like follows:
 
 ```ts
-import { rootConfigServiceFactory } from '@backstage/backend-app-api';
+import { rootConfigServiceFactory } from '@backstage/backend-defaults/rootConfig';
 
 const backend = createBackend();
 


### PR DESCRIPTION
Just noticed this import seems to be wrong. Also I noticed clicking "edit this page" on https://backstage.io/docs/backend-system/core-services/root-config/ took me to a 404, not sure if that is a known issue or not.

## Hey, I just made a Pull Request!

Wrong import in docs.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
