### PR TITLE
fix(catalog): update search table in transaction

### DIFF
--- a/.changeset/stale-ravens-clap.md
+++ b/.changeset/stale-ravens-clap.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Update catalog search table in transaction


### PR DESCRIPTION
## Hey, I just made a Pull Request!

- run the delete and insert in transaction for entity search
- mark the deferred stitching done only after search is also updated

relates to #26997 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
