### PR TITLE
cli: add --successCache option for repo test

### DIFF
--- a/.changeset/small-donkeys-attack.md
+++ b/.changeset/small-donkeys-attack.md
@@ -2,6 +2,6 @@
 '@backstage/cli': patch
 ---
 
-Added a new `--successCache` option to the `backstage-cli repo lint` command. The cache keeps track of successful lint runs and avoids re-running linting of individual packages if they haven't changed. This option is primarily intended to be used in CI.
+Added a new `--successCache` option to the `backstage-cli repo test` and `backstage-cli repo lint` commands. The cache keeps track of successful runs and avoids re-running for individual packages if they haven't changed. This option is intended only to be used in CI.
 
-In addition a `--successCacheDir` option has also been added to be able to override the default cache directory.
+In addition a `--successCacheDir <path>` option has also been added to be able to override the default cache directory.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,7 @@ jobs:
         run: yarn backstage-cli repo lint --since origin/master --successCache
 
       - name: test changed packages
-        run: yarn backstage-cli repo test --maxWorkers=3 --workerIdleMemoryLimit=1300M --since origin/master
+        run: yarn backstage-cli repo test --maxWorkers=3 --workerIdleMemoryLimit=1300M --since origin/master --successCache
         env:
           BACKSTAGE_TEST_DISABLE_DOCKER: 1
           BACKSTAGE_TEST_DATABASE_POSTGRES16_CONNECTION_STRING: postgresql://postgres:postgres@localhost:${{ job.services.postgres16.ports[5432] }}

--- a/.github/workflows/verify_windows.yml
+++ b/.github/workflows/verify_windows.yml
@@ -55,7 +55,7 @@ jobs:
         run: yarn lint:type-deps
 
       - name: test
-        run: yarn backstage-cli repo test --maxWorkers=3 --workerIdleMemoryLimit=1300M
+        run: yarn backstage-cli repo test --maxWorkers=3 --workerIdleMemoryLimit=1300M --successCache
         env:
           BACKSTAGE_TEST_DISABLE_DOCKER: 1
 

--- a/docs/tooling/cli/02-build-system.md
+++ b/docs/tooling/cli/02-build-system.md
@@ -564,6 +564,7 @@ The overrides in a single `package.json` may for example look like this:
 Caching is used sparingly throughout the Backstage build system. It is always used as a way to squeeze out a little bit of extra performance, rather than requirement to keep things fast. The following is a list of places where optional caching is available:
 
 - **TypeScript** - The default `tsconfig.json` used by Backstage projects has `incremental` set to `true`, which enables local caching of type checking results. It is however generally not recommended in CI, where `yarn tsc:full` is preferred, which sets `--incremental false`.
+- **Testing** - The `backstage-cli repo test` command has a `--successCache` flag that enables caching of successful test results. This is done at the package level, meaning that if a package has not been changed since the last test run and it was successful, the testing will be skipped. This is recommended to be used in CI, but not during local development.
 - **Linting** - The `backstage-cli repo lint` command has a `--successCache` flag that enables caching of successful linting results. This is done at the package level, meaning that if a package has not been changed since the last lint run and it was successful, the linting will be skipped. This is recommended to be used in CI, but not during local development.
 - **Webpack** - It is possible to enable experimental caching of frontend package builds using the `BACKSTAGE_CLI_EXPERIMENTAL_BUILD_CACHE` environment variable. This will enable the Webpack filesystem cache.
 

--- a/packages/cli/cli-report.md
+++ b/packages/cli/cli-report.md
@@ -469,6 +469,8 @@ Usage: backstage-cli repo test [options]
 
 Options:
   --since <ref>
+  --successCache
+  --successCacheDir <path>
   --jest-help
   -h, --help
 ```

--- a/packages/cli/config/jest.js
+++ b/packages/cli/config/jest.js
@@ -306,7 +306,7 @@ async function getRootConfig() {
     ),
   ).then(_ => _.flat());
 
-  const configs = await Promise.all(
+  let configs = await Promise.all(
     projectPaths.flat().map(async projectPath => {
       const packagePath = path.resolve(projectPath, 'package.json');
       if (!(await fs.pathExists(packagePath))) {
@@ -331,9 +331,15 @@ async function getRootConfig() {
     }),
   ).then(cs => cs.filter(Boolean));
 
+  const cache = global.__backstageCli_jestSuccessCache;
+  if (cache) {
+    configs = await cache.filterConfigs(configs, globalRootConfig);
+  }
+
   return {
     rootDir: paths.targetRoot,
     projects: configs,
+    testResultsProcessor: require.resolve('./jestCacheResultProcessor.cjs'),
     ...globalRootConfig,
   };
 }

--- a/packages/cli/config/jest.js
+++ b/packages/cli/config/jest.js
@@ -339,7 +339,9 @@ async function getRootConfig() {
   return {
     rootDir: paths.targetRoot,
     projects: configs,
-    testResultsProcessor: require.resolve('./jestCacheResultProcessor.cjs'),
+    testResultsProcessor: cache
+      ? require.resolve('./jestCacheResultProcessor.cjs')
+      : undefined,
     ...globalRootConfig,
   };
 }

--- a/packages/cli/config/jestCacheResultProcessor.cjs
+++ b/packages/cli/config/jestCacheResultProcessor.cjs
@@ -16,25 +16,8 @@
 
 module.exports = async results => {
   const cache = global.__backstageCli_jestSuccessCache;
-  if (!cache) {
-    return results;
+  if (cache) {
+    await cache.reportResults(results);
   }
-
-  const successful = new Set();
-  const failed = new Set();
-  for (const testResult of results.testResults) {
-    const projectName = testResult.displayName.name;
-    if (testResult.numFailingTests > 0) {
-      failed.add(projectName);
-      successful.delete(projectName);
-    } else if (!failed.has(projectName)) {
-      successful.add(projectName);
-    }
-  }
-
-  await cache.reportResults({
-    successful: successful,
-  });
-
   return results;
 };

--- a/packages/cli/config/jestCacheResultProcessor.cjs
+++ b/packages/cli/config/jestCacheResultProcessor.cjs
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = async results => {
+  const cache = global.__backstageCli_jestSuccessCache;
+  if (!cache) {
+    return results;
+  }
+
+  const successful = new Set();
+  const failed = new Set();
+  for (const testResult of results.testResults) {
+    const projectName = testResult.displayName.name;
+    if (testResult.numFailingTests > 0) {
+      failed.add(projectName);
+      successful.delete(projectName);
+    } else if (!failed.has(projectName)) {
+      successful.add(projectName);
+    }
+  }
+
+  await cache.reportResults({
+    successful: successful,
+  });
+
+  return results;
+};

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -113,6 +113,7 @@
     "html-webpack-plugin": "^5.3.1",
     "inquirer": "^8.2.0",
     "jest": "^29.7.0",
+    "jest-cli": "^29.7.0",
     "jest-css-modules": "^2.1.0",
     "jest-environment-jsdom": "^29.0.2",
     "jest-runtime": "^29.0.2",
@@ -152,6 +153,7 @@
     "webpack-dev-server": "^5.0.0",
     "webpack-node-externals": "^3.0.0",
     "yaml": "^2.0.0",
+    "yargs": "^16.2.0",
     "yml-loader": "^2.1.0",
     "yn": "^4.0.0",
     "zod": "^3.22.4"

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -106,6 +106,14 @@ export function registerRepoCommand(program: Command) {
       'Only test packages that changed since the specified ref',
     )
     .option(
+      '--successCache',
+      'Enable success caching, which skips running tests for unchanged packages that were successful in the previous run',
+    )
+    .option(
+      '--successCacheDir <path>',
+      'Set the success cache location, (default: node_modules/.cache/backstage-cli)',
+    )
+    .option(
       '--jest-help',
       'Show help for Jest CLI options, which are passed through',
     )

--- a/packages/cli/src/commands/repo/test.ts
+++ b/packages/cli/src/commands/repo/test.ts
@@ -112,7 +112,7 @@ export function createFlagFinder(args: string[]) {
   };
 }
 
-function removeOptionArg(args: string[], option: string) {
+function removeOptionArg(args: string[], option: string, size: number = 2) {
   let changed = false;
   do {
     changed = false;
@@ -120,7 +120,7 @@ function removeOptionArg(args: string[], option: string) {
     const index = args.indexOf(option);
     if (index >= 0) {
       changed = true;
-      args.splice(index, 2);
+      args.splice(index, size);
     }
     const indexEq = args.findIndex(arg => arg.startsWith(`${option}=`));
     if (indexEq >= 0) {
@@ -243,7 +243,7 @@ export async function command(opts: OptionValues, cmd: Command): Promise<void> {
   // This code path is enabled by the --successCache flag, which is specific to
   // the `repo test` command in the Backstage CLI.
   if (opts.successCache) {
-    removeOptionArg(args, '--successCache');
+    removeOptionArg(args, '--successCache', 1);
     removeOptionArg(args, '--successCacheDir');
 
     const cacheDir = resolvePath(

--- a/yarn.lock
+++ b/yarn.lock
@@ -3988,6 +3988,7 @@ __metadata:
     html-webpack-plugin: ^5.3.1
     inquirer: ^8.2.0
     jest: ^29.7.0
+    jest-cli: ^29.7.0
     jest-css-modules: ^2.1.0
     jest-environment-jsdom: ^29.0.2
     jest-runtime: ^29.0.2
@@ -4032,6 +4033,7 @@ __metadata:
     webpack-dev-server: ^5.0.0
     webpack-node-externals: ^3.0.0
     yaml: ^2.0.0
+    yargs: ^16.2.0
     yml-loader: ^2.1.0
     yn: ^4.0.0
     zod: ^3.22.4


### PR DESCRIPTION
## Hey, I just made a Pull Request!

On top of #26986, and it implements the same `--successCache` flag, except this time for `repo test`. It behaves the same, in that it's intended as a CI cache that avoids re-running tests that were successful in the previous run.

The implementation is of course quite different from the lint command. It sets up a bridge for communication with the Jest configuration and additional modules. The result collection is implemented using a custom result processor. I would've preferred calling Jest APIs directly and reading out the results that way, but Jest doesn't export enough utilities to make that worthwhile.

This time around the hashing is a bit of repo-wide metadata, dependency hashes, serialized project config, and file tree hash from Git (@freben 😁). Using the full project config means that the cache keys will change if the workspace location changes in CI. It's quite tricky to trim them out though so I figured we see if it's much of an issue or not, afaik most CI providers ensures a stable working directory path.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
