### PR TITLE
events-backend: skip tests if postgres tests are skipped

### DIFF
--- a/plugins/events-backend/src/migrations.test.ts
+++ b/plugins/events-backend/src/migrations.test.ts
@@ -41,11 +41,14 @@ async function migrateUntilBefore(knex: Knex, target: string): Promise<void> {
 
 jest.setTimeout(60_000);
 
-describe('migrations', () => {
-  const databases = TestDatabases.create({
-    ids: ['POSTGRES_9', 'POSTGRES_13', 'POSTGRES_16'],
-  });
+const databases = TestDatabases.create({
+  ids: ['POSTGRES_9', 'POSTGRES_13', 'POSTGRES_16'],
+});
 
+const maybeDescribe =
+  databases.eachSupportedId().length > 0 ? describe : describe.skip;
+
+maybeDescribe('migrations', () => {
   it.each(databases.eachSupportedId())(
     '20240523100528_init.js, %p',
     async databaseId => {

--- a/plugins/events-backend/src/service/hub/DatabaseEventBusStore.test.ts
+++ b/plugins/events-backend/src/service/hub/DatabaseEventBusStore.test.ts
@@ -27,7 +27,10 @@ const databases = TestDatabases.create({
   ids: ['POSTGRES_9', 'POSTGRES_13', 'POSTGRES_16'],
 });
 
-describe('DatabaseEventBusStore', () => {
+const maybeDescribe =
+  databases.eachSupportedId().length > 0 ? describe : describe.skip;
+
+maybeDescribe('DatabaseEventBusStore', () => {
   it.each(databases.eachSupportedId())(
     'should clean up old events, %p',
     async databaseId => {


### PR DESCRIPTION
🧹, these trigger an error when running tests without PostgreSQL available