### PR TITLE
fix(scaffolder): change entity picker single value behavior

### DIFF
--- a/.changeset/gorgeous-months-fix.md
+++ b/.changeset/gorgeous-months-fix.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Change behavior of scaffolder entity pickers (EntityPicker, MultiEntityPicker, MyGroupsPicker) to not auto-fill and disable the field if there is only a single value option.

--- a/.changeset/gorgeous-months-fix.md
+++ b/.changeset/gorgeous-months-fix.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder': patch
 ---
 
-Change behavior of scaffolder entity pickers (EntityPicker, MultiEntityPicker, MyGroupsPicker) to not auto-fill and disable the field if there is only a single value option.
+Fix behavior of scaffolder entity pickers (EntityPicker, MultiEntityPicker, MyGroupsPicker) to not auto-fill and disable the field if there is only a single value option and the field is not required.

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
@@ -35,7 +35,7 @@ import Autocomplete, {
   AutocompleteChangeReason,
   createFilterOptions,
 } from '@material-ui/lab/Autocomplete';
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback } from 'react';
 import useAsync from 'react-use/esm/useAsync';
 import {
   EntityPickerFilterQueryValue,
@@ -166,12 +166,6 @@ export const EntityPicker = (props: EntityPickerProps) => {
     entities?.catalogEntities.find(e => stringifyEntityRef(e) === formData) ??
     (allowArbitraryValues && formData ? getLabel(formData) : '');
 
-  useEffect(() => {
-    if (entities?.catalogEntities.length === 1 && selectedEntity === '') {
-      onChange(stringifyEntityRef(entities.catalogEntities[0]));
-    }
-  }, [entities, onChange, selectedEntity]);
-
   return (
     <FormControl
       margin="normal"
@@ -179,7 +173,6 @@ export const EntityPicker = (props: EntityPickerProps) => {
       error={rawErrors?.length > 0 && !formData}
     >
       <Autocomplete
-        disabled={entities?.catalogEntities.length === 1}
         id={idSchema?.$id}
         value={selectedEntity}
         loading={loading}

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
@@ -35,7 +35,7 @@ import Autocomplete, {
   AutocompleteChangeReason,
   createFilterOptions,
 } from '@material-ui/lab/Autocomplete';
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import useAsync from 'react-use/esm/useAsync';
 import {
   EntityPickerFilterQueryValue,
@@ -166,6 +166,17 @@ export const EntityPicker = (props: EntityPickerProps) => {
     entities?.catalogEntities.find(e => stringifyEntityRef(e) === formData) ??
     (allowArbitraryValues && formData ? getLabel(formData) : '');
 
+  useEffect(() => {
+    if (
+      required &&
+      !allowArbitraryValues &&
+      entities?.catalogEntities.length === 1 &&
+      selectedEntity === ''
+    ) {
+      onChange(stringifyEntityRef(entities.catalogEntities[0]));
+    }
+  }, [entities, onChange, selectedEntity, required, allowArbitraryValues]);
+
   return (
     <FormControl
       margin="normal"
@@ -173,6 +184,11 @@ export const EntityPicker = (props: EntityPickerProps) => {
       error={rawErrors?.length > 0 && !formData}
     >
       <Autocomplete
+        disabled={
+          required &&
+          !allowArbitraryValues &&
+          entities?.catalogEntities.length === 1
+        }
         id={idSchema?.$id}
         value={selectedEntity}
         loading={loading}

--- a/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.tsx
@@ -34,7 +34,7 @@ import FormControl from '@material-ui/core/FormControl';
 import Autocomplete, {
   AutocompleteChangeReason,
 } from '@material-ui/lab/Autocomplete';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import useAsync from 'react-use/esm/useAsync';
 import { FieldValidation } from '@rjsf/utils';
 import {
@@ -135,12 +135,6 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
     [onChange, formData, defaultKind, defaultNamespace, allowArbitraryValues],
   );
 
-  useEffect(() => {
-    if (entities?.entities?.length === 1) {
-      onChange([stringifyEntityRef(entities?.entities[0])]);
-    }
-  }, [entities, onChange]);
-
   return (
     <FormControl
       margin="normal"
@@ -150,7 +144,6 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
       <Autocomplete
         multiple
         filterSelectedOptions
-        disabled={entities?.entities?.length === 1}
         id={idSchema?.$id}
         defaultValue={formData}
         loading={loading}

--- a/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.tsx
@@ -34,7 +34,7 @@ import FormControl from '@material-ui/core/FormControl';
 import Autocomplete, {
   AutocompleteChangeReason,
 } from '@material-ui/lab/Autocomplete';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import useAsync from 'react-use/esm/useAsync';
 import { FieldValidation } from '@rjsf/utils';
 import {
@@ -135,6 +135,12 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
     [onChange, formData, defaultKind, defaultNamespace, allowArbitraryValues],
   );
 
+  useEffect(() => {
+    if (required && !allowArbitraryValues && entities?.entities?.length === 1) {
+      onChange([stringifyEntityRef(entities?.entities[0])]);
+    }
+  }, [entities, onChange, required, allowArbitraryValues]);
+
   return (
     <FormControl
       margin="normal"
@@ -144,6 +150,9 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
       <Autocomplete
         multiple
         filterSelectedOptions
+        disabled={
+          required && !allowArbitraryValues && entities?.entities?.length === 1
+        }
         id={idSchema?.$id}
         defaultValue={formData}
         loading={loading}

--- a/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useEffect } from 'react';
+import React from 'react';
 import {
   errorApiRef,
   identityApiRef,
@@ -101,12 +101,6 @@ export const MyGroupsPicker = (props: MyGroupsPickerProps) => {
     groups?.catalogEntities.find(e => stringifyEntityRef(e) === formData) ||
     null;
 
-  useEffect(() => {
-    if (groups?.catalogEntities.length === 1 && !selectedEntity) {
-      onChange(stringifyEntityRef(groups.catalogEntities[0]));
-    }
-  }, [groups, onChange, selectedEntity]);
-
   return (
     <FormControl
       margin="normal"
@@ -114,7 +108,6 @@ export const MyGroupsPicker = (props: MyGroupsPickerProps) => {
       error={rawErrors?.length > 0}
     >
       <Autocomplete
-        disabled={groups?.catalogEntities.length === 1}
         id="OwnershipEntityRefPicker-dropdown"
         options={groups?.catalogEntities || []}
         value={selectedEntity}

--- a/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
   errorApiRef,
   identityApiRef,
@@ -101,6 +101,12 @@ export const MyGroupsPicker = (props: MyGroupsPickerProps) => {
     groups?.catalogEntities.find(e => stringifyEntityRef(e) === formData) ||
     null;
 
+  useEffect(() => {
+    if (required && groups?.catalogEntities.length === 1 && !selectedEntity) {
+      onChange(stringifyEntityRef(groups.catalogEntities[0]));
+    }
+  }, [groups, onChange, selectedEntity, required]);
+
   return (
     <FormControl
       margin="normal"
@@ -108,6 +114,7 @@ export const MyGroupsPicker = (props: MyGroupsPickerProps) => {
       error={rawErrors?.length > 0}
     >
       <Autocomplete
+        disabled={required && groups?.catalogEntities.length === 1}
         id="OwnershipEntityRefPicker-dropdown"
         options={groups?.catalogEntities || []}
         value={selectedEntity}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #26107 

The issue is when you have a single result in an entity picker the value is automatically filled and disabled so it can't be changed. The main problem with this is if your field is supposed to be optional, then there's no way to proceed with an empty value, effectively making it a non-intended required field.

I thought about making a new `ui:option` to disable this behavior but ultimately decided the best way to fix this is to remove this behavior all together because in most scenarios it just causes more issues than it solves. Changes in this PR:
1. Entity picker fields are no longer auto-filled with a value if only a single value is available.
2. Entity picker fields are no longer disabled when only a single value is available.

These changes should not affect any current templates other than the fact users will have to manually click the dropdown value when only a single option is available.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
