### PR TITLE
cli: disable feature detection for backend builds

### DIFF
--- a/.changeset/neat-geckos-end.md
+++ b/.changeset/neat-geckos-end.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Tweaked the new package feature detection to not be active when building backend packages.

--- a/packages/cli/src/commands/buildWorkspace.ts
+++ b/packages/cli/src/commands/buildWorkspace.ts
@@ -29,5 +29,6 @@ export default async (dir: string, packages: string[], options: Options) => {
   await createDistWorkspace(packages, {
     targetDir: dir,
     alwaysYarnPack: options.alwaysYarnPack,
+    enableFeatureDetection: true,
   });
 };

--- a/packages/cli/src/commands/pack.ts
+++ b/packages/cli/src/commands/pack.ts
@@ -21,6 +21,7 @@ import {
 import { paths } from '../lib/paths';
 import fs from 'fs-extra';
 import { publishPreflightCheck } from '../lib/publishing';
+import { createTypeDistProject } from '../lib/typeDistProject';
 
 export const pre = async () => {
   publishPreflightCheck({
@@ -28,7 +29,10 @@ export const pre = async () => {
     packageJson: await fs.readJson(paths.resolveTarget('package.json')),
   });
 
-  await productionPack({ packageDir: paths.targetDir });
+  await productionPack({
+    packageDir: paths.targetDir,
+    featureDetectionProject: await createTypeDistProject(),
+  });
 };
 
 export const post = async () => {

--- a/packages/cli/src/lib/packager/createDistWorkspace.ts
+++ b/packages/cli/src/lib/packager/createDistWorkspace.ts
@@ -106,6 +106,12 @@ type Options = {
   alwaysYarnPack?: boolean;
 
   /**
+   * If set to true, the TypeScript feature detection will be enabled, which
+   * annotates the package exports field with the `backstage` export type.
+   */
+  enableFeatureDetection?: boolean;
+
+  /**
    * If set to true, the generated code will be minified.
    */
   minify?: boolean;
@@ -237,6 +243,7 @@ export async function createDistWorkspace(
     targetDir,
     targets,
     Boolean(options.alwaysYarnPack),
+    Boolean(options.enableFeatureDetection),
   );
 
   const files: FileEntry[] = options.files ?? ['yarn.lock', 'package.json'];
@@ -280,6 +287,7 @@ async function moveToDistWorkspace(
   workspaceDir: string,
   localPackages: PackageGraphNode[],
   alwaysYarnPack: boolean,
+  enableFeatureDetection: boolean,
 ): Promise<void> {
   const [fastPackPackages, slowPackPackages] = partition(
     localPackages,
@@ -288,8 +296,10 @@ async function moveToDistWorkspace(
       FAST_PACK_SCRIPTS.includes(pkg.packageJson.scripts?.prepack),
   );
 
-  const tsMorphProject =
-    fastPackPackages.length > 0 ? await createTypeDistProject() : undefined;
+  const featureDetectionProject =
+    fastPackPackages.length > 0 && enableFeatureDetection
+      ? await createTypeDistProject()
+      : undefined;
 
   // New an improved flow where we avoid calling `yarn pack`
   await Promise.all(
@@ -301,7 +311,7 @@ async function moveToDistWorkspace(
       await productionPack({
         packageDir: target.dir,
         targetDir: absoluteOutputPath,
-        project: tsMorphProject,
+        featureDetectionProject,
       });
     }),
   );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This disabled the new feature detection introduced in #26524 in backend builds. The intention was to only have it present in published packages.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
