### PR TITLE
yarn-plugin: Only throw if the version is not already bound

### DIFF
--- a/packages/yarn-plugin/src/resolver/BackstageResolver.test.ts
+++ b/packages/yarn-plugin/src/resolver/BackstageResolver.test.ts
@@ -114,15 +114,20 @@ describe('BackstageResolver', () => {
     });
 
     describe('with range "backstage:1.23.45"', () => {
-      it('throws an error', () => {
-        expect(() =>
+      it('returns the correct descriptor', () => {
+        expect(
           backstageResolver.bindDescriptor(
             structUtils.makeDescriptor(
               structUtils.makeIdent('backstage', 'core'),
               'backstage:1.23.45',
             ),
           ),
-        ).toThrow(/unsupported version range/i);
+        ).toEqual(
+          structUtils.makeDescriptor(
+            structUtils.makeIdent('backstage', 'core'),
+            'backstage:1.23.45',
+          ),
+        );
       });
     });
   });

--- a/packages/yarn-plugin/src/resolver/BackstageResolver.ts
+++ b/packages/yarn-plugin/src/resolver/BackstageResolver.ts
@@ -44,23 +44,14 @@ export class BackstageResolver implements Resolver {
    * the version in backstage.json changes.
    */
   bindDescriptor(descriptor: Descriptor): Descriptor {
-    if (
-      descriptor.range !== 'backstage:^' &&
-      !descriptor.range.startsWith('backstage:')
-    ) {
-      throw new Error(
-        `Unsupported version range "${
-          descriptor.range
-        }" for package ${structUtils.stringifyIdent(
-          descriptor,
-        )}. The backstage protocol only supports the range "backstage:^".`,
+    if (descriptor.range === 'backstage:^') {
+      return structUtils.makeDescriptor(
+        descriptor,
+        `${PROTOCOL}${getCurrentBackstageVersion()}`,
       );
     }
 
-    return structUtils.makeDescriptor(
-      descriptor,
-      `${PROTOCOL}${getCurrentBackstageVersion()}`,
-    );
+    return descriptor;
   }
 
   /**

--- a/packages/yarn-plugin/src/resolver/BackstageResolver.ts
+++ b/packages/yarn-plugin/src/resolver/BackstageResolver.ts
@@ -44,7 +44,10 @@ export class BackstageResolver implements Resolver {
    * the version in backstage.json changes.
    */
   bindDescriptor(descriptor: Descriptor): Descriptor {
-    if (descriptor.range !== 'backstage:^') {
+    if (
+      descriptor.range !== 'backstage:^' &&
+      !descriptor.range.startsWith('backstage:')
+    ) {
       throw new Error(
         `Unsupported version range "${
           descriptor.range


### PR DESCRIPTION
Ran into an issue internally that this gets called with `backstage:1.31.0` or whatever as a resolved version and then ends up throwing an error. Not sure if this is the right fix or not?
