### PR TITLE
make the code palette optional

### DIFF
--- a/packages/theme/report.api.md
+++ b/packages/theme/report.api.md
@@ -81,7 +81,7 @@ export type BackstagePaletteAdditions = {
     closeButtonColor?: string;
     warning?: string;
   };
-  code: {
+  code?: {
     background?: string;
   };
 };

--- a/packages/theme/src/base/types.ts
+++ b/packages/theme/src/base/types.ts
@@ -82,7 +82,7 @@ export type BackstagePaletteAdditions = {
     closeButtonColor?: string;
     warning?: string;
   };
-  code: {
+  code?: {
     background?: string;
   };
 };


### PR DESCRIPTION
On top of #26953, since I don't want this to be a forced part of the type anywhere.

Piggybacking on the pre-existing changesets