### PR TITLE
cli: disable parsing of input source maps in tests

### DIFF
--- a/.changeset/ten-apes-turn.md
+++ b/.changeset/ten-apes-turn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Disabled parsing of input source maps in the SWC transform for Jest.

--- a/packages/cli/config/jestSwcTransform.js
+++ b/packages/cli/config/jestSwcTransform.js
@@ -18,7 +18,10 @@ const { createTransformer: createSwcTransformer } = require('@swc/jest');
 const ESM_REGEX = /\b(?:import|export)\b/;
 
 function createTransformer(config) {
-  const swcTransformer = createSwcTransformer(config);
+  const swcTransformer = createSwcTransformer({
+    inputSourceMap: false,
+    ...config,
+  });
   const process = (source, filePath, jestOptions) => {
     if (filePath.endsWith('.js') && !ESM_REGEX.test(source)) {
       return { code: source };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

SWC currently has some very noisy logging when failing to read the input source maps, which as far as I can tell is not possible to filter out or disable. This completely disables the reading of input source maps in tests, in order to clean up logs. It's quite common that published packages have either bad source maps or reference source maps that don't exist.

The impact of this change is that stack traces in tests will no longer show locations relative to source files for `node_modules` dependencies, but instead the location within the published code. Honestly this might be an improvement when debugging tests locally 😅 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
