### PR TITLE
workflows: use separate cache for the CLI success cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,17 +233,32 @@ jobs:
       - name: verify release
         run: node scripts/verify-release.js
 
+      # Use the lower-level cache actions for the success cache, so that we can store the cache even on failed builds
+      - name: restore backstage-cli cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .cache/backstage-cli
+          key: ${{ runner.os }}-v${{ matrix.node-version }}-backstage-cli
+
       - name: lint changed packages
-        run: yarn backstage-cli repo lint --since origin/master --successCache
+        run: yarn backstage-cli repo lint --since origin/master --successCache --successCacheDir .cache/backstage-cli
 
       - name: test changed packages
-        run: yarn backstage-cli repo test --maxWorkers=3 --workerIdleMemoryLimit=1300M --since origin/master --successCache
+        run: yarn backstage-cli repo test --maxWorkers=3 --workerIdleMemoryLimit=1300M --since origin/master --successCache --successCacheDir .cache/backstage-cli
         env:
           BACKSTAGE_TEST_DISABLE_DOCKER: 1
           BACKSTAGE_TEST_DATABASE_POSTGRES16_CONNECTION_STRING: postgresql://postgres:postgres@localhost:${{ job.services.postgres16.ports[5432] }}
           BACKSTAGE_TEST_DATABASE_POSTGRES12_CONNECTION_STRING: postgresql://postgres:postgres@localhost:${{ job.services.postgres12.ports[5432] }}
           BACKSTAGE_TEST_DATABASE_MYSQL8_CONNECTION_STRING: mysql://root:root@localhost:${{ job.services.mysql8.ports[3306] }}/ignored
           BACKSTAGE_TEST_CACHE_REDIS7_CONNECTION_STRING: redis://localhost:${{ job.services.redis.ports[6379] }}
+
+      # Always save success cache even if there were failures, that way it can be used in re-triggered builds
+      - name: save backstage-cli cache
+        uses: actions/cache/save@v4
+        if: always()
+        with:
+          path: .cache/backstage-cli
+          key: ${{ runner.os }}-v${{ matrix.node-version }}-backstage-cli
 
       # We run the test cases before verifying the specs to prevent any failing tests from causing errors.
       - name: verify openapi specs against test cases

--- a/.github/workflows/deploy_packages.yml
+++ b/.github/workflows/deploy_packages.yml
@@ -93,8 +93,14 @@ jobs:
       - name: validate config
         run: yarn backstage-cli config:check --lax
 
+      - name: backstage-cli cache
+        uses: actions/cache@v4
+        with:
+          path: .cache/backstage-cli
+          key: ${{ runner.os }}-v${{ matrix.node-version }}-backstage-cli
+
       - name: lint
-        run: yarn backstage-cli repo lint --successCache
+        run: yarn backstage-cli repo lint --successCache --successCacheDir .cache/backstage-cli
 
       - name: type checking and declarations
         run: yarn tsc:full


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Mixing the CLI cache with the default `node_modules` cache doesn't work well in CI, since we won't be storing the cache on cache hits and it limits sharing.

This also changes the caching strategy for CI so that we store the cache even on failed builds, which should speed up re-triggered builds significantly.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
