### PR TITLE
workflows/deploy_packages: cache test results and stop tracking test coverage

### DIFF
--- a/.github/workflows/deploy_packages.yml
+++ b/.github/workflows/deploy_packages.yml
@@ -113,12 +113,7 @@ jobs:
 
       - name: test (and upload coverage)
         run: |
-          yarn backstage-cli repo test --maxWorkers=3 --workerIdleMemoryLimit=1300M --coverage
-          # bash <(curl -s https://codecov.io/bash)
-          # Upload code coverage for some specific flags. Also see .codecov.yml
-          # bash <(curl -s https://codecov.io/bash) -f packages/core-app-api/coverage/* -F core-app-api
-          # bash <(curl -s https://codecov.io/bash) -f packages/core-components/coverage/* -F core-components
-          # bash <(curl -s https://codecov.io/bash) -f packages/core-plugin-api/coverage/* -F core-plugin-api
+          yarn backstage-cli repo test --maxWorkers=3 --workerIdleMemoryLimit=1300M --coverage --successCache --successCacheDir .cache/backstage-cli
         env:
           BACKSTAGE_TEST_DISABLE_DOCKER: 1
           BACKSTAGE_TEST_DATABASE_POSTGRES16_CONNECTION_STRING: postgresql://postgres:postgres@localhost:${{ job.services.postgres16.ports[5432] }}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

On top of #27019. I'm suggesting that we stop tracking test coverage in master branch builds and instead use the success cache for tests. We could combine the two but I don't think the coverage results are gonna be too useful. Still running with `--coverage` though, in case of coverage limits and to be able to inspect the CI logs.

I can't remember the last time I looked at the coverage statistics, I think we'd benefit a lot more from speedier CI builds. I don't expect this to speed up PR builds though, because we're using `--since` so we're not testing any packages for which we'd get a cache hit anyway.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
