### PR TITLE
fix(catalog-react) : fixing text overflow

### DIFF
--- a/.changeset/stupid-insects-allow.md
+++ b/.changeset/stupid-insects-allow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Fixed bug in EntityDisplayName where text was overflowing

--- a/.changeset/stupid-insects-allow.md
+++ b/.changeset/stupid-insects-allow.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-react': patch
 ---
 
-Fixed bug in EntityDisplayName where text was overflowing
+Fixed bug in `EntityDisplayName` where text was overflowing.

--- a/plugins/catalog-react/src/components/EntityDisplayName/EntityDisplayName.tsx
+++ b/plugins/catalog-react/src/components/EntityDisplayName/EntityDisplayName.tsx
@@ -44,13 +44,6 @@ const useStyles = makeStyles(
         verticalAlign: 'middle',
       },
     },
-    truncate: {
-      whiteSpace: 'nowrap',
-      overflow: 'hidden',
-      textOverflow: 'ellipsis',
-      maxWidth: '100%',
-      display: 'block',
-    },
   }),
   { name: 'CatalogReactEntityDisplayName' },
 );
@@ -87,7 +80,9 @@ export const EntityDisplayName = (
 
   // The innermost "body" content
   let content = (
-    <Typography className={classes.truncate}>{primaryTitle}</Typography>
+    <Tooltip title={primaryTitle} placement="top" arrow>
+      <Typography noWrap>{primaryTitle}</Typography>
+    </Tooltip>
   );
 
   // Optionally an icon, and wrapper around them both

--- a/plugins/catalog-react/src/components/EntityDisplayName/EntityDisplayName.tsx
+++ b/plugins/catalog-react/src/components/EntityDisplayName/EntityDisplayName.tsx
@@ -20,6 +20,7 @@ import Tooltip from '@material-ui/core/Tooltip';
 import { Theme, makeStyles } from '@material-ui/core/styles';
 import React from 'react';
 import { useEntityPresentation } from '../../apis';
+import Typography from '@material-ui/core/Typography';
 
 /**
  * The available style class keys for {@link EntityDisplayName}, under the name
@@ -34,6 +35,7 @@ const useStyles = makeStyles(
     root: {
       display: 'inline-flex',
       alignItems: 'center',
+      maxWidth: '100%',
     },
     icon: {
       marginRight: theme.spacing(0.5),
@@ -41,6 +43,13 @@ const useStyles = makeStyles(
       '& svg': {
         verticalAlign: 'middle',
       },
+    },
+    truncate: {
+      whiteSpace: 'nowrap',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      maxWidth: '100%',
+      display: 'block',
     },
   }),
   { name: 'CatalogReactEntityDisplayName' },
@@ -77,7 +86,9 @@ export const EntityDisplayName = (
   );
 
   // The innermost "body" content
-  let content = <>{primaryTitle}</>;
+  let content = (
+    <Typography className={classes.truncate}>{primaryTitle}</Typography>
+  );
 
   // Optionally an icon, and wrapper around them both
   content = (

--- a/plugins/catalog-react/src/components/EntityDisplayName/EntityDisplayName.tsx
+++ b/plugins/catalog-react/src/components/EntityDisplayName/EntityDisplayName.tsx
@@ -80,8 +80,19 @@ export const EntityDisplayName = (
 
   // The innermost "body" content
   let content = (
-    <Tooltip title={primaryTitle} placement="top" arrow>
-      <Typography noWrap>{primaryTitle}</Typography>
+    <Tooltip
+      title={primaryTitle}
+      placement="top"
+      arrow
+      aria-label={primaryTitle}
+    >
+      <Typography
+        noWrap
+        title={primaryTitle}
+        aria-describedby="tooltip-description"
+      >
+        {primaryTitle}
+      </Typography>
     </Tooltip>
   );
 


### PR DESCRIPTION
PR for the issue :[ 26990  ](https://github.com/backstage/backstage/issues/26990)

With this fix the text will not overflow as we can see in the below screenshot . 
<img width="1710" alt="Screenshot 2024-10-09 at 1 19 08 PM" src="https://github.com/user-attachments/assets/50b85e36-eb5a-43bf-89a5-b6fd9dcdc4c9">


