### PR TITLE
cli: repo lint fixes

### DIFF
--- a/.changeset/rotten-rockets-deny.md
+++ b/.changeset/rotten-rockets-deny.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Running `repo lint` with the `--successCache` flag now respects `.gitinore`, and it ignores projects without a `lint` script.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -109,6 +109,7 @@
     "git-url-parse": "^15.0.0",
     "glob": "^7.1.7",
     "global-agent": "^3.0.0",
+    "globby": "^11.1.0",
     "handlebars": "^4.7.3",
     "html-webpack-plugin": "^5.3.1",
     "inquirer": "^8.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3991,6 +3991,7 @@ __metadata:
     git-url-parse: ^15.0.0
     glob: ^7.1.7
     global-agent: ^3.0.0
+    globby: ^11.1.0
     handlebars: ^4.7.3
     html-webpack-plugin: ^5.3.1
     inquirer: ^8.2.0


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Some fixes for the `--successCache` path of `repo lint`. This switches to using globby to enumerate files, so can take `.gitignore` into account. It's slower, but more accurate. Using the git tree sha strategy from `repo test` is tricky still because we need to make sure the lint config for each file is part of the cache key, and we can only get that by enumerating it for each file. Long-term I'm thinking the best solution here is to rely on the new ESLint config format, but for now I think this is fine. I might evaluate using `git` to list files instead of globby though, could be that that's a lot faster.

Other fix is to only include packages that actually have a `lint` script.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
