### PR TITLE
feat: added the ability to disable catalog processing

### DIFF
--- a/.changeset/silly-ligers-tan.md
+++ b/.changeset/silly-ligers-tan.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend': patch
 ---
 
-Adds the ability to disable catalog processing with `catalog.processingEnabled` config flag
+Adds the ability to disable catalog processing `catalog.processingInterval: false` in `app-config`

--- a/.changeset/silly-ligers-tan.md
+++ b/.changeset/silly-ligers-tan.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Adds the ability to disable catalog processing with `catalog.processingEnabled` config flag

--- a/plugins/catalog-backend/config.d.ts
+++ b/plugins/catalog-backend/config.d.ts
@@ -164,7 +164,6 @@ export interface Config {
 
     /**
      * The interval at which the catalog should process its entities.
-     *
      * @remarks
      *
      * Example:
@@ -186,5 +185,20 @@ export interface Config {
      * housing catalog-info files.
      */
     processingInterval?: HumanDuration;
+    /**
+     * If the processing engine should be started or not, defaults to true.
+     * @remarks
+     *
+     * Example:
+     *
+     * ```yaml
+     * catalog:
+     *   processingInterval: false
+     * ```
+     *
+     * This will enable or disable the processing of entities in the Catalog. This can be useful
+     * to use with Read Replica deployments of the catalog.
+     */
+    processingEnabled?: boolean;
   };
 }

--- a/plugins/catalog-backend/config.d.ts
+++ b/plugins/catalog-backend/config.d.ts
@@ -173,6 +173,13 @@ export interface Config {
      *   processingInterval: { minutes: 30 }
      * ```
      *
+     * or to disabled processing:
+     *
+     * ```yaml
+     * catalog:
+     *  processingInterval: false
+     * ```
+     *
      * Note that this is only a suggested minimum, and the actual interval may
      * be longer. Internally, the catalog will scale up this number by a small
      * factor and choose random numbers in that range to spread out the load. If
@@ -184,7 +191,7 @@ export interface Config {
      * systems that are queried by processors, such as version control systems
      * housing catalog-info files.
      */
-    processingInterval?: HumanDuration;
+    processingInterval?: HumanDuration | false;
     /**
      * If the processing engine should be started or not, defaults to true.
      * @remarks
@@ -199,6 +206,5 @@ export interface Config {
      * This will enable or disable the processing of entities in the Catalog. This can be useful
      * to use with Read Replica deployments of the catalog.
      */
-    processingEnabled?: boolean;
   };
 }

--- a/plugins/catalog-backend/config.d.ts
+++ b/plugins/catalog-backend/config.d.ts
@@ -192,19 +192,5 @@ export interface Config {
      * housing catalog-info files.
      */
     processingInterval?: HumanDuration | false;
-    /**
-     * If the processing engine should be started or not, defaults to true.
-     * @remarks
-     *
-     * Example:
-     *
-     * ```yaml
-     * catalog:
-     *   processingInterval: false
-     * ```
-     *
-     * This will enable or disable the processing of entities in the Catalog. This can be useful
-     * to use with Read Replica deployments of the catalog.
-     */
   };
 }

--- a/plugins/catalog-backend/src/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.ts
@@ -843,9 +843,18 @@ export class CatalogBuilder {
       });
     }
 
+    if (!Boolean(config.get('catalog.processingInterval'))) {
+      return () => {
+        throw new Error(
+          'catalog.processingInterval is set to false, processing is disabled.',
+        );
+      };
+    }
+
     const duration = readDurationFromConfig(config, {
       key: processingIntervalKey,
     });
+
     const seconds = Math.max(
       1,
       Math.round(durationToMilliseconds(duration) / 1000),

--- a/plugins/catalog-backend/src/service/CatalogPlugin.ts
+++ b/plugins/catalog-backend/src/service/CatalogPlugin.ts
@@ -301,7 +301,7 @@ export const catalogPlugin = createBackendPlugin({
 
         const { processingEngine, router } = await builder.build();
 
-        if (config.get('catalog.processingInterval') ?? true) {
+        if (config.getOptional('catalog.processingInterval') ?? true) {
           lifecycle.addStartupHook(async () => {
             await processingEngine.start();
           });

--- a/plugins/catalog-backend/src/service/CatalogPlugin.ts
+++ b/plugins/catalog-backend/src/service/CatalogPlugin.ts
@@ -42,6 +42,7 @@ import {
 import { merge } from 'lodash';
 import { Permission } from '@backstage/plugin-permission-common';
 import { ForwardedError } from '@backstage/errors';
+import { constrainedMemory } from 'node:process';
 
 class CatalogLocationsExtensionPointImpl
   implements CatalogLocationsExtensionPoint
@@ -301,10 +302,13 @@ export const catalogPlugin = createBackendPlugin({
 
         const { processingEngine, router } = await builder.build();
 
-        lifecycle.addStartupHook(async () => {
-          await processingEngine.start();
-        });
-        lifecycle.addShutdownHook(() => processingEngine.stop());
+        if (config.getOptionalBoolean('catalog.processingEnabled') ?? true) {
+          lifecycle.addStartupHook(async () => {
+            await processingEngine.start();
+          });
+          lifecycle.addShutdownHook(() => processingEngine.stop());
+        }
+
         httpRouter.use(router);
       },
     });

--- a/plugins/catalog-backend/src/service/CatalogPlugin.ts
+++ b/plugins/catalog-backend/src/service/CatalogPlugin.ts
@@ -42,7 +42,6 @@ import {
 import { merge } from 'lodash';
 import { Permission } from '@backstage/plugin-permission-common';
 import { ForwardedError } from '@backstage/errors';
-import { constrainedMemory } from 'node:process';
 
 class CatalogLocationsExtensionPointImpl
   implements CatalogLocationsExtensionPoint

--- a/plugins/catalog-backend/src/service/CatalogPlugin.ts
+++ b/plugins/catalog-backend/src/service/CatalogPlugin.ts
@@ -302,7 +302,7 @@ export const catalogPlugin = createBackendPlugin({
 
         const { processingEngine, router } = await builder.build();
 
-        if (config.getOptionalBoolean('catalog.processingEnabled') ?? true) {
+        if (config.get('catalog.processingInterval') ?? true) {
           lifecycle.addStartupHook(async () => {
             await processingEngine.start();
           });


### PR DESCRIPTION
This adds the ability to disable catalog processing with config. 

Was in two minds to just add this ability to the existing `readonly` config, but thought that it could be an unexpected breaking change in behaviour for people that don't allow new locations to be registered through the API, but have Discovery Providers.

I also wanted to move both `processingInterval` and `processingEnabled` to `processing.interval` and `processing.enabled`, but thought best to leave that for now, and revisit the config on Catalog 2.0
