### PR TITLE
backend-defaults: fix SQLite shutdown hanging

### DIFF
--- a/.changeset/silver-comics-attend.md
+++ b/.changeset/silver-comics-attend.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Fix for backend shutdown hanging during local development due to SQLite connection shutdown never resolving.

--- a/packages/backend-defaults/src/entrypoints/database/DatabaseManager.ts
+++ b/packages/backend-defaults/src/entrypoints/database/DatabaseManager.ts
@@ -117,6 +117,9 @@ export class DatabaseManagerImpl {
 
         const connection = await this.databaseCache.get(pluginId);
         if (connection) {
+          if (connection.client.config.includes('sqlite3')) {
+            return; // sqlite3 does not support destroy, it hangs
+          }
           await connection.destroy().catch((error: unknown) => {
             deps?.logger?.error(
               `Problem closing database connection for ${pluginId}: ${stringifyError(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I noticed the dev server doesn't restart properly during local development, turns out it was because `.destroy()` never settles with SQLite. Followup for #26922

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
