### PR TITLE
.github/workflows: update backstage-cli cache to use unique keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,9 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .cache/backstage-cli
-          key: ${{ runner.os }}-v${{ matrix.node-version }}-backstage-cli
+          key: ${{ runner.os }}-v${{ matrix.node-version }}-backstage-cli-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-v${{ matrix.node-version }}-backstage-cli-
 
       - name: lint changed packages
         run: yarn backstage-cli repo lint --since origin/master --successCache --successCacheDir .cache/backstage-cli
@@ -258,7 +260,7 @@ jobs:
         if: always()
         with:
           path: .cache/backstage-cli
-          key: ${{ runner.os }}-v${{ matrix.node-version }}-backstage-cli
+          key: ${{ runner.os }}-v${{ matrix.node-version }}-backstage-cli-${{ github.run_id }}
 
       # We run the test cases before verifying the specs to prevent any failing tests from causing errors.
       - name: verify openapi specs against test cases

--- a/.github/workflows/deploy_packages.yml
+++ b/.github/workflows/deploy_packages.yml
@@ -97,7 +97,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .cache/backstage-cli
-          key: ${{ runner.os }}-v${{ matrix.node-version }}-backstage-cli
+          key: ${{ runner.os }}-v${{ matrix.node-version }}-backstage-cli-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-v${{ matrix.node-version }}-backstage-cli-
 
       - name: lint
         run: yarn backstage-cli repo lint --successCache --successCacheDir .cache/backstage-cli


### PR DESCRIPTION
Cache entries are immutable, so using the same cache key doesn't work. See https://github.com/actions/cache/blob/8469c94c6a180dfb41a1bd7e1b46ac557ea124f1/tips-and-workarounds.md?plain=1#L9