### PR TITLE
feat: Additional project settings related to MR discussions and pipelines

### DIFF
--- a/plugins/scaffolder-backend-module-gitlab/report.api.md
+++ b/plugins/scaffolder-backend-module-gitlab/report.api.md
@@ -154,6 +154,9 @@ export function createPublishGitlabAction(options: {
             | undefined;
           topics?: string[] | undefined;
           visibility?: 'internal' | 'private' | 'public' | undefined;
+          only_allow_merge_if_all_discussions_are_resolved?: boolean | undefined;
+          only_allow_merge_if_pipeline_succeeds?: boolean | undefined;
+          allow_merge_on_skipped_pipeline?: boolean | undefined;
         }
       | undefined;
     branches?:

--- a/plugins/scaffolder-backend-module-gitlab/report.api.md
+++ b/plugins/scaffolder-backend-module-gitlab/report.api.md
@@ -154,7 +154,9 @@ export function createPublishGitlabAction(options: {
             | undefined;
           topics?: string[] | undefined;
           visibility?: 'internal' | 'private' | 'public' | undefined;
-          only_allow_merge_if_all_discussions_are_resolved?: boolean | undefined;
+          only_allow_merge_if_all_discussions_are_resolved?:
+            | boolean
+            | undefined;
           only_allow_merge_if_pipeline_succeeds?: boolean | undefined;
           allow_merge_on_skipped_pipeline?: boolean | undefined;
         }

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlab.examples.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlab.examples.ts
@@ -163,4 +163,43 @@ export const examples: TemplateExample[] = [
       ],
     }),
   },
+  {
+    description:
+      'Initializes a GitLab repository with pipeline must succeed and allow merge on skipped pipeline settings.',
+    example: yaml.stringify({
+      steps: [
+        {
+          id: 'publish',
+          action: 'publish:gitlab',
+          name: 'Publish to GitLab',
+          input: {
+            repoUrl: 'gitlab.com?repo=project_name&owner=group_name',
+            settings: {
+              only_allow_merge_if_pipeline_succeeds: true,
+              allow_merge_on_skipped_pipeline: true,
+            },
+          },
+        },
+      ],
+    }),
+  },
+  {
+    description:
+      'Initializes a GitLab repository with setting to require all threads (discussions) on merge request to be resolved before merging.',
+    example: yaml.stringify({
+      steps: [
+        {
+          id: 'publish',
+          action: 'publish:gitlab',
+          name: 'Publish to GitLab',
+          input: {
+            repoUrl: 'gitlab.com?repo=project_name&owner=group_name',
+            settings: {
+              only_allow_merge_if_all_discussions_are_resolved: true,
+            },
+          },
+        },
+      ],
+    }),
+  },
 ];

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlab.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlab.ts
@@ -204,17 +204,20 @@ export function createPublishGitlabAction(options: {
               },
               only_allow_merge_if_all_discussions_are_resolved: {
                 title: 'All threads must be resolved',
-                description: 'Set whether merge requests can only be merged when all the discussions are resolved.',
+                description:
+                  'Set whether merge requests can only be merged when all the discussions are resolved.',
                 type: 'boolean',
               },
               only_allow_merge_if_pipeline_succeeds: {
                 title: 'Pipelines must succeed',
-                description: 'Set whether merge requests can only be merged with successful pipelines. This setting is named Pipelines must succeed in the project settings.',
+                description:
+                  'Set whether merge requests can only be merged with successful pipelines. This setting is named Pipelines must succeed in the project settings.',
                 type: 'boolean',
               },
               allow_merge_on_skipped_pipeline: {
                 title: 'Skipped pipelines are considered successful',
-                description: 'Set whether or not merge requests can be merged with skipped jobs.',
+                description:
+                  'Set whether or not merge requests can be merged with skipped jobs.',
                 type: 'boolean',
               },
             },

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlab.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlab.ts
@@ -60,6 +60,9 @@ export function createPublishGitlabAction(options: {
       squash_option?: 'default_off' | 'default_on' | 'never' | 'always';
       topics?: string[];
       visibility?: 'private' | 'internal' | 'public';
+      only_allow_merge_if_all_discussions_are_resolved?: boolean;
+      only_allow_merge_if_pipeline_succeeds?: boolean;
+      allow_merge_on_skipped_pipeline?: boolean;
     };
     branches?: Array<{
       name: string;
@@ -198,6 +201,21 @@ export function createPublishGitlabAction(options: {
                   'The visibility of the project. Can be private, internal, or public. The default value is private.',
                 type: 'string',
                 enum: ['private', 'public', 'internal'],
+              },
+              only_allow_merge_if_all_discussions_are_resolved: {
+                title: 'All threads must be resolved',
+                description: 'Set whether merge requests can only be merged when all the discussions are resolved.',
+                type: 'boolean',
+              },
+              only_allow_merge_if_pipeline_succeeds: {
+                title: 'Pipelines must succeed',
+                description: 'Set whether merge requests can only be merged with successful pipelines. This setting is named Pipelines must succeed in the project settings.',
+                type: 'boolean',
+              },
+              allow_merge_on_skipped_pipeline: {
+                title: 'Skipped pipelines are considered successful',
+                description: 'Set whether or not merge requests can be merged with skipped jobs.',
+                type: 'boolean',
               },
             },
           },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds the following settings for projects as exposed by [Projects API](https://docs.gitlab.com/ee/api/projects.html):

-  only_allow_merge_if_all_discussions_are_resolved
-  only_allow_merge_if_pipeline_succeeds
- allow_merge_on_skipped_pipeline

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
