### PR TITLE
cli: repo test tweaks

### DIFF
--- a/.changeset/beige-ghosts-enjoy.md
+++ b/.changeset/beige-ghosts-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': minor
+---
+
+The `repo test` command will no longer default to watch mode if the `--since` flag is provided.

--- a/packages/cli/src/commands/repo/test.ts
+++ b/packages/cli/src/commands/repo/test.ts
@@ -172,7 +172,11 @@ export async function command(opts: OptionValues, cmd: Command): Promise<void> {
   }
 
   // Run in watch mode unless in CI, coverage mode, or running all tests
-  if (!process.env.CI && !hasFlags('--coverage', '--watch', '--watchAll')) {
+  if (
+    !opts.since &&
+    !process.env.CI &&
+    !hasFlags('--coverage', '--watch', '--watchAll')
+  ) {
     const isGitRepo = () =>
       runCheck('git', 'rev-parse', '--is-inside-work-tree');
     const isMercurialRepo = () => runCheck('hg', '--cwd', '.', 'root');

--- a/packages/cli/src/commands/repo/test.ts
+++ b/packages/cli/src/commands/repo/test.ts
@@ -221,6 +221,7 @@ export async function command(opts: OptionValues, cmd: Command): Promise<void> {
     return packageGraph;
   }
 
+  let selectedProjects: string[] | undefined = undefined;
   if (opts.since && !hasFlags('--selectProjects')) {
     const graph = await getPackageGraph();
     const changedPackages = await graph.listChangedPackages({
@@ -228,19 +229,20 @@ export async function command(opts: OptionValues, cmd: Command): Promise<void> {
       analyzeLockfile: true,
     });
 
-    const packageNames = Array.from(
+    selectedProjects = Array.from(
       graph.collectPackageNames(
         changedPackages.map(pkg => pkg.name),
         pkg => pkg.allLocalDependents.keys(),
       ),
     );
 
-    if (packageNames.length === 0) {
+    if (selectedProjects.length === 0) {
       console.log(`No packages changed since ${opts.since}`);
       return;
     }
 
-    args.push('--selectProjects', ...packageNames);
+    selectedProjects = selectedProjects.filter(pkg => pkg.includes('app'));
+    args.push('--selectProjects', ...selectedProjects);
   }
 
   // This is the only thing that is not implemented by jest.run(), so we do it here instead
@@ -350,7 +352,9 @@ export async function command(opts: OptionValues, cmd: Command): Promise<void> {
           projectHashes.set(packageName, sha);
 
           if (cache?.includes(sha)) {
-            console.log(`Skipped ${packageName} due to cache hit`);
+            if (!selectedProjects || selectedProjects.includes(packageName)) {
+              console.log(`Skipped ${packageName} due to cache hit`);
+            }
             outputSuccessCache.push(sha);
             return undefined;
           }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Two small fixes:
- No longer default `rep test` to watch mode when `--since` option is provided. It doesn't really make sense to default to watch because watch itself as a built-in diff of non-commited changes, which doesn't really make sense in combination with the `--since` flag.
- No longer log if there's a success cache hit that has been excluded due to a `--since` flag. We still generate hash and include the hash though, as to not drop the cache for packages that happened to be excluded.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
