### PR TITLE
add rulesets to create repo action

### DIFF
--- a/plugins/scaffolder-backend-module-github/src/actions/github.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/github.ts
@@ -29,6 +29,7 @@ import {
   createGithubRepoWithCollaboratorsAndTopics,
   getOctokitOptions,
   initRepoPushAndProtect,
+  RuleSet,
 } from './helpers';
 import * as inputProps from './inputProperties';
 import * as outputProps from './outputProperties';
@@ -116,6 +117,7 @@ export function createPublishGithubAction(options: {
     };
     requiredCommitSigning?: boolean;
     customProperties?: { [key: string]: string };
+    rulesets?: RuleSet[];
   }>({
     id: 'publish:github',
     description:
@@ -217,8 +219,10 @@ export function createPublishGithubAction(options: {
         token: providedToken,
         customProperties,
         requiredCommitSigning = false,
+        rulesets,
       } = ctx.input;
 
+      console.log('ctx.input', ctx.input);
       const octokitOptions = await getOctokitOptions({
         integrations,
         credentialsProvider: githubCredentialsProvider,
@@ -258,6 +262,7 @@ export function createPublishGithubAction(options: {
         oidcCustomization,
         customProperties,
         ctx.logger,
+        rulesets,
       );
 
       const remoteUrl = newRepo.clone_url;

--- a/plugins/scaffolder-backend-module-github/src/actions/githubRepoCreate.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubRepoCreate.ts
@@ -27,6 +27,7 @@ import {
 import {
   createGithubRepoWithCollaboratorsAndTopics,
   getOctokitOptions,
+  RuleSet,
 } from './helpers';
 import * as inputProps from './inputProperties';
 import * as outputProps from './outputProperties';
@@ -101,6 +102,7 @@ export function createGithubRepoCreateAction(options: {
     };
     requireCommitSigning?: boolean;
     customProperties?: { [key: string]: string };
+    rulesets?: RuleSet[];
   }>({
     id: 'github:repo:create',
     description: 'Creates a GitHub repository.',
@@ -141,6 +143,7 @@ export function createGithubRepoCreateAction(options: {
           oidcCustomization: inputProps.oidcCustomization,
           requiredCommitSigning: inputProps.requiredCommitSigning,
           customProperties: inputProps.customProperties,
+          rulesets: inputProps.rulesets,
         },
       },
       output: {
@@ -175,6 +178,7 @@ export function createGithubRepoCreateAction(options: {
         oidcCustomization,
         customProperties,
         token: providedToken,
+        rulesets,
       } = ctx.input;
 
       const octokitOptions = await getOctokitOptions({
@@ -216,6 +220,7 @@ export function createGithubRepoCreateAction(options: {
         oidcCustomization,
         customProperties,
         ctx.logger,
+        rulesets,
       );
 
       ctx.output('remoteUrl', newRepo.clone_url);

--- a/plugins/scaffolder-backend-module-github/src/actions/inputProperties.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/inputProperties.ts
@@ -311,6 +311,615 @@ const customProperties = {
   type: 'object',
 };
 
+const patternMatchingProperties = {
+  name: {
+    description: 'How this rule will appear to users.',
+    type: 'string',
+  },
+  negate: {
+    description: 'If true, the rule will fail if the pattern matches.',
+    type: 'boolean',
+  },
+  operator: {
+    description: 'The operator to use for matching.',
+    enum: ['starts_with', 'ends_with', 'contains', 'regex'],
+    type: 'string',
+  },
+  pattern: {
+    description: 'The pattern to match with.',
+    type: 'string',
+  },
+};
+const rulesets = {
+  title: 'Repository Rulesets.',
+  description: 'Rulesets definitions for the repository.',
+  items: {
+    additionalProperties: false,
+    properties: {
+      bypass_actors: {
+        title: 'Bypass Actors',
+        description: 'The actors that can bypass the rules in this ruleset.',
+        items: {
+          additionalProperties: false,
+          properties: {
+            actor_id: {
+              title: 'Actor ID',
+              description:
+                'The ID of the actor that can bypass a ruleset. If `actor_type` is `OrganizationAdmin`, this should be `1`. If `actor_type` is `DeployKey`, this should be null. `OrganizationAdmin` is not applicable for personal repositories.',
+              type: ['number', 'null'],
+            },
+            actor_type: {
+              title: 'Actor Type',
+              description: 'The type of actor that can bypass a ruleset.',
+              enum: [
+                'OrganizationAdmin',
+                'Integration',
+                'RepositoryRole',
+                'Team',
+                'DeployKey',
+              ],
+              type: 'string',
+            },
+            bypass_mode: {
+              title: 'Bypass Mode',
+              description:
+                'When the specified actor can bypass the ruleset. `pull_request` means that an actor can only bypass rules on pull requests. `pull_request` is not applicable for the `DeployKey` actor type. Also, `pull_request` is only applicable to branch rulesets. Default: `always`',
+              enum: ['always', 'pull_request'],
+              type: 'string',
+            },
+          },
+          required: ['actor_type', 'bypass_mode'],
+          type: 'object',
+        },
+        type: 'array',
+      },
+      conditions: {
+        title: 'Ruleset Conditions',
+        description: 'Parameters for a repository ruleset ref name condition',
+        additionalProperties: false,
+        properties: {
+          ref_name: {
+            title: 'Ref Name conditions',
+            description:
+              'Parameters for a repository ruleset ref name condition',
+            additionalProperties: false,
+            properties: {
+              exclude: {
+                title: 'Exclude',
+                description:
+                  'Array of ref names or patterns to include. One of these patterns must match for the condition to pass. Also accepts `~DEFAULT_BRANCH` to include the default branch or `~ALL` to include all branches.',
+                items: {
+                  type: 'string',
+                },
+                type: 'array',
+              },
+              include: {
+                title: 'Include',
+                description:
+                  'Array of ref names or patterns to exclude. The condition will not pass if any of these patterns match.',
+                items: {
+                  type: 'string',
+                },
+                type: 'array',
+              },
+            },
+            type: 'object',
+          },
+        },
+        type: 'object',
+      },
+      enforcement: {
+        title: 'Ruleset Enforcement',
+        description:
+          'The enforcement level of the ruleset. evaluate allows admins to test rules before enforcing them. Admins can view insights on the Rule Insights page (`evaluate` is only available with GitHub Enterprise).',
+        enum: ['active', 'disabled', 'evaluate'],
+        type: 'string',
+      },
+      name: {
+        title: 'Ruleset Name',
+        description: `The name of the ruleset.`,
+        type: 'string',
+      },
+      rules: {
+        title: 'Ruleset Rules',
+        description: 'An array of rules within the ruleset.',
+        items: {
+          anyOf: [
+            {
+              title: 'Creation Rule',
+              description:
+                'Only allow users with bypass permission to create matching refs.',
+              additionalProperties: false,
+              properties: {
+                type: {
+                  const: 'creation',
+                  type: 'string',
+                },
+              },
+              required: ['type'],
+              type: 'object',
+            },
+            {
+              title: 'Update Rule',
+              description:
+                'Only allow users with bypass permission to update matching refs.',
+              additionalProperties: false,
+              properties: {
+                parameters: {
+                  additionalProperties: false,
+                  properties: {
+                    update_allows_fetch_and_merge: {
+                      description:
+                        'Branch can pull changes from its upstream repository',
+                      type: 'boolean',
+                    },
+                  },
+                  required: ['update_allows_fetch_and_merge'],
+                  type: 'object',
+                },
+                type: {
+                  const: 'update',
+                  type: 'string',
+                },
+              },
+              required: ['type'],
+              type: 'object',
+            },
+            {
+              title: 'Deletion Rule',
+              description:
+                'Only allow users with bypass permissions to delete matching refs.',
+              additionalProperties: false,
+              properties: {
+                type: {
+                  const: 'deletion',
+                  type: 'string',
+                },
+              },
+              required: ['type'],
+              type: 'object',
+            },
+            {
+              title: 'Required Linear History Rule',
+              description:
+                'Prevent merge commits from being pushed to matching refs.',
+              additionalProperties: false,
+              properties: {
+                type: {
+                  const: 'required_linear_history',
+                  type: 'string',
+                },
+              },
+              required: ['type'],
+              type: 'object',
+            },
+            {
+              title: 'Required Deployments Rule',
+              description:
+                'Choose which environments must be successfully deployed to before refs can be pushed into a ref that matches this rule.',
+              additionalProperties: false,
+              properties: {
+                parameters: {
+                  additionalProperties: false,
+                  properties: {
+                    required_deployment_environments: {
+                      title: 'Required Deployment Environments',
+                      description:
+                        'The environments that must be successfully deployed to before branches can be merged.',
+                      items: {
+                        type: 'string',
+                      },
+                      type: 'array',
+                    },
+                  },
+                  required: ['required_deployment_environments'],
+                  type: 'object',
+                },
+                type: {
+                  const: 'required_deployments',
+                  type: 'string',
+                },
+              },
+              required: ['type'],
+              type: 'object',
+            },
+            {
+              title: 'Required Signatures Rule',
+              description:
+                'Commits pushed to matching refs must have verified signatures.',
+              additionalProperties: false,
+              properties: {
+                type: {
+                  const: 'required_signatures',
+                  type: 'string',
+                },
+              },
+              required: ['type'],
+              type: 'object',
+            },
+            {
+              title: 'Pull Request Rule',
+              description:
+                'Require all commits be made to a non-target branch and submitted via a pull request before they can be merged.',
+              additionalProperties: false,
+              properties: {
+                parameters: {
+                  additionalProperties: false,
+                  properties: {
+                    dismiss_stale_reviews_on_push: {
+                      description:
+                        'New, reviewable commits pushed will dismiss previous pull request review approvals.',
+                      type: 'boolean',
+                    },
+                    require_code_owner_review: {
+                      description:
+                        'Require an approving review in pull requests that modify files that have a designated code owner.',
+                      type: 'boolean',
+                    },
+                    require_last_push_approval: {
+                      description:
+                        'Whether the most recent reviewable push must be approved by someone other than the person who pushed it.',
+                      type: 'boolean',
+                    },
+                    required_approving_review_count: {
+                      description:
+                        'The number of approving reviews that are required before a pull request can be merged.',
+                      type: 'number',
+                    },
+                    required_review_thread_resolution: {
+                      description:
+                        'All conversations on code must be resolved before a pull request can be merged.',
+                      type: 'boolean',
+                    },
+                  },
+                  required: [
+                    'dismiss_stale_reviews_on_push',
+                    'require_code_owner_review',
+                    'require_last_push_approval',
+                    'required_approving_review_count',
+                    'required_review_thread_resolution',
+                  ],
+                  type: 'object',
+                },
+                type: {
+                  const: 'pull_request',
+                  type: 'string',
+                },
+              },
+              required: ['type'],
+              type: 'object',
+            },
+            {
+              title: 'Required Status Checks Rule',
+              description:
+                'Choose which status checks must pass before the ref is updated. When enabled, commits must first be pushed to another ref where the checks pass.',
+              additionalProperties: false,
+              properties: {
+                parameters: {
+                  additionalProperties: false,
+                  properties: {
+                    required_status_checks: {
+                      items: {
+                        additionalProperties: false,
+                        properties: {
+                          context: {
+                            description:
+                              'The status check context name that must be present on the commit.',
+                            type: 'string',
+                          },
+                          integration_id: {
+                            description:
+                              'The optional integration ID that this status check must originate from.',
+                            type: 'number',
+                          },
+                        },
+                        required: ['context'],
+                        type: 'object',
+                      },
+                      type: 'array',
+                    },
+                    strict_required_status_checks_policy: {
+                      description:
+                        'Whether pull requests targeting a matching branch must be tested with the latest code. This setting will not take effect unless at least one status check is enabled.',
+                      type: 'boolean',
+                    },
+                  },
+                  required: [
+                    'required_status_checks',
+                    'strict_required_status_checks_policy',
+                  ],
+                  type: 'object',
+                },
+                type: {
+                  const: 'required_status_checks',
+                  type: 'string',
+                },
+              },
+              required: ['type'],
+              type: 'object',
+            },
+            {
+              title: 'Non Fast Forward Rule',
+              description:
+                'Prevent users with push access from force pushing to refs.',
+              additionalProperties: false,
+              properties: {
+                type: {
+                  const: 'non_fast_forward',
+                  type: 'string',
+                },
+              },
+              required: ['type'],
+              type: 'object',
+            },
+            {
+              title: 'Commit Message Pattern Rule',
+              description:
+                'Parameters to be used for the commit_message_pattern rule',
+              additionalProperties: false,
+              properties: {
+                parameters: {
+                  additionalProperties: false,
+                  properties: patternMatchingProperties,
+                  required: ['operator', 'pattern'],
+                  type: 'object',
+                },
+                type: {
+                  const: 'commit_message_pattern',
+                  type: 'string',
+                },
+              },
+              required: ['type'],
+              type: 'object',
+            },
+            {
+              title: 'Commit Author Email Pattern Rule',
+              description:
+                'Parameters to be used for the commit_author_email_pattern rule',
+              additionalProperties: false,
+              properties: {
+                parameters: {
+                  additionalProperties: false,
+                  properties: patternMatchingProperties,
+                  required: ['operator', 'pattern'],
+                  type: 'object',
+                },
+                type: {
+                  const: 'commit_author_email_pattern',
+                  type: 'string',
+                },
+              },
+              required: ['type'],
+              type: 'object',
+            },
+            {
+              additionalProperties: false,
+              properties: {
+                parameters: {
+                  additionalProperties: false,
+                  properties: patternMatchingProperties,
+                  required: ['operator', 'pattern'],
+                  type: 'object',
+                },
+                type: {
+                  const: 'committer_email_pattern',
+                  type: 'string',
+                },
+              },
+              required: ['type'],
+              type: 'object',
+            },
+            {
+              additionalProperties: false,
+              properties: {
+                parameters: {
+                  additionalProperties: false,
+                  properties: patternMatchingProperties,
+                  required: ['operator', 'pattern'],
+                  type: 'object',
+                },
+                type: {
+                  const: 'branch_name_pattern',
+                  type: 'string',
+                },
+              },
+              required: ['type'],
+              type: 'object',
+            },
+            {
+              additionalProperties: false,
+              properties: {
+                parameters: {
+                  additionalProperties: false,
+                  properties: patternMatchingProperties,
+                  required: ['operator', 'pattern'],
+                  type: 'object',
+                },
+                type: {
+                  const: 'tag_name_pattern',
+                  type: 'string',
+                },
+              },
+              required: ['type'],
+              type: 'object',
+            },
+            {
+              title: 'File Path Restriction Rule',
+              description:
+                'Prevent commits that include changes in specified file paths from being pushed to the commit graph.',
+              additionalProperties: false,
+              properties: {
+                parameters: {
+                  additionalProperties: false,
+                  properties: {
+                    restricted_file_paths: {
+                      description:
+                        'The file paths that are restricted from being pushed to the commit graph.',
+                      items: {
+                        type: 'string',
+                      },
+                      type: 'array',
+                    },
+                  },
+                  required: ['restricted_file_paths'],
+                  type: 'object',
+                },
+                type: {
+                  const: 'file_path_restriction',
+                  type: 'string',
+                },
+              },
+              required: ['type'],
+              type: 'object',
+            },
+            {
+              title: 'Max File Path Length Rule',
+              description:
+                'Prevent commits that include file paths that exceed a specified character limit from being pushed to the commit graph.',
+              additionalProperties: false,
+              properties: {
+                parameters: {
+                  additionalProperties: false,
+                  properties: {
+                    max_file_path_length: {
+                      type: 'number',
+                    },
+                  },
+                  required: ['max_file_path_length'],
+                  type: 'object',
+                },
+                type: {
+                  const: 'max_file_path_length',
+                  type: 'string',
+                },
+              },
+              required: ['type'],
+              type: 'object',
+            },
+            {
+              title: 'File Extension Restriction Rule',
+              description:
+                'Prevent commits that include files with specified file extensions from being pushed to the commit graph.',
+              additionalProperties: false,
+              properties: {
+                parameters: {
+                  additionalProperties: false,
+                  properties: {
+                    restricted_file_extensions: {
+                      description:
+                        'The file extensions that are restricted from being pushed to the commit graph.',
+                      items: {
+                        type: 'string',
+                      },
+                      type: 'array',
+                    },
+                  },
+                  required: ['restricted_file_extensions'],
+                  type: 'object',
+                },
+                type: {
+                  const: 'file_extension_restriction',
+                  type: 'string',
+                },
+              },
+              required: ['type'],
+              type: 'object',
+            },
+            {
+              title: 'Max File Size Rule',
+              description:
+                'Prevent commits that exceed a specified file size limit from being pushed to the commit.',
+              additionalProperties: false,
+              properties: {
+                parameters: {
+                  additionalProperties: false,
+                  properties: {
+                    max_file_size: {
+                      description:
+                        'The maximum file size allowed in megabytes. This limit does not apply to Git Large File Storage (Git LFS).',
+                      type: 'number',
+                    },
+                  },
+                  required: ['max_file_size'],
+                  type: 'object',
+                },
+                type: {
+                  const: 'max_file_size',
+                  type: 'string',
+                },
+              },
+              required: ['type'],
+              type: 'object',
+            },
+            {
+              title: 'Workflows Rule',
+              description:
+                'Require all changes made to a targeted branch to pass the specified workflows before they can be merged.',
+              additionalProperties: false,
+              properties: {
+                parameters: {
+                  additionalProperties: false,
+                  properties: {
+                    workflows: {
+                      description:
+                        'Workflows that must pass for this rule to pass.',
+                      items: {
+                        additionalProperties: false,
+                        properties: {
+                          path: {
+                            description: 'The path to the workflow file',
+                            type: 'string',
+                          },
+                          ref: {
+                            description:
+                              'The ref (branch or tag) of the workflow file to use',
+                            type: 'string',
+                          },
+                          repository_id: {
+                            description:
+                              'The ID of the repository where the workflow is defined',
+                            type: 'number',
+                          },
+                          sha: {
+                            description:
+                              'The commit SHA of the workflow file to use',
+                            type: 'string',
+                          },
+                        },
+                        required: ['path', 'repository_id'],
+                        type: 'object',
+                      },
+                      type: 'array',
+                    },
+                  },
+                  required: ['workflows'],
+                  type: 'object',
+                },
+                type: {
+                  const: 'workflows',
+                  type: 'string',
+                },
+              },
+              required: ['type'],
+              type: 'object',
+            },
+          ],
+        },
+        type: 'array',
+      },
+      target: {
+        title: 'Ruleset Target',
+        description: `The target of the ruleset.`,
+        enum: ['branch', 'tag', 'push'],
+        type: 'string',
+      },
+    },
+    required: ['name', 'enforcement'],
+    type: 'object',
+  },
+  type: 'array',
+};
+
 export { access };
 export { allowMergeCommit };
 export { allowRebaseMerge };
@@ -350,3 +959,4 @@ export { repoVariables };
 export { secrets };
 export { oidcCustomization };
 export { customProperties };
+export { rulesets };


### PR DESCRIPTION
Adding rule set to the `publish:github ` action

GH  has rulesets for a while now.

I'm considering 2 possible approaches to to allow setting this on repo creation. One is adding the ruleset scheme to the posible `publish:github` properties,  or adding  a ruleset file path and read the file into the action. or both maybe

GH have some "export" ruleset features and there is some community sharing basic rulesets, so maybe the second option is worth to consider 


Signed-off-by: Juan Pablo Garcia Ripa <sarabadu@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
