### PR TITLE
nerf incremental log levels

### DIFF
--- a/.changeset/nasty-geese-repeat.md
+++ b/.changeset/nasty-geese-repeat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-incremental-ingestion': patch
+---
+
+Turn down the logging level on most "all is well" type log messages

--- a/plugins/catalog-backend-module-incremental-ingestion/src/engine/IncrementalIngestionEngine.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/engine/IncrementalIngestionEngine.ts
@@ -67,13 +67,13 @@ export class IncrementalIngestionEngine
             await this.manager.clearFinishedIngestions(
               this.options.provider.getProviderName(),
             );
-            this.options.logger.info(
+            this.options.logger.debug(
               `incremental-engine: Ingestion ${ingestionId} rest period complete. Ingestion will start again`,
             );
 
             await this.manager.setProviderComplete(ingestionId);
           } else {
-            this.options.logger.info(
+            this.options.logger.debug(
               `incremental-engine: Ingestion '${ingestionId}' rest period continuing`,
             );
           }
@@ -92,7 +92,7 @@ export class IncrementalIngestionEngine
               );
             } else {
               await this.manager.setProviderInterstitial(ingestionId);
-              this.options.logger.info(
+              this.options.logger.debug(
                 `incremental-engine: Ingestion '${ingestionId}' continuing`,
               );
             }
@@ -140,7 +140,7 @@ export class IncrementalIngestionEngine
             );
             await this.manager.setProviderIngesting(ingestionId);
           } else {
-            this.options.logger.info(
+            this.options.logger.debug(
               `incremental-engine: Ingestion '${ingestionId}' backoff continuing`,
             );
           }
@@ -167,7 +167,7 @@ export class IncrementalIngestionEngine
     const providerName = this.options.provider.getProviderName();
     const record = await this.manager.getCurrentIngestionRecord(providerName);
     if (record) {
-      this.options.logger.info(
+      this.options.logger.debug(
         `incremental-engine: Ingestion record found: '${record.id}'`,
       );
       return {

--- a/plugins/catalog-backend-module-incremental-ingestion/src/service/IncrementalCatalogBuilder.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/service/IncrementalCatalogBuilder.ts
@@ -89,8 +89,6 @@ export class IncrementalCatalogBuilder {
           entityProvider: provider.getProviderName(),
         });
 
-        logger.info(`Connecting`);
-
         engine = new IncrementalIngestionEngine({
           ...options,
           ready,


### PR DESCRIPTION
The incremental provider is way too noisy in its logging during normal operation. Especially egregious are the "rest period continuing" messages. Let's pull down most of these to a lower level.