### PR TITLE
Fixing issue with `ParamKeys` type inferrence

### DIFF
--- a/.changeset/thin-doors-rule.md
+++ b/.changeset/thin-doors-rule.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-plugin-api': patch
+---
+
+Fixing issue with types for `ParamKeys` leading to type mismatches across versions

--- a/packages/core-plugin-api/report.api.md
+++ b/packages/core-plugin-api/report.api.md
@@ -613,9 +613,13 @@ export type OptionalParams<
 > = Params[keyof Params] extends never ? undefined : Params;
 
 // @public @deprecated
-export type ParamKeys<Params extends AnyParams> = keyof Params extends never
+export type ParamKeys<Params extends AnyParams> = [AnyRouteRefParams] extends [
+  Params,
+]
+  ? string[]
+  : keyof Params extends never
   ? []
-  : (keyof Params)[];
+  : Array<keyof Params>;
 
 // @public @deprecated
 export type ParamNames<S extends string> =

--- a/packages/core-plugin-api/src/routing/ExternalRouteRef.test.ts
+++ b/packages/core-plugin-api/src/routing/ExternalRouteRef.test.ts
@@ -87,7 +87,7 @@ describe('ExternalRouteRef', () => {
     const _3 = createExternalRouteRef({ id: '3', params: ['x', 'y'] });
     // @ts-expect-error
     validateType<{ x: string }, any>(_3);
-    // extra z, we validate this at runtime instead
+    // @ts-expect-error
     validateType<{ x: string; y: string; z: string }, any>(_3);
     validateType<{ x: string; y: string }, false>(_3);
 

--- a/packages/core-plugin-api/src/routing/RouteRef.test.ts
+++ b/packages/core-plugin-api/src/routing/RouteRef.test.ts
@@ -78,21 +78,19 @@ describe('RouteRef', () => {
     validateType<ParamKeys<{ x: string; y: string }>>(['x', 'y']);
 
     // @ts-expect-error
-    validateType<ParamKeys<{}>>(['asd']);
+    validateType<ParamKeys<{}>>(['foo']);
     validateType<ParamKeys<{}>>([]);
 
     // @ts-expect-error
     validateType<ParamKeys<{ [key in string]: string }>>([1]);
-    validateType<ParamKeys<{ [key in string]: string }>>(['migrationId']);
+    validateType<ParamKeys<{ [key in string]: string }>>(['foo']);
 
     // @ts-expect-error
     validateType<ParamKeys<{ [key in string]: string } | undefined>>([1]);
-    validateType<ParamKeys<{ [key in string]: string } | undefined>>([
-      'migrationId',
-    ]);
+    validateType<ParamKeys<{ [key in string]: string } | undefined>>(['foo']);
 
     // @ts-expect-error
-    validateType<ParamKeys<undefined>>(['asd']);
+    validateType<ParamKeys<undefined>>(['foo']);
     validateType<ParamKeys<undefined>>([]);
 
     expect(true).toBeDefined();

--- a/packages/core-plugin-api/src/routing/RouteRef.test.ts
+++ b/packages/core-plugin-api/src/routing/RouteRef.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { AnyParams, RouteRef } from './types';
+import { AnyParams, RouteRef, ParamKeys } from './types';
 import { createRouteRef } from './RouteRef';
 
 describe('RouteRef', () => {
@@ -54,7 +54,7 @@ describe('RouteRef', () => {
     validateType<undefined>(_2);
     // @ts-expect-error
     validateType<{ x: string; z: string }>(_2);
-    // extra z, we validate this at runtime instead
+    // @ts-expect-error
     validateType<{ x: string; y: string; z: string }>(_2);
     validateType<{ x: string; y: string }>(_2);
 
@@ -70,5 +70,31 @@ describe('RouteRef', () => {
 
     // To avoid complains about missing expectations and unused vars
     expect([_1, _2, _3, _4].join('')).toEqual(expect.any(String));
+  });
+
+  it('should properly infer param keys', () => {
+    function validateType<T>(_test: T) {}
+
+    validateType<ParamKeys<{ x: string; y: string }>>(['x', 'y']);
+
+    // @ts-expect-error
+    validateType<ParamKeys<{}>>(['asd']);
+    validateType<ParamKeys<{}>>([]);
+
+    // @ts-expect-error
+    validateType<ParamKeys<{ [key in string]: string }>>([1]);
+    validateType<ParamKeys<{ [key in string]: string }>>(['migrationId']);
+
+    // @ts-expect-error
+    validateType<ParamKeys<{ [key in string]: string } | undefined>>([1]);
+    validateType<ParamKeys<{ [key in string]: string } | undefined>>([
+      'migrationId',
+    ]);
+
+    // @ts-expect-error
+    validateType<ParamKeys<undefined>>(['asd']);
+    validateType<ParamKeys<undefined>>([]);
+
+    expect(true).toBeDefined();
   });
 });

--- a/packages/core-plugin-api/src/routing/SubRouteRef.test.ts
+++ b/packages/core-plugin-api/src/routing/SubRouteRef.test.ts
@@ -102,7 +102,7 @@ describe('SubRouteRef', () => {
     validateType<{ x: string; z: string }>(_2);
     // @ts-expect-error
     validateType<{ y: string }>(_2);
-    // extra z, we validate this at runtime instead
+    // @ts-expect-error
     validateType<{ x: string; y: string; z: string }>(_2);
     validateType<{ x: string; y: string }>(_2);
 

--- a/packages/core-plugin-api/src/routing/types.ts
+++ b/packages/core-plugin-api/src/routing/types.ts
@@ -35,9 +35,13 @@ export type AnyParams = AnyRouteRefParams;
  * @public
  * @deprecated this type is deprecated and will be removed in the future
  */
-export type ParamKeys<Params extends AnyParams> = keyof Params extends never
+export type ParamKeys<Params extends AnyParams> = [AnyRouteRefParams] extends [
+  Params,
+]
+  ? string[]
+  : keyof Params extends never
   ? []
-  : (keyof Params)[];
+  : Array<keyof Params>;
 
 /**
  * Optional route params.


### PR DESCRIPTION
Bonus addition for `@ts-expect-errror` in some test cases as this is now checked in TypeScript.