### PR TITLE
fix: use default catalog toolbar for offset catalog table

### DIFF
--- a/.changeset/curvy-poems-joke.md
+++ b/.changeset/curvy-poems-joke.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog': patch
 ---
 
-Use default `CatalogTableToolbar` for offset paginated catalog table
+Fixed an issue causing the `CatalogIndexPage` to not properly filter results when using offset pagination.

--- a/.changeset/curvy-poems-joke.md
+++ b/.changeset/curvy-poems-joke.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Use default `CatalogTableToolbar` for offset paginated catalog table

--- a/plugins/catalog/src/components/CatalogTable/OffsetPaginatedCatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/OffsetPaginatedCatalogTable.tsx
@@ -18,10 +18,8 @@ import React, { useEffect } from 'react';
 
 import { Table, TableProps } from '@backstage/core-components';
 import { CatalogTableRow } from './types';
-import {
-  EntityTextFilter,
-  useEntityList,
-} from '@backstage/plugin-catalog-react';
+import { useEntityList } from '@backstage/plugin-catalog-react';
+import { CatalogTableToolbar } from './CatalogTableToolbar';
 
 /**
  * @internal
@@ -30,8 +28,8 @@ export function OffsetPaginatedCatalogTable(
   props: TableProps<CatalogTableRow>,
 ) {
   const { columns, data, isLoading, options } = props;
-  const { updateFilters, setLimit, setOffset, limit, totalItems, offset } =
-    useEntityList();
+  const { setLimit, setOffset, limit, totalItems, offset } = useEntityList();
+
   const [page, setPage] = React.useState(
     offset && limit ? Math.floor(offset / limit) : 0,
   );
@@ -55,11 +53,9 @@ export function OffsetPaginatedCatalogTable(
         emptyRowsWhenPaging: false,
         ...options,
       }}
-      onSearchChange={(searchText: string) =>
-        updateFilters({
-          text: searchText ? new EntityTextFilter(searchText) : undefined,
-        })
-      }
+      components={{
+        Toolbar: CatalogTableToolbar,
+      }}
       page={page}
       onPageChange={newPage => {
         setPage(newPage);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

mostly to get debounce working the same way with the entity text filter

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
