### PR TITLE
Add DOCS SIG members to Codeowners for /docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@ yarn.lock                                         @backstage/maintainers @backst
 */yarn.lock                                       @backstage/maintainers @backstage-service
 /.changeset/*.md
 /beps/0001-notifications-system                   @backstage/maintainers @backstage/notifications-maintainers
-/docs/*.md                                        @parsifal-m @awanlin @aramissennyeydd
+/docs/*.md                                        @backstage/documentation-maintainers
 /docs/assets/search                               @backstage/search-maintainers
 /docs/features/search                             @backstage/search-maintainers
 /docs/features/techdocs                           @backstage/techdocs-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,7 @@ yarn.lock                                         @backstage/maintainers @backst
 */yarn.lock                                       @backstage/maintainers @backstage-service
 /.changeset/*.md
 /beps/0001-notifications-system                   @backstage/maintainers @backstage/notifications-maintainers
+/docs/*.md                                        @parsifal-m @awanlin @aramissennyeydd
 /docs/assets/search                               @backstage/search-maintainers
 /docs/features/search                             @backstage/search-maintainers
 /docs/features/techdocs                           @backstage/techdocs-maintainers


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Hey Team! 👋 

Something we discussed in the last Docs SIG was about adding ourselves to the codeowners so we can actually see when any docs changes happen as right now we don't see anything or are notified making it hard to keep track of changes.

It was mentioned if we could do this in a round-robin way, but I have not done that before and not sure how to set it up other than doing what I have done here.

Also this is a bit of a blanket approach so happy for any guidance on how we could better set this up 😄 

FYI @awanlin, @aramissennyeydd 

The end goal is that we can keep an 👁️  on whats happening in the `/docs/*.md` 

Thanks all!
