### PR TITLE
Exclude browser-actions/setup-chrome from renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -40,6 +40,7 @@
       matchSourceUrls: ['https://github.com/yarnpkg/berry'],
       enabled: false,
     },
+    // https://github.com/backstage/backstage/issues/27123
     {
       matchPackageNames: ['browser-actions/setup-chrome'],
       enabled: false,

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -40,6 +40,10 @@
       matchSourceUrls: ['https://github.com/yarnpkg/berry'],
       enabled: false,
     },
+    {
+      matchPackageNames: ['browser-actions/setup-chrome'],
+      enabled: false,
+    },
     // ESM only majors, that we're not ready for yet
     {
       matchPackageNames: ['node-fetch'],


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Excluding the action from renovate until we can dig more into what is causing the issue.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
