### PR TITLE
Use theme values for OpenApiDefinition styles

### DIFF
--- a/.changeset/mighty-jobs-unite.md
+++ b/.changeset/mighty-jobs-unite.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-api-docs': minor
+---
+
+Uses theme values to style the API definition schema so that theme overrides apply.

--- a/.changeset/mighty-jobs-unite.md
+++ b/.changeset/mighty-jobs-unite.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-api-docs': minor
+'@backstage/plugin-api-docs': patch
 ---
 
 Uses theme values to style the API definition schema so that theme overrides apply.

--- a/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinition.tsx
+++ b/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinition.tsx
@@ -94,7 +94,8 @@ const useStyles = makeStyles(theme => ({
           .errors small`]: {
         color: theme.palette.text.secondary,
       },
-      [`& .parameter__name.required:after`]: {
+      [`& .parameter__name.required:after,
+        .parameter__name.required span`]: {
         color: theme.palette.warning.dark,
       },
       [`& table.model,
@@ -165,11 +166,9 @@ const useStyles = makeStyles(theme => ({
       [`.json-schema-2020-12__constraint--string`]: {
         backgroundColor: theme.palette.primary.main,
       },
-      [`& .json-schema-2020-12__attribute--primary,
-          .json-schema-2020-12-property--required>.json-schema-2020-12:first-of-type>.json-schema-2020-12-head .json-schema-2020-12__title:after`]:
-        {
-          color: theme.palette.primary.main,
-        },
+      [`& .json-schema-2020-12__attribute--primary`]: {
+        color: theme.palette.primary.main,
+      },
       [`& .json-schema-2020-12-property--required>.json-schema-2020-12:first-of-type>.json-schema-2020-12-head .json-schema-2020-12__title:after`]:
         {
           color: theme.palette.warning.dark,

--- a/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinition.tsx
+++ b/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinition.tsx
@@ -132,6 +132,48 @@ const useStyles = makeStyles(theme => ({
       [`& span.prop-type`]: {
         color: theme.palette.success.light,
       },
+      [`& .opblock-control-arrow svg, .authorization__btn .unlocked`]: {
+        fill: theme.palette.text.primary,
+      },
+      [`& .json-schema-2020-12__title,
+          .json-schema-2020-12-keyword__name,
+          .json-schema-2020-12-property .json-schema-2020-12__title,
+          .json-schema-2020-12-keyword--description`]: {
+        color: theme.palette.text.primary,
+      },
+      [`.json-schema-2020-12-accordion__icon svg`]: {
+        fill: theme.palette.text.primary,
+      },
+      [`& .json-schema-2020-12-accordion,
+          .json-schema-2020-12-expand-deep-button`]: {
+        background: 'none',
+        appearance: 'none',
+      },
+      [`& .json-schema-2020-12-expand-deep-button,
+          .json-schema-2020-12-keyword__name--secondary,
+          .json-schema-2020-12-keyword__value--secondary,
+          .json-schema-2020-12__attribute--muted,
+          .json-schema-2020-12-keyword__value--const,
+          .json-schema-2020-12-keyword__value--warning`]: {
+        color: theme.palette.text.secondary,
+      },
+      [`& .json-schema-2020-12-body,
+          .json-schema-2020-12-keyword__value--const,
+          .json-schema-2020-12-keyword__value--warning`]: {
+        borderColor: theme.palette.text.secondary,
+      },
+      [`.json-schema-2020-12__constraint--string`]: {
+        backgroundColor: theme.palette.primary.main,
+      },
+      [`& .json-schema-2020-12__attribute--primary,
+          .json-schema-2020-12-property--required>.json-schema-2020-12:first-of-type>.json-schema-2020-12-head .json-schema-2020-12__title:after`]:
+        {
+          color: theme.palette.primary.main,
+        },
+      [`& .json-schema-2020-12-property--required>.json-schema-2020-12:first-of-type>.json-schema-2020-12-head .json-schema-2020-12__title:after`]:
+        {
+          color: theme.palette.warning.dark,
+        },
     },
   },
 }));


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Uses theme values to style the API definition schema so that theme overrides apply.

<details>
<summary>Before</summary>

![Screenshot 2024-10-15 at 13 31 09](https://github.com/user-attachments/assets/4da185f0-70a7-479e-b3a3-9b3b34cea03b)

![Screenshot 2024-10-15 at 14 00 58](https://github.com/user-attachments/assets/f20487c7-10f7-4f8e-bdf0-469873e44ba0)
</details>

<details>
<summary>After</summary>

![Screenshot 2024-10-15 at 13 30 46](https://github.com/user-attachments/assets/3b740aad-9652-4e72-acb8-5bde34c1d6ea)

![Screenshot 2024-10-15 at 14 00 46](https://github.com/user-attachments/assets/885a492e-68ab-4045-9217-694a6611caf4)
</details>

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
