### PR TITLE
Update errata-ai/vale-action to v2.1.1

### DIFF
--- a/.github/workflows/verify_docs-quality.yml
+++ b/.github/workflows/verify_docs-quality.yml
@@ -26,7 +26,7 @@ jobs:
         run: echo "args=$(node scripts/check-docs-quality.js --ci-args)" >> $GITHUB_OUTPUT
 
       - name: documentation quality check
-        uses: errata-ai/vale-action@38bf078c328061f59879b347ca344a718a736018 # v2.1.0
+        uses: errata-ai/vale-action@d89dee975228ae261d22c15adcd03578634d429c # v2.1.1
         with:
           # This also contains --config=.github/vale/config.ini ... :/
           files: '${{ steps.generate.outputs.args }}'


### PR DESCRIPTION
## Hey, I just made a Pull Request!

GitHub is slowly rolling out a change that points `ubuntu-latest` to `ubuntu-24.04` instead of `ubuntu-22.04`, this pull request updates to v2.1.1 of the errata-ai/vale-action which is compatible with the current ubuntu-latest flavor

Fixes #27154
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
