### PR TITLE
fix(1.32.0): scaffolder total query

### DIFF
--- a/.changeset/forty-spoons-burn.md
+++ b/.changeset/forty-spoons-burn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Fix tasks listing with postgres

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.ts
@@ -213,6 +213,9 @@ export class DatabaseTaskStore implements TaskStore {
       queryBuilder.whereIn('status', [...new Set(arr)]);
     }
 
+    const countQuery = queryBuilder.clone();
+    countQuery.count('tasks.id', { as: 'count' });
+
     if (order) {
       order.forEach(f => {
         queryBuilder.orderBy(f.field, f.order);
@@ -220,9 +223,6 @@ export class DatabaseTaskStore implements TaskStore {
     } else {
       queryBuilder.orderBy('created_at', 'desc');
     }
-
-    const countQuery = queryBuilder.clone();
-    countQuery.count('tasks.id', { as: 'count' });
 
     if (pagination?.limit !== undefined) {
       queryBuilder.limit(pagination.limit);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

After upgrading to 1.32.0, the scaffolder tasks page fails to load with Postgres.

fixes scaffolder list error with postgres: error: select count("tasks"."id") as "count" from "tasks" order by "created_at" desc - column "tasks.created_at" must appear in the GROUP BY clause or be used in an aggregate function

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
