### PR TITLE
scaffolder: Fix forwarding of non-enumerable property

### DIFF
--- a/.changeset/mean-years-deliver.md
+++ b/.changeset/mean-years-deliver.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Fix issue with token not being available because it's now non-enumerable

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -493,6 +493,7 @@ export async function createRouter(
       });
 
       const credentials = await httpAuth.credentials(req);
+
       await checkPermission({
         credentials,
         permissions: [taskCreatePermission],
@@ -563,7 +564,11 @@ export async function createRouter(
       const secrets: InternalTaskSecrets = {
         ...req.body.secrets,
         backstageToken: token,
-        __initiatorCredentials: JSON.stringify(credentials),
+        __initiatorCredentials: JSON.stringify({
+          ...credentials,
+          // credentials.token is nonenumerable and will not be serialized, so we need to add it explicitly
+          token: (credentials as any).token,
+        }),
       };
 
       const result = await taskBroker.dispatch({


### PR DESCRIPTION
Since #27080 the token is non-enumerable, which means it's not serializable when we're stringifying.

We need to explicitly pass it through, as we don't want people accidentally logging the token still.