### PR TITLE
feat: Added custom timeout for oidc provider

### DIFF
--- a/.changeset/early-feet-lay.md
+++ b/.changeset/early-feet-lay.md
@@ -3,3 +3,15 @@
 ---
 
 Added custom timeout setting for oidc provider
+
+Here is an example of how to use a custom timeout with the configuration:
+
+```yaml
+auth:
+  oidc:
+    production:
+      clientId: ${AUTH_GOOGLE_CLIENT_ID}
+      clientSecret: ${AUTH_GOOGLE_CLIENT_SECRET}
+      timeout:
+        seconds: 30
+```

--- a/.changeset/early-feet-lay.md
+++ b/.changeset/early-feet-lay.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-oidc-provider': minor
+---
+
+Added custom timeout setting for oidc provider

--- a/plugins/auth-backend-module-oidc-provider/config.d.ts
+++ b/plugins/auth-backend-module-oidc-provider/config.d.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { HumanDuration } from '@backstage/types';
 
 export interface Config {
   auth?: {
@@ -31,6 +32,7 @@ export interface Config {
           tokenSignedResponseAlg?: string;
           additionalScopes?: string | string[];
           prompt?: string;
+          timeout?: HumanDuration;
           signIn?: {
             resolvers: Array<
               | {

--- a/plugins/auth-backend-module-oidc-provider/package.json
+++ b/plugins/auth-backend-module-oidc-provider/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@backstage/backend-common": "^0.25.0",
     "@backstage/backend-plugin-api": "workspace:^",
+    "@backstage/config": "workspace:^",
     "@backstage/plugin-auth-backend": "workspace:^",
     "@backstage/plugin-auth-node": "workspace:^",
     "@backstage/types": "workspace:^",
@@ -47,7 +48,6 @@
     "@backstage/backend-defaults": "workspace:^",
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
-    "@backstage/config": "workspace:^",
     "cookie-parser": "^1.4.6",
     "express-promise-router": "^4.1.1",
     "express-session": "^1.17.3",

--- a/plugins/auth-backend-module-oidc-provider/package.json
+++ b/plugins/auth-backend-module-oidc-provider/package.json
@@ -38,6 +38,7 @@
     "@backstage/backend-plugin-api": "workspace:^",
     "@backstage/plugin-auth-backend": "workspace:^",
     "@backstage/plugin-auth-node": "workspace:^",
+    "@backstage/types": "workspace:^",
     "express": "^4.18.2",
     "openid-client": "^5.5.0",
     "passport": "^0.7.0"

--- a/plugins/auth-backend-module-oidc-provider/src/authenticator.test.ts
+++ b/plugins/auth-backend-module-oidc-provider/src/authenticator.test.ts
@@ -28,6 +28,7 @@ import { ConfigReader } from '@backstage/config';
 import { JWK, SignJWT, exportJWK, generateKeyPair } from 'jose';
 import { rest } from 'msw';
 import express from 'express';
+import { custom } from 'openid-client';
 
 describe('oidcAuthenticator', () => {
   let implementation: any;
@@ -167,6 +168,81 @@ describe('oidcAuthenticator', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+  });
+
+  describe('timeout configuration', () => {
+    const TEST_URL = new URL('https://test.com');
+
+    it('should use default timeout when no timeout is configured', async () => {
+      const { promise } = oidcAuthenticator.initialize({
+        callbackUrl: 'https://backstage.test/callback',
+        config: new ConfigReader({
+          metadataUrl: 'https://oidc.test/.well-known/openid-configuration',
+          clientId: 'clientId',
+          clientSecret: 'clientSecret',
+        }),
+      });
+      const { client } = await promise;
+
+      const timeout = client[custom.http_options](TEST_URL, {}).timeout;
+
+      // Check if the HTTP timeout is set to the default value
+      expect(timeout).toBeDefined();
+      expect(timeout).toBe(10000);
+    });
+
+    it('should use configured timeout when provided in the config', async () => {
+      const { promise } = oidcAuthenticator.initialize({
+        callbackUrl: 'https://backstage.test/callback',
+        config: new ConfigReader({
+          metadataUrl: 'https://oidc.test/.well-known/openid-configuration',
+          clientId: 'clientId',
+          clientSecret: 'clientSecret',
+          timeout: {
+            seconds: 30,
+          },
+        }),
+      });
+      const { client } = await promise;
+
+      const timeout = client[custom.http_options](TEST_URL, {}).timeout;
+
+      // Check if the HTTP timeout is set to the configured value (30 seconds)
+      expect(timeout).toBeDefined();
+      expect(timeout).toBe(30000);
+    });
+
+    it('should handle invalid timeout configuration gracefully', async () => {
+      expect(() => {
+        oidcAuthenticator.initialize({
+          callbackUrl: 'https://backstage.test/callback',
+          config: new ConfigReader({
+            metadataUrl: 'https://oidc.test/.well-known/openid-configuration',
+            clientId: 'clientId',
+            clientSecret: 'clientSecret',
+            timeout: '30s',
+          }),
+        });
+      }).toThrow(
+        "Failed to read duration from config, TypeError: Invalid type in config for key 'timeout' in 'mock-config', got string, wanted object",
+      );
+
+      expect(() => {
+        oidcAuthenticator.initialize({
+          callbackUrl: 'https://backstage.test/callback',
+          config: new ConfigReader({
+            metadataUrl: 'https://oidc.test/.well-known/openid-configuration',
+            clientId: 'clientId',
+            clientSecret: 'clientSecret',
+            timeout: {
+              seconds: '30s',
+            },
+          }),
+        });
+      }).toThrow(
+        "Failed to read duration from config, Error: Unable to convert config value for key 'timeout.seconds' in 'mock-config' to a number",
+      );
+    });
   });
 
   describe('#start', () => {

--- a/plugins/auth-backend-module-oidc-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-oidc-provider/src/authenticator.ts
@@ -32,7 +32,7 @@ import {
   PassportOAuthAuthenticatorHelper,
   PassportOAuthPrivateInfo,
 } from '@backstage/plugin-auth-node';
-import { durationToMilliseconds, HumanDuration } from '@backstage/types';
+import { durationToMilliseconds } from '@backstage/types';
 import { readDurationFromConfig } from '@backstage/config';
 
 const HTTP_OPTION_TIMEOUT = 10000;

--- a/plugins/auth-backend-module-oidc-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-oidc-provider/src/authenticator.ts
@@ -33,6 +33,7 @@ import {
   PassportOAuthPrivateInfo,
 } from '@backstage/plugin-auth-node';
 import { durationToMilliseconds, HumanDuration } from '@backstage/types';
+import { readDurationFromConfig } from '@backstage/config';
 
 const HTTP_OPTION_TIMEOUT = 10000;
 const createHttpOptionsProvider =
@@ -88,12 +89,11 @@ export const oidcAuthenticator = createOAuthAuthenticator({
       );
     }
 
-    const timeoutHumanDuration = config.getOptional<HumanDuration>('timeout');
-    const timeoutMilliseconds =
-      typeof timeoutHumanDuration === 'object'
-        ? durationToMilliseconds(timeoutHumanDuration)
-        : undefined;
-
+    const timeoutMilliseconds = config.has('timeout')
+      ? durationToMilliseconds(
+          readDurationFromConfig(config, { key: 'timeout' }),
+        )
+      : undefined;
     const httpOptionsProvider = createHttpOptionsProvider({
       timeout: timeoutMilliseconds,
     });

--- a/plugins/auth-backend-module-oidc-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-oidc-provider/src/authenticator.ts
@@ -32,6 +32,7 @@ import {
   PassportOAuthAuthenticatorHelper,
   PassportOAuthPrivateInfo,
 } from '@backstage/plugin-auth-node';
+import { durationToMilliseconds, HumanDuration } from '@backstage/types';
 
 const HTTP_OPTION_TIMEOUT = 10000;
 const createHttpOptionsProvider =
@@ -86,8 +87,15 @@ export const oidcAuthenticator = createOAuthAuthenticator({
         'The oidc provider no longer supports the "scope" configuration option. Please use the "additionalScopes" option instead.',
       );
     }
+
+    const timeoutHumanDuration = config.getOptional<HumanDuration>('timeout');
+    const timeoutMilliseconds =
+      typeof timeoutHumanDuration === 'object'
+        ? durationToMilliseconds(timeoutHumanDuration)
+        : undefined;
+
     const httpOptionsProvider = createHttpOptionsProvider({
-      timeout: config.getOptionalNumber('timeout'),
+      timeout: timeoutMilliseconds,
     });
 
     Issuer[custom.http_options] = httpOptionsProvider;

--- a/plugins/auth-backend-module-oidc-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-oidc-provider/src/authenticator.ts
@@ -34,12 +34,14 @@ import {
 } from '@backstage/plugin-auth-node';
 
 const HTTP_OPTION_TIMEOUT = 10000;
-const httpOptionsProvider: CustomHttpOptionsProvider = (_url, options) => {
-  return {
-    ...options,
-    timeout: HTTP_OPTION_TIMEOUT,
+const createHttpOptionsProvider =
+  ({ timeout }: { timeout?: number }): CustomHttpOptionsProvider =>
+  (_url, options) => {
+    return {
+      ...options,
+      timeout: timeout ?? HTTP_OPTION_TIMEOUT,
+    };
   };
-};
 
 /**
  * authentication result for the OIDC which includes the token set and user
@@ -84,6 +86,9 @@ export const oidcAuthenticator = createOAuthAuthenticator({
         'The oidc provider no longer supports the "scope" configuration option. Please use the "additionalScopes" option instead.',
       );
     }
+    const httpOptionsProvider = createHttpOptionsProvider({
+      timeout: config.getOptionalNumber('timeout'),
+    });
 
     Issuer[custom.http_options] = httpOptionsProvider;
     const promise = Issuer.discover(metadataUrl).then(issuer => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5285,6 +5285,7 @@ __metadata:
     "@backstage/config": "workspace:^"
     "@backstage/plugin-auth-backend": "workspace:^"
     "@backstage/plugin-auth-node": "workspace:^"
+    "@backstage/types": "workspace:^"
     cookie-parser: ^1.4.6
     express: ^4.18.2
     express-promise-router: ^4.1.1


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Hi folks! I have used [this way](https://discord.com/channels/687207715902193673/978977570852835379/1070438453944270998) to handle oauth requests time out. But seems like this is not working now. Now the code was changed and there is no way how to override the timeout.

![image](https://github.com/user-attachments/assets/e93cafcc-d55c-4a9a-9841-07160831ad95)

I suggest configuring timeout using config file. Here is my attempt to do this.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
