### PR TITLE
auth-backend-module-aws-alb-provider: no longer lowercase username and email

### DIFF
--- a/.changeset/healthy-lions-judge.md
+++ b/.changeset/healthy-lions-judge.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-auth-backend-module-aws-alb-provider': minor
+'@backstage/plugin-auth-backend': minor
+---
+
+**BREAKING**: The AWS ALB `fullProfile` will no longer have the its username or email converted to lowercase. This is to ensure unique handling of the users. You may need to update and configure a custom sign-in resolver or profile transform as a result.

--- a/plugins/auth-backend-module-aws-alb-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-aws-alb-provider/src/authenticator.ts
@@ -77,12 +77,12 @@ export const awsAlbAuthenticator = createProxyAuthenticator({
         provider: 'unknown',
         id: claims.sub,
         displayName: claims.name,
-        username: claims.email.split('@')[0].toLowerCase(),
+        username: claims.email.split('@')[0],
         name: {
           familyName: claims.family_name,
           givenName: claims.given_name,
         },
-        emails: [{ value: claims.email.toLowerCase() }],
+        emails: [{ value: claims.email }],
         photos: [{ value: claims.picture }],
       };
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Making sure we have unique handling of users, so that integration of a case sensitive auth system doesn't lead to issues.

For context, the `.toLowerCase()` were added in the initial contribution where the profile was introduced, but there's no clear indication as to why or that it's needed: #7380

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
