### PR TITLE
fix(catalog-backend-module-github): update parent to not send a object with empty value

### DIFF
--- a/.changeset/rotten-mangos-hug.md
+++ b/.changeset/rotten-mangos-hug.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+Fix bug when receive a `team.creted` github event without parent

--- a/.changeset/rotten-mangos-hug.md
+++ b/.changeset/rotten-mangos-hug.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend-module-github': patch
 ---
 
-Fix bug when receive a `team.creted` github event without parent
+Fixed an issue in `GithubOrgEntityProvider` that caused an error when processing teams without a parent.

--- a/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.ts
@@ -511,7 +511,9 @@ export class GithubOrgEntityProvider implements EntityProvider {
         editTeamUrl: `${url}/edit`,
         combinedSlug: `${org}/${slug}`,
         description: description || undefined,
-        parentTeam: { slug: event.team?.parent?.slug || '' } as GithubTeam,
+        parentTeam: event.team?.parent?.slug
+          ? ({ slug: event.team.parent.slug } as GithubTeam)
+          : undefined,
         // entity will be removed
         members: [],
       },


### PR DESCRIPTION
## Hey, I just made a Pull Request!


Fix #26109 

When a team is created without a parent, we are sending a object with empty value and the entity created is invalid.

This PR should fix this behavior.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
