### PR TITLE
Add `spec.tier` as an optional Component entity descriptor

### DIFF
--- a/.changeset/fair-shrimps-ring.md
+++ b/.changeset/fair-shrimps-ring.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-model': minor
+---
+
+Add `spec.tier` as an optional Component entity descriptor

--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -609,6 +609,13 @@ which the component is a part, e.g. `spotify-ios-app`. This field is optional.
 | ---------------------------------------- | ------------------------------------------ | ----------------------------------------------------------------------------- |
 | [`Component`](#kind-component) (default) | Same as this entity, typically `default`   | [`partOf`, and reverse `hasPart`](well-known-relations.md#partof-and-haspart) |
 
+### `spec.tier` [optional]
+
+The tier of the component, e.g. `0` or `critical`. This field is optional.
+
+The software catalog accepts any tier value, but an organization should
+take great care to establish a proper taxonomy for these.
+
 ### `spec.providesApis` [optional]
 
 An array of [entity references](references.md#string-references) to the APIs

--- a/packages/catalog-model/src/kinds/ComponentEntityV1alpha1.test.ts
+++ b/packages/catalog-model/src/kinds/ComponentEntityV1alpha1.test.ts
@@ -34,6 +34,7 @@ describe('ComponentV1alpha1Validator', () => {
         lifecycle: 'production',
         owner: 'me',
         subcomponentOf: 'monolith',
+        tier: '0',
         providesApis: ['api-0'],
         consumesApis: ['api-0'],
         dependsOn: ['resource:resource-0', 'component:component-0'],
@@ -119,6 +120,21 @@ describe('ComponentV1alpha1Validator', () => {
   it('rejects empty subcomponentOf', async () => {
     (entity as any).spec.subcomponentOf = '';
     await expect(validator.check(entity)).rejects.toThrow(/subcomponentOf/);
+  });
+
+  it('accepts missing tier', async () => {
+    delete (entity as any).spec.tier;
+    await expect(validator.check(entity)).resolves.toBe(true);
+  });
+
+  it('rejects wrong tier', async () => {
+    (entity as any).spec.tier = 7;
+    await expect(validator.check(entity)).rejects.toThrow(/tier/);
+  });
+
+  it('rejects empty tier', async () => {
+    (entity as any).spec.tier = '';
+    await expect(validator.check(entity)).rejects.toThrow(/tier/);
   });
 
   it('accepts missing providesApis', async () => {

--- a/packages/catalog-model/src/kinds/ComponentEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/ComponentEntityV1alpha1.ts
@@ -35,6 +35,7 @@ export interface ComponentEntityV1alpha1 extends Entity {
     lifecycle: string;
     owner: string;
     subcomponentOf?: string;
+    tier?: string;
     providesApis?: string[];
     consumesApis?: string[];
     dependsOn?: string[];

--- a/packages/catalog-model/src/schema/kinds/Component.v1alpha1.schema.json
+++ b/packages/catalog-model/src/schema/kinds/Component.v1alpha1.schema.json
@@ -69,6 +69,11 @@
               "description": "An entity reference to another component of which the component is a part.",
               "minLength": 1
             },
+            "tier": {
+              "type": "string",
+              "description": "The tier of the component.",
+              "minLength": 1
+            },
             "providesApis": {
               "type": "array",
               "description": "An array of entity references to the APIs that are provided by the component.",


### PR DESCRIPTION
Similar to `spec.lifecycle`, a Component entity could specify its "tier" in an organization's software ecosystem. Tier would indicate the criticality of the service, e.g. `tier: '0'` would be the most critical, `tier: '1'` less critical, ... `tier: 'n'` least critical.

Our use case is to be able to quickly see our Components / Services that are most critical to our business. Criticality could be used to add additional production readiness criteria, operational requirements, etc.

Resolves https://github.com/backstage/backstage/issues/27197

Signed-off-by: Nicholas Calugar <nicholas.calugar@gusto.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
