### PR TITLE
feat(cli): move config to its own "module" in the CLI

### DIFF
--- a/packages/cli/src/commands/build/buildFrontend.ts
+++ b/packages/cli/src/commands/build/buildFrontend.ts
@@ -18,7 +18,7 @@ import fs from 'fs-extra';
 import { resolve as resolvePath } from 'path';
 import { buildBundle, getModuleFederationOptions } from '../../lib/bundler';
 import { getEnvironmentParallelism } from '../../lib/parallel';
-import { loadCliConfig } from '../../lib/config';
+import { loadCliConfig } from '../../modules/config/lib/config';
 
 interface BuildAppOptions {
   targetDir: string;

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -15,15 +15,11 @@
  */
 
 import { Command } from 'commander';
-import { assertError } from '@backstage/errors';
-import { exitWithError } from '../lib/errors';
-
-const configOption = [
-  '--config <path>',
-  'Config files to load instead of app-config.yaml',
-  (opt: string, opts: string[]) => (opts ? [...opts, opt] : [opt]),
-  Array<string>(),
-] as const;
+import { lazy } from '../lib/lazy';
+import {
+  configOption,
+  registerCommands as registerConfigCommands,
+} from '../modules/config';
 
 export function registerRepoCommand(program: Command) {
   const command = program
@@ -278,66 +274,7 @@ export function registerCommands(program: Command) {
     .option('--no-private', 'Do not mark new packages as private')
     .action(lazy(() => import('./new/new').then(m => m.default)));
 
-  program
-    .command('config:docs')
-    .option(
-      '--package <name>',
-      'Only include the schema that applies to the given package',
-    )
-    .description('Browse the configuration reference documentation')
-    .action(lazy(() => import('./config/docs').then(m => m.default)));
-
-  program
-    .command('config:print')
-    .option(
-      '--package <name>',
-      'Only load config schema that applies to the given package',
-    )
-    .option('--lax', 'Do not require environment variables to be set')
-    .option('--frontend', 'Print only the frontend configuration')
-    .option('--with-secrets', 'Include secrets in the printed configuration')
-    .option(
-      '--format <format>',
-      'Format to print the configuration in, either json or yaml [yaml]',
-    )
-    .option(...configOption)
-    .description('Print the app configuration for the current package')
-    .action(lazy(() => import('./config/print').then(m => m.default)));
-
-  program
-    .command('config:check')
-    .option(
-      '--package <name>',
-      'Only load config schema that applies to the given package',
-    )
-    .option('--lax', 'Do not require environment variables to be set')
-    .option('--frontend', 'Only validate the frontend configuration')
-    .option('--deprecated', 'Output deprecated configuration settings')
-    .option(
-      '--strict',
-      'Enable strict config validation, forbidding errors and unknown keys',
-    )
-    .option(...configOption)
-    .description(
-      'Validate that the given configuration loads and matches schema',
-    )
-    .action(lazy(() => import('./config/validate').then(m => m.default)));
-
-  program
-    .command('config:schema')
-    .option(
-      '--package <name>',
-      'Only output config schema that applies to the given package',
-    )
-    .option(
-      '--format <format>',
-      'Format to print the schema in, either json or yaml [yaml]',
-    )
-    .option('--merge', 'Print the config schemas merged', true)
-    .option('--no-merge', 'Print the config schemas not merged')
-    .description('Print configuration schema')
-    .action(lazy(() => import('./config/schema').then(m => m.default)));
-
+  registerConfigCommands(program);
   registerRepoCommand(program);
   registerScriptCommand(program);
   registerMigrateCommand(program);
@@ -433,22 +370,5 @@ function removed(message?: string) {
         : 'This command has been removed',
     );
     process.exit(1);
-  };
-}
-
-// Wraps an action function so that it always exits and handles errors
-function lazy(
-  getActionFunc: () => Promise<(...args: any[]) => Promise<void>>,
-): (...args: any[]) => Promise<never> {
-  return async (...args: any[]) => {
-    try {
-      const actionFunc = await getActionFunc();
-      await actionFunc(...args);
-
-      process.exit(0);
-    } catch (error) {
-      assertError(error);
-      exitWithError(error);
-    }
   };
 }

--- a/packages/cli/src/lib/bundler/server.ts
+++ b/packages/cli/src/lib/bundler/server.ts
@@ -22,7 +22,7 @@ import webpack from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';
 
 import { paths as libPaths } from '../../lib/paths';
-import { loadCliConfig } from '../config';
+import { loadCliConfig } from '../../modules/config/lib/config';
 import { createConfig, resolveBaseUrl, resolveEndpoint } from './config';
 import { createDetectedModulesEntryPoint } from './packageDetection';
 import { resolveBundlingPaths, resolveOptionalBundlingPaths } from './paths';

--- a/packages/cli/src/lib/lazy.ts
+++ b/packages/cli/src/lib/lazy.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { assertError } from '@backstage/errors';
+import { exitWithError } from '../lib/errors';
+
+// Wraps an action function so that it always exits and handles errors
+export function lazy(
+  getActionFunc: () => Promise<(...args: any[]) => Promise<void>>,
+): (...args: any[]) => Promise<never> {
+  return async (...args: any[]) => {
+    try {
+      const actionFunc = await getActionFunc();
+      await actionFunc(...args);
+
+      process.exit(0);
+    } catch (error) {
+      assertError(error);
+      exitWithError(error);
+    }
+  };
+}

--- a/packages/cli/src/modules/config/alpha.ts
+++ b/packages/cli/src/modules/config/alpha.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { CliInitializer } from '../../wiring/Command';
+import { z } from 'zod';
+
+(async () => {
+  const initializer = new CliInitializer();
+  initializer.addCommand({
+    path: ['config:docs'],
+    description: 'Browse the configuration reference documentation',
+    schema: z.object({
+      package: z.string().optional(),
+    }),
+    execute: async options => {
+      const m = await import('./commands/docs');
+      await m.default(options);
+    },
+  });
+  initializer.addCommand({
+    path: ['config:print'],
+    description: 'Print the app configuration for the current package',
+    schema: z.object({
+      package: z.string().optional(),
+      lax: z.boolean().optional(),
+      frontend: z.boolean().optional(),
+      'with-secrets': z.boolean().optional(),
+      format: z.enum(['json', 'yaml']).optional(),
+      config: z.array(z.string()).optional(),
+    }),
+    execute: async options => {
+      const m = await import('./commands/print');
+      await m.default(options);
+    },
+  });
+  initializer.addCommand({
+    path: ['config:check'],
+    description:
+      'Validate that the given configuration loads and matches schema',
+    schema: z.object({
+      package: z.string().optional(),
+      lax: z.boolean().optional(),
+      frontend: z.boolean().optional(),
+      deprecated: z.boolean().optional(),
+      strict: z.boolean().optional(),
+      config: z.array(z.string()).optional(),
+    }),
+    execute: async options => {
+      const m = await import('./commands/validate');
+      await m.default(options);
+    },
+  });
+  await initializer.run();
+})();

--- a/packages/cli/src/modules/config/commands/docs.ts
+++ b/packages/cli/src/modules/config/commands/docs.ts
@@ -19,7 +19,7 @@ import { mergeConfigSchemas } from '@backstage/config-loader';
 import { OptionValues } from 'commander';
 import { JSONSchema7 as JSONSchema } from 'json-schema';
 import openBrowser from 'react-dev-utils/openBrowser';
-import { loadCliConfig } from '../../lib/config';
+import { loadCliConfig } from '../lib/config';
 
 const DOCS_URL = 'https://config.backstage.io';
 

--- a/packages/cli/src/modules/config/commands/print.ts
+++ b/packages/cli/src/modules/config/commands/print.ts
@@ -17,7 +17,7 @@
 import { OptionValues } from 'commander';
 import { stringify as stringifyYaml } from 'yaml';
 import { AppConfig, ConfigReader } from '@backstage/config';
-import { loadCliConfig } from '../../lib/config';
+import { loadCliConfig } from '../lib/config';
 import { ConfigSchema, ConfigVisibility } from '@backstage/config-loader';
 
 export default async (opts: OptionValues) => {

--- a/packages/cli/src/modules/config/commands/schema.ts
+++ b/packages/cli/src/modules/config/commands/schema.ts
@@ -17,7 +17,7 @@
 import { OptionValues } from 'commander';
 import { JSONSchema7 as JSONSchema } from 'json-schema';
 import { stringify as stringifyYaml } from 'yaml';
-import { loadCliConfig } from '../../lib/config';
+import { loadCliConfig } from '../lib/config';
 import { JsonObject } from '@backstage/types';
 import { mergeConfigSchemas } from '@backstage/config-loader';
 

--- a/packages/cli/src/modules/config/commands/validate.ts
+++ b/packages/cli/src/modules/config/commands/validate.ts
@@ -15,7 +15,7 @@
  */
 
 import { OptionValues } from 'commander';
-import { loadCliConfig } from '../../lib/config';
+import { loadCliConfig } from '../lib/config';
 
 export default async (opts: OptionValues) => {
   await loadCliConfig({

--- a/packages/cli/src/modules/config/index.ts
+++ b/packages/cli/src/modules/config/index.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Command } from 'commander';
+import { lazy } from '../../lib/lazy';
+
+export const configOption = [
+  '--config <path>',
+  'Config files to load instead of app-config.yaml',
+  (opt: string, opts: string[]) => (opts ? [...opts, opt] : [opt]),
+  Array<string>(),
+] as const;
+
+export function registerCommands(program: Command) {
+  program
+    .command('config:docs')
+    .option(
+      '--package <name>',
+      'Only include the schema that applies to the given package',
+    )
+    .description('Browse the configuration reference documentation')
+    .action(lazy(() => import('./commands/docs').then(m => m.default)));
+
+  program
+    .command('config:print')
+    .option(
+      '--package <name>',
+      'Only load config schema that applies to the given package',
+    )
+    .option('--lax', 'Do not require environment variables to be set')
+    .option('--frontend', 'Print only the frontend configuration')
+    .option('--with-secrets', 'Include secrets in the printed configuration')
+    .option(
+      '--format <format>',
+      'Format to print the configuration in, either json or yaml [yaml]',
+    )
+    .option(...configOption)
+    .description('Print the app configuration for the current package')
+    .action(lazy(() => import('./commands/print').then(m => m.default)));
+
+  program
+    .command('config:check')
+    .option(
+      '--package <name>',
+      'Only load config schema that applies to the given package',
+    )
+    .option('--lax', 'Do not require environment variables to be set')
+    .option('--frontend', 'Only validate the frontend configuration')
+    .option('--deprecated', 'Output deprecated configuration settings')
+    .option(
+      '--strict',
+      'Enable strict config validation, forbidding errors and unknown keys',
+    )
+    .option(...configOption)
+    .description(
+      'Validate that the given configuration loads and matches schema',
+    )
+    .action(lazy(() => import('./commands/validate').then(m => m.default)));
+
+  program
+    .command('config:schema')
+    .option(
+      '--package <name>',
+      'Only output config schema that applies to the given package',
+    )
+    .option(
+      '--format <format>',
+      'Format to print the schema in, either json or yaml [yaml]',
+    )
+    .option('--merge', 'Print the config schemas merged', true)
+    .option('--no-merge', 'Print the config schemas not merged')
+    .description('Print configuration schema')
+    .action(lazy(() => import('./commands/schema').then(m => m.default)));
+}

--- a/packages/cli/src/modules/config/lib/config.ts
+++ b/packages/cli/src/modules/config/lib/config.ts
@@ -16,7 +16,7 @@
 
 import { ConfigSources, loadConfigSchema } from '@backstage/config-loader';
 import { AppConfig, ConfigReader } from '@backstage/config';
-import { paths } from './paths';
+import { paths } from '../../../lib/paths';
 import { getPackages } from '@manypkg/get-packages';
 import { PackageGraph } from '@backstage/cli-node';
 

--- a/packages/cli/src/wiring/Command.ts
+++ b/packages/cli/src/wiring/Command.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import yargs from 'yargs';
+import { ZodObject, ZodRawShape } from 'zod';
+
+interface BackstageCommand<T extends ZodRawShape = ZodRawShape> {
+  path: string[];
+  description: string;
+  schema: ZodObject<T>;
+  execute: (options: T) => Promise<void>;
+}
+
+type Node<T extends ZodRawShape = ZodRawShape> = TreeNode | LeafNode<T>;
+
+interface TreeNode {
+  type: '$$treeNode';
+  name: string;
+  children: TreeNode[];
+}
+
+interface LeafNode<T extends ZodRawShape> {
+  type: '$$leafNode';
+  name: string;
+  command: BackstageCommand<T>;
+}
+
+/**
+ * A sparse graph of commands.
+ */
+export class CommandGraph {
+  private graph: Node[] = [];
+
+  /**
+   * Adds a command to the graph. The graph is sparse, so we use the path to determine the nodes
+   *    to traverse. Only leaf nodes should have a command/action.
+   */
+  add<T extends ZodRawShape>(command: BackstageCommand<T>) {
+    const path = command.path;
+    let current = this.graph;
+    for (let i = 0; i < path.length - 1; i++) {
+      const name = path[i];
+      let next = current.find(n => n.name === name);
+      if (!next) {
+        next = { type: '$$treeNode', name, children: [] };
+        current.push(next);
+      } else if (next.type === '$$leafNode') {
+        throw new Error(
+          `Command already exists at path: "${path.slice(0, i).join(' ')}"`,
+        );
+      }
+      current = next.children;
+    }
+    const last = current.find(n => n.name === path[path.length - 1]) as Node<T>;
+    if (last && last.type === '$$leafNode') {
+      throw new Error(
+        `Command already exists at path: "${path.slice(0, -1).join(' ')}"`,
+      );
+    } else {
+      current.push({
+        type: '$$leafNode',
+        name: path[path.length - 1],
+        command,
+      } as Node<any>);
+    }
+  }
+
+  /**
+   * Given a path, try to find a command that matches it.
+   */
+  find<T extends ZodRawShape>(path: string[]): BackstageCommand<T> | undefined {
+    let current = this.graph;
+    for (let i = 0; i < path.length - 1; i++) {
+      const name = path[i];
+      const next = current.find(n => n.name === name);
+      if (!next) {
+        return undefined;
+      } else if (next.type === '$$leafNode') {
+        return undefined;
+      }
+      current = next.children;
+    }
+    const last = current.find(n => n.name === path[path.length - 1]) as Node<T>;
+    if (!last || last.type === '$$treeNode') {
+      return undefined;
+    }
+    return last?.command;
+  }
+}
+
+export class CliInitializer {
+  private graph = new CommandGraph();
+
+  /**
+   * Add a command to the CLI. This will be mostly used to prevent command overlaps
+   *    and to create `help` commands.
+   */
+  addCommand<T extends ZodRawShape>(command: BackstageCommand<T>) {
+    this.graph.add(command);
+  }
+
+  /**
+   * Actually parse argv and pass it to the command.
+   */
+  async run() {
+    const {
+      _: commandName,
+      $0: binaryName,
+      ...options
+    } = await yargs(process.argv.slice(2)).parse();
+    const command = this.graph.find(commandName.map(String));
+    if (!command) {
+      console.error(`Command not found: "${commandName.join(' ')}"`);
+      process.exit(1);
+    }
+    const parsedOptions = command.schema.parse(options);
+    await command?.execute(parsedOptions);
+  }
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Based on @Rugvip's comment [here](https://github.com/backstage/backstage/pull/24904#pullrequestreview-2342349766).

Tested locally with all 4 config commands and everything looked good 😁 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
