### PR TITLE
cli: refactor success cache to be additive

### DIFF
--- a/.changeset/loud-trainers-yawn.md
+++ b/.changeset/loud-trainers-yawn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+The `--successCache` option for the `repo test` and `repo lint` commands now use an additive store that keeps old entries around for a week before they are cleaned up automatically.

--- a/.changeset/two-donuts-float.md
+++ b/.changeset/two-donuts-float.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-client': patch
+---
+
+Fix for certain filter fields in the `catalogApiMock` being case sensitive.

--- a/packages/catalog-client/src/testUtils/InMemoryCatalogClient.test.ts
+++ b/packages/catalog-client/src/testUtils/InMemoryCatalogClient.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { CATALOG_FILTER_EXISTS } from '../types';
 import { InMemoryCatalogClient } from './InMemoryCatalogClient';
 import { Entity } from '@backstage/catalog-model';
 
@@ -25,6 +26,7 @@ const entity1: Entity = {
     name: 'e1',
     uid: 'u1',
   },
+  relations: [{ type: 'relatedTo', targetRef: 'customkind:default/e2' }],
 };
 
 const entity2: Entity = {
@@ -42,10 +44,32 @@ const entities = [entity1, entity2];
 describe('InMemoryCatalogClient', () => {
   it('getEntities', async () => {
     const client = new InMemoryCatalogClient({ entities });
+
     await expect(client.getEntities()).resolves.toEqual({ items: entities });
+
+    await expect(
+      client.getEntities({ filter: { 'metadata.name': 'E1' } }),
+    ).resolves.toEqual({ items: [entity1] });
+
     await expect(
       client.getEntities({ filter: { 'metadata.uid': 'u2' } }),
     ).resolves.toEqual({ items: [entity2] });
+
+    await expect(
+      client.getEntities({ filter: { 'metadata.uid': 'U2' } }),
+    ).resolves.toEqual({ items: [entity2] });
+
+    await expect(
+      client.getEntities({
+        filter: { 'relations.relatedto': CATALOG_FILTER_EXISTS },
+      }),
+    ).resolves.toEqual({ items: [entity1] });
+
+    await expect(
+      client.getEntities({
+        filter: { 'relations.relatedTo': 'customkind:default/e2' },
+      }),
+    ).resolves.toEqual({ items: [entity1] });
   });
 
   it('getEntitiesByRefs', async () => {

--- a/packages/catalog-client/src/testUtils/InMemoryCatalogClient.ts
+++ b/packages/catalog-client/src/testUtils/InMemoryCatalogClient.ts
@@ -48,13 +48,22 @@ function buildEntitySearch(entity: Entity) {
   const rows = traverse(entity);
 
   if (entity.metadata?.name) {
-    rows.push({ key: 'metadata.name', value: entity.metadata.name });
+    rows.push({
+      key: 'metadata.name',
+      value: entity.metadata.name.toLocaleLowerCase('en-US'),
+    });
   }
   if (entity.metadata?.namespace) {
-    rows.push({ key: 'metadata.namespace', value: entity.metadata.namespace });
+    rows.push({
+      key: 'metadata.namespace',
+      value: entity.metadata.namespace.toLocaleLowerCase('en-US'),
+    });
   }
   if (entity.metadata?.uid) {
-    rows.push({ key: 'metadata.uid', value: entity.metadata.uid });
+    rows.push({
+      key: 'metadata.uid',
+      value: entity.metadata.uid.toLocaleLowerCase('en-US'),
+    });
   }
 
   if (!entity.metadata.namespace) {
@@ -64,8 +73,8 @@ function buildEntitySearch(entity: Entity) {
   // Visit relations
   for (const relation of entity.relations ?? []) {
     rows.push({
-      key: `relations.${relation.type}`,
-      value: relation.targetRef,
+      key: `relations.${relation.type.toLocaleLowerCase('en-US')}`,
+      value: relation.targetRef.toLocaleLowerCase('en-US'),
     });
   }
 

--- a/packages/cli/src/commands/repo/test.ts
+++ b/packages/cli/src/commands/repo/test.ts
@@ -16,14 +16,14 @@
 
 import os from 'os';
 import crypto from 'node:crypto';
-import fs from 'fs-extra';
 import yargs from 'yargs';
-import { resolve as resolvePath, relative as relativePath } from 'path';
+import { relative as relativePath } from 'path';
 import { Command, OptionValues } from 'commander';
 import { Lockfile, PackageGraph } from '@backstage/cli-node';
 import { paths } from '../../lib/paths';
 import { runCheck, runPlain } from '../../lib/run';
 import { isChildPath } from '@backstage/cli-common';
+import { SuccessCache } from '../../lib/cache/SuccessCache';
 
 type JestProject = {
   displayName: string;
@@ -48,30 +48,6 @@ interface GlobalWithCache extends Global {
       }>;
     }): Promise<void>;
   };
-}
-
-const CACHE_FILE_NAME = 'test-cache.json';
-
-type Cache = string[];
-
-async function readCache(dir: string): Promise<Cache | undefined> {
-  try {
-    const data = await fs.readJson(resolvePath(dir, CACHE_FILE_NAME));
-    if (!Array.isArray(data)) {
-      return undefined;
-    }
-    if (data.some(x => typeof x !== 'string')) {
-      return undefined;
-    }
-    return data as Cache;
-  } catch {
-    return undefined;
-  }
-}
-
-function writeCache(dir: string, cache: Cache) {
-  fs.mkdirpSync(dir);
-  fs.writeJsonSync(resolvePath(dir, CACHE_FILE_NAME), cache, { spaces: 2 });
 }
 
 /**
@@ -272,10 +248,6 @@ export async function command(opts: OptionValues, cmd: Command): Promise<void> {
     removeOptionArg(args, '--successCache', 1);
     removeOptionArg(args, '--successCacheDir');
 
-    const cacheDir = resolvePath(
-      opts.successCacheDir ?? 'node_modules/.cache/backstage-cli',
-    );
-
     // Parse the args to ensure that no file filters are provided, in which case we refuse to run
     const { _: parsedArgs } = await yargs(args).options(jestCli.yargsOptions)
       .argv;
@@ -293,6 +265,7 @@ export async function command(opts: OptionValues, cmd: Command): Promise<void> {
       );
     }
 
+    const cache = new SuccessCache('test', opts.successCacheDir);
     const graph = await getPackageGraph();
 
     // Shared state for the bridge
@@ -305,7 +278,7 @@ export async function command(opts: OptionValues, cmd: Command): Promise<void> {
     globalWithCache.__backstageCli_jestSuccessCache = {
       // This is called by `config/jest.js` after the project configs have been gathered
       async filterConfigs(projectConfigs, globalRootConfig) {
-        const cache = await readCache(cacheDir);
+        const cacheEntries = await cache.read();
         const lockfile = await Lockfile.load(
           paths.resolveTargetRoot('yarn.lock'),
         );
@@ -350,7 +323,7 @@ export async function command(opts: OptionValues, cmd: Command): Promise<void> {
 
           projectHashes.set(packageName, sha);
 
-          if (cache?.includes(sha)) {
+          if (cacheEntries.has(sha)) {
             if (!selectedProjects || selectedProjects.includes(packageName)) {
               console.log(`Skipped ${packageName} due to cache hit`);
             }
@@ -391,7 +364,7 @@ export async function command(opts: OptionValues, cmd: Command): Promise<void> {
           }
         }
 
-        await writeCache(cacheDir, outputSuccessCache);
+        await cache.write(outputSuccessCache);
       },
     };
   }

--- a/packages/cli/src/lib/cache/SuccessCache.ts
+++ b/packages/cli/src/lib/cache/SuccessCache.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs-extra';
+import { resolve as resolvePath } from 'node:path';
+
+const DEFAULT_CACHE_BASE_PATH = 'node_modules/.cache/backstage-cli';
+
+const CACHE_MAX_AGE_MS = 7 * 24 * 3600_000;
+
+export class SuccessCache {
+  readonly #path: string;
+
+  constructor(name: string, basePath?: string) {
+    this.#path = resolvePath(basePath ?? DEFAULT_CACHE_BASE_PATH, name);
+  }
+
+  async read(): Promise<Set<string>> {
+    const state = await fs.stat(this.#path).catch(error => {
+      if (error.code === 'ENOENT') {
+        return undefined;
+      }
+      throw error;
+    });
+    if (!state || !state.isDirectory()) {
+      return new Set();
+    }
+    const items = await fs.readdir(this.#path);
+
+    const returned = new Set<string>();
+    const removed = new Set<string>();
+
+    const now = Date.now();
+
+    for (const item of items) {
+      const split = item.split('_');
+      if (split.length !== 2) {
+        removed.add(item);
+        continue;
+      }
+      const createdAt = parseInt(split[0], 10);
+      if (Number.isNaN(createdAt) || now - createdAt > CACHE_MAX_AGE_MS) {
+        removed.add(item);
+      } else {
+        returned.add(split[1]);
+      }
+    }
+
+    for (const item of removed) {
+      await fs.unlink(resolvePath(this.#path, item));
+    }
+
+    return returned;
+  }
+
+  async write(newEntries: Iterable<string>): Promise<void> {
+    const now = Date.now();
+
+    await fs.ensureDir(this.#path);
+
+    const existingItems = await fs.readdir(this.#path);
+
+    const empty = Buffer.alloc(0);
+    for (const key of newEntries) {
+      // Remove any existing items with the key we're about to add
+      const trimmedItems = existingItems.filter(item =>
+        item.endsWith(`_${key}`),
+      );
+      for (const trimmedItem of trimmedItems) {
+        await fs.unlink(resolvePath(this.#path, trimmedItem));
+      }
+
+      await fs.writeFile(resolvePath(this.#path, `${now}_${key}`), empty);
+    }
+  }
+}

--- a/packages/cli/src/lib/cache/SuccessCache.ts
+++ b/packages/cli/src/lib/cache/SuccessCache.ts
@@ -29,15 +29,19 @@ export class SuccessCache {
   }
 
   async read(): Promise<Set<string>> {
-    const state = await fs.stat(this.#path).catch(error => {
+    try {
+      const stat = await fs.stat(this.#path);
+      if (!stat.isDirectory()) {
+        await fs.rm(this.#path);
+        return new Set();
+      }
+    } catch (error) {
       if (error.code === 'ENOENT') {
-        return undefined;
+        return new Set();
       }
       throw error;
-    });
-    if (!state || !state.isDirectory()) {
-      return new Set();
     }
+
     const items = await fs.readdir(this.#path);
 
     const returned = new Set<string>();


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This changes the success cache to store each entry in a marker file rather than all of them in a JSON file. This lets us keep old entries around and increases the chance for cache hits at a slight cost to storage and complexity. Still aiming to keep the implementation very simple, so the cache items are just empty files, all information needed is stored in the filename.

And a bit of a refactor to use the same implementation for the two commands.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
