### PR TITLE
fix: disable blur-handler when selecting option from Autocomplete

### DIFF
--- a/.changeset/moody-pandas-marry.md
+++ b/.changeset/moody-pandas-marry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+disable blur-handler when selecting option from Autocomplete


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes #27214 by introducing another state to the component in order to bypass blur handler if the user select an option from Autocomplete component. The issue here is that freesolo-mode allows freeform-text to the Textfield component and that is treated "as-is" while selected option from Autocomplete should be kept as entity reference. This is really hard thing to do as event happens in the following order:

 * The user selects Option from Autocomplete
 * Title from the selected Option in filled to Textfield complete and user's focus move to the field
 * User click outside of Textfield
 * Another change event is issued and now containing "freeform" input (entity display name as text)

So, this PR introduces another state; when user types something to the text field it known that it should be treated as text meanwhile selecting option from Autocomplete says in entity reference because `blur` effect is ignored as user didn't touch the text field (mode is changed via `keyDown` event).

At best; This is a hack but `EntityPicker` does so much already! I'm also fine with reverting back to old version :)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
