### PR TITLE
events-node: more resilient and configurable events service

### DIFF
--- a/.changeset/cyan-trees-bow.md
+++ b/.changeset/cyan-trees-bow.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-events-node': patch
+---
+
+Fixed an issue where subscribing to events threw an error and gave up too easily. Calling the subscribe method will cause the background polling loop to keep trying to connect to the events backend, even if the initial request fails.
+
+By default the events service will attempt to publish and subscribe to events from the events bus API in the events backend, but if it fails due to the events backend not being installed, it will bail and never try calling the API again. There is now a new `events.useEventBus` configuration and option for the `DefaultEventsService` that lets you control this behavior. You can set it to `'never'` to disabled API calls to the events backend completely, or `'always'` to never allow it to be disabled.

--- a/plugins/events-node/config.d.ts
+++ b/plugins/events-node/config.d.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface Config {
+  events?: {
+    /**
+     * Whether to use the event bus API in the events plugin backend to
+     * distribute events across multiple instances when publishing and
+     * subscribing to events.
+     *
+     * The default is 'auto', which means means that the event bus API will be
+     * used if it's available, but will be disabled if the events backend
+     * returns a 404.
+     *
+     * If set to 'never', the events service will only ever publish events
+     * locally to the same instance, while if set to 'always', the event bus API
+     * will never be disabled, even if the events backend returns a 404.
+     */
+    useEventBus?: 'never' | 'always' | 'auto';
+  };
+}

--- a/plugins/events-node/package.json
+++ b/plugins/events-node/package.json
@@ -39,7 +39,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "config.d.ts"
   ],
   "scripts": {
     "build": "backstage-cli package build",
@@ -60,6 +61,8 @@
   "devDependencies": {
     "@backstage/backend-common": "^0.25.0",
     "@backstage/backend-test-utils": "workspace:^",
-    "@backstage/cli": "workspace:^"
-  }
+    "@backstage/cli": "workspace:^",
+    "msw": "^1.0.0"
+  },
+  "configSchema": "config.d.ts"
 }

--- a/plugins/events-node/report.api.md
+++ b/plugins/events-node/report.api.md
@@ -7,13 +7,18 @@ import { AuthService } from '@backstage/backend-plugin-api';
 import { DiscoveryService } from '@backstage/backend-plugin-api';
 import { LifecycleService } from '@backstage/backend-plugin-api';
 import { LoggerService } from '@backstage/backend-plugin-api';
+import { RootConfigService } from '@backstage/backend-plugin-api';
 import { ServiceFactory } from '@backstage/backend-plugin-api';
 import { ServiceRef } from '@backstage/backend-plugin-api';
 
 // @public
 export class DefaultEventsService implements EventsService {
   // (undocumented)
-  static create(options: { logger: LoggerService }): DefaultEventsService;
+  static create(options: {
+    logger: LoggerService;
+    config?: RootConfigService;
+    useEventBus?: EventBusMode;
+  }): DefaultEventsService;
   forPlugin(
     pluginId: string,
     options?: {
@@ -36,6 +41,9 @@ export interface EventBroker {
     ...subscribers: Array<EventSubscriber | Array<EventSubscriber>>
   ): void;
 }
+
+// @public (undocumented)
+export type EventBusMode = 'never' | 'always' | 'auto';
 
 // @public (undocumented)
 export interface EventParams<TPayload = unknown> {

--- a/plugins/events-node/src/api/DefaultEventsService.test.ts
+++ b/plugins/events-node/src/api/DefaultEventsService.test.ts
@@ -16,12 +16,16 @@
 
 import { DefaultEventsService } from './DefaultEventsService';
 import { EventParams } from './EventParams';
-import { mockServices } from '@backstage/backend-test-utils';
-
-const logger = mockServices.logger.mock();
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import {
+  mockServices,
+  registerMswTestHooks,
+} from '@backstage/backend-test-utils';
 
 describe('DefaultEventsService', () => {
   it('passes events to interested subscribers', async () => {
+    const logger = mockServices.logger.mock();
     const events = DefaultEventsService.create({ logger });
     const eventsSubscriber1: EventParams[] = [];
     const eventsSubscriber2: EventParams[] = [];
@@ -70,6 +74,7 @@ describe('DefaultEventsService', () => {
   it('logs errors from subscribers', async () => {
     const topic = 'testTopic';
 
+    const logger = mockServices.logger.mock();
     const warnSpy = jest.spyOn(logger, 'warn');
     const events = DefaultEventsService.create({ logger });
 
@@ -107,5 +112,166 @@ describe('DefaultEventsService', () => {
       'Subscriber "subscriber2" failed to process event for topic "testTopic"',
       new Error('NOPE 2'),
     );
+  });
+
+  describe('with event bus', () => {
+    const mswServer = setupServer();
+    registerMswTestHooks(mswServer);
+
+    it('should read events from events bus API', async () => {
+      const logger = mockServices.logger.mock();
+      const service = DefaultEventsService.create({ logger }).forPlugin('a', {
+        auth: mockServices.auth(),
+        logger,
+        discovery: mockServices.discovery(),
+        lifecycle: mockServices.lifecycle.mock(),
+      });
+
+      mswServer.use(
+        rest.put(
+          'http://localhost:0/api/events/bus/v1/subscriptions/a.tester',
+          (_req, res, ctx) => res(ctx.status(200)),
+        ),
+        rest.get(
+          'http://localhost:0/api/events/bus/v1/subscriptions/a.tester/events',
+          (_req, res, ctx) =>
+            res(
+              ctx.status(200),
+              ctx.json({
+                events: [{ topic: 'test', payload: { foo: 'bar' } }],
+              }),
+            ),
+        ),
+      );
+
+      const event = await new Promise(resolve => {
+        service.subscribe({
+          id: 'tester',
+          topics: ['test'],
+          async onEvent(newEvent) {
+            resolve(newEvent);
+          },
+        });
+      });
+
+      expect(event).toEqual({ topic: 'test', eventPayload: { foo: 'bar' } });
+
+      // Internal call to clean up subscriptions
+      await (service as any).shutdown();
+    });
+
+    it('should not read events from bus if disabled', async () => {
+      const logger = mockServices.logger.mock();
+      const service = DefaultEventsService.create({
+        logger,
+        useEventBus: 'never',
+      }).forPlugin('a', {
+        auth: mockServices.auth(),
+        logger,
+        discovery: mockServices.discovery(),
+        lifecycle: mockServices.lifecycle.mock(),
+      });
+
+      let calledApi = false;
+      mswServer.use(
+        rest.put(
+          'http://localhost:0/api/events/bus/v1/subscriptions/a.tester',
+          (_req, res, ctx) => {
+            calledApi = true;
+            res(ctx.status(200));
+          },
+        ),
+      );
+
+      await service.subscribe({
+        id: 'tester',
+        topics: ['test'],
+        async onEvent() {
+          expect('not').toBe('reached');
+        },
+      });
+
+      // Internal call to clean up subscriptions, and wait for the API call
+      await (service as any).shutdown();
+
+      expect(calledApi).toBe(false);
+    });
+
+    it('should deactivate event bus on 404', async () => {
+      expect.assertions(1);
+
+      const logger = mockServices.logger.mock();
+      const service = DefaultEventsService.create({ logger }).forPlugin('a', {
+        auth: mockServices.auth(),
+        logger,
+        discovery: mockServices.discovery(),
+        lifecycle: mockServices.lifecycle.mock(),
+      });
+
+      mswServer.use(
+        rest.put(
+          'http://localhost:0/api/events/bus/v1/subscriptions/a.tester',
+          (_req, res, ctx) => res(ctx.status(404)),
+        ),
+      );
+
+      service.subscribe({
+        id: 'tester',
+        topics: ['test'],
+        async onEvent() {
+          expect('not').toBe('reached');
+        },
+      });
+
+      const msg = await new Promise(resolve => {
+        logger.warn.mockImplementationOnce(resolve);
+      });
+
+      expect(msg).toMatch(/Event subscribe request failed with status 404/);
+
+      // Internal call to clean up subscriptions
+      await (service as any).shutdown();
+    });
+
+    it('should not deactivate event bus if configured to always be used', async () => {
+      expect.assertions(1);
+
+      const logger = mockServices.logger.mock();
+      const service = DefaultEventsService.create({
+        logger,
+        useEventBus: 'always',
+      }).forPlugin('a', {
+        auth: mockServices.auth(),
+        logger,
+        discovery: mockServices.discovery(),
+        lifecycle: mockServices.lifecycle.mock(),
+      });
+
+      mswServer.use(
+        rest.put(
+          'http://localhost:0/api/events/bus/v1/subscriptions/a.tester',
+          (_req, res, ctx) => res(ctx.status(404)),
+        ),
+      );
+
+      service.subscribe({
+        id: 'tester',
+        topics: ['test'],
+        async onEvent() {
+          expect('not').toBe('reached');
+        },
+      });
+
+      const msg = await new Promise(resolve => {
+        logger.warn.mockImplementationOnce(resolve);
+      });
+
+      expect(msg).toMatch(
+        'Poll failed for subscription "a.tester", retrying in 1000ms',
+      );
+
+      // Internal call to clean up subscriptions
+      await (service as any).shutdown();
+    });
   });
 });

--- a/plugins/events-node/src/api/index.ts
+++ b/plugins/events-node/src/api/index.ts
@@ -21,6 +21,9 @@ export type {
   EventsServiceSubscribeOptions,
   EventsServiceEventHandler,
 } from './EventsService';
-export { DefaultEventsService } from './DefaultEventsService';
+export {
+  DefaultEventsService,
+  type EventBusMode,
+} from './DefaultEventsService';
 export * from './http';
 export { SubTopicEventRouter } from './SubTopicEventRouter';

--- a/yarn.lock
+++ b/yarn.lock
@@ -6325,6 +6325,7 @@ __metadata:
     "@backstage/errors": "workspace:^"
     "@backstage/types": "workspace:^"
     cross-fetch: ^4.0.0
+    msw: ^1.0.0
     uri-template: ^2.0.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #27207

We no longer try to set up the subscription upfront, but leave it to the background polling.

In addition I though it makes sense to include a configuration option as part of this change, so that the events bus can be explicitly enabled or disabled.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
