### PR TITLE
signals-backend: fan-out signal events in order to support scaled deployments

### DIFF
--- a/.changeset/spotty-snails-worry.md
+++ b/.changeset/spotty-snails-worry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-signals-backend': patch
+---
+
+The signals backend now supports scaled deployments where clients may be connecting to one of many signal backend instances.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

By using a unique subscriber ID for each instance all events will be fanned out to all instances and reach users regardless of what instance they're connected to.

👀  @drodil 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
