### PR TITLE
Patch release of #27227, #27230, #27231

### DIFF
--- a/.changeset/cyan-trees-bow.md
+++ b/.changeset/cyan-trees-bow.md
@@ -1,7 +1,0 @@
----
-'@backstage/plugin-events-node': patch
----
-
-Fixed an issue where subscribing to events threw an error and gave up too easily. Calling the subscribe method will cause the background polling loop to keep trying to connect to the events backend, even if the initial request fails.
-
-By default the events service will attempt to publish and subscribe to events from the events bus API in the events backend, but if it fails due to the events backend not being installed, it will bail and never try calling the API again. There is now a new `events.useEventBus` configuration and option for the `DefaultEventsService` that lets you control this behavior. You can set it to `'never'` to disabled API calls to the events backend completely, or `'always'` to never allow it to be disabled.

--- a/.changeset/cyan-trees-bow.md
+++ b/.changeset/cyan-trees-bow.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-events-node': patch
+---
+
+Fixed an issue where subscribing to events threw an error and gave up too easily. Calling the subscribe method will cause the background polling loop to keep trying to connect to the events backend, even if the initial request fails.
+
+By default the events service will attempt to publish and subscribe to events from the events bus API in the events backend, but if it fails due to the events backend not being installed, it will bail and never try calling the API again. There is now a new `events.useEventBus` configuration and option for the `DefaultEventsService` that lets you control this behavior. You can set it to `'never'` to disabled API calls to the events backend completely, or `'always'` to never allow it to be disabled.

--- a/.changeset/green-tools-arrive.md
+++ b/.changeset/green-tools-arrive.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+Fix issue with form state not refreshing when updating

--- a/.changeset/green-tools-arrive.md
+++ b/.changeset/green-tools-arrive.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-scaffolder-react': patch
----
-
-Fix issue with form state not refreshing when updating

--- a/.changeset/silent-wasps-whisper.md
+++ b/.changeset/silent-wasps-whisper.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Revert the change of the option label for `EntityPicker`

--- a/.changeset/silent-wasps-whisper.md
+++ b/.changeset/silent-wasps-whisper.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-scaffolder': patch
----
-
-Revert the change of the option label for `EntityPicker`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.32.1",
+  "version": "1.32.2",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/app-next/CHANGELOG.md
+++ b/packages/app-next/CHANGELOG.md
@@ -1,5 +1,14 @@
 # example-app-next
 
+## 0.0.17
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-scaffolder-react@1.13.1
+  - @backstage/plugin-scaffolder@1.26.1
+  - @backstage/cli@0.28.0
+
 ## 0.0.16
 
 ### Patch Changes

--- a/packages/app-next/package.json
+++ b/packages/app-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-app-next",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "backstage": {
     "role": "frontend"
   },

--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -1,5 +1,14 @@
 # example-app
 
+## 0.2.103
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-scaffolder-react@1.13.1
+  - @backstage/plugin-scaffolder@1.26.1
+  - @backstage/cli@0.28.0
+
 ## 0.2.102
 
 ### Patch Changes

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-app",
-  "version": "0.2.102",
+  "version": "0.2.103",
   "backstage": {
     "role": "frontend"
   },

--- a/packages/backend-defaults/CHANGELOG.md
+++ b/packages/backend-defaults/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage/backend-defaults
 
+## 0.5.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-events-node@0.4.2
+  - @backstage/backend-app-api@1.0.1
+  - @backstage/backend-plugin-api@1.0.1
+  - @backstage/cli-node@0.2.9
+  - @backstage/config-loader@1.9.1
+  - @backstage/plugin-auth-node@0.5.3
+  - @backstage/plugin-permission-node@0.8.4
+
 ## 0.5.1
 
 ### Patch Changes

--- a/packages/backend-defaults/package.json
+++ b/packages/backend-defaults/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/backend-defaults",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Backend defaults used by Backstage backend apps",
   "backstage": {
     "role": "node-library"

--- a/packages/backend-dynamic-feature-service/CHANGELOG.md
+++ b/packages/backend-dynamic-feature-service/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @backstage/backend-dynamic-feature-service
 
+## 0.4.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-events-node@0.4.2
+  - @backstage/backend-defaults@0.5.2
+  - @backstage/plugin-catalog-backend@1.27.1
+  - @backstage/plugin-events-backend@0.3.14
+  - @backstage/backend-app-api@1.0.1
+  - @backstage/plugin-search-backend-node@1.3.4
+  - @backstage/backend-plugin-api@1.0.1
+  - @backstage/cli-node@0.2.9
+  - @backstage/config-loader@1.9.1
+  - @backstage/plugin-auth-node@0.5.3
+  - @backstage/plugin-permission-node@0.8.4
+  - @backstage/plugin-scaffolder-node@0.5.0
+
 ## 0.4.2
 
 ### Patch Changes

--- a/packages/backend-dynamic-feature-service/package.json
+++ b/packages/backend-dynamic-feature-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/backend-dynamic-feature-service",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Backstage dynamic feature service",
   "backstage": {
     "role": "node-library"

--- a/packages/backend-legacy/CHANGELOG.md
+++ b/packages/backend-legacy/CHANGELOG.md
@@ -1,5 +1,40 @@
 # example-backend-legacy
 
+## 0.2.105
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-events-node@0.4.2
+  - @backstage/backend-defaults@0.5.2
+  - @backstage/plugin-catalog-backend@1.27.1
+  - @backstage/plugin-events-backend@0.3.14
+  - @backstage/plugin-signals-backend@0.2.2
+  - @backstage/plugin-signals-node@0.1.13
+  - @backstage/plugin-app-backend@0.3.76
+  - @backstage/plugin-auth-backend@0.23.1
+  - @backstage/plugin-devtools-backend@0.4.1
+  - @backstage/plugin-kubernetes-backend@0.18.7
+  - @backstage/plugin-proxy-backend@0.5.7
+  - @backstage/plugin-scaffolder-backend@1.26.2
+  - @backstage/plugin-search-backend@1.6.1
+  - @backstage/plugin-search-backend-node@1.3.4
+  - @backstage/plugin-techdocs-backend@1.11.1
+  - @backstage/backend-plugin-api@1.0.1
+  - @backstage/plugin-auth-node@0.5.3
+  - @backstage/plugin-catalog-backend-module-scaffolder-entity-model@0.2.1
+  - @backstage/plugin-catalog-node@1.13.1
+  - @backstage/plugin-permission-backend@0.5.50
+  - @backstage/plugin-permission-node@0.8.4
+  - @backstage/plugin-scaffolder-backend-module-confluence-to-markdown@0.3.1
+  - @backstage/plugin-scaffolder-backend-module-gitlab@0.6.0
+  - @backstage/plugin-scaffolder-backend-module-rails@0.5.1
+  - @backstage/plugin-search-backend-module-catalog@0.2.4
+  - @backstage/plugin-search-backend-module-elasticsearch@1.6.1
+  - @backstage/plugin-search-backend-module-explore@0.2.4
+  - @backstage/plugin-search-backend-module-pg@0.5.37
+  - @backstage/plugin-search-backend-module-techdocs@0.3.1
+
 ## 0.2.104
 
 ### Patch Changes

--- a/packages/backend-legacy/package.json
+++ b/packages/backend-legacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-backend-legacy",
-  "version": "0.2.104",
+  "version": "0.2.105",
   "backstage": {
     "role": "backend"
   },

--- a/packages/backend-test-utils/CHANGELOG.md
+++ b/packages/backend-test-utils/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage/backend-test-utils
 
+## 1.0.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-events-node@0.4.2
+  - @backstage/backend-defaults@0.5.2
+  - @backstage/backend-app-api@1.0.1
+  - @backstage/backend-plugin-api@1.0.1
+  - @backstage/plugin-auth-node@0.5.3
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/backend-test-utils/package.json
+++ b/packages/backend-test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/backend-test-utils",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Test helpers library for Backstage backends",
   "backstage": {
     "role": "node-library"

--- a/packages/backend/CHANGELOG.md
+++ b/packages/backend/CHANGELOG.md
@@ -1,5 +1,38 @@
 # example-backend
 
+## 0.0.33
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-defaults@0.5.2
+  - @backstage/plugin-catalog-backend@1.27.1
+  - @backstage/plugin-events-backend@0.3.14
+  - @backstage/plugin-notifications-backend@0.4.2
+  - @backstage/plugin-signals-backend@0.2.2
+  - @backstage/plugin-app-backend@0.3.76
+  - @backstage/plugin-auth-backend@0.23.1
+  - @backstage/plugin-auth-backend-module-github-provider@0.2.1
+  - @backstage/plugin-devtools-backend@0.4.1
+  - @backstage/plugin-kubernetes-backend@0.18.7
+  - @backstage/plugin-proxy-backend@0.5.7
+  - @backstage/plugin-scaffolder-backend@1.26.2
+  - @backstage/plugin-search-backend@1.6.1
+  - @backstage/plugin-search-backend-node@1.3.4
+  - @backstage/plugin-techdocs-backend@1.11.1
+  - @backstage/backend-plugin-api@1.0.1
+  - @backstage/plugin-auth-backend-module-guest-provider@0.2.1
+  - @backstage/plugin-auth-node@0.5.3
+  - @backstage/plugin-catalog-backend-module-openapi@0.2.3
+  - @backstage/plugin-catalog-backend-module-scaffolder-entity-model@0.2.1
+  - @backstage/plugin-permission-backend@0.5.50
+  - @backstage/plugin-permission-backend-module-allow-all-policy@0.2.1
+  - @backstage/plugin-permission-node@0.8.4
+  - @backstage/plugin-scaffolder-backend-module-github@0.5.1
+  - @backstage/plugin-search-backend-module-catalog@0.2.4
+  - @backstage/plugin-search-backend-module-explore@0.2.4
+  - @backstage/plugin-search-backend-module-techdocs@0.3.1
+
 ## 0.0.32
 
 ### Patch Changes

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-backend",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "backstage": {
     "role": "backend"
   },

--- a/packages/scaffolder-internal/CHANGELOG.md
+++ b/packages/scaffolder-internal/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @internal/scaffolder
 
+## 0.0.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-scaffolder-react@1.13.1
+
 ## 0.0.2
 
 ### Patch Changes

--- a/packages/scaffolder-internal/package.json
+++ b/packages/scaffolder-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internal/scaffolder",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "backstage": {
     "role": "web-library",
     "inline": true

--- a/packages/techdocs-cli/CHANGELOG.md
+++ b/packages/techdocs-cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @techdocs/cli
 
+## 1.8.21
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-defaults@0.5.2
+  - @backstage/plugin-techdocs-node@1.12.12
+
 ## 1.8.20
 
 ### Patch Changes

--- a/packages/techdocs-cli/package.json
+++ b/packages/techdocs-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@techdocs/cli",
-  "version": "1.8.20",
+  "version": "1.8.21",
   "description": "Utility CLI for managing TechDocs sites in Backstage.",
   "backstage": {
     "role": "cli"

--- a/plugins/catalog-backend-module-aws/CHANGELOG.md
+++ b/plugins/catalog-backend-module-aws/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-catalog-backend-module-aws
 
+## 0.4.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-defaults@0.5.2
+  - @backstage/backend-plugin-api@1.0.1
+  - @backstage/plugin-catalog-node@1.13.1
+
 ## 0.4.3
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-aws/package.json
+++ b/plugins/catalog-backend-module-aws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-aws",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "A Backstage catalog backend module that helps integrate towards AWS",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/catalog-backend-module-bitbucket-cloud/CHANGELOG.md
+++ b/plugins/catalog-backend-module-bitbucket-cloud/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-catalog-backend-module-bitbucket-cloud
 
+## 0.4.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-events-node@0.4.2
+  - @backstage/backend-plugin-api@1.0.1
+  - @backstage/plugin-catalog-node@1.13.1
+
 ## 0.4.0
 
 ### Minor Changes

--- a/plugins/catalog-backend-module-bitbucket-cloud/package.json
+++ b/plugins/catalog-backend-module-bitbucket-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-bitbucket-cloud",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A Backstage catalog backend module that helps integrate towards Bitbucket Cloud",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/catalog-backend-module-github-org/CHANGELOG.md
+++ b/plugins/catalog-backend-module-github-org/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/plugin-catalog-backend-module-github-org
 
+## 0.3.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-events-node@0.4.2
+  - @backstage/plugin-catalog-backend-module-github@0.7.6
+  - @backstage/backend-plugin-api@1.0.1
+  - @backstage/plugin-catalog-node@1.13.1
+
 ## 0.3.2
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-github-org/package.json
+++ b/plugins/catalog-backend-module-github-org/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-github-org",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "The github-org backend module for the catalog plugin.",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/catalog-backend-module-github/CHANGELOG.md
+++ b/plugins/catalog-backend-module-github/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/plugin-catalog-backend-module-github
 
+## 0.7.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-events-node@0.4.2
+  - @backstage/plugin-catalog-backend@1.27.1
+  - @backstage/backend-plugin-api@1.0.1
+  - @backstage/plugin-catalog-node@1.13.1
+
 ## 0.7.5
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-github/package.json
+++ b/plugins/catalog-backend-module-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-github",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "A Backstage catalog backend module that helps integrate towards GitHub",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/catalog-backend-module-gitlab-org/CHANGELOG.md
+++ b/plugins/catalog-backend-module-gitlab-org/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/plugin-catalog-backend-module-gitlab-org
 
+## 0.2.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-events-node@0.4.2
+  - @backstage/plugin-catalog-backend-module-gitlab@0.4.4
+  - @backstage/backend-plugin-api@1.0.1
+  - @backstage/plugin-catalog-node@1.13.1
+
 ## 0.2.1
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-gitlab-org/package.json
+++ b/plugins/catalog-backend-module-gitlab-org/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-gitlab-org",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "The gitlab-org backend module for the catalog plugin.",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/catalog-backend-module-gitlab/CHANGELOG.md
+++ b/plugins/catalog-backend-module-gitlab/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/plugin-catalog-backend-module-gitlab
 
+## 0.4.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-events-node@0.4.2
+  - @backstage/backend-defaults@0.5.2
+  - @backstage/backend-plugin-api@1.0.1
+  - @backstage/plugin-catalog-node@1.13.1
+
 ## 0.4.3
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-gitlab/package.json
+++ b/plugins/catalog-backend-module-gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-gitlab",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "A Backstage catalog backend module that helps integrate towards GitLab",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/catalog-backend-module-incremental-ingestion/CHANGELOG.md
+++ b/plugins/catalog-backend-module-incremental-ingestion/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/plugin-catalog-backend-module-incremental-ingestion
 
+## 0.5.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-events-node@0.4.2
+  - @backstage/plugin-catalog-backend@1.27.1
+  - @backstage/backend-plugin-api@1.0.1
+  - @backstage/plugin-catalog-node@1.13.1
+
 ## 0.5.5
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-incremental-ingestion/package.json
+++ b/plugins/catalog-backend-module-incremental-ingestion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-incremental-ingestion",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "An entity provider for streaming large asset sources into the catalog",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/catalog-backend-module-logs/CHANGELOG.md
+++ b/plugins/catalog-backend-module-logs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-catalog-backend-module-logs
 
+## 0.1.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-events-node@0.4.2
+  - @backstage/plugin-catalog-backend@1.27.1
+  - @backstage/backend-plugin-api@1.0.1
+
 ## 0.1.2
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-logs/package.json
+++ b/plugins/catalog-backend-module-logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-logs",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A module that subscribes to catalog releated events and logs them.",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/catalog-backend-module-openapi/CHANGELOG.md
+++ b/plugins/catalog-backend-module-openapi/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-catalog-backend-module-openapi
 
+## 0.2.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-backend@1.27.1
+  - @backstage/backend-plugin-api@1.0.1
+  - @backstage/plugin-catalog-node@1.13.1
+
 ## 0.2.2
 
 ### Patch Changes

--- a/plugins/catalog-backend-module-openapi/package.json
+++ b/plugins/catalog-backend-module-openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-openapi",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A Backstage catalog backend module that helps with OpenAPI specifications",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/catalog-backend/CHANGELOG.md
+++ b/plugins/catalog-backend/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage/plugin-catalog-backend
 
+## 1.27.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-events-node@0.4.2
+  - @backstage/backend-plugin-api@1.0.1
+  - @backstage/plugin-catalog-node@1.13.1
+  - @backstage/plugin-permission-node@0.8.4
+  - @backstage/plugin-search-backend-module-catalog@0.2.4
+
 ## 1.27.0
 
 ### Minor Changes

--- a/plugins/catalog-backend/package.json
+++ b/plugins/catalog-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "description": "The Backstage backend plugin that provides the Backstage catalog",
   "backstage": {
     "role": "backend-plugin",

--- a/plugins/events-backend-module-aws-sqs/CHANGELOG.md
+++ b/plugins/events-backend-module-aws-sqs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-events-backend-module-aws-sqs
 
+## 0.4.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-events-node@0.4.2
+  - @backstage/backend-plugin-api@1.0.1
+
 ## 0.4.3
 
 ### Patch Changes

--- a/plugins/events-backend-module-aws-sqs/package.json
+++ b/plugins/events-backend-module-aws-sqs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-events-backend-module-aws-sqs",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "backstage": {
     "role": "backend-plugin-module",
     "pluginId": "events",

--- a/plugins/events-backend-module-azure/CHANGELOG.md
+++ b/plugins/events-backend-module-azure/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-events-backend-module-azure
 
+## 0.2.13
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-events-node@0.4.2
+  - @backstage/backend-plugin-api@1.0.1
+
 ## 0.2.12
 
 ### Patch Changes

--- a/plugins/events-backend-module-azure/package.json
+++ b/plugins/events-backend-module-azure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-events-backend-module-azure",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "backstage": {
     "role": "backend-plugin-module",
     "pluginId": "events",

--- a/plugins/events-backend-module-bitbucket-cloud/CHANGELOG.md
+++ b/plugins/events-backend-module-bitbucket-cloud/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-events-backend-module-bitbucket-cloud
 
+## 0.2.13
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-events-node@0.4.2
+  - @backstage/backend-plugin-api@1.0.1
+
 ## 0.2.12
 
 ### Patch Changes

--- a/plugins/events-backend-module-bitbucket-cloud/package.json
+++ b/plugins/events-backend-module-bitbucket-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-events-backend-module-bitbucket-cloud",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "backstage": {
     "role": "backend-plugin-module",
     "pluginId": "events",

--- a/plugins/events-backend-module-gerrit/CHANGELOG.md
+++ b/plugins/events-backend-module-gerrit/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-events-backend-module-gerrit
 
+## 0.2.13
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-events-node@0.4.2
+  - @backstage/backend-plugin-api@1.0.1
+
 ## 0.2.12
 
 ### Patch Changes

--- a/plugins/events-backend-module-gerrit/package.json
+++ b/plugins/events-backend-module-gerrit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-events-backend-module-gerrit",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "backstage": {
     "role": "backend-plugin-module",
     "pluginId": "events",

--- a/plugins/events-backend-module-github/CHANGELOG.md
+++ b/plugins/events-backend-module-github/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-events-backend-module-github
 
+## 0.2.13
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-events-node@0.4.2
+  - @backstage/backend-plugin-api@1.0.1
+
 ## 0.2.12
 
 ### Patch Changes

--- a/plugins/events-backend-module-github/package.json
+++ b/plugins/events-backend-module-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-events-backend-module-github",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "backstage": {
     "role": "backend-plugin-module",
     "pluginId": "events",

--- a/plugins/events-backend-module-gitlab/CHANGELOG.md
+++ b/plugins/events-backend-module-gitlab/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-events-backend-module-gitlab
 
+## 0.2.13
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-events-node@0.4.2
+  - @backstage/backend-plugin-api@1.0.1
+
 ## 0.2.12
 
 ### Patch Changes

--- a/plugins/events-backend-module-gitlab/package.json
+++ b/plugins/events-backend-module-gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-events-backend-module-gitlab",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "backstage": {
     "role": "backend-plugin-module",
     "pluginId": "events",

--- a/plugins/events-backend-test-utils/CHANGELOG.md
+++ b/plugins/events-backend-test-utils/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-events-backend-test-utils
 
+## 0.1.37
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-events-node@0.4.2
+
 ## 0.1.36
 
 ### Patch Changes

--- a/plugins/events-backend-test-utils/package.json
+++ b/plugins/events-backend-test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-events-backend-test-utils",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "description": "The plugin-events-backend-test-utils for @backstage/plugin-events-node",
   "backstage": {
     "role": "node-library",

--- a/plugins/events-backend/CHANGELOG.md
+++ b/plugins/events-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-events-backend
 
+## 0.3.14
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-events-node@0.4.2
+  - @backstage/backend-plugin-api@1.0.1
+
 ## 0.3.13
 
 ### Patch Changes

--- a/plugins/events-backend/package.json
+++ b/plugins/events-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-events-backend",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "events",

--- a/plugins/events-node/CHANGELOG.md
+++ b/plugins/events-node/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage/plugin-events-node
 
+## 0.4.2
+
+### Patch Changes
+
+- 52a5d21: Fixed an issue where subscribing to events threw an error and gave up too easily. Calling the subscribe method will cause the background polling loop to keep trying to connect to the events backend, even if the initial request fails.
+
+  By default the events service will attempt to publish and subscribe to events from the events bus API in the events backend, but if it fails due to the events backend not being installed, it will bail and never try calling the API again. There is now a new `events.useEventBus` configuration and option for the `DefaultEventsService` that lets you control this behavior. You can set it to `'never'` to disabled API calls to the events backend completely, or `'always'` to never allow it to be disabled.
+
+- Updated dependencies
+  - @backstage/backend-plugin-api@1.0.1
+
 ## 0.4.1
 
 ### Patch Changes

--- a/plugins/events-node/config.d.ts
+++ b/plugins/events-node/config.d.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface Config {
+  events?: {
+    /**
+     * Whether to use the event bus API in the events plugin backend to
+     * distribute events across multiple instances when publishing and
+     * subscribing to events.
+     *
+     * The default is 'auto', which means means that the event bus API will be
+     * used if it's available, but will be disabled if the events backend
+     * returns a 404.
+     *
+     * If set to 'never', the events service will only ever publish events
+     * locally to the same instance, while if set to 'always', the event bus API
+     * will never be disabled, even if the events backend returns a 404.
+     */
+    useEventBus?: 'never' | 'always' | 'auto';
+  };
+}

--- a/plugins/events-node/package.json
+++ b/plugins/events-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-events-node",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "The plugin-events-node module for @backstage/plugin-events-backend",
   "backstage": {
     "role": "node-library",

--- a/plugins/events-node/package.json
+++ b/plugins/events-node/package.json
@@ -39,7 +39,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "config.d.ts"
   ],
   "scripts": {
     "build": "backstage-cli package build",
@@ -60,6 +61,8 @@
   "devDependencies": {
     "@backstage/backend-common": "^0.25.0",
     "@backstage/backend-test-utils": "workspace:^",
-    "@backstage/cli": "workspace:^"
-  }
+    "@backstage/cli": "workspace:^",
+    "msw": "^1.0.0"
+  },
+  "configSchema": "config.d.ts"
 }

--- a/plugins/events-node/report.api.md
+++ b/plugins/events-node/report.api.md
@@ -7,13 +7,18 @@ import { AuthService } from '@backstage/backend-plugin-api';
 import { DiscoveryService } from '@backstage/backend-plugin-api';
 import { LifecycleService } from '@backstage/backend-plugin-api';
 import { LoggerService } from '@backstage/backend-plugin-api';
+import { RootConfigService } from '@backstage/backend-plugin-api';
 import { ServiceFactory } from '@backstage/backend-plugin-api';
 import { ServiceRef } from '@backstage/backend-plugin-api';
 
 // @public
 export class DefaultEventsService implements EventsService {
   // (undocumented)
-  static create(options: { logger: LoggerService }): DefaultEventsService;
+  static create(options: {
+    logger: LoggerService;
+    config?: RootConfigService;
+    useEventBus?: EventBusMode;
+  }): DefaultEventsService;
   forPlugin(
     pluginId: string,
     options?: {
@@ -36,6 +41,9 @@ export interface EventBroker {
     ...subscribers: Array<EventSubscriber | Array<EventSubscriber>>
   ): void;
 }
+
+// @public (undocumented)
+export type EventBusMode = 'never' | 'always' | 'auto';
 
 // @public (undocumented)
 export interface EventParams<TPayload = unknown> {

--- a/plugins/events-node/src/api/DefaultEventsService.test.ts
+++ b/plugins/events-node/src/api/DefaultEventsService.test.ts
@@ -16,12 +16,16 @@
 
 import { DefaultEventsService } from './DefaultEventsService';
 import { EventParams } from './EventParams';
-import { mockServices } from '@backstage/backend-test-utils';
-
-const logger = mockServices.logger.mock();
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import {
+  mockServices,
+  registerMswTestHooks,
+} from '@backstage/backend-test-utils';
 
 describe('DefaultEventsService', () => {
   it('passes events to interested subscribers', async () => {
+    const logger = mockServices.logger.mock();
     const events = DefaultEventsService.create({ logger });
     const eventsSubscriber1: EventParams[] = [];
     const eventsSubscriber2: EventParams[] = [];
@@ -70,6 +74,7 @@ describe('DefaultEventsService', () => {
   it('logs errors from subscribers', async () => {
     const topic = 'testTopic';
 
+    const logger = mockServices.logger.mock();
     const warnSpy = jest.spyOn(logger, 'warn');
     const events = DefaultEventsService.create({ logger });
 
@@ -107,5 +112,166 @@ describe('DefaultEventsService', () => {
       'Subscriber "subscriber2" failed to process event for topic "testTopic"',
       new Error('NOPE 2'),
     );
+  });
+
+  describe('with event bus', () => {
+    const mswServer = setupServer();
+    registerMswTestHooks(mswServer);
+
+    it('should read events from events bus API', async () => {
+      const logger = mockServices.logger.mock();
+      const service = DefaultEventsService.create({ logger }).forPlugin('a', {
+        auth: mockServices.auth(),
+        logger,
+        discovery: mockServices.discovery(),
+        lifecycle: mockServices.lifecycle.mock(),
+      });
+
+      mswServer.use(
+        rest.put(
+          'http://localhost:0/api/events/bus/v1/subscriptions/a.tester',
+          (_req, res, ctx) => res(ctx.status(200)),
+        ),
+        rest.get(
+          'http://localhost:0/api/events/bus/v1/subscriptions/a.tester/events',
+          (_req, res, ctx) =>
+            res(
+              ctx.status(200),
+              ctx.json({
+                events: [{ topic: 'test', payload: { foo: 'bar' } }],
+              }),
+            ),
+        ),
+      );
+
+      const event = await new Promise(resolve => {
+        service.subscribe({
+          id: 'tester',
+          topics: ['test'],
+          async onEvent(newEvent) {
+            resolve(newEvent);
+          },
+        });
+      });
+
+      expect(event).toEqual({ topic: 'test', eventPayload: { foo: 'bar' } });
+
+      // Internal call to clean up subscriptions
+      await (service as any).shutdown();
+    });
+
+    it('should not read events from bus if disabled', async () => {
+      const logger = mockServices.logger.mock();
+      const service = DefaultEventsService.create({
+        logger,
+        useEventBus: 'never',
+      }).forPlugin('a', {
+        auth: mockServices.auth(),
+        logger,
+        discovery: mockServices.discovery(),
+        lifecycle: mockServices.lifecycle.mock(),
+      });
+
+      let calledApi = false;
+      mswServer.use(
+        rest.put(
+          'http://localhost:0/api/events/bus/v1/subscriptions/a.tester',
+          (_req, res, ctx) => {
+            calledApi = true;
+            res(ctx.status(200));
+          },
+        ),
+      );
+
+      await service.subscribe({
+        id: 'tester',
+        topics: ['test'],
+        async onEvent() {
+          expect('not').toBe('reached');
+        },
+      });
+
+      // Internal call to clean up subscriptions, and wait for the API call
+      await (service as any).shutdown();
+
+      expect(calledApi).toBe(false);
+    });
+
+    it('should deactivate event bus on 404', async () => {
+      expect.assertions(1);
+
+      const logger = mockServices.logger.mock();
+      const service = DefaultEventsService.create({ logger }).forPlugin('a', {
+        auth: mockServices.auth(),
+        logger,
+        discovery: mockServices.discovery(),
+        lifecycle: mockServices.lifecycle.mock(),
+      });
+
+      mswServer.use(
+        rest.put(
+          'http://localhost:0/api/events/bus/v1/subscriptions/a.tester',
+          (_req, res, ctx) => res(ctx.status(404)),
+        ),
+      );
+
+      service.subscribe({
+        id: 'tester',
+        topics: ['test'],
+        async onEvent() {
+          expect('not').toBe('reached');
+        },
+      });
+
+      const msg = await new Promise(resolve => {
+        logger.warn.mockImplementationOnce(resolve);
+      });
+
+      expect(msg).toMatch(/Event subscribe request failed with status 404/);
+
+      // Internal call to clean up subscriptions
+      await (service as any).shutdown();
+    });
+
+    it('should not deactivate event bus if configured to always be used', async () => {
+      expect.assertions(1);
+
+      const logger = mockServices.logger.mock();
+      const service = DefaultEventsService.create({
+        logger,
+        useEventBus: 'always',
+      }).forPlugin('a', {
+        auth: mockServices.auth(),
+        logger,
+        discovery: mockServices.discovery(),
+        lifecycle: mockServices.lifecycle.mock(),
+      });
+
+      mswServer.use(
+        rest.put(
+          'http://localhost:0/api/events/bus/v1/subscriptions/a.tester',
+          (_req, res, ctx) => res(ctx.status(404)),
+        ),
+      );
+
+      service.subscribe({
+        id: 'tester',
+        topics: ['test'],
+        async onEvent() {
+          expect('not').toBe('reached');
+        },
+      });
+
+      const msg = await new Promise(resolve => {
+        logger.warn.mockImplementationOnce(resolve);
+      });
+
+      expect(msg).toMatch(
+        'Poll failed for subscription "a.tester", retrying in 1000ms',
+      );
+
+      // Internal call to clean up subscriptions
+      await (service as any).shutdown();
+    });
   });
 });

--- a/plugins/events-node/src/api/index.ts
+++ b/plugins/events-node/src/api/index.ts
@@ -21,6 +21,9 @@ export type {
   EventsServiceSubscribeOptions,
   EventsServiceEventHandler,
 } from './EventsService';
-export { DefaultEventsService } from './DefaultEventsService';
+export {
+  DefaultEventsService,
+  type EventBusMode,
+} from './DefaultEventsService';
 export * from './http';
 export { SubTopicEventRouter } from './SubTopicEventRouter';

--- a/plugins/notifications-backend-module-email/CHANGELOG.md
+++ b/plugins/notifications-backend-module-email/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-notifications-backend-module-email
 
+## 0.3.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-plugin-api@1.0.1
+  - @backstage/plugin-catalog-node@1.13.1
+  - @backstage/plugin-notifications-node@0.2.8
+
 ## 0.3.1
 
 ### Patch Changes

--- a/plugins/notifications-backend-module-email/package.json
+++ b/plugins/notifications-backend-module-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-notifications-backend-module-email",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "The email backend module for the notifications plugin.",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/notifications-backend/CHANGELOG.md
+++ b/plugins/notifications-backend/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage/plugin-notifications-backend
 
+## 0.4.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-events-node@0.4.2
+  - @backstage/plugin-signals-node@0.1.13
+  - @backstage/backend-plugin-api@1.0.1
+  - @backstage/plugin-auth-node@0.5.3
+  - @backstage/plugin-catalog-node@1.13.1
+  - @backstage/plugin-notifications-node@0.2.8
+
 ## 0.4.1
 
 ### Patch Changes

--- a/plugins/notifications-backend/package.json
+++ b/plugins/notifications-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-notifications-backend",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "notifications",

--- a/plugins/notifications-node/CHANGELOG.md
+++ b/plugins/notifications-node/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-notifications-node
 
+## 0.2.8
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-signals-node@0.1.13
+  - @backstage/backend-plugin-api@1.0.1
+
 ## 0.2.7
 
 ### Patch Changes

--- a/plugins/notifications-node/package.json
+++ b/plugins/notifications-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-notifications-node",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Node.js library for the notifications plugin",
   "backstage": {
     "role": "node-library",

--- a/plugins/scaffolder-backend-module-cookiecutter/CHANGELOG.md
+++ b/plugins/scaffolder-backend-module-cookiecutter/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-scaffolder-backend-module-cookiecutter
 
+## 0.3.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-defaults@0.5.2
+  - @backstage/backend-plugin-api@1.0.1
+  - @backstage/plugin-scaffolder-node@0.5.0
+
 ## 0.3.1
 
 ### Patch Changes

--- a/plugins/scaffolder-backend-module-cookiecutter/package.json
+++ b/plugins/scaffolder-backend-module-cookiecutter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-scaffolder-backend-module-cookiecutter",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A module for the scaffolder backend that lets you template projects using cookiecutter",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/scaffolder-backend-module-notifications/CHANGELOG.md
+++ b/plugins/scaffolder-backend-module-notifications/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-scaffolder-backend-module-notifications
 
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-plugin-api@1.0.1
+  - @backstage/plugin-notifications-node@0.2.8
+  - @backstage/plugin-scaffolder-node@0.5.0
+
 ## 0.1.1
 
 ### Patch Changes

--- a/plugins/scaffolder-backend-module-notifications/package.json
+++ b/plugins/scaffolder-backend-module-notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-scaffolder-backend-module-notifications",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "The notifications backend module for the scaffolder plugin.",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/scaffolder-backend-module-yeoman/CHANGELOG.md
+++ b/plugins/scaffolder-backend-module-yeoman/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-scaffolder-backend-module-yeoman
 
+## 0.4.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-plugin-api@1.0.1
+  - @backstage/plugin-scaffolder-node@0.5.0
+  - @backstage/plugin-scaffolder-node-test-utils@0.1.14
+
 ## 0.4.1
 
 ### Patch Changes

--- a/plugins/scaffolder-backend-module-yeoman/package.json
+++ b/plugins/scaffolder-backend-module-yeoman/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-scaffolder-backend-module-yeoman",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "backstage": {
     "role": "backend-plugin-module",
     "pluginId": "scaffolder",

--- a/plugins/scaffolder-backend/CHANGELOG.md
+++ b/plugins/scaffolder-backend/CHANGELOG.md
@@ -1,5 +1,26 @@
 # @backstage/plugin-scaffolder-backend
 
+## 1.26.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-defaults@0.5.2
+  - @backstage/backend-plugin-api@1.0.1
+  - @backstage/plugin-auth-node@0.5.3
+  - @backstage/plugin-catalog-backend-module-scaffolder-entity-model@0.2.1
+  - @backstage/plugin-catalog-node@1.13.1
+  - @backstage/plugin-permission-node@0.8.4
+  - @backstage/plugin-scaffolder-backend-module-bitbucket@0.3.1
+  - @backstage/plugin-scaffolder-backend-module-bitbucket-cloud@0.2.1
+  - @backstage/plugin-scaffolder-backend-module-bitbucket-server@0.2.1
+  - @backstage/plugin-scaffolder-backend-module-gerrit@0.2.1
+  - @backstage/plugin-scaffolder-backend-module-gitea@0.2.1
+  - @backstage/plugin-scaffolder-backend-module-github@0.5.1
+  - @backstage/plugin-scaffolder-backend-module-gitlab@0.6.0
+  - @backstage/plugin-scaffolder-node@0.5.0
+  - @backstage/plugin-scaffolder-backend-module-azure@0.2.1
+
 ## 1.26.1
 
 ### Patch Changes

--- a/plugins/scaffolder-backend/package.json
+++ b/plugins/scaffolder-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-scaffolder-backend",
-  "version": "1.26.1",
+  "version": "1.26.2",
   "description": "The Backstage backend plugin that helps you create new things",
   "backstage": {
     "role": "backend-plugin",

--- a/plugins/scaffolder-node-test-utils/CHANGELOG.md
+++ b/plugins/scaffolder-node-test-utils/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-scaffolder-node-test-utils
 
+## 0.1.14
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-test-utils@1.0.2
+  - @backstage/plugin-scaffolder-node@0.5.0
+
 ## 0.1.13
 
 ### Patch Changes

--- a/plugins/scaffolder-node-test-utils/package.json
+++ b/plugins/scaffolder-node-test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-scaffolder-node-test-utils",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "backstage": {
     "role": "node-library",
     "pluginId": "scaffolder",

--- a/plugins/scaffolder-react/CHANGELOG.md
+++ b/plugins/scaffolder-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/plugin-scaffolder-react
 
+## 1.13.1
+
+### Patch Changes
+
+- 42ef107: Fix issue with form state not refreshing when updating
+
 ## 1.13.0
 
 ### Minor Changes

--- a/plugins/scaffolder-react/package.json
+++ b/plugins/scaffolder-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-scaffolder-react",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "A frontend library that helps other Backstage plugins interact with the Scaffolder",
   "backstage": {
     "role": "web-library",

--- a/plugins/scaffolder-react/src/next/components/Stepper/Stepper.tsx
+++ b/plugins/scaffolder-react/src/next/components/Stepper/Stepper.tsx
@@ -124,15 +124,14 @@ export const Stepper = (stepperProps: StepperProps) => {
   const apiHolder = useApiHolder();
   const [activeStep, setActiveStep] = useState(0);
   const [isValidating, setIsValidating] = useState(false);
+
   const [initialState] = useFormDataFromQuery(props.initialState);
-  const [formState, setFormState] = useState<{
-    [step: string]: Record<string, JsonValue>;
-  }>();
+  const [stepsState, setStepsState] = useState<Record<string, JsonValue>[]>(
+    steps.map(() => initialState),
+  );
 
   const [errors, setErrors] = useState<undefined | FormValidation>();
   const styles = useStyles();
-
-  const makeStepKey = (step: string | number) => `step-${step}`;
 
   const backLabel =
     presentation?.buttonLabels?.backButtonText ?? backButtonText;
@@ -168,15 +167,15 @@ export const Stepper = (stepperProps: StepperProps) => {
     setActiveStep(prevActiveStep => prevActiveStep - 1);
   };
 
-  const handleChange = useCallback(
-    (e: IChangeEvent) => {
-      setFormState(current => ({
-        ...current,
-        [makeStepKey(activeStep)]: e.formData,
-      }));
-    },
-    [setFormState, activeStep],
-  );
+  const handleChange = (e: IChangeEvent) => {
+    setStepsState(current => {
+      const newState = [...current];
+      newState[activeStep] = {
+        ...e.formData,
+      };
+      return newState;
+    });
+  };
 
   const currentStep = useTransformSchemaToProps(steps[activeStep], { layouts });
 
@@ -197,6 +196,13 @@ export const Stepper = (stepperProps: StepperProps) => {
     if (hasErrors(returnedValidation)) {
       setErrors(returnedValidation);
     } else {
+      setStepsState(current => {
+        const newState = [...current];
+        newState[activeStep] = {
+          ...formData,
+        };
+        return newState;
+      });
       setErrors(undefined);
       setActiveStep(prevActiveStep => {
         const stepNum = prevActiveStep + 1;
@@ -204,10 +210,6 @@ export const Stepper = (stepperProps: StepperProps) => {
         return stepNum;
       });
     }
-    setFormState(current => ({
-      ...current,
-      [makeStepKey(activeStep)]: formData,
-    }));
   };
 
   const {
@@ -218,23 +220,14 @@ export const Stepper = (stepperProps: StepperProps) => {
 
   const mergedUiSchema = merge({}, propUiSchema, currentStep?.uiSchema);
 
-  const mergedState = useMemo(() => {
-    if (!formState) {
-      return initialState;
-    }
-    const { [makeStepKey(activeStep)]: activeState, ...historicalState } =
-      formState;
-    const chronologicalState = {
-      ...historicalState,
-      [makeStepKey(activeStep)]: activeState,
-    };
-    return merge({}, ...Object.values(chronologicalState));
-  }, [formState, activeStep, initialState]);
+  const formState = stepsState.reduce((acc, step) => {
+    return { ...acc, ...step };
+  }, {});
 
   const handleCreate = useCallback(() => {
-    props.onCreate(mergedState);
+    props.onCreate(formState);
     analytics.captureEvent('click', `${createLabel}`);
-  }, [props, mergedState, analytics, createLabel]);
+  }, [props, formState, analytics, createLabel]);
 
   return (
     <>
@@ -269,12 +262,15 @@ export const Stepper = (stepperProps: StepperProps) => {
         {/* eslint-disable-next-line no-nested-ternary */}
         {activeStep < steps.length ? (
           <Form
+            key={activeStep}
             validator={validator}
             extraErrors={errors as unknown as ErrorSchema}
-            formData={mergedState}
-            formContext={{ ...propFormContext, formData: mergedState }}
+            formData={{ ...stepsState[activeStep] }}
+            formContext={{ ...propFormContext, formData: formState }}
             schema={currentStep.schema}
             uiSchema={mergedUiSchema}
+            omitExtraData
+            liveOmit
             onSubmit={handleNext}
             fields={fields}
             showErrorList="top"
@@ -308,7 +304,7 @@ export const Stepper = (stepperProps: StepperProps) => {
         ReviewStepComponent ? (
           <ReviewStepComponent
             disableButtons={isValidating}
-            formData={mergedState}
+            formData={formState}
             handleBack={handleBack}
             handleReset={() => {}}
             steps={steps}
@@ -316,7 +312,7 @@ export const Stepper = (stepperProps: StepperProps) => {
           />
         ) : (
           <>
-            <ReviewStateComponent formState={mergedState} schemas={steps} />
+            <ReviewStateComponent formState={formState} schemas={steps} />
             <div className={styles.footer}>
               <Button
                 onClick={handleBack}

--- a/plugins/scaffolder/CHANGELOG.md
+++ b/plugins/scaffolder/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-scaffolder
 
+## 1.26.1
+
+### Patch Changes
+
+- 316b1dd: Revert the change of the option label for `EntityPicker`
+- Updated dependencies
+  - @backstage/plugin-scaffolder-react@1.13.1
+
 ## 1.26.0
 
 ### Minor Changes

--- a/plugins/scaffolder/package.json
+++ b/plugins/scaffolder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-scaffolder",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "description": "The Backstage plugin that helps you create new things",
   "backstage": {
     "role": "frontend-plugin",

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
@@ -199,7 +199,7 @@ export const EntityPicker = (props: EntityPickerProps) => {
           typeof option === 'string'
             ? option
             : entities?.entityRefToPresentation.get(stringifyEntityRef(option))
-                ?.primaryTitle!
+                ?.entityRef!
         }
         autoSelect
         freeSolo={allowArbitraryValues}

--- a/plugins/search-backend-module-catalog/CHANGELOG.md
+++ b/plugins/search-backend-module-catalog/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-search-backend-module-catalog
 
+## 0.2.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-search-backend-node@1.3.4
+  - @backstage/backend-plugin-api@1.0.1
+  - @backstage/plugin-catalog-node@1.13.1
+
 ## 0.2.3
 
 ### Patch Changes

--- a/plugins/search-backend-module-catalog/package.json
+++ b/plugins/search-backend-module-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-search-backend-module-catalog",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "A module for the search backend that exports catalog modules",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/search-backend-module-elasticsearch/CHANGELOG.md
+++ b/plugins/search-backend-module-elasticsearch/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-search-backend-module-elasticsearch
 
+## 1.6.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-search-backend-node@1.3.4
+  - @backstage/backend-plugin-api@1.0.1
+
 ## 1.6.0
 
 ### Minor Changes

--- a/plugins/search-backend-module-elasticsearch/package.json
+++ b/plugins/search-backend-module-elasticsearch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-search-backend-module-elasticsearch",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "A module for the search backend that implements search using ElasticSearch",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/search-backend-module-explore/CHANGELOG.md
+++ b/plugins/search-backend-module-explore/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-search-backend-module-explore
 
+## 0.2.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-search-backend-node@1.3.4
+  - @backstage/backend-plugin-api@1.0.1
+
 ## 0.2.3
 
 ### Patch Changes

--- a/plugins/search-backend-module-explore/package.json
+++ b/plugins/search-backend-module-explore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-search-backend-module-explore",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "A module for the search backend that exports explore modules",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/search-backend-module-pg/CHANGELOG.md
+++ b/plugins/search-backend-module-pg/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-search-backend-module-pg
 
+## 0.5.37
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-search-backend-node@1.3.4
+  - @backstage/backend-plugin-api@1.0.1
+
 ## 0.5.36
 
 ### Patch Changes

--- a/plugins/search-backend-module-pg/package.json
+++ b/plugins/search-backend-module-pg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-search-backend-module-pg",
-  "version": "0.5.36",
+  "version": "0.5.37",
   "description": "A module for the search backend that implements search using PostgreSQL",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/search-backend-module-stack-overflow-collator/CHANGELOG.md
+++ b/plugins/search-backend-module-stack-overflow-collator/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-search-backend-module-stack-overflow-collator
 
+## 0.3.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-search-backend-node@1.3.4
+  - @backstage/backend-plugin-api@1.0.1
+
 ## 0.3.1
 
 ### Patch Changes

--- a/plugins/search-backend-module-stack-overflow-collator/package.json
+++ b/plugins/search-backend-module-stack-overflow-collator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-search-backend-module-stack-overflow-collator",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A module for the search backend that exports stack overflow modules",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/search-backend-module-techdocs/CHANGELOG.md
+++ b/plugins/search-backend-module-techdocs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/plugin-search-backend-module-techdocs
 
+## 0.3.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-search-backend-node@1.3.4
+  - @backstage/backend-plugin-api@1.0.1
+  - @backstage/plugin-catalog-node@1.13.1
+  - @backstage/plugin-techdocs-node@1.12.12
+
 ## 0.3.0
 
 ### Minor Changes

--- a/plugins/search-backend-module-techdocs/package.json
+++ b/plugins/search-backend-module-techdocs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-search-backend-module-techdocs",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A module for the search backend that exports techdocs modules",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/search-backend-node/CHANGELOG.md
+++ b/plugins/search-backend-node/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-search-backend-node
 
+## 1.3.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-defaults@0.5.2
+  - @backstage/backend-plugin-api@1.0.1
+
 ## 1.3.3
 
 ### Patch Changes

--- a/plugins/search-backend-node/package.json
+++ b/plugins/search-backend-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-search-backend-node",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "A library for Backstage backend plugins that want to interact with the search backend plugin",
   "backstage": {
     "role": "node-library",

--- a/plugins/search-backend/CHANGELOG.md
+++ b/plugins/search-backend/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/plugin-search-backend
 
+## 1.6.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-defaults@0.5.2
+  - @backstage/plugin-search-backend-node@1.3.4
+  - @backstage/backend-plugin-api@1.0.1
+  - @backstage/plugin-permission-node@0.8.4
+
 ## 1.6.0
 
 ### Minor Changes

--- a/plugins/search-backend/package.json
+++ b/plugins/search-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-search-backend",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "The Backstage backend plugin that provides your backstage app with search",
   "backstage": {
     "role": "backend-plugin",

--- a/plugins/signals-backend/CHANGELOG.md
+++ b/plugins/signals-backend/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/plugin-signals-backend
 
+## 0.2.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-events-node@0.4.2
+  - @backstage/plugin-signals-node@0.1.13
+  - @backstage/backend-plugin-api@1.0.1
+  - @backstage/plugin-auth-node@0.5.3
+
 ## 0.2.1
 
 ### Patch Changes

--- a/plugins/signals-backend/package.json
+++ b/plugins/signals-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-signals-backend",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "signals",

--- a/plugins/signals-node/CHANGELOG.md
+++ b/plugins/signals-node/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage/plugin-signals-node
 
+## 0.1.13
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-events-node@0.4.2
+  - @backstage/backend-plugin-api@1.0.1
+  - @backstage/plugin-auth-node@0.5.3
+
 ## 0.1.12
 
 ### Patch Changes

--- a/plugins/signals-node/package.json
+++ b/plugins/signals-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-signals-node",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Node.js library for the signals plugin",
   "backstage": {
     "role": "node-library",

--- a/plugins/techdocs-backend/CHANGELOG.md
+++ b/plugins/techdocs-backend/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/plugin-techdocs-backend
 
+## 1.11.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-plugin-api@1.0.1
+  - @backstage/plugin-catalog-node@1.13.1
+  - @backstage/plugin-search-backend-module-techdocs@0.3.1
+  - @backstage/plugin-techdocs-node@1.12.12
+
 ## 1.11.0
 
 ### Minor Changes

--- a/plugins/techdocs-backend/package.json
+++ b/plugins/techdocs-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-techdocs-backend",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "The Backstage backend plugin that renders technical documentation for your components",
   "backstage": {
     "role": "backend-plugin",

--- a/plugins/user-settings-backend/CHANGELOG.md
+++ b/plugins/user-settings-backend/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage/plugin-user-settings-backend
 
+## 0.2.26
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/backend-defaults@0.5.2
+  - @backstage/plugin-signals-node@0.1.13
+  - @backstage/backend-plugin-api@1.0.1
+  - @backstage/plugin-auth-node@0.5.3
+
 ## 0.2.25
 
 ### Patch Changes

--- a/plugins/user-settings-backend/package.json
+++ b/plugins/user-settings-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-user-settings-backend",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "description": "The Backstage backend plugin to manage user settings",
   "backstage": {
     "role": "backend-plugin",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6327,6 +6327,7 @@ __metadata:
     "@backstage/errors": "workspace:^"
     "@backstage/types": "workspace:^"
     cross-fetch: ^4.0.0
+    msw: ^1.0.0
     uri-template: ^2.0.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
This release fixes the following issues:

- Scaffolder forms would not update existing state when going back to update previous values
- Fixes an issue with the `EntityPicker` not setting the correct value in the form
- Fixes some resiliency issues with the new `events-backend` bus