### PR TITLE
catalog-client: fix case sensitive filters in mock api

### DIFF
--- a/.changeset/two-donuts-float.md
+++ b/.changeset/two-donuts-float.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-client': patch
+---
+
+Fix for certain filter fields in the `catalogApiMock` being case sensitive.

--- a/packages/catalog-client/src/testUtils/InMemoryCatalogClient.test.ts
+++ b/packages/catalog-client/src/testUtils/InMemoryCatalogClient.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { CATALOG_FILTER_EXISTS } from '../types';
 import { InMemoryCatalogClient } from './InMemoryCatalogClient';
 import { Entity } from '@backstage/catalog-model';
 
@@ -25,6 +26,7 @@ const entity1: Entity = {
     name: 'e1',
     uid: 'u1',
   },
+  relations: [{ type: 'relatedTo', targetRef: 'customkind:default/e2' }],
 };
 
 const entity2: Entity = {
@@ -42,10 +44,32 @@ const entities = [entity1, entity2];
 describe('InMemoryCatalogClient', () => {
   it('getEntities', async () => {
     const client = new InMemoryCatalogClient({ entities });
+
     await expect(client.getEntities()).resolves.toEqual({ items: entities });
+
+    await expect(
+      client.getEntities({ filter: { 'metadata.name': 'E1' } }),
+    ).resolves.toEqual({ items: [entity1] });
+
     await expect(
       client.getEntities({ filter: { 'metadata.uid': 'u2' } }),
     ).resolves.toEqual({ items: [entity2] });
+
+    await expect(
+      client.getEntities({ filter: { 'metadata.uid': 'U2' } }),
+    ).resolves.toEqual({ items: [entity2] });
+
+    await expect(
+      client.getEntities({
+        filter: { 'relations.relatedto': CATALOG_FILTER_EXISTS },
+      }),
+    ).resolves.toEqual({ items: [entity1] });
+
+    await expect(
+      client.getEntities({
+        filter: { 'relations.relatedTo': 'customkind:default/e2' },
+      }),
+    ).resolves.toEqual({ items: [entity1] });
   });
 
   it('getEntitiesByRefs', async () => {

--- a/packages/catalog-client/src/testUtils/InMemoryCatalogClient.ts
+++ b/packages/catalog-client/src/testUtils/InMemoryCatalogClient.ts
@@ -48,13 +48,22 @@ function buildEntitySearch(entity: Entity) {
   const rows = traverse(entity);
 
   if (entity.metadata?.name) {
-    rows.push({ key: 'metadata.name', value: entity.metadata.name });
+    rows.push({
+      key: 'metadata.name',
+      value: entity.metadata.name.toLocaleLowerCase('en-US'),
+    });
   }
   if (entity.metadata?.namespace) {
-    rows.push({ key: 'metadata.namespace', value: entity.metadata.namespace });
+    rows.push({
+      key: 'metadata.namespace',
+      value: entity.metadata.namespace.toLocaleLowerCase('en-US'),
+    });
   }
   if (entity.metadata?.uid) {
-    rows.push({ key: 'metadata.uid', value: entity.metadata.uid });
+    rows.push({
+      key: 'metadata.uid',
+      value: entity.metadata.uid.toLocaleLowerCase('en-US'),
+    });
   }
 
   if (!entity.metadata.namespace) {
@@ -64,8 +73,8 @@ function buildEntitySearch(entity: Entity) {
   // Visit relations
   for (const relation of entity.relations ?? []) {
     rows.push({
-      key: `relations.${relation.type}`,
-      value: relation.targetRef,
+      key: `relations.${relation.type.toLocaleLowerCase('en-US')}`,
+      value: relation.targetRef.toLocaleLowerCase('en-US'),
     });
   }
 


### PR DESCRIPTION
🧹, ran into this when trying to query relations with the mock client.