### PR TITLE
cli: conditionally include yarnPlugin query param in versions:bump upgrade-helper link

### DIFF
--- a/.changeset/swift-laws-applaud.md
+++ b/.changeset/swift-laws-applaud.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Update upgrade-helper link in versions:bump command to include yarnPlugin param when the yarn plugin is installed

--- a/.changeset/swift-laws-applaud.md
+++ b/.changeset/swift-laws-applaud.md
@@ -2,4 +2,4 @@
 '@backstage/cli': patch
 ---
 
-Update upgrade-helper link in versions:bump command to include yarnPlugin param when the yarn plugin is installed
+Update upgrade-helper link in `versions:bump` command to include `yarnPlugin` param when the yarn plugin is installed

--- a/packages/cli/src/commands/versions/bump.ts
+++ b/packages/cli/src/commands/versions/bump.ts
@@ -228,7 +228,10 @@ export default async (opts: OptionValues) => {
 
     // Do not update backstage.json when upgrade patterns are used.
     if (pattern === DEFAULT_PATTERN_GLOB) {
-      await bumpBackstageJsonVersion(releaseManifest.releaseVersion);
+      await bumpBackstageJsonVersion(
+        releaseManifest.releaseVersion,
+        hasYarnPlugin,
+      );
     } else {
       console.log(
         chalk.yellow(
@@ -410,7 +413,10 @@ async function getBackstageJson() {
   });
 }
 
-export async function bumpBackstageJsonVersion(version: string) {
+export async function bumpBackstageJsonVersion(
+  version: string,
+  useYarnPlugin?: boolean,
+) {
   const backstageJson = await getBackstageJson();
   const prevVersion = backstageJson?.version;
 
@@ -422,7 +428,12 @@ export async function bumpBackstageJsonVersion(version: string) {
   if (prevVersion) {
     const from = encodeURIComponent(prevVersion);
     const to = encodeURIComponent(version);
-    const link = `https://backstage.github.io/upgrade-helper/?from=${from}&to=${to}`;
+    let link = `https://backstage.github.io/upgrade-helper/?from=${from}&to=${to}`;
+
+    if (useYarnPlugin) {
+      link += '&yarnPlugin=1';
+    }
+
     console.log(
       yellow(
         `Upgraded from release ${green(prevVersion)} to ${green(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Depends on https://github.com/backstage/upgrade-helper/pull/16. With this change we automatically link to the right flavor of the diff in upgrade helper based on whether the yarn plugin is installed.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
