### PR TITLE
fix search collator filter

### DIFF
--- a/.changeset/forty-pets-wave.md
+++ b/.changeset/forty-pets-wave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend-module-catalog': patch
+---
+
+Fixed a bug where the `filter` setting of the collator was not permitted to be an array.

--- a/plugins/search-backend-module-catalog/src/collators/config.ts
+++ b/plugins/search-backend-module-catalog/src/collators/config.ts
@@ -73,7 +73,7 @@ export function readCollatorConfigOptions(configRoot: Config): {
       config.getOptionalString('locationTemplate') ??
       defaults.collatorOptions.locationTemplate,
     filter:
-      config.getOptionalConfig('filter')?.get<EntityFilterQuery>() ??
+      config.getOptional<EntityFilterQuery>('filter') ??
       defaults.collatorOptions.filter,
     batchSize:
       config.getOptionalNumber('batchSize') ??


### PR DESCRIPTION
Fixes #27265

This should be allowed to both be an object and an array.
