### PR TITLE
Move msw to devDependencies in backend-openapi-utils/package.json

### DIFF
--- a/.changeset/three-mangos-dance.md
+++ b/.changeset/three-mangos-dance.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-openapi-utils': patch
+---
+
+Moves msw from dependencies to devDependencies

--- a/packages/backend-openapi-utils/package.json
+++ b/packages/backend-openapi-utils/package.json
@@ -47,13 +47,13 @@
     "json-schema-to-ts": "^3.0.0",
     "lodash": "^4.17.21",
     "mockttp": "^3.13.0",
-    "msw": "^1.0.0",
     "openapi-merge": "^1.3.2",
     "openapi3-ts": "^3.1.2"
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",
     "@backstage/test-utils": "workspace:^",
+    "msw": "^1.0.0",
     "supertest": "^7.0.0"
   }
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Moves `msw` to devDependencies in backend-openapi-utils/package.json so that it isn't bundled in production builds.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
