### PR TITLE
RepoUrlPickerRepoName did not keep the input value

### DIFF
--- a/.changeset/rare-trains-scream.md
+++ b/.changeset/rare-trains-scream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+fix(scaffolder): use onInputChange instead onChange in RepoUrlPickerRepoName because need to keep the input value when move focus.

--- a/.changeset/rare-trains-scream.md
+++ b/.changeset/rare-trains-scream.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder': patch
 ---
 
-fix(scaffolder): use onInputChange instead onChange in RepoUrlPickerRepoName because need to keep the input value when move focus.
+fix(scaffolder): use `onInputChange` in `RepoUrlPicker` to fix issue with the value not updating properly

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPickerRepoName.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPickerRepoName.tsx
@@ -67,7 +67,7 @@ export const RepoUrlPickerRepoName = (props: {
         ) : (
           <Autocomplete
             value={repoName}
-            onChange={(_, newValue) => {
+            onInputChange={(_, newValue) => {
               onChange(newValue || '');
             }}
             options={availableRepos || []}


### PR DESCRIPTION
Use onInputChange instead of onChange for propagating the input evnet.

Previous version was used <Input /> .
In this case onChange was fired each input event.
But in <Autocomplete /> is not fired.

fixes #27289 

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
