### PR TITLE
cli: raw-loader fix

### DIFF
--- a/.changeset/pretty-zebras-listen.md
+++ b/.changeset/pretty-zebras-listen.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Fixed an issue where the `raw-loader` for loading HTML templates was not resolved from the context of the CLI package.

--- a/packages/cli/src/lib/bundler/config.ts
+++ b/packages/cli/src/lib/bundler/config.ts
@@ -209,7 +209,7 @@ export async function createConfig(
         minify: false,
         publicPath: '<%= publicPath %>',
         filename: 'index.html.tmpl',
-        template: `raw-loader!${paths.targetHtml}`,
+        template: `${require.resolve('raw-loader')}!${paths.targetHtml}`,
       }),
     );
   }


### PR DESCRIPTION
🧹, this should be done for all loaders, see for example

https://github.com/backstage/backstage/blob/e4125fb698cd361086918a5acd4f21727126c001/packages/cli/src/lib/bundler/transforms.ts#L182