### PR TITLE
fix: typo in bitbucket server oauth scopes

### DIFF
--- a/packages/integration-react/src/api/ScmAuth.ts
+++ b/packages/integration-react/src/api/ScmAuth.ts
@@ -258,7 +258,7 @@ export class ScmAuth implements ScmAuthApi {
    *
    * The default scopes are:
    *
-   * `PUBLIC_REPOS REPOS_READ`
+   * `PUBLIC_REPOS REPO_READ`
    *
    * If the additional `repoWrite` permission is requested, these scopes are added:
    *
@@ -277,10 +277,7 @@ export class ScmAuth implements ScmAuthApi {
     return this.forBitbucket(bitbucketAuthApi, {
       host: options.host,
       scopeMapping: {
-        default: options.scopeMapping?.default ?? [
-          'PUBLIC_REPOS',
-          'REPOS_READ',
-        ],
+        default: options.scopeMapping?.default ?? ['PUBLIC_REPOS', 'REPO_READ'],
         repoWrite: options.scopeMapping?.repoWrite ?? ['REPO_WRITE'],
       },
     });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In my previous PR I made a typo when defining default scopes for bitbucket server:
https://github.com/backstage/backstage/pull/26839/files#diff-340bc674a36364ba30b7ebf0ff52c29500d6faa12bc4fae5716ebbe0a71a8da0R282

https://confluence.atlassian.com/bitbucketserver0720/bitbucket-oauth-2-0-provider-api-1116282017.html#BitbucketOAuth2.0providerAPI-scopesScopes

`PUBLIC_REPOS` is the only pluralized one.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
