### PR TITLE
Gitlab discovery rate limit

### DIFF
--- a/.changeset/fresh-elephants-care.md
+++ b/.changeset/fresh-elephants-care.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-gitlab': patch
+---
+
+handle rate GitLab rate limiting

--- a/.changeset/fresh-elephants-care.md
+++ b/.changeset/fresh-elephants-care.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend-module-gitlab': patch
 ---
 
-handle rate GitLab rate limiting
+Added support for Rate Limiting in GitLab API client

--- a/plugins/catalog-backend-module-gitlab/src/__testUtils__/handlers.ts
+++ b/plugins/catalog-backend-module-gitlab/src/__testUtils__/handlers.ts
@@ -35,6 +35,8 @@ import {
 } from './mocks';
 import { maxRetry } from '../lib/client';
 
+let callCount = 0;
+
 const httpHandlers = [
   /**
    * Project REST endpoint mocks
@@ -144,23 +146,17 @@ const httpHandlers = [
     );
   }),
 
-  (() => {
-    let count = 0;
-    return rest.get(
-      `${apiBaseUrl}${retry_endpoint_recover}`,
-      (req, res, ctx) => {
-        if (count < maxRetry) {
-          count++;
-          return res(
-            ctx.status(429),
-            ctx.set('Retry-After', '1'),
-            ctx.json({ message: 'Too Many Requests' }),
-          );
-        }
-        return res(ctx.json([{ endpoint: req.url.toString() }]));
-      },
-    );
-  })(),
+  rest.get(`${apiBaseUrl}${retry_endpoint_recover}`, (req, res, ctx) => {
+    if (callCount < maxRetry) {
+      callCount++;
+      return res(
+        ctx.status(429),
+        ctx.set('Retry-After', '1'),
+        ctx.json({ message: 'Too Many Requests' }),
+      );
+    }
+    return res(ctx.json([{ endpoint: req.url.toString() }]));
+  }),
 ];
 
 // dynamic handlers

--- a/plugins/catalog-backend-module-gitlab/src/__testUtils__/mocks.ts
+++ b/plugins/catalog-backend-module-gitlab/src/__testUtils__/mocks.ts
@@ -38,6 +38,8 @@ export const projectID: number = 1;
 export const paged_endpoint: string = `/paged-endpoint`;
 export const some_endpoint: string = `/some-endpoint`;
 export const unhealthy_endpoint = `/unhealthy-endpoint`;
+export const retry_endpoint_recover = '/retry-endpoint-recover';
+export const retry_endpoint_forever = '/retry-endpoint-forever';
 
 /**
  * Integration Configurations


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR makes, without disruptive changes to e.g. specify retry strategies/limits, an attempt to take into account GitLab's published rate limiting strategy, by checking for the `429` HTTP status and waiting for the duration recommended by the accompanying `Retry-After` response header.

Related links:
* https://docs.gitlab.com/ee/user/gitlab_com/index.html#gitlabcom-specific-rate-limits
* https://docs.gitlab.com/ee/administration/settings/user_and_ip_rate_limits.html#response-headers

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
