### PR TITLE
cli: fix tree sha reading for repo test

### DIFF
--- a/.changeset/grumpy-shoes-return.md
+++ b/.changeset/grumpy-shoes-return.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Fixed an issue with the `--successCache` flag for `repo test` where the tree hash for the wrong package directory would sometimes be used to generate the cache key.

--- a/packages/backend-dynamic-feature-service/src/scanner/plugin-scanner.test.ts
+++ b/packages/backend-dynamic-feature-service/src/scanner/plugin-scanner.test.ts
@@ -30,6 +30,7 @@ const mockDir = createMockDirectory();
 
 describe('plugin-scanner', () => {
   const env = process.env;
+
   beforeEach(() => {
     jest.resetModules();
   });
@@ -38,7 +39,6 @@ describe('plugin-scanner', () => {
     mockDir.clear();
     process.env = env;
   });
-
   describe('applyConfig', () => {
     type TestCase = {
       name: string;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Turns out `git ls-tree` doesn't always return the objects in the same order as the input, so this is a lil bit more resilient x)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
