### PR TITLE
fix(backend-dynamic-feature-service): add `resolvePackagePath` support in the `CommonJSModuleLoader`.

### DIFF
--- a/.changeset/friendly-melons-shake.md
+++ b/.changeset/friendly-melons-shake.md
@@ -1,0 +1,6 @@
+---
+'@backstage/backend-dynamic-feature-service': patch
+---
+
+Enhance the `CommonJSModuleLoader` to add support for `resolvePackagePath` calls from backend dynamic plugins, with customizable package resolution, and make the `CommonJSModuleLoader` public API.
+Fixing this backend dynamic plugin limitation related to `resolvePackagePath` is important for backend dynamic plugins which use the database, since database migration scripts systematically use `resolvePackagePath`.

--- a/packages/backend-dynamic-feature-service/report.api.md
+++ b/packages/backend-dynamic-feature-service/report.api.md
@@ -69,6 +69,32 @@ export interface BaseDynamicPlugin {
 }
 
 // @public (undocumented)
+export class CommonJSModuleLoader implements ModuleLoader {
+  constructor(options: CommonJSModuleLoaderOptions);
+  // (undocumented)
+  bootstrap(
+    backstageRoot: string,
+    dynamicPluginsPaths: string[],
+    scannedPluginManifests: Map<string, ScannedPluginManifest>,
+  ): Promise<void>;
+  // (undocumented)
+  load(packagePath: string): Promise<any>;
+  // (undocumented)
+  readonly options: CommonJSModuleLoaderOptions;
+}
+
+// @public (undocumented)
+export type CommonJSModuleLoaderOptions = {
+  logger: LoggerService;
+  dynamicPluginPackageNameSuffixes?: String[];
+  customResolveDynamicPackage?: (
+    logger: LoggerService,
+    searchedPackageName: string,
+    scannedPluginManifests: Map<string, ScannedPluginManifest>,
+  ) => string | undefined;
+};
+
+// @public (undocumented)
 export type DynamicPlugin = FrontendDynamicPlugin | BackendDynamicPlugin;
 
 // @public (undocumented)
@@ -264,7 +290,11 @@ export type LegacyPluginEnvironment = {
 // @public (undocumented)
 export interface ModuleLoader {
   // (undocumented)
-  bootstrap(backstageRoot: string, dynamicPluginPaths: string[]): Promise<void>;
+  bootstrap(
+    backstageRoot: string,
+    dynamicPluginPaths: string[],
+    scannedPluginManifests?: Map<string, ScannedPluginManifest>,
+  ): Promise<void>;
   // (undocumented)
   load(id: string): Promise<any>;
 }

--- a/packages/backend-dynamic-feature-service/src/features/__fixtures__/dynamic-plugins-root/test-backend-dynamic/dist/index.cjs.js
+++ b/packages/backend-dynamic-feature-service/src/features/__fixtures__/dynamic-plugins-root/test-backend-dynamic/dist/index.cjs.js
@@ -10,6 +10,8 @@ const url = require('url');
 
 const privateDep = require('private-dep-with-frontend-plugin-index-path');
 
+const someResource = backendPluginApi.resolvePackagePath('plugin-test-backend', 'someResource.txt');
+
 const testPlugin = backendPluginApi.createBackendPlugin({
   pluginId: "test",
   register(env) {

--- a/packages/backend-dynamic-feature-service/src/loader/CommonJSModuleLoader.ts
+++ b/packages/backend-dynamic-feature-service/src/loader/CommonJSModuleLoader.ts
@@ -16,17 +16,35 @@
 import { ModuleLoader } from './types';
 import { LoggerService } from '@backstage/backend-plugin-api';
 import path from 'path';
+import { ScannedPluginManifest } from '../scanner';
 
+/**
+ * @public
+ */
+export type CommonJSModuleLoaderOptions = {
+  logger: LoggerService;
+  dynamicPluginPackageNameSuffixes?: String[];
+  customResolveDynamicPackage?: (
+    logger: LoggerService,
+    searchedPackageName: string,
+    scannedPluginManifests: Map<string, ScannedPluginManifest>,
+  ) => string | undefined;
+};
+
+/**
+ * @public
+ */
 export class CommonJSModuleLoader implements ModuleLoader {
   private module: any;
 
-  constructor(public readonly logger: LoggerService) {
+  constructor(public readonly options: CommonJSModuleLoaderOptions) {
     this.module = require('node:module');
   }
 
   async bootstrap(
     backstageRoot: string,
     dynamicPluginsPaths: string[],
+    scannedPluginManifests: Map<string, ScannedPluginManifest>,
   ): Promise<void> {
     const backstageRootNodeModulesPath = `${backstageRoot}/node_modules`;
     const dynamicNodeModulesPaths = [
@@ -44,10 +62,90 @@ export class CommonJSModuleLoader implements ModuleLoader {
           dynamicNodeModulesPaths.some(p => nodeModulePath.startsWith(p))
         );
       });
-      this.logger.debug(
+      this.options.logger.debug(
         `Overriding node_modules search path for dynamic plugin ${from} to: ${filtered}`,
       );
       return filtered;
+    };
+
+    // The whole piece of code below is a way to accomodate the limitations of
+    // the current `resolvePackagePath` implementation, which cannot be provided
+    // some custom locations where it should find the assets of some given packages.
+    //
+    // Since the packages for dynamic plugins are not located in the main backstage
+    // monorepo structure, and since dynamic plugins could also be repackaged
+    // (typically renamed with a `-dynamic` suffix), for now we have to customize
+    // module file name resolution here to support these use-cases.
+    //
+    // This might not be necessary anymore according to future enhancements to the
+    // `resolvePackagePath` feature.
+    const oldResolveFileName = this.module._resolveFilename;
+    this.module._resolveFilename = (
+      request: string,
+      mod: NodeModule,
+      _: boolean,
+      options: any,
+    ): any => {
+      let errorToThrow: any;
+      try {
+        return oldResolveFileName(request, mod, _, options);
+      } catch (e) {
+        errorToThrow = e;
+        this.options.logger.debug(
+          `Could not resolve '${request}' inside the Core backstage backend application`,
+          e instanceof Error ? e : undefined,
+        );
+      }
+
+      // Are we trying to resolve a `package.json` from an originating module of the core backstage application
+      // (this is mostly done by calling `@backstage/backend-plugin-api/resolvePackagePath`).
+      const resolvingPackageJsonFromBackstageApplication =
+        request?.endsWith('/package.json') &&
+        mod?.path &&
+        !dynamicPluginsPaths.some(p => mod.path.startsWith(p));
+
+      // If not, we don't need the dedicated specfic case below.
+      if (!resolvingPackageJsonFromBackstageApplication) {
+        throw errorToThrow;
+      }
+
+      this.options.logger.info(
+        `Resolving '${request}' in the dynamic backend plugins`,
+      );
+      const searchedPackageName = request.replace(/\/package.json$/, '');
+
+      // First search for a dynamic plugin package matching the expected package name,
+      // taking in account accepted dynamic plugin package name suffixes
+      // (suffix accepted by default is '-dynamic').
+      const searchedPackageNamesWithSuffixes = (
+        this.options.dynamicPluginPackageNameSuffixes ?? ['-dynamic']
+      ).map(s => `${searchedPackageName}${s}`);
+      for (const [realPath, pkg] of scannedPluginManifests.entries()) {
+        if (
+          [searchedPackageName, ...searchedPackageNamesWithSuffixes].includes(
+            pkg.name,
+          )
+        ) {
+          const resolvedPath = path.resolve(realPath, 'package.json');
+          this.options.logger.info(`Resolved '${request}' at ${resolvedPath}`);
+          return resolvedPath;
+        }
+      }
+
+      // If a custom resolution is provided, use it.
+      // This allows accomodating alternate ways to package dynamic plugins:
+      // static plugin package wrapped inside a distinct dynamic plugin package for example.
+      if (this.options.customResolveDynamicPackage) {
+        const resolvedPath = this.options.customResolveDynamicPackage(
+          this.options.logger,
+          searchedPackageName,
+          scannedPluginManifests,
+        );
+        if (resolvedPath) {
+          return resolvedPath;
+        }
+      }
+      throw errorToThrow;
     };
   }
 

--- a/packages/backend-dynamic-feature-service/src/loader/index.ts
+++ b/packages/backend-dynamic-feature-service/src/loader/index.ts
@@ -15,3 +15,5 @@
  */
 
 export type { ModuleLoader } from './types';
+export type { CommonJSModuleLoaderOptions } from './CommonJSModuleLoader';
+export { CommonJSModuleLoader } from './CommonJSModuleLoader';

--- a/packages/backend-dynamic-feature-service/src/loader/types.ts
+++ b/packages/backend-dynamic-feature-service/src/loader/types.ts
@@ -14,11 +14,17 @@
  * limitations under the License.
  */
 
+import { ScannedPluginManifest } from '../scanner';
+
 /**
  * @public
  */
 export interface ModuleLoader {
-  bootstrap(backstageRoot: string, dynamicPluginPaths: string[]): Promise<void>;
+  bootstrap(
+    backstageRoot: string,
+    dynamicPluginPaths: string[],
+    scannedPluginManifests?: Map<string, ScannedPluginManifest>,
+  ): Promise<void>;
 
   load(id: string): Promise<any>;
 }

--- a/packages/backend-dynamic-feature-service/src/manager/plugin-manager.test.ts
+++ b/packages/backend-dynamic-feature-service/src/manager/plugin-manager.test.ts
@@ -1086,9 +1086,25 @@ describe('backend-dynamic-feature-service', () => {
       expect(fromConfigSpier).toHaveBeenCalled();
       expect(applyConfigSpier).toHaveBeenCalled();
       expect(scanRootSpier).toHaveBeenCalled();
+      const realPath = fs.realpathSync(
+        otherMockDir.resolve('a-dynamic-plugin'),
+      );
       expect(mockedModuleLoader.bootstrap).toHaveBeenCalledWith(
         findPaths(__dirname).targetRoot,
-        [fs.realpathSync(otherMockDir.resolve('a-dynamic-plugin'))],
+        [realPath],
+        new Map<string, ScannedPluginManifest>([
+          [
+            realPath,
+            {
+              name: 'test',
+              main: 'dist/index.cjs.js',
+              version: '0.0.0',
+              backstage: {
+                role: 'backend-plugin',
+              },
+            },
+          ],
+        ]),
       );
       expect(mockedModuleLoader.load).toHaveBeenCalledWith(
         mockDir.resolve(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `resolvePackagePath` function of the `backend-plugin-api` Core backstage package, tries to resolve the `package.json` of a package by package name, to find out the local folder of the plugin.
This works out-of-the-box for static plugins which are in the main monorepo structure of the application.
But for the dynamic backend plugins which are loaded for an external place (as sub-folders of the `dynamic-plugins-root`), the default `require.resolve` algorithm isn't sufficient.

This PR overrides the CommonJS `resolveFileName` logic, in order to also search such a `package.json` file in the list of loaded backend dynamic plugins.

It also allows customizing this search, in order to support cases when the name of the dynamic plugin (after some repackaging for example) doesn't match exactly the name expected by the code that called `resolvePackagePath`.

Fixing this backend dynamic plugin limitation related to `resolvePackagePath` is important for backend dynamic plugins which use the database, since database migration scripts systematically use `resolvePackagePath`.

_**NOTE:** this is indeed a contribution to upstream, in a more generic shape, of [a fix](https://github.com/janus-idp/backstage-showcase/commit/3522f3d81e70683c87bf2c93f5a4b4b42171608f) which is in place in the [`janus-idp/backstage-showcase`](https://github.com/janus-idp/backstage-showcase) (Red hat Developer Hub upstream project) since 7 months._

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
