### PR TITLE
backend-dynamic-feature-service: fix scanner test

### DIFF
--- a/packages/backend-dynamic-feature-service/src/scanner/plugin-scanner.test.ts
+++ b/packages/backend-dynamic-feature-service/src/scanner/plugin-scanner.test.ts
@@ -542,9 +542,11 @@ Please add '${mockDir.resolve(
         expectedLogs: {
           errors: [
             {
-              message: `failed to load dynamic plugin manifest from '${mockDir.resolve(
-                'backstageRoot/dist-dynamic/test-backend-plugin/alpha',
-              )}'; caused by SyntaxError: Unexpected token 'i', "invalid js"... is not valid JSON`,
+              message: expect.stringContaining(
+                `failed to load dynamic plugin manifest from '${mockDir.resolve(
+                  'backstageRoot/dist-dynamic/test-backend-plugin/alpha',
+                )}'; caused by SyntaxError: Unexpected token`,
+              ),
               meta: {
                 name: 'SyntaxError',
                 message: expect.stringContaining('Unexpected token'),


### PR DESCRIPTION
🧹, fix for failing Node.js 18 tests