### PR TITLE
Fix link for READ MORE button

### DIFF
--- a/.changeset/blue-mails-march.md
+++ b/.changeset/blue-mails-march.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-user-settings': minor
+---
+
+Changed the link for 'READ MORE' button to Feature Flags docs

--- a/plugins/user-settings/src/components/FeatureFlags/EmptyFlags.tsx
+++ b/plugins/user-settings/src/components/FeatureFlags/EmptyFlags.tsx
@@ -47,7 +47,7 @@ export const EmptyFlags = () => (
         <Button
           variant="contained"
           color="primary"
-          href="https://backstage.io/docs/api/utility-apis"
+          href="https://backstage.io/docs/plugins/feature-flags/"
         >
           Read More
         </Button>


### PR DESCRIPTION
Not sure why it points to utility-apis, link to feature flags seems more appropriate.

(Will create a changeset, if the change makes sense)
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
