### PR TITLE
Revert "fix(catalog-react) : fixing text overflow"

### DIFF
--- a/.changeset/stupid-insects-allow.md
+++ b/.changeset/stupid-insects-allow.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-catalog-react': patch
----
-
-Fixed bug in `EntityDisplayName` where text was overflowing.

--- a/plugins/catalog-react/src/components/EntityDisplayName/EntityDisplayName.tsx
+++ b/plugins/catalog-react/src/components/EntityDisplayName/EntityDisplayName.tsx
@@ -20,7 +20,6 @@ import Tooltip from '@material-ui/core/Tooltip';
 import { Theme, makeStyles } from '@material-ui/core/styles';
 import React from 'react';
 import { useEntityPresentation } from '../../apis';
-import Typography from '@material-ui/core/Typography';
 
 /**
  * The available style class keys for {@link EntityDisplayName}, under the name
@@ -35,7 +34,6 @@ const useStyles = makeStyles(
     root: {
       display: 'inline-flex',
       alignItems: 'center',
-      maxWidth: '100%',
     },
     icon: {
       marginRight: theme.spacing(0.5),
@@ -79,22 +77,7 @@ export const EntityDisplayName = (
   );
 
   // The innermost "body" content
-  let content = (
-    <Tooltip
-      title={primaryTitle}
-      placement="top"
-      arrow
-      aria-label={primaryTitle}
-    >
-      <Typography
-        noWrap
-        title={primaryTitle}
-        aria-describedby="tooltip-description"
-      >
-        {primaryTitle}
-      </Typography>
-    </Tooltip>
-  );
+  let content = <>{primaryTitle}</>;
 
   // Optionally an icon, and wrapper around them both
   content = (


### PR DESCRIPTION
This breaks the styling for the `EntityRef` in the header and the tables.