### PR TITLE
cli: fixes for success cache hashing for workspace path and .eslintignore

### DIFF
--- a/.changeset/afraid-bananas-behave.md
+++ b/.changeset/afraid-bananas-behave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Fixed an issue where the `--successCache` option for the `repo test` and `repo lint` commands would be include the workspace path in generated cache keys. This previously broke caching in environments where the workspace path varies across builds.

--- a/.changeset/short-geckos-sniff.md
+++ b/.changeset/short-geckos-sniff.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Fixed an issue with the `repo lint` command where the cache key for the `--successCache` option would not properly ignore files that should be ignored according to `.eslintignore`s.

--- a/packages/cli/config/jest.js
+++ b/packages/cli/config/jest.js
@@ -264,7 +264,7 @@ async function getProjectConfig(targetPath, extraConfig, extraOptions) {
       .createHash('sha256')
       .update(version)
       .update(Buffer.alloc(1))
-      .update(JSON.stringify(config.transform))
+      .update(JSON.stringify(config.transform).replaceAll(paths.targetRoot, ''))
       .digest('hex');
     config.id = `backstage_cli_${configHash}`;
   }

--- a/packages/cli/src/commands/repo/test.ts
+++ b/packages/cli/src/commands/repo/test.ts
@@ -300,7 +300,9 @@ export async function command(opts: OptionValues, cmd: Command): Promise<void> {
         baseHash.update('\0');
         baseHash.update(process.version); // Node.js version
         baseHash.update('\0');
-        baseHash.update(JSON.stringify(globalRootConfig)); // Variable global jest config
+        baseHash.update(
+          SuccessCache.trimPaths(JSON.stringify(globalRootConfig)),
+        ); // Variable global jest config
         const baseSha = baseHash.digest('hex');
 
         return projectConfigs.filter(project => {
@@ -326,7 +328,7 @@ export async function command(opts: OptionValues, cmd: Command): Promise<void> {
 
           // The project ID is a hash of the transform configuration, which helps
           // us bust the cache when any changes are made to the transform implementation.
-          hash.update(JSON.stringify(project));
+          hash.update(SuccessCache.trimPaths(JSON.stringify(project)));
           hash.update(lockfile.getDependencyTreeHash(packageName));
 
           const sha = hash.digest('hex');

--- a/packages/cli/src/lib/cache/SuccessCache.ts
+++ b/packages/cli/src/lib/cache/SuccessCache.ts
@@ -16,6 +16,7 @@
 
 import fs from 'fs-extra';
 import { resolve as resolvePath } from 'node:path';
+import { paths } from '../paths';
 
 const DEFAULT_CACHE_BASE_PATH = 'node_modules/.cache/backstage-cli';
 
@@ -23,6 +24,15 @@ const CACHE_MAX_AGE_MS = 7 * 24 * 3600_000;
 
 export class SuccessCache {
   readonly #path: string;
+
+  /**
+   * Trim any occurrences of the workspace root path from the input string. This
+   * is useful to ensure stable hashes that don't vary based on the workspace
+   * location.
+   */
+  static trimPaths(input: string) {
+    return input.replaceAll(paths.targetRoot, '');
+  }
 
   constructor(name: string, basePath?: string) {
     this.#path = resolvePath(basePath ?? DEFAULT_CACHE_BASE_PATH, name);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

See the changesets, two separate fixes that made the success cache hash generation less stable.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
