### PR TITLE
catalog: Add `entity_ref` to the `final_entities` table

### DIFF
--- a/.changeset/tender-feet-scream.md
+++ b/.changeset/tender-feet-scream.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-catalog-backend': patch
+'@backstage/plugin-catalog-backend': minor
 ---
 
 Added `entity_ref` column to `final_entities` in order to move `refresh_state` away from the read path

--- a/.changeset/tender-feet-scream.md
+++ b/.changeset/tender-feet-scream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Added `entity_ref` column to `final_entities` in order to move `refresh_state` away from the read path

--- a/plugins/catalog-backend/migrations/20241024104700_add_entity_ref_to_final_entities.js
+++ b/plugins/catalog-backend/migrations/20241024104700_add_entity_ref_to_final_entities.js
@@ -38,6 +38,13 @@ exports.up = async function up(knex) {
         .where('r.entity_id', knex.raw('f.entity_id')),
     })
     .table('final_entities as f');
+
+  // SQLite does not support ALTER COLUMN.
+  if (!knex.client.config.client.includes('sqlite3')) {
+    await knex.schema.alterTable('final_entities', table => {
+      table.text('entity_ref').notNullable().alter({ alterNullable: true });
+    });
+  }
 };
 
 /**

--- a/plugins/catalog-backend/migrations/20241024104700_add_entity_ref_to_final_entities.js
+++ b/plugins/catalog-backend/migrations/20241024104700_add_entity_ref_to_final_entities.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @ts-check
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function up(knex) {
+  await knex.schema.alterTable('final_entities', table => {
+    table
+      .text('entity_ref')
+      .nullable()
+      .comment(
+        'The entity reference of the entity that was created from the catalog processing',
+      );
+  });
+
+  // Set the default entity_ref in final_entities from the refresh_state table
+  await knex.raw(
+    `UPDATE final_entities SET entity_ref = refresh_state.entity_ref FROM refresh_state WHERE refresh_state.entity_id = final_entities.entity_id`,
+  );
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function down(knex) {
+  await knex.schema.alterTable('final_entities', table => {
+    table.dropColumn('entity_ref');
+  });
+};

--- a/plugins/catalog-backend/migrations/20241024104700_add_entity_ref_to_final_entities.js
+++ b/plugins/catalog-backend/migrations/20241024104700_add_entity_ref_to_final_entities.js
@@ -26,8 +26,6 @@ exports.up = async function up(knex) {
       .string('entity_ref')
       .nullable()
       .comment('The entity reference of the entity');
-
-    table.index('entity_ref', 'entity_ref_idx');
   });
 
   await knex
@@ -39,12 +37,12 @@ exports.up = async function up(knex) {
     })
     .table('final_entities as f');
 
-  // SQLite does not support ALTER COLUMN.
-  if (!knex.client.config.client.includes('sqlite3')) {
-    await knex.schema.alterTable('final_entities', table => {
-      table.string('entity_ref').notNullable().alter({ alterNullable: true });
+  await knex.schema.alterTable('final_entities', table => {
+    table.string('entity_ref').notNullable().alter({ alterNullable: true });
+    table.unique(['entity_ref'], {
+      indexName: 'final_entities_entity_ref_uniq',
     });
-  }
+  });
 };
 
 /**
@@ -53,7 +51,7 @@ exports.up = async function up(knex) {
  */
 exports.down = async function down(knex) {
   await knex.schema.alterTable('final_entities', table => {
-    table.dropIndex([], 'entity_ref_idx');
+    table.dropUnique([], 'final_entities_entity_ref_uniq');
     table.dropColumn('entity_ref');
   });
 };

--- a/plugins/catalog-backend/migrations/20241024104700_add_entity_ref_to_final_entities.js
+++ b/plugins/catalog-backend/migrations/20241024104700_add_entity_ref_to_final_entities.js
@@ -30,12 +30,6 @@ exports.up = async function up(knex) {
       );
   });
 
-  // // Set the default entity_ref in final_entities from the table
-  // await knex.raw(
-  //   `UPDATE final_entities SET entity_ref = refresh_state.entity_ref FROM refresh_state WHERE refresh_state.entity_id = final_entities.entity_id`,
-  // );
-
-  // 2
   await knex
     .update({
       entity_ref: knex

--- a/plugins/catalog-backend/migrations/20241024104700_add_entity_ref_to_final_entities.js
+++ b/plugins/catalog-backend/migrations/20241024104700_add_entity_ref_to_final_entities.js
@@ -28,6 +28,8 @@ exports.up = async function up(knex) {
       .comment(
         'The entity reference of the entity that was created from the catalog processing',
       );
+
+    table.index('entity_ref', 'entity_ref_idx');
   });
 
   await knex
@@ -53,6 +55,7 @@ exports.up = async function up(knex) {
  */
 exports.down = async function down(knex) {
   await knex.schema.alterTable('final_entities', table => {
+    table.dropIndex('entity_ref_idx');
     table.dropColumn('entity_ref');
   });
 };

--- a/plugins/catalog-backend/migrations/20241024104700_add_entity_ref_to_final_entities.js
+++ b/plugins/catalog-backend/migrations/20241024104700_add_entity_ref_to_final_entities.js
@@ -30,10 +30,20 @@ exports.up = async function up(knex) {
       );
   });
 
-  // Set the default entity_ref in final_entities from the refresh_state table
-  await knex.raw(
-    `UPDATE final_entities SET entity_ref = refresh_state.entity_ref FROM refresh_state WHERE refresh_state.entity_id = final_entities.entity_id`,
-  );
+  // // Set the default entity_ref in final_entities from the table
+  // await knex.raw(
+  //   `UPDATE final_entities SET entity_ref = refresh_state.entity_ref FROM refresh_state WHERE refresh_state.entity_id = final_entities.entity_id`,
+  // );
+
+  // 2
+  await knex
+    .update({
+      entity_ref: knex
+        .select('r.entity_ref')
+        .from('refresh_state as r')
+        .where('r.entity_id', knex.raw('f.entity_id')),
+    })
+    .table('final_entities as f');
 };
 
 /**

--- a/plugins/catalog-backend/migrations/20241024104700_add_entity_ref_to_final_entities.js
+++ b/plugins/catalog-backend/migrations/20241024104700_add_entity_ref_to_final_entities.js
@@ -23,11 +23,9 @@
 exports.up = async function up(knex) {
   await knex.schema.alterTable('final_entities', table => {
     table
-      .text('entity_ref')
+      .string('entity_ref')
       .nullable()
-      .comment(
-        'The entity reference of the entity that was created from the catalog processing',
-      );
+      .comment('The entity reference of the entity');
 
     table.index('entity_ref', 'entity_ref_idx');
   });
@@ -44,7 +42,7 @@ exports.up = async function up(knex) {
   // SQLite does not support ALTER COLUMN.
   if (!knex.client.config.client.includes('sqlite3')) {
     await knex.schema.alterTable('final_entities', table => {
-      table.text('entity_ref').notNullable().alter({ alterNullable: true });
+      table.string('entity_ref').notNullable().alter({ alterNullable: true });
     });
   }
 };
@@ -55,7 +53,7 @@ exports.up = async function up(knex) {
  */
 exports.down = async function down(knex) {
   await knex.schema.alterTable('final_entities', table => {
-    table.dropIndex('entity_ref_idx');
+    table.dropIndex([], 'entity_ref_idx');
     table.dropColumn('entity_ref');
   });
 };

--- a/plugins/catalog-backend/src/database/operations/stitcher/markForStitching.test.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/markForStitching.test.ts
@@ -252,24 +252,28 @@ describe('markForStitching', () => {
         {
           entity_id: '1',
           final_entity: '{}',
+          entity_ref: 'k:ns/one',
           hash: 'old',
           stitch_ticket: 'old',
         },
         {
           entity_id: '2',
           final_entity: '{}',
+          entity_ref: 'k:ns/two',
           hash: 'old',
           stitch_ticket: 'old',
         },
         {
           entity_id: '3',
           final_entity: '{}',
+          entity_ref: 'k:ns/three',
           hash: 'old',
           stitch_ticket: 'old',
         },
         {
           entity_id: '4',
           final_entity: '{}',
+          entity_ref: 'k:ns/four',
           hash: 'old',
           stitch_ticket: 'old',
         },

--- a/plugins/catalog-backend/src/database/operations/stitcher/performStitching.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/performStitching.ts
@@ -69,6 +69,7 @@ export async function performStitching(options: {
     .insert({
       entity_id: entityResult[0].entity_id,
       hash: '',
+      entity_ref: entityRef,
       stitch_ticket: stitchTicket,
     })
     .onConflict('entity_id')

--- a/plugins/catalog-backend/src/database/operations/stitcher/performStitching.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/performStitching.ts
@@ -218,7 +218,7 @@ export async function performStitching(options: {
     .where('entity_id', entityId)
     .where('stitch_ticket', stitchTicket)
     .onConflict('entity_id')
-    .merge(['final_entity', 'hash', 'last_updated_at', 'entity_ref']);
+    .merge(['final_entity', 'hash', 'last_updated_at']);
 
   const markDeferred = async () => {
     if (options.strategy.mode !== 'deferred') {

--- a/plugins/catalog-backend/src/database/operations/stitcher/performStitching.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/performStitching.ts
@@ -212,11 +212,12 @@ export async function performStitching(options: {
       final_entity: JSON.stringify(entity),
       hash,
       last_updated_at: knex.fn.now(),
+      entity_ref: entityRef,
     })
     .where('entity_id', entityId)
     .where('stitch_ticket', stitchTicket)
     .onConflict('entity_id')
-    .merge(['final_entity', 'hash', 'last_updated_at']);
+    .merge(['final_entity', 'hash', 'last_updated_at', 'entity_ref']);
 
   const markDeferred = async () => {
     if (options.strategy.mode !== 'deferred') {

--- a/plugins/catalog-backend/src/database/operations/util/deleteOrphanedEntities.test.ts
+++ b/plugins/catalog-backend/src/database/operations/util/deleteOrphanedEntities.test.ts
@@ -69,6 +69,7 @@ describe('deleteOrphanedEntities', () => {
       await knex<DbFinalEntitiesRow>('final_entities').insert({
         entity_id: `id-${ref}`,
         hash: 'original',
+        entity_ref: ref,
         stitch_ticket: '',
       });
     }

--- a/plugins/catalog-backend/src/database/tables.ts
+++ b/plugins/catalog-backend/src/database/tables.ts
@@ -179,7 +179,7 @@ export type DbFinalEntitiesRow = {
   stitch_ticket: string;
   final_entity?: string;
   last_updated_at?: string | Date;
-  entity_ref?: string;
+  entity_ref: string;
 };
 
 export type DbSearchRow = {

--- a/plugins/catalog-backend/src/database/tables.ts
+++ b/plugins/catalog-backend/src/database/tables.ts
@@ -179,6 +179,7 @@ export type DbFinalEntitiesRow = {
   stitch_ticket: string;
   final_entity?: string;
   last_updated_at?: string | Date;
+  entity_ref?: string;
 };
 
 export type DbSearchRow = {

--- a/plugins/catalog-backend/src/providers/DefaultLocationStore.test.ts
+++ b/plugins/catalog-backend/src/providers/DefaultLocationStore.test.ts
@@ -204,6 +204,7 @@ describe('DefaultLocationStore', () => {
           hash: 'hash',
           last_updated_at: new Date(),
           stitch_ticket: '',
+          entity_ref: 'k:ns/n',
         });
 
         await knex<DbSearchRow>('search').insert({

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
@@ -76,6 +76,7 @@ describe('DefaultEntitiesCatalog', () => {
 
     await knex<DbFinalEntitiesRow>('final_entities').insert({
       entity_id: id,
+      entity_ref: entityRef,
       final_entity: entityJson,
       hash: 'h',
       stitch_ticket: '',

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
@@ -114,6 +114,7 @@ describe('DefaultEntitiesCatalog', () => {
 
     await knex<DbFinalEntitiesRow>('final_entities').insert({
       entity_id: id,
+      entity_ref: entityRef,
       final_entity: entityJson,
       hash: 'h',
       stitch_ticket: '',

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -684,7 +684,6 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
       const parentRows = await this.database<DbRefreshStateReferencesRow>(
         'refresh_state_references',
       )
-
         .innerJoin<DbFinalEntitiesRow>('final_entities', {
           'refresh_state_references.source_entity_ref':
             'final_entities.entity_ref',

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -251,13 +251,7 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
     });
 
     if (!request?.order) {
-      entitiesQuery = entitiesQuery
-        .leftOuterJoin(
-          'refresh_state',
-          'refresh_state.entity_id',
-          'final_entities.entity_id',
-        )
-        .orderBy('refresh_state.entity_ref', 'asc'); // default sort
+      entitiesQuery = entitiesQuery.orderBy('final_entities.entity_ref', 'asc'); // default sort
     } else {
       entitiesQuery.orderBy('final_entities.entity_id', 'asc'); // stable sort
     }
@@ -326,16 +320,11 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
 
     for (const chunk of lodashChunk(request.entityRefs, 200)) {
       let query = this.database<DbFinalEntitiesRow>('final_entities')
-        .innerJoin<DbRefreshStateRow>(
-          'refresh_state',
-          'refresh_state.entity_id',
-          'final_entities.entity_id',
-        )
         .select({
-          entityRef: 'refresh_state.entity_ref',
+          entityRef: 'final_entities.entity_ref',
           entity: 'final_entities.final_entity',
         })
-        .whereIn('refresh_state.entity_ref', chunk);
+        .whereIn('final_entities.entity_ref', chunk);
 
       if (request?.filter) {
         query = parseFilter(
@@ -343,7 +332,7 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
           query,
           this.database,
           false,
-          'refresh_state.entity_id',
+          'final_entities.entity_id',
         );
       }
 
@@ -669,11 +658,8 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
   }
 
   async entityAncestry(rootRef: string): Promise<EntityAncestryResponse> {
-    const [rootRow] = await this.database<DbRefreshStateRow>('refresh_state')
-      .leftJoin<DbFinalEntitiesRow>('final_entities', {
-        'refresh_state.entity_id': 'final_entities.entity_id',
-      })
-      .where('refresh_state.entity_ref', '=', rootRef)
+    const [rootRow] = await this.database<DbFinalEntitiesRow>('final_entities')
+      .where('final_entities.entity_ref', '=', rootRef)
       .select({
         entityJson: 'final_entities.final_entity',
       });
@@ -698,16 +684,14 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
       const parentRows = await this.database<DbRefreshStateReferencesRow>(
         'refresh_state_references',
       )
-        .innerJoin<DbRefreshStateRow>('refresh_state', {
-          'refresh_state_references.source_entity_ref':
-            'refresh_state.entity_ref',
-        })
+
         .innerJoin<DbFinalEntitiesRow>('final_entities', {
-          'refresh_state.entity_id': 'final_entities.entity_id',
+          'refresh_state_references.source_entity_ref':
+            'final_entities.entity_ref',
         })
         .where('refresh_state_references.target_entity_ref', '=', currentRef)
         .select({
-          parentEntityRef: 'refresh_state.entity_ref',
+          parentEntityRef: 'final_entities.entity_ref',
           parentEntityJson: 'final_entities.final_entity',
         });
 

--- a/plugins/catalog-backend/src/tests/migrations.test.ts
+++ b/plugins/catalog-backend/src/tests/migrations.test.ts
@@ -93,6 +93,7 @@ describe('migrations', () => {
           hash: 'h',
           stitch_ticket: '',
           final_entity: '{}',
+          entity_ref: 'k:ns/n1',
         })
         .into('final_entities');
 
@@ -418,7 +419,7 @@ describe('migrations', () => {
         })
         .into('refresh_state');
 
-      // Insert a simple URL before the migration
+      // Insert a simple entity before the migration
       await knex
         .insert({
           entity_id: '8222246a-b572-49cf-a702-1a0fcfaae901',
@@ -428,11 +429,15 @@ describe('migrations', () => {
         })
         .into('final_entities');
 
+      // verify that the entity_ref column is not present
+      const preColumnInfo = await knex('final_entities').columnInfo();
+      expect(preColumnInfo.entity_ref).toBeUndefined();
+
       await migrateUpOnce(knex);
 
       // verify that the entity_ref column has been added
-      const columnInfo = await knex('final_entities').columnInfo();
-      expect(columnInfo.entity_ref).not.toBeUndefined();
+      const afterColumnInfo = await knex('final_entities').columnInfo();
+      expect(afterColumnInfo.entity_ref).not.toBeUndefined();
 
       // verify that the contents of the entity_ref column are correct
       await expect(knex('final_entities')).resolves.toEqual(


### PR DESCRIPTION
We're hoping to move away from needing to join the `refresh_state` table with a lot of the read path SQL requests to improve performance, mainly across read-replicas.
