### PR TITLE
fix: double branch creation in `public:bitbucket{Cloud,Server}:pull-r…

### DIFF
--- a/.changeset/tricky-crabs-lick.md
+++ b/.changeset/tricky-crabs-lick.md
@@ -1,0 +1,13 @@
+---
+'@backstage/plugin-scaffolder-backend-module-bitbucket-server': patch
+'@backstage/plugin-scaffolder-backend-module-bitbucket-cloud': patch
+---
+
+Fix double branch creation in `public:bitbucket{Cloud,Server}:pull-request`
+This resulted in the following error when using the actions:
+
+```
+AlreadyExistsError: Failed to create branch at create-test because it already exists.
+```
+
+The issue was original introduced in d103a48fa306d745599dc0c793668c9e6a479d32

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPullRequest.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPullRequest.ts
@@ -21,7 +21,6 @@ import {
   getRepoSourceDirectory,
   commitAndPushBranch,
   addFiles,
-  createBranch as createGitBranch,
   cloneRepo,
   parseRepoUrl,
 } from '@backstage/plugin-scaffolder-node';
@@ -406,13 +405,6 @@ export function createPublishBitbucketCloudPullRequestAction(options: {
         const sourceDir = getRepoSourceDirectory(ctx.workspacePath, undefined);
         await cloneRepo({
           url: remoteUrl,
-          dir: tempDir,
-          auth,
-          logger: ctx.logger,
-          ref: sourceBranch,
-        });
-
-        await createGitBranch({
           dir: tempDir,
           auth,
           logger: ctx.logger,

--- a/plugins/scaffolder-backend-module-bitbucket-server/src/actions/bitbucketServerPullRequest.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-server/src/actions/bitbucketServerPullRequest.ts
@@ -24,7 +24,6 @@ import {
   getRepoSourceDirectory,
   commitAndPushBranch,
   addFiles,
-  createBranch as createGitBranch,
   cloneRepo,
   parseRepoUrl,
 } from '@backstage/plugin-scaffolder-node';
@@ -446,13 +445,6 @@ export function createPublishBitbucketServerPullRequestAction(options: {
         const sourceDir = getRepoSourceDirectory(ctx.workspacePath, undefined);
         await cloneRepo({
           url: remoteUrl,
-          dir: tempDir,
-          auth,
-          logger: ctx.logger,
-          ref: sourceBranch,
-        });
-
-        await createGitBranch({
           dir: tempDir,
           auth,
           logger: ctx.logger,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix double branch creation in `public:bitbucket{Cloud,Server}:pull-request`
The issue was originaly introduced in d103a48fa306d745599dc0c793668c9e6a479d32
The checkout should have been unecessary anyways since the branch is passed to `cloneRepo` above.

I did not test this changeset.
I also only know for sure that it happens on bitbucket server, but I find it very unlikely that the same issue doesn't exist on bitbucket cloud.

Complete (anonymized) log of a failure after updating backstage:
```
info: source branch not found -> creating branch named: create-test lastCommit: d103a48fa306d745599dc0c793668c9e6a479d32
info: Cloning repo {dir=/tmp/uuid,url=https://example.com/scm/project/repo.git}
info: Counting objects
info: Compressing objects
info: Receiving objects
info: Resolving deltas
info: Analyzing workdir
info: Updating workdir
info: Creating branch {dir=/tmp/uuid,ref=create-test
AlreadyExistsError: Failed to create branch at create-test because it already exists.
    at _branch (/app/node_modules/isomorphic-git/index.cjs:6174:13)
    at async Object.branch (/app/node_modules/isomorphic-git/index.cjs:6236:12)
    at async Object.createBranch (/app/node_modules/@backstage/plugin-scaffolder-node/dist/actions/gitHelpers.cjs.js:93:3)
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
