### PR TITLE
Update Google Auth plugin to add Frontend Visibility header

### DIFF
--- a/.changeset/few-hornets-rush.md
+++ b/.changeset/few-hornets-rush.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-google-provider': patch
+---
+
+Fix visibility of config for use in front end code

--- a/plugins/auth-backend-module-google-provider/config.d.ts
+++ b/plugins/auth-backend-module-google-provider/config.d.ts
@@ -18,6 +18,7 @@ export interface Config {
   /** Configuration options for the auth plugin */
   auth?: {
     providers?: {
+      /** @visibility frontend */
       google?: {
         [authEnv: string]: {
           clientId: string;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When running locally I found that the following frontend code was not returning the `google` keyword

```
const providersConfig = configApi.getOptionalConfig('auth.providers');
const configuredProviders = providersConfig?.keys() || [];
```

It was however present and could be seen via the DevTools plugin, and by the backend code.
I tried different config blocks
```
auth:
  environment: development
  providers:
    github:
      development:
        <blah>
    chicken:
      development:
        <blah>
    cfaccess:
      <blah>
```

which did return all keywords.  I reviewed the differences with the Github Auth provider and the Google Auth provider and spotted this difference which I believe will resolve my issue

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
