### PR TITLE
repo-tools: fix yarn version check for generate-patch

### DIFF
--- a/packages/repo-tools/src/commands/generate-patch/generate-patch.ts
+++ b/packages/repo-tools/src/commands/generate-patch/generate-patch.ts
@@ -234,16 +234,10 @@ async function loadTrimmedRootPkg(ctx: PatchContext, query?: string) {
 
 // Verify that a repo is using a supported Yarn version
 async function verifyYarnVersion(cwd: string) {
-  const { stdout } = await exec('yarn', ['--version'], {
-    cwd,
-  });
-  const version = stdout.toString('utf8').trim();
-
-  if (version.startsWith('1.')) {
+  const exists = await fs.pathExists(joinPath(cwd, '.yarnrc.yml'));
+  if (!exists) {
     throw new Error(
-      `Unsupported Yarn version in target repository, got ${stdout
-        .toString('utf8')
-        .trim()} but 2+ is required`,
+      `Missing .yarnrc.yml in ${cwd}, Yarn v1 (classic) is not support by this command`,
     );
   }
 }


### PR DESCRIPTION
More followup for #27331, `yarn --version` will now do what you expect when run in a separate workspace that is not using Yarn berry, it will just report the local version instead. Turns out there's no great way to actually check the Yarn version, so just opting to check whether we're using berry by detecting the `.yarnrc.yml` file instead. According to [Yarn docs](https://yarnpkg.com/configuration/yarnrc) there are no other options than calling it `.yarnrc.yml`, so expecting this to be a safe way to check.