### PR TITLE
Add custom column example for existing Kind

### DIFF
--- a/docs/features/software-catalog/catalog-customization.md
+++ b/docs/features/software-catalog/catalog-customization.md
@@ -63,7 +63,51 @@ There are many options that can be set using `tableOptions`, the full list of se
 
 ## Customize Columns
 
-By default the columns you see in the `CatalogIndexPage` were selected to be a good starting point for most but there may be reasons that you would like to customize these with more or less columns. One primary use case for this customization is if you added a custom Kind. Support for this was added in v1.23.0 of Backstage, make sure you are on that version or newer to use this feature. Here's an example of how to make this customization:
+The columns you see in the `CatalogIndexPage` were selected to be a good starting point for most, but there may be cases where you would like to add or remove columns from existing or custom Kinds.
+
+### Adding a column to an existing Kind
+
+Suppose we want to add a new User Email column to the `User` kind in the Catalog. We can do this by creating a new column factory in `/plugins/catalog/src/components/CatalogTable/columns.tsx`:
+
+```tsx title="packages/catalog/src/components/CatalogTable/columns.tsx"
+export const columnFactories = Object.freeze({
+  createNameColumn(options?: {
+    defaultKind?: string;
+  }): TableColumn<CatalogTableRow> {
+    // ...
+    createUserEmailColumn(): TableColumn<CatalogTableRow> {
+      return {
+        title: 'User Email',
+        field: 'entity.spec?.profile?.["email"]',
+        render: ({ entity }) => (
+          <OverflowTooltip
+            text={entity.spec?.profile?.['email'] || 'N/A'}
+            placement="bottom-start"
+          />
+        ),
+      };
+    },
+  }
+});
+```
+
+Then, we can call this new column factory in `/plugins/catalog/src/components/CatalogTable/defaultCatalogTableColumnsFunc.tsx`:
+
+```tsx title="packages/catalog/src/components/CatalogTable/defaultCatalogTableColumnsFunc.tsx"
+// ...
+    switch (filters.kind?.value) {
+      case 'user':
+        return [
+          ...descriptionTagColumns,
+          {/* highlight-add-next-line */}
+          columnFactories.createUserEmailColumn(),
+        ];
+// ...
+```
+
+### Adding columns to a custom or specific Kind
+
+Another use case for customization is when adding a custom `Kind`. This feature is available in Backstage >= `v1.23.0`. For example:
 
 ```tsx title="packages/app/src/App.tsx"
 import {

--- a/docs/features/software-catalog/catalog-customization.md
+++ b/docs/features/software-catalog/catalog-customization.md
@@ -76,10 +76,8 @@ Suppose we want to add a new User Email column to the `User` kind in the Catalog
 const myColumnsFunc: CatalogTableColumnsFunc = entityListContext => {
   if (entityListContext.filters.kind?.value === 'user') {
     return [
-      // Existing columns (Name, Description, Tags)
-      CatalogTable.columns.createNameColumn(),
-      CatalogTable.columns.createMetadataDescriptionColumn(),
-      CatalogTable.columns.createTagsColumn(),
+      // Render existing columns
+      ...CatalogTable.defaultColumnsFunc(entityListContext),
       // Add new columns here
     ];
   }

--- a/docs/features/software-catalog/catalog-customization.md
+++ b/docs/features/software-catalog/catalog-customization.md
@@ -108,10 +108,9 @@ const createUserEmailColumn = (): TableColumn<CatalogTableRow> => ({
 const myColumnsFunc: CatalogTableColumnsFunc = entityListContext => {
   if (entityListContext.filters.kind?.value === 'user') {
     return [
-      // Existing columns (Name, Description, Tags)
-      CatalogTable.columns.createNameColumn(),
-      CatalogTable.columns.createMetadataDescriptionColumn(),
-      CatalogTable.columns.createTagsColumn(),
+    return [
+      // Render existing columns
+      ...CatalogTable.defaultColumnsFunc(entityListContext),
       // Add new columns here
       {/* highlight-add-next-line */}
       createUserEmailColumn(),

--- a/docs/features/software-catalog/catalog-customization.md
+++ b/docs/features/software-catalog/catalog-customization.md
@@ -91,8 +91,6 @@ const myColumnsFunc: CatalogTableColumnsFunc = entityListContext => {
 }
 ```
 
-Some other possible values for the existing entity kinds are `user`, `domain`, `system`, `group`, `template` and `location`.
-
 Then, we can implement the `createUserEmailColumn` function and add it to the list of columns. `field` is used to access the data from the entity, while `render` lets us customize how we display the data:
 
 ```tsx title="packages/app/src/App.tsx"

--- a/docs/features/software-catalog/catalog-customization.md
+++ b/docs/features/software-catalog/catalog-customization.md
@@ -75,6 +75,7 @@ export const columnFactories = Object.freeze({
     defaultKind?: string;
   }): TableColumn<CatalogTableRow> {
     // ...
+    {/* highlight-add-start */}
     createUserEmailColumn(): TableColumn<CatalogTableRow> {
       return {
         title: 'User Email',
@@ -87,6 +88,7 @@ export const columnFactories = Object.freeze({
         ),
       };
     },
+    {/* highlight-add-end */}
   }
 });
 ```
@@ -141,7 +143,7 @@ const myColumnsFunc: CatalogTableColumnsFunc = entityListContext => {
 
 :::note Note
 
-The above example has been simplified and you will most likely have more code then just this in your `App.tsx` file.
+In the examples above, the contents of the files have been shortened for simplicity.
 
 :::
 
@@ -212,15 +214,15 @@ const customActions: TableProps<CatalogTableRow>['actions'] = [
 
 :::note Note
 
-The above example has been simplified and you will most likely have more code then just this in your `App.tsx` file.
+In the example above, the contents of `App.tsx` has been shortened for simplicity.
 
 :::
 
-The above customization will override the existing actions. Currently the only way to keep them and add your own is to also include the existing actions in your array by copying them from the [`defaultActions`](https://github.com/backstage/backstage/blob/57397e7d6d2d725712c439f4ab93f2ac6aa27bf8/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx#L113-L168).
+The above customization will override the existing actions. Currently, the only way to keep them and add your own is to also include the existing actions in your array by copying them from the [`defaultActions`](https://github.com/backstage/backstage/blob/57397e7d6d2d725712c439f4ab93f2ac6aa27bf8/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx#L113-L168).
 
 ## Customize Filters
 
-There are three options you have for filters: adjusting the existing filters with props, adding or removing the default filters, or creating a brand new custom filter. The following sections cover these cases
+There are various ways to customize filters: adjusting the existing filters with props, adding or removing default filters, creating brand-new custom filters, etc. The following sections cover these cases:
 
 ### Default Filter Props
 
@@ -249,7 +251,7 @@ import { DefaultFilters } from '@backstage/plugin-catalog-react';
 
 ### Removing Default Filters
 
-You may have reasons not use the Lifecycle, Tag, and Processing Status filters, here's an example of how you would remove them:
+If you have reasons not to use the Lifecycle, Tag, and Processing Status filters, here's an example of how to remove them:
 
 ```tsx title="packages/app/src/App.tsx"
 import {
@@ -280,7 +282,7 @@ import {
 
 ### Custom Filters
 
-You can add custom filters. For example, suppose that I want to allow filtering by a custom annotation added to entities, `company.com/security-tier`. Here is how we can build a filter to support that need.
+You can add custom filters. For example, suppose that we want to allow filtering by a custom annotation added to entities, `company.com/security-tier`. Here is how we can build a filter to support that need.
 
 First we need to create a new filter that implements the `EntityFilter` interface:
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Related Issue: #27238

**Note:** I might have completely missed the point with my example. Should the user only be able to modify the `App.tsx`, in which case we want to pass in a `CatalogTableColumnsFunc` which checks for the User entity and adds the columns instead of an array to the `CatalogIndexPage` component? Or is what I wrote a valid approach too? In both cases the desired behaviour can be achieved.

Implemented User Email column based on example code:
![image](https://github.com/user-attachments/assets/e72defef-2566-42ea-82a9-90d622b2abc8)

### Changelog
- Added new examples to `software-catalog/catalog-customization.md` doc on how to create or modify columns for existing Kinds.
- Clarified/reworded existing sections
