### PR TITLE
refactor(backend-dynamic-feature-service): Allow providing config-aware root logger options

### DIFF
--- a/.changeset/bright-singers-do.md
+++ b/.changeset/bright-singers-do.md
@@ -1,0 +1,10 @@
+---
+'@backstage/backend-dynamic-feature-service': minor
+---
+
+**BREAKING** The `dynamicPluginsFeatureLoader` options related to the root logger behavior (`transports`, `level`, `format`) are now gathered under a single `logger` option which is a function taking an optional `Config` argument and returning the logger options.
+
+This breaking change is required for 2 reasons:
+
+- it's totally possible that the current `Config` would be required to provide the logger options,
+- the logger-related options should be gathered under a common `logger` option because, when the root auditing service is introduced, distinct but similarly-named options would be required for the auditor as well.

--- a/packages/backend-dynamic-feature-service/report.api.md
+++ b/packages/backend-dynamic-feature-service/report.api.md
@@ -139,8 +139,9 @@ export const dynamicPluginsFeatureLoader: ((
 
 // @public (undocumented)
 export type DynamicPluginsFeatureLoaderOptions = DynamicPluginsFactoryOptions &
-  DynamicPluginsSchemasOptions &
-  DynamicPluginsRootLoggerFactoryOptions;
+  DynamicPluginsSchemasOptions & {
+    logger?: (config?: Config) => DynamicPluginsRootLoggerFactoryOptions;
+  };
 
 // @public @deprecated (undocumented)
 export const dynamicPluginsFrontendSchemas: BackendFeature;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When enabling the dynamic feature in the backend application with the 1-liner `dynamicPluginsFeatureLoader`, the root logger is overridden in order to also hide secret values defined in config schemas of dynamic plugins.
However we want users of this feature loader to be able to customize as much as possible the behavior of this overridden root logger.
This was already available with the `transports`, `level`, and `format` option values.

However there are cases where we want to define the above options based on the application config (think of a rotating logging mechanism that should be driven by configuration for example).

This PR changes these logger-related options, and gathers them under a single `logger` option value which is a function taking a `Config`.

_**NOTE:** it is required to switch the Janus backstage-showcase backend application to the one-liner activation of the dynamic backend plugins support, while still providing audit logging through config-based custom transports and format._

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
