### PR TITLE
Added  parameter for auth config. It will create new session if refre…

### DIFF
--- a/.changeset/strange-suits-attend.md
+++ b/.changeset/strange-suits-attend.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-app-api': minor
+---
+
+Recreate session if it failed to refresh

--- a/packages/core-app-api/src/lib/AuthSessionManager/RefreshingAuthSessionManager.ts
+++ b/packages/core-app-api/src/lib/AuthSessionManager/RefreshingAuthSessionManager.ts
@@ -86,17 +86,10 @@ export class RefreshingAuthSessionManager<T> implements SessionManager<T> {
         if (options.optional) {
           return undefined;
         }
-        throw error;
+        this.stateTracker.setIsSignedIn(false);
       }
     }
 
-    // The user may still have a valid refresh token in their cookies. Attempt to
-    // initiate a fresh session through the backend using that refresh token.
-    //
-    // We skip this check if an instant login popup is requested, as we need to
-    // stay in a synchronous call stack from the user interaction. The downside
-    // is that the user will sometimes be requested to log in even if they
-    // already had an existing session.
     if (!this.currentSession && !options.instantPopup) {
       try {
         const newSession = await this.collapsedSessionRefresh(options.scopes);
@@ -105,6 +98,7 @@ export class RefreshingAuthSessionManager<T> implements SessionManager<T> {
         return this.getSession(options);
       } catch {
         // If the refresh attempt fails we assume we don't have a session, so continue to create one.
+        this.stateTracker.setIsSignedIn(false); // Add this line to reflect signed-out state
       }
     }
 


### PR DESCRIPTION
…sh failed

## Hey, I just made a Pull Request!

Hi team! I encountered an issue where the refresh token action fails, causing all authorized requests afterward to stop working. It would be great if, in such cases, there is a way to recover the current session without a full page reload. I attempted to fix this issue, but I'm not entirely sure if my approach is correct. This issue is critical for our product, so I would appreciate it if you could review my changes and provide feedback. If my changes are not correct, I am open to resolving the issue differently based on your advice. Thank you!

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
