### PR TITLE
docs(sofware-templates): improves instruction for --no-node-snapshot

### DIFF
--- a/docs/features/software-templates/index.md
+++ b/docs/features/software-templates/index.md
@@ -25,7 +25,7 @@ locations like GitHub or GitLab.
 If you're running Backstage with Node 20 or later, you'll need to pass the flag `--no-node-snapshot` to Node in order to
 use the templates feature.
 One way to do this is to specify the `NODE_OPTIONS` environment variable before starting Backstage:
-`export NODE_OPTIONS="$NODE_OPTIONS --no-node-snapshot"`
+`export NODE_OPTIONS="${NODE_OPTIONS:-} --no-node-snapshot"`
 
 > It's important to append to the existing `NODE_OPTIONS` value, if it's already set, rather than overwriting it, since some NodeJS Debugging tools may rely on this environment variable to work properly.
 

--- a/docs/features/software-templates/index.md
+++ b/docs/features/software-templates/index.md
@@ -25,7 +25,9 @@ locations like GitHub or GitLab.
 If you're running Backstage with Node 20 or later, you'll need to pass the flag `--no-node-snapshot` to Node in order to
 use the templates feature.
 One way to do this is to specify the `NODE_OPTIONS` environment variable before starting Backstage:
-`export NODE_OPTIONS=--no-node-snapshot`
+`export NODE_OPTIONS="$NODE_OPTIONS --no-node-snapshot"`
+
+> It's important to append to the existing `NODE_OPTIONS` value, if it's already set, rather than overwriting it, since some NodeJS Debugging tools may rely on this environment variable to work properly.
 
 :::
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

I'm just making it clear in the docs that the best practice is to append flags to the NODE_OPTIONS environment variable, since other [debugging tools](https://code.visualstudio.com/docs/nodejs/nodejs-debugging#_how-can-i-set-nodeoptions) rely on that variable, and overriding it directly as it was suggested before was breaking the debugging capabilities.

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
