### PR TITLE
Add Support for Google LDAP Vendor

### DIFF
--- a/.changeset/heavy-phones-shave.md
+++ b/.changeset/heavy-phones-shave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-ldap': minor
+---
+
+Add Support for Google LDAP Vendor

--- a/plugins/catalog-backend-module-ldap/src/ldap/client.ts
+++ b/plugins/catalog-backend-module-ldap/src/ldap/client.ts
@@ -25,6 +25,7 @@ import {
   AEDirVendor,
   ActiveDirectoryVendor,
   DefaultLdapVendor,
+  GoogleLdapVendor,
   FreeIpaVendor,
   LdapVendor,
 } from './vendors';
@@ -236,6 +237,7 @@ export class LdapClient {
     if (this.vendor) {
       return this.vendor;
     }
+    const clientHost = this.client?.host || '';
     this.vendor = this.getRootDSE()
       .then(root => {
         if (root && root.raw?.forestFunctionality) {
@@ -244,6 +246,8 @@ export class LdapClient {
           return FreeIpaVendor;
         } else if (root && 'aeRoot' in root.raw) {
           return AEDirVendor;
+        } else if (clientHost === 'ldap.google.com') {
+          return GoogleLdapVendor;
         }
         return DefaultLdapVendor;
       })

--- a/plugins/catalog-backend-module-ldap/src/ldap/vendors.ts
+++ b/plugins/catalog-backend-module-ldap/src/ldap/vendors.ts
@@ -89,6 +89,16 @@ export const AEDirVendor: LdapVendor = {
   },
 };
 
+export const GoogleLdapVendor: LdapVendor = {
+  dnAttributeName: 'dn',
+  uuidAttributeName: 'uid',
+  decodeStringAttribute: (entry, name) => {
+    return decode(entry, name, value => {
+      return value.toString();
+    });
+  },
+};
+
 // Decode an attribute to a consumer
 function decode(
   entry: SearchEntry,


### PR DESCRIPTION
This PR introduces support for Google as a new LDAP vendor within the `@backstage/plugin-catalog-backend-module-ldap`. The change enables proper mapping and association between users and groups retrieved from Google's LDAP service.

Resolves https://github.com/backstage/backstage/issues/27323

**Key Change**: extended the existing LDAP integration to support Google's specific schema, ensuring correct user group associations are reflected in the Backstage catalog.

This enhancement will allow Backstage users working with Google LDAP to seamlessly synchronize their organization's user and group data.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
