### PR TITLE
feat(lint): Add `--quiet` option to repo lint

### DIFF
--- a/.changeset/giant-shoes-reflect.md
+++ b/.changeset/giant-shoes-reflect.md
@@ -1,0 +1,6 @@
+---
+'@backstage/cli': minor
+---
+
+Add `--quiet` flag for repo lint to reduce logging on rules marked as warnings in ESLint.
+This does not affect how max-warnings is handled.

--- a/docs/tooling/cli/03-commands.md
+++ b/docs/tooling/cli/03-commands.md
@@ -97,6 +97,7 @@ Options:
   --successCache            Enable success caching, which skips running tests for unchanged packages that were successful in the previous run
   --successCacheDir <path>  Set the success cache location, (default: node_modules/.cache/backstage-cli)
   --fix                     Attempt to automatically fix violations
+  --quiet                   Report errors only. Rules marked as warnings are not logged out, unless max-warnings threshold is reached.
 ```
 
 ## repo test

--- a/packages/cli/cli-report.md
+++ b/packages/cli/cli-report.md
@@ -453,6 +453,7 @@ Options:
   --successCache
   --successCacheDir <path>
   --max-warnings <number>
+  --quiet
   --fix
   -h, --help
 ```

--- a/packages/cli/src/modules/lint/commands/repo/lint.ts
+++ b/packages/cli/src/modules/lint/commands/repo/lint.ts
@@ -233,9 +233,11 @@ export async function command(opts: OptionValues, cmd: Command): Promise<void> {
     if (runFailed) {
       console.log(chalk.red(`Lint failed in ${relativeDir}`));
       failed = true;
+    } else if (sha) {
+      outputSuccessCache.push(sha);
+    }
 
-      // When doing repo lint, only list the results if the lint failed to avoid a log
-      // dump of all warnings that might be irrelevant
+    if (failed || !opts.quiet) {
       if (resultText) {
         if (opts.outputFile) {
           errorOutput += `${resultText}\n`;
@@ -244,8 +246,6 @@ export async function command(opts: OptionValues, cmd: Command): Promise<void> {
           console.log(resultText.trimStart());
         }
       }
-    } else if (sha) {
-      outputSuccessCache.push(sha);
     }
   }
 

--- a/packages/cli/src/modules/lint/index.ts
+++ b/packages/cli/src/modules/lint/index.ts
@@ -66,6 +66,10 @@ export function registerRepoCommands(command: Command) {
       '--max-warnings <number>',
       'Fail if more than this number of warnings. -1 allows warnings. (default: -1)',
     )
+    .option(
+      '--quiet',
+      'Report errors only. Rules marked as warnings are not logged out, unless max-warnings threshold is reached.',
+    )
     .option('--fix', 'Attempt to automatically fix violations')
     .action(lazy(() => import('./commands/repo/lint'), 'command'));
 }


### PR DESCRIPTION
With `--quiet`, eslint ruled marked as warn do not cause non-zero exit code. This is useful in enviroments, where new new eslint rules are introduced but cannot be enforced immediately. 

Implements backstage/backstage#27346

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
