### PR TITLE
Added a `permission-module` template

### DIFF
--- a/.changeset/clever-pumpkins-smile.md
+++ b/.changeset/clever-pumpkins-smile.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Added a `permission-module` template

--- a/packages/cli/src/lib/new/factories/index.ts
+++ b/packages/cli/src/lib/new/factories/index.ts
@@ -23,3 +23,4 @@ export { pluginCommon } from './pluginCommon';
 export { pluginNode } from './pluginNode';
 export { pluginWeb } from './pluginWeb';
 export { scaffolderModule } from './scaffolderModule';
+export { permissionModule as permissionsModule } from './permissionModule';

--- a/packages/cli/src/lib/new/factories/permissionModule.test.ts
+++ b/packages/cli/src/lib/new/factories/permissionModule.test.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs-extra';
+import { sep } from 'path';
+import { Task } from '../../tasks';
+import { FactoryRegistry } from '../FactoryRegistry';
+import {
+  createMockOutputStream,
+  expectLogsToMatch,
+  mockPaths,
+} from './common/testUtils';
+import { permissionModule } from './permissionModule';
+import { createMockDirectory } from '@backstage/backend-test-utils';
+
+describe('permissionModule factory', () => {
+  const mockDir = createMockDirectory();
+
+  beforeEach(() => {
+    mockPaths({
+      targetRoot: mockDir.path,
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should create a permission backend module package', async () => {
+    mockDir.setContent({
+      plugins: {},
+    });
+
+    const options = await FactoryRegistry.populateOptions(permissionModule, {
+      id: 'test',
+    });
+
+    let modified = false;
+
+    const [output, mockStream] = createMockOutputStream();
+    jest.spyOn(process, 'stderr', 'get').mockReturnValue(mockStream);
+    jest.spyOn(Task, 'forCommand').mockResolvedValue();
+
+    await permissionModule.create(options, {
+      private: true,
+      isMonoRepo: true,
+      defaultVersion: '1.0.0',
+      markAsModified: () => {
+        modified = true;
+      },
+      createTemporaryDirectory: (name: string) => fs.mkdtemp(name),
+      license: 'Apache-2.0',
+    });
+
+    expect(modified).toBe(true);
+
+    expectLogsToMatch(output, [
+      'Creating module backstage-plugin-permission-backend-module-test',
+      'Checking Prerequisites:',
+      `availability  plugins${sep}permission-backend-module-test`,
+      'creating      temp dir',
+      'Executing Template:',
+      'copying       customPermissionPolicy.ts',
+      'templating    README.md.hbs',
+      'templating    package.json.hbs',
+      'templating    index.ts.hbs',
+      'templating    .eslintrc.js.hbs',
+      'copying       module.ts',
+      'Installing:',
+      `moving        plugins${sep}permission-backend-module-test`,
+    ]);
+
+    await expect(
+      fs.readJson(
+        mockDir.resolve('plugins/permission-backend-module-test/package.json'),
+      ),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        name: 'backstage-plugin-permission-backend-module-test',
+        description: 'The test module for @backstage/plugin-permission-backend',
+        private: true,
+        version: '1.0.0',
+      }),
+    );
+
+    expect(Task.forCommand).toHaveBeenCalledTimes(2);
+    expect(Task.forCommand).toHaveBeenCalledWith('yarn install', {
+      cwd: mockDir.resolve('plugins/permission-backend-module-test'),
+      optional: true,
+    });
+    expect(Task.forCommand).toHaveBeenCalledWith('yarn lint --fix', {
+      cwd: mockDir.resolve('plugins/permission-backend-module-test'),
+      optional: true,
+    });
+  });
+});

--- a/packages/cli/src/lib/new/factories/permissionModule.ts
+++ b/packages/cli/src/lib/new/factories/permissionModule.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs-extra';
+import chalk from 'chalk';
+import { paths } from '../../paths';
+import { addCodeownersEntry, getCodeownersFilePath } from '../../codeowners';
+import { CreateContext, createFactory } from '../types';
+import { addPackageDependency, addToBackend, Task } from '../../tasks';
+import { ownerPrompt } from './common/prompts';
+import { executePluginPackageTemplate } from './common/tasks';
+import { resolvePackageName } from './common/util';
+
+type Options = {
+  id: string;
+  owner?: string;
+  codeOwnersPath?: string;
+};
+
+export const permissionModule = createFactory<Options>({
+  name: 'permission-module',
+  description:
+    'A module exporting a custom permission policy for @backstage/plugin-permission-backend',
+  optionsDiscovery: async () => ({
+    codeOwnersPath: await getCodeownersFilePath(paths.targetRoot),
+  }),
+  optionsPrompts: [
+    {
+      type: 'input',
+      name: 'id',
+      message: 'Enter the name of the module [required]',
+      validate: (value: string) => {
+        if (!value) {
+          return 'Please enter the name of the module';
+        } else if (!/^[a-z0-9]+(-[a-z0-9]+)*$/.test(value)) {
+          return 'Module names must be lowercase and contain only letters, digits, and dashes.';
+        }
+        return true;
+      },
+    },
+    ownerPrompt(),
+  ],
+  async create(options: Options, ctx: CreateContext) {
+    const { id } = options;
+    const slug = `permission-backend-module-${id}`;
+
+    const name = resolvePackageName({
+      baseName: slug,
+      scope: ctx.scope,
+      plugin: true,
+    });
+
+    Task.log();
+    Task.log(`Creating module ${chalk.cyan(name)}`);
+
+    const targetDir = ctx.isMonoRepo
+      ? paths.resolveTargetRoot('plugins', slug)
+      : paths.resolveTargetRoot(`backstage-plugin-${slug}`);
+
+    await executePluginPackageTemplate(ctx, {
+      targetDir,
+      templateName: 'permission-module',
+      values: {
+        id,
+        name,
+        privatePackage: ctx.private,
+        npmRegistry: ctx.npmRegistry,
+        pluginVersion: ctx.defaultVersion,
+        license: ctx.license,
+      },
+    });
+
+    if (await fs.pathExists(paths.resolveTargetRoot('packages/backend'))) {
+      await Task.forItem('backend', 'adding dependency', async () => {
+        await addPackageDependency(
+          paths.resolveTargetRoot('packages/backend/package.json'),
+          {
+            dependencies: {
+              [name]: `^${ctx.defaultVersion}`,
+            },
+          },
+        );
+      });
+
+      await addToBackend(name, {
+        type: 'plugin',
+      });
+    }
+
+    if (options.owner) {
+      await addCodeownersEntry(`/plugins/${slug}`, options.owner);
+    }
+
+    await Task.forCommand('yarn install', { cwd: targetDir, optional: true });
+    await Task.forCommand('yarn lint --fix', {
+      cwd: targetDir,
+      optional: true,
+    });
+  },
+});

--- a/packages/cli/src/lib/version.ts
+++ b/packages/cli/src/lib/version.ts
@@ -43,6 +43,8 @@ import { version as corePluginApi } from '../../../../packages/core-plugin-api/p
 import { version as devUtils } from '../../../../packages/dev-utils/package.json';
 import { version as errors } from '../../../../packages/errors/package.json';
 import { version as testUtils } from '../../../../packages/test-utils/package.json';
+import { version as permissionCommon } from '../../../../plugins/permission-common/package.json';
+import { version as permissionNode } from '../../../../plugins/permission-node/package.json';
 import { version as scaffolderNode } from '../../../../plugins/scaffolder-node/package.json';
 import { version as scaffolderNodeTestUtils } from '../../../../plugins/scaffolder-node-test-utils/package.json';
 import { version as authBackend } from '../../../../plugins/auth-backend/package.json';
@@ -65,6 +67,8 @@ export const packageVersions: Record<string, string> = {
   '@backstage/errors': errors,
   '@backstage/test-utils': testUtils,
   '@backstage/theme': theme,
+  '@backstage/plugin-permission-common': permissionCommon,
+  '@backstage/plugin-permission-node': permissionNode,
   '@backstage/plugin-scaffolder-node': scaffolderNode,
   '@backstage/plugin-scaffolder-node-test-utils': scaffolderNodeTestUtils,
   '@backstage/plugin-auth-backend': authBackend,

--- a/packages/cli/templates/permission-module/.eslintrc.js.hbs
+++ b/packages/cli/templates/permission-module/.eslintrc.js.hbs
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/packages/cli/templates/permission-module/README.md.hbs
+++ b/packages/cli/templates/permission-module/README.md.hbs
@@ -1,0 +1,5 @@
+# {{name}}
+
+The {{id}} module for [@backstage/plugin-scaffolder-backend](https://www.npmjs.com/package/@backstage/plugin-scaffolder-backend).
+
+_This plugin was created through the Backstage CLI_

--- a/packages/cli/templates/permission-module/package.json.hbs
+++ b/packages/cli/templates/permission-module/package.json.hbs
@@ -1,0 +1,42 @@
+{
+  "name": "{{name}}",
+  "description": "The {{id}} module for @backstage/plugin-permission-backend",
+  "version": "{{pluginVersion}}",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "{{license}}",
+{{#if privatePackage}}
+  "private": {{privatePackage}},
+{{/if}}
+  "publishConfig": {
+{{#if npmRegistry}}
+    "registry": "{{npmRegistry}}",
+{{/if}}
+    "access": "public",
+    "main": "dist/index.cjs.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "backend-plugin-module"
+  },
+  "scripts": {
+    "start": "backstage-cli package start",
+    "build": "backstage-cli package build",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test",
+    "clean": "backstage-cli package clean",
+    "prepack": "backstage-cli package prepack",
+    "postpack": "backstage-cli package postpack"
+  },
+  "dependencies": {
+    "@backstage/backend-plugin-api": "{{versionQuery '@backstage/backend-plugin-api'}}",
+    "@backstage/plugin-permission-common": "{{versionQuery '@backstage/plugin-permission-common'}}",
+    "@backstage/plugin-permission-node": "{{versionQuery '@backstage/plugin-permission-node'}}"
+  },
+  "devDependencies": {
+    "@backstage/cli": "{{versionQuery '@backstage/cli'}}"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/cli/templates/permission-module/src/customPermissionPolicy.ts
+++ b/packages/cli/templates/permission-module/src/customPermissionPolicy.ts
@@ -1,0 +1,13 @@
+import {
+  PolicyDecision,
+  AuthorizeResult,
+} from '@backstage/plugin-permission-common';
+import { PermissionPolicy } from '@backstage/plugin-permission-node';
+
+export class CustomPermissionPolicy implements PermissionPolicy {
+  async handle(): Promise<PolicyDecision> {
+      // This acts as an allow all policy
+      // See https://backstage.io/docs/permissions/writing-a-policy for how to write your own custom policy
+    return { result: AuthorizeResult.ALLOW };
+  }
+}

--- a/packages/cli/templates/permission-module/src/index.ts.hbs
+++ b/packages/cli/templates/permission-module/src/index.ts.hbs
@@ -1,0 +1,8 @@
+/***/
+/**
+ * The {{id}} module for @backstage/plugin-permission-backend.
+ *
+ * @packageDocumentation
+ */
+
+export { default } from './module'

--- a/packages/cli/templates/permission-module/src/module.ts
+++ b/packages/cli/templates/permission-module/src/module.ts
@@ -1,0 +1,19 @@
+import { createBackendModule } from '@backstage/backend-plugin-api';
+import { policyExtensionPoint } from '@backstage/plugin-permission-node/alpha';
+import { CustomPermissionPolicy } from './customPermissionPolicy';
+
+/**
+ * A backend module that registers the customer permission policy into the permissions framework
+ */
+export default createBackendModule({
+  pluginId: 'permission',
+  moduleId: 'custom-permission-policy',
+  register(reg) {
+    reg.registerInit({
+      deps: { policy: policyExtensionPoint },
+      async init({ policy }) {
+        policy.setPolicy(new CustomPermissionPolicy());
+      },
+    });
+  },
+});

--- a/packages/cli/templates/permission-module/tsconfig.json
+++ b/packages/cli/templates/permission-module/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@backstage/cli/config/tsconfig.json",
+  "include": ["src"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist-types",
+    "rootDir": "."
+  }
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added a `permission-module` template to make getting started with the Permissions Framework easier. This will create a backend module that include a very basic Permission Policy which you can then extend. 

The intention is to follow up this PR with a refactor of the current Permissions Framework docs to use this as it will simplify them and make them easier to follow as the boiler plate is handled by this template.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
