### PR TITLE
Added `catalog-entity-provider-module` template

### DIFF
--- a/.changeset/rare-donkeys-hide.md
+++ b/.changeset/rare-donkeys-hide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Added `catalog-entity-provider-module` template

--- a/packages/cli/src/lib/new/factories/catalogEntityProviderModule.test.ts
+++ b/packages/cli/src/lib/new/factories/catalogEntityProviderModule.test.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs-extra';
+import { sep } from 'path';
+import { Task } from '../../tasks';
+import { FactoryRegistry } from '../FactoryRegistry';
+import {
+  createMockOutputStream,
+  expectLogsToMatch,
+  mockPaths,
+} from './common/testUtils';
+import { catalogEntityProviderModule } from './catalogEntityProviderModule';
+import { createMockDirectory } from '@backstage/backend-test-utils';
+
+describe('catalogEntityProviderModule factory', () => {
+  const mockDir = createMockDirectory();
+
+  beforeEach(() => {
+    mockPaths({
+      targetRoot: mockDir.path,
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should create a catalog backend module package', async () => {
+    mockDir.setContent({
+      plugins: {},
+    });
+
+    const options = await FactoryRegistry.populateOptions(
+      catalogEntityProviderModule,
+      {
+        id: 'test',
+      },
+    );
+
+    let modified = false;
+
+    const [output, mockStream] = createMockOutputStream();
+    jest.spyOn(process, 'stderr', 'get').mockReturnValue(mockStream);
+    jest.spyOn(Task, 'forCommand').mockResolvedValue();
+
+    await catalogEntityProviderModule.create(options, {
+      private: true,
+      isMonoRepo: true,
+      defaultVersion: '1.0.0',
+      markAsModified: () => {
+        modified = true;
+      },
+      createTemporaryDirectory: (name: string) => fs.mkdtemp(name),
+      license: 'Apache-2.0',
+    });
+
+    expect(modified).toBe(true);
+
+    expectLogsToMatch(output, [
+      'Creating module backstage-plugin-catalog-backend-entity-provider-module-test',
+      'Checking Prerequisites:',
+      `availability  plugins${sep}catalog-backend-entity-provider-module-test`,
+      'creating      temp dir',
+      'Executing Template:',
+      'templating    README.md.hbs',
+      'templating    config.d.ts.hbs',
+      'templating    .eslintrc.js.hbs',
+      'templating    package.json.hbs',
+      'templating    EntityProvider.ts.hbs',
+      'templating    index.ts.hbs',
+      'templating    module.ts.hbs',
+      'Installing:',
+      `moving        plugins${sep}catalog-backend-entity-provider-module-test`,
+    ]);
+
+    await expect(
+      fs.readJson(
+        mockDir.resolve(
+          'plugins/catalog-backend-entity-provider-module-test/package.json',
+        ),
+      ),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        name: 'backstage-plugin-catalog-backend-entity-provider-module-test',
+        description: 'The test module for @backstage/plugin-catalog-backend',
+        private: true,
+        version: '1.0.0',
+      }),
+    );
+
+    expect(Task.forCommand).toHaveBeenCalledTimes(2);
+    expect(Task.forCommand).toHaveBeenCalledWith('yarn install', {
+      cwd: mockDir.resolve(
+        'plugins/catalog-backend-entity-provider-module-test',
+      ),
+      optional: true,
+    });
+    expect(Task.forCommand).toHaveBeenCalledWith('yarn lint --fix', {
+      cwd: mockDir.resolve(
+        'plugins/catalog-backend-entity-provider-module-test',
+      ),
+      optional: true,
+    });
+  });
+});

--- a/packages/cli/src/lib/new/factories/catalogEntityProviderModule.ts
+++ b/packages/cli/src/lib/new/factories/catalogEntityProviderModule.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs-extra';
+import chalk from 'chalk';
+import { paths } from '../../paths';
+import { addCodeownersEntry, getCodeownersFilePath } from '../../codeowners';
+import { CreateContext, createFactory } from '../types';
+import { addPackageDependency, addToBackend, Task } from '../../tasks';
+import { ownerPrompt } from './common/prompts';
+import { executePluginPackageTemplate } from './common/tasks';
+import { resolvePackageName } from './common/util';
+import { camelCase } from 'lodash';
+
+type Options = {
+  id: string;
+  owner?: string;
+  codeOwnersPath?: string;
+};
+
+export const catalogEntityProviderModule = createFactory<Options>({
+  name: 'catalog-entity-provider-module',
+  description:
+    'A module exporting a custom entity provider for @backstage/plugin-catalog-backend',
+  optionsDiscovery: async () => ({
+    codeOwnersPath: await getCodeownersFilePath(paths.targetRoot),
+  }),
+  optionsPrompts: [
+    {
+      type: 'input',
+      name: 'id',
+      message: 'Enter the name of the module [required]',
+      validate: (value: string) => {
+        if (!value) {
+          return 'Please enter the name of the module';
+        } else if (!/^[a-z0-9]+(-[a-z0-9]+)*$/.test(value)) {
+          return 'Module names must be lowercase and contain only letters, digits, and dashes.';
+        }
+        return true;
+      },
+    },
+    ownerPrompt(),
+  ],
+  async create(options: Options, ctx: CreateContext) {
+    const { id } = options;
+    const slug = `catalog-backend-entity-provider-module-${id}`;
+
+    const name = resolvePackageName({
+      baseName: slug,
+      scope: ctx.scope,
+      plugin: true,
+    });
+
+    Task.log();
+    Task.log(`Creating module ${chalk.cyan(name)}`);
+
+    const targetDir = ctx.isMonoRepo
+      ? paths.resolveTargetRoot('plugins', slug)
+      : paths.resolveTargetRoot(`backstage-plugin-${slug}`);
+
+    await executePluginPackageTemplate(ctx, {
+      targetDir,
+      templateName: 'catalog-entity-provider-module',
+      values: {
+        id,
+        name,
+        camelCaseId: camelCase(id),
+        pascalCaseId:
+          camelCase(id).charAt(0).toUpperCase() + camelCase(id).slice(1),
+        privatePackage: ctx.private,
+        npmRegistry: ctx.npmRegistry,
+        pluginVersion: ctx.defaultVersion,
+        license: ctx.license,
+      },
+    });
+
+    if (await fs.pathExists(paths.resolveTargetRoot('packages/backend'))) {
+      await Task.forItem('backend', 'adding dependency', async () => {
+        await addPackageDependency(
+          paths.resolveTargetRoot('packages/backend/package.json'),
+          {
+            dependencies: {
+              [name]: `^${ctx.defaultVersion}`,
+            },
+          },
+        );
+      });
+
+      await addToBackend(name, {
+        type: 'plugin',
+      });
+    }
+
+    if (options.owner) {
+      await addCodeownersEntry(`/plugins/${slug}`, options.owner);
+    }
+
+    await Task.forCommand('yarn install', { cwd: targetDir, optional: true });
+    await Task.forCommand('yarn lint --fix', {
+      cwd: targetDir,
+      optional: true,
+    });
+  },
+});

--- a/packages/cli/src/lib/new/factories/index.ts
+++ b/packages/cli/src/lib/new/factories/index.ts
@@ -23,3 +23,4 @@ export { pluginCommon } from './pluginCommon';
 export { pluginNode } from './pluginNode';
 export { pluginWeb } from './pluginWeb';
 export { scaffolderModule } from './scaffolderModule';
+export { catalogEntityProviderModule } from './catalogEntityProviderModule';

--- a/packages/cli/src/lib/version.ts
+++ b/packages/cli/src/lib/version.ts
@@ -35,6 +35,7 @@ leaving any imports in place.
 import { version as backendPluginApi } from '../../../../packages/backend-plugin-api/package.json';
 import { version as backendTestUtils } from '../../../../packages/backend-test-utils/package.json';
 import { version as catalogClient } from '../../../../packages/catalog-client/package.json';
+import { version as catalogModel } from '../../../../packages/catalog-model/package.json';
 import { version as cli } from '../../../../packages/cli/package.json';
 import { version as config } from '../../../../packages/config/package.json';
 import { version as coreAppApi } from '../../../../packages/core-app-api/package.json';
@@ -43,11 +44,11 @@ import { version as corePluginApi } from '../../../../packages/core-plugin-api/p
 import { version as devUtils } from '../../../../packages/dev-utils/package.json';
 import { version as errors } from '../../../../packages/errors/package.json';
 import { version as testUtils } from '../../../../packages/test-utils/package.json';
+import { version as catalogNode } from '../../../../plugins/catalog-node/package.json';
 import { version as scaffolderNode } from '../../../../plugins/scaffolder-node/package.json';
 import { version as scaffolderNodeTestUtils } from '../../../../plugins/scaffolder-node-test-utils/package.json';
 import { version as authBackend } from '../../../../plugins/auth-backend/package.json';
 import { version as authBackendModuleGuestProvider } from '../../../../plugins/auth-backend-module-guest-provider/package.json';
-import { version as catalogNode } from '../../../../plugins/catalog-node/package.json';
 import { version as theme } from '../../../../packages/theme/package.json';
 import { version as backendDefaults } from '../../../../packages/backend-defaults/package.json';
 
@@ -56,6 +57,7 @@ export const packageVersions: Record<string, string> = {
   '@backstage/backend-plugin-api': backendPluginApi,
   '@backstage/backend-test-utils': backendTestUtils,
   '@backstage/catalog-client': catalogClient,
+  '@backstage/catalog-model': catalogModel,
   '@backstage/cli': cli,
   '@backstage/config': config,
   '@backstage/core-app-api': coreAppApi,
@@ -65,12 +67,12 @@ export const packageVersions: Record<string, string> = {
   '@backstage/errors': errors,
   '@backstage/test-utils': testUtils,
   '@backstage/theme': theme,
+  '@backstage/plugin-catalog-node': catalogNode,
   '@backstage/plugin-scaffolder-node': scaffolderNode,
   '@backstage/plugin-scaffolder-node-test-utils': scaffolderNodeTestUtils,
   '@backstage/plugin-auth-backend': authBackend,
   '@backstage/plugin-auth-backend-module-guest-provider':
     authBackendModuleGuestProvider,
-  '@backstage/plugin-catalog-node': catalogNode,
 };
 
 export function findVersion() {

--- a/packages/cli/templates/catalog-entity-provider-module/.eslintrc.js.hbs
+++ b/packages/cli/templates/catalog-entity-provider-module/.eslintrc.js.hbs
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/packages/cli/templates/catalog-entity-provider-module/README.md.hbs
+++ b/packages/cli/templates/catalog-entity-provider-module/README.md.hbs
@@ -1,0 +1,5 @@
+# {{name}}
+
+The {{id}} module for [@backstage/plugin-catalog-backend](https://www.npmjs.com/package/@backstage/plugin-catalog-backend).
+
+_This plugin was created through the Backstage CLI_

--- a/packages/cli/templates/catalog-entity-provider-module/config.d.ts.hbs
+++ b/packages/cli/templates/catalog-entity-provider-module/config.d.ts.hbs
@@ -1,0 +1,20 @@
+import { SchedulerServiceTaskScheduleDefinitionConfig } from '@backstage/backend-plugin-api';
+
+export interface Config {
+  catalog?: {
+    /**
+     * List of provider-specific options and attributes
+     */
+    providers?: {
+      /**
+       * {{pascalCaseId}}EntityProvider configuration
+       */
+      {{camelCaseId}}EntityProvider?: {
+        /**
+         * TaskScheduleDefinition for the refresh.
+         */
+        schedule: SchedulerServiceTaskScheduleDefinitionConfig;
+      };
+    };
+  };
+}

--- a/packages/cli/templates/catalog-entity-provider-module/package.json.hbs
+++ b/packages/cli/templates/catalog-entity-provider-module/package.json.hbs
@@ -1,0 +1,49 @@
+{
+  "name": "{{name}}",
+  "description": "The {{id}} module for @backstage/plugin-catalog-backend",
+  "version": "{{pluginVersion}}",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "{{license}}",
+{{#if privatePackage}}
+  "private": {{privatePackage}},
+{{/if}}
+  "publishConfig": {
+{{#if npmRegistry}}
+    "registry": "{{npmRegistry}}",
+{{/if}}
+    "access": "public",
+    "main": "dist/index.cjs.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "backend-plugin-module"
+  },
+  "scripts": {
+    "start": "backstage-cli package start",
+    "build": "backstage-cli package build",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test",
+    "clean": "backstage-cli package clean",
+    "prepack": "backstage-cli package prepack",
+    "postpack": "backstage-cli package postpack"
+  },
+  "dependencies": {
+    "@backstage/backend-plugin-api": "{{versionQuery '@backstage/backend-plugin-api'}}",
+    "@backstage/catalog-model": "{{versionQuery '@backstage/catalog-model'}}",
+    "@backstage/config": "{{versionQuery '@backstage/config'}}",
+    "@backstage/errors": "{{versionQuery '@backstage/errors'}}",
+    "@backstage/plugin-catalog-node": "{{versionQuery '@backstage/plugin-catalog-node'}}",
+    "uuid": "^9.0.0"
+  },
+  "devDependencies": {
+    "@backstage/cli": "{{versionQuery '@backstage/cli'}}",
+    "@backstage/backend-test-utils": "{{versionQuery '@backstage/backend-test-utils'}}",
+    "@types/uuid": "^10.0.0"
+  },
+  "files": [
+    "dist",
+    "config.d.ts"
+  ],
+  "configSchema": "config.d.ts"
+}

--- a/packages/cli/templates/catalog-entity-provider-module/src/EntityProvider.ts.hbs
+++ b/packages/cli/templates/catalog-entity-provider-module/src/EntityProvider.ts.hbs
@@ -1,0 +1,118 @@
+import {
+  EntityProvider,
+  EntityProviderConnection,
+} from '@backstage/plugin-catalog-node';
+import {
+  SchedulerService,
+  SchedulerServiceTaskRunner,
+  LoggerService,
+  readSchedulerServiceTaskScheduleDefinitionFromConfig,
+} from '@backstage/backend-plugin-api';
+import { Entity } from '@backstage/catalog-model';
+import { Config } from '@backstage/config';
+import { assertError } from '@backstage/errors';
+import * as uuid from 'uuid';
+
+export class {{pascalCaseId}}EntityProvider implements EntityProvider {
+  private readonly logger: LoggerService;
+  private readonly scheduleFn: () => Promise<void>;
+  private connection?: EntityProviderConnection;
+
+  static fromConfig(
+    config: Config,
+    options: {
+      logger: LoggerService;
+      scheduler: SchedulerService;
+    },
+  ): {{pascalCaseId}}EntityProvider {
+    const configSchedule = readSchedulerServiceTaskScheduleDefinitionFromConfig(
+      config.getConfig('catalog.providers.entityProvider.schedule'),
+    );
+
+    const taskRunner =
+      options.scheduler.createScheduledTaskRunner(configSchedule);
+
+    return new {{pascalCaseId}}EntityProvider(options.logger, taskRunner);
+  }
+
+  private constructor(
+    logger: LoggerService,
+    taskRunner: SchedulerServiceTaskRunner,
+  ) {
+    this.logger = logger.child({
+      target: this.getProviderName(),
+    });
+
+    this.scheduleFn = this.createScheduleFn(taskRunner);
+  }
+
+  getProviderName(): string {
+    return '{{pascalCaseId}}EntityProvider';
+  }
+
+  async connect(connection: EntityProviderConnection): Promise<void> {
+    this.connection = connection;
+    await this.scheduleFn();
+  }
+
+  private createScheduleFn(
+    taskRunner: SchedulerServiceTaskRunner,
+  ): () => Promise<void> {
+    return async () => {
+      const taskId = `${this.getProviderName()}:refresh`;
+      return taskRunner.run({
+        id: taskId,
+        fn: async () => {
+          const logger = this.logger.child({
+            class: {{pascalCaseId}}EntityProvider.prototype.constructor.name,
+            taskId,
+            taskInstanceId: uuid.v4(),
+          });
+
+          try {
+            await this.refresh(logger);
+          } catch (error) {
+            assertError(error);
+            logger.error(
+              `${this.getProviderName()} refresh failed, ${error}`,
+              error,
+            );
+          }
+        },
+      });
+    };
+  }
+
+  async refresh(logger: LoggerService) {
+    if (!this.connection) {
+      throw new Error('Not initialized');
+    }
+
+    logger.info(`Discovering entities for ${this.getProviderName()}`);
+
+    const entities: Entity[] = [];
+
+    if (entities.length > 0) {
+      logger.info(
+        `Attempting to apply mutations on ${
+          entities.length
+        } entities from the ${this.getProviderName()} provider`,
+      );
+      await this.connection.applyMutation({
+        type: 'full',
+        entities: entities.map(entity => ({
+          entity,
+          locationKey: this.getProviderName(),
+        })),
+      });
+    } else {
+      logger.warn(
+        `No entities discovered by ${this.getProviderName()}, mutation not being attempted this run`,
+      );
+    }
+
+    logger.info(
+      `Completed refreshing entities for the ${this.getProviderName()} provider`,
+    );
+  }
+}

--- a/packages/cli/templates/catalog-entity-provider-module/src/index.ts.hbs
+++ b/packages/cli/templates/catalog-entity-provider-module/src/index.ts.hbs
@@ -1,0 +1,8 @@
+/***/
+/**
+ * The {{id}} module for @backstage/plugin-catalog-backend.
+ *
+ * @packageDocumentation
+ */
+
+export { catalogModule{{pascalCaseId}}EntityProvider as default } from './module'

--- a/packages/cli/templates/catalog-entity-provider-module/src/module.ts.hbs
+++ b/packages/cli/templates/catalog-entity-provider-module/src/module.ts.hbs
@@ -1,0 +1,31 @@
+import {
+    coreServices,
+    createBackendModule,
+  } from '@backstage/backend-plugin-api';
+  import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
+  import { {{pascalCaseId}}EntityProvider } from './EntityProvider';
+  
+  export const catalogModule{{pascalCaseId}}EntityProvider = createBackendModule({
+    pluginId: 'catalog',
+    moduleId: '{{name}}-entity-provider',
+    register(env) {
+      env.registerInit({
+        deps: {
+          catalog: catalogProcessingExtensionPoint,
+          config: coreServices.rootConfig,
+          logger: coreServices.logger,
+          scheduler: coreServices.scheduler,
+          httpRouter: coreServices.httpRouter,
+        },
+        async init({ catalog, config, logger, scheduler }) {
+          const provider = {{pascalCaseId}}EntityProvider.fromConfig(config, {
+            logger: logger,
+            scheduler,
+          });
+  
+          catalog.addEntityProvider(provider);
+  
+        },
+      });
+    },
+  });

--- a/packages/cli/templates/catalog-entity-provider-module/tsconfig.json
+++ b/packages/cli/templates/catalog-entity-provider-module/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@backstage/cli/config/tsconfig.json",
+  "include": ["src"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist-types",
+    "rootDir": "."
+  }
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added `catalog-entity-provider-module` template, this should help make it easier to create an `EntityProvider` as this will create the proper backend module along with an `EntityProvider` starting point.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
