### PR TITLE
fix: database config is already prefixed

### DIFF
--- a/.changeset/selfish-spies-cough.md
+++ b/.changeset/selfish-spies-cough.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/backend-defaults': minor
+'@backstage/backend-defaults': patch
 ---
 
 Disabling database migrations now correctly uses the `backend.default.skipMigrations` config value.

--- a/.changeset/selfish-spies-cough.md
+++ b/.changeset/selfish-spies-cough.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': minor
+---
+
+Disabling database migrations now correctly uses the `backend.default.skipMigrations` config value.

--- a/packages/backend-defaults/src/entrypoints/database/DatabaseManager.test.ts
+++ b/packages/backend-defaults/src/entrypoints/database/DatabaseManager.test.ts
@@ -106,12 +106,8 @@ describe('DatabaseManagerImpl', () => {
     const impl = new DatabaseManagerImpl(
       new ConfigReader({
         client: 'pg',
-        backend: {
-          database: {
-            skipMigrations: true,
-            plugin: { plugin1: { skipMigrations: true } },
-          },
-        },
+        skipMigrations: true,
+        plugin: { plugin1: { skipMigrations: true } },
       }),
       {
         pg: connector,
@@ -139,9 +135,7 @@ describe('DatabaseManagerImpl', () => {
     const impl = new DatabaseManagerImpl(
       new ConfigReader({
         client: 'pg',
-        backend: {
-          database: { plugin: { plugin1: { skipMigrations: true } } },
-        },
+        plugin: { plugin1: { skipMigrations: true } },
       }),
       {
         pg: connector,
@@ -158,12 +152,8 @@ describe('DatabaseManagerImpl', () => {
     const impl2 = new DatabaseManagerImpl(
       new ConfigReader({
         client: 'pg',
-        backend: {
-          database: {
-            skipMigrations: true,
-            plugin: { plugin1: { skipMigrations: false } },
-          },
-        },
+        skipMigrations: true,
+        plugin: { plugin1: { skipMigrations: false } },
       }),
       {
         pg: connector,

--- a/packages/backend-defaults/src/entrypoints/database/DatabaseManager.ts
+++ b/packages/backend-defaults/src/entrypoints/database/DatabaseManager.ts
@@ -96,10 +96,8 @@ export class DatabaseManagerImpl {
 
     const skip =
       this.options?.migrations?.skip ??
-      this.config.getOptionalBoolean(
-        `backend.database.plugin.${pluginId}.skipMigrations`,
-      ) ??
-      this.config.getOptionalBoolean('backend.database.skipMigrations') ??
+      this.config.getOptionalBoolean(`plugin.${pluginId}.skipMigrations`) ??
+      this.config.getOptionalBoolean('skipMigrations') ??
       false;
 
     return { getClient, migrations: { skip } };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Noticed this while trying to migrate to 1.31. We're expecting the config to be double nested as `backend.database.backend.database.skipMigrations` to disable migrations which feels weird 😅 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
