### PR TITLE
fix(search): fix collator text formatting for entities without description

### DIFF
--- a/.changeset/three-parrots-dress.md
+++ b/.changeset/three-parrots-dress.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend-module-catalog': patch
+---
+
+Fix search collator text formatting for catalog entities without description

--- a/plugins/search-backend-module-catalog/src/collators/defaultCatalogCollatorEntityTransformer.test.ts
+++ b/plugins/search-backend-module-catalog/src/collators/defaultCatalogCollatorEntityTransformer.test.ts
@@ -147,5 +147,34 @@ describe('DefaultCatalogCollatorEntityTransformer', () => {
         owner: '',
       });
     });
+
+    it('sets text correctly when description is not provided', async () => {
+      const userEntityWithoutDescription = {
+        ...userEntity,
+        metadata: {
+          ...userEntity.metadata,
+          description: undefined,
+        },
+        spec: {
+          profile: {
+            ...userEntity.spec.profile,
+            email: undefined,
+          },
+        },
+      };
+
+      const document = defaultCatalogCollatorEntityTransformer(
+        userEntityWithoutDescription,
+      );
+
+      expect(document).toMatchObject({
+        title: userEntity.metadata.name,
+        text: userEntity.spec.profile.displayName,
+        namespace: 'default',
+        componentType: 'other',
+        lifecycle: '',
+        owner: '',
+      });
+    });
   });
 });

--- a/plugins/search-backend-module-catalog/src/collators/defaultCatalogCollatorEntityTransformer.ts
+++ b/plugins/search-backend-module-catalog/src/collators/defaultCatalogCollatorEntityTransformer.ts
@@ -19,7 +19,9 @@ import { CatalogCollatorEntityTransformer } from './CatalogCollatorEntityTransfo
 
 const getDocumentText = (entity: Entity): string => {
   const documentTexts: string[] = [];
-  documentTexts.push(entity.metadata.description || '');
+  if (entity.metadata.description) {
+    documentTexts.push(entity.metadata.description);
+  }
 
   if (isUserEntity(entity) || isGroupEntity(entity)) {
     if (entity.spec?.profile?.displayName) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

User and group entities that don't have a description show incorrectly in the UI if only 1 of `displayName` or `email` is populated. For example:
- A user that has a `displayName`, but no `email` or `description` will show subtitle text in the UI search results as: 
```
 : Stephen Glass
```

In this case, the result should just be 
```
Stephen Glass
```

This PR fixes the formatting so it will only add description to the collated text only if it exists.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
