### PR TITLE
Update incorrect comments about optional app options for createApp(...)

### DIFF
--- a/packages/app-defaults/src/createApp.tsx
+++ b/packages/app-defaults/src/createApp.tsx
@@ -86,7 +86,7 @@ export type OptionalAppOptions = {
   /**
    * A set of components to override the default components with.
    *
-   * The override is applied for each icon individually.
+   * The override is applied for each app component individually.
    *
    * @public
    */


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I fixed an incorrect comment for [OptionalAppOptions](https://github.com/backstage/backstage/blob/cfb9a94dbed5d70b6d6669d8fb8bd42bcbcb72d5/packages/app-defaults/src/createApp.tsx#L89) for createApp

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
  - Not needed [See here](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets:~:text=Changesets%20are%20also%20not%20needed%20for%20changes%20that%20do%20not%20affect%20the%20published%20version%20of%20each%20package%2C%20for%20example%20changes%20to%20tests%20or%20in%2Dline%20source%20code%20comments.)
- [x] Added or updated documentation
  - Checked through existing documentation that shows usage of createApp(...). Might have missed something minor. So,See attached file of grepped search results
[createApp.txt](https://github.com/user-attachments/files/17580520/createApp.txt)
You can use that file from the docs folder like so. `backstage/docs$ vim -q createApp.txt` and then `:cn` or `:cp`
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
