### PR TITLE
fix(core-components): content component can now be rendered as other element than article

### DIFF
--- a/.changeset/thirty-needles-pay.md
+++ b/.changeset/thirty-needles-pay.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Added a way to render <Content /> component as other element instead of article.

--- a/packages/core-components/src/layout/Content/Content.tsx
+++ b/packages/core-components/src/layout/Content/Content.tsx
@@ -51,6 +51,7 @@ type Props = {
   stretch?: boolean;
   noPadding?: boolean;
   className?: string;
+  as?: React.ElementType;
 };
 
 /**
@@ -59,13 +60,22 @@ type Props = {
  * @public
  *
  */
-
 export function Content(props: PropsWithChildren<Props>) {
-  const { className, stretch, noPadding, children, ...restProps } = props;
+  const {
+    className,
+    stretch,
+    noPadding,
+    children,
+    as: asElement,
+    ...restProps
+  } = props;
 
   const classes = useStyles();
+
+  const Element = asElement || 'article';
+
   return (
-    <article
+    <Element
       {...restProps}
       className={classNames(classes.root, className, {
         [classes.stretch]: stretch,
@@ -73,6 +83,6 @@ export function Content(props: PropsWithChildren<Props>) {
       })}
     >
       {children}
-    </article>
+    </Element>
   );
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Content component can now be passed an element string as a prop to render it as other element than article.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
