### PR TITLE
Fixes #27325 Stitch entity for which target of relationship has changed

### DIFF
--- a/.changeset/short-pots-remember.md
+++ b/.changeset/short-pots-remember.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Fixed an issue where entities would not be marked for restitching if only the target of a relationship changed.

--- a/plugins/catalog-backend/src/processing/DefaultCatalogProcessingEngine.ts
+++ b/plugins/catalog-backend/src/processing/DefaultCatalogProcessingEngine.ts
@@ -295,7 +295,7 @@ export class DefaultCatalogProcessingEngine {
                 });
               oldRelationSources = new Map(
                 previous.relations.map(r => [
-                  `${r.source_entity_ref}:${r.type}`,
+                  `${r.source_entity_ref}:${r.type}->${r.target_entity_ref}`,
                   r.source_entity_ref,
                 ]),
               );
@@ -304,7 +304,11 @@ export class DefaultCatalogProcessingEngine {
             const newRelationSources = new Map<string, string>(
               result.relations.map(relation => {
                 const sourceEntityRef = stringifyEntityRef(relation.source);
-                return [`${sourceEntityRef}:${relation.type}`, sourceEntityRef];
+                const targetEntityRef = stringifyEntityRef(relation.target);
+                return [
+                  `${sourceEntityRef}:${relation.type}->${targetEntityRef}`,
+                  sourceEntityRef,
+                ];
               }),
             );
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #27325. Fix a bug where if the target of the relationship changes, the entity now be restitched.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
