### PR TITLE
Cleaning up event subscriptions after the max age window

### DIFF
--- a/.changeset/silly-kiwis-destroy.md
+++ b/.changeset/silly-kiwis-destroy.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-events-backend': patch
+---
+
+Cleaning up event subscriptions after the max age window

--- a/plugins/events-backend/src/service/hub/DatabaseEventBusStore.ts
+++ b/plugins/events-backend/src/service/hub/DatabaseEventBusStore.ts
@@ -602,7 +602,9 @@ export class DatabaseEventBusStore implements EventBusStore {
       if (minId === null) {
         // No events left, remove all subscribers. This can happen if no events
         // are published within the max age window.
-        subscriberCount = await this.#db(TABLE_SUBSCRIPTIONS).delete();
+        subscriberCount = await this.#db(TABLE_SUBSCRIPTIONS)
+          .where('updated_at', '<', new Date(Date.now() - this.#windowMaxAge))
+          .delete();
       } else {
         subscriberCount = await this.#db(TABLE_SUBSCRIPTIONS)
           .delete()


### PR DESCRIPTION
## Hey, I just made a Pull Request!

During the test of the issue with WebSockets (when some of WS messages are lost) on the deployment with multiple nodes I found that the logic which has to distribute events across the nodes doesn't work always correctly.

Namely, if you'll run your cluster when in your database is yet no events and no subscriptions, WS sends the request to store the subscription, and it stored. But after few seconds cleanup job will remove it, because `event_bus_events` is empty yet. 
So this logic will work only if *subscription* and *event(s)* will be saved in the database within few seconds.

Though instead it should wait with cleaning up as the comment properly says:

        // No events left, remove all subscribers. This can happen if no events
        // are published within the max age window.

This PR just does what it says.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
