### PR TITLE
Add support for custom filters in Scaffolder Page

### DIFF
--- a/.changeset/moody-chicken-decide.md
+++ b/.changeset/moody-chicken-decide.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-scaffolder-react': minor
+'@backstage/plugin-scaffolder': minor
+---
+
+Added support for custom filters in Scaffolder page

--- a/.changeset/moody-chicken-decide.md
+++ b/.changeset/moody-chicken-decide.md
@@ -1,6 +1,5 @@
 ---
 '@backstage/plugin-scaffolder-react': minor
-'@backstage/plugin-scaffolder': minor
 ---
 
 Added support for custom filters in Scaffolder page

--- a/docs/features/software-templates/writing-custom-filters.md
+++ b/docs/features/software-templates/writing-custom-filters.md
@@ -1,0 +1,143 @@
+---
+id: writing-custom-filters
+title: Writing Custom Filters
+description: How to write your own filters for software templates
+---
+
+By default, the scaffolder page provides a set of filters that you can use to filter the available software templates. However, you can also write your own filters based on custom kinds and properties, and mix and match them with the default filters.
+
+## Writing a Custom Filter
+
+Writing a custom filter for the scaffolder is almost identical to [writing custom filters for the catalog](/docs/features/software-catalog/catalog-customization.md/#customize-filters).
+
+The following example will show you how to write a custom filter to split the default tag filter into multiple customized categories. Instead of having a single tag filter, we can have one filter for Languages, another for AWS Services and a third for Status.
+
+First, we create a new component called `CustomEntityTagPicker` that will render a single tag picker for a specific category. We will use this component in `App.tsx` to override the default filters.
+
+Then, we add a `CustomEntityTagFilter` which implements the `EntityFilter` interface. The `filterEntity` implementation will depend on the custom filter logic you want to apply. We also need to create a new type `CustomFilters` that extends the `DefaultEntityFilters` and adds the custom filter we created.
+
+Finally, we use the `useEntityList` hook to get the current filters and add/update the list of filters when the user interacts with our custom filter. We can then plug in the custom tags into the view.
+
+```tsx title="src/components/scaffolder/CustomEntityTagPicker.tsx"
+import React from 'react';
+import {
+  DefaultEntityFilters,
+  EntityFilter,
+  useEntityList,
+} from '@backstage/plugin-catalog-react';
+import { Entity } from '@backstage/catalog-model';
+import Checkbox from '@material-ui/core/Checkbox';
+import FormControl from '@material-ui/core/FormControl';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import FormGroup from '@material-ui/core/FormGroup';
+import Typography from '@material-ui/core/Typography';
+
+export type EntityTagPickerProps = {
+  label: string;
+  allowedTags: string[];
+  showCounts?: boolean;
+};
+
+class CustomEntityTagFilter implements EntityFilter {
+  constructor(readonly values: string[]) {}
+
+  filterEntity(entity: Entity): boolean {
+    const entityTags = entity.metadata.tags ?? [];
+    return this.values.every(tag => entityTags.includes(tag));
+  }
+}
+
+export type CustomFilters = DefaultEntityFilters & {
+  customTags: CustomEntityTagFilter;
+};
+
+export const CustomEntityTagPicker = (props: EntityTagPickerProps) => {
+  const {
+    filters: { customTags },
+    updateFilters,
+  } = useEntityList<CustomFilters>();
+
+  function onChange(value: string) {
+    const newTags = customTags?.values.includes(value)
+      ? customTags.values.filter(tag => tag !== value)
+      : [...(customTags?.values ?? []), value];
+    updateFilters({
+      customTags: newTags.length
+        ? new CustomEntityTagFilter(newTags)
+        : undefined,
+    });
+  }
+  const allowedTags = props.allowedTags.map(tag =>
+    tag.toLocaleLowerCase('en-US'),
+  );
+
+  return (
+    <FormControl component="fieldset">
+      <Typography variant="button">{props.label}</Typography>
+      <FormGroup>
+        {allowedTags.map(tier => (
+          <FormControlLabel
+            key={tier}
+            control={
+              <Checkbox
+                checked={customTags?.values.includes(tier)}
+                onChange={() => onChange(tier)}
+              />
+            }
+            label={`${tier.charAt(0).toLocaleUpperCase('en-US')}${tier.slice(
+              1,
+            )}`}
+          />
+        ))}
+      </FormGroup>
+    </FormControl>
+  );
+};
+```
+
+Once we have the `CustomEntityTagPicker` component, we can use it in `App.tsx` to override the default filters. We can also add other filters like `EntityTagPicker` and `EntityOwnerPicker` to the list of filters.
+
+:::note Note
+
+The `EntityKindPicker` is required in order to display all the existing templates. It is hidden by default in order to improve the user experience.
+
+:::
+
+```tsx title="src/App.tsx"
+// ...
+<Route
+  path="/create"
+  element={
+    <ScaffolderPage
+      defaultPreviewTemplate={defaultPreviewTemplate}
+      groups={[
+        {
+          title: 'Recommended',
+          filter: entity =>
+            entity?.metadata?.tags?.includes('recommended') ?? false,
+        },
+      ]}
+      {/* highlight-add-start */}
+      overrideFilters={
+        <>
+          <EntityKindPicker initialFilter="template" hidden />
+          <EntityTagPicker />
+          <CustomEntityTagPicker label='languages' allowedTags={['React', 'Java', 'Go']} />
+          <CustomEntityTagPicker label='aws services' allowedTags={['AWS-Lambda', 's3', 'Fargate']} />
+          <CustomEntityTagPicker label='status' allowedTags={['Experimental', 'First Class', 'Community Contributed']} />
+          <EntityOwnerPicker />
+        </>
+      }
+      {/* highlight-add-end */}
+    />
+  }
+>
+  <ScaffolderFieldExtensions>
+    <DelayingComponentFieldExtension />
+  </ScaffolderFieldExtensions>
+  <ScaffolderLayouts>
+    <TwoColumnLayout />
+  </ScaffolderLayouts>
+</Route>
+// ...
+```

--- a/docs/features/software-templates/writing-custom-filters.md
+++ b/docs/features/software-templates/writing-custom-filters.md
@@ -8,7 +8,7 @@ By default, the scaffolder page provides a set of filters that you can use to fi
 
 ## Writing a Custom Filter
 
-Writing a custom filter for the scaffolder is almost identical to [writing custom filters for the catalog](https://github.com/backstage/backstage/blob/master/docs/features/software-catalog/catalog-customization.md/#customize-filters).
+Writing a custom filter for the scaffolder is almost identical to [writing custom filters for the catalog](docs/features/software-catalog/catalog-customization.md/#customize-filters).
 
 The following example will show you how to write a custom filter to split the default tag filter into multiple customized categories. Instead of having a single tag filter, we can have one filter for Languages, another for AWS Services and a third for Status.
 

--- a/docs/features/software-templates/writing-custom-filters.md
+++ b/docs/features/software-templates/writing-custom-filters.md
@@ -8,7 +8,7 @@ By default, the scaffolder page provides a set of filters that you can use to fi
 
 ## Writing a Custom Filter
 
-Writing a custom filter for the scaffolder is almost identical to [writing custom filters for the catalog](docs/features/software-catalog/catalog-customization.md/#customize-filters).
+Writing a custom filter for the scaffolder is almost identical to [writing custom filters for the catalog](https://backstage.io/docs/features/software-catalog/catalog-customization/#customize-filters).
 
 The following example will show you how to write a custom filter to split the default tag filter into multiple customized categories. Instead of having a single tag filter, we can have one filter for Languages, another for AWS Services and a third for Status.
 

--- a/docs/features/software-templates/writing-custom-filters.md
+++ b/docs/features/software-templates/writing-custom-filters.md
@@ -8,7 +8,7 @@ By default, the scaffolder page provides a set of filters that you can use to fi
 
 ## Writing a Custom Filter
 
-Writing a custom filter for the scaffolder is almost identical to [writing custom filters for the catalog](/docs/features/software-catalog/catalog-customization.md/#customize-filters).
+Writing a custom filter for the scaffolder is almost identical to [writing custom filters for the catalog](https://github.com/backstage/backstage/blob/master/docs/features/software-catalog/catalog-customization.md/#customize-filters).
 
 The following example will show you how to write a custom filter to split the default tag filter into multiple customized categories. Instead of having a single tag filter, we can have one filter for Languages, another for AWS Services and a third for Status.
 

--- a/docs/features/software-templates/writing-custom-filters.md
+++ b/docs/features/software-templates/writing-custom-filters.md
@@ -72,25 +72,27 @@ export const CustomEntityTagPicker = (props: EntityTagPickerProps) => {
   );
 
   return (
-    <FormControl component="fieldset">
-      <Typography variant="button">{props.label}</Typography>
-      <FormGroup>
-        {allowedTags.map(tier => (
-          <FormControlLabel
-            key={tier}
-            control={
-              <Checkbox
-                checked={customTags?.values.includes(tier)}
-                onChange={() => onChange(tier)}
-              />
-            }
-            label={`${tier.charAt(0).toLocaleUpperCase('en-US')}${tier.slice(
-              1,
-            )}`}
-          />
-        ))}
-      </FormGroup>
-    </FormControl>
+    <Box display="flex" flexDirection="column">
+      <FormControl component="fieldset">
+        <Typography variant="button">{props.label}</Typography>
+        <FormGroup>
+          {allowedTags.map(tier => (
+            <FormControlLabel
+              key={tier}
+              control={
+                <Checkbox
+                  checked={customTags?.values.includes(tier)}
+                  onChange={() => onChange(tier)}
+                />
+              }
+              label={`${tier.charAt(0).toLocaleUpperCase('en-US')}${tier.slice(
+                1,
+              )}`}
+            />
+          ))}
+        </FormGroup>
+      </FormControl>
+    </Box>
   );
 };
 ```

--- a/plugins/scaffolder-react/report.api.md
+++ b/plugins/scaffolder-react/report.api.md
@@ -72,6 +72,11 @@ export function createScaffolderFieldExtension<
 ): Extension<FieldExtensionComponent<TReturnValue, TInputProps>>;
 
 // @public
+export function createScaffolderFilter(
+  options: FilterOptions,
+): Extension<FilterTemplate>;
+
+// @public
 export function createScaffolderLayout<TInputProps = unknown>(
   options: LayoutOptions,
 ): Extension<LayoutComponent<TInputProps>>;
@@ -137,6 +142,21 @@ export interface FieldSchema<TReturn, TUiOptions> {
   // @deprecated (undocumented)
   readonly uiOptionsType: TUiOptions;
 }
+
+// @public
+export interface FilterOptions<P = any> {
+  // (undocumented)
+  component: FilterTemplate<P>;
+  // (undocumented)
+  name: string;
+}
+
+// @public
+export type FilterTemplate<T = any> = React_2.ComponentType<
+  {
+    onChange: (value: any) => void;
+  } & T
+>;
 
 // @public
 export type FormProps = Pick<
@@ -492,6 +512,11 @@ export type ScaffolderTaskStatus =
   | 'skipped';
 
 // @public
+export const ScaffolderTemplateFilter: React_2.ComponentType<
+  React_2.PropsWithChildren<{}>
+>;
+
+// @public
 export interface ScaffolderUseTemplateSecrets {
   // (undocumented)
   secrets: Record<string, string>;
@@ -544,6 +569,11 @@ export type TemplateParameterSchema = {
 export const useCustomFieldExtensions: <
   TComponentDataType = FieldExtensionOptions,
 >(
+  outlet: React.ReactNode,
+) => TComponentDataType[];
+
+// @public
+export const useCustomFilters: <TComponentDataType = FilterOptions<any>>(
   outlet: React.ReactNode,
 ) => TComponentDataType[];
 

--- a/plugins/scaffolder-react/src/filters/createScaffolderFilter.ts
+++ b/plugins/scaffolder-react/src/filters/createScaffolderFilter.ts
@@ -17,17 +17,32 @@ import { attachComponentData, Extension } from '@backstage/core-plugin-api';
 import { FILTERS_KEY, FILTERS_WRAPPER_KEY } from './keys';
 import React from 'react';
 
+/**
+ * A filter template that can be used to create custom filters.
+ *
+ * @public
+ */
 export type FilterTemplate<T = any> = React.ComponentType<
   {
     onChange: (value: any) => void;
   } & T
 >;
 
+/**
+ * Options for creating a filter.
+ *
+ * @public
+ */
 export interface FilterOptions<P = any> {
   name: string;
   component: FilterTemplate<P>;
 }
 
+/**
+ * Method for creating custom filters that can be used in the scaffolder frontend form.
+ *
+ * @public
+ */
 export function createScaffolderFilter(
   options: FilterOptions,
 ): Extension<FilterTemplate> {
@@ -40,6 +55,11 @@ export function createScaffolderFilter(
   };
 }
 
+/**
+ * The wrapping component for defining scaffolder filters as children
+ *
+ * @public
+ */
 export const ScaffolderTemplateFilter: React.ComponentType<
   React.PropsWithChildren<{}>
 > = (): JSX.Element | null => null;

--- a/plugins/scaffolder-react/src/filters/createScaffolderFilter.ts
+++ b/plugins/scaffolder-react/src/filters/createScaffolderFilter.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { attachComponentData, Extension } from '@backstage/core-plugin-api';
+import { FILTERS_KEY, FILTERS_WRAPPER_KEY } from './keys';
+import React from 'react';
+
+export type FilterTemplate<T = any> = React.ComponentType<
+  {
+    onChange: (value: any) => void;
+  } & T
+>;
+
+export interface FilterOptions<P = any> {
+  name: string;
+  component: FilterTemplate<P>;
+}
+
+export function createScaffolderFilter(
+  options: FilterOptions,
+): Extension<FilterTemplate> {
+  return {
+    expose() {
+      const FilterDataHolder: any = () => null;
+      attachComponentData(FilterDataHolder, FILTERS_KEY, options);
+      return FilterDataHolder;
+    },
+  };
+}
+
+export const ScaffolderTemplateFilter: React.ComponentType<
+  React.PropsWithChildren<{}>
+> = (): JSX.Element | null => null;
+
+attachComponentData(ScaffolderTemplateFilter, FILTERS_WRAPPER_KEY, true);

--- a/plugins/scaffolder-react/src/filters/index.ts
+++ b/plugins/scaffolder-react/src/filters/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 The Backstage Authors
+ * Copyright 2024 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-export { useCustomFieldExtensions } from './useCustomFieldExtensions';
-export { useCustomLayouts } from './useCustomLayouts';
-export { useCustomFilters } from './useCustomFilters';
 export {
-  useTaskEventStream,
-  type TaskStream,
-  type ScaffolderStep,
-} from './useEventStream';
+  ScaffolderTemplateFilter,
+  createScaffolderFilter,
+} from './createScaffolderFilter';
+export type { FilterTemplate, FilterOptions } from './createScaffolderFilter';

--- a/plugins/scaffolder-react/src/filters/keys.ts
+++ b/plugins/scaffolder-react/src/filters/keys.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 The Backstage Authors
+ * Copyright 2024 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,12 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-export { useCustomFieldExtensions } from './useCustomFieldExtensions';
-export { useCustomLayouts } from './useCustomLayouts';
-export { useCustomFilters } from './useCustomFilters';
-export {
-  useTaskEventStream,
-  type TaskStream,
-  type ScaffolderStep,
-} from './useEventStream';
+export const FILTERS_KEY = 'scaffolder.filters.v1';
+export const FILTERS_WRAPPER_KEY = 'scaffolder.filters.wrapper.v1';

--- a/plugins/scaffolder-react/src/hooks/useCustomFilters.ts
+++ b/plugins/scaffolder-react/src/hooks/useCustomFilters.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useElementFilter } from '@backstage/core-plugin-api';
+import { FILTERS_KEY, FILTERS_WRAPPER_KEY } from '../filters/keys';
+import { FilterOptions } from '../filters';
+
+/**
+ * Hook that returns all custom field extensions from the current outlet.
+ * @public
+ */
+export const useCustomFilters = <TComponentDataType = FilterOptions>(
+  outlet: React.ReactNode,
+) => {
+  return useElementFilter(outlet, elements =>
+    elements
+      .selectByComponentData({
+        key: FILTERS_WRAPPER_KEY,
+      })
+      .findComponentData<TComponentDataType>({
+        key: FILTERS_KEY,
+      }),
+  );
+};

--- a/plugins/scaffolder-react/src/hooks/useCustomFilters.ts
+++ b/plugins/scaffolder-react/src/hooks/useCustomFilters.ts
@@ -18,7 +18,7 @@ import { FILTERS_KEY, FILTERS_WRAPPER_KEY } from '../filters/keys';
 import { FilterOptions } from '../filters';
 
 /**
- * Hook that returns all custom field extensions from the current outlet.
+ * Hook that returns all custom filter extensions from the current outlet.
  * @public
  */
 export const useCustomFilters = <TComponentDataType = FilterOptions>(

--- a/plugins/scaffolder-react/src/index.ts
+++ b/plugins/scaffolder-react/src/index.ts
@@ -22,3 +22,4 @@ export * from './api';
 export * from './hooks';
 export * from './layouts';
 export * from './utils';
+export * from './filters';

--- a/plugins/scaffolder/report-alpha.api.md
+++ b/plugins/scaffolder/report-alpha.api.md
@@ -12,6 +12,7 @@ import { ExtensionDefinition } from '@backstage/frontend-plugin-api';
 import { ExtensionInput } from '@backstage/frontend-plugin-api';
 import { ExternalRouteRef } from '@backstage/frontend-plugin-api';
 import { FieldExtensionOptions } from '@backstage/plugin-scaffolder-react';
+import { FilterOptions } from '@backstage/plugin-scaffolder-react';
 import { FormField } from '@internal/scaffolder';
 import type { FormProps as FormProps_2 } from '@rjsf/core';
 import { FormProps as FormProps_3 } from '@backstage/plugin-scaffolder-react';
@@ -362,7 +363,7 @@ export type TemplateListPageProps = {
     title?: string;
     subtitle?: string;
   };
-  overrideFilters?: React_2.ReactNode;
+  additionalFilters?: FilterOptions[];
 };
 
 // @alpha (undocumented)

--- a/plugins/scaffolder/report-alpha.api.md
+++ b/plugins/scaffolder/report-alpha.api.md
@@ -362,6 +362,7 @@ export type TemplateListPageProps = {
     title?: string;
     subtitle?: string;
   };
+  overrideFilters?: React_2.ReactNode;
 };
 
 // @alpha (undocumented)

--- a/plugins/scaffolder/report.api.md
+++ b/plugins/scaffolder/report.api.md
@@ -500,6 +500,7 @@ export type RouterProps = {
     actions?: boolean;
     tasks?: boolean;
   };
+  overrideFilters?: React_2.ReactNode;
 };
 
 // @public @deprecated (undocumented)

--- a/plugins/scaffolder/src/alpha/components/TemplateListPage/TemplateListPage.tsx
+++ b/plugins/scaffolder/src/alpha/components/TemplateListPage/TemplateListPage.tsx
@@ -78,6 +78,7 @@ export type TemplateListPageProps = {
     title?: string;
     subtitle?: string;
   };
+  overrideFilters?: React.ReactNode;
 };
 
 const createGroupsWithOther = (
@@ -191,15 +192,21 @@ export const TemplateListPage = (props: TemplateListPageProps) => {
 
           <CatalogFilterLayout>
             <CatalogFilterLayout.Filters>
-              <EntitySearchBar />
-              <EntityKindPicker initialFilter="template" hidden />
-              <UserListPicker
-                initialFilter="all"
-                availableFilters={['all', 'starred']}
-              />
-              <TemplateCategoryPicker />
-              <EntityTagPicker />
-              <EntityOwnerPicker />
+              {props.overrideFilters ? (
+                props.overrideFilters
+              ) : (
+                <>
+                  <EntitySearchBar />
+                  <EntityKindPicker initialFilter="template" hidden />
+                  <UserListPicker
+                    initialFilter="all"
+                    availableFilters={['all', 'starred']}
+                  />
+                  <TemplateCategoryPicker />
+                  <EntityTagPicker />
+                  <EntityOwnerPicker />
+                </>
+              )}
             </CatalogFilterLayout.Filters>
             <CatalogFilterLayout.Content>
               <TemplateGroups

--- a/plugins/scaffolder/src/alpha/components/TemplateListPage/TemplateListPage.tsx
+++ b/plugins/scaffolder/src/alpha/components/TemplateListPage/TemplateListPage.tsx
@@ -52,7 +52,10 @@ import {
   viewTechDocRouteRef,
 } from '../../../routes';
 import { parseEntityRef, stringifyEntityRef } from '@backstage/catalog-model';
-import { TemplateGroupFilter } from '@backstage/plugin-scaffolder-react';
+import {
+  FilterOptions,
+  TemplateGroupFilter,
+} from '@backstage/plugin-scaffolder-react';
 import {
   TranslationFunction,
   useTranslationRef,
@@ -78,7 +81,7 @@ export type TemplateListPageProps = {
     title?: string;
     subtitle?: string;
   };
-  overrideFilters?: React.ReactNode;
+  additionalFilters?: FilterOptions[];
 };
 
 const createGroupsWithOther = (
@@ -192,21 +195,20 @@ export const TemplateListPage = (props: TemplateListPageProps) => {
 
           <CatalogFilterLayout>
             <CatalogFilterLayout.Filters>
-              {props.overrideFilters ? (
-                props.overrideFilters
-              ) : (
-                <>
-                  <EntitySearchBar />
-                  <EntityKindPicker initialFilter="template" hidden />
-                  <UserListPicker
-                    initialFilter="all"
-                    availableFilters={['all', 'starred']}
-                  />
-                  <TemplateCategoryPicker />
-                  <EntityTagPicker />
-                  <EntityOwnerPicker />
-                </>
-              )}
+              <>
+                <EntitySearchBar />
+                <EntityKindPicker initialFilter="template" hidden />
+                <UserListPicker
+                  initialFilter="all"
+                  availableFilters={['all', 'starred']}
+                />
+                <TemplateCategoryPicker />
+                <EntityTagPicker />
+                <EntityOwnerPicker />
+                {props.additionalFilters?.map(filter => (
+                  <>{React.createElement(filter.component)}</>
+                ))}
+              </>
             </CatalogFilterLayout.Filters>
             <CatalogFilterLayout.Content>
               <TemplateGroups

--- a/plugins/scaffolder/src/components/Router/Router.tsx
+++ b/plugins/scaffolder/src/components/Router/Router.tsx
@@ -26,6 +26,7 @@ import {
   ScaffolderTaskOutput,
   SecretsContextProvider,
   useCustomFieldExtensions,
+  useCustomFilters,
   useCustomLayouts,
 } from '@backstage/plugin-scaffolder-react';
 
@@ -134,6 +135,8 @@ export const Router = (props: PropsWithChildren<RouterProps>) => {
 
   const customLayouts = useCustomLayouts(outlet);
 
+  const customFilters = useCustomFilters(outlet);
+
   return (
     <Routes>
       <Route
@@ -145,7 +148,7 @@ export const Router = (props: PropsWithChildren<RouterProps>) => {
             groups={props.groups}
             templateFilter={props.templateFilter}
             headerOptions={props.headerOptions}
-            overrideFilters={props.overrideFilters}
+            additionalFilters={customFilters}
           />
         }
       />

--- a/plugins/scaffolder/src/components/Router/Router.tsx
+++ b/plugins/scaffolder/src/components/Router/Router.tsx
@@ -97,6 +97,7 @@ export type RouterProps = {
     /** Whether to show a link to the tasks page */
     tasks?: boolean;
   };
+  overrideFilters?: React.ReactNode;
 };
 
 /**
@@ -144,6 +145,7 @@ export const Router = (props: PropsWithChildren<RouterProps>) => {
             groups={props.groups}
             templateFilter={props.templateFilter}
             headerOptions={props.headerOptions}
+            overrideFilters={props.overrideFilters}
           />
         }
       />


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Related issue: #27313 

Please let me know which tests I should fix up if necessary! Also, I'm not sure if the changeset is valid or if I should re-generate it.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
### Changelog
- Added support for overriding default filters in the Scaffolder page
- Added custom tags filter example to documentation

The example I added allows splitting the Tags filter into multiple separate filters based on user-defined categories. It makes it easier to filter through lengthy template collections.

![image](https://github.com/user-attachments/assets/2554d845-27dc-4a2a-802f-a9fa05b42345)

Overriding the filters also lets users filter on custom template attributes, as described in the [Catalog Customization docs](https://github.com/backstage/backstage/blob/master/docs/features/software-catalog/catalog-customization.md/#customize-filters).

When the filters are not overridden (via `overrideFilters` prop), the previously availble default filters will be shown instead.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Thank you!