### PR TITLE
Catalog react owner text overflow

### DIFF
--- a/.changeset/healthy-planets-confess.md
+++ b/.changeset/healthy-planets-confess.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Fixed bug in `EntityDisplayName` where text was overflowing.

--- a/plugins/catalog-react/src/components/EntityDisplayName/EntityDisplayName.tsx
+++ b/plugins/catalog-react/src/components/EntityDisplayName/EntityDisplayName.tsx
@@ -77,7 +77,16 @@ export const EntityDisplayName = (
   );
 
   // The innermost "body" content
-  let content = <>{primaryTitle}</>;
+  let content = (
+    <div
+      style={{
+        overflow: 'hidden',
+        wordBreak: 'break-word',
+      }}
+    >
+      {primaryTitle}
+    </div>
+  );
 
   // Optionally an icon, and wrapper around them both
   content = (


### PR DESCRIPTION
PR for the issue :[26990](https://github.com/backstage/backstage/issues/26990)

With this fix the text will not overflow as we can see in the below screenshot .

<img width="1710" alt="Screenshot 2024-11-04 at 2 33 21 PM" src="https://github.com/user-attachments/assets/740ed82e-a69c-4d8e-8ef0-e00f831acaaa">
