### PR TITLE
feat(lint): Add `--max-warnings -1` option to package lint

### DIFF
--- a/.changeset/loud-plants-dream.md
+++ b/.changeset/loud-plants-dream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Add `--max-warnings -1` support to `backstage-cli package lint`

--- a/docs/tooling/cli/03-commands.md
+++ b/docs/tooling/cli/03-commands.md
@@ -92,9 +92,11 @@ Usage: backstage-cli repo lint [options]
 Lint all packages in the project
 
 Options:
-  --format <format>  Lint report output format (default: "eslint-formatter-friendly")
-  --since <ref>      Only lint packages that changed since the specified ref
-  --fix              Attempt to automatically fix violations
+  --format <format>         Lint report output format (default: "eslint-formatter-friendly")
+  --since <ref>             Only lint packages that changed since the specified ref
+  --successCache            Enable success caching, which skips running tests for unchanged packages that were successful in the previous run
+  --successCacheDir <path>  Set the success cache location, (default: node_modules/.cache/backstage-cli)
+  --fix                     Attempt to automatically fix violations
 ```
 
 ## repo test
@@ -185,8 +187,9 @@ Usage: backstage-cli package lint [options]
 Lint a package
 
 Options:
-  --format <format>  Lint report output format (default: "eslint-formatter-friendly")
-  --fix              Attempt to automatically fix violations
+  --format <format>        Lint report output format (default: "eslint-formatter-friendly")
+  --fix                    Attempt to automatically fix violations
+  --max-warnings <number>  Fail if more than this number of warnings. -1 allows warnings. (default: 0)
 ```
 
 ## package test

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -175,7 +175,7 @@ export function registerScriptCommand(program: Command) {
     .option('--fix', 'Attempt to automatically fix violations')
     .option(
       '--max-warnings <number>',
-      'Fail if more than this number of warnings (default: 0)',
+      'Fail if more than this number of warnings. -1 allows warnings. (default: 0)',
     )
     .description('Lint a package')
     .action(lazy(() => import('./lint').then(m => m.default)));

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -30,11 +30,13 @@ export default async (directories: string[], opts: OptionValues) => {
   );
 
   const maxWarnings = opts.maxWarnings ?? 0;
+  const ignoreWarnings = +maxWarnings === -1;
 
   const failed =
     results.some(r => r.errorCount > 0) ||
-    results.reduce((current, next) => current + next.warningCount, 0) >
-      maxWarnings;
+    (!ignoreWarnings &&
+      results.reduce((current, next) => current + next.warningCount, 0) >
+        maxWarnings);
 
   if (opts.fix) {
     await ESLint.outputFixes(results);

--- a/packages/cli/src/commands/repo/lint.ts
+++ b/packages/cli/src/commands/repo/lint.ts
@@ -199,11 +199,14 @@ export async function command(opts: OptionValues, cmd: Command): Promise<void> {
         }
 
         const maxWarnings = lintOptions?.maxWarnings ?? 0;
+        const ignoreWarnings = +maxWarnings === -1;
+
         const resultText = formatter.format(results) as string;
         const failed =
           results.some(r => r.errorCount > 0) ||
-          results.reduce((current, next) => current + next.warningCount, 0) >
-            maxWarnings;
+          (!ignoreWarnings &&
+            results.reduce((current, next) => current + next.warningCount, 0) >
+              maxWarnings);
 
         return {
           relativeDir,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add `--max-warnings -1` support to `backstage-cli package lint`. This reflects ESLint behaviour.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))