### PR TITLE
feat:add pagination to api-docs DefaultApiEplorerPage

### DIFF
--- a/.changeset/selfish-boxes-jog.md
+++ b/.changeset/selfish-boxes-jog.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-api-docs': minor
+---
+
+added pagination to defaultApiExplorerPage

--- a/.changeset/silver-kings-sort.md
+++ b/.changeset/silver-kings-sort.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-gitlab': minor
+---
+
+Extended the configuration with the includeArchivedRepos property, which allows including repositories when the project is archived.

--- a/.changeset/silver-kings-sort.md
+++ b/.changeset/silver-kings-sort.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend-module-gitlab': minor
 ---
 
-Extended the configuration with the includeArchivedRepos property, which allows including repositories when the project is archived.
+Extended the configuration with the `includeArchivedRepos` property, which allows including repositories when the project is archived.

--- a/docs/integrations/gitlab/discovery.md
+++ b/docs/integrations/gitlab/discovery.md
@@ -150,6 +150,7 @@ catalog:
         branch: main # Optional. Used to discover on a specific branch
         fallbackBranch: master # Optional. Fallback to be used if there is no default branch configured at the Gitlab repository. It is only used, if `branch` is undefined. Uses `master` as default
         skipForkedRepos: false # Optional. If the project is a fork, skip repository
+        includeArchivedRepos: false # Optional. If project is archived, include repository
         group: example-group # Optional. Group and subgroup (if needed) to look for repositories. If not present the whole instance will be scanned
         entityFilename: catalog-info.yaml # Optional. Defaults to `catalog-info.yaml`
         projectPattern: '[\s\S]*' # Optional. Filters found projects based on provided patter. Defaults to `[\s\S]*`, which means to not filter anything
@@ -212,3 +213,5 @@ catalog:
 If you don't want create location object if file with component definition do not exists in project, you can set the `skipReposWithoutExactFileMatch` option. That can reduce count of request to gitlab with 404 status code.
 
 If you don't want to create location object if the project is a fork, you can set the `skipForkedRepos` option.
+
+If you want to create location object if the project is archived, you can set the `includeArchivedRepos` option.

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -200,7 +200,10 @@ const routes = (
       </ScaffolderLayouts>
     </Route>
 
-    <Route path="/api-docs" element={<ApiExplorerPage pagination={{ mode: 'offset', limit: 20 }} />} />
+    <Route
+      path="/api-docs"
+      element={<ApiExplorerPage pagination={{ mode: 'offset', limit: 20 }} />}
+    />
     <Route path="/search" element={<SearchPage />}>
       {searchPage}
     </Route>

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -200,7 +200,7 @@ const routes = (
       </ScaffolderLayouts>
     </Route>
 
-    <Route path="/api-docs" element={<ApiExplorerPage />} />
+    <Route path="/api-docs" element={<ApiExplorerPage pagination={{ mode: 'offset', limit: 20 }} />} />
     <Route path="/search" element={<SearchPage />}>
       {searchPage}
     </Route>

--- a/plugins/api-docs/src/components/ApiExplorerPage/DefaultApiExplorerPage.tsx
+++ b/plugins/api-docs/src/components/ApiExplorerPage/DefaultApiExplorerPage.tsx
@@ -76,7 +76,7 @@ export const DefaultApiExplorerPage = (props: DefaultApiExplorerPageProps) => {
     columns,
     actions,
     ownerPickerMode,
-    pagination
+    pagination,
   } = props;
 
   const configApi = useApi(configApiRef);

--- a/plugins/api-docs/src/components/ApiExplorerPage/DefaultApiExplorerPage.tsx
+++ b/plugins/api-docs/src/components/ApiExplorerPage/DefaultApiExplorerPage.tsx
@@ -29,6 +29,7 @@ import {
   EntityKindPicker,
   EntityLifecyclePicker,
   EntityListProvider,
+  EntityListPagination,
   EntityOwnerPicker,
   EntityTagPicker,
   EntityTypePicker,
@@ -62,6 +63,7 @@ export type DefaultApiExplorerPageProps = {
   columns?: TableColumn<CatalogTableRow>[];
   actions?: TableProps<CatalogTableRow>['actions'];
   ownerPickerMode?: EntityOwnerPickerProps['mode'];
+  pagination?: EntityListPagination;
 };
 
 /**
@@ -74,6 +76,7 @@ export const DefaultApiExplorerPage = (props: DefaultApiExplorerPageProps) => {
     columns,
     actions,
     ownerPickerMode,
+    pagination
   } = props;
 
   const configApi = useApi(configApiRef);
@@ -102,7 +105,7 @@ export const DefaultApiExplorerPage = (props: DefaultApiExplorerPageProps) => {
           )}
           <SupportButton>All your APIs</SupportButton>
         </ContentHeader>
-        <EntityListProvider>
+        <EntityListProvider pagination={pagination}>
           <CatalogFilterLayout>
             <CatalogFilterLayout.Filters>
               <EntityKindPicker initialFilter="api" hidden />

--- a/plugins/catalog-backend-module-gitlab/config.d.ts
+++ b/plugins/catalog-backend-module-gitlab/config.d.ts
@@ -64,6 +64,10 @@ export interface Config {
            */
           skipForkedRepos?: boolean;
           /**
+           * (Optional) Include archived repository
+           */
+          includeArchivedRepos?: boolean;
+          /**
            * (Optional) A list of strings containing the paths of the repositories to skip
            * Should be in the format group/subgroup/repo, with no leading or trailing slashes.
            */

--- a/plugins/catalog-backend-module-gitlab/report.api.md
+++ b/plugins/catalog-backend-module-gitlab/report.api.md
@@ -51,6 +51,7 @@ export class GitLabDiscoveryProcessor implements CatalogProcessor {
       logger: LoggerService;
       skipReposWithoutExactFileMatch?: boolean;
       skipForkedRepos?: boolean;
+      includeArchivedRepos?: boolean;
     },
   ): GitLabDiscoveryProcessor;
   // (undocumented)
@@ -116,6 +117,7 @@ export type GitlabProviderConfig = {
   orgEnabled?: boolean;
   schedule?: SchedulerServiceTaskScheduleDefinition;
   skipForkedRepos?: boolean;
+  includeArchivedRepos?: boolean;
   excludeRepos?: string[];
   includeUsersWithoutSeat?: boolean;
 };

--- a/plugins/catalog-backend-module-gitlab/src/__testUtils__/handlers.ts
+++ b/plugins/catalog-backend-module-gitlab/src/__testUtils__/handlers.ts
@@ -37,9 +37,18 @@ const httpHandlers = [
    * Project REST endpoint mocks
    */
 
-  // fetch all projects in an instance
-  rest.get(`${apiBaseUrl}/projects`, (_, res, ctx) => {
-    return res(ctx.set('x-next-page', ''), ctx.json(all_projects_response));
+  // fetch all projects in an instance handling archived ones
+  rest.get(`${apiBaseUrl}/projects`, (req, res, ctx) => {
+    const archived = req.url.searchParams.get('archived');
+
+    return res(
+      ctx.set('x-next-page', ''),
+      ctx.json(
+        all_projects_response.filter(p =>
+          archived === 'false' ? !p.archived : true,
+        ),
+      ),
+    );
   }),
 
   rest.get(`${apiBaseUrl}/projects/42`, (_, res, ctx) => {
@@ -136,9 +145,13 @@ const httpGroupFindByIdDynamic = all_groups_response.map(group => {
 const httpGroupListDescendantProjectsById = all_groups_response.map(group => {
   return rest.get(
     `${apiBaseUrl}/groups/${group.id}/projects`,
-    (_, res, ctx) => {
-      const projectsInGroup = all_projects_response.filter(p =>
-        p.path_with_namespace?.includes(group.name),
+    (req, res, ctx) => {
+      const archived = req.url.searchParams.get('archived');
+
+      const projectsInGroup = all_projects_response.filter(
+        p =>
+          p.path_with_namespace?.includes(group.name) &&
+          (archived === 'false' ? !p.archived : true),
       );
 
       return res(ctx.json(projectsInGroup));
@@ -149,9 +162,13 @@ const httpGroupListDescendantProjectsById = all_groups_response.map(group => {
 const httpGroupListDescendantProjectsByName = all_groups_response.map(group => {
   return rest.get(
     `${apiBaseUrl}/groups/${group.name}/projects`,
-    (_, res, ctx) => {
-      const projectsInGroup = all_projects_response.filter(p =>
-        p.path_with_namespace?.includes(group.name),
+    (req, res, ctx) => {
+      const archived = req.url.searchParams.get('archived');
+
+      const projectsInGroup = all_projects_response.filter(
+        p =>
+          p.path_with_namespace?.includes(group.name) &&
+          (archived === 'false' ? !p.archived : true),
       );
 
       return res(ctx.json(projectsInGroup));

--- a/plugins/catalog-backend-module-gitlab/src/lib/client.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/client.test.ts
@@ -143,6 +143,31 @@ describe('GitLabClient', () => {
       expect(allItems).toHaveLength(expectedProjects.length);
     });
 
+    it('should get not archived projects', async () => {
+      const client = new GitLabClient({
+        config: readGitLabIntegrationConfig(
+          new ConfigReader(mock.config_self_managed),
+        ),
+        logger: mockServices.logger.mock(),
+      });
+
+      const archivedProjectsGen = paginated(
+        options => client.listProjects(options),
+        { archived: false },
+      );
+
+      const expectedProjects = mock.all_projects_response.filter(
+        project => !project.archived,
+      );
+
+      const allItems = [];
+      for await (const item of archivedProjectsGen) {
+        allItems.push(item);
+      }
+
+      expect(allItems).toHaveLength(expectedProjects.length);
+    });
+
     it('should get all projects for an instance', async () => {
       const client = new GitLabClient({
         config: readGitLabIntegrationConfig(
@@ -159,6 +184,7 @@ describe('GitLabClient', () => {
       for await (const project of instanceProjects) {
         allProjects.push(project);
       }
+
       expect(allProjects).toHaveLength(mock.all_projects_response.length);
     });
   });

--- a/plugins/catalog-backend-module-gitlab/src/lib/types.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/types.ts
@@ -233,6 +233,10 @@ export type GitlabProviderConfig = {
    */
   skipForkedRepos?: boolean;
   /**
+   * If the project is archived, include repository
+   */
+  includeArchivedRepos?: boolean;
+  /**
    * List of repositories to exclude from discovery, should be the full path to the repository, e.g. `group/project`
    * Paths should not start or end with a slash.
    */

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.test.ts
@@ -232,6 +232,35 @@ describe('GitlabDiscoveryEntityProvider - refresh', () => {
     });
   });
 
+  it('should include archived projects', async () => {
+    const config = new ConfigReader(
+      mock.config_single_integration_include_archived,
+    );
+    const schedule = new PersistingTaskRunner();
+    const entityProviderConnection: EntityProviderConnection = {
+      applyMutation: jest.fn(),
+      refresh: jest.fn(),
+    };
+    const provider = GitlabDiscoveryEntityProvider.fromConfig(config, {
+      logger,
+      schedule,
+    })[0];
+
+    await provider.connect(entityProviderConnection);
+
+    await provider.refresh(logger);
+
+    expect(entityProviderConnection.applyMutation).toHaveBeenCalledWith({
+      type: 'full',
+      entities: mock.expected_location_entities_including_archived.filter(
+        entity =>
+          !entity.entity.metadata.annotations[
+            'backstage.io/managed-by-location'
+          ].includes('awesome'),
+      ),
+    });
+  });
+
   it('should filter repositories that are excluded', async () => {
     const config = new ConfigReader(
       mock.config_single_integration_exclude_repos,

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.ts
@@ -210,10 +210,10 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
     const projects = paginated<GitLabProject>(
       options => this.gitLabClient.listProjects(options),
       {
-        archived: false,
         group: this.config.group,
         page: 1,
         per_page: 50,
+        ...(!this.config.includeArchivedRepos && { archived: false }),
       },
     );
 

--- a/plugins/catalog-backend-module-gitlab/src/providers/config.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/config.test.ts
@@ -61,6 +61,7 @@ describe('config', () => {
         relations: [],
         schedule: undefined,
         skipForkedRepos: false,
+        includeArchivedRepos: false,
         excludeRepos: [],
         restrictUsersToGroup: false,
         includeUsersWithoutSeat: false,
@@ -104,6 +105,7 @@ describe('config', () => {
         relations: [],
         schedule: undefined,
         skipForkedRepos: false,
+        includeArchivedRepos: false,
         excludeRepos: [],
         restrictUsersToGroup: false,
         includeUsersWithoutSeat: true,
@@ -149,6 +151,51 @@ describe('config', () => {
         restrictUsersToGroup: false,
         excludeRepos: [],
         skipForkedRepos: true,
+        includeArchivedRepos: false,
+        includeUsersWithoutSeat: false,
+      }),
+    );
+  });
+
+  it('valid config with includeArchivedRepos', () => {
+    const config = new ConfigReader({
+      catalog: {
+        providers: {
+          gitlab: {
+            test: {
+              group: 'group',
+              host: 'host',
+              branch: 'not-master',
+              fallbackBranch: 'main',
+              entityFilename: 'custom-file.yaml',
+              includeArchivedRepos: true,
+            },
+          },
+        },
+      },
+    });
+
+    const result = readGitlabConfigs(config);
+    expect(result).toHaveLength(1);
+    result.forEach(r =>
+      expect(r).toStrictEqual({
+        id: 'test',
+        group: 'group',
+        branch: 'not-master',
+        fallbackBranch: 'main',
+        host: 'host',
+        catalogFile: 'custom-file.yaml',
+        projectPattern: /[\s\S]*/,
+        groupPattern: /[\s\S]*/,
+        userPattern: /[\s\S]*/,
+        orgEnabled: false,
+        allowInherited: false,
+        relations: [],
+        schedule: undefined,
+        restrictUsersToGroup: false,
+        excludeRepos: [],
+        skipForkedRepos: false,
+        includeArchivedRepos: true,
         includeUsersWithoutSeat: false,
       }),
     );
@@ -192,6 +239,7 @@ describe('config', () => {
         schedule: undefined,
         restrictUsersToGroup: false,
         skipForkedRepos: false,
+        includeArchivedRepos: false,
         excludeRepos: ['foo/bar', 'quz/qux'],
         includeUsersWithoutSeat: false,
       }),
@@ -235,6 +283,7 @@ describe('config', () => {
         allowInherited: false,
         relations: [],
         skipForkedRepos: false,
+        includeArchivedRepos: false,
         restrictUsersToGroup: false,
         excludeRepos: [],
         includeUsersWithoutSeat: false,

--- a/plugins/catalog-backend-module-gitlab/src/providers/config.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/config.ts
@@ -49,6 +49,9 @@ function readGitlabConfig(id: string, config: Config): GitlabProviderConfig {
 
   const skipForkedRepos: boolean =
     config.getOptionalBoolean('skipForkedRepos') ?? false;
+
+  const includeArchivedRepos: boolean =
+    config.getOptionalBoolean('includeArchivedRepos') ?? false;
   const excludeRepos: string[] =
     config.getOptionalStringArray('excludeRepos') ?? [];
 
@@ -78,6 +81,7 @@ function readGitlabConfig(id: string, config: Config): GitlabProviderConfig {
     allowInherited,
     relations,
     skipForkedRepos,
+    includeArchivedRepos,
     excludeRepos,
     restrictUsersToGroup,
     includeUsersWithoutSeat,


### PR DESCRIPTION
## Hey, I just made a Pull Request!


Added pagination suppport to api-docs plugin  **DefaultApiExplorerPage.tsx** following **@backstage/plugin-catalog-react** **EntityProviderList** pagination. 


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

![{D2565E9D-DACD-4765-94D5-B045367EF1E2}](https://github.com/user-attachments/assets/42d62f03-af4e-4909-bffc-67e18461b14d)

