### PR TITLE
cli: fix linking with react-router

### DIFF
--- a/.changeset/slimy-penguins-care.md
+++ b/.changeset/slimy-penguins-care.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Fix for the `--link` flag for `package start` to deduplicate `react-router` and `react-router-dom`.

--- a/packages/cli/src/lib/bundler/linkWorkspaces.ts
+++ b/packages/cli/src/lib/bundler/linkWorkspaces.ts
@@ -48,10 +48,13 @@ export async function createWorkspaceLinkingPlugins(
     }),
     // react and react-dom are always resolved from the target directory
     // Note: this often requires that the linked and target workspace use the same versions of React
-    new bundler.NormalModuleReplacementPlugin(/^react(?:-dom)?$/, resource => {
-      if (!relativePath(linkedRoot.dir, resource.context).startsWith('..')) {
-        resource.context = paths.targetDir;
-      }
-    }),
+    new bundler.NormalModuleReplacementPlugin(
+      /^react(?:-router)?(?:-dom)?$/,
+      resource => {
+        if (!relativePath(linkedRoot.dir, resource.context).startsWith('..')) {
+          resource.context = paths.targetDir;
+        }
+      },
+    ),
   ];
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

🧹, we need to make sure we use the same instance of `react-router` too. Reported by @mitchhentgesspotify 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
