### PR TITLE
Remove card UI from result type filter on Search page

### DIFF
--- a/.changeset/friendly-kids-judge.md
+++ b/.changeset/friendly-kids-judge.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search': patch
+---
+
+Removes the card UI from the search results type filter for a cleaner UI consistent with other filters

--- a/packages/app/src/components/search/SearchPage.tsx
+++ b/packages/app/src/components/search/SearchPage.tsx
@@ -73,7 +73,7 @@ const SearchPage = () => {
           {!isMobile && (
             <Grid item xs={3}>
               <SearchType.Accordion
-                name="Result Type"
+                name="Result type"
                 defaultValue="software-catalog"
                 showCounts
                 types={[

--- a/plugins/search/src/components/SearchType/SearchType.Accordion.tsx
+++ b/plugins/search/src/components/SearchType/SearchType.Accordion.tsx
@@ -143,7 +143,9 @@ export const SearchTypeAccordion = (props: SearchTypeAccordionProps) => {
 
   return (
     <Box>
-      <Typography variant="overline">{name}</Typography>
+      <Typography variant="body2" component="h3">
+        {name}
+      </Typography>
       <Accordion
         className={classes.accordion}
         expanded={expanded}

--- a/plugins/search/src/components/SearchType/SearchType.Accordion.tsx
+++ b/plugins/search/src/components/SearchType/SearchType.Accordion.tsx
@@ -20,9 +20,7 @@ import { searchApiRef, useSearch } from '@backstage/plugin-search-react';
 import Accordion from '@material-ui/core/Accordion';
 import AccordionSummary from '@material-ui/core/AccordionSummary';
 import AccordionDetails from '@material-ui/core/AccordionDetails';
-import Card from '@material-ui/core/Card';
-import CardContent from '@material-ui/core/CardContent';
-import CardHeader from '@material-ui/core/CardHeader';
+import Box from '@material-ui/core/Box';
 import Divider from '@material-ui/core/Divider';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
@@ -30,16 +28,11 @@ import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
 import { makeStyles } from '@material-ui/core/styles';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import Typography from '@material-ui/core/Typography';
 import AllIcon from '@material-ui/icons/FontDownload';
 import useAsync from 'react-use/esm/useAsync';
 
 const useStyles = makeStyles(theme => ({
-  card: {
-    backgroundColor: 'rgba(0, 0, 0, .11)',
-  },
-  cardContent: {
-    paddingTop: theme.spacing(1),
-  },
   icon: {
     color: theme.palette.text.primary,
   },
@@ -149,61 +142,59 @@ export const SearchTypeAccordion = (props: SearchTypeAccordionProps) => {
   }, [filters, showCounts, term, types]);
 
   return (
-    <Card className={classes.card}>
-      <CardHeader title={name} titleTypographyProps={{ variant: 'overline' }} />
-      <CardContent className={classes.cardContent}>
-        <Accordion
-          className={classes.accordion}
-          expanded={expanded}
-          onChange={toggleExpanded}
+    <Box>
+      <Typography variant="overline">{name}</Typography>
+      <Accordion
+        className={classes.accordion}
+        expanded={expanded}
+        onChange={toggleExpanded}
+      >
+        <AccordionSummary
+          classes={{
+            root: classes.accordionSummary,
+            content: classes.accordionSummaryContent,
+          }}
+          expandIcon={<ExpandMoreIcon className={classes.icon} />}
+          IconButtonProps={{ size: 'small' }}
         >
-          <AccordionSummary
-            classes={{
-              root: classes.accordionSummary,
-              content: classes.accordionSummaryContent,
-            }}
-            expandIcon={<ExpandMoreIcon className={classes.icon} />}
-            IconButtonProps={{ size: 'small' }}
+          {expanded
+            ? 'Collapse'
+            : definedTypes.filter(t => t.value === selected)[0]!.name}
+        </AccordionSummary>
+        <AccordionDetails classes={{ root: classes.accordionDetails }}>
+          <List
+            className={classes.list}
+            component="nav"
+            aria-label="filter by type"
+            disablePadding
+            dense
           >
-            {expanded
-              ? 'Collapse'
-              : definedTypes.filter(t => t.value === selected)[0]!.name}
-          </AccordionSummary>
-          <AccordionDetails classes={{ root: classes.accordionDetails }}>
-            <List
-              className={classes.list}
-              component="nav"
-              aria-label="filter by type"
-              disablePadding
-              dense
-            >
-              {definedTypes.map(type => (
-                <Fragment key={type.value}>
-                  <Divider />
-                  <ListItem
-                    selected={
-                      types[0] === type.value ||
-                      (types.length === 0 && type.value === '')
-                    }
-                    onClick={handleClick(type.value)}
-                    button
-                  >
-                    <ListItemIcon>
-                      {cloneElement(type.icon, {
-                        className: classes.listItemIcon,
-                      })}
-                    </ListItemIcon>
-                    <ListItemText
-                      primary={type.name}
-                      secondary={resultCounts && resultCounts[type.value]}
-                    />
-                  </ListItem>
-                </Fragment>
-              ))}
-            </List>
-          </AccordionDetails>
-        </Accordion>
-      </CardContent>
-    </Card>
+            {definedTypes.map(type => (
+              <Fragment key={type.value}>
+                <Divider />
+                <ListItem
+                  selected={
+                    types[0] === type.value ||
+                    (types.length === 0 && type.value === '')
+                  }
+                  onClick={handleClick(type.value)}
+                  button
+                >
+                  <ListItemIcon>
+                    {cloneElement(type.icon, {
+                      className: classes.listItemIcon,
+                    })}
+                  </ListItemIcon>
+                  <ListItemText
+                    primary={type.name}
+                    secondary={resultCounts && resultCounts[type.value]}
+                  />
+                </ListItem>
+              </Fragment>
+            ))}
+          </List>
+        </AccordionDetails>
+      </Accordion>
+    </Box>
   );
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Removes the card UI from the search results type filter for a cleaner UI consistent with other filters.

### Before
![Screenshot 2024-11-05 at 17 21 47](https://github.com/user-attachments/assets/363f9345-c032-47d4-92a5-32c359b6fa61)

### After
![Screenshot 2024-11-05 at 17 18 09](https://github.com/user-attachments/assets/84326201-1c75-4bae-9b9f-1246e41dad4c)


- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
