### PR TITLE
Fix unnecessary re-rendering of site's index page.

### DIFF
--- a/.changeset/hungry-cats-juggle.md
+++ b/.changeset/hungry-cats-juggle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Fix an issue with index page of documentation site being re-rendered.

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx
@@ -47,6 +47,7 @@ import {
   handleMetaRedirects,
 } from '../../transformers';
 import { useNavigateUrl } from './useNavigateUrl';
+import { useParams } from 'react-router-dom';
 
 const MOBILE_MEDIA_QUERY = 'screen and (max-width: 76.1875em)';
 
@@ -69,6 +70,7 @@ export const useTechDocsReaderDom = (
   const scmIntegrationsApi = useApi(scmIntegrationsApiRef);
 
   const { state, path, content: rawPage } = useTechDocsReader();
+  const { '*': currPath = '' } = useParams();
 
   const [dom, setDom] = useState<HTMLElement | null>(null);
   const isStyleLoading = useShadowDomStylesLoading(dom);
@@ -277,8 +279,8 @@ export const useTechDocsReaderDom = (
       }
 
       // Skip this update if the location's path has changed but the state
-      // contains a page for another page that isn't loaded yet.
-      if (!window.location.pathname.endsWith(path)) {
+      // contains a page that isn't loaded yet.
+      if (currPath !== path) {
         return;
       }
 
@@ -297,7 +299,7 @@ export const useTechDocsReaderDom = (
     return () => {
       shouldReplaceContent = false;
     };
-  }, [rawPage, path, preRender, postRender]);
+  }, [rawPage, currPath, path, preRender, postRender]);
 
   return dom;
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

There is an edge case in a check determining if we should skip updating the dom due to the reader state not having loaded yet. In the check, the current url is compared using `endsWith` to the reader state's `path` value. If they are different, we return because we know the reader state doesn't have the new page. The value of `path` is defined [here](https://github.com/backstage/backstage/blob/0b729da922571a7583602baab2c53475805b6834/plugins/techdocs/src/reader/components/TechDocsReaderProvider.tsx#L54) in `TechDocsReaderProvider.tsx`.

 We get an edge case because `path` value for the index page of a site is an empty string. The check will pass no matter what string value the current `window.location.pathname` is. This means that when navigating from the index page to another page, we do not prevent a duplicate re-rendering. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
