### PR TITLE
chore: Fix documentation for catalog backend stitching

### DIFF
--- a/docs/features/software-catalog/configuration.md
+++ b/docs/features/software-catalog/configuration.md
@@ -204,7 +204,8 @@ It can be configured with the `stitchingStrategy` app-config parameter.
 
 ```yaml title="app-config.yaml"
 catalog:
-  stitchingStrategy: immediate
+  stitchingStrategy:
+    mode: immediate
 ```
 
 For the `deferred` mode you can set up additional parameters to further tune the process,
@@ -217,9 +218,10 @@ These parameters accept a duration object, similar to the `processingInterval` p
 
 ```yaml title="app-config.yaml"
 catalog:
-  stitchingStrategy: deferred
-  pollingInterval: { seconds: 1 }
-  stitchTimeout: { minutes: 1 };
+  stitchingStrategy:
+    mode: deferred
+    pollingInterval: { seconds: 1 }
+    stitchTimeout: { minutes: 1 };
 ```
 
 ## Subscribing to Catalog Errors


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I followed the [documentation](https://backstage.io/docs/features/software-catalog/configuration#stitching-strategy) for modifying the stitching configuration and received the following error:
```
ForwardedError [TypeError]: Plugin 'catalog' startup failed; caused by TypeError: Invalid type in config for key 'catalog.stitchingStrategy' in 'app-config.yaml', got string, wanted object
```

Based on the type definitions [here](https://github.com/backstage/backstage/blob/e937ae7b1f9b9b8822a965e48046e568f75a33da/plugins/catalog-backend/config.d.ts#L151) I believe the documentation should be updated to nest these configuration properties underneath the `catalog.stitchingStrategy` property.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
