### PR TITLE
repo-tools: new file and resolution fallback fix for generate-patch

### DIFF
--- a/.changeset/ninety-panthers-provide.md
+++ b/.changeset/ninety-panthers-provide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/repo-tools': patch
+---
+
+The `generate-patch` command now properly includes newly created files in the patch.

--- a/.changeset/strange-clocks-pretend.md
+++ b/.changeset/strange-clocks-pretend.md
@@ -1,0 +1,5 @@
+---
+'@backstage/repo-tools': patch
+---
+
+The `generate-patch` command will now fall back to always adding a `resolutions` entry, even if no matching descriptors are found.

--- a/packages/repo-tools/src/commands/generate-patch/generate-patch.ts
+++ b/packages/repo-tools/src/commands/generate-patch/generate-patch.ts
@@ -217,8 +217,12 @@ async function loadTrimmedRootPkg(ctx: PatchContext, query?: string) {
   }
 
   return async (patchEntry?: string) => {
-    for (const descriptor of descriptors) {
-      resolutionsObj[descriptor] = patchEntry;
+    if (descriptors.length > 0) {
+      for (const descriptor of descriptors) {
+        resolutionsObj[descriptor] = patchEntry;
+      }
+    } else {
+      resolutionsObj[ctx.packageName] = patchEntry;
     }
     // We use the same patch for all versions of the package, if they don't
     // apply it might require manual intervention using the --query option


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Two fixes for the `backstage-repo-tools generate-patch` command:

- Fall back to adding a global `resolutions` entry if no valid descriptors are found, typical case for this is if a dependency is only brought in via our Yarn plugin.
- Fix for new files not being included in the patch (👀 @benjdlambert)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
