### PR TITLE
Ensure EntityDisplayName component link receives underline on hover

### DIFF
--- a/.changeset/neat-buttons-wait.md
+++ b/.changeset/neat-buttons-wait.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Ensure EntityDisplayName component link receives underline on hover.

--- a/plugins/catalog-react/src/components/EntityDisplayName/EntityDisplayName.tsx
+++ b/plugins/catalog-react/src/components/EntityDisplayName/EntityDisplayName.tsx
@@ -34,6 +34,7 @@ const useStyles = makeStyles(
     root: {
       display: 'inline-flex',
       alignItems: 'center',
+      textDecoration: 'inherit',
     },
     icon: {
       marginRight: theme.spacing(0.5),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Ensure EntityDisplayName component link receives underline on hover.

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
