### PR TITLE
cli: improve autocomplete of extra entry points in published packages

### DIFF
--- a/.changeset/seven-berries-listen.md
+++ b/.changeset/seven-berries-listen.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': minor
+---
+
+The package packing now populates `typesVersions` for additional entry points rather than using additional `package.json` files for type resolution. This improves auto completion of separate entry points when consuming published packages.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I found that using extra entry points in published packages doesn't autocomplete correctly. Using `typesVersions` instead of our placeholders seems a lot more resilient. I see little risk in switching over to this as it's been supported for a long while, along with `exports` for the actual runtime entry points.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
