### PR TITLE
cli: fix watching of dynamic plugin discovery

### DIFF
--- a/.changeset/bright-buckets-laugh.md
+++ b/.changeset/bright-buckets-laugh.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Fix dev server reloads of plugin discovery for new frontend system.

--- a/packages/cli/src/lib/bundler/config.ts
+++ b/packages/cli/src/lib/bundler/config.ts
@@ -372,7 +372,7 @@ export async function createConfig(
     ...(isDev
       ? {
           watchOptions: {
-            ignored: /node_modules/,
+            ignored: /node_modules\/(?!__backstage-autodetected-plugins__)/,
           },
         }
       : {}),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes reloads of dynamically discovered plugins, which has been broken since we disabled watching of `node_modules`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
