### PR TITLE
Enable customization of CatalogTable pagination

### DIFF
--- a/.changeset/serious-penguins-remain.md
+++ b/.changeset/serious-penguins-remain.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog': minor
 ---
 
-Allow CursorPaginatedCatalogTable and OffsetPaginatedCatalogTable to configure Table options, specifically `paginationPostition`
+Allow `OffsetPaginatedCatalogTable` to configure Table options and `CursorPaginatedCatalogTable` to configure `paginationPosition`.

--- a/.changeset/serious-penguins-remain.md
+++ b/.changeset/serious-penguins-remain.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': minor
+---
+
+Allow CursorPaginatedCatalogTable and OffsetPaginatedCatalogTable to configure Table options, specifically `paginationPostition`

--- a/plugins/catalog/src/components/CatalogTable/CursorPaginatedCatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CursorPaginatedCatalogTable.tsx
@@ -39,9 +39,9 @@ export function CursorPaginatedCatalogTable(props: PaginatedCatalogTableProps) {
       columns={columns}
       data={data}
       options={{
+        paginationPosition: 'both',
         ...options,
         // These settings are configured to force server side pagination
-        paginationPosition: 'both',
         pageSizeOptions: [],
         showFirstLastPageButtons: false,
         pageSize: Number.MAX_SAFE_INTEGER,

--- a/plugins/catalog/src/components/CatalogTable/OffsetPaginatedCatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/OffsetPaginatedCatalogTable.tsx
@@ -29,7 +29,7 @@ import {
 export function OffsetPaginatedCatalogTable(
   props: TableProps<CatalogTableRow>,
 ) {
-  const { columns, data, isLoading } = props;
+  const { columns, data, isLoading, options } = props;
   const { updateFilters, setLimit, setOffset, limit, totalItems, offset } =
     useEntityList();
   const [page, setPage] = React.useState(
@@ -53,6 +53,7 @@ export function OffsetPaginatedCatalogTable(
         pageSizeOptions: [5, 10, 20, 50, 100],
         pageSize: limit,
         emptyRowsWhenPaging: false,
+        ...options,
       }}
       onSearchChange={(searchText: string) =>
         updateFilters({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I was looking to make use of one of the server side paginated CatalogTables but realised neither of them allowed you to remove the awful (IMHO) top pagination buttons. For `CursorPaginatedCatalogTable` I left the `...options` at the conservative spot above the other pagination options since it seemed deliberate to not allow overriding them.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
