### PR TITLE
Fix link styling in ProvidedApisCard component

### DIFF
--- a/.changeset/strong-papayas-remember.md
+++ b/.changeset/strong-papayas-remember.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-api-docs': patch
+---
+
+Fix link styling in ProvidedApisCard component so it aligns with other card components.

--- a/plugins/api-docs/src/components/ApisCards/ProvidedApisCard.tsx
+++ b/plugins/api-docs/src/components/ApisCards/ProvidedApisCard.tsx
@@ -84,12 +84,14 @@ export const ProvidedApisCard = (props: {
             This {entity.kind.toLocaleLowerCase('en-US')} does not provide any
             APIs.
           </Typography>
-          <Link
-            to="https://backstage.io/docs/features/software-catalog/descriptor-format#specprovidesapis-optional"
-            externalLinkIcon
-          >
-            Learn how to change this
-          </Link>
+          <Typography variant="body2">
+            <Link
+              to="https://backstage.io/docs/features/software-catalog/descriptor-format#specprovidesapis-optional"
+              externalLinkIcon
+            >
+              Learn how to change this
+            </Link>
+          </Typography>
         </div>
       }
       columns={columns}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix link styling in ProvidedApisCard component so it aligns with other card components e.g. [here](https://github.com/backstage/backstage/blob/align-entity-cards-html/plugins/api-docs/src/components/ApisCards/ConsumedApisCard.tsx#L87-L94) and [here](https://github.com/backstage/backstage/blob/align-entity-cards-html/plugins/api-docs/src/components/ApisCards/HasApisCard.tsx#L96-L100).

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
