### PR TITLE
chore: deprecate createRouter and RouterOptions  in plugins

### DIFF
--- a/.changeset/chatty-steaks-brush.md
+++ b/.changeset/chatty-steaks-brush.md
@@ -1,0 +1,23 @@
+---
+'@backstage/plugin-notifications-backend': patch
+'@backstage/plugin-user-settings-backend': patch
+'@backstage/plugin-signals-backend': patch
+---
+
+---
+
+'@backstage/plugin-notifications-backend': patch
+
+Deprecated createRouter and RouteOptions
+
+---
+
+'@backstage/plugin-user-settings-backend': patch
+
+Deprecated createRouter and RouteOptions
+
+---
+
+'@backstage/plugin-signals-backend': patch
+
+Deprecated createRouter and RouteOptions

--- a/plugins/example-todo-list-backend/src/service/router.ts
+++ b/plugins/example-todo-list-backend/src/service/router.ts
@@ -23,6 +23,7 @@ import { HttpAuthService, LoggerService } from '@backstage/backend-plugin-api';
 
 /**
  * Dependencies of the todo-list router
+ * @deprecated
  */
 export interface RouterOptions {
   logger: LoggerService;
@@ -33,6 +34,7 @@ export interface RouterOptions {
  * Creates an express.Router with some endpoints
  * for creating, editing and deleting todo items.
  *
+ * @deprecated Please migrate to the new backend system as this will be removed in the future.
  * @param options - the dependencies of the router
  * @returns an express.Router
  *

--- a/plugins/notifications-backend/src/service/router.ts
+++ b/plugins/notifications-backend/src/service/router.ts
@@ -49,7 +49,10 @@ import { parseEntityOrderFieldParams } from './parseEntityOrderFieldParams';
 import { getUsersForEntityRef } from './getUsersForEntityRef';
 import { Config } from '@backstage/config';
 
-/** @internal */
+/**
+ * @internal
+ * @deprecated
+ * */
 export interface RouterOptions {
   logger: LoggerService;
   config: Config;
@@ -62,7 +65,10 @@ export interface RouterOptions {
   processors?: NotificationProcessor[];
 }
 
-/** @internal */
+/**
+ * @internal
+ * @deprecated
+ */
 export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {

--- a/plugins/signals-backend/src/service/router.ts
+++ b/plugins/signals-backend/src/service/router.ts
@@ -31,6 +31,9 @@ import { WebSocket, WebSocketServer } from 'ws';
 import { Duplex } from 'stream';
 import { Config } from '@backstage/config';
 
+/**
+ * @deprecated
+ */
 export interface RouterOptions {
   logger: LoggerService;
   events: EventsService;
@@ -41,6 +44,9 @@ export interface RouterOptions {
   auth: AuthService;
 }
 
+/**
+ * @deprecated
+ */
 export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {

--- a/plugins/user-settings-backend/src/service/router.ts
+++ b/plugins/user-settings-backend/src/service/router.ts
@@ -29,6 +29,7 @@ import {
 
 /**
  * @public
+ * @deprecated
  */
 export interface RouterOptions {
   database: DatabaseService;
@@ -40,6 +41,7 @@ export interface RouterOptions {
  * Create the user settings backend routes.
  *
  * @public
+ * @deprecated
  */
 export async function createRouter(
   options: RouterOptions,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Deprecated the createRouter and RouterOptions as part of #26353 
- example-todo-list-backend
- notifications-backend
- signals-backend
- user-settings-backend

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
