### PR TITLE
feat(notifications): show count of unread notifications in the left-side MenuItem

### DIFF
--- a/.changeset/two-beds-bow.md
+++ b/.changeset/two-beds-bow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications': patch
+---
+
+Show count of unread notifications in the left-side MenuItem. This replaces the simple true/false bullet.

--- a/plugins/notifications/src/components/NotificationsSideBarItem/NotificationsSideBarItem.tsx
+++ b/plugins/notifications/src/components/NotificationsSideBarItem/NotificationsSideBarItem.tsx
@@ -45,6 +45,7 @@ import { SeverityIcon } from '../NotificationsTable/SeverityIcon';
 import OpenInNew from '@material-ui/icons/OpenInNew';
 import MarkAsReadIcon from '@material-ui/icons/CheckCircle';
 import IconButton from '@material-ui/core/IconButton';
+import Chip from '@material-ui/core/Chip';
 import { styled } from '@material-ui/core/styles';
 
 const StyledMaterialDesignContent = styled(MaterialDesignContent)(
@@ -253,7 +254,8 @@ export const NotificationsSidebarItem = (props?: {
     }
   }, [titleCounterEnabled, unreadCount, setNotificationCount]);
 
-  // TODO: Figure out if the count can be added to hasNotifications
+  const count = !error && !!unreadCount ? unreadCount : undefined;
+
   return (
     <>
       {snackbarEnabled && (
@@ -277,11 +279,12 @@ export const NotificationsSidebarItem = (props?: {
         onClick={() => {
           requestUserPermission();
         }}
-        hasNotifications={!error && !!unreadCount}
         text={text}
         icon={icon}
         {...restProps}
-      />
+      >
+        {count && <Chip size="small" label={count > 99 ? '99+' : count} />}
+      </SidebarItem>
     </>
   );
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The Notifications' left-side MenuItem shows the count of unread messages instead of just a simple bullet.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
