### PR TITLE
feat(notifications): emphasize notification's title

### DIFF
--- a/.changeset/pretty-ligers-bake.md
+++ b/.changeset/pretty-ligers-bake.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications': patch
+---
+
+The notification's title is emphasized to be clearly distinguished from the description.

--- a/plugins/notifications/src/components/NotificationsTable/NotificationsTable.tsx
+++ b/plugins/notifications/src/components/NotificationsTable/NotificationsTable.tsx
@@ -222,7 +222,7 @@ export const NotificationsTable = ({
               </Grid>
               <Grid item xs={11}>
                 <Box>
-                  <Typography variant="subtitle2">
+                  <Typography variant="subtitle1">
                     {notification.payload.link ? (
                       <Link
                         to={notification.payload.link}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The notification's title is emphasized to be clearly distinguished from the description.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
