### PR TITLE
fix(notifications): rename "Created after" to "Sent out"

### DIFF
--- a/.changeset/kind-steaks-flow.md
+++ b/.changeset/kind-steaks-flow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications': patch
+---
+
+The "Created after" filter renamed to the "Sent out" based on the received users' feedback.

--- a/plugins/notifications/src/components/NotificationsFilters/NotificationsFilters.tsx
+++ b/plugins/notifications/src/components/NotificationsFilters/NotificationsFilters.tsx
@@ -207,12 +207,10 @@ export const NotificationsFilters = ({
 
         <Grid item xs={12}>
           <FormControl fullWidth variant="outlined" size="small">
-            <InputLabel id="notifications-filter-created">
-              Created after
-            </InputLabel>
+            <InputLabel id="notifications-filter-created">Sent out</InputLabel>
 
             <Select
-              label="Created after"
+              label="Sent out"
               labelId="notifications-filter-created"
               placeholder="Notifications since"
               value={createdAfter}


### PR DESCRIPTION
The "Created after" filter renamed to the "Sent out".
Based on received users' feedback, the purpose of the field seems to be more clear this way.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
