### PR TITLE
Improve UI consistency of Catalog filter pickers

### DIFF
--- a/.changeset/pink-schools-shave.md
+++ b/.changeset/pink-schools-shave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Improve UI consistency of default catalog filters

--- a/plugins/catalog-react/src/components/EntityAutocompletePicker/EntityAutocompletePicker.tsx
+++ b/plugins/catalog-react/src/components/EntityAutocompletePicker/EntityAutocompletePicker.tsx
@@ -63,7 +63,10 @@ export type CatalogReactEntityAutocompletePickerClassKey = 'root' | 'label';
 const useStyles = makeStyles(
   {
     root: {},
-    label: {},
+    label: {
+      textTransform: 'none',
+      fontWeight: 'bold',
+    },
   },
   { name: 'CatalogReactEntityAutocompletePicker' },
 );

--- a/plugins/catalog-react/src/components/EntityAutocompletePicker/EntityAutocompletePickerInput.tsx
+++ b/plugins/catalog-react/src/components/EntityAutocompletePicker/EntityAutocompletePickerInput.tsx
@@ -14,14 +14,17 @@
  * limitations under the License.
  */
 import TextField, { TextFieldProps } from '@material-ui/core/TextField';
-import { makeStyles } from '@material-ui/core/styles';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import React from 'react';
 import classnames from 'classnames';
 
 const useStyles = makeStyles(
-  {
-    input: {},
-  },
+  (theme: Theme) =>
+    createStyles({
+      input: {
+        backgroundColor: theme.palette.background.paper,
+      },
+    }),
   {
     name: 'CatalogReactEntityAutocompletePickerInput',
   },

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
@@ -25,7 +25,7 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import TextField from '@material-ui/core/TextField';
 import Typography from '@material-ui/core/Typography';
 import Tooltip from '@material-ui/core/Tooltip';
-import { makeStyles } from '@material-ui/core/styles';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import CheckBoxIcon from '@material-ui/icons/CheckBox';
 import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
@@ -47,17 +47,23 @@ import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 export type CatalogReactEntityOwnerPickerClassKey = 'input';
 
 const useStyles = makeStyles(
-  {
-    root: {},
-    label: {},
-    input: {},
-    fullWidth: { width: '100%' },
-    boxLabel: {
-      width: '100%',
-      textOverflow: 'ellipsis',
-      overflow: 'hidden',
-    },
-  },
+  (theme: Theme) =>
+    createStyles({
+      root: {},
+      label: {
+        textTransform: 'none',
+        fontWeight: 'bold',
+      },
+      input: {
+        backgroundColor: theme.palette.background.paper,
+      },
+      fullWidth: { width: '100%' },
+      boxLabel: {
+        width: '100%',
+        textOverflow: 'ellipsis',
+        overflow: 'hidden',
+      },
+    }),
   { name: 'CatalogReactEntityOwnerPicker' },
 );
 

--- a/plugins/catalog-react/src/components/EntityProcessingStatusPicker/EntityProcessingStatusPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityProcessingStatusPicker/EntityProcessingStatusPicker.tsx
@@ -20,7 +20,7 @@ import Checkbox from '@material-ui/core/Checkbox';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import TextField from '@material-ui/core/TextField';
 import Typography from '@material-ui/core/Typography';
-import { makeStyles } from '@material-ui/core/styles';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import CheckBoxIcon from '@material-ui/icons/CheckBox';
 import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
@@ -34,11 +34,17 @@ import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 export type CatalogReactEntityProcessingStatusPickerClassKey = 'input';
 
 const useStyles = makeStyles(
-  {
-    root: {},
-    input: {},
-    label: {},
-  },
+  (theme: Theme) =>
+    createStyles({
+      root: {},
+      input: {
+        backgroundColor: theme.palette.background.paper,
+      },
+      label: {
+        textTransform: 'none',
+        fontWeight: 'bold',
+      },
+    }),
   { name: 'CatalogReactEntityProcessingStatusPickerPicker' },
 );
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

A few small style tweaks to make the "rest" of the filters match the Kind and Type filters at the top. It's still not perfect, note how Kind and Type have dropdowns that pop out above the page while the autocomplete-based filters reflow the content below.

### Before

![before screenshot](https://github.com/user-attachments/assets/8b461f27-f4a9-476c-b2d4-f54dcd32f4d0)

### After

![after screenshot](https://github.com/user-attachments/assets/d9679691-577f-4987-bff3-1bdfa131b9d7)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
