### PR TITLE
remove redundant indices

### DIFF
--- a/.changeset/twelve-masks-call.md
+++ b/.changeset/twelve-masks-call.md
@@ -1,0 +1,14 @@
+---
+'@backstage/plugin-catalog-backend': minor
+---
+
+Drop redundant indices from the database.
+
+The following redundant indices are removed in this version:
+
+- `final_entities_entity_id_idx` - overlaps with `final_entities_pkey`
+- `refresh_state_entity_id_idx` - overlaps with `refresh_state_pkey`
+- `refresh_state_entity_ref_idx` - overlaps with `refresh_state_entity_ref_uniq`
+- `search_key_idx` and `search_value_idx` - these were replaced by the composite index `search_key_value_idx` in #22594
+
+No negative end user impact is expected, but rather that performance should increase due to less index churn.

--- a/plugins/catalog-backend/migrations/20241111000000_drop_redundant_indices.js
+++ b/plugins/catalog-backend/migrations/20241111000000_drop_redundant_indices.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @ts-check
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function up(knex) {
+  await knex.schema.alterTable('final_entities', table => {
+    table.dropIndex([], 'final_entities_entity_id_idx'); // overlaps with final_entities_pkey
+  });
+
+  await knex.schema.alterTable('refresh_state', table => {
+    table.dropIndex([], 'refresh_state_entity_id_idx'); // overlaps with refresh_state_pkey
+    table.dropIndex([], 'refresh_state_entity_ref_idx'); // overlaps with refresh_state_entity_ref_uniq
+  });
+
+  await knex.schema.alterTable('search', table => {
+    table.dropIndex([], 'search_key_idx'); // was replaced by search_key_value_idx in 20240130092632_search_index
+    table.dropIndex([], 'search_value_idx'); // was replaced by search_key_value_idx in 20240130092632_search_index
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function down(knex) {
+  await knex.schema.alterTable('final_entities', table => {
+    table.index('entity_id', 'final_entities_entity_id_idx');
+  });
+
+  await knex.schema.alterTable('refresh_state', table => {
+    table.index('entity_id', 'refresh_state_entity_id_idx');
+    table.index('entity_ref', 'refresh_state_entity_ref_idx');
+  });
+
+  await knex.schema.alterTable('search', table => {
+    table.index(['key'], 'search_key_idx');
+    table.index(['value'], 'search_value_idx');
+  });
+};

--- a/plugins/catalog-backend/src/tests/migrations.test.ts
+++ b/plugins/catalog-backend/src/tests/migrations.test.ts
@@ -502,4 +502,23 @@ describe('migrations', () => {
       await knex.destroy();
     },
   );
+
+  it.each(databases.eachSupportedId())(
+    '20241111000000_drop_redundant_indices.js, %p',
+    async databaseId => {
+      const knex = await databases.init(databaseId);
+
+      await migrateUntilBefore(
+        knex,
+        '20241111000000_drop_redundant_indices.js',
+      );
+
+      await migrateUpOnce(knex);
+
+      await migrateDownOnce(knex);
+
+      expect(true).toBe(true);
+      await knex.destroy();
+    },
+  );
 });


### PR DESCRIPTION
This is on top of #27341

The time has come to remove these indices, that are lingering around for historical reasons. At this point people should have had enough time to migrate after #22594 to have that deferred index into place.

Ping @drodil and @Rugvip here too.

For reference, here follows a dump of indices on a postgres installation before the PR:

## `final_entities`:

| index | query |
| - | - |
| entity_ref_idx | CREATE INDEX entity_ref_idx<br>ON public.final_entities<br>USING btree (entity_ref) |
| ~final_entities_entity_id_idx~ | ~CREATE INDEX final_entities_entity_id_idx<br>ON public.final_entities<br>USING btree (entity_id)~ |
| final_entities_pkey | CREATE UNIQUE INDEX final_entities_pkey<br>ON public.final_entities<br>USING btree (entity_id) |

## `refresh_state`:

| index | query |
| - | - |
| ~refresh_state_entity_id_idx~ | ~CREATE INDEX refresh_state_entity_id_idx<br>ON public.refresh_state<br>USING btree (entity_id)~ |
| ~refresh_state_entity_ref_idx~ | ~CREATE INDEX refresh_state_entity_ref_idx<br>ON public.refresh_state<br>USING btree (entity_ref)~ |
| refresh_state_entity_ref_uniq | CREATE UNIQUE INDEX refresh_state_entity_ref_uniq<br>ON public.refresh_state<br>USING btree (entity_ref) |
| refresh_state_next_stitch_at_idx | CREATE INDEX refresh_state_next_stitch_at_idx<br>ON public.refresh_state<br>USING btree (next_stitch_at)<br>WHERE (next_stitch_at IS NOT NULL) |
| refresh_state_next_update_at_idx | CREATE INDEX refresh_state_next_update_at_idx<br>ON public.refresh_state<br>USING btree (next_update_at) |
| refresh_state_pkey | CREATE UNIQUE INDEX refresh_state_pkey<br>ON public.refresh_state<br>USING btree (entity_id) |

## `search`:

| index | query |
| - | - |
| search_entity_id_idx | CREATE INDEX search_entity_id_idx<br>ON public.search<br>USING btree (entity_id) |
| ~search_key_idx~ | ~CREATE INDEX search_key_idx<br>ON public.search<br>USING btree (key)~ |
| search_key_original_value_idx | CREATE INDEX search_key_original_value_idx<br>ON public.search<br>USING btree (key, original_value) |
| search_key_value_idx | CREATE INDEX search_key_value_idx<br>ON public.search<br>USING btree (key, value) |
| ~search_value_idx~ | ~CREATE INDEX search_value_idx<br>ON public.search<br>USING btree (value)~ |

## `refresh_state_references`:

| index | query |
| - | - |
| refresh_state_references_pkey | CREATE UNIQUE INDEX refresh_state_references_pkey<br>ON public.refresh_state_references<br>USING btree (id) |
| refresh_state_references_source_entity_ref_idx | CREATE INDEX refresh_state_references_source_entity_ref_idx<br>ON public.refresh_state_references<br>USING btree (source_entity_ref) |
| refresh_state_references_source_key_idx | CREATE INDEX refresh_state_references_source_key_idx<br>ON public.refresh_state_references<br>USING btree (source_key) |
| refresh_state_references_target_entity_ref_idx | CREATE INDEX refresh_state_references_target_entity_ref_idx<br>ON public.refresh_state_references<br>USING btree (target_entity_ref) |
