### PR TITLE
Techdocs: fix re-rendering issue TechDocsReaderPageContent

### DIFF
--- a/.changeset/flat-rivers-smell.md
+++ b/.changeset/flat-rivers-smell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Fixed an issue where `<TechDocsReaderPageContent />` would re-render infinitely under certain conditions.

--- a/plugins/techdocs/src/reader/components/useReaderState.test.tsx
+++ b/plugins/techdocs/src/reader/components/useReaderState.test.tsx
@@ -687,5 +687,43 @@ describe('useReaderState', () => {
         expect.any(Function),
       );
     });
+
+    it('should return the same data if re-rendered', async () => {
+      techdocsStorageApi.getEntityDocs.mockResolvedValue('my content');
+      techdocsStorageApi.syncEntityDocs.mockImplementation(async () => {
+        return 'cached';
+      });
+
+      const { result, rerender } = renderHook(
+        () => useReaderState('Component', 'default', 'backstage', '/example'),
+        { wrapper: Wrapper },
+      );
+
+      expect(result.current).toEqual({
+        state: 'CHECKING',
+        path: '/example',
+        content: undefined,
+        contentErrorMessage: undefined,
+        syncErrorMessage: undefined,
+        buildLog: [],
+        contentReload: expect.any(Function),
+      });
+
+      await waitFor(() => {
+        expect(result.current).toEqual({
+          state: 'CONTENT_FRESH',
+          path: '/example',
+          content: 'my content',
+          contentErrorMessage: undefined,
+          syncErrorMessage: undefined,
+          buildLog: [],
+          contentReload: expect.any(Function),
+        });
+      });
+      const firstResult = result.current;
+
+      rerender();
+      expect(result.current).toBe(firstResult);
+    });
   });
 });

--- a/plugins/techdocs/src/reader/components/useReaderState.ts
+++ b/plugins/techdocs/src/reader/components/useReaderState.ts
@@ -343,13 +343,24 @@ export function useReaderState(
     [state.activeSyncState, state.content, state.contentLoading],
   );
 
-  return {
-    state: displayState,
-    contentReload,
-    path: state.path,
-    content: state.content,
-    contentErrorMessage: state.contentError?.toString(),
-    syncErrorMessage: state.syncError?.toString(),
-    buildLog: state.buildLog,
-  };
+  return useMemo(
+    () => ({
+      state: displayState,
+      contentReload,
+      path: state.path,
+      content: state.content,
+      contentErrorMessage: state.contentError?.toString(),
+      syncErrorMessage: state.syncError?.toString(),
+      buildLog: state.buildLog,
+    }),
+    [
+      displayState,
+      contentReload,
+      state.path,
+      state.content,
+      state.contentError,
+      state.syncError,
+      state.buildLog,
+    ],
+  );
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes an issue where `<TechDocsReaderPageContent />` would re-render infinitely under certain conditions. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
