### PR TITLE
Scaffolder: Gitlab - Include description field when displaying error messages

### DIFF
--- a/.changeset/khaki-badgers-watch.md
+++ b/.changeset/khaki-badgers-watch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gitlab': patch
+---
+
+Improve error messages from Gitlab

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabIssueCreate.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabIssueCreate.ts
@@ -22,6 +22,7 @@ import { examples } from './gitlabIssueCreate.examples';
 import { z } from 'zod';
 import { checkEpicScope, convertDate, getClient, parseRepoUrl } from '../util';
 import { CreateIssueOptions, IssueSchema } from '@gitbeaker/rest';
+import { getErrorMessage } from './helpers';
 
 const issueInputProperties = z.object({
   projectId: z.number().describe('Project Id'),
@@ -189,7 +190,9 @@ export const createGitlabIssueAction = (options: {
           });
         }
         // Handling other errors
-        throw new InputError(`Failed to create GitLab issue: ${error.message}`);
+        throw new InputError(
+          `Failed to create GitLab issue: ${getErrorMessage(error)}`,
+        );
       }
     },
   });

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabIssueEdit.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabIssueEdit.ts
@@ -25,6 +25,7 @@ import { examples } from './gitlabIssueEdit.examples';
 import { z } from 'zod';
 import { checkEpicScope, convertDate, getClient, parseRepoUrl } from '../util';
 import { IssueSchema, EditIssueOptions } from '@gitbeaker/rest';
+import { getErrorMessage } from './helpers';
 
 const editIssueInputProperties = z.object({
   projectId: z
@@ -237,7 +238,7 @@ export const editGitlabIssueAction = (options: {
         }
         // Handling other errors
         throw new InputError(
-          `Failed to edit/modify GitLab issue: ${error.message}`,
+          `Failed to edit/modify GitLab issue: ${getErrorMessage(error)}`,
         );
       }
     },

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabMergeRequest.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabMergeRequest.ts
@@ -28,7 +28,7 @@ import {
   LoggerService,
   resolveSafeChildPath,
 } from '@backstage/backend-plugin-api';
-import { createGitlabApi } from './helpers';
+import { createGitlabApi, getErrorMessage } from './helpers';
 import { examples } from './gitlabMergeRequest.examples';
 import { createHash } from 'crypto';
 
@@ -235,7 +235,9 @@ which uses additional API calls in order to detect whether to 'create', 'update'
           assigneeId = assigneeUser[0].id;
         } catch (e) {
           ctx.logger.warn(
-            `Failed to find gitlab user id for ${assignee}: ${e}. Proceeding with MR creation without an assignee.`,
+            `Failed to find gitlab user id for ${assignee}: ${getErrorMessage(
+              e,
+            )}. Proceeding with MR creation without an assignee.`,
           );
         }
       }
@@ -272,7 +274,9 @@ which uses additional API calls in order to detect whether to 'create', 'update'
           });
         } catch (e) {
           ctx.logger.warn(
-            `Could not retrieve the list of files for ${repoID} (branch: ${targetBranch}) : ${e}`,
+            `Could not retrieve the list of files for ${repoID} (branch: ${targetBranch}) : ${getErrorMessage(
+              e,
+            )}`,
           );
         }
       }
@@ -327,7 +331,9 @@ which uses additional API calls in order to detect whether to 'create', 'update'
           await api.Branches.create(repoID, branchName, String(targetBranch));
         } catch (e) {
           throw new InputError(
-            `The branch creation failed. Please check that your repo does not already contain a branch named '${branchName}'. ${e}`,
+            `The branch creation failed. Please check that your repo does not already contain a branch named '${branchName}'. ${getErrorMessage(
+              e,
+            )}`,
           );
         }
       }
@@ -336,7 +342,9 @@ which uses additional API calls in order to detect whether to 'create', 'update'
           await api.Commits.create(repoID, branchName, title, actions);
         } catch (e) {
           throw new InputError(
-            `Committing the changes to ${branchName} failed. Please check that none of the files created by the template already exists. ${e}`,
+            `Committing the changes to ${branchName} failed. Please check that none of the files created by the template already exists. ${getErrorMessage(
+              e,
+            )}`,
           );
         }
       }
@@ -359,7 +367,9 @@ which uses additional API calls in order to detect whether to 'create', 'update'
         ctx.output('projectPath', repoID);
         ctx.output('mergeRequestUrl', mergeRequestUrl);
       } catch (e) {
-        throw new InputError(`Merge request creation failed${e}`);
+        throw new InputError(
+          `Merge request creation failed. ${getErrorMessage(e)}`,
+        );
       }
     },
   });

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabPipelineTrigger.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabPipelineTrigger.ts
@@ -25,6 +25,7 @@ import { z } from 'zod';
 import commonGitlabConfig from '../commonGitlabConfig';
 import { getClient, parseRepoUrl } from '../util';
 import { examples } from './gitlabPipelineTrigger.examples';
+import { getErrorMessage } from './helpers';
 
 const pipelineInputProperties = z.object({
   projectId: z.number().describe('Project Id'),
@@ -109,7 +110,9 @@ export const createTriggerGitlabPipelineAction = (options: {
           });
         }
         // Handling other errors
-        throw new InputError(`Failed to trigger Pipeline: ${error.message}`);
+        throw new InputError(
+          `Failed to trigger Pipeline: ${getErrorMessage(error)}`,
+        );
       } finally {
         // Delete the pipeline token if it was created
         if (pipelineTokenResponse && pipelineTokenResponse.id) {

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.ts
@@ -24,7 +24,7 @@ import path from 'path';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import { InputError } from '@backstage/errors';
 import { resolveSafeChildPath } from '@backstage/backend-plugin-api';
-import { createGitlabApi } from './helpers';
+import { createGitlabApi, getErrorMessage } from './helpers';
 import { examples } from './gitlabRepoPush.examples';
 
 /**
@@ -158,7 +158,9 @@ export const createGitlabRepoPushAction = (options: {
       } catch (e: any) {
         if (e.response?.statusCode !== 404) {
           throw new InputError(
-            `Failed to check status of branch '${branchName}'. Please make sure that branch already exists or Backstage has permissions to create one. ${e}`,
+            `Failed to check status of branch '${branchName}'. Please make sure that branch already exists or Backstage has permissions to create one. ${getErrorMessage(
+              e,
+            )}`,
           );
         }
       }
@@ -171,7 +173,9 @@ export const createGitlabRepoPushAction = (options: {
           await api.Branches.create(repoID, branchName, String(defaultBranch));
         } catch (e) {
           throw new InputError(
-            `The branch '${branchName}' was not found and creation failed with error. Please make sure that branch already exists or Backstage has permissions to create one. ${e}`,
+            `The branch '${branchName}' was not found and creation failed with error. Please make sure that branch already exists or Backstage has permissions to create one. ${getErrorMessage(
+              e,
+            )}`,
           );
         }
       }
@@ -188,7 +192,9 @@ export const createGitlabRepoPushAction = (options: {
         ctx.output('commitHash', commit.id);
       } catch (e) {
         throw new InputError(
-          `Committing the changes to ${branchName} failed. Please check that none of the files created by the template already exists. ${e}`,
+          `Committing the changes to ${branchName} failed. Please check that none of the files created by the template already exists. ${getErrorMessage(
+            e,
+          )}`,
         );
       }
     },

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/helpers.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/helpers.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { parseRepoUrl } from '@backstage/plugin-scaffolder-node';
-import { InputError } from '@backstage/errors';
+import { ErrorLike, InputError, isError } from '@backstage/errors';
 import { Gitlab } from '@gitbeaker/node';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import { Resources } from '@gitbeaker/core';
@@ -47,4 +47,18 @@ export function createGitlabApi(options: {
     host: integrationConfig.config.baseUrl,
     [tokenType]: token,
   });
+}
+
+interface GitlabError extends ErrorLike {
+  // Errors from Gitlab may also include a description field that contains additional info
+  description: string;
+}
+
+function isGitlabError(e: unknown): e is GitlabError {
+  return isError(e) && 'description' in e && typeof e.description === 'string';
+}
+
+export function getErrorMessage(e: unknown): string {
+  if (isGitlabError(e)) return `${e} - ${e.description}`;
+  return String(e);
 }


### PR DESCRIPTION
Ran into an issue when trying to create a Merge Request in Gitlab from the scaffolder. When there are branch name rules configured for the repo, Backstage wasn't displaying the error correctly, as GitLab (or at least Gitbeaker) puts additional info about the error under a `description` field.

This PR adds a helper that will pull out additional data from the error object, when available.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
