### PR TITLE
doc: remove runtime config from docker build instructions

### DIFF
--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -46,8 +46,7 @@ yarn install --immutable
 yarn tsc
 
 # Build the backend, which bundles it all up into the packages/backend/dist folder.
-# The configuration files here should match the one you use inside the Dockerfile below.
-yarn build:backend --config ../../app-config.yaml --config ../../app-config.production.yaml
+yarn build:backend
 ```
 
 Once the host build is complete, we are ready to build our image. The following


### PR DESCRIPTION
## Hey, I just made a Pull Request!

According to https://github.com/backstage/backstage/issues/27075#issuecomment-2410446962 we shouldn't need the config at build time anymore, and this can instead cause issues if some included secret files don't exist.
Also fixes #27075

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
