### PR TITLE
Fix MembersListCard description overflow.

### DIFF
--- a/.changeset/gorgeous-masks-beg.md
+++ b/.changeset/gorgeous-masks-beg.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Fix rendering of description in MembersListCard. Add guardrails for potential long texts to prevent it from breaking the UI.

--- a/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
+++ b/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
@@ -112,7 +112,9 @@ const MemberComponent = (props: { member: UserEntity }) => {
             </Link>
           )}
           {description && (
-            <Typography variant="subtitle2">{description}</Typography>
+            <Typography variant="subtitle2">
+              <OverflowTooltip text={description} line={5} />
+            </Typography>
           )}
         </Box>
       </Box>


### PR DESCRIPTION
Before: 
![image](https://github.com/user-attachments/assets/bb356a06-5ec1-42a5-8f03-0a743f5a65d5)



After:
![image](https://github.com/user-attachments/assets/e5260ced-ce7e-4aa0-8916-b207497a958c)

Hover view:
![image](https://github.com/user-attachments/assets/7723e65d-226a-4883-a229-1107f61ed26b)
![image](https://github.com/user-attachments/assets/384a3093-bd6e-44c9-940f-811b9ef0a8e7)


#### :heavy_check_mark: Checklist


- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [n/a] Added or updated documentation
- [n/a] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
