### PR TITLE
Add @backstage/repo-tools version to versions.ts in create-app

### DIFF
--- a/.changeset/rude-shrimps-brake.md
+++ b/.changeset/rude-shrimps-brake.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+This update adds the @backstage/repo-tools package to the versions.ts file, enabling proper version resolution for templates. The {{version '@backstage/repo-tools'}} placeholder now works as expected in the create-app process.

--- a/packages/create-app/src/lib/versions.ts
+++ b/packages/create-app/src/lib/versions.ts
@@ -45,6 +45,7 @@ import { version as errors } from '../../../errors/package.json';
 import { version as integrationReact } from '../../../integration-react/package.json';
 import { version as testUtils } from '../../../test-utils/package.json';
 import { version as theme } from '../../../theme/package.json';
+import { version as repoTools } from '../../../repo-tools/package.json';
 
 import { version as pluginApiDocs } from '../../../../plugins/api-docs/package.json';
 import { version as pluginAppBackend } from '../../../../plugins/app-backend/package.json';
@@ -98,6 +99,7 @@ export const packageVersions = {
   '@backstage/e2e-test-utils': e2eTestUtils,
   '@backstage/errors': errors,
   '@backstage/integration-react': integrationReact,
+  '@backstage/repo-tools': repoTools,
   '@backstage/plugin-api-docs': pluginApiDocs,
   '@backstage/plugin-app-backend': pluginAppBackend,
   '@backstage/plugin-auth-backend': pluginAuthBackend,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In the community-plugins repo, we use [this template](https://github.com/backstage/community-plugins/blob/main/workspaces/repo-tools/packages/cli/src/lib/workspaces/templates/workspace/package.json.hbs#L38) while creating a new workspace. Since `@backstage/repo-tools` ins't mentioned in https://github.com/backstage/backstage/blob/master/packages/create-app/src/lib/versions.ts, attempting to create a new workspace results in the following error:

```
? Enter a name for the app [required] my-workspace

Creating the app...

 Checking that supplied path exists:
  checking      /home/.../community-plugins/workspaces/my-workspace ✔ 

 Preparing files:
  copying       .dockerignore ✔ 
  templating    .eslintrc.js.hbs ✔ 
  copying       .eslintignore ✔ 
  templating    .gitignore.hbs ✔ 
  copying       .prettierignore ✔ 
  copying       README.md ✔ 
  templating    backstage.json.hbs ✔ 
  templating    catalog-info.yaml.hbs ✔ 
  templating    package.json.hbs ✖ 

Error: No version available for package @backstage/repo-tools

It seems that something went wrong when creating the app 🤔

🔥  Failed to create app!
```

This PR adds  @backstage/repo-tools  to https://github.com/backstage/backstage/blob/master/packages/create-app/src/lib/versions.ts to resolve this error.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
