### PR TITLE
feat(device-auth): create new backend and frontend plugins to implement device authorization flow

### DIFF
--- a/.changeset/nice-squids-worry.md
+++ b/.changeset/nice-squids-worry.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-device-auth-backend': minor
+'@backstage/plugin-device-auth': minor
+---
+
+Create new device-auth backend and frontend plugins

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -43,6 +43,7 @@
     "@backstage/plugin-catalog-backend-module-openapi": "workspace:^",
     "@backstage/plugin-catalog-backend-module-scaffolder-entity-model": "workspace:^",
     "@backstage/plugin-catalog-backend-module-unprocessed": "workspace:^",
+    "@backstage/plugin-device-auth-backend": "workspace:^",
     "@backstage/plugin-devtools-backend": "workspace:^",
     "@backstage/plugin-events-backend": "workspace:^",
     "@backstage/plugin-kubernetes-backend": "workspace:^",

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -60,4 +60,6 @@ backend.add(import('@backstage/plugin-techdocs-backend'));
 backend.add(import('@backstage/plugin-signals-backend'));
 backend.add(import('@backstage/plugin-notifications-backend'));
 
+backend.add(import('@backstage/plugin-device-auth-backend'));
+
 backend.start();

--- a/plugins/device-auth-backend/.eslintrc.js
+++ b/plugins/device-auth-backend/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/plugins/device-auth-backend/README.md
+++ b/plugins/device-auth-backend/README.md
@@ -1,0 +1,173 @@
+# Device Authentication
+
+This device authorization flow takes advantage of Backstage's [Auth Plugin](https://github.com/backstage/backstage/blob/master/docs/auth/oauth.md) to authenticate users with the Auth Provider, returning the Backstage User Token to the CLI for use in subsequent calls to the Backstage backend API.
+
+From a User's perspective, this flow is identical to the OAuth2 Device Authorization Grant flow. However, the implementation of the authorization flow is somewhat unique, in that the actual authorization is performed by the Backstage Auth Plugin, which is responsible for authenticating users with the configured Auth Provider.
+
+This flow is heavily inspired by the [OAuth 2.0 Device Authorization Grant](https://tools.ietf.org/html/rfc8628) specification and [OAuth device flow documentation](https://www.oauth.com/oauth2-servers/device-flow/user-flow/), with some modifications to accommodate the unique requirements of a CLI authenticating with Backstage.
+
+## Flow
+
+The authorization flow is initiated with a user CLI command to `login`. The CLI first performs a request to the authorization token endpoint in the Device Auth Backend API, which returns a device code, user code, and a verification URI. The CLI then displays the device code, user code, and the verification URI to the user, and opens the verification URI in the user's default browser.
+
+When the browser opens the verification page a check is performed to confirm the user has an active Backstage session. If they don't have an active session, a popup is opened by the Backstage Auth plugin for the user to authenticate with the configured Auth Provider. Once this is complete and a valid session is established, the user is able to verify the pre-filled user code by clicking the verify button. Clicking the button to verify the user code sends a request to the CLI Auth Backend API's device_authorization endpoint.
+
+The CLI then polls the Device Auth `/token` endpoint until the user has successfully authenticated with the configured Auth Provider and verified the user code. Once the user has authenticated, the Device Auth Backend API returns the users's Backstage Identity token to the CLI, which is then used to authenticate the user on subsequent called to Backstage Backend APIs.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor User
+    participant cli
+    participant CodeVerificationPage as Device User Code Verification Page
+    box Backstage Backend Plugins
+    participant BackstageAuthPlugin as Backstage Auth Plugin
+    participant DeviceAuthBackendAPI as Device Auth Backend API
+    participant BackstageBackendApis as Backstage Backend APIs
+    end
+    participant ExternalAuthProvider as External Auth Provider
+
+    User ->> cli: `cli login`
+    cli ->> DeviceAuthBackendAPI: POST /api/device_auth/device_authorization
+    DeviceAuthBackendAPI -->> cli: Return Device Code
+    cli ->> User: Display User Code and Verification URL
+    cli ->> User: Open Verification URL in browser
+
+    User ->> CodeVerificationPage: Attempts to verify User Code
+    CodeVerificationPage ->> BackstageAuthPlugin: Verify user session
+
+    alt User session invalid
+        BackstageAuthPlugin ->> ExternalAuthProvider: Normal User Authentication Flow
+        ExternalAuthProvider -->> BackstageAuthPlugin: Return User Authentication
+    end
+
+    User ->> CodeVerificationPage: Verifies User Code
+
+    loop Polling for token
+        cli ->> DeviceAuthBackendAPI: POST /api/device_auth/token
+    end
+
+    DeviceAuthBackendAPI -->> cli: Return Bearer Token
+
+    Note over cli, User: Authenticated User Actions
+
+    User ->> cli: `cli deploy --app my-app`
+    cli ->> BackstageBackendApis: Protected Resource Request
+    BackstageBackendApis -->> cli: Response
+    cli ->> User: Display response
+```
+
+## CLI Auth API Endpoints
+
+### POST `/api/cli/device_authorization`
+
+Handles the initial request from the CLI to start the device authorization flow.
+
+The request body includes the `client_id` as well as an optional `scope`, and the CLI Auth Backend API returns a device code, user code, and verification URI. The backend also creates a database record for the device code and user code, and a field to indicate if the user has verified the user code. Request body:
+
+```
+{
+  "client_id": "launchpad-cli",
+  "scope": "launchpad"
+}
+```
+
+Response body:
+
+```
+{
+  "device_code": "device_code",
+  "user_code": "user_code",
+  "verification_uri": "https://backstage.mgt-itbl.co/api/cli/device_authorization",
+  "verification_uri_complete": "https://backstage.mgt-itbl.co/api/cli/device_authorization?device_code=device_code",
+  "interval": 5,
+  "expires_in": 300
+}
+```
+
+### POST `/api/cli/oauth/token`
+
+The CLI Auth Backend API checks the database record for the provided `client_id` and `device_code` to see if the user has verified the user code. Request body:
+
+```
+{
+  "client_id": "launchpad-cli",
+  "device_code": "device_code",
+  "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+}
+```
+
+If the user has verified the user code, the backend will return the user's Backstage identity token. Response body:
+
+```
+{
+  "access_token": "access_token"
+}
+```
+
+If the user has not verified the user code, the backend will return a 401 Unauthorized response.
+
+```
+{
+  "error": "authorization_pending"
+}
+```
+
+The endpoint may also return a 400 Bad Request response if the device code is expired.
+
+```
+{
+  "error": "expired_token"
+}
+```
+
+Or a 403 Forbidden response if the user denied the request.
+
+```
+{
+  "error": "access_denied"
+}
+```
+
+The server may also return a 429 Too Many Requests response if the client is polling too frequently.
+
+```
+{
+  "error": "slow_down"
+}
+```
+
+### POST `/api/cli/user_code/verify`
+
+Handles the request from the browser to verify the user code. This endpoint has the side effect of updating the database record for the device code and user code to indicate that the user has verified the user code.
+
+Request body:
+
+```
+{
+  "device_code": "device_code",
+  "user_code": "user_code"
+}
+```
+
+Response body:
+
+```
+{
+  "status": "verified"
+}
+```
+
+## State Management
+
+The CLI Auth backend must store the device code and user code in state in order to determine if the user has verified the user code. This state could technically live in any storage mechanism, such as memory, file, database, or external cache. The state should be stored in a way that is accessible by all instances of the CLI Auth backend API, as the CLI may be running in multiple instances. Given this requirement, the state should be stored in a shared database or cache. While it possible to use an external cache, such as Redis, for this purpose, there is no guarentee that the cache will be secure (e.g. if the cache is not encrypted or authenticated). Therefore, it is recommended to store the state in a the Backstage database, where Backstage itself stores its secure state.
+
+## Security Considerations
+
+The primary risk of this implementation is that the CLI Auth Backend returns a Backstage Identity token to the CLI for which an attacker does not have valid access to. In other words, an attacker somehow bypasses the Backstage Auth flow and does not authorize against the configured Auth Provider.
+
+This could happen if the attacker brute forces the token endpoint, randomly guessing a device code and user code which have been authorized by a legitimate user. To mitigate this risk, the CLI Auth Backend should immediately remove the device code and user code from the state once the user has verified the user code. This will prevent an attacker from guessing a valid device code and user code after the legitimate user has verified the user code.
+
+This could also happen if the attacker generates a device code and user code and is able to verify the user code without authenticating with a Auth Provider to create a user session. To mitigate this risk, the Backstage authentication system must be configured to require authorization against an Auth Provider before allowing the user to verify the user code. This is the default behavior of the Backstage Auth Plugin, but it is important to ensure that this behavior is enforced.
+
+#

--- a/plugins/device-auth-backend/catalog-info.yaml
+++ b/plugins/device-auth-backend/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-device-auth-backend
+  title: '@backstage/plugin-device-auth-backend'
+spec:
+  lifecycle: experimental
+  type: backstage-backend-plugin
+  owner: maintainers

--- a/plugins/device-auth-backend/config.d.ts
+++ b/plugins/device-auth-backend/config.d.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export interface Config {
+  deviceAuth?: {
+    /**
+     * The interval in seconds at which to instruct the client
+     * device to poll for tokens
+     */
+    initialInterval: number;
+
+    /**
+     * The expiration time in seconds for device codes
+     */
+    deviceCodeExpiration: number;
+
+    /**
+     * The URL path to the user code authentication endpoint. Used to generate
+     * the validation_uri. Should match the path set for the DeviceAuthPage
+     * component in the packages/app/src/App.tsx file.
+     */
+
+    userCodeAuthUrlPath: string;
+  };
+}

--- a/plugins/device-auth-backend/dev/index.ts
+++ b/plugins/device-auth-backend/dev/index.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createBackend } from '@backstage/backend-defaults';
+
+const backend = createBackend();
+
+backend.add(import('@backstage/plugin-auth-backend'));
+backend.add(import('@backstage/plugin-auth-backend-module-guest-provider'));
+backend.add(import('../src'));
+
+backend.start();

--- a/plugins/device-auth-backend/migrations/0001-init.js
+++ b/plugins/device-auth-backend/migrations/0001-init.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function up(knex) {
+  await knex.schema.createTable('user_codes', table => {
+    table.string('user_code').primary();
+    table.string('client_id').notNullable();
+    table.string('device_code').notNullable();
+    table.string('access_token', 5000);
+    table.boolean('is_validated').notNullable().defaultTo(false);
+    table.datetime('expires_at').notNullable();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function down(knex) {
+  await knex.schema.dropTable('user_codes');
+};

--- a/plugins/device-auth-backend/package.json
+++ b/plugins/device-auth-backend/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@backstage/plugin-device-auth-backend",
+  "version": "0.1.0",
+  "backstage": {
+    "role": "backend-plugin"
+  },
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.cjs.js",
+    "types": "dist/index.d.ts"
+  },
+  "license": "Apache-2.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "backstage-cli package build",
+    "clean": "backstage-cli package clean",
+    "lint": "backstage-cli package lint",
+    "prepack": "backstage-cli package prepack",
+    "postpack": "backstage-cli package postpack",
+    "start": "backstage-cli package start",
+    "test": "backstage-cli package test"
+  },
+  "dependencies": {
+    "@backstage/backend-common": "^0.23.3",
+    "@backstage/backend-defaults": "^0.4.0",
+    "@backstage/backend-plugin-api": "^0.7.0",
+    "@backstage/config": "^1.2.0",
+    "@backstage/errors": "^1.2.4",
+    "express": "^4.17.1",
+    "express-promise-router": "^4.1.0",
+    "knex": "^3.1.0",
+    "nanoid": "3",
+    "node-fetch": "^2.6.7",
+    "uuid": "^10.0.0"
+  },
+  "devDependencies": {
+    "@backstage/backend-test-utils": "^0.4.4",
+    "@backstage/cli": "^0.26.11",
+    "@backstage/plugin-auth-backend": "^0.22.9",
+    "@backstage/plugin-auth-backend-module-guest-provider": "^0.1.8",
+    "@types/express": "*",
+    "@types/supertest": "^2.0.12",
+    "msw": "^2.2.14",
+    "supertest": "^6.2.4"
+  }
+}

--- a/plugins/device-auth-backend/src/database/DatabaseDeviceAuthStore.test.ts
+++ b/plugins/device-auth-backend/src/database/DatabaseDeviceAuthStore.test.ts
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TestDatabaseId, TestDatabases } from '@backstage/backend-test-utils';
+import { Knex } from 'knex';
+import {
+  DatabaseDeviceAuthStore,
+  RawDbDeviceAuthRow,
+} from './DatabaseDeviceAuthStore';
+
+jest.setTimeout(60_000);
+
+const databases = TestDatabases.create({});
+
+async function createStore(databaseId: TestDatabaseId) {
+  const knex = await databases.init(databaseId);
+  const databaseManager = {
+    getClient: async () => knex,
+    migrations: {
+      skip: false,
+    },
+  };
+
+  return {
+    knex,
+    storage: await DatabaseDeviceAuthStore.create({
+      database: databaseManager,
+    }),
+  };
+}
+
+describe.each(databases.eachSupportedId())(
+  'DatabaseDeviceAuthStore (%s)',
+  databaseId => {
+    let storage: DatabaseDeviceAuthStore;
+    let knex: Knex;
+
+    beforeAll(async () => {
+      ({ knex, storage } = await createStore(databaseId));
+    });
+
+    afterEach(async () => {
+      jest.resetAllMocks();
+
+      await knex('user_codes').del();
+    });
+
+    const insert = (data: RawDbDeviceAuthRow[]) =>
+      knex<RawDbDeviceAuthRow>('user_codes').insert(data);
+    const query = () =>
+      knex<RawDbDeviceAuthRow>('user_codes').orderBy('user_code').select();
+
+    describe('getByUserCode', () => {
+      it('should throw an error', async () => {
+        await expect(() =>
+          storage.getByUserCode({
+            userCode: 'abcdefgh',
+          }),
+        ).rejects.toThrow(`No device auth entry found for user code abcdefgh`);
+      });
+
+      it('should return the entry', async () => {
+        await insert([
+          {
+            user_code: 'abcdefgh',
+            client_id: 'client-1',
+            device_code: 'device-1',
+            is_validated: false,
+            expires_at: new Date(),
+          },
+        ]);
+
+        await expect(
+          storage.getByUserCode({
+            userCode: 'abcdefgh',
+          }),
+        ).resolves.toEqual({
+          userCode: 'abcdefgh',
+          clientId: 'client-1',
+          deviceCode: 'device-1',
+          accessToken: null,
+          isValidated: 0,
+          expiresAt: expect.any(Date),
+        });
+      });
+    });
+
+    describe('getByDeviceCode', () => {
+      it('should throw an error', async () => {
+        await expect(() =>
+          storage.getByDeviceCode({
+            deviceCode: 'abcdefgh',
+          }),
+        ).rejects.toThrow(
+          `No device auth entry found for device code abcdefgh`,
+        );
+      });
+
+      it('should return the entry', async () => {
+        await insert([
+          {
+            user_code: 'ijklmnop',
+            client_id: 'client-2',
+            device_code: 'device-2',
+            access_token: 'token-2',
+            is_validated: true,
+            expires_at: new Date(),
+          },
+        ]);
+
+        await expect(
+          storage.getByDeviceCode({
+            deviceCode: 'device-2',
+          }),
+        ).resolves.toEqual({
+          userCode: 'ijklmnop',
+          clientId: 'client-2',
+          deviceCode: 'device-2',
+          accessToken: 'token-2',
+          isValidated: 1,
+          expiresAt: expect.any(Date),
+        });
+      });
+    });
+
+    describe('create', () => {
+      it('should create a new entry', async () => {
+        await storage.create({
+          userCode: 'user-1',
+          clientId: 'client-1',
+          deviceCode: 'device-1',
+          expiresAt: new Date(),
+        });
+
+        await expect(query()).resolves.toEqual([
+          {
+            user_code: 'user-1',
+            client_id: 'client-1',
+            device_code: 'device-1',
+            access_token: '',
+            is_validated: 0,
+            expires_at: expect.any(Number),
+          },
+        ]);
+      });
+
+      it('should throw an error', async () => {
+        await storage.create({
+          userCode: 'user-1',
+          clientId: 'client-1',
+          deviceCode: 'device-1',
+          expiresAt: new Date(),
+        });
+
+        await expect(() =>
+          storage.create({
+            userCode: 'user-1',
+            clientId: 'client-1',
+            deviceCode: 'device-1',
+            expiresAt: new Date(),
+          }),
+        ).rejects.toThrow(
+          `Device auth entry already exists for user code user-1`,
+        );
+      });
+    });
+
+    describe('setValidated', () => {
+      it('should throw an error if the entry does not exist', async () => {
+        await expect(() =>
+          storage.setValidated({
+            userCode: 'user-1',
+            accessToken: 'token-1',
+          }),
+        ).rejects.toThrow(`No device auth entry found for user code user-1`);
+      });
+
+      it('should set the validated flag', async () => {
+        await insert([
+          {
+            user_code: 'user-1',
+            client_id: 'client-1',
+            device_code: 'device-1',
+            is_validated: false,
+            expires_at: new Date(),
+          },
+        ]);
+
+        await storage.setValidated({
+          userCode: 'user-1',
+          accessToken: 'token-1',
+        });
+
+        await expect(query()).resolves.toEqual([
+          {
+            user_code: 'user-1',
+            client_id: 'client-1',
+            device_code: 'device-1',
+            access_token: 'token-1',
+            is_validated: 1,
+            expires_at: expect.any(Number),
+          },
+        ]);
+      });
+    });
+
+    describe('deleteByUserCode', () => {
+      it('should not throw an error if the entry does not exist', async () => {
+        await expect(
+          storage.deleteByUserCode({
+            userCode: 'user-1',
+          }),
+        ).resolves.toBeUndefined();
+      });
+
+      it('should delete the row', async () => {
+        await insert([
+          {
+            user_code: 'user-1',
+            client_id: 'client-1',
+            device_code: 'device-1',
+            is_validated: false,
+            expires_at: new Date(),
+          },
+        ]);
+
+        await storage.deleteByUserCode({
+          userCode: 'user-1',
+        });
+        await expect(query()).resolves.toEqual([]);
+      });
+    });
+
+    describe('deleteByDeviceCode', () => {
+      it('should not throw an error if the entry does not exist', async () => {
+        await expect(
+          storage.deleteByDeviceCode({
+            deviceCode: 'device-1',
+          }),
+        ).resolves.toBeUndefined();
+      });
+
+      it('should delete the row', async () => {
+        await insert([
+          {
+            user_code: 'user-1',
+            client_id: 'client-1',
+            device_code: 'device-1',
+            is_validated: false,
+            expires_at: new Date(),
+          },
+        ]);
+
+        await storage.deleteByDeviceCode({
+          deviceCode: 'device-1',
+        });
+        await expect(query()).resolves.toEqual([]);
+      });
+    });
+  },
+);

--- a/plugins/device-auth-backend/src/database/DatabaseDeviceAuthStore.ts
+++ b/plugins/device-auth-backend/src/database/DatabaseDeviceAuthStore.ts
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  DatabaseService,
+  resolvePackagePath,
+} from '@backstage/backend-plugin-api';
+import { NotFoundError } from '@backstage/errors';
+import { Knex } from 'knex';
+import { DeviceAuthStore, type DeviceAuthEntry } from './DeviceAuthStore';
+
+/**
+ * @public
+ */
+export type RawDbDeviceAuthRow = {
+  user_code: string;
+  client_id: string;
+  device_code: string;
+  access_token?: string;
+  is_validated: boolean;
+  expires_at: Date;
+};
+
+/**
+ * Store to manage device authorization data in the database.
+ *
+ * @public
+ */
+export class DatabaseDeviceAuthStore implements DeviceAuthStore {
+  static async create(options: {
+    database: DatabaseService;
+  }): Promise<DatabaseDeviceAuthStore> {
+    const { database } = options;
+    const client = await database.getClient();
+    const migrationsDir = resolvePackagePath(
+      '@backstage/plugin-device-auth-backend',
+      'migrations',
+    );
+    if (!database.migrations?.skip) {
+      await client.migrate.latest({
+        directory: migrationsDir,
+      });
+    }
+
+    return new DatabaseDeviceAuthStore(client);
+  }
+
+  private constructor(private readonly db: Knex) {}
+
+  private rowToEntry(row: RawDbDeviceAuthRow): DeviceAuthEntry {
+    return {
+      userCode: row.user_code,
+      clientId: row.client_id,
+      deviceCode: row.device_code,
+      accessToken: row.access_token,
+      isValidated: row.is_validated,
+      expiresAt: new Date(row.expires_at),
+    };
+  }
+
+  async getByUserCode(options: { userCode: string }): Promise<DeviceAuthEntry> {
+    const row = await this.db<RawDbDeviceAuthRow>('user_codes')
+      .where('user_code', options.userCode)
+      .first();
+
+    if (!row) {
+      throw new NotFoundError(
+        `No device auth entry found for user code ${options.userCode}`,
+      );
+    }
+
+    return this.rowToEntry(row);
+  }
+
+  async getByDeviceCode(options: {
+    deviceCode: string;
+  }): Promise<DeviceAuthEntry> {
+    const row = await this.db<RawDbDeviceAuthRow>('user_codes')
+      .where('device_code', options.deviceCode)
+      .first();
+
+    if (!row) {
+      throw new NotFoundError(
+        `No device auth entry found for device code ${options.deviceCode}`,
+      );
+    }
+
+    return this.rowToEntry(row);
+  }
+
+  async create(options: {
+    userCode: string;
+    clientId: string;
+    deviceCode: string;
+    accessToken?: string;
+    isValidated?: boolean;
+    expiresAt: Date;
+  }): Promise<void> {
+    const existingRow = await this.db<RawDbDeviceAuthRow>('user_codes')
+      .where({ user_code: options.userCode })
+      .first();
+
+    if (existingRow) {
+      throw new Error(
+        `Device auth entry already exists for user code ${options.userCode}`,
+      );
+    }
+
+    await this.db<RawDbDeviceAuthRow>('user_codes').insert({
+      user_code: options.userCode,
+      client_id: options.clientId,
+      device_code: options.deviceCode,
+      access_token: options.accessToken ?? '',
+      is_validated: options.isValidated ?? false,
+      expires_at: options.expiresAt,
+    });
+  }
+
+  async setValidated(options: {
+    userCode: string;
+    accessToken: string;
+  }): Promise<void> {
+    const affectedRows = await this.db<RawDbDeviceAuthRow>('user_codes')
+      .where('user_code', options.userCode)
+      .update({
+        is_validated: true,
+        access_token: options.accessToken,
+      });
+
+    if (affectedRows === 0) {
+      throw new NotFoundError(
+        `No device auth entry found for user code ${options.userCode}`,
+      );
+    }
+  }
+
+  async deleteByUserCode(options: { userCode: string }): Promise<void> {
+    await this.db<RawDbDeviceAuthRow>('user_codes')
+      .where('user_code', options.userCode)
+      .delete();
+  }
+
+  async deleteByDeviceCode(options: { deviceCode: string }): Promise<void> {
+    await this.db<RawDbDeviceAuthRow>('user_codes')
+      .where('device_code', options.deviceCode)
+      .delete();
+  }
+}

--- a/plugins/device-auth-backend/src/database/DeviceAuthStore.ts
+++ b/plugins/device-auth-backend/src/database/DeviceAuthStore.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * An entry in the device auth store representing a device authorization flow attempt.
+ */
+export type DeviceAuthEntry = {
+  userCode: string;
+  clientId: string;
+  deviceCode: string;
+  accessToken?: string;
+  isValidated: boolean;
+  expiresAt: Date;
+};
+
+/**
+ * Store definition for device authorization data.
+ */
+export interface DeviceAuthStore {
+  getByUserCode(options: { userCode: string }): Promise<DeviceAuthEntry>;
+
+  getByDeviceCode(options: { deviceCode: string }): Promise<DeviceAuthEntry>;
+
+  create(options: {
+    userCode: string;
+    clientId: string;
+    deviceCode: string;
+    accessToken?: string;
+    isValidated?: boolean;
+    expiresAt: Date;
+  }): Promise<void>;
+
+  setValidated(options: {
+    userCode: string;
+    accessToken: string;
+  }): Promise<void>;
+
+  deleteByUserCode(options: { userCode: string }): Promise<void>;
+
+  deleteByDeviceCode(options: { deviceCode: string }): Promise<void>;
+}

--- a/plugins/device-auth-backend/src/index.ts
+++ b/plugins/device-auth-backend/src/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './service/router';
+export { deviceAuthPlugin as default } from './plugin';

--- a/plugins/device-auth-backend/src/plugin.ts
+++ b/plugins/device-auth-backend/src/plugin.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  coreServices,
+  createBackendPlugin,
+} from '@backstage/backend-plugin-api';
+import { createRouter } from './service/router';
+
+/**
+ * deviceAuthPlugin backend plugin
+ *
+ * @public
+ */
+export const deviceAuthPlugin = createBackendPlugin({
+  pluginId: 'device-auth',
+  register(env) {
+    env.registerInit({
+      deps: {
+        httpRouter: coreServices.httpRouter,
+        logger: coreServices.logger,
+        config: coreServices.rootConfig,
+        database: coreServices.database,
+        auth: coreServices.auth,
+        httpAuth: coreServices.httpAuth,
+      },
+      async init({ httpRouter, logger, config, database, auth, httpAuth }) {
+        httpRouter.use(
+          await createRouter({
+            logger,
+            config,
+            database,
+            auth,
+            httpAuth,
+          }),
+        );
+        // Ensure unauthenticated access to the device authorization and token endpoints,
+        // allowing device clients to generate new device codes and query for tokens.
+        httpRouter.addAuthPolicy({
+          path: '/device_authorization',
+          allow: 'unauthenticated',
+        });
+        httpRouter.addAuthPolicy({
+          path: '/token',
+          allow: 'unauthenticated',
+        });
+        httpRouter.addAuthPolicy({
+          path: '/health',
+          allow: 'unauthenticated',
+        });
+      },
+    });
+  },
+});

--- a/plugins/device-auth-backend/src/service/router.test.ts
+++ b/plugins/device-auth-backend/src/service/router.test.ts
@@ -1,0 +1,326 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import express from 'express';
+import request from 'supertest';
+import { DeviceAuthEntry, DeviceAuthStore } from '../database/DeviceAuthStore';
+import { mockCredentials, mockServices } from '@backstage/backend-test-utils';
+import { NotFoundError } from '@backstage/errors';
+import { createRouterInternal } from './router';
+
+describe('createRouter', () => {
+  const deviceAuthStore: jest.Mocked<DeviceAuthStore> = {
+    getByDeviceCode: jest.fn(),
+    getByUserCode: jest.fn(),
+    create: jest.fn(),
+    setValidated: jest.fn(),
+    deleteByDeviceCode: jest.fn(),
+    deleteByUserCode: jest.fn(),
+  };
+
+  let app: express.Express;
+
+  beforeEach(async () => {
+    const mockConfig = mockServices.rootConfig({
+      data: {
+        app: {
+          baseUrl: 'http://localhost:7000',
+        },
+      },
+    });
+    const router = await createRouterInternal({
+      logger: mockServices.logger.mock(),
+      config: mockConfig,
+      deviceAuthStore,
+      httpAuth: mockServices.httpAuth(),
+      auth: mockServices.auth(),
+    });
+
+    app = express().use(router);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  // const mockUserRef = mockCredentials.user().principal.userEntityRef;
+  // const mockAccessToken = 'my-access-token';
+
+  describe('POST /user_code/verify', () => {
+    it('returns ok', async () => {
+      const deviceAuthEntry: DeviceAuthEntry = {
+        deviceCode: 'my-device-code',
+        userCode: 'my-user-code',
+        clientId: 'my-client',
+        isValidated: false,
+        expiresAt: new Date(new Date().getTime() + 10000),
+      };
+      deviceAuthStore.getByUserCode.mockResolvedValue(deviceAuthEntry);
+      const mockAuthHeader = mockCredentials.user.header();
+
+      const response = await request(app)
+        .post('/user_code/verify')
+        .set('authorization', mockAuthHeader)
+        .send({ user_code: deviceAuthEntry.userCode });
+
+      expect(deviceAuthStore.getByUserCode).toHaveBeenCalledWith(
+        deviceAuthEntry.userCode,
+      );
+      expect(deviceAuthStore.setValidated).toHaveBeenCalledWith({
+        userCode: deviceAuthEntry.userCode,
+        accessToken: mockAuthHeader.split(' ')[1],
+      });
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual({ status: 'ok' });
+    });
+
+    it('returns an error when unauthorized', async () => {
+      const response = await request(app)
+        .post('/user_code/verify')
+        .send({ user_code: 'user-code' });
+
+      expect(response.status).toEqual(401);
+    });
+
+    it('returns an error when an invalid user code is sent', async () => {
+      deviceAuthStore.getByUserCode.mockImplementation(() => {
+        throw new NotFoundError(
+          'No device auth entry found for user code invalid-user-code',
+        );
+      });
+      const mockAuthHeader = mockCredentials.user.header();
+
+      const response = await request(app)
+        .post('/user_code/verify')
+        .set('authorization', mockAuthHeader)
+        .send({ user_code: 'invalid-user-code' });
+
+      expect(deviceAuthStore.getByUserCode).toHaveBeenCalledWith(
+        'invalid-user-code',
+      );
+      expect(response.status).toEqual(400);
+      expect(response.body).toEqual({ error: 'Invalid user code' });
+    });
+  });
+
+  describe('POST /user_code/deny', () => {
+    it('returns ok', async () => {
+      const deviceAuthEntry: DeviceAuthEntry = {
+        deviceCode: 'my-device-code',
+        userCode: 'my-user-code',
+        clientId: 'my-client',
+        isValidated: false,
+        expiresAt: new Date(new Date().getTime() + 10000),
+      };
+      deviceAuthStore.getByUserCode.mockResolvedValue(deviceAuthEntry);
+      const mockAuthHeader = mockCredentials.user.header();
+
+      const response = await request(app)
+        .post('/user_code/deny')
+        .set('authorization', mockAuthHeader)
+        .send({ user_code: deviceAuthEntry.userCode });
+
+      expect(deviceAuthStore.getByUserCode).toHaveBeenCalledWith(
+        deviceAuthEntry.userCode,
+      );
+      expect(deviceAuthStore.deleteByUserCode).toHaveBeenCalledWith({
+        userCode: deviceAuthEntry.userCode,
+      });
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual({ status: 'denied' });
+    });
+
+    it('returns an error when unauthorized', async () => {
+      const response = await request(app)
+        .post('/user_code/deny')
+        .send({ user_code: 'user-code' });
+
+      expect(response.status).toEqual(401);
+    });
+
+    it('returns an error when an invalid user code is sent', async () => {
+      deviceAuthStore.getByUserCode.mockImplementation(() => {
+        throw new NotFoundError(
+          'No device auth entry found for user code invalid-user-code',
+        );
+      });
+      const mockAuthHeader = mockCredentials.user.header();
+
+      const response = await request(app)
+        .post('/user_code/deny')
+        .set('authorization', mockAuthHeader)
+        .send({ user_code: 'invalid-user-code' });
+
+      expect(deviceAuthStore.getByUserCode).toHaveBeenCalledWith(
+        'invalid-user-code',
+      );
+      expect(response.status).toEqual(400);
+      expect(response.body).toEqual({ error: 'Invalid user code' });
+    });
+  });
+
+  describe('POST /device_authorization', () => {
+    it('returns a valid device and user code response', async () => {
+      deviceAuthStore.create.mockImplementation(() => Promise.resolve());
+      const response = await request(app)
+        .post('/device_authorization')
+        .send({ client_id: 'cli' });
+
+      expect(deviceAuthStore.create).toHaveBeenCalledWith({
+        userCode: expect.any(String),
+        clientId: 'cli',
+        deviceCode: expect.any(String),
+        expiresAt: expect.any(Date),
+      });
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual({
+        device_code: expect.any(String),
+        user_code: expect.any(String),
+        verification_uri: expect.any(String),
+        verification_uri_complete: expect.any(String),
+        expires_at: expect.any(String),
+        interval: 5,
+      });
+    });
+
+    it('returns an error when no client id is sent', async () => {
+      const response = await request(app)
+        .post('/device_authorization')
+        .send({});
+
+      expect(response.status).toEqual(400);
+      expect(response.body).toEqual({ error: 'client_id is required' });
+    });
+  });
+
+  describe('POST /token', () => {
+    it('returns a validated token', async () => {
+      const mockAuthHeader = mockCredentials.user.header();
+      const deviceAuthEntry: DeviceAuthEntry = {
+        deviceCode: 'my-device-code',
+        userCode: 'my-user-code',
+        clientId: 'my-client',
+        isValidated: true,
+        accessToken: mockAuthHeader.split(' ')[1],
+        expiresAt: new Date(new Date().getTime() + 10000),
+      };
+      deviceAuthStore.getByDeviceCode.mockResolvedValue(deviceAuthEntry);
+
+      const response = await request(app)
+        .post('/token')
+        .set('authorization', mockAuthHeader)
+        .send({
+          device_code: deviceAuthEntry.deviceCode,
+          client_id: deviceAuthEntry.clientId,
+          grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+        });
+
+      expect(deviceAuthStore.getByDeviceCode).toHaveBeenCalledWith({
+        deviceCode: deviceAuthEntry.deviceCode,
+      });
+      expect(deviceAuthStore.deleteByDeviceCode).toHaveBeenCalledWith({
+        deviceCode: deviceAuthEntry.deviceCode,
+      });
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual({
+        access_token: mockAuthHeader.split(' ')[1],
+      });
+    });
+
+    it('returns authorization_pending', async () => {
+      const mockAuthHeader = mockCredentials.user.header();
+      const deviceAuthEntry: DeviceAuthEntry = {
+        deviceCode: 'my-device-code',
+        userCode: 'my-user-code',
+        clientId: 'my-client',
+        isValidated: false,
+        expiresAt: new Date(new Date().getTime() + 10000),
+      };
+      deviceAuthStore.getByDeviceCode.mockResolvedValue(deviceAuthEntry);
+
+      const response = await request(app)
+        .post('/token')
+        .set('authorization', mockAuthHeader)
+        .send({
+          device_code: deviceAuthEntry.deviceCode,
+          client_id: deviceAuthEntry.clientId,
+          grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+        });
+
+      expect(deviceAuthStore.getByDeviceCode).toHaveBeenCalledWith({
+        deviceCode: deviceAuthEntry.deviceCode,
+      });
+      expect(response.status).toEqual(401);
+      expect(response.body).toEqual({ error: 'authorization_pending' });
+    });
+
+    it('returns expired_token', async () => {
+      const mockAuthHeader = mockCredentials.user.header();
+      const deviceAuthEntry: DeviceAuthEntry = {
+        deviceCode: 'my-device-code',
+        userCode: 'my-user-code',
+        clientId: 'my-client',
+        isValidated: false,
+        expiresAt: new Date(new Date().getTime() - 10000),
+      };
+      deviceAuthStore.getByDeviceCode.mockResolvedValue(deviceAuthEntry);
+
+      const response = await request(app)
+        .post('/token')
+        .set('authorization', mockAuthHeader)
+        .send({
+          device_code: deviceAuthEntry.deviceCode,
+          client_id: deviceAuthEntry.clientId,
+          grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+        });
+
+      expect(deviceAuthStore.getByDeviceCode).toHaveBeenCalledWith({
+        deviceCode: deviceAuthEntry.deviceCode,
+      });
+      expect(response.status).toEqual(400);
+      expect(response.body).toEqual({ error: 'expired_token' });
+    });
+
+    it('returns invalid code', async () => {
+      deviceAuthStore.getByDeviceCode.mockImplementation(() => {
+        throw new NotFoundError(
+          'No device auth entry found for user code invalid-user-code',
+        );
+      });
+
+      const response = await request(app).post('/token').send({
+        device_code: 'invalid-device-code',
+        client_id: 'cli',
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+      });
+
+      expect(deviceAuthStore.getByDeviceCode).toHaveBeenCalledWith({
+        deviceCode: 'invalid-device-code',
+      });
+      expect(response.status).toEqual(400);
+      expect(response.body).toEqual({ error: 'Invalid user code' });
+    });
+  });
+
+  describe('GET /health', () => {
+    it('returns ok', async () => {
+      const response = await request(app).get('/health');
+
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual({ status: 'ok' });
+    });
+  });
+});

--- a/plugins/device-auth-backend/src/service/router.ts
+++ b/plugins/device-auth-backend/src/service/router.ts
@@ -1,0 +1,340 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MiddlewareFactory } from '@backstage/backend-defaults/rootHttpRouter';
+import {
+  AuthService,
+  DatabaseService,
+  HttpAuthService,
+  LoggerService,
+} from '@backstage/backend-plugin-api';
+import { Config } from '@backstage/config';
+import { NotFoundError } from '@backstage/errors';
+import express from 'express';
+import Router from 'express-promise-router';
+import { nanoid, customAlphabet } from 'nanoid';
+import { DatabaseDeviceAuthStore } from '../database/DatabaseDeviceAuthStore';
+import { DeviceAuthStore } from '../database/DeviceAuthStore';
+
+export interface RouterOptions {
+  logger: LoggerService;
+  config: Config;
+  database: DatabaseService;
+  auth: AuthService;
+  httpAuth: HttpAuthService;
+}
+
+const INITIAL_INTERVAL = 5; // seconds
+const DEVICE_CODE_EXPIRATION = 300; // seconds
+
+/**
+ * Create the user settings backend routes.
+ *
+ * @public
+ */
+export async function createRouter(
+  options: RouterOptions,
+): Promise<express.Router> {
+  const deviceAuthStore = await DatabaseDeviceAuthStore.create({
+    database: options.database,
+  });
+
+  return await createRouterInternal({
+    ...options,
+    deviceAuthStore,
+  });
+}
+
+export async function createRouterInternal(options: {
+  logger: LoggerService;
+  config: Config;
+  deviceAuthStore: DeviceAuthStore;
+  auth: AuthService;
+  httpAuth: HttpAuthService;
+}): Promise<express.Router> {
+  // const { logger, config, deviceAuthStore, auth, httpAuth } = options;
+  const { logger, config, deviceAuthStore } = options;
+
+  const router = Router();
+  router.use(express.json());
+
+  router.get('/health', (_, response) => {
+    response.send({ status: 'ok' });
+  });
+
+  /**
+   * POST /user_code/verify
+   *
+   * Verifies the provided user code and device code. If both codes are valid,
+   * it sets the `is_validated` field to true in the database and returns a 200 response.
+   *
+   * If the `user_code` is missing from the request body, it returns a 400 response and a message indicating which field is missing.
+   * If the provided user code and device code do not match any records in the database, it returns a 400 response.
+   * If there is an error during the verification process, it returns a 500 response.
+   *
+   * @param {Object} request - The request object.
+   * @param {Object} request.body - The body of the request.
+   * @param {string} request.body.user_code - The user code to be verified.
+   * @param {Object} response - The response object.
+   * @returns {void}
+   */
+  router.post('/user_code/verify', async (request, response) => {
+    if (!request.body.user_code) {
+      response.status(400).json({ error: 'user_code is required' });
+      return;
+    }
+
+    const token = request.headers.authorization?.split(' ')[1];
+    if (!token) {
+      response.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+
+    try {
+      const userCode = await deviceAuthStore.getByUserCode(
+        request.body.user_code,
+      );
+
+      if (userCode.expiresAt < new Date()) {
+        response.status(400).json({ error: 'expired_token' });
+        return;
+      }
+      await deviceAuthStore.setValidated({
+        userCode: request.body.user_code,
+        accessToken: token,
+      });
+      response.status(200).json({ status: 'ok' });
+      return;
+    } catch (error) {
+      if (error instanceof NotFoundError) {
+        response.status(400).json({ error: 'Invalid user code' });
+        return;
+      }
+      if (error instanceof Error) {
+        logger.error('Error verifying user code: ', error);
+      }
+      response
+        .status(500)
+        .json({ error: 'Unable to update user code verification' });
+      return;
+    }
+  });
+
+  /**
+   * POST /user_code/deny
+   *
+   * Denies the provided user code and device code,
+   * deleting the user code entry from the database.
+   *
+   * If the `user_code` is missing from the request body, it returns a 400 response and a message indicating which field is missing.
+   * If the provided user code and device code do not match any records in the database, it returns a 400 response.
+   * If there is an error during the process, it returns a 500 response.
+   *
+   * @param {Object} request - The request object.
+   * @param {Object} request.body - The body of the request.
+   * @param {string} request.body.user_code - The user code to be verified.
+   * @param {Object} response - The response object.
+   * @returns {void}
+   */
+  router.post('/user_code/deny', async (request, response) => {
+    const token = request.headers.authorization?.split(' ')[1];
+    if (!token) {
+      response.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+
+    if (!request.body.user_code) {
+      response.status(400).json({ error: 'user_code is required' });
+      return;
+    }
+
+    try {
+      // const userCode = await deviceAuthStore.getByUserCode(request.body.user_code);
+      await deviceAuthStore.deleteByUserCode({
+        userCode: request.body.user_code,
+      });
+      response.status(200).json({ status: 'denied' });
+      return;
+    } catch (error) {
+      if (error instanceof NotFoundError) {
+        response.status(400).json({ error: 'Invalid user code' });
+        return;
+      }
+      if (error instanceof Error) {
+        logger.error('Error denying user code: ', error);
+      }
+      response.status(500).json({ error: 'Unable to deny user code' });
+      return;
+    }
+  });
+
+  /**
+   * POST /device_authorization
+   *
+   * Initiates the device authorization flow. It generates a random device code
+   * and user code, and stores them in the database. It then returns the device code
+   * and user code in the response along with the verification URI.
+   *
+   * @param {Object} request - The request object.
+   * @param {Object} request.body - The body of the request.
+   * @param {string} request.body.client_id - The client ID of the application.
+   * @param {string} [request.body.scope] - The scope of the authorization request (optional, currently unused).
+   * @returns {void}
+   */
+  router.post('/device_authorization', async (request, response) => {
+    if (!request.body.client_id) {
+      response.status(400).json({ error: 'client_id is required' });
+      return;
+    }
+    // Currently unused
+    // const scope = request.body.scope || '';
+
+    const deviceCode = nanoid();
+
+    // Generate a random user code using numbers and lower-case consonants, to avoid confusion with similar characters
+    // When the frontend displays the user code, it should be formatted in groups of 4 upper-case characters for readability
+    // When the frontend sends the user code to the backend to verify it, the cose should be sent as a single lower-case string without punctuation.
+    const userCode = customAlphabet('123456789bcdfghjklmnpqrstvwxyz', 8)();
+
+    const userCodeAuthUrlPath =
+      config.getOptionalString('deviceAuth.userCodeAuthUrlPath') ||
+      '/device-auth';
+    const expiresAt = new Date();
+    expiresAt.setTime(
+      expiresAt.getTime() +
+        (config.getOptionalNumber('deviceAuth.deviceCodeExpiration') ||
+          DEVICE_CODE_EXPIRATION) *
+          1000,
+    );
+
+    try {
+      // Save the device code and user code in the database
+      await deviceAuthStore.create({
+        userCode,
+        clientId: request.body.client_id,
+        deviceCode,
+        expiresAt,
+      });
+      response.status(200).json({
+        device_code: deviceCode,
+        user_code: userCode,
+        verification_uri: `${config.getString(
+          'app.baseUrl',
+        )}${userCodeAuthUrlPath}`,
+        verification_uri_complete: `${config.getString(
+          'app.baseUrl',
+        )}${userCodeAuthUrlPath}?user_code=${userCode}`,
+        interval:
+          config.getOptionalNumber('deviceAuth.initialInterval') ||
+          INITIAL_INTERVAL,
+        expires_at: expiresAt,
+      });
+      return;
+    } catch (error) {
+      if (error instanceof Error) {
+        logger.error(
+          `Error saving device code and user code: ${error.message}`,
+        );
+        response.status(500).json({
+          error: `Error saving device code and user code: ${error.message}`,
+        });
+        return;
+      }
+    }
+  });
+
+  /**
+   * POST /token
+   *
+   * Exchanges the device code and user code for an access token if the user has
+   * successfully authenticated and verified the associated user code.
+   * After returning the access token, it deletes the device code and user code
+   * from the database.
+   *
+   * @param {Object} request - The request object.
+   * @param {Object} request.body - The body of the request.
+   * @param {string} request.body.device_code - The device code to be exchanged for an access token.
+   * @param {string} request.body.client_id - The client ID of the application.
+   * @param {string} request.body.grant_type - The grant type of the request (must be urn:ietf:params:oauth:grant-type:device_code).
+   * @returns {void}
+   */
+  router.post('/token', async (request, response) => {
+    if (
+      !request.body.grant_type ||
+      request.body.grant_type !== 'urn:ietf:params:oauth:grant-type:device_code'
+    ) {
+      return response.status(400).json({ error: 'invalid_grant' });
+    }
+    if (!request.body.client_id) {
+      return response.status(400).json({ error: 'client_id is required' });
+    }
+    if (!request.body.device_code) {
+      return response.status(400).json({ error: 'device_code is required' });
+    }
+
+    // Check if the user code has been verified
+    try {
+      const userCode = await deviceAuthStore.getByDeviceCode({
+        deviceCode: request.body.device_code,
+      });
+
+      // Check if the device code has expired
+      if (userCode.expiresAt < new Date()) {
+        // Delete the device code and user code from the database
+        await deviceAuthStore.deleteByDeviceCode({
+          deviceCode: request.body.device_code,
+        });
+        return response.status(400).json({ error: 'expired_token' });
+      }
+
+      if (!userCode.isValidated) {
+        return response.status(401).json({ error: 'authorization_pending' });
+      } else if (
+        userCode.accessToken !== null &&
+        userCode.accessToken !== undefined
+      ) {
+        // Remove the device code and user code from the database and return the access token
+        await deviceAuthStore.deleteByDeviceCode({
+          deviceCode: request.body.device_code,
+        });
+        return response
+          .status(200)
+          .json({ access_token: userCode.accessToken });
+      }
+      return response.status(500).json({ error: 'No access token found' });
+    } catch (error) {
+      if (error instanceof NotFoundError) {
+        return response.status(400).json({ error: 'Invalid user code' });
+      }
+      if (error instanceof Error) {
+        logger.error('Error exchanging device code for access token: ', error);
+      }
+      return response
+        .status(500)
+        .json({ error: 'Error exchanging device code for access token' });
+    }
+  });
+
+  router.get('/health', (_, response) => {
+    logger.info('PONG!');
+    response.json({ status: 'ok' });
+  });
+
+  const middleware = MiddlewareFactory.create({ logger, config });
+
+  router.use(middleware.error());
+  return router;
+}

--- a/plugins/device-auth-backend/src/setupTests.ts
+++ b/plugins/device-auth-backend/src/setupTests.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export {};

--- a/plugins/device-auth/.eslintrc.js
+++ b/plugins/device-auth/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/plugins/device-auth/README.md
+++ b/plugins/device-auth/README.md
@@ -1,0 +1,13 @@
+# device-auth
+
+Welcome to the device-auth plugin!
+
+_This plugin was created through the Backstage CLI_
+
+## Getting started
+
+Your plugin has been added to the example app in this repository, meaning you'll be able to access it by running `yarn start` in the root directory, and then navigating to [/device-auth](http://localhost:3000/device-auth).
+
+You can also serve the plugin in isolation by running `yarn start` in the plugin directory.
+This method of serving the plugin provides quicker iteration speed and a faster startup and hot reloads.
+It is only meant for local development, and the setup for it can be found inside the [/dev](./dev) directory.

--- a/plugins/device-auth/catalog-info.yaml
+++ b/plugins/device-auth/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-device-auth
+  title: '@backstage/plugin-device-auth'
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin
+  owner: maintainers

--- a/plugins/device-auth/dev/index.tsx
+++ b/plugins/device-auth/dev/index.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { createDevApp } from '@backstage/dev-utils';
+import { deviceAuthPlugin, DeviceAuthPage } from '../src/plugin';
+
+createDevApp()
+  .registerPlugin(deviceAuthPlugin)
+  .addPage({
+    element: <DeviceAuthPage />,
+    title: 'Root Page',
+    path: '/device-auth',
+  })
+  .render();

--- a/plugins/device-auth/package.json
+++ b/plugins/device-auth/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@backstage/plugin-device-auth",
+  "version": "0.1.0",
+  "backstage": {
+    "role": "frontend-plugin"
+  },
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.esm.js",
+    "types": "dist/index.d.ts"
+  },
+  "license": "Apache-2.0",
+  "sideEffects": false,
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "backstage-cli package build",
+    "clean": "backstage-cli package clean",
+    "lint": "backstage-cli package lint",
+    "prepack": "backstage-cli package prepack",
+    "postpack": "backstage-cli package postpack",
+    "start": "backstage-cli package start",
+    "test": "backstage-cli package test"
+  },
+  "dependencies": {
+    "@backstage/core-components": "^0.14.9",
+    "@backstage/core-plugin-api": "^1.9.3",
+    "@backstage/theme": "^0.5.6",
+    "@material-ui/core": "^4.9.13",
+    "@material-ui/icons": "^4.9.1",
+    "@material-ui/lab": "^4.0.0-alpha.61",
+    "react-use": "^17.2.4"
+  },
+  "devDependencies": {
+    "@backstage/cli": "^0.26.11",
+    "@backstage/dev-utils": "^1.0.36",
+    "@backstage/test-utils": "^1.5.9",
+    "@testing-library/jest-dom": "^5.10.1",
+    "@testing-library/react": "^12.1.3",
+    "@testing-library/user-event": "^14.0.0",
+    "msw": "^1.0.0"
+  },
+  "peerDependencies": {
+    "react": "^16.13.1 || ^17.0.0",
+    "react-router": "^6.24.0",
+    "react-router-dom": "^6.22.2"
+  }
+}

--- a/plugins/device-auth/src/api.ts
+++ b/plugins/device-auth/src/api.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  createApiRef,
+  DiscoveryApi,
+  FetchApi,
+} from '@backstage/core-plugin-api';
+
+export interface VerificationResponse {
+  error?: string;
+}
+
+export interface DeviceAuthApi {
+  verifyUserCode(userCode: string): Promise<VerificationResponse>;
+  denyUserCode(userCode: string): Promise<VerificationResponse>;
+}
+
+export const deviceAuthApiRef = createApiRef<DeviceAuthApi>({
+  id: 'plugin.device-auth.service',
+});
+
+export class DeviceAuthClient implements DeviceAuthApi {
+  constructor(public discovery: DiscoveryApi, public fetchApi: FetchApi) {}
+
+  private async fetch(path: string, init?: RequestInit): Promise<Response> {
+    const url = await this.discovery.getBaseUrl('device-auth');
+    return await this.fetchApi.fetch(`${url}/${path}`, init);
+  }
+
+  async verifyUserCode(userCode: string): Promise<VerificationResponse> {
+    const resp = await this.fetch('user_code/verify', {
+      method: 'POST',
+      body: JSON.stringify({ user_code: userCode }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+    if (!resp.ok) {
+      const respJson = await resp.json();
+      return {
+        error: respJson.error,
+      };
+    }
+    return {};
+  }
+
+  async denyUserCode(userCode: string): Promise<VerificationResponse> {
+    const resp = await this.fetch('user_code/deny', {
+      method: 'POST',
+      body: JSON.stringify({ user_code: userCode }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+    if (!resp.ok) {
+      const respJson = await resp.json();
+      return {
+        error: respJson.error,
+      };
+    }
+    return {};
+  }
+}

--- a/plugins/device-auth/src/components/DeviceAuthVerifyPage/DeviceAuthVerifyPage.test.tsx
+++ b/plugins/device-auth/src/components/DeviceAuthVerifyPage/DeviceAuthVerifyPage.test.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { DeviceAuthVerifyPage } from './DeviceAuthVerifyPage';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { screen } from '@testing-library/react';
+import { registerMswTestHooks, renderInTestApp } from '@backstage/test-utils';
+
+describe('DeviceAuthVerifyPage', () => {
+  const server = setupServer();
+  // Enable sane handlers for network requests
+  registerMswTestHooks(server);
+
+  // setup mock response
+  beforeEach(() => {
+    server.use(
+      rest.get('/*', (_, res, ctx) => res(ctx.status(200), ctx.json({}))),
+    );
+  });
+
+  it('should render', async () => {
+    await renderInTestApp(<DeviceAuthVerifyPage />);
+    expect(
+      screen.getByText('Backstage Device Code Verification'),
+    ).toBeInTheDocument();
+  });
+});

--- a/plugins/device-auth/src/components/DeviceAuthVerifyPage/DeviceAuthVerifyPage.tsx
+++ b/plugins/device-auth/src/components/DeviceAuthVerifyPage/DeviceAuthVerifyPage.tsx
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useEffect, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Grid,
+  TextField,
+} from '@material-ui/core';
+import {
+  InfoCard,
+  Header,
+  Page,
+  Content,
+  LinkButton,
+  WarningPanel,
+} from '@backstage/core-components';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { identityApiRef, useApi } from '@backstage/core-plugin-api';
+import { deviceAuthApiRef } from '../../api';
+
+export const DeviceAuthVerifyPage = () => {
+  const identityApi = useApi(identityApiRef);
+  const deviceAuthApi = useApi(deviceAuthApiRef);
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [userCode, setUserCode] = useState('');
+  const [hasUserIdentity, setHasUserIdentity] = useState<boolean>(false);
+  const [showWarning, setShowWarning] = useState(false);
+  const [warningMessage, setWarningMessage] = useState('');
+  const [completeDialogOpen, setCompleteDialogOpen] = useState(false);
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const useCodeValue = params.get('user_code');
+    if (useCodeValue) {
+      setUserCode(useCodeValue);
+    }
+  }, [location]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const { token } = await identityApi.getCredentials();
+      setHasUserIdentity(!!token);
+    };
+    fetchData();
+  }, [identityApi]);
+
+  const handleConfirm = async () => {
+    console.log('Confirming user code', userCode); // eslint-disable-line no-console
+    const resp = await deviceAuthApi.verifyUserCode(userCode);
+    if (resp.error) {
+      console.error('Error confirming user code', resp.error); // eslint-disable-line
+      setWarningMessage(resp.error);
+      setShowWarning(true);
+    } else {
+      setCompleteDialogOpen(true);
+    }
+  };
+
+  const handleDeny = async () => {
+    console.log('Denying user code', userCode); // eslint-disable-line no-console
+    const resp = await deviceAuthApi.denyUserCode(userCode);
+    if (resp.error) {
+      console.error('Error denying user code', resp.error); // eslint-disable-line
+      setWarningMessage(resp.error);
+      setShowWarning(true);
+    }
+  };
+
+  const formatUserCode = (value: string) => {
+    const cleaned = value.replace(/[^a-zA-Z0-9]/g, '');
+    const upperCased = cleaned.toLocaleUpperCase('en-US');
+    return upperCased.match(/.{1,4}/g)?.join('-') || upperCased;
+  };
+
+  const sanitizedUserCode = (value: string) => {
+    return value.toLocaleLowerCase('en-US').replace(/[^a-zA-Z0-9]/g, '');
+  };
+
+  const handleUserCodeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const searchParams = new URLSearchParams(location.search);
+    searchParams.set(
+      'user_code',
+      sanitizedUserCode(event.target.value.slice(0, 9)),
+    );
+    navigate({ search: searchParams.toString().toLocaleLowerCase('en-US') });
+  };
+
+  return (
+    <Page themeId="tool">
+      <Header title="Backstage Device Code Verification" />
+      <Content>
+        <Dialog open={completeDialogOpen}>
+          <DialogTitle>Verification Complete</DialogTitle>
+          <DialogContent>
+            <DialogContentText>
+              You may now close this window.
+            </DialogContentText>
+          </DialogContent>
+        </Dialog>
+        <Grid container>
+          <Grid item xs={4}>
+            <InfoCard title="Verify Code">
+              <Grid container>
+                {showWarning && (
+                  <Grid item xs={12}>
+                    <WarningPanel
+                      severity="error"
+                      message={warningMessage}
+                      defaultExpanded
+                    />
+                  </Grid>
+                )}
+                <Grid item xs={12}>
+                  <TextField
+                    id="user-code"
+                    label="Code"
+                    helperText="Confirm this is the code displayed in your terminal"
+                    onChange={handleUserCodeChange}
+                    value={formatUserCode(userCode)}
+                  />
+                </Grid>
+                <Grid container spacing={2} item xs={12}>
+                  <Grid item>
+                    <LinkButton
+                      variant="contained"
+                      color="secondary"
+                      to="#"
+                      onClick={handleDeny}
+                      disabled={!hasUserIdentity}
+                    >
+                      Deny
+                    </LinkButton>
+                  </Grid>
+                  <Grid item>
+                    <LinkButton
+                      variant="contained"
+                      color="primary"
+                      to="#"
+                      onClick={handleConfirm}
+                      disabled={!hasUserIdentity}
+                    >
+                      Confirm
+                    </LinkButton>
+                  </Grid>
+                </Grid>
+              </Grid>
+            </InfoCard>
+          </Grid>
+        </Grid>
+      </Content>
+    </Page>
+  );
+};

--- a/plugins/device-auth/src/components/DeviceAuthVerifyPage/index.ts
+++ b/plugins/device-auth/src/components/DeviceAuthVerifyPage/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { DeviceAuthVerifyPage } from './DeviceAuthVerifyPage';

--- a/plugins/device-auth/src/index.ts
+++ b/plugins/device-auth/src/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { deviceAuthPlugin, DeviceAuthPage } from './plugin';

--- a/plugins/device-auth/src/plugin.test.ts
+++ b/plugins/device-auth/src/plugin.test.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { deviceAuthPlugin } from './plugin';
+
+describe('device-auth', () => {
+  it('should export plugin', () => {
+    expect(deviceAuthPlugin).toBeDefined();
+  });
+});

--- a/plugins/device-auth/src/plugin.ts
+++ b/plugins/device-auth/src/plugin.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  createApiFactory,
+  createPlugin,
+  createRoutableExtension,
+  discoveryApiRef,
+  fetchApiRef,
+} from '@backstage/core-plugin-api';
+
+import { rootRouteRef } from './routes';
+import { deviceAuthApiRef, DeviceAuthClient } from './api';
+
+export const deviceAuthPlugin = createPlugin({
+  id: 'device-auth',
+  routes: {
+    root: rootRouteRef,
+  },
+  apis: [
+    createApiFactory({
+      api: deviceAuthApiRef,
+      deps: {
+        discoveryApi: discoveryApiRef,
+        fetchApi: fetchApiRef,
+      },
+      factory: ({ discoveryApi, fetchApi }) =>
+        new DeviceAuthClient(discoveryApi, fetchApi),
+    }),
+  ],
+});
+
+export const DeviceAuthPage = deviceAuthPlugin.provide(
+  createRoutableExtension({
+    name: 'DeviceAuthPage',
+    component: () =>
+      import('./components/DeviceAuthVerifyPage').then(
+        m => m.DeviceAuthVerifyPage,
+      ),
+    mountPoint: rootRouteRef,
+  }),
+);

--- a/plugins/device-auth/src/routes.ts
+++ b/plugins/device-auth/src/routes.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createRouteRef } from '@backstage/core-plugin-api';
+
+export const rootRouteRef = createRouteRef({
+  id: 'device-auth',
+});

--- a/plugins/device-auth/src/setupTests.ts
+++ b/plugins/device-auth/src/setupTests.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '@testing-library/jest-dom';

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,10 +12,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@adobe/css-tools@npm:^4.4.0":
-  version: 4.4.0
-  resolution: "@adobe/css-tools@npm:4.4.0"
-  checksum: 1f08fb49bf17fc7f2d1a86d3e739f29ca80063d28168307f1b0a962ef37501c5667271f6771966578897f2e94e43c4770fd802728a6e6495b812da54112d506a
+"@adobe/css-tools@npm:^4.0.1, @adobe/css-tools@npm:^4.4.0":
+  version: 4.4.1
+  resolution: "@adobe/css-tools@npm:4.4.1"
+  checksum: bbded8a03c314afee0fb0b42922f664f437e0e2f0b86eeeb06dee9d02cd8fc958cf87aa3314952b00074e0b22fc5b8da23f45b61b6f8291c8aaa7cffc56a76e9
   languageName: node
   linkType: hard
 
@@ -3427,6 +3427,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/app-defaults@npm:^1.5.12":
+  version: 1.5.12
+  resolution: "@backstage/app-defaults@npm:1.5.12"
+  dependencies:
+    "@backstage/core-app-api": ^1.15.1
+    "@backstage/core-components": ^0.15.1
+    "@backstage/core-plugin-api": ^1.10.0
+    "@backstage/plugin-permission-react": ^0.4.27
+    "@backstage/theme": ^0.6.0
+    "@material-ui/core": ^4.12.2
+    "@material-ui/icons": ^4.9.1
+  peerDependencies:
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 8dcb107bc954ed423260d8d2bde4d23436da9772550623ca10f62928de0b8eea982730f593594376f2bf5257094d287cda649b1527548738011e3c08e29a41ca
+  languageName: node
+  linkType: hard
+
 "@backstage/app-defaults@workspace:^, @backstage/app-defaults@workspace:packages/app-defaults":
   version: 0.0.0-use.local
   resolution: "@backstage/app-defaults@workspace:packages/app-defaults"
@@ -3456,6 +3479,95 @@ __metadata:
       optional: true
   languageName: unknown
   linkType: soft
+
+"@backstage/backend-app-api@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "@backstage/backend-app-api@npm:0.8.0"
+  dependencies:
+    "@backstage/backend-common": ^0.23.3
+    "@backstage/backend-plugin-api": ^0.7.0
+    "@backstage/backend-tasks": ^0.5.27
+    "@backstage/cli-common": ^0.1.14
+    "@backstage/cli-node": ^0.2.7
+    "@backstage/config": ^1.2.0
+    "@backstage/config-loader": ^1.8.1
+    "@backstage/errors": ^1.2.4
+    "@backstage/plugin-auth-node": ^0.4.17
+    "@backstage/plugin-permission-node": ^0.8.0
+    "@backstage/types": ^1.1.1
+    "@manypkg/get-packages": ^1.1.3
+    "@types/cors": ^2.8.6
+    "@types/express": ^4.17.6
+    compression: ^1.7.4
+    cookie: ^0.6.0
+    cors: ^2.8.5
+    express: ^4.17.1
+    express-promise-router: ^4.1.0
+    fs-extra: ^11.2.0
+    helmet: ^6.0.0
+    jose: ^5.0.0
+    knex: ^3.0.0
+    lodash: ^4.17.21
+    logform: ^2.3.2
+    luxon: ^3.0.0
+    minimatch: ^9.0.0
+    minimist: ^1.2.5
+    morgan: ^1.10.0
+    node-fetch: ^2.6.7
+    node-forge: ^1.3.1
+    path-to-regexp: ^6.2.1
+    selfsigned: ^2.0.0
+    stoppable: ^1.1.0
+    triple-beam: ^1.4.1
+    uuid: ^9.0.0
+    winston: ^3.2.1
+    winston-transport: ^4.5.0
+  checksum: 663b0517e7d4c948d005c2120a83f7720ea02e68ad9600b5e5a3b22441a23b70523ebaf725b0598c7a1916c6a36261367d8316cfa1686a09955bdfdf457497d6
+  languageName: node
+  linkType: hard
+
+"@backstage/backend-app-api@npm:^0.9.3":
+  version: 0.9.3
+  resolution: "@backstage/backend-app-api@npm:0.9.3"
+  dependencies:
+    "@backstage/backend-common": ^0.24.1
+    "@backstage/backend-plugin-api": ^0.8.1
+    "@backstage/cli-common": ^0.1.14
+    "@backstage/cli-node": ^0.2.7
+    "@backstage/config": ^1.2.0
+    "@backstage/config-loader": ^1.9.0
+    "@backstage/errors": ^1.2.4
+    "@backstage/plugin-auth-node": ^0.5.1
+    "@backstage/plugin-permission-node": ^0.8.2
+    "@backstage/types": ^1.1.1
+    "@manypkg/get-packages": ^1.1.3
+    compression: ^1.7.4
+    cookie: ^0.6.0
+    cors: ^2.8.5
+    express: ^4.17.1
+    express-promise-router: ^4.1.0
+    fs-extra: ^11.2.0
+    helmet: ^6.0.0
+    jose: ^5.0.0
+    knex: ^3.0.0
+    lodash: ^4.17.21
+    logform: ^2.3.2
+    luxon: ^3.0.0
+    minimatch: ^9.0.0
+    minimist: ^1.2.5
+    morgan: ^1.10.0
+    node-fetch: ^2.7.0
+    node-forge: ^1.3.1
+    path-to-regexp: ^6.2.1
+    selfsigned: ^2.0.0
+    stoppable: ^1.1.0
+    triple-beam: ^1.4.1
+    uuid: ^9.0.0
+    winston: ^3.2.1
+    winston-transport: ^4.5.0
+  checksum: 42c41bf9c71bcd5a34675e9116879949693f388d74147a6f1c8ad4b483799ee03be999b5d431547f0ab3f3e24cc9a7a813315fc627b2ba4af961f99b237e9dd5
+  languageName: node
+  linkType: hard
 
 "@backstage/backend-app-api@workspace:^, @backstage/backend-app-api@workspace:packages/backend-app-api":
   version: 0.0.0-use.local
@@ -3508,6 +3620,159 @@ __metadata:
     winston-transport: ^4.5.0
   languageName: unknown
   linkType: soft
+
+"@backstage/backend-common@npm:^0.23.3":
+  version: 0.23.3
+  resolution: "@backstage/backend-common@npm:0.23.3"
+  dependencies:
+    "@aws-sdk/abort-controller": ^3.347.0
+    "@aws-sdk/client-codecommit": ^3.350.0
+    "@aws-sdk/client-s3": ^3.350.0
+    "@aws-sdk/credential-providers": ^3.350.0
+    "@aws-sdk/types": ^3.347.0
+    "@backstage/backend-dev-utils": ^0.1.4
+    "@backstage/backend-plugin-api": ^0.7.0
+    "@backstage/cli-common": ^0.1.14
+    "@backstage/config": ^1.2.0
+    "@backstage/config-loader": ^1.8.1
+    "@backstage/errors": ^1.2.4
+    "@backstage/integration": ^1.13.0
+    "@backstage/integration-aws-node": ^0.1.12
+    "@backstage/plugin-auth-node": ^0.4.17
+    "@backstage/types": ^1.1.1
+    "@google-cloud/storage": ^7.0.0
+    "@keyv/memcache": ^1.3.5
+    "@keyv/redis": ^2.5.3
+    "@kubernetes/client-node": 0.20.0
+    "@manypkg/get-packages": ^1.1.3
+    "@octokit/rest": ^19.0.3
+    "@types/cors": ^2.8.6
+    "@types/dockerode": ^3.3.0
+    "@types/express": ^4.17.6
+    "@types/luxon": ^3.0.0
+    "@types/webpack-env": ^1.15.2
+    archiver: ^6.0.0
+    base64-stream: ^1.0.0
+    compression: ^1.7.4
+    concat-stream: ^2.0.0
+    cors: ^2.8.5
+    dockerode: ^4.0.0
+    express: ^4.17.1
+    express-promise-router: ^4.1.0
+    fs-extra: ^11.2.0
+    git-url-parse: ^14.0.0
+    helmet: ^6.0.0
+    isomorphic-git: ^1.23.0
+    jose: ^5.0.0
+    keyv: ^4.5.2
+    knex: ^3.0.0
+    lodash: ^4.17.21
+    logform: ^2.3.2
+    luxon: ^3.0.0
+    minimatch: ^9.0.0
+    minimist: ^1.2.5
+    morgan: ^1.10.0
+    mysql2: ^3.0.0
+    node-fetch: ^2.6.7
+    node-forge: ^1.3.1
+    p-limit: ^3.1.0
+    path-to-regexp: ^6.2.1
+    pg: ^8.11.3
+    raw-body: ^2.4.1
+    selfsigned: ^2.0.0
+    stoppable: ^1.1.0
+    tar: ^6.1.12
+    triple-beam: ^1.4.1
+    uuid: ^9.0.0
+    winston: ^3.2.1
+    winston-transport: ^4.5.0
+    yauzl: ^3.0.0
+    yn: ^4.0.0
+  peerDependencies:
+    pg-connection-string: ^2.3.0
+  peerDependenciesMeta:
+    pg-connection-string:
+      optional: true
+  checksum: 3cd96e153a5537e95c783fb7f5783c7ba15700375248f102b89aae1144962e64382caec2fec5b27d5ed08ae988c0fc6b3bc34921e9355d12bdbf8ce78aa99acb
+  languageName: node
+  linkType: hard
+
+"@backstage/backend-common@npm:^0.24.1":
+  version: 0.24.1
+  resolution: "@backstage/backend-common@npm:0.24.1"
+  dependencies:
+    "@aws-sdk/abort-controller": ^3.347.0
+    "@aws-sdk/client-codecommit": ^3.350.0
+    "@aws-sdk/client-s3": ^3.350.0
+    "@aws-sdk/credential-providers": ^3.350.0
+    "@aws-sdk/types": ^3.347.0
+    "@backstage/backend-dev-utils": ^0.1.5
+    "@backstage/backend-plugin-api": ^0.8.1
+    "@backstage/cli-common": ^0.1.14
+    "@backstage/config": ^1.2.0
+    "@backstage/config-loader": ^1.9.0
+    "@backstage/errors": ^1.2.4
+    "@backstage/integration": ^1.14.0
+    "@backstage/integration-aws-node": ^0.1.12
+    "@backstage/plugin-auth-node": ^0.5.1
+    "@backstage/types": ^1.1.1
+    "@google-cloud/storage": ^7.0.0
+    "@keyv/memcache": ^1.3.5
+    "@keyv/redis": ^2.5.3
+    "@kubernetes/client-node": 0.20.0
+    "@manypkg/get-packages": ^1.1.3
+    "@octokit/rest": ^19.0.3
+    "@types/cors": ^2.8.6
+    "@types/dockerode": ^3.3.0
+    "@types/express": ^4.17.6
+    "@types/luxon": ^3.0.0
+    "@types/webpack-env": ^1.15.2
+    archiver: ^6.0.0
+    base64-stream: ^1.0.0
+    compression: ^1.7.4
+    concat-stream: ^2.0.0
+    cors: ^2.8.5
+    dockerode: ^4.0.0
+    express: ^4.17.1
+    express-promise-router: ^4.1.0
+    fs-extra: ^11.2.0
+    git-url-parse: ^14.0.0
+    helmet: ^6.0.0
+    isomorphic-git: ^1.23.0
+    jose: ^5.0.0
+    keyv: ^4.5.2
+    knex: ^3.0.0
+    lodash: ^4.17.21
+    logform: ^2.3.2
+    luxon: ^3.0.0
+    minimatch: ^9.0.0
+    minimist: ^1.2.5
+    morgan: ^1.10.0
+    mysql2: ^3.0.0
+    node-fetch: ^2.7.0
+    node-forge: ^1.3.1
+    p-limit: ^3.1.0
+    path-to-regexp: ^6.2.1
+    pg: ^8.11.3
+    pg-format: ^1.0.4
+    raw-body: ^2.4.1
+    selfsigned: ^2.0.0
+    stoppable: ^1.1.0
+    tar: ^6.1.12
+    triple-beam: ^1.4.1
+    uuid: ^9.0.0
+    winston: ^3.2.1
+    winston-transport: ^4.5.0
+    yauzl: ^3.0.0
+    yn: ^4.0.0
+  peerDependencies:
+    pg-connection-string: ^2.3.0
+  peerDependenciesMeta:
+    pg-connection-string:
+      optional: true
+  checksum: 5a326dec02d1d43a819e5b1d4a0be87ee00be23013e4a74c7c700f996d3b486d359ba2866c20a25788a9eef6a97d2f99b5ccbb140bcac3180d703eee6ad82c04
+  languageName: node
+  linkType: hard
 
 "@backstage/backend-common@npm:^0.25.0":
   version: 0.25.0
@@ -3583,6 +3848,83 @@ __metadata:
     pg-connection-string:
       optional: true
   checksum: 34d2b92b5fd7f6d8f25975d121634079586d022665a51b676ba47053050e0f22556f80d59a75a10e0a8f1803a718448b7aed4bd1dcd6f1d348785c97cf5a8c9d
+  languageName: node
+  linkType: hard
+
+"@backstage/backend-defaults@npm:^0.4.0":
+  version: 0.4.4
+  resolution: "@backstage/backend-defaults@npm:0.4.4"
+  dependencies:
+    "@aws-sdk/abort-controller": ^3.347.0
+    "@aws-sdk/client-codecommit": ^3.350.0
+    "@aws-sdk/client-s3": ^3.350.0
+    "@aws-sdk/credential-providers": ^3.350.0
+    "@aws-sdk/types": ^3.347.0
+    "@backstage/backend-app-api": ^0.9.3
+    "@backstage/backend-common": ^0.24.1
+    "@backstage/backend-dev-utils": ^0.1.5
+    "@backstage/backend-plugin-api": ^0.8.1
+    "@backstage/cli-common": ^0.1.14
+    "@backstage/config": ^1.2.0
+    "@backstage/config-loader": ^1.9.0
+    "@backstage/errors": ^1.2.4
+    "@backstage/integration": ^1.14.0
+    "@backstage/integration-aws-node": ^0.1.12
+    "@backstage/plugin-auth-node": ^0.5.1
+    "@backstage/plugin-events-node": ^0.3.10
+    "@backstage/plugin-permission-node": ^0.8.2
+    "@backstage/types": ^1.1.1
+    "@google-cloud/storage": ^7.0.0
+    "@keyv/memcache": ^1.3.5
+    "@keyv/redis": ^2.5.3
+    "@manypkg/get-packages": ^1.1.3
+    "@octokit/rest": ^19.0.3
+    "@opentelemetry/api": ^1.3.0
+    "@types/cors": ^2.8.6
+    "@types/express": ^4.17.6
+    archiver: ^6.0.0
+    base64-stream: ^1.0.0
+    better-sqlite3: ^11.0.0
+    compression: ^1.7.4
+    concat-stream: ^2.0.0
+    cookie: ^0.6.0
+    cors: ^2.8.5
+    cron: ^3.0.0
+    express: ^4.17.1
+    express-promise-router: ^4.1.0
+    fs-extra: ^11.2.0
+    git-url-parse: ^14.0.0
+    helmet: ^6.0.0
+    isomorphic-git: ^1.23.0
+    jose: ^5.0.0
+    keyv: ^4.5.2
+    knex: ^3.0.0
+    lodash: ^4.17.21
+    logform: ^2.3.2
+    luxon: ^3.0.0
+    minimatch: ^9.0.0
+    minimist: ^1.2.5
+    morgan: ^1.10.0
+    mysql2: ^3.0.0
+    node-fetch: ^2.7.0
+    node-forge: ^1.3.1
+    p-limit: ^3.1.0
+    path-to-regexp: ^6.2.1
+    pg: ^8.11.3
+    pg-connection-string: ^2.3.0
+    pg-format: ^1.0.4
+    raw-body: ^2.4.1
+    selfsigned: ^2.0.0
+    stoppable: ^1.1.0
+    tar: ^6.1.12
+    triple-beam: ^1.4.1
+    uuid: ^9.0.0
+    winston: ^3.2.1
+    winston-transport: ^4.5.0
+    yauzl: ^3.0.0
+    yn: ^4.0.0
+    zod: ^3.22.4
+  checksum: 07f02b0eed51b5741b8e32f3026b8a2a29c8598a60bd20c4c4ae98dcdf849321f55672266ae50de9f28fb6f1e9c65409d8a76760ca405af175739eb00a01be21
   languageName: node
   linkType: hard
 
@@ -3680,7 +4022,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@backstage/backend-dev-utils@^0.1.5, @backstage/backend-dev-utils@workspace:^, @backstage/backend-dev-utils@workspace:packages/backend-dev-utils":
+"@backstage/backend-dev-utils@^0.1.4, @backstage/backend-dev-utils@^0.1.5, @backstage/backend-dev-utils@workspace:^, @backstage/backend-dev-utils@workspace:packages/backend-dev-utils":
   version: 0.0.0-use.local
   resolution: "@backstage/backend-dev-utils@workspace:packages/backend-dev-utils"
   dependencies:
@@ -3754,6 +4096,44 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@backstage/backend-plugin-api@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "@backstage/backend-plugin-api@npm:0.7.0"
+  dependencies:
+    "@backstage/cli-common": ^0.1.14
+    "@backstage/config": ^1.2.0
+    "@backstage/errors": ^1.2.4
+    "@backstage/plugin-auth-node": ^0.4.17
+    "@backstage/plugin-permission-common": ^0.8.0
+    "@backstage/types": ^1.1.1
+    "@types/express": ^4.17.6
+    "@types/luxon": ^3.0.0
+    express: ^4.17.1
+    knex: ^3.0.0
+    luxon: ^3.0.0
+  checksum: ea3f8a97750b8f9afae5ee45e0afdb4b04f46c889108b32fe0a86447d1578f4d5e1bca37c4fccdd6270593b6db0729d2e281349d8e11e2528e76ab18ab649c33
+  languageName: node
+  linkType: hard
+
+"@backstage/backend-plugin-api@npm:^0.8.1":
+  version: 0.8.1
+  resolution: "@backstage/backend-plugin-api@npm:0.8.1"
+  dependencies:
+    "@backstage/cli-common": ^0.1.14
+    "@backstage/config": ^1.2.0
+    "@backstage/errors": ^1.2.4
+    "@backstage/plugin-auth-node": ^0.5.1
+    "@backstage/plugin-permission-common": ^0.8.1
+    "@backstage/types": ^1.1.1
+    "@types/express": ^4.17.6
+    "@types/luxon": ^3.0.0
+    express: ^4.17.1
+    knex: ^3.0.0
+    luxon: ^3.0.0
+  checksum: 4a6614ceec13ff5ace3e04e8a1bad40567ce6a66afc19c02935161d12bdd7edbf4863d1d0203539e8a353dd78184078eb873fd14da6cbd093d1d9e4ced44c0fb
+  languageName: node
+  linkType: hard
+
 "@backstage/backend-plugin-api@npm:^1.0.0, @backstage/backend-plugin-api@npm:^1.0.1":
   version: 1.0.1
   resolution: "@backstage/backend-plugin-api@npm:1.0.1"
@@ -3792,6 +4172,62 @@ __metadata:
     luxon: ^3.0.0
   languageName: unknown
   linkType: soft
+
+"@backstage/backend-tasks@npm:^0.5.27":
+  version: 0.5.27
+  resolution: "@backstage/backend-tasks@npm:0.5.27"
+  dependencies:
+    "@backstage/backend-common": ^0.23.3
+    "@backstage/backend-plugin-api": ^0.7.0
+    "@backstage/config": ^1.2.0
+    "@backstage/errors": ^1.2.4
+    "@backstage/types": ^1.1.1
+    "@opentelemetry/api": ^1.3.0
+    "@types/luxon": ^3.0.0
+    cron: ^3.0.0
+    knex: ^3.0.0
+    lodash: ^4.17.21
+    luxon: ^3.0.0
+    uuid: ^9.0.0
+    zod: ^3.22.4
+  checksum: 69afa09bb380cdc93d52bf4e93b94a4aa8b3c9ef74f3e4350a6beedbbc623095805c0613f691a42a3995795fe0c9f9ccce689ce8c2f3a11277534d13ac4aa2a6
+  languageName: node
+  linkType: hard
+
+"@backstage/backend-test-utils@npm:^0.4.4":
+  version: 0.4.4
+  resolution: "@backstage/backend-test-utils@npm:0.4.4"
+  dependencies:
+    "@backstage/backend-app-api": ^0.8.0
+    "@backstage/backend-defaults": ^0.4.0
+    "@backstage/backend-plugin-api": ^0.7.0
+    "@backstage/config": ^1.2.0
+    "@backstage/errors": ^1.2.4
+    "@backstage/plugin-auth-node": ^0.4.17
+    "@backstage/plugin-events-node": ^0.3.8
+    "@backstage/types": ^1.1.1
+    "@keyv/memcache": ^1.3.5
+    "@keyv/redis": ^2.5.3
+    "@types/keyv": ^4.2.0
+    better-sqlite3: ^11.0.0
+    cookie: ^0.6.0
+    express: ^4.17.1
+    fs-extra: ^11.0.0
+    keyv: ^4.5.2
+    knex: ^3.0.0
+    msw: ^1.0.0
+    mysql2: ^3.0.0
+    pg: ^8.11.3
+    pg-connection-string: ^2.3.0
+    testcontainers: ^10.0.0
+    textextensions: ^5.16.0
+    uuid: ^9.0.0
+    yn: ^4.0.0
+  peerDependencies:
+    "@types/jest": "*"
+  checksum: 89b551093b4dc90b169646c0238b885bd31f4c2cafaf251aa6b4c2f6c4783e52b00068e43c5e6fcd0ac648a76b8502d43b0b133a1f36bbe7f4e3c1e1db17d417
+  languageName: node
+  linkType: hard
 
 "@backstage/backend-test-utils@workspace:^, @backstage/backend-test-utils@workspace:packages/backend-test-utils":
   version: 0.0.0-use.local
@@ -3832,7 +4268,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@backstage/catalog-client@npm:^1.7.1":
+"@backstage/catalog-client@npm:^1.6.5, @backstage/catalog-client@npm:^1.6.6, @backstage/catalog-client@npm:^1.7.1":
   version: 1.7.1
   resolution: "@backstage/catalog-client@npm:1.7.1"
   dependencies:
@@ -3857,7 +4293,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@backstage/catalog-model@^1.4.3, @backstage/catalog-model@^1.7.0, @backstage/catalog-model@workspace:^, @backstage/catalog-model@workspace:packages/catalog-model":
+"@backstage/catalog-model@^1.4.3, @backstage/catalog-model@^1.5.0, @backstage/catalog-model@^1.6.0, @backstage/catalog-model@^1.7.0, @backstage/catalog-model@workspace:^, @backstage/catalog-model@workspace:packages/catalog-model":
   version: 0.0.0-use.local
   resolution: "@backstage/catalog-model@workspace:packages/catalog-model"
   dependencies:
@@ -3888,6 +4324,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@backstage/cli-node@npm:^0.2.7":
+  version: 0.2.9
+  resolution: "@backstage/cli-node@npm:0.2.9"
+  dependencies:
+    "@backstage/cli-common": ^0.1.14
+    "@backstage/errors": ^1.2.4
+    "@backstage/types": ^1.1.1
+    "@manypkg/get-packages": ^1.1.3
+    "@yarnpkg/parsers": ^3.0.0
+    fs-extra: ^11.2.0
+    semver: ^7.5.3
+    zod: ^3.22.4
+  checksum: 39a3332cc0dd732a51726d803c322ec7423c6380e494b3ef91d5c71aabd60626bc355ede3fbb8a4da4714806c4663b6bef109bb6c7100160452c0e71620dac9b
+  languageName: node
+  linkType: hard
+
 "@backstage/cli-node@workspace:^, @backstage/cli-node@workspace:packages/cli-node":
   version: 0.0.0-use.local
   resolution: "@backstage/cli-node@workspace:packages/cli-node"
@@ -3904,6 +4356,142 @@ __metadata:
     zod: ^3.22.4
   languageName: unknown
   linkType: soft
+
+"@backstage/cli@npm:^0.26.11":
+  version: 0.26.11
+  resolution: "@backstage/cli@npm:0.26.11"
+  dependencies:
+    "@backstage/catalog-model": ^1.5.0
+    "@backstage/cli-common": ^0.1.14
+    "@backstage/cli-node": ^0.2.7
+    "@backstage/config": ^1.2.0
+    "@backstage/config-loader": ^1.8.1
+    "@backstage/errors": ^1.2.4
+    "@backstage/eslint-plugin": ^0.1.8
+    "@backstage/integration": ^1.13.0
+    "@backstage/release-manifests": ^0.0.11
+    "@backstage/types": ^1.1.1
+    "@manypkg/get-packages": ^1.1.3
+    "@module-federation/enhanced": ^0.1.19
+    "@octokit/graphql": ^5.0.0
+    "@octokit/graphql-schema": ^13.7.0
+    "@octokit/oauth-app": ^4.2.0
+    "@octokit/request": ^6.0.0
+    "@pmmmwh/react-refresh-webpack-plugin": ^0.5.7
+    "@rollup/plugin-commonjs": ^25.0.0
+    "@rollup/plugin-json": ^6.0.0
+    "@rollup/plugin-node-resolve": ^15.0.0
+    "@rollup/plugin-yaml": ^4.0.0
+    "@spotify/eslint-config-base": ^15.0.0
+    "@spotify/eslint-config-react": ^15.0.0
+    "@spotify/eslint-config-typescript": ^15.0.0
+    "@sucrase/webpack-loader": ^2.0.0
+    "@svgr/core": 6.5.x
+    "@svgr/plugin-jsx": 6.5.x
+    "@svgr/plugin-svgo": 6.5.x
+    "@svgr/rollup": 6.5.x
+    "@svgr/webpack": 6.5.x
+    "@swc/core": ^1.3.46
+    "@swc/helpers": ^0.5.0
+    "@swc/jest": ^0.2.22
+    "@types/jest": ^29.5.11
+    "@types/webpack-env": ^1.15.2
+    "@typescript-eslint/eslint-plugin": ^6.12.0
+    "@typescript-eslint/parser": ^6.7.2
+    "@yarnpkg/lockfile": ^1.1.0
+    "@yarnpkg/parsers": ^3.0.0
+    bfj: ^8.0.0
+    buffer: ^6.0.3
+    chalk: ^4.0.0
+    chokidar: ^3.3.1
+    commander: ^12.0.0
+    cross-fetch: ^4.0.0
+    cross-spawn: ^7.0.3
+    css-loader: ^6.5.1
+    ctrlc-windows: ^2.1.0
+    diff: ^5.0.0
+    esbuild: ^0.21.0
+    esbuild-loader: ^4.0.0
+    eslint: ^8.6.0
+    eslint-config-prettier: ^9.0.0
+    eslint-formatter-friendly: ^7.0.0
+    eslint-plugin-deprecation: ^2.0.0
+    eslint-plugin-import: ^2.25.4
+    eslint-plugin-jest: ^27.0.0
+    eslint-plugin-jsx-a11y: ^6.5.1
+    eslint-plugin-react: ^7.28.0
+    eslint-plugin-react-hooks: ^4.3.0
+    eslint-plugin-unused-imports: ^3.0.0
+    eslint-webpack-plugin: ^4.0.0
+    express: ^4.17.1
+    fork-ts-checker-webpack-plugin: ^9.0.0
+    fs-extra: ^11.2.0
+    git-url-parse: ^14.0.0
+    glob: ^7.1.7
+    global-agent: ^3.0.0
+    handlebars: ^4.7.3
+    html-webpack-plugin: ^5.3.1
+    inquirer: ^8.2.0
+    jest: ^29.7.0
+    jest-css-modules: ^2.1.0
+    jest-environment-jsdom: ^29.0.2
+    jest-runtime: ^29.0.2
+    json-schema: ^0.4.0
+    lodash: ^4.17.21
+    mini-css-extract-plugin: ^2.4.2
+    minimatch: ^9.0.0
+    node-fetch: ^2.6.7
+    node-libs-browser: ^2.2.1
+    npm-packlist: ^5.0.0
+    ora: ^5.3.0
+    p-limit: ^3.1.0
+    p-queue: ^6.6.2
+    pirates: ^4.0.6
+    postcss: ^8.1.0
+    process: ^0.11.10
+    react-dev-utils: ^12.0.0-next.60
+    react-refresh: ^0.14.0
+    recursive-readdir: ^2.2.2
+    replace-in-file: ^7.1.0
+    rollup: ^4.0.0
+    rollup-plugin-dts: ^6.1.0
+    rollup-plugin-esbuild: ^6.1.1
+    rollup-plugin-postcss: ^4.0.0
+    rollup-pluginutils: ^2.8.2
+    run-script-webpack-plugin: ^0.2.0
+    semver: ^7.5.3
+    style-loader: ^3.3.1
+    sucrase: ^3.20.2
+    swc-loader: ^0.2.3
+    tar: ^6.1.12
+    terser-webpack-plugin: ^5.1.3
+    util: ^0.12.3
+    webpack: ^5.70.0
+    webpack-dev-server: ^5.0.0
+    webpack-node-externals: ^3.0.0
+    yaml: ^2.0.0
+    yml-loader: ^2.1.0
+    yn: ^4.0.0
+    zod: ^3.22.4
+  peerDependencies:
+    "@vitejs/plugin-react": ^4.0.4
+    vite: ^4.4.9
+    vite-plugin-html: ^3.2.0
+    vite-plugin-node-polyfills: ^0.22.0
+  peerDependenciesMeta:
+    "@vitejs/plugin-react":
+      optional: true
+    vite:
+      optional: true
+    vite-plugin-html:
+      optional: true
+    vite-plugin-node-polyfills:
+      optional: true
+  bin:
+    backstage-cli: bin/backstage-cli
+  checksum: 328525101cfa824722e7bdace20dbdb8f7ef55a1eb3b7084f03394177db5f13fe3e49a4746d07ae5d7fbb9ee45f01f239bb19cf4f59f28bf5c8093c395caea0f
+  languageName: node
+  linkType: hard
 
 "@backstage/cli@workspace:*, @backstage/cli@workspace:^, @backstage/cli@workspace:packages/cli":
   version: 0.0.0-use.local
@@ -4112,7 +4700,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@backstage/config-loader@npm:^1.9.1":
+"@backstage/config-loader@npm:^1.8.1, @backstage/config-loader@npm:^1.9.0, @backstage/config-loader@npm:^1.9.1":
   version: 1.9.1
   resolution: "@backstage/config-loader@npm:1.9.1"
   dependencies:
@@ -4326,6 +4914,55 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/core-components@npm:^0.14.9":
+  version: 0.14.10
+  resolution: "@backstage/core-components@npm:0.14.10"
+  dependencies:
+    "@backstage/config": ^1.2.0
+    "@backstage/core-plugin-api": ^1.9.3
+    "@backstage/errors": ^1.2.4
+    "@backstage/theme": ^0.5.6
+    "@backstage/version-bridge": ^1.0.8
+    "@date-io/core": ^1.3.13
+    "@material-table/core": ^3.1.0
+    "@material-ui/core": ^4.12.2
+    "@material-ui/icons": ^4.9.1
+    "@material-ui/lab": 4.0.0-alpha.61
+    "@react-hookz/web": ^24.0.0
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    "@types/react-sparklines": ^1.7.0
+    ansi-regex: ^6.0.1
+    classnames: ^2.2.6
+    d3-selection: ^3.0.0
+    d3-shape: ^3.0.0
+    d3-zoom: ^3.0.0
+    dagre: ^0.8.5
+    linkify-react: 4.1.3
+    linkifyjs: 4.1.3
+    lodash: ^4.17.21
+    pluralize: ^8.0.0
+    qs: ^6.9.4
+    rc-progress: 3.5.1
+    react-helmet: 6.1.0
+    react-hook-form: ^7.12.2
+    react-idle-timer: 5.7.2
+    react-markdown: ^8.0.0
+    react-sparklines: ^1.7.0
+    react-syntax-highlighter: ^15.4.5
+    react-use: ^17.3.2
+    react-virtualized-auto-sizer: ^1.0.11
+    react-window: ^1.8.6
+    remark-gfm: ^3.0.1
+    zen-observable: ^0.10.0
+    zod: ^3.22.4
+  peerDependencies:
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  checksum: 303682d411b846a4892b27c1064d499dbd4eccb5a3cdc5acbb1d3247e1141f4704efc7bd286744c19818487e52a61891943156817f59e3bd6555926f7331f575
+  languageName: node
+  linkType: hard
+
 "@backstage/core-components@npm:^0.15.1":
   version: 0.15.1
   resolution: "@backstage/core-components@npm:0.15.1"
@@ -4456,7 +5093,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@backstage/core-plugin-api@^1.10.0, @backstage/core-plugin-api@^1.8.2, @backstage/core-plugin-api@workspace:^, @backstage/core-plugin-api@workspace:packages/core-plugin-api":
+"@backstage/core-plugin-api@^1.10.0, @backstage/core-plugin-api@^1.8.2, @backstage/core-plugin-api@^1.9.3, @backstage/core-plugin-api@workspace:^, @backstage/core-plugin-api@workspace:packages/core-plugin-api":
   version: 0.0.0-use.local
   resolution: "@backstage/core-plugin-api@workspace:packages/core-plugin-api"
   dependencies:
@@ -4513,6 +5150,33 @@ __metadata:
     backstage-create-app: bin/backstage-create-app
   languageName: unknown
   linkType: soft
+
+"@backstage/dev-utils@npm:^1.0.36":
+  version: 1.1.2
+  resolution: "@backstage/dev-utils@npm:1.1.2"
+  dependencies:
+    "@backstage/app-defaults": ^1.5.12
+    "@backstage/catalog-model": ^1.7.0
+    "@backstage/core-app-api": ^1.15.1
+    "@backstage/core-components": ^0.15.1
+    "@backstage/core-plugin-api": ^1.10.0
+    "@backstage/integration-react": ^1.2.0
+    "@backstage/plugin-catalog-react": ^1.14.0
+    "@backstage/theme": ^0.6.0
+    "@material-ui/core": ^4.12.2
+    "@material-ui/icons": ^4.9.1
+    react-use: ^17.2.4
+  peerDependencies:
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 6695acd5d4633892a3f55848e95b3ea2c969ad0f4601134aad1256a5366505f29fcfe1b0ee35c6086c1b16a92706fa585b6d91fdbff30bf0697d47815e6724b6
+  languageName: node
+  linkType: hard
 
 "@backstage/dev-utils@workspace:^, @backstage/dev-utils@workspace:packages/dev-utils":
   version: 0.0.0-use.local
@@ -4578,7 +5242,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@backstage/eslint-plugin@workspace:^, @backstage/eslint-plugin@workspace:packages/eslint-plugin":
+"@backstage/eslint-plugin@^0.1.8, @backstage/eslint-plugin@workspace:^, @backstage/eslint-plugin@workspace:packages/eslint-plugin":
   version: 0.0.0-use.local
   resolution: "@backstage/eslint-plugin@workspace:packages/eslint-plugin"
   dependencies:
@@ -4880,7 +5544,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@backstage/integration@^1.15.0, @backstage/integration@workspace:^, @backstage/integration@workspace:packages/integration":
+"@backstage/integration@^1.13.0, @backstage/integration@^1.14.0, @backstage/integration@^1.15.0, @backstage/integration@workspace:^, @backstage/integration@workspace:packages/integration":
   version: 0.0.0-use.local
   resolution: "@backstage/integration@workspace:packages/integration"
   dependencies:
@@ -5104,6 +5768,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@backstage/plugin-auth-backend-module-atlassian-provider@npm:^0.2.5":
+  version: 0.2.5
+  resolution: "@backstage/plugin-auth-backend-module-atlassian-provider@npm:0.2.5"
+  dependencies:
+    "@backstage/backend-plugin-api": ^0.8.1
+    "@backstage/plugin-auth-node": ^0.5.1
+    express: ^4.18.2
+    passport: ^0.7.0
+    passport-atlassian-oauth2: ^2.1.0
+  checksum: f0e06b787cd84d7ef598392907ea2f552f04c6d9a1b6d6451f55c3719e2e8b678a9ef53788f783fd4629569d9e452d3c47aebddba4fd9fc4be0cdcd447a4beda
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-auth-backend-module-atlassian-provider@workspace:^, @backstage/plugin-auth-backend-module-atlassian-provider@workspace:plugins/auth-backend-module-atlassian-provider":
   version: 0.0.0-use.local
   resolution: "@backstage/plugin-auth-backend-module-atlassian-provider@workspace:plugins/auth-backend-module-atlassian-provider"
@@ -5140,6 +5817,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@backstage/plugin-auth-backend-module-aws-alb-provider@npm:^0.1.17":
+  version: 0.1.17
+  resolution: "@backstage/plugin-auth-backend-module-aws-alb-provider@npm:0.1.17"
+  dependencies:
+    "@backstage/backend-common": ^0.24.1
+    "@backstage/backend-plugin-api": ^0.8.1
+    "@backstage/errors": ^1.2.4
+    "@backstage/plugin-auth-backend": ^0.22.12
+    "@backstage/plugin-auth-node": ^0.5.1
+    jose: ^5.0.0
+    node-cache: ^5.1.2
+    node-fetch: ^2.7.0
+  checksum: 0f8cacaa646a871521b2d5aac8f0689ab6ca9d439853460f3f2ebcb1c2d17d0d91080cfa4920fb76873ec07e289b40ecbb412e7a444c2813ee1370124ed3eff0
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-auth-backend-module-aws-alb-provider@workspace:^, @backstage/plugin-auth-backend-module-aws-alb-provider@workspace:plugins/auth-backend-module-aws-alb-provider":
   version: 0.0.0-use.local
   resolution: "@backstage/plugin-auth-backend-module-aws-alb-provider@workspace:plugins/auth-backend-module-aws-alb-provider"
@@ -5160,6 +5853,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@backstage/plugin-auth-backend-module-azure-easyauth-provider@npm:^0.1.7":
+  version: 0.1.7
+  resolution: "@backstage/plugin-auth-backend-module-azure-easyauth-provider@npm:0.1.7"
+  dependencies:
+    "@backstage/backend-plugin-api": ^0.8.1
+    "@backstage/catalog-model": ^1.6.0
+    "@backstage/errors": ^1.2.4
+    "@backstage/plugin-auth-node": ^0.5.1
+    "@types/passport": ^1.0.16
+    express: ^4.19.2
+    jose: ^5.0.0
+    passport: ^0.7.0
+  checksum: 9d737d73685430c1c23840e1ec6e8fa41fa281c7117814965f48f5cf6dad2a1f18e7ad31375e5c55bd426654476165cc7dc389b6a613331c03750be1fedbe525
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-auth-backend-module-azure-easyauth-provider@workspace:^, @backstage/plugin-auth-backend-module-azure-easyauth-provider@workspace:plugins/auth-backend-module-azure-easyauth-provider":
   version: 0.0.0-use.local
   resolution: "@backstage/plugin-auth-backend-module-azure-easyauth-provider@workspace:plugins/auth-backend-module-azure-easyauth-provider"
@@ -5177,6 +5886,19 @@ __metadata:
     passport: ^0.7.0
   languageName: unknown
   linkType: soft
+
+"@backstage/plugin-auth-backend-module-bitbucket-provider@npm:^0.1.7":
+  version: 0.1.7
+  resolution: "@backstage/plugin-auth-backend-module-bitbucket-provider@npm:0.1.7"
+  dependencies:
+    "@backstage/backend-plugin-api": ^0.8.1
+    "@backstage/plugin-auth-node": ^0.5.1
+    express: ^4.18.2
+    passport: ^0.7.0
+    passport-bitbucket-oauth2: ^0.1.2
+  checksum: f6877dc918c13b14d5b91e08921aba531401fcfe5f5d19c3611185c8fe51046bd3bc804e9154662297c3bf3f1a3b96ba90a6076f14770cef494d72c9bfced597
+  languageName: node
+  linkType: hard
 
 "@backstage/plugin-auth-backend-module-bitbucket-provider@workspace:^, @backstage/plugin-auth-backend-module-bitbucket-provider@workspace:plugins/auth-backend-module-bitbucket-provider":
   version: 0.0.0-use.local
@@ -5213,6 +5935,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@backstage/plugin-auth-backend-module-cloudflare-access-provider@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "@backstage/plugin-auth-backend-module-cloudflare-access-provider@npm:0.2.1"
+  dependencies:
+    "@backstage/backend-plugin-api": ^0.8.1
+    "@backstage/config": ^1.2.0
+    "@backstage/errors": ^1.2.4
+    "@backstage/plugin-auth-node": ^0.5.1
+    express: ^4.18.2
+    jose: ^5.0.0
+    node-fetch: ^2.7.0
+  checksum: 2b282f60f3fd3fee6d9a2711ba8cd311072a693190873e295b32717249194139d68f649afe8be76555e741d4dda40f30984565b69ae39606acd89204ee9c1a40
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-auth-backend-module-cloudflare-access-provider@workspace:^, @backstage/plugin-auth-backend-module-cloudflare-access-provider@workspace:plugins/auth-backend-module-cloudflare-access-provider":
   version: 0.0.0-use.local
   resolution: "@backstage/plugin-auth-backend-module-cloudflare-access-provider@workspace:plugins/auth-backend-module-cloudflare-access-provider"
@@ -5235,6 +5972,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@backstage/plugin-auth-backend-module-gcp-iap-provider@npm:^0.2.19":
+  version: 0.2.19
+  resolution: "@backstage/plugin-auth-backend-module-gcp-iap-provider@npm:0.2.19"
+  dependencies:
+    "@backstage/backend-plugin-api": ^0.8.1
+    "@backstage/errors": ^1.2.4
+    "@backstage/plugin-auth-node": ^0.5.1
+    "@backstage/types": ^1.1.1
+    google-auth-library: ^9.0.0
+  checksum: e134f52757cad54201aaaa43bae82a69476a1d59987d8114a6317b9825d41a75e73080e6e90efcaf58a75249ef74e626c358ad08083c5d539ef7d0464e736adc
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-auth-backend-module-gcp-iap-provider@workspace:^, @backstage/plugin-auth-backend-module-gcp-iap-provider@workspace:plugins/auth-backend-module-gcp-iap-provider":
   version: 0.0.0-use.local
   resolution: "@backstage/plugin-auth-backend-module-gcp-iap-provider@workspace:plugins/auth-backend-module-gcp-iap-provider"
@@ -5250,6 +6000,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@backstage/plugin-auth-backend-module-github-provider@npm:^0.1.21":
+  version: 0.1.21
+  resolution: "@backstage/plugin-auth-backend-module-github-provider@npm:0.1.21"
+  dependencies:
+    "@backstage/backend-plugin-api": ^0.8.1
+    "@backstage/plugin-auth-node": ^0.5.1
+    passport-github2: ^0.1.12
+  checksum: 24de5c8d44a840096c37554e2f1e6602d560dc763c5a4a6906231af1f4737834af99b954c923feb2effd2e03e11a65185740b4387fec95a03202e2dc07be4551
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-auth-backend-module-github-provider@workspace:^, @backstage/plugin-auth-backend-module-github-provider@workspace:plugins/auth-backend-module-github-provider":
   version: 0.0.0-use.local
   resolution: "@backstage/plugin-auth-backend-module-github-provider@workspace:plugins/auth-backend-module-github-provider"
@@ -5264,6 +6025,19 @@ __metadata:
     supertest: ^7.0.0
   languageName: unknown
   linkType: soft
+
+"@backstage/plugin-auth-backend-module-gitlab-provider@npm:^0.1.21":
+  version: 0.1.21
+  resolution: "@backstage/plugin-auth-backend-module-gitlab-provider@npm:0.1.21"
+  dependencies:
+    "@backstage/backend-plugin-api": ^0.8.1
+    "@backstage/plugin-auth-node": ^0.5.1
+    express: ^4.18.2
+    passport: ^0.7.0
+    passport-gitlab2: ^5.0.0
+  checksum: 053cd58acebe0c46accd1392a273751df7be85c836459933176bebc9c86e95dbb447eaf9cd406b47371d8ddc462cfbe18f12b86edfca9b4e3e958c59d151e3b3
+  languageName: node
+  linkType: hard
 
 "@backstage/plugin-auth-backend-module-gitlab-provider@workspace:^, @backstage/plugin-auth-backend-module-gitlab-provider@workspace:plugins/auth-backend-module-gitlab-provider":
   version: 0.0.0-use.local
@@ -5282,6 +6056,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@backstage/plugin-auth-backend-module-google-provider@npm:^0.1.21":
+  version: 0.1.21
+  resolution: "@backstage/plugin-auth-backend-module-google-provider@npm:0.1.21"
+  dependencies:
+    "@backstage/backend-plugin-api": ^0.8.1
+    "@backstage/plugin-auth-node": ^0.5.1
+    google-auth-library: ^9.0.0
+    passport-google-oauth20: ^2.0.0
+  checksum: e6f1e6204cbbd504c91d7230b02ce8f72c80e00ac42ebce671c8598239bdbebca90a005cc721d7c8ca8a4c8b1e9e5ef4a7df01609c7a7f6cd093a019851d5095
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-auth-backend-module-google-provider@workspace:^, @backstage/plugin-auth-backend-module-google-provider@workspace:plugins/auth-backend-module-google-provider":
   version: 0.0.0-use.local
   resolution: "@backstage/plugin-auth-backend-module-google-provider@workspace:plugins/auth-backend-module-google-provider"
@@ -5297,6 +6083,20 @@ __metadata:
     supertest: ^7.0.0
   languageName: unknown
   linkType: soft
+
+"@backstage/plugin-auth-backend-module-guest-provider@npm:^0.1.8":
+  version: 0.1.10
+  resolution: "@backstage/plugin-auth-backend-module-guest-provider@npm:0.1.10"
+  dependencies:
+    "@backstage/backend-common": ^0.24.1
+    "@backstage/backend-plugin-api": ^0.8.1
+    "@backstage/catalog-model": ^1.6.0
+    "@backstage/errors": ^1.2.4
+    "@backstage/plugin-auth-node": ^0.5.1
+    passport-oauth2: ^1.7.0
+  checksum: e123c5a3ce2df0c959627d730ac0a263d4c34223d01e4965fd1e21ddd1f4250086361d4641444c1e8f685a67fa85913b3f32e9a405b878f2308d7da77073cb80
+  languageName: node
+  linkType: hard
 
 "@backstage/plugin-auth-backend-module-guest-provider@workspace:^, @backstage/plugin-auth-backend-module-guest-provider@workspace:plugins/auth-backend-module-guest-provider":
   version: 0.0.0-use.local
@@ -5314,6 +6114,20 @@ __metadata:
     passport-oauth2: ^1.7.0
   languageName: unknown
   linkType: soft
+
+"@backstage/plugin-auth-backend-module-microsoft-provider@npm:^0.1.19":
+  version: 0.1.19
+  resolution: "@backstage/plugin-auth-backend-module-microsoft-provider@npm:0.1.19"
+  dependencies:
+    "@backstage/backend-plugin-api": ^0.8.1
+    "@backstage/plugin-auth-node": ^0.5.1
+    express: ^4.18.2
+    jose: ^5.0.0
+    node-fetch: ^2.7.0
+    passport-microsoft: ^1.0.0
+  checksum: 8666baab5828547db2ad703e164adde8103e759411cd38612dd3c0f8468355afcabd5cf868060fda0701303bffb05cd9132c4a17598d506d74a72762ee716d4c
+  languageName: node
+  linkType: hard
 
 "@backstage/plugin-auth-backend-module-microsoft-provider@workspace:^, @backstage/plugin-auth-backend-module-microsoft-provider@workspace:plugins/auth-backend-module-microsoft-provider":
   version: 0.0.0-use.local
@@ -5336,6 +6150,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@backstage/plugin-auth-backend-module-oauth2-provider@npm:^0.2.5":
+  version: 0.2.5
+  resolution: "@backstage/plugin-auth-backend-module-oauth2-provider@npm:0.2.5"
+  dependencies:
+    "@backstage/backend-plugin-api": ^0.8.1
+    "@backstage/plugin-auth-node": ^0.5.1
+    passport: ^0.7.0
+    passport-oauth2: ^1.6.1
+  checksum: 597e31e90a313efa185f06840a4733ea213f8462fc5d0a8463ae500b556514035c2c5d5c46f4b2eed64130b190f929a84503d0b8e6a43a6eefef47d647bbec1d
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-auth-backend-module-oauth2-provider@workspace:^, @backstage/plugin-auth-backend-module-oauth2-provider@workspace:plugins/auth-backend-module-oauth2-provider":
   version: 0.0.0-use.local
   resolution: "@backstage/plugin-auth-backend-module-oauth2-provider@workspace:plugins/auth-backend-module-oauth2-provider"
@@ -5352,6 +6178,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@backstage/plugin-auth-backend-module-oauth2-proxy-provider@npm:^0.1.17":
+  version: 0.1.17
+  resolution: "@backstage/plugin-auth-backend-module-oauth2-proxy-provider@npm:0.1.17"
+  dependencies:
+    "@backstage/backend-plugin-api": ^0.8.1
+    "@backstage/errors": ^1.2.4
+    "@backstage/plugin-auth-node": ^0.5.1
+    jose: ^5.0.0
+  checksum: 507b422c280054da7e02473549f6b41864132445cabedc4e5c89ba17dc71b3411291370d3f8e1629c727174dd336602a151d17aa9f62e9e95013075b303abb2d
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-auth-backend-module-oauth2-proxy-provider@workspace:^, @backstage/plugin-auth-backend-module-oauth2-proxy-provider@workspace:plugins/auth-backend-module-oauth2-proxy-provider":
   version: 0.0.0-use.local
   resolution: "@backstage/plugin-auth-backend-module-oauth2-proxy-provider@workspace:plugins/auth-backend-module-oauth2-proxy-provider"
@@ -5364,6 +6202,21 @@ __metadata:
     jose: ^5.0.0
   languageName: unknown
   linkType: soft
+
+"@backstage/plugin-auth-backend-module-oidc-provider@npm:^0.2.6":
+  version: 0.2.6
+  resolution: "@backstage/plugin-auth-backend-module-oidc-provider@npm:0.2.6"
+  dependencies:
+    "@backstage/backend-common": ^0.24.1
+    "@backstage/backend-plugin-api": ^0.8.1
+    "@backstage/plugin-auth-backend": ^0.22.12
+    "@backstage/plugin-auth-node": ^0.5.1
+    express: ^4.18.2
+    openid-client: ^5.5.0
+    passport: ^0.7.0
+  checksum: 22ebd4c379cf3c82cebe1858d76efaadb1a4b32bf7ed8e8a3dbc0d9412286d3fe19a171450da4e67fd2780a302b63143556ad88a1930eca71d9fd83afbc38a24
+  languageName: node
+  linkType: hard
 
 "@backstage/plugin-auth-backend-module-oidc-provider@workspace:^, @backstage/plugin-auth-backend-module-oidc-provider@workspace:plugins/auth-backend-module-oidc-provider":
   version: 0.0.0-use.local
@@ -5389,6 +6242,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@backstage/plugin-auth-backend-module-okta-provider@npm:^0.0.17":
+  version: 0.0.17
+  resolution: "@backstage/plugin-auth-backend-module-okta-provider@npm:0.0.17"
+  dependencies:
+    "@backstage/backend-plugin-api": ^0.8.1
+    "@backstage/plugin-auth-node": ^0.5.1
+    "@davidzemon/passport-okta-oauth": ^0.0.5
+    express: ^4.18.2
+    passport: ^0.7.0
+  checksum: 02e40d702cd5b7da3eaf6bf5bb435848d3ee18e5ccd012f6195e8840b0921e8441f4ee3cfd9210f1ab502bf28c79813a9fe09ef369f10b6d529238fa08821574
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-auth-backend-module-okta-provider@workspace:^, @backstage/plugin-auth-backend-module-okta-provider@workspace:plugins/auth-backend-module-okta-provider":
   version: 0.0.0-use.local
   resolution: "@backstage/plugin-auth-backend-module-okta-provider@workspace:plugins/auth-backend-module-okta-provider"
@@ -5405,6 +6271,19 @@ __metadata:
     supertest: ^7.0.0
   languageName: unknown
   linkType: soft
+
+"@backstage/plugin-auth-backend-module-onelogin-provider@npm:^0.1.5":
+  version: 0.1.5
+  resolution: "@backstage/plugin-auth-backend-module-onelogin-provider@npm:0.1.5"
+  dependencies:
+    "@backstage/backend-plugin-api": ^0.8.1
+    "@backstage/plugin-auth-node": ^0.5.1
+    express: ^4.18.2
+    passport: ^0.7.0
+    passport-onelogin-oauth: ^0.0.1
+  checksum: 033b04e8c1dcf138aab2a9a75c99a09748dae0c9dae36f562edffce11c1acdb6c75d67cac5cb291dac2a70b5500f50ad171e6abae448b16adb97c9fe2b25618c
+  languageName: node
+  linkType: hard
 
 "@backstage/plugin-auth-backend-module-onelogin-provider@workspace:^, @backstage/plugin-auth-backend-module-onelogin-provider@workspace:plugins/auth-backend-module-onelogin-provider":
   version: 0.0.0-use.local
@@ -5466,6 +6345,70 @@ __metadata:
     supertest: ^7.0.0
   languageName: unknown
   linkType: soft
+
+"@backstage/plugin-auth-backend@npm:^0.22.12, @backstage/plugin-auth-backend@npm:^0.22.9":
+  version: 0.22.12
+  resolution: "@backstage/plugin-auth-backend@npm:0.22.12"
+  dependencies:
+    "@backstage/backend-common": ^0.24.1
+    "@backstage/backend-plugin-api": ^0.8.1
+    "@backstage/catalog-client": ^1.6.6
+    "@backstage/catalog-model": ^1.6.0
+    "@backstage/config": ^1.2.0
+    "@backstage/errors": ^1.2.4
+    "@backstage/plugin-auth-backend-module-atlassian-provider": ^0.2.5
+    "@backstage/plugin-auth-backend-module-aws-alb-provider": ^0.1.17
+    "@backstage/plugin-auth-backend-module-azure-easyauth-provider": ^0.1.7
+    "@backstage/plugin-auth-backend-module-bitbucket-provider": ^0.1.7
+    "@backstage/plugin-auth-backend-module-cloudflare-access-provider": ^0.2.1
+    "@backstage/plugin-auth-backend-module-gcp-iap-provider": ^0.2.19
+    "@backstage/plugin-auth-backend-module-github-provider": ^0.1.21
+    "@backstage/plugin-auth-backend-module-gitlab-provider": ^0.1.21
+    "@backstage/plugin-auth-backend-module-google-provider": ^0.1.21
+    "@backstage/plugin-auth-backend-module-microsoft-provider": ^0.1.19
+    "@backstage/plugin-auth-backend-module-oauth2-provider": ^0.2.5
+    "@backstage/plugin-auth-backend-module-oauth2-proxy-provider": ^0.1.17
+    "@backstage/plugin-auth-backend-module-oidc-provider": ^0.2.6
+    "@backstage/plugin-auth-backend-module-okta-provider": ^0.0.17
+    "@backstage/plugin-auth-backend-module-onelogin-provider": ^0.1.5
+    "@backstage/plugin-auth-node": ^0.5.1
+    "@backstage/plugin-catalog-node": ^1.12.6
+    "@backstage/types": ^1.1.1
+    "@google-cloud/firestore": ^7.0.0
+    "@node-saml/passport-saml": ^4.0.4
+    "@types/express": ^4.17.6
+    "@types/passport": ^1.0.3
+    compression: ^1.7.4
+    connect-session-knex: ^4.0.0
+    cookie-parser: ^1.4.5
+    cors: ^2.8.5
+    express: ^4.17.1
+    express-promise-router: ^4.1.0
+    express-session: ^1.17.1
+    fs-extra: ^11.2.0
+    google-auth-library: ^9.0.0
+    jose: ^5.0.0
+    knex: ^3.0.0
+    lodash: ^4.17.21
+    luxon: ^3.0.0
+    minimatch: ^9.0.0
+    morgan: ^1.10.0
+    node-cache: ^5.1.2
+    node-fetch: ^2.7.0
+    openid-client: ^5.2.1
+    passport: ^0.7.0
+    passport-auth0: ^1.4.3
+    passport-github2: ^0.1.12
+    passport-google-oauth20: ^2.0.0
+    passport-microsoft: ^1.0.0
+    passport-oauth2: ^1.6.1
+    passport-onelogin-oauth: ^0.0.1
+    uuid: ^9.0.0
+    winston: ^3.2.1
+    yn: ^4.0.0
+  checksum: f571f444f692f903f16d4a6490868529b22beafb8a7ea034aacca68aa67e33c84e6118675638a62c76d40b73e23db3e7e692585c8f6c9b60f3b85db36c4e1775
+  languageName: node
+  linkType: hard
 
 "@backstage/plugin-auth-backend@workspace:^, @backstage/plugin-auth-backend@workspace:plugins/auth-backend":
   version: 0.0.0-use.local
@@ -5547,7 +6490,32 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@backstage/plugin-auth-node@npm:^0.5.2, @backstage/plugin-auth-node@npm:^0.5.3":
+"@backstage/plugin-auth-node@npm:^0.4.17":
+  version: 0.4.17
+  resolution: "@backstage/plugin-auth-node@npm:0.4.17"
+  dependencies:
+    "@backstage/backend-common": ^0.23.3
+    "@backstage/backend-plugin-api": ^0.7.0
+    "@backstage/catalog-client": ^1.6.5
+    "@backstage/catalog-model": ^1.5.0
+    "@backstage/config": ^1.2.0
+    "@backstage/errors": ^1.2.4
+    "@backstage/types": ^1.1.1
+    "@types/express": "*"
+    "@types/passport": ^1.0.3
+    express: ^4.17.1
+    jose: ^5.0.0
+    lodash: ^4.17.21
+    node-fetch: ^2.6.7
+    passport: ^0.7.0
+    winston: ^3.2.1
+    zod: ^3.22.4
+    zod-to-json-schema: ^3.21.4
+  checksum: 2506045877e9f76f70d4d5541725a0c6cf9ba0f1604bade22ec92852e887e7b844bc815cdace74c5053ef23c4306e18b6b1b4bdefe6dfab62dd9e03bd66e2d08
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-auth-node@npm:^0.5.1, @backstage/plugin-auth-node@npm:^0.5.2, @backstage/plugin-auth-node@npm:^0.5.3":
   version: 0.5.3
   resolution: "@backstage/plugin-auth-node@npm:0.5.3"
   dependencies:
@@ -6205,6 +7173,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@backstage/plugin-catalog-node@npm:^1.12.6":
+  version: 1.13.1
+  resolution: "@backstage/plugin-catalog-node@npm:1.13.1"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.0.1
+    "@backstage/catalog-client": ^1.7.1
+    "@backstage/catalog-model": ^1.7.0
+    "@backstage/errors": ^1.2.4
+    "@backstage/plugin-catalog-common": ^1.1.0
+    "@backstage/plugin-permission-common": ^0.8.1
+    "@backstage/plugin-permission-node": ^0.8.4
+    "@backstage/types": ^1.1.1
+  checksum: f492a9bc517eb726bd3c0baddc6da28d74b446b373628db0cc91068e7a260c7f377acd30884c81bb12dec459421912b14199dc924be14ad0c69e1c1f8959cae6
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-catalog-node@workspace:^, @backstage/plugin-catalog-node@workspace:plugins/catalog-node":
   version: 0.0.0-use.local
   resolution: "@backstage/plugin-catalog-node@workspace:plugins/catalog-node"
@@ -6450,6 +7434,57 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@backstage/plugin-device-auth-backend@workspace:^, @backstage/plugin-device-auth-backend@workspace:plugins/device-auth-backend":
+  version: 0.0.0-use.local
+  resolution: "@backstage/plugin-device-auth-backend@workspace:plugins/device-auth-backend"
+  dependencies:
+    "@backstage/backend-common": ^0.23.3
+    "@backstage/backend-defaults": ^0.4.0
+    "@backstage/backend-plugin-api": ^0.7.0
+    "@backstage/backend-test-utils": ^0.4.4
+    "@backstage/cli": ^0.26.11
+    "@backstage/config": ^1.2.0
+    "@backstage/errors": ^1.2.4
+    "@backstage/plugin-auth-backend": ^0.22.9
+    "@backstage/plugin-auth-backend-module-guest-provider": ^0.1.8
+    "@types/express": "*"
+    "@types/supertest": ^2.0.12
+    express: ^4.17.1
+    express-promise-router: ^4.1.0
+    knex: ^3.1.0
+    msw: ^2.2.14
+    nanoid: 3
+    node-fetch: ^2.6.7
+    supertest: ^6.2.4
+    uuid: ^10.0.0
+  languageName: unknown
+  linkType: soft
+
+"@backstage/plugin-device-auth@workspace:plugins/device-auth":
+  version: 0.0.0-use.local
+  resolution: "@backstage/plugin-device-auth@workspace:plugins/device-auth"
+  dependencies:
+    "@backstage/cli": ^0.26.11
+    "@backstage/core-components": ^0.14.9
+    "@backstage/core-plugin-api": ^1.9.3
+    "@backstage/dev-utils": ^1.0.36
+    "@backstage/test-utils": ^1.5.9
+    "@backstage/theme": ^0.5.6
+    "@material-ui/core": ^4.9.13
+    "@material-ui/icons": ^4.9.1
+    "@material-ui/lab": ^4.0.0-alpha.61
+    "@testing-library/jest-dom": ^5.10.1
+    "@testing-library/react": ^12.1.3
+    "@testing-library/user-event": ^14.0.0
+    msw: ^1.0.0
+    react-use: ^17.2.4
+  peerDependencies:
+    react: ^16.13.1 || ^17.0.0
+    react-router: ^6.24.0
+    react-router-dom: ^6.22.2
+  languageName: unknown
+  linkType: soft
+
 "@backstage/plugin-devtools-backend@workspace:^, @backstage/plugin-devtools-backend@workspace:plugins/devtools-backend":
   version: 0.0.0-use.local
   resolution: "@backstage/plugin-devtools-backend@workspace:plugins/devtools-backend"
@@ -6647,6 +7682,15 @@ __metadata:
     winston: ^3.2.1
   languageName: unknown
   linkType: soft
+
+"@backstage/plugin-events-node@npm:^0.3.10, @backstage/plugin-events-node@npm:^0.3.8":
+  version: 0.3.10
+  resolution: "@backstage/plugin-events-node@npm:0.3.10"
+  dependencies:
+    "@backstage/backend-plugin-api": ^0.8.1
+  checksum: 19a6cb5541e08e905d6015c92c3e3f3c8707b0ec31a9638832106b55b0e9999156ff7a4360c424f12b105f4d1b710fa14f1435fb58812a64601e4890d575287b
+  languageName: node
+  linkType: hard
 
 "@backstage/plugin-events-node@workspace:^, @backstage/plugin-events-node@workspace:plugins/events-node":
   version: 0.0.0-use.local
@@ -7224,7 +8268,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@backstage/plugin-permission-common@^0.8.1, @backstage/plugin-permission-common@workspace:^, @backstage/plugin-permission-common@workspace:plugins/permission-common":
+"@backstage/plugin-permission-common@^0.8.0, @backstage/plugin-permission-common@^0.8.1, @backstage/plugin-permission-common@workspace:^, @backstage/plugin-permission-common@workspace:plugins/permission-common":
   version: 0.0.0-use.local
   resolution: "@backstage/plugin-permission-common@workspace:plugins/permission-common"
   dependencies:
@@ -7239,6 +8283,25 @@ __metadata:
     zod-to-json-schema: ^3.20.4
   languageName: unknown
   linkType: soft
+
+"@backstage/plugin-permission-node@npm:^0.8.0, @backstage/plugin-permission-node@npm:^0.8.2, @backstage/plugin-permission-node@npm:^0.8.4":
+  version: 0.8.4
+  resolution: "@backstage/plugin-permission-node@npm:0.8.4"
+  dependencies:
+    "@backstage/backend-common": ^0.25.0
+    "@backstage/backend-plugin-api": ^1.0.1
+    "@backstage/config": ^1.2.0
+    "@backstage/errors": ^1.2.4
+    "@backstage/plugin-auth-node": ^0.5.3
+    "@backstage/plugin-permission-common": ^0.8.1
+    "@types/express": ^4.17.6
+    express: ^4.17.1
+    express-promise-router: ^4.1.0
+    zod: ^3.22.4
+    zod-to-json-schema: ^3.20.4
+  checksum: a00c269e4777ff5e10db7a3859110f3a487c91e4c9422eb0650cbef3cfffc3dbd2f38e98fd793daef8242da2777ffbd87adb5715d21f0dff998b90c65261904e
+  languageName: node
+  linkType: hard
 
 "@backstage/plugin-permission-node@workspace:^, @backstage/plugin-permission-node@workspace:plugins/permission-node":
   version: 0.0.0-use.local
@@ -8601,7 +9664,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@backstage/release-manifests@workspace:^, @backstage/release-manifests@workspace:packages/release-manifests":
+"@backstage/release-manifests@^0.0.11, @backstage/release-manifests@workspace:^, @backstage/release-manifests@workspace:packages/release-manifests":
   version: 0.0.0-use.local
   resolution: "@backstage/release-manifests@workspace:packages/release-manifests"
   dependencies:
@@ -8673,7 +9736,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@backstage/test-utils@npm:^1.7.0":
+"@backstage/test-utils@npm:^1.5.9, @backstage/test-utils@npm:^1.7.0":
   version: 1.7.0
   resolution: "@backstage/test-utils@npm:1.7.0"
   dependencies:
@@ -8744,7 +9807,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@backstage/theme@npm:^0.5.0":
+"@backstage/theme@npm:^0.5.0, @backstage/theme@npm:^0.5.6":
   version: 0.5.7
   resolution: "@backstage/theme@npm:0.5.7"
   dependencies:
@@ -8818,7 +9881,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@backstage/version-bridge@^1.0.10, @backstage/version-bridge@^1.0.7, @backstage/version-bridge@workspace:^, @backstage/version-bridge@workspace:packages/version-bridge":
+"@backstage/version-bridge@^1.0.10, @backstage/version-bridge@^1.0.7, @backstage/version-bridge@^1.0.8, @backstage/version-bridge@workspace:^, @backstage/version-bridge@workspace:packages/version-bridge":
   version: 0.0.0-use.local
   resolution: "@backstage/version-bridge@workspace:packages/version-bridge"
   dependencies:
@@ -11638,6 +12701,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@module-federation/dts-plugin@npm:0.1.21":
+  version: 0.1.21
+  resolution: "@module-federation/dts-plugin@npm:0.1.21"
+  dependencies:
+    "@module-federation/managers": 0.1.21
+    "@module-federation/sdk": 0.1.21
+    "@module-federation/third-party-dts-extractor": 0.1.21
+    adm-zip: ^0.5.10
+    ansi-colors: ^4.1.3
+    axios: ^1.6.7
+    chalk: 3.0.0
+    fs-extra: 9.1.0
+    isomorphic-ws: 5.0.0
+    koa: 2.11.0
+    lodash.clonedeepwith: 4.5.0
+    log4js: 6.9.1
+    node-schedule: 2.1.1
+    rambda: ^9.1.0
+    ws: 8.17.0
+  peerDependencies:
+    typescript: ^4.9.0 || ^5.0.0
+    vue-tsc: ^1.0.24
+  peerDependenciesMeta:
+    vue-tsc:
+      optional: true
+  checksum: ec4cd030a25617698754cbac2da5463f8942cdd0a64bdc95f6ff5fd29fff6b88cf3db90e53e6b260cd3593893fe6ee2d6e149d0a46698eb7f9cc19a9df26193d
+  languageName: node
+  linkType: hard
+
 "@module-federation/dts-plugin@npm:0.7.3":
   version: 0.7.3
   resolution: "@module-federation/dts-plugin@npm:0.7.3"
@@ -11665,6 +12757,32 @@ __metadata:
     vue-tsc:
       optional: true
   checksum: 20c74e809a5d1826ff0c3976e38da15d3f375e3b32d73845b0b8cd17958e1720701c4a23d0954676eb1e7444b4c6dc8c35dd5c9033b0091cd63ef944cfd8d122
+  languageName: node
+  linkType: hard
+
+"@module-federation/enhanced@npm:^0.1.19":
+  version: 0.1.21
+  resolution: "@module-federation/enhanced@npm:0.1.21"
+  dependencies:
+    "@module-federation/dts-plugin": 0.1.21
+    "@module-federation/managers": 0.1.21
+    "@module-federation/manifest": 0.1.21
+    "@module-federation/rspack": 0.1.21
+    "@module-federation/runtime-tools": 0.1.21
+    "@module-federation/sdk": 0.1.21
+    upath: 2.0.1
+  peerDependencies:
+    typescript: ^4.9.0 || ^5.0.0
+    vue-tsc: ^1.0.24
+    webpack: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+    vue-tsc:
+      optional: true
+    webpack:
+      optional: true
+  checksum: bc0ff541db1066b290b3ad9ab868437dc3d0754b9d06ab263f8fb7f54e08238eae9232a482a681dd6152e4a175578d65df9f27fe181fc8fb602d7cc1ae34807d
   languageName: node
   linkType: hard
 
@@ -11704,6 +12822,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@module-federation/managers@npm:0.1.21":
+  version: 0.1.21
+  resolution: "@module-federation/managers@npm:0.1.21"
+  dependencies:
+    "@module-federation/sdk": 0.1.21
+    find-pkg: 2.0.0
+    fs-extra: 9.1.0
+  checksum: 5f230d5795d86dfd68c404ee2b7a1264950c283a4b1c6f4ee9cc9579fabb413718dfbc1ff726b9c213f9d3223d944dd38dd9d04b700962e6398c3c3728d6323e
+  languageName: node
+  linkType: hard
+
 "@module-federation/managers@npm:0.7.3":
   version: 0.7.3
   resolution: "@module-federation/managers@npm:0.7.3"
@@ -11712,6 +12841,19 @@ __metadata:
     find-pkg: 2.0.0
     fs-extra: 9.1.0
   checksum: 162844cb587adfb70daed500381046e89bd5c9e678518763333e213faed0bef7763652d11a016719fc430f0b3c263ba4942a05fe11127218a8848ac156d21ed4
+  languageName: node
+  linkType: hard
+
+"@module-federation/manifest@npm:0.1.21":
+  version: 0.1.21
+  resolution: "@module-federation/manifest@npm:0.1.21"
+  dependencies:
+    "@module-federation/dts-plugin": 0.1.21
+    "@module-federation/managers": 0.1.21
+    "@module-federation/sdk": 0.1.21
+    chalk: 3.0.0
+    find-pkg: 2.0.0
+  checksum: cef2011875f14e853a355626ae1dbc8ae3b0714d31140e329b5dd71525782b08c2e1d6ca45276a563bb3c3b7f7c4e64a31f0698ef12606f05aa6da46e759f345
   languageName: node
   linkType: hard
 
@@ -11725,6 +12867,19 @@ __metadata:
     chalk: 3.0.0
     find-pkg: 2.0.0
   checksum: 5211b8685f2566c0b373463dd9b3eae26c2c963f40b0d4f11dc6c7b0fdafc24c3aea406d3f612b2df16ec15291d1d26d30fb9ee028eee51b16568933f0d62b7a
+  languageName: node
+  linkType: hard
+
+"@module-federation/rspack@npm:0.1.21":
+  version: 0.1.21
+  resolution: "@module-federation/rspack@npm:0.1.21"
+  dependencies:
+    "@module-federation/dts-plugin": 0.1.21
+    "@module-federation/managers": 0.1.21
+    "@module-federation/manifest": 0.1.21
+    "@module-federation/runtime-tools": 0.1.21
+    "@module-federation/sdk": 0.1.21
+  checksum: 55516285e23f4ca7127afafb14af667defbe46dc3224f85d7e07edbc8937d7fac909dfebc2f9dd73120b99bbe5135372cf0fbbe282990d80e6953a60dfa4c93e
   languageName: node
   linkType: hard
 
@@ -11750,6 +12905,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@module-federation/runtime-tools@npm:0.1.21":
+  version: 0.1.21
+  resolution: "@module-federation/runtime-tools@npm:0.1.21"
+  dependencies:
+    "@module-federation/runtime": 0.1.21
+    "@module-federation/webpack-bundler-runtime": 0.1.21
+  checksum: 628c0c4834093520f9c71481d587c9e18163f82e481b05b1900f04e2d5da4abb69af6d814ac5cd1951057b28d73f3adeb1cee7cd83628305b10cc7988405fbc5
+  languageName: node
+  linkType: hard
+
 "@module-federation/runtime-tools@npm:0.5.1":
   version: 0.5.1
   resolution: "@module-federation/runtime-tools@npm:0.5.1"
@@ -11767,6 +12932,15 @@ __metadata:
     "@module-federation/runtime": 0.7.3
     "@module-federation/webpack-bundler-runtime": 0.7.3
   checksum: a8519a15a05427df80eac038f5d46921044e7ea95b27c7a4c41cede0303b306ea4b071247f016116cf0681189a4352783e866f239fef8ac0e77698e430f1f71e
+  languageName: node
+  linkType: hard
+
+"@module-federation/runtime@npm:0.1.21":
+  version: 0.1.21
+  resolution: "@module-federation/runtime@npm:0.1.21"
+  dependencies:
+    "@module-federation/sdk": 0.1.21
+  checksum: ce4de8515b54f1cd07a3c7c4cbd35fea163294b9fb24be10827872f3ebb62cd5c289f3602efe4149d963282739f79b51947afa039ee6f36be7f66dea83d590fc
   languageName: node
   linkType: hard
 
@@ -11789,6 +12963,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@module-federation/sdk@npm:0.1.21":
+  version: 0.1.21
+  resolution: "@module-federation/sdk@npm:0.1.21"
+  checksum: 6856dcfe2ef5ae939890b82010aaad911fa6c4330a05f290ae054c316c9b532d3691456a1f9e176fe05f1df2d6f2d8c7e0c842ca5648a0fd7abf270e44ed9ecb
+  languageName: node
+  linkType: hard
+
 "@module-federation/sdk@npm:0.5.1":
   version: 0.5.1
   resolution: "@module-federation/sdk@npm:0.5.1"
@@ -11805,6 +12986,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@module-federation/third-party-dts-extractor@npm:0.1.21":
+  version: 0.1.21
+  resolution: "@module-federation/third-party-dts-extractor@npm:0.1.21"
+  dependencies:
+    find-pkg: 2.0.0
+    fs-extra: 9.1.0
+    resolve: 1.22.8
+  checksum: e394fd7c2e6dbdf8df6937628680e7356ac897ee6f1309d7fbc38c00bcf4be9c0363f8bc1a75c29f7987a5a2f11f7855481813889b18e8b444ee9006aeb4a299
+  languageName: node
+  linkType: hard
+
 "@module-federation/third-party-dts-extractor@npm:0.7.3":
   version: 0.7.3
   resolution: "@module-federation/third-party-dts-extractor@npm:0.7.3"
@@ -11813,6 +13005,16 @@ __metadata:
     fs-extra: 9.1.0
     resolve: 1.22.8
   checksum: 72f23de2780eff7ea7d96b14d7fbdae9ed6c71f1ffcbc625d5e8d804225ca51d297a345d1be9793339da7c3a6c3fece05e542b9d34be08940bb273b27cd22f4a
+  languageName: node
+  linkType: hard
+
+"@module-federation/webpack-bundler-runtime@npm:0.1.21":
+  version: 0.1.21
+  resolution: "@module-federation/webpack-bundler-runtime@npm:0.1.21"
+  dependencies:
+    "@module-federation/runtime": 0.1.21
+    "@module-federation/sdk": 0.1.21
+  checksum: 7d96002066e63bdb503964fd5fb2798be25f4135a599d87721f4d26ebe1de1affbf447c56b082f7ee850ae7798d0ac637f6a486f58591269065e114051b466e5
   languageName: node
   linkType: hard
 
@@ -12190,6 +13392,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@node-saml/node-saml@npm:^4.0.4":
+  version: 4.0.5
+  resolution: "@node-saml/node-saml@npm:4.0.5"
+  dependencies:
+    "@types/debug": ^4.1.7
+    "@types/passport": ^1.0.11
+    "@types/xml-crypto": ^1.4.2
+    "@types/xml-encryption": ^1.2.1
+    "@types/xml2js": ^0.4.11
+    "@xmldom/xmldom": ^0.8.6
+    debug: ^4.3.4
+    xml-crypto: ^3.0.1
+    xml-encryption: ^3.0.2
+    xml2js: ^0.5.0
+    xmlbuilder: ^15.1.1
+  checksum: 7d97575111a381ef2d0f16e1fc85ae3f84322ccba06dcb0594b00cf598e429658f45e479b78836943f69f249c08a8593e5168404acf7f1ed659ead53ceef465e
+  languageName: node
+  linkType: hard
+
 "@node-saml/node-saml@npm:^5.0.0":
   version: 5.0.0
   resolution: "@node-saml/node-saml@npm:5.0.0"
@@ -12207,6 +13428,20 @@ __metadata:
     xmlbuilder: ^15.1.1
     xpath: ^0.0.34
   checksum: 6a9ff9d922befc8ccb3338fe8f989eba66d3f781a3d1f39c4bd1d5c58fc1acd74ae05d94a08ef9c4ff1990ad38d0ca97135de52bbfe79196594e76f75e7b7e13
+  languageName: node
+  linkType: hard
+
+"@node-saml/passport-saml@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "@node-saml/passport-saml@npm:4.0.4"
+  dependencies:
+    "@node-saml/node-saml": ^4.0.4
+    "@types/express": ^4.17.14
+    "@types/passport": ^1.0.11
+    "@types/passport-strategy": ^0.2.35
+    passport: ^0.6.0
+    passport-strategy: ^1.0.0
+  checksum: 75178669d7d47038c33bb0602454cb5030fc9b3ecdcae9163a35cef436bc6c22e68e57d06213e0118ff1cb0dcd2f2fa25112672ebe4cbad90578df21bec67fce
   languageName: node
   linkType: hard
 
@@ -15091,6 +16326,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/plugin-commonjs@npm:^25.0.0":
+  version: 25.0.8
+  resolution: "@rollup/plugin-commonjs@npm:25.0.8"
+  dependencies:
+    "@rollup/pluginutils": ^5.0.1
+    commondir: ^1.0.1
+    estree-walker: ^2.0.2
+    glob: ^8.0.3
+    is-reference: 1.2.1
+    magic-string: ^0.30.3
+  peerDependencies:
+    rollup: ^2.68.0||^3.0.0||^4.0.0
+  peerDependenciesMeta:
+    rollup:
+      optional: true
+  checksum: dd105ee5625fbcaf832c0cf80be0aaf6a86bbd8fe99ff911f9ac4b78c79f26e9e99442b5aa0cc1136b5ddf89ec0b6c5728e5341ac04d687aef1b53063670b395
+  languageName: node
+  linkType: hard
+
 "@rollup/plugin-commonjs@npm:^26.0.0":
   version: 26.0.3
   resolution: "@rollup/plugin-commonjs@npm:26.0.3"
@@ -17615,6 +18869,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/dom@npm:^8.0.0":
+  version: 8.20.1
+  resolution: "@testing-library/dom@npm:8.20.1"
+  dependencies:
+    "@babel/code-frame": ^7.10.4
+    "@babel/runtime": ^7.12.5
+    "@types/aria-query": ^5.0.1
+    aria-query: 5.1.3
+    chalk: ^4.1.0
+    dom-accessibility-api: ^0.5.9
+    lz-string: ^1.5.0
+    pretty-format: ^27.0.2
+  checksum: 06fc8dc67849aadb726cbbad0e7546afdf8923bd39acb64c576d706249bd7d0d05f08e08a31913fb621162e3b9c2bd0dce15964437f030f9fa4476326fdd3007
+  languageName: node
+  linkType: hard
+
+"@testing-library/jest-dom@npm:^5.10.1":
+  version: 5.17.0
+  resolution: "@testing-library/jest-dom@npm:5.17.0"
+  dependencies:
+    "@adobe/css-tools": ^4.0.1
+    "@babel/runtime": ^7.9.2
+    "@types/testing-library__jest-dom": ^5.9.1
+    aria-query: ^5.0.0
+    chalk: ^3.0.0
+    css.escape: ^1.5.1
+    dom-accessibility-api: ^0.5.6
+    lodash: ^4.17.15
+    redent: ^3.0.0
+  checksum: 9f28dbca8b50d7c306aae40c3aa8e06f0e115f740360004bd87d57f95acf7ab4b4f4122a7399a76dbf2bdaaafb15c99cc137fdcb0ae457a92e2de0f3fbf9b03b
+  languageName: node
+  linkType: hard
+
 "@testing-library/jest-dom@npm:^6.0.0":
   version: 6.6.3
   resolution: "@testing-library/jest-dom@npm:6.6.3"
@@ -17649,6 +18936,20 @@ __metadata:
     react-test-renderer:
       optional: true
   checksum: 7fe44352e920deb5cb1876f80d64e48615232072c9d5382f1e0284b3aab46bb1c659a040b774c45cdf084a5257b8fe463f7e08695ad8480d8a15635d4d3d1f6d
+  languageName: node
+  linkType: hard
+
+"@testing-library/react@npm:^12.1.3":
+  version: 12.1.5
+  resolution: "@testing-library/react@npm:12.1.5"
+  dependencies:
+    "@babel/runtime": ^7.12.5
+    "@testing-library/dom": ^8.0.0
+    "@types/react-dom": <18.0.0
+  peerDependencies:
+    react: <18.0.0
+    react-dom: <18.0.0
+  checksum: 4abd0490405e709a7df584a0db604e508a4612398bb1326e8fa32dd9393b15badc826dcf6d2f7525437886d507871f719f127b9860ed69ddd204d1fa834f576a
   languageName: node
   linkType: hard
 
@@ -18179,6 +19480,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/eslint-scope@npm:^3.7.7":
+  version: 3.7.7
+  resolution: "@types/eslint-scope@npm:3.7.7"
+  dependencies:
+    "@types/eslint": "*"
+    "@types/estree": "*"
+  checksum: e2889a124aaab0b89af1bab5959847c5bec09809209255de0e63b9f54c629a94781daa04adb66bffcdd742f5e25a17614fb933965093c0eea64aacda4309380e
+  languageName: node
+  linkType: hard
+
+"@types/eslint@npm:*":
+  version: 9.6.1
+  resolution: "@types/eslint@npm:9.6.1"
+  dependencies:
+    "@types/estree": "*"
+    "@types/json-schema": "*"
+  checksum: c286e79707ab604b577cf8ce51d9bbb9780e3d6a68b38a83febe13fa05b8012c92de17c28532fac2b03d3c460123f5055d603a579685325246ca1c86828223e0
+  languageName: node
+  linkType: hard
+
 "@types/eslint@npm:^8.56.10":
   version: 8.56.12
   resolution: "@types/eslint@npm:8.56.12"
@@ -18189,7 +19510,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:*, @types/estree@npm:1.0.6, @types/estree@npm:^1.0.0, @types/estree@npm:^1.0.5":
+"@types/estree@npm:*, @types/estree@npm:1.0.6, @types/estree@npm:^1.0.0, @types/estree@npm:^1.0.5, @types/estree@npm:^1.0.6":
   version: 1.0.6
   resolution: "@types/estree@npm:1.0.6"
   checksum: 8825d6e729e16445d9a1dd2fb1db2edc5ed400799064cd4d028150701031af012ba30d6d03fe9df40f4d7a437d0de6d2b256020152b7b09bde9f2e420afdffd9
@@ -18243,7 +19564,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/express@npm:*, @types/express@npm:^4.17.21, @types/express@npm:^4.17.6":
+"@types/express@npm:*, @types/express@npm:^4.17.14, @types/express@npm:^4.17.21, @types/express@npm:^4.17.6":
   version: 4.17.21
   resolution: "@types/express@npm:4.17.21"
   dependencies:
@@ -18874,7 +20195,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/passport@npm:*, @types/passport@npm:^1.0.16, @types/passport@npm:^1.0.3":
+"@types/passport@npm:*, @types/passport@npm:^1.0.11, @types/passport@npm:^1.0.16, @types/passport@npm:^1.0.3":
   version: 1.0.17
   resolution: "@types/passport@npm:1.0.17"
   dependencies:
@@ -19349,7 +20670,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/supertest@npm:^2.0.8":
+"@types/supertest@npm:^2.0.12, @types/supertest@npm:^2.0.8":
   version: 2.0.16
   resolution: "@types/supertest@npm:2.0.16"
   dependencies:
@@ -19410,6 +20731,15 @@ __metadata:
   dependencies:
     terser-webpack-plugin: "*"
   checksum: 475b0f160c9f83641255f6516b69d7908b9e3e8e8ab653f3a257690249f9614f9386c0897eba6e4e35182ec0d83f57454d62fb94b38ae7c171891641350072ee
+  languageName: node
+  linkType: hard
+
+"@types/testing-library__jest-dom@npm:^5.9.1":
+  version: 5.14.9
+  resolution: "@types/testing-library__jest-dom@npm:5.14.9"
+  dependencies:
+    "@types/jest": "*"
+  checksum: d364494fc2545316292e88861146146af1e3818792ca63b62a63758b2f737669b687f4aaddfcfbcb7d0e1ed7890a9bd05de23ff97f277d5e68de574497a9ee72
   languageName: node
   linkType: hard
 
@@ -19526,7 +20856,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/xml-encryption@npm:^1.2.4":
+"@types/xml-crypto@npm:^1.4.2":
+  version: 1.4.6
+  resolution: "@types/xml-crypto@npm:1.4.6"
+  dependencies:
+    "@types/node": "*"
+    xpath: 0.0.27
+  checksum: e53516a2f5e4e018e164eb1cb9fc922294b9a339624e567c1c00a2b1496e9f86826210473e62ceb0b45949638c9d149da088b3598f6b3acd86e933f0a2b23f2c
+  languageName: node
+  linkType: hard
+
+"@types/xml-encryption@npm:^1.2.1, @types/xml-encryption@npm:^1.2.4":
   version: 1.2.4
   resolution: "@types/xml-encryption@npm:1.2.4"
   dependencies:
@@ -19535,7 +20875,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/xml2js@npm:^0.4.14, @types/xml2js@npm:^0.4.7":
+"@types/xml2js@npm:^0.4.11, @types/xml2js@npm:^0.4.14, @types/xml2js@npm:^0.4.7":
   version: 0.4.14
   resolution: "@types/xml2js@npm:0.4.14"
   dependencies:
@@ -19783,7 +21123,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:^5.62.0":
+"@typescript-eslint/utils@npm:^5.10.0, @typescript-eslint/utils@npm:^5.62.0":
   version: 5.62.0
   resolution: "@typescript-eslint/utils@npm:5.62.0"
   dependencies:
@@ -20354,7 +21694,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmldom/xmldom@npm:^0.8.10, @xmldom/xmldom@npm:^0.8.3, @xmldom/xmldom@npm:^0.8.5":
+"@xmldom/xmldom@npm:^0.8.10, @xmldom/xmldom@npm:^0.8.3, @xmldom/xmldom@npm:^0.8.5, @xmldom/xmldom@npm:^0.8.6, @xmldom/xmldom@npm:^0.8.8":
   version: 0.8.10
   resolution: "@xmldom/xmldom@npm:0.8.10"
   checksum: 4c136aec31fb3b49aaa53b6fcbfe524d02a1dc0d8e17ee35bd3bf35e9ce1344560481cd1efd086ad1a4821541482528672306d5e37cdbd187f33d7fadd3e2cf0
@@ -21078,12 +22418,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.4.1, acorn@npm:^8.7.1, acorn@npm:^8.8.2, acorn@npm:^8.9.0":
-  version: 8.11.3
-  resolution: "acorn@npm:8.11.3"
+"acorn@npm:^8.14.0, acorn@npm:^8.4.1, acorn@npm:^8.7.1, acorn@npm:^8.8.2, acorn@npm:^8.9.0":
+  version: 8.14.0
+  resolution: "acorn@npm:8.14.0"
   bin:
     acorn: bin/acorn
-  checksum: 76d8e7d559512566b43ab4aadc374f11f563f0a9e21626dd59cb2888444e9445923ae9f3699972767f18af61df89cd89f5eaaf772d1327b055b45cb829b4a88c
+  checksum: 8755074ba55fff94e84e81c72f1013c2d9c78e973c31231c8ae505a5f966859baf654bddd75046bffd73ce816b149298977fff5077a3033dedba0ae2aad152d4
   languageName: node
   linkType: hard
 
@@ -21415,7 +22755,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"any-promise@npm:^1.0.0":
+"any-promise@npm:^1.0.0, any-promise@npm:^1.1.0":
   version: 1.3.0
   resolution: "any-promise@npm:1.3.0"
   checksum: 0ee8a9bdbe882c90464d75d1f55cf027f5458650c4bd1f0467e65aec38ccccda07ca5844969ee77ed46d04e7dded3eaceb027e8d32f385688523fe305fa7e1de
@@ -21478,6 +22818,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"archiver-utils@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "archiver-utils@npm:4.0.1"
+  dependencies:
+    glob: ^8.0.0
+    graceful-fs: ^4.2.0
+    lazystream: ^1.0.0
+    lodash: ^4.17.15
+    normalize-path: ^3.0.0
+    readable-stream: ^3.6.0
+  checksum: 2917cdf63a912c74002a4a1e6de3076a4691030b4e722efdd6d862447b61cd64c8b7688d331b1d35f8d4fc661d6e34f91bc1ffc79478fca2e48ad060acece18c
+  languageName: node
+  linkType: hard
+
 "archiver-utils@npm:^5.0.0, archiver-utils@npm:^5.0.2":
   version: 5.0.2
   resolution: "archiver-utils@npm:5.0.2"
@@ -21490,6 +22844,21 @@ __metadata:
     normalize-path: ^3.0.0
     readable-stream: ^4.0.0
   checksum: 7dc4f3001dc373bd0fa7671ebf08edf6f815cbc539c78b5478a2eaa67e52e3fc0e92f562cdef2ba016c4dcb5468d3d069eb89535c6844da4a5bb0baf08ad5720
+  languageName: node
+  linkType: hard
+
+"archiver@npm:^6.0.0":
+  version: 6.0.2
+  resolution: "archiver@npm:6.0.2"
+  dependencies:
+    archiver-utils: ^4.0.1
+    async: ^3.2.4
+    buffer-crc32: ^0.2.1
+    readable-stream: ^3.6.0
+    readdir-glob: ^1.1.2
+    tar-stream: ^3.0.0
+    zip-stream: ^5.0.1
+  checksum: 17a20a1291d9bf41e25c96f029373bec5306d6e381063b3ab06ea805d234afaf55a7829c3577dd003558c188c6631769a80c51f245175fdb8310631df36ceb4b
   languageName: node
   linkType: hard
 
@@ -21572,6 +22941,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"aria-query@npm:5.1.3":
+  version: 5.1.3
+  resolution: "aria-query@npm:5.1.3"
+  dependencies:
+    deep-equal: ^2.0.5
+  checksum: 929ff95f02857b650fb4cbcd2f41072eee2f46159a6605ea03bf63aa572e35ffdff43d69e815ddc462e16e07de8faba3978afc2813650b4448ee18c9895d982b
+  languageName: node
+  linkType: hard
+
 "aria-query@npm:5.3.0":
   version: 5.3.0
   resolution: "aria-query@npm:5.3.0"
@@ -21588,7 +22966,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array-buffer-byte-length@npm:^1.0.1":
+"array-buffer-byte-length@npm:^1.0.0, array-buffer-byte-length@npm:^1.0.1":
   version: 1.0.1
   resolution: "array-buffer-byte-length@npm:1.0.1"
   dependencies:
@@ -22038,7 +23416,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.7.7, axios@npm:^1.0.0, axios@npm:^1.6.0, axios@npm:^1.7.4, axios@npm:^1.7.7":
+"axios@npm:1.7.7, axios@npm:^1.0.0, axios@npm:^1.6.0, axios@npm:^1.6.7, axios@npm:^1.7.4, axios@npm:^1.7.7":
   version: 1.7.7
   resolution: "axios@npm:1.7.7"
   dependencies:
@@ -22727,17 +24105,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.0.0, browserslist@npm:^4.16.0, browserslist@npm:^4.16.6, browserslist@npm:^4.18.1, browserslist@npm:^4.21.10, browserslist@npm:^4.23.1":
-  version: 4.23.3
-  resolution: "browserslist@npm:4.23.3"
+"browserslist@npm:^4.0.0, browserslist@npm:^4.16.0, browserslist@npm:^4.16.6, browserslist@npm:^4.18.1, browserslist@npm:^4.21.10, browserslist@npm:^4.23.1, browserslist@npm:^4.24.0":
+  version: 4.24.2
+  resolution: "browserslist@npm:4.24.2"
   dependencies:
-    caniuse-lite: ^1.0.30001646
-    electron-to-chromium: ^1.5.4
+    caniuse-lite: ^1.0.30001669
+    electron-to-chromium: ^1.5.41
     node-releases: ^2.0.18
-    update-browserslist-db: ^1.1.0
+    update-browserslist-db: ^1.1.1
   bin:
     browserslist: cli.js
-  checksum: 7906064f9970aeb941310b2fcb8b4ace4a1b50aa657c986677c6f1553a8cabcc94ee9c5922f715baffbedaa0e6cf0831b6fed7b059dde6873a4bfadcbe069c7e
+  checksum: cf64085f12132d38638f38937a255edb82c7551b164a98577b055dd79719187a816112f7b97b9739e400c4954cd66479c0d7a843cb816e346f4795dc24fd5d97
   languageName: node
   linkType: hard
 
@@ -22766,17 +24144,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"buffer-crc32@npm:^0.2.1, buffer-crc32@npm:~0.2.3":
+  version: 0.2.13
+  resolution: "buffer-crc32@npm:0.2.13"
+  checksum: 06252347ae6daca3453b94e4b2f1d3754a3b146a111d81c68924c22d91889a40623264e95e67955b1cb4a68cbedf317abeabb5140a9766ed248973096db5ce1c
+  languageName: node
+  linkType: hard
+
 "buffer-crc32@npm:^1.0.0":
   version: 1.0.0
   resolution: "buffer-crc32@npm:1.0.0"
   checksum: bc114c0e02fe621249e0b5093c70e6f12d4c2b1d8ddaf3b1b7bbe3333466700100e6b1ebdc12c050d0db845bc582c4fce8c293da487cc483f97eea027c480b23
-  languageName: node
-  linkType: hard
-
-"buffer-crc32@npm:~0.2.3":
-  version: 0.2.13
-  resolution: "buffer-crc32@npm:0.2.13"
-  checksum: 06252347ae6daca3453b94e4b2f1d3754a3b146a111d81c68924c22d91889a40623264e95e67955b1cb4a68cbedf317abeabb5140a9766ed248973096db5ce1c
   languageName: node
   linkType: hard
 
@@ -23105,10 +24483,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001616, caniuse-lite@npm:^1.0.30001646":
-  version: 1.0.30001668
-  resolution: "caniuse-lite@npm:1.0.30001668"
-  checksum: ce6996901b5883454a8ddb3040f82342277b6a6275876dfefcdecb11f7e472e29877f34cae47c2b674f08f2e71971dd4a2acb9bc01adfe8421b7148a7e9e8297
+"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001616, caniuse-lite@npm:^1.0.30001669":
+  version: 1.0.30001680
+  resolution: "caniuse-lite@npm:1.0.30001680"
+  checksum: 2641d2b18c5ab0a6663cb350c5adc81e5ede1a7677d1c7518a8053ada87bf6f206419e1820a2608f76fa5e4f7bea327cbe47df423783e571569a88c0ea645270
   languageName: node
   linkType: hard
 
@@ -23921,6 +25299,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"compress-commons@npm:^5.0.1":
+  version: 5.0.3
+  resolution: "compress-commons@npm:5.0.3"
+  dependencies:
+    crc-32: ^1.2.0
+    crc32-stream: ^5.0.0
+    normalize-path: ^3.0.0
+    readable-stream: ^3.6.0
+  checksum: a88c58bbde4859036396209d36928003ea3494c713e9476af51c2f720d299b96c46ed966a86707aa5dc07672c850291ed1a6802ce37dd2b532f9733b600f00b7
+  languageName: node
+  linkType: hard
+
 "compress-commons@npm:^6.0.2":
   version: 6.0.2
   resolution: "compress-commons@npm:6.0.2"
@@ -24233,10 +25623,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cookie@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "cookie@npm:0.6.0"
+  checksum: f56a7d32a07db5458e79c726b77e3c2eff655c36792f2b6c58d351fb5f61531e5b1ab7f46987150136e366c65213cbe31729e02a3eaed630c3bf7334635fb410
+  languageName: node
+  linkType: hard
+
 "cookiejar@npm:^2.1.4":
   version: 2.1.4
   resolution: "cookiejar@npm:2.1.4"
   checksum: c4442111963077dc0e5672359956d6556a195d31cbb35b528356ce5f184922b99ac48245ac05ed86cf993f7df157c56da10ab3efdadfed79778a0d9b1b092d5b
+  languageName: node
+  linkType: hard
+
+"cookies@npm:~0.8.0":
+  version: 0.8.0
+  resolution: "cookies@npm:0.8.0"
+  dependencies:
+    depd: ~2.0.0
+    keygrip: ~1.1.0
+  checksum: 806055a44f128705265b1bc6a853058da18bf80dea3654ad99be20985b1fa1b14f86c1eef73644aab8071241f8a78acd57202b54c4c5c70769fc694fbb9c4edc
   languageName: node
   linkType: hard
 
@@ -24376,6 +25783,16 @@ __metadata:
   bin:
     crc32: ./bin/crc32.njs
   checksum: 7bcde8bea262f6629ac3c70e20bdfa3d058dc77091705ce8620513f76f19b41fc273ddd65a716eef9b4e33fbb61ff7f9b266653d214319aef27e4223789c6b9e
+  languageName: node
+  linkType: hard
+
+"crc32-stream@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "crc32-stream@npm:5.0.1"
+  dependencies:
+    crc-32: ^1.2.0
+    readable-stream: ^3.4.0
+  checksum: 5bd40b58488d9a4387ad799fb04d0896e7e2ca63afeedd56df9a115af3437cf83976ae07fd2402692f88efcbd2f738134a1f25366ca47e217601b6baa5388f89
   languageName: node
   linkType: hard
 
@@ -24638,6 +26055,30 @@ __metadata:
   dependencies:
     hyphenate-style-name: ^1.0.3
   checksum: 066318e918c04a5e5bce46b38fe81052ea6ac051bcc6d3c369a1d59ceb1546cb2b6086901ab5d22be084122ee3732169996a3dfb04d3406eaee205af77aec61b
+  languageName: node
+  linkType: hard
+
+"css-loader@npm:^6.5.1":
+  version: 6.11.0
+  resolution: "css-loader@npm:6.11.0"
+  dependencies:
+    icss-utils: ^5.1.0
+    postcss: ^8.4.33
+    postcss-modules-extract-imports: ^3.1.0
+    postcss-modules-local-by-default: ^4.0.5
+    postcss-modules-scope: ^3.2.0
+    postcss-modules-values: ^4.0.0
+    postcss-value-parser: ^4.2.0
+    semver: ^7.5.4
+  peerDependencies:
+    "@rspack/core": 0.x || 1.x
+    webpack: ^5.0.0
+  peerDependenciesMeta:
+    "@rspack/core":
+      optional: true
+    webpack:
+      optional: true
+  checksum: 5c8d35975a7121334905394e88e28f05df72f037dbed2fb8fec4be5f0b313ae73a13894ba791867d4a4190c35896da84a7fd0c54fb426db55d85ba5e714edbe3
   languageName: node
   linkType: hard
 
@@ -25166,6 +26607,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"debug@npm:~3.1.0":
+  version: 3.1.0
+  resolution: "debug@npm:3.1.0"
+  dependencies:
+    ms: 2.0.0
+  checksum: 0b52718ab957254a5b3ca07fc34543bc778f358620c206a08452251eb7fc193c3ea3505072acbf4350219c14e2d71ceb7bdaa0d3370aa630b50da790458d08b3
+  languageName: node
+  linkType: hard
+
 "debuglog@npm:^1.0.1":
   version: 1.0.1
   resolution: "debuglog@npm:1.0.1"
@@ -25230,6 +26680,32 @@ __metadata:
   version: 5.0.2
   resolution: "deep-eql@npm:5.0.2"
   checksum: 6aaaadb4c19cbce42e26b2bbe5bd92875f599d2602635dc97f0294bae48da79e89470aedee05f449e0ca8c65e9fd7e7872624d1933a1db02713d99c2ca8d1f24
+  languageName: node
+  linkType: hard
+
+"deep-equal@npm:^2.0.5":
+  version: 2.2.3
+  resolution: "deep-equal@npm:2.2.3"
+  dependencies:
+    array-buffer-byte-length: ^1.0.0
+    call-bind: ^1.0.5
+    es-get-iterator: ^1.1.3
+    get-intrinsic: ^1.2.2
+    is-arguments: ^1.1.1
+    is-array-buffer: ^3.0.2
+    is-date-object: ^1.0.5
+    is-regex: ^1.1.4
+    is-shared-array-buffer: ^1.0.2
+    isarray: ^2.0.5
+    object-is: ^1.1.5
+    object-keys: ^1.1.1
+    object.assign: ^4.1.4
+    regexp.prototype.flags: ^1.5.1
+    side-channel: ^1.0.4
+    which-boxed-primitive: ^1.0.2
+    which-collection: ^1.0.1
+    which-typed-array: ^1.1.13
+  checksum: ee8852f23e4d20a5626c13b02f415ba443a1b30b4b3d39eaf366d59c4a85e6545d7ec917db44d476a85ae5a86064f7e5f7af7479f38f113995ba869f3a1ddc53
   languageName: node
   linkType: hard
 
@@ -25669,7 +27145,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dom-accessibility-api@npm:^0.5.9":
+"dom-accessibility-api@npm:^0.5.6, dom-accessibility-api@npm:^0.5.9":
   version: 0.5.16
   resolution: "dom-accessibility-api@npm:0.5.16"
   checksum: 005eb283caef57fc1adec4d5df4dd49189b628f2f575af45decb210e04d634459e3f1ee64f18b41e2dcf200c844bc1d9279d80807e686a30d69a4756151ad248
@@ -26030,10 +27506,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-to-chromium@npm:^1.5.4":
-  version: 1.5.13
-  resolution: "electron-to-chromium@npm:1.5.13"
-  checksum: f18ac84dd3bf9a200654a6a9292b9ec4bced0cf9bd26cec9941b775f4470c581c9d043e70b37a124d9752dcc0f47fc96613d52b2defd8e59632852730cb418b9
+"electron-to-chromium@npm:^1.5.41":
+  version: 1.5.59
+  resolution: "electron-to-chromium@npm:1.5.59"
+  checksum: dc8f77964df2dc98829ea197fc1e20167bbce8922965754e275c4170255caea4edacacae5f3cb00c8e1705e0f748b70d512d6af2dcb8d0de0f14a65000c986de
   languageName: node
   linkType: hard
 
@@ -26197,6 +27673,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"error-inject@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "error-inject@npm:1.0.0"
+  checksum: 258cb26c7c7e04d9b730d074926ff5e18755b6945781540fdd124cafc5015610d97e4b971eb3226469f407fd34fa899a60fbcf9ade8923ab42fa2a3c61e246cf
+  languageName: node
+  linkType: hard
+
 "error-stack-parser@npm:^2.0.6":
   version: 2.0.6
   resolution: "error-stack-parser@npm:2.0.6"
@@ -26295,6 +27778,23 @@ __metadata:
   version: 1.3.0
   resolution: "es-errors@npm:1.3.0"
   checksum: ec1414527a0ccacd7f15f4a3bc66e215f04f595ba23ca75cdae0927af099b5ec865f9f4d33e9d7e86f512f252876ac77d4281a7871531a50678132429b1271b5
+  languageName: node
+  linkType: hard
+
+"es-get-iterator@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "es-get-iterator@npm:1.1.3"
+  dependencies:
+    call-bind: ^1.0.2
+    get-intrinsic: ^1.1.3
+    has-symbols: ^1.0.3
+    is-arguments: ^1.1.1
+    is-map: ^2.0.2
+    is-set: ^2.0.2
+    is-string: ^1.0.7
+    isarray: ^2.0.5
+    stop-iteration-iterator: ^1.0.0
+  checksum: 8fa118da42667a01a7c7529f8a8cca514feeff243feec1ce0bb73baaa3514560bd09d2b3438873cf8a5aaec5d52da248131de153b28e2638a061b6e4df13267d
   languageName: node
   linkType: hard
 
@@ -26605,10 +28105,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escalade@npm:^3.1.1, escalade@npm:^3.1.2":
-  version: 3.1.2
-  resolution: "escalade@npm:3.1.2"
-  checksum: 1ec0977aa2772075493002bdbd549d595ff6e9393b1cb0d7d6fcaf78c750da0c158f180938365486f75cb69fba20294351caddfce1b46552a7b6c3cde52eaa02
+"escalade@npm:^3.1.1, escalade@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "escalade@npm:3.2.0"
+  checksum: 47b029c83de01b0d17ad99ed766347b974b0d628e848de404018f3abee728e987da0d2d370ad4574aa3d5b5bfc368754fd085d69a30f8e75903486ec4b5b709e
   languageName: node
   linkType: hard
 
@@ -26778,6 +28278,24 @@ __metadata:
   peerDependencies:
     eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9
   checksum: b1d2ac268b3582ff1af2a72a2c476eae4d250c100f2e335b6e102036e4a35efa530b80ec578dfc36761fabb34a635b9bf5ab071abe9d4404a4bb054fdf22d415
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-jest@npm:^27.0.0":
+  version: 27.9.0
+  resolution: "eslint-plugin-jest@npm:27.9.0"
+  dependencies:
+    "@typescript-eslint/utils": ^5.10.0
+  peerDependencies:
+    "@typescript-eslint/eslint-plugin": ^5.0.0 || ^6.0.0 || ^7.0.0
+    eslint: ^7.0.0 || ^8.0.0
+    jest: "*"
+  peerDependenciesMeta:
+    "@typescript-eslint/eslint-plugin":
+      optional: true
+    jest:
+      optional: true
+  checksum: e2a4b415105408de28ad146818fcc6f4e122f6a39c6b2216ec5c24a80393f1390298b20231b0467bc5fd730f6e24b05b89e1a6a3ce651fc159aa4174ecc233d0
   languageName: node
   linkType: hard
 
@@ -27395,6 +28913,7 @@ __metadata:
     "@backstage/plugin-catalog-backend-module-openapi": "workspace:^"
     "@backstage/plugin-catalog-backend-module-scaffolder-entity-model": "workspace:^"
     "@backstage/plugin-catalog-backend-module-unprocessed": "workspace:^"
+    "@backstage/plugin-device-auth-backend": "workspace:^"
     "@backstage/plugin-devtools-backend": "workspace:^"
     "@backstage/plugin-events-backend": "workspace:^"
     "@backstage/plugin-kubernetes-backend": "workspace:^"
@@ -28362,6 +29881,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"formidable@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "formidable@npm:2.1.2"
+  dependencies:
+    dezalgo: ^1.0.4
+    hexoid: ^1.0.0
+    once: ^1.4.0
+    qs: ^6.11.0
+  checksum: 81c8e5d89f5eb873e992893468f0de22c01678ca3d315db62be0560f9de1c77d4faefc9b1f4575098eb2263b3c81ba1024833a9fc3206297ddbac88a4f69b7a8
+  languageName: node
+  linkType: hard
+
 "formidable@npm:^3.5.1":
   version: 3.5.1
   resolution: "formidable@npm:3.5.1"
@@ -28702,7 +30233,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-intrinsic@npm:^1.1.1, get-intrinsic@npm:^1.1.3, get-intrinsic@npm:^1.2.1, get-intrinsic@npm:^1.2.3, get-intrinsic@npm:^1.2.4":
+"get-intrinsic@npm:^1.1.1, get-intrinsic@npm:^1.1.3, get-intrinsic@npm:^1.2.1, get-intrinsic@npm:^1.2.2, get-intrinsic@npm:^1.2.3, get-intrinsic@npm:^1.2.4":
   version: 1.2.4
   resolution: "get-intrinsic@npm:1.2.4"
   dependencies:
@@ -28941,7 +30472,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^8.0.1, glob@npm:^8.0.3, glob@npm:^8.1.0":
+"glob@npm:^8.0.0, glob@npm:^8.0.1, glob@npm:^8.0.3, glob@npm:^8.1.0":
   version: 8.1.0
   resolution: "glob@npm:8.1.0"
   dependencies:
@@ -30407,7 +31938,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"internal-slot@npm:^1.0.7":
+"internal-slot@npm:^1.0.4, internal-slot@npm:^1.0.7":
   version: 1.0.7
   resolution: "internal-slot@npm:1.0.7"
   dependencies:
@@ -30549,7 +32080,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-arguments@npm:^1.0.4":
+"is-arguments@npm:^1.0.4, is-arguments@npm:^1.1.1":
   version: 1.1.1
   resolution: "is-arguments@npm:1.1.1"
   dependencies:
@@ -30559,7 +32090,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-array-buffer@npm:^3.0.4":
+"is-array-buffer@npm:^3.0.2, is-array-buffer@npm:^3.0.4":
   version: 3.0.4
   resolution: "is-array-buffer@npm:3.0.4"
   dependencies:
@@ -30843,7 +32374,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-map@npm:^2.0.1":
+"is-map@npm:^2.0.1, is-map@npm:^2.0.2":
   version: 2.0.3
   resolution: "is-map@npm:2.0.3"
   checksum: e6ce5f6380f32b141b3153e6ba9074892bbbbd655e92e7ba5ff195239777e767a976dcd4e22f864accaf30e53ebf961ab1995424aef91af68788f0591b7396cc
@@ -31046,7 +32577,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-set@npm:^2.0.1":
+"is-set@npm:^2.0.1, is-set@npm:^2.0.2":
   version: 2.0.3
   resolution: "is-set@npm:2.0.3"
   checksum: 36e3f8c44bdbe9496c9689762cc4110f6a6a12b767c5d74c0398176aa2678d4467e3bf07595556f2dba897751bde1422480212b97d973c7b08a343100b0c0dfe
@@ -32794,7 +34325,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"knex@npm:3, knex@npm:^3.0.0":
+"knex@npm:3, knex@npm:^3.0.0, knex@npm:^3.1.0":
   version: 3.1.0
   resolution: "knex@npm:3.1.0"
   dependencies:
@@ -32863,10 +34394,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"koa-compose@npm:^3.0.0":
+  version: 3.2.1
+  resolution: "koa-compose@npm:3.2.1"
+  dependencies:
+    any-promise: ^1.1.0
+  checksum: ff8e5fc0348455acf751179c6c613eb030a5fac6406d3b49ae9e00460b7ee8770db3ef62633fd3db0306cd4a6d2a0b5152399ebd5bb5e684418f9eeeb251c2de
+  languageName: node
+  linkType: hard
+
 "koa-compose@npm:^4.1.0":
   version: 4.1.0
   resolution: "koa-compose@npm:4.1.0"
   checksum: 46cb16792d96425e977c2ae4e5cb04930280740e907242ec9c25e3fb8b4a1d7b54451d7432bc24f40ec62255edea71894d2ceeb8238501842b4e48014f2e83db
+  languageName: node
+  linkType: hard
+
+"koa-convert@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "koa-convert@npm:1.2.0"
+  dependencies:
+    co: ^4.6.0
+    koa-compose: ^3.0.0
+  checksum: a33944dbda4ed87565985f5b37ba1122a012db872724b216b6fd8f9176d4bba42c4a9bf3c129330e45f6474d28f50ca0ed28d41b9bccd2ab5d36d6436cf0d676
   languageName: node
   linkType: hard
 
@@ -32877,6 +34427,38 @@ __metadata:
     co: ^4.6.0
     koa-compose: ^4.1.0
   checksum: 7385b3391995f59c1312142e110d5dff677f9850dbfbcf387cd36a7b0af03b5d26e82b811eb9bb008b4f3e661cdab1f8817596e46b1929da2cf6e97a2f7456ed
+  languageName: node
+  linkType: hard
+
+"koa@npm:2.11.0":
+  version: 2.11.0
+  resolution: "koa@npm:2.11.0"
+  dependencies:
+    accepts: ^1.3.5
+    cache-content-type: ^1.0.0
+    content-disposition: ~0.5.2
+    content-type: ^1.0.4
+    cookies: ~0.8.0
+    debug: ~3.1.0
+    delegates: ^1.0.0
+    depd: ^1.1.2
+    destroy: ^1.0.4
+    encodeurl: ^1.0.2
+    error-inject: ^1.0.0
+    escape-html: ^1.0.3
+    fresh: ~0.5.2
+    http-assert: ^1.3.0
+    http-errors: ^1.6.3
+    is-generator-function: ^1.0.7
+    koa-compose: ^4.1.0
+    koa-convert: ^1.2.0
+    on-finished: ^2.3.0
+    only: ~0.0.2
+    parseurl: ^1.3.2
+    statuses: ^1.5.0
+    type-is: ^1.6.16
+    vary: ^1.1.2
+  checksum: b08e1aea03e70fe4ff6e35dee9f9e979e8608461ee1002f6e8dd72f45fc49404873888ea9a3aab2904e24bf43522df7c601033522f4151189e4055e87f94a979
   languageName: node
   linkType: hard
 
@@ -35233,7 +36815,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"msw@npm:^2.0.0, msw@npm:^2.0.8":
+"msw@npm:^2.0.0, msw@npm:^2.0.8, msw@npm:^2.2.14":
   version: 2.6.4
   resolution: "msw@npm:2.6.4"
   dependencies:
@@ -35385,7 +36967,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.7":
+"nanoid@npm:3, nanoid@npm:^3.3.7":
   version: 3.3.7
   resolution: "nanoid@npm:3.3.7"
   bin:
@@ -37109,6 +38691,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"passport@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "passport@npm:0.6.0"
+  dependencies:
+    passport-strategy: 1.x.x
+    pause: 0.0.1
+    utils-merge: ^1.0.1
+  checksum: ef932ad671d50de34765c7a53cd1e058d8331a82a6df09265a9c6c1168911aee4a7b5215803d0101110ab7f317e096b4954ca7e18fb2c33b9929f0bd17dbe159
+  languageName: node
+  linkType: hard
+
 "passport@npm:^0.7.0":
   version: 0.7.0
   resolution: "passport@npm:0.7.0"
@@ -37228,7 +38821,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:^6.3.0":
+"path-to-regexp@npm:^6.2.1, path-to-regexp@npm:^6.3.0":
   version: 6.3.0
   resolution: "path-to-regexp@npm:6.3.0"
   checksum: eca78602e6434a1b6799d511d375ec044e8d7e28f5a48aa5c28d57d8152fb52f3fc62fb1cfc5dfa2198e1f041c2a82ed14043d75740a2fe60e91b5089a153250
@@ -37456,7 +39049,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picocolors@npm:^1.0.0, picocolors@npm:^1.0.1, picocolors@npm:^1.1.0, picocolors@npm:^1.1.1":
+"picocolors@npm:^1.0.0, picocolors@npm:^1.1.0, picocolors@npm:^1.1.1":
   version: 1.1.1
   resolution: "picocolors@npm:1.1.1"
   checksum: e1cf46bf84886c79055fdfa9dcb3e4711ad259949e3565154b004b260cd356c5d54b31a1437ce9782624bf766272fe6b0154f5f0c744fb7af5d454d2b60db045
@@ -39937,15 +41530,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regexp.prototype.flags@npm:^1.5.2":
-  version: 1.5.2
-  resolution: "regexp.prototype.flags@npm:1.5.2"
+"regexp.prototype.flags@npm:^1.5.1, regexp.prototype.flags@npm:^1.5.2":
+  version: 1.5.3
+  resolution: "regexp.prototype.flags@npm:1.5.3"
   dependencies:
-    call-bind: ^1.0.6
+    call-bind: ^1.0.7
     define-properties: ^1.2.1
     es-errors: ^1.3.0
-    set-function-name: ^2.0.1
-  checksum: d7f333667d5c564e2d7a97c56c3075d64c722c9bb51b2b4df6822b2e8096d623a5e63088fb4c83df919b6951ef8113841de8b47de7224872fa6838bc5d8a7d64
+    set-function-name: ^2.0.2
+  checksum: 83ff0705b837f7cb6d664010a11642250f36d3f642263dd0f3bdfe8f150261aa7b26b50ee97f21c1da30ef82a580bb5afedbef5f45639d69edaafbeac9bbb0ed
   languageName: node
   linkType: hard
 
@@ -40700,6 +42293,13 @@ __metadata:
   dependencies:
     queue-microtask: ^1.2.2
   checksum: cb4f97ad25a75ebc11a8ef4e33bb962f8af8516bb2001082ceabd8902e15b98f4b84b4f8a9b222e5d57fc3bd1379c483886ed4619367a7680dad65316993021d
+  languageName: node
+  linkType: hard
+
+"run-script-webpack-plugin@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "run-script-webpack-plugin@npm:0.2.0"
+  checksum: 1f5df65b726e098d602b4cc27472d9e2cd88841862f7ca2112f702b01f3c4fc1cd89b54fa63780691d988c9ab36cc9adc08a6fa056cdb9c7b85b027b21ba6cdd
   languageName: node
   linkType: hard
 
@@ -41942,6 +43542,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stop-iteration-iterator@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "stop-iteration-iterator@npm:1.0.0"
+  dependencies:
+    internal-slot: ^1.0.4
+  checksum: d04173690b2efa40e24ab70e5e51a3ff31d56d699550cfad084104ab3381390daccb36652b25755e420245f3b0737de66c1879eaa2a8d4fc0a78f9bf892fcb42
+  languageName: node
+  linkType: hard
+
 "stoppable@npm:^1.1.0":
   version: 1.1.0
   resolution: "stoppable@npm:1.1.0"
@@ -42511,6 +44120,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"superagent@npm:^8.1.2":
+  version: 8.1.2
+  resolution: "superagent@npm:8.1.2"
+  dependencies:
+    component-emitter: ^1.3.0
+    cookiejar: ^2.1.4
+    debug: ^4.3.4
+    fast-safe-stringify: ^2.1.1
+    form-data: ^4.0.0
+    formidable: ^2.1.2
+    methods: ^1.1.2
+    mime: 2.6.0
+    qs: ^6.11.0
+    semver: ^7.3.8
+  checksum: f3601c5ccae34d5ba684a03703394b5d25931f4ae2e1e31a1de809f88a9400e997ece037f9accf148a21c408f950dc829db1e4e23576a7f9fe0efa79fd5c9d2f
+  languageName: node
+  linkType: hard
+
 "superagent@npm:^9.0.1":
   version: 9.0.2
   resolution: "superagent@npm:9.0.2"
@@ -42525,6 +44152,16 @@ __metadata:
     mime: 2.6.0
     qs: ^6.11.0
   checksum: f471461b21f034d844fd0aca332128d61e3afb75c2ee5950f3339f2a3b5ca8b23e2861224f19ad9b43f21c9184d28b7d9384af5a4fde64fdef479efdb15036db
+  languageName: node
+  linkType: hard
+
+"supertest@npm:^6.2.4":
+  version: 6.3.4
+  resolution: "supertest@npm:6.3.4"
+  dependencies:
+    methods: ^1.1.2
+    superagent: ^8.1.2
+  checksum: 875c6fa7940f21e5be9bb646579cdb030d4057bf2da643e125e1f0480add1200395d2b17e10b8e54e1009efc63e047422501e9eb30e12828668498c0910f295f
   languageName: node
   linkType: hard
 
@@ -44282,17 +45919,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"update-browserslist-db@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "update-browserslist-db@npm:1.1.0"
+"update-browserslist-db@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "update-browserslist-db@npm:1.1.1"
   dependencies:
-    escalade: ^3.1.2
-    picocolors: ^1.0.1
+    escalade: ^3.2.0
+    picocolors: ^1.1.0
   peerDependencies:
     browserslist: ">= 4.21.0"
   bin:
     update-browserslist-db: cli.js
-  checksum: 7b74694d96f0c360f01b702e72353dc5a49df4fe6663d3ee4e5c628f061576cddf56af35a3a886238c01dd3d8f231b7a86a8ceaa31e7a9220ae31c1c1238e562
+  checksum: 2ea11bd2562122162c3e438d83a1f9125238c0844b6d16d366e3276d0c0acac6036822dc7df65fc5a89c699cdf9f174acf439c39bedf3f9a2f3983976e4b4c3e
   languageName: node
   linkType: hard
 
@@ -44571,6 +46208,15 @@ __metadata:
   bin:
     uuid: dist/bin/uuid
   checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "uuid@npm:10.0.0"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 4b81611ade2885d2313ddd8dc865d93d8dccc13ddf901745edca8f86d99bc46d7a330d678e7532e7ebf93ce616679fb19b2e3568873ac0c14c999032acb25869
   languageName: node
   linkType: hard
 
@@ -45105,6 +46751,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"webpack-node-externals@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "webpack-node-externals@npm:3.0.0"
+  checksum: 355080c35c821115b97dda8c93d9d0565a90a6012a532324eb0d6a64f8f0d609431fd29504fc7ce414755841ac14f601f3eef99472c2c5dc00233b504ebe73f2
+  languageName: node
+  linkType: hard
+
 "webpack-sources@npm:^1.4.3":
   version: 1.4.3
   resolution: "webpack-sources@npm:1.4.3"
@@ -45122,17 +46775,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack@npm:^5, webpack@npm:^5.94.0":
-  version: 5.95.0
-  resolution: "webpack@npm:5.95.0"
+"webpack@npm:^5, webpack@npm:^5.70.0, webpack@npm:^5.94.0":
+  version: 5.96.1
+  resolution: "webpack@npm:5.96.1"
   dependencies:
-    "@types/estree": ^1.0.5
+    "@types/eslint-scope": ^3.7.7
+    "@types/estree": ^1.0.6
     "@webassemblyjs/ast": ^1.12.1
     "@webassemblyjs/wasm-edit": ^1.12.1
     "@webassemblyjs/wasm-parser": ^1.12.1
-    acorn: ^8.7.1
-    acorn-import-attributes: ^1.9.5
-    browserslist: ^4.21.10
+    acorn: ^8.14.0
+    browserslist: ^4.24.0
     chrome-trace-event: ^1.0.2
     enhanced-resolve: ^5.17.1
     es-module-lexer: ^1.2.1
@@ -45154,7 +46807,7 @@ __metadata:
       optional: true
   bin:
     webpack: bin/webpack.js
-  checksum: 0c3dfe288de4d62f8f3dc25478a618894883cab739121330763b7847e43304630ea2815ae2351a5f8ff6ab7c9642caf530d503d89bda261fe2cd220e524dd5d1
+  checksum: ec3662f64895fae408440a997f87299e374c9d9f911f77b880bab46402f52221c7836bdf101fc2556338d07fc7cb86da50661f944eb1d1041a8361a5b9247876
   languageName: node
   linkType: hard
 
@@ -45293,7 +46946,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which-typed-array@npm:^1.1.14, which-typed-array@npm:^1.1.15, which-typed-array@npm:^1.1.2, which-typed-array@npm:^1.1.9":
+"which-typed-array@npm:^1.1.13, which-typed-array@npm:^1.1.14, which-typed-array@npm:^1.1.15, which-typed-array@npm:^1.1.2, which-typed-array@npm:^1.1.9":
   version: 1.1.15
   resolution: "which-typed-array@npm:1.1.15"
   dependencies:
@@ -45499,6 +47152,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ws@npm:8.17.0":
+  version: 8.17.0
+  resolution: "ws@npm:8.17.0"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 147ef9eab0251364e1d2c55338ad0efb15e6913923ccbfdf20f7a8a6cb8f88432bcd7f4d8f66977135bfad35575644f9983201c1a361019594a4e53977bf6d4e
+  languageName: node
+  linkType: hard
+
 "ws@npm:^7, ws@npm:^7.5.5":
   version: 7.5.10
   resolution: "ws@npm:7.5.10"
@@ -45534,6 +47202,16 @@ __metadata:
   dependencies:
     repeat-string: ^1.5.2
   checksum: 66b400079d8f2b2a149d437d94a1286318fb80a4c181a9597282711b595de15640b0066a72a4a7093afce6369798dc9725d5c2338bde59ba1a33fd7f5e753635
+  languageName: node
+  linkType: hard
+
+"xml-crypto@npm:^3.0.1":
+  version: 3.2.0
+  resolution: "xml-crypto@npm:3.2.0"
+  dependencies:
+    "@xmldom/xmldom": ^0.8.8
+    xpath: 0.0.32
+  checksum: 6c4974a7518307ea006dcfc1405f61c6738b45574b4d9d1e62f53b602bfcf894d34017f99d618f26f67c40a5e6d78e6228116ded2768b2ca5b2df5c8bf7774b7
   languageName: node
   linkType: hard
 
@@ -45573,6 +47251,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"xml2js@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "xml2js@npm:0.5.0"
+  dependencies:
+    sax: ">=0.6.0"
+    xmlbuilder: ~11.0.0
+  checksum: 1aa71d62e5bc2d89138e3929b9ea46459157727759cbc62ef99484b778641c0cd21fb637696c052d901a22f82d092a3e740a16b4ce218e81ac59b933535124ea
+  languageName: node
+  linkType: hard
+
 "xml2js@npm:^0.6.2":
   version: 0.6.2
   resolution: "xml2js@npm:0.6.2"
@@ -45608,6 +47296,13 @@ __metadata:
   version: 2.2.0
   resolution: "xmlchars@npm:2.2.0"
   checksum: 8c70ac94070ccca03f47a81fcce3b271bd1f37a591bf5424e787ae313fcb9c212f5f6786e1fa82076a2c632c0141552babcd85698c437506dfa6ae2d58723062
+  languageName: node
+  linkType: hard
+
+"xpath@npm:0.0.27":
+  version: 0.0.27
+  resolution: "xpath@npm:0.0.27"
+  checksum: 51f45d211a9a552a8f6a12a474061e89bafb07e0aecd4bad18a557411feb975919c158e1a66e4ea0542198c6ed442481d9f709c625cca57b97aaedeaeded902e
   languageName: node
   linkType: hard
 
@@ -45942,6 +47637,17 @@ __metadata:
   version: 4.0.2
   resolution: "zenscroll@npm:4.0.2"
   checksum: 5fe5c8b685246985cbb8eb270bbbac013bddaf5cde0fb9042c7b5640e31877d11a28892a802426659fe505b0b514d4d004fedd27c0cc22682611cc8f9e43132e
+  languageName: node
+  linkType: hard
+
+"zip-stream@npm:^5.0.1":
+  version: 5.0.2
+  resolution: "zip-stream@npm:5.0.2"
+  dependencies:
+    archiver-utils: ^4.0.1
+    compress-commons: ^5.0.1
+    readable-stream: ^3.6.0
+  checksum: caf33dd9624d781ea2ded059c83e3e7adc963557ca399512d2da6ab6e219b35c2985f6ff1a334dd2ab241b4067db6819398c723f3fca89b51b078757df8e3c44
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This creates a Frontend and Backend plugin to implement the OAuth Device Auth flow, enabling clients like CLIs to make authenticated requests against the Backstage backend using a user's token.

A detailed description of the implementation is included in the device-auth backend plugin's README, but in short the backend plugin has endpoints to generate and validate device auth codes while the frontend plugin includes a simple page used to call the validate auth code plugin. Doing so allows the backend to store the user's session token and pass it to the device, which continuously polls the backend until the user authorizes the device auth request.

Device Code Authorization Page
<img width="818" alt="image" src="https://github.com/user-attachments/assets/b0c03650-5ad8-45e4-bc88-6937c312918c">

Sequence Diagram
![image](https://github.com/user-attachments/assets/2176b025-f968-4712-b9cd-0b725341ee86)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
