### PR TITLE
slightly speed up the refresh loop

### DIFF
--- a/.changeset/warm-boats-move.md
+++ b/.changeset/warm-boats-move.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Internal refactor to slightly speed up the processing loop

--- a/plugins/catalog-backend/src/database/types.ts
+++ b/plugins/catalog-backend/src/database/types.ts
@@ -23,6 +23,7 @@ import {
 } from '@backstage/plugin-catalog-node';
 import { DbRelationsRow } from './tables';
 import { RefreshKeyData } from '../processing/types';
+import { Knex } from 'knex';
 
 /**
  * An abstraction for transactions of the underlying database technology.
@@ -59,10 +60,8 @@ export type RefreshStateItem = {
   id: string;
   entityRef: string;
   unprocessedEntity: Entity;
-  processedEntity?: Entity;
   resultHash: string;
   nextUpdateAt: DateTime;
-  lastDiscoveryAt: DateTime; // remove?
   state?: JsonObject;
   errors?: string;
   locationKey?: string;
@@ -116,7 +115,7 @@ export interface ProcessingDatabase {
   transaction<T>(fn: (tx: Transaction) => Promise<T>): Promise<T>;
 
   getProcessableEntities(
-    txOpaque: Transaction,
+    txOpaque: Transaction | Knex,
     request: { processBatchSize: number },
   ): Promise<GetProcessableEntitiesResult>;
 

--- a/plugins/catalog-backend/src/processing/DefaultCatalogProcessingEngine.test.ts
+++ b/plugins/catalog-backend/src/processing/DefaultCatalogProcessingEngine.test.ts
@@ -92,7 +92,6 @@ describe('DefaultCatalogProcessingEngine', () => {
             resultHash: '',
             state: [] as any,
             nextUpdateAt: DateTime.now(),
-            lastDiscoveryAt: DateTime.now(),
           },
         ],
       });
@@ -161,7 +160,6 @@ describe('DefaultCatalogProcessingEngine', () => {
             resultHash: '',
             state: { cache: { myProcessor: { myKey: 'myValue' } } },
             nextUpdateAt: DateTime.now(),
-            lastDiscoveryAt: DateTime.now(),
           },
         ],
       });

--- a/plugins/catalog-backend/src/processing/DefaultCatalogProcessingEngine.ts
+++ b/plugins/catalog-backend/src/processing/DefaultCatalogProcessingEngine.ts
@@ -135,13 +135,10 @@ export class DefaultCatalogProcessingEngine {
       pollingIntervalMs: this.pollingIntervalMs,
       loadTasks: async count => {
         try {
-          const { items } = await this.processingDatabase.transaction(
-            async tx => {
-              return this.processingDatabase.getProcessableEntities(tx, {
-                processBatchSize: count,
-              });
-            },
-          );
+          const { items } =
+            await this.processingDatabase.getProcessableEntities(this.knex, {
+              processBatchSize: count,
+            });
           return items;
         } catch (error) {
           this.logger.warn('Failed to load processing items', error);

--- a/plugins/catalog-backend/src/tests/performance/getEntitiesPerformance.test.ts
+++ b/plugins/catalog-backend/src/tests/performance/getEntitiesPerformance.test.ts
@@ -28,7 +28,6 @@ import {
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
 import { Knex } from 'knex';
 import { default as catalogPlugin } from '../..';
-import { applyDatabaseMigrations } from '../../database/migrations';
 import {
   SyntheticLoadEntitiesProcessor,
   SyntheticLoadEntitiesProvider,
@@ -57,8 +56,6 @@ async function createBackend(
   numberOfEntities: number;
   stop: () => Promise<void>;
 }> {
-  await applyDatabaseMigrations(knex);
-
   const numberOfEntities =
     load.baseEntitiesCount + load.baseEntitiesCount * load.childrenCount;
 

--- a/plugins/catalog-backend/src/tests/performance/getProcessableEntitiesPerformance.test.ts
+++ b/plugins/catalog-backend/src/tests/performance/getProcessableEntitiesPerformance.test.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TestDatabases, mockServices } from '@backstage/backend-test-utils';
+import { Knex } from 'knex';
+import { DefaultProcessingDatabase } from '../../database/DefaultProcessingDatabase';
+import { applyDatabaseMigrations } from '../../database/migrations';
+import { describePerformanceTest, performanceTraceEnabled } from './lib/env';
+
+// #region Helpers
+
+jest.setTimeout(600_000);
+
+const databases = TestDatabases.create({
+  ids: [/* 'MYSQL_8', */ 'POSTGRES_16', /* 'POSTGRES_12',*/ 'SQLITE_3'],
+  disableDocker: false,
+});
+
+const traceLog: typeof console.log = performanceTraceEnabled
+  ? console.log
+  : () => {};
+
+async function setupDatabase(knex: Knex): Promise<void> {
+  await applyDatabaseMigrations(knex);
+
+  traceLog(`Creating test dataset`);
+
+  const now = knex.fn.now();
+  const largeEntity = `"${'x'.repeat(3 * 1024)}"`;
+
+  for (let i = 0; i < 100; ++i) {
+    await knex.batchInsert(
+      'refresh_state',
+      new Array(100).fill(null).map((_, j) => ({
+        entity_id: `id-${i}-${j}`,
+        entity_ref: `entity-${i}-${j}`,
+        unprocessed_entity: largeEntity,
+        processed_entity: largeEntity,
+        errors: '{}',
+        next_update_at: now,
+        last_discovery_at: now,
+      })),
+    );
+  }
+}
+
+// #endregion
+// #region Tests
+
+describePerformanceTest('getProcessableEntities', () => {
+  let knex: Knex;
+
+  describe.each(databases.eachSupportedId())('%p', databaseId => {
+    beforeAll(async () => {
+      knex = await databases.init(databaseId);
+      await setupDatabase(knex);
+    });
+
+    afterAll(async () => {
+      await knex.destroy();
+    });
+
+    it.each([2, 5, 10])(
+      'reads as fast as possible, batch size %p',
+      async processBatchSize => {
+        const sut = new DefaultProcessingDatabase({
+          database: knex,
+          logger: mockServices.logger.mock(),
+          refreshInterval: () => 0,
+        });
+
+        const start = Date.now();
+        let total = 0;
+        while (total < 10000) {
+          const result = await sut.getProcessableEntities(knex, {
+            processBatchSize,
+          });
+          total += result.items.length;
+        }
+
+        const perSecond = Math.round(total / ((Date.now() - start) / 1000));
+        traceLog(
+          `${databaseId} processed ${perSecond} entities per second at a batch size of ${processBatchSize}`,
+        );
+
+        expect(true).toBe(true);
+      },
+    );
+  });
+});
+
+// #endregion

--- a/plugins/catalog-backend/src/tests/performance/stitchingPerformance.test.ts
+++ b/plugins/catalog-backend/src/tests/performance/stitchingPerformance.test.ts
@@ -22,6 +22,7 @@ import {
 } from '@backstage/backend-test-utils';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
 import { Knex } from 'knex';
+import { default as catalogPlugin } from '../..';
 import { applyDatabaseMigrations } from '../../database/migrations';
 import {
   SyntheticLoadEntitiesProcessor,
@@ -176,7 +177,7 @@ describePerformanceTest('stitchingPerformance', () => {
 
       const backend = await startTestBackend({
         features: [
-          import('@backstage/plugin-catalog-backend/alpha'),
+          catalogPlugin,
           mockServices.rootConfig.factory({ data: config }),
           mockServices.database.factory({ knex }),
           createBackendModule({


### PR DESCRIPTION
This does two things to the `getProcessableEntities` call:

* No longer run it in a transaction. This really doesn't matter for this use case.
* Do not fetch the `processed_entity` and `last_discovery_at` columns because these are of no interest to the processing system

This in total ends up being of comparable speed for small batch sizes since there's so much other overhead there. But in high speed scenarios like when catching up with a backed up queue, it's 10-15% faster at least in the local perf test.