### PR TITLE
Change create-app yarn test to use `--since`

### DIFF
--- a/.changeset/perfect-tomatoes-complain.md
+++ b/.changeset/perfect-tomatoes-complain.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Change 'test' package script to use --since just like 'lint'

--- a/packages/create-app/templates/default-app/package.json.hbs
+++ b/packages/create-app/templates/default-app/package.json.hbs
@@ -15,7 +15,7 @@
     "tsc": "tsc",
     "tsc:full": "tsc --skipLibCheck false --incremental false",
     "clean": "backstage-cli repo clean",
-    "test": "backstage-cli repo test",
+    "test": "backstage-cli repo test --since origin/{{defaultBranch}}",
     "test:all": "backstage-cli repo test --coverage",
     "test:e2e": "playwright test",
     "fix": "backstage-cli repo fix",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Just a proposal. IMHO the behaviour of `yarn test` should match `yarn lint`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
