### PR TITLE
app-backend: serve templated index.html from memory

### DIFF
--- a/.changeset/five-tables-remain.md
+++ b/.changeset/five-tables-remain.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-app-backend': patch
+---
+
+The `index.html` templating is now done and served from memory rather than written to the filesystem. This means that you can now use config injection with a read-only filesystem, and you no longer need to use the `app.disableConfigInjection` flag.

--- a/.changeset/itchy-masks-work.md
+++ b/.changeset/itchy-masks-work.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-app-backend': minor
+---
+
+Configuration is no longer injected into static assets if a `index.html.tmpl` file is present.

--- a/plugins/app-backend/src/lib/config/injectConfig.ts
+++ b/plugins/app-backend/src/lib/config/injectConfig.ts
@@ -24,13 +24,12 @@ import { InjectOptions } from './types';
  */
 export async function injectConfig(
   options: InjectOptions,
-): Promise<string | undefined> {
-  // In order to minimize the potential impact when rolling out the new config
-  // injection, we use both methods for a few releases. This allows the frontend
-  // app to be behind the backend by a version or two, but temporarily increases
-  // config injection overhead.
-  // TODO(Rugvip): After the 1.32 release we can stop calling the static injection if the HTML one is successful
-  await injectConfigIntoHtml(options);
+): Promise<{ injectedPath?: string | undefined; indexHtmlContent?: Buffer }> {
+  const indexHtmlContent = await injectConfigIntoHtml(options);
+  if (indexHtmlContent) {
+    return { indexHtmlContent };
+  }
 
-  return injectConfigIntoStatic(options);
+  const injectedPath = await injectConfigIntoStatic(options);
+  return { injectedPath };
 }

--- a/plugins/app-backend/src/lib/config/injectConfigIntoHtml.test.ts
+++ b/plugins/app-backend/src/lib/config/injectConfigIntoHtml.test.ts
@@ -38,25 +38,22 @@ describe('injectConfigIntoHtml', () => {
     mockDir.setContent({
       'index.html.tmpl': "<html><%= config.getNumber('x') %></html>",
     });
-    await injectConfigIntoHtml({
+    const result = await injectConfigIntoHtml({
       ...baseOptions,
       appConfigs: [{ context: 'mock', data: { x: 1 } }],
     });
-    expect(mockDir.content()).toMatchObject({
-      'index.html': '<html>1</html>',
-    });
+    expect(result?.toString('utf8')).toBe('<html>1</html>');
   });
 
   it('should inject config', async () => {
     mockDir.setContent({
       'index.html.tmpl': '<html><head></head></html>',
     });
-    await injectConfigIntoHtml({
+    const result = await injectConfigIntoHtml({
       ...baseOptions,
       appConfigs: [{ context: 'mock', data: { x: 1 } }],
     });
-    expect(mockDir.content()).toMatchObject({
-      'index.html': `<html><head>
+    expect(result?.toString('utf8')).toBe(`<html><head>
 <script type="backstage.io/config">
 [
   {
@@ -67,15 +64,14 @@ describe('injectConfigIntoHtml', () => {
   }
 ]
 </script>
-</head></html>`,
-    });
+</head></html>`);
   });
 
   it('should trim script tag endings from injected config', async () => {
     mockDir.setContent({
       'index.html.tmpl': '<html><head></head></html>',
     });
-    await injectConfigIntoHtml({
+    const result = await injectConfigIntoHtml({
       ...baseOptions,
       appConfigs: [
         {
@@ -84,8 +80,7 @@ describe('injectConfigIntoHtml', () => {
         },
       ],
     });
-    expect(mockDir.content()).toMatchObject({
-      'index.html': `<html><head>
+    expect(result?.toString('utf8')).toBe(`<html><head>
 <script type="backstage.io/config">
 [
   {
@@ -96,7 +91,6 @@ describe('injectConfigIntoHtml', () => {
   }
 ]
 </script>
-</head></html>`,
-    });
+</head></html>`);
   });
 });

--- a/plugins/app-backend/src/lib/config/injectConfigIntoHtml.ts
+++ b/plugins/app-backend/src/lib/config/injectConfigIntoHtml.ts
@@ -25,13 +25,13 @@ const HTML_TEMPLATE_NAME = 'index.html.tmpl';
 /** @internal */
 export async function injectConfigIntoHtml(
   options: InjectOptions,
-): Promise<boolean> {
+): Promise<Buffer | undefined> {
   const { rootDir, appConfigs } = options;
 
   const templatePath = resolvePath(rootDir, HTML_TEMPLATE_NAME);
 
   if (!(await fs.exists(templatePath))) {
-    return false;
+    return undefined;
   }
 
   const templateContent = await fs.readFile(
@@ -67,13 +67,7 @@ ${JSON.stringify(appConfigs, null, 2)
 </head>`,
   );
 
-  await fs.writeFile(
-    resolvePath(rootDir, 'index.html'),
-    indexHtmlContentWithConfig,
-    'utf8',
-  );
-
-  return true;
+  return Buffer.from(indexHtmlContentWithConfig, 'utf8');
 }
 
 export function resolvePublicPath(config: Config) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This switches the templating of `index.html` in the app backend to happen in memory rather than being written to the filesystem. This means you no longer need to use the `app.disableConfigInjection` flag when using a read-only filesystem, allowing for config injection there too.

This also removes the double config injection that was present for a few releases as we move from injecting config into the static config to instead have it in `index.html`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
