### PR TITLE
cli: inject config via index.html for rspack

### DIFF
--- a/.changeset/metal-carrots-brush.md
+++ b/.changeset/metal-carrots-brush.md
@@ -1,0 +1,9 @@
+---
+'@backstage/cli': patch
+---
+
+When using the experimental Rspack flag the app build and dev server now injects configuration via a `<script type="backstage.io/config">...</script>` tag in `index.html` rather than the `process.env.APP_CONFIG` definition, which will now be defined as an empty array instead.
+
+This requires the app to be using the config loader from the 1.31 release of Backstage. Make sure your app is using at least that version if you are upgrading to this version of the CLI.
+
+If you have copied the implementation of the `defaultConfigLoader`, make sure to update it to the new implementation. In particular the config loader needs to be able to read configuration from `script` tags with the type `backstage.io/config`.

--- a/.changeset/sweet-pigs-pump.md
+++ b/.changeset/sweet-pigs-pump.md
@@ -1,0 +1,6 @@
+---
+'@backstage/core-app-api': patch
+'@backstage/frontend-defaults': patch
+---
+
+The default config loader no longer requires `process.env.APP_CONFIG` to be set, allowing config to be read from other sources instead.

--- a/packages/cli/src/lib/bundler/ConfigInjectingHtmlWebpackPlugin.ts
+++ b/packages/cli/src/lib/bundler/ConfigInjectingHtmlWebpackPlugin.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AppConfig } from '@backstage/config';
+import HtmlWebpackPlugin from 'html-webpack-plugin';
+
+export class ConfigInjectingHtmlWebpackPlugin extends HtmlWebpackPlugin {
+  readonly name = 'ConfigInjectingHtmlWebpackPlugin';
+  readonly #getFrontendAppConfigs: () => AppConfig[];
+
+  constructor(
+    options: HtmlWebpackPlugin.Options,
+    getFrontendAppConfigs: () => AppConfig[],
+  ) {
+    super(options);
+    this.#getFrontendAppConfigs = getFrontendAppConfigs;
+  }
+
+  apply: HtmlWebpackPlugin['apply'] = compiler => {
+    super.apply(compiler);
+
+    compiler.hooks.compilation.tap(this.name, compilation => {
+      const hooks = HtmlWebpackPlugin.getCompilationHooks(compilation);
+      hooks.alterAssetTagGroups.tap(this.name, ctx => {
+        if (ctx.plugin !== this) {
+          return ctx;
+        }
+        return {
+          ...ctx,
+          headTags: [
+            ...ctx.headTags,
+            HtmlWebpackPlugin.createHtmlTagObject(
+              'script',
+              { type: 'backstage.io/config' },
+              `\n${JSON.stringify(this.#getFrontendAppConfigs(), null, 2)}\n`,
+            ),
+          ],
+        };
+      });
+    });
+  };
+}

--- a/packages/cli/src/lib/bundler/server.ts
+++ b/packages/cli/src/lib/bundler/server.ts
@@ -59,6 +59,26 @@ DEPRECATION WARNING: React Router Beta is deprecated and support for it will be 
 
   let latestFrontendAppConfigs: AppConfig[] = [];
 
+  /** Triggers a full reload of all clients */
+  const triggerReload = () => {
+    if (viteServer) {
+      viteServer.restart();
+    }
+
+    if (webpackServer) {
+      webpackServer.invalidate();
+
+      // For the Rspack server it's not enough to invalidate, we also need to
+      // tell the browser to reload, which we do with a 'static-changed' message
+      if (process.env.EXPERIMENTAL_RSPACK) {
+        webpackServer.sendMessage(
+          webpackServer.webSocketServer?.clients ?? [],
+          'static-changed',
+        );
+      }
+    }
+  };
+
   const cliConfig = await loadCliConfig({
     args: options.configPaths,
     fromPackage: name,
@@ -66,8 +86,7 @@ DEPRECATION WARNING: React Router Beta is deprecated and support for it will be 
     watch(appConfigs) {
       latestFrontendAppConfigs = appConfigs;
 
-      webpackServer?.invalidate();
-      viteServer?.restart();
+      triggerReload();
     },
   });
   latestFrontendAppConfigs = cliConfig.frontendAppConfigs;
@@ -102,8 +121,7 @@ DEPRECATION WARNING: React Router Beta is deprecated and support for it will be 
     config: fullConfig,
     targetPath: paths.targetPath,
     watch() {
-      webpackServer?.invalidate();
-      viteServer?.restart();
+      triggerReload();
     },
   });
 

--- a/packages/core-app-api/src/app/defaultConfigLoader.test.tsx
+++ b/packages/core-app-api/src/app/defaultConfigLoader.test.tsx
@@ -29,6 +29,10 @@ describe('defaultConfigLoaderSync', () => {
     delete anyWindow.__APP_CONFIG__;
   });
 
+  it('loads nothing is config is missing', () => {
+    expect(defaultConfigLoaderSync()).toEqual([]);
+  });
+
   it('loads static config', () => {
     anyEnv.APP_CONFIG = [
       { data: { my: 'config' }, context: 'a' },
@@ -93,12 +97,6 @@ describe('defaultConfigLoaderSync', () => {
       { data: { my: 'override-config' }, context: 'b' },
     ]);
     expect(ConfigReader.fromConfigs(configs).get('my')).toBe('override-config');
-  });
-
-  it('fails to load invalid missing config', () => {
-    expect(() => defaultConfigLoaderSync()).toThrow(
-      'No static configuration provided',
-    );
   });
 
   it('fails to load invalid static config', () => {

--- a/packages/core-app-api/src/app/defaultConfigLoader.ts
+++ b/packages/core-app-api/src/app/defaultConfigLoader.ts
@@ -40,14 +40,15 @@ export function defaultConfigLoaderSync(
   // It's a param so we can test it, but at runtime this will always fall back to default.
   runtimeConfigJson: string = '__APP_INJECTED_RUNTIME_CONFIG__',
 ) {
-  const appConfig = process.env.APP_CONFIG;
-  if (!appConfig) {
-    throw new Error('No static configuration provided');
+  const configs = new Array<AppConfig>();
+
+  const staticConfig = process.env.APP_CONFIG;
+  if (staticConfig) {
+    if (!Array.isArray(staticConfig)) {
+      throw new Error('Static configuration has invalid format');
+    }
+    configs.push(...staticConfig);
   }
-  if (!Array.isArray(appConfig)) {
-    throw new Error('Static configuration has invalid format');
-  }
-  const configs = appConfig.slice() as unknown as AppConfig[];
 
   // Check if we have any config script tags, otherwise fall back to injected config
   const configScripts = document.querySelectorAll(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This switches the config injection for Rspack builds and the dev server to be done via `index.html` instead, just like the `app-backend` now does. I would've liked to switch over the WebPack path as well, but for some reason it doesn't update correctly across reloads so keeping that as is for now.

Long-term I'm hoping that we can completely move over to Rspack and do all config injection straight into `index.html` both in the CLI and at runtime.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
