### PR TITLE
fix: make schedule in catalog.providers.github required

### DIFF
--- a/.changeset/late-mails-pull.md
+++ b/.changeset/late-mails-pull.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+Make schedule config required as is expected from the code

--- a/plugins/catalog-backend-module-github/config.d.ts
+++ b/plugins/catalog-backend-module-github/config.d.ts
@@ -114,9 +114,9 @@ export interface Config {
               visibility?: Array<'private' | 'internal' | 'public'>;
             };
             /**
-             * (Optional) TaskScheduleDefinition for the refresh.
+             * TaskScheduleDefinition for the refresh.
              */
-            schedule?: SchedulerServiceTaskScheduleDefinitionConfig;
+            schedule: SchedulerServiceTaskScheduleDefinitionConfig;
           }
         | {
             [name: string]: {
@@ -183,9 +183,9 @@ export interface Config {
                 visibility?: Array<'private' | 'internal' | 'public'>;
               };
               /**
-               * (Optional) TaskScheduleDefinition for the refresh.
+               * TaskScheduleDefinition for the refresh.
                */
-              schedule?: SchedulerServiceTaskScheduleDefinitionConfig;
+              schedule: SchedulerServiceTaskScheduleDefinitionConfig;
             };
           };
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Seems the code expects this config to be set else it will error. So, making it required in the schema. Same has been done for `githubOrg`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
