### PR TITLE
cli: fix .getCompilationHooks error

### DIFF
--- a/.changeset/poor-hounds-jump.md
+++ b/.changeset/poor-hounds-jump.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Bumped the version range for `html-webpack-plugin` to fix the `htmlPluginExports.getCompilationHooks is not a function` error when using experimental Rspack.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -111,7 +111,7 @@
     "global-agent": "^3.0.0",
     "globby": "^11.1.0",
     "handlebars": "^4.7.3",
-    "html-webpack-plugin": "^5.3.1",
+    "html-webpack-plugin": "^5.6.3",
     "inquirer": "^8.2.0",
     "jest": "^29.7.0",
     "jest-cli": "^29.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3961,7 +3961,7 @@ __metadata:
     global-agent: ^3.0.0
     globby: ^11.1.0
     handlebars: ^4.7.3
-    html-webpack-plugin: ^5.3.1
+    html-webpack-plugin: ^5.6.3
     inquirer: ^8.2.0
     jest: ^29.7.0
     jest-cli: ^29.7.0
@@ -29378,7 +29378,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"html-webpack-plugin@npm:^5.3.1":
+"html-webpack-plugin@npm:^5.6.3":
   version: 5.6.3
   resolution: "html-webpack-plugin@npm:5.6.3"
   dependencies:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #27721

The `getCompilationHooks` is a recent addition, bumping the version range ensures that all consumers get a compatible version.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
