### PR TITLE
Patch release of #27724

### DIFF
--- a/.changeset/poor-hounds-jump.md
+++ b/.changeset/poor-hounds-jump.md
@@ -1,5 +1,0 @@
----
-'@backstage/cli': patch
----
-
-Bumped the version range for `html-webpack-plugin` to fix the `htmlPluginExports.getCompilationHooks is not a function` error when using experimental Rspack.

--- a/.changeset/poor-hounds-jump.md
+++ b/.changeset/poor-hounds-jump.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Bumped the version range for `html-webpack-plugin` to fix the `htmlPluginExports.getCompilationHooks is not a function` error when using experimental Rspack.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.33.0",
+  "version": "1.33.1",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/app-next/CHANGELOG.md
+++ b/packages/app-next/CHANGELOG.md
@@ -1,5 +1,50 @@
 # example-app-next
 
+## 0.0.18
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/cli@0.29.1
+  - @backstage/app-defaults@1.5.13
+  - @backstage/catalog-model@1.7.1
+  - @backstage/config@1.3.0
+  - @backstage/core-app-api@1.15.2
+  - @backstage/core-compat-api@0.3.2
+  - @backstage/core-components@0.16.0
+  - @backstage/core-plugin-api@1.10.1
+  - @backstage/frontend-app-api@0.10.1
+  - @backstage/frontend-defaults@0.1.2
+  - @backstage/frontend-plugin-api@0.9.1
+  - @backstage/integration-react@1.2.1
+  - @backstage/theme@0.6.1
+  - @backstage/plugin-api-docs@0.12.0
+  - @backstage/plugin-app@0.1.2
+  - @backstage/plugin-app-visualizer@0.1.12
+  - @backstage/plugin-auth-react@0.1.8
+  - @backstage/plugin-catalog@1.25.0
+  - @backstage/plugin-catalog-common@1.1.1
+  - @backstage/plugin-catalog-graph@0.4.12
+  - @backstage/plugin-catalog-import@0.12.6
+  - @backstage/plugin-catalog-react@1.14.1
+  - @backstage/plugin-catalog-unprocessed-entities@0.2.10
+  - @backstage/plugin-home@0.8.1
+  - @backstage/plugin-kubernetes@0.12.0
+  - @backstage/plugin-kubernetes-cluster@0.0.18
+  - @backstage/plugin-notifications@0.4.0
+  - @backstage/plugin-org@0.6.32
+  - @backstage/plugin-permission-react@0.4.28
+  - @backstage/plugin-scaffolder@1.27.0
+  - @backstage/plugin-scaffolder-react@1.14.0
+  - @backstage/plugin-search@1.4.19
+  - @backstage/plugin-search-common@1.2.15
+  - @backstage/plugin-search-react@1.8.2
+  - @backstage/plugin-signals@0.0.12
+  - @backstage/plugin-techdocs@1.11.1
+  - @backstage/plugin-techdocs-module-addons-contrib@1.1.17
+  - @backstage/plugin-techdocs-react@1.2.10
+  - @backstage/plugin-user-settings@0.8.15
+
 ## 0.0.17
 
 ### Patch Changes

--- a/packages/app-next/package.json
+++ b/packages/app-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-app-next",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "backstage": {
     "role": "frontend"
   },

--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -1,5 +1,46 @@
 # example-app
 
+## 0.2.104
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/cli@0.29.1
+  - @backstage/app-defaults@1.5.13
+  - @backstage/catalog-model@1.7.1
+  - @backstage/config@1.3.0
+  - @backstage/core-app-api@1.15.2
+  - @backstage/core-components@0.16.0
+  - @backstage/core-plugin-api@1.10.1
+  - @backstage/frontend-app-api@0.10.1
+  - @backstage/integration-react@1.2.1
+  - @backstage/theme@0.6.1
+  - @backstage/plugin-api-docs@0.12.0
+  - @backstage/plugin-auth-react@0.1.8
+  - @backstage/plugin-catalog@1.25.0
+  - @backstage/plugin-catalog-common@1.1.1
+  - @backstage/plugin-catalog-graph@0.4.12
+  - @backstage/plugin-catalog-import@0.12.6
+  - @backstage/plugin-catalog-react@1.14.1
+  - @backstage/plugin-catalog-unprocessed-entities@0.2.10
+  - @backstage/plugin-devtools@0.1.20
+  - @backstage/plugin-home@0.8.1
+  - @backstage/plugin-kubernetes@0.12.0
+  - @backstage/plugin-kubernetes-cluster@0.0.18
+  - @backstage/plugin-notifications@0.4.0
+  - @backstage/plugin-org@0.6.32
+  - @backstage/plugin-permission-react@0.4.28
+  - @backstage/plugin-scaffolder@1.27.0
+  - @backstage/plugin-scaffolder-react@1.14.0
+  - @backstage/plugin-search@1.4.19
+  - @backstage/plugin-search-common@1.2.15
+  - @backstage/plugin-search-react@1.8.2
+  - @backstage/plugin-signals@0.0.12
+  - @backstage/plugin-techdocs@1.11.1
+  - @backstage/plugin-techdocs-module-addons-contrib@1.1.17
+  - @backstage/plugin-techdocs-react@1.2.10
+  - @backstage/plugin-user-settings@0.8.15
+
 ## 0.2.103
 
 ### Patch Changes

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-app",
-  "version": "0.2.103",
+  "version": "0.2.104",
   "backstage": {
     "role": "frontend"
   },

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @backstage/cli
 
+## 0.29.1
+
+### Patch Changes
+
+- 0121b32: Bumped the version range for `html-webpack-plugin` to fix the `htmlPluginExports.getCompilationHooks is not a function` error when using experimental Rspack.
+- Updated dependencies
+  - @backstage/catalog-model@1.7.1
+  - @backstage/cli-common@0.1.15
+  - @backstage/cli-node@0.2.10
+  - @backstage/config@1.3.0
+  - @backstage/config-loader@1.9.2
+  - @backstage/errors@1.2.5
+  - @backstage/eslint-plugin@0.1.10
+  - @backstage/integration@1.15.2
+  - @backstage/release-manifests@0.0.11
+  - @backstage/types@1.2.0
+
 ## 0.29.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -111,7 +111,7 @@
     "global-agent": "^3.0.0",
     "globby": "^11.1.0",
     "handlebars": "^4.7.3",
-    "html-webpack-plugin": "^5.3.1",
+    "html-webpack-plugin": "^5.6.3",
     "inquirer": "^8.2.0",
     "jest": "^29.7.0",
     "jest-cli": "^29.7.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/cli",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "description": "CLI for developing Backstage plugins and apps",
   "backstage": {
     "role": "cli"

--- a/packages/techdocs-cli-embedded-app/CHANGELOG.md
+++ b/packages/techdocs-cli-embedded-app/CHANGELOG.md
@@ -1,5 +1,24 @@
 # techdocs-cli-embedded-app
 
+## 0.2.103
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/cli@0.29.1
+  - @backstage/app-defaults@1.5.13
+  - @backstage/catalog-model@1.7.1
+  - @backstage/config@1.3.0
+  - @backstage/core-app-api@1.15.2
+  - @backstage/core-components@0.16.0
+  - @backstage/core-plugin-api@1.10.1
+  - @backstage/integration-react@1.2.1
+  - @backstage/test-utils@1.7.1
+  - @backstage/theme@0.6.1
+  - @backstage/plugin-catalog@1.25.0
+  - @backstage/plugin-techdocs@1.11.1
+  - @backstage/plugin-techdocs-react@1.2.10
+
 ## 0.2.102
 
 ### Patch Changes

--- a/packages/techdocs-cli-embedded-app/package.json
+++ b/packages/techdocs-cli-embedded-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "techdocs-cli-embedded-app",
-  "version": "0.2.102",
+  "version": "0.2.103",
   "backstage": {
     "role": "frontend"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3961,7 +3961,7 @@ __metadata:
     global-agent: ^3.0.0
     globby: ^11.1.0
     handlebars: ^4.7.3
-    html-webpack-plugin: ^5.3.1
+    html-webpack-plugin: ^5.6.3
     inquirer: ^8.2.0
     jest: ^29.7.0
     jest-cli: ^29.7.0
@@ -29378,7 +29378,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"html-webpack-plugin@npm:^5.3.1":
+"html-webpack-plugin@npm:^5.6.3":
   version: 5.6.3
   resolution: "html-webpack-plugin@npm:5.6.3"
   dependencies:


### PR DESCRIPTION
This release fixes an issue where the experimental Rspack build could fail due to an outdated `html-webpack-plugin` dependency.