### PR TITLE
app-backend: fix config injection for index path

### DIFF
--- a/.changeset/great-buttons-cross.md
+++ b/.changeset/great-buttons-cross.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-app-backend': patch
+---
+
+Fixed a bug where config would not be injected on the `/` and `/index.html` paths.

--- a/plugins/app-backend/src/service/appPlugin.test.ts
+++ b/plugins/app-backend/src/service/appPlugin.test.ts
@@ -75,6 +75,7 @@ describe('appPlugin', () => {
       'package.json': '{}',
       dist: {
         static: {},
+        'index.html': '<html><head></head></html>',
         'index.html.tmpl': '<html><head></head></html>',
       },
     });
@@ -91,6 +92,26 @@ describe('appPlugin', () => {
         }),
       ],
     });
+
+    const rootContent = await fetch(`http://localhost:${server.port()}`).then(
+      res => res.text(),
+    );
+
+    expect(rootContent).toBe(`<html><head>
+<script type="backstage.io/config">
+[]
+</script>
+</head></html>`);
+
+    const indexContent = await fetch(
+      `http://localhost:${server.port()}/index.html`,
+    ).then(res => res.text());
+
+    expect(indexContent).toBe(`<html><head>
+<script type="backstage.io/config">
+[]
+</script>
+</head></html>`);
 
     const htmlContent = await fetch(
       `http://localhost:${server.port()}/api/app/some/html5/route`,

--- a/plugins/app-backend/src/service/router.ts
+++ b/plugins/app-backend/src/service/router.ts
@@ -302,7 +302,17 @@ async function createEntryPointRouter({
   staticRouter.use(notFoundHandler());
 
   router.use('/static', staticRouter);
-  router.use(
+
+  const rootRouter = Router();
+  rootRouter.use((req, _res, next) => {
+    // Make sure / and /index.html are handled by the HTML5 route below
+    if (req.url === '/' || req.url === '/index.html') {
+      next('router');
+    } else {
+      next();
+    }
+  });
+  rootRouter.use(
     express.static(rootDir, {
       setHeaders: (res, path) => {
         // The Cache-Control header instructs the browser to not cache html files since it might
@@ -315,7 +325,9 @@ async function createEntryPointRouter({
       },
     }),
   );
+  router.use(rootRouter);
 
+  // HTML5 routing
   router.get('/*', (_req, res) => {
     if (injectResult?.indexHtmlContent) {
       res.setHeader('Content-Type', 'text/html; charset=utf-8');


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #27733

The `/` and `/index.html` paths were being served by the express static router rather than the HTML5 fallback one, which doesn't do config injection. Fixed + regression test.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
