### PR TITLE
catalog-client: fix queryEntities error handling

### DIFF
--- a/.changeset/swift-kangaroos-drop.md
+++ b/.changeset/swift-kangaroos-drop.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-client': patch
+---
+
+Fixed a bug in the `queryEntities` method where errors were not being handled properly.

--- a/packages/catalog-client/src/CatalogClient.test.ts
+++ b/packages/catalog-client/src/CatalogClient.test.ts
@@ -525,6 +525,18 @@ describe('CatalogClient', () => {
         '?cursor=prevcursor',
       );
     });
+
+    it('should handle errors', async () => {
+      const mockedEndpoint = jest
+        .fn()
+        .mockImplementation((_req, res, ctx) => res(ctx.status(401)));
+
+      server.use(rest.get(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
+
+      await expect(() => client.queryEntities()).rejects.toThrow(
+        /Request failed with 401 Unauthorized/,
+      );
+    });
   });
 
   describe('getEntityByRef', () => {

--- a/packages/catalog-client/src/CatalogClient.ts
+++ b/packages/catalog-client/src/CatalogClient.ts
@@ -237,9 +237,9 @@ export class CatalogClient implements CatalogApi {
       }
     }
 
-    return this.apiClient
-      .getEntitiesByQuery({ query: params }, options)
-      .then(r => r.json());
+    return this.requestRequired(
+      await this.apiClient.getEntitiesByQuery({ query: params }, options),
+    );
   }
 
   /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Probably this was missed after some refactoring

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
