### PR TITLE
Fix api-reports space-after-comma bug

### DIFF
--- a/packages/repo-tools/src/commands/api-reports/api-reports.ts
+++ b/packages/repo-tools/src/commands/api-reports/api-reports.ts
@@ -45,7 +45,15 @@ export const buildApiReports = async (paths: string[] = [], opts: Options) => {
   const runTsc = opts.tsc;
   const allowWarnings = parseArrayOption(opts.allowWarnings);
   const allowAllWarnings = opts.allowAllWarnings;
-  const omitMessages = parseArrayOption(opts.omitMessages);
+  const omitMessagesRaw = opts.omitMessages;
+
+  if (omitMessagesRaw && omitMessagesRaw.endsWith(',')) {
+    throw new Error(
+      `Invalid value for --omit-messages: ${omitMessagesRaw}\nMust be a comma-separated list of strings without spaces or wrapped in quotations.`,
+    );
+  }
+
+  const omitMessages = parseArrayOption(omitMessagesRaw);
 
   const isAllPackages = !paths?.length;
   const selectedPackageDirs = await resolvePackagePaths({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #27551 (error when executing `yarn build:api-reports` and `-o` flag has a space after the comma without double quote wrapping.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Steps to execute:

- Change the `build:api-reports:only` script in `package.json` to `NODE_OPTIONS=--max-old-space-size=8192 backstage-repo-tools api-reports -o ae-wrong-input-file-type, ae-undocumented --validate-release-tags`
- Execute `yarn build:api-reports`

Now, it should throw an error and stop the execution, as expected:

![image](https://github.com/user-attachments/assets/c3cbecc0-7312-45b8-82c1-d1a3a2bcd4ef)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
