### PR TITLE
backend-defaults: Add support for decoration of the pluginTokenHandler

### DIFF
--- a/.changeset/cuddly-chicken-wink.md
+++ b/.changeset/cuddly-chicken-wink.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Export `PluginTokenHandler` and `pluginTokenHandlerDecoratorServiceRef` to allow for custom decoration of the plugin token handler without having to re-implement the entire handler.

--- a/docs/auth/service-to-service-auth.md
+++ b/docs/auth/service-to-service-auth.md
@@ -415,7 +415,7 @@ Each entry has one or more of the following fields:
 
 ## Adding custom or logic for validation and issuing of tokens
 
-The `pluginTokenHandlerDecoratorServiceRef` can be used to decorate the existing token handler without having to re-implement the entire `PluginTokenHandler`.
+The `pluginTokenHandlerDecoratorServiceRef` can be used to decorate the existing token handler without having to re-implement the entire `AuthService` implementation.
 This is particularly useful when you want to add additional logic to the handler, such as logging or metrics or custom token validation.
 
 The `PluginTokenHandler` interface has two methods:

--- a/docs/auth/service-to-service-auth.md
+++ b/docs/auth/service-to-service-auth.md
@@ -436,24 +436,7 @@ const decoratedPluginTokenHandler = createServiceFactory({
   deps: {},
   async factory() {
     return (defaultImplementation: PluginTokenHandler) =>
-      new (class CustomHandler implements PluginTokenHandler {
-        verifyToken(
-          token: string,
-        ): Promise<{ subject: string; limitedUserToken?: string } | undefined> {
-          // custom logic here
-          if (isMyCustomToken(token)) {
-            return { subject: 'custom-subject' };
-          }
-          return defaultImplementation.verifyToken(token);
-        }
-        issueToken(options: {
-          pluginId: string;
-          targetPluginId: string;
-          limitedUserToken?: { token: string; expiresAt: Date };
-        }): Promise<{ token: string }> {
-          return defaultImplementation.issueToken(options);
-        }
-      })();
+      new CustomTokenHandler(defaultImplementation);
   },
 });
 ```

--- a/docs/auth/service-to-service-auth.md
+++ b/docs/auth/service-to-service-auth.md
@@ -412,3 +412,48 @@ Each entry has one or more of the following fields:
         # Also supports the shorthand form:
         # action: create, read
   ```
+
+## Adding custom or logic for validation and issuing of tokens
+
+The `pluginTokenHandlerDecoratorServiceRef` can be used to decorate the existing token handler without having to re-implement the entire `PluginTokenHandler`.
+This is particularly useful when you want to add additional logic to the handler, such as logging or metrics or custom token validation.
+
+The `PluginTokenHandler` interface has two methods:
+
+- `issueToken`: This method is used to issue a token for a plugin. It takes in the `pluginId` and `targetPluginId` as arguments, and an optional `limitedUserToken` object which can be used to issue a token on behalf of another user. The method returns a promise that resolves to an object containing the issued token.
+
+- `verifyToken`: This method is used to verify a token. It takes in the token as an argument and returns a promise that resolves to an object containing the subject of the token and an optional limited user token.
+
+```ts
+import {
+  PluginTokenHandler,
+  pluginTokenHandlerDecoratorServiceRef,
+} from '@backstage/backend-defaults/auth';
+import { createServiceFactory } from '@backstage/backend-plugin-api';
+
+const decoratedPluginTokenHandler = createServiceFactory({
+  service: pluginTokenHandlerDecoratorServiceRef,
+  deps: {},
+  async factory() {
+    return (defaultImplementation: PluginTokenHandler) =>
+      new (class CustomHandler implements PluginTokenHandler {
+        verifyToken(
+          token: string,
+        ): Promise<{ subject: string; limitedUserToken?: string } | undefined> {
+          // custom logic here
+          if (isMyCustomToken(token)) {
+            return { subject: 'custom-subject' };
+          }
+          return defaultImplementation.verifyToken(token);
+        }
+        issueToken(options: {
+          pluginId: string;
+          targetPluginId: string;
+          limitedUserToken?: { token: string; expiresAt: Date };
+        }): Promise<{ token: string }> {
+          return defaultImplementation.issueToken(options);
+        }
+      })();
+  },
+});
+```

--- a/packages/backend-defaults/report-auth.api.md
+++ b/packages/backend-defaults/report-auth.api.md
@@ -5,10 +5,41 @@
 ```ts
 import { AuthService } from '@backstage/backend-plugin-api';
 import { ServiceFactory } from '@backstage/backend-plugin-api';
+import { ServiceRef } from '@backstage/backend-plugin-api';
 
 // @public
 export const authServiceFactory: ServiceFactory<
   AuthService,
+  'plugin',
+  'singleton'
+>;
+
+// @public
+export interface PluginTokenHandler {
+  // (undocumented)
+  issueToken(options: {
+    pluginId: string;
+    targetPluginId: string;
+    onBehalfOf?: {
+      limitedUserToken: string;
+      expiresAt: Date;
+    };
+  }): Promise<{
+    token: string;
+  }>;
+  // (undocumented)
+  verifyToken(token: string): Promise<
+    | {
+        subject: string;
+        limitedUserToken?: string;
+      }
+    | undefined
+  >;
+}
+
+// @public
+export const pluginTokenHandlerDecoratorServiceRef: ServiceRef<
+  (defaultImplementation: PluginTokenHandler) => PluginTokenHandler,
   'plugin',
   'singleton'
 >;

--- a/packages/backend-defaults/src/entrypoints/auth/DefaultAuthService.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/DefaultAuthService.ts
@@ -169,7 +169,10 @@ export class DefaultAuthService implements AuthService {
         return this.pluginTokenHandler.issueToken({
           pluginId: this.pluginId,
           targetPluginId,
-          onBehalfOf,
+          onBehalfOf: {
+            limitedUserToken: onBehalfOf.token,
+            expiresAt: onBehalfOf.expiresAt,
+          },
         });
       }
       default:

--- a/packages/backend-defaults/src/entrypoints/auth/authServiceFactory.test.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/authServiceFactory.test.ts
@@ -19,12 +19,17 @@ import {
   mockServices,
   registerMswTestHooks,
 } from '@backstage/backend-test-utils';
-import { authServiceFactory } from './authServiceFactory';
+import {
+  authServiceFactory,
+  pluginTokenHandlerDecoratorServiceRef,
+} from './authServiceFactory';
 import { base64url, decodeJwt } from 'jose';
 import { discoveryServiceFactory } from '../discovery';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { toInternalBackstageCredentials } from './helpers';
+import { PluginTokenHandler } from './plugin/PluginTokenHandler';
+import { createServiceFactory } from '@backstage/backend-plugin-api';
 
 const server = setupServer();
 
@@ -405,6 +410,43 @@ describe('authServiceFactory', () => {
       scaffolderAuth.authenticate('unlimited-static-token'),
     ).resolves.toMatchObject({
       principal: { subject: 'unlimited-static-subject' },
+    });
+  });
+
+  describe('decorate PluginTokenHandler', () => {
+    it('should allow custom logic to be injected into the plugin token handler', async () => {
+      const customLogic = jest.fn();
+      const customPluginTokenHandler = createServiceFactory({
+        service: pluginTokenHandlerDecoratorServiceRef,
+        deps: {},
+        async factory() {
+          return (defaultImplementation: PluginTokenHandler) =>
+            new (class CustomHandler implements PluginTokenHandler {
+              verifyToken(
+                token: string,
+              ): Promise<
+                { subject: string; limitedUserToken?: string } | undefined
+              > {
+                customLogic(token);
+                // check if token is iam/auth or basicAuth, verify.
+                return defaultImplementation.verifyToken(token);
+              }
+              issueToken(options: {
+                pluginId: string;
+                targetPluginId: string;
+                limitedUserToken?: { token: string; expiresAt: Date };
+              }): Promise<{ token: string }> {
+                return defaultImplementation.issueToken(options);
+              }
+            })();
+        },
+      });
+      const tester = ServiceFactoryTester.from(authServiceFactory, {
+        dependencies: [...mockDeps, customPluginTokenHandler],
+      });
+      const searchAuth = await tester.getSubject('search');
+      searchAuth.authenticate('unlimited-static-token');
+      expect(customLogic).toHaveBeenCalledWith('unlimited-static-token');
     });
   });
 });

--- a/packages/backend-defaults/src/entrypoints/auth/authServiceFactory.test.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/authServiceFactory.test.ts
@@ -428,7 +428,6 @@ describe('authServiceFactory', () => {
                 { subject: string; limitedUserToken?: string } | undefined
               > {
                 customLogic(token);
-                // check if token is iam/auth or basicAuth, verify.
                 return defaultImplementation.verifyToken(token);
               }
               issueToken(options: {

--- a/packages/backend-defaults/src/entrypoints/auth/index.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/index.ts
@@ -14,4 +14,9 @@
  * limitations under the License.
  */
 
-export { authServiceFactory } from './authServiceFactory';
+export {
+  authServiceFactory,
+  pluginTokenHandlerDecoratorServiceRef,
+} from './authServiceFactory';
+
+export type { PluginTokenHandler } from './plugin/PluginTokenHandler';

--- a/packages/backend-defaults/src/entrypoints/auth/plugin/PluginTokenHandler.test.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/plugin/PluginTokenHandler.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { mockServices } from '@backstage/backend-test-utils';
-import { PluginTokenHandler } from './PluginTokenHandler';
+import { DefaultPluginTokenHandler } from './PluginTokenHandler';
 import { decodeJwt } from 'jose';
 
 describe('PluginTokenHandler', () => {
@@ -42,7 +42,7 @@ describe('PluginTokenHandler', () => {
     });
 
     const getKeyMock = jest.fn(async () => mockPrivateKey);
-    const handler = PluginTokenHandler.create({
+    const handler = DefaultPluginTokenHandler.create({
       discovery: mockServices.discovery(),
       keyDuration: { seconds: 10 },
       logger: mockServices.logger.mock(),

--- a/packages/backend-defaults/src/entrypoints/auth/plugin/PluginTokenHandler.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/plugin/PluginTokenHandler.ts
@@ -46,7 +46,7 @@ type Options = {
 
 /**
  * @public
- * PluginTokenHandler is responsible for issuing and verifying tokens
+ * Issues and verifies {@link https://backstage.io/docs/auth/service-to-service-auth | service-to-service tokens}.
  */
 export interface PluginTokenHandler {
   verifyToken(

--- a/packages/backend-defaults/src/entrypoints/auth/plugin/PluginTokenHandler.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/plugin/PluginTokenHandler.ts
@@ -16,7 +16,7 @@
 
 import { DiscoveryService, LoggerService } from '@backstage/backend-plugin-api';
 import { decodeJwt, importJWK, SignJWT, decodeProtectedHeader } from 'jose';
-import { AuthenticationError } from '@backstage/errors';
+import { assertError, AuthenticationError } from '@backstage/errors';
 import { jwtVerify } from 'jose';
 import { tokenTypes } from '@backstage/plugin-auth-node';
 import { JwksClient } from '../JwksClient';
@@ -46,7 +46,7 @@ type Options = {
 
 /**
  * @public
- * Issues and verifies {@link https://backstage.io/docs/auth/service-to-service-auth | service-to-service tokens}.
+ * Issues and verifies {@link https://backstage.iceio/docs/auth/service-to-service-auth | service-to-service tokens}.
  */
 export interface PluginTokenHandler {
   verifyToken(
@@ -194,7 +194,8 @@ export class DefaultPluginTokenHandler implements PluginTokenHandler {
 
         this.supportedTargetPlugins.add(targetPluginId);
         return true;
-      } catch (error: any) {
+      } catch (error) {
+        assertError(error);
         this.logger.error('Unexpected failure for target JWKS check', error);
         return false;
       } finally {


### PR DESCRIPTION
Exported `PluginTokenHandler` and `pluginTokenHandlerDecoratorServiceRef` to allow custom decoration of the plugin token handler without re-implementing the entire handler
