### PR TITLE
events-node: clarify purpose of subscriber ID

### DIFF
--- a/.changeset/khaki-ladybugs-swim.md
+++ b/.changeset/khaki-ladybugs-swim.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-events-node': patch
+---
+
+Clarified purpose of subscriber ID in TSDoc for `EventsServiceSubscribeOptions`.

--- a/plugins/events-node/src/api/EventsService.ts
+++ b/plugins/events-node/src/api/EventsService.ts
@@ -44,7 +44,7 @@ export interface EventsService {
  */
 export type EventsServiceSubscribeOptions = {
   /**
-   * Identifier for the subscription. E.g., used as part of log messages.
+   * Subscriber ID that is scoped to the calling plugin. Subscribers with the same ID will have events distributed between them.
    */
   id: string;
   topics: string[];


### PR DESCRIPTION
🧹 