### PR TITLE
fix(catalog): fix catalog search by display name

### DIFF
--- a/.changeset/lazy-years-float.md
+++ b/.changeset/lazy-years-float.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Fix catalog filtering to allow searching entities by display name

--- a/plugins/catalog-react/src/filters.test.ts
+++ b/plugins/catalog-react/src/filters.test.ts
@@ -72,6 +72,33 @@ const templates: TemplateEntityV1beta3[] = [
   },
 ];
 
+const users: Entity[] = [
+  {
+    apiVersion: '1',
+    kind: 'User',
+    metadata: {
+      name: 'jd1234',
+    },
+    spec: {
+      profile: {
+        displayName: 'DOE, JOHN',
+      },
+    },
+  },
+  {
+    apiVersion: '1',
+    kind: 'User',
+    metadata: {
+      name: 'fb3456',
+    },
+    spec: {
+      profile: {
+        displayName: 'BAR, FOO',
+      },
+    },
+  },
+];
+
 describe('EntityTextFilter', () => {
   it('should search name', () => {
     const filter = new EntityTextFilter('app');
@@ -95,6 +122,12 @@ describe('EntityTextFilter', () => {
     const filter = new EntityTextFilter('JaVa');
     expect(filter.filterEntity(entities[0])).toBeFalsy();
     expect(filter.filterEntity(entities[1])).toBeTruthy();
+  });
+
+  it('should search display name', () => {
+    const filter = new EntityTextFilter('doe');
+    expect(filter.filterEntity(users[0])).toBeTruthy();
+    expect(filter.filterEntity(users[1])).toBeFalsy();
   });
 });
 

--- a/plugins/catalog-react/src/filters.ts
+++ b/plugins/catalog-react/src/filters.ts
@@ -94,6 +94,13 @@ export class EntityTextFilter implements EntityFilter {
     const partialMatch = this.toUpperArray([
       entity.metadata.name,
       entity.metadata.title,
+      ...(typeof entity.spec?.profile === 'object' &&
+      entity.spec?.profile !== null &&
+      !Array.isArray(entity.spec.profile) &&
+      'displayName' in entity.spec.profile &&
+      typeof entity.spec.profile.displayName === 'string'
+        ? [entity.spec.profile.displayName]
+        : []),
     ]);
 
     for (const word of words) {

--- a/plugins/catalog-react/src/filters.ts
+++ b/plugins/catalog-react/src/filters.ts
@@ -94,13 +94,7 @@ export class EntityTextFilter implements EntityFilter {
     const partialMatch = this.toUpperArray([
       entity.metadata.name,
       entity.metadata.title,
-      ...(typeof entity.spec?.profile === 'object' &&
-      entity.spec?.profile !== null &&
-      !Array.isArray(entity.spec.profile) &&
-      'displayName' in entity.spec.profile &&
-      typeof entity.spec.profile.displayName === 'string'
-        ? [entity.spec.profile.displayName]
-        : []),
+      (entity.spec?.profile as { displayName?: string })?.displayName,
     ]);
 
     for (const word of words) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes not being able to search an entity by display name in the catalog.
Resolves #27354, #27728. The fix brought by #27355 (released in 1.33.0) only partially resolves the issue because the frontend still is filtering only the `name` and `title` properties. This PR resolves the filtering issue on the frontend and adds test cases.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
