### PR TITLE
Decrease OAuth2 token refresh grace period

### DIFF
--- a/.changeset/wet-rats-exist.md
+++ b/.changeset/wet-rats-exist.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-app-api': patch
+---
+
+Decrease OAuth2 token refresh grace period

--- a/packages/core-app-api/src/apis/implementations/auth/oauth2/OAuth2.ts
+++ b/packages/core-app-api/src/apis/implementations/auth/oauth2/OAuth2.ts
@@ -148,7 +148,7 @@ export default class OAuth2
             (session.backstageIdentity.expiresAt.getTime() - Date.now()) / 1000,
           );
         }
-        return min < 60 * 5;
+        return min < 60 * 3;
       },
     });
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!
To determine whether or not a session should be refreshed/ a new refresh token should be requested, the grace period is set [here](https://github.com/backstage/backstage/blob/6cbe4f999c9c8e9e090d3be5a7c3af71d59e507d/packages/core-app-api/src/apis/implementations/auth/oauth2/OAuth2.ts#L151) at 5 minutes.

For IAM solutions like Keycloak, the default access token lifespan is set to 5 minutes. This means that by default, every single API call will send a request to http://<backstage-url>/api/auth/oidc/refresh?optional&scope=&env=development to get a new oidc-refresh-token. This slows down the application and sends a lot of unnecessary requests.

This PR brings down this grace period from 5 minutes to 3 minutes so that requests are not made on each API call.

Addresses this issue: https://github.com/backstage/backstage/issues/27281
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
