### PR TITLE
core-app-api: try to refresh session if scopes are missing

### DIFF
--- a/.changeset/dry-needles-taste.md
+++ b/.changeset/dry-needles-taste.md
@@ -1,0 +1,6 @@
+---
+'@backstage/core-app-api': patch
+'@backstage/plugin-app': patch
+---
+
+The OAuth 2 client implementations will now attempt to refresh the session when the existing session doesn't have the required scopes. The previous behavior was to only try to refresh the session of it was missing, and otherwise directly request a new session. This fixes an issue where some auth providers will not return access tokens with certain scopes unless explicitly requested, leading to an auth popup even if the underlying session already had been granted the requested scopes.

--- a/packages/core-app-api/src/lib/AuthSessionManager/RefreshingAuthSessionManager.ts
+++ b/packages/core-app-api/src/lib/AuthSessionManager/RefreshingAuthSessionManager.ts
@@ -97,7 +97,7 @@ export class RefreshingAuthSessionManager<T> implements SessionManager<T> {
     // stay in a synchronous call stack from the user interaction. The downside
     // is that the user will sometimes be requested to log in even if they
     // already had an existing session.
-    if (!this.currentSession && !options.instantPopup) {
+    if (!options.instantPopup) {
       try {
         const newSession = await this.collapsedSessionRefresh(options.scopes);
         this.currentSession = newSession;
@@ -143,6 +143,11 @@ export class RefreshingAuthSessionManager<T> implements SessionManager<T> {
 
     try {
       const session = await this.refreshPromise;
+      if (!this.helper.sessionExistsAndHasScope(session, scopes)) {
+        throw new Error(
+          'Refreshed session did not receive the required scopes',
+        );
+      }
       this.stateTracker.setIsSignedIn(true);
       return session;
     } finally {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

We ran into an issue with the Google auth provider where users were being requested to log in too often. This fixes it by attempting a session refresh with the requested scopes before falling back to creating a new session. It's fairly likely that this might affect some other providers too.

The main danger in this change is the risk of infinite recursion of the `.getSession` call, which I've worked against by checking that the returned session actually contains the requested scopes. It might be a bit of a risky change in case session scopes aren't being reported correctly, but to be honest I think it's worth rolling out without fallback since those cases would lead to session refresh bugs that we'd want to uncover anyway.

Another option to this change is to configure the provider or auth backend to always request all scopes that have been granted by the session so far, but I think that's best to avoid as it reduces the blast radius of access token leakage.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
