### PR TITLE
correctly measure stitching queue length

### DIFF
--- a/.changeset/odd-worms-peel.md
+++ b/.changeset/odd-worms-peel.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Correctly report stitching queue length

--- a/plugins/catalog-backend/src/stitching/progressTracker.ts
+++ b/plugins/catalog-backend/src/stitching/progressTracker.ts
@@ -54,8 +54,7 @@ export function progressTracker(knex: Knex, logger: LoggerService) {
   stitchingQueueCount.addCallback(async result => {
     const total = await knex<DbRefreshStateRow>('refresh_state')
       .count({ count: '*' })
-      .whereNotNull('next_stitch_at')
-      .where('next_stitch_at', '<=', knex.fn.now());
+      .whereNotNull('next_stitch_at');
     result.observe(Number(total[0].count));
   });
 


### PR DESCRIPTION
It doesn't matter whether the `next_stitch_at` value is in the past or not. If it's still non-null, it's either due for stitching or undergoing stitching right now. The only case where it's in the future, is right after it gets picked up for a stitch attempt, since that's a retry mechanism that ensures that some other worker also tries to stitch it if the current one dies.

The problem is, there seems to be some bug where entities can sometimes end up staying indefinitely in the stitch queue, in deferred stitching mode. If that happens, we definitely want to see the ever-growing queue size rise in this metric.

Yes, this number will now include _currently_ stitching entities. But that's not a bad thing, I think.

The metric of how far behind we are on stitching, is instead covered by the `catalog.stitching.queue.delay` metric, so no information is lost by this change.