### PR TITLE
Add LLDAP Vendor implementation for ldap org ingestion

### DIFF
--- a/.changeset/weak-avocados-suffer.md
+++ b/.changeset/weak-avocados-suffer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-ldap': minor
+---
+
+Add new ldap vendor config 'LLDAP'

--- a/plugins/catalog-backend-module-ldap/src/ldap/client.ts
+++ b/plugins/catalog-backend-module-ldap/src/ldap/client.ts
@@ -26,6 +26,7 @@ import {
   ActiveDirectoryVendor,
   DefaultLdapVendor,
   GoogleLdapVendor,
+  LLDAPVendor,
   FreeIpaVendor,
   LdapVendor,
 } from './vendors';
@@ -248,6 +249,8 @@ export class LdapClient {
           return AEDirVendor;
         } else if (clientHost === 'ldap.google.com') {
           return GoogleLdapVendor;
+        } else if (root && root.raw?.vendorName?.toString() === 'LLDAP') {
+          return LLDAPVendor;
         }
         return DefaultLdapVendor;
       })

--- a/plugins/catalog-backend-module-ldap/src/ldap/vendors.ts
+++ b/plugins/catalog-backend-module-ldap/src/ldap/vendors.ts
@@ -94,6 +94,16 @@ export const GoogleLdapVendor: LdapVendor = {
   },
 };
 
+export const LLDAPVendor: LdapVendor = {
+  dnAttributeName: 'dn',
+  uuidAttributeName: 'entryuuid',
+  decodeStringAttribute: (entry, name) => {
+    return decode(entry, name.toLocaleLowerCase('en-US'), value => {
+      return value.toString();
+    });
+  },
+};
+
 // Decode an attribute to a consumer
 function decode(
   entry: SearchEntry,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds the default implementation requirements for **LLDAP** vendor for org-ingestion.

Discussed with _Nitnelave_ (Owner of [LLDAP](https://github.com/lldap/lldap))

I'll be producing a how-to guide in LLDAP's repository for configuring LLDAP with Backstage.

**Note:** `name.toLocaleLowerCase('en-US')` is used on attribute names, due to how lldap stores 'custom' names.


#### :heavy_check_mark: Checklist

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
