### PR TITLE
Compute some metrics using search table facet aggregations

### DIFF
--- a/.changeset/young-carrots-collect.md
+++ b/.changeset/young-carrots-collect.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Compute some metrics using search table facet aggregations instead of reading the full refresh state

--- a/plugins/catalog-backend/src/database/metrics.ts
+++ b/plugins/catalog-backend/src/database/metrics.ts
@@ -31,9 +31,9 @@ export function initDatabaseMetrics(knex: Knex) {
       async collect() {
         const results = await knex<DbSearchRow>('search')
           .where('key', '=', 'kind')
-          .whereNotNull('original_value')
-          .select({ kind: 'original_value', count: knex.raw('count(*)') })
-          .groupBy('original_value');
+          .whereNotNull('value')
+          .select({ kind: 'value', count: knex.raw('count(*)') })
+          .groupBy('value');
 
         results.forEach(({ kind, count }) => {
           seenProm.add(kind);
@@ -76,9 +76,9 @@ export function initDatabaseMetrics(knex: Knex) {
       .addCallback(async gauge => {
         const results = await knex<DbSearchRow>('search')
           .where('key', '=', 'kind')
-          .whereNotNull('original_value')
-          .select({ kind: 'original_value', count: knex.raw('count(*)') })
-          .groupBy('original_value');
+          .whereNotNull('value')
+          .select({ kind: 'value', count: knex.raw('count(*)') })
+          .groupBy('value');
 
         results.forEach(({ kind, count }) => {
           seen.add(kind);


### PR DESCRIPTION
This metric takes an unnecessary amount of resources to compute. Better to leverage the search table indices. This is basically the facets query structure, actually. This of course mans that the metric now represents how many entities that exist in the final entities, not in the refresh state. Arguably, this is more correct.

Example prometheus output:

```
catalog_entities_count{kind="api"} 6
catalog_entities_count{kind="component"} 14
catalog_entities_count{kind="domain"} 3
catalog_entities_count{kind="group"} 8
catalog_entities_count{kind="location"} 14
catalog_entities_count{kind="resource"} 1
catalog_entities_count{kind="system"} 3
catalog_entities_count{kind="template"} 6
catalog_entities_count{kind="user"} 17
```