### PR TITLE
Fix issues with type incompatibility between major versions of @types/express

### DIFF
--- a/.changeset/cold-icons-worry.md
+++ b/.changeset/cold-icons-worry.md
@@ -1,0 +1,6 @@
+---
+'@backstage/cli': patch
+---
+
+Remove special-casing for `@types` packages when generating dependency entries
+during templating

--- a/.changeset/odd-apples-explain.md
+++ b/.changeset/odd-apples-explain.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-auth-node': patch
+'@backstage/plugin-permission-backend': patch
+'@backstage/plugin-devtools-backend': patch
+'@backstage/plugin-signals-backend': patch
+---
+
+Restrict `@types/express` version range from `*` to `^4.17.6`.

--- a/packages/cli/src/lib/version.test.ts
+++ b/packages/cli/src/lib/version.test.ts
@@ -66,6 +66,10 @@ describe('createPackageVersionProvider', () => {
     expect(provider('c', '0.3.0-rc1')).toBe('0.3.0-rc1');
     expect(provider('c', '0.3.0')).toBe('^0.3.0');
     expect(provider('c', '0.3.6')).toBe('^0.3.4');
+
+    // No special handling for @types packages.
+    expect(provider('@types/t', '1.4.2')).toBe('^1.2.3');
+
     const cliVersion = packageVersions['@backstage/cli'];
     expect(provider('@backstage/cli')).toBe(
       // If we're currently in pre-release we expect that to be picked instead
@@ -74,6 +78,5 @@ describe('createPackageVersionProvider', () => {
     expect(provider('@backstage/core-plugin-api')).toBe(
       `^${corePluginApiPkg.version}`,
     );
-    expect(provider('@types/t', '1.4.2')).toBe('*');
   });
 });

--- a/packages/cli/src/lib/version.ts
+++ b/packages/cli/src/lib/version.ts
@@ -90,12 +90,6 @@ export function createPackageVersionProvider(lockfile?: Lockfile) {
     }
 
     const lockfileEntries = lockfile?.get(name);
-    if (
-      name.startsWith('@types/') &&
-      lockfileEntries?.some(entry => entry.range === '*')
-    ) {
-      return '*';
-    }
 
     for (const specifier of ['^', '~', '*']) {
       const range = `workspace:${specifier}`;

--- a/plugins/auth-node/package.json
+++ b/plugins/auth-node/package.json
@@ -44,7 +44,7 @@
     "@backstage/config": "workspace:^",
     "@backstage/errors": "workspace:^",
     "@backstage/types": "workspace:^",
-    "@types/express": "*",
+    "@types/express": "^4.17.6",
     "@types/passport": "^1.0.3",
     "express": "^4.17.1",
     "jose": "^5.0.0",

--- a/plugins/devtools-backend/package.json
+++ b/plugins/devtools-backend/package.json
@@ -49,7 +49,7 @@
     "@backstage/plugin-permission-node": "workspace:^",
     "@backstage/types": "workspace:^",
     "@manypkg/get-packages": "^1.1.3",
-    "@types/express": "*",
+    "@types/express": "^4.17.6",
     "@yarnpkg/lockfile": "^1.1.0",
     "@yarnpkg/parsers": "^3.0.0",
     "express": "^4.18.1",

--- a/plugins/permission-backend/package.json
+++ b/plugins/permission-backend/package.json
@@ -58,7 +58,7 @@
     "@backstage/plugin-auth-node": "workspace:^",
     "@backstage/plugin-permission-common": "workspace:^",
     "@backstage/plugin-permission-node": "workspace:^",
-    "@types/express": "*",
+    "@types/express": "^4.17.6",
     "dataloader": "^2.0.0",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",

--- a/plugins/signals-backend/package.json
+++ b/plugins/signals-backend/package.json
@@ -44,7 +44,7 @@
     "@backstage/plugin-events-node": "workspace:^",
     "@backstage/plugin-signals-node": "workspace:^",
     "@backstage/types": "workspace:^",
-    "@types/express": "*",
+    "@types/express": "^4.17.6",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
     "http-proxy-middleware": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5319,7 +5319,7 @@ __metadata:
     "@backstage/config": "workspace:^"
     "@backstage/errors": "workspace:^"
     "@backstage/types": "workspace:^"
-    "@types/express": "*"
+    "@types/express": ^4.17.6
     "@types/passport": ^1.0.3
     cookie-parser: ^1.4.6
     express: ^4.17.1
@@ -6158,7 +6158,7 @@ __metadata:
     "@backstage/plugin-permission-node": "workspace:^"
     "@backstage/types": "workspace:^"
     "@manypkg/get-packages": ^1.1.3
-    "@types/express": "*"
+    "@types/express": ^4.17.6
     "@types/ping": ^0.4.1
     "@types/supertest": ^2.0.8
     "@types/yarnpkg__lockfile": ^1.1.4
@@ -6896,7 +6896,7 @@ __metadata:
     "@backstage/plugin-auth-node": "workspace:^"
     "@backstage/plugin-permission-common": "workspace:^"
     "@backstage/plugin-permission-node": "workspace:^"
-    "@types/express": "*"
+    "@types/express": ^4.17.6
     "@types/lodash": ^4.14.151
     "@types/supertest": ^2.0.8
     dataloader: ^2.0.0
@@ -7862,7 +7862,7 @@ __metadata:
     "@backstage/plugin-events-node": "workspace:^"
     "@backstage/plugin-signals-node": "workspace:^"
     "@backstage/types": "workspace:^"
-    "@types/express": "*"
+    "@types/express": ^4.17.6
     "@types/supertest": ^2.0.8
     "@types/ws": ^8.5.10
     express: ^4.17.1


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Ran into this while looking into the failures on https://github.com/backstage/backstage/pull/27802. PR includes a couple of fixes:

1. Make all dependencies on @types/express more restrictive. Using `*` doesn't make sense, since [`@types` packages follow major versions of the packages they target](https://github.com/DefinitelyTyped/DefinitelyTyped?tab=readme-ov-file#how-do-definitely-typed-package-versions-relate-to-versions-of-the-corresponding-library). Since we restrict express to v4, we should restrict the corresponding types package in the same way.
2. Stop adding `*` dependencies for @types packages in templated plugins. This was causing e2e test failures (and also of course leaking `*` dependencies into templated plugins in the real world).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
