### PR TITLE
feat(notifications): Support Markdown rendering in description field

### DIFF
--- a/.changeset/rich-dragons-relax.md
+++ b/.changeset/rich-dragons-relax.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications': patch
+---
+
+Support Markdown rendering in description field

--- a/plugins/notifications/src/components/NotificationsTable/NotificationsTable.tsx
+++ b/plugins/notifications/src/components/NotificationsTable/NotificationsTable.tsx
@@ -32,6 +32,7 @@ import {
   TableColumn,
   TableProps,
 } from '@backstage/core-components';
+import { MarkdownContent } from '@backstage/core-components';
 
 import { notificationsApiRef } from '../../api';
 import { SelectAll } from './SelectAll';
@@ -42,6 +43,10 @@ const ThrottleDelayMs = 1000;
 
 const useStyles = makeStyles(theme => ({
   description: {
+    /** to make the styles for React Markdown not leak into the description */
+    '& :first-child': {
+      margin: 0,
+    },
     maxHeight: '5rem',
     overflow: 'auto',
   },
@@ -57,6 +62,26 @@ const useStyles = makeStyles(theme => ({
     marginRight: theme.spacing(0.5),
   },
 }));
+
+const unescapeString = (str: string) => {
+  return str
+    .replace(/\\n/g, '\n')
+    .replace(/\\r/g, '\r')
+    .replace(/\\t/g, '\t')
+    .replace(/\\"/g, '"')
+    .replace(/\\\\/g, '\\')
+    .replace(/&#(\d+);/g, (_, dec) => String.fromCharCode(dec))
+    .replace(/&([^;]+);/g, entity => {
+      const entities: Record<string, string> = {
+        '&amp;': '&',
+        '&lt;': '<',
+        '&gt;': '>',
+        '&quot;': '"',
+        '&#39;': "'",
+      };
+      return entities[entity] || entity;
+    });
+};
 
 /** @public */
 export type NotificationsTableProps = Pick<
@@ -240,9 +265,10 @@ export const NotificationsTable = ({
                     )}
                   </Typography>
                   {notification.payload.description ? (
-                    <Typography variant="body2" className={classes.description}>
-                      {notification.payload.description}
-                    </Typography>
+                    <MarkdownContent
+                      className={classes.description}
+                      content={unescapeString(notification.payload.description)}
+                    />
                   ) : null}
 
                   <Typography variant="caption">


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I've got a use case where I need to show a short changelog in notifications' UI and therefore I've modified the plugin code to support Markdown rendering for it. Check the following screenshot and the example code, how empty description, plain text description and Markdown description are showing up.

![image](https://github.com/user-attachments/assets/51bb6edd-c204-40e9-9661-4d26f8fc6cc8)

```bash
#!/bin/bash

notify () {
  BACKSTAGE_API_URL="http://localhost:7007"
  BACKSTAGE_API_TOKEN="foobar123"
  NOTIFICATION_TITLE="My title"
  NOTIFICATION_LINK="https://backstage.io"
  NOTIFICATION_SEVERITY="normal"
  NOTIFICATION_TOPIC="My topic"
  NOTIFICATION_DESCRIPTION="${1}"
  DATA=$(jq -n --arg title "${NOTIFICATION_TITLE}" --arg description "${NOTIFICATION_DESCRIPTION}" --arg link "${NOTIFICATION_LINK}" --arg severity "${NOTIFICATION_SEVERITY}" --arg topic "${NOTIFICATION_TOPIC}" '{"recipients":{"type":"broadcast"},"payload":$ARGS.named}')
  curl -s -X POST "${BACKSTAGE_API_URL}/api/notifications" \
    -H "Authorization: Bearer ${BACKSTAGE_API_TOKEN}" \
    -H "Content-Type: application/json" \
    -d "${DATA}"
}

# Description: empty
notify ""

# Description: plain text
notify "My description"

# Description: markdown
notify "# My description\n- First &amp; second item\n- Third &#35; **item**"
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
