### PR TITLE
EntityOwnerPicker: fix scroll reset

### DIFF
--- a/.changeset/few-pillows-remember.md
+++ b/.changeset/few-pillows-remember.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Fixed an issue causing the `EntityOwnerPicker` to reset scrolling when more elements are loaded.

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
@@ -93,10 +93,6 @@ export type EntityOwnerPickerProps = {
   mode?: 'owners-only' | 'all';
 };
 
-const Popper = React.memo(function Popper({ children }: PopperProps) {
-  return <div>{children as ReactNode}</div>;
-});
-
 function RenderOptionLabel(props: { entity: Entity; isSelected: boolean }) {
   const classes = useStyles();
   const isGroup = props.entity.kind.toLocaleLowerCase('en-US') === 'group';
@@ -267,3 +263,7 @@ export const EntityOwnerPicker = (props?: EntityOwnerPickerProps) => {
     </Box>
   );
 };
+
+function Popper({ children }: PopperProps) {
+  return <div>{children as ReactNode}</div>;
+}

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
@@ -42,6 +42,7 @@ import { withStyles } from '@material-ui/core/styles';
 import { useEntityPresentation } from '../../apis';
 import { catalogReactTranslationRef } from '../../translation';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import { PopperProps } from '@material-ui/core/Popper';
 
 /** @public */
 export type CatalogReactEntityOwnerPickerClassKey = 'input';
@@ -91,6 +92,10 @@ const checkedIcon = <CheckBoxIcon fontSize="small" />;
 export type EntityOwnerPickerProps = {
   mode?: 'owners-only' | 'all';
 };
+
+const Popper = React.memo(function Popper({ children }: PopperProps) {
+  return <div>{children as ReactNode}</div>;
+});
 
 function RenderOptionLabel(props: { entity: Entity; isSelected: boolean }) {
   const classes = useStyles();
@@ -188,9 +193,7 @@ export const EntityOwnerPicker = (props?: EntityOwnerPickerProps) => {
       <Typography className={classes.label} variant="button" component="label">
         {t('entityOwnerPicker.title')}
         <Autocomplete
-          PopperComponent={popperProps => (
-            <div {...popperProps}>{popperProps.children as ReactNode}</div>
-          )}
+          PopperComponent={Popper}
           multiple
           disableCloseOnSelect
           loading={loading}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixing an issue causing `EntityOwnerPicker` to reset scrolling when more elements are loaded.

Before:
https://github.com/user-attachments/assets/1120f983-a7d8-477d-8fa3-8a5c34847992

After:
https://github.com/user-attachments/assets/2e72eca1-775a-45b5-b0b5-b5f15c5871bd

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
