### PR TITLE
[backend-defaults] show zero for empty content length logs

### DIFF
--- a/packages/backend-defaults/src/entrypoints/rootHttpRouter/http/MiddlewareFactory.test.ts
+++ b/packages/backend-defaults/src/entrypoints/rootHttpRouter/http/MiddlewareFactory.test.ts
@@ -245,13 +245,13 @@ describe('MiddlewareFactory', () => {
     it('should log incoming requests', async () => {
       const app = express();
       app.use(middleware.logging());
-      app.get('/', (_req, res) => res.send('Hello World'));
+      app.get('/', (_req, res) => res.send(''));
 
       await request(app).get('/').expect(200);
 
       expect(logger.info).toHaveBeenCalledWith(
         expect.stringContaining(
-          '[2024-11-20T00:00:00.000Z] "GET / HTTP/1.1" 200 11 "-" "-"',
+          '[2024-11-20T00:00:00.000Z] "GET / HTTP/1.1" 200 0 "-" "-"',
         ),
         {
           type: 'incomingRequest',
@@ -260,7 +260,7 @@ describe('MiddlewareFactory', () => {
           url: '/',
           status: 200,
           httpVersion: '1.1',
-          contentLength: 11,
+          contentLength: 0,
         },
       );
     });

--- a/packages/backend-defaults/src/entrypoints/rootHttpRouter/http/MiddlewareFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/rootHttpRouter/http/MiddlewareFactory.ts
@@ -182,9 +182,9 @@ export class MiddlewareFactory {
         logger.info(
           `[${meta.date}] "${meta.method} ${meta.url} HTTP/${
             meta.httpVersion
-          }" ${meta.status} ${meta.contentLength} "${meta.referrer ?? '-'}" "${
-            meta.userAgent ?? '-'
-          }"`,
+          }" ${meta.status} ${meta.contentLength ?? 0} "${
+            meta.referrer ?? '-'
+          }" "${meta.userAgent ?? '-'}"`,
           {
             type: 'incomingRequest',
             ...meta,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Follow-up of: https://github.com/backstage/backstage/pull/27756

Use zero for empty response `contentLength` instead of printing `undefined` on the default log message.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
