### PR TITLE
add timestamp gauge metric for task run start/ends

### DIFF
--- a/.changeset/heavy-needles-poke.md
+++ b/.changeset/heavy-needles-poke.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Add task scheduler metrics as two gauges that track the last start and end timestamps as epoch seconds.

--- a/.changeset/heavy-needles-poke.md
+++ b/.changeset/heavy-needles-poke.md
@@ -1,5 +1,6 @@
 ---
 '@backstage/backend-defaults': patch
+'@backstage/plugin-catalog-backend-module-incremental-ingestion': patch
 ---
 
-Add task scheduler metrics as two gauges that track the last start and end timestamps as epoch seconds.
+Add task metrics as two gauges that track the last start and end timestamps as epoch seconds.

--- a/plugins/catalog-backend-module-incremental-ingestion/package.json
+++ b/plugins/catalog-backend-module-incremental-ingestion/package.json
@@ -61,6 +61,7 @@
     "@backstage/plugin-events-node": "workspace:^",
     "@backstage/plugin-permission-common": "workspace:^",
     "@backstage/types": "workspace:^",
+    "@opentelemetry/api": "^1.3.0",
     "@types/express": "^4.17.6",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5955,6 +5955,7 @@ __metadata:
     "@backstage/plugin-events-node": "workspace:^"
     "@backstage/plugin-permission-common": "workspace:^"
     "@backstage/types": "workspace:^"
+    "@opentelemetry/api": ^1.3.0
     "@types/express": ^4.17.6
     "@types/luxon": ^3.0.0
     express: ^4.17.1


### PR DESCRIPTION
The goal is simply to be able to graph task runs, and correlate them with other performance metrics going on, such as increased processing load after an ingestion run in the catalog.

These are two gauges that are just set to the epoch seconds timestamp when the task was last started and ended, respectively. Based on these, you can graph e.g. `time() - backend_tasks_task_runs_completed{...}` in grafana, and alert when it goes too high etc.