### PR TITLE
deprecate IncrementalCatalogBuilder, stop using old event interface

### DIFF
--- a/.changeset/fast-cheetahs-deliver.md
+++ b/.changeset/fast-cheetahs-deliver.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-incremental-ingestion': patch
+---
+
+Deprecate old-backend-system `IncrementalCatalogBuilder`

--- a/plugins/catalog-backend-module-incremental-ingestion/report-alpha.api.md
+++ b/plugins/catalog-backend-module-incremental-ingestion/report-alpha.api.md
@@ -5,7 +5,7 @@
 ```ts
 import { BackendFeature } from '@backstage/backend-plugin-api';
 
-// @alpha (undocumented)
+// @alpha @deprecated (undocumented)
 const _feature: BackendFeature;
 export default _feature;
 

--- a/plugins/catalog-backend-module-incremental-ingestion/report.api.md
+++ b/plugins/catalog-backend-module-incremental-ingestion/report.api.md
@@ -39,7 +39,7 @@ export type EntityIteratorResult<T> =
       cursor?: T;
     };
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export class IncrementalCatalogBuilder {
   // (undocumented)
   addIncrementalEntityProvider<TCursor, TContext>(

--- a/plugins/catalog-backend-module-incremental-ingestion/src/alpha.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/alpha.ts
@@ -16,6 +16,9 @@
 
 import { default as feature } from './module';
 
-/** @alpha */
+/**
+ * @alpha
+ * @deprecated Please import from `@backstage/plugin-catalog-backend-module-incremental-ingestion` instead
+ */
 const _feature = feature;
 export default _feature;

--- a/plugins/catalog-backend-module-incremental-ingestion/src/engine/IncrementalIngestionEngine.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/engine/IncrementalIngestionEngine.ts
@@ -21,12 +21,10 @@ import { performance } from 'perf_hooks';
 import { Duration } from 'luxon';
 import { v4 } from 'uuid';
 import { stringifyError } from '@backstage/errors';
-import { EventParams, EventSubscriber } from '@backstage/plugin-events-node';
+import { EventParams } from '@backstage/plugin-events-node';
 import { HumanDuration } from '@backstage/types';
 
-export class IncrementalIngestionEngine
-  implements IterationEngine, EventSubscriber
-{
+export class IncrementalIngestionEngine implements IterationEngine {
   private readonly restLength: Duration;
   private readonly backoff: HumanDuration[];
 

--- a/plugins/catalog-backend-module-incremental-ingestion/src/service/IncrementalCatalogBuilder.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/service/IncrementalCatalogBuilder.ts
@@ -29,7 +29,10 @@ import { IncrementalIngestionDatabaseManager } from '../database/IncrementalInge
 import { IncrementalProviderRouter } from '../router/routes';
 import { EventParams, EventSubscriber } from '@backstage/plugin-events-node';
 
-/** @public */
+/**
+ * @public
+ * @deprecated Please migrate to the new backend system and import `@backstage/plugin-catalog-backend-module-incremental-ingestion` as a module, and add providers to the `incrementalIngestionProvidersExtensionPoint` instead
+ */
 export class IncrementalCatalogBuilder {
   /**
    * Creates the incremental catalog builder, which extends the regular catalog builder.


### PR DESCRIPTION
Found some old EventSubscriber remnants, and a missed deprecation in alpha