### PR TITLE
Scaffolder - open links in descriptions in a new tab

### DIFF
--- a/.changeset/warm-pumpkins-bathe.md
+++ b/.changeset/warm-pumpkins-bathe.md
@@ -1,5 +1,4 @@
 ---
-'@backstage/core-components': patch
 '@backstage/plugin-scaffolder-react': patch
 ---
 

--- a/.changeset/warm-pumpkins-bathe.md
+++ b/.changeset/warm-pumpkins-bathe.md
@@ -1,0 +1,6 @@
+---
+'@backstage/core-components': patch
+'@backstage/plugin-scaffolder-react': patch
+---
+
+Open links in the scaffolder entity and step descriptions in a new tab, to ensure consistency and improve user experience

--- a/packages/core-components/src/components/MarkdownContent/MarkdownContent.test.tsx
+++ b/packages/core-components/src/components/MarkdownContent/MarkdownContent.test.tsx
@@ -120,6 +120,23 @@ describe('<MarkdownContent />', () => {
     );
   });
 
+  it('render MarkdownContent component with link target set to _blank', async () => {
+    await renderInTestApp(
+      <MarkdownContent
+        content="Take a look at the [README](https://github.com/backstage/backstage/blob/master/README.md) file."
+        linkTarget="_blank"
+      />,
+    );
+    const readme = screen.getByText('README', {
+      selector: 'a',
+    });
+    expect(readme).toBeInTheDocument();
+    expect(readme.getAttribute('href')).toEqual(
+      'https://github.com/backstage/backstage/blob/master/README.md',
+    );
+    expect(readme.getAttribute('target')).toEqual('_blank');
+  });
+
   it('render MarkdownContent component with headings given proper ids', async () => {
     await renderInTestApp(
       <MarkdownContent

--- a/plugins/scaffolder-react/src/next/components/Form/DescriptionFieldTemplate.tsx
+++ b/plugins/scaffolder-react/src/next/components/Form/DescriptionFieldTemplate.tsx
@@ -56,6 +56,7 @@ export const DescriptionFieldTemplate = <
       return (
         <MarkdownContent
           content={description}
+          linkTarget="_blank"
           className={classes.markdownDescription}
         />
       );

--- a/plugins/scaffolder-react/src/next/components/Workflow/Workflow.tsx
+++ b/plugins/scaffolder-react/src/next/components/Workflow/Workflow.tsx
@@ -121,6 +121,7 @@ export const Workflow = (workflowProps: WorkflowProps): JSX.Element | null => {
           subheader={
             <MarkdownContent
               className={styles.markdown}
+              linkTarget="_blank"
               content={
                 description ?? sortedManifest.description ?? 'No description'
               }


### PR DESCRIPTION
## Description
When the user clicks on the link in the description of the entity and the description of the step, a new tab will open.

Reasons for this: 
- To improve consistency, link in the description of the template and the step will open in a new tab.
- To improve user experience, the user won't lose the data already filled in the form if the link opens in a new tab.

### Related Bug report: https://github.com/backstage/backstage/issues/27747

### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
