### PR TITLE
Fixed WinstonLogger logging fields which are not castable to a string

### DIFF
--- a/.changeset/ten-keys-nail.md
+++ b/.changeset/ten-keys-nail.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Fixed an issue in the WinstonLogger where Errors thrown and given to logger.error with field values that could not be cast to a string would throw a TypeError

--- a/packages/backend-defaults/src/entrypoints/rootLogger/WinstonLogger.test.ts
+++ b/packages/backend-defaults/src/entrypoints/rootLogger/WinstonLogger.test.ts
@@ -93,4 +93,28 @@ describe('WinstonLogger', () => {
       expect.any(Function),
     );
   });
+
+  it('gracefully handles fields that are not castable to a string', () => {
+    const mockTransport = new Transport({
+      log: jest.fn(),
+      logv: jest.fn(),
+    });
+
+    const logger = WinstonLogger.create({
+      transports: [mockTransport],
+    });
+
+    logger.error('something went wrong', {
+      field: Object.create(null),
+    });
+
+    expect(mockTransport.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        [MESSAGE]: expect.stringContaining(
+          '[field value not castable to string]',
+        ),
+      }),
+      expect.any(Function),
+    );
+  });
 });

--- a/packages/backend-defaults/src/entrypoints/rootLogger/WinstonLogger.ts
+++ b/packages/backend-defaults/src/entrypoints/rootLogger/WinstonLogger.ts
@@ -147,10 +147,17 @@ export class WinstonLogger implements RootLoggerService {
         const prefixColor = colorizer.colorize('prefix', prefix);
 
         const extraFields = Object.entries(fields)
-          .map(
-            ([key, value]) =>
-              `${colorizer.colorize('field', `${key}`)}=${value}`,
-          )
+          .map(([key, value]) => {
+            let stringValue = '';
+
+            try {
+              stringValue = `${value}`;
+            } catch (e) {
+              stringValue = '[field value not castable to string]';
+            }
+
+            return `${colorizer.colorize('field', `${key}`)}=${stringValue}`;
+          })
           .join(' ');
 
         return `${timestampColor} ${prefixColor} ${level} ${message} ${extraFields}`;


### PR DESCRIPTION
Encountered an error between the LoggerService and a package called `npm-registry-fetch` which throws an Error that when passed to the `logger.error` itself threw another error `TypeError: Cannot convert object to primitive value`. This was due to fields on the original thrown error not being castable to strings. 

`TransformableInfo` which the logger is working with, is typed as `unknown` so it feels like the logger service should not assume that the values are castable to a string. 