### PR TITLE
Entity owner picker owners only rollback

### DIFF
--- a/.changeset/strange-brooms-check.md
+++ b/.changeset/strange-brooms-check.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Fixed an issue where the `EntityOwnerPicker` component failed to load when the `mode` prop was set to `owners-only`. In this mode, the `EntityOwnerPicker` does not load details about the owners, such as `displayName` or `title`. To display these details, use `mode=all` instead.

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/useFacetsEntities.test.ts
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/useFacetsEntities.test.ts
@@ -82,9 +82,6 @@ describe('useFacetsEntities', () => {
     mockCatalogApi.getEntityFacets.mockResolvedValue(
       facetsFromEntityRefs(entityRefs),
     );
-    mockCatalogApi.getEntitiesByRefs.mockResolvedValue(
-      entitiesFromEntityRefs(entityRefs),
-    );
 
     const { result } = renderHook(() => useFacetsEntities({ enabled: true }));
 
@@ -110,47 +107,19 @@ describe('useFacetsEntities', () => {
     });
   });
 
-  it(`should return the owners sorted by namespace, (displayName or title or name) and kind`, async () => {
+  it(`should return the owners sorted by kind, namespace and name`, async () => {
     const entityRefs = [
       'group:namespace/team-b',
-      'component:default/c',
+      'user:default/c',
       'group:default/a',
-      'component:default/a',
-      'component:default/b',
+      'user:default/a',
+      'user:default/b',
       'group:default/d',
       'group:default/e',
     ];
 
-    const enrichedEntities: { [key: string]: Entity } = {
-      'group:default/a': {
-        apiVersion: 'backstage.io/v1beta1',
-        kind: 'group',
-        metadata: { name: 'a', namespace: 'default', title: 'My title A' },
-      },
-      'component:default/a': {
-        apiVersion: 'backstage.io/v1beta1',
-        kind: 'component',
-        metadata: { name: 'a', namespace: 'default', title: 'My title B' },
-      },
-      'group:default/d': {
-        apiVersion: 'backstage.io/v1beta1',
-        kind: 'group',
-        metadata: { name: 'd', namespace: 'default' },
-        spec: { profile: { displayName: 'My display name D' } },
-      },
-      'group:default/e': {
-        apiVersion: 'backstage.io/v1beta1',
-        kind: 'group',
-        metadata: { name: 'e', namespace: 'default' },
-        spec: { profile: { displayName: 'My display name E' } },
-      },
-    };
-
     mockCatalogApi.getEntityFacets.mockResolvedValue(
       facetsFromEntityRefs(entityRefs),
-    );
-    mockCatalogApi.getEntitiesByRefs.mockResolvedValue(
-      entitiesFromEntityRefs(entityRefs, enrichedEntities),
     );
 
     const { result } = renderHook(() => useFacetsEntities({ enabled: true }));
@@ -162,48 +131,47 @@ describe('useFacetsEntities', () => {
           items: [
             {
               apiVersion: 'backstage.io/v1beta1',
-              kind: 'component',
-              metadata: { name: 'b', namespace: 'default' },
-            },
-            {
-              apiVersion: 'backstage.io/v1beta1',
-              kind: 'component',
-              metadata: { name: 'c', namespace: 'default' },
+              kind: 'group',
+              metadata: { name: 'a', namespace: 'default' },
             },
             {
               apiVersion: 'backstage.io/v1beta1',
               kind: 'group',
               metadata: { name: 'd', namespace: 'default' },
-              spec: { profile: { displayName: 'My display name D' } },
             },
             {
               apiVersion: 'backstage.io/v1beta1',
               kind: 'group',
               metadata: { name: 'e', namespace: 'default' },
-              spec: { profile: { displayName: 'My display name E' } },
-            },
-            {
-              apiVersion: 'backstage.io/v1beta1',
-              kind: 'group',
-              metadata: {
-                name: 'a',
-                namespace: 'default',
-                title: 'My title A',
-              },
-            },
-            {
-              apiVersion: 'backstage.io/v1beta1',
-              kind: 'component',
-              metadata: {
-                name: 'a',
-                namespace: 'default',
-                title: 'My title B',
-              },
             },
             {
               apiVersion: 'backstage.io/v1beta1',
               kind: 'group',
               metadata: { name: 'team-b', namespace: 'namespace' },
+            },
+            {
+              apiVersion: 'backstage.io/v1beta1',
+              kind: 'user',
+              metadata: {
+                name: 'a',
+                namespace: 'default',
+              },
+            },
+            {
+              apiVersion: 'backstage.io/v1beta1',
+              kind: 'user',
+              metadata: {
+                name: 'b',
+                namespace: 'default',
+              },
+            },
+            {
+              apiVersion: 'backstage.io/v1beta1',
+              kind: 'user',
+              metadata: {
+                name: 'c',
+                namespace: 'default',
+              },
             },
           ],
         },
@@ -215,17 +183,14 @@ describe('useFacetsEntities', () => {
   it(`should paginate the data accordingly`, async () => {
     const entityRefs = [
       'group:namespace/team-b',
-      'component:default/c',
+      'user:default/c',
       'group:default/a',
-      'component:default/a',
-      'component:default/b',
+      'user:default/a',
+      'user:default/b',
     ];
 
     mockCatalogApi.getEntityFacets.mockResolvedValue(
       facetsFromEntityRefs(entityRefs),
-    );
-    mockCatalogApi.getEntitiesByRefs.mockResolvedValue(
-      entitiesFromEntityRefs(entityRefs),
     );
 
     const { result } = renderHook(() => useFacetsEntities({ enabled: true }));
@@ -237,13 +202,13 @@ describe('useFacetsEntities', () => {
           items: [
             {
               apiVersion: 'backstage.io/v1beta1',
-              kind: 'component',
+              kind: 'group',
               metadata: { name: 'a', namespace: 'default' },
             },
             {
               apiVersion: 'backstage.io/v1beta1',
               kind: 'group',
-              metadata: { name: 'a', namespace: 'default' },
+              metadata: { name: 'team-b', namespace: 'namespace' },
             },
           ],
           cursor: 'eyJ0ZXh0IjoiIiwic3RhcnQiOjJ9',
@@ -259,23 +224,23 @@ describe('useFacetsEntities', () => {
           items: [
             {
               apiVersion: 'backstage.io/v1beta1',
-              kind: 'component',
-              metadata: { name: 'a', namespace: 'default' },
-            },
-            {
-              apiVersion: 'backstage.io/v1beta1',
               kind: 'group',
               metadata: { name: 'a', namespace: 'default' },
             },
             {
               apiVersion: 'backstage.io/v1beta1',
-              kind: 'component',
-              metadata: { name: 'b', namespace: 'default' },
+              kind: 'group',
+              metadata: { name: 'team-b', namespace: 'namespace' },
             },
             {
               apiVersion: 'backstage.io/v1beta1',
-              kind: 'component',
-              metadata: { name: 'c', namespace: 'default' },
+              kind: 'user',
+              metadata: { name: 'a', namespace: 'default' },
+            },
+            {
+              apiVersion: 'backstage.io/v1beta1',
+              kind: 'user',
+              metadata: { name: 'b', namespace: 'default' },
             },
           ],
           cursor: 'eyJ0ZXh0IjoiIiwic3RhcnQiOjR9',
@@ -291,28 +256,28 @@ describe('useFacetsEntities', () => {
           items: [
             {
               apiVersion: 'backstage.io/v1beta1',
-              kind: 'component',
-              metadata: { name: 'a', namespace: 'default' },
-            },
-            {
-              apiVersion: 'backstage.io/v1beta1',
               kind: 'group',
               metadata: { name: 'a', namespace: 'default' },
-            },
-            {
-              apiVersion: 'backstage.io/v1beta1',
-              kind: 'component',
-              metadata: { name: 'b', namespace: 'default' },
-            },
-            {
-              apiVersion: 'backstage.io/v1beta1',
-              kind: 'component',
-              metadata: { name: 'c', namespace: 'default' },
             },
             {
               apiVersion: 'backstage.io/v1beta1',
               kind: 'group',
               metadata: { name: 'team-b', namespace: 'namespace' },
+            },
+            {
+              apiVersion: 'backstage.io/v1beta1',
+              kind: 'user',
+              metadata: { name: 'a', namespace: 'default' },
+            },
+            {
+              apiVersion: 'backstage.io/v1beta1',
+              kind: 'user',
+              metadata: { name: 'b', namespace: 'default' },
+            },
+            {
+              apiVersion: 'backstage.io/v1beta1',
+              kind: 'user',
+              metadata: { name: 'c', namespace: 'default' },
             },
           ],
         },
@@ -337,34 +302,15 @@ describe('useFacetsEntities', () => {
     mockCatalogApi.getEntityFacets.mockResolvedValue(
       facetsFromEntityRefs(entityRefs),
     );
-    const enrichedEntities: { [key: string]: Entity } = {
-      'group:default/go': {
-        apiVersion: 'backstage.io/v1beta1',
-        kind: 'group',
-        metadata: { name: 'go', namespace: 'default', title: 'Hidden Spider' },
-      },
-      'component:default/lemon': {
-        apiVersion: 'backstage.io/v1beta1',
-        kind: 'component',
-        metadata: { name: 'lemon', namespace: 'default' },
-        spec: {
-          profile: { displayName: 'Lemon Spider' },
-        },
-      },
-    };
-    mockCatalogApi.getEntitiesByRefs.mockResolvedValue(
-      entitiesFromEntityRefs(entityRefs, enrichedEntities),
-    );
 
     const { result } = renderHook(() => useFacetsEntities({ enabled: true }));
 
     result.current[1]({ text: 'der  ' });
+
     await waitFor(() => {
       expect(result.current[0]).toEqual({
         value: {
           items: [
-            enrichedEntities['group:default/go'],
-            enrichedEntities['component:default/lemon'],
             {
               apiVersion: 'backstage.io/v1beta1',
               kind: 'component',
@@ -372,13 +318,13 @@ describe('useFacetsEntities', () => {
             },
             {
               apiVersion: 'backstage.io/v1beta1',
-              kind: 'group',
-              metadata: { name: 'spiderman', namespace: 'namespace' },
+              kind: 'component',
+              metadata: { name: 'a-component', namespace: 'spiders' },
             },
             {
               apiVersion: 'backstage.io/v1beta1',
-              kind: 'component',
-              metadata: { name: 'a-component', namespace: 'spiders' },
+              kind: 'group',
+              metadata: { name: 'spiderman', namespace: 'namespace' },
             },
             {
               apiVersion: 'backstage.io/v1beta1',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR rolls back #25366. Unfortunately, the approach used in #25366 does not work with a large catalog, as `getEntitiesByRefs` doesn't scale. #27167 attempts to address this issue by ensuring that `getEntitiesByRefs()`
 doesn't fail anymore, but the latency of fetching all the entities is still very high.

In this PR, we roll back to using `getEntityFacets()` to fetch the owners. This means that we won't be able to fetch the details of the entities, such as `displayName` or `title`. This tradeoff was decided to move toward #12247 but was probably overlooked when #25366 was merged. In case an adopter wishes to see more details of the entities, make sure to pass `ownerPickerMode="all"` to `CatalogIndexPage`:

```jsx
<CatalogIndexPage ownerPickerMode="all" />
```

 
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
