### PR TITLE
auth-{backend,node}: improved error forwarding from passport helpers

### DIFF
--- a/.changeset/fluffy-falcons-shout.md
+++ b/.changeset/fluffy-falcons-shout.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-auth-backend': patch
+'@backstage/plugin-auth-node': patch
+---
+
+Improved error forwarding for OAuth refresh endpoints

--- a/plugins/auth-backend/src/lib/passport/PassportStrategyHelper.ts
+++ b/plugins/auth-backend/src/lib/passport/PassportStrategyHelper.ts
@@ -21,6 +21,7 @@ import { InternalOAuthError } from 'passport-oauth2';
 import { ProfileInfo } from '@backstage/plugin-auth-node';
 import { PassportProfile } from './types';
 import { OAuthStartResponse } from '../../providers/types';
+import { ForwardedError } from '@backstage/errors';
 
 export type PassportDoneCallback<Res, Private = never> = (
   err?: Error,
@@ -66,7 +67,10 @@ export const makeProfileInfo = (
         displayName = decoded.name;
       }
     } catch (e) {
-      throw new Error(`Failed to parse id token and get profile info, ${e}`);
+      throw new ForwardedError(
+        `Failed to parse id token and get profile info`,
+        e,
+      );
     }
   }
 
@@ -176,7 +180,7 @@ export const executeRefreshTokenStrategy = async (
         params: any,
       ) => {
         if (err) {
-          reject(new Error(`Failed to refresh access token ${err.toString()}`));
+          reject(new ForwardedError(`Failed to refresh access token`, err));
         }
         if (!accessToken) {
           reject(

--- a/plugins/auth-node/src/passport/PassportHelpers.ts
+++ b/plugins/auth-node/src/passport/PassportHelpers.ts
@@ -19,6 +19,7 @@ import { decodeJwt } from 'jose';
 import { Strategy } from 'passport';
 import { PassportProfile } from './types';
 import { ProfileInfo } from '../types';
+import { ForwardedError } from '@backstage/errors';
 
 // Re-declared here to avoid direct dependency on passport-oauth2
 /** @internal */
@@ -76,7 +77,10 @@ export class PassportHelpers {
           displayName = decoded.name;
         }
       } catch (e) {
-        throw new Error(`Failed to parse id token and get profile info, ${e}`);
+        throw new ForwardedError(
+          `Failed to parse id token and get profile info`,
+          e,
+        );
       }
     }
 
@@ -191,9 +195,7 @@ export class PassportHelpers {
           params: any,
         ) => {
           if (err) {
-            reject(
-              new Error(`Failed to refresh access token ${err.toString()}`),
-            );
+            reject(new ForwardedError(`Failed to refresh access token`, err));
           }
           if (!accessToken) {
             reject(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Seeing some `[object Object]` errors, this is the first stab an properly forwarding errors from passport strategies. It might still be that they're objects without `name` or `message` properties, in which case this won't help. Might be worth tweaking `ForwardedError` in that case.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
