### PR TITLE
googleAuth: `includeGrantedScopes` to persist scopes across refreshes

### DIFF
--- a/.changeset/stale-rats-tease.md
+++ b/.changeset/stale-rats-tease.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-google-provider': patch
+---
+
+Pass through `includeGrantedScopes` in order to persist scopes across refresh calls

--- a/plugins/auth-backend-module-google-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-google-provider/src/authenticator.ts
@@ -73,6 +73,7 @@ export const googleAuthenticator = createOAuthAuthenticator({
     return helper.start(input, {
       accessType: 'offline',
       prompt: 'consent',
+      includeGrantedScopes: 'true',
     });
   },
 

--- a/plugins/auth-backend-module-google-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-google-provider/src/module.test.ts
@@ -67,6 +67,7 @@ describe('authModuleGoogleProvider', () => {
       prompt: 'consent',
       response_type: 'code',
       client_id: 'my-client-id',
+      include_granted_scopes: 'true',
       redirect_uri: `http://localhost:${server.port()}/api/auth/google/handler/frame`,
       state: expect.any(String),
       scope:


### PR DESCRIPTION
Need to pass this through otherwise on refreshes of both the token and the browser can lose the scopes that have already been requested which can lead to popups for auth all the time across tabs and across pages.