### PR TITLE
Added support for ISO timestamps to convertTimeToLocalTimezone

### DIFF
--- a/.changeset/fifty-tigers-suffer.md
+++ b/.changeset/fifty-tigers-suffer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-unprocessed-entities': minor
+---
+
+Fixed a bug in convertTimeToLocalTimezone where there was no support for ISO dates

--- a/plugins/catalog-unprocessed-entities/src/components/FailedEntities.tsx
+++ b/plugins/catalog-unprocessed-entities/src/components/FailedEntities.tsx
@@ -93,13 +93,17 @@ const RenderErrorContext = ({
  * easily understand the times.
  */
 const convertTimeToLocalTimezone = (strDateTime: string | Date) => {
-  const dateTime = DateTime.fromFormat(
+  let dateTime = DateTime.fromFormat(
     strDateTime.toLocaleString(),
     'yyyy-MM-dd hh:mm:ss',
     {
       zone: 'UTC',
     },
   );
+
+  if (!dateTime.isValid) {
+    dateTime = DateTime.fromISO(strDateTime.toLocaleString());
+  }
 
   const dateTimeLocalTz = dateTime.setZone(DateTime.local().zoneName);
 


### PR DESCRIPTION
Related to [#27840](https://github.com/backstage/backstage/issues/27840)

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Fixed a bug where timestamps form postgres database did not work. Now a valid `DateTime` is displayed as seen below.
![image](https://github.com/user-attachments/assets/d42f337f-c7a1-46ec-a073-caec0bcbae2f)
