### PR TITLE
chore: ignore storybook build output in packages/canon

### DIFF
--- a/packages/canon/.gitignore
+++ b/packages/canon/.gitignore
@@ -1,0 +1,2 @@
+# Build output
+storybook-static


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Ignore default storybook build directory in canon package.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
