### PR TITLE
build: add workflow to sync Canon storybook build to canon-storybook repo

### DIFF
--- a/.github/workflows/sync_canon.yml
+++ b/.github/workflows/sync_canon.yml
@@ -1,0 +1,56 @@
+name: Sync Canon Storybook
+on:
+  push:
+    branches: [master]
+
+jobs:
+  sync-canon-storybook:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: 20.x
+          registry-url: https://registry.npmjs.org/ # Needed for auth
+
+      - name: yarn install
+        uses: backstage/actions/yarn-install@25145dd4117d50e1da9330e9ed2893bc6b75373e # v0.6.15
+        with:
+          cache-prefix: ${{ runner.os }}-v20.x
+
+      - name: Checkout backstage/canon-storybook
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: backstage/canon-storybook
+          path: canon-storybook
+          token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config --global user.email noreply@backstage.io
+          git config --global user.name 'Github Canon Storybook workflow'
+
+      - name: Build Canon Storybook
+        run: |
+          yarn workspace @backstage/canon run build-storybook
+
+      - name: Replace contents of canon-storybook repo with Storybook build output
+        working-directory: canon-storybook
+        run: |
+          git rm -rf .
+          cp -R ../packages/canon/storybook-static/. .
+
+      - name: Commit to canon-storybook repo
+        working-directory: canon-storybook
+        run: |
+          git add .
+          git commit -am "Canon Storybook build for backstage/backstage@${{ github.sha }}"
+          git push


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Sets up a workflow to build the storybook for the @backstage/canon and sync the build output to the backstage/canon-storybook repo for serving via GitHub pages.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
