### PR TITLE
Implement `/entities` in terms of `queryEntities`

### DIFF
--- a/.changeset/fifty-countries-decide.md
+++ b/.changeset/fifty-countries-decide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': minor
+---
+
+Implement `/entities` in terms of `queryEntities` to not run into memory and performance problems on large catalogs

--- a/plugins/catalog-backend/src/catalog/types.ts
+++ b/plugins/catalog-backend/src/catalog/types.ts
@@ -203,6 +203,7 @@ export interface QueryEntitiesInitialRequest {
     term: string;
     fields?: string[];
   };
+  skipTotalItems?: boolean;
 }
 
 /**

--- a/plugins/catalog-backend/src/service/createRouter.test.ts
+++ b/plugins/catalog-backend/src/service/createRouter.test.ts
@@ -173,6 +173,7 @@ describe('createRouter readonly disabled', () => {
         },
         limit: 10000,
         credentials: mockCredentials.user(),
+        skipTotalItems: true,
       });
     });
   });

--- a/plugins/catalog-backend/src/service/createRouter.test.ts
+++ b/plugins/catalog-backend/src/service/createRouter.test.ts
@@ -135,9 +135,10 @@ describe('createRouter readonly disabled', () => {
         { apiVersion: 'a', kind: 'b', metadata: { name: 'n' } },
       ];
 
-      entitiesCatalog.entities.mockResolvedValueOnce({
-        entities: [entities[0]],
-        pageInfo: { hasNextPage: false },
+      entitiesCatalog.queryEntities.mockResolvedValueOnce({
+        items: [entities[0]],
+        pageInfo: {},
+        totalItems: 1,
       });
 
       const response = await request(app).get('/entities');
@@ -147,17 +148,18 @@ describe('createRouter readonly disabled', () => {
     });
 
     it('parses single and multiple request parameters and passes them down', async () => {
-      entitiesCatalog.entities.mockResolvedValueOnce({
-        entities: [],
-        pageInfo: { hasNextPage: false },
+      entitiesCatalog.queryEntities.mockResolvedValueOnce({
+        items: [],
+        pageInfo: {},
+        totalItems: 0,
       });
       const response = await request(app).get(
         '/entities?filter=a=1,a=2,b=3&filter=c=4',
       );
 
       expect(response.status).toEqual(200);
-      expect(entitiesCatalog.entities).toHaveBeenCalledTimes(1);
-      expect(entitiesCatalog.entities).toHaveBeenCalledWith({
+      expect(entitiesCatalog.queryEntities).toHaveBeenCalledTimes(1);
+      expect(entitiesCatalog.queryEntities).toHaveBeenCalledWith({
         filter: {
           anyOf: [
             {
@@ -169,6 +171,7 @@ describe('createRouter readonly disabled', () => {
             { key: 'c', values: ['4'] },
           ],
         },
+        limit: 10000,
         credentials: mockCredentials.user(),
       });
     });
@@ -913,9 +916,10 @@ describe('createRouter readonly enabled', () => {
         { apiVersion: 'a', kind: 'b', metadata: { name: 'n' } },
       ];
 
-      entitiesCatalog.entities.mockResolvedValueOnce({
-        entities: [entities[0]],
-        pageInfo: { hasNextPage: false },
+      entitiesCatalog.queryEntities.mockResolvedValueOnce({
+        items: [entities[0]],
+        pageInfo: {},
+        totalItems: 1,
       });
 
       const response = await request(app).get('/entities');

--- a/plugins/catalog-backend/src/service/createRouter.ts
+++ b/plugins/catalog-backend/src/service/createRouter.ts
@@ -192,7 +192,14 @@ export async function createRouter(
           do {
             const result = await entitiesCatalog.queryEntities(
               !cursor
-                ? { credentials, fields, limit, filter, orderFields: order }
+                ? {
+                    credentials,
+                    fields,
+                    limit,
+                    filter,
+                    orderFields: order,
+                    skipTotalItems: true,
+                  }
                 : { credentials, fields, limit, cursor },
             );
 

--- a/plugins/catalog-backend/src/service/util.ts
+++ b/plugins/catalog-backend/src/service/util.ts
@@ -15,7 +15,7 @@
  */
 
 import { InputError, NotAllowedError } from '@backstage/errors';
-import { Request } from 'express';
+import { Request, Response } from 'express';
 import lodash from 'lodash';
 import { z } from 'zod';
 import {
@@ -25,6 +25,11 @@ import {
   QueryEntitiesRequest,
 } from '../catalog/types';
 import { EntityFilter } from '@backstage/plugin-catalog-node';
+import {
+  Entity,
+  parseEntityRef,
+  stringifyEntityRef,
+} from '@backstage/catalog-model';
 
 export async function requireRequestBody(req: Request): Promise<unknown> {
   const contentType = req.header('content-type');
@@ -137,4 +142,81 @@ export function decodeCursor(encodedCursor: string) {
   } catch (e) {
     throw new InputError(`Malformed cursor: ${e}`);
   }
+}
+
+// TODO(freben): This is added as a compatibility guarantee, until we can be
+// sure that all adopters have re-stitched their entities so that the new
+// targetRef field is present on them, and that they have stopped consuming
+// the now-removed old field
+// TODO(jhaals): Remove this in April 2022
+export function expandLegacyCompoundRelationRefsInResponse(
+  entities: Entity[],
+): void {
+  for (const entity of entities) {
+    if (entity.relations) {
+      for (const relation of entity.relations as any) {
+        if (!relation.targetRef && relation.target) {
+          // This is the case where an old-form entity, not yet stitched with
+          // the updated code, was in the database
+          relation.targetRef = stringifyEntityRef(relation.target);
+        } else if (!relation.target && relation.targetRef) {
+          // This is the case where a new-form entity, stitched with the
+          // updated code, was in the database but we still want to produce
+          // the old data shape as well for compatibility reasons
+          relation.target = parseEntityRef(relation.targetRef);
+        }
+      }
+    }
+  }
+}
+
+export interface EntityArrayJsonStream {
+  send(entities: Entity[]): boolean;
+  complete(): void;
+  close(): void;
+}
+
+// Helps stream Entity[] as a JSON response stream to avoid performance issues
+export function createEntityArrayJsonStream(
+  res: Response,
+): EntityArrayJsonStream {
+  // Imitate the httpRouter behavior of pretty-printing in development
+  const prettyPrint = process.env.NODE_ENV === 'development';
+  let firstSend = true;
+  let completed = false;
+
+  return {
+    send(entities) {
+      if (firstSend) {
+        res.setHeader('Content-Type', 'application/json; charset=utf-8');
+        res.status(200);
+        res.flushHeaders();
+      }
+
+      let data: string;
+      if (prettyPrint) {
+        data = JSON.stringify(entities, null, 2);
+        data = firstSend ? data.slice(0, -2) : `,\n${data.slice(2, -2)}`;
+      } else {
+        data = JSON.stringify(entities);
+        data = firstSend ? data.slice(0, -1) : `,${data.slice(1, -1)}`;
+      }
+
+      firstSend = false;
+      return res.write(data);
+    },
+    complete() {
+      if (firstSend) {
+        res.json([]);
+      } else {
+        res.end(prettyPrint ? '\n]' : ']');
+      }
+      completed = true;
+    },
+    close() {
+      if (!completed) {
+        res.end();
+      }
+    },
+  };
 }


### PR DESCRIPTION
In very large catalogs, it is a risky proposition to allow callers to use the `/entities` endpoint indiscriminately. It reads every single entity out of the database in a single operation which is heavy for the database, consumes huge amounts of heap space for the service, and may even run into limits where the json serialization throws an exception because the payload hits hard restriction limits.

To get around this problem, implement the `/entities` endpoint on top of `queryEntities` based pagination, and stream out pages of JSON data to the response as they arrive.

On my machine, a 65k entity catalog that gives a 77MB json response on the endpoint, is curled out in 2.2 seconds. The old code is decidedly faster at 1.8 seconds. These timings will obviously vary depending on circumstances.