### PR TITLE
fix(website): fix different broken icons on the plugin page

### DIFF
--- a/microsite/data/plugins/github-codespaces.yaml
+++ b/microsite/data/plugins/github-codespaces.yaml
@@ -5,7 +5,7 @@ authorUrl: https://github.com/adityasinghal26
 category: Development
 description: Integrates GitHub Codespaces for a Backstage component with the Authenticated User.
 documentation: https://github.com/adityasinghal26/backstage-plugins/tree/main/plugins/github-codespaces
-iconUrl: https://github.com/adityasinghal26/backstage-plugins/blob/main/plugins/github-codespaces/images/GitHubLogo.png
+iconUrl: https://avatars.githubusercontent.com/u/9919?s=200&v=4
 npmPackageName: '@adityasinghal26/plugin-github-codespaces'
 tags:
   - github

--- a/microsite/data/plugins/gitops-cluster.yaml
+++ b/microsite/data/plugins/gitops-cluster.yaml
@@ -5,7 +5,6 @@ authorUrl: https://www.weave.works/
 category: Kubernetes
 description: Create GitOps-managed Kubernetes clusters. Currently, it supports provisioning EKS clusters on GitHub via GitHub Actions.
 documentation: https://github.com/backstage/community-plugins/tree/main/workspaces/gitops-profiles/plugins/gitops-profiles
-iconUrl: https://res-5.cloudinary.com/crunchbase-production/image/upload/c_lpad,h_256,w_256,f_auto,q_auto:eco/v1462316670/i9d3delzvx1erzjhmcws.png
 npmPackageName: '@backstage-community/plugin-gitops-profiles'
 tags:
   - kubernetes

--- a/microsite/data/plugins/rollbar.yaml
+++ b/microsite/data/plugins/rollbar.yaml
@@ -5,6 +5,6 @@ authorUrl: https://github.com/andrewthauer
 category: Monitoring
 description: View Rollbar errors for your services in Backstage.
 documentation: https://github.com/backstage/community-plugins/tree/main/workspaces/rollbar/plugins/rollbar
-iconUrl: https://rollbar.com/assets/media/rollbar-mark-color.png
+iconUrl: https://cdn.rollbar.com/wp-content/themes/rollbar/assets/img/logo-white-rollbar.svg
 npmPackageName: '@backstage-community/plugin-rollbar'
 addedDate: '2020-11-03'

--- a/microsite/data/plugins/tech-radar.yaml
+++ b/microsite/data/plugins/tech-radar.yaml
@@ -5,6 +5,6 @@ authorUrl: https://github.com/spotify
 category: Discovery
 description: Visualize the your company's official guidelines of different areas of software development.
 documentation: https://github.com/backstage/community-plugins/tree/main/workspaces/tech-radar/plugins/tech-radar
-iconUrl: https://www.materialui.co/materialIcons/action/track_changes_white_192x192.png
+iconUrl: /img/tech-radar.svg
 npmPackageName: '@backstage-community/plugin-tech-radar'
 addedDate: '2020-11-03'

--- a/microsite/static/img/tech-radar.svg
+++ b/microsite/static/img/tech-radar.svg
@@ -1,0 +1,14 @@
+<!--
+Icon downloaded from https://fonts.google.com/icons?icon.set=Material+Icons&selected=Material+Icons+Outlined:track_changes:&icon.query=track+changes&icon.size=80&icon.color=%23e8eaed
+
+The Material Icon font is licensed under Apache License, Version 2.0, see LICENSE in the Backstage source code root folder.
+
+Additional information are available under:
+- https://developers.google.com/fonts/docs/material_icons
+- https://github.com/google/material-design-icons
+-->
+<svg
+	xmlns="http://www.w3.org/2000/svg" height="48px" viewBox="0 0 24 24" width="48px" fill="#e8eaed">
+	<path d="M0 0h24v24H0V0z" fill="none"/>
+	<path d="M19.07 4.93l-1.41 1.41C19.1 7.79 20 9.79 20 12c0 4.42-3.58 8-8 8s-8-3.58-8-8c0-4.08 3.05-7.44 7-7.93v2.02C8.16 6.57 6 9.03 6 12c0 3.31 2.69 6 6 6s6-2.69 6-6c0-1.66-.67-3.16-1.76-4.24l-1.41 1.41C15.55 9.9 16 10.9 16 12c0 2.21-1.79 4-4 4s-4-1.79-4-4c0-1.86 1.28-3.41 3-3.86v2.14c-.6.35-1 .98-1 1.72 0 1.1.9 2 2 2s2-.9 2-2c0-.74-.4-1.38-1-1.72V2h-1C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10c0-2.76-1.12-5.26-2.93-7.07z"/>
+</svg>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes some broken icons on https://backstage.io/plugins/

* `github-codespaces` used the github avatar from https://github.com/github 
* `gitops-cluster`: I couldn't find what kind of icon it was, so I removed it.
* `rollbar`: picked up an icon from their website 
* `tech-radar`: downloaded the material UI icon "track changed" from https://fonts.google.com/icons?icon.set=Material+Icons&selected=Material+Icons+Outlined:track_changes:&icon.query=track+changes&icon.size=80&icon.color=%23e8eaed, it's licensed under Apache. I added manually some license notes to the svg

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
