### PR TITLE
fix(website): fix incorrect default plugin icon path

### DIFF
--- a/microsite/src/pages/plugins/_pluginCard.tsx
+++ b/microsite/src/pages/plugins/_pluginCard.tsx
@@ -9,14 +9,14 @@ export interface IPluginData {
   category: string;
   description: string;
   documentation: string;
-  iconUrl: string;
+  iconUrl?: string;
   title: string;
   addedDate: string;
   isNew: boolean;
   order?: number;
 }
 
-const defaultIconUrl = 'img/logo-gradient-on-dark.svg';
+const defaultIconUrl = '/img/logo-gradient-on-dark.svg';
 
 export const PluginCard = ({
   author,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Plugins without an icon doesn't show an icon because the default icon path missed the prefix `/`. :)

Currently:

![Screenshot From 2024-11-29 00-47-51](https://github.com/user-attachments/assets/e61f5e71-64b1-4f8b-8c07-b444a6b5336e)

with this PR:

![Screenshot From 2024-11-29 00-47-25](https://github.com/user-attachments/assets/9e30eee9-01e6-43c3-8379-c84de70141f7)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
