### PR TITLE
Allow iframe relative paths (preliminary implementation)

### DIFF
--- a/.changeset/blue-feet-press.md
+++ b/.changeset/blue-feet-press.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': minor
+---
+
+Added support for relative iframe src

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx
@@ -62,12 +62,12 @@ export const useTechDocsReaderDom = (
   const navigate = useNavigateUrl();
   const theme = useTheme();
   const isMobileMedia = useMediaQuery(MOBILE_MEDIA_QUERY);
-  const sanitizerTransformer = useSanitizerTransformer();
   const stylesTransformer = useStylesTransformer();
   const analytics = useAnalytics();
 
   const techdocsStorageApi = useApi(techdocsStorageApiRef);
   const scmIntegrationsApi = useApi(scmIntegrationsApiRef);
+  const sanitizerTransformer = useSanitizerTransformer(techdocsStorageApi);
 
   const { state, path, content: rawPage } = useTechDocsReader();
   const { '*': currPath = '' } = useParams();

--- a/plugins/techdocs/src/reader/transformers/html/hooks/iframes.ts
+++ b/plugins/techdocs/src/reader/transformers/html/hooks/iframes.ts
@@ -25,19 +25,15 @@ const isIframe = (node: Element) => node.nodeName === 'IFRAME';
 
 const parseRelativeUrl = (resource: string, baseApiUrl: string) => {
   try {
-    // Extract the frontend base path from document.baseURI (e.g., '/docs/default/Resource/simple-docs/')
-    const frontendBaseUrl = new URL(document.baseURI).pathname;
+    const frontendBaseUrl = new URL(document.baseURI).pathname.replace(
+      /\/$/,
+      '',
+    );
+    const updatedResource = resource.replace(/^\./, '').replace(/^\//, '');
 
-    let updatedResource = resource;
-
-    if (resource.startsWith('.')) {
-      updatedResource = resource.slice(1);
-    }
-
-    const constructedUrl = `${baseApiUrl}/static${frontendBaseUrl}${updatedResource}`;
-    const parsedUrl = new URL(constructedUrl);
-
-    return parsedUrl.href;
+    const sanitizedBaseApiUrl = baseApiUrl.replace(/\/$/, '');
+    const constructedUrl = `${sanitizedBaseApiUrl}/static${frontendBaseUrl}/${updatedResource}`;
+    return new URL(constructedUrl).href;
   } catch (error) {
     return null;
   }

--- a/plugins/techdocs/src/reader/transformers/html/transformer.sanitizer.test.tsx
+++ b/plugins/techdocs/src/reader/transformers/html/transformer.sanitizer.test.tsx
@@ -22,6 +22,7 @@ import { ConfigApi, configApiRef } from '@backstage/core-plugin-api';
 import { TestApiProvider } from '@backstage/test-utils';
 
 import { useSanitizerTransformer } from './transformer';
+import { TechDocsStorageApi } from '@backstage/plugin-techdocs-react';
 
 const configApiMock: ConfigApi = new ConfigReader({
   techdocs: {
@@ -32,6 +33,15 @@ const configApiMock: ConfigApi = new ConfigReader({
   },
 });
 
+const techdocsStorageApiMock: TechDocsStorageApi = {
+  getApiOrigin: () => Promise.resolve('http://localhost:7000'),
+  getBaseUrl: () => Promise.resolve('http://localhost:7000'),
+  getEntityDocs: () => Promise.resolve(''),
+  getBuilder: () => Promise.resolve(''),
+  getStorageUrl: () => Promise.resolve(''),
+  syncEntityDocs: () => Promise.resolve('cached'),
+};
+
 const wrapper: FC<PropsWithChildren<{}>> = ({ children }) => (
   <TestApiProvider apis={[[configApiRef, configApiMock]]}>
     {children}
@@ -40,7 +50,10 @@ const wrapper: FC<PropsWithChildren<{}>> = ({ children }) => (
 
 describe('Transformers > Html > Sanitizer Custom Elements', () => {
   it('should return a function that allows custom elements matching the pattern in the given dom element', async () => {
-    const { result } = renderHook(() => useSanitizerTransformer(), { wrapper });
+    const { result } = renderHook(
+      () => useSanitizerTransformer(techdocsStorageApiMock),
+      { wrapper },
+    );
 
     const dirtyDom = document.createElement('html');
     dirtyDom.innerHTML = `
@@ -59,7 +72,10 @@ describe('Transformers > Html > Sanitizer Custom Elements', () => {
   });
 
   it('should return a function that removes custom elements not matching the pattern in the given dom element', async () => {
-    const { result } = renderHook(() => useSanitizerTransformer(), { wrapper });
+    const { result } = renderHook(
+      () => useSanitizerTransformer(techdocsStorageApiMock),
+      { wrapper },
+    );
 
     const dirtyDom = document.createElement('html');
     dirtyDom.innerHTML = `
@@ -79,7 +95,10 @@ describe('Transformers > Html > Sanitizer Custom Elements', () => {
   });
 
   it('should return a function that removes custom element attributes not matching the pattern in the given dom element', async () => {
-    const { result } = renderHook(() => useSanitizerTransformer(), { wrapper });
+    const { result } = renderHook(
+      () => useSanitizerTransformer(techdocsStorageApiMock),
+      { wrapper },
+    );
 
     const dirtyDom = document.createElement('html');
     dirtyDom.innerHTML = `

--- a/plugins/techdocs/src/reader/transformers/html/transformer.test.tsx
+++ b/plugins/techdocs/src/reader/transformers/html/transformer.test.tsx
@@ -22,6 +22,7 @@ import { ConfigApi, configApiRef } from '@backstage/core-plugin-api';
 import { TestApiProvider } from '@backstage/test-utils';
 
 import { useSanitizerTransformer } from './transformer';
+import { TechDocsStorageApi } from '@backstage/plugin-techdocs-react';
 
 const configApiMock: ConfigApi = new ConfigReader({
   techdocs: {
@@ -31,6 +32,15 @@ const configApiMock: ConfigApi = new ConfigReader({
   },
 });
 
+const techdocsStorageApiMock: TechDocsStorageApi = {
+  getApiOrigin: () => Promise.resolve('http://localhost:7000'),
+  getBaseUrl: () => Promise.resolve('http://localhost:7000'),
+  getEntityDocs: () => Promise.resolve(''),
+  getBuilder: () => Promise.resolve(''),
+  getStorageUrl: () => Promise.resolve(''),
+  syncEntityDocs: () => Promise.resolve('cached'),
+};
+
 const wrapper: FC<PropsWithChildren<{}>> = ({ children }) => (
   <TestApiProvider apis={[[configApiRef, configApiMock]]}>
     {children}
@@ -39,7 +49,10 @@ const wrapper: FC<PropsWithChildren<{}>> = ({ children }) => (
 
 describe('Transformers > Html', () => {
   it('should return a function that removes unsafe links from a given dom element', async () => {
-    const { result } = renderHook(() => useSanitizerTransformer(), { wrapper });
+    const { result } = renderHook(
+      () => useSanitizerTransformer(techdocsStorageApiMock),
+      { wrapper },
+    );
 
     const dirtyDom = document.createElement('html');
     dirtyDom.innerHTML = `
@@ -62,7 +75,10 @@ describe('Transformers > Html', () => {
   });
 
   it('should return a function that removes unsafe iframes from a given dom element', async () => {
-    const { result } = renderHook(() => useSanitizerTransformer(), { wrapper });
+    const { result } = renderHook(
+      () => useSanitizerTransformer(techdocsStorageApiMock),
+      { wrapper },
+    );
 
     const dirtyDom = document.createElement('html');
     dirtyDom.innerHTML = `
@@ -83,7 +99,10 @@ describe('Transformers > Html', () => {
   });
 
   it('should return a function that allows refresh meta tags', async () => {
-    const { result } = renderHook(() => useSanitizerTransformer(), { wrapper });
+    const { result } = renderHook(
+      () => useSanitizerTransformer(techdocsStorageApiMock),
+      { wrapper },
+    );
 
     const dirtyDom = document.createElement('html');
     dirtyDom.innerHTML = `
@@ -105,7 +124,10 @@ describe('Transformers > Html', () => {
   });
 
   it('should return a function that does not allow non-refresh meta tags', async () => {
-    const { result } = renderHook(() => useSanitizerTransformer(), { wrapper });
+    const { result } = renderHook(
+      () => useSanitizerTransformer(techdocsStorageApiMock),
+      { wrapper },
+    );
 
     const dirtyDom = document.createElement('html');
     dirtyDom.innerHTML = `

--- a/plugins/techdocs/src/reader/transformers/html/transformer.ts
+++ b/plugins/techdocs/src/reader/transformers/html/transformer.ts
@@ -21,6 +21,7 @@ import { configApiRef, useApi } from '@backstage/core-plugin-api';
 
 import { Transformer } from '../transformer';
 import { removeUnsafeIframes, removeUnsafeLinks } from './hooks';
+import { TechDocsStorageApi } from '@backstage/plugin-techdocs-react';
 
 /**
  * Returns html sanitizer configuration
@@ -36,7 +37,9 @@ const useSanitizerConfig = () => {
 /**
  * Returns a transformer that sanitizes the dom
  */
-export const useSanitizerTransformer = (): Transformer => {
+export const useSanitizerTransformer = (
+  techdocsStorageApi: TechDocsStorageApi,
+): Transformer => {
   const config = useSanitizerConfig();
 
   return useCallback(
@@ -48,7 +51,10 @@ export const useSanitizerTransformer = (): Transformer => {
 
       if (hosts) {
         tags.push('iframe');
-        DOMPurify.addHook('beforeSanitizeElements', removeUnsafeIframes(hosts));
+        DOMPurify.addHook(
+          'beforeSanitizeElements',
+          removeUnsafeIframes(hosts, techdocsStorageApi),
+        );
       }
 
       // Only allow meta tags if they are used for refreshing the page. They are required for the redirect feature.
@@ -94,6 +100,6 @@ export const useSanitizerTransformer = (): Transformer => {
         },
       });
     },
-    [config],
+    [config, techdocsStorageApi],
   );
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Implements/fixes #27470 *(preliminary fix)*

In MkDocs, custom HTML templates can be defined under `extra_templates` as follows:
`mkdocs.yml`
```yml
---
site_name: Simple Docs
nav:
  - 'Home': './index.md'
docs_dir: docs
repo_url: https://localhost:3000/
edit_uri_template: edit/main/data/docs/simple-docs/docs/{path}
plugins:
  - techdocs-core
markdown_extensions:
  - md_in_html
extra_templates:
  - emails/examples/html_template.html
```

These templates are accessible from the backend API. In this case, the file is hosted at `http://localhost:7007/api/techdocs/static/docs/default/resource/simple-docs/emails/examples/html_template.html`.

I managed to get the techdocs plugin to parse the relative URL by using the frontend (techdocs) and backend (API) URLs. The problem is that `localhost:7007` has the `X-Frame-Options` header set to `sameorigin` so it won't allow the iframe to get embedded. Users looking to use relative URLs to embed iframes would have to manually set the origin in the current implementation:

### Relative URL
![image](https://github.com/user-attachments/assets/47170013-5b0c-4157-a5ea-cec229187b41)

What would be the best solution here? Hosting the template files under `localhost:3000` (the frontend) to comply with the origin requirement? Or something else entirely?

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

**Note:** I modified one failing test because relative URLs get automatically parsed according to the base API URL.

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
