### PR TITLE
recommend undici

### DIFF
--- a/docs/architecture-decisions/adr013-use-fetch.md
+++ b/docs/architecture-decisions/adr013-use-fetch.md
@@ -2,7 +2,7 @@
 id: adrs-adr013
 title: 'ADR013: Proper use of HTTP fetching libraries'
 # prettier-ignore
-description: Architecture Decision Record (ADR) for the proper use of fetchApiRef, node-fetch, and cross-fetch for data fetching.
+description: Architecture Decision Record (ADR) for the proper use of fetchApiRef, native fetch, and cross-fetch for data fetching.
 ---
 
 ## Context
@@ -12,13 +12,13 @@ support burden of keeping said package up to date.
 
 ## Decision
 
-Backend (node) packages should use the `node-fetch` package for HTTP data
-fetching. Example:
+Backend (node) packages should use the native `fetch` for HTTP data fetching,
+and importing `undici` where necessary. Example:
 
 ```ts
-import fetch from 'node-fetch';
 import { ResponseError } from '@backstage/errors';
 
+// this is implicitly global.fetch
 const response = await fetch('https://example.com/api/v1/users.json');
 if (!response.ok) {
   throw await ResponseError.fromResponse(response);
@@ -28,12 +28,11 @@ const users = await response.json();
 
 Frontend plugins and packages should prefer to use the
 [`fetchApiRef`](https://backstage.io/docs/reference/core-plugin-api.fetchapiref).
-It uses `cross-fetch` internally. Example:
 
 ```ts
 import { useApi } from '@backstage/core-plugin-api';
 
-// Inside some functional React component...
+// Inside some React component...
 const { fetch } = useApi(fetchApiRef);
 
 const response = await fetch('https://example.com/api/v1/users.json');
@@ -69,5 +68,4 @@ export class MyClient {
 ## Consequences
 
 We will gradually transition away from third party packages such as `axios`,
-`got` and others. Once we have transitioned to `node-fetch` we will add lint
-rules to enforce this decision.
+`got`, `node-fetch` and others.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -226,7 +226,7 @@ nav:
       - ADR010 - Luxon Date Library: 'architecture-decisions/adr010-luxon-date-library.md'
       - ADR011 - Plugin Package Structure: 'architecture-decisions/adr011-plugin-package-structure.md'
       - ADR012 - Use Luxon Locale: 'architecture-decisions/adr012-use-luxon-locale-and-date-presets.md'
-      - ADR013 - Use node-fetch: 'architecture-decisions/adr013-use-node-fetch.md'
+      - ADR013 - Use node-fetch: 'architecture-decisions/adr013-use-fetch.md'
   - FAQ:
       - Overview: 'faq/index.md'
       - Product FAQ: 'faq/product.md'


### PR DESCRIPTION
Now that node 20 is the minimum, we should move to using the native (undici) fetch in the backend. This may also partially help with [some issues](https://github.com/backstage/backstage/issues/24590) with the use of other libraries.