### PR TITLE
Added support for authProvider and owner configuration in GkeEntityProvider

### DIFF
--- a/.changeset/two-carrots-work.md
+++ b/.changeset/two-carrots-work.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-gcp': patch
+---
+
+Added support for optional `authProvider` and `owner` configuration parameters for GkeEntityProvider

--- a/plugins/catalog-backend-module-gcp/README.md
+++ b/plugins/catalog-backend-module-gcp/README.md
@@ -33,6 +33,10 @@ catalog:
           - 'projects/some-project/locations/-'
           # list all clusters in the region, in the project
           - 'projects/some-other-project/locations/some-region'
+        # optional; authentication provider to be used, default 'google'
+        authProvider: 'googleServiceAccount'
+        # optional, owner of the resource, default 'unknown'
+        owner: 'SRE'
         schedule: # optional; same options as in TaskScheduleDefinition
           # supports cron, ISO duration, "human duration" as used in code
           frequency: { minutes: 30 }

--- a/plugins/catalog-backend-module-gcp/src/providers/GkeEntityProvider.ts
+++ b/plugins/catalog-backend-module-gcp/src/providers/GkeEntityProvider.ts
@@ -47,6 +47,8 @@ export class GkeEntityProvider implements EntityProvider {
   private readonly logger: LoggerService;
   private readonly scheduleFn: () => Promise<void>;
   private readonly gkeParents: string[];
+  private readonly gkeAuthProvider: string | undefined;
+  private readonly gkeOwner: string | undefined;
   private readonly clusterManagerClient: container.v1.ClusterManagerClient;
   private connection?: EntityProviderConnection;
 
@@ -54,11 +56,15 @@ export class GkeEntityProvider implements EntityProvider {
     logger: LoggerService,
     taskRunner: SchedulerServiceTaskRunner,
     gkeParents: string[],
+    gkeAuthProvider: string | undefined,
+    gkeOwner: string | undefined,
     clusterManagerClient: container.v1.ClusterManagerClient,
   ) {
     this.logger = logger;
     this.scheduleFn = this.createScheduleFn(taskRunner);
     this.gkeParents = gkeParents;
+    this.gkeAuthProvider = gkeAuthProvider;
+    this.gkeOwner = gkeOwner;
     this.clusterManagerClient = clusterManagerClient;
   }
 
@@ -98,6 +104,8 @@ export class GkeEntityProvider implements EntityProvider {
       logger,
       scheduler.createScheduledTaskRunner(schedule),
       gkeProviderConfig.getStringArray('parents'),
+      gkeProviderConfig.getOptionalString('authProvider'),
+      gkeProviderConfig.getOptionalString('owner'),
       clusterManagerClient,
     );
   }
@@ -152,7 +160,8 @@ export class GkeEntityProvider implements EntityProvider {
             [ANNOTATION_KUBERNETES_API_SERVER]: `https://${cluster.endpoint}`,
             [ANNOTATION_KUBERNETES_API_SERVER_CA]:
               cluster.masterAuth?.clusterCaCertificate || '',
-            [ANNOTATION_KUBERNETES_AUTH_PROVIDER]: 'google',
+            [ANNOTATION_KUBERNETES_AUTH_PROVIDER]:
+              this.gkeAuthProvider || 'google',
             [ANNOTATION_KUBERNETES_DASHBOARD_APP]: 'gke',
             [ANNOTATION_LOCATION]: location,
             [ANNOTATION_ORIGIN_LOCATION]: location,
@@ -167,7 +176,7 @@ export class GkeEntityProvider implements EntityProvider {
         },
         spec: {
           type: 'kubernetes-cluster',
-          owner: 'unknown',
+          owner: this.gkeOwner || 'unknown',
         },
       },
     };

--- a/plugins/catalog-backend-module-gcp/src/providers/__snapshots__/GkeEntityProvider.test.ts.snap
+++ b/plugins/catalog-backend-module-gcp/src/providers/__snapshots__/GkeEntityProvider.test.ts.snap
@@ -67,3 +67,47 @@ exports[`GkeEntityProvider should return clusters as Resources 1`] = `
   ],
 }
 `;
+
+exports[`GkeEntityProvider should use configured values for authProvider and owner 1`] = `
+[MockFunction] {
+  "calls": [
+    [
+      {
+        "entities": [
+          {
+            "entity": {
+              "apiVersion": "backstage.io/v1alpha1",
+              "kind": "Resource",
+              "metadata": {
+                "annotations": {
+                  "backstage.io/managed-by-location": "gcp-gke:some-location",
+                  "backstage.io/managed-by-origin-location": "gcp-gke:some-location",
+                  "kubernetes.io/api-server": "https://127.0.0.1",
+                  "kubernetes.io/api-server-certificate-authority": "abcdefg",
+                  "kubernetes.io/auth-provider": "googleServiceAccount",
+                  "kubernetes.io/dashboard-app": "gke",
+                  "kubernetes.io/dashboard-parameters": "{"projectId":"parent1","region":"some-location","clusterName":"some-cluster"}",
+                },
+                "name": "some-cluster",
+                "namespace": "default",
+              },
+              "spec": {
+                "owner": "sre",
+                "type": "kubernetes-cluster",
+              },
+            },
+            "locationKey": "gcp-gke:some-location",
+          },
+        ],
+        "type": "full",
+      },
+    ],
+  ],
+  "results": [
+    {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Work for [27737](https://github.com/backstage/backstage/issues/27737). 
The existing [GkeEntityProvider](https://github.com/backstage/backstage/blob/master/plugins/catalog-backend-module-gcp/src/providers/GkeEntityProvider.ts) has hardcoded values for authentication provider and owner for the ingested clusters which limits flexibility.

I added optional `authProvider` and `owner` configuration parameters to allow customization while maintaining backward compatibility. If these parameters are not specified, the default values are `google` and `unknown`, respectively (previously hardcoded values).

I have updated README file and added a test case to validate the new functionality.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
