### PR TITLE
Configurable columns for HasSubdomainsCard and new defaults

### DIFF
--- a/.changeset/dull-ties-film.md
+++ b/.changeset/dull-ties-film.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': minor
+---
+
+Adds an optional columns attribute to HasSubdomainsCardProps and changes its default columns

--- a/plugins/catalog/report-alpha.api.md
+++ b/plugins/catalog/report-alpha.api.md
@@ -146,6 +146,27 @@ const _default: FrontendPlugin<
     unregisterRedirect: ExternalRouteRef<undefined>;
   },
   {
+    'nav-item:catalog': ExtensionDefinition<{
+      kind: 'nav-item';
+      name: undefined;
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        {
+          title: string;
+          icon: IconComponent;
+          routeRef: RouteRef<undefined>;
+        },
+        'core.nav-item.target',
+        {}
+      >;
+      inputs: {};
+      params: {
+        title: string;
+        icon: IconComponent;
+        routeRef: RouteRef<undefined>;
+      };
+    }>;
     'api:catalog': ExtensionDefinition<{
       kind: 'api';
       name: undefined;
@@ -823,27 +844,6 @@ const _default: FrontendPlugin<
         defaultPath: string;
         loader: () => Promise<JSX.Element>;
         routeRef?: RouteRef<AnyRouteRefParams> | undefined;
-      };
-    }>;
-    'nav-item:catalog': ExtensionDefinition<{
-      kind: 'nav-item';
-      name: undefined;
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        {
-          title: string;
-          icon: IconComponent;
-          routeRef: RouteRef<undefined>;
-        },
-        'core.nav-item.target',
-        {}
-      >;
-      inputs: {};
-      params: {
-        title: string;
-        icon: IconComponent;
-        routeRef: RouteRef<undefined>;
       };
     }>;
     'search-result-list-item:catalog': ExtensionDefinition<{

--- a/plugins/catalog/report-alpha.api.md
+++ b/plugins/catalog/report-alpha.api.md
@@ -146,27 +146,6 @@ const _default: FrontendPlugin<
     unregisterRedirect: ExternalRouteRef<undefined>;
   },
   {
-    'nav-item:catalog': ExtensionDefinition<{
-      kind: 'nav-item';
-      name: undefined;
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        {
-          title: string;
-          icon: IconComponent;
-          routeRef: RouteRef<undefined>;
-        },
-        'core.nav-item.target',
-        {}
-      >;
-      inputs: {};
-      params: {
-        title: string;
-        icon: IconComponent;
-        routeRef: RouteRef<undefined>;
-      };
-    }>;
     'api:catalog': ExtensionDefinition<{
       kind: 'api';
       name: undefined;
@@ -844,6 +823,27 @@ const _default: FrontendPlugin<
         defaultPath: string;
         loader: () => Promise<JSX.Element>;
         routeRef?: RouteRef<AnyRouteRefParams> | undefined;
+      };
+    }>;
+    'nav-item:catalog': ExtensionDefinition<{
+      kind: 'nav-item';
+      name: undefined;
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        {
+          title: string;
+          icon: IconComponent;
+          routeRef: RouteRef<undefined>;
+        },
+        'core.nav-item.target',
+        {}
+      >;
+      inputs: {};
+      params: {
+        title: string;
+        icon: IconComponent;
+        routeRef: RouteRef<undefined>;
       };
     }>;
     'search-result-list-item:catalog': ExtensionDefinition<{

--- a/plugins/catalog/report.api.md
+++ b/plugins/catalog/report.api.md
@@ -10,6 +10,7 @@ import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { CatalogApi } from '@backstage/plugin-catalog-react';
 import { ComponentEntity } from '@backstage/catalog-model';
 import { CompoundEntityRef } from '@backstage/catalog-model';
+import { DomainEntity } from '@backstage/catalog-model';
 import { Entity } from '@backstage/catalog-model';
 import { EntityListContextProps } from '@backstage/plugin-catalog-react';
 import { EntityListPagination } from '@backstage/plugin-catalog-react';
@@ -584,6 +585,8 @@ export interface HasSubcomponentsCardProps {
 
 // @public (undocumented)
 export interface HasSubdomainsCardProps {
+  // (undocumented)
+  columns?: TableColumn<DomainEntity>[];
   // (undocumented)
   tableOptions?: TableOptions;
   // (undocumented)

--- a/plugins/catalog/src/components/HasSubdomainsCard/HasSubdomainsCard.tsx
+++ b/plugins/catalog/src/components/HasSubdomainsCard/HasSubdomainsCard.tsx
@@ -14,12 +14,17 @@
  * limitations under the License.
  */
 
-import { RELATION_HAS_PART } from '@backstage/catalog-model';
-import { InfoCardVariants, TableOptions } from '@backstage/core-components';
+import { DomainEntity, RELATION_HAS_PART } from '@backstage/catalog-model';
+import {
+  InfoCardVariants,
+  TableColumn,
+  TableOptions,
+} from '@backstage/core-components';
 import React from 'react';
 import {
-  asComponentEntities,
-  componentEntityColumns,
+  asDomainEntities,
+  domainEntityColumns,
+  domainEntityHelpLink,
   RelatedEntitiesCard,
 } from '../RelatedEntitiesCard';
 import { catalogTranslationRef } from '../../alpha/translation';
@@ -29,6 +34,7 @@ import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 export interface HasSubdomainsCardProps {
   variant?: InfoCardVariants;
   tableOptions?: TableOptions;
+  columns?: TableColumn<DomainEntity>[];
   title?: string;
 }
 
@@ -36,8 +42,9 @@ export function HasSubdomainsCard(props: HasSubdomainsCardProps) {
   const { t } = useTranslationRef(catalogTranslationRef);
   const {
     variant = 'gridItem',
-    tableOptions = {},
     title = t('hasSubdomainsCard.title'),
+    columns = domainEntityColumns,
+    tableOptions = {},
   } = props;
   return (
     <RelatedEntitiesCard
@@ -45,10 +52,10 @@ export function HasSubdomainsCard(props: HasSubdomainsCardProps) {
       title={title}
       entityKind="Domain"
       relationType={RELATION_HAS_PART}
-      columns={componentEntityColumns}
-      asRenderableEntities={asComponentEntities}
+      columns={columns}
+      asRenderableEntities={asDomainEntities}
       emptyMessage={t('hasSubdomainsCard.emptyMessage')}
-      emptyHelpLink="https://backstage.io/docs/features/software-catalog/descriptor-format/#specsubdomainof-optional"
+      emptyHelpLink={domainEntityHelpLink}
       tableOptions={tableOptions}
     />
   );

--- a/plugins/catalog/src/components/RelatedEntitiesCard/RelatedEntitiesCard.tsx
+++ b/plugins/catalog/src/components/RelatedEntitiesCard/RelatedEntitiesCard.tsx
@@ -33,10 +33,13 @@ import {
 } from '@backstage/core-components';
 import {
   asComponentEntities,
+  asDomainEntities,
   asResourceEntities,
   asSystemEntities,
   componentEntityColumns,
   componentEntityHelpLink,
+  domainEntityColumns,
+  domainEntityHelpLink,
   resourceEntityColumns,
   resourceEntityHelpLink,
   systemEntityColumns,
@@ -137,3 +140,6 @@ RelatedEntitiesCard.asResourceEntities = asResourceEntities;
 RelatedEntitiesCard.systemEntityColumns = systemEntityColumns;
 RelatedEntitiesCard.systemEntityHelpLink = systemEntityHelpLink;
 RelatedEntitiesCard.asSystemEntities = asSystemEntities;
+RelatedEntitiesCard.domainEntityColums = domainEntityColumns;
+RelatedEntitiesCard.domainEntityHelpLink = domainEntityHelpLink;
+RelatedEntitiesCard.asDomainEntities = asDomainEntities;

--- a/plugins/catalog/src/components/RelatedEntitiesCard/presets.ts
+++ b/plugins/catalog/src/components/RelatedEntitiesCard/presets.ts
@@ -15,6 +15,7 @@
  */
 import {
   ComponentEntity,
+  DomainEntity,
   Entity,
   ResourceEntity,
   SystemEntity,
@@ -55,3 +56,13 @@ export const systemEntityHelpLink: string =
   'https://backstage.io/docs/features/software-catalog/descriptor-format#kind-system';
 export const asSystemEntities = (entities: Entity[]): SystemEntity[] =>
   entities as SystemEntity[];
+
+export const domainEntityColumns: TableColumn<DomainEntity>[] = [
+  EntityTable.columns.createEntityRefColumn({ defaultKind: 'domain' }),
+  EntityTable.columns.createOwnerColumn(),
+  EntityTable.columns.createMetadataDescriptionColumn(),
+];
+export const domainEntityHelpLink: string =
+  'https://backstage.io/docs/features/software-catalog/descriptor-format#kind-domain';
+export const asDomainEntities = (entities: Entity[]): DomainEntity[] =>
+  entities as DomainEntity[];


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds the optional `columns` attribute to `HasSubdomainsCardProps` to make the columns of the `HasSubdomainsCard`  introduced in https://github.com/backstage/backstage/pull/25893  configurable.

Also, changes the default columns to entity, owner and description for consistency with the `HasSystemsCard`.

 Examples with `2` subdomains, one with a title attribute and one without it:

- Before:

<img width="839" alt="Screenshot 2024-11-29 at 17 05 40" src="https://github.com/user-attachments/assets/13e44009-ba74-458f-a217-6e46e828c41a">

- After:

<img width="836" alt="Screenshot 2024-11-29 at 17 05 07" src="https://github.com/user-attachments/assets/44c16218-52c4-4760-b5cc-9cf1fa736c25">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
