### PR TITLE
release-manifests: allow overriding fetch implementation

### DIFF
--- a/.changeset/violet-snakes-laugh.md
+++ b/.changeset/violet-snakes-laugh.md
@@ -1,0 +1,5 @@
+---
+'@backstage/release-manifests': patch
+---
+
+Allow overriding the fetch function used inside getManifestByVersion

--- a/packages/release-manifests/report.api.md
+++ b/packages/release-manifests/report.api.md
@@ -21,6 +21,12 @@ export function getManifestByVersion(
 // @public
 export type GetManifestByVersionOptions = {
   version: string;
+  fetch?: (
+    url: string,
+    options?: {
+      signal?: AbortSignal;
+    },
+  ) => Promise<Pick<Response, 'status' | 'json' | 'url'>>;
 };
 
 // @public


### PR DESCRIPTION


## Hey, I just made a Pull Request!

This allows us to use yarn's built in HTTP request utilities in the Backstage yarn plugin, thereby benefiting from the built-in caching and proxy configuration utilities.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
