### PR TITLE
GitlabOrgDiscoveryEntityProvider restrictUsersToGroup should use the entire groupPath

### DIFF
--- a/.changeset/blue-dragons-shout.md
+++ b/.changeset/blue-dragons-shout.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-gitlab': patch
+---
+
+restrictUsersToGroup should use the entire groupPath

--- a/.changeset/blue-dragons-shout.md
+++ b/.changeset/blue-dragons-shout.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend-module-gitlab': patch
 ---
 
-restrictUsersToGroup should use the entire groupPath
+`restrictUsersToGroup` should use the entire group path when getting members

--- a/plugins/catalog-backend-module-gitlab/src/__testUtils__/handlers.ts
+++ b/plugins/catalog-backend-module-gitlab/src/__testUtils__/handlers.ts
@@ -83,7 +83,7 @@ const httpHandlers = [
   }),
 
   rest.get(
-    `${apiBaseUrlSaas}/groups/subgroup1/members/all`,
+    `${apiBaseUrlSaas}/groups/group1%2Fsubgroup1/members/all`,
     (_req, res, ctx) => {
       return res(ctx.json(subgroup_saas_users_response)); // To-DO change
     },

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.ts
@@ -396,13 +396,13 @@ export class GitlabOrgDiscoveryEntityProvider implements EntityProvider {
       groups = (await this.gitLabClient.listDescendantGroups(this.config.group))
         .items;
       const rootGroupSplit = this.config.group.split('/');
-      const rootGroup = this.config.restrictUsersToGroup
-        ? rootGroupSplit[rootGroupSplit.length - 1]
+      const groupPath = this.config.restrictUsersToGroup
+        ? this.config.group
         : rootGroupSplit[0];
       users = paginated<GitLabUser>(
         options =>
           this.gitLabClient.listSaaSUsers(
-            rootGroup,
+            groupPath,
             options,
             this.config.includeUsersWithoutSeat,
           ),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

GithubOrg.restrictUsersToGroup should use the entire groupPath as it calls `GitLabClient.listGroupMembers` in https://github.com/backstage/backstage/blob/master/plugins/catalog-backend-module-gitlab/src/lib/client.ts#L117

which uses:

```
return this.pagedRequest(
      `/groups/${encodeURIComponent(groupPath)}/members/all`,
      options,
    );
```

current behaviour:

```yaml
catalog:
  providers:
    gitlab:
      myProviderId:
        host: gitlab.com  # Identifies one of the hosts set up in the integrations
        fallbackBranch: main  # Optional. Fallback to be used if there is no default branch configured at the Gitlab repository. It is only used, if `branch` is undefined. Uses `master` as default
        group: my-org/kubernetes  # Optional. Group and subgroup (if needed) to look for repositories. If not present the whole instance will be scanned
        ...
       orgEnabled: true  # import users
        restrictUsersToGroup: true #
```

which would invoke
`https://gitlab.com/api/v4/groups/kubernetes/members/all`

and return 0 users as the org is missing...

instead of

`https://gitlab.com/api/v4/groups/my-org%2Fkubernetes/members/all`

which returns the expected users (I have tested it)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
