### PR TITLE
yarn-plugin: backfill changelog

### DIFF
--- a/packages/yarn-plugin/CHANGELOG.md
+++ b/packages/yarn-plugin/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Patch Changes
 
+- 27600c2: Verify type of `beforeWorkspacePacking` hook signature
+- d8bd6f5: Cherry-pick lodash method to reduce bundle size
+- 344c591: Use native `Array.some` instead of lodash to reduce bundle size
+- 9296a33: Remove dependency on `chalk` to reduce bundle size
+- 9017481: Move Backstage version to parameter in bound descriptor for better
+  compatibility with third-party lockfile parsing tools
 - Updated dependencies
   - @backstage/release-manifests@0.0.12-next.0
   - @backstage/cli-common@0.1.15
@@ -20,6 +26,7 @@
 
 ### Patch Changes
 
+- aba538d: Do not throw when descriptors are already bound in bindDescriptor
 - Updated dependencies
   - @backstage/cli-common@0.1.15-next.0
   - @backstage/release-manifests@0.0.11
@@ -28,6 +35,9 @@
 
 ### Patch Changes
 
+- a8bd401: Validate version of yarn in plugin to ensure compatibility
+- b207f69: Memoize fetching of release manifest
+- 9e29186: Ensure plugin works correctly when running yarn dedupe
 - bd32d5a: Add additional check before packing workspace to verify that all backstage:^ versions have been removed.
 - Updated dependencies
   - @backstage/cli-common@0.1.14
@@ -45,6 +55,7 @@
 
 ### Patch Changes
 
+- Initial release
 - Updated dependencies
   - @backstage/cli-common@0.1.14-next.0
   - @backstage/release-manifests@0.0.11


### PR DESCRIPTION
Realised that even though we don't release this package via npm, it'll still be useful to have an accurate changelog. With that in mind, this PR backfills the changes for previous releases, and I'm proposing that we include changesets for changes in this package going forward.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
