### PR TITLE
repo-tools: make generate-patch only create a single resolutions entry

### DIFF
--- a/.changeset/tiny-mice-run.md
+++ b/.changeset/tiny-mice-run.md
@@ -1,0 +1,5 @@
+---
+'@backstage/repo-tools': patch
+---
+
+The `generate-patch` command will now add a single resolution entry for all versions of the patched package, rather than separate entries for each version query.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This makes the `generate-patch` command just add a single resolutions entry for the package, rather than one for each existing dependency range. It's a lot simpler and reduces friction, but gives a bit less control. I think this is what you'd actually want most of the time though, and if one wants to patch a specific range that can stoll be done manually fairly easily.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
