### PR TITLE
cli: add support for --output-file option for lint commands

### DIFF
--- a/.changeset/seven-bulldogs-count.md
+++ b/.changeset/seven-bulldogs-count.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Add support for `--output-file` option from ESLint to `package lint` and `repo lint` commands.

--- a/packages/cli/cli-report.md
+++ b/packages/cli/cli-report.md
@@ -236,6 +236,7 @@ Usage: backstage-cli package lint [options] [directories...]
 
 Options:
   --format <format>
+  --output-file <path>
   --fix
   --max-warnings <number>
   -h, --help
@@ -446,6 +447,7 @@ Usage: backstage-cli repo lint [options]
 
 Options:
   --format <format>
+  --output-file <path>
   --since <ref>
   --successCache
   --successCacheDir <path>

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -54,6 +54,10 @@ export function registerRepoCommand(program: Command) {
       'eslint-formatter-friendly',
     )
     .option(
+      '--output-file <path>',
+      'Write the lint report to a file instead of stdout',
+    )
+    .option(
       '--since <ref>',
       'Only lint packages that changed since the specified ref',
     )
@@ -167,6 +171,10 @@ export function registerScriptCommand(program: Command) {
       '--format <format>',
       'Lint report output format',
       'eslint-formatter-friendly',
+    )
+    .option(
+      '--output-file <path>',
+      'Write the lint report to a file instead of stdout',
     )
     .option('--fix', 'Attempt to automatically fix violations')
     .option(

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import fs from 'fs-extra';
 import { OptionValues } from 'commander';
 import { paths } from '../lib/paths';
 import { ESLint } from 'eslint';
@@ -49,10 +50,14 @@ export default async (directories: string[], opts: OptionValues) => {
     process.chdir(paths.targetRoot);
   }
 
-  const resultText = formatter.format(results);
+  const resultText = await formatter.format(results);
 
   if (resultText) {
-    console.log(resultText);
+    if (opts.outputFile) {
+      await fs.writeFile(paths.resolveTarget(opts.outputFile), resultText);
+    } else {
+      console.log(resultText);
+    }
   }
 
   if (failed) {

--- a/packages/cli/src/commands/repo/lint.ts
+++ b/packages/cli/src/commands/repo/lint.ts
@@ -15,6 +15,7 @@
  */
 
 import chalk from 'chalk';
+import fs from 'fs-extra';
 import { Command, OptionValues } from 'commander';
 import { createHash } from 'crypto';
 import { relative as relativePath } from 'path';
@@ -220,6 +221,8 @@ export async function command(opts: OptionValues, cmd: Command): Promise<void> {
 
   const outputSuccessCache = [];
 
+  let errorOutput = '';
+
   let failed = false;
   for (const {
     relativeDir,
@@ -234,12 +237,20 @@ export async function command(opts: OptionValues, cmd: Command): Promise<void> {
       // When doing repo lint, only list the results if the lint failed to avoid a log
       // dump of all warnings that might be irrelevant
       if (resultText) {
-        console.log();
-        console.log(resultText.trimStart());
+        if (opts.outputFile) {
+          errorOutput += `${resultText}\n`;
+        } else {
+          console.log();
+          console.log(resultText.trimStart());
+        }
       }
     } else if (sha) {
       outputSuccessCache.push(sha);
     }
+  }
+
+  if (opts.outputFile && errorOutput) {
+    await fs.writeFile(paths.resolveTargetRoot(opts.outputFile), errorOutput);
   }
 
   if (cacheContext) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

An option from ESLint that can be handy to have available, especially for writing all outputs from `repo lint` to a file in the root.

This aims to mirror the implementation of `--output-file` in ESLint, behaving the same way. For example it simply writes whatever would've gone to `stdout` to the file instead, and it doesn't create the file or remove an existing one if there are no errors.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
