### PR TITLE
postgres: set the `connection.type` to `default` when not provided

### DIFF
--- a/packages/backend-defaults/src/entrypoints/database/connectors/postgres.test.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/postgres.test.ts
@@ -220,6 +220,41 @@ describe('postgres', () => {
         useNullAsDefault: true,
       });
     });
+
+    it('throws an error when the connection type is not supported', async () => {
+      await expect(
+        buildPgDatabaseConfig(
+          new ConfigReader({
+            client: 'pg',
+            connection: {
+              type: 'not-supported',
+            },
+          }),
+        ),
+      ).rejects.toThrow('Unknown connection type: not-supported');
+    });
+
+    it('supports default as the default connection type', async () => {
+      await expect(
+        buildPgDatabaseConfig(
+          new ConfigReader({
+            client: 'pg',
+            connection: {
+              type: 'default',
+              port: '5432',
+              database: 'other_db',
+            },
+          }),
+        ),
+      ).resolves.toEqual({
+        client: 'pg',
+        connection: {
+          port: '5432',
+          database: 'other_db',
+        },
+        useNullAsDefault: true,
+      });
+    });
   });
 
   describe('getPgConnectionConfig', () => {

--- a/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
@@ -69,7 +69,6 @@ export async function buildPgDatabaseConfig(
   overrides?: Knex.Config,
 ) {
   const config = mergeDatabaseConfig(
-    { connection: { type: 'default' } },
     dbConfig.get(),
     {
       connection: getPgConnectionConfig(dbConfig, !!overrides),
@@ -78,48 +77,48 @@ export async function buildPgDatabaseConfig(
     overrides,
   );
 
-  let transformedConfig = config;
+  const sanitizedConfig = JSON.parse(JSON.stringify(config));
 
-  if (config.connection.type) {
-    if (config.connection.type === 'cloudsql') {
-      if (config.client !== 'pg') {
-        throw new Error('Cloud SQL only supports the pg client');
-      }
+  // Trim additional properties from the connection object passed to knex
+  delete sanitizedConfig.connection.type;
+  delete sanitizedConfig.connection.instance;
 
-      if (!config.connection.instance) {
-        throw new Error('Missing instance connection name for Cloud SQL');
-      }
-
-      const {
-        Connector: CloudSqlConnector,
-        IpAddressTypes,
-        AuthTypes,
-      } = await import('@google-cloud/cloud-sql-connector');
-      const connector = new CloudSqlConnector();
-      const clientOpts = await connector.getOptions({
-        instanceConnectionName: config.connection.instance,
-        ipType: IpAddressTypes.PUBLIC,
-        authType: AuthTypes.IAM,
-      });
-
-      transformedConfig = {
-        ...config,
-        client: 'pg',
-        connection: {
-          ...config.connection,
-          ...clientOpts,
-        },
-      };
-    } else if (config.connection.type !== 'default') {
-      throw new Error(`Unknown connection type: ${config.connection.type}`);
-    }
+  if (config.connection.type === 'default' || !config.connection.type) {
+    return sanitizedConfig;
   }
 
-  // Remove the connection type and instance from the config
-  delete transformedConfig.connection.type;
-  delete transformedConfig.connection.instance;
+  if (config.connection.type !== 'cloudsql') {
+    throw new Error(`Unknown connection type: ${config.connection.type}`);
+  }
 
-  return transformedConfig;
+  if (config.client !== 'pg') {
+    throw new Error('Cloud SQL only supports the pg client');
+  }
+
+  if (!config.connection.instance) {
+    throw new Error('Missing instance connection name for Cloud SQL');
+  }
+
+  const {
+    Connector: CloudSqlConnector,
+    IpAddressTypes,
+    AuthTypes,
+  } = await import('@google-cloud/cloud-sql-connector');
+  const connector = new CloudSqlConnector();
+  const clientOpts = await connector.getOptions({
+    instanceConnectionName: config.connection.instance,
+    ipType: IpAddressTypes.PUBLIC,
+    authType: AuthTypes.IAM,
+  });
+
+  return {
+    ...sanitizedConfig,
+    client: 'pg',
+    connection: {
+      ...sanitizedConfig.connection,
+      ...clientOpts,
+    },
+  };
 }
 
 /**


### PR DESCRIPTION
Backing off the changeset in #27901.

This sets the `connection.type` to `default` if not provided, and will throw if it's neither `default` or `cloudsql`