### PR TITLE
fix nulls in by-query

### DIFF
--- a/.changeset/gold-stingrays-cross.md
+++ b/.changeset/gold-stingrays-cross.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Fix a bug where sometimes the `by-query` endpoint could return nulls for entities that were not yet stitched.

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
@@ -1797,6 +1797,51 @@ describe('DefaultEntitiesCatalog', () => {
         ).resolves.toEqual(['BB', 'CC', 'AA']); // 'AA' has no title, ends up last
       },
     );
+
+    it.each(databases.eachSupportedId())(
+      'should silently skip over entities that are not yet stitched, %p',
+      async databaseId => {
+        await createDatabase(databaseId);
+
+        const entity1 = entityFrom('AA', { uid: 'id1' });
+        const entity2 = entityFrom('BB', { uid: 'id2' });
+        await Promise.all([
+          addEntityToSearch(entity1),
+          addEntityToSearch(entity2),
+        ]);
+
+        const catalog = new DefaultEntitiesCatalog({
+          database: knex,
+          logger: mockServices.logger.mock(),
+          stitcher,
+        });
+
+        await expect(
+          catalog
+            .queryEntities({
+              orderFields: [{ field: 'metadata.uid', order: 'asc' }],
+              limit: 10,
+              credentials: mockCredentials.none(),
+            })
+            .then(r => r.items.map(e => e.metadata.name)),
+        ).resolves.toEqual(['AA', 'BB']);
+
+        // simulate a situation where stitching is not yet complete
+        await knex('final_entities')
+          .update({ final_entity: null })
+          .where({ entity_ref: stringifyEntityRef(entity1) });
+
+        await expect(
+          catalog
+            .queryEntities({
+              orderFields: [{ field: 'metadata.uid', order: 'asc' }],
+              limit: 10,
+              credentials: mockCredentials.none(),
+            })
+            .then(r => r.items.map(e => e.metadata.name)),
+        ).resolves.toEqual(['BB']);
+      },
+    );
   });
 
   describe('removeEntityByUid', () => {

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -379,11 +379,13 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
     const [prevItemOrderFieldValue, prevItemUid] =
       cursor.orderFieldValues || [];
 
-    const dbQuery = db('final_entities').leftOuterJoin('search', qb =>
-      qb
-        .on('search.entity_id', 'final_entities.entity_id')
-        .andOnVal('search.key', sortField.field),
-    );
+    const dbQuery = db('final_entities')
+      .leftOuterJoin('search', qb =>
+        qb
+          .on('search.entity_id', 'final_entities.entity_id')
+          .andOnVal('search.key', sortField.field),
+      )
+      .whereNotNull('final_entities.final_entity');
 
     if (cursor.filter) {
       parseFilter(


### PR DESCRIPTION
The root query accidentally included entities where the `final_entity` column was null.