### PR TITLE
Stop accepting traffic before shutdown

### DIFF
--- a/.changeset/green-carpets-smell.md
+++ b/.changeset/green-carpets-smell.md
@@ -3,3 +3,5 @@
 ---
 
 The `RootLifecycleService` now has a new `addBeforeShutdownHook` method, and hooks added through this method will run immediately when a termination event is received.
+
+The backend will not proceed with the shutdown and run the `Shutdown` hooks until all `BeforeShutdown` hooks have completed.

--- a/.changeset/green-carpets-smell.md
+++ b/.changeset/green-carpets-smell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-plugin-api': patch
+---
+
+The `RootLifecycleService` now has a new `addBeforeShutdownHook` method, and hooks added through this method will run immediately when a termination event is received.

--- a/.changeset/large-birds-watch.md
+++ b/.changeset/large-birds-watch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-test-utils': patch
+---
+
+Mock the new `RootLifecycleService.addBeforeShutdownHook` method.

--- a/.changeset/pretty-kiwis-travel.md
+++ b/.changeset/pretty-kiwis-travel.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Implements the `DefaultRootLifecycleService.addBeforeShutdownHook` method, and updates `DefaultRootHttpRouterService` and `DefaultRootHealthService` to listen to that event to stop accepting traffic and close service connections.

--- a/.changeset/rude-pears-tie.md
+++ b/.changeset/rude-pears-tie.md
@@ -2,4 +2,5 @@
 '@backstage/backend-defaults': patch
 ---
 
-Remove use of the `stoppable` library as Node's native http server [close](https://nodejs.org/api/http.html#serverclosecallback) method already drains requests.
+Remove use of the `stoppable` library on the `DefaultRootHttpRouterService` as Node's native http server [close](https://nodejs.org/api/http.html#serverclosecallback) method already drains requests.
+Also, we pass a new `lifecycleMiddleware` to the `rootHttpRouterServiceFactory` configure function that must be called manually if you don't call `applyDefaults`.

--- a/.changeset/rude-pears-tie.md
+++ b/.changeset/rude-pears-tie.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Remove use of the `stoppable` library as Node's native http server [close](https://nodejs.org/api/http.html#serverclosecallback) method already drains requests.

--- a/.changeset/young-cobras-add.md
+++ b/.changeset/young-cobras-add.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+As soon as a backend termination signal is received, call before shutting down root lifecycle hooks.

--- a/docs/backend-system/core-services/root-http-router.md
+++ b/docs/backend-system/core-services/root-http-router.md
@@ -50,8 +50,16 @@ The `app-config.yaml` file provides configurable options that can be adjusted to
 backend:
   lifecycle:
     # (Optional) The maximum time that paused requests will wait for the service to start, before returning an error (defaults to 5 seconds).
+    # Supported formats:
+    # - A string in the format of '1d', '2 seconds' etc. as supported by the `ms` library.
+    # - A standard ISO formatted duration string, e.g. 'P2DT6H' or 'PT1M'.
+    # - An object with individual units (in plural) as keys, e.g. `{ days: 2, hours: 6 }`.
     startupRequestPauseTimeout: { seconds: 10 }
     # (Optional) The maximum time that the server will wait for stop accepting traffic, before returning an error (defaults to 30 seconds).
+    # Supported formats:
+    # - A string in the format of '1d', '2 seconds' etc. as supported by the `ms` library.
+    # - A standard ISO formatted duration string, e.g. 'P2DT6H' or 'PT1M'.
+    # - An object with individual units (in plural) as keys, e.g. `{ days: 2, hours: 6 }`.
     shutdownRequestPauseTimeout: { seconds: 20 }
 ```
 

--- a/docs/backend-system/core-services/root-http-router.md
+++ b/docs/backend-system/core-services/root-http-router.md
@@ -55,12 +55,12 @@ backend:
     # - A standard ISO formatted duration string, e.g. 'P2DT6H' or 'PT1M'.
     # - An object with individual units (in plural) as keys, e.g. `{ days: 2, hours: 6 }`.
     startupRequestPauseTimeout: { seconds: 10 }
-    # (Optional) The maximum time that the server will wait for stop accepting traffic, before returning an error (defaults to 30 seconds).
+    # (Optional) The minimum time that the HTTP server will delay the shutdown of the backend. During this delay health checks will be set to failing, allowing traffic to drain (defaults to 0 seconds).
     # Supported formats:
     # - A string in the format of '1d', '2 seconds' etc. as supported by the `ms` library.
     # - A standard ISO formatted duration string, e.g. 'P2DT6H' or 'PT1M'.
     # - An object with individual units (in plural) as keys, e.g. `{ days: 2, hours: 6 }`.
-    shutdownRequestPauseTimeout: { seconds: 20 }
+    serverShutdownTimeout: { seconds: 20 }
 ```
 
 ### Via Code

--- a/docs/backend-system/core-services/root-http-router.md
+++ b/docs/backend-system/core-services/root-http-router.md
@@ -42,6 +42,21 @@ createBackendPlugin({
 
 ## Configuring the service
 
+### Via `app-config.yaml`
+
+The `app-config.yaml` file provides configurable options that can be adjusted to meet your `RootHttpRouterService` specific requirements:
+
+```yaml
+backend:
+  lifecycle:
+    # (Optional) The maximum time that paused requests will wait for the service to start, before returning an error (defaults to 5 seconds).
+    startupRequestPauseTimeout: { seconds: 10 }
+    # (Optional) The maximum time that the server will wait for stop accepting traffic, before returning an error (defaults to 30 seconds).
+    shutdownRequestPauseTimeout: { seconds: 20 }
+```
+
+### Via Code
+
 There's additional options that you can pass to configure the root HTTP Router service. These options are passed when you call `createBackend`.
 
 - `indexPath` - optional path to forward all unmatched requests to. Defaults to `/api/app` which is the `app-backend` plugin responsible for serving the frontend application through the backend.

--- a/packages/backend-app-api/src/wiring/BackendInitializer.ts
+++ b/packages/backend-app-api/src/wiring/BackendInitializer.ts
@@ -452,7 +452,7 @@ export class BackendInitializer {
     const rootLifecycleService = await this.#getRootLifecycleImpl();
 
     // Root services like the health one need to immediatelly be notified of the shutdown
-    await rootLifecycleService.preShutdown();
+    await rootLifecycleService.beforeShutdown();
 
     // Get all plugins.
     const allPlugins = new Set<string>();
@@ -480,7 +480,7 @@ export class BackendInitializer {
   async #getRootLifecycleImpl(): Promise<
     RootLifecycleService & {
       startup(): Promise<void>;
-      preShutdown(): Promise<void>;
+      beforeShutdown(): Promise<void>;
       shutdown(): Promise<void>;
     }
   > {

--- a/packages/backend-app-api/src/wiring/createSpecializedBackend.test.ts
+++ b/packages/backend-app-api/src/wiring/createSpecializedBackend.test.ts
@@ -36,6 +36,7 @@ describe('createSpecializedBackend', () => {
             deps: {},
             factory: async () => ({
               addStartupHook: () => {},
+              addBeforeShutdownHook: () => {},
               addShutdownHook: () => {},
             }),
           }),
@@ -44,6 +45,7 @@ describe('createSpecializedBackend', () => {
             deps: {},
             factory: async () => ({
               addStartupHook: () => {},
+              addBeforeShutdownHook: () => {},
               addShutdownHook: () => {},
             }),
           }),

--- a/packages/backend-defaults/config.d.ts
+++ b/packages/backend-defaults/config.d.ts
@@ -28,6 +28,19 @@ export interface Config {
      */
     baseUrl: string;
 
+    lifecycle?: {
+      /**
+       * The maximum time that paused requests will wait for the service to start, before returning an error.
+       * Defaults to 5 seconds.
+       */
+      startupRequestPauseTimeout?: HumanDuration;
+      /**
+       * The maximum time that the server will wait for stop accepting traffic, before returning an error.
+       * Defaults to 30 seconds.
+       */
+      shutdownRequestPauseTimeout?: HumanDuration;
+    };
+
     /** Address that the backend should listen to. */
     listen?:
       | string

--- a/packages/backend-defaults/config.d.ts
+++ b/packages/backend-defaults/config.d.ts
@@ -31,14 +31,16 @@ export interface Config {
     lifecycle?: {
       /**
        * The maximum time that paused requests will wait for the service to start, before returning an error.
+       * If you pass a number or string, it will be interpreted as milliseconds.
        * Defaults to 5 seconds.
        */
-      startupRequestPauseTimeout?: HumanDuration;
+      startupRequestPauseTimeout?: number | string | HumanDuration;
       /**
        * The maximum time that the server will wait for stop accepting traffic, before returning an error.
+       * If you pass a number or string, it will be interpreted as milliseconds.
        * Defaults to 30 seconds.
        */
-      shutdownRequestPauseTimeout?: HumanDuration;
+      shutdownRequestDelayTimeout?: number | string | HumanDuration;
     };
 
     /** Address that the backend should listen to. */

--- a/packages/backend-defaults/config.d.ts
+++ b/packages/backend-defaults/config.d.ts
@@ -40,8 +40,8 @@ export interface Config {
        */
       startupRequestPauseTimeout?: string | HumanDuration;
       /**
-       * The maximum time that the server will wait for stop accepting traffic, before returning an error.
-       * Defaults to 30 seconds.
+       * The minimum time that the HTTP server will delay the shutdown of the backend. During this delay health checks will be set to failing, allowing traffic to drain.
+       * Defaults to 0 seconds.
        * Supported formats:
        * - A string in the format of '1d', '2 seconds' etc. as supported by the `ms`
        *   library.

--- a/packages/backend-defaults/config.d.ts
+++ b/packages/backend-defaults/config.d.ts
@@ -31,16 +31,24 @@ export interface Config {
     lifecycle?: {
       /**
        * The maximum time that paused requests will wait for the service to start, before returning an error.
-       * If you pass a number or string, it will be interpreted as milliseconds.
-       * Defaults to 5 seconds.
+       * Defaults to 5 seconds
+       * Supported formats:
+       * - A string in the format of '1d', '2 seconds' etc. as supported by the `ms`
+       *   library.
+       * - A standard ISO formatted duration string, e.g. 'P2DT6H' or 'PT1M'.
+       * - An object with individual units (in plural) as keys, e.g. `{ days: 2, hours: 6 }`.
        */
-      startupRequestPauseTimeout?: number | string | HumanDuration;
+      startupRequestPauseTimeout?: string | HumanDuration;
       /**
        * The maximum time that the server will wait for stop accepting traffic, before returning an error.
-       * If you pass a number or string, it will be interpreted as milliseconds.
        * Defaults to 30 seconds.
+       * Supported formats:
+       * - A string in the format of '1d', '2 seconds' etc. as supported by the `ms`
+       *   library.
+       * - A standard ISO formatted duration string, e.g. 'P2DT6H' or 'PT1M'.
+       * - An object with individual units (in plural) as keys, e.g. `{ days: 2, hours: 6 }`.
        */
-      shutdownRequestDelayTimeout?: number | string | HumanDuration;
+      serverShutdownDelay?: string | HumanDuration;
     };
 
     /** Address that the backend should listen to. */

--- a/packages/backend-defaults/package.json
+++ b/packages/backend-defaults/package.json
@@ -175,7 +175,6 @@
     "pg-format": "^1.0.4",
     "raw-body": "^2.4.1",
     "selfsigned": "^2.0.0",
-    "stoppable": "^1.1.0",
     "tar": "^6.1.12",
     "triple-beam": "^1.4.1",
     "uuid": "^11.0.0",

--- a/packages/backend-defaults/report-rootHttpRouter.api.md
+++ b/packages/backend-defaults/report-rootHttpRouter.api.md
@@ -134,6 +134,8 @@ export interface RootHttpRouterConfigureContext {
   // (undocumented)
   lifecycle: LifecycleService;
   // (undocumented)
+  lifecycleMiddleware: RequestHandler;
+  // (undocumented)
   logger: LoggerService;
   // (undocumented)
   middleware: MiddlewareFactory;

--- a/packages/backend-defaults/src/CreateBackend.test.ts
+++ b/packages/backend-defaults/src/CreateBackend.test.ts
@@ -47,6 +47,7 @@ describe('createBackend', () => {
         deps: {},
         factory: async () => ({
           addStartupHook: () => {},
+          addBeforeShutdownHook: () => {},
           addShutdownHook: () => {},
         }),
       }),
@@ -57,6 +58,7 @@ describe('createBackend', () => {
         deps: {},
         factory: async () => ({
           addStartupHook: () => {},
+          addBeforeShutdownHook: () => {},
           addShutdownHook: () => {},
         }),
       }),

--- a/packages/backend-defaults/src/entrypoints/httpRouter/httpRouterServiceFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/httpRouter/httpRouterServiceFactory.ts
@@ -22,7 +22,6 @@ import {
   HttpRouterServiceAuthPolicy,
 } from '@backstage/backend-plugin-api';
 import {
-  createLifecycleMiddleware,
   createCookieAuthRefreshMiddleware,
   createCredentialsBarrier,
   createAuthIntegrationRouter,
@@ -43,12 +42,11 @@ export const httpRouterServiceFactory = createServiceFactory({
   deps: {
     plugin: coreServices.pluginMetadata,
     config: coreServices.rootConfig,
-    lifecycle: coreServices.lifecycle,
     rootHttpRouter: coreServices.rootHttpRouter,
     auth: coreServices.auth,
     httpAuth: coreServices.httpAuth,
   },
-  async factory({ auth, httpAuth, config, plugin, rootHttpRouter, lifecycle }) {
+  async factory({ auth, httpAuth, config, plugin, rootHttpRouter }) {
     const router = PromiseRouter();
 
     rootHttpRouter.use(`/api/${plugin.getId()}`, router);
@@ -59,7 +57,6 @@ export const httpRouterServiceFactory = createServiceFactory({
     });
 
     router.use(createAuthIntegrationRouter({ auth }));
-    router.use(createLifecycleMiddleware({ lifecycle }));
     router.use(credentialsBarrier.middleware);
     router.use(createCookieAuthRefreshMiddleware({ auth, httpAuth }));
 

--- a/packages/backend-defaults/src/entrypoints/rootHealth/rootHealthServiceFactory.test.ts
+++ b/packages/backend-defaults/src/entrypoints/rootHealth/rootHealthServiceFactory.test.ts
@@ -51,31 +51,13 @@ describe('DefaultRootHealthService', () => {
       });
     });
 
-    it(`should return a 503 response if the server is stopping`, async () => {
-      const service = new DefaultRootHealthService({
-        lifecycle: mockServices.rootLifecycle.mock(),
-      });
-
-      process.exitCode = 1;
-
-      await expect(service.getReadiness()).resolves.toEqual({
-        status: 503,
-        payload: {
-          message: 'Backend has not started yet',
-          status: 'error',
-        },
-      });
-
-      process.exitCode = undefined; // Reset exitCode for other tests
-    });
-
     it(`should return a 500 response if the server has stopped`, async () => {
       let mockServerStartedFn = () => {};
-      let mockServerStoppedFn = () => {};
+      let mockServerBeforeStoppedFn = () => {};
 
       const lifecycle = mockServices.rootLifecycle.mock({
         addStartupHook: jest.fn(fn => (mockServerStartedFn = fn)),
-        addShutdownHook: jest.fn(fn => (mockServerStoppedFn = fn)),
+        addBeforeShutdownHook: jest.fn(fn => (mockServerBeforeStoppedFn = fn)),
       });
 
       const service = new DefaultRootHealthService({
@@ -83,7 +65,7 @@ describe('DefaultRootHealthService', () => {
       });
 
       mockServerStartedFn();
-      mockServerStoppedFn();
+      mockServerBeforeStoppedFn();
       await expect(service.getReadiness()).resolves.toEqual({
         status: 503,
         payload: {

--- a/packages/backend-defaults/src/entrypoints/rootHealth/rootHealthServiceFactory.test.ts
+++ b/packages/backend-defaults/src/entrypoints/rootHealth/rootHealthServiceFactory.test.ts
@@ -69,7 +69,7 @@ describe('DefaultRootHealthService', () => {
       await expect(service.getReadiness()).resolves.toEqual({
         status: 503,
         payload: {
-          message: 'Backend has not started yet',
+          message: 'Backend is shuttting down',
           status: 'error',
         },
       });

--- a/packages/backend-defaults/src/entrypoints/rootHealth/rootHealthServiceFactory.test.ts
+++ b/packages/backend-defaults/src/entrypoints/rootHealth/rootHealthServiceFactory.test.ts
@@ -51,6 +51,24 @@ describe('DefaultRootHealthService', () => {
       });
     });
 
+    it(`should return a 503 response if the server is stopping`, async () => {
+      const service = new DefaultRootHealthService({
+        lifecycle: mockServices.rootLifecycle.mock(),
+      });
+
+      process.exitCode = 1;
+
+      await expect(service.getReadiness()).resolves.toEqual({
+        status: 503,
+        payload: {
+          message: 'Backend has not started yet',
+          status: 'error',
+        },
+      });
+
+      process.exitCode = undefined; // Reset exitCode for other tests
+    });
+
     it(`should return a 500 response if the server has stopped`, async () => {
       let mockServerStartedFn = () => {};
       let mockServerStoppedFn = () => {};

--- a/packages/backend-defaults/src/entrypoints/rootHealth/rootHealthServiceFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/rootHealth/rootHealthServiceFactory.ts
@@ -29,7 +29,7 @@ export class DefaultRootHealthService implements RootHealthService {
     options.lifecycle.addStartupHook(() => {
       this.#isRunning = true;
     });
-    options.lifecycle.addPreShutdownHook(() => {
+    options.lifecycle.addBeforeShutdownHook(() => {
       this.#isRunning = false;
     });
   }

--- a/packages/backend-defaults/src/entrypoints/rootHealth/rootHealthServiceFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/rootHealth/rootHealthServiceFactory.ts
@@ -39,7 +39,8 @@ export class DefaultRootHealthService implements RootHealthService {
   }
 
   async getReadiness(): Promise<{ status: number; payload?: any }> {
-    if (!this.#isRunning) {
+    // If the process has been told to exit, or if the backend has not started yet
+    if (process.exitCode !== undefined || !this.#isRunning) {
       return {
         status: 503,
         payload: { message: 'Backend has not started yet', status: 'error' },

--- a/packages/backend-defaults/src/entrypoints/rootHealth/rootHealthServiceFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/rootHealth/rootHealthServiceFactory.ts
@@ -23,14 +23,14 @@ import {
 
 /** @internal */
 export class DefaultRootHealthService implements RootHealthService {
-  #isRunning = false;
+  #state: 'init' | 'up' | 'down' = 'init';
 
   constructor(readonly options: { lifecycle: RootLifecycleService }) {
     options.lifecycle.addStartupHook(() => {
-      this.#isRunning = true;
+      this.#state = 'up';
     });
     options.lifecycle.addBeforeShutdownHook(() => {
-      this.#isRunning = false;
+      this.#state = 'down';
     });
   }
 
@@ -39,10 +39,16 @@ export class DefaultRootHealthService implements RootHealthService {
   }
 
   async getReadiness(): Promise<{ status: number; payload?: any }> {
-    if (!this.#isRunning) {
+    if (this.#state === 'init') {
       return {
         status: 503,
         payload: { message: 'Backend has not started yet', status: 'error' },
+      };
+    }
+    if (this.#state === 'down') {
+      return {
+        status: 503,
+        payload: { message: 'Backend is shuttting down', status: 'error' },
       };
     }
 

--- a/packages/backend-defaults/src/entrypoints/rootHealth/rootHealthServiceFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/rootHealth/rootHealthServiceFactory.ts
@@ -29,7 +29,7 @@ export class DefaultRootHealthService implements RootHealthService {
     options.lifecycle.addStartupHook(() => {
       this.#isRunning = true;
     });
-    options.lifecycle.addShutdownHook(() => {
+    options.lifecycle.addPreShutdownHook(() => {
       this.#isRunning = false;
     });
   }
@@ -39,8 +39,7 @@ export class DefaultRootHealthService implements RootHealthService {
   }
 
   async getReadiness(): Promise<{ status: number; payload?: any }> {
-    // If the process has been told to exit, or if the backend has not started yet
-    if (process.exitCode !== undefined || !this.#isRunning) {
+    if (!this.#isRunning) {
       return {
         status: 503,
         payload: { message: 'Backend has not started yet', status: 'error' },

--- a/packages/backend-defaults/src/entrypoints/rootHttpRouter/createLifecycleMiddleware.test.ts
+++ b/packages/backend-defaults/src/entrypoints/rootHttpRouter/createLifecycleMiddleware.test.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createLifecycleMiddleware } from './createLifecycleMiddleware';
+import { BackendLifecycleImpl } from '../rootLifecycle/rootLifecycleServiceFactory';
+import { mockServices } from '@backstage/backend-test-utils';
+import { ServiceUnavailableError } from '@backstage/errors';
+
+describe('createLifecycleMiddleware', () => {
+  it('should pause requests when plugin is not ready', async () => {
+    const lifecycle = new BackendLifecycleImpl(mockServices.rootLogger());
+
+    const middleware = createLifecycleMiddleware({ lifecycle });
+
+    const next = jest.fn();
+    middleware({} as any, {} as any, next);
+    expect(next).not.toHaveBeenCalled();
+    await lifecycle.startup();
+
+    // pending call
+    expect(next).toHaveBeenCalledWith();
+
+    // new call
+    const next2 = jest.fn();
+    middleware({} as any, {} as any, next2);
+    expect(next2).toHaveBeenCalledWith();
+  });
+
+  it('should throw ServiceUnavailableError after shutdown', async () => {
+    const lifecycle = new BackendLifecycleImpl(mockServices.rootLogger());
+    const middleware = createLifecycleMiddleware({ lifecycle });
+
+    const next = jest.fn();
+    middleware({} as any, {} as any, next);
+    expect(next).not.toHaveBeenCalled();
+    await lifecycle.shutdown();
+
+    // pending call
+    expect(next).toHaveBeenCalledWith(
+      new ServiceUnavailableError('Service is shutting down'),
+    );
+
+    // new call
+    const next2 = jest.fn();
+    middleware({} as any, {} as any, next2);
+    expect(next2).toHaveBeenCalledWith(
+      new ServiceUnavailableError('Service is shutting down'),
+    );
+  });
+
+  it('should throw ServiceUnavailableError after timeout', async () => {
+    const lifecycle = new BackendLifecycleImpl(mockServices.rootLogger());
+    const middleware = createLifecycleMiddleware({
+      lifecycle,
+      startupRequestPauseTimeout: { milliseconds: 1 },
+    });
+
+    const next = jest.fn();
+    middleware({} as any, {} as any, next);
+    expect(next).not.toHaveBeenCalled();
+
+    await new Promise(r => setTimeout(r, 2));
+
+    expect(next).toHaveBeenCalledWith(
+      new ServiceUnavailableError('Service has not started up yet'),
+    );
+  });
+
+  it('should delay service shutdown for the default timeout duration', async () => {
+    jest.useFakeTimers();
+    const defaultTimeout = 30000;
+    const lifecycle = new BackendLifecycleImpl(mockServices.rootLogger());
+    createLifecycleMiddleware({ lifecycle });
+    const beforeShutdownPromise = lifecycle.beforeShutdown().then(() => {
+      jest.useRealTimers();
+    });
+    jest.advanceTimersByTime(defaultTimeout);
+    return expect(beforeShutdownPromise).resolves.toBeUndefined();
+  });
+
+  it('should delay service shutdown for the configured timeout duration', async () => {
+    jest.useFakeTimers();
+    const configuredTimeout = 20000;
+    const lifecycle = new BackendLifecycleImpl(mockServices.rootLogger());
+    createLifecycleMiddleware({
+      lifecycle,
+      shutdownRequestPauseTimeout: { milliseconds: configuredTimeout },
+    });
+    const beforeShutdownPromise = lifecycle.beforeShutdown().then(() => {
+      jest.useRealTimers();
+    });
+    jest.advanceTimersByTime(configuredTimeout);
+    return expect(beforeShutdownPromise).resolves.toBeUndefined();
+  });
+});

--- a/packages/backend-defaults/src/entrypoints/rootHttpRouter/createLifecycleMiddleware.test.ts
+++ b/packages/backend-defaults/src/entrypoints/rootHttpRouter/createLifecycleMiddleware.test.ts
@@ -97,7 +97,7 @@ describe('createLifecycleMiddleware', () => {
     const lifecycle = new BackendLifecycleImpl(mockServices.rootLogger());
     createLifecycleMiddleware({
       lifecycle,
-      shutdownRequestPauseTimeout: { milliseconds: configuredTimeout },
+      shutdownRequestDelayTimeout: { milliseconds: configuredTimeout },
     });
     const beforeShutdownPromise = lifecycle.beforeShutdown().then(() => {
       jest.useRealTimers();

--- a/packages/backend-defaults/src/entrypoints/rootHttpRouter/createLifecycleMiddleware.test.ts
+++ b/packages/backend-defaults/src/entrypoints/rootHttpRouter/createLifecycleMiddleware.test.ts
@@ -91,13 +91,13 @@ describe('createLifecycleMiddleware', () => {
     return expect(beforeShutdownPromise).resolves.toBeUndefined();
   });
 
-  it('should delay service shutdown for the configured timeout duration', async () => {
+  it('should delay service shutdown for the configured timeout duration - time in human duration', async () => {
     jest.useFakeTimers();
     const configuredTimeout = 20000;
     const lifecycle = new BackendLifecycleImpl(mockServices.rootLogger());
     createLifecycleMiddleware({
       lifecycle,
-      shutdownRequestDelayTimeout: { milliseconds: configuredTimeout },
+      serverShutdownDelay: { milliseconds: configuredTimeout },
     });
     const beforeShutdownPromise = lifecycle.beforeShutdown().then(() => {
       jest.useRealTimers();

--- a/packages/backend-defaults/src/entrypoints/rootHttpRouter/createLifecycleMiddleware.ts
+++ b/packages/backend-defaults/src/entrypoints/rootHttpRouter/createLifecycleMiddleware.ts
@@ -20,7 +20,7 @@ import { HumanDuration, durationToMilliseconds } from '@backstage/types';
 import { RequestHandler } from 'express';
 
 export const DEFAULT_STARTUP_REQUEST_PAUSE_TIMEOUT = { seconds: 5 };
-export const DEFAULT_SHUTDOWN_REQUEST_DELAY_TIMEOUT = { seconds: 30 };
+export const DEFAULT_SERVER_SHUTDOWN_TIMEOUT = { seconds: 30 };
 
 /**
  * Options for {@link createLifecycleMiddleware}.
@@ -39,7 +39,7 @@ export interface LifecycleMiddlewareOptions {
    *
    * Defaults to 30 seconds.
    */
-  shutdownRequestDelayTimeout?: HumanDuration;
+  serverShutdownDelay?: HumanDuration;
 }
 
 /**
@@ -59,7 +59,7 @@ export interface LifecycleMiddlewareOptions {
 export function createLifecycleMiddleware(
   options: LifecycleMiddlewareOptions,
 ): RequestHandler {
-  const { lifecycle, startupRequestPauseTimeout, shutdownRequestDelayTimeout } =
+  const { lifecycle, startupRequestPauseTimeout, serverShutdownDelay } =
     options;
 
   let state: 'init' | 'up' | 'down' = 'init';
@@ -81,7 +81,7 @@ export function createLifecycleMiddleware(
 
   lifecycle.addBeforeShutdownHook(async () => {
     const timeoutMs = durationToMilliseconds(
-      shutdownRequestDelayTimeout ?? DEFAULT_SHUTDOWN_REQUEST_DELAY_TIMEOUT,
+      serverShutdownDelay ?? DEFAULT_SERVER_SHUTDOWN_TIMEOUT,
     );
     return await new Promise(resolve => {
       setTimeout(resolve, timeoutMs);

--- a/packages/backend-defaults/src/entrypoints/rootHttpRouter/createLifecycleMiddleware.ts
+++ b/packages/backend-defaults/src/entrypoints/rootHttpRouter/createLifecycleMiddleware.ts
@@ -20,7 +20,7 @@ import { HumanDuration, durationToMilliseconds } from '@backstage/types';
 import { RequestHandler } from 'express';
 
 export const DEFAULT_STARTUP_REQUEST_PAUSE_TIMEOUT = { seconds: 5 };
-export const DEFAULT_SHUTDOWN_REQUEST_PAUSE_TIMEOUT = { seconds: 30 };
+export const DEFAULT_SHUTDOWN_REQUEST_DELAY_TIMEOUT = { seconds: 30 };
 
 /**
  * Options for {@link createLifecycleMiddleware}.
@@ -39,7 +39,7 @@ export interface LifecycleMiddlewareOptions {
    *
    * Defaults to 30 seconds.
    */
-  shutdownRequestPauseTimeout?: HumanDuration;
+  shutdownRequestDelayTimeout?: HumanDuration;
 }
 
 /**
@@ -59,7 +59,7 @@ export interface LifecycleMiddlewareOptions {
 export function createLifecycleMiddleware(
   options: LifecycleMiddlewareOptions,
 ): RequestHandler {
-  const { lifecycle, startupRequestPauseTimeout, shutdownRequestPauseTimeout } =
+  const { lifecycle, startupRequestPauseTimeout, shutdownRequestDelayTimeout } =
     options;
 
   let state: 'init' | 'up' | 'down' = 'init';
@@ -81,7 +81,7 @@ export function createLifecycleMiddleware(
 
   lifecycle.addBeforeShutdownHook(async () => {
     const timeoutMs = durationToMilliseconds(
-      shutdownRequestPauseTimeout ?? DEFAULT_SHUTDOWN_REQUEST_PAUSE_TIMEOUT,
+      shutdownRequestDelayTimeout ?? DEFAULT_SHUTDOWN_REQUEST_DELAY_TIMEOUT,
     );
     return await new Promise(resolve => {
       setTimeout(resolve, timeoutMs);

--- a/packages/backend-defaults/src/entrypoints/rootHttpRouter/createLifecycleMiddleware.ts
+++ b/packages/backend-defaults/src/entrypoints/rootHttpRouter/createLifecycleMiddleware.ts
@@ -20,7 +20,7 @@ import { HumanDuration, durationToMilliseconds } from '@backstage/types';
 import { RequestHandler } from 'express';
 
 export const DEFAULT_STARTUP_REQUEST_PAUSE_TIMEOUT = { seconds: 5 };
-export const DEFAULT_SERVER_SHUTDOWN_TIMEOUT = { seconds: 30 };
+export const DEFAULT_SERVER_SHUTDOWN_TIMEOUT = { seconds: 0 };
 
 /**
  * Options for {@link createLifecycleMiddleware}.
@@ -37,7 +37,7 @@ export interface LifecycleMiddlewareOptions {
   /**
    * The maximum time that the server will wait for stop accepting traffic, before returning an error.
    *
-   * Defaults to 30 seconds.
+   * Defaults to 0 seconds.
    */
   serverShutdownDelay?: HumanDuration;
 }

--- a/packages/backend-defaults/src/entrypoints/rootHttpRouter/createLifecycleMiddleware.ts
+++ b/packages/backend-defaults/src/entrypoints/rootHttpRouter/createLifecycleMiddleware.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RootLifecycleService } from '@backstage/backend-plugin-api';
+import { ServiceUnavailableError } from '@backstage/errors';
+import { HumanDuration, durationToMilliseconds } from '@backstage/types';
+import { RequestHandler } from 'express';
+
+export const DEFAULT_STARTUP_REQUEST_PAUSE_TIMEOUT = { seconds: 5 };
+export const DEFAULT_SHUTDOWN_REQUEST_PAUSE_TIMEOUT = { seconds: 30 };
+
+/**
+ * Options for {@link createLifecycleMiddleware}.
+ * @public
+ */
+export interface LifecycleMiddlewareOptions {
+  lifecycle: RootLifecycleService;
+  /**
+   * The maximum time that paused requests will wait for the service to start, before returning an error.
+   *
+   * Defaults to 5 seconds.
+   */
+  startupRequestPauseTimeout?: HumanDuration;
+  /**
+   * The maximum time that the server will wait for stop accepting traffic, before returning an error.
+   *
+   * Defaults to 30 seconds.
+   */
+  shutdownRequestPauseTimeout?: HumanDuration;
+}
+
+/**
+ * Creates a middleware that pauses requests until the service has started.
+ *
+ * @remarks
+ *
+ * Requests that arrive before the service has started will be paused until startup is complete.
+ * If the service does not start within the provided timeout, the request will be rejected with a
+ * {@link @backstage/errors#ServiceUnavailableError}.
+ *
+ * If the service is shutting down, all requests will be rejected with a
+ * {@link @backstage/errors#ServiceUnavailableError}.
+ *
+ * @public
+ */
+export function createLifecycleMiddleware(
+  options: LifecycleMiddlewareOptions,
+): RequestHandler {
+  const { lifecycle, startupRequestPauseTimeout, shutdownRequestPauseTimeout } =
+    options;
+
+  let state: 'init' | 'up' | 'down' = 'init';
+  const waiting = new Set<{
+    next: (err?: Error) => void;
+    timeout: NodeJS.Timeout;
+  }>();
+
+  lifecycle.addStartupHook(async () => {
+    if (state === 'init') {
+      state = 'up';
+      for (const item of waiting) {
+        clearTimeout(item.timeout);
+        item.next();
+      }
+      waiting.clear();
+    }
+  });
+
+  lifecycle.addBeforeShutdownHook(async () => {
+    const timeoutMs = durationToMilliseconds(
+      shutdownRequestPauseTimeout ?? DEFAULT_SHUTDOWN_REQUEST_PAUSE_TIMEOUT,
+    );
+    return await new Promise(resolve => {
+      setTimeout(resolve, timeoutMs);
+    });
+  });
+
+  lifecycle.addShutdownHook(async () => {
+    state = 'down';
+    for (const item of waiting) {
+      clearTimeout(item.timeout);
+      item.next(new ServiceUnavailableError('Service is shutting down'));
+    }
+    waiting.clear();
+  });
+
+  return (_req, _res, next) => {
+    if (state === 'up') {
+      next();
+      return;
+    } else if (state === 'down') {
+      next(new ServiceUnavailableError('Service is shutting down'));
+      return;
+    }
+
+    const timeoutMs = durationToMilliseconds(
+      startupRequestPauseTimeout ?? DEFAULT_STARTUP_REQUEST_PAUSE_TIMEOUT,
+    );
+
+    const item = {
+      next,
+      timeout: setTimeout(() => {
+        if (waiting.delete(item)) {
+          next(new ServiceUnavailableError('Service has not started up yet'));
+        }
+      }, timeoutMs),
+    };
+
+    waiting.add(item);
+  };
+}

--- a/packages/backend-defaults/src/entrypoints/rootHttpRouter/http/createHttpServer.ts
+++ b/packages/backend-defaults/src/entrypoints/rootHttpRouter/http/createHttpServer.ts
@@ -16,7 +16,6 @@
 
 import * as http from 'http';
 import * as https from 'https';
-import stoppableServer from 'stoppable';
 import { RequestListener } from 'http';
 import { LoggerService } from '@backstage/backend-plugin-api';
 import { HttpServerOptions, ExtendedHttpServer } from './types';
@@ -33,13 +32,6 @@ export async function createHttpServer(
   deps: { logger: LoggerService },
 ): Promise<ExtendedHttpServer> {
   const server = await createServer(listener, options, deps);
-
-  const stopper = stoppableServer(server, 0);
-  // The stopper here is actually the server itself, so if we try
-  // to call stopper.stop() down in the stop implementation, we'll
-  // be calling ourselves.
-  const stopServer = stopper.stop.bind(stopper);
-
   return Object.assign(server, {
     start() {
       return new Promise<void>((resolve, reject) => {
@@ -61,7 +53,7 @@ export async function createHttpServer(
 
     stop() {
       return new Promise<void>((resolve, reject) => {
-        stopServer((error?: Error) => {
+        server.close(error => {
           if (error) {
             reject(error);
           } else {

--- a/packages/backend-defaults/src/entrypoints/rootHttpRouter/rootHttpRouterServiceFactory.test.ts
+++ b/packages/backend-defaults/src/entrypoints/rootHttpRouter/rootHttpRouterServiceFactory.test.ts
@@ -21,7 +21,12 @@ import {
 import { Express } from 'express';
 import request from 'supertest';
 import { rootHttpRouterServiceFactory } from './rootHttpRouterServiceFactory';
-import { ServiceFactory, coreServices } from '@backstage/backend-plugin-api';
+import {
+  ServiceFactory,
+  coreServices,
+  createServiceFactory,
+} from '@backstage/backend-plugin-api';
+import { BackendLifecycleImpl } from '../rootLifecycle/rootLifecycleServiceFactory';
 
 async function createExpressApp(...dependencies: ServiceFactory[]) {
   let app: Express | undefined = undefined;
@@ -197,5 +202,72 @@ describe('rootHttpRouterServiceFactory', () => {
     ).rejects.toThrow(
       'Invalid header value in at backend.health.headers, must be a non-empty string',
     );
+  });
+
+  it('should wait the server shutdown', async () => {
+    jest.useFakeTimers();
+
+    let app: Express | undefined = undefined;
+    const lifecycleMock = new BackendLifecycleImpl(mockServices.rootLogger());
+
+    const tester = ServiceFactoryTester.from(
+      rootHttpRouterServiceFactory({
+        configure(options) {
+          console.log('configure');
+          options.app.use(options.lifecycleMiddleware);
+          options.app.get('/test', (_req, res) => {
+            res.status(200).send({ status: 'ok' }).end();
+          });
+          app = options.app;
+        },
+      }),
+      {
+        dependencies: [
+          mockServices.rootConfig.factory({
+            data: {
+              app: { baseUrl: 'http://localhost' },
+              backend: {
+                baseUrl: 'http://localhost',
+                listen: { host: '', port: 0 },
+              },
+            },
+          }),
+          createServiceFactory({
+            service: coreServices.rootLifecycle,
+            deps: {},
+            factory() {
+              return lifecycleMock;
+            },
+          }),
+        ],
+      },
+    );
+
+    await tester.getSubject();
+
+    // Trigger creation of the http service, accessing the app instance through the configure callback
+    const lifecycle = await tester.getService(coreServices.rootLifecycle);
+
+    await (lifecycle as any).startup(); // Trigger startup by calling the private startup method
+
+    await request(app!).get('/test').expect(200, {
+      status: 'ok',
+    });
+
+    const beforeShutdownPromise = (lifecycle as any)
+      .beforeShutdown()
+      .then(() => {
+        return (lifecycle as any).shutdown();
+      });
+
+    await request(app!).get('/test').expect(200, {
+      status: 'ok',
+    });
+
+    jest.advanceTimersByTime(30000);
+
+    await request(app!).get('/test').expect(500, {});
+
+    return await expect(beforeShutdownPromise).resolves.toBeUndefined();
   });
 });

--- a/packages/backend-defaults/src/entrypoints/rootHttpRouter/rootHttpRouterServiceFactory.test.ts
+++ b/packages/backend-defaults/src/entrypoints/rootHttpRouter/rootHttpRouterServiceFactory.test.ts
@@ -20,55 +20,13 @@ import {
 } from '@backstage/backend-test-utils';
 import { Express } from 'express';
 import request from 'supertest';
-import {
-  getConfigInHumanDuration,
-  rootHttpRouterServiceFactory,
-} from './rootHttpRouterServiceFactory';
+import { rootHttpRouterServiceFactory } from './rootHttpRouterServiceFactory';
 import {
   ServiceFactory,
   coreServices,
   createServiceFactory,
 } from '@backstage/backend-plugin-api';
 import { BackendLifecycleImpl } from '../rootLifecycle/rootLifecycleServiceFactory';
-import { ConfigReader } from '@backstage/config';
-
-describe('getConfigInHumanDuration', () => {
-  const values = ['20000', 20000, { milliseconds: 20000 }];
-
-  it.each(values)(
-    'should parse the lifecycle startup request timeout from a %s config value',
-    async value => {
-      const key = 'backend.lifecycle.startupRequestPauseTimeout';
-      const config = new ConfigReader({
-        backend: {
-          lifecycle: {
-            startupRequestPauseTimeout: value,
-          },
-        },
-      });
-      expect(getConfigInHumanDuration(config, key)).toMatchObject({
-        milliseconds: 20000,
-      });
-    },
-  );
-
-  it.each(values)(
-    'should parse the lifecycle shutdown delay timeout from a %s config value',
-    async value => {
-      const key = 'backend.lifecycle.shutdownRequestDelayTimeout';
-      const config = new ConfigReader({
-        backend: {
-          lifecycle: {
-            shutdownRequestDelayTimeout: value,
-          },
-        },
-      });
-      expect(getConfigInHumanDuration(config, key)).toMatchObject({
-        milliseconds: 20000,
-      });
-    },
-  );
-});
 
 async function createExpressApp(...dependencies: ServiceFactory[]) {
   let app: Express | undefined = undefined;

--- a/packages/backend-defaults/src/entrypoints/rootHttpRouter/rootHttpRouterServiceFactory.test.ts
+++ b/packages/backend-defaults/src/entrypoints/rootHttpRouter/rootHttpRouterServiceFactory.test.ts
@@ -231,6 +231,9 @@ describe('rootHttpRouterServiceFactory', () => {
               backend: {
                 baseUrl: 'http://localhost',
                 listen: { host: '', port: 0 },
+                lifecycle: {
+                  serverShutdownDelay: '30s',
+                },
               },
             },
           }),
@@ -281,7 +284,7 @@ describe('rootHttpRouterServiceFactory', () => {
 
     // Immediately start failing the readiness health check
     await request(app).get('/.backstage/health/v1/readiness').expect(503, {
-      message: 'Backend has not started yet',
+      message: 'Backend is shuttting down',
       status: 'error',
     });
 
@@ -297,7 +300,7 @@ describe('rootHttpRouterServiceFactory', () => {
       .expect(200, { status: 'ok' });
 
     await request(app).get('/.backstage/health/v1/readiness').expect(503, {
-      message: 'Backend has not started yet',
+      message: 'Backend is shuttting down',
       status: 'error',
     });
 
@@ -320,7 +323,7 @@ describe('rootHttpRouterServiceFactory', () => {
       .expect(200, { status: 'ok' });
 
     await request(app).get('/.backstage/health/v1/readiness').expect(503, {
-      message: 'Backend has not started yet',
+      message: 'Backend is shuttting down',
       status: 'error',
     });
 

--- a/packages/backend-defaults/src/entrypoints/rootHttpRouter/rootHttpRouterServiceFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/rootHttpRouter/rootHttpRouterServiceFactory.ts
@@ -120,7 +120,7 @@ const rootHttpRouterServiceFactoryWithOptions = (
         },
       });
 
-      lifecycle.addShutdownHook(() => server.stop());
+      lifecycle.addPreShutdownHook(() => server.stop());
 
       await server.start();
 

--- a/packages/backend-defaults/src/entrypoints/rootHttpRouter/rootHttpRouterServiceFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/rootHttpRouter/rootHttpRouterServiceFactory.ts
@@ -120,7 +120,7 @@ const rootHttpRouterServiceFactoryWithOptions = (
         },
       });
 
-      lifecycle.addPreShutdownHook(() => server.stop());
+      lifecycle.addBeforeShutdownHook(() => server.stop());
 
       await server.start();
 

--- a/packages/backend-defaults/src/entrypoints/rootLifecycle/rootLifecycleServiceFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/rootLifecycle/rootLifecycleServiceFactory.ts
@@ -66,7 +66,7 @@ export class BackendLifecycleImpl implements RootLifecycleService {
   }
 
   #hasBeforeShutdown = false;
-  #beforeShutdownTasks: Array<{ hook: () => void }> = [];
+  #beforeShutdownTasks: Array<{ hook: () => void | Promise<void> }> = [];
 
   addBeforeShutdownHook(hook: () => void): void {
     if (this.#hasBeforeShutdown) {

--- a/packages/backend-defaults/src/entrypoints/rootLifecycle/rootLifecycleServiceFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/rootLifecycle/rootLifecycleServiceFactory.ts
@@ -65,32 +65,34 @@ export class BackendLifecycleImpl implements RootLifecycleService {
     );
   }
 
-  #hasPreShutdown = false;
-  #preShutdownTasks: Array<{ hook: () => void }> = [];
+  #hasBeforeShutdown = false;
+  #beforeShutdownTasks: Array<{ hook: () => void }> = [];
 
-  addPreShutdownHook(hook: () => void): void {
-    if (this.#hasPreShutdown) {
-      throw new Error('Attempted to add pre shutdown hook after pre shutdown');
+  addBeforeShutdownHook(hook: () => void): void {
+    if (this.#hasBeforeShutdown) {
+      throw new Error(
+        'Attempt to add before shutdown hook after shutdown has started',
+      );
     }
-    this.#preShutdownTasks.push({ hook });
+    this.#beforeShutdownTasks.push({ hook });
   }
 
-  async preShutdown(): Promise<void> {
-    if (this.#hasPreShutdown) {
+  async beforeShutdown(): Promise<void> {
+    if (this.#hasBeforeShutdown) {
       return;
     }
-    this.#hasPreShutdown = true;
+    this.#hasBeforeShutdown = true;
 
     this.logger.debug(
-      `Running ${this.#preShutdownTasks.length} pre shutdown tasks...`,
+      `Running ${this.#beforeShutdownTasks.length} before shutdown tasks...`,
     );
     await Promise.all(
-      this.#preShutdownTasks.map(async ({ hook }) => {
+      this.#beforeShutdownTasks.map(async ({ hook }) => {
         try {
           await hook();
-          this.logger.debug(`Pre shutdown hook succeeded`);
+          this.logger.debug(`Before shutdown hook succeeded`);
         } catch (error) {
-          this.logger.error(`Pre shutdown hook failed, ${error}`);
+          this.logger.error(`Before shutdown hook failed, ${error}`);
         }
       }),
     );

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/PluginTaskSchedulerImpl.test.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/PluginTaskSchedulerImpl.test.ts
@@ -55,7 +55,11 @@ describe('PluginTaskManagerImpl', () => {
     const manager = new PluginTaskSchedulerImpl(
       async () => knex,
       mockServices.logger.mock(),
-      { addShutdownHook, addStartupHook: jest.fn() },
+      {
+        addShutdownHook,
+        addBeforeShutdownHook: jest.fn(),
+        addStartupHook: jest.fn(),
+      },
     );
     return { knex, manager };
   }

--- a/packages/backend-plugin-api/report.api.md
+++ b/packages/backend-plugin-api/report.api.md
@@ -507,7 +507,10 @@ export interface RootHttpRouterService {
 }
 
 // @public
-export interface RootLifecycleService extends LifecycleService {}
+export interface RootLifecycleService extends LifecycleService {
+  // (undocumented)
+  addBeforeShutdownHook(hook: () => void): void;
+}
 
 // @public
 export interface RootLoggerService extends LoggerService {}

--- a/packages/backend-plugin-api/report.api.md
+++ b/packages/backend-plugin-api/report.api.md
@@ -509,7 +509,7 @@ export interface RootHttpRouterService {
 // @public
 export interface RootLifecycleService extends LifecycleService {
   // (undocumented)
-  addBeforeShutdownHook(hook: () => void): void;
+  addBeforeShutdownHook(hook: () => void | Promise<void>): void;
 }
 
 // @public

--- a/packages/backend-plugin-api/src/services/definitions/RootLifecycleService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/RootLifecycleService.ts
@@ -23,4 +23,6 @@ import { LifecycleService } from './LifecycleService';
  *
  * @public
  */
-export interface RootLifecycleService extends LifecycleService {}
+export interface RootLifecycleService extends LifecycleService {
+  addPreShutdownHook(hook: () => void): void;
+}

--- a/packages/backend-plugin-api/src/services/definitions/RootLifecycleService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/RootLifecycleService.ts
@@ -24,5 +24,5 @@ import { LifecycleService } from './LifecycleService';
  * @public
  */
 export interface RootLifecycleService extends LifecycleService {
-  addBeforeShutdownHook(hook: () => void): void;
+  addBeforeShutdownHook(hook: () => void | Promise<void>): void;
 }

--- a/packages/backend-plugin-api/src/services/definitions/RootLifecycleService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/RootLifecycleService.ts
@@ -24,5 +24,5 @@ import { LifecycleService } from './LifecycleService';
  * @public
  */
 export interface RootLifecycleService extends LifecycleService {
-  addPreShutdownHook(hook: () => void): void;
+  addBeforeShutdownHook(hook: () => void): void;
 }

--- a/packages/backend-test-utils/src/next/services/mockServices.ts
+++ b/packages/backend-test-utils/src/next/services/mockServices.ts
@@ -472,6 +472,7 @@ export namespace mockServices {
     export const factory = () => rootLifecycleServiceFactory;
     export const mock = simpleMock(coreServices.rootLifecycle, () => ({
       addShutdownHook: jest.fn(),
+      addBeforeShutdownHook: jest.fn(),
       addStartupHook: jest.fn(),
     }));
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3651,7 +3651,6 @@ __metadata:
     pg-format: ^1.0.4
     raw-body: ^2.4.1
     selfsigned: ^2.0.0
-    stoppable: ^1.1.0
     supertest: ^7.0.0
     tar: ^6.1.12
     triple-beam: ^1.4.1


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Immediately cease accepting traffic when a termination event occurs, rather than waiting until plugins and services are stopped.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
