### PR TITLE
fix: typed router export

### DIFF
--- a/.changeset/rich-suns-drive.md
+++ b/.changeset/rich-suns-drive.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-openapi-utils': minor
+---
+
+Fixed a Typescript error when trying to use the new OpenAPI server-side generated code.

--- a/packages/backend-openapi-utils/report.api.md
+++ b/packages/backend-openapi-utils/report.api.md
@@ -530,7 +530,6 @@ declare namespace internal {
     DocEndpointTemplate,
     TemplateToDocEndpoint,
     EndpointMapRequestMatcher,
-    TypedRouter,
   };
 }
 export { internal };
@@ -902,7 +901,8 @@ type TuplifyUnion<
 > = true extends N ? [] : Push<TuplifyUnion<Exclude<T, L>>, L>;
 
 // @public (undocumented)
-interface TypedRouter<GeneratedEndpointMap extends EndpointMap> extends Router {
+export interface TypedRouter<GeneratedEndpointMap extends EndpointMap>
+  extends Router {
   // (undocumented)
   delete: EndpointMapRequestMatcher<GeneratedEndpointMap, this, '_delete'>;
   // (undocumented)

--- a/packages/backend-openapi-utils/src/index.ts
+++ b/packages/backend-openapi-utils/src/index.ts
@@ -30,7 +30,7 @@ export type {
   CookieParameters,
   PathParameters,
 } from './utility';
-export type { ApiRouter } from './router';
+export type { ApiRouter, TypedRouter } from './router';
 export type { PathTemplate } from './types/common';
 export { wrapInOpenApiTestServer, wrapServer } from './testUtils';
 export {

--- a/packages/backend-openapi-utils/src/router.ts
+++ b/packages/backend-openapi-utils/src/router.ts
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 import { Router } from 'express';
-import { DocRequestMatcher, RequiredDoc } from './types';
+import {
+  DocRequestMatcher,
+  EndpointMap,
+  EndpointMapRequestMatcher,
+  RequiredDoc,
+} from './types';
 
 /**
  * Typed Express router based on an OpenAPI 3.1 spec.
@@ -36,4 +41,15 @@ export interface ApiRouter<Doc extends RequiredDoc> extends Router {
   options: DocRequestMatcher<Doc, this, 'options'>;
 
   head: DocRequestMatcher<Doc, this, 'head'>;
+}
+
+/**
+ * @public
+ */
+export interface TypedRouter<GeneratedEndpointMap extends EndpointMap>
+  extends Router {
+  get: EndpointMapRequestMatcher<GeneratedEndpointMap, this, 'get'>;
+  post: EndpointMapRequestMatcher<GeneratedEndpointMap, this, 'post'>;
+  put: EndpointMapRequestMatcher<GeneratedEndpointMap, this, 'put'>;
+  delete: EndpointMapRequestMatcher<GeneratedEndpointMap, this, '_delete'>;
 }

--- a/packages/backend-openapi-utils/src/stub.ts
+++ b/packages/backend-openapi-utils/src/stub.ts
@@ -15,8 +15,8 @@
  */
 
 import PromiseRouter from 'express-promise-router';
-import { ApiRouter } from './router';
-import { EndpointMap, RequiredDoc, TypedRouter } from './types';
+import { ApiRouter, TypedRouter } from './router';
+import { EndpointMap, RequiredDoc } from './types';
 import {
   ErrorRequestHandler,
   RequestHandler,

--- a/packages/backend-openapi-utils/src/types/generated.ts
+++ b/packages/backend-openapi-utils/src/types/generated.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Router } from 'express';
 import type core from 'express-serve-static-core';
 import { PathTemplate, ValueOf } from './common';
 
@@ -208,15 +207,4 @@ export interface EndpointMapRequestMatcher<
       >
     >
   ): T;
-}
-
-/**
- * @public
- */
-export interface TypedRouter<GeneratedEndpointMap extends EndpointMap>
-  extends Router {
-  get: EndpointMapRequestMatcher<GeneratedEndpointMap, this, 'get'>;
-  post: EndpointMapRequestMatcher<GeneratedEndpointMap, this, 'post'>;
-  put: EndpointMapRequestMatcher<GeneratedEndpointMap, this, 'put'>;
-  delete: EndpointMapRequestMatcher<GeneratedEndpointMap, this, '_delete'>;
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

https://discord.com/channels/687207715902193673/1034089724664610938/1309619723729768448

Fixing this issue:
```
plugins/plugin-backend/src/schema/openapi/generated/router.ts:245:14 - error TS4023: Exported variable 'createOpenApiRouter' has or is using name 'TypedRouter' from external module "/Users/user/cyclops-backstage/node_modules/@backstage/backend-openapi-utils/dist/index" but cannot be named.
```
with the TypedRouter import in the generated OpenAPI code.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
