### PR TITLE
bugfix: Handle not modified error in Azure blob storage plugin

### DIFF
--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/AzureBlobStorageUrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/AzureBlobStorageUrlReader.ts
@@ -44,7 +44,7 @@ export function parseUrl(url: string): { path: string; container: string } {
   const parsedUrl = new URL(url);
   const pathSegments = parsedUrl.pathname.split('/').filter(Boolean);
 
-  if (pathSegments.length < 2) {
+  if (pathSegments.length < 1) {
     throw new Error(`Invalid Azure Blob Storage URL format: ${url}`);
   }
 
@@ -171,7 +171,7 @@ export class AzureBlobStorageUrlReader implements UrlReaderService {
         },
       );
     } catch (e) {
-      if (e.$metadata && e.$metadata.httpStatusCode === 304) {
+      if (e.statusCode === 304) {
         throw new NotModifiedError();
       }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR contains the changes to properly handle the `NotModifiedError`. It is currently being handled but expected error format is not same as actual error.
P.S.: Getting error couldn't find a script named `changeset`
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
