### PR TITLE
Add OpenFGA permission plugin backstage to market place

### DIFF
--- a/microsite/data/plugins/openfga-permission.yaml
+++ b/microsite/data/plugins/openfga-permission.yaml
@@ -1,0 +1,10 @@
+---
+title: OpenFGA Permission
+author: Infosys
+authorUrl: https://github.com/Infosys
+category: Authentication/Authorization
+description: Manage your Backstage permissions with OpenFGA
+documentation: https://github.com/Infosys/openfga-plugin-backstage/blob/main/plugins/openfga/README.md
+iconUrl: https://github.com/Infosys/openfga-plugin-backstage/blob/main/plugins/openfga/src/docs/openfgalogo.png
+npmPackageName: '@infosys_ltd/openfga-plugin-backstage'
+addedDate: '2024-12-04'


### PR DESCRIPTION
Add OpenFGA permission plugin backstage to market place:

**This plugin wraps around the Backstage Permission Framework and uses the OPENFGA client to evaluate policies. It will send a request to OPENFGA with the permission and identity information, OPENFGA will then evaluate the policy and return a decision, which is then passed back to the Permission Framework.**

![image](https://github.com/user-attachments/assets/a917f637-b8d1-413a-b202-e7de391e439c)


Here the complete documentation about the plugin : https://github.com/Infosys/openfga-plugin-backstage/blob/main/plugins/openfga/README.md


A webinar submitted to cncf on this: **https://youtu.be/wWFbLPvwOyQ?si=_odKh_afogm8Ta5K**

