### PR TITLE
Fix check for --no-node-snapshot

### DIFF
--- a/.changeset/gorgeous-panthers-count.md
+++ b/.changeset/gorgeous-panthers-count.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+The --no-node-snapshot check needs to be done against process.execArgv instead of process.argv

--- a/plugins/scaffolder-backend/src/lib/templating/helpers.ts
+++ b/plugins/scaffolder-backend/src/lib/templating/helpers.ts
@@ -17,7 +17,7 @@
 export function isNoNodeSnapshotOptionProvided(): boolean {
   return (
     process.env.NODE_OPTIONS?.includes('--no-node-snapshot') ||
-    process.argv.includes('--no-node-snapshot')
+    process.execArgv.includes('--no-node-snapshot')
   );
 }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

There is a helper to ensure that, when running the scaffolder plugin in node >=v20, that the `--no-node-snapshot` is specified. The helper checks the `NODE_OPTIONS` environment variable but it is also a valid option to specify `--no-node-snapshot` on the `node` command line as a literal argument. Options passed to the `node` binary can be found in `process.execArgv` but the code previously was checking just `process.argv` which is only for arguments provided to the script being executed by `node`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
