### PR TITLE
backend-defaults: add backend.health.headers config

### DIFF
--- a/.changeset/chilly-games-trade.md
+++ b/.changeset/chilly-games-trade.md
@@ -1,0 +1,7 @@
+---
+'@backstage/backend-defaults': minor
+---
+
+Added a new `backend.health.headers` configuration that can be used to set additional headers to include in health check responses.
+
+**BREAKING CONSUMERS**: As part of this change the `createHealthRouter` function exported from `@backstage/backend-defaults/rootHttpRouter` now requires the root config service to be passed through the `config` option.

--- a/docs/backend-system/core-services/root-health.md
+++ b/docs/backend-system/core-services/root-health.md
@@ -38,3 +38,29 @@ backend.add(
   }),
 );
 ```
+
+### Custom headers in health check responses
+
+While not implemented directly in the root health service, the default implementation of the [RootHttpRouter](./root-http-router.md) service includes a configuration option to set additional headers to include in health check responses. For example, you can add a `service-name` header using the following configuration:
+
+```yaml
+backend:
+  health:
+    headers:
+      service-name: my-service
+```
+
+It can be a good idea to set a header for your health check responses that
+uniquely identifies your service in a multi-service environment. This ensures
+that the health check that is configured for your service is actually hitting
+your service and not another.
+
+For example, if using Envoy you can use the [`service_name_matcher`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/health_checking#health-check-identity) configuration and
+set the `x-envoy-upstream-healthchecked-cluster` header to a matching value. For example:
+
+```yaml
+backend:
+  health:
+    headers:
+      x-envoy-upstream-healthchecked-cluster: my-service
+```

--- a/packages/backend-defaults/config.d.ts
+++ b/packages/backend-defaults/config.d.ts
@@ -553,6 +553,23 @@ export interface Config {
     csp?: { [policyId: string]: string[] | false };
 
     /**
+     * Options for the health check service and endpoint.
+     */
+    health?: {
+      /**
+       * Additional headers to always include in the health check response.
+       *
+       * It can be a good idea to set a header that uniquely identifies your service
+       * in a multi-service environment. This ensures that the health check that is
+       * configured for your service is actually hitting your service and not another.
+       *
+       * For example, if using Envoy you can use the `service_name_matcher` configuration
+       * and set the `x-envoy-upstream-healthchecked-cluster` header to a matching value.
+       */
+      headers?: { [name: string]: string };
+    };
+
+    /**
      * Configuration related to URL reading, used for example for reading catalog info
      * files, scaffolder templates, and techdocs content.
      */

--- a/packages/backend-defaults/report-rootHttpRouter.api.md
+++ b/packages/backend-defaults/report-rootHttpRouter.api.md
@@ -27,6 +27,7 @@ import { ServiceFactory } from '@backstage/backend-plugin-api';
 // @public (undocumented)
 export function createHealthRouter(options: {
   health: RootHealthService;
+  config: RootConfigService;
 }): Router;
 
 // @public

--- a/packages/backend-defaults/src/entrypoints/rootHttpRouter/createHealthRouter.ts
+++ b/packages/backend-defaults/src/entrypoints/rootHttpRouter/createHealthRouter.ts
@@ -14,20 +14,50 @@
  * limitations under the License.
  */
 
-import { RootHealthService } from '@backstage/backend-plugin-api';
+import {
+  RootConfigService,
+  RootHealthService,
+} from '@backstage/backend-plugin-api';
 import Router from 'express-promise-router';
 import { Request, Response } from 'express';
+
+const HEADER_CONFIG_KEY = 'backend.health.headers';
 
 /**
  * @public
  */
-export function createHealthRouter(options: { health: RootHealthService }) {
+export function createHealthRouter(options: {
+  health: RootHealthService;
+  config: RootConfigService;
+}) {
+  const headersConfig = options.config
+    .getOptionalConfig(HEADER_CONFIG_KEY)
+    ?.get();
+  if (headersConfig) {
+    for (const [key, value] of Object.entries(headersConfig)) {
+      if (!key || typeof key !== 'string') {
+        throw new Error(
+          `Invalid header name in at ${HEADER_CONFIG_KEY}, must be a non-empty string`,
+        );
+      }
+      if (!value || typeof value !== 'string') {
+        throw new Error(
+          `Invalid header value in at ${HEADER_CONFIG_KEY}, must be a non-empty string`,
+        );
+      }
+    }
+  }
+  const headers = headersConfig && new Headers(headersConfig as HeadersInit);
+
   const router = Router();
 
   router.get(
     '/.backstage/health/v1/readiness',
     async (_request: Request, response: Response) => {
       const { status, payload } = await options.health.getReadiness();
+      if (headers) {
+        response.setHeaders(headers);
+      }
       response.status(status).json(payload);
     },
   );
@@ -36,6 +66,9 @@ export function createHealthRouter(options: { health: RootHealthService }) {
     '/.backstage/health/v1/liveness',
     async (_request: Request, response: Response) => {
       const { status, payload } = await options.health.getLiveness();
+      if (headers) {
+        response.setHeaders(headers);
+      }
       response.status(status).json(payload);
     },
   );

--- a/packages/backend-defaults/src/entrypoints/rootHttpRouter/rootHttpRouterServiceFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/rootHttpRouter/rootHttpRouterServiceFactory.ts
@@ -89,7 +89,7 @@ const rootHttpRouterServiceFactoryWithOptions = (
       const middleware = MiddlewareFactory.create({ config, logger });
       const routes = router.handler();
 
-      const healthRouter = createHealthRouter({ health });
+      const healthRouter = createHealthRouter({ config, health });
       const server = await createHttpServer(
         app,
         readHttpServerOptions(config.getOptionalConfig('backend')),

--- a/packages/backend-test-utils/src/next/wiring/TestBackend.ts
+++ b/packages/backend-test-utils/src/next/wiring/TestBackend.ts
@@ -251,7 +251,7 @@ export async function startTestBackend<TExtensionPoints extends any[]>(
       const app = express();
 
       const middleware = MiddlewareFactory.create({ config, logger });
-      const healthRouter = createHealthRouter({ health });
+      const healthRouter = createHealthRouter({ config, health });
 
       app.use(healthRouter);
       app.use(router.handler());


### PR DESCRIPTION
## Hey, I just made a Pull Request!

As mentioned in the docs/config schema update, this allows you to configure custom headers in health check responses, which can be useful to ensure that your health checks are hitting the expected service.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
