### PR TITLE
feat: Add "Cancel" Button to Revert Unsaved Widget Changes for Home page

### DIFF
--- a/.changeset/neat-adults-glow.md
+++ b/.changeset/neat-adults-glow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-home': patch
+---
+
+- Introduced a "Cancel" button to discard unsaved widget changes and revert to the last saved state on the homepage.

--- a/plugins/home/src/components/CustomHomepage/CustomHomepageButtons.tsx
+++ b/plugins/home/src/components/CustomHomepage/CustomHomepageButtons.tsx
@@ -117,18 +117,16 @@ export const CustomHomepageButtons = (props: CustomHomepageButtonsProps) => {
               Save
             </Button>
           )}
-          {numWidgets > 0 && (
-            <Button
-              className={styles.contentHeaderBtn}
-              variant="contained"
-              color="secondary"
-              onClick={() => discardChanges()}
-              size="small"
-              startIcon={<CancelIcon />}
-            >
-              Cancel
-            </Button>
-          )}
+          <Button
+            className={styles.contentHeaderBtn}
+            variant="contained"
+            color="secondary"
+            onClick={() => discardChanges()}
+            size="small"
+            startIcon={<CancelIcon />}
+          >
+            Cancel
+          </Button>
         </>
       )}
     </>

--- a/plugins/home/src/components/CustomHomepage/CustomHomepageButtons.tsx
+++ b/plugins/home/src/components/CustomHomepage/CustomHomepageButtons.tsx
@@ -44,6 +44,7 @@ interface CustomHomepageButtonsProps {
   changeEditMode: (mode: boolean) => void;
   defaultConfigAvailable: boolean;
   restoreDefault: () => void;
+  discardChanges: () => void;
 }
 export const CustomHomepageButtons = (props: CustomHomepageButtonsProps) => {
   const {
@@ -54,6 +55,7 @@ export const CustomHomepageButtons = (props: CustomHomepageButtonsProps) => {
     changeEditMode,
     defaultConfigAvailable,
     restoreDefault,
+    discardChanges,
   } = props;
   const styles = useStyles();
 
@@ -113,6 +115,18 @@ export const CustomHomepageButtons = (props: CustomHomepageButtonsProps) => {
               startIcon={<SaveIcon />}
             >
               Save
+            </Button>
+          )}
+          {numWidgets > 0 && (
+            <Button
+              className={styles.contentHeaderBtn}
+              variant="contained"
+              color="secondary"
+              onClick={() => discardChanges()}
+              size="small"
+              startIcon={<CancelIcon />}
+            >
+              Cancel
             </Button>
           )}
         </>

--- a/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.tsx
+++ b/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.tsx
@@ -297,6 +297,13 @@ export const CustomHomepageGrid = (props: CustomHomepageGridProps) => {
   };
 
   const discardChanges = () => {
+    // eslint-disable-next-line no-alert
+    const accepted = window.confirm(
+      'Are you sure? Unsaved changes will be lost',
+    );
+    if (!accepted) {
+      return;
+    }
     setWidgets(lastStoredWidgets);
     setEditMode(false);
     setLastStoredWidgets([]);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
This PR introduces a "Cancel" button to the homepage customization feature. The button allows users to discard any unsaved changes to their widget configurations and revert to the last stored state.

Before: 
<img width="606" alt="image" src="https://github.com/user-attachments/assets/fe868909-a31f-4ced-b78d-3d97246d0d81">


After:
<img width="698" alt="image" src="https://github.com/user-attachments/assets/bb83c9d9-5816-4556-8831-1c6bac198987">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
