### PR TITLE
More safeguards against stack traces in error responses

### DIFF
--- a/.changeset/dull-bulldogs-learn.md
+++ b/.changeset/dull-bulldogs-learn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+The user and plugin token verification in the default `AuthService` implementation will no longer forward verification errors to the caller, and instead log them as warnings.

--- a/.changeset/forty-ravens-fry.md
+++ b/.changeset/forty-ravens-fry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+The default `authServiceFactory` now correctly depends on the plugin scoped `Logger` services rather than the root scoped one.

--- a/.changeset/thin-hotels-explode.md
+++ b/.changeset/thin-hotels-explode.md
@@ -1,0 +1,5 @@
+---
+'@backstage/errors': patch
+---
+
+Trim `error.cause.stack` in addition to `error.stack` when trimming stack traces from serialized errors.

--- a/packages/backend-defaults/src/entrypoints/auth/authServiceFactory.test.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/authServiceFactory.test.ts
@@ -109,8 +109,9 @@ describe('authServiceFactory', () => {
   });
 
   it('should authenticate issued tokens with new auth', async () => {
+    const logger = mockServices.logger.mock();
     const tester = ServiceFactoryTester.from(authServiceFactory, {
-      dependencies: mockDeps,
+      dependencies: [...mockDeps, logger.factory],
     });
 
     const searchAuth = await tester.getSubject('search');
@@ -134,8 +135,13 @@ describe('authServiceFactory', () => {
       targetPluginId: 'catalog',
     });
 
+    expect(logger.warn).not.toHaveBeenCalled();
     await expect(searchAuth.authenticate(searchToken)).rejects.toThrow(
-      'Invalid plugin token',
+      'Failed plugin token verification',
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Failed to verify incoming plugin token',
+      expect.any(Error),
     );
     await expect(catalogAuth.authenticate(searchToken)).resolves.toEqual(
       expect.objectContaining({

--- a/packages/backend-defaults/src/entrypoints/auth/authServiceFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/authServiceFactory.ts
@@ -59,7 +59,7 @@ export const authServiceFactory = createServiceFactory({
   service: coreServices.auth,
   deps: {
     config: coreServices.rootConfig,
-    logger: coreServices.rootLogger,
+    logger: coreServices.logger,
     discovery: coreServices.discovery,
     plugin: coreServices.pluginMetadata,
     database: coreServices.database,
@@ -89,6 +89,7 @@ export const authServiceFactory = createServiceFactory({
 
     const userTokens = UserTokenHandler.create({
       discovery,
+      logger,
     });
 
     const pluginTokens = pluginTokenHandlerDecorator(

--- a/packages/backend-defaults/src/entrypoints/auth/plugin/PluginTokenHandler.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/plugin/PluginTokenHandler.ts
@@ -120,7 +120,8 @@ export class DefaultPluginTokenHandler implements PluginTokenHandler {
         requiredClaims: ['iat', 'exp', 'sub', 'aud'],
       },
     ).catch(e => {
-      throw new AuthenticationError('Invalid plugin token', e);
+      this.logger.warn('Failed to verify incoming plugin token', e);
+      throw new AuthenticationError('Failed plugin token verification');
     });
 
     return { subject: `plugin:${payload.sub}`, limitedUserToken: payload.obo };

--- a/packages/errors/src/serialization/error.test.ts
+++ b/packages/errors/src/serialization/error.test.ts
@@ -63,6 +63,20 @@ describe('serialization', () => {
     expect(withoutStack2.stack).not.toBeDefined();
   });
 
+  it('serializes stack traces only when allowed with error cause', () => {
+    const before = new CustomError('m');
+    before.cause = new Error('cause');
+    const withStack: any = serializeError(before, { includeStack: true });
+    const withoutStack1: any = serializeError(before, { includeStack: false });
+    const withoutStack2: any = serializeError(before);
+    expect(withStack.stack).toEqual(before.stack);
+    expect(withStack.cause.stack).toEqual(withStack.cause.stack);
+    expect(withoutStack1.stack).not.toBeDefined();
+    expect(withoutStack2.stack).not.toBeDefined();
+    expect(withoutStack1.cause.stack).not.toBeDefined();
+    expect(withoutStack2.cause.stack).not.toBeDefined();
+  });
+
   it('stringifies all supported forms', () => {
     expect(stringifyError({})).toEqual("unknown error '[object Object]'");
     expect(

--- a/packages/errors/src/serialization/error.ts
+++ b/packages/errors/src/serialization/error.ts
@@ -60,6 +60,14 @@ export function serializeError(
 
   if (!options?.includeStack) {
     delete result.stack;
+
+    if (
+      result.cause &&
+      typeof result.cause === 'object' &&
+      'stack' in result.cause
+    ) {
+      delete result.cause.stack;
+    }
   }
 
   return result;

--- a/plugins/catalog-backend/src/tests/integration.test.ts
+++ b/plugins/catalog-backend/src/tests/integration.test.ts
@@ -442,7 +442,6 @@ describe('Catalog Backend Integration', () => {
                 cause: {
                   name: 'Error',
                   message: 'NOPE',
-                  stack: expect.stringMatching(/^Error: NOPE/),
                 },
               },
             },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Double fix for #27629, both making sure we never return `error.cause.stack` in production, and also stop returning underlying token verification errors.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
