### PR TITLE
canon: use inset box-shadows for button styles

### DIFF
--- a/packages/canon/src/components/Button/styles.css
+++ b/packages/canon/src/components/Button/styles.css
@@ -36,18 +36,18 @@
 
 .button.primary:hover {
   background-color: transparent;
-  box-shadow: 0 0 0 1px var(--canon-outline-focus);
+  box-shadow: inset 0 0 0 1px var(--canon-outline-focus);
   color: var(--canon-text-primary);
 }
 
 .button.secondary {
   background-color: transparent;
-  box-shadow: 0 0 0 1px var(--canon-outline);
+  box-shadow: inset 0 0 0 1px var(--canon-outline);
   color: var(--canon-text-primary);
 }
 
 .button.secondary:hover {
-  box-shadow: 0 0 0 1px var(--canon-outline-hover);
+  box-shadow: inset 0 0 0 1px var(--canon-outline-hover);
 }
 
 .button.tertiary {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The use of box-shadows for button borders meant that when a button was styled with a border, it expanded by 1px. This commit retains the use of shadows for borders, but switches them to [inset shadows](https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow#inset) so that the component size stays consistent between buttons with and without borders (and between the same button in hover and non-hover states).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
