### PR TITLE
Perform the by-query count inlined with the main query

### DIFF
--- a/.changeset/dry-badgers-prove.md
+++ b/.changeset/dry-badgers-prove.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Perform the by-query count inlined with the main query


### PR DESCRIPTION
This moves the filtering and subsequent `count(*)` into subqueries, so that

- They can be run as a single query instead of two concurrent ones
- We can effectively cut out the counting part from the query structure where needed

This looks like a kind of big diff, but it's mostly just shifting the initial query+filter into a `WITH`, and the subsequent effects of that. Reviewing while ignoring whitespace helps.

The effects of this aren't huge.
- Counts are only computed on the first page, either way, so for long pagination runs any optimization here has limited effect.
- And the runtime of the compound query after the refactor is going to be equal to the runtime of the count query of the old code - it's not been optimized as such; the same amount of work is performed.

But it does result in just a single database dispatch, and consumes just one connection out of the pool, and when there's pool contention it avoids the two pre-refactor queries from pipelining and waiting for each other.