### PR TITLE
backend-app-api: enable service overrides over feature loaders

### DIFF
--- a/.changeset/heavy-tomatoes-laugh.md
+++ b/.changeset/heavy-tomatoes-laugh.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': minor
+---
+
+Service factories added by feature loaders now have lower priority and will be ignored if a factory for the same service is added directly by `backend.add(serviceFactory)`.

--- a/docs/backend-system/architecture/07-feature-loaders.md
+++ b/docs/backend-system/architecture/07-feature-loaders.md
@@ -75,7 +75,7 @@ export default createBackendFeatureLoader({
 
 ### Overriding service factories
 
-Service factories registered by feature loaders have lower priority by ones added directly via `backend.add`. This allows you to use a feature loader for a larger number of service implementations, but still override individual services.
+Service factories registered by feature loaders have lower priority than ones added directly via `backend.add`. This allows you to use a feature loader for a larger number of service implementations, but still override individual services.
 
 The ordering in which different feature loaders or service factories are added does not matter. There is also no priority between feature loaders, if two different feature loaders add a factory for the same service, the backend will fail to start.
 

--- a/docs/backend-system/architecture/07-feature-loaders.md
+++ b/docs/backend-system/architecture/07-feature-loaders.md
@@ -73,6 +73,29 @@ export default createBackendFeatureLoader({
 });
 ```
 
+### Overriding service factories
+
+Service factories registered by feature loaders have lower priority by ones added directly via `backend.add`. This allows you to use a feature loader for a larger number of service implementations, but still override individual services.
+
+The ordering in which different feature loaders or service factories are added does not matter. There is also no priority between feature loaders, if two different feature loaders add a factory for the same service, the backend will fail to start.
+
+```ts
+const backend = createBackend();
+
+backend.add(
+  createBackendFeatureLoader({
+    async *loader() {
+      yield import('./commonDiscoveryService'); // discovery service
+      yield import('./commonRootLoggerService'); // root logger service
+    },
+  }),
+);
+
+backend.add(import('./myDiscoveryService')); // discovery service
+```
+
+The result of the above example is that the backend starts up with `./myDiscoveryService` as the discovery service implementation, while `./commonDiscoveryService` is ignored. The `./commonRootLoggerService` will still be used.
+
 ### Dynamic logic
 
 A feature loader can also be asynchronous, and for example fetch data from an external source to determine which features to load:

--- a/packages/backend-app-api/src/wiring/BackendInitializer.ts
+++ b/packages/backend-app-api/src/wiring/BackendInitializer.ts
@@ -576,7 +576,7 @@ export class BackendInitializer {
           //
           // If a factory has already been explicitly installed, the service
           // factory provided by the loader will simply be ignored.
-          if (isServiceFactory(feature)) {
+          if (isServiceFactory(feature) && !feature.service.multiton) {
             const conflictingLoader = servicesAddedByLoaders.get(
               feature.service.id,
             );

--- a/packages/backend-app-api/src/wiring/BackendInitializer.ts
+++ b/packages/backend-app-api/src/wiring/BackendInitializer.ts
@@ -519,6 +519,11 @@ export class BackendInitializer {
   }
 
   async #applyBackendFeatureLoaders(loaders: InternalBackendFeatureLoader[]) {
+    const servicesAddedByLoaders = new Map<
+      string,
+      InternalBackendFeatureLoader
+    >();
+
     for (const loader of loaders) {
       const deps = new Map<string, unknown>();
       const missingRefs = new Set<ServiceOrExtensionPoint>();
@@ -564,8 +569,32 @@ export class BackendInitializer {
         if (isBackendFeatureLoader(feature)) {
           newLoaders.push(feature);
         } else {
-          didAddServiceFactory ||= isServiceFactory(feature);
-          this.#addFeature(feature);
+          // This block makes sure that feature loaders do not provide duplicate
+          // implementations for the same service, but at the same time allows
+          // service factories provided by feature loaders to be overridden by
+          // ones that are explicitly installed with backend.add(serviceFactory).
+          //
+          // If a factory has already been explicitly installed, the service
+          // factory provided by the loader will simply be ignored.
+          if (isServiceFactory(feature)) {
+            const conflictingLoader = servicesAddedByLoaders.get(
+              feature.service.id,
+            );
+            if (conflictingLoader) {
+              throw new Error(
+                `Duplicate service implementations provided for ${feature.service.id} by both feature loader ${loader.description} and feature loader ${conflictingLoader.description}`,
+              );
+            }
+
+            // Check that this service wasn't already explicitly added by backend.add(serviceFactory)
+            if (!this.#serviceRegistry.hasBeenAdded(feature.service)) {
+              didAddServiceFactory = true;
+              servicesAddedByLoaders.set(feature.service.id, loader);
+              this.#addFeature(feature);
+            }
+          } else {
+            this.#addFeature(feature);
+          }
         }
       }
 

--- a/packages/backend-app-api/src/wiring/ServiceRegistry.ts
+++ b/packages/backend-app-api/src/wiring/ServiceRegistry.ts
@@ -191,6 +191,16 @@ export class ServiceRegistry {
     }
   }
 
+  hasBeenAdded(ref: ServiceRef<any>) {
+    if (ref.id === coreServices.pluginMetadata.id) {
+      return true;
+    }
+    if (ref.multiton) {
+      return false;
+    }
+    return this.#addedFactoryIds.has(ref.id);
+  }
+
   add(factory: ServiceFactory) {
     const factoryId = factory.service.id;
     if (factoryId === coreServices.pluginMetadata.id) {

--- a/packages/backend-app-api/src/wiring/ServiceRegistry.ts
+++ b/packages/backend-app-api/src/wiring/ServiceRegistry.ts
@@ -195,9 +195,6 @@ export class ServiceRegistry {
     if (ref.id === coreServices.pluginMetadata.id) {
       return true;
     }
-    if (ref.multiton) {
-      return false;
-    }
     return this.#addedFactoryIds.has(ref.id);
   }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds the ability to override service factories from feature loaders by explicitly adding a different factory via `backend.add(serviceFactory)`. You still can't add conflicting service factories across feature loaders, that'll lead to an error.

The purpose of this is to be able to use a feature loader to install common service factories across multiple backends, but still be able to install overrides in individual backends without the need for config flags, separate imports, etc.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
