### PR TITLE
feat: added description to renderer

### DIFF
--- a/.changeset/tasty-waves-reply.md
+++ b/.changeset/tasty-waves-reply.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-home-react': patch
+---
+
+Added `description` to the renderer escape hatch to allow for further customization.

--- a/plugins/home-react/report.api.md
+++ b/plugins/home-react/report.api.md
@@ -17,6 +17,7 @@ export type CardConfig = {
 // @public (undocumented)
 export type CardExtensionProps<T> = ComponentRenderer & {
   title?: string;
+  description?: string;
 } & T;
 
 // @public (undocumented)
@@ -65,6 +66,7 @@ export function createCardExtension<T>(options: {
 // @public (undocumented)
 export type RendererProps = {
   title?: string;
+  description?: string;
 } & ComponentParts;
 
 // @public (undocumented)

--- a/plugins/home-react/src/extensions.tsx
+++ b/plugins/home-react/src/extensions.tsx
@@ -42,12 +42,18 @@ export type ComponentParts = {
 /**
  * @public
  */
-export type RendererProps = { title?: string } & ComponentParts;
+export type RendererProps = {
+  title?: string;
+  description?: string;
+} & ComponentParts;
 
 /**
  * @public
  */
-export type CardExtensionProps<T> = ComponentRenderer & { title?: string } & T;
+export type CardExtensionProps<T> = ComponentRenderer & {
+  title?: string;
+  description?: string;
+} & T;
 
 /**
  * @public
@@ -102,6 +108,7 @@ export function createCardExtension<T>(options: {
                 {...props}
                 {...componentParts}
                 title={props.title || title}
+                description={props.description || description}
                 isCustomizable={isCustomizable}
               />
             );
@@ -126,6 +133,7 @@ function CardExtension<T>(props: CardExtensionComponentProps<T>) {
     ContextProvider,
     isCustomizable,
     title,
+    description,
     ...childProps
   } = props;
   const app = useApp();
@@ -137,6 +145,7 @@ function CardExtension<T>(props: CardExtensionComponentProps<T>) {
       <Suspense fallback={<Progress />}>
         <Renderer
           {...(title && { title })}
+          {...(description && { description })}
           {...{
             Content,
             ...(Actions ? { Actions } : {}),


### PR DESCRIPTION
This pull request introduces a new `description` field to the `CardExtension` component in the `@backstage/plugin-home-react` package, allowing for further customization of the renderer.

Key changes include:

  * [`plugins/home-react/report.api.md`](diffhunk://#diff-3fa824729a018afd31f55f053639f28d9c019467c88244c030215a7c1eed6633R20): Updated `CardExtensionProps` and `RendererProps` types to include the new `description` field. [[1]](diffhunk://#diff-3fa824729a018afd31f55f053639f28d9c019467c88244c030215a7c1eed6633R20) [[2]](diffhunk://#diff-3fa824729a018afd31f55f053639f28d9c019467c88244c030215a7c1eed6633R69)

* **Component Integration:**
  * [`plugins/home-react/src/extensions.tsx`](diffhunk://#diff-3de0b0a0648ad78e3011bb7c631d83ef85ee50e45f3f70eb65c7cec7330f9cebL45-R56): Modified `RendererProps` and `CardExtensionProps` types to include `description`, and updated `createCardExtension` and `CardExtension` functions to handle the new field. [[1]](diffhunk://#diff-3de0b0a0648ad78e3011bb7c631d83ef85ee50e45f3f70eb65c7cec7330f9cebL45-R56) [[2]](diffhunk://#diff-3de0b0a0648ad78e3011bb7c631d83ef85ee50e45f3f70eb65c7cec7330f9cebR111) [[3]](diffhunk://#diff-3de0b0a0648ad78e3011bb7c631d83ef85ee50e45f3f70eb65c7cec7330f9cebR136) [[4]](diffhunk://#diff-3de0b0a0648ad78e3011bb7c631d83ef85ee50e45f3f70eb65c7cec7330f9cebR148)

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
