### PR TITLE
count metrics faster

### DIFF
--- a/.changeset/gold-crabs-agree.md
+++ b/.changeset/gold-crabs-agree.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Use a faster count method on pg when computing some metrics


### PR DESCRIPTION
https://stackoverflow.com/questions/7943233/fast-way-to-discover-the-row-count-of-a-table-in-postgresql

Turns out that on the postgres master server, it's often the case that these counts end up in the absolute top of the CPU time spent on the server. Counting can be very very expensive on PG. Thus, return a (typically VERY good) estimate instead.