### PR TITLE
Register custom fields from FormFieldBlueprint

### DIFF
--- a/.changeset/smart-islands-judge.md
+++ b/.changeset/smart-islands-judge.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+'@backstage/plugin-scaffolder': patch
+---
+
+Scaffolder field extensions registered with `FormFieldBlueprint` are now collected in the `useCustomFieldExtensions` hook, enabling them for use in the scaffolder.

--- a/plugins/scaffolder-react/report-alpha.api.md
+++ b/plugins/scaffolder-react/report-alpha.api.md
@@ -5,13 +5,17 @@
 ```ts
 /// <reference types="react" />
 
+import { AnyApiFactory } from '@backstage/frontend-plugin-api';
 import { AnyApiRef } from '@backstage/core-plugin-api';
 import { ApiHolder } from '@backstage/core-plugin-api';
+import { ApiRef } from '@backstage/frontend-plugin-api';
 import { ComponentType } from 'react';
 import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { CustomFieldValidator } from '@backstage/plugin-scaffolder-react';
 import { Dispatch } from 'react';
 import { ExtensionBlueprint } from '@backstage/frontend-plugin-api';
+import { ExtensionDefinition } from '@backstage/frontend-plugin-api';
+import { ExtensionInput } from '@backstage/frontend-plugin-api';
 import { FieldExtensionComponentProps } from '@backstage/plugin-scaffolder-react';
 import { FieldExtensionOptions } from '@backstage/plugin-scaffolder-react';
 import { FieldSchema } from '@backstage/plugin-scaffolder-react';
@@ -172,6 +176,34 @@ export type FormFieldExtensionData<
 };
 
 // @alpha (undocumented)
+export const formFieldsApi: ExtensionDefinition<{
+  config: {};
+  configInput: {};
+  output: ConfigurableExtensionDataRef<AnyApiFactory, 'core.api.factory', {}>;
+  inputs: {
+    formFields: ExtensionInput<
+      ConfigurableExtensionDataRef<
+        () => Promise<FormField>,
+        'scaffolder.form-field-loader',
+        {}
+      >,
+      {
+        singleton: false;
+        optional: false;
+      }
+    >;
+  };
+  kind: 'api';
+  name: 'form-fields';
+  params: {
+    factory: AnyApiFactory;
+  };
+}>;
+
+// @alpha (undocumented)
+export const formFieldsApiRef: ApiRef<ScaffolderFormFieldsApi>;
+
+// @alpha (undocumented)
 export type FormValidation = {
   [name: string]: FieldValidation | FormValidation;
 };
@@ -244,6 +276,12 @@ export type ScaffolderFormDecoratorContext<
     fn: (currentState: Record<string, string>) => Record<string, string>,
   ) => void;
 };
+
+// @alpha (undocumented)
+export interface ScaffolderFormFieldsApi {
+  // (undocumented)
+  getFormFields(): Promise<FormFieldExtensionData[]>;
+}
 
 // @alpha (undocumented)
 export function ScaffolderPageContextMenu(

--- a/plugins/scaffolder-react/report.api.md
+++ b/plugins/scaffolder-react/report.api.md
@@ -550,7 +550,7 @@ export const useCustomFieldExtensions: <
   TComponentDataType = FieldExtensionOptions,
 >(
   outlet: React.ReactNode,
-) => TComponentDataType[];
+) => (TComponentDataType | FieldExtensionOptions)[];
 
 // @public
 export const useCustomLayouts: <TComponentDataType = LayoutOptions<any>>(

--- a/plugins/scaffolder-react/report.api.md
+++ b/plugins/scaffolder-react/report.api.md
@@ -550,7 +550,7 @@ export const useCustomFieldExtensions: <
   TComponentDataType = FieldExtensionOptions,
 >(
   outlet: React.ReactNode,
-) => (TComponentDataType | FieldExtensionOptions)[];
+) => TComponentDataType[];
 
 // @public
 export const useCustomLayouts: <TComponentDataType = LayoutOptions<any>>(

--- a/plugins/scaffolder-react/src/hooks/useCustomFieldExtensions.test.tsx
+++ b/plugins/scaffolder-react/src/hooks/useCustomFieldExtensions.test.tsx
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { PropsWithChildren } from 'react';
+import { createPlugin } from '@backstage/core-plugin-api';
+import { TestApiProvider, wrapInTestApp } from '@backstage/test-utils';
+import { renderHook, waitFor } from '@testing-library/react';
+import { ScaffolderFormFieldsApi, formFieldsApiRef } from '../alpha';
+import { useCustomFieldExtensions } from './useCustomFieldExtensions';
+import {
+  ScaffolderFieldExtensions,
+  createScaffolderFieldExtension,
+} from '../extensions';
+
+const plugin = createPlugin({
+  id: 'scaffolder',
+  apis: [],
+  routes: {},
+  externalRoutes: {},
+});
+
+describe('useCustomFieldExtensions', () => {
+  const mockFormFieldsApi: jest.Mocked<ScaffolderFormFieldsApi> = {
+    getFormFields: jest.fn(),
+  };
+  const wrapper = ({ children }: PropsWithChildren<{}>) =>
+    wrapInTestApp(
+      <TestApiProvider apis={[[formFieldsApiRef, mockFormFieldsApi]]}>
+        {children}
+      </TestApiProvider>,
+    );
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should return field extensions from the React tree', async () => {
+    mockFormFieldsApi.getFormFields.mockResolvedValue([]);
+    const CustomFieldExtension = plugin.provide(
+      createScaffolderFieldExtension({
+        name: 'test',
+        component: () => <div>Test</div>,
+      }),
+    );
+
+    const { result } = renderHook(
+      () =>
+        useCustomFieldExtensions(
+          <ScaffolderFieldExtensions>
+            <CustomFieldExtension />
+          </ScaffolderFieldExtensions>,
+        ),
+      {
+        wrapper,
+      },
+    );
+
+    expect(result.current).toEqual([expect.objectContaining({ name: 'test' })]);
+  });
+
+  it('should return field extensions from formFieldsApi', async () => {
+    mockFormFieldsApi.getFormFields.mockResolvedValue([
+      {
+        name: 'blueprint',
+        component: () => <div>Test</div>,
+      },
+    ]);
+
+    const { result } = renderHook(() => useCustomFieldExtensions(<div />), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.length).toBeGreaterThan(0);
+    });
+
+    expect(result.current).toEqual([
+      expect.objectContaining({ name: 'blueprint' }),
+    ]);
+  });
+
+  it('should return field extensions from both sources', async () => {
+    mockFormFieldsApi.getFormFields.mockResolvedValue([
+      {
+        name: 'blueprint',
+        component: () => <div>Test</div>,
+      },
+    ]);
+
+    const CustomFieldExtension = plugin.provide(
+      createScaffolderFieldExtension({
+        name: 'test',
+        component: () => <div>Test</div>,
+      }),
+    );
+
+    const { result } = renderHook(
+      () =>
+        useCustomFieldExtensions(
+          <ScaffolderFieldExtensions>
+            <CustomFieldExtension />
+          </ScaffolderFieldExtensions>,
+        ),
+      {
+        wrapper,
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current).toHaveLength(2);
+    });
+
+    const fieldNames = result.current.map(field => field.name);
+    expect(fieldNames).toEqual(expect.arrayContaining(['test', 'blueprint']));
+  });
+});

--- a/plugins/scaffolder-react/src/hooks/useCustomFieldExtensions.ts
+++ b/plugins/scaffolder-react/src/hooks/useCustomFieldExtensions.ts
@@ -50,5 +50,17 @@ export const useCustomFieldExtensions = <
       }),
   );
 
-  return [...blueprintFields, ...outletFields];
+  // This should really be a different type moving foward, but we do this to keep type compatibility.
+  // should probably also move the defaults into the API eventually too, but that will come with the move
+  // to the new frontend system.
+  const blueprintsToLegacy: FieldExtensionOptions[] = blueprintFields?.map(
+    field => ({
+      component: field.component,
+      name: field.name,
+      validation: field.validation,
+      schema: field.schema?.schema,
+    }),
+  );
+
+  return [...blueprintsToLegacy, ...outletFields];
 };

--- a/plugins/scaffolder-react/src/hooks/useCustomFieldExtensions.ts
+++ b/plugins/scaffolder-react/src/hooks/useCustomFieldExtensions.ts
@@ -27,6 +27,7 @@ import {
  * @public
  */
 export const useCustomFieldExtensions = <
+  // todo(blam): this shouldn't be here, should remove this, but this is a breaking change to remove the generic.
   TComponentDataType = FieldExtensionOptions,
 >(
   outlet: React.ReactNode,
@@ -62,5 +63,5 @@ export const useCustomFieldExtensions = <
     }),
   );
 
-  return [...blueprintsToLegacy, ...outletFields];
+  return [...blueprintsToLegacy, ...outletFields] as TComponentDataType[];
 };

--- a/plugins/scaffolder-react/src/hooks/useCustomFieldExtensions.ts
+++ b/plugins/scaffolder-react/src/hooks/useCustomFieldExtensions.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { useAsync, useMountEffect } from '@react-hookz/web';
-import { useApi, useElementFilter } from '@backstage/core-plugin-api';
+import { useApiHolder, useElementFilter } from '@backstage/core-plugin-api';
 import { formFieldsApiRef } from '../next';
 import { FieldExtensionOptions } from '../extensions';
 import {
@@ -33,9 +33,10 @@ export const useCustomFieldExtensions = <
   outlet: React.ReactNode,
 ) => {
   // Get custom fields created with FormFieldBlueprint
-  const formFieldsApi = useApi(formFieldsApiRef);
+  const apiHolder = useApiHolder();
+  const formFieldsApi = apiHolder.get(formFieldsApiRef);
   const [{ result: blueprintFields }, methods] = useAsync(
-    formFieldsApi.getFormFields,
+    formFieldsApi?.getFormFields ?? (async () => []),
     [],
   );
   useMountEffect(methods.execute);

--- a/plugins/scaffolder-react/src/hooks/useCustomFieldExtensions.ts
+++ b/plugins/scaffolder-react/src/hooks/useCustomFieldExtensions.ts
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useElementFilter } from '@backstage/core-plugin-api';
+import { useAsync, useMountEffect } from '@react-hookz/web';
+import { useApi, useElementFilter } from '@backstage/core-plugin-api';
+import { formFieldsApiRef } from '../next';
 import { FieldExtensionOptions } from '../extensions';
 import {
   FIELD_EXTENSION_KEY,
@@ -29,7 +31,16 @@ export const useCustomFieldExtensions = <
 >(
   outlet: React.ReactNode,
 ) => {
-  return useElementFilter(outlet, elements =>
+  // Get custom fields created with FormFieldBlueprint
+  const formFieldsApi = useApi(formFieldsApiRef);
+  const [{ result: blueprintFields }, methods] = useAsync(
+    formFieldsApi.getFormFields,
+    [],
+  );
+  useMountEffect(methods.execute);
+
+  // Get custom fields created with ScaffolderFieldExtensions
+  const outletFields = useElementFilter(outlet, elements =>
     elements
       .selectByComponentData({
         key: FIELD_EXTENSION_WRAPPER_KEY,
@@ -38,4 +49,6 @@ export const useCustomFieldExtensions = <
         key: FIELD_EXTENSION_KEY,
       }),
   );
+
+  return [...blueprintFields, ...outletFields];
 };

--- a/plugins/scaffolder-react/src/next/api/FormFieldsApi.ts
+++ b/plugins/scaffolder-react/src/next/api/FormFieldsApi.ts
@@ -40,6 +40,7 @@ class DefaultScaffolderFormFieldsApi implements ScaffolderFormFieldsApi {
   }
 }
 
+/** @alpha */
 export const formFieldsApi = ApiBlueprint.makeWithOverrides({
   name: 'form-fields',
   inputs: {

--- a/plugins/scaffolder-react/src/next/api/FormFieldsApi.ts
+++ b/plugins/scaffolder-react/src/next/api/FormFieldsApi.ts
@@ -21,7 +21,7 @@ import {
 } from '@backstage/frontend-plugin-api';
 import { formFieldsApiRef } from './ref';
 import { ScaffolderFormFieldsApi } from './types';
-import { FormFieldBlueprint } from '@backstage/plugin-scaffolder-react/alpha';
+import { FormFieldBlueprint } from '../blueprints';
 import { FormField, OpaqueFormField } from '@internal/scaffolder';
 
 class DefaultScaffolderFormFieldsApi implements ScaffolderFormFieldsApi {

--- a/plugins/scaffolder-react/src/next/api/index.ts
+++ b/plugins/scaffolder-react/src/next/api/index.ts
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-export { formDecoratorsApiRef } from './ref';
-export type { ScaffolderFormDecoratorsApi } from './types';
-export { DefaultScaffolderFormDecoratorsApi } from './FormDecoratorsApi';
+export { formFieldsApi } from './FormFieldsApi';
+export { formFieldsApiRef } from './ref';
+export type { ScaffolderFormFieldsApi } from './types';

--- a/plugins/scaffolder-react/src/next/api/ref.ts
+++ b/plugins/scaffolder-react/src/next/api/ref.ts
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
-export { formDecoratorsApiRef } from './ref';
-export type { ScaffolderFormDecoratorsApi } from './types';
-export { DefaultScaffolderFormDecoratorsApi } from './FormDecoratorsApi';
+import { createApiRef } from '@backstage/frontend-plugin-api';
+import { ScaffolderFormFieldsApi } from './types';
+
+/** @alpha */
+export const formFieldsApiRef = createApiRef<ScaffolderFormFieldsApi>({
+  id: 'plugin.scaffolder.form-fields',
+});

--- a/plugins/scaffolder-react/src/next/api/types.ts
+++ b/plugins/scaffolder-react/src/next/api/types.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
-export { formDecoratorsApiRef } from './ref';
-export type { ScaffolderFormDecoratorsApi } from './types';
-export { DefaultScaffolderFormDecoratorsApi } from './FormDecoratorsApi';
+import { FormFieldExtensionData } from '../blueprints';
+
+/** @alpha */
+export interface ScaffolderFormFieldsApi {
+  getFormFields(): Promise<FormFieldExtensionData[]>;
+}

--- a/plugins/scaffolder-react/src/next/index.ts
+++ b/plugins/scaffolder-react/src/next/index.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+export * from './api';
 export * from './components';
 export * from './lib';
 export * from './hooks';

--- a/plugins/scaffolder/report-alpha.api.md
+++ b/plugins/scaffolder/report-alpha.api.md
@@ -14,7 +14,6 @@ import { ExtensionInput } from '@backstage/frontend-plugin-api';
 import { ExternalRouteRef } from '@backstage/frontend-plugin-api';
 import { FieldExtensionOptions } from '@backstage/plugin-scaffolder-react';
 import { FormField } from '@internal/scaffolder';
-import { FormFieldExtensionData } from '@backstage/plugin-scaffolder-react/alpha';
 import type { FormProps as FormProps_2 } from '@rjsf/core';
 import { FormProps as FormProps_3 } from '@backstage/plugin-scaffolder-react';
 import { FrontendPlugin } from '@backstage/frontend-plugin-api';
@@ -52,6 +51,33 @@ const _default: FrontendPlugin<
     }>;
   },
   {
+    'api:scaffolder/form-fields': ExtensionDefinition<{
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {
+        formFields: ExtensionInput<
+          ConfigurableExtensionDataRef<
+            () => Promise<FormField>,
+            'scaffolder.form-field-loader',
+            {}
+          >,
+          {
+            singleton: false;
+            optional: false;
+          }
+        >;
+      };
+      kind: 'api';
+      name: 'form-fields';
+      params: {
+        factory: AnyApiFactory;
+      };
+    }>;
     'page:scaffolder': ExtensionDefinition<{
       kind: 'page';
       name: undefined;
@@ -129,33 +155,6 @@ const _default: FrontendPlugin<
         factory: AnyApiFactory;
       };
     }>;
-    'api:scaffolder/form-fields': ExtensionDefinition<{
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        AnyApiFactory,
-        'core.api.factory',
-        {}
-      >;
-      inputs: {
-        formFields: ExtensionInput<
-          ConfigurableExtensionDataRef<
-            () => Promise<FormField>,
-            'scaffolder.form-field-loader',
-            {}
-          >,
-          {
-            singleton: false;
-            optional: false;
-          }
-        >;
-      };
-      kind: 'api';
-      name: 'form-fields';
-      params: {
-        factory: AnyApiFactory;
-      };
-    }>;
   }
 >;
 export default _default;
@@ -175,9 +174,6 @@ export class DefaultScaffolderFormDecoratorsApi
 // @alpha (undocumented)
 export const formDecoratorsApiRef: ApiRef<ScaffolderFormDecoratorsApi>;
 
-// @alpha (undocumented)
-export const formFieldsApiRef: ApiRef<ScaffolderFormFieldsApi>;
-
 // @alpha @deprecated
 export type FormProps = Pick<
   FormProps_2,
@@ -195,12 +191,6 @@ export type ScaffolderCustomFieldExplorerClassKey =
 export interface ScaffolderFormDecoratorsApi {
   // (undocumented)
   getFormDecorators(): Promise<ScaffolderFormDecorator[]>;
-}
-
-// @alpha (undocumented)
-export interface ScaffolderFormFieldsApi {
-  // (undocumented)
-  getFormFields(): Promise<FormFieldExtensionData[]>;
 }
 
 // @public (undocumented)

--- a/plugins/scaffolder/report-alpha.api.md
+++ b/plugins/scaffolder/report-alpha.api.md
@@ -14,6 +14,7 @@ import { ExtensionInput } from '@backstage/frontend-plugin-api';
 import { ExternalRouteRef } from '@backstage/frontend-plugin-api';
 import { FieldExtensionOptions } from '@backstage/plugin-scaffolder-react';
 import { FormField } from '@internal/scaffolder';
+import { formFieldsApiRef } from '@backstage/plugin-scaffolder-react/alpha';
 import type { FormProps as FormProps_2 } from '@rjsf/core';
 import { FormProps as FormProps_3 } from '@backstage/plugin-scaffolder-react';
 import { FrontendPlugin } from '@backstage/frontend-plugin-api';
@@ -25,6 +26,7 @@ import { default as React_2 } from 'react';
 import { ReviewStepProps } from '@backstage/plugin-scaffolder-react';
 import { RouteRef } from '@backstage/frontend-plugin-api';
 import { ScaffolderFormDecorator } from '@backstage/plugin-scaffolder-react/alpha';
+import { ScaffolderFormFieldsApi } from '@backstage/plugin-scaffolder-react/alpha';
 import { SubRouteRef } from '@backstage/frontend-plugin-api';
 import { TemplateEntityV1beta3 } from '@backstage/plugin-scaffolder-common';
 import { TemplateGroupFilter } from '@backstage/plugin-scaffolder-react';
@@ -174,6 +176,8 @@ export class DefaultScaffolderFormDecoratorsApi
 // @alpha (undocumented)
 export const formDecoratorsApiRef: ApiRef<ScaffolderFormDecoratorsApi>;
 
+export { formFieldsApiRef };
+
 // @alpha @deprecated
 export type FormProps = Pick<
   FormProps_2,
@@ -192,6 +196,8 @@ export interface ScaffolderFormDecoratorsApi {
   // (undocumented)
   getFormDecorators(): Promise<ScaffolderFormDecorator[]>;
 }
+
+export { ScaffolderFormFieldsApi };
 
 // @public (undocumented)
 export type ScaffolderTemplateEditorClassKey =

--- a/plugins/scaffolder/src/alpha/api/ref.ts
+++ b/plugins/scaffolder/src/alpha/api/ref.ts
@@ -15,12 +15,7 @@
  */
 
 import { createApiRef } from '@backstage/frontend-plugin-api';
-import { ScaffolderFormFieldsApi, ScaffolderFormDecoratorsApi } from './types';
-
-/** @alpha */
-export const formFieldsApiRef = createApiRef<ScaffolderFormFieldsApi>({
-  id: 'plugin.scaffolder.form-fields',
-});
+import { ScaffolderFormDecoratorsApi } from './types';
 
 /** @alpha */
 export const formDecoratorsApiRef = createApiRef<ScaffolderFormDecoratorsApi>({

--- a/plugins/scaffolder/src/alpha/api/types.ts
+++ b/plugins/scaffolder/src/alpha/api/types.ts
@@ -14,15 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  FormFieldExtensionData,
-  ScaffolderFormDecorator,
-} from '@backstage/plugin-scaffolder-react/alpha';
-
-/** @alpha */
-export interface ScaffolderFormFieldsApi {
-  getFormFields(): Promise<FormFieldExtensionData[]>;
-}
+import { ScaffolderFormDecorator } from '@backstage/plugin-scaffolder-react/alpha';
 
 /** @alpha */
 export interface ScaffolderFormDecoratorsApi {

--- a/plugins/scaffolder/src/alpha/index.ts
+++ b/plugins/scaffolder/src/alpha/index.ts
@@ -25,4 +25,9 @@ export {
 export { scaffolderTranslationRef } from '../translation';
 export * from './api';
 
+export {
+  formFieldsApiRef,
+  type ScaffolderFormFieldsApi,
+} from '@backstage/plugin-scaffolder-react/alpha';
+
 export { default } from './plugin';

--- a/plugins/scaffolder/src/alpha/plugin.tsx
+++ b/plugins/scaffolder/src/alpha/plugin.tsx
@@ -32,7 +32,7 @@ import {
   scaffolderPage,
   scaffolderApi,
 } from './extensions';
-import { formFieldsApi } from './api/FormFieldsApi';
+import { formFieldsApi } from '@backstage/plugin-scaffolder-react/alpha';
 
 /** @alpha */
 export default createFrontendPlugin({

--- a/plugins/scaffolder/src/plugin.tsx
+++ b/plugins/scaffolder/src/plugin.tsx
@@ -80,6 +80,7 @@ import { RepoBranchPicker } from './components/fields/RepoBranchPicker/RepoBranc
 import { RepoBranchPickerSchema } from './components/fields/RepoBranchPicker/schema';
 import { formDecoratorsApiRef } from './alpha/api/ref';
 import { DefaultScaffolderFormDecoratorsApi } from './alpha/api/FormDecoratorsApi';
+import { formFieldsApiRef } from '@backstage/plugin-scaffolder-react/alpha';
 
 /**
  * The main plugin export for the scaffolder.
@@ -108,6 +109,11 @@ export const scaffolderPlugin = createPlugin({
       api: formDecoratorsApiRef,
       deps: {},
       factory: () => DefaultScaffolderFormDecoratorsApi.create(),
+    }),
+    createApiFactory({
+      api: formFieldsApiRef,
+      deps: {},
+      factory: () => ({ getFormFields: async () => [] }),
     }),
   ],
   routes: {


### PR DESCRIPTION
#26674 added a `FormFieldBlueprint`, but the results of registering a custom field extension this way were not yet reflected in the `useCustomFieldExtensions` hook that the scaffolder uses. This updates the hook to pull custom fields from either registration method (React tree or blueprint).

Since the hook is in `scaffolder-react`, I moved the `formFieldsApiRef` to this package, so as not to introduce a backwards dependency. The registration of the default API is still done in the `scaffolder` package.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
