### PR TITLE
notifications: refactor backend routes to avoid using root route

### DIFF
--- a/.changeset/mighty-birds-rest.md
+++ b/.changeset/mighty-birds-rest.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications': minor
+---
+
+Switched to using the new `/notifications` endpoints. Be sure to update the `notifications` plugin backend before deploying this frontend plugin change.

--- a/.changeset/odd-days-push.md
+++ b/.changeset/odd-days-push.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications-backend': patch
+---
+
+Deprecated root '/' endpoints, moving them under `/notifications` instead.

--- a/.changeset/perfect-fishes-kick.md
+++ b/.changeset/perfect-fishes-kick.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications-backend': minor
+---
+
+**BREAKING**: Removed redundant `/health` endpoint, switch to using [the built-in endpoint instead](https://backstage.io/docs/backend-system/core-services/root-health).

--- a/docs/notifications/index.md
+++ b/docs/notifications/index.md
@@ -385,7 +385,7 @@ Refer to the [service-to-service auth documentation](https://backstage.io/docs/a
 An example request for creating a broadcast notification might look like:
 
 ```bash
-curl -X POST https://[BACKSTAGE_BACKEND]/api/notifications -H "Content-Type: application/json" -H "Authorization: Bearer YOUR_BASE64_SHARED_KEY_TOKEN" -d '{"recipients":{"type":"broadcast"},"payload": {"title": "Title of broadcast message","link": "http://foo.com/bar","severity": "high","topic": "The topic"}}'
+curl -X POST https://[BACKSTAGE_BACKEND]/api/notifications/notifications -H "Content-Type: application/json" -H "Authorization: Bearer YOUR_BASE64_SHARED_KEY_TOKEN" -d '{"recipients":{"type":"broadcast"},"payload": {"title": "Title of broadcast message","link": "http://foo.com/bar","severity": "high","topic": "The topic"}}'
 ```
 
 ## Additional info

--- a/plugins/notifications-backend/README.md
+++ b/plugins/notifications-backend/README.md
@@ -29,5 +29,5 @@ To be able to do so, `external access` needs to be enabled as described in the [
 Once the API can be accessed, the request can look like:
 
 ```
-curl -X POST [YOUR_SERVER_URL]/api/notifications -H "Content-Type: application/json" -H "Authorization: Bearer [BASE64_ENCODED_ACCESS_TOKEN]" -d '{"recipients":{"type":"entity","entityRef":"user:development/guest"},"payload": {"title": "Title of user-targeted external message","description": "The description","link": "http://foo.com/bar","severity": "high","topic": "The topic"}}'
+curl -X POST [YOUR_SERVER_URL]/api/notifications/notifications -H "Content-Type: application/json" -H "Authorization: Bearer [BASE64_ENCODED_ACCESS_TOKEN]" -d '{"recipients":{"type":"entity","entityRef":"user:development/guest"},"payload": {"title": "Title of user-targeted external message","description": "The description","link": "http://foo.com/bar","severity": "high","topic": "The topic"}}'
 ```

--- a/plugins/notifications-backend/src/service/router.test.ts
+++ b/plugins/notifications-backend/src/service/router.test.ts
@@ -23,7 +23,11 @@ import request from 'supertest';
 import { createRouter } from './router';
 import { ConfigReader } from '@backstage/config';
 import { SignalsService } from '@backstage/plugin-signals-node';
-import { mockCredentials, mockServices } from '@backstage/backend-test-utils';
+import {
+  mockCredentials,
+  mockErrorHandler,
+  mockServices,
+} from '@backstage/backend-test-utils';
 import { NotificationSendOptions } from '@backstage/plugin-notifications-node';
 import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
 
@@ -68,26 +72,17 @@ describe('createRouter', () => {
       auth,
       catalog,
     });
-    app = express().use(router);
+    app = express().use(router).use(mockErrorHandler());
   });
 
   beforeEach(() => {
     jest.resetAllMocks();
   });
 
-  describe('GET /health', () => {
-    it('returns ok', async () => {
-      const response = await request(app).get('/health');
-
-      expect(response.status).toEqual(200);
-      expect(response.body).toEqual({ status: 'ok' });
-    });
-  });
-
-  describe('POST /', () => {
+  describe('POST /notifications', () => {
     const sendNotification = async (data: NotificationSendOptions) =>
       request(app)
-        .post('/')
+        .post('/notifications')
         .send(data)
         .set('Content-Type', 'application/json')
         .set('Accept', 'application/json');

--- a/plugins/notifications/src/api/NotificationsClient.test.ts
+++ b/plugins/notifications/src/api/NotificationsClient.test.ts
@@ -48,7 +48,7 @@ describe('NotificationsClient', () => {
 
     it('should fetch notifications from correct endpoint', async () => {
       server.use(
-        rest.get(`${mockBaseUrl}/`, (_, res, ctx) =>
+        rest.get(`${mockBaseUrl}/notifications`, (_, res, ctx) =>
           res(ctx.json(expectedResp)),
         ),
       );
@@ -58,7 +58,7 @@ describe('NotificationsClient', () => {
 
     it('should fetch notifications with options', async () => {
       server.use(
-        rest.get(`${mockBaseUrl}/`, (req, res, ctx) => {
+        rest.get(`${mockBaseUrl}/notifications`, (req, res, ctx) => {
           expect(req.url.search).toBe(
             '?limit=10&offset=0&search=find+me&read=true&createdAfter=1970-01-01T00%3A00%3A00.005Z',
           );
@@ -77,7 +77,7 @@ describe('NotificationsClient', () => {
 
     it('should omit unselected fetch options', async () => {
       server.use(
-        rest.get(`${mockBaseUrl}/`, (req, res, ctx) => {
+        rest.get(`${mockBaseUrl}/notifications`, (req, res, ctx) => {
           expect(req.url.search).toBe('?limit=10');
           return res(ctx.json(expectedResp));
         }),
@@ -91,7 +91,7 @@ describe('NotificationsClient', () => {
 
     it('should fetch single notification', async () => {
       server.use(
-        rest.get(`${mockBaseUrl}/:id`, (req, res, ctx) => {
+        rest.get(`${mockBaseUrl}/notifications/:id`, (req, res, ctx) => {
           expect(req.params.id).toBe('acdaa8ca-262b-43c1-b74b-de06e5f3b3c7');
           return res(ctx.json(testNotification));
         }),
@@ -115,12 +115,15 @@ describe('NotificationsClient', () => {
 
     it('should update notifications', async () => {
       server.use(
-        rest.post(`${mockBaseUrl}/update`, async (req, res, ctx) => {
-          expect(await req.json()).toEqual({
-            ids: ['acdaa8ca-262b-43c1-b74b-de06e5f3b3c7'],
-          });
-          return res(ctx.json(expectedResp));
-        }),
+        rest.post(
+          `${mockBaseUrl}/notifications/update`,
+          async (req, res, ctx) => {
+            expect(await req.json()).toEqual({
+              ids: ['acdaa8ca-262b-43c1-b74b-de06e5f3b3c7'],
+            });
+            return res(ctx.json(expectedResp));
+          },
+        ),
       );
       const response = await client.updateNotifications({
         ids: ['acdaa8ca-262b-43c1-b74b-de06e5f3b3c7'],

--- a/plugins/notifications/src/api/NotificationsClient.ts
+++ b/plugins/notifications/src/api/NotificationsClient.ts
@@ -71,23 +71,26 @@ export class NotificationsClient implements NotificationsApi {
     if (options?.minimumSeverity !== undefined) {
       queryString.append('minimumSeverity', options.minimumSeverity);
     }
-    const urlSegment = `?${queryString}`;
 
-    return await this.request<GetNotificationsResponse>(urlSegment);
+    return await this.request<GetNotificationsResponse>(
+      `/notifications?${queryString}`,
+    );
   }
 
   async getNotification(id: string): Promise<Notification> {
-    return await this.request<Notification>(`${id}`);
+    return await this.request<Notification>(
+      `/notifications/${encodeURIComponent(id)}`,
+    );
   }
 
   async getStatus(): Promise<NotificationStatus> {
-    return await this.request<NotificationStatus>('status');
+    return await this.request<NotificationStatus>('/status');
   }
 
   async updateNotifications(
     options: UpdateNotificationsOptions,
   ): Promise<Notification[]> {
-    return await this.request<Notification[]>('update', {
+    return await this.request<Notification[]>('/notifications/update', {
       method: 'POST',
       body: JSON.stringify(options),
       headers: { 'Content-Type': 'application/json' },
@@ -95,29 +98,27 @@ export class NotificationsClient implements NotificationsApi {
   }
 
   async getNotificationSettings(): Promise<NotificationSettings> {
-    return await this.request<NotificationSettings>('settings');
+    return await this.request<NotificationSettings>('/settings');
   }
 
   async updateNotificationSettings(
     settings: NotificationSettings,
   ): Promise<NotificationSettings> {
-    return await this.request<NotificationSettings>('settings', {
+    return await this.request<NotificationSettings>('/settings', {
       method: 'POST',
       body: JSON.stringify(settings),
       headers: { 'Content-Type': 'application/json' },
     });
   }
 
-  private async request<T>(path: string, init?: any): Promise<T> {
-    const baseUrl = `${await this.discoveryApi.getBaseUrl('notifications')}/`;
-    const url = new URL(path, baseUrl);
+  private async request<T>(path: string, init?: RequestInit): Promise<T> {
+    const baseUrl = await this.discoveryApi.getBaseUrl('notifications');
+    const res = await this.fetchApi.fetch(`${baseUrl}${path}`, init);
 
-    const response = await this.fetchApi.fetch(url.toString(), init);
-
-    if (!response.ok) {
-      throw await ResponseError.fromResponse(response);
+    if (!res.ok) {
+      throw await ResponseError.fromResponse(res);
     }
 
-    return response.json() as Promise<T>;
+    return res.json() as Promise<T>;
   }
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Some work towards #24963, making sure the notifications plugin uses similar API design to other plugins.

I did consider updating the `POST /update` endpoint to be `PATCH /notifications` instead as well @backstage/notifications-maintainers , with body switching to `[{ id: '...', ...changeFields }, ...moreUpdates ]` instead. Lemme know if you think that's a better path, but felt it was best to keep the update simply for now.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
