### PR TITLE
.github/workflows: switch storybook verification upload to point to canon instead

### DIFF
--- a/.github/workflows/verify_storybook.yml
+++ b/.github/workflows/verify_storybook.yml
@@ -49,7 +49,10 @@ jobs:
         run: yarn install --immutable
         working-directory: storybook
 
+        # Only for verification, the canon one is what we upload to Chromatic
       - run: yarn build-storybook
+
+      - run: yarn --cwd packages/canon build-storybook
 
       - uses: chromaui/action@0efa3230f403b7848d5d65c6ce140b617fb68380 # v11
         with:
@@ -57,5 +60,5 @@ jobs:
           # projectToken intentionally shared to allow collaborators to run Chromatic on forks
           # https://www.chromatic.com/docs/custom-ci-provider#run-chromatic-on-external-forks-of-open-source-projects
           projectToken: chpt_dab72dc0f97d55b
-          workingDir: storybook
-          storybookBuildDir: dist
+          workingDir: packages/canon
+          storybookBuildDir: storybook-static


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Trying to get Chromatic going again, and doing it towards the new canon storybook instead.

See #27726 for more context.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
