### PR TITLE
Move startup lifecycle back to plugin service

### DIFF
--- a/.changeset/curvy-fishes-rule.md
+++ b/.changeset/curvy-fishes-rule.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Fix server response time by moving the lifecycle startup hooks back to the plugin lifecycle service.

--- a/.changeset/fast-tools-fix.md
+++ b/.changeset/fast-tools-fix.md
@@ -2,7 +2,7 @@
 '@backstage/backend-defaults': minor
 ---
 
-**BREAKING CHANGE**: The `LifecycleMiddlewareOptions.startupRequestPauseTimeout` has been removed. Use the `backend.lifecycle.startupRequestPauseTimeout` setting in your `app-config.yaml` file to customize how the `createLifecycleMiddleware` function should behave. Also the root config service is required as an options when calling the `createLifecycleMiddleware` function:
+**BREAKING PRODUCERS**: The `LifecycleMiddlewareOptions.startupRequestPauseTimeout` has been removed. Use the `backend.lifecycle.startupRequestPauseTimeout` setting in your `app-config.yaml` file to customize how the `createLifecycleMiddleware` function should behave. Also the root config service is required as an option when calling the `createLifecycleMiddleware` function:
 
 ```diff
 - createLifecycleMiddleware({ lifecycle, startupRequestPauseTimeout })

--- a/.changeset/fast-tools-fix.md
+++ b/.changeset/fast-tools-fix.md
@@ -1,0 +1,10 @@
+---
+'@backstage/backend-defaults': minor
+---
+
+**BREAKING CHANGE**: The `LifecycleMiddlewareOptions.startupRequestPauseTimeout` has been removed. Use the `backend.lifecycle.startupRequestPauseTimeout` setting in your `app-config.yaml` file to customize how the `createLifecycleMiddleware` function should behave. Also the root config service is required as an options when calling the `createLifecycleMiddleware` function:
+
+```diff
+- createLifecycleMiddleware({ lifecycle, startupRequestPauseTimeout })
++ createLifecycleMiddleware({ config,  lifecycle })
+```

--- a/.changeset/rude-pears-tie.md
+++ b/.changeset/rude-pears-tie.md
@@ -3,4 +3,3 @@
 ---
 
 Remove use of the `stoppable` library on the `DefaultRootHttpRouterService` as Node's native http server [close](https://nodejs.org/api/http.html#serverclosecallback) method already drains requests.
-Also, we pass a new `lifecycleMiddleware` to the `rootHttpRouterServiceFactory` configure function that must be called manually if you don't call `applyDefaults`.

--- a/packages/backend-defaults/report-httpRouter.api.md
+++ b/packages/backend-defaults/report-httpRouter.api.md
@@ -10,7 +10,6 @@ import express from 'express';
 import { HttpAuthService } from '@backstage/backend-plugin-api';
 import { HttpRouterService } from '@backstage/backend-plugin-api';
 import { HttpRouterServiceAuthPolicy } from '@backstage/backend-plugin-api';
-import { HumanDuration } from '@backstage/types';
 import { LifecycleService } from '@backstage/backend-plugin-api';
 import { RequestHandler } from 'express';
 import { RootConfigService } from '@backstage/backend-plugin-api';
@@ -52,8 +51,9 @@ export const httpRouterServiceFactory: ServiceFactory<
 // @public
 export interface LifecycleMiddlewareOptions {
   // (undocumented)
+  config: RootConfigService;
+  // (undocumented)
   lifecycle: LifecycleService;
-  startupRequestPauseTimeout?: HumanDuration;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/packages/backend-defaults/report-rootHttpRouter.api.md
+++ b/packages/backend-defaults/report-rootHttpRouter.api.md
@@ -134,8 +134,6 @@ export interface RootHttpRouterConfigureContext {
   // (undocumented)
   lifecycle: LifecycleService;
   // (undocumented)
-  lifecycleMiddleware: RequestHandler;
-  // (undocumented)
   logger: LoggerService;
   // (undocumented)
   middleware: MiddlewareFactory;

--- a/packages/backend-defaults/src/entrypoints/httpRouter/createLifecycleMiddleware.test.ts
+++ b/packages/backend-defaults/src/entrypoints/httpRouter/createLifecycleMiddleware.test.ts
@@ -78,31 +78,4 @@ describe('createLifecycleMiddleware', () => {
       new ServiceUnavailableError('Service has not started up yet'),
     );
   });
-
-  it('should delay service shutdown for the default timeout duration', async () => {
-    jest.useFakeTimers();
-    const defaultTimeout = 30000;
-    const lifecycle = new BackendLifecycleImpl(mockServices.rootLogger());
-    createLifecycleMiddleware({ lifecycle });
-    const beforeShutdownPromise = lifecycle.beforeShutdown().then(() => {
-      jest.useRealTimers();
-    });
-    jest.advanceTimersByTime(defaultTimeout);
-    return expect(beforeShutdownPromise).resolves.toBeUndefined();
-  });
-
-  it('should delay service shutdown for the configured timeout duration - time in human duration', async () => {
-    jest.useFakeTimers();
-    const configuredTimeout = 20000;
-    const lifecycle = new BackendLifecycleImpl(mockServices.rootLogger());
-    createLifecycleMiddleware({
-      lifecycle,
-      serverShutdownDelay: { milliseconds: configuredTimeout },
-    });
-    const beforeShutdownPromise = lifecycle.beforeShutdown().then(() => {
-      jest.useRealTimers();
-    });
-    jest.advanceTimersByTime(configuredTimeout);
-    return expect(beforeShutdownPromise).resolves.toBeUndefined();
-  });
 });

--- a/packages/backend-defaults/src/entrypoints/httpRouter/createLifecycleMiddleware.ts
+++ b/packages/backend-defaults/src/entrypoints/httpRouter/createLifecycleMiddleware.ts
@@ -34,12 +34,6 @@ export interface LifecycleMiddlewareOptions {
    * Defaults to 5 seconds.
    */
   startupRequestPauseTimeout?: HumanDuration;
-  /**
-   * The maximum time that the server will wait for stop accepting traffic, before returning an error.
-   *
-   * Defaults to 0 seconds.
-   */
-  serverShutdownDelay?: HumanDuration;
 }
 
 /**
@@ -59,8 +53,7 @@ export interface LifecycleMiddlewareOptions {
 export function createLifecycleMiddleware(
   options: LifecycleMiddlewareOptions,
 ): RequestHandler {
-  const { lifecycle, startupRequestPauseTimeout, serverShutdownDelay } =
-    options;
+  const { lifecycle, startupRequestPauseTimeout } = options;
 
   let state: 'init' | 'up' | 'down' = 'init';
   const waiting = new Set<{
@@ -77,15 +70,6 @@ export function createLifecycleMiddleware(
       }
       waiting.clear();
     }
-  });
-
-  lifecycle.addBeforeShutdownHook(async () => {
-    const timeoutMs = durationToMilliseconds(
-      serverShutdownDelay ?? DEFAULT_SERVER_SHUTDOWN_TIMEOUT,
-    );
-    return await new Promise(resolve => {
-      setTimeout(resolve, timeoutMs);
-    });
   });
 
   lifecycle.addShutdownHook(async () => {

--- a/packages/backend-defaults/src/entrypoints/httpRouter/http/createLifecycleMiddleware.test.ts
+++ b/packages/backend-defaults/src/entrypoints/httpRouter/http/createLifecycleMiddleware.test.ts
@@ -20,10 +20,14 @@ import { mockServices } from '@backstage/backend-test-utils';
 import { ServiceUnavailableError } from '@backstage/errors';
 
 describe('createLifecycleMiddleware', () => {
+  const config = mockServices.rootConfig.mock();
   it('should pause requests when plugin is not ready', async () => {
     const lifecycle = new BackendLifecycleImpl(mockServices.rootLogger());
 
-    const middleware = createLifecycleMiddleware({ lifecycle });
+    const middleware = createLifecycleMiddleware({
+      config,
+      lifecycle,
+    });
 
     const next = jest.fn();
     middleware({} as any, {} as any, next);
@@ -41,7 +45,7 @@ describe('createLifecycleMiddleware', () => {
 
   it('should throw ServiceUnavailableError after shutdown', async () => {
     const lifecycle = new BackendLifecycleImpl(mockServices.rootLogger());
-    const middleware = createLifecycleMiddleware({ lifecycle });
+    const middleware = createLifecycleMiddleware({ config, lifecycle });
 
     const next = jest.fn();
     middleware({} as any, {} as any, next);
@@ -65,7 +69,15 @@ describe('createLifecycleMiddleware', () => {
     const lifecycle = new BackendLifecycleImpl(mockServices.rootLogger());
     const middleware = createLifecycleMiddleware({
       lifecycle,
-      startupRequestPauseTimeout: { milliseconds: 1 },
+      config: mockServices.rootConfig({
+        data: {
+          backend: {
+            lifecycle: {
+              startupRequestPauseTimeout: { milliseconds: 1 },
+            },
+          },
+        },
+      }),
     });
 
     const next = jest.fn();

--- a/packages/backend-defaults/src/entrypoints/httpRouter/http/createLifecycleMiddleware.ts
+++ b/packages/backend-defaults/src/entrypoints/httpRouter/http/createLifecycleMiddleware.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { LifecycleService } from '@backstage/backend-plugin-api';
+import {
+  RootConfigService,
+  LifecycleService,
+} from '@backstage/backend-plugin-api';
+import { readDurationFromConfig } from '@backstage/config';
 import { ServiceUnavailableError } from '@backstage/errors';
 import { HumanDuration, durationToMilliseconds } from '@backstage/types';
 import { RequestHandler } from 'express';
@@ -26,13 +30,8 @@ export const DEFAULT_TIMEOUT = { seconds: 5 };
  * @public
  */
 export interface LifecycleMiddlewareOptions {
+  config: RootConfigService;
   lifecycle: LifecycleService;
-  /**
-   * The maximum time that paused requests will wait for the service to start, before returning an error.
-   *
-   * Defaults to 5 seconds.
-   */
-  startupRequestPauseTimeout?: HumanDuration;
 }
 
 /**
@@ -52,7 +51,7 @@ export interface LifecycleMiddlewareOptions {
 export function createLifecycleMiddleware(
   options: LifecycleMiddlewareOptions,
 ): RequestHandler {
-  const { lifecycle, startupRequestPauseTimeout = DEFAULT_TIMEOUT } = options;
+  const { lifecycle } = options;
 
   let state: 'init' | 'up' | 'down' = 'init';
   const waiting = new Set<{
@@ -80,6 +79,17 @@ export function createLifecycleMiddleware(
     }
     waiting.clear();
   });
+
+  let startupRequestPauseTimeout: HumanDuration = DEFAULT_TIMEOUT;
+
+  if (
+    'config' in options &&
+    options.config.has('backend.lifecycle.startupRequestPauseTimeout')
+  ) {
+    startupRequestPauseTimeout = readDurationFromConfig(options.config, {
+      key: 'backend.lifecycle.startupRequestPauseTimeout',
+    });
+  }
 
   const timeoutMs = durationToMilliseconds(startupRequestPauseTimeout);
 

--- a/packages/backend-defaults/src/entrypoints/httpRouter/http/createLifecycleMiddleware.ts
+++ b/packages/backend-defaults/src/entrypoints/httpRouter/http/createLifecycleMiddleware.ts
@@ -51,7 +51,7 @@ export interface LifecycleMiddlewareOptions {
 export function createLifecycleMiddleware(
   options: LifecycleMiddlewareOptions,
 ): RequestHandler {
-  const { lifecycle } = options;
+  const { config, lifecycle } = options;
 
   let state: 'init' | 'up' | 'down' = 'init';
   const waiting = new Set<{
@@ -82,11 +82,8 @@ export function createLifecycleMiddleware(
 
   let startupRequestPauseTimeout: HumanDuration = DEFAULT_TIMEOUT;
 
-  if (
-    'config' in options &&
-    options.config.has('backend.lifecycle.startupRequestPauseTimeout')
-  ) {
-    startupRequestPauseTimeout = readDurationFromConfig(options.config, {
+  if (config.has('backend.lifecycle.startupRequestPauseTimeout')) {
+    startupRequestPauseTimeout = readDurationFromConfig(config, {
       key: 'backend.lifecycle.startupRequestPauseTimeout',
     });
   }

--- a/packages/backend-defaults/src/entrypoints/httpRouter/httpRouterServiceFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/httpRouter/httpRouterServiceFactory.ts
@@ -22,6 +22,7 @@ import {
   HttpRouterServiceAuthPolicy,
 } from '@backstage/backend-plugin-api';
 import {
+  createLifecycleMiddleware,
   createCookieAuthRefreshMiddleware,
   createCredentialsBarrier,
   createAuthIntegrationRouter,
@@ -42,11 +43,12 @@ export const httpRouterServiceFactory = createServiceFactory({
   deps: {
     plugin: coreServices.pluginMetadata,
     config: coreServices.rootConfig,
+    lifecycle: coreServices.lifecycle,
     rootHttpRouter: coreServices.rootHttpRouter,
     auth: coreServices.auth,
     httpAuth: coreServices.httpAuth,
   },
-  async factory({ auth, httpAuth, config, plugin, rootHttpRouter }) {
+  async factory({ auth, httpAuth, config, plugin, rootHttpRouter, lifecycle }) {
     const router = PromiseRouter();
 
     rootHttpRouter.use(`/api/${plugin.getId()}`, router);
@@ -57,6 +59,7 @@ export const httpRouterServiceFactory = createServiceFactory({
     });
 
     router.use(createAuthIntegrationRouter({ auth }));
+    router.use(createLifecycleMiddleware({ config, lifecycle }));
     router.use(credentialsBarrier.middleware);
     router.use(createCookieAuthRefreshMiddleware({ auth, httpAuth }));
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Follow-up of https://github.com/backstage/backstage/pull/27961

Fix server response time by moving the lifecycle startup hooks back to the plugin lifecycle service.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
