### PR TITLE
catalog-backend: avoid JSON parsing when possible

### DIFF
--- a/.changeset/curly-teachers-marry.md
+++ b/.changeset/curly-teachers-marry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': minor
+---
+
+Added a new `catalog.enableRawJsonResponse` configuration option that avoids JSON deserialization and serialization if possible when reading entities. This can significantly improve the overall performance of the catalog, but it removes the backwards compatibility processing that ensures that both `entity.relation[].target` and `entity.relation[].targetRef` are present in returned entities.

--- a/.changeset/curly-teachers-marry.md
+++ b/.changeset/curly-teachers-marry.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend': minor
 ---
 
-Added a new `catalog.disableRelationsCompatibility` configuration option that avoids JSON deserialization and serialization if possible when reading entities. This can significantly improve the overall performance of the catalog, but it removes the backwards compatibility processing that ensures that both `entity.relation[].target` and `entity.relation[].targetRef` are present in returned entities.
+Added a new `catalog.disableRelationsCompatibility` configuration option that avoids JSON deserialization and serialization if possible when reading entities. This significantly reduces the memory usage of the catalog, and slightly increases performance, but it removes the backwards compatibility processing that ensures that both `entity.relation[].target` and `entity.relation[].targetRef` are present in returned entities.

--- a/.changeset/curly-teachers-marry.md
+++ b/.changeset/curly-teachers-marry.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend': minor
 ---
 
-Added a new `catalog.enableRawJsonResponse` configuration option that avoids JSON deserialization and serialization if possible when reading entities. This can significantly improve the overall performance of the catalog, but it removes the backwards compatibility processing that ensures that both `entity.relation[].target` and `entity.relation[].targetRef` are present in returned entities.
+Added a new `catalog.disableRelationsCompatibility` configuration option that avoids JSON deserialization and serialization if possible when reading entities. This can significantly improve the overall performance of the catalog, but it removes the backwards compatibility processing that ensures that both `entity.relation[].target` and `entity.relation[].targetRef` are present in returned entities.

--- a/.github/vale/config/vocabularies/Backstage/accept.txt
+++ b/.github/vale/config/vocabularies/Backstage/accept.txt
@@ -97,6 +97,7 @@ deliverables
 denormalized
 dependabot
 deps
+deserialization
 destructured
 destructuring
 Deutsche

--- a/plugins/catalog-backend/config.d.ts
+++ b/plugins/catalog-backend/config.d.ts
@@ -139,6 +139,16 @@ export interface Config {
     }>;
 
     /**
+     * Disables the compatibility layer for relations in returned entities that
+     * ensures that all relations objects have both `target` and `targetRef`.
+     *
+     * Enabling this option can very significantly improve the performance of
+     * the catalog, but may break consumers that rely on the existence of
+     * `target` in the relations objects.
+     */
+    disableRelationsCompatibility?: boolean;
+
+    /**
      * The strategy to use for entities that are orphaned, i.e. no longer have
      * any other entities or providers referencing them. The default value is
      * "keep".

--- a/plugins/catalog-backend/config.d.ts
+++ b/plugins/catalog-backend/config.d.ts
@@ -142,9 +142,9 @@ export interface Config {
      * Disables the compatibility layer for relations in returned entities that
      * ensures that all relations objects have both `target` and `targetRef`.
      *
-     * Enabling this option can very significantly improve the performance of
-     * the catalog, but may break consumers that rely on the existence of
-     * `target` in the relations objects.
+     * Enabling this option significantly reduces the memory usage of the
+     * catalog, and slightly increases performance, but may break consumers that
+     * rely on the existence of `target` in the relations objects.
      */
     disableRelationsCompatibility?: boolean;
 

--- a/plugins/catalog-backend/src/catalog/types.ts
+++ b/plugins/catalog-backend/src/catalog/types.ts
@@ -58,7 +58,7 @@ export type EntitiesRequest = {
  */
 export type EntitiesResponseItems =
   | {
-      type: 'objects';
+      type: 'object';
       entities: (Entity | null)[];
     }
   | {

--- a/plugins/catalog-backend/src/catalog/types.ts
+++ b/plugins/catalog-backend/src/catalog/types.ts
@@ -52,8 +52,22 @@ export type EntitiesRequest = {
   credentials: BackstageCredentials;
 };
 
+/**
+ * Encapsulates either a deserialized or serialized entities to be sent in a response.
+ * @internal
+ */
+export type EntitiesResponseItems =
+  | {
+      type: 'objects';
+      entities: (Entity | null)[];
+    }
+  | {
+      type: 'raw';
+      entities: (string | null)[];
+    };
+
 export type EntitiesResponse = {
-  entities: Entity[];
+  entities: EntitiesResponseItems;
   pageInfo: PageInfo;
 };
 
@@ -86,7 +100,7 @@ export interface EntitiesBatchResponse {
    * The list of entities, in the same order as the refs in the request. Entries
    * that are null signify that no entity existed with that ref.
    */
-  items: Array<Entity | null>;
+  items: EntitiesResponseItems;
 }
 
 export type EntityAncestryResponse = {
@@ -224,7 +238,7 @@ export interface QueryEntitiesResponse {
   /**
    * The entities for the current pagination request
    */
-  items: Entity[];
+  items: EntitiesResponseItems;
 
   pageInfo: {
     /**

--- a/plugins/catalog-backend/src/service/AuthorizedEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/AuthorizedEntitiesCatalog.test.ts
@@ -226,7 +226,7 @@ describe('AuthorizedEntitiesCatalog', () => {
       ];
 
       fakeCatalog.queryEntities.mockResolvedValue({
-        items: entities,
+        items: { type: 'objects', entities },
         pageInfo: {
           nextCursor: {
             isPrevious: false,

--- a/plugins/catalog-backend/src/service/AuthorizedEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/AuthorizedEntitiesCatalog.test.ts
@@ -64,7 +64,7 @@ describe('AuthorizedEntitiesCatalog', () => {
           credentials: mockCredentials.none(),
         }),
       ).toEqual({
-        entities: [],
+        entities: { type: 'object', entities: [] },
         pageInfo: { hasNextPage: false },
       });
     });
@@ -113,7 +113,7 @@ describe('AuthorizedEntitiesCatalog', () => {
           credentials: mockCredentials.none(),
         }),
       ).resolves.toEqual({
-        items: [null],
+        items: { type: 'object', entities: [null] },
       });
 
       expect(fakeCatalog.entitiesBatch).not.toHaveBeenCalled();
@@ -174,7 +174,7 @@ describe('AuthorizedEntitiesCatalog', () => {
           filter: { key: 'kind', values: ['b'] },
         }),
       ).resolves.toEqual({
-        items: [],
+        items: { type: 'object', entities: [] },
         pageInfo: {},
         totalItems: 0,
       });
@@ -226,7 +226,7 @@ describe('AuthorizedEntitiesCatalog', () => {
       ];
 
       fakeCatalog.queryEntities.mockResolvedValue({
-        items: { type: 'objects', entities },
+        items: { type: 'object', entities },
         pageInfo: {
           nextCursor: {
             isPrevious: false,
@@ -254,7 +254,7 @@ describe('AuthorizedEntitiesCatalog', () => {
       });
 
       expect(response).toEqual({
-        items: entities,
+        items: { type: 'object', entities: entities },
         totalItems: 4,
         pageInfo: {
           nextCursor: {
@@ -290,7 +290,7 @@ describe('AuthorizedEntitiesCatalog', () => {
       });
 
       expect(response).toEqual({
-        items: entities,
+        items: { type: 'object', entities: entities },
         totalItems: 4,
         pageInfo: {
           nextCursor: {
@@ -338,7 +338,9 @@ describe('AuthorizedEntitiesCatalog', () => {
           conditions: { rule: 'IS_ENTITY_KIND', params: { kinds: ['b'] } },
         },
       ]);
-      fakeCatalog.entities.mockResolvedValue({ entities: [] });
+      fakeCatalog.entities.mockResolvedValue({
+        entities: { type: 'object', entities: [] },
+      });
       const catalog = new AuthorizedEntitiesCatalog(
         fakeCatalog,
         fakePermissionApi,
@@ -360,7 +362,10 @@ describe('AuthorizedEntitiesCatalog', () => {
         },
       ]);
       fakeCatalog.entities.mockResolvedValue({
-        entities: [{ kind: 'b', namespace: 'default', name: 'my-component' }],
+        entities: {
+          type: 'object',
+          entities: [{ kind: 'b', namespace: 'default', name: 'my-component' }],
+        },
       });
       const catalog = new AuthorizedEntitiesCatalog(
         fakeCatalog,

--- a/plugins/catalog-backend/src/service/AuthorizedEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/AuthorizedEntitiesCatalog.ts
@@ -60,7 +60,7 @@ export class AuthorizedEntitiesCatalog implements EntitiesCatalog {
 
     if (authorizeDecision.result === AuthorizeResult.DENY) {
       return {
-        entities: { type: 'objects', entities: [] },
+        entities: { type: 'object', entities: [] },
         pageInfo: { hasNextPage: false },
       };
     }
@@ -93,7 +93,7 @@ export class AuthorizedEntitiesCatalog implements EntitiesCatalog {
     if (authorizeDecision.result === AuthorizeResult.DENY) {
       return {
         items: {
-          type: 'objects',
+          type: 'object',
           entities: new Array(request.entityRefs.length).fill(null),
         },
       };
@@ -126,7 +126,7 @@ export class AuthorizedEntitiesCatalog implements EntitiesCatalog {
 
     if (authorizeDecision.result === AuthorizeResult.DENY) {
       return {
-        items: { type: 'objects', entities: [] },
+        items: { type: 'object', entities: [] },
         pageInfo: {},
         totalItems: 0,
       };

--- a/plugins/catalog-backend/src/service/AuthorizedEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/AuthorizedEntitiesCatalog.ts
@@ -60,7 +60,7 @@ export class AuthorizedEntitiesCatalog implements EntitiesCatalog {
 
     if (authorizeDecision.result === AuthorizeResult.DENY) {
       return {
-        entities: [],
+        entities: { type: 'objects', entities: [] },
         pageInfo: { hasNextPage: false },
       };
     }
@@ -92,7 +92,10 @@ export class AuthorizedEntitiesCatalog implements EntitiesCatalog {
 
     if (authorizeDecision.result === AuthorizeResult.DENY) {
       return {
-        items: new Array(request.entityRefs.length).fill(null),
+        items: {
+          type: 'objects',
+          entities: new Array(request.entityRefs.length).fill(null),
+        },
       };
     }
 
@@ -123,7 +126,7 @@ export class AuthorizedEntitiesCatalog implements EntitiesCatalog {
 
     if (authorizeDecision.result === AuthorizeResult.DENY) {
       return {
-        items: [],
+        items: { type: 'objects', entities: [] },
         pageInfo: {},
         totalItems: 0,
       };
@@ -208,7 +211,7 @@ export class AuthorizedEntitiesCatalog implements EntitiesCatalog {
           allOf: [permissionFilter, basicEntityFilter({ 'metadata.uid': uid })],
         },
       });
-      if (entities.length === 0) {
+      if (entities.entities.length === 0) {
         throw new NotAllowedError();
       }
     }

--- a/plugins/catalog-backend/src/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.ts
@@ -115,6 +115,7 @@ import {
   UrlReaderService,
   SchedulerService,
 } from '@backstage/backend-plugin-api';
+import { entitiesResponseToObjects } from './response';
 
 /**
  * This is a duplicate of the alpha `CatalogPermissionRule` type, for use in the stable API.
@@ -485,6 +486,10 @@ export class CatalogBuilder {
       discovery,
     });
 
+    const enableRawJson = config.getOptionalBoolean(
+      'catalog.enableRawJsonResponses',
+    );
+
     const policy = this.buildEntityPolicy();
     const processors = this.buildProcessors();
     const parser = this.parser || defaultEntityDataParser;
@@ -521,6 +526,7 @@ export class CatalogBuilder {
       database: dbClient,
       logger,
       stitcher,
+      enableRawJson,
     });
 
     let permissionsService: PermissionsService;
@@ -566,7 +572,10 @@ export class CatalogBuilder {
           },
         });
 
-        const entitiesByRef = keyBy(entities, stringifyEntityRef);
+        const entitiesByRef = keyBy(
+          entitiesResponseToObjects(entities),
+          stringifyEntityRef,
+        );
 
         return resourceRefs.map(
           resourceRef =>
@@ -629,6 +638,7 @@ export class CatalogBuilder {
       auth,
       httpAuth,
       permissionsService,
+      enableRawJson,
     });
 
     await connectEntityProviders(providerDatabase, entityProviders);

--- a/plugins/catalog-backend/src/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.ts
@@ -486,8 +486,8 @@ export class CatalogBuilder {
       discovery,
     });
 
-    const enableRawJson = config.getOptionalBoolean(
-      'catalog.enableRawJsonResponses',
+    const disableRelationsCompatibility = config.getOptionalBoolean(
+      'catalog.disableRelationsCompatibility',
     );
 
     const policy = this.buildEntityPolicy();
@@ -526,7 +526,7 @@ export class CatalogBuilder {
       database: dbClient,
       logger,
       stitcher,
-      enableRawJson,
+      disableRelationsCompatibility,
     });
 
     let permissionsService: PermissionsService;
@@ -638,7 +638,7 @@ export class CatalogBuilder {
       auth,
       httpAuth,
       permissionsService,
-      enableRawJson,
+      disableRelationsCompatibility,
     });
 
     await connectEntityProviders(providerDatabase, entityProviders);

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
@@ -896,7 +896,10 @@ describe('DefaultEntitiesCatalog', () => {
           credentials: mockCredentials.none(),
         };
         const response1 = await catalog.queryEntities(request1);
-        expect(response1.items).toEqual([entityFrom('A'), entityFrom('B')]);
+        expect(entitiesResponseToObjects(response1.items)).toEqual([
+          entityFrom('A'),
+          entityFrom('B'),
+        ]);
         expect(response1.pageInfo.nextCursor).toBeDefined();
         expect(response1.pageInfo.prevCursor).toBeUndefined();
         expect(response1.totalItems).toBe(names.length);
@@ -908,7 +911,10 @@ describe('DefaultEntitiesCatalog', () => {
           credentials: mockCredentials.none(),
         };
         const response2 = await catalog.queryEntities(request2);
-        expect(response2.items).toEqual([entityFrom('C'), entityFrom('D')]);
+        expect(entitiesResponseToObjects(response2.items)).toEqual([
+          entityFrom('C'),
+          entityFrom('D'),
+        ]);
         expect(response2.pageInfo.nextCursor).toBeDefined();
         expect(response2.pageInfo.prevCursor).toBeDefined();
         expect(response2.totalItems).toBe(names.length);
@@ -920,7 +926,10 @@ describe('DefaultEntitiesCatalog', () => {
           credentials: mockCredentials.none(),
         };
         const response3 = await catalog.queryEntities(request3);
-        expect(response3.items).toEqual([entityFrom('E'), entityFrom('F')]);
+        expect(entitiesResponseToObjects(response3.items)).toEqual([
+          entityFrom('E'),
+          entityFrom('F'),
+        ]);
         expect(response3.pageInfo.nextCursor).toBeDefined();
         expect(response3.pageInfo.prevCursor).toBeDefined();
         expect(response3.totalItems).toBe(names.length);
@@ -932,7 +941,10 @@ describe('DefaultEntitiesCatalog', () => {
           credentials: mockCredentials.none(),
         };
         const response4 = await catalog.queryEntities(request4);
-        expect(response4.items).toEqual([entityFrom('C'), entityFrom('D')]);
+        expect(entitiesResponseToObjects(response4.items)).toEqual([
+          entityFrom('C'),
+          entityFrom('D'),
+        ]);
         expect(response4.pageInfo.nextCursor).toBeDefined();
         expect(response4.pageInfo.prevCursor).toBeDefined();
         expect(response4.totalItems).toBe(names.length);
@@ -944,7 +956,10 @@ describe('DefaultEntitiesCatalog', () => {
           credentials: mockCredentials.none(),
         };
         const response5 = await catalog.queryEntities(request5);
-        expect(response5.items).toEqual([entityFrom('A'), entityFrom('B')]);
+        expect(entitiesResponseToObjects(response5.items)).toEqual([
+          entityFrom('A'),
+          entityFrom('B'),
+        ]);
         expect(response5.pageInfo.nextCursor).toBeDefined();
         expect(response5.pageInfo.prevCursor).toBeUndefined();
         expect(response5.totalItems).toBe(names.length);
@@ -956,7 +971,10 @@ describe('DefaultEntitiesCatalog', () => {
           credentials: mockCredentials.none(),
         };
         const response6 = await catalog.queryEntities(request6);
-        expect(response6.items).toEqual([entityFrom('C'), entityFrom('D')]);
+        expect(entitiesResponseToObjects(response6.items)).toEqual([
+          entityFrom('C'),
+          entityFrom('D'),
+        ]);
         expect(response6.pageInfo.nextCursor).toBeDefined();
         expect(response6.pageInfo.prevCursor).toBeDefined();
         expect(response6.totalItems).toBe(names.length);
@@ -968,7 +986,10 @@ describe('DefaultEntitiesCatalog', () => {
           credentials: mockCredentials.none(),
         };
         const response7 = await catalog.queryEntities(request7);
-        expect(response7.items).toEqual([entityFrom('E'), entityFrom('F')]);
+        expect(entitiesResponseToObjects(response7.items)).toEqual([
+          entityFrom('E'),
+          entityFrom('F'),
+        ]);
         expect(response7.pageInfo.nextCursor).toBeDefined();
         expect(response7.pageInfo.prevCursor).toBeDefined();
         expect(response7.totalItems).toBe(names.length);
@@ -980,7 +1001,7 @@ describe('DefaultEntitiesCatalog', () => {
           credentials: mockCredentials.none(),
         };
         const response7bis = await catalog.queryEntities(request7bis);
-        expect(response7bis.items).toEqual([
+        expect(entitiesResponseToObjects(response7bis.items)).toEqual([
           entityFrom('E'),
           entityFrom('F'),
           entityFrom('G'),
@@ -996,7 +1017,9 @@ describe('DefaultEntitiesCatalog', () => {
           credentials: mockCredentials.none(),
         };
         const response8 = await catalog.queryEntities(request8);
-        expect(response8.items).toEqual([entityFrom('G')]);
+        expect(entitiesResponseToObjects(response8.items)).toEqual([
+          entityFrom('G'),
+        ]);
         expect(response8.pageInfo.nextCursor).toBeUndefined();
         expect(response8.pageInfo.prevCursor).toBeDefined();
         expect(response8.totalItems).toBe(names.length);
@@ -1050,7 +1073,10 @@ describe('DefaultEntitiesCatalog', () => {
           credentials: mockCredentials.none(),
         };
         const response1 = await catalog.queryEntities(request1);
-        expect(response1.items).toEqual([entityFrom('G'), entityFrom('F')]);
+        expect(entitiesResponseToObjects(response1.items)).toEqual([
+          entityFrom('G'),
+          entityFrom('F'),
+        ]);
         expect(response1.pageInfo.nextCursor).toBeDefined();
         expect(response1.pageInfo.prevCursor).toBeUndefined();
         expect(response1.totalItems).toBe(names.length);
@@ -1062,7 +1088,10 @@ describe('DefaultEntitiesCatalog', () => {
           credentials: mockCredentials.none(),
         };
         const response2 = await catalog.queryEntities(request2);
-        expect(response2.items).toEqual([entityFrom('E'), entityFrom('D')]);
+        expect(entitiesResponseToObjects(response2.items)).toEqual([
+          entityFrom('E'),
+          entityFrom('D'),
+        ]);
         expect(response2.pageInfo.nextCursor).toBeDefined();
         expect(response2.pageInfo.prevCursor).toBeDefined();
         expect(response2.totalItems).toBe(names.length);
@@ -1074,7 +1103,10 @@ describe('DefaultEntitiesCatalog', () => {
           credentials: mockCredentials.none(),
         };
         const response3 = await catalog.queryEntities(request3);
-        expect(response3.items).toEqual([entityFrom('C'), entityFrom('B')]);
+        expect(entitiesResponseToObjects(response3.items)).toEqual([
+          entityFrom('C'),
+          entityFrom('B'),
+        ]);
         expect(response3.pageInfo.nextCursor).toBeDefined();
         expect(response3.pageInfo.prevCursor).toBeDefined();
         expect(response3.totalItems).toBe(names.length);
@@ -1087,7 +1119,10 @@ describe('DefaultEntitiesCatalog', () => {
         };
         const response4 = await catalog.queryEntities(request4);
 
-        expect(response4.items).toEqual([entityFrom('E'), entityFrom('D')]);
+        expect(entitiesResponseToObjects(response4.items)).toEqual([
+          entityFrom('E'),
+          entityFrom('D'),
+        ]);
         expect(response4.pageInfo.nextCursor).toBeDefined();
         expect(response4.pageInfo.prevCursor).toBeDefined();
         expect(response4.totalItems).toBe(names.length);
@@ -1099,7 +1134,10 @@ describe('DefaultEntitiesCatalog', () => {
           credentials: mockCredentials.none(),
         };
         const response5 = await catalog.queryEntities(request5);
-        expect(response5.items).toEqual([entityFrom('G'), entityFrom('F')]);
+        expect(entitiesResponseToObjects(response5.items)).toEqual([
+          entityFrom('G'),
+          entityFrom('F'),
+        ]);
         expect(response5.pageInfo.nextCursor).toBeDefined();
         expect(response5.pageInfo.prevCursor).toBeUndefined();
         expect(response5.totalItems).toBe(names.length);
@@ -1111,7 +1149,10 @@ describe('DefaultEntitiesCatalog', () => {
           credentials: mockCredentials.none(),
         };
         const response6 = await catalog.queryEntities(request6);
-        expect(response6.items).toEqual([entityFrom('E'), entityFrom('D')]);
+        expect(entitiesResponseToObjects(response6.items)).toEqual([
+          entityFrom('E'),
+          entityFrom('D'),
+        ]);
         expect(response6.pageInfo.nextCursor).toBeDefined();
         expect(response6.pageInfo.prevCursor).toBeDefined();
         expect(response6.totalItems).toBe(names.length);
@@ -1123,7 +1164,10 @@ describe('DefaultEntitiesCatalog', () => {
           credentials: mockCredentials.none(),
         };
         const response7 = await catalog.queryEntities(request7);
-        expect(response7.items).toEqual([entityFrom('C'), entityFrom('B')]);
+        expect(entitiesResponseToObjects(response7.items)).toEqual([
+          entityFrom('C'),
+          entityFrom('B'),
+        ]);
         expect(response7.pageInfo.nextCursor).toBeDefined();
         expect(response7.pageInfo.prevCursor).toBeDefined();
         expect(response7.totalItems).toBe(names.length);
@@ -1135,7 +1179,7 @@ describe('DefaultEntitiesCatalog', () => {
           credentials: mockCredentials.none(),
         };
         const response7bis = await catalog.queryEntities(request7bis);
-        expect(response7bis.items).toEqual([
+        expect(entitiesResponseToObjects(response7bis.items)).toEqual([
           entityFrom('C'),
           entityFrom('B'),
           entityFrom('A'),
@@ -1151,7 +1195,9 @@ describe('DefaultEntitiesCatalog', () => {
           credentials: mockCredentials.none(),
         };
         const response8 = await catalog.queryEntities(request8);
-        expect(response8.items).toEqual([entityFrom('A')]);
+        expect(entitiesResponseToObjects(response8.items)).toEqual([
+          entityFrom('A'),
+        ]);
         expect(response8.pageInfo.nextCursor).toBeUndefined();
         expect(response8.pageInfo.prevCursor).toBeDefined();
         expect(response8.totalItems).toBe(names.length);
@@ -1203,7 +1249,7 @@ describe('DefaultEntitiesCatalog', () => {
           credentials: mockCredentials.none(),
         };
         const response = await catalog.queryEntities(request);
-        expect(response.items).toEqual([
+        expect(entitiesResponseToObjects(response.items)).toEqual([
           entityFrom('atcatss'),
           entityFrom('cat'),
           entityFrom('dogcat'),
@@ -1261,7 +1307,7 @@ describe('DefaultEntitiesCatalog', () => {
           credentials: mockCredentials.none(),
         };
         const response = await catalog.queryEntities(request);
-        expect(response.items).toEqual(entities);
+        expect(entitiesResponseToObjects(response.items)).toEqual(entities);
         expect(response.pageInfo.nextCursor).toBeUndefined();
         expect(response.pageInfo.prevCursor).toBeUndefined();
         expect(response.totalItems).toBe(1);
@@ -1316,7 +1362,7 @@ describe('DefaultEntitiesCatalog', () => {
           credentials: mockCredentials.none(),
         };
         const response = await catalog.queryEntities(request);
-        expect(response.items).toEqual([
+        expect(entitiesResponseToObjects(response.items)).toEqual([
           entityFrom('1', { uid: 'id1', title: 'cat' }),
           entityFrom('2', { uid: 'id2', title: 'atcatss' }),
           entityFrom('4', { uid: 'id4', title: 'dogcat' }),
@@ -1329,7 +1375,7 @@ describe('DefaultEntitiesCatalog', () => {
           ...request,
           limit: 2,
         });
-        expect(paginatedResponse.items).toEqual([
+        expect(entitiesResponseToObjects(paginatedResponse.items)).toEqual([
           entityFrom('1', { uid: 'id1', title: 'cat' }),
           entityFrom('2', { uid: 'id2', title: 'atcatss' }),
         ]);
@@ -1341,7 +1387,7 @@ describe('DefaultEntitiesCatalog', () => {
           cursor: paginatedResponse.pageInfo.nextCursor!,
           credentials: mockCredentials.none(),
         });
-        expect(paginatedResponseNext.items).toEqual([
+        expect(entitiesResponseToObjects(paginatedResponseNext.items)).toEqual([
           entityFrom('4', { uid: 'id4', title: 'dogcat' }),
         ]);
         expect(paginatedResponseNext.pageInfo.nextCursor).toBeUndefined();
@@ -1419,7 +1465,7 @@ describe('DefaultEntitiesCatalog', () => {
         };
         const response = await catalog.queryEntities(request);
 
-        expect(response.items).toEqual([
+        expect(entitiesResponseToObjects(response.items)).toEqual([
           entityFrom('KingOfTheJungle', { uid: 'id0', title: 'lion' }),
           entityFrom('NotKingOfTheJungle', { uid: 'id1', title: 'cat' }),
           entityFrom('NotACatKing', { uid: 'id2', title: 'atcatss' }),
@@ -1433,7 +1479,7 @@ describe('DefaultEntitiesCatalog', () => {
           ...request,
           limit: 2,
         });
-        expect(paginatedResponse.items).toEqual([
+        expect(entitiesResponseToObjects(paginatedResponse.items)).toEqual([
           entityFrom('KingOfTheJungle', { uid: 'id0', title: 'lion' }),
           entityFrom('NotKingOfTheJungle', { uid: 'id1', title: 'cat' }),
         ]);
@@ -1445,7 +1491,7 @@ describe('DefaultEntitiesCatalog', () => {
           cursor: paginatedResponse.pageInfo.nextCursor!,
           credentials: mockCredentials.none(),
         });
-        expect(paginatedResponseNext.items).toEqual([
+        expect(entitiesResponseToObjects(paginatedResponseNext.items)).toEqual([
           entityFrom('NotACatKing', { uid: 'id2', title: 'atcatss' }),
           entityFrom('123', { uid: 'id3', title: 'king' }),
         ]);
@@ -1489,7 +1535,11 @@ describe('DefaultEntitiesCatalog', () => {
           credentials: mockCredentials.none(),
         };
         const response = await catalog.queryEntities(request);
-        expect(response).toEqual({ totalItems: 20, items: [], pageInfo: {} });
+        expect(response).toEqual({
+          totalItems: 20,
+          items: { type: 'raw', entities: [] },
+          pageInfo: {},
+        });
       },
     );
 
@@ -1524,7 +1574,10 @@ describe('DefaultEntitiesCatalog', () => {
         let response = await catalog.queryEntities(request);
         expect(response).toEqual({
           totalItems: 0,
-          items: expect.objectContaining({ length: 10 }),
+          items: {
+            type: 'raw',
+            entities: expect.objectContaining({ length: 10 }),
+          },
           pageInfo: { nextCursor: expect.anything() },
         });
         response = await catalog.queryEntities({
@@ -1533,7 +1586,10 @@ describe('DefaultEntitiesCatalog', () => {
         });
         expect(response).toEqual({
           totalItems: 0,
-          items: expect.objectContaining({ length: 5 }),
+          items: {
+            type: 'raw',
+            entities: expect.objectContaining({ length: 5 }),
+          },
           pageInfo: { prevCursor: expect.anything() },
         });
       },
@@ -1568,7 +1624,7 @@ describe('DefaultEntitiesCatalog', () => {
           credentials: mockCredentials.none(),
         };
         const response1 = await catalog.queryEntities(request1);
-        expect(response1.items).toMatchObject([
+        expect(entitiesResponseToObjects(response1.items)).toMatchObject([
           entityFrom('AA'),
           entityFrom('AA'),
         ]);
@@ -1583,7 +1639,7 @@ describe('DefaultEntitiesCatalog', () => {
           credentials: mockCredentials.none(),
         };
         const response2 = await catalog.queryEntities(request2);
-        expect(response2.items).toMatchObject([
+        expect(entitiesResponseToObjects(response2.items)).toMatchObject([
           entityFrom('AA'),
           entityFrom('AA'),
         ]);
@@ -1598,7 +1654,10 @@ describe('DefaultEntitiesCatalog', () => {
           credentials: mockCredentials.none(),
         };
         const response3 = await catalog.queryEntities(request3);
-        expect(response3.items).toEqual([entityFrom('CC'), entityFrom('DD')]);
+        expect(entitiesResponseToObjects(response3.items)).toEqual([
+          entityFrom('CC'),
+          entityFrom('DD'),
+        ]);
         expect(response3.pageInfo.nextCursor).toBeUndefined();
         expect(response3.pageInfo.prevCursor).toBeDefined();
         expect(response3.totalItems).toBe(6);
@@ -1610,7 +1669,7 @@ describe('DefaultEntitiesCatalog', () => {
           credentials: mockCredentials.none(),
         };
         const response4 = await catalog.queryEntities(request4);
-        expect(response4.items).toMatchObject([
+        expect(entitiesResponseToObjects(response4.items)).toMatchObject([
           entityFrom('AA'),
           entityFrom('AA'),
         ]);
@@ -1625,7 +1684,7 @@ describe('DefaultEntitiesCatalog', () => {
           credentials: mockCredentials.none(),
         };
         const response5 = await catalog.queryEntities(request5);
-        expect(response5.items).toMatchObject([
+        expect(entitiesResponseToObjects(response5.items)).toMatchObject([
           entityFrom('AA'),
           entityFrom('AA'),
         ]);
@@ -1693,7 +1752,7 @@ describe('DefaultEntitiesCatalog', () => {
           credentials: mockCredentials.none(),
         };
         const response1 = await catalog.queryEntities(request1);
-        expect(response1.items).toMatchObject([
+        expect(entitiesResponseToObjects(response1.items)).toMatchObject([
           entityFrom('AA', { uid: '1', kind: 'included' }),
           entityFrom('AA', { uid: '2', kind: 'included' }),
         ]);
@@ -1708,7 +1767,7 @@ describe('DefaultEntitiesCatalog', () => {
           credentials: mockCredentials.none(),
         };
         const response2 = await catalog.queryEntities(request2);
-        expect(response2.items).toMatchObject([
+        expect(entitiesResponseToObjects(response2.items)).toMatchObject([
           entityFrom('AA', { uid: '4', kind: 'included' }),
           entityFrom('AA', { uid: '5', kind: 'included' }),
         ]);
@@ -1752,7 +1811,7 @@ describe('DefaultEntitiesCatalog', () => {
           credentials: mockCredentials.none(),
         };
         const response1 = await catalog.queryEntities(request1);
-        expect(response1.items).toMatchObject([
+        expect(entitiesResponseToObjects(response1.items)).toMatchObject([
           entityFrom('AA'),
           entityFrom('CC'),
         ]);
@@ -1767,7 +1826,7 @@ describe('DefaultEntitiesCatalog', () => {
           credentials: mockCredentials.none(),
         };
         const response2 = await catalog.queryEntities(request2);
-        expect(response2.items).toMatchObject([
+        expect(entitiesResponseToObjects(response2.items)).toMatchObject([
           entityFrom('DD'),
           entityFrom('AA', { namespace: 'namespace2' }),
         ]);
@@ -1782,7 +1841,7 @@ describe('DefaultEntitiesCatalog', () => {
           credentials: mockCredentials.none(),
         };
         const response3 = await catalog.queryEntities(request3);
-        expect(response3.items).toMatchObject([
+        expect(entitiesResponseToObjects(response3.items)).toMatchObject([
           entityFrom('AA', { namespace: 'namespace3' }),
           entityFrom('AA', { namespace: 'namespace4' }),
         ]);
@@ -1797,7 +1856,7 @@ describe('DefaultEntitiesCatalog', () => {
           credentials: mockCredentials.none(),
         };
         const response4 = await catalog.queryEntities(request4);
-        expect(response4.items).toMatchObject([
+        expect(entitiesResponseToObjects(response4.items)).toMatchObject([
           entityFrom('DD'),
           entityFrom('AA', { namespace: 'namespace2' }),
         ]);
@@ -1812,7 +1871,7 @@ describe('DefaultEntitiesCatalog', () => {
           credentials: mockCredentials.none(),
         };
         const response5 = await catalog.queryEntities(request5);
-        expect(response5.items).toMatchObject([
+        expect(entitiesResponseToObjects(response5.items)).toMatchObject([
           entityFrom('AA'),
           entityFrom('CC'),
         ]);

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -105,18 +105,20 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
   private readonly database: Knex;
   private readonly logger: LoggerService;
   private readonly stitcher: Stitcher;
-  private readonly enableRawJson: boolean;
+  private readonly disableRelationsCompatibility: boolean;
 
   constructor(options: {
     database: Knex;
     logger: LoggerService;
     stitcher: Stitcher;
-    enableRawJson?: boolean;
+    disableRelationsCompatibility?: boolean;
   }) {
     this.database = options.database;
     this.logger = options.logger;
     this.stitcher = options.stitcher;
-    this.enableRawJson = Boolean(options.enableRawJson);
+    this.disableRelationsCompatibility = Boolean(
+      options.disableRelationsCompatibility,
+    );
   }
 
   async entities(request?: EntitiesRequest): Promise<EntitiesResponse> {
@@ -197,7 +199,7 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
     return {
       entities: processRawEntitiesResult(
         rows.map(r => r.final_entity!),
-        this.enableRawJson
+        this.disableRelationsCompatibility
           ? request?.fields
           : e => {
               expandLegacyCompoundRelationsInEntity(e);

--- a/plugins/catalog-backend/src/service/createRouter.test.ts
+++ b/plugins/catalog-backend/src/service/createRouter.test.ts
@@ -860,7 +860,7 @@ describe('createRouter readonly disabled', () => {
   });
 });
 
-describe('createRouter readonly enabled', () => {
+describe('createRouter readonly and raw json enabled', () => {
   let entitiesCatalog: jest.Mocked<EntitiesCatalog>;
   let app: express.Express;
   let locationService: jest.Mocked<LocationService>;
@@ -883,6 +883,7 @@ describe('createRouter readonly enabled', () => {
       getLocationByEntity: jest.fn(),
     };
     const router = await createRouter({
+      enableRawJson: true,
       entitiesCatalog,
       locationService,
       logger: mockServices.logger.mock(),
@@ -910,7 +911,7 @@ describe('createRouter readonly enabled', () => {
       ];
 
       entitiesCatalog.queryEntities.mockResolvedValueOnce({
-        items: { type: 'object', entities: [entities[0]] },
+        items: { type: 'raw', entities: [JSON.stringify(entities[0])] },
         pageInfo: {},
         totalItems: 1,
       });

--- a/plugins/catalog-backend/src/service/createRouter.test.ts
+++ b/plugins/catalog-backend/src/service/createRouter.test.ts
@@ -136,7 +136,7 @@ describe('createRouter readonly disabled', () => {
       ];
 
       entitiesCatalog.queryEntities.mockResolvedValueOnce({
-        items: { type: 'objects', entities: [entities[0]] },
+        items: { type: 'object', entities: [entities[0]] },
         pageInfo: {},
         totalItems: 1,
       });
@@ -149,7 +149,7 @@ describe('createRouter readonly disabled', () => {
 
     it('parses single and multiple request parameters and passes them down', async () => {
       entitiesCatalog.queryEntities.mockResolvedValueOnce({
-        items: { type: 'objects', entities: [] },
+        items: { type: 'object', entities: [] },
         pageInfo: {},
         totalItems: 0,
       });
@@ -185,7 +185,7 @@ describe('createRouter readonly disabled', () => {
       ];
 
       entitiesCatalog.queryEntities.mockResolvedValueOnce({
-        items: { type: 'objects', entities: items },
+        items: { type: 'object', entities: items },
         totalItems: 100,
         pageInfo: { nextCursor: mockCursor() },
       });
@@ -203,7 +203,7 @@ describe('createRouter readonly disabled', () => {
 
     it('parses initial request', async () => {
       entitiesCatalog.queryEntities.mockResolvedValueOnce({
-        items: { type: 'objects', entities: [] },
+        items: { type: 'object', entities: [] },
         pageInfo: {},
         totalItems: 0,
       });
@@ -239,7 +239,7 @@ describe('createRouter readonly disabled', () => {
 
     it('parses encoded params request', async () => {
       entitiesCatalog.queryEntities.mockResolvedValueOnce({
-        items: { type: 'objects', entities: [] },
+        items: { type: 'object', entities: [] },
         pageInfo: {},
         totalItems: 0,
       });
@@ -283,7 +283,7 @@ describe('createRouter readonly disabled', () => {
       ];
 
       entitiesCatalog.queryEntities.mockResolvedValueOnce({
-        items: { type: 'objects', entities: items },
+        items: { type: 'object', entities: items },
         totalItems: 100,
         pageInfo: { nextCursor: mockCursor() },
       });
@@ -312,7 +312,7 @@ describe('createRouter readonly disabled', () => {
       ];
 
       entitiesCatalog.queryEntities.mockResolvedValueOnce({
-        items: { type: 'objects', entities: items },
+        items: { type: 'object', entities: items },
         totalItems: 100,
         pageInfo: {
           nextCursor: mockCursor({ fullTextFilter: { term: 'mySearch' } }),
@@ -354,7 +354,7 @@ describe('createRouter readonly disabled', () => {
       ];
 
       entitiesCatalog.queryEntities.mockResolvedValueOnce({
-        items: { type: 'objects', entities: items },
+        items: { type: 'object', entities: items },
         totalItems: 100,
         pageInfo: { nextCursor: mockCursor() },
       });
@@ -379,7 +379,7 @@ describe('createRouter readonly disabled', () => {
       ];
 
       entitiesCatalog.queryEntities.mockResolvedValueOnce({
-        items: { type: 'objects', entities: items },
+        items: { type: 'object', entities: items },
         totalItems: 100,
         pageInfo: { nextCursor: mockCursor() },
       });
@@ -402,7 +402,7 @@ describe('createRouter readonly disabled', () => {
         },
       };
       entitiesCatalog.entities.mockResolvedValue({
-        entities: { type: 'objects', entities: [entity] },
+        entities: { type: 'object', entities: [entity] },
         pageInfo: { hasNextPage: false },
       });
 
@@ -419,7 +419,7 @@ describe('createRouter readonly disabled', () => {
 
     it('responds with a 404 for missing entities', async () => {
       entitiesCatalog.entities.mockResolvedValue({
-        entities: { type: 'objects', entities: [] },
+        entities: { type: 'object', entities: [] },
         pageInfo: { hasNextPage: false },
       });
 
@@ -446,7 +446,7 @@ describe('createRouter readonly disabled', () => {
         },
       };
       entitiesCatalog.entitiesBatch.mockResolvedValue({
-        items: { type: 'objects', entities: [entity] },
+        items: { type: 'object', entities: [entity] },
       });
 
       const response = await request(app).get('/entities/by-name/k/ns/n');
@@ -462,7 +462,7 @@ describe('createRouter readonly disabled', () => {
 
     it('responds with a 404 for missing entities', async () => {
       entitiesCatalog.entitiesBatch.mockResolvedValue({
-        items: { type: 'objects', entities: [null] },
+        items: { type: 'object', entities: [null] },
       });
 
       const response = await request(app).get('/entities/by-name/b/d/c');
@@ -534,7 +534,7 @@ describe('createRouter readonly disabled', () => {
       };
       const entityRef = stringifyEntityRef(entity);
       entitiesCatalog.entitiesBatch.mockResolvedValue({
-        items: { type: 'objects', entities: [entity] },
+        items: { type: 'object', entities: [entity] },
       });
       const response = await request(app)
         .post('/entities/by-refs?filter=kind=Component')
@@ -910,7 +910,7 @@ describe('createRouter readonly enabled', () => {
       ];
 
       entitiesCatalog.queryEntities.mockResolvedValueOnce({
-        items: { type: 'objects', entities: [entities[0]] },
+        items: { type: 'object', entities: [entities[0]] },
         pageInfo: {},
         totalItems: 1,
       });
@@ -1130,7 +1130,7 @@ describe('NextRouter permissioning', () => {
       },
     };
     entitiesCatalog.entities.mockResolvedValueOnce({
-      entities: { type: 'objects', entities: [spideySense] },
+      entities: { type: 'object', entities: [spideySense] },
       pageInfo: { hasNextPage: false },
     });
 

--- a/plugins/catalog-backend/src/service/createRouter.test.ts
+++ b/plugins/catalog-backend/src/service/createRouter.test.ts
@@ -883,7 +883,7 @@ describe('createRouter readonly and raw json enabled', () => {
       getLocationByEntity: jest.fn(),
     };
     const router = await createRouter({
-      enableRawJson: true,
+      disableRelationsCompatibility: true,
       entitiesCatalog,
       locationService,
       logger: mockServices.logger.mock(),

--- a/plugins/catalog-backend/src/service/createRouter.test.ts
+++ b/plugins/catalog-backend/src/service/createRouter.test.ts
@@ -136,7 +136,7 @@ describe('createRouter readonly disabled', () => {
       ];
 
       entitiesCatalog.queryEntities.mockResolvedValueOnce({
-        items: [entities[0]],
+        items: { type: 'objects', entities: [entities[0]] },
         pageInfo: {},
         totalItems: 1,
       });
@@ -149,7 +149,7 @@ describe('createRouter readonly disabled', () => {
 
     it('parses single and multiple request parameters and passes them down', async () => {
       entitiesCatalog.queryEntities.mockResolvedValueOnce({
-        items: [],
+        items: { type: 'objects', entities: [] },
         pageInfo: {},
         totalItems: 0,
       });
@@ -185,7 +185,7 @@ describe('createRouter readonly disabled', () => {
       ];
 
       entitiesCatalog.queryEntities.mockResolvedValueOnce({
-        items,
+        items: { type: 'objects', entities: items },
         totalItems: 100,
         pageInfo: { nextCursor: mockCursor() },
       });
@@ -203,7 +203,7 @@ describe('createRouter readonly disabled', () => {
 
     it('parses initial request', async () => {
       entitiesCatalog.queryEntities.mockResolvedValueOnce({
-        items: [],
+        items: { type: 'objects', entities: [] },
         pageInfo: {},
         totalItems: 0,
       });
@@ -239,7 +239,7 @@ describe('createRouter readonly disabled', () => {
 
     it('parses encoded params request', async () => {
       entitiesCatalog.queryEntities.mockResolvedValueOnce({
-        items: [],
+        items: { type: 'objects', entities: [] },
         pageInfo: {},
         totalItems: 0,
       });
@@ -283,7 +283,7 @@ describe('createRouter readonly disabled', () => {
       ];
 
       entitiesCatalog.queryEntities.mockResolvedValueOnce({
-        items,
+        items: { type: 'objects', entities: items },
         totalItems: 100,
         pageInfo: { nextCursor: mockCursor() },
       });
@@ -312,7 +312,7 @@ describe('createRouter readonly disabled', () => {
       ];
 
       entitiesCatalog.queryEntities.mockResolvedValueOnce({
-        items,
+        items: { type: 'objects', entities: items },
         totalItems: 100,
         pageInfo: {
           nextCursor: mockCursor({ fullTextFilter: { term: 'mySearch' } }),
@@ -354,7 +354,7 @@ describe('createRouter readonly disabled', () => {
       ];
 
       entitiesCatalog.queryEntities.mockResolvedValueOnce({
-        items,
+        items: { type: 'objects', entities: items },
         totalItems: 100,
         pageInfo: { nextCursor: mockCursor() },
       });
@@ -379,7 +379,7 @@ describe('createRouter readonly disabled', () => {
       ];
 
       entitiesCatalog.queryEntities.mockResolvedValueOnce({
-        items,
+        items: { type: 'objects', entities: items },
         totalItems: 100,
         pageInfo: { nextCursor: mockCursor() },
       });
@@ -402,7 +402,7 @@ describe('createRouter readonly disabled', () => {
         },
       };
       entitiesCatalog.entities.mockResolvedValue({
-        entities: [entity],
+        entities: { type: 'objects', entities: [entity] },
         pageInfo: { hasNextPage: false },
       });
 
@@ -419,7 +419,7 @@ describe('createRouter readonly disabled', () => {
 
     it('responds with a 404 for missing entities', async () => {
       entitiesCatalog.entities.mockResolvedValue({
-        entities: [],
+        entities: { type: 'objects', entities: [] },
         pageInfo: { hasNextPage: false },
       });
 
@@ -446,7 +446,7 @@ describe('createRouter readonly disabled', () => {
         },
       };
       entitiesCatalog.entitiesBatch.mockResolvedValue({
-        items: [entity],
+        items: { type: 'objects', entities: [entity] },
       });
 
       const response = await request(app).get('/entities/by-name/k/ns/n');
@@ -462,7 +462,7 @@ describe('createRouter readonly disabled', () => {
 
     it('responds with a 404 for missing entities', async () => {
       entitiesCatalog.entitiesBatch.mockResolvedValue({
-        items: [null],
+        items: { type: 'objects', entities: [null] },
       });
 
       const response = await request(app).get('/entities/by-name/b/d/c');
@@ -533,7 +533,9 @@ describe('createRouter readonly disabled', () => {
         },
       };
       const entityRef = stringifyEntityRef(entity);
-      entitiesCatalog.entitiesBatch.mockResolvedValue({ items: [entity] });
+      entitiesCatalog.entitiesBatch.mockResolvedValue({
+        items: { type: 'objects', entities: [entity] },
+      });
       const response = await request(app)
         .post('/entities/by-refs?filter=kind=Component')
         .set('Content-Type', 'application/json')
@@ -908,7 +910,7 @@ describe('createRouter readonly enabled', () => {
       ];
 
       entitiesCatalog.queryEntities.mockResolvedValueOnce({
-        items: [entities[0]],
+        items: { type: 'objects', entities: [entities[0]] },
         pageInfo: {},
         totalItems: 1,
       });
@@ -1128,7 +1130,7 @@ describe('NextRouter permissioning', () => {
       },
     };
     entitiesCatalog.entities.mockResolvedValueOnce({
-      entities: [spideySense],
+      entities: { type: 'objects', entities: [spideySense] },
       pageInfo: { hasNextPage: false },
     });
 

--- a/plugins/catalog-backend/src/service/createRouter.ts
+++ b/plugins/catalog-backend/src/service/createRouter.ts
@@ -41,7 +41,6 @@ import { parseEntityFacetParams } from './request/parseEntityFacetParams';
 import { parseEntityOrderParams } from './request/parseEntityOrderParams';
 import { LocationService, RefreshService } from './types';
 import {
-  createEntityArrayJsonStream,
   disallowReadonlyMode,
   encodeCursor,
   expandLegacyCompoundRelationsInEntity,
@@ -61,6 +60,7 @@ import { LocationAnalyzer } from '@backstage/plugin-catalog-node';
 import { AuthorizedValidationService } from './AuthorizedValidationService';
 import { DeferredPromise, createDeferred } from '@backstage/types';
 import {
+  createEntityArrayJsonStream,
   processEntitiesResponseItems,
   writeEntitiesResponse,
   writeSingleEntityResponse,

--- a/plugins/catalog-backend/src/service/createRouter.ts
+++ b/plugins/catalog-backend/src/service/createRouter.ts
@@ -216,7 +216,7 @@ export async function createRouter(
               signal.throwIfAborted();
 
               if (!disableRelationsCompatibility) {
-                processEntitiesResponseItems(
+                result.items = processEntitiesResponseItems(
                   result.items,
                   expandLegacyCompoundRelationsInEntity,
                 );

--- a/plugins/catalog-backend/src/service/createRouter.ts
+++ b/plugins/catalog-backend/src/service/createRouter.ts
@@ -171,7 +171,7 @@ export async function createRouter(
             res.setHeader('link', `<${url.pathname}${url.search}>; rel="next"`);
           }
 
-          writeEntitiesResponse(res, entities);
+          await writeEntitiesResponse(res, entities);
           return;
         }
 
@@ -253,7 +253,7 @@ export async function createRouter(
             credentials: await httpAuth.credentials(req),
           });
 
-        writeEntitiesResponse(res, items, entities => ({
+        await writeEntitiesResponse(res, items, entities => ({
           items: entities,
           totalItems,
           pageInfo: {
@@ -312,7 +312,9 @@ export async function createRouter(
           fields: parseEntityTransformParams(req.query, request.fields),
           credentials: await httpAuth.credentials(req),
         });
-        writeEntitiesResponse(res, items, entities => ({ items: entities }));
+        await writeEntitiesResponse(res, items, entities => ({
+          items: entities,
+        }));
       })
       .get('/entity-facets', async (req, res) => {
         const response = await entitiesCatalog.facets({

--- a/plugins/catalog-backend/src/service/createRouter.ts
+++ b/plugins/catalog-backend/src/service/createRouter.ts
@@ -23,7 +23,7 @@ import {
   stringifyEntityRef,
 } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
-import { InputError, NotFoundError, serializeError } from '@backstage/errors';
+import { InputError, serializeError } from '@backstage/errors';
 import express from 'express';
 import yn from 'yn';
 import { z } from 'zod';
@@ -272,9 +272,7 @@ export async function createRouter(
           filter: basicEntityFilter({ 'metadata.uid': uid }),
           credentials: await httpAuth.credentials(req),
         });
-        if (!writeSingleEntityResponse(res, entities)) {
-          throw new NotFoundError(`No entity with uid ${uid}`);
-        }
+        writeSingleEntityResponse(res, entities, `No entity with uid ${uid}`);
       })
       .delete('/entities/by-uid/:uid', async (req, res) => {
         const { uid } = req.params;
@@ -289,11 +287,11 @@ export async function createRouter(
           entityRefs: [stringifyEntityRef({ kind, namespace, name })],
           credentials: await httpAuth.credentials(req),
         });
-        if (!writeSingleEntityResponse(res, items)) {
-          throw new NotFoundError(
-            `No entity named '${name}' found, with kind '${kind}' in namespace '${namespace}'`,
-          );
-        }
+        writeSingleEntityResponse(
+          res,
+          items,
+          `No entity named '${name}' found, with kind '${kind}' in namespace '${namespace}'`,
+        );
       })
       .get(
         '/entities/by-name/:kind/:namespace/:name/ancestry',

--- a/plugins/catalog-backend/src/service/createRouter.ts
+++ b/plugins/catalog-backend/src/service/createRouter.ts
@@ -85,7 +85,7 @@ export interface RouterOptions {
   auth: AuthService;
   httpAuth: HttpAuthService;
   permissionsService: PermissionsService;
-  enableRawJson?: boolean;
+  disableRelationsCompatibility?: boolean;
 }
 
 /**
@@ -113,7 +113,7 @@ export async function createRouter(
     permissionsService,
     auth,
     httpAuth,
-    enableRawJson = false,
+    disableRelationsCompatibility = false,
   } = options;
 
   const readonlyEnabled =
@@ -215,7 +215,7 @@ export async function createRouter(
 
               signal.throwIfAborted();
 
-              if (!enableRawJson) {
+              if (!disableRelationsCompatibility) {
                 processEntitiesResponseItems(
                   result.items,
                   expandLegacyCompoundRelationsInEntity,

--- a/plugins/catalog-backend/src/service/response/createEntityArrayJsonStream.ts
+++ b/plugins/catalog-backend/src/service/response/createEntityArrayJsonStream.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { EntitiesResponseItems } from '../../catalog/types';
+import { Response } from 'express';
+
+export interface EntityArrayJsonStream {
+  send(entities: EntitiesResponseItems): boolean;
+  complete(): void;
+  close(): void;
+}
+
+// Helps stream EntitiesResponseItems[] as a JSON response stream to avoid performance issues
+export function createEntityArrayJsonStream(
+  res: Response,
+): EntityArrayJsonStream {
+  // Imitate the httpRouter behavior of pretty-printing in development
+  const prettyPrint = process.env.NODE_ENV === 'development';
+  let firstSend = true;
+  let completed = false;
+
+  return {
+    send(response) {
+      if (firstSend) {
+        res.setHeader('Content-Type', 'application/json; charset=utf-8');
+        res.status(200);
+        res.flushHeaders();
+      }
+
+      if (response.type === 'raw') {
+        let needsDrain = false;
+        for (const item of response.entities) {
+          const prefix = firstSend ? '[' : ',';
+          firstSend = false;
+          needsDrain ||= !res.write(prefix + item, 'utf8');
+        }
+        return !needsDrain;
+      }
+
+      let data: string;
+      if (prettyPrint) {
+        data = JSON.stringify(response.entities, null, 2);
+        data = firstSend ? data.slice(0, -2) : `,\n${data.slice(2, -2)}`;
+      } else {
+        data = JSON.stringify(response.entities);
+        data = firstSend ? data.slice(0, -1) : `,${data.slice(1, -1)}`;
+      }
+
+      firstSend = false;
+      return res.write(data, 'utf8');
+    },
+    complete() {
+      if (firstSend) {
+        res.json([]);
+      } else {
+        res.end(prettyPrint ? '\n]' : ']', 'utf8');
+      }
+      completed = true;
+    },
+    close() {
+      if (!completed) {
+        res.end();
+      }
+    },
+  };
+}

--- a/plugins/catalog-backend/src/service/response/index.ts
+++ b/plugins/catalog-backend/src/service/response/index.ts
@@ -20,3 +20,4 @@ export {
   entitiesResponseToObjects,
 } from './process';
 export { writeSingleEntityResponse, writeEntitiesResponse } from './write';
+export { createEntityArrayJsonStream } from './createEntityArrayJsonStream';

--- a/plugins/catalog-backend/src/service/response/index.ts
+++ b/plugins/catalog-backend/src/service/response/index.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export {
+  processRawEntitiesResult,
+  processEntitiesResponseItems,
+  entitiesResponseToObjects,
+} from './process';
+export { writeSingleEntityResponse, writeEntitiesResponse } from './write';

--- a/plugins/catalog-backend/src/service/response/process.test.ts
+++ b/plugins/catalog-backend/src/service/response/process.test.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity } from '@backstage/catalog-model';
+import {
+  entitiesResponseToObjects,
+  processEntitiesResponseItems,
+  processRawEntitiesResult,
+} from './process';
+
+const mockTransform = (entity: Entity): Entity => ({
+  ...entity,
+  kind: `transformed-${entity.kind}`,
+});
+
+describe('processRawEntitiesResult', () => {
+  it('should prefer keeping results in raw form', () => {
+    expect(processRawEntitiesResult(['{"kind":"test"}', null])).toEqual({
+      type: 'raw',
+      entities: ['{"kind":"test"}', null],
+    });
+
+    expect(
+      processRawEntitiesResult(['{"kind":"test"}', null], mockTransform),
+    ).toEqual({
+      type: 'object',
+      entities: [{ kind: 'transformed-test' }, null],
+    });
+  });
+});
+
+describe('processEntitiesResponseItems', () => {
+  it('should transform entities in object form', () => {
+    expect(
+      processEntitiesResponseItems({
+        type: 'object',
+        entities: [{ kind: 'test' } as Entity, null],
+      }),
+    ).toEqual({
+      type: 'object',
+      entities: [{ kind: 'test' }, null],
+    });
+
+    expect(
+      processEntitiesResponseItems(
+        {
+          type: 'object',
+          entities: [{ kind: 'test' } as Entity, null],
+        },
+        mockTransform,
+      ),
+    ).toEqual({
+      type: 'object',
+      entities: [{ kind: 'transformed-test' }, null],
+    });
+  });
+
+  it('should transform entities in raw form', () => {
+    expect(
+      processEntitiesResponseItems({
+        type: 'raw',
+        entities: ['{"kind":"test"}', null],
+      }),
+    ).toEqual({
+      type: 'raw',
+      entities: ['{"kind":"test"}', null],
+    });
+
+    expect(
+      processEntitiesResponseItems(
+        {
+          type: 'raw',
+          entities: ['{"kind":"test"}', null],
+        },
+        mockTransform,
+      ),
+    ).toEqual({
+      type: 'object',
+      entities: [{ kind: 'transformed-test' }, null],
+    });
+  });
+});
+
+describe('entitiesResponseToObjects', () => {
+  it('should convert entities in object form', () => {
+    expect(
+      entitiesResponseToObjects({
+        type: 'object',
+        entities: [null, { kind: 'test' } as Entity],
+      }),
+    ).toEqual([null, { kind: 'test' }]);
+  });
+
+  it('should convert entities in raw form', () => {
+    expect(
+      entitiesResponseToObjects({
+        type: 'raw',
+        entities: [null, '{"kind":"test"}'],
+      }),
+    ).toEqual([null, { kind: 'test' }]);
+  });
+});

--- a/plugins/catalog-backend/src/service/response/process.ts
+++ b/plugins/catalog-backend/src/service/response/process.ts
@@ -39,7 +39,7 @@ export function processRawEntitiesResult(
 export function processEntitiesResponseItems(
   response: EntitiesResponseItems,
   transform?: (entity: Entity) => Entity,
-) {
+): EntitiesResponseItems {
   if (!transform) {
     return response;
   }

--- a/plugins/catalog-backend/src/service/response/process.ts
+++ b/plugins/catalog-backend/src/service/response/process.ts
@@ -23,7 +23,7 @@ export function processRawEntitiesResult(
 ): EntitiesResponseItems {
   if (transform) {
     return {
-      type: 'objects',
+      type: 'object',
       entities: serializedEntities.map(e =>
         e !== null ? transform(JSON.parse(e)) : e,
       ),
@@ -47,7 +47,7 @@ export function processEntitiesResponseItems(
     return processRawEntitiesResult(response.entities, transform);
   }
   return {
-    type: 'objects',
+    type: 'object',
     entities: response.entities.map(e => (e !== null ? transform(e) : e)),
   };
 }
@@ -55,7 +55,7 @@ export function processEntitiesResponseItems(
 export function entitiesResponseToObjects(
   response: EntitiesResponseItems,
 ): (Entity | null)[] {
-  if (response.type === 'objects') {
+  if (response.type === 'object') {
     return response.entities;
   }
   return response.entities.map(e => (e !== null ? JSON.parse(e) : e));

--- a/plugins/catalog-backend/src/service/response/process.ts
+++ b/plugins/catalog-backend/src/service/response/process.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity } from '@backstage/catalog-model';
+import { EntitiesResponseItems } from '../../catalog/types';
+
+export function processRawEntitiesResult(
+  serializedEntities: (string | null)[],
+  transform?: (entity: Entity) => Entity,
+): EntitiesResponseItems {
+  if (transform) {
+    return {
+      type: 'objects',
+      entities: serializedEntities.map(e =>
+        e !== null ? transform(JSON.parse(e)) : e,
+      ),
+    };
+  }
+
+  return {
+    type: 'raw',
+    entities: serializedEntities,
+  };
+}
+
+export function processEntitiesResponseItems(
+  response: EntitiesResponseItems,
+  transform?: (entity: Entity) => Entity,
+) {
+  if (!transform) {
+    return response;
+  }
+  if (response.type === 'raw') {
+    return processRawEntitiesResult(response.entities, transform);
+  }
+  return {
+    type: 'objects',
+    entities: response.entities.map(e => (e !== null ? transform(e) : e)),
+  };
+}
+
+export function entitiesResponseToObjects(
+  response: EntitiesResponseItems,
+): (Entity | null)[] {
+  if (response.type === 'objects') {
+    return response.entities;
+  }
+  return response.entities.map(e => (e !== null ? JSON.parse(e) : e));
+}

--- a/plugins/catalog-backend/src/service/response/write.test.ts
+++ b/plugins/catalog-backend/src/service/response/write.test.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import express from 'express';
+import { mockErrorHandler } from '@backstage/backend-test-utils';
+import request from 'supertest';
+import { writeSingleEntityResponse } from './write';
+
+describe('writeSingleEntityResponse', () => {
+  const app = express();
+  app.use(express.json());
+  app.get('/echo', (req, res) => {
+    writeSingleEntityResponse(res, req.body, 'not found');
+  });
+  app.use(mockErrorHandler());
+
+  describe('in object form', () => {
+    it('should write a single entity', async () => {
+      const res = await request(app)
+        .get('/echo')
+        .send({
+          type: 'object',
+          entities: [{ kind: 'Component' }, { kind: 'User' }],
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.type).toBe('application/json');
+      expect(res.header['content-type']).toBe(
+        'application/json; charset=utf-8',
+      );
+      expect(res.body).toEqual({ kind: 'Component' });
+    });
+
+    it('should write a missing entity', async () => {
+      const res = await request(app)
+        .get('/echo')
+        .send({ type: 'object', entities: [null] });
+
+      expect(res.status).toBe(404);
+      expect(res.type).toBe('application/json');
+      expect(res.header['content-type']).toBe(
+        'application/json; charset=utf-8',
+      );
+      expect(res.body).toMatchObject({
+        error: { name: 'NotFoundError', message: 'not found' },
+      });
+    });
+
+    it('should write no entities', async () => {
+      const res = await request(app)
+        .get('/echo')
+        .send({ type: 'object', entities: [] });
+
+      expect(res.status).toBe(404);
+      expect(res.type).toBe('application/json');
+      expect(res.header['content-type']).toBe(
+        'application/json; charset=utf-8',
+      );
+      expect(res.body).toMatchObject({
+        error: { name: 'NotFoundError', message: 'not found' },
+      });
+    });
+  });
+
+  describe('in raw form', () => {
+    it('should write a single entity', async () => {
+      const res = await request(app)
+        .get('/echo')
+        .send({
+          type: 'raw',
+          entities: ['{"kind":"Component"}', '{"kind":"User"}'],
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.type).toBe('application/json');
+      expect(res.header['content-type']).toBe(
+        'application/json; charset=utf-8',
+      );
+      expect(res.body).toEqual({ kind: 'Component' });
+    });
+
+    it('should write a missing entity', async () => {
+      const res = await request(app)
+        .get('/echo')
+        .send({ type: 'raw', entities: [null] });
+
+      expect(res.status).toBe(404);
+      expect(res.type).toBe('application/json');
+      expect(res.header['content-type']).toBe(
+        'application/json; charset=utf-8',
+      );
+      expect(res.body).toMatchObject({
+        error: { name: 'NotFoundError', message: 'not found' },
+      });
+    });
+
+    it('should write no entities', async () => {
+      const res = await request(app)
+        .get('/echo')
+        .send({ type: 'raw', entities: [] });
+
+      expect(res.status).toBe(404);
+      expect(res.type).toBe('application/json');
+      expect(res.header['content-type']).toBe(
+        'application/json; charset=utf-8',
+      );
+      expect(res.body).toMatchObject({
+        error: { name: 'NotFoundError', message: 'not found' },
+      });
+    });
+  });
+});

--- a/plugins/catalog-backend/src/service/response/write.test.ts
+++ b/plugins/catalog-backend/src/service/response/write.test.ts
@@ -277,5 +277,41 @@ describe('writeEntitiesResponse', () => {
         totalItems: 1337,
       });
     });
+
+    it('should write a large wrapped response', async () => {
+      const entityMock = JSON.stringify({
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: {
+          name: 'my-component',
+          namespace: 'default',
+          annotations: {
+            'backstage.io/managed-by-location': 'url:https://example.com',
+          },
+        },
+        spec: {
+          type: 'service',
+          owner: 'me',
+          lifecycle: 'production',
+        },
+      });
+      const res = await request(app)
+        .get('/wrapped')
+        .send({
+          type: 'raw',
+          entities: Array(300).fill(entityMock),
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.type).toBe('application/json');
+      expect(res.header['content-type']).toBe(
+        'application/json; charset=utf-8',
+      );
+      expect(res.body).toEqual({
+        page: 1,
+        items: expect.objectContaining({ length: 300 }),
+        totalItems: 1337,
+      });
+    });
   });
 });

--- a/plugins/catalog-backend/src/service/response/write.ts
+++ b/plugins/catalog-backend/src/service/response/write.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Response } from 'express';
+import { EntitiesResponseItems } from '../../catalog/types';
+import { JsonValue } from '@backstage/types';
+
+const JSON_CONTENT_TYPE = 'application/json; charset=utf-8';
+
+export function writeSingleEntityResponse(
+  res: Response,
+  response: EntitiesResponseItems,
+): boolean {
+  const entity = response.entities[0];
+  if (!entity) {
+    return false;
+  }
+
+  if (typeof entity === 'string') {
+    res.setHeader('Content-Type', JSON_CONTENT_TYPE);
+    res.status(200);
+    res.write(entity);
+  } else {
+    res.json(entity);
+  }
+
+  return true;
+}
+
+export function writeEntitiesResponse(
+  res: Response,
+  response: EntitiesResponseItems,
+  responseWrapper?: (entities: JsonValue) => JsonValue,
+) {
+  if (response.type === 'objects') {
+    res.json(
+      responseWrapper
+        ? responseWrapper?.(response.entities)
+        : response.entities,
+    );
+    return;
+  }
+
+  res.setHeader('Content-Type', JSON_CONTENT_TYPE);
+  res.status(200);
+
+  // responseWrapper allows the caller to render the entities within an object
+  let trailing = '';
+  if (responseWrapper) {
+    const marker = `__MARKER_${Math.random().toString(36).slice(2, 10)}__`;
+    const wrapped = JSON.stringify(responseWrapper(marker));
+    const parts = wrapped.split(marker);
+    if (parts.length !== 2) {
+      throw new Error(
+        `Entity items response was incorrectly wrapped into ${parts.length} different parts`,
+      );
+    }
+    res.write(parts[0], 'utf8');
+    trailing = parts[1];
+  }
+
+  let first = true;
+  for (const entity of response.entities) {
+    if (first) {
+      res.write('[', 'utf8');
+      first = false;
+    } else {
+      res.write(',', 'utf8');
+    }
+    res.write(entity, 'utf8');
+  }
+  res.end(']');
+  if (trailing) {
+    res.write(trailing, 'utf8');
+  }
+}

--- a/plugins/catalog-backend/src/service/util.ts
+++ b/plugins/catalog-backend/src/service/util.ts
@@ -192,17 +192,13 @@ export function createEntityArrayJsonStream(
       }
 
       if (response.type === 'raw') {
-        let result = true;
+        let needsDrain = false;
         for (const item of response.entities) {
-          if (firstSend) {
-            result ||= res.write('[');
-            firstSend = false;
-          } else {
-            result ||= res.write(',');
-          }
-          result ||= res.write(item);
+          const prefix = firstSend ? '[' : ',';
+          firstSend = false;
+          needsDrain ||= !res.write(prefix + item, 'utf8');
         }
-        return result;
+        return !needsDrain;
       }
 
       let data: string;
@@ -215,13 +211,13 @@ export function createEntityArrayJsonStream(
       }
 
       firstSend = false;
-      return res.write(data);
+      return res.write(data, 'utf8');
     },
     complete() {
       if (firstSend) {
         res.json([]);
       } else {
-        res.end(prettyPrint ? '\n]' : ']');
+        res.end(prettyPrint ? '\n]' : ']', 'utf8');
       }
       completed = true;
     },

--- a/plugins/catalog-backend/src/tests/integration.test.ts
+++ b/plugins/catalog-backend/src/tests/integration.test.ts
@@ -30,7 +30,6 @@ import {
   processingResult,
 } from '@backstage/plugin-catalog-node';
 import { PermissionEvaluator } from '@backstage/plugin-permission-common';
-import { JsonObject } from '@backstage/types';
 import { createHash } from 'crypto';
 import { Knex } from 'knex';
 import { EntitiesCatalog } from '../catalog/types';
@@ -199,7 +198,7 @@ class TestHarness {
   readonly #proxyProgressTracker: ProxyProgressTracker;
 
   static async create(options?: {
-    config?: JsonObject;
+    enableRawJson?: boolean;
     logger?: LoggerService;
     db?: Knex;
     permissions?: PermissionEvaluator;
@@ -209,21 +208,19 @@ class TestHarness {
       emit: CatalogProcessorEmit,
     ): Promise<Entity>;
   }) {
-    const config = new ConfigReader(
-      options?.config ?? {
-        backend: {
-          database: {
-            client: 'better-sqlite3',
-            connection: ':memory:',
-          },
-        },
-        catalog: {
-          stitchingStrategy: {
-            mode: 'immediate',
-          },
+    const config = new ConfigReader({
+      backend: {
+        database: {
+          client: 'better-sqlite3',
+          connection: ':memory:',
         },
       },
-    );
+      catalog: {
+        stitchingStrategy: {
+          mode: 'immediate',
+        },
+      },
+    });
     const logger = options?.logger ?? mockServices.logger.mock();
     const db =
       options?.db ??
@@ -280,6 +277,7 @@ class TestHarness {
       database: db,
       logger,
       stitcher,
+      enableRawJson: options?.enableRawJson,
     });
     const proxyProgressTracker = new ProxyProgressTracker(
       new NoopProgressTracker(),
@@ -785,6 +783,59 @@ describe('Catalog Backend Integration', () => {
           "Invalid location ref 'url:javascript:bad()', target is a javascript: URL",
         ),
       ],
+    });
+  });
+
+  it('should return valid responses in raw JSON mode', async () => {
+    const harness = await TestHarness.create({
+      enableRawJson: true,
+    });
+
+    const entityA = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: {
+        name: 'a',
+        annotations: {
+          'backstage.io/managed-by-location': 'url:.',
+          'backstage.io/managed-by-origin-location': 'url:.',
+        },
+      },
+    };
+    const entityB = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: {
+        name: 'b',
+        annotations: {
+          'backstage.io/managed-by-location': 'url:.',
+          'backstage.io/managed-by-origin-location': 'url:.',
+        },
+      },
+    };
+
+    await harness.setInputEntities([entityA, entityB]);
+    await expect(harness.process()).resolves.toEqual({});
+
+    await expect(harness.getOutputEntities()).resolves.toEqual({
+      'component:default/a': {
+        ...entityA,
+        metadata: {
+          ...entityA.metadata,
+          etag: expect.any(String),
+          uid: expect.any(String),
+        },
+        relations: [],
+      },
+      'component:default/b': {
+        ...entityB,
+        metadata: {
+          ...entityB.metadata,
+          etag: expect.any(String),
+          uid: expect.any(String),
+        },
+        relations: [],
+      },
     });
   });
 });

--- a/plugins/catalog-backend/src/tests/integration.test.ts
+++ b/plugins/catalog-backend/src/tests/integration.test.ts
@@ -55,6 +55,7 @@ import { DefaultStitcher } from '../stitching/DefaultStitcher';
 import { mockServices } from '@backstage/backend-test-utils';
 import { LoggerService } from '@backstage/backend-plugin-api';
 import { DatabaseManager } from '@backstage/backend-common';
+import { entitiesResponseToObjects } from '../service/response';
 
 const voidLogger = mockServices.logger.mock();
 
@@ -365,7 +366,12 @@ class TestHarness {
 
   async getOutputEntities(): Promise<Record<string, Entity>> {
     const { entities } = await this.#catalog.entities();
-    return Object.fromEntries(entities.map(e => [stringifyEntityRef(e), e]));
+    return Object.fromEntries(
+      entitiesResponseToObjects(entities).map(e => [
+        stringifyEntityRef(e!),
+        e!,
+      ]),
+    );
   }
 
   async refresh(options: RefreshOptions) {

--- a/plugins/catalog-backend/src/tests/integration.test.ts
+++ b/plugins/catalog-backend/src/tests/integration.test.ts
@@ -198,7 +198,7 @@ class TestHarness {
   readonly #proxyProgressTracker: ProxyProgressTracker;
 
   static async create(options?: {
-    enableRawJson?: boolean;
+    disableRelationsCompatibility?: boolean;
     logger?: LoggerService;
     db?: Knex;
     permissions?: PermissionEvaluator;
@@ -277,7 +277,7 @@ class TestHarness {
       database: db,
       logger,
       stitcher,
-      enableRawJson: options?.enableRawJson,
+      disableRelationsCompatibility: options?.disableRelationsCompatibility,
     });
     const proxyProgressTracker = new ProxyProgressTracker(
       new NoopProgressTracker(),
@@ -788,7 +788,7 @@ describe('Catalog Backend Integration', () => {
 
   it('should return valid responses in raw JSON mode', async () => {
     const harness = await TestHarness.create({
-      enableRawJson: true,
+      disableRelationsCompatibility: true,
     });
 
     const entityA = {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

`JSON.parse` and `JSON.stringify` is a significant source of synchronous work in the catalog, which blocks the main thread and slows down the entire backend. This change avoids JSON deserialization and serialization in many situations when reading entities, especially for list endpoints.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
