### PR TITLE
catalog-backend: fix for not waiting for response buffer to drain as needed

### DIFF
--- a/plugins/catalog-backend/src/service/response/write.ts
+++ b/plugins/catalog-backend/src/service/response/write.ts
@@ -94,6 +94,9 @@ export async function writeEntitiesResponse(
 export async function writeResponseData(res: Response, data: string | Buffer) {
   const ok = res.write(data, 'utf8');
   if (!ok) {
+    if (!res.writableNeedDrain) {
+      return true;
+    }
     const closed = await new Promise<boolean>(resolve => {
       function onContinue() {
         res.off('drain', onContinue);


### PR DESCRIPTION
Followup fix for #28121. I think the Node.js docs tricked me a bit here, claiming that additional writes would be buffered internally. Turns out that's not at all what happens and it seems the rest of the writes get lost instead until waiting for darin.