### PR TITLE
Update CodeOwnersProcessor helper

### DIFF
--- a/.changeset/twenty-laws-tie.md
+++ b/.changeset/twenty-laws-tie.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend': patch
 ---
 
-Updated condition in resolveCodeOwner to fix a bug where normalizeCodeOwner could potentially be called with an invalid arg causing an error in CodeOwnersProcessor.
+Updated condition in `resolveCodeOwner` to fix a bug where `normalizeCodeOwner` could potentially be called with an invalid argument causing an error in `CodeOwnersProcessor`

--- a/.changeset/twenty-laws-tie.md
+++ b/.changeset/twenty-laws-tie.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Updated condition in resolveCodeOwner to fix a bug where normalizeCodeOwner could potentially be called with an invalid arg causing an error in CodeOwnersProcessor.

--- a/plugins/catalog-backend/src/processors/codeowners/resolve.test.ts
+++ b/plugins/catalog-backend/src/processors/codeowners/resolve.test.ts
@@ -46,6 +46,14 @@ describe('resolveCodeOwner', () => {
       ),
     ).toBe('team-foo');
   });
+  it('should return undefined if the codeowners file contains no names', () => {
+    expect(
+      resolveCodeOwner(
+        `*`,
+        'https://github.com/acme/repo/tree/docs/catalog-info.yaml',
+      ),
+    ).toBe(undefined);
+  });
 });
 
 describe('normalizeCodeOwner', () => {

--- a/plugins/catalog-backend/src/processors/codeowners/resolve.ts
+++ b/plugins/catalog-backend/src/processors/codeowners/resolve.ts
@@ -30,7 +30,9 @@ export function resolveCodeOwner(
   const { filepath } = parseGitUrl(catalogInfoFileUrl);
   const match = codeowners.matchFile(filepath, codeOwnerEntries);
 
-  return match ? normalizeCodeOwner(match.owners[0]) : undefined;
+  return match?.owners?.length
+    ? normalizeCodeOwner(match.owners[0])
+    : undefined;
 }
 
 export function normalizeCodeOwner(owner: string) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

We noticed a component from our org that was imported from github ended up as an unprocessed entity due to the error: `Processor CodeOwnersProcessor threw an error while preprocessing; caused by TypeError: Cannot read properties of undefined (reading 'match')`

<img width="1840" alt="Screenshot 2024-12-02 at 9 27 57 AM" src="https://github.com/user-attachments/assets/734f97ca-a46f-42ca-ac2a-553f4ef8949e" />

Debugging in the backstage demo app revealed that the error was happening in one of the helper functions for the processor, a bug in a conditional check when the function is called allowed for `undefined` to be passed into the function in certain circumstances causing the function to throw an error.
 
With the existing code:
`return match ? normalizeCodeOwner(match.owners[0]) : undefined;`
the type of the `match` object is:
```
export interface CodeOwnersEntry {
	pattern: string
	owners: Array<string>
}
```
the ternary operator is only checking if the `match` object exists and then calling `normalizeCodeOwner()` on the first item in `match.owners` however `match` can exist with an empty `owners` array which is what will cause the error that we're seeing. In order to fix this the condition in the ternary operator can be updated to add a check that will make sure that `match.owner` isn't empty.

The stack trace on the unprocessed entity object in our database also shows that the error is happening in `normalizeCodeOwners`:

`TypeError: Cannot read properties of undefined (reading 'match')\n    at normalizeCodeOwner...`


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))