### PR TITLE
add support for experimental rspack bundler for the cli repo build command

### DIFF
--- a/.changeset/ten-cars-end.md
+++ b/.changeset/ten-cars-end.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+added experimental RSPack support for build command in the repo scope

--- a/packages/cli/src/commands/repo/build.ts
+++ b/packages/cli/src/commands/repo/build.ts
@@ -31,6 +31,11 @@ import { createScriptOptionsParser } from './optionsParser';
 
 export async function command(opts: OptionValues, cmd: Command): Promise<void> {
   let packages = await PackageGraph.listTargetPackages();
+  const shouldUseRspack = Boolean(process.env.EXPERIMENTAL_RSPACK);
+
+  const rspack = shouldUseRspack
+    ? (require('@rspack/core') as typeof import('@rspack/core').rspack)
+    : undefined;
 
   if (opts.since) {
     const graph = PackageGraph.fromPackages(packages);
@@ -111,6 +116,7 @@ export async function command(opts: OptionValues, cmd: Command): Promise<void> {
           targetDir: pkg.dir,
           configPaths: (buildOptions.config as string[]) ?? [],
           writeStats: Boolean(buildOptions.stats),
+          rspack,
         });
       },
     });

--- a/packages/cli/src/lib/bundler/bundle.ts
+++ b/packages/cli/src/lib/bundler/bundle.ts
@@ -119,6 +119,12 @@ export async function buildBundle(options: BuildOptions) {
     );
   }
 
+  if (rspack) {
+    console.log(
+      chalk.yellow(`⚠️  WARNING: Using experimental RSPack bundler.`),
+    );
+  }
+
   const { stats } = await build(configs, isCi, rspack);
 
   if (!stats) {

--- a/packages/cli/src/lib/bundler/server.ts
+++ b/packages/cli/src/lib/bundler/server.ts
@@ -233,6 +233,12 @@ DEPRECATION WARNING: React Router Beta is deprecated and support for it will be 
       ? require('@rspack/dev-server').RspackDevServer
       : WebpackDevServer;
 
+    if (rspack) {
+      console.log(
+        chalk.yellow(`⚠️  WARNING: Using experimental RSPack dev server.`),
+      );
+    }
+
     const publicPaths = await resolveOptionalBundlingPaths({
       entry: 'src/index-public-experimental',
       dist: 'dist/public',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Support for the experimental use of RSPack is currently only offered for the build command per package. The command in the repo scope currently doesn't support RSPack

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [c] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
