### PR TITLE
backend-defaults: immediately close connections on shutdown in local dev

### DIFF
--- a/.changeset/bright-boats-dream.md
+++ b/.changeset/bright-boats-dream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Immediately close all connections when shutting down in local development.

--- a/packages/backend-defaults/src/entrypoints/rootHttpRouter/http/createHttpServer.ts
+++ b/packages/backend-defaults/src/entrypoints/rootHttpRouter/http/createHttpServer.ts
@@ -53,6 +53,12 @@ export async function createHttpServer(
 
     stop() {
       return new Promise<void>((resolve, reject) => {
+        if (process.env.NODE_ENV === 'development') {
+          // Ensure that various polling connections are shut down fast in development
+          server.closeAllConnections();
+        } else {
+          server.closeIdleConnections();
+        }
         server.close(error => {
           if (error) {
             reject(error);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Right now local development iteration is a bit slow because we need to wait for connections to close. The particularly bad one is the events polling, but you might have other long-polling endpoints too. Rather than trying to cleanly shut down those I figured it's better to be a bit aggressive about closing all connections in local  development.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
