### PR TITLE
fix: wrong usage of fslib causes wrong paths to be used on windows

### DIFF
--- a/.changeset/pretty-pets-deliver.md
+++ b/.changeset/pretty-pets-deliver.md
@@ -1,0 +1,5 @@
+---
+'yarn-plugin-backstage': minor
+---
+
+Fixed windows path resolution on windows

--- a/packages/yarn-plugin/src/util.ts
+++ b/packages/yarn-plugin/src/util.ts
@@ -20,7 +20,7 @@ import {
   httpUtils,
   structUtils,
 } from '@yarnpkg/core';
-import { ppath, xfs } from '@yarnpkg/fslib';
+import { ppath, npath, xfs } from '@yarnpkg/fslib';
 import { valid as semverValid } from 'semver';
 import { BACKSTAGE_JSON, findPaths } from '@backstage/cli-common';
 import { getManifestByVersion } from '@backstage/release-manifests';
@@ -28,7 +28,9 @@ import { getManifestByVersion } from '@backstage/release-manifests';
 import { PROTOCOL } from './constants';
 
 export const getCurrentBackstageVersion = () => {
-  const workspaceRoot = ppath.resolve(findPaths(ppath.cwd()).targetRoot);
+  const workspaceRoot = npath.toPortablePath(
+    findPaths(npath.fromPortablePath(ppath.cwd())).targetRoot,
+  );
 
   const backstageJson = xfs.readJsonSync(
     ppath.join(workspaceRoot, BACKSTAGE_JSON),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When using the backstage yarn plugin on windows, path resolution failes due to the plugin not being able to find the 
`package.json` file.

This is caused by wrong usage of the `@yarnpkg/fslib` library.


Fixes #28077

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
