### PR TITLE
catalog-backend: fix for request being treated as closed

### DIFF
--- a/plugins/catalog-backend/src/service/response/write.ts
+++ b/plugins/catalog-backend/src/service/response/write.ts
@@ -94,7 +94,7 @@ export async function writeEntitiesResponse(
 export async function writeResponseData(res: Response, data: string | Buffer) {
   const ok = res.write(data, 'utf8');
   if (!ok) {
-    if (!res.writableNeedDrain) {
+    if (res.closed) {
       return true;
     }
     const closed = await new Promise<boolean>(resolve => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Looks like there are some situation where `.write` fails and the response buffer needs draining, but `writableNeedDrain` isn't set 🤷. Explicitly checking for closed instead should be safer. Followup for #28133 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
