### PR TITLE
Updates to allow users to subscribe to the newly created GitHub repo

### DIFF
--- a/.changeset/breezy-coats-sort.md
+++ b/.changeset/breezy-coats-sort.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-github': patch
+---
+
+Updates to allow users to subscribe to the newly created repository within GitHub to mimic similar functionality found within the GitHub UI.

--- a/plugins/scaffolder-backend-module-github/report.api.md
+++ b/plugins/scaffolder-backend-module-github/report.api.md
@@ -279,6 +279,7 @@ export function createGithubRepoCreateAction(options: {
           [key: string]: string;
         }
       | undefined;
+    subscribe?: boolean | undefined;
   },
   JsonObject
 >;
@@ -441,6 +442,7 @@ export function createPublishGithubAction(options: {
           [key: string]: string;
         }
       | undefined;
+    subscribe?: boolean | undefined;
   },
   JsonObject
 >;

--- a/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
@@ -74,6 +74,9 @@ const mockOctokit = {
       createOrUpdateRepoSecret: jest.fn(),
       getRepoPublicKey: jest.fn(),
     },
+    activity: {
+      setRepoSubscription: jest.fn(),
+    },
   },
   request: jest.fn(),
 };
@@ -1796,4 +1799,26 @@ describe('publish:github', () => {
       });
     },
   );
+
+  it('should add user subscription', async () => {
+    mockOctokit.rest.users.getByUsername.mockResolvedValue({
+      data: { type: 'Organization' },
+    });
+    mockOctokit.rest.repos.createInOrg.mockResolvedValue({ data: {} });
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        subscribe: true,
+      },
+    });
+
+    expect(mockOctokit.rest.activity.setRepoSubscription).toHaveBeenCalledWith({
+      owner: 'owner',
+      repo: 'repo',
+      subscribed: true,
+      ignored: false,
+    });
+  });
 });

--- a/plugins/scaffolder-backend-module-github/src/actions/github.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/github.ts
@@ -117,6 +117,7 @@ export function createPublishGithubAction(options: {
     requiredCommitSigning?: boolean;
     requiredLinearHistory?: boolean;
     customProperties?: { [key: string]: string };
+    subscribe?: boolean;
   }>({
     id: 'publish:github',
     description:
@@ -168,6 +169,7 @@ export function createPublishGithubAction(options: {
           requiredCommitSigning: inputProps.requiredCommitSigning,
           requiredLinearHistory: inputProps.requiredLinearHistory,
           customProperties: inputProps.customProperties,
+          subscribe: inputProps.subscribe,
         },
       },
       output: {
@@ -218,6 +220,7 @@ export function createPublishGithubAction(options: {
         oidcCustomization,
         token: providedToken,
         customProperties,
+        subscribe = false,
         requiredCommitSigning = false,
         requiredLinearHistory = false,
       } = ctx.input;
@@ -260,6 +263,7 @@ export function createPublishGithubAction(options: {
         secrets,
         oidcCustomization,
         customProperties,
+        subscribe,
         ctx.logger,
       );
 

--- a/plugins/scaffolder-backend-module-github/src/actions/githubRepoCreate.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubRepoCreate.test.ts
@@ -55,6 +55,9 @@ const mockOctokit = {
       createOrUpdateRepoSecret: jest.fn(),
       getRepoPublicKey: jest.fn(),
     },
+    activity: {
+      setRepoSubscription: jest.fn(),
+    },
   },
   request: jest.fn(),
 };
@@ -753,5 +756,27 @@ describe('github:repo:create', () => {
       'remoteUrl',
       'https://github.com/clone/url.git',
     );
+  });
+
+  it('should subscribe user to repository', async () => {
+    mockOctokit.rest.users.getByUsername.mockResolvedValue({
+      data: { type: 'Organization' },
+    });
+    mockOctokit.rest.repos.createInOrg.mockResolvedValue({ data: {} });
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        subscribe: true,
+      },
+    });
+
+    expect(mockOctokit.rest.activity.setRepoSubscription).toHaveBeenCalledWith({
+      owner: 'owner',
+      repo: 'repo',
+      subscribed: true,
+      ignored: false,
+    });
   });
 });

--- a/plugins/scaffolder-backend-module-github/src/actions/githubRepoCreate.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubRepoCreate.ts
@@ -102,6 +102,7 @@ export function createGithubRepoCreateAction(options: {
     requireCommitSigning?: boolean;
     requiredLinearHistory?: boolean;
     customProperties?: { [key: string]: string };
+    subscribe?: boolean;
   }>({
     id: 'github:repo:create',
     description: 'Creates a GitHub repository.',
@@ -143,6 +144,7 @@ export function createGithubRepoCreateAction(options: {
           requiredCommitSigning: inputProps.requiredCommitSigning,
           requiredLinearHistory: inputProps.requiredLinearHistory,
           customProperties: inputProps.customProperties,
+          subscribe: inputProps.subscribe,
         },
       },
       output: {
@@ -176,6 +178,7 @@ export function createGithubRepoCreateAction(options: {
         secrets,
         oidcCustomization,
         customProperties,
+        subscribe,
         token: providedToken,
       } = ctx.input;
 
@@ -217,6 +220,7 @@ export function createGithubRepoCreateAction(options: {
         secrets,
         oidcCustomization,
         customProperties,
+        subscribe,
         ctx.logger,
       );
 

--- a/plugins/scaffolder-backend-module-github/src/actions/helpers.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/helpers.ts
@@ -149,6 +149,7 @@ export async function createGithubRepoWithCollaboratorsAndTopics(
       }
     | undefined,
   customProperties: { [key: string]: string } | undefined,
+  subscribe: boolean | undefined,
   logger: LoggerService,
 ) {
   // eslint-disable-next-line testing-library/no-await-sync-queries
@@ -328,6 +329,15 @@ export async function createGithubRepoWithCollaboratorsAndTopics(
         include_claim_keys: oidcCustomization.includeClaimKeys,
       },
     );
+  }
+
+  if (subscribe) {
+    await client.rest.activity.setRepoSubscription({
+      subscribed: true,
+      ignored: false,
+      owner,
+      repo,
+    });
   }
 
   return newRepo;

--- a/plugins/scaffolder-backend-module-github/src/actions/inputProperties.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/inputProperties.ts
@@ -317,6 +317,12 @@ const customProperties = {
   type: 'object',
 };
 
+const subscribe = {
+  title: 'Subscribe to repository',
+  description: `Subscribe to the repository. The default value is 'false'`,
+  type: 'boolean',
+};
+
 export { access };
 export { allowMergeCommit };
 export { allowRebaseMerge };
@@ -357,3 +363,4 @@ export { repoVariables };
 export { secrets };
 export { oidcCustomization };
 export { customProperties };
+export { subscribe };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This change adds in a way for a user to subscribe to a newly created GitHub repository in the same way when they create one from the GitHub UI. Previously if a user were to create a new GitHub repository via a scaffolder action, the repository would not be subscribed to by default. In order to ensure that similar functionality that exists within the GitHub UI was present within the GitHub scaffolder action, a way to subscribe the user has been added.

FIXES #28123 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
