### PR TITLE
catalog-backend: fully feature flag streamed raw json responses

### DIFF
--- a/plugins/catalog-backend/src/service/createRouter.ts
+++ b/plugins/catalog-backend/src/service/createRouter.ts
@@ -168,7 +168,11 @@ export async function createRouter(
             res.setHeader('link', `<${url.pathname}${url.search}>; rel="next"`);
           }
 
-          await writeEntitiesResponse(res, entities);
+          await writeEntitiesResponse({
+            res,
+            items: entities,
+            alwaysUseObjectMode: !disableRelationsCompatibility,
+          });
           return;
         }
 
@@ -214,18 +218,23 @@ export async function createRouter(
             credentials: await httpAuth.credentials(req),
           });
 
-        await writeEntitiesResponse(res, items, entities => ({
-          items: entities,
-          totalItems,
-          pageInfo: {
-            ...(pageInfo.nextCursor && {
-              nextCursor: encodeCursor(pageInfo.nextCursor),
-            }),
-            ...(pageInfo.prevCursor && {
-              prevCursor: encodeCursor(pageInfo.prevCursor),
-            }),
-          },
-        }));
+        await writeEntitiesResponse({
+          res,
+          items,
+          alwaysUseObjectMode: !disableRelationsCompatibility,
+          responseWrapper: entities => ({
+            items: entities,
+            totalItems,
+            pageInfo: {
+              ...(pageInfo.nextCursor && {
+                nextCursor: encodeCursor(pageInfo.nextCursor),
+              }),
+              ...(pageInfo.prevCursor && {
+                prevCursor: encodeCursor(pageInfo.prevCursor),
+              }),
+            },
+          }),
+        });
       })
       .get('/entities/by-uid/:uid', async (req, res) => {
         const { uid } = req.params;
@@ -273,9 +282,14 @@ export async function createRouter(
           fields: parseEntityTransformParams(req.query, request.fields),
           credentials: await httpAuth.credentials(req),
         });
-        await writeEntitiesResponse(res, items, entities => ({
-          items: entities,
-        }));
+        await writeEntitiesResponse({
+          res,
+          items,
+          alwaysUseObjectMode: !disableRelationsCompatibility,
+          responseWrapper: entities => ({
+            items: entities,
+          }),
+        });
       })
       .get('/entity-facets', async (req, res) => {
         const response = await entitiesCatalog.facets({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Making sure we never attempt to stream raw JSON responses unless the `catalog.disableRelationsCompatibility` flag is set.

More followup to #28121 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
