### PR TITLE
emit database connection pool metrics

### DIFF
--- a/.changeset/green-lobsters-look.md
+++ b/.changeset/green-lobsters-look.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Emit connection pool metrics from the database by default

--- a/packages/backend-defaults/src/entrypoints/database/DatabaseManager.ts
+++ b/packages/backend-defaults/src/entrypoints/database/DatabaseManager.ts
@@ -53,8 +53,6 @@ export type DatabaseManagerOptions = {
  * Testable implementation class for {@link DatabaseManager} below.
  */
 export class DatabaseManagerImpl {
-  private didRegisterMetrics: boolean = false;
-
   constructor(
     private readonly config: Config,
     private readonly connectors: Record<string, Connector>,
@@ -72,6 +70,8 @@ export class DatabaseManagerImpl {
         await this.shutdown({ logger: options.rootLogger });
       });
     }
+
+    this.registerMetrics();
   }
 
   /**
@@ -188,7 +188,6 @@ export class DatabaseManagerImpl {
       );
     }
 
-    this.registerMetricsOnFirstConnection();
     return clientPromise;
   }
 
@@ -223,12 +222,7 @@ export class DatabaseManagerImpl {
     );
   }
 
-  private registerMetricsOnFirstConnection(): void {
-    if (this.didRegisterMetrics) {
-      return;
-    }
-    this.didRegisterMetrics = true;
-
+  private registerMetrics(): void {
     const meter = metrics.getMeter('default');
 
     const poolConnections = meter.createObservableGauge(


### PR DESCRIPTION
Experimenting with a variation of https://github.com/backstage/backstage/pull/28113 to discuss among the maintainers.

This results in metrics on the form

```
# HELP backend_database_pool_connections_count Number of database pool connections
# TYPE backend_database_pool_connections_count gauge
backend_database_pool_connections_count{plugin="auth",state="used"} 0
backend_database_pool_connections_count{plugin="auth",state="free"} 2
backend_database_pool_connections_count{plugin="auth",state="pending"} 0
backend_database_pool_connections_count{plugin="app",state="used"} 0
backend_database_pool_connections_count{plugin="app",state="free"} 1
backend_database_pool_connections_count{plugin="app",state="pending"} 0
backend_database_pool_connections_count{plugin="catalog",state="used"} 0
backend_database_pool_connections_count{plugin="catalog",state="free"} 4
backend_database_pool_connections_count{plugin="catalog",state="pending"} 0
...
```
