### PR TITLE
🧹  use `mockServices` more

### DIFF
--- a/plugins/catalog-backend/src/processors/PlaceholderProcessor.test.ts
+++ b/plugins/catalog-backend/src/processors/PlaceholderProcessor.test.ts
@@ -28,16 +28,12 @@ import {
   textPlaceholderResolver,
   yamlPlaceholderResolver,
 } from './PlaceholderProcessor';
-import { UrlReaderService } from '@backstage/backend-plugin-api';
+import { mockServices } from '@backstage/backend-test-utils';
 
 const integrations = ScmIntegrations.fromConfig(new ConfigReader({}));
 
 describe('PlaceholderProcessor', () => {
-  const reader: jest.Mocked<UrlReaderService> = {
-    readTree: jest.fn(),
-    search: jest.fn(),
-    readUrl: jest.fn(),
-  };
+  const reader = mockServices.urlReader.mock();
 
   beforeEach(() => {
     jest.resetAllMocks();

--- a/plugins/catalog-backend/src/processors/UrlReaderProcessor.test.ts
+++ b/plugins/catalog-backend/src/processors/UrlReaderProcessor.test.ts
@@ -31,7 +31,6 @@ import {
 import { defaultEntityDataParser } from '../util/parse';
 import { UrlReaderProcessor } from './UrlReaderProcessor';
 import { UrlReaders } from '@backstage/backend-defaults/urlReader';
-import { UrlReaderService } from '@backstage/backend-plugin-api';
 
 describe('UrlReaderProcessor', () => {
   const mockApiOrigin = 'http://localhost';
@@ -193,11 +192,9 @@ describe('UrlReaderProcessor', () => {
   it('uses search when there are globs', async () => {
     const logger = mockServices.logger.mock();
 
-    const reader: jest.Mocked<UrlReaderService> = {
-      readUrl: jest.fn(),
-      readTree: jest.fn(),
-      search: jest.fn().mockImplementation(async () => []),
-    };
+    const reader = mockServices.urlReader.mock({
+      search: jest.fn().mockResolvedValue([]),
+    });
 
     const processor = new UrlReaderProcessor({ reader, logger });
 

--- a/plugins/catalog-backend/src/service/createRouter.test.ts
+++ b/plugins/catalog-backend/src/service/createRouter.test.ts
@@ -42,7 +42,6 @@ import { wrapServer } from '@backstage/backend-openapi-utils';
 import { Server } from 'http';
 import { mockCredentials, mockServices } from '@backstage/backend-test-utils';
 import { LocationAnalyzer } from '@backstage/plugin-catalog-node';
-import { PermissionsService } from '@backstage/backend-plugin-api';
 
 describe('createRouter readonly disabled', () => {
   let entitiesCatalog: jest.Mocked<EntitiesCatalog>;
@@ -51,7 +50,7 @@ describe('createRouter readonly disabled', () => {
   let app: express.Express | Server;
   let refreshService: RefreshService;
   let locationAnalyzer: jest.Mocked<LocationAnalyzer>;
-  let permissionsService: jest.Mocked<PermissionsService>;
+  const permissionsService = mockServices.permissions.mock();
 
   beforeEach(async () => {
     entitiesCatalog = {
@@ -69,15 +68,9 @@ describe('createRouter readonly disabled', () => {
       deleteLocation: jest.fn(),
       getLocationByEntity: jest.fn(),
     };
-
     locationAnalyzer = {
       analyzeLocation: jest.fn(),
     };
-    permissionsService = {
-      authorize: jest.fn(),
-      authorizeConditional: jest.fn(),
-    };
-
     refreshService = { refresh: jest.fn() };
     orchestrator = { process: jest.fn() };
     const router = await createRouter({
@@ -91,13 +84,13 @@ describe('createRouter readonly disabled', () => {
       auth: mockServices.auth(),
       httpAuth: mockServices.httpAuth(),
       locationAnalyzer,
-      permissionsService: permissionsService,
+      permissionsService,
     });
     app = await wrapServer(express().use(router));
   });
 
   beforeEach(() => {
-    jest.resetAllMocks();
+    jest.clearAllMocks();
   });
 
   describe('POST /refresh', () => {
@@ -158,7 +151,7 @@ describe('createRouter readonly disabled', () => {
         auth: mockServices.auth(),
         httpAuth: mockServices.httpAuth(),
         locationAnalyzer,
-        permissionsService: permissionsService,
+        permissionsService,
         disableRelationsCompatibility: true, // added
       });
       app = await wrapServer(express().use(router));
@@ -218,7 +211,7 @@ describe('createRouter readonly disabled', () => {
         auth: mockServices.auth(),
         httpAuth: mockServices.httpAuth(),
         locationAnalyzer,
-        permissionsService: permissionsService,
+        permissionsService,
         disableRelationsCompatibility: true, // added
       });
       app = await wrapServer(express().use(router));
@@ -939,7 +932,7 @@ describe('createRouter readonly and raw json enabled', () => {
   let entitiesCatalog: jest.Mocked<EntitiesCatalog>;
   let app: express.Express;
   let locationService: jest.Mocked<LocationService>;
-  let permissionsService: jest.Mocked<PermissionsService>;
+  const permissionsService = mockServices.permissions.mock();
 
   beforeAll(async () => {
     entitiesCatalog = {
@@ -970,13 +963,13 @@ describe('createRouter readonly and raw json enabled', () => {
       permissionIntegrationRouter: express.Router(),
       auth: mockServices.auth(),
       httpAuth: mockServices.httpAuth(),
-      permissionsService: permissionsService,
+      permissionsService,
     });
     app = express().use(router);
   });
 
   beforeEach(() => {
-    jest.resetAllMocks();
+    jest.clearAllMocks();
   });
 
   describe('GET /entities', () => {
@@ -1141,7 +1134,7 @@ describe('NextRouter permissioning', () => {
   let locationService: jest.Mocked<LocationService>;
   let app: express.Express;
   let refreshService: RefreshService;
-  let permissionsService: jest.Mocked<PermissionsService>;
+  const permissionsService = mockServices.permissions.mock();
 
   const fakeRule = createPermissionRule({
     name: 'FAKE_RULE',
@@ -1188,13 +1181,13 @@ describe('NextRouter permissioning', () => {
       }),
       auth: mockServices.auth(),
       httpAuth: mockServices.httpAuth(),
-      permissionsService: permissionsService,
+      permissionsService,
     });
     app = express().use(router);
   });
 
   afterEach(() => {
-    jest.resetAllMocks();
+    jest.clearAllMocks();
   });
 
   it('accepts and evaluates conditions at the apply-conditions endpoint', async () => {

--- a/plugins/kubernetes-backend/src/service/KubernetesProxy.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesProxy.test.ts
@@ -23,10 +23,7 @@ import {
   registerMswTestHooks,
 } from '@backstage/backend-test-utils';
 import { NotFoundError } from '@backstage/errors';
-import {
-  AuthorizeResult,
-  PermissionEvaluator,
-} from '@backstage/plugin-permission-common';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
 import {
   ANNOTATION_KUBERNETES_AUTH_PROVIDER,
   KubernetesRequestAuth,
@@ -55,10 +52,7 @@ import {
 } from './KubernetesProxy';
 
 import type { Request } from 'express';
-import {
-  BackstageCredentials,
-  DiscoveryService,
-} from '@backstage/backend-plugin-api';
+import { BackstageCredentials } from '@backstage/backend-plugin-api';
 
 const mockCertDir = createMockDirectory({
   content: {
@@ -79,15 +73,8 @@ describe('KubernetesProxy', () => {
     >(),
   };
 
-  const permissionApi: jest.Mocked<PermissionEvaluator> = {
-    authorize: jest.fn(),
-    authorizeConditional: jest.fn(),
-  };
-
-  const mockDisocveryApi: jest.Mocked<DiscoveryService> = {
-    getBaseUrl: jest.fn(),
-    getExternalBaseUrl: jest.fn(),
-  };
+  const permissionApi = mockServices.permissions.mock();
+  const mockDisocveryApi = mockServices.discovery.mock();
 
   registerMswTestHooks(worker);
 

--- a/plugins/search-backend-module-explore/src/collators/ToolDocumentCollatorFactory.test.ts
+++ b/plugins/search-backend-module-explore/src/collators/ToolDocumentCollatorFactory.test.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ConfigReader } from '@backstage/config';
+
 import { TestPipeline } from '@backstage/plugin-search-backend-node';
 import {
   mockServices,
@@ -23,7 +23,6 @@ import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { Readable } from 'stream';
 import { ToolDocumentCollatorFactory } from './ToolDocumentCollatorFactory';
-import { DiscoveryService } from '@backstage/backend-plugin-api';
 
 const logger = mockServices.logger.mock();
 
@@ -54,11 +53,10 @@ const mockTools = {
 };
 
 describe('ToolDocumentCollatorFactory', () => {
-  const config = new ConfigReader({});
-  const mockDiscoveryApi: jest.Mocked<DiscoveryService> = {
-    getBaseUrl: jest.fn().mockResolvedValue('http://test-backend/api/explore'),
-    getExternalBaseUrl: jest.fn(),
-  };
+  const config = mockServices.rootConfig();
+  const mockDiscoveryApi = mockServices.discovery.mock({
+    getBaseUrl: async () => 'http://test-backend/api/explore',
+  });
 
   const options = {
     discovery: mockDiscoveryApi,

--- a/plugins/search-backend-module-techdocs/src/collators/DefaultTechDocsCollatorFactory.test.ts
+++ b/plugins/search-backend-module-techdocs/src/collators/DefaultTechDocsCollatorFactory.test.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { Entity } from '@backstage/catalog-model';
 import { ConfigReader } from '@backstage/config';
 import { TestPipeline } from '@backstage/plugin-search-backend-node';
@@ -25,7 +26,6 @@ import { setupServer } from 'msw/node';
 import { Readable } from 'stream';
 import { DefaultTechDocsCollatorFactory } from './DefaultTechDocsCollatorFactory';
 import { TechDocsCollatorEntityTransformer } from './TechDocsCollatorEntityTransformer';
-import { DiscoveryService } from '@backstage/backend-plugin-api';
 import {
   MkSearchIndexDoc,
   TechDocsCollatorDocumentTransformer,
@@ -81,11 +81,10 @@ const expectedEntities: Entity[] = [
 ];
 
 describe('DefaultTechDocsCollatorFactory', () => {
-  const config = new ConfigReader({});
-  const mockDiscoveryApi: jest.Mocked<DiscoveryService> = {
-    getBaseUrl: jest.fn().mockResolvedValue('http://test-backend'),
-    getExternalBaseUrl: jest.fn(),
-  };
+  const config = mockServices.rootConfig.mock();
+  const mockDiscoveryApi = mockServices.discovery.mock({
+    getBaseUrl: async () => 'http://test-backend',
+  });
   const options = {
     logger,
     discovery: mockDiscoveryApi,

--- a/plugins/signals-backend/src/service/router.test.ts
+++ b/plugins/signals-backend/src/service/router.test.ts
@@ -18,27 +18,14 @@ import express from 'express';
 import request from 'supertest';
 
 import { createRouter } from './router';
-import { EventsService } from '@backstage/plugin-events-node';
-import {
-  DiscoveryService,
-  UserInfoService,
-} from '@backstage/backend-plugin-api';
 import { ConfigReader } from '@backstage/config';
 import { mockErrorHandler, mockServices } from '@backstage/backend-test-utils';
 
-const eventsServiceMock: jest.Mocked<EventsService> = {
-  subscribe: jest.fn(),
-  publish: jest.fn(),
-};
-
-const discovery: jest.Mocked<DiscoveryService> = {
-  getBaseUrl: jest.fn().mockResolvedValue('/api/signals'),
-  getExternalBaseUrl: jest.fn(),
-};
-
-const userInfo: jest.Mocked<UserInfoService> = {
-  getUserInfo: jest.fn(),
-};
+const eventsServiceMock = mockServices.events.mock();
+const discovery = mockServices.discovery.mock({
+  getBaseUrl: async () => '/api/signals',
+});
+const userInfo = mockServices.userInfo.mock();
 
 describe('createRouter', () => {
   let app: express.Express;

--- a/plugins/techdocs-backend/src/search/DefaultTechDocsCollator.test.ts
+++ b/plugins/techdocs-backend/src/search/DefaultTechDocsCollator.test.ts
@@ -25,7 +25,6 @@ import { setupServer } from 'msw/node';
 import { http, HttpResponse } from 'msw';
 import { ConfigReader } from '@backstage/config';
 import { TECHDOCS_ANNOTATION } from '@backstage/plugin-techdocs-common';
-import { DiscoveryService } from '@backstage/backend-plugin-api';
 
 const logger = loggerToWinstonLogger(mockServices.logger.mock());
 
@@ -80,15 +79,14 @@ describe('TechDocs Collator', () => {
   registerMswTestHooks(worker);
 
   describe('DefaultTechDocsCollator with legacyPathCasing configuration', () => {
-    let mockDiscoveryApi: jest.Mocked<DiscoveryService>;
+    const mockDiscoveryApi = mockServices.discovery.mock({
+      getBaseUrl: async () => 'http://test-backend',
+    });
     let mockTokenManager: jest.Mocked<TokenManager>;
     let collator: DefaultTechDocsCollator;
 
     beforeEach(() => {
-      mockDiscoveryApi = {
-        getBaseUrl: jest.fn().mockResolvedValue('http://test-backend'),
-        getExternalBaseUrl: jest.fn(),
-      };
+      jest.clearAllMocks();
       mockTokenManager = {
         getToken: jest.fn().mockResolvedValue({ token: '' }),
         authenticate: jest.fn(),
@@ -144,15 +142,13 @@ describe('TechDocs Collator', () => {
   });
 
   describe('DefaultTechDocsCollator', () => {
-    let mockDiscoveryApi: jest.Mocked<DiscoveryService>;
+    const mockDiscoveryApi = mockServices.discovery.mock({
+      getBaseUrl: async () => 'http://test-backend',
+    });
     let mockTokenManager: jest.Mocked<TokenManager>;
     let collator: DefaultTechDocsCollator;
 
     beforeEach(() => {
-      mockDiscoveryApi = {
-        getBaseUrl: jest.fn().mockResolvedValue('http://test-backend'),
-        getExternalBaseUrl: jest.fn(),
-      };
       mockTokenManager = {
         getToken: jest.fn().mockResolvedValue({ token: '' }),
         authenticate: jest.fn(),

--- a/plugins/techdocs-backend/src/service/DocsSynchronizer.test.ts
+++ b/plugins/techdocs-backend/src/service/DocsSynchronizer.test.ts
@@ -31,7 +31,6 @@ import {
   mockServices,
   registerMswTestHooks,
 } from '@backstage/backend-test-utils';
-import { DiscoveryService } from '@backstage/backend-plugin-api';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 
@@ -59,10 +58,7 @@ describe('DocsSynchronizer', () => {
     hasDocsBeenGenerated: jest.fn(),
     publish: jest.fn(),
   };
-  const discovery: jest.Mocked<DiscoveryService> = {
-    getBaseUrl: jest.fn(),
-    getExternalBaseUrl: jest.fn(),
-  };
+  const discovery = mockServices.discovery.mock();
   const cache: jest.Mocked<TechDocsCache> = {
     get: jest.fn(),
     set: jest.fn(),

--- a/plugins/techdocs-backend/src/service/router.test.ts
+++ b/plugins/techdocs-backend/src/service/router.test.ts
@@ -32,7 +32,6 @@ import { CachedEntityLoader } from './CachedEntityLoader';
 import { createEventStream, createRouter, RouterOptions } from './router';
 import { TechDocsCache } from '../cache';
 import { mockErrorHandler, mockServices } from '@backstage/backend-test-utils';
-import { DiscoveryService } from '@backstage/backend-plugin-api';
 
 jest.mock('@backstage/catalog-client');
 jest.mock('@backstage/config');
@@ -111,10 +110,7 @@ describe('createRouter', () => {
     hasDocsBeenGenerated: jest.fn(),
     publish: jest.fn(),
   };
-  const discovery: jest.Mocked<DiscoveryService> = {
-    getBaseUrl: jest.fn(),
-    getExternalBaseUrl: jest.fn(),
-  };
+  const discovery = mockServices.discovery.mock();
   const cache: jest.Mocked<PluginCacheManager> = {
     getClient: jest.fn(),
   };

--- a/plugins/techdocs-node/src/stages/prepare/dir.test.ts
+++ b/plugins/techdocs-node/src/stages/prepare/dir.test.ts
@@ -13,11 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { TECHDOCS_ANNOTATION } from '@backstage/plugin-techdocs-common';
-import { ConfigReader } from '@backstage/config';
 import { DirectoryPreparer } from './dir';
 import { mockServices } from '@backstage/backend-test-utils';
-import { UrlReaderService } from '@backstage/backend-plugin-api';
 
 function normalizePath(path: string) {
   return path
@@ -45,12 +44,8 @@ const createMockEntity = (annotations: {}) => {
   };
 };
 
-const mockConfig = new ConfigReader({});
-const mockUrlReader: jest.Mocked<UrlReaderService> = {
-  readUrl: jest.fn(),
-  readTree: jest.fn(),
-  search: jest.fn(),
-};
+const mockConfig = mockServices.rootConfig();
+const mockUrlReader = mockServices.urlReader.mock();
 
 describe('directory preparer', () => {
   it('should merge managed-by-location and techdocs-ref when techdocs-ref is relative', async () => {

--- a/plugins/techdocs-node/src/stages/publish/local.test.ts
+++ b/plugins/techdocs-node/src/stages/publish/local.test.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { overridePackagePathResolution } from '@backstage/backend-plugin-api/testUtils';
 import { ConfigReader } from '@backstage/config';
 import express from 'express';
@@ -24,7 +25,6 @@ import {
   createMockDirectory,
   mockServices,
 } from '@backstage/backend-test-utils';
-import { DiscoveryService } from '@backstage/backend-plugin-api';
 
 const createMockEntity = (annotations = {}, lowerCase = false) => {
   return {
@@ -39,10 +39,9 @@ const createMockEntity = (annotations = {}, lowerCase = false) => {
   };
 };
 
-const testDiscovery: jest.Mocked<DiscoveryService> = {
-  getBaseUrl: jest.fn().mockResolvedValue('http://localhost:7007/api/techdocs'),
-  getExternalBaseUrl: jest.fn(),
-};
+const testDiscovery = mockServices.discovery.mock({
+  getBaseUrl: async () => 'http://localhost:7007/api/techdocs',
+});
 
 const mockPublishDir = createMockDirectory();
 

--- a/plugins/techdocs-node/src/stages/publish/publish.test.ts
+++ b/plugins/techdocs-node/src/stages/publish/publish.test.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { ConfigReader } from '@backstage/config';
 import { Publisher } from './publish';
 import { LocalPublish } from './local';
@@ -22,13 +23,11 @@ import { AzureBlobStoragePublish } from './azureBlobStorage';
 import { OpenStackSwiftPublish } from './openStackSwift';
 import { mockServices } from '@backstage/backend-test-utils';
 import { PublisherBase } from './types';
-import { DiscoveryService } from '@backstage/backend-plugin-api';
 
 const logger = mockServices.logger.mock();
-const discovery: jest.Mocked<DiscoveryService> = {
-  getBaseUrl: jest.fn().mockResolvedValueOnce('http://localhost:7007'),
-  getExternalBaseUrl: jest.fn(),
-};
+const discovery = mockServices.discovery.mock({
+  getBaseUrl: async () => 'http://localhost:7007',
+});
 
 jest.mock('@azure/identity', () => ({
   __esModule: true,


### PR DESCRIPTION
Happened to come upon this pattern around the repo while doing other stuff. No functional changes, just moving from explicit `jest.Mocked<FooService>` to `mockServices.foo`