### PR TITLE
:broom: Update environment variable name in kubernetes deployment docs

### DIFF
--- a/docs/deployment/k8s.md
+++ b/docs/deployment/k8s.md
@@ -210,6 +210,11 @@ spec:
           envFrom:
             - secretRef:
                 name: postgres-secrets
+          env:
+            - name: POSTGRES_HOST
+              value: postgres.backstage
+            - name: POSTGRES_PORT
+              value: '5432'
           volumeMounts:
             - mountPath: /var/lib/postgresql/data
               name: postgresdb

--- a/docs/deployment/k8s.md
+++ b/docs/deployment/k8s.md
@@ -387,8 +387,8 @@ $ yarn build-image --tag backstage:1.0.0
 ```
 
 There is no special wiring needed to access the PostgreSQL service. Since it's
-running on the same cluster, Kubernetes will inject `POSTGRES_SERVICE_HOST` and
-`POSTGRES_SERVICE_PORT` environment variables into our Backstage container.
+running on the same cluster, Kubernetes will inject `POSTGRES_HOST` and
+`POSTGRES_PORT` environment variables into our Backstage container.
 These can be used in the Backstage `app-config.yaml` along with the secrets. Apply this to `app-config.production.yaml` as well if you have one:
 
 ```yaml
@@ -396,8 +396,8 @@ backend:
   database:
     client: pg
     connection:
-      host: ${POSTGRES_SERVICE_HOST}
-      port: ${POSTGRES_SERVICE_PORT}
+      host: ${POSTGRES_HOST}
+      port: ${POSTGRES_PORT}
       user: ${POSTGRES_USER}
       password: ${POSTGRES_PASSWORD}
 ```


### PR DESCRIPTION
## Update Environment Variable Name in Kubernetes Deployment Docs

This PR updates the Kubernetes deployment documentation to use POSTGRES_HOST instead of POSTGRES_SERVICE_HOST for the PostgreSQL connection environment variable.

Rationale:

* Aligns documentation with existing docs, `example-app` generated config, and expected Kubernetes behavior.
* POSTGRES_HOST appears to be the correct and consistently used environment variable.
* This change improves clarity and consistency for users deploying Backstage on Kubernetes.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
