### PR TITLE
Add ApiBlueprint for form-decorators

### DIFF
--- a/.changeset/strong-schools-fix.md
+++ b/.changeset/strong-schools-fix.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+'@backstage/plugin-scaffolder': patch
+---
+
+Added support for `FormDecoratorBlueprint` to create form decorators in the Scaffolder plugin

--- a/plugins/scaffolder-react/report-alpha.api.md
+++ b/plugins/scaffolder-react/report-alpha.api.md
@@ -133,6 +133,30 @@ export const Form: (
 ) => React_2.JSX.Element;
 
 // @alpha
+export const FormDecoratorBlueprint: ExtensionBlueprint<{
+  kind: 'scaffolder-form-decorator';
+  name: undefined;
+  params: {
+    decorator: ScaffolderFormDecorator;
+  };
+  output: ConfigurableExtensionDataRef<
+    ScaffolderFormDecorator,
+    'scaffolder.form-decorator-loader',
+    {}
+  >;
+  inputs: {};
+  config: {};
+  configInput: {};
+  dataRefs: {
+    formDecoratorLoader: ConfigurableExtensionDataRef<
+      ScaffolderFormDecorator,
+      'scaffolder.form-decorator-loader',
+      {}
+    >;
+  };
+}>;
+
+// @alpha
 export const FormFieldBlueprint: ExtensionBlueprint<{
   kind: 'scaffolder-form-field';
   name: undefined;

--- a/plugins/scaffolder-react/src/next/blueprints/FormDecoratorBlueprint.tsx
+++ b/plugins/scaffolder-react/src/next/blueprints/FormDecoratorBlueprint.tsx
@@ -30,7 +30,7 @@ const formDecoratorExtensionDataRef =
  * */
 export const FormDecoratorBlueprint = createExtensionBlueprint({
   kind: 'scaffolder-form-decorator',
-  attachTo: { id: 'api:scaffolder/form-decorator', input: 'formDecorators' },
+  attachTo: { id: 'api:scaffolder/form-decorators', input: 'formDecorators' },
   dataRefs: {
     formDecoratorLoader: formDecoratorExtensionDataRef,
   },

--- a/plugins/scaffolder-react/src/next/blueprints/FormDecoratorBlueprint.tsx
+++ b/plugins/scaffolder-react/src/next/blueprints/FormDecoratorBlueprint.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  createExtensionBlueprint,
+  createExtensionDataRef,
+} from '@backstage/frontend-plugin-api';
+import { ScaffolderFormDecorator } from '../extensions';
+
+const formDecoratorExtensionDataRef =
+  createExtensionDataRef<ScaffolderFormDecorator>().with({
+    id: 'scaffolder.form-decorator-loader',
+  });
+
+/**
+ * @alpha
+ * Creates extensions that are Field Extensions for the Scaffolder
+ * */
+export const FormDecoratorBlueprint = createExtensionBlueprint({
+  kind: 'scaffolder-form-decorator',
+  attachTo: { id: 'api:scaffolder/form-decorator', input: 'formDecorators' },
+  dataRefs: {
+    formDecoratorLoader: formDecoratorExtensionDataRef,
+  },
+  output: [formDecoratorExtensionDataRef],
+  *factory(params: { decorator: ScaffolderFormDecorator }) {
+    yield formDecoratorExtensionDataRef(params.decorator);
+  },
+});

--- a/plugins/scaffolder-react/src/next/blueprints/index.ts
+++ b/plugins/scaffolder-react/src/next/blueprints/index.ts
@@ -14,5 +14,6 @@
  * limitations under the License.
  */
 
+export * from './FormDecoratorBlueprint';
 export * from './FormFieldBlueprint';
 export * from './types';

--- a/plugins/scaffolder/report-alpha.api.md
+++ b/plugins/scaffolder/report-alpha.api.md
@@ -80,6 +80,33 @@ const _default: FrontendPlugin<
         factory: AnyApiFactory;
       };
     }>;
+    'api:scaffolder/form-decorators': ExtensionDefinition<{
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {
+        formDecorators: ExtensionInput<
+          ConfigurableExtensionDataRef<
+            ScaffolderFormDecorator,
+            'scaffolder.form-decorator-loader',
+            {}
+          >,
+          {
+            singleton: false;
+            optional: false;
+          }
+        >;
+      };
+      kind: 'api';
+      name: 'form-decorators';
+      params: {
+        factory: AnyApiFactory;
+      };
+    }>;
     'page:scaffolder': ExtensionDefinition<{
       kind: 'page';
       name: undefined;
@@ -172,6 +199,31 @@ export class DefaultScaffolderFormDecoratorsApi
   // (undocumented)
   getFormDecorators(): Promise<ScaffolderFormDecorator[]>;
 }
+
+// @alpha (undocumented)
+export const formDecoratorsApi: ExtensionDefinition<{
+  config: {};
+  configInput: {};
+  output: ConfigurableExtensionDataRef<AnyApiFactory, 'core.api.factory', {}>;
+  inputs: {
+    formDecorators: ExtensionInput<
+      ConfigurableExtensionDataRef<
+        ScaffolderFormDecorator,
+        'scaffolder.form-decorator-loader',
+        {}
+      >,
+      {
+        singleton: false;
+        optional: false;
+      }
+    >;
+  };
+  kind: 'api';
+  name: 'form-decorators';
+  params: {
+    factory: AnyApiFactory;
+  };
+}>;
 
 // @alpha (undocumented)
 export const formDecoratorsApiRef: ApiRef<ScaffolderFormDecoratorsApi>;

--- a/plugins/scaffolder/src/alpha/api/FormDecoratorsApi.ts
+++ b/plugins/scaffolder/src/alpha/api/FormDecoratorsApi.ts
@@ -14,8 +14,14 @@
  * limitations under the License.
  */
 
+import {
+  ApiBlueprint,
+  createApiFactory,
+  createExtensionInput,
+} from '@backstage/frontend-plugin-api';
 import { ScaffolderFormDecoratorsApi } from './types';
 import { ScaffolderFormDecorator } from '@backstage/plugin-scaffolder-react/alpha';
+import { formDecoratorsApiRef } from './ref';
 
 /** @alpha */
 export class DefaultScaffolderFormDecoratorsApi
@@ -37,3 +43,28 @@ export class DefaultScaffolderFormDecoratorsApi
     return this.options.decorators;
   }
 }
+
+/** @alpha */
+export const formDecoratorsApi = ApiBlueprint.makeWithOverrides({
+  name: 'form-decorators',
+  inputs: {
+    // TODO: this should come from the inputs that the form decorators use
+    formDecorators: createExtensionInput([]),
+  },
+  factory(originalFactory, { inputs }) {
+    // TODO: this should come from the inputs that the form decorators use
+    const formDecorators =
+      inputs.formDecorators as unknown as ScaffolderFormDecorator[];
+
+    return originalFactory({
+      factory: createApiFactory({
+        api: formDecoratorsApiRef,
+        deps: {},
+        factory: () =>
+          DefaultScaffolderFormDecoratorsApi.create({
+            decorators: formDecorators,
+          }),
+      }),
+    });
+  },
+});

--- a/plugins/scaffolder/src/alpha/api/FormDecoratorsApi.ts
+++ b/plugins/scaffolder/src/alpha/api/FormDecoratorsApi.ts
@@ -22,6 +22,7 @@ import {
 import { ScaffolderFormDecoratorsApi } from './types';
 import { ScaffolderFormDecorator } from '@backstage/plugin-scaffolder-react/alpha';
 import { formDecoratorsApiRef } from './ref';
+import { FormDecoratorBlueprint } from '@backstage/plugin-scaffolder-react/alpha';
 
 /** @alpha */
 export class DefaultScaffolderFormDecoratorsApi
@@ -48,13 +49,14 @@ export class DefaultScaffolderFormDecoratorsApi
 export const formDecoratorsApi = ApiBlueprint.makeWithOverrides({
   name: 'form-decorators',
   inputs: {
-    // TODO: this should come from the inputs that the form decorators use
-    formDecorators: createExtensionInput([]),
+    formDecorators: createExtensionInput([
+      FormDecoratorBlueprint.dataRefs.formDecoratorLoader,
+    ]),
   },
   factory(originalFactory, { inputs }) {
-    // TODO: this should come from the inputs that the form decorators use
-    const formDecorators =
-      inputs.formDecorators as unknown as ScaffolderFormDecorator[];
+    const formDecorators = inputs.formDecorators.map(e =>
+      e.get(FormDecoratorBlueprint.dataRefs.formDecoratorLoader),
+    );
 
     return originalFactory({
       factory: createApiFactory({

--- a/plugins/scaffolder/src/alpha/api/index.ts
+++ b/plugins/scaffolder/src/alpha/api/index.ts
@@ -16,4 +16,4 @@
 
 export { formDecoratorsApiRef } from './ref';
 export type { ScaffolderFormDecoratorsApi } from './types';
-export { DefaultScaffolderFormDecoratorsApi } from './FormDecoratorsApi';
+export * from './FormDecoratorsApi';

--- a/plugins/scaffolder/src/alpha/plugin.tsx
+++ b/plugins/scaffolder/src/alpha/plugin.tsx
@@ -33,6 +33,7 @@ import {
   scaffolderApi,
 } from './extensions';
 import { formFieldsApi } from '@backstage/plugin-scaffolder-react/alpha';
+import { formDecoratorsApi } from './api';
 
 /** @alpha */
 export default createFrontendPlugin({
@@ -53,6 +54,7 @@ export default createFrontendPlugin({
     scaffolderApi,
     scaffolderPage,
     scaffolderNavItem,
+    formDecoratorsApi,
     formFieldsApi,
     repoUrlPickerFormField,
   ],


### PR DESCRIPTION
The form-decorators apiRef is not initialized when running with `app-next`:

![form-decorators](https://github.com/user-attachments/assets/e3052d53-fddf-4da5-9cab-68ba928aa70c)

This adds the ApiBlueprint and extension to register the `formDecoratorsApiRef` in applications using the new frontend.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
