### PR TITLE
fix(catalog-backend-module-github): update parent to not send a object with empty string

### DIFF
--- a/.changeset/weak-frogs-nail.md
+++ b/.changeset/weak-frogs-nail.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+Fixes an issue in `GithubMultiOrgEntityProvider` that caused an error when processing teams without a parent.

--- a/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
@@ -602,7 +602,9 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
         editTeamUrl: `${url}/edit`,
         combinedSlug: `${org}/${slug}`,
         description: description ?? undefined,
-        parentTeam: { slug: event.team?.parent?.slug || '' } as GithubTeam,
+        parentTeam: event.team?.parent?.slug
+          ? ({ slug: event.team.parent.slug } as GithubTeam)
+          : undefined,
         // entity will be removed or is new
         members: [],
       },
@@ -705,7 +707,9 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
         slug: oldSlug,
         combinedSlug: `${org}/${oldSlug}`,
         description: event.changes.description?.from,
-        parentTeam: { slug: event.team?.parent?.slug || '' } as GithubTeam,
+        parentTeam: event.team?.parent?.slug
+          ? ({ slug: event.team.parent.slug } as GithubTeam)
+          : undefined,
         // entity will be removed
         members: [],
       },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This continuation to #26109 as it was resolved by fixing `GithubOrgEntityProvider` here: #27192

This PR does the change for `GithubMultiOrgEntityProvider` as the issue seems to be present in there.

To give you some context, whenever `GithubMultiOrgEntityProvider` receives a `team.created` event  with `team.parent` property set as `null` then the provider converts (incorrectly) that into empty-string and causes producing an entity with `spec.parent` set as an empty string.

The entity continues to its journey into `BuiltinKindsEntityProcessor` that throws an error while validating the entity against entity kind schema:

```
Processor BuiltinKindsEntityProcessor threw an error while validating the entity group:default/this-is-test;
caused by TypeError: /spec/parent must NOT have fewer than 1 characters - limit: 1
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
