### PR TITLE
Add missing exports for @backstage/plugin-home and @backstage/plugin-scaffolder-react

### DIFF
--- a/.changeset/big-seals-drum.md
+++ b/.changeset/big-seals-drum.md
@@ -1,0 +1,13 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+'@backstage/plugin-home': patch
+---
+
+Added missing exports to surface recently added plugin changes as follows:
+`@backstage/plugin-scaffolder-react`
+
+- add exports needed to override template styles for `BackstageTemplateStepper` and `ScaffolderReactTemplateCategoryPicker`
+
+`@backstage/plugin-home`
+
+- add exports needed to have a valid `import { QuickStartCard } from '@backstage/plugin-home';`

--- a/plugins/home/report.api.md
+++ b/plugins/home/report.api.md
@@ -188,6 +188,11 @@ export type LayoutConfiguration = {
 export type Operators = '<' | '<=' | '==' | '!=' | '>' | '>=' | 'contains';
 
 // @public
+export const QuickStartCard: (
+  props: CardExtensionProps_2<QuickStartCardProps>,
+) => JSX_2.Element;
+
+// @public
 export type QuickStartCardProps = {
   modalTitle?: string | React_2.JSX.Element;
   docsLinkTitle?: string;

--- a/plugins/home/src/index.ts
+++ b/plugins/home/src/index.ts
@@ -35,6 +35,7 @@ export {
   HomePageTopVisited,
   HomePageRecentlyVisited,
   FeaturedDocsCard,
+  QuickStartCard,
 } from './plugin';
 export * from './components';
 export * from './assets';

--- a/plugins/scaffolder-react/report-alpha.api.md
+++ b/plugins/scaffolder-react/report-alpha.api.md
@@ -46,14 +46,14 @@ import { UiSchema } from '@rjsf/utils';
 import { WidgetProps } from '@rjsf/utils';
 import { z } from 'zod';
 
-// @alpha (undocumented)
+// @public (undocumented)
 export type BackstageOverrides = Overrides & {
   [Name in keyof ScaffolderReactComponentsNameToClassKey]?: Partial<
     StyleRules<ScaffolderReactComponentsNameToClassKey[Name]>
   >;
 };
 
-// @alpha (undocumented)
+// @public (undocumented)
 export type BackstageTemplateStepperClassKey =
   | 'backButton'
   | 'footer'
@@ -296,13 +296,13 @@ export type ScaffolderPageContextMenuProps = {
   onCreateClicked?: () => void;
 };
 
-// @alpha (undocumented)
+// @public (undocumented)
 export type ScaffolderReactComponentsNameToClassKey = {
   ScaffolderReactTemplateCategoryPicker: ScaffolderReactTemplateCategoryPickerClassKey;
   BackstageTemplateStepper: BackstageTemplateStepperClassKey;
 };
 
-// @alpha (undocumented)
+// @public (undocumented)
 export type ScaffolderReactTemplateCategoryPickerClassKey = 'root' | 'label';
 
 // @alpha

--- a/plugins/scaffolder-react/report.api.md
+++ b/plugins/scaffolder-react/report.api.md
@@ -27,6 +27,7 @@ import { JsonObject } from '@backstage/types';
 import { JSONSchema7 } from 'json-schema';
 import { JsonValue } from '@backstage/types';
 import { Observable } from '@backstage/types';
+import { Overrides } from '@material-ui/core/styles/overrides';
 import { PropsWithChildren } from 'react';
 import { default as React_2 } from 'react';
 import { ReactNode } from 'react';
@@ -36,6 +37,7 @@ import { RegistryWidgetsType } from '@rjsf/utils';
 import { RJSFSchema } from '@rjsf/utils';
 import { RJSFValidationError } from '@rjsf/utils';
 import { StrictRJSFSchema } from '@rjsf/utils';
+import { StyleRules } from '@material-ui/core/styles/withStyles';
 import { TaskSpec } from '@backstage/plugin-scaffolder-common';
 import { TaskStep } from '@backstage/plugin-scaffolder-common';
 import { TemplateEntityV1beta3 } from '@backstage/plugin-scaffolder-common';
@@ -62,6 +64,19 @@ export type ActionExample = {
   description: string;
   example: string;
 };
+
+// @public (undocumented)
+export type BackstageOverrides = Overrides & {
+  [Name in keyof ScaffolderReactComponentsNameToClassKey]?: Partial<
+    StyleRules<ScaffolderReactComponentsNameToClassKey[Name]>
+  >;
+};
+
+// @public (undocumented)
+export type BackstageTemplateStepperClassKey =
+  | 'backButton'
+  | 'footer'
+  | 'formWrapper';
 
 // @public
 export function createScaffolderFieldExtension<
@@ -324,6 +339,15 @@ export type ScaffolderOutputText = {
   content?: string;
   default?: boolean;
 };
+
+// @public (undocumented)
+export type ScaffolderReactComponentsNameToClassKey = {
+  ScaffolderReactTemplateCategoryPicker: ScaffolderReactTemplateCategoryPickerClassKey;
+  BackstageTemplateStepper: BackstageTemplateStepperClassKey;
+};
+
+// @public (undocumented)
+export type ScaffolderReactTemplateCategoryPickerClassKey = 'root' | 'label';
 
 // @public
 export type ScaffolderRJSFField<

--- a/plugins/scaffolder-react/src/index.ts
+++ b/plugins/scaffolder-react/src/index.ts
@@ -22,3 +22,9 @@ export * from './api';
 export * from './hooks';
 export * from './layouts';
 export * from './utils';
+export type {
+  BackstageOverrides,
+  ScaffolderReactComponentsNameToClassKey,
+  ScaffolderReactTemplateCategoryPickerClassKey,
+  BackstageTemplateStepperClassKey,
+} from './next';

--- a/plugins/scaffolder-react/src/next/components/Stepper/Stepper.tsx
+++ b/plugins/scaffolder-react/src/next/components/Stepper/Stepper.tsx
@@ -56,7 +56,7 @@ import { merge } from 'lodash';
 const validator = customizeValidator();
 ajvErrors(validator.ajv);
 
-/** @alpha */
+/** @public */
 export type BackstageTemplateStepperClassKey =
   | 'backButton'
   | 'footer'

--- a/plugins/scaffolder-react/src/next/components/TemplateCategoryPicker/TemplateCategoryPicker.tsx
+++ b/plugins/scaffolder-react/src/next/components/TemplateCategoryPicker/TemplateCategoryPicker.tsx
@@ -33,7 +33,7 @@ import { alertApiRef, useApi } from '@backstage/core-plugin-api';
 const icon = <CheckBoxOutlineBlankIcon fontSize="small" />;
 const checkedIcon = <CheckBoxIcon fontSize="small" />;
 
-/** @alpha */
+/** @public */
 export type ScaffolderReactTemplateCategoryPickerClassKey = 'root' | 'label';
 
 const useStyles = makeStyles(

--- a/plugins/scaffolder-react/src/next/overridableComponents.ts
+++ b/plugins/scaffolder-react/src/next/overridableComponents.ts
@@ -19,13 +19,13 @@ import { StyleRules } from '@material-ui/core/styles/withStyles';
 import { ScaffolderReactTemplateCategoryPickerClassKey } from './components/TemplateCategoryPicker/TemplateCategoryPicker';
 import { BackstageTemplateStepperClassKey } from './components/Stepper/Stepper';
 
-/** @alpha */
+/** @public */
 export type ScaffolderReactComponentsNameToClassKey = {
   ScaffolderReactTemplateCategoryPicker: ScaffolderReactTemplateCategoryPickerClassKey;
   BackstageTemplateStepper: BackstageTemplateStepperClassKey;
 };
 
-/** @alpha */
+/** @public */
 export type BackstageOverrides = Overrides & {
   [Name in keyof ScaffolderReactComponentsNameToClassKey]?: Partial<
     StyleRules<ScaffolderReactComponentsNameToClassKey[Name]>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

I made these two contributions recently but I failed to export all the way! 😞 
[[scaffolder-react] Add an overridable className to template stepper ](https://github.com/backstage/backstage/pull/26959)
[[plugins/home] Add Home Page Quick Start Card #27705
](https://github.com/backstage/backstage/pull/27705)

This PR adds the necessary exports so that people can actually use the new types/plugins added previously. 

**Before** 
<img width="752" alt="Screenshot 2024-12-19 at 3 40 10 PM" src="https://github.com/user-attachments/assets/0c960657-6ec2-4cb0-bb5e-3e3541e313b5" />

**After**
<img width="736" alt="Screenshot 2024-12-19 at 5 36 29 PM" src="https://github.com/user-attachments/assets/023fbbb9-461c-47df-aa7a-3c00ab596789" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
