### PR TITLE
fixed typo in the createInitializationLogger

### DIFF
--- a/.changeset/lemon-students-care.md
+++ b/.changeset/lemon-students-care.md
@@ -2,6 +2,4 @@
 '@backstage/backend-app-api': patch
 ---
 
-[Fix] Corrected spelling mistake in createInitializationLogger
-
-Fixed a typo error in the createInitializationLogger.ts file where “thew” was changed to “threw”. This correction improves clarity in the logging
+Corrected spelling mistake in error message

--- a/.changeset/lemon-students-care.md
+++ b/.changeset/lemon-students-care.md
@@ -1,0 +1,7 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+[Fix] Corrected spelling mistake in createInitializationLogger
+
+Fixed a typo error in the createInitializationLogger.ts file where “thew” was changed to “threw”. This correction improves clarity in the logging

--- a/packages/backend-app-api/src/wiring/createInitializationLogger.ts
+++ b/packages/backend-app-api/src/wiring/createInitializationLogger.ts
@@ -75,7 +75,7 @@ export function createInitializationLogger(
           ? `, waiting for ${starting.size} other plugins to finish before shutting down the process`
           : '';
       logger?.error(
-        `Plugin '${pluginId}' thew an error during startup${status}`,
+        `Plugin '${pluginId}' threw an error during startup${status}`,
       );
     },
     onAllStarted() {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I fixed the typo in the packages/backend-app-api/src/wiring/createInitializationLogger.ts file.
This [issue](https://github.com/backstage/backstage/issues/28200) was raised by @avila-m-6

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
