### PR TITLE
Fix formFieldsApi resolution in useCustomFieldExtensions hook

### DIFF
--- a/.changeset/rich-penguins-stare.md
+++ b/.changeset/rich-penguins-stare.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+Fixed scaffolder form fields not resolving correctly in the `useCustomFieldExtensions` hook.

--- a/plugins/scaffolder-react/src/hooks/useCustomFieldExtensions.ts
+++ b/plugins/scaffolder-react/src/hooks/useCustomFieldExtensions.ts
@@ -34,11 +34,11 @@ export const useCustomFieldExtensions = <
 ) => {
   // Get custom fields created with FormFieldBlueprint
   const formFieldsApi = useApi(formFieldsApiRef);
-  const [{ result: blueprintFields }, methods] = useAsync(
-    formFieldsApi.getFormFields,
+  const [{ result: blueprintFields }, { execute }] = useAsync(
+    () => formFieldsApi.getFormFields(),
     [],
   );
-  useMountEffect(methods.execute);
+  useMountEffect(execute);
 
   // Get custom fields created with ScaffolderFieldExtensions
   const outletFields = useElementFilter(outlet, elements =>


### PR DESCRIPTION
The `useCustomFieldExtensions` hook called `formFieldsApi.getFormFields`, but in a manner that messed up the `this` reference. This caused the `formFieldsApi` method to fail a bit silently.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
