### PR TITLE
🧹  remove usages of some backend-common helpers

### DIFF
--- a/.changeset/nervous-bottles-occur.md
+++ b/.changeset/nervous-bottles-occur.md
@@ -1,0 +1,11 @@
+---
+'@backstage/plugin-catalog-backend-module-gitlab-org': patch
+'@backstage/plugin-permission-backend': patch
+'@backstage/plugin-catalog-backend': patch
+'@backstage/plugin-permission-node': patch
+'@backstage/plugin-events-backend': patch
+'@backstage/plugin-app-backend': patch
+'@backstage/plugin-auth-node': patch
+---
+
+Remove some internal usages of the backend-common package

--- a/plugins/app-backend/src/service/appPlugin.test.ts
+++ b/plugins/app-backend/src/service/appPlugin.test.ts
@@ -20,7 +20,6 @@ import {
   startTestBackend,
 } from '@backstage/backend-test-utils';
 import { appPlugin } from './appPlugin';
-import { createRootLogger } from '@backstage/backend-common';
 import { overridePackagePathResolution } from '@backstage/backend-plugin-api/testUtils';
 
 const mockDir = createMockDirectory();
@@ -28,9 +27,6 @@ overridePackagePathResolution({
   packageName: 'app',
   path: mockDir.path,
 });
-
-// Make sure root logger is initialized ahead of FS mock
-createRootLogger();
 
 describe('appPlugin', () => {
   afterEach(() => {

--- a/plugins/app-backend/src/service/router.ts
+++ b/plugins/app-backend/src/service/router.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { notFoundHandler } from '@backstage/backend-common';
 import {
   DatabaseService,
   resolvePackagePath,
@@ -22,7 +21,7 @@ import {
 } from '@backstage/backend-plugin-api';
 import { AppConfig } from '@backstage/config';
 import helmet from 'helmet';
-import express from 'express';
+import express, { Request, Response } from 'express';
 import Router from 'express-promise-router';
 import fs from 'fs-extra';
 import { resolve as resolvePath } from 'path';
@@ -299,7 +298,9 @@ async function createEntryPointRouter({
   if (staticFallbackHandler) {
     staticRouter.use(staticFallbackHandler);
   }
-  staticRouter.use(notFoundHandler());
+  staticRouter.use((_req: Request, res: Response) => {
+    res.status(404).end();
+  });
 
   router.use('/static', staticRouter);
 

--- a/plugins/auth-node/package.json
+++ b/plugins/auth-node/package.json
@@ -56,6 +56,7 @@
     "zod-validation-error": "^3.4.0"
   },
   "devDependencies": {
+    "@backstage/backend-defaults": "workspace:^",
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "cookie-parser": "^1.4.6",

--- a/plugins/catalog-backend-module-gitlab-org/package.json
+++ b/plugins/catalog-backend-module-gitlab-org/package.json
@@ -33,7 +33,6 @@
     "test": "backstage-cli package test"
   },
   "dependencies": {
-    "@backstage/backend-common": "^0.25.0",
     "@backstage/backend-plugin-api": "workspace:^",
     "@backstage/plugin-catalog-backend-module-gitlab": "workspace:^",
     "@backstage/plugin-catalog-node": "workspace:^",

--- a/plugins/catalog-backend-module-gitlab-org/src/catalogModuleGitlabOrgDiscoveryEntityProvider.ts
+++ b/plugins/catalog-backend-module-gitlab-org/src/catalogModuleGitlabOrgDiscoveryEntityProvider.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { loggerToWinstonLogger } from '@backstage/backend-common';
 import {
   coreServices,
   createBackendModule,
@@ -44,7 +43,7 @@ export const catalogModuleGitlabOrgDiscoveryEntityProvider =
         async init({ config, catalog, logger, scheduler, events }) {
           const gitlabOrgDiscoveryEntityProvider =
             GitlabOrgDiscoveryEntityProvider.fromConfig(config, {
-              logger: loggerToWinstonLogger(logger),
+              logger,
               events,
               scheduler,
             });

--- a/plugins/catalog-backend/src/service/createRouter.test.ts
+++ b/plugins/catalog-backend/src/service/createRouter.test.ts
@@ -42,6 +42,12 @@ import { wrapServer } from '@backstage/backend-openapi-utils';
 import { Server } from 'http';
 import { mockCredentials, mockServices } from '@backstage/backend-test-utils';
 import { LocationAnalyzer } from '@backstage/plugin-catalog-node';
+import { MiddlewareFactory } from '@backstage/backend-defaults/rootHttpRouter';
+
+const middleware = MiddlewareFactory.create({
+  logger: mockServices.logger.mock(),
+  config: mockServices.rootConfig(),
+});
 
 describe('createRouter readonly disabled', () => {
   let entitiesCatalog: jest.Mocked<EntitiesCatalog>;
@@ -86,6 +92,7 @@ describe('createRouter readonly disabled', () => {
       locationAnalyzer,
       permissionsService,
     });
+    router.use(middleware.error());
     app = await wrapServer(express().use(router));
   });
 
@@ -965,6 +972,7 @@ describe('createRouter readonly and raw json enabled', () => {
       httpAuth: mockServices.httpAuth(),
       permissionsService,
     });
+    router.use(middleware.error());
     app = express().use(router);
   });
 

--- a/plugins/catalog-backend/src/service/createRouter.ts
+++ b/plugins/catalog-backend/src/service/createRouter.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { errorHandler } from '@backstage/backend-common';
 import {
   ANNOTATION_LOCATION,
   ANNOTATION_ORIGIN_LOCATION,
@@ -446,6 +445,5 @@ export async function createRouter(
     });
   }
 
-  router.use(errorHandler());
   return router;
 }

--- a/plugins/events-backend/src/service/http/HttpPostIngressEventPublisher.test.ts
+++ b/plugins/events-backend/src/service/http/HttpPostIngressEventPublisher.test.ts
@@ -21,6 +21,12 @@ import Router from 'express-promise-router';
 import request from 'supertest';
 import { HttpPostIngressEventPublisher } from './HttpPostIngressEventPublisher';
 import { mockServices } from '@backstage/backend-test-utils';
+import { MiddlewareFactory } from '@backstage/backend-defaults/rootHttpRouter';
+
+const middleware = MiddlewareFactory.create({
+  logger: mockServices.logger.mock(),
+  config: mockServices.rootConfig(),
+});
 
 describe('HttpPostIngressEventPublisher', () => {
   const logger = mockServices.logger.mock();
@@ -110,6 +116,7 @@ describe('HttpPostIngressEventPublisher', () => {
       logger,
     });
     publisher.bind(router);
+    router.use(middleware.error());
 
     const response = await request(app)
       .post('/http/testA')
@@ -124,7 +131,7 @@ describe('HttpPostIngressEventPublisher', () => {
             'Failed to retrieve raw body from incoming event for topic testA; not a buffer: object',
           name: 'Error',
         },
-        request: { method: 'POST', url: '/testA' },
+        request: { method: 'POST', url: '/http/testA' },
         response: { statusCode: 500 },
       }),
     );
@@ -149,6 +156,7 @@ describe('HttpPostIngressEventPublisher', () => {
       logger,
     });
     publisher.bind(router);
+    router.use(middleware.error());
 
     const response = await request(app)
       .post('/http/testA')
@@ -163,7 +171,7 @@ describe('HttpPostIngressEventPublisher', () => {
           name: 'UnsupportedCharsetError',
           statusCode: 415,
         },
-        request: { method: 'POST', url: '/testA' },
+        request: { method: 'POST', url: '/http/testA' },
         response: { statusCode: 415 },
       }),
     );
@@ -188,6 +196,7 @@ describe('HttpPostIngressEventPublisher', () => {
       logger,
     });
     publisher.bind(router);
+    router.use(middleware.error());
 
     const response = await request(app)
       .post('/http/testA')
@@ -202,7 +211,7 @@ describe('HttpPostIngressEventPublisher', () => {
           name: 'UnsupportedMediaTypeError',
           statusCode: 415,
         },
-        request: { method: 'POST', url: '/testA' },
+        request: { method: 'POST', url: '/http/testA' },
         response: { statusCode: 415 },
       }),
     );

--- a/plugins/events-backend/src/service/http/HttpPostIngressEventPublisher.ts
+++ b/plugins/events-backend/src/service/http/HttpPostIngressEventPublisher.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { errorHandler } from '@backstage/backend-common';
 import { LoggerService } from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
 import { CustomErrorBase } from '@backstage/errors';
@@ -97,7 +96,6 @@ export class HttpPostIngressEventPublisher {
       this.addRouteForTopic(router, topic, ingresses[topic].validator),
     );
 
-    router.use(errorHandler());
     return router;
   }
 

--- a/plugins/example-todo-list-backend/src/service/router.ts
+++ b/plugins/example-todo-list-backend/src/service/router.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { errorHandler } from '@backstage/backend-common';
 import express from 'express';
 import Router from 'express-promise-router';
 import { add, getAll, update } from './todos';
@@ -75,7 +74,6 @@ export async function createRouter(
     res.json(update(req.body));
   });
 
-  router.use(errorHandler());
   return router;
 }
 

--- a/plugins/kubernetes-backend/src/service/KubernetesProxy.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesProxy.test.ts
@@ -16,7 +16,6 @@
 
 import 'buffer';
 import { resolve as resolvePath } from 'path';
-import { errorHandler } from '@backstage/backend-common';
 import {
   createMockDirectory,
   mockServices,
@@ -53,6 +52,12 @@ import {
 
 import type { Request } from 'express';
 import { BackstageCredentials } from '@backstage/backend-plugin-api';
+import { MiddlewareFactory } from '@backstage/backend-defaults/rootHttpRouter';
+
+const middleware = MiddlewareFactory.create({
+  logger: mockServices.logger.mock(),
+  config: mockServices.rootConfig(),
+});
 
 const mockCertDir = createMockDirectory({
   content: {
@@ -117,7 +122,7 @@ describe('KubernetesProxy', () => {
     const app = express().use(
       Router()
         .use(proxyPath, proxy.createRequestHandler({ permissionApi }))
-        .use(errorHandler()),
+        .use(middleware.error()),
     );
 
     const requestPromise = request(app).get(proxyPath + requestPath);
@@ -924,7 +929,7 @@ describe('KubernetesProxy', () => {
           .use(
             Router()
               .use(proxyPath, proxy.createRequestHandler({ permissionApi }))
-              .use(errorHandler()),
+              .use(middleware.error()),
           )
           .listen(0, '0.0.0.0', () => {
             proxyPort = (expressServer.address() as AddressInfo).port;

--- a/plugins/permission-backend/package.json
+++ b/plugins/permission-backend/package.json
@@ -67,6 +67,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@backstage/backend-defaults": "workspace:^",
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@types/lodash": "^4.14.151",

--- a/plugins/permission-backend/src/service/router.test.ts
+++ b/plugins/permission-backend/src/service/router.test.ts
@@ -27,6 +27,7 @@ import { createRouter } from './router';
 import { ConfigReader } from '@backstage/config';
 import { BackstageCredentials } from '@backstage/backend-plugin-api';
 import { mockCredentials, mockServices } from '@backstage/backend-test-utils';
+import { MiddlewareFactory } from '@backstage/backend-defaults/rootHttpRouter';
 
 const mockApplyConditions: jest.MockedFunction<
   InstanceType<typeof PermissionIntegrationClient>['applyConditions']
@@ -60,6 +61,11 @@ const policy = {
   }),
 };
 
+const middleware = MiddlewareFactory.create({
+  logger: mockServices.logger.mock(),
+  config: mockServices.rootConfig(),
+});
+
 describe('createRouter', () => {
   let app: express.Express;
 
@@ -75,7 +81,7 @@ describe('createRouter', () => {
       userInfo: mockServices.userInfo(),
       policy,
     });
-
+    router.use(middleware.error());
     app = express().use(router);
   });
 

--- a/plugins/permission-backend/src/service/router.ts
+++ b/plugins/permission-backend/src/service/router.ts
@@ -17,10 +17,7 @@
 import { z } from 'zod';
 import express, { Request, Response } from 'express';
 import Router from 'express-promise-router';
-import {
-  createLegacyAuthAdapters,
-  errorHandler,
-} from '@backstage/backend-common';
+import { createLegacyAuthAdapters } from '@backstage/backend-common';
 import { InputError } from '@backstage/errors';
 import { IdentityApi } from '@backstage/plugin-auth-node';
 import {
@@ -250,8 +247,6 @@ export async function createRouter(
       });
     },
   );
-
-  router.use(errorHandler());
 
   return router;
 }

--- a/plugins/permission-node/package.json
+++ b/plugins/permission-node/package.json
@@ -69,6 +69,7 @@
     "zod-to-json-schema": "^3.20.4"
   },
   "devDependencies": {
+    "@backstage/backend-defaults": "workspace:^",
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@types/supertest": "^2.0.8",

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
@@ -29,6 +29,8 @@ import {
   PermissionIntegrationRouterOptions,
 } from './createPermissionIntegrationRouter';
 import { createPermissionRule } from './createPermissionRule';
+import { MiddlewareFactory } from '@backstage/backend-defaults/rootHttpRouter';
+import { mockServices } from '@backstage/backend-test-utils';
 
 const testPermission: Permission = createPermission({
   name: 'test.permission',
@@ -109,6 +111,11 @@ const mockedOptionResources: PermissionIntegrationRouterOptions = {
   ],
 };
 
+const middleware = MiddlewareFactory.create({
+  logger: mockServices.logger.mock(),
+  config: mockServices.rootConfig(),
+});
+
 const createApp = (
   mockedGetResources:
     | typeof defaultMockedGetResources1 = defaultMockedGetResources1,
@@ -122,7 +129,7 @@ const createApp = (
       })
     : createPermissionIntegrationRouter({ permissions: [testPermission] });
 
-  return express().use(router);
+  return express().use(router.use(middleware.error()));
 };
 
 describe('createPermissionIntegrationRouter', () => {
@@ -453,7 +460,9 @@ describe('createPermissionIntegrationRouter', () => {
 
       beforeEach(async () => {
         const app = express().use(
-          createPermissionIntegrationRouter(mockedOptionResources),
+          createPermissionIntegrationRouter(mockedOptionResources).use(
+            middleware.error(),
+          ),
         );
 
         response = await request(app)
@@ -765,7 +774,7 @@ describe('createPermissionIntegrationRouter', () => {
             resourceType: 'test-resource',
             permissions: [testPermission],
             rules: [testRule1, testRule2],
-          }),
+          }).use(middleware.error()),
         ),
       )
         .post('/.well-known/backstage/permissions/apply-conditions')

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
@@ -19,7 +19,6 @@ import Router from 'express-promise-router';
 import { z } from 'zod';
 import zodToJsonSchema from 'zod-to-json-schema';
 import { InputError } from '@backstage/errors';
-import { errorHandler } from '@backstage/backend-common';
 import {
   AuthorizeResult,
   DefinitivePolicyDecision,
@@ -482,9 +481,6 @@ export function createPermissionIntegrationRouter<
       });
     },
   );
-
-  // TODO(belugas): Remove this when dropping support to the legacy backend system because setting the error handler manually is no logger required in the new system.
-  router.use(errorHandler());
 
   return router;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5350,6 +5350,7 @@ __metadata:
   resolution: "@backstage/plugin-auth-node@workspace:plugins/auth-node"
   dependencies:
     "@backstage/backend-common": ^0.25.0
+    "@backstage/backend-defaults": "workspace:^"
     "@backstage/backend-plugin-api": "workspace:^"
     "@backstage/backend-test-utils": "workspace:^"
     "@backstage/catalog-client": "workspace:^"
@@ -5612,7 +5613,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@backstage/plugin-catalog-backend-module-gitlab-org@workspace:plugins/catalog-backend-module-gitlab-org"
   dependencies:
-    "@backstage/backend-common": ^0.25.0
     "@backstage/backend-plugin-api": "workspace:^"
     "@backstage/backend-test-utils": "workspace:^"
     "@backstage/cli": "workspace:^"
@@ -6914,6 +6914,7 @@ __metadata:
   resolution: "@backstage/plugin-permission-backend@workspace:plugins/permission-backend"
   dependencies:
     "@backstage/backend-common": ^0.25.0
+    "@backstage/backend-defaults": "workspace:^"
     "@backstage/backend-plugin-api": "workspace:^"
     "@backstage/backend-test-utils": "workspace:^"
     "@backstage/cli": "workspace:^"
@@ -6957,6 +6958,7 @@ __metadata:
   resolution: "@backstage/plugin-permission-node@workspace:plugins/permission-node"
   dependencies:
     "@backstage/backend-common": ^0.25.0
+    "@backstage/backend-defaults": "workspace:^"
     "@backstage/backend-plugin-api": "workspace:^"
     "@backstage/backend-test-utils": "workspace:^"
     "@backstage/cli": "workspace:^"


### PR DESCRIPTION
This is on top of #28266. It targets `notFoundHandler`, `errorHandler` etc from the old `backend-common`.