### PR TITLE
🧹  remove `backend-common` from `catalog-backend-module-openapi`

### DIFF
--- a/.changeset/cuddly-lions-knock.md
+++ b/.changeset/cuddly-lions-knock.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-openapi': patch
+---
+
+Refactor to no longer use backend-common

--- a/plugins/catalog-backend-module-openapi/package.json
+++ b/plugins/catalog-backend-module-openapi/package.json
@@ -38,16 +38,12 @@
   },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.0.0",
-    "@backstage/backend-common": "^0.25.0",
     "@backstage/backend-plugin-api": "workspace:^",
     "@backstage/catalog-model": "workspace:^",
-    "@backstage/config": "workspace:^",
     "@backstage/integration": "workspace:^",
-    "@backstage/plugin-catalog-backend": "workspace:^",
     "@backstage/plugin-catalog-common": "workspace:^",
     "@backstage/plugin-catalog-node": "workspace:^",
     "@backstage/types": "workspace:^",
-    "winston": "^3.2.1",
     "yaml": "^2.1.1"
   },
   "devDependencies": {

--- a/plugins/catalog-backend-module-openapi/report.api.md
+++ b/plugins/catalog-backend-module-openapi/report.api.md
@@ -5,12 +5,12 @@
 ```ts
 import { BackendFeature } from '@backstage/backend-plugin-api';
 import { CatalogProcessor } from '@backstage/plugin-catalog-node';
-import { Config } from '@backstage/config';
 import { Entity } from '@backstage/catalog-model';
 import { JsonValue } from '@backstage/types';
 import { LocationSpec } from '@backstage/plugin-catalog-common';
-import { Logger } from 'winston';
-import { PlaceholderResolverParams } from '@backstage/plugin-catalog-backend';
+import { LoggerService } from '@backstage/backend-plugin-api';
+import { PlaceholderResolverParams } from '@backstage/plugin-catalog-node';
+import { RootConfigService } from '@backstage/backend-plugin-api';
 import { ScmIntegrations } from '@backstage/integration';
 import { UrlReaderService } from '@backstage/backend-plugin-api';
 
@@ -30,14 +30,14 @@ export const openApiPlaceholderResolver: typeof jsonSchemaRefPlaceholderResolver
 export class OpenApiRefProcessor implements CatalogProcessor {
   constructor(options: {
     integrations: ScmIntegrations;
-    logger: Logger;
+    logger: LoggerService;
     reader: UrlReaderService;
   });
   // (undocumented)
   static fromConfig(
-    config: Config,
+    config: RootConfigService,
     options: {
-      logger: Logger;
+      logger: LoggerService;
       reader: UrlReaderService;
     },
   ): OpenApiRefProcessor;

--- a/plugins/catalog-backend-module-openapi/src/OpenApiRefProcessor.test.ts
+++ b/plugins/catalog-backend-module-openapi/src/OpenApiRefProcessor.test.ts
@@ -13,12 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ConfigReader } from '@backstage/config';
-import { LocationSpec } from '@backstage/plugin-catalog-backend';
+
+import { LocationSpec } from '@backstage/plugin-catalog-common';
 import { OpenApiRefProcessor } from './OpenApiRefProcessor';
 import { bundleFileWithRefs } from './lib';
 import { mockServices } from '@backstage/backend-test-utils';
-import { loggerToWinstonLogger } from '@backstage/backend-common';
 
 jest.mock('./lib', () => ({
   bundleFileWithRefs: jest.fn(),
@@ -46,15 +45,10 @@ describe('OpenApiRefProcessor', () => {
         kind,
         spec: { definition: '<openapi-definition>', ...spec },
       };
-      const config = new ConfigReader({});
-      const reader = {
-        read: jest.fn(),
-        readUrl: jest.fn(),
-        readTree: jest.fn(),
-        search: jest.fn(),
-      };
+      const config = mockServices.rootConfig();
+      const reader = mockServices.urlReader.mock();
       const processor = OpenApiRefProcessor.fromConfig(config, {
-        logger: loggerToWinstonLogger(mockServices.logger.mock()),
+        logger: mockServices.logger.mock(),
         reader,
       });
 

--- a/plugins/catalog-backend-module-openapi/src/OpenApiRefProcessor.ts
+++ b/plugins/catalog-backend-module-openapi/src/OpenApiRefProcessor.ts
@@ -13,14 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { UrlReaderService } from '@backstage/backend-plugin-api';
+
+import {
+  LoggerService,
+  RootConfigService,
+  UrlReaderService,
+} from '@backstage/backend-plugin-api';
 import { Entity } from '@backstage/catalog-model';
-import { Config } from '@backstage/config';
 import { ScmIntegrations } from '@backstage/integration';
 import { CatalogProcessor } from '@backstage/plugin-catalog-node';
 import { LocationSpec } from '@backstage/plugin-catalog-common';
 import { bundleFileWithRefs } from './lib';
-import { Logger } from 'winston';
 
 /**
  * @public
@@ -28,12 +31,12 @@ import { Logger } from 'winston';
  */
 export class OpenApiRefProcessor implements CatalogProcessor {
   private readonly integrations: ScmIntegrations;
-  private readonly logger: Logger;
+  private readonly logger: LoggerService;
   private readonly reader: UrlReaderService;
 
   static fromConfig(
-    config: Config,
-    options: { logger: Logger; reader: UrlReaderService },
+    config: RootConfigService,
+    options: { logger: LoggerService; reader: UrlReaderService },
   ) {
     const integrations = ScmIntegrations.fromConfig(config);
 
@@ -45,7 +48,7 @@ export class OpenApiRefProcessor implements CatalogProcessor {
 
   constructor(options: {
     integrations: ScmIntegrations;
-    logger: Logger;
+    logger: LoggerService;
     reader: UrlReaderService;
   }) {
     this.integrations = options.integrations;

--- a/plugins/catalog-backend-module-openapi/src/jsonSchemaRefPlaceholderResolver.test.ts
+++ b/plugins/catalog-backend-module-openapi/src/jsonSchemaRefPlaceholderResolver.test.ts
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { PlaceholderResolverParams } from '@backstage/plugin-catalog-backend';
+
+import { PlaceholderResolverParams } from '@backstage/plugin-catalog-node';
 import { jsonSchemaRefPlaceholderResolver } from './jsonSchemaRefPlaceholderResolver';
 import { bundleFileWithRefs } from './lib';
 

--- a/plugins/catalog-backend-module-openapi/src/jsonSchemaRefPlaceholderResolver.ts
+++ b/plugins/catalog-backend-module-openapi/src/jsonSchemaRefPlaceholderResolver.ts
@@ -13,9 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { PlaceholderResolverParams } from '@backstage/plugin-catalog-backend';
+
 import { JsonValue } from '@backstage/types';
-import { processingResult } from '@backstage/plugin-catalog-node';
+import {
+  PlaceholderResolverParams,
+  processingResult,
+} from '@backstage/plugin-catalog-node';
 import { bundleFileWithRefs } from './lib';
 
 /** @public */

--- a/yarn.lock
+++ b/yarn.lock
@@ -5735,19 +5735,15 @@ __metadata:
   resolution: "@backstage/plugin-catalog-backend-module-openapi@workspace:plugins/catalog-backend-module-openapi"
   dependencies:
     "@apidevtools/json-schema-ref-parser": ^11.0.0
-    "@backstage/backend-common": ^0.25.0
     "@backstage/backend-plugin-api": "workspace:^"
     "@backstage/backend-test-utils": "workspace:^"
     "@backstage/catalog-model": "workspace:^"
     "@backstage/cli": "workspace:^"
-    "@backstage/config": "workspace:^"
     "@backstage/integration": "workspace:^"
-    "@backstage/plugin-catalog-backend": "workspace:^"
     "@backstage/plugin-catalog-common": "workspace:^"
     "@backstage/plugin-catalog-node": "workspace:^"
     "@backstage/types": "workspace:^"
     openapi-types: ^12.0.0
-    winston: ^3.2.1
     yaml: ^2.1.1
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
This is on top of #28268.

As part of this, the Logger arguments have been replaced with LoggerService. They are basically compatible from a consumption standpoint though.