### PR TITLE
Go back to using node-fetch for gitlab

### DIFF
--- a/.changeset/famous-balloons-punch.md
+++ b/.changeset/famous-balloons-punch.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-catalog-backend-module-gitlab': patch
+'@backstage/backend-defaults': patch
+---
+
+Go back to using `node-fetch` for gitlab

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/GitlabUrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/GitlabUrlReader.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+// NOTE(freben): Intentionally uses node-fetch because of https://github.com/backstage/backstage/issues/28190
+import fetch, { Response } from 'node-fetch';
+
 import {
   UrlReaderService,
   UrlReaderServiceReadTreeOptions,
@@ -34,8 +37,10 @@ import {
 import parseGitUrl from 'git-url-parse';
 import { trimEnd, trimStart } from 'lodash';
 import { Minimatch } from 'minimatch';
+import { Readable } from 'stream';
 import { ReadUrlResponseFactory } from './ReadUrlResponseFactory';
 import { ReadTreeResponseFactory, ReaderFactory } from './types';
+import { parseLastModified } from './util';
 
 /**
  * Implements a {@link @backstage/backend-plugin-api#UrlReaderService} for files on GitLab.
@@ -98,7 +103,12 @@ export class GitlabUrlReader implements UrlReaderService {
     }
 
     if (response.ok) {
-      return ReadUrlResponseFactory.fromResponse(response);
+      return ReadUrlResponseFactory.fromNodeJSReadable(response.body, {
+        etag: response.headers.get('ETag') ?? undefined,
+        lastModifiedAt: parseLastModified(
+          response.headers.get('Last-Modified'),
+        ),
+      });
     }
 
     const message = `${url} could not be read as ${builtUrl}, ${response.status} ${response.statusText}`;
@@ -220,7 +230,7 @@ export class GitlabUrlReader implements UrlReaderService {
     }
 
     return await this.deps.treeResponseFactory.fromTarArchive({
-      response: archiveGitLabResponse,
+      stream: Readable.from(archiveGitLabResponse.body),
       subpath: filepath,
       etag: commitSha,
       filter: options?.filter,

--- a/plugins/catalog-backend-module-gitlab/package.json
+++ b/plugins/catalog-backend-module-gitlab/package.json
@@ -61,6 +61,7 @@
     "@backstage/plugin-events-node": "workspace:^",
     "@gitbeaker/rest": "^40.0.3",
     "lodash": "^4.17.21",
+    "node-fetch": "^2.7.0",
     "uuid": "^11.0.0"
   },
   "devDependencies": {

--- a/plugins/catalog-backend-module-gitlab/src/lib/client.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/client.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+// NOTE(freben): Intentionally uses node-fetch because of https://github.com/backstage/backstage/issues/28190
+import fetch from 'node-fetch';
+
 import {
   getGitLabRequestOptions,
   GitLabIntegrationConfig,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5643,6 +5643,7 @@ __metadata:
     lodash: ^4.17.21
     luxon: ^3.0.0
     msw: ^1.0.0
+    node-fetch: ^2.7.0
     uuid: ^11.0.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Fixes https://github.com/backstage/backstage/issues/28190

Basically reverts https://github.com/backstage/backstage/commit/f41ea01bbe913a7cdf74874e89e0e7bd81325a42#diff-374ae7c3b186d58fd2f8d803cf9fe48503012df767b6b8e8d259ecea58d2d832R41 and https://github.com/backstage/backstage/commit/5c9cc05eee5493cc7acd48587ff71d037b04c309 temporarily, since it was a bit more work to try to get it to use undici short term. 