### PR TITLE
Patch release of #28283

### DIFF
--- a/.changeset/famous-balloons-punch.md
+++ b/.changeset/famous-balloons-punch.md
@@ -1,6 +1,0 @@
----
-'@backstage/plugin-catalog-backend-module-gitlab': patch
-'@backstage/backend-defaults': patch
----
-
-Go back to using `node-fetch` for gitlab

--- a/.changeset/famous-balloons-punch.md
+++ b/.changeset/famous-balloons-punch.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-catalog-backend-module-gitlab': patch
+'@backstage/backend-defaults': patch
+---
+
+Go back to using `node-fetch` for gitlab

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.34.1",
+  "version": "1.34.2",
   "private": true,
   "repository": {
     "type": "git",
@@ -84,6 +84,9 @@
     ]
   },
   "prettier": "@backstage/cli/config/prettier",
+  "jest": {
+    "rejectFrontendNetworkRequests": true
+  },
   "resolutions": {
     "@changesets/assemble-release-plan@^6.0.0": "patch:@changesets/assemble-release-plan@npm%3A6.0.0#./.yarn/patches/@changesets-assemble-release-plan-npm-6.0.0-f7b3005037.patch",
     "@material-ui/pickers@^3.2.10": "patch:@material-ui/pickers@npm%3A3.3.11#./.yarn/patches/@material-ui-pickers-npm-3.3.11-1c8f68ea20.patch",
@@ -133,9 +136,6 @@
     "sloc": "^0.3.1",
     "sort-package-json": "^2.8.0",
     "typescript": "~5.2.0"
-  },
-  "jest": {
-    "rejectFrontendNetworkRequests": true
   },
   "packageManager": "yarn@3.8.1",
   "engines": {

--- a/packages/backend-defaults/CHANGELOG.md
+++ b/packages/backend-defaults/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/backend-defaults
 
+## 0.6.2
+
+### Patch Changes
+
+- 81a46cf: Go back to using `node-fetch` for gitlab
+
 ## 0.6.1
 
 ### Patch Changes

--- a/packages/backend-defaults/package.json
+++ b/packages/backend-defaults/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/backend-defaults",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Backend defaults used by Backstage backend apps",
   "backstage": {
     "role": "node-library"
@@ -185,14 +185,6 @@
     "yn": "^4.0.0",
     "zod": "^3.22.4"
   },
-  "peerDependencies": {
-    "@google-cloud/cloud-sql-connector": "^1.4.0"
-  },
-  "peerDependenciesMeta": {
-    "@google-cloud/cloud-sql-connector": {
-      "optional": true
-    }
-  },
   "devDependencies": {
     "@aws-sdk/util-stream-node": "^3.350.0",
     "@backstage/backend-plugin-api": "workspace:^",
@@ -213,6 +205,14 @@
     "node-mocks-http": "^1.0.0",
     "supertest": "^7.0.0",
     "wait-for-expect": "^3.0.2"
+  },
+  "peerDependencies": {
+    "@google-cloud/cloud-sql-connector": "^1.4.0"
+  },
+  "peerDependenciesMeta": {
+    "@google-cloud/cloud-sql-connector": {
+      "optional": true
+    }
   },
   "configSchema": "config.d.ts"
 }

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/GitlabUrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/GitlabUrlReader.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+// NOTE(freben): Intentionally uses node-fetch because of https://github.com/backstage/backstage/issues/28190
+import fetch, { Response } from 'node-fetch';
+
 import {
   UrlReaderService,
   UrlReaderServiceReadTreeOptions,
@@ -34,8 +37,10 @@ import {
 import parseGitUrl from 'git-url-parse';
 import { trimEnd, trimStart } from 'lodash';
 import { Minimatch } from 'minimatch';
+import { Readable } from 'stream';
 import { ReadUrlResponseFactory } from './ReadUrlResponseFactory';
 import { ReadTreeResponseFactory, ReaderFactory } from './types';
+import { parseLastModified } from './util';
 
 /**
  * Implements a {@link @backstage/backend-plugin-api#UrlReaderService} for files on GitLab.
@@ -98,7 +103,12 @@ export class GitlabUrlReader implements UrlReaderService {
     }
 
     if (response.ok) {
-      return ReadUrlResponseFactory.fromResponse(response);
+      return ReadUrlResponseFactory.fromNodeJSReadable(response.body, {
+        etag: response.headers.get('ETag') ?? undefined,
+        lastModifiedAt: parseLastModified(
+          response.headers.get('Last-Modified'),
+        ),
+      });
     }
 
     const message = `${url} could not be read as ${builtUrl}, ${response.status} ${response.statusText}`;
@@ -220,7 +230,7 @@ export class GitlabUrlReader implements UrlReaderService {
     }
 
     return await this.deps.treeResponseFactory.fromTarArchive({
-      response: archiveGitLabResponse,
+      stream: Readable.from(archiveGitLabResponse.body),
       subpath: filepath,
       etag: commitSha,
       filter: options?.filter,

--- a/plugins/catalog-backend-module-gitlab/CHANGELOG.md
+++ b/plugins/catalog-backend-module-gitlab/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-catalog-backend-module-gitlab
 
+## 0.6.1
+
+### Patch Changes
+
+- 81a46cf: Go back to using `node-fetch` for gitlab
+- Updated dependencies
+  - @backstage/backend-defaults@0.6.2
+
 ## 0.6.0
 
 ### Minor Changes

--- a/plugins/catalog-backend-module-gitlab/package.json
+++ b/plugins/catalog-backend-module-gitlab/package.json
@@ -61,6 +61,7 @@
     "@backstage/plugin-events-node": "workspace:^",
     "@gitbeaker/rest": "^40.0.3",
     "lodash": "^4.17.21",
+    "node-fetch": "^2.7.0",
     "uuid": "^11.0.0"
   },
   "devDependencies": {

--- a/plugins/catalog-backend-module-gitlab/package.json
+++ b/plugins/catalog-backend-module-gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-gitlab",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A Backstage catalog backend module that helps integrate towards GitLab",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/catalog-backend-module-gitlab/src/lib/client.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/client.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+// NOTE(freben): Intentionally uses node-fetch because of https://github.com/backstage/backstage/issues/28190
+import fetch from 'node-fetch';
+
 import {
   getGitLabRequestOptions,
   GitLabIntegrationConfig,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5648,6 +5648,7 @@ __metadata:
     lodash: ^4.17.21
     luxon: ^3.0.0
     msw: ^1.0.0
+    node-fetch: ^2.7.0
     uuid: ^11.0.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
This release fixes an issue where the GitLab reader was returning 406 errors when reading from a repository.