### PR TITLE
fix(config): add missing parameters to configuration schema

### DIFF
--- a/.changeset/light-wasps-unite.md
+++ b/.changeset/light-wasps-unite.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-catalog-backend-module-msgraph': patch
+'@backstage/plugin-techdocs-backend': patch
+---
+
+fix(config): add missing parameters in config schema

--- a/plugins/catalog-backend-module-msgraph/config.d.ts
+++ b/plugins/catalog-backend-module-msgraph/config.d.ts
@@ -165,6 +165,12 @@ export interface Config {
                * This can be useful for huge organizations.
                */
               loadPhotos?: boolean;
+              /**
+               * The fields to be fetched on query.
+               *
+               * E.g. ["id", "displayName", "description"]
+               */
+              select?: string[];
             };
 
             group?: {
@@ -258,14 +264,37 @@ export interface Config {
               queryMode?: string;
               user?: {
                 /**
+                 * The "expand" argument to apply to users.
+                 *
+                 * E.g. "manager".
+                 */
+                expand?: string;
+                /**
                  * The filter to apply to extract users.
                  *
                  * E.g. "accountEnabled eq true and userType eq 'member'"
                  */
                 filter?: string;
+                /**
+                 * Set to false to not load user photos.
+                 * This can be useful for huge organizations.
+                 */
+                loadPhotos?: boolean;
+                /**
+                 * The fields to be fetched on query.
+                 *
+                 * E.g. ["id", "displayName", "description"]
+                 */
+                select?: string[];
               };
 
               group?: {
+                /**
+                 * The "expand" argument to apply to groups.
+                 *
+                 * E.g. "member".
+                 */
+                expand?: string;
                 /**
                  * The filter to apply to extract groups.
                  *
@@ -284,6 +313,11 @@ export interface Config {
                  * E.g. ["id", "displayName", "description"]
                  */
                 select?: string[];
+                /**
+                 * Whether to ingest groups that are members of the found/filtered/searched groups.
+                 * Default value is `false`.
+                 */
+                includeSubGroups?: boolean;
               };
 
               userGroupMember?: {

--- a/plugins/techdocs-backend/config.d.ts
+++ b/plugins/techdocs-backend/config.d.ts
@@ -263,6 +263,11 @@ export interface Config {
              * the credentials belongs to a different project to the bucket.
              */
             projectId?: string;
+            /**
+             * (Optional) Location in storage bucket to save files
+             * If not set, the default location will be the root of the storage bucket
+             */
+            bucketRootPath?: string;
           };
         };
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Hello :wave:

- Added configuration parameters to the schema for `@backstage/plugin-catalog-backend-module-msgraph` and `@backstage/plugin-techdocs-backend`
  - The parameters are read but not present in schema, hence validation/autocompletion errors.

Note:

The microsoftGraph catalog configuration is duplicated, as they are two ways to declare: top level or with provider name. 
Should we declare it once and import it? If so, where should we put it, as we can only declare a single symbol in `config.d.ts`? Most packages seem to duplicate the configuration schema. Feedback appreciated :)

#### :heavy_check_mark: Checklist

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
