### PR TITLE
create-app - Added `-j 2` to `dev` script

### DIFF
--- a/.changeset/orange-icons-sell.md
+++ b/.changeset/orange-icons-sell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Added `-j 2` to `dev` script to help cases where the backend does not start up during local development

--- a/packages/create-app/templates/default-app/package.json.hbs
+++ b/packages/create-app/templates/default-app/package.json.hbs
@@ -6,7 +6,7 @@
     "node": "20 || 22"
   },
   "scripts": {
-    "dev": "yarn workspaces foreach -A --include backend --include app --parallel -v -i run start",
+    "dev": "yarn workspaces foreach -A --include backend --include app --parallel -j 2 -v -i run start",
     "start": "yarn workspace app start",
     "start-backend": "yarn workspace backend start",
     "build:backend": "yarn workspace backend build",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added `-j 2` to `dev` script to help cases where the backend does not start up during local development. 

More details on `-j` here: https://yarnpkg.com/cli/workspaces/foreach#details

Also this Discord post: https://discord.com/channels/687207715902193673/1299061992241500210

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
