### PR TITLE
docs(vscode): update vscode debugger instructions for backend

### DIFF
--- a/docs/tooling/local-dev/debugging.md
+++ b/docs/tooling/local-dev/debugging.md
@@ -56,19 +56,19 @@ In your `launch.json`, add a new entry with the following,
 
 ```jsonc
 {
-    "name": "Start Backend",
-    "type": "node",
-    "request": "launch",
-    "args": [
-        "package",
-        "start"
-    ],
-    "cwd": "${workspaceFolder}/packages/backend",
-    "program": "${workspaceFolder}/node_modules/.bin/backstage-cli",
-    "skipFiles": [
-        "<node_internals>/**"
-    ],
-    "console": "integratedTerminal"
+   "name": "Start Backend",
+   "type": "node",
+   "request": "launch",
+   "cwd": "${workspaceFolder}",
+   "runtimeExecutable": "yarn",
+   "args": [
+      "start-backend",
+      "--inspect"
+   ],
+   "skipFiles": [
+      "<node_internals>/**"
+   ],
+   "console": "integratedTerminal"
 },
 ```
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Updated docs for starting backend in debug mode in vscode as per [issue](https://github.com/backstage/backstage/issues/27870#issuecomment-2561516506)

Has been broken for quite some time now, with the current way that is set in the docs. As u get the following error when trying to start the backend with it:

```bash
Debugger attached.
Waiting for the debugger to disconnect...
<REDACTED>\node_modules\.bin\backstage-cli:2
basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
          ^^^^^^^

SyntaxError: missing ) after argument list
    at wrapSafe (node:internal/modules/cjs/loader:1281:20)
    at Module._compile (node:internal/modules/cjs/loader:1321:27)
    at Module._extensions..js (node:internal/modules/cjs/loader:1416:10)
    at Module.load (node:internal/modules/cjs/loader:1208:32)
    at Module._load (node:internal/modules/cjs/loader:1024:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:174:12)
    at node:internal/main/run_main_module:28:49

Node.js v20.15.1
```

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
