### PR TITLE
cli: experimental support for using embedded-postgres as dev DB

### DIFF
--- a/.changeset/thin-elephants-joke.md
+++ b/.changeset/thin-elephants-joke.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+The `package start` command now supports an experimental `EXPERIMENTAL_DEV_DB` env flag that can be set to enable the use of `embedded-postgres` as the database for local development, rather than SQLite. For this to work the desired version of the `embedded-postgres` package must be installed in your project, typically as a `devDependency`.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -90,6 +90,7 @@
     "cross-spawn": "^7.0.3",
     "css-loader": "^6.5.1",
     "ctrlc-windows": "^2.1.0",
+    "embedded-postgres": "^17.2.0-beta.15",
     "esbuild": "^0.24.0",
     "esbuild-loader": "^4.0.0",
     "eslint": "^8.6.0",
@@ -128,6 +129,7 @@
     "p-limit": "^3.1.0",
     "p-queue": "^6.6.2",
     "pirates": "^4.0.6",
+    "portfinder": "^1.0.32",
     "postcss": "^8.1.0",
     "process": "^0.11.10",
     "raw-loader": "^4.0.2",
@@ -194,6 +196,7 @@
     "@types/yarnpkg__lockfile": "^1.1.4",
     "@vitejs/plugin-react": "^4.3.1",
     "del": "^8.0.0",
+    "embedded-postgres": "17.2.0-beta.15",
     "msw": "^1.0.0",
     "nodemon": "^3.0.1",
     "vite": "^5.0.0",
@@ -206,6 +209,7 @@
     "@rspack/dev-server": "^1.0.9",
     "@rspack/plugin-react-refresh": "^1.0.0",
     "@vitejs/plugin-react": "^4.0.4",
+    "embedded-postgres": "17.2.0-beta.15",
     "vite": "^5.0.0",
     "vite-plugin-html": "^3.2.0",
     "vite-plugin-node-polyfills": "^0.22.0"
@@ -224,6 +228,9 @@
       "optional": true
     },
     "@vitejs/plugin-react": {
+      "optional": true
+    },
+    "embedded-postgres": {
       "optional": true
     },
     "vite": {

--- a/packages/cli/src/lib/runner/startEmbeddedDb.ts
+++ b/packages/cli/src/lib/runner/startEmbeddedDb.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import os from 'node:os';
+import fs from 'fs-extra';
+import { resolve as resolvePath } from 'path';
+import { getPortPromise } from 'portfinder';
+
+export async function startEmbeddedDb() {
+  const { default: EmbeddedPostgres } = await import('embedded-postgres').catch(
+    error => {
+      throw new Error(
+        `Failed to load peer dependency 'embedded-postgres' for generating SQL reports. ` +
+          `It must be installed as an explicit dependency in your project. Caused by; ${error}`,
+      );
+    },
+  );
+
+  const host = 'localhost';
+  const user = 'postgres';
+  const password = 'password';
+  const port = await getPortPromise();
+  const tmpDir = await fs.mkdtemp(
+    resolvePath(os.tmpdir(), 'backstage-dev-db-'),
+  );
+  const pg = new EmbeddedPostgres({
+    databaseDir: tmpDir,
+    user,
+    password,
+    port,
+    persistent: false,
+    onError(_messageOrError) {},
+    onLog(_message) {},
+  });
+
+  // Create the cluster config files
+  await pg.initialise();
+
+  // Start the server
+  await pg.start();
+
+  return {
+    connection: {
+      host,
+      user,
+      password,
+      port,
+    },
+    async close() {
+      await pg.stop();
+      await fs.rmdir(tmpDir, { recursive: true, maxRetries: 3 });
+    },
+  };
+}

--- a/packages/cli/src/types.d.ts
+++ b/packages/cli/src/types.d.ts
@@ -265,3 +265,8 @@ declare module 'webpack-node-externals' {
 }
 
 declare module '@esbuild-kit/cjs-loader' {}
+
+// It's missing a types entry point, but has types in dist
+declare module 'embedded-postgres' {
+  export { default } from 'embedded-postgres/dist/index';
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3987,6 +3987,7 @@ __metadata:
     css-loader: ^6.5.1
     ctrlc-windows: ^2.1.0
     del: ^8.0.0
+    embedded-postgres: 17.2.0-beta.15
     esbuild: ^0.24.0
     esbuild-loader: ^4.0.0
     eslint: ^8.6.0
@@ -4027,6 +4028,7 @@ __metadata:
     p-limit: ^3.1.0
     p-queue: ^6.6.2
     pirates: ^4.0.6
+    portfinder: ^1.0.32
     postcss: ^8.1.0
     process: ^0.11.10
     raw-loader: ^4.0.2
@@ -4063,6 +4065,7 @@ __metadata:
     "@rspack/dev-server": ^1.0.9
     "@rspack/plugin-react-refresh": ^1.0.0
     "@vitejs/plugin-react": ^4.0.4
+    embedded-postgres: 17.2.0-beta.15
     vite: ^5.0.0
     vite-plugin-html: ^3.2.0
     vite-plugin-node-polyfills: ^0.22.0
@@ -4076,6 +4079,8 @@ __metadata:
     "@rspack/plugin-react-refresh":
       optional: true
     "@vitejs/plugin-react":
+      optional: true
+    embedded-postgres:
       optional: true
     vite:
       optional: true
@@ -8987,6 +8992,62 @@ __metadata:
     ms: ^2.1.3
     secure-json-parse: ^2.4.0
   checksum: 08113bcb14203c5700e6575cb720aa32f5573a1776e13b78bf101ffeae46308c3664b94f16f7e2c5ec26e14c459d8d1491e234940e635cddfe3ee61a52fb51f9
+  languageName: node
+  linkType: hard
+
+"@embedded-postgres/darwin-arm64@npm:^17.2.0-beta.15":
+  version: 17.2.0-beta.15
+  resolution: "@embedded-postgres/darwin-arm64@npm:17.2.0-beta.15"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@embedded-postgres/darwin-x64@npm:^17.2.0-beta.15":
+  version: 17.2.0-beta.15
+  resolution: "@embedded-postgres/darwin-x64@npm:17.2.0-beta.15"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@embedded-postgres/linux-arm64@npm:^17.2.0-beta.15":
+  version: 17.2.0-beta.15
+  resolution: "@embedded-postgres/linux-arm64@npm:17.2.0-beta.15"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@embedded-postgres/linux-arm@npm:^17.2.0-beta.15":
+  version: 17.2.0-beta.15
+  resolution: "@embedded-postgres/linux-arm@npm:17.2.0-beta.15"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@embedded-postgres/linux-ia32@npm:^17.2.0-beta.15":
+  version: 17.2.0-beta.15
+  resolution: "@embedded-postgres/linux-ia32@npm:17.2.0-beta.15"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@embedded-postgres/linux-ppc64@npm:^17.2.0-beta.15":
+  version: 17.2.0-beta.15
+  resolution: "@embedded-postgres/linux-ppc64@npm:17.2.0-beta.15"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@embedded-postgres/linux-x64@npm:^17.2.0-beta.15":
+  version: 17.2.0-beta.15
+  resolution: "@embedded-postgres/linux-x64@npm:17.2.0-beta.15"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@embedded-postgres/windows-x64@npm:^17.2.0-beta.15":
+  version: 17.2.0-beta.15
+  resolution: "@embedded-postgres/windows-x64@npm:17.2.0-beta.15"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -27179,6 +27240,41 @@ __metadata:
   languageName: node
   linkType: hard
 
+"embedded-postgres@npm:17.2.0-beta.15":
+  version: 17.2.0-beta.15
+  resolution: "embedded-postgres@npm:17.2.0-beta.15"
+  dependencies:
+    "@embedded-postgres/darwin-arm64": ^17.2.0-beta.15
+    "@embedded-postgres/darwin-x64": ^17.2.0-beta.15
+    "@embedded-postgres/linux-arm": ^17.2.0-beta.15
+    "@embedded-postgres/linux-arm64": ^17.2.0-beta.15
+    "@embedded-postgres/linux-ia32": ^17.2.0-beta.15
+    "@embedded-postgres/linux-ppc64": ^17.2.0-beta.15
+    "@embedded-postgres/linux-x64": ^17.2.0-beta.15
+    "@embedded-postgres/windows-x64": ^17.2.0-beta.15
+    async-exit-hook: ^2.0.1
+    pg: ^8.7.3
+  dependenciesMeta:
+    "@embedded-postgres/darwin-arm64":
+      optional: true
+    "@embedded-postgres/darwin-x64":
+      optional: true
+    "@embedded-postgres/linux-arm":
+      optional: true
+    "@embedded-postgres/linux-arm64":
+      optional: true
+    "@embedded-postgres/linux-ia32":
+      optional: true
+    "@embedded-postgres/linux-ppc64":
+      optional: true
+    "@embedded-postgres/linux-x64":
+      optional: true
+    "@embedded-postgres/windows-x64":
+      optional: true
+  checksum: 53b261693dcc83cea6cc2589794dbc69bcf4cae508f2021d4686d7fb08e686e93db97392ebd28dfd2bb0126060b54fa609487d9929a4fee19da6d66dc568863f
+  languageName: node
+  linkType: hard
+
 "emittery@npm:^0.13.1":
   version: 0.13.1
   resolution: "emittery@npm:0.13.1"
@@ -38938,7 +39034,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pg@npm:^8.11.3, pg@npm:^8.9.0":
+"pg@npm:^8.11.3, pg@npm:^8.7.3, pg@npm:^8.9.0":
   version: 8.13.1
   resolution: "pg@npm:8.13.1"
   dependencies:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Does what is says on the tin. This is on top of #28308 because it needs support for module-only packages, and is a parallel to #28315.

Some rough benchmarking shows that this slows down the initial startup time of the backend somewhat, while restarts are about the same speed for a small DB, but noticeably faster with a large DB. Of course performance isn't really the main concern with moving in this direction as long as it's good enough. The biggest upside would be to eventually be able to drop the need for supporting SQLite and thereby simplifying DB code a lot.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
