### PR TITLE
Enhanced EntityOwnerPicker component to respect existing kind and type filters

### DIFF
--- a/.changeset/smooth-mayflies-smell.md
+++ b/.changeset/smooth-mayflies-smell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': minor
+---
+
+Enhanced EntityOwnerPicker component to respect existing kind and type filters

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.test.tsx
@@ -21,7 +21,11 @@ import {
   MockEntityListContextProvider,
   catalogApiMock,
 } from '@backstage/plugin-catalog-react/testUtils';
-import { EntityOwnerFilter } from '../../filters';
+import {
+  EntityKindFilter,
+  EntityOwnerFilter,
+  EntityTypeFilter,
+} from '../../filters';
 import { EntityOwnerPicker } from './EntityOwnerPicker';
 import { ApiProvider } from '@backstage/core-app-api';
 import {
@@ -413,7 +417,7 @@ describe('<EntityOwnerPicker mode="owners-only" />', () => {
       },
     );
 
-    expect(mockCatalogApi.getEntityFacets).toHaveBeenCalledTimes(1);
+    expect(mockCatalogApi.getEntityFacets).toHaveBeenCalledTimes(2);
 
     fireEvent.scroll(screen.getByTestId('owner-picker-listbox'));
 
@@ -466,6 +470,69 @@ describe('<EntityOwnerPicker mode="owners-only" />', () => {
     );
     expect(mockCatalogApi.getEntityFacets).toHaveBeenCalledWith({
       facets: ['relations.ownedBy'],
+      filter: {},
+    });
+    expect(updateFilters).toHaveBeenLastCalledWith({
+      owners: undefined,
+    });
+
+    fireEvent.click(screen.getByTestId('owner-picker-expand'));
+    await waitFor(() => screen.getByText('some-owner'));
+
+    fireEvent.click(screen.getByText('some-owner'));
+    expect(updateFilters).toHaveBeenLastCalledWith({
+      owners: new EntityOwnerFilter(['group:default/some-owner']),
+    });
+  });
+
+  it('adds kind to filters', async () => {
+    const updateFilters = jest.fn();
+    await renderInTestApp(
+      <ApiProvider apis={mockApis}>
+        <MockEntityListContextProvider
+          value={{
+            updateFilters,
+            filters: { kind: new EntityKindFilter('component', 'Component') },
+          }}
+        >
+          <EntityOwnerPicker mode="owners-only" />
+        </MockEntityListContextProvider>
+      </ApiProvider>,
+    );
+    expect(mockCatalogApi.getEntityFacets).toHaveBeenCalledWith({
+      facets: ['relations.ownedBy'],
+      filter: { kind: 'component' },
+    });
+    expect(updateFilters).toHaveBeenLastCalledWith({
+      owners: undefined,
+    });
+
+    fireEvent.click(screen.getByTestId('owner-picker-expand'));
+    await waitFor(() => screen.getByText('some-owner'));
+
+    fireEvent.click(screen.getByText('some-owner'));
+    expect(updateFilters).toHaveBeenLastCalledWith({
+      owners: new EntityOwnerFilter(['group:default/some-owner']),
+    });
+  });
+
+  it('adds type to filters', async () => {
+    const updateFilters = jest.fn();
+    await renderInTestApp(
+      <ApiProvider apis={mockApis}>
+        <MockEntityListContextProvider
+          value={{
+            updateFilters,
+            filters: { type: new EntityTypeFilter('service') },
+          }}
+        >
+          <EntityOwnerPicker mode="owners-only" />
+        </MockEntityListContextProvider>
+      </ApiProvider>,
+    );
+    expect(mockCatalogApi.getEntityFacets).toHaveBeenCalledWith({
+      facets: ['relations.ownedBy'],
+      filter: { 'spec.type': ['service'] },
     });
     expect(updateFilters).toHaveBeenLastCalledWith({
       owners: undefined,

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
@@ -152,6 +152,7 @@ export const EntityOwnerPicker = (props?: EntityOwnerPickerProps) => {
   );
 
   const [{ value, loading }, handleFetch, cache] = useFetchEntities({
+    filters,
     mode,
     initialSelectedOwnersRefs: selectedOwners,
   });

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/useFetchEntities.ts
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/useFetchEntities.ts
@@ -21,17 +21,21 @@ import { useApi } from '@backstage/core-plugin-api';
 import { catalogApiRef } from '../../api';
 import useAsyncFn from 'react-use/esm/useAsyncFn';
 import { useMountEffect } from '@react-hookz/web';
+import { DefaultEntityFilters } from '../../hooks/useEntityListProvider';
 
 export function useFetchEntities({
+  filters,
   mode,
   initialSelectedOwnersRefs,
 }: {
+  filters: DefaultEntityFilters;
   mode: 'owners-only' | 'all';
   initialSelectedOwnersRefs: string[];
 }) {
   const isOwnersOnlyMode = mode === 'owners-only';
   const queryEntitiesResponse = useQueryEntities();
   const facetsEntitiesResponse = useFacetsEntities({
+    filters,
     enabled: isOwnersOnlyMode,
   });
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Enhanced EntityOwnerPicker component to respect existing kind and type filters. Currently, the component lists all owners in the catalog without respecting the `Kind` selection (even when it's selected by default)`. This fix filters the owners based on the selections made to `Kind` filter and `Type` filter.

fixes [#28137](https://github.com/backstage/backstage/issues/28137).

#### Results

Default Selection - Only owners for `Component` kinds are shown

![image](https://github.com/user-attachments/assets/2c818a1b-a32e-4c11-8288-93087533fd3b)


When `Kind` & `Type` selections are made, owners are filtered accordingly

![image](https://github.com/user-attachments/assets/796c7df7-8ada-44c2-9757-c46b2330128d)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
