### PR TITLE
api-docs: fix typos in README and default path

### DIFF
--- a/.changeset/smart-plants-sip.md
+++ b/.changeset/smart-plants-sip.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-api-docs': patch
+---
+
+Fix typo in default path of api docs definition route

--- a/plugins/api-docs/README-alpha.md
+++ b/plugins/api-docs/README-alpha.md
@@ -826,10 +826,10 @@ export default createFrontendModule({
     createEntityContentExtension({
       // Name is necessary so the system knows that this extension will override the default 'definition' entity content extension provided by the 'api-docs' plugin
       name: 'definition',
-      // Returing a custom content component
+      // Returning a custom content component
       loader: () =>
         import('./components').then(m => (
-          <m.MyCustomApiDefintionEntityContent />
+          <m.MyCustomApiDefinitionEntityContent />
         )),
     }),
   ],

--- a/plugins/api-docs/src/alpha.tsx
+++ b/plugins/api-docs/src/alpha.tsx
@@ -189,7 +189,7 @@ const apiDocsProvidingComponentsEntityCard = EntityCardBlueprint.make({
 const apiDocsDefinitionEntityContent = EntityContentBlueprint.make({
   name: 'definition',
   params: {
-    defaultPath: '/defintion',
+    defaultPath: '/definition',
     defaultTitle: 'Definition',
     filter: 'kind:api',
     loader: async () =>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes a couple related typos. We should discuss whether the defaultPath should be a breaking change - if so, perhaps it isn't worth doing 😬.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
