### PR TITLE
Move `Expand` types to `@backstage/types`

### DIFF
--- a/.changeset/long-parrots-hide.md
+++ b/.changeset/long-parrots-hide.md
@@ -1,0 +1,7 @@
+---
+'@backstage/frontend-plugin-api': patch
+'@backstage/core-plugin-api': patch
+'@backstage/types': patch
+---
+
+Move `Expand` and `ExpandRecursive` to `@backstage/types`

--- a/packages/core-plugin-api/report-alpha.api.md
+++ b/packages/core-plugin-api/report-alpha.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 import { ApiRef } from '@backstage/core-plugin-api';
+import { Expand } from '@backstage/types';
+import { ExpandRecursive } from '@backstage/types';
 import { Observable } from '@backstage/types';
 import { TranslationMessages as TranslationMessages_2 } from '@backstage/core-plugin-api/alpha';
 import { TranslationRef as TranslationRef_2 } from '@backstage/core-plugin-api/alpha';

--- a/packages/core-plugin-api/src/apis/definitions/TranslationApi.ts
+++ b/packages/core-plugin-api/src/apis/definitions/TranslationApi.ts
@@ -15,7 +15,7 @@
  */
 
 import { ApiRef, createApiRef } from '@backstage/core-plugin-api';
-import { Observable } from '@backstage/types';
+import { Expand, ExpandRecursive, Observable } from '@backstage/types';
 import { TranslationRef } from '../../translation';
 
 /**
@@ -97,22 +97,6 @@ type CollapsedMessages<TMessages extends { [key in string]: string }> = {
     ? K
     : key]: TMessages[key];
 };
-
-/**
- * Helper type that expands type hints
- *
- * @ignore
- */
-type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
-
-/**
- * Helper type that expands type hints recursively
- *
- * @ignore
- */
-type ExpandRecursive<T> = T extends infer O
-  ? { [K in keyof O]: ExpandRecursive<O[K]> }
-  : never;
 
 /**
  * Trim away whitespace

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -39,6 +39,7 @@ import { ErrorApi } from '@backstage/core-plugin-api';
 import { ErrorApiError } from '@backstage/core-plugin-api';
 import { ErrorApiErrorContext } from '@backstage/core-plugin-api';
 import { errorApiRef } from '@backstage/core-plugin-api';
+import { Expand } from '@backstage/types';
 import { FeatureFlag } from '@backstage/core-plugin-api';
 import { FeatureFlagsApi } from '@backstage/core-plugin-api';
 import { featureFlagsApiRef } from '@backstage/core-plugin-api';

--- a/packages/frontend-plugin-api/src/types.ts
+++ b/packages/frontend-plugin-api/src/types.ts
@@ -17,13 +17,6 @@
 import { ReactNode } from 'react';
 import { FrontendPlugin } from './wiring';
 
-// TODO(Rugvip): This might be a quite useful utility type, maybe add to @backstage/types?
-/**
- * Utility type to expand type aliases into their equivalent type.
- * @ignore
- */
-export type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
-
 /** @public */
 export type CoreProgressProps = {};
 

--- a/packages/frontend-plugin-api/src/wiring/createExtension.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.ts
@@ -15,7 +15,7 @@
  */
 
 import { ApiHolder, AppNode } from '../apis';
-import { Expand } from '../types';
+import { Expand } from '@backstage/types';
 import {
   ResolveInputValueOverrides,
   resolveInputOverrides,

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
@@ -15,7 +15,7 @@
  */
 
 import { ApiHolder, AppNode } from '../apis';
-import { Expand } from '../types';
+import { Expand } from '@backstage/types';
 import {
   ExtensionDefinition,
   ResolvedExtensionInputs,

--- a/packages/frontend-plugin-api/src/wiring/resolveInputOverrides.ts
+++ b/packages/frontend-plugin-api/src/wiring/resolveInputOverrides.ts
@@ -15,7 +15,7 @@
  */
 
 import { AppNode } from '../apis';
-import { Expand } from '../types';
+import { Expand } from '@backstage/types';
 import { ResolvedExtensionInput } from './createExtension';
 import {
   ExtensionDataContainer,

--- a/packages/types/report.api.md
+++ b/packages/types/report.api.md
@@ -22,6 +22,20 @@ export type DeferredPromise<
 export function durationToMilliseconds(duration: HumanDuration): number;
 
 // @public
+export type Expand<T> = T extends infer O
+  ? {
+      [K in keyof O]: O[K];
+    }
+  : never;
+
+// @public
+export type ExpandRecursive<T> = T extends infer O
+  ? {
+      [K in keyof O]: ExpandRecursive<O[K]>;
+    }
+  : never;
+
+// @public
 export type HumanDuration = {
   years?: number;
   months?: number;

--- a/packages/types/src/expand.test.ts
+++ b/packages/types/src/expand.test.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Expand, ExpandRecursive } from './expand';
+
+describe('expand', () => {
+  it('should expand type aliases into their equivalent type', () => {
+    type Test = { a: string } & { b: number };
+    // expanded type
+    type Result = Expand<Test>;
+
+    const result: Result = { a: 'string', b: 1 };
+    expect(result).toEqual({ a: 'string', b: 1 });
+  });
+
+  it('should expand types recursively', () => {
+    type Test = { a: string } & { b: { c: { e: string } } } & {
+      b: { c: { d: boolean } };
+    };
+    // expanded type
+    type Result = ExpandRecursive<Test>;
+
+    const result: Result = { a: 'string', b: { c: { e: 'string', d: true } } };
+    expect(result).toEqual({ a: 'string', b: { c: { e: 'string', d: true } } });
+  });
+});

--- a/packages/types/src/expand.ts
+++ b/packages/types/src/expand.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2025 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,17 @@
  */
 
 /**
- * Common TypeScript types used within Backstage
- *
- * @packageDocumentation
+ * Utility type to expand type aliases into their equivalent type.
+ * @public
  */
 
-export { createDeferred, type DeferredPromise } from './deferred';
-export type { JsonArray, JsonObject, JsonPrimitive, JsonValue } from './json';
-export type { Observable, Observer, Subscription } from './observable';
-export { type HumanDuration, durationToMilliseconds } from './time';
-export { type Expand, type ExpandRecursive } from './expand';
+export type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
+
+/**
+ * Helper type that expands type hints recursively
+ *
+ * @public
+ */
+export type ExpandRecursive<T> = T extends infer O
+  ? { [K in keyof O]: ExpandRecursive<O[K]> }
+  : never;


### PR DESCRIPTION
There's some other duplication of this type across the project and in upcoming PR's so let's move this out as shared.