### PR TITLE
fix: encode URI components in location template

### DIFF
--- a/plugins/search-backend-module-catalog/src/collators/DefaultCatalogCollatorFactory.ts
+++ b/plugins/search-backend-module-catalog/src/collators/DefaultCatalogCollatorFactory.ts
@@ -120,9 +120,9 @@ export class DefaultCatalogCollatorFactory implements DocumentCollatorFactory {
             resourceRef: stringifyEntityRef(entity),
           },
           location: this.applyArgsToFormat(this.locationTemplate, {
-            namespace: entity.metadata.namespace || 'default',
-            kind: entity.kind,
-            name: entity.metadata.name,
+            namespace: encodeURIComponent(entity.metadata.namespace || 'default') ,
+            kind: encodeURIComponent(entity.kind),
+            name: encodeURIComponent( entity.metadata.name),
           }),
         };
       }


### PR DESCRIPTION
fix: encode URI components in location template

This commit ensures that the `namespace`, `kind`, and `name` parameters are properly encoded using `encodeURIComponent` before being applied to the `locationTemplate`. This prevents issues with special characters in these values when constructing URIs, improving the robustness of the application.

bad case
<img width="1199" alt="image" src="https://github.com/user-attachments/assets/a77904c1-f9e8-48a2-9db5-945b93027b37" />

