### PR TITLE
feat: Improve JSON format of OpenAPI definition, allow YAML format

### DIFF
--- a/.changeset/nine-hounds-rest.md
+++ b/.changeset/nine-hounds-rest.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-backstage-openapi': minor
+---
+
+feat: Improve JSON format of OpenAPI definition, allow YAML format

--- a/plugins/catalog-backend-module-backstage-openapi/README.md
+++ b/plugins/catalog-backend-module-backstage-openapi/README.md
@@ -28,6 +28,7 @@ catalog:
         - catalog
         - events
         - search
+      definitionFormat: 'yaml"' # Optional, defaults to 'json'
       entityOverrides: # All optional
         metadata:
           name: 'my-name'

--- a/plugins/catalog-backend-module-backstage-openapi/config.d.ts
+++ b/plugins/catalog-backend-module-backstage-openapi/config.d.ts
@@ -33,7 +33,7 @@ export interface Config {
          * The format of the definition.
          * @defaultValue json
          */
-        definitionFormat: 'json' | 'yaml';
+        definitionFormat?: 'json' | 'yaml';
       };
     };
   };

--- a/plugins/catalog-backend-module-backstage-openapi/config.d.ts
+++ b/plugins/catalog-backend-module-backstage-openapi/config.d.ts
@@ -29,6 +29,11 @@ export interface Config {
          * Properties to override on the final entity object.
          */
         entityOverrides?: object;
+        /**
+         * The format of the definition.
+         * @defaultValue json
+         */
+        definitionFormat: 'json' | 'yaml';
       };
     };
   };

--- a/plugins/catalog-backend-module-backstage-openapi/package.json
+++ b/plugins/catalog-backend-module-backstage-openapi/package.json
@@ -42,7 +42,8 @@
     "cross-fetch": "^4.0.0",
     "lodash": "^4.17.21",
     "openapi-merge": "^1.3.2",
-    "uuid": "^11.0.0"
+    "uuid": "^11.0.0",
+    "yaml": "^2.7.0"
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",

--- a/plugins/catalog-backend-module-backstage-openapi/src/InternalOpenApiDocumentationProvider.ts
+++ b/plugins/catalog-backend-module-backstage-openapi/src/InternalOpenApiDocumentationProvider.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+import yaml from 'yaml';
 import {
   ANNOTATION_LOCATION,
   ANNOTATION_ORIGIN_LOCATION,
@@ -155,6 +155,19 @@ const loadSpecs = async ({
   return mergeSpecs({ baseUrl, specs });
 };
 
+const formatDefinition = (
+  definition: any,
+  format: string | 'json' | 'yaml',
+) => {
+  if (format === 'json') {
+    return JSON.stringify(definition, null, 2);
+  }
+  if (format === 'yaml') {
+    return yaml.stringify(definition);
+  }
+  throw new Error(`Unsupported format type: ${format}`);
+};
+
 export class InternalOpenApiDocumentationProvider implements EntityProvider {
   private connection?: EntityProviderConnection;
   private readonly scheduleFn: () => Promise<void>;
@@ -236,6 +249,10 @@ export class InternalOpenApiDocumentationProvider implements EntityProvider {
     const configToMerge = this.config.getOptional(
       'catalog.providers.backstageOpenapi.entityOverrides',
     );
+    const formatConfig =
+      this.config.getOptionalString(
+        'catalog.providers.backstageOpenapi.definitionFormat',
+      ) ?? 'json';
 
     const baseConfig = {
       metadata: {
@@ -262,7 +279,7 @@ export class InternalOpenApiDocumentationProvider implements EntityProvider {
       },
       spec: {
         type: 'openapi',
-        definition: JSON.stringify(
+        definition: formatDefinition(
           await loadSpecs({
             baseUrl: this.config.getString('backend.baseUrl'),
             discovery: this.discovery,
@@ -270,6 +287,7 @@ export class InternalOpenApiDocumentationProvider implements EntityProvider {
             plugins: pluginsToMerge,
             logger,
           }),
+          formatConfig,
         ),
       },
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5797,6 +5797,7 @@ __metadata:
     openapi-merge: ^1.3.2
     openapi3-ts: ^3.1.2
     uuid: ^11.0.0
+    yaml: ^2.7.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Hello :wave:!

-  **Improve JSON format of OpenAPI definition, allow YAML format**
    - By default, OpenAPI definition will now have JSON with spaces instead of minified JSON, for better visualization in the UI.
    - Configuration `catalog.providers.backstageOpenapi.definitionFormat` was also added, and can take values `json` (default) or `yaml`, so organizations can use their preferred/standard format.
    - Adding spaces to the JSON _could_ be considered breaking changes.
- Moved to new PR #28364 
  - **docs: Use a valid configuration as example**
      - Previous configuration used an entity name with a space. 

Have a great day!

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
