### PR TITLE
Pass down `withSearch` from `EntityTechdocsContent` component

### DIFF
--- a/.changeset/gentle-deers-return.md
+++ b/.changeset/gentle-deers-return.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Allow passing down `withSearch` prop to `EntityTechdocsContent` component since it was `true` by default, now user can use the `EntityTechdocsContent` component _without_ showing the search field on top of the content.

--- a/plugins/techdocs/report.api.md
+++ b/plugins/techdocs/report.api.md
@@ -133,9 +133,12 @@ export type DocsTableRow = {
 };
 
 // @public
-export const EmbeddedDocsRouter: (
-  props: PropsWithChildren<{}>,
-) => React_2.JSX.Element;
+export const EmbeddedDocsRouter: ({
+  children,
+  withSearch,
+}: React_2.PropsWithChildren<{
+  withSearch?: boolean | undefined;
+}>) => React_2.JSX.Element;
 
 // @public
 export const EntityListDocsGrid: (
@@ -191,9 +194,12 @@ export type EntityListDocsTableProps = {
 };
 
 // @public
-export const EntityTechdocsContent: (props: {
-  children?: ReactNode;
-}) => JSX_2.Element;
+export const EntityTechdocsContent: ({
+  children,
+  withSearch,
+}: PropsWithChildren<{
+  withSearch?: boolean | undefined;
+}>) => JSX_2.Element;
 
 // @public
 export const isTechDocsAvailable: (entity: Entity) => boolean;

--- a/plugins/techdocs/src/Router.tsx
+++ b/plugins/techdocs/src/Router.tsx
@@ -57,16 +57,19 @@ export const Router = () => {
 };
 
 export const EmbeddedDocsRouter = (
-  props: PropsWithChildren<{ emptyState?: React.ReactElement }>,
+  props: PropsWithChildren<{
+    emptyState?: React.ReactElement;
+    withSearch?: boolean;
+  }>,
 ) => {
-  const { children, emptyState } = props;
+  const { children, emptyState, withSearch = true } = props;
   const { entity } = useEntity();
 
   // Using objects instead of <Route> elements, otherwise "outlet" will be null on sub-pages and add-ons won't render
   const element = useRoutes([
     {
       path: '/*',
-      element: <EntityPageDocs entity={entity} />,
+      element: <EntityPageDocs entity={entity} withSearch={withSearch} />,
       children: [
         {
           path: '*',
@@ -96,8 +99,11 @@ export const EmbeddedDocsRouter = (
  *
  * @public
  */
-export const LegacyEmbeddedDocsRouter = (props: PropsWithChildren<{}>) => {
+export const LegacyEmbeddedDocsRouter = ({
+  children,
+  withSearch = true,
+}: PropsWithChildren<{ withSearch?: boolean }>) => {
   // Wrap the Router to avoid exposing the emptyState prop in the non-alpha
   // public API and make it easier for us to change later.
-  return <EmbeddedDocsRouter children={props.children} />;
+  return <EmbeddedDocsRouter children={children} withSearch={withSearch} />;
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Just a very simple passing down of the prop `withSearch`. 
In some version, the `Search bar` was added to the `EntityTechdocsContent` on top, but it's neither customizable nor included in the "shadowDom" part, while the prop already existed in `EntityPageDocs` with a default value, it didn't get a real value.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
