### PR TITLE
docs: use a valid configuration as example for catalog-backend-module-backstage-openapi

### DIFF
--- a/.changeset/tasty-chairs-beam.md
+++ b/.changeset/tasty-chairs-beam.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-backstage-openapi': patch
+---
+
+docs: Use a valid configuration as example

--- a/plugins/catalog-backend-module-backstage-openapi/README.md
+++ b/plugins/catalog-backend-module-backstage-openapi/README.md
@@ -26,14 +26,14 @@ catalog:
     backstageOpenapi:
       plugins:
         - catalog
-        - todo
+        - events
         - search
       entityOverrides: # All optional
         metadata:
-          name: 'my name'
+          name: 'my-name'
           title: 'my title'
         spec:
-          owner: 'my team'
+          owner: 'my-team'
 ```
 
 We will attempt to load each plugin's OpenAPI spec hosted at `${pluginRoute}/openapi.json`. These are automatically added if you are using `@backstage/backend-openapi-utils`'s `createValidatedOpenApiRouter`.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Hello :wave:!

- `@backstage/plugin-catalog-backend-module-backstage-openapi`: **docs: Use a valid configuration as example**
    - Previous configuration used an entity name with a space. 

Have a great day!

#### :heavy_check_mark: Checklist

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
