### PR TITLE
search-catalog add encodeURIComponent for location

### DIFF
--- a/.changeset/sharp-years-drive.md
+++ b/.changeset/sharp-years-drive.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-search-backend-module-catalog': patch
 ---
 
-Modified the logic for generating the location URL by encoding the entity property values with encodeURIComponent. This enhancement improves the safety and reliability of the URL.
+Modified the logic for generating the location URL by encoding the entity property values with `encodeURIComponent`. This enhancement improves the safety and reliability of the URL.

--- a/.changeset/sharp-years-drive.md
+++ b/.changeset/sharp-years-drive.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend-module-catalog': patch
+---
+
+Modified the logic for generating the location URL by encoding the entity property values with encodeURIComponent. This enhancement improves the safety and reliability of the URL.

--- a/plugins/search-backend-module-catalog/src/collators/DefaultCatalogCollatorFactory.ts
+++ b/plugins/search-backend-module-catalog/src/collators/DefaultCatalogCollatorFactory.ts
@@ -120,9 +120,11 @@ export class DefaultCatalogCollatorFactory implements DocumentCollatorFactory {
             resourceRef: stringifyEntityRef(entity),
           },
           location: this.applyArgsToFormat(this.locationTemplate, {
-            namespace: entity.metadata.namespace || 'default',
-            kind: entity.kind,
-            name: entity.metadata.name,
+            namespace: encodeURIComponent(
+              entity.metadata.namespace || 'default',
+            ),
+            kind: encodeURIComponent(entity.kind),
+            name: encodeURIComponent(entity.metadata.name),
           }),
         };
       }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

`@backstage/plugin-search-backend-module-catalog`: Modified the logic for generating the location URL by encoding the entity property values with encodeURIComponent instead of directly concatenating strings. This enhancement improves the safety and reliability of the URL.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))