### PR TITLE
Fix checkpoint example in "Writing custom actions"

### DIFF
--- a/docs/features/software-templates/writing-custom-actions.md
+++ b/docs/features/software-templates/writing-custom-actions.md
@@ -263,15 +263,18 @@ Idempotent action could be achieved via the usage of checkpoints.
 Example:
 
 ```ts title="plugins/my-company-scaffolder-actions-plugin/src/vendor/my-custom-action.ts"
-const res = await ctx.checkpoint?.({key: 'create.projects', fn: async () => {
-  const projectStgId = createStagingProjectId();
-  const projectProId = createProductionProjectId();
+const res = await ctx.checkpoint?.({
+  key: 'create.projects',
+  fn: async () => {
+    const projectStgId = createStagingProjectId();
+    const projectProId = createProductionProjectId();
 
-  return {
-    projectStgId,
-    projectProId,
-  };
-}});
+    return {
+      projectStgId,
+      projectProId,
+    };
+  },
+});
 ```
 
 You have to define the unique key in scope of the scaffolder task for your checkpoint. During the execution task engine


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixed the example for using checkpoints when writing custom actions. The example was not using the correct parameters for setting up the checkpoint - You pass in an `opts` object rather than individual parameters.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
