### PR TITLE
fix: fixed the bug on 'My Squads' section of the sidebar, to display the titles for the list of squads using displayName, instead of the current metadata name

### DIFF
--- a/.changeset/purple-years-cross.md
+++ b/.changeset/purple-years-cross.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-org': patch
 ---
 
-Added support for `spec.profile.displayName` to be used in the `MyGroupsSidebarItem` component via the `EntityDisplayName` component  when you are a member of multiple Groups.
+Added support for `spec.profile.displayName` to be used in the `MyGroupsSidebarItem` component via the `EntityDisplayName` component when you are a member of multiple Groups.

--- a/.changeset/purple-years-cross.md
+++ b/.changeset/purple-years-cross.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Fixed bug in MyGroupsSidebarItem component, for the 'My Squads' section to display a list of Squads using the displayName from the entity config, instead of using the metadata name and title. This is to ensure increased readability to the user.

--- a/plugins/org/src/components/MyGroupsSidebarItem/MyGroupsSidebarItem.test.tsx
+++ b/plugins/org/src/components/MyGroupsSidebarItem/MyGroupsSidebarItem.test.tsx
@@ -24,8 +24,15 @@ import { MyGroupsSidebarItem } from './MyGroupsSidebarItem';
 import GroupIcon from '@material-ui/icons/People';
 import { identityApiRef } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
-import { catalogApiRef, entityRouteRef } from '@backstage/plugin-catalog-react';
+import {
+  catalogApiRef,
+  entityPresentationApiRef,
+  entityRouteRef,
+} from '@backstage/plugin-catalog-react';
 import { catalogApiMock } from '@backstage/plugin-catalog-react/testUtils';
+import { DefaultEntityPresentationApi } from '@backstage/plugin-catalog';
+import userEvent from '@testing-library/user-event';
+import { screen } from '@testing-library/react';
 
 describe('MyGroupsSidebarItem Test', () => {
   describe('For guests or users with no groups', () => {
@@ -40,6 +47,10 @@ describe('MyGroupsSidebarItem Test', () => {
           apis={[
             [identityApiRef, identityApi],
             [catalogApiRef, catalogApi],
+            [
+              entityPresentationApiRef,
+              DefaultEntityPresentationApi.create({ catalogApi }),
+            ],
           ]}
         >
           <MyGroupsSidebarItem
@@ -78,9 +89,6 @@ describe('MyGroupsSidebarItem Test', () => {
               spec: {
                 type: 'team',
                 children: [],
-                profile: {
-                  displayName: 'Team A',
-                },
               },
             },
           ] as Entity[],
@@ -91,6 +99,10 @@ describe('MyGroupsSidebarItem Test', () => {
           apis={[
             [identityApiRef, identityApi],
             [catalogApiRef, catalogApi],
+            [
+              entityPresentationApiRef,
+              DefaultEntityPresentationApi.create({ catalogApi }),
+            ],
           ]}
         >
           <MyGroupsSidebarItem
@@ -113,71 +125,116 @@ describe('MyGroupsSidebarItem Test', () => {
     });
   });
 
+  async function renderSideBarWithUserGroups() {
+    const identityApi = mockApis.identity({
+      userEntityRef: 'user:default/nigel.manning',
+      ownershipEntityRefs: ['user:default/nigel.manning'],
+    });
+    const catalogApi = catalogApiMock.mock({
+      getEntities: async () => ({
+        items: [
+          {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'Group',
+            metadata: {
+              name: 'team-a',
+              namespace: 'default',
+            },
+            spec: {
+              type: 'team',
+              children: [],
+            },
+          },
+          {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'Group',
+            metadata: {
+              name: 'team-b',
+              title: 'Team B',
+              namespace: 'default',
+            },
+            spec: {
+              type: 'team',
+              children: [],
+            },
+          },
+          {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'Group',
+            metadata: {
+              name: 'team-c',
+              namespace: 'default',
+            },
+            spec: {
+              type: 'team',
+              children: [],
+              profile: {
+                displayName: 'Team C',
+              },
+            },
+          },
+        ] as Entity[],
+      }),
+    });
+
+    await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [identityApiRef, identityApi],
+          [catalogApiRef, catalogApi],
+          [
+            entityPresentationApiRef,
+            DefaultEntityPresentationApi.create({ catalogApi }),
+          ],
+        ]}
+      >
+        <MyGroupsSidebarItem
+          singularTitle="My Squad"
+          pluralTitle="My Squads"
+          icon={GroupIcon}
+        />
+      </TestApiProvider>,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': entityRouteRef,
+        },
+      },
+    );
+  }
+
   describe('For users that are members of multiple groups', () => {
-    it('MyGroupsSidebarItem should display a sub-menu with all their groups, with displaying the title through displayName, and a link to each group', async () => {
+    beforeEach(async () => {
+      await renderSideBarWithUserGroups();
+    });
+
+    it('MyGroupsSidebarItem should display a sub-menu with all their groups and a link to each group', async () => {
+      expect(screen.getByLabelText('My Squads')).toBeInTheDocument();
+    });
+
+    it('MyGroupsSidebarItem should display the displayName for each group in the list instead of the metadata name using the entityPresentationApi', async () => {
+      await userEvent.hover(screen.getByLabelText('My Squads'));
+      expect(screen.getByText('team-a')).toBeInTheDocument();
+      expect(screen.getByText('Team B')).toBeInTheDocument();
+      expect(screen.getByText('Team C')).toBeInTheDocument();
+    });
+  });
+
+  describe('When an additional filter is not provided', () => {
+    const entityPresentationApi = {
+      forEntity: jest.fn(),
+    };
+    it('catalogApi.getEntities() should be called with the default filter', async () => {
       const identityApi = mockApis.identity({
-        userEntityRef: 'user:default/nigel.manning',
-        ownershipEntityRefs: ['user:default/nigel.manning'],
+        userEntityRef: 'user:default/guest',
+        ownershipEntityRefs: ['user:default/guest'],
       });
-      const catalogApi = catalogApiMock.mock({
-        getEntities: async () => ({
-          items: [
-            {
-              apiVersion: 'backstage.io/v1alpha1',
-              kind: 'Group',
-              metadata: {
-                name: 'team-a',
-                title: 'Team A',
-                namespace: 'default',
-              },
-              spec: {
-                type: 'team',
-                children: [],
-                profile: {
-                  displayName: 'Team A',
-                },
-              },
-            },
-            {
-              apiVersion: 'backstage.io/v1alpha1',
-              kind: 'Group',
-              metadata: {
-                name: 'team-b',
-                title: 'Team B',
-                namespace: 'default',
-              },
-              spec: {
-                type: 'team',
-                children: [],
-                profile: {
-                  displayName: 'Team B',
-                },
-              },
-            },
-            {
-              apiVersion: 'backstage.io/v1alpha1',
-              kind: 'Group',
-              metadata: {
-                name: 'team-c',
-                title: 'Team C',
-                namespace: 'default',
-              },
-              spec: {
-                type: 'team',
-                children: [],
-                profile: {
-                  displayName: 'Team C',
-                },
-              },
-            },
-          ] as Entity[],
-        }),
-      });
-      const rendered = await renderInTestApp(
+      const mockCatalogApi = catalogApiMock.mock();
+      await renderInTestApp(
         <TestApiProvider
           apis={[
             [identityApiRef, identityApi],
-            [catalogApiRef, catalogApi],
+            [catalogApiRef, mockCatalogApi],
+            [entityPresentationApiRef, entityPresentationApi],
           ]}
         >
           <MyGroupsSidebarItem
@@ -192,77 +249,42 @@ describe('MyGroupsSidebarItem Test', () => {
           },
         },
       );
-
-      expect(rendered.getByLabelText('My Squads')).toBeInTheDocument();
-      expect(rendered.getByLabelText('Team B')).toBeInTheDocument();
-      expect(rendered.getByLabelText('Team A')).not.toBeInTheDocument();
-      expect(rendered.getByLabelText('Team C')).toHaveAttribute(
-        'href',
-        '/catalog/default/Group/team-c',
-      );
+      expect(mockCatalogApi.getEntities).toHaveBeenCalledWith({
+        filter: [
+          {
+            kind: 'group',
+            'relations.hasMember': 'user:default/guest',
+          },
+        ],
+        fields: ['metadata', 'kind'],
+      });
     });
+  });
 
-    it('MyGroupsSidebarItem should display the metadata name when the displayName property is not available in the entity', async () => {
+  describe('When an additional filter is provided', () => {
+    const entityPresentationApi = {
+      forEntity: jest.fn(),
+    };
+
+    it('catalogApi.getEntities() should be called with an additional filter item', async () => {
       const identityApi = mockApis.identity({
-        userEntityRef: 'user:default/nigel.manning',
-        ownershipEntityRefs: ['user:default/nigel.manning'],
+        userEntityRef: 'user:default/guest',
+        ownershipEntityRefs: ['user:default/guest'],
       });
-      const catalogApi = catalogApiMock.mock({
-        getEntities: async () => ({
-          items: [
-            {
-              apiVersion: 'backstage.io/v1alpha1',
-              kind: 'Group',
-              metadata: {
-                name: 'team-a',
-                title: 'Team A',
-                namespace: 'default',
-              },
-              spec: {
-                type: 'team',
-                children: [],
-              },
-            },
-            {
-              apiVersion: 'backstage.io/v1alpha1',
-              kind: 'Group',
-              metadata: {
-                name: 'team-b',
-                title: 'Team B',
-                namespace: 'default',
-              },
-              spec: {
-                type: 'team',
-                children: [],
-              },
-            },
-            {
-              apiVersion: 'backstage.io/v1alpha1',
-              kind: 'Group',
-              metadata: {
-                name: 'team-c',
-                title: 'Team C',
-                namespace: 'default',
-              },
-              spec: {
-                type: 'team',
-                children: [],
-              },
-            },
-          ] as Entity[],
-        }),
-      });
-      const rendered = await renderInTestApp(
+      const mockCatalogApi = catalogApiMock.mock();
+      await renderInTestApp(
         <TestApiProvider
           apis={[
             [identityApiRef, identityApi],
-            [catalogApiRef, catalogApi],
+            [catalogApiRef, mockCatalogApi],
+            [entityPresentationApiRef, entityPresentationApi],
           ]}
         >
           <MyGroupsSidebarItem
             singularTitle="My Squad"
             pluralTitle="My Squads"
             icon={GroupIcon}
+            filter={{ 'spec.type': 'team' }}
           />
         </TestApiProvider>,
         {
@@ -271,87 +293,16 @@ describe('MyGroupsSidebarItem Test', () => {
           },
         },
       );
-      expect(rendered.getByLabelText('Team-a')).toBeInTheDocument();
-      expect(rendered.getByLabelText('Team-b')).toBeInTheDocument();
-      expect(rendered.getByLabelText('Team-c')).toBeInTheDocument();
-    });
-  });
-});
-
-describe('When an additional filter is not provided', () => {
-  it('catalogApi.getEntities() should be called with the default filter', async () => {
-    const identityApi = mockApis.identity({
-      userEntityRef: 'user:default/guest',
-      ownershipEntityRefs: ['user:default/guest'],
-    });
-    const mockCatalogApi = catalogApiMock.mock();
-    await renderInTestApp(
-      <TestApiProvider
-        apis={[
-          [identityApiRef, identityApi],
-          [catalogApiRef, mockCatalogApi],
-        ]}
-      >
-        <MyGroupsSidebarItem
-          singularTitle="My Squad"
-          pluralTitle="My Squads"
-          icon={GroupIcon}
-        />
-      </TestApiProvider>,
-      {
-        mountedRoutes: {
-          '/catalog/:namespace/:kind/:name': entityRouteRef,
-        },
-      },
-    );
-    expect(mockCatalogApi.getEntities).toHaveBeenCalledWith({
-      filter: [
-        {
-          kind: 'group',
-          'relations.hasMember': 'user:default/guest',
-        },
-      ],
-      fields: ['metadata', 'kind'],
-    });
-  });
-});
-
-describe('When an additional filter is provided', () => {
-  it('catalogApi.getEntities() should be called with an additional filter item', async () => {
-    const identityApi = mockApis.identity({
-      userEntityRef: 'user:default/guest',
-      ownershipEntityRefs: ['user:default/guest'],
-    });
-    const mockCatalogApi = catalogApiMock.mock();
-    await renderInTestApp(
-      <TestApiProvider
-        apis={[
-          [identityApiRef, identityApi],
-          [catalogApiRef, mockCatalogApi],
-        ]}
-      >
-        <MyGroupsSidebarItem
-          singularTitle="My Squad"
-          pluralTitle="My Squads"
-          icon={GroupIcon}
-          filter={{ 'spec.type': 'team' }}
-        />
-      </TestApiProvider>,
-      {
-        mountedRoutes: {
-          '/catalog/:namespace/:kind/:name': entityRouteRef,
-        },
-      },
-    );
-    expect(mockCatalogApi.getEntities).toHaveBeenCalledWith({
-      filter: [
-        {
-          kind: 'group',
-          'relations.hasMember': 'user:default/guest',
-          'spec.type': 'team',
-        },
-      ],
-      fields: ['metadata', 'kind'],
+      expect(mockCatalogApi.getEntities).toHaveBeenCalledWith({
+        filter: [
+          {
+            kind: 'group',
+            'relations.hasMember': 'user:default/guest',
+            'spec.type': 'team',
+          },
+        ],
+        fields: ['metadata', 'kind'],
+      });
     });
   });
 });

--- a/plugins/org/src/components/MyGroupsSidebarItem/MyGroupsSidebarItem.test.tsx
+++ b/plugins/org/src/components/MyGroupsSidebarItem/MyGroupsSidebarItem.test.tsx
@@ -195,6 +195,7 @@ describe('MyGroupsSidebarItem Test', () => {
 
       expect(rendered.getByLabelText('My Squads')).toBeInTheDocument();
       expect(rendered.getByLabelText('Team B')).toBeInTheDocument();
+      expect(rendered.getByLabelText('Team A')).not.toBeInTheDocument();
       expect(rendered.getByLabelText('Team C')).toHaveAttribute(
         'href',
         '/catalog/default/Group/team-c',

--- a/plugins/org/src/components/MyGroupsSidebarItem/MyGroupsSidebarItem.tsx
+++ b/plugins/org/src/components/MyGroupsSidebarItem/MyGroupsSidebarItem.tsx
@@ -37,6 +37,7 @@ import {
   entityRouteRef,
 } from '@backstage/plugin-catalog-react';
 import { getCompoundEntityRef } from '@backstage/catalog-model';
+import { EntityDisplayName } from '@backstage/plugin-catalog-react';
 
 /**
  * MyGroupsSidebarItem can be added to your sidebar providing quick access to groups the logged in user is a member of
@@ -66,7 +67,7 @@ export const MyGroupsSidebarItem = (props: {
           ...(filter ?? {}),
         },
       ],
-      fields: ['metadata', 'kind'],
+      fields: ['metadata', 'kind', 'spec'],
     });
 
     return response.items;
@@ -96,7 +97,7 @@ export const MyGroupsSidebarItem = (props: {
         {groups?.map(function groupsMap(group) {
           return (
             <SidebarSubmenuItem
-              title={group.metadata.title || group.metadata.name}
+              title={<EntityDisplayName entityRef={group} />}
               subtitle={
                 group.metadata.namespace !== DEFAULT_NAMESPACE
                   ? group.metadata.namespace

--- a/plugins/org/src/components/MyGroupsSidebarItem/MyGroupsSidebarItem.tsx
+++ b/plugins/org/src/components/MyGroupsSidebarItem/MyGroupsSidebarItem.tsx
@@ -37,7 +37,8 @@ import {
   entityRouteRef,
 } from '@backstage/plugin-catalog-react';
 import { getCompoundEntityRef } from '@backstage/catalog-model';
-import { EntityDisplayName } from '@backstage/plugin-catalog-react';
+
+import { entityPresentationApiRef } from '@backstage/plugin-catalog-react';
 
 /**
  * MyGroupsSidebarItem can be added to your sidebar providing quick access to groups the logged in user is a member of
@@ -55,6 +56,7 @@ export const MyGroupsSidebarItem = (props: {
   const identityApi = useApi(identityApiRef);
   const catalogApi: CatalogApi = useApi(catalogApiRef);
   const catalogEntityRoute = useRouteRef(entityRouteRef);
+  const entityPresentationApi = useApi(entityPresentationApiRef);
 
   const { value: groups } = useAsync(async () => {
     const profile = await identityApi.getBackstageIdentity();
@@ -67,13 +69,11 @@ export const MyGroupsSidebarItem = (props: {
           ...(filter ?? {}),
         },
       ],
-      fields: ['metadata', 'kind', 'spec'],
+      fields: ['metadata', 'kind'],
     });
-
     return response.items;
   }, []);
 
-  // Not a member of any groups
   if (!groups?.length) {
     return null;
   }
@@ -94,10 +94,11 @@ export const MyGroupsSidebarItem = (props: {
   return (
     <SidebarItem icon={icon} text={pluralTitle}>
       <SidebarSubmenu title={pluralTitle}>
-        {groups?.map(function groupsMap(group) {
+        {groups?.map(group => {
+          const entityDisplayName = entityPresentationApi.forEntity(group);
           return (
             <SidebarSubmenuItem
-              title={<EntityDisplayName entityRef={group} hideIcon />}
+              title={entityDisplayName.snapshot.primaryTitle}
               subtitle={
                 group.metadata.namespace !== DEFAULT_NAMESPACE
                   ? group.metadata.namespace

--- a/plugins/org/src/components/MyGroupsSidebarItem/MyGroupsSidebarItem.tsx
+++ b/plugins/org/src/components/MyGroupsSidebarItem/MyGroupsSidebarItem.tsx
@@ -97,7 +97,7 @@ export const MyGroupsSidebarItem = (props: {
         {groups?.map(function groupsMap(group) {
           return (
             <SidebarSubmenuItem
-              title={<EntityDisplayName entityRef={group} />}
+              title={<EntityDisplayName entityRef={group} hideIcon />}
               subtitle={
                 group.metadata.namespace !== DEFAULT_NAMESPACE
                   ? group.metadata.namespace


### PR DESCRIPTION
## Hey, I just made a Pull Request!

**Problem**: When accessing the squads that a user is part of from the sidebar, the metadata name gets displayed for each squad. They should instead use the spec.profile.displayName - This approach makes it easier for the logged in user to switch between squads as the actual title of the group will be displayed in the sidebar instead of the metadata.

**Solution**: Fixed this bug from the component function, where in 'My Squads' sub menu items section to display a list of Squads - I have used the EntityDisplayName function for the list of squads to display their title using spec.profile.displayName - instead of the current metadata name/title. This is to ensure increased readability to the user. In case there is no such property for displayName defined on the entities, then the function will display the metadata name. 

Current Version 
![Screenshot 2025-01-06 113704](https://github.com/user-attachments/assets/1477191c-84b6-4f4f-a90a-fd400a9d85b7)

Upcoming Version
![Screenshot 2025-01-06 113628](https://github.com/user-attachments/assets/d8a2d70f-b94c-4248-bb3e-e5dff54f92c3)

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

fixes Github Issue #28363 