### PR TITLE
yarn-plugin: include entries for both `backstage:` and `npm:` ranges in lockfile

### DIFF
--- a/.changeset/wise-pillows-smile.md
+++ b/.changeset/wise-pillows-smile.md
@@ -1,0 +1,5 @@
+---
+'yarn-plugin-backstage': patch
+---
+
+Add both `npm:` and `backstage:` ranges to the lockfile to ensure compatibility with tools that parse the lockfile and ensure dependencies stay locked when building dist workspaces.

--- a/.yarn/patches/@yarnpkg-plugin-npm-npm-3.1.0-6533d0f5a1.patch
+++ b/.yarn/patches/@yarnpkg-plugin-npm-npm-3.1.0-6533d0f5a1.patch
@@ -1,0 +1,11 @@
+diff --git a/lib/NpmHttpFetcher.d.ts b/lib/NpmHttpFetcher.d.ts
+index 015aeb8113776d0bc8d2d11154f02f0f2fd7d889..1398792d977fac7f10c7325a7a56d43914a26d17 100644
+--- a/lib/NpmHttpFetcher.d.ts
++++ b/lib/NpmHttpFetcher.d.ts
+@@ -9,5 +9,5 @@ export declare class NpmHttpFetcher implements Fetcher {
+         prefixPath: import("@yarnpkg/fslib").PortablePath;
+         checksum: string | null;
+     }>;
+-    fetchFromNetwork(locator: Locator, opts: FetchOptions): Promise<import("/home/runner/work/berry/berry/.yarn/__virtual__/@yarnpkg-libzip-virtual-4957b34c08/1/packages/yarnpkg-libzip").ZipFS>;
++    private fetchFromNetwork;
+ }

--- a/package.json
+++ b/package.json
@@ -106,7 +106,8 @@
     "csstype@npm:^3.0.2": "3.0.9",
     "csstype@npm:^3.1.2": "3.0.9",
     "csstype@npm:^3.1.3": "3.0.9",
-    "jest-haste-map@^29.7.0": "patch:jest-haste-map@npm%3A29.7.0#./.yarn/patches/jest-haste-map-npm-29.7.0-e3be419eff.patch"
+    "jest-haste-map@^29.7.0": "patch:jest-haste-map@npm%3A29.7.0#./.yarn/patches/jest-haste-map-npm-29.7.0-e3be419eff.patch",
+    "@yarnpkg/plugin-npm@npm:^3.1.0": "patch:@yarnpkg/plugin-npm@npm%3A3.1.0#~/.yarn/patches/@yarnpkg-plugin-npm-npm-3.1.0-6533d0f5a1.patch"
   },
   "dependencies": {
     "@backstage/errors": "workspace:^",

--- a/packages/yarn-plugin/README.md
+++ b/packages/yarn-plugin/README.md
@@ -38,3 +38,47 @@ The plugin can be manually tested in any repository running at least yarn 4.1.1.
 Sadly it can't be manually tested directly in the Backstage monorepo - since
 packages in this repository use `workspace:^` dependencies, there's no use case
 for the yarn plugin.
+
+## Architecture
+
+This section is intended for people working directly on this package. It
+describes the architecture of the plugin, and the means by which it manages npm
+package versions.
+
+The Backstage yarn plugin operates on `backstage:^` version ranges in
+package.json files using the following three components:
+
+### `reduceDependency` hook
+
+_Converts `backstage:^` to `backstage:^::backstage=1.34.0&npm=1.2.3`_
+
+This hook is called by yarn when resolving direct and indirect dependencies in
+the workspace, and allows modifying the version range. The yarn plugin uses this
+hook to parameterize `backstage:^` ranges with the current Backstage version and
+the corresponding npm package version from the manifest. This uses the system
+built into yarn for adding parameters to version ranges. An
+
+### `BackstageNpmResolver`
+
+_Resolves the appropriate npm package for `backstage:^` ranges and adds the
+`npm` range as a dependency_
+
+The `BackstageNpmResolver` ensures that the lockfile contains entries for _both_
+the `backstage:^` range, and the corresponding `npm:^<version>` range. Including
+an entry for the `backstage:^` range means that tools that reconcile the
+lockfile and package.json can match entries for Backstage packages together.
+Including an entry for the corresponding `npm:` range ensures that dependencies
+are not unlocked when switching between `backstage:^` and `npm:` ranges in the
+lockfile, as happens when publishing the package or building a dist workspace
+using `backstage-cli build-workspace`.
+
+### `beforeWorkspacePacking` hook
+
+_Replaces `backstage:^` ranges with the corresponding npm version ranges when
+packing packages for publishing_
+
+The yarn plugin is strictly optional, and intended to be opted-into in a
+specific Backstage repository. As such, when publishing packages, all
+`backstage:^` versions should be removed from the package.json and replaced with
+the appropriate npm version ranges. This is handled by the
+`beforeWorkspacePacking` hook.

--- a/packages/yarn-plugin/README.md
+++ b/packages/yarn-plugin/README.md
@@ -56,7 +56,7 @@ This hook is called by yarn when resolving direct and indirect dependencies in
 the workspace, and allows modifying the version range. The yarn plugin uses this
 hook to parameterize `backstage:^` ranges with the current Backstage version and
 the corresponding npm package version from the manifest. This uses the system
-built into yarn for adding parameters to version ranges. An
+built into yarn for adding parameters to version ranges.
 
 ### `BackstageNpmResolver`
 

--- a/packages/yarn-plugin/package.json
+++ b/packages/yarn-plugin/package.json
@@ -43,6 +43,7 @@
     "@yarnpkg/builder": "^4.0.0",
     "fs-extra": "^11.2.0",
     "nodemon": "^3.0.1",
+    "snyk-nodejs-lockfile-parser": "^1.58.14",
     "yaml": "^2.0.0"
   }
 }

--- a/packages/yarn-plugin/package.json
+++ b/packages/yarn-plugin/package.json
@@ -34,6 +34,7 @@
     "@backstage/release-manifests": "workspace:^",
     "@yarnpkg/core": "^4.0.3",
     "@yarnpkg/fslib": "^3.0.2",
+    "@yarnpkg/plugin-npm": "^3.0.1",
     "@yarnpkg/plugin-pack": "^4.0.0",
     "semver": "^7.6.0"
   },

--- a/packages/yarn-plugin/package.json
+++ b/packages/yarn-plugin/package.json
@@ -32,16 +32,16 @@
   "dependencies": {
     "@backstage/cli-common": "workspace:^",
     "@backstage/release-manifests": "workspace:^",
-    "@yarnpkg/core": "^4.0.3",
-    "@yarnpkg/fslib": "^3.0.2",
-    "@yarnpkg/plugin-npm": "^3.0.1",
-    "@yarnpkg/plugin-pack": "^4.0.0",
+    "@yarnpkg/core": "^4.4.0",
+    "@yarnpkg/fslib": "^3.1.2",
+    "@yarnpkg/plugin-npm": "patch:@yarnpkg/plugin-npm@npm%3A3.1.0#~/.yarn/patches/@yarnpkg-plugin-npm-npm-3.1.0-6533d0f5a1.patch",
+    "@yarnpkg/plugin-pack": "^4.0.1",
     "semver": "^7.6.0"
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
-    "@yarnpkg/builder": "^4.0.0",
+    "@yarnpkg/builder": "^4.2.1",
     "fs-extra": "^11.2.0",
     "nodemon": "^3.0.1",
     "snyk-nodejs-lockfile-parser": "^1.58.14",

--- a/packages/yarn-plugin/src/handlers/reduceDependency.test.ts
+++ b/packages/yarn-plugin/src/handlers/reduceDependency.test.ts
@@ -107,7 +107,7 @@ describe('reduceDependency', () => {
           ),
           project,
         ),
-      ).rejects.toThrow(/unexpected version selector/i);
+      ).rejects.toThrow(/invalid backstage: version range/i);
     },
   );
 
@@ -127,20 +127,31 @@ describe('reduceDependency', () => {
       );
     });
 
-    it('replaces the range with the corresponding npm package range', async () => {
-      await expect(
-        reduceDependency(
-          structUtils.makeDescriptor(
-            structUtils.makeIdent('backstage', 'core'),
-            'backstage:^',
-          ),
-          project,
-        ),
-      ).resolves.toEqual(
+    it('adds the current Backstage version as a parameter on the range', async () => {
+      const result = await reduceDependency(
         structUtils.makeDescriptor(
           structUtils.makeIdent('backstage', 'core'),
-          'npm:^6.7.8',
+          'backstage:^',
         ),
+        project,
+      );
+
+      await expect(
+        structUtils.parseRange(result.range).params?.backstage,
+      ).toEqual('1.23.45');
+    });
+
+    it('adds the appropriate npm package version based on the Backstage manifest as a parameter on the range', async () => {
+      const result = await reduceDependency(
+        structUtils.makeDescriptor(
+          structUtils.makeIdent('backstage', 'core'),
+          'backstage:^',
+        ),
+        project,
+      );
+
+      await expect(structUtils.parseRange(result.range).params?.npm).toEqual(
+        '6.7.8',
       );
     });
 

--- a/packages/yarn-plugin/src/index.test.ts
+++ b/packages/yarn-plugin/src/index.test.ts
@@ -67,10 +67,10 @@ const runYarnInstall = () =>
 const nonWorkspaceEntries = (lockFileString: string = '') => {
   const lockFile = yaml.parse(lockFileString);
 
-  const result: Record<string, string> = {};
+  const result = [];
   for (const key of Object.keys(lockFile)) {
     if (lockFile[key].version !== '0.0.0-use.local') {
-      result[key] = lockFile[key];
+      result.push(lockFile[key]);
     }
   }
 
@@ -232,15 +232,17 @@ describe('Backstage yarn plugin', () => {
           'utf-8',
         );
 
-        const lockFile = yaml.parse(lockFileContent);
+        const descriptors = Object.keys(yaml.parse(lockFileContent)).flatMap(
+          entry => entry.split(', '),
+        );
 
         // Versions from old manifest no longer appear in lockfile
-        expect(lockFile['@backstage/cli-common@npm:^0.1.1']).toBeUndefined();
-        expect(lockFile['@backstage/config@npm:^0.1.2']).toBeUndefined();
+        expect(descriptors).not.toContain('@backstage/cli-common@npm:^0.1.1');
+        expect(descriptors).not.toContain('@backstage/config@npm:^0.1.2');
 
         // Versions from new manifest have been added to lockfile
-        expect(lockFile['@backstage/cli-common@npm:^0.1.8']).toBeDefined();
-        expect(lockFile['@backstage/config@npm:^1.0.0']).toBeDefined();
+        expect(descriptors).toContain('@backstage/cli-common@npm:^0.1.8');
+        expect(descriptors).toContain('@backstage/config@npm:^1.0.0');
       });
 
       describe('after removing backstage:^ dependencies', () => {

--- a/packages/yarn-plugin/src/index.test.ts
+++ b/packages/yarn-plugin/src/index.test.ts
@@ -18,6 +18,7 @@ import { join as joinPath } from 'path';
 import { spawn, SpawnOptionsWithoutStdio } from 'child_process';
 import fs from 'fs-extra';
 import yaml from 'yaml';
+import { buildDepTreeFromFiles } from 'snyk-nodejs-lockfile-parser';
 import { findPaths } from '@backstage/cli-common';
 import { createMockDirectory } from '@backstage/backend-test-utils';
 
@@ -301,6 +302,23 @@ describe('Backstage yarn plugin', () => {
           });
         },
       );
+
+      it('successfully parses the lockfile with snyk-nodejs-lockfile-parser', async () => {
+        await expect(
+          buildDepTreeFromFiles(
+            mockDir.path,
+            'packages/b/package.json',
+            'yarn.lock',
+          ),
+        ).resolves.toEqual(
+          expect.objectContaining({
+            dependencies: expect.objectContaining({
+              '@backstage/cli-common': expect.anything(),
+              '@backstage/config': expect.anything(),
+            }),
+          }),
+        );
+      });
     });
   });
 });

--- a/packages/yarn-plugin/src/index.ts
+++ b/packages/yarn-plugin/src/index.ts
@@ -24,6 +24,7 @@
 import { Plugin, Hooks, semverUtils, YarnVersion } from '@yarnpkg/core';
 import { Hooks as PackHooks } from '@yarnpkg/plugin-pack';
 import { beforeWorkspacePacking, reduceDependency } from './handlers';
+import { BackstageNpmResolver } from './resolvers';
 
 // All dependencies of the yarn plugin are bundled during the build. Chalk
 // triples the size of the plugin bundle when included, so we avoid the
@@ -48,6 +49,7 @@ const plugin: Plugin<Hooks & PackHooks> = {
     reduceDependency,
     beforeWorkspacePacking,
   },
+  resolvers: [BackstageNpmResolver],
 };
 
 export default plugin;

--- a/packages/yarn-plugin/src/resolvers/BackstageNpmResolver.test.ts
+++ b/packages/yarn-plugin/src/resolvers/BackstageNpmResolver.test.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ResolveOptions, structUtils } from '@yarnpkg/core';
+import { BackstageNpmResolver } from './BackstageNpmResolver';
+import { NpmSemverResolver } from '@yarnpkg/plugin-npm';
+
+const mockGetCandidates = jest.fn();
+const mockGetSatisfying = jest.fn();
+jest.mock('@yarnpkg/plugin-npm', () => {
+  return {
+    ...jest.requireActual('@yarnpkg/plugin-npm'),
+    NpmSemverResolver: function MockNpmSemverResolver() {
+      return {
+        getCandidates: mockGetCandidates,
+        getSatisfying: mockGetSatisfying,
+      };
+    } as unknown as NpmSemverResolver,
+  };
+});
+
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+describe('BackstageNpmResolver', () => {
+  const ident = structUtils.makeIdent('backstage', 'core');
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getCandidates', () => {
+    it('should throw an error if the npm param is missing from the descriptor', async () => {
+      const resolver = new BackstageNpmResolver();
+
+      const descriptor = structUtils.bindDescriptor(
+        structUtils.makeDescriptor(ident, 'backstage:^'),
+        { backstage: '1.0.0' },
+      );
+
+      await expect(
+        resolver.getCandidates(descriptor, undefined!, undefined!),
+      ).rejects.toThrow(/Missing npm parameter/);
+    });
+
+    it('should call the npm resolver with the correct descriptor', async () => {
+      const resolver = new BackstageNpmResolver();
+
+      mockGetCandidates.mockResolvedValue([
+        structUtils.makeLocator(ident, '1.2.5'),
+        structUtils.makeLocator(ident, '1.2.4'),
+        structUtils.makeLocator(ident, '1.2.3'),
+      ]);
+
+      const descriptor = structUtils.bindDescriptor(
+        structUtils.makeDescriptor(ident, 'backstage:^'),
+        { backstage: '1.0.0', npm: '1.2.3' },
+      );
+
+      const deps = {};
+      const opts = {};
+
+      await expect(
+        resolver.getCandidates(descriptor, deps, opts as ResolveOptions),
+      ).resolves.toEqual([
+        structUtils.makeLocator(ident, '1.2.5'),
+        structUtils.makeLocator(ident, '1.2.4'),
+        structUtils.makeLocator(ident, '1.2.3'),
+      ]);
+
+      expect(mockGetCandidates).toHaveBeenCalledWith(
+        structUtils.makeDescriptor(descriptor, 'npm:^1.2.3'),
+        deps,
+        opts,
+      );
+    });
+  });
+
+  describe('getResolutionDependencies', () => {
+    it('should return the correct resolution dependencies', () => {
+      const resolver = new BackstageNpmResolver();
+
+      const descriptor = structUtils.bindDescriptor(
+        structUtils.makeDescriptor(ident, 'backstage:^'),
+        { backstage: '1.0.0', npm: '1.2.3' },
+      );
+
+      expect(resolver.getResolutionDependencies(descriptor)).toEqual({
+        '@backstage/core': {
+          descriptorHash: expect.any(String),
+          identHash: descriptor.identHash,
+          name: 'core',
+          range: 'npm:^1.2.3',
+          scope: 'backstage',
+        },
+      });
+    });
+  });
+
+  describe('getSatisfying', () => {
+    it('should return the correct satisfying locator', async () => {
+      const resolver = new BackstageNpmResolver();
+
+      mockGetSatisfying.mockResolvedValue({
+        locators: [
+          structUtils.makeLocator(ident, '1.2.5'),
+          structUtils.makeLocator(ident, '1.2.4'),
+          structUtils.makeLocator(ident, '1.2.3'),
+        ],
+        sorted: false,
+      });
+
+      const descriptor = structUtils.bindDescriptor(
+        structUtils.makeDescriptor(ident, 'backstage:^'),
+        { backstage: '1.0.0', npm: '1.2.3' },
+      );
+
+      await expect(
+        resolver.getSatisfying(descriptor, {}, [], {} as ResolveOptions),
+      ).resolves.toEqual({
+        locators: [
+          structUtils.makeLocator(ident, '1.2.5'),
+          structUtils.makeLocator(ident, '1.2.4'),
+          structUtils.makeLocator(ident, '1.2.3'),
+        ],
+        sorted: false,
+      });
+
+      expect(mockGetSatisfying).toHaveBeenCalledWith(
+        {
+          descriptorHash: expect.any(String),
+          identHash: ident.identHash,
+          name: 'core',
+          range: 'npm:^1.2.3',
+          scope: 'backstage',
+        },
+        {},
+        [],
+        {} as ResolveOptions,
+      );
+    });
+  });
+});

--- a/packages/yarn-plugin/src/resolvers/BackstageNpmResolver.ts
+++ b/packages/yarn-plugin/src/resolvers/BackstageNpmResolver.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  structUtils,
+  Descriptor,
+  Locator,
+  Package,
+  Resolver,
+  ResolveOptions,
+} from '@yarnpkg/core';
+import { NpmSemverResolver } from '@yarnpkg/plugin-npm';
+import { PROTOCOL } from '../constants';
+
+export class BackstageNpmResolver implements Resolver {
+  static protocol = PROTOCOL;
+
+  /**
+   * Target only descriptors using the `backstage:` protocol
+   */
+  supportsDescriptor = (descriptor: Descriptor) =>
+    descriptor.range.startsWith(BackstageNpmResolver.protocol);
+
+  /**
+   * We treat any `backstage:` descriptor as if it's targeting the npm package
+   * version from the manifest for the current version of Backstage, by pulling
+   * in the `NpmSemverResolver` and deferring to its `getCandidates` method.
+   *
+   * The version itself comes from the `npm` parameter on the incoming
+   * descriptor, which is set by the `reduceDependency` hook.
+   */
+  async getCandidates(
+    descriptor: Descriptor,
+    dependencies: Record<string, Package>,
+    opts: ResolveOptions,
+  ): Promise<Locator[]> {
+    const npmVersion = structUtils.parseRange(descriptor.range).params?.npm;
+
+    if (!npmVersion || Array.isArray(npmVersion)) {
+      throw new Error(
+        `Missing npm parameter on backstage: range "${descriptor.range}"`,
+      );
+    }
+
+    return new NpmSemverResolver().getCandidates(
+      structUtils.makeDescriptor(descriptor, `npm:^${npmVersion}`),
+      dependencies,
+      opts,
+    );
+  }
+
+  /**
+   * We insert the `npm:^<version>` descriptor as an additional dependency to
+   * ensure that dependencies remain locked when adding and removing the plugin
+   * from repositories. This is relevant for example when building packed
+   * production-like workspaces for testing using `backstage-cli
+   * build-workspace`.
+   */
+  getResolutionDependencies(
+    descriptor: Descriptor,
+  ): Record<string, Descriptor> {
+    const npmVersion = structUtils.parseRange(descriptor.range).params?.npm;
+
+    if (!npmVersion) {
+      throw new Error(`Unreachable`);
+    }
+
+    return {
+      [structUtils.stringifyIdent(descriptor)]: structUtils.makeDescriptor(
+        descriptor,
+        `npm:^${npmVersion}`,
+      ),
+    };
+  }
+
+  /**
+   * This method is called when deduplicating locators. We first convert any
+   * `backstage:` locators into the corresponding `npm:` locator, and then defer
+   * to the implementation from `NpmSemverResolver`.
+   */
+  async getSatisfying(
+    descriptor: Descriptor,
+    dependencies: Record<string, Package>,
+    locators: Array<Locator>,
+    opts: ResolveOptions,
+  ) {
+    let npmDescriptor = descriptor;
+    const range = structUtils.parseRange(npmDescriptor.range);
+
+    if (range.protocol === PROTOCOL) {
+      const npmVersion = range.params?.npm;
+      npmDescriptor = structUtils.makeDescriptor(
+        descriptor,
+        `npm:^${npmVersion}`,
+      );
+    }
+
+    return new NpmSemverResolver().getSatisfying(
+      npmDescriptor,
+      dependencies,
+      locators,
+      opts,
+    );
+  }
+
+  /**
+   * Stub - no descriptor binding is needed in this resolver (note though that
+   * it does rely on the binding performed in the `reduceDependency` hook).
+   */
+  bindDescriptor = (descriptor: Descriptor) => descriptor;
+
+  /**
+   * This plugin does not need to support any locators itself, since the
+   * `getCandidates` method will always convert `backstage:` versions into
+   * `npm:` versions which are resolved using the `NpmSemverResolver`.
+   */
+  supportsLocator = () => false;
+
+  /**
+   * This method should never be called, since all emitted locators use the
+   * `npm:` protocol.
+   */
+  shouldPersistResolution = () => {
+    throw new Error('Unreachable');
+  };
+
+  /**
+   * This method should never be called, since all emitted locators use the
+   * `npm:` protocol.
+   */
+  resolve = async () => {
+    throw new Error(`Unreachable`);
+  };
+}

--- a/packages/yarn-plugin/src/resolvers/BackstageNpmResolver.ts
+++ b/packages/yarn-plugin/src/resolvers/BackstageNpmResolver.ts
@@ -74,7 +74,9 @@ export class BackstageNpmResolver implements Resolver {
     const npmVersion = structUtils.parseRange(descriptor.range).params?.npm;
 
     if (!npmVersion) {
-      throw new Error(`Unreachable`);
+      throw new Error(
+        `Missing npm parameter on backstage: range "${descriptor.range}".`,
+      );
     }
 
     return {
@@ -133,7 +135,9 @@ export class BackstageNpmResolver implements Resolver {
    * `npm:` protocol.
    */
   shouldPersistResolution = () => {
-    throw new Error('Unreachable');
+    throw new Error(
+      'Unreachable: BackstageNpmResolver should never persist resolution as it uses npm: protocol',
+    );
   };
 
   /**
@@ -141,6 +145,8 @@ export class BackstageNpmResolver implements Resolver {
    * `npm:` protocol.
    */
   resolve = async () => {
-    throw new Error(`Unreachable`);
+    throw new Error(
+      'Unreachable: BackstageNpmResolver should never resolve as it uses npm: protocol',
+    );
   };
 }

--- a/packages/yarn-plugin/src/resolvers/index.ts
+++ b/packages/yarn-plugin/src/resolvers/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-export { getCurrentBackstageVersion } from './getCurrentBackstageVersion';
-export { getPackageVersion } from './getPackageVersion';
+export { BackstageNpmResolver } from './BackstageNpmResolver';

--- a/yarn.lock
+++ b/yarn.lock
@@ -16348,6 +16348,64 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sigstore/bundle@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@sigstore/bundle@npm:3.1.0"
+  dependencies:
+    "@sigstore/protobuf-specs": "npm:^0.4.0"
+  checksum: 10/21b246ec63462e8508a8d001ca5d7937f63b6e15d5f2947ee2726d1e4674fb3f7640faa47b165bfea1d5b09df93fbdf10d1556427bba7e005e7f3a65b87f89b2
+  languageName: node
+  linkType: hard
+
+"@sigstore/core@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@sigstore/core@npm:2.0.0"
+  checksum: 10/ec1deae9430eeff580ad0f4ef2328b4eb7252db04587474fe9423d97736134ad79ee83aa2dfbc1fccfb18420c249e26e6e72e7176b592d7013eae5379dcb124d
+  languageName: node
+  linkType: hard
+
+"@sigstore/protobuf-specs@npm:^0.4.0":
+  version: 0.4.1
+  resolution: "@sigstore/protobuf-specs@npm:0.4.1"
+  checksum: 10/8d2840fdd2bb529ade50b0fc4ed34797386272f50b42575bd033002a89bea7a4030e2c2b7f2c077ef09c02d73b51182652a25114c5dc13b83a0853b86c204bd0
+  languageName: node
+  linkType: hard
+
+"@sigstore/sign@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@sigstore/sign@npm:3.1.0"
+  dependencies:
+    "@sigstore/bundle": "npm:^3.1.0"
+    "@sigstore/core": "npm:^2.0.0"
+    "@sigstore/protobuf-specs": "npm:^0.4.0"
+    make-fetch-happen: "npm:^14.0.2"
+    proc-log: "npm:^5.0.0"
+    promise-retry: "npm:^2.0.1"
+  checksum: 10/e0ce0aa52b572eefa06a8260a7329f349c56217f2bbb6f167259c6e02e148987073e0dddc5e3c40ea4aafc89b8b0176e2617fb16f9c8c50cf0c1437b6c90fca4
+  languageName: node
+  linkType: hard
+
+"@sigstore/tuf@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@sigstore/tuf@npm:3.1.0"
+  dependencies:
+    "@sigstore/protobuf-specs": "npm:^0.4.0"
+    tuf-js: "npm:^3.0.1"
+  checksum: 10/7040aaa8b05ab2ff62fec078ccb2ebfe8d96b862ad11dc4daebb707e11b72e424f54c55b6878b6a5b6b551afd1209078dc4140dda0f93c5b3afac7cc5fb9bb16
+  languageName: node
+  linkType: hard
+
+"@sigstore/verify@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@sigstore/verify@npm:2.1.0"
+  dependencies:
+    "@sigstore/bundle": "npm:^3.1.0"
+    "@sigstore/core": "npm:^2.0.0"
+    "@sigstore/protobuf-specs": "npm:^0.4.0"
+  checksum: 10/bb0a8472c80d27f0647106f18fe71112262bc13f21384c224c62bfd69e0672e0dd635537e7df566018d37f6604c437f162bcbdfe0a9d427d77541da7f36b51eb
+  languageName: node
+  linkType: hard
+
 "@sinclair/typebox@npm:0.31.28":
   version: 0.31.28
   resolution: "@sinclair/typebox@npm:0.31.28"
@@ -19187,6 +19245,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tufjs/canonical-json@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@tufjs/canonical-json@npm:2.0.0"
+  checksum: 10/cc719a1d0d0ae1aa1ba551a82c87dcbefac088e433c03a3d8a1d547ea721350e47dab4ab5b0fca40d5c7ab1f4882e72edc39c9eae15bf47c45c43bcb6ee39f4f
+  languageName: node
+  linkType: hard
+
+"@tufjs/models@npm:3.0.1":
+  version: 3.0.1
+  resolution: "@tufjs/models@npm:3.0.1"
+  dependencies:
+    "@tufjs/canonical-json": "npm:2.0.0"
+    minimatch: "npm:^9.0.5"
+  checksum: 10/00636238b2e3ce557e7b5f6884594ee2379fd5a9588401fd6c8be2e2867fcaf836e226c6be81d87006701746037847e13bbc263c0ed0f38b4f28b1108a4b1d81
+  languageName: node
+  linkType: hard
+
 "@types/ansi-regex@npm:^5.0.0":
   version: 5.0.4
   resolution: "@types/ansi-regex@npm:5.0.4"
@@ -21888,64 +21963,65 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@yarnpkg/builder@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@yarnpkg/builder@npm:4.0.0"
+"@yarnpkg/builder@npm:^4.2.1":
+  version: 4.2.1
+  resolution: "@yarnpkg/builder@npm:4.2.1"
   dependencies:
-    "@yarnpkg/cli": "npm:^4.0.0"
-    "@yarnpkg/core": "npm:^4.0.0"
-    "@yarnpkg/fslib": "npm:^3.0.0"
+    "@yarnpkg/cli": "npm:^4.7.0"
+    "@yarnpkg/core": "npm:^4.2.1"
+    "@yarnpkg/fslib": "npm:^3.1.2"
     chalk: "npm:^3.0.0"
     clipanion: "npm:^4.0.0-rc.2"
-    esbuild: "npm:esbuild-wasm@^0.15.15"
+    esbuild: "npm:esbuild-wasm@^0.23.0"
     semver: "npm:^7.1.2"
     tslib: "npm:^2.4.0"
   bin:
     builder: ./lib/cli.js
-  checksum: 10/555b97fea9a8d297a19d04899a473db9e76b9e635c68106ad685e366a85b900831bd4f5cd6932026439d03f9f19fcb7ceb8c552e49d355bab8552708dcc7b2d6
+  checksum: 10/e809d7283e08adf2c447d87ea98a6fccaa5b4f8a5e92796faa95c725329ce0300efbe068361ae4fd5a219979aaf1a4db4882a5eb9fcc84ed8296280f939926cd
   languageName: node
   linkType: hard
 
-"@yarnpkg/cli@npm:^4.0.0":
-  version: 4.1.1
-  resolution: "@yarnpkg/cli@npm:4.1.1"
+"@yarnpkg/cli@npm:^4.7.0":
+  version: 4.9.0
+  resolution: "@yarnpkg/cli@npm:4.9.0"
   dependencies:
-    "@yarnpkg/core": "npm:^4.0.3"
-    "@yarnpkg/fslib": "npm:^3.0.2"
-    "@yarnpkg/libzip": "npm:^3.0.1"
-    "@yarnpkg/parsers": "npm:^3.0.0"
-    "@yarnpkg/plugin-compat": "npm:^4.0.3"
-    "@yarnpkg/plugin-constraints": "npm:^4.0.2"
-    "@yarnpkg/plugin-dlx": "npm:^4.0.0"
-    "@yarnpkg/plugin-essentials": "npm:^4.1.1"
-    "@yarnpkg/plugin-exec": "npm:^3.0.0"
-    "@yarnpkg/plugin-file": "npm:^3.0.0"
-    "@yarnpkg/plugin-git": "npm:^3.0.0"
-    "@yarnpkg/plugin-github": "npm:^3.0.0"
-    "@yarnpkg/plugin-http": "npm:^3.0.1"
-    "@yarnpkg/plugin-init": "npm:^4.0.1"
-    "@yarnpkg/plugin-interactive-tools": "npm:^4.0.0"
-    "@yarnpkg/plugin-link": "npm:^3.0.0"
-    "@yarnpkg/plugin-nm": "npm:^4.0.2"
-    "@yarnpkg/plugin-npm": "npm:^3.0.1"
-    "@yarnpkg/plugin-npm-cli": "npm:^4.0.2"
-    "@yarnpkg/plugin-pack": "npm:^4.0.0"
-    "@yarnpkg/plugin-patch": "npm:^4.0.1"
-    "@yarnpkg/plugin-pnp": "npm:^4.0.2"
-    "@yarnpkg/plugin-pnpm": "npm:^2.0.0"
-    "@yarnpkg/plugin-stage": "npm:^4.0.0"
-    "@yarnpkg/plugin-typescript": "npm:^4.0.0"
-    "@yarnpkg/plugin-version": "npm:^4.0.1"
-    "@yarnpkg/plugin-workspace-tools": "npm:^4.1.0"
-    "@yarnpkg/shell": "npm:^4.0.0"
-    ci-info: "npm:^3.2.0"
+    "@yarnpkg/core": "npm:^4.4.0"
+    "@yarnpkg/fslib": "npm:^3.1.2"
+    "@yarnpkg/libzip": "npm:^3.2.0"
+    "@yarnpkg/parsers": "npm:^3.0.3"
+    "@yarnpkg/plugin-compat": "npm:^4.0.11"
+    "@yarnpkg/plugin-constraints": "npm:^4.0.3"
+    "@yarnpkg/plugin-dlx": "npm:^4.0.1"
+    "@yarnpkg/plugin-essentials": "npm:^4.4.0"
+    "@yarnpkg/plugin-exec": "npm:^3.0.1"
+    "@yarnpkg/plugin-file": "npm:^3.0.1"
+    "@yarnpkg/plugin-git": "npm:^3.1.1"
+    "@yarnpkg/plugin-github": "npm:^3.0.1"
+    "@yarnpkg/plugin-http": "npm:^3.0.2"
+    "@yarnpkg/plugin-init": "npm:^4.1.1"
+    "@yarnpkg/plugin-interactive-tools": "npm:^4.0.2"
+    "@yarnpkg/plugin-jsr": "npm:^1.1.0"
+    "@yarnpkg/plugin-link": "npm:^3.0.1"
+    "@yarnpkg/plugin-nm": "npm:^4.0.6"
+    "@yarnpkg/plugin-npm": "npm:^3.1.0"
+    "@yarnpkg/plugin-npm-cli": "npm:^4.1.0"
+    "@yarnpkg/plugin-pack": "npm:^4.0.1"
+    "@yarnpkg/plugin-patch": "npm:^4.0.2"
+    "@yarnpkg/plugin-pnp": "npm:^4.1.0"
+    "@yarnpkg/plugin-pnpm": "npm:^2.1.0"
+    "@yarnpkg/plugin-stage": "npm:^4.0.1"
+    "@yarnpkg/plugin-typescript": "npm:^4.1.2"
+    "@yarnpkg/plugin-version": "npm:^4.1.0"
+    "@yarnpkg/plugin-workspace-tools": "npm:^4.1.4"
+    "@yarnpkg/shell": "npm:^4.1.2"
+    ci-info: "npm:^4.0.0"
     clipanion: "npm:^4.0.0-rc.2"
     semver: "npm:^7.1.2"
     tslib: "npm:^2.4.0"
     typanion: "npm:^3.14.0"
   peerDependencies:
-    "@yarnpkg/core": ^4.0.3
-  checksum: 10/6345543bf3c4043733ed9fe95aa0db4cadaf8d0c612480650434986adb559249aec8641c1d40306892297e1744bd5297ceb5a8954f4dc53a254f32c8ada16d30
+    "@yarnpkg/core": ^4.4.0
+  checksum: 10/8f5c4f7da123acd8a4a2f5994dae4c5eb432e7dc4fa16080f2888a32a933d404f89793fb3c0fee5ac6f92e8b22ef28d1f4b89592960e363c183473941a52b411
   languageName: node
   linkType: hard
 
@@ -21988,22 +22064,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@yarnpkg/core@npm:^4.0.0, @yarnpkg/core@npm:^4.0.3":
-  version: 4.1.3
-  resolution: "@yarnpkg/core@npm:4.1.3"
+"@yarnpkg/core@npm:^4.2.1, @yarnpkg/core@npm:^4.4.0":
+  version: 4.4.0
+  resolution: "@yarnpkg/core@npm:4.4.0"
   dependencies:
     "@arcanis/slice-ansi": "npm:^1.1.1"
     "@types/semver": "npm:^7.1.0"
     "@types/treeify": "npm:^1.0.0"
-    "@yarnpkg/fslib": "npm:^3.1.0"
-    "@yarnpkg/libzip": "npm:^3.1.0"
-    "@yarnpkg/parsers": "npm:^3.0.2"
-    "@yarnpkg/shell": "npm:^4.1.0"
+    "@yarnpkg/fslib": "npm:^3.1.2"
+    "@yarnpkg/libzip": "npm:^3.2.0"
+    "@yarnpkg/parsers": "npm:^3.0.3"
+    "@yarnpkg/shell": "npm:^4.1.2"
     camelcase: "npm:^5.3.1"
     chalk: "npm:^3.0.0"
     ci-info: "npm:^4.0.0"
     clipanion: "npm:^4.0.0-rc.2"
-    cross-spawn: "npm:7.0.3"
+    cross-spawn: "npm:^7.0.3"
     diff: "npm:^5.1.0"
     dotenv: "npm:^16.3.1"
     fast-glob: "npm:^3.2.2"
@@ -22018,16 +22094,16 @@ __metadata:
     treeify: "npm:^1.1.0"
     tslib: "npm:^2.4.0"
     tunnel: "npm:^0.0.6"
-  checksum: 10/e7dc7098fa9466c09b162bce6704534687f8ffb95cae90440d47635bc737b0f0083f4f6eb87370114881eccfc96ff056a2d062b1a85aa6d326298e9f3f642a60
+  checksum: 10/59c3757ebda89b506d0bbb22baf20983f467c038917f5730da6bd76a0e91b2f244ea9cbd079281a00f949a0ad3abc09129e62e89dd1b9460a6318e98796f3e08
   languageName: node
   linkType: hard
 
-"@yarnpkg/extensions@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@yarnpkg/extensions@npm:2.0.1"
+"@yarnpkg/extensions@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "@yarnpkg/extensions@npm:2.0.5"
   peerDependencies:
-    "@yarnpkg/core": ^4.0.3
-  checksum: 10/138774e2ac4c821da9dd3d4b46c2de2be2d4b48a4817004c7639b9a5af062781d799db91507489616ef417a6b9ba3043a4c8507353f3ae56c3d71be58f84ba82
+    "@yarnpkg/core": ^4.2.1
+  checksum: 10/d264d84a4d5f7a8f7d53960618b2a138e51f50a994ffbf388ac35ff610006cc89dc825af3df8c980f506d6cc6a4de499c993b0eef7e80749385e1e804cb3dcaa
   languageName: node
   linkType: hard
 
@@ -22041,12 +22117,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@yarnpkg/fslib@npm:^3.0.0, @yarnpkg/fslib@npm:^3.0.1, @yarnpkg/fslib@npm:^3.0.2, @yarnpkg/fslib@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "@yarnpkg/fslib@npm:3.1.0"
+"@yarnpkg/fslib@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "@yarnpkg/fslib@npm:3.1.2"
   dependencies:
     tslib: "npm:^2.4.0"
-  checksum: 10/99537cff3269f0728b440bc801872346f8f698ada479b00df82967c0fea1fc61588e69f669174fdf8274107a1b34dfb656513db8789db12afd7e6778bd2b4e86
+  checksum: 10/be7ed5d418c1adadd24bfa68abb0a95aceb39aafb6dd22644fcae3a8b0185d30868904f4df59de94536ea3eb36bfb4ee1304cc058afeec8d9ee6837d28f6bcd4
   languageName: node
   linkType: hard
 
@@ -22060,15 +22136,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@yarnpkg/libui@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@yarnpkg/libui@npm:3.0.0"
+"@yarnpkg/libui@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "@yarnpkg/libui@npm:3.0.2"
   dependencies:
     tslib: "npm:^2.4.0"
   peerDependencies:
     ink: ^3.0.8
-    react: ^16.8.4
-  checksum: 10/80757636151368e538d46245352b82d47366438755c6660328c944e1727a15bd7559def013297a85d4380f43384d58dffbb4b54707878fa9609c963a4cc0fbf4
+    react: ^17.0.2
+  checksum: 10/021164d87df6d70d3ed0f3ceeeab492488c77c260533fc1116b31b5affc6278ac2d136e950c28562f6ac558f6a75d2681611ed935538f5d8451c8544355f67cf
   languageName: node
   linkType: hard
 
@@ -22082,16 +22158,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@yarnpkg/libzip@npm:^3.0.0, @yarnpkg/libzip@npm:^3.0.1, @yarnpkg/libzip@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "@yarnpkg/libzip@npm:3.1.0"
+"@yarnpkg/libzip@npm:^3.1.1, @yarnpkg/libzip@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "@yarnpkg/libzip@npm:3.2.0"
   dependencies:
     "@types/emscripten": "npm:^1.39.6"
-    "@yarnpkg/fslib": "npm:^3.1.0"
+    "@yarnpkg/fslib": "npm:^3.1.2"
     tslib: "npm:^2.4.0"
   peerDependencies:
-    "@yarnpkg/fslib": ^3.1.0
-  checksum: 10/d3113b362d24cea53a00afe30ca0a5589649317c25812251dd3dbc14d37779b20e00118f040dfa2fc3d9ab78f0341ed827ccc03cad859647f05eaf388a6f1890
+    "@yarnpkg/fslib": ^3.1.2
+  checksum: 10/158f80177dfc51d0efefaa7dcc3a725a0cc07114538774799b64d1ed50951e08511fe154db22b4a6eb4c639773fe9b5835005c14b9bb87df443c885c25c58115
   languageName: node
   linkType: hard
 
@@ -22102,14 +22178,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@yarnpkg/nm@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "@yarnpkg/nm@npm:4.0.2"
+"@yarnpkg/nm@npm:^4.0.6":
+  version: 4.0.6
+  resolution: "@yarnpkg/nm@npm:4.0.6"
   dependencies:
-    "@yarnpkg/core": "npm:^4.0.3"
-    "@yarnpkg/fslib": "npm:^3.0.2"
-    "@yarnpkg/pnp": "npm:^4.0.2"
-  checksum: 10/f5b1fc596bab690b45d7c6ea5479c76462736bf840bbee263e147643384876836d09b311c195366d628780de613ec5353a05226272076f3940eb3d5f23329da6
+    "@yarnpkg/core": "npm:^4.2.1"
+    "@yarnpkg/fslib": "npm:^3.1.2"
+    "@yarnpkg/pnp": "npm:^4.0.9"
+  checksum: 10/9f43680503193e2b98d2f2bfdf7abf51604354c9b82ada3569374f54c815f8d44be94ed4f4c6178e516d8046ae5c0a0808542a53b74cb57d85ebb99b1a2d5ac3
   languageName: node
   linkType: hard
 
@@ -22123,65 +22199,65 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@yarnpkg/parsers@npm:^3.0.0, @yarnpkg/parsers@npm:^3.0.2":
-  version: 3.0.2
-  resolution: "@yarnpkg/parsers@npm:3.0.2"
+"@yarnpkg/parsers@npm:^3.0.0, @yarnpkg/parsers@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "@yarnpkg/parsers@npm:3.0.3"
   dependencies:
     js-yaml: "npm:^3.10.0"
     tslib: "npm:^2.4.0"
-  checksum: 10/87506f140d6c401bdd89ff22073c3dd3ec7b6858e7f576e63ec1aea1b0b8a8ec241eb46ca5582dc2071098a86d6a55c3b0628da5eeff91d33afb4fa7cac0cf65
+  checksum: 10/379f7ff8fc1b37d3818dfeba4e18a72f8e9817bb41aab9332b50bbc843e45c9bf135563a7a06882ffb50e4cdd29c8da33c8e4f3739201de2fbcd38ecb59e3a8e
   languageName: node
   linkType: hard
 
-"@yarnpkg/plugin-compat@npm:^4.0.3":
-  version: 4.0.3
-  resolution: "@yarnpkg/plugin-compat@npm:4.0.3"
+"@yarnpkg/plugin-compat@npm:^4.0.11":
+  version: 4.0.11
+  resolution: "@yarnpkg/plugin-compat@npm:4.0.11"
   dependencies:
-    "@yarnpkg/extensions": "npm:^2.0.1"
+    "@yarnpkg/extensions": "npm:^2.0.5"
   peerDependencies:
-    "@yarnpkg/core": ^4.0.3
-    "@yarnpkg/plugin-patch": ^4.0.1
-  checksum: 10/3429c8900cac6df12f7475d9b68082ffef46a02bbbc514b58a607e0fdb811d479e867554e65173fc22798c79c5510cb18f4159060365a8bd5eac44ac99c19264
+    "@yarnpkg/core": ^4.2.1
+    "@yarnpkg/plugin-patch": ^4.0.2
+  checksum: 10/880298b026d72ade2b1903a4f1f3bfd4d6a3385429718447bdf2bd1224c738d3feee9d7e54f810afff39388b0de1cee75ff265ae0c59cdd084de3872759fdf95
   languageName: node
   linkType: hard
 
-"@yarnpkg/plugin-constraints@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "@yarnpkg/plugin-constraints@npm:4.0.2"
+"@yarnpkg/plugin-constraints@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "@yarnpkg/plugin-constraints@npm:4.0.3"
   dependencies:
-    "@yarnpkg/fslib": "npm:^3.0.1"
+    "@yarnpkg/fslib": "npm:^3.1.2"
     clipanion: "npm:^4.0.0-rc.2"
     lodash: "npm:^4.17.15"
     tau-prolog: "npm:^0.2.66"
     tslib: "npm:^2.4.0"
   peerDependencies:
-    "@yarnpkg/cli": ^4.0.2
-    "@yarnpkg/core": ^4.0.2
-  checksum: 10/ffea175adb82a7990e772039aa42f5045193b53e3a5ce6f658cbd6ea5f587f0b2cf9e7e9f881a63f0aaabfdfea41764554e5326c4f7925b600a3caf65f4156c6
+    "@yarnpkg/cli": ^4.7.0
+    "@yarnpkg/core": ^4.2.1
+  checksum: 10/00ac9cba0b2b4cefa4c30e19717515ee25ee5575d6fb73121fd2ead31e0aa8dacbf09a5157dba4e4a405e1e39d920d7cf97eb29c3bd2f2dcc82b8f08caabf012
   languageName: node
   linkType: hard
 
-"@yarnpkg/plugin-dlx@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@yarnpkg/plugin-dlx@npm:4.0.0"
+"@yarnpkg/plugin-dlx@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@yarnpkg/plugin-dlx@npm:4.0.1"
   dependencies:
-    "@yarnpkg/fslib": "npm:^3.0.0"
+    "@yarnpkg/fslib": "npm:^3.1.2"
     clipanion: "npm:^4.0.0-rc.2"
     tslib: "npm:^2.4.0"
   peerDependencies:
-    "@yarnpkg/cli": ^4.0.0
-    "@yarnpkg/core": ^4.0.0
-  checksum: 10/2a145c10b4714e7c4c1192705f40df5b574f58caf088decea9f24273e99aa4276c030f8d33f46512d8983de3d97d74041eafe3a4a3c9b6ad0c8489024aea190c
+    "@yarnpkg/cli": ^4.7.0
+    "@yarnpkg/core": ^4.2.1
+  checksum: 10/542103b44ec2bf2dcbbb04193b52adfaa9b003cf9df1f90d2f3b0027f53148189dc7321eda2d55215acfe649d7f16bada5082c1683553e205cac80459a26f20f
   languageName: node
   linkType: hard
 
-"@yarnpkg/plugin-essentials@npm:^4.1.1":
-  version: 4.1.1
-  resolution: "@yarnpkg/plugin-essentials@npm:4.1.1"
+"@yarnpkg/plugin-essentials@npm:^4.4.0":
+  version: 4.4.0
+  resolution: "@yarnpkg/plugin-essentials@npm:4.4.0"
   dependencies:
-    "@yarnpkg/fslib": "npm:^3.0.2"
-    "@yarnpkg/parsers": "npm:^3.0.0"
-    ci-info: "npm:^3.2.0"
+    "@yarnpkg/fslib": "npm:^3.1.2"
+    "@yarnpkg/parsers": "npm:^3.0.3"
+    ci-info: "npm:^4.0.0"
     clipanion: "npm:^4.0.0-rc.2"
     enquirer: "npm:^2.3.6"
     lodash: "npm:^4.17.15"
@@ -22190,151 +22266,163 @@ __metadata:
     tslib: "npm:^2.4.0"
     typanion: "npm:^3.14.0"
   peerDependencies:
-    "@yarnpkg/cli": ^4.1.1
-    "@yarnpkg/core": ^4.0.3
-    "@yarnpkg/plugin-git": ^3.0.0
-  checksum: 10/b9e4ca21a68167ac0c6778840a4ce125d9ede13d2de9967e8a3f6e3a3c87aad36fedc550c850699ae0fe7546f10d9add35c7e917b95fabe56073cef65441f23d
+    "@yarnpkg/cli": ^4.9.0
+    "@yarnpkg/core": ^4.4.0
+    "@yarnpkg/plugin-git": ^3.1.1
+  checksum: 10/29a72a5cff3889b429a4c23c451ee5bedf222fc70ffa15ce162b5a5a74b5eccbca2131b6c8c77f439f94477ddd6aee718c5cd9896ba2f29efc871b55aa473578
   languageName: node
   linkType: hard
 
-"@yarnpkg/plugin-exec@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@yarnpkg/plugin-exec@npm:3.0.0"
+"@yarnpkg/plugin-exec@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@yarnpkg/plugin-exec@npm:3.0.1"
   dependencies:
-    "@yarnpkg/fslib": "npm:^3.0.0"
+    "@yarnpkg/fslib": "npm:^3.1.2"
     tslib: "npm:^2.4.0"
   peerDependencies:
-    "@yarnpkg/core": ^4.0.0
-  checksum: 10/e6bbe9fc7a78f44d2853bd477edc2820bc5f707179e761bf44425b64e9caf3e802ea23379f57900cfb2ae228b083f1426bad2b201998b84982a96960502af740
+    "@yarnpkg/core": ^4.2.1
+  checksum: 10/f56fc973187fb4b555ccb2e5730e4fd0ec61c37a07d51f408ca5cff3d4cf91b3ebcff019f9595dbff585b28931fe7aed62de85ed8e4d6f9c42b6af0b4d1e264f
   languageName: node
   linkType: hard
 
-"@yarnpkg/plugin-file@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@yarnpkg/plugin-file@npm:3.0.0"
+"@yarnpkg/plugin-file@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@yarnpkg/plugin-file@npm:3.0.1"
   dependencies:
-    "@yarnpkg/fslib": "npm:^3.0.0"
-    "@yarnpkg/libzip": "npm:^3.0.0"
+    "@yarnpkg/fslib": "npm:^3.1.2"
+    "@yarnpkg/libzip": "npm:^3.1.1"
     tslib: "npm:^2.4.0"
   peerDependencies:
-    "@yarnpkg/core": ^4.0.0
-  checksum: 10/149e57f555666b77eaf8e4035629f28bfbb026d20dc97720b7b8ee01781639ac29db5e27212a6b4980dd67097da4baa6297786c964f1e0321137489cdcb1fd31
+    "@yarnpkg/core": ^4.2.1
+  checksum: 10/c910d3e4313060188cd32b180bc1e6ee989ab6e739eec2750d52d1bd1411e132a9266964dbad0ddc6a6549166ef4b9a491e71a750836b4ddb92eb124ed88a26b
   languageName: node
   linkType: hard
 
-"@yarnpkg/plugin-git@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@yarnpkg/plugin-git@npm:3.0.0"
+"@yarnpkg/plugin-git@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "@yarnpkg/plugin-git@npm:3.1.1"
   dependencies:
     "@types/semver": "npm:^7.1.0"
-    "@yarnpkg/fslib": "npm:^3.0.0"
+    "@yarnpkg/fslib": "npm:^3.1.2"
     clipanion: "npm:^4.0.0-rc.2"
     git-url-parse: "npm:^13.1.0"
     lodash: "npm:^4.17.15"
     semver: "npm:^7.1.2"
     tslib: "npm:^2.4.0"
   peerDependencies:
-    "@yarnpkg/core": ^4.0.0
-  checksum: 10/b32f09b081c8c5832ac8da537c75f23a3db0afc69abf5bcf8e0a83a8c27fda05f901af5810d800014750447375c42c0724d047ab3cffc672704d2402cfdaf692
+    "@yarnpkg/core": ^4.2.1
+  checksum: 10/8243ed4c5b81bc965dbcd39f27ed2170286fc6a0bfc9de509990c3e8d97deebf5ad0a2900392b446545a0cbfcfd43a17aaf4cc95fc67beb931e1ffa32e55bfa7
   languageName: node
   linkType: hard
 
-"@yarnpkg/plugin-github@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@yarnpkg/plugin-github@npm:3.0.0"
-  dependencies:
-    "@yarnpkg/fslib": "npm:^3.0.0"
-    tslib: "npm:^2.4.0"
-  peerDependencies:
-    "@yarnpkg/core": ^4.0.0
-    "@yarnpkg/plugin-git": ^3.0.0
-  checksum: 10/08f749d67f37eb18f9ac9ccc6705483ce2fbf7be57b7f7bc95408bcd3725a6b18ca2f07e3b4989e9013631dd6b278f4fc5b7e66824ee0e0d01e9475be0373aaa
-  languageName: node
-  linkType: hard
-
-"@yarnpkg/plugin-http@npm:^3.0.1":
+"@yarnpkg/plugin-github@npm:^3.0.1":
   version: 3.0.1
-  resolution: "@yarnpkg/plugin-http@npm:3.0.1"
+  resolution: "@yarnpkg/plugin-github@npm:3.0.1"
   dependencies:
+    "@yarnpkg/fslib": "npm:^3.1.2"
     tslib: "npm:^2.4.0"
   peerDependencies:
-    "@yarnpkg/core": ^4.0.2
-  checksum: 10/928d22cf37ff90501fbbc48ddff162c63e254100fe5f01c46b979458514f14d892f577047e90ced997e4c938edbe4b65b6580f9f5c0390b6b28bce1f0b2f4804
+    "@yarnpkg/core": ^4.2.1
+    "@yarnpkg/plugin-git": ^3.1.1
+  checksum: 10/4cb144e994e804ceb910dac7a0ea3570cbe1c945434dc4fb4c30df4d228db40a28c10ff71457c67ff3a31b58b26916a0b27da15efbf6ebcdeb247920838703a3
   languageName: node
   linkType: hard
 
-"@yarnpkg/plugin-init@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "@yarnpkg/plugin-init@npm:4.0.1"
+"@yarnpkg/plugin-http@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "@yarnpkg/plugin-http@npm:3.0.2"
   dependencies:
-    "@yarnpkg/fslib": "npm:^3.0.1"
+    tslib: "npm:^2.4.0"
+  peerDependencies:
+    "@yarnpkg/core": ^4.2.1
+  checksum: 10/6177444b11d0321f65bce0d34787980b553ee98cec74cee924adcede869228be389b153c29c5ffb764b38ac2149b1d7594126ffd7f0ba66773f6e9a55c7a9cf4
+  languageName: node
+  linkType: hard
+
+"@yarnpkg/plugin-init@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "@yarnpkg/plugin-init@npm:4.1.1"
+  dependencies:
+    "@yarnpkg/fslib": "npm:^3.1.2"
     clipanion: "npm:^4.0.0-rc.2"
     tslib: "npm:^2.4.0"
   peerDependencies:
-    "@yarnpkg/cli": ^4.0.2
-    "@yarnpkg/core": ^4.0.2
-  checksum: 10/1a5d2bb615e9f3688568fa06530fc2eb33ad631e8bc67334c5f4534436462dfbca83a25ca0c934c00985a2ef849a3f122bdd9b754c42e3972491c74dbf0566da
+    "@yarnpkg/cli": ^4.8.0
+    "@yarnpkg/core": ^4.3.0
+  checksum: 10/9803d1fef7ffa827ae77c040d6fc9a2c29a1c27acefb71cd35d42cd36cfb8f600e6106a067619d15d9c810e7524afc5beb0f3c1c5f856798abff825225d529f0
   languageName: node
   linkType: hard
 
-"@yarnpkg/plugin-interactive-tools@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@yarnpkg/plugin-interactive-tools@npm:4.0.0"
+"@yarnpkg/plugin-interactive-tools@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "@yarnpkg/plugin-interactive-tools@npm:4.0.2"
   dependencies:
-    "@yarnpkg/libui": "npm:^3.0.0"
+    "@yarnpkg/libui": "npm:^3.0.2"
     algoliasearch: "npm:^4.2.0"
     clipanion: "npm:^4.0.0-rc.2"
     diff: "npm:^5.1.0"
-    ink: "npm:^3.0.8"
-    ink-text-input: "npm:^4.0.1"
-    react: "npm:^16.13.1"
+    ink: "npm:^3.2.0"
+    ink-text-input: "npm:^4.0.3"
+    react: "npm:^17.0.2"
     semver: "npm:^7.1.2"
     tslib: "npm:^2.4.0"
   peerDependencies:
-    "@yarnpkg/cli": ^4.0.0
-    "@yarnpkg/core": ^4.0.0
-    "@yarnpkg/plugin-essentials": ^4.0.0
-  checksum: 10/640740a3e25f0e85874632dfaa31a423c48e9cfdc2f30e29f0704f5ce845f9185a964dbd438d2fcf74f9e3cb96e45f82c92ddaa499ccaf706d746c12543e0e74
+    "@yarnpkg/cli": ^4.7.0
+    "@yarnpkg/core": ^4.2.1
+    "@yarnpkg/plugin-essentials": ^4.3.1
+  checksum: 10/f479fe834bc50f28636da0fb876212c7fdb444057c71c228060b40f7db9a586a5deb132b2989b185d2769d94c227698219be4d603ac33c17abf12f3927840c14
   languageName: node
   linkType: hard
 
-"@yarnpkg/plugin-link@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@yarnpkg/plugin-link@npm:3.0.0"
+"@yarnpkg/plugin-jsr@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@yarnpkg/plugin-jsr@npm:1.1.0"
   dependencies:
-    "@yarnpkg/fslib": "npm:^3.0.0"
+    "@yarnpkg/fslib": "npm:^3.1.2"
     tslib: "npm:^2.4.0"
   peerDependencies:
-    "@yarnpkg/core": ^4.0.0
-  checksum: 10/48bdb0e7ac8f9544999237d90f8b64163c1959d9e6f6a67d14799ef1c6533d5f30c7fa896129ed7b7ac693a9ce111646878ec4f505a39f5494df5db34cc372c4
+    "@yarnpkg/core": ^4.4.0
+  checksum: 10/7bd8ccdb71c7bfe8e6fee36aecd44fc25642b7fbeaed5a6bc897dec9bea385a652ebef0929f9841441666228d8504b277fe95389f6e444dae4f65dedd2649eeb
   languageName: node
   linkType: hard
 
-"@yarnpkg/plugin-nm@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "@yarnpkg/plugin-nm@npm:4.0.2"
+"@yarnpkg/plugin-link@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@yarnpkg/plugin-link@npm:3.0.1"
   dependencies:
-    "@yarnpkg/fslib": "npm:^3.0.2"
-    "@yarnpkg/libzip": "npm:^3.0.1"
-    "@yarnpkg/nm": "npm:^4.0.2"
-    "@yarnpkg/parsers": "npm:^3.0.0"
-    "@yarnpkg/plugin-pnp": "npm:^4.0.2"
-    "@yarnpkg/pnp": "npm:^4.0.2"
+    "@yarnpkg/fslib": "npm:^3.1.2"
+    tslib: "npm:^2.4.0"
+  peerDependencies:
+    "@yarnpkg/core": ^4.2.1
+  checksum: 10/057925c3ba3da138be09f15288199b832fc78125848f0689a9731c54ccb85c18287f041a2cefdf764aaadabd14acb9917a41a54272a0d7e3e0f8f90ced62043d
+  languageName: node
+  linkType: hard
+
+"@yarnpkg/plugin-nm@npm:^4.0.6":
+  version: 4.0.6
+  resolution: "@yarnpkg/plugin-nm@npm:4.0.6"
+  dependencies:
+    "@yarnpkg/fslib": "npm:^3.1.2"
+    "@yarnpkg/libzip": "npm:^3.1.1"
+    "@yarnpkg/nm": "npm:^4.0.6"
+    "@yarnpkg/parsers": "npm:^3.0.3"
+    "@yarnpkg/plugin-pnp": "npm:^4.0.7"
+    "@yarnpkg/pnp": "npm:^4.0.9"
     "@zkochan/cmd-shim": "npm:^5.1.0"
     clipanion: "npm:^4.0.0-rc.2"
     tslib: "npm:^2.4.0"
   peerDependencies:
-    "@yarnpkg/cli": ^4.1.0
-    "@yarnpkg/core": ^4.0.3
-  checksum: 10/f16811dfa3f434f51e6a1f723cc7ca1721371c88cb59b81376a9a2c4799197261ead95c3892665fcaf77a7a6c72866381efb8345bd5eaf0733319acb448dd2b9
+    "@yarnpkg/cli": ^4.7.0
+    "@yarnpkg/core": ^4.2.1
+  checksum: 10/7b659084f2f5f97d5461799a4cb3e55b6391adc940d492dfcc20257c0137e2d41b4877306063b27e4be96e91a6fecbd931d77de69aba68230280c67a1cfbc840
   languageName: node
   linkType: hard
 
-"@yarnpkg/plugin-npm-cli@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "@yarnpkg/plugin-npm-cli@npm:4.0.2"
+"@yarnpkg/plugin-npm-cli@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@yarnpkg/plugin-npm-cli@npm:4.1.0"
   dependencies:
-    "@yarnpkg/fslib": "npm:^3.0.2"
+    "@yarnpkg/fslib": "npm:^3.1.2"
     clipanion: "npm:^4.0.0-rc.2"
     enquirer: "npm:^2.3.6"
     micromatch: "npm:^4.0.2"
@@ -22342,163 +22430,182 @@ __metadata:
     tslib: "npm:^2.4.0"
     typanion: "npm:^3.14.0"
   peerDependencies:
-    "@yarnpkg/cli": ^4.1.0
-    "@yarnpkg/core": ^4.0.3
-    "@yarnpkg/plugin-npm": ^3.0.1
-    "@yarnpkg/plugin-pack": ^4.0.0
-  checksum: 10/bc117374c6f193bea3a4a3b3c55a01ebf6ec9c98e18598d38b7f37dd8bb37d8f8d58163aff7382f00abdd89e8a3d2a9a76c1df7431d94c2bf849f273bc97adf1
+    "@yarnpkg/cli": ^4.9.0
+    "@yarnpkg/core": ^4.4.0
+    "@yarnpkg/plugin-npm": ^3.1.0
+    "@yarnpkg/plugin-pack": ^4.0.1
+  checksum: 10/93f42aed8ce11c0f158577078d47acf7a996d0c9abf836035e70760a0f69e2d66c2e811d23bf582d065672043e1e41ec09b7d15eab291080d09e5787a253a5bb
   languageName: node
   linkType: hard
 
-"@yarnpkg/plugin-npm@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "@yarnpkg/plugin-npm@npm:3.0.1"
+"@yarnpkg/plugin-npm@npm:3.1.0":
+  version: 3.1.0
+  resolution: "@yarnpkg/plugin-npm@npm:3.1.0"
   dependencies:
-    "@yarnpkg/fslib": "npm:^3.0.2"
+    "@yarnpkg/fslib": "npm:^3.1.2"
     enquirer: "npm:^2.3.6"
     lodash: "npm:^4.17.15"
     semver: "npm:^7.1.2"
-    ssri: "npm:^6.0.1"
+    sigstore: "npm:^3.1.0"
+    ssri: "npm:^12.0.0"
     tslib: "npm:^2.4.0"
   peerDependencies:
-    "@yarnpkg/core": ^4.0.3
-    "@yarnpkg/plugin-pack": ^4.0.0
-  checksum: 10/30c3948b90f621abbd9c60c616221683bf198643c991e222d67bf3e00f0748a16e04c978e5cf4b35a587919723836a66a9dc86fee2ee5fe18a480a00782b701c
+    "@yarnpkg/core": ^4.4.0
+    "@yarnpkg/plugin-pack": ^4.0.1
+  checksum: 10/40582195679708de477a91c306badf7046190de59ea2f35f21d491fcd6d7d7471f49b98764e89bc6225a464220f764b65cf52c8771a27144cd916043da0cd9fa
   languageName: node
   linkType: hard
 
-"@yarnpkg/plugin-pack@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@yarnpkg/plugin-pack@npm:4.0.0"
+"@yarnpkg/plugin-npm@patch:@yarnpkg/plugin-npm@npm%3A3.1.0#~/.yarn/patches/@yarnpkg-plugin-npm-npm-3.1.0-6533d0f5a1.patch":
+  version: 3.1.0
+  resolution: "@yarnpkg/plugin-npm@patch:@yarnpkg/plugin-npm@npm%3A3.1.0#~/.yarn/patches/@yarnpkg-plugin-npm-npm-3.1.0-6533d0f5a1.patch::version=3.1.0&hash=febfda"
   dependencies:
-    "@yarnpkg/fslib": "npm:^3.0.0"
+    "@yarnpkg/fslib": "npm:^3.1.2"
+    enquirer: "npm:^2.3.6"
+    lodash: "npm:^4.17.15"
+    semver: "npm:^7.1.2"
+    sigstore: "npm:^3.1.0"
+    ssri: "npm:^12.0.0"
+    tslib: "npm:^2.4.0"
+  peerDependencies:
+    "@yarnpkg/core": ^4.4.0
+    "@yarnpkg/plugin-pack": ^4.0.1
+  checksum: 10/c96cf24d272598d7bab7ff2568324c73f853fdabed98b547b9fa0509d9754611d4602700d656adc4ee8125827ea1d79ab6872df061ee0336fcbcbaad8e818f0e
+  languageName: node
+  linkType: hard
+
+"@yarnpkg/plugin-pack@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@yarnpkg/plugin-pack@npm:4.0.1"
+  dependencies:
+    "@yarnpkg/fslib": "npm:^3.1.2"
     clipanion: "npm:^4.0.0-rc.2"
     micromatch: "npm:^4.0.2"
     tar-stream: "npm:^2.0.1"
     tslib: "npm:^2.4.0"
   peerDependencies:
-    "@yarnpkg/cli": ^4.0.0
-    "@yarnpkg/core": ^4.0.0
-  checksum: 10/af36966c777a3a270257597ecbebc85297df26b2694101b7afcacad890f9ab6026762408f7ab8c27555a91a1fc550e00c38856f793041eadab491c6f15e3b876
+    "@yarnpkg/cli": ^4.7.0
+    "@yarnpkg/core": ^4.2.1
+  checksum: 10/4fae66f576401e11166109120a741c2437f94946c449ac28e3409e63c72bcaaecfe7b3c7ee623bdf260db77f78c26eabc5b572d538565fbd615c032f2b2075b9
   languageName: node
   linkType: hard
 
-"@yarnpkg/plugin-patch@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "@yarnpkg/plugin-patch@npm:4.0.1"
+"@yarnpkg/plugin-patch@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "@yarnpkg/plugin-patch@npm:4.0.2"
   dependencies:
-    "@yarnpkg/fslib": "npm:^3.0.1"
-    "@yarnpkg/libzip": "npm:^3.0.0"
+    "@yarnpkg/fslib": "npm:^3.1.2"
+    "@yarnpkg/libzip": "npm:^3.1.1"
     clipanion: "npm:^4.0.0-rc.2"
     tslib: "npm:^2.4.0"
   peerDependencies:
-    "@yarnpkg/cli": ^4.0.2
-    "@yarnpkg/core": ^4.0.2
-  checksum: 10/9dd326cc4c3859ea21ad4fd7678ed8f12bd0c360c5fb7b23a2f3c45e2c6127c0cf1420b95b80ceb9271c3a7aa05b59a2eb12d8f565d47264a0d32137ab0f9464
+    "@yarnpkg/cli": ^4.7.0
+    "@yarnpkg/core": ^4.2.1
+  checksum: 10/ecb5413f273a5ff7fccb30d738c15238ba17c9b36f56748b718d518c71aa6036c7f46c9fbb431fe1977a867cc27b71d42e6501f03feb2d31d0cb7356efe79f7d
   languageName: node
   linkType: hard
 
-"@yarnpkg/plugin-pnp@npm:^4.0.0, @yarnpkg/plugin-pnp@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "@yarnpkg/plugin-pnp@npm:4.0.2"
+"@yarnpkg/plugin-pnp@npm:^4.0.7, @yarnpkg/plugin-pnp@npm:^4.0.8, @yarnpkg/plugin-pnp@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@yarnpkg/plugin-pnp@npm:4.1.0"
   dependencies:
-    "@yarnpkg/fslib": "npm:^3.0.1"
-    "@yarnpkg/plugin-stage": "npm:^4.0.0"
-    "@yarnpkg/pnp": "npm:^4.0.1"
+    "@yarnpkg/fslib": "npm:^3.1.2"
+    "@yarnpkg/plugin-stage": "npm:^4.0.1"
+    "@yarnpkg/pnp": "npm:^4.1.0"
     clipanion: "npm:^4.0.0-rc.2"
     micromatch: "npm:^4.0.2"
     tslib: "npm:^2.4.0"
   peerDependencies:
-    "@yarnpkg/cli": ^4.0.2
-    "@yarnpkg/core": ^4.0.2
-  checksum: 10/dd0bbc05c8aab2d234e31d3e3fc7b4311acc770ead12fb9fd8cc060210b66b1993cbbf71e4a1f4484891ec52079be85d9a4722edaa5131695e8e2047172f4756
+    "@yarnpkg/cli": ^4.9.0
+    "@yarnpkg/core": ^4.4.0
+  checksum: 10/5ac084b851ef2b0aaa684de94976907d15246bf0fdd47cc15b02db549c69250c33502e54929841acebea5816b4a26b2c4da97fe892abdddf3b7f4e03eab9373e
   languageName: node
   linkType: hard
 
-"@yarnpkg/plugin-pnpm@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@yarnpkg/plugin-pnpm@npm:2.0.0"
+"@yarnpkg/plugin-pnpm@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@yarnpkg/plugin-pnpm@npm:2.1.0"
   dependencies:
-    "@yarnpkg/fslib": "npm:^3.0.0"
-    "@yarnpkg/plugin-pnp": "npm:^4.0.0"
-    "@yarnpkg/plugin-stage": "npm:^4.0.0"
+    "@yarnpkg/fslib": "npm:^3.1.2"
+    "@yarnpkg/plugin-pnp": "npm:^4.0.8"
+    "@yarnpkg/plugin-stage": "npm:^4.0.1"
     clipanion: "npm:^4.0.0-rc.2"
     p-limit: "npm:^2.2.0"
     tslib: "npm:^2.4.0"
   peerDependencies:
-    "@yarnpkg/cli": ^4.0.0
-    "@yarnpkg/core": ^4.0.0
-  checksum: 10/4f418b94ca77b2433d81cab39a369e710f4320359e6b16de4421b009eaedd9ddbdb181fed47fbef21d93a77dbf7f71daf31b165901d352172f8d50ef89e8e514
+    "@yarnpkg/cli": ^4.8.0
+    "@yarnpkg/core": ^4.3.0
+  checksum: 10/958edaff62a5d21e0ec25807e5f7a46b27b075d154f5365440585257ec6d830964bc1da9cb0189d0d2c9185569cd770d3c807ddbe7c94c5250d14032eae5db9e
   languageName: node
   linkType: hard
 
-"@yarnpkg/plugin-stage@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@yarnpkg/plugin-stage@npm:4.0.0"
+"@yarnpkg/plugin-stage@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@yarnpkg/plugin-stage@npm:4.0.1"
   dependencies:
-    "@yarnpkg/fslib": "npm:^3.0.0"
+    "@yarnpkg/fslib": "npm:^3.1.2"
     clipanion: "npm:^4.0.0-rc.2"
     tslib: "npm:^2.4.0"
   peerDependencies:
-    "@yarnpkg/cli": ^4.0.0
-    "@yarnpkg/core": ^4.0.0
-  checksum: 10/504fd0075e2cf36b168eca3be6fe5d586fb1b63d7ac2c9a3073f3dfe4341480f569602f62b3a6c233fbf99276342e1647b3b73d89f4bc8bcc920407342b00d68
+    "@yarnpkg/cli": ^4.7.0
+    "@yarnpkg/core": ^4.2.1
+  checksum: 10/ba5e04e95dd37d5640709692ccbe3c7e067d3e0035d4cd8769be7511deb57fbb1e79e1f1e18911c75543f42f8c6214264d403f7f8322f20c6dc719c1ac72304b
   languageName: node
   linkType: hard
 
-"@yarnpkg/plugin-typescript@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@yarnpkg/plugin-typescript@npm:4.0.0"
+"@yarnpkg/plugin-typescript@npm:^4.1.2":
+  version: 4.1.2
+  resolution: "@yarnpkg/plugin-typescript@npm:4.1.2"
   dependencies:
-    "@yarnpkg/fslib": "npm:^3.0.0"
-    "@yarnpkg/plugin-pack": "npm:^4.0.0"
+    "@yarnpkg/fslib": "npm:^3.1.2"
+    "@yarnpkg/plugin-pack": "npm:^4.0.1"
     algoliasearch: "npm:^4.2.0"
     semver: "npm:^7.1.2"
     tslib: "npm:^2.4.0"
   peerDependencies:
-    "@yarnpkg/cli": ^4.0.0
-    "@yarnpkg/core": ^4.0.0
-    "@yarnpkg/plugin-essentials": ^4.0.0
-  checksum: 10/1fabc077e517119161fb61ee20327fef5cd0745f5cf1d9b94dc335fc76a45b7ee2ca5fe93dd0b8365a2b240b28ce91921bc357df3a9f06ff769e2b6d5b930d54
+    "@yarnpkg/cli": ^4.7.0
+    "@yarnpkg/core": ^4.2.1
+    "@yarnpkg/plugin-essentials": ^4.3.1
+  checksum: 10/99be57dd03683aa2c1e0e990e458e9a56a050fc37bc5faa87bf5206d6fde2feeb53f7cedacda62d38b9e1347bd8f53424b7932b4f72dc121cb13ea33e5cfb47e
   languageName: node
   linkType: hard
 
-"@yarnpkg/plugin-version@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "@yarnpkg/plugin-version@npm:4.0.1"
+"@yarnpkg/plugin-version@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@yarnpkg/plugin-version@npm:4.1.0"
   dependencies:
-    "@yarnpkg/fslib": "npm:^3.0.2"
-    "@yarnpkg/libui": "npm:^3.0.0"
-    "@yarnpkg/parsers": "npm:^3.0.0"
+    "@yarnpkg/fslib": "npm:^3.1.2"
+    "@yarnpkg/libui": "npm:^3.0.2"
+    "@yarnpkg/parsers": "npm:^3.0.3"
     clipanion: "npm:^4.0.0-rc.2"
-    ink: "npm:^3.0.8"
+    ink: "npm:^3.2.0"
     lodash: "npm:^4.17.15"
-    react: "npm:^16.13.1"
+    react: "npm:^17.0.2"
     semver: "npm:^7.1.2"
     tslib: "npm:^2.4.0"
   peerDependencies:
-    "@yarnpkg/cli": ^4.1.0
-    "@yarnpkg/core": ^4.0.3
-    "@yarnpkg/plugin-git": ^3.0.0
-  checksum: 10/f85fe4ed1cda8e61563de87fb9f6c7b8ec89569398a21defea28f8d477be61fb05e58ad7e783c3ebf0e2653ee776643b71bed3e268859a541e762bd3e501c475
+    "@yarnpkg/cli": ^4.8.0
+    "@yarnpkg/core": ^4.3.0
+    "@yarnpkg/plugin-git": ^3.1.1
+  checksum: 10/20e0c6de5363e43095b348e5c0ee84c4e99f167bc74c0138a5dbda06a06376bfc493b4b3eea27e4efee5fefde07c428d4c585232cedc8210d1a0938bfccd4452
   languageName: node
   linkType: hard
 
-"@yarnpkg/plugin-workspace-tools@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "@yarnpkg/plugin-workspace-tools@npm:4.1.0"
+"@yarnpkg/plugin-workspace-tools@npm:^4.1.4":
+  version: 4.1.4
+  resolution: "@yarnpkg/plugin-workspace-tools@npm:4.1.4"
   dependencies:
-    "@yarnpkg/fslib": "npm:^3.0.2"
+    "@yarnpkg/fslib": "npm:^3.1.2"
     clipanion: "npm:^4.0.0-rc.2"
     micromatch: "npm:^4.0.2"
     p-limit: "npm:^2.2.0"
     tslib: "npm:^2.4.0"
     typanion: "npm:^3.14.0"
   peerDependencies:
-    "@yarnpkg/cli": ^4.1.0
-    "@yarnpkg/core": ^4.0.3
-    "@yarnpkg/plugin-git": ^3.0.0
-  checksum: 10/d52a27dc3a916eb11fb05fe0fa109a4301571ab19dc16537a1a335bb078d7a22ec0b6872aab0b68b79c8c70de65c4a3777164344f2df40987efc379062f92efc
+    "@yarnpkg/cli": ^4.8.0
+    "@yarnpkg/core": ^4.3.0
+    "@yarnpkg/plugin-git": ^3.1.1
+  checksum: 10/529129c5c63e4ad098acda6de9175f8476f92c0d3529e476faf0bd0eea6e9f9c929cad4e951d6e83bbac7ad82f2d8f77ae1034af69b9eb61577b3ec4b73fd564
   languageName: node
   linkType: hard
 
@@ -22513,13 +22620,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@yarnpkg/pnp@npm:^4.0.1, @yarnpkg/pnp@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "@yarnpkg/pnp@npm:4.0.2"
+"@yarnpkg/pnp@npm:^4.0.9, @yarnpkg/pnp@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@yarnpkg/pnp@npm:4.1.0"
   dependencies:
     "@types/node": "npm:^18.17.15"
-    "@yarnpkg/fslib": "npm:^3.0.2"
-  checksum: 10/7671b5226065d6ee2b010a2f935c579ad1b60400a8d704558ec1c70ec4e6fe4adb6eb67cf3baeeccf27c489fc55a494d4e781ddd2937724e0987efd673d6f3cb
+    "@yarnpkg/fslib": "npm:^3.1.2"
+  checksum: 10/9f16befa7bba8691a17ecb34b2caaa8cb1e1f91d43b13174d968af9b02ae69a39924fcd472411609d4bece2f6527fe02493019f553452561295216215599da18
   languageName: node
   linkType: hard
 
@@ -22541,21 +22648,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@yarnpkg/shell@npm:^4.0.0, @yarnpkg/shell@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "@yarnpkg/shell@npm:4.1.0"
+"@yarnpkg/shell@npm:^4.1.2":
+  version: 4.1.2
+  resolution: "@yarnpkg/shell@npm:4.1.2"
   dependencies:
-    "@yarnpkg/fslib": "npm:^3.1.0"
-    "@yarnpkg/parsers": "npm:^3.0.2"
+    "@yarnpkg/fslib": "npm:^3.1.2"
+    "@yarnpkg/parsers": "npm:^3.0.3"
     chalk: "npm:^3.0.0"
     clipanion: "npm:^4.0.0-rc.2"
-    cross-spawn: "npm:7.0.3"
+    cross-spawn: "npm:^7.0.3"
     fast-glob: "npm:^3.2.2"
     micromatch: "npm:^4.0.2"
     tslib: "npm:^2.4.0"
   bin:
     shell: ./lib/cli.js
-  checksum: 10/f817fae3eba4fc76dbbfdbe8a25d4238259f79799485c4b1882d6c33fa96a2818cda87bf796d3ab0590c870a650cc4f088b7c0a22d76b6ff0f6e220273e3eeec
+  checksum: 10/66e32a6748821816ca5416030d8000e4f75fdef359df5546f85ead2d5bb9abce08c8d534750d2b8c9bbfe6845192e5667eb16e13d2967d05c668912e90f1d294
   languageName: node
   linkType: hard
 
@@ -28434,12 +28541,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:esbuild-wasm@^0.15.15":
-  version: 0.15.18
-  resolution: "esbuild-wasm@npm:0.15.18"
+"esbuild@npm:esbuild-wasm@^0.23.0":
+  version: 0.23.1
+  resolution: "esbuild-wasm@npm:0.23.1"
   bin:
     esbuild: bin/esbuild
-  checksum: 10/54107e58e8ab6bb6910912c7f96e373e187ef63cd744ad44039daecf1cb56a93bef10366c1b9f38e044f19a0f773ee224ceb39e626bcad3c60712f1c5d6c8be0
+  checksum: 10/30677e4ea96211d15f7b3780d70ecee564267767bc4465ba6539f57b565f2505ab930ca409d7b85695b5931fc37afb508f62c694c2e2092dd519efdecf62959b
   languageName: node
   linkType: hard
 
@@ -29719,13 +29826,6 @@ __metadata:
   version: 4.2.0
   resolution: "fecha@npm:4.2.0"
   checksum: 10/ab89ab86b75689afdd1baeaa7c840f4d7eff6d69567d6d79972d71474927a216a5a81c7eeb40ece66ae0a8ee7de064c593afd7dfcdf23123126f40ca9a629129
-  languageName: node
-  linkType: hard
-
-"figgy-pudding@npm:^3.5.1":
-  version: 3.5.2
-  resolution: "figgy-pudding@npm:3.5.2"
-  checksum: 10/1d15176fc49ce407edbecc8df286b19cf8a918900eda924609181aecec5337645e3532a01ce4154412e028ddc43f6fa558cf3916b5c9d322b6521f128da40382
   languageName: node
   linkType: hard
 
@@ -32209,7 +32309,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ink-text-input@npm:^4.0.1":
+"ink-text-input@npm:^4.0.3":
   version: 4.0.3
   resolution: "ink-text-input@npm:4.0.3"
   dependencies:
@@ -32222,7 +32322,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ink@npm:^3.0.8":
+"ink@npm:^3.2.0":
   version: 3.2.0
   resolution: "ink@npm:3.2.0"
   dependencies:
@@ -36046,7 +36146,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"make-fetch-happen@npm:^14.0.3":
+"make-fetch-happen@npm:^14.0.1, make-fetch-happen@npm:^14.0.2, make-fetch-happen@npm:^14.0.3":
   version: 14.0.3
   resolution: "make-fetch-happen@npm:14.0.3"
   dependencies:
@@ -42109,21 +42209,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:^16.13.1":
-  version: 16.14.0
-  resolution: "react@npm:16.14.0"
-  dependencies:
-    loose-envify: "npm:^1.1.0"
-    object-assign: "npm:^4.1.1"
-    prop-types: "npm:^15.6.2"
-  checksum: 10/ee04c82f5ecb70fe15a48d8cfc3fb20ce2f7e65277d4adcb56a0ac2b82c54550d4c65eabce0d5dc0cc90d053831b9586d72ee515b11cdf0c5436c7f95aafdcda
-  languageName: node
-  linkType: hard
-
 "react@npm:^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0":
   version: 19.0.0
   resolution: "react@npm:19.0.0"
   checksum: 10/2490969c503f644703c88990d20e4011fa6119ddeca451e9de48f6d7ab058d670d2852a5fcd3aa3cd90a923ab2815d532637bd4a814add402ae5c0d4f129ee71
+  languageName: node
+  linkType: hard
+
+"react@npm:^17.0.2":
+  version: 17.0.2
+  resolution: "react@npm:17.0.2"
+  dependencies:
+    loose-envify: "npm:^1.1.0"
+    object-assign: "npm:^4.1.1"
+  checksum: 10/ece60c31c1d266d132783aaaffa185d2e4c9b4db144f853933ec690cee1e0600c8929a1dd0a9e79323eea8e2df636c9a06d40f6cfdc9f797f65225433e67f707
   languageName: node
   linkType: hard
 
@@ -43934,6 +44033,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sigstore@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "sigstore@npm:3.1.0"
+  dependencies:
+    "@sigstore/bundle": "npm:^3.1.0"
+    "@sigstore/core": "npm:^2.0.0"
+    "@sigstore/protobuf-specs": "npm:^0.4.0"
+    "@sigstore/sign": "npm:^3.1.0"
+    "@sigstore/tuf": "npm:^3.1.0"
+    "@sigstore/verify": "npm:^2.1.0"
+  checksum: 10/fc2a38d11bd0e02b5dc8271e906ba7ea1aaa3dc19010dc6d29602b900532fa16b132cd6c80ec1c294f201f81f1277fb351020d0c65b6a62968f229db0b6c5a4f
+  languageName: node
+  linkType: hard
+
 "simple-concat@npm:^1.0.0":
   version: 1.0.1
   resolution: "simple-concat@npm:1.0.1"
@@ -44474,15 +44587,6 @@ __metadata:
   dependencies:
     minipass: "npm:^7.0.3"
   checksum: 10/7024c1a6e39b3f18aa8f1c8290e884fe91b0f9ca5a6c6d410544daad54de0ba664db879afe16412e187c6c292fd60b937f047ee44292e5c2af2dcc6d8e1a9b48
-  languageName: node
-  linkType: hard
-
-"ssri@npm:^6.0.1":
-  version: 6.0.2
-  resolution: "ssri@npm:6.0.2"
-  dependencies:
-    figgy-pudding: "npm:^3.5.1"
-  checksum: 10/7f8062604b50bd647ee11c6e03bc0d8f39d9dfe3bd871f711676c1ab862435feb1dae40b20ca44fa27ef1485b814bb769d4557ff6af7e5c28bb18db3aba64510
   languageName: node
   linkType: hard
 
@@ -46281,6 +46385,17 @@ __metadata:
   version: 0.0.1
   resolution: "tty-browserify@npm:0.0.1"
   checksum: 10/93b745d43fa5a7d2b948fa23be8d313576d1d884b48acd957c07710bac1c0d8ac34c0556ad4c57c73d36e11741763ef66b3fb4fb97b06b7e4d525315a3cd45f5
+  languageName: node
+  linkType: hard
+
+"tuf-js@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "tuf-js@npm:3.0.1"
+  dependencies:
+    "@tufjs/models": "npm:3.0.1"
+    debug: "npm:^4.3.6"
+    make-fetch-happen: "npm:^14.0.1"
+  checksum: 10/880219a55e9575fcbf2c15129284a13d093fb2a053874151df59b11511d1ba097df359deae7b4e731b16fc3abd8fceda5125a167ec0d16eb926a32b8f778faa8
   languageName: node
   linkType: hard
 
@@ -48445,11 +48560,11 @@ __metadata:
     "@backstage/cli": "workspace:^"
     "@backstage/cli-common": "workspace:^"
     "@backstage/release-manifests": "workspace:^"
-    "@yarnpkg/builder": "npm:^4.0.0"
-    "@yarnpkg/core": "npm:^4.0.3"
-    "@yarnpkg/fslib": "npm:^3.0.2"
-    "@yarnpkg/plugin-npm": "npm:^3.0.1"
-    "@yarnpkg/plugin-pack": "npm:^4.0.0"
+    "@yarnpkg/builder": "npm:^4.2.1"
+    "@yarnpkg/core": "npm:^4.4.0"
+    "@yarnpkg/fslib": "npm:^3.1.2"
+    "@yarnpkg/plugin-npm": "patch:@yarnpkg/plugin-npm@npm%3A3.1.0#~/.yarn/patches/@yarnpkg-plugin-npm-npm-3.1.0-6533d0f5a1.patch"
+    "@yarnpkg/plugin-pack": "npm:^4.0.1"
     fs-extra: "npm:^11.2.0"
     nodemon: "npm:^3.0.1"
     semver: "npm:^7.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -48448,6 +48448,7 @@ __metadata:
     "@yarnpkg/builder": "npm:^4.0.0"
     "@yarnpkg/core": "npm:^4.0.3"
     "@yarnpkg/fslib": "npm:^3.0.2"
+    "@yarnpkg/plugin-npm": "npm:^3.0.1"
     "@yarnpkg/plugin-pack": "npm:^4.0.0"
     fs-extra: "npm:^11.2.0"
     nodemon: "npm:^3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -22065,14 +22065,14 @@ __metadata:
   linkType: hard
 
 "@yarnpkg/core@npm:^4.2.1, @yarnpkg/core@npm:^4.4.0":
-  version: 4.4.0
-  resolution: "@yarnpkg/core@npm:4.4.0"
+  version: 4.4.1
+  resolution: "@yarnpkg/core@npm:4.4.1"
   dependencies:
     "@arcanis/slice-ansi": "npm:^1.1.1"
     "@types/semver": "npm:^7.1.0"
     "@types/treeify": "npm:^1.0.0"
     "@yarnpkg/fslib": "npm:^3.1.2"
-    "@yarnpkg/libzip": "npm:^3.2.0"
+    "@yarnpkg/libzip": "npm:^3.2.1"
     "@yarnpkg/parsers": "npm:^3.0.3"
     "@yarnpkg/shell": "npm:^4.1.2"
     camelcase: "npm:^5.3.1"
@@ -22094,7 +22094,7 @@ __metadata:
     treeify: "npm:^1.1.0"
     tslib: "npm:^2.4.0"
     tunnel: "npm:^0.0.6"
-  checksum: 10/59c3757ebda89b506d0bbb22baf20983f467c038917f5730da6bd76a0e91b2f244ea9cbd079281a00f949a0ad3abc09129e62e89dd1b9460a6318e98796f3e08
+  checksum: 10/05be6d775778dfbf005d6c74dad28beb33f57153af4628cef9f4752441f25942c8f97728008d9db0c8d5bbe6fa5a91463e8164b743f2d4cf3592577f04244f2f
   languageName: node
   linkType: hard
 
@@ -22158,16 +22158,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@yarnpkg/libzip@npm:^3.1.1, @yarnpkg/libzip@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "@yarnpkg/libzip@npm:3.2.0"
+"@yarnpkg/libzip@npm:^3.1.1, @yarnpkg/libzip@npm:^3.2.0, @yarnpkg/libzip@npm:^3.2.1":
+  version: 3.2.1
+  resolution: "@yarnpkg/libzip@npm:3.2.1"
   dependencies:
     "@types/emscripten": "npm:^1.39.6"
     "@yarnpkg/fslib": "npm:^3.1.2"
     tslib: "npm:^2.4.0"
   peerDependencies:
     "@yarnpkg/fslib": ^3.1.2
-  checksum: 10/158f80177dfc51d0efefaa7dcc3a725a0cc07114538774799b64d1ed50951e08511fe154db22b4a6eb4c639773fe9b5835005c14b9bb87df443c885c25c58115
+  checksum: 10/c8c3bc43777e2ef3c812c991266b9bbccef4d01cea5de44a6b8c359c953dab5325e26fda5640ff611567b61f9dd62ac3a0c3ba79343eb53224d733915a7eb664
   languageName: node
   linkType: hard
 
@@ -47427,11 +47427,11 @@ __metadata:
   linkType: hard
 
 "uuid@npm:^11.0.0, uuid@npm:^11.0.2, uuid@npm:^11.0.3":
-  version: 11.0.5
-  resolution: "uuid@npm:11.0.5"
+  version: 11.1.0
+  resolution: "uuid@npm:11.1.0"
   bin:
     uuid: dist/esm/bin/uuid
-  checksum: 10/0594ecdff3051e15d4a2c614b4c72e73af373bde0a5d156512353c01156975295d024ae8d7151846d7bd4d22ccd251b16ed51b4318fa71505fb20ad984102dc1
+  checksum: 10/d2da43b49b154d154574891ced66d0c83fc70caaad87e043400cf644423b067542d6f3eb641b7c819224a7cd3b4c2f21906acbedd6ec9c6a05887aa9115a9cf5
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -255,7 +255,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@arcanis/slice-ansi@npm:^1.1.1":
+"@arcanis/slice-ansi@npm:^1.0.2, @arcanis/slice-ansi@npm:^1.1.1":
   version: 1.1.1
   resolution: "@arcanis/slice-ansi@npm:1.1.1"
   dependencies:
@@ -14722,6 +14722,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@pnpm/crypto.base32-hash@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@pnpm/crypto.base32-hash@npm:1.0.1"
+  dependencies:
+    rfc4648: "npm:^1.5.1"
+  checksum: 10/4c5d3a6399e307e830f9adebc2644520cb7e0cb2a807e1b09513164f1b1930f2375cba3c1e4cbd7914f27eaf916ebbb61e83d370c4fac33594051a3c8ba8eb7b
+  languageName: node
+  linkType: hard
+
+"@pnpm/types@npm:8.9.0":
+  version: 8.9.0
+  resolution: "@pnpm/types@npm:8.9.0"
+  checksum: 10/b5a9332720122a168664a9b4e23155bccef76f3cb93615b61a98d6d05618a1e0c1cbebd40cfe064d9fa728269de19dda7ae37ecbafaf56a2fccea9657dd727a7
+  languageName: node
+  linkType: hard
+
 "@popperjs/core@npm:^2.11.8":
   version: 2.11.8
   resolution: "@popperjs/core@npm:2.11.8"
@@ -17150,6 +17166,43 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@snyk/dep-graph@npm:^2.3.0":
+  version: 2.9.0
+  resolution: "@snyk/dep-graph@npm:2.9.0"
+  dependencies:
+    event-loop-spinner: "npm:^2.1.0"
+    lodash.clone: "npm:^4.5.0"
+    lodash.constant: "npm:^3.0.0"
+    lodash.filter: "npm:^4.6.0"
+    lodash.foreach: "npm:^4.5.0"
+    lodash.isempty: "npm:^4.4.0"
+    lodash.isequal: "npm:^4.5.0"
+    lodash.isfunction: "npm:^3.0.9"
+    lodash.isundefined: "npm:^3.0.1"
+    lodash.map: "npm:^4.6.0"
+    lodash.reduce: "npm:^4.6.0"
+    lodash.size: "npm:^4.2.0"
+    lodash.transform: "npm:^4.6.0"
+    lodash.union: "npm:^4.6.0"
+    lodash.values: "npm:^4.3.0"
+    object-hash: "npm:^3.0.0"
+    packageurl-js: "npm:1.2.0"
+    semver: "npm:^7.0.0"
+    tslib: "npm:^2"
+  checksum: 10/60228f3b0999b42139907f7be67aa6769a4885ca6a291ebaa4d4f296e653f60e0e291f7dc2696c658fea76f086583cc61d67f34fc1d1e5dacf00f6ca46362d21
+  languageName: node
+  linkType: hard
+
+"@snyk/error-catalog-nodejs-public@npm:^5.16.0":
+  version: 5.35.0
+  resolution: "@snyk/error-catalog-nodejs-public@npm:5.35.0"
+  dependencies:
+    tslib: "npm:^2.8.1"
+    uuid: "npm:^11.0.3"
+  checksum: 10/af0185b6ad433138114e902a4940808b4ef18aded14d1274c49f06ce1afd8488b7dd377b953ce4df8a24e390019f057c1c3deedef60e6c4438875ce9cd3fcd99
+  languageName: node
+  linkType: hard
+
 "@snyk/github-codeowners@npm:1.1.0":
   version: 1.1.0
   resolution: "@snyk/github-codeowners@npm:1.1.0"
@@ -17160,6 +17213,29 @@ __metadata:
   bin:
     github-codeowners: dist/cli.js
   checksum: 10/34120ef622616fef1ed8af12869d8c1803842aafa3fbacca263805ee7c85f58d11bdc301ef698c9b41268b275b9fd090f5d9f6d89c556abe9d52196e72d1c510
+  languageName: node
+  linkType: hard
+
+"@snyk/graphlib@npm:2.1.9-patch.3":
+  version: 2.1.9-patch.3
+  resolution: "@snyk/graphlib@npm:2.1.9-patch.3"
+  dependencies:
+    lodash.clone: "npm:^4.5.0"
+    lodash.constant: "npm:^3.0.0"
+    lodash.filter: "npm:^4.6.0"
+    lodash.foreach: "npm:^4.5.0"
+    lodash.has: "npm:^4.5.2"
+    lodash.isempty: "npm:^4.4.0"
+    lodash.isfunction: "npm:^3.0.9"
+    lodash.isundefined: "npm:^3.0.1"
+    lodash.keys: "npm:^4.2.0"
+    lodash.map: "npm:^4.6.0"
+    lodash.reduce: "npm:^4.6.0"
+    lodash.size: "npm:^4.2.0"
+    lodash.transform: "npm:^4.6.0"
+    lodash.union: "npm:^4.6.0"
+    lodash.values: "npm:^4.3.0"
+  checksum: 10/f522b175fcdfa24630648fde9557380da29fc811277badbe24cbdfdf561fcc4011ec95083beaed1d80e8cb93041b16c44345c1641ce1015bd7722b1426ff9ea6
   languageName: node
   linkType: hard
 
@@ -20120,11 +20196,11 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:*, @types/node@npm:>=12, @types/node@npm:>=12.0.0, @types/node@npm:>=13.7.0, @types/node@npm:>=18.0.0, @types/node@npm:^22.0.0":
-  version: 22.14.0
-  resolution: "@types/node@npm:22.14.0"
+  version: 22.13.10
+  resolution: "@types/node@npm:22.13.10"
   dependencies:
-    undici-types: "npm:~6.21.0"
-  checksum: 10/d0669a8a37a18532c886ccfa51eb3fe1e46088deb4d3d27ebcd5d7d68bd6343ad1c7a3fcb85164780a57629359c33a6c917ecff748ea232bceac7692acc96537
+    undici-types: "npm:~6.20.0"
+  checksum: 10/57dc6a5e0110ca9edea8d7047082e649fa7fa813f79e4a901653b9174141c622f4336435648baced5b38d9f39843f404fa2d8d7a10981610da26066bc8caab48
   languageName: node
   linkType: hard
 
@@ -20132,6 +20208,13 @@ __metadata:
   version: 12.20.55
   resolution: "@types/node@npm:12.20.55"
   checksum: 10/1f916a06fff02faadb09a16ed6e31820ce170798b202ef0b14fc244bfbd721938c54a3a99836e185e4414ca461fe96c5bb5c67c3d248f153555b7e6347f061dd
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^13.7.0":
+  version: 13.13.52
+  resolution: "@types/node@npm:13.13.52"
+  checksum: 10/a1fbd080dd2462f6f0d0c10cb8328ee6b22e59941fb6beb8bca907f96e00798ce85e94320ccab3bf04f87d6c5443535a62e6896ac59c34c79a286821223e56cd
   languageName: node
   linkType: hard
 
@@ -21866,6 +21949,45 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@yarnpkg/core@npm:^2.4.0":
+  version: 2.4.0
+  resolution: "@yarnpkg/core@npm:2.4.0"
+  dependencies:
+    "@arcanis/slice-ansi": "npm:^1.0.2"
+    "@types/semver": "npm:^7.1.0"
+    "@types/treeify": "npm:^1.0.0"
+    "@yarnpkg/fslib": "npm:^2.4.0"
+    "@yarnpkg/json-proxy": "npm:^2.1.0"
+    "@yarnpkg/libzip": "npm:^2.2.1"
+    "@yarnpkg/parsers": "npm:^2.3.0"
+    "@yarnpkg/pnp": "npm:^2.3.2"
+    "@yarnpkg/shell": "npm:^2.4.1"
+    binjumper: "npm:^0.1.4"
+    camelcase: "npm:^5.3.1"
+    chalk: "npm:^3.0.0"
+    ci-info: "npm:^2.0.0"
+    clipanion: "npm:^2.6.2"
+    cross-spawn: "npm:7.0.3"
+    diff: "npm:^4.0.1"
+    globby: "npm:^11.0.1"
+    got: "npm:^11.7.0"
+    json-file-plus: "npm:^3.3.1"
+    lodash: "npm:^4.17.15"
+    micromatch: "npm:^4.0.2"
+    mkdirp: "npm:^0.5.1"
+    p-limit: "npm:^2.2.0"
+    pluralize: "npm:^7.0.0"
+    pretty-bytes: "npm:^5.1.0"
+    semver: "npm:^7.1.2"
+    stream-to-promise: "npm:^2.2.0"
+    tar-stream: "npm:^2.0.1"
+    treeify: "npm:^1.1.0"
+    tslib: "npm:^1.13.0"
+    tunnel: "npm:^0.0.6"
+  checksum: 10/a963ddc09afdfd7dd40acf89bdffb0f6d134240fa2e9bd46dc1bcbe5501b96b7d65b6f30f36354386de097e0a43ea54f4dc4317ce75e2d5b3d6329e4ab0def67
+  languageName: node
+  linkType: hard
+
 "@yarnpkg/core@npm:^4.0.0, @yarnpkg/core@npm:^4.0.3":
   version: 4.1.3
   resolution: "@yarnpkg/core@npm:4.1.3"
@@ -21909,12 +22031,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@yarnpkg/fslib@npm:^2.4.0, @yarnpkg/fslib@npm:^2.5.0":
+  version: 2.10.4
+  resolution: "@yarnpkg/fslib@npm:2.10.4"
+  dependencies:
+    "@yarnpkg/libzip": "npm:^2.3.0"
+    tslib: "npm:^1.13.0"
+  checksum: 10/c683b91a17138806f11db83af6e6aefd71f485570008effcd68cc39bf84e4243c0072c2a11d613c8289926bcd460e012b9476dd89e61018e21103bc3f42917ca
+  languageName: node
+  linkType: hard
+
 "@yarnpkg/fslib@npm:^3.0.0, @yarnpkg/fslib@npm:^3.0.1, @yarnpkg/fslib@npm:^3.0.2, @yarnpkg/fslib@npm:^3.1.0":
   version: 3.1.0
   resolution: "@yarnpkg/fslib@npm:3.1.0"
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10/99537cff3269f0728b440bc801872346f8f698ada479b00df82967c0fea1fc61588e69f669174fdf8274107a1b34dfb656513db8789db12afd7e6778bd2b4e86
+  languageName: node
+  linkType: hard
+
+"@yarnpkg/json-proxy@npm:^2.1.0":
+  version: 2.1.1
+  resolution: "@yarnpkg/json-proxy@npm:2.1.1"
+  dependencies:
+    "@yarnpkg/fslib": "npm:^2.5.0"
+    tslib: "npm:^1.13.0"
+  checksum: 10/22f41ac5c3ee201132c6519da88252d5eea7eda96f554cabb1cdc4b7ff951f3b30f727b8abf457a91b2c8a4d2e7679101347e0beb606350cb4d524fea1159e60
   languageName: node
   linkType: hard
 
@@ -21927,6 +22069,16 @@ __metadata:
     ink: ^3.0.8
     react: ^16.8.4
   checksum: 10/80757636151368e538d46245352b82d47366438755c6660328c944e1727a15bd7559def013297a85d4380f43384d58dffbb4b54707878fa9609c963a4cc0fbf4
+  languageName: node
+  linkType: hard
+
+"@yarnpkg/libzip@npm:^2.2.1, @yarnpkg/libzip@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "@yarnpkg/libzip@npm:2.3.0"
+  dependencies:
+    "@types/emscripten": "npm:^1.39.6"
+    tslib: "npm:^1.13.0"
+  checksum: 10/0eb147f39eab2830c29120d17e8bfba5aa15dedb940a7378070c67d4de08e9ba8d34068522e15e6b4db94ecaed4ad520e1e517588a36a348d1aa160bc36156ea
   languageName: node
   linkType: hard
 
@@ -21958,6 +22110,16 @@ __metadata:
     "@yarnpkg/fslib": "npm:^3.0.2"
     "@yarnpkg/pnp": "npm:^4.0.2"
   checksum: 10/f5b1fc596bab690b45d7c6ea5479c76462736bf840bbee263e147643384876836d09b311c195366d628780de613ec5353a05226272076f3940eb3d5f23329da6
+  languageName: node
+  linkType: hard
+
+"@yarnpkg/parsers@npm:^2.3.0":
+  version: 2.6.0
+  resolution: "@yarnpkg/parsers@npm:2.6.0"
+  dependencies:
+    js-yaml: "npm:^3.10.0"
+    tslib: "npm:^1.13.0"
+  checksum: 10/da2c22ce1271383af817b91286fd7532ca8d597a405005e777cb53e702bb7cf688b0b4637c3161351e4e76be43dba0694873cc7845cb9494b9060ddafc5bac3c
   languageName: node
   linkType: hard
 
@@ -22340,6 +22502,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@yarnpkg/pnp@npm:^2.3.2":
+  version: 2.3.2
+  resolution: "@yarnpkg/pnp@npm:2.3.2"
+  dependencies:
+    "@types/node": "npm:^13.7.0"
+    "@yarnpkg/fslib": "npm:^2.4.0"
+    tslib: "npm:^1.13.0"
+  checksum: 10/be736c950e888e115a50043e684326fb965ce3ba946dada4a7657faf7a2858afef6b5166a366f095b9498ced114325ae3e0341d9cea83a575938e8a8859e74ef
+  languageName: node
+  linkType: hard
+
 "@yarnpkg/pnp@npm:^4.0.1, @yarnpkg/pnp@npm:^4.0.2":
   version: 4.0.2
   resolution: "@yarnpkg/pnp@npm:4.0.2"
@@ -22347,6 +22520,24 @@ __metadata:
     "@types/node": "npm:^18.17.15"
     "@yarnpkg/fslib": "npm:^3.0.2"
   checksum: 10/7671b5226065d6ee2b010a2f935c579ad1b60400a8d704558ec1c70ec4e6fe4adb6eb67cf3baeeccf27c489fc55a494d4e781ddd2937724e0987efd673d6f3cb
+  languageName: node
+  linkType: hard
+
+"@yarnpkg/shell@npm:^2.4.1":
+  version: 2.4.1
+  resolution: "@yarnpkg/shell@npm:2.4.1"
+  dependencies:
+    "@yarnpkg/fslib": "npm:^2.4.0"
+    "@yarnpkg/parsers": "npm:^2.3.0"
+    clipanion: "npm:^2.6.2"
+    cross-spawn: "npm:7.0.3"
+    fast-glob: "npm:^3.2.2"
+    micromatch: "npm:^4.0.2"
+    stream-buffers: "npm:^3.0.2"
+    tslib: "npm:^1.13.0"
+  bin:
+    shell: ./lib/cli.js
+  checksum: 10/ae7c07561ba4ec968b73385bbd4a9ed01a4f30b52f4fc1b46725dcbca29447e221e1c81ed1f94a6e1527397705e95f51489d3696be45a208a88c00d4c33b1da0
   languageName: node
   linkType: hard
 
@@ -22836,7 +23027,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"any-promise@npm:^1.0.0":
+"any-promise@npm:^1.0.0, any-promise@npm:^1.1.0, any-promise@npm:~1.3.0":
   version: 1.3.0
   resolution: "any-promise@npm:1.3.0"
   checksum: 10/6737469ba353b5becf29e4dc3680736b9caa06d300bda6548812a8fee63ae7d336d756f88572fa6b5219aed36698d808fa55f62af3e7e6845c7a1dc77d240edb
@@ -23170,7 +23361,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"asap@npm:^2.0.0, asap@npm:^2.0.3, asap@npm:~2.0.3":
+"asap@npm:^2.0.0, asap@npm:^2.0.3, asap@npm:~2.0.3, asap@npm:~2.0.6":
   version: 2.0.6
   resolution: "asap@npm:2.0.6"
   checksum: 10/b244c0458c571945e4b3be0b14eb001bea5596f9868cc50cc711dc03d58a7e953517d3f0dad81ccde3ff37d1f074701fa76a6f07d41aaa992d7204a37b915dda
@@ -23324,7 +23515,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"async@npm:^3.2.3, async@npm:^3.2.4, async@npm:^3.2.6":
+"async@npm:^3.2.2, async@npm:^3.2.3, async@npm:^3.2.4, async@npm:^3.2.6":
   version: 3.2.6
   resolution: "async@npm:3.2.6"
   checksum: 10/cb6e0561a3c01c4b56a799cc8bab6ea5fef45f069ab32500b6e19508db270ef2dffa55e5aed5865c5526e9907b1f8be61b27530823b411ffafb5e1538c86c368
@@ -23926,6 +24117,13 @@ __metadata:
   dependencies:
     file-uri-to-path: "npm:1.0.0"
   checksum: 10/593d5ae975ffba15fbbb4788fe5abd1e125afbab849ab967ab43691d27d6483751805d98cb92f7ac24a2439a8a8678cd0131c535d5d63de84e383b0ce2786133
+  languageName: node
+  linkType: hard
+
+"binjumper@npm:^0.1.4":
+  version: 0.1.4
+  resolution: "binjumper@npm:0.1.4"
+  checksum: 10/9ae6de33ca27b9cc40425227d3d6560ce63f8977855fed70788dc0492f9a048895d79617d8d8152b7b8f66f93d935f25a4bca94cc74d477c3c7cba2c15662dea
   languageName: node
   linkType: hard
 
@@ -25015,6 +25213,13 @@ __metadata:
   version: 0.0.1
   resolution: "client-only@npm:0.0.1"
   checksum: 10/0c16bf660dadb90610553c1d8946a7fdfb81d624adea073b8440b7d795d5b5b08beb3c950c6a2cf16279365a3265158a236876d92bce16423c485c322d7dfaf8
+  languageName: node
+  linkType: hard
+
+"clipanion@npm:^2.6.2":
+  version: 2.6.2
+  resolution: "clipanion@npm:2.6.2"
+  checksum: 10/f87ca32dd41a7e7898e72f425590c267818c81717c33ea52270354a3f9232a4c4d4f38a5acc0c4b52cb9f9b67962dcf3d326cd57ec2cc3d4345292f0b84e025b
   languageName: node
   linkType: hard
 
@@ -26972,6 +27177,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dependency-path@npm:^9.2.8":
+  version: 9.2.8
+  resolution: "dependency-path@npm:9.2.8"
+  dependencies:
+    "@pnpm/crypto.base32-hash": "npm:1.0.1"
+    "@pnpm/types": "npm:8.9.0"
+    encode-registry: "npm:^3.0.0"
+    semver: "npm:^7.3.8"
+  checksum: 10/f63cce9e7b4006216ef711fdaf898f621f343a28be93b3c23787c7da142c8c2ae3058f8317f56635721d89f0c9a2f013bf90150fada944e6e058034266add709
+  languageName: node
+  linkType: hard
+
 "deprecation@npm:^2.0.0, deprecation@npm:^2.3.1":
   version: 2.3.1
   resolution: "deprecation@npm:2.3.1"
@@ -27647,6 +27864,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"encode-registry@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "encode-registry@npm:3.0.1"
+  dependencies:
+    mem: "npm:^8.0.0"
+  checksum: 10/6fef2ed0cd00ce1cbcbb6a4ef21b92f2613c063424302032463532be4513227614a889e6c888680adbe9a29ff9b6d18ddc0e0a467e38e6ee76527bdfd5ff56d4
+  languageName: node
+  linkType: hard
+
 "encodeurl@npm:^1.0.2, encodeurl@npm:~1.0.2":
   version: 1.0.2
   resolution: "encodeurl@npm:1.0.2"
@@ -27676,6 +27902,15 @@ __metadata:
   dependencies:
     once: "npm:^1.4.0"
   checksum: 10/530a5a5a1e517e962854a31693dbb5c0b2fc40b46dad2a56a2deec656ca040631124f4795823acc68238147805f8b021abbe221f4afed5ef3c8e8efc2024908b
+  languageName: node
+  linkType: hard
+
+"end-of-stream@npm:~1.1.0":
+  version: 1.1.0
+  resolution: "end-of-stream@npm:1.1.0"
+  dependencies:
+    once: "npm:~1.3.0"
+  checksum: 10/9fa637e259e50e5e3634e8e14064a183bd0d407733594631362f9df596409739bef5f7064840e6725212a9edc8b4a70a5a3088ac423e8564f9dc183dd098c719
   languageName: node
   linkType: hard
 
@@ -28738,6 +28973,15 @@ __metadata:
     d: "npm:1"
     es5-ext: "npm:~0.10.14"
   checksum: 10/a7f5ea80029193f4869782d34ef7eb43baa49cd397013add1953491b24588468efbe7e3cc9eb87d53f33397e7aab690fd74c079ec440bf8b12856f6bdb6e9396
+  languageName: node
+  linkType: hard
+
+"event-loop-spinner@npm:^2.0.0, event-loop-spinner@npm:^2.1.0":
+  version: 2.3.2
+  resolution: "event-loop-spinner@npm:2.3.2"
+  dependencies:
+    tslib: "npm:^2.6.3"
+  checksum: 10/0804950c444f2511cc46ebf5de9469bae4bdc1915b8e15aa55998cf585d6bc320f3107af70bfb4e91769aa9a14be84bd2cb2f0c38ebd7463b5a562a1bf595034
   languageName: node
   linkType: hard
 
@@ -32287,7 +32531,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-callable@npm:^1.1.3, is-callable@npm:^1.2.7":
+"is-callable@npm:^1.1.3, is-callable@npm:^1.1.5, is-callable@npm:^1.2.7":
   version: 1.2.7
   resolution: "is-callable@npm:1.2.7"
   checksum: 10/48a9297fb92c99e9df48706241a189da362bff3003354aea4048bd5f7b2eb0d823cd16d0a383cece3d76166ba16d85d9659165ac6fcce1ac12e6c649d66dbdb9
@@ -32901,6 +33145,13 @@ __metadata:
   version: 0.3.0
   resolution: "is-yarn-global@npm:0.3.0"
   checksum: 10/bca013d65fee2862024c9fbb3ba13720ffca2fe750095174c1c80922fdda16402b5c233f5ac9e265bc12ecb5446e7b7f519a32d9541788f01d4d44e24d2bf481
+  languageName: node
+  linkType: hard
+
+"is@npm:^3.2.1, is@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "is@npm:3.3.0"
+  checksum: 10/f77dc5a05a1e8fd1f1de282add9bb01c44dae27af72b883bf0ce342151dec48f125b0b8923efa78c1e93c4fb866095629b2c7de3e5e3853aea4ed17c82c5cd8d
   languageName: node
   linkType: hard
 
@@ -34026,6 +34277,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-file-plus@npm:^3.3.1":
+  version: 3.3.1
+  resolution: "json-file-plus@npm:3.3.1"
+  dependencies:
+    is: "npm:^3.2.1"
+    node.extend: "npm:^2.0.0"
+    object.assign: "npm:^4.1.0"
+    promiseback: "npm:^2.0.2"
+    safer-buffer: "npm:^2.0.2"
+  checksum: 10/6b71dad39e0fd8d0a23a82ca70b7c94adfcd59986e63165935d2adba5502076b75f3267e357372dd118f9d680ecc142f0f67617de9f27139c3c8b113cdd9c574
+  languageName: node
+  linkType: hard
+
 "json-parse-even-better-errors@npm:^2.3.0, json-parse-even-better-errors@npm:^2.3.1":
   version: 2.3.1
   resolution: "json-parse-even-better-errors@npm:2.3.1"
@@ -35140,6 +35404,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.clone@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "lodash.clone@npm:4.5.0"
+  checksum: 10/387ca92bb9182197dd8de48cd51f846589abbfbf2b03d7f739eafadcd8f5968be5f4f170d848277edfc2a9b05a23732a1435799b13ddbd85c533c64ea7375dfd
+  languageName: node
+  linkType: hard
+
 "lodash.clonedeep@npm:^4.5.0":
   version: 4.5.0
   resolution: "lodash.clonedeep@npm:4.5.0"
@@ -35151,6 +35422,13 @@ __metadata:
   version: 4.5.0
   resolution: "lodash.clonedeepwith@npm:4.5.0"
   checksum: 10/4bc1db18374addc891cab4c0b5d263f60801a6339831289f5745d9dc8b6d9487f82c4413a08de944d3d6bef3bf19e19c03d56bbe4d95e137916fa114577864ff
+  languageName: node
+  linkType: hard
+
+"lodash.constant@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "lodash.constant@npm:3.0.0"
+  checksum: 10/897c7b4b564c0481f93b935815b8f19d11d855ed330ac2c3f79791918a02551bbbbda191c6a4b6253e125c913764d2f4df60e7f0e32105efe3b3cfeef9d11e11
   languageName: node
   linkType: hard
 
@@ -35175,6 +35453,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.filter@npm:^4.6.0":
+  version: 4.6.0
+  resolution: "lodash.filter@npm:4.6.0"
+  checksum: 10/a95c363b6cad0025b1f74a5125d2b156251f9da2ff3d94385524e7622e4c1e4d499dd4c2b4dbc201de6e4c1f753b5af01d7c7696b6062bfb47af15ff4ba8d823
+  languageName: node
+  linkType: hard
+
+"lodash.flatmap@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "lodash.flatmap@npm:4.5.0"
+  checksum: 10/39343922440addb7e281fce7594ce6e23d17f1a2c3de060f1c445027e73657603edf55e8ec6cb87374a69d1dd8dd8547d55afce2e3d0ad5034ea90939406fb39
+  languageName: node
+  linkType: hard
+
 "lodash.flattendeep@npm:^4.0.0":
   version: 4.4.0
   resolution: "lodash.flattendeep@npm:4.4.0"
@@ -35186,6 +35478,13 @@ __metadata:
   version: 3.5.0
   resolution: "lodash.flow@npm:3.5.0"
   checksum: 10/da39497f388971e1949607882e608d5b2306f025f0b5cc3953f2c25fca7db5a8dba23bd3ddeaed4b0dbd2d44c5aaa6f6f12016b5511b08a3d61de1e1c1f59eb7
+  languageName: node
+  linkType: hard
+
+"lodash.foreach@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "lodash.foreach@npm:4.5.0"
+  checksum: 10/1917091b9e2529f6c9280fbc3e320765df6688c66457d7fafc6b3473b39cd17f16258e888e762eba309625fbe3522cfec5ad72907df72c1e642779dd416e299a
   languageName: node
   linkType: hard
 
@@ -35245,6 +35544,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.isfunction@npm:^3.0.9":
+  version: 3.0.9
+  resolution: "lodash.isfunction@npm:3.0.9"
+  checksum: 10/99e54c34b1e8a9ba75c034deb39cedbd2aca7af685815e67a2a8ec4f73ec9748cda6ebee5a07d7de4b938e90d421fd280e9c385cc190f903ac217ac8aff30314
+  languageName: node
+  linkType: hard
+
 "lodash.isnil@npm:^4.0.0":
   version: 4.0.0
   resolution: "lodash.isnil@npm:4.0.0"
@@ -35263,6 +35569,27 @@ __metadata:
   version: 4.0.1
   resolution: "lodash.isstring@npm:4.0.1"
   checksum: 10/eaac87ae9636848af08021083d796e2eea3d02e80082ab8a9955309569cb3a463ce97fd281d7dc119e402b2e7d8c54a23914b15d2fc7fff56461511dc8937ba0
+  languageName: node
+  linkType: hard
+
+"lodash.isundefined@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "lodash.isundefined@npm:3.0.1"
+  checksum: 10/52b4d99a47bd41daa4e2860200258f56b1f2c99263c11a5f607fbbd91d6447fe674bdafc172735d099908a09136d4a0f98cf79715e38ca4b490fdda7162be289
+  languageName: node
+  linkType: hard
+
+"lodash.keys@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "lodash.keys@npm:4.2.0"
+  checksum: 10/4f9c1806038219a447982a5d47fa53eb3301adb07e4043f427aea814901cfe1f19a4f1bc413bf8c5003a8680134a83ac26d6e1129947a34ca74ebe4fabf98178
+  languageName: node
+  linkType: hard
+
+"lodash.map@npm:^4.6.0":
+  version: 4.6.0
+  resolution: "lodash.map@npm:4.6.0"
+  checksum: 10/f1e69def35025be1e6213f1099df8acfa478442de8dfac3511e6eeeb5ef939b911f59db858251cc6b96076984d869fdd329ea360982d83240206124589f56f5d
   languageName: node
   linkType: hard
 
@@ -35294,6 +35621,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.reduce@npm:^4.6.0":
+  version: 4.6.0
+  resolution: "lodash.reduce@npm:4.6.0"
+  checksum: 10/1cfefb3dd1a71a567526b6a3ea5127ce52312e60a24e7cc141236927429dc2cb6f196a814e880a74382a7a0931b63986e3f7ec3d0fd373d9247adc017101fc75
+  languageName: node
+  linkType: hard
+
+"lodash.size@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "lodash.size@npm:4.2.0"
+  checksum: 10/8bba7808767541b3f880e03e09a9009c6a3aea09e28b2614aea422c110284f429151b5e981f505c666923c5c2ec46571cf2166da55e3c85ffb45b385e282282b
+  languageName: node
+  linkType: hard
+
 "lodash.snakecase@npm:^4.1.1":
   version: 4.1.1
   resolution: "lodash.snakecase@npm:4.1.1"
@@ -35315,6 +35656,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.topairs@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "lodash.topairs@npm:4.3.0"
+  checksum: 10/32a0e8654e025676288310e0c1401edd8a4255ed6413693e62f38dac68c24f547734df51893ea44a5e5b2d67e99f0f77f014090de5e3b747e6129650257b4871
+  languageName: node
+  linkType: hard
+
 "lodash.topath@npm:^4.5.2":
   version: 4.5.2
   resolution: "lodash.topath@npm:4.5.2"
@@ -35322,10 +35670,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.transform@npm:^4.6.0":
+  version: 4.6.0
+  resolution: "lodash.transform@npm:4.6.0"
+  checksum: 10/b6a8c99de8a61b23c8e541a1b94dd569fbc234332edfd56db4a6b4cd2b743ae8b3b6beb5ce9dcf15c3f5d3564417468efeafdaed3e1f70c2cbe8dc235637fab3
+  languageName: node
+  linkType: hard
+
+"lodash.union@npm:^4.6.0":
+  version: 4.6.0
+  resolution: "lodash.union@npm:4.6.0"
+  checksum: 10/175f5786efc527238c1350ce561c28e5ba527b5957605f9e5b8a804fce78801d09ced7b72de0302325e5b14c711f94690b1a733c13ad3674cc1a76e1172db1f8
+  languageName: node
+  linkType: hard
+
 "lodash.uniq@npm:^4.5.0":
   version: 4.5.0
   resolution: "lodash.uniq@npm:4.5.0"
   checksum: 10/86246ca64ac0755c612e5df6d93cfe92f9ecac2e5ff054b965efbbb1d9a647b6310969e78545006f70f52760554b03233ad0103324121ae31474c20d5f7a2812
+  languageName: node
+  linkType: hard
+
+"lodash.values@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "lodash.values@npm:4.3.0"
+  checksum: 10/efc5af093b10b63f16d1a1ad02d278ab3e690bfcdd1f40e04577516f06df6db4e6199c967ece9dc34c29cf947c7b285730fdb4dd9c0849bbec1b4068ef46ebbd
   languageName: node
   linkType: hard
 
@@ -35729,6 +36098,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"map-age-cleaner@npm:^0.1.3":
+  version: 0.1.3
+  resolution: "map-age-cleaner@npm:0.1.3"
+  dependencies:
+    p-defer: "npm:^1.0.0"
+  checksum: 10/cb2804a5bcb3cbdfe4b59066ea6d19f5e7c8c196cd55795ea4c28f792b192e4c442426ae52524e5e1acbccf393d3bddacefc3d41f803e66453f6c4eda3650bc1
+  languageName: node
+  linkType: hard
+
 "map-or-similar@npm:^1.5.0":
   version: 1.5.0
   resolution: "map-or-similar@npm:1.5.0"
@@ -36067,6 +36445,16 @@ __metadata:
     vinyl: "npm:^2.0.1"
     vinyl-file: "npm:^3.0.0"
   checksum: 10/e44fb4acf8391a847b9e9494115b27300eda77aa7c6caea533786f43d385253515b0c0ff4f00906744b2bd31010df923cc448bb6efb9593f41df5d40b0e69046
+  languageName: node
+  linkType: hard
+
+"mem@npm:^8.0.0":
+  version: 8.1.1
+  resolution: "mem@npm:8.1.1"
+  dependencies:
+    map-age-cleaner: "npm:^0.1.3"
+    mimic-fn: "npm:^3.1.0"
+  checksum: 10/5f22117d8a24775f0a61d333bd7fdbe19f7a9f8dc8ccee66f57ba98aeb4ed67e83cc130c482b78fd6a39887547749d8fe376fc44ca7efa81579ad9d0c0fa5acd
   languageName: node
   linkType: hard
 
@@ -36592,7 +36980,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mimic-fn@npm:^3.0.0":
+"mimic-fn@npm:^3.0.0, mimic-fn@npm:^3.1.0":
   version: 3.1.0
   resolution: "mimic-fn@npm:3.1.0"
   checksum: 10/f7b167f9115b8bbdf2c3ee55dce9149d14be9e54b237259c4bc1d8d0512ea60f25a1b323f814eb1fe8f5a541662804bcfcfff3202ca58df143edb986849d58db
@@ -37787,6 +38175,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node.extend@npm:^2.0.0":
+  version: 2.0.3
+  resolution: "node.extend@npm:2.0.3"
+  dependencies:
+    hasown: "npm:^2.0.0"
+    is: "npm:^3.3.0"
+  checksum: 10/f500ace16d0b90e9db3919676de593eb37e7b82d8d9b67d95a40e5856ef5842592df3364b4d01fc2c3f4c0dea6dd9d627444dd85fe18581b7a22caad5ffab249
+  languageName: node
+  linkType: hard
+
 "nodemailer@npm:^6.9.13":
   version: 6.9.16
   resolution: "nodemailer@npm:6.9.16"
@@ -38172,7 +38570,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.assign@npm:^4.1.4, object.assign@npm:^4.1.7":
+"object.assign@npm:^4.1.0, object.assign@npm:^4.1.4, object.assign@npm:^4.1.7":
   version: 4.1.7
   resolution: "object.assign@npm:4.1.7"
   dependencies:
@@ -38312,6 +38710,15 @@ __metadata:
   dependencies:
     wrappy: "npm:1"
   checksum: 10/cd0a88501333edd640d95f0d2700fbde6bff20b3d4d9bdc521bdd31af0656b5706570d6c6afe532045a20bb8dc0849f8332d6f2a416e0ba6d3d3b98806c7db68
+  languageName: node
+  linkType: hard
+
+"once@npm:~1.3.0":
+  version: 1.3.3
+  resolution: "once@npm:1.3.3"
+  dependencies:
+    wrappy: "npm:1"
+  checksum: 10/8e832de08b1d73b470e01690c211cb4fcefccab1fd1bd19e706d572d74d3e9b7e38a8bfcdabdd364f9f868757d9e8e5812a59817dc473eaf698ff3bfae2219f2
   languageName: node
   linkType: hard
 
@@ -38575,6 +38982,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"p-defer@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "p-defer@npm:1.0.0"
+  checksum: 10/1d8fb7138a0ccebb65479160fd93f245303c06c977c976105d75838f7f504a9a6ef11b7e058f98b4c957a6a8df268c616da1ee339285d565f9e5ba00304e027b
+  languageName: node
+  linkType: hard
+
 "p-defer@npm:^3.0.0":
   version: 3.0.0
   resolution: "p-defer@npm:3.0.0"
@@ -38793,6 +39207,13 @@ __metadata:
   version: 0.2.0
   resolution: "package-manager-detector@npm:0.2.0"
   checksum: 10/5a361717e7de78ca055de0ae99c368c338631ef9f52867ab7788b81862aeb016916abb0a0d37e7c0117d62b0ad954ec942ab228790eaa8d30cace4edb2819763
+  languageName: node
+  linkType: hard
+
+"packageurl-js@npm:1.2.0":
+  version: 1.2.0
+  resolution: "packageurl-js@npm:1.2.0"
+  checksum: 10/b780ad6cf9f75055effafe8fbed37617eb1924e3dc5b055fb3ecceaaaa93da73ea1508a3874b04bd13342a77bd852b70a4e52596c171cbc57840c4b8452d2d56
   languageName: node
   linkType: hard
 
@@ -39637,6 +40058,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pluralize@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "pluralize@npm:7.0.0"
+  checksum: 10/905274e679d3802650fdfdd977434757d4680082da7a23c0938a608d1d5c8246790b62dc15ff1f737b0d57baa6ad2f6ebb0857b1950435a583e32af76ee58e1f
+  languageName: node
+  linkType: hard
+
 "polished@npm:^4.2.2":
   version: 4.3.1
   resolution: "polished@npm:4.3.1"
@@ -40278,7 +40706,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pretty-bytes@npm:^5.3.0":
+"pretty-bytes@npm:^5.1.0, pretty-bytes@npm:^5.3.0":
   version: 5.6.0
   resolution: "pretty-bytes@npm:5.6.0"
   checksum: 10/9c082500d1e93434b5b291bd651662936b8bd6204ec9fa17d563116a192d6d86b98f6d328526b4e8d783c07d5499e2614a807520249692da9ec81564b2f439cd
@@ -40401,6 +40829,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"promise-deferred@npm:^2.0.3":
+  version: 2.0.4
+  resolution: "promise-deferred@npm:2.0.4"
+  dependencies:
+    promise: "npm:^8.3.0"
+  checksum: 10/1d0e306d54a7436e288836c0784abdf11798011a6c3309f4ce8e24564ba958c41ca0d21bb7ec95386f04ac8f9691fdd8e3dd0af5176b496a2303d00db96acf5a
+  languageName: node
+  linkType: hard
+
 "promise-inflight@npm:^1.0.1":
   version: 1.0.1
   resolution: "promise-inflight@npm:1.0.1"
@@ -40445,6 +40882,25 @@ __metadata:
   dependencies:
     asap: "npm:~2.0.3"
   checksum: 10/37dbe58ca7b0716cc881f0618128f1fd6ff9c46cdc529a269fd70004e567126a449a94e9428e2d19b53d06182d11b45d0c399828f103e06b2bb87643319bd2e7
+  languageName: node
+  linkType: hard
+
+"promise@npm:^8.3.0":
+  version: 8.3.0
+  resolution: "promise@npm:8.3.0"
+  dependencies:
+    asap: "npm:~2.0.6"
+  checksum: 10/55e9d0d723c66810966bc055c6c77a3658c0af7e4a8cc88ea47aeaf2949ca0bd1de327d9c631df61236f5406ad478384fa19a77afb3f88c0303eba9e5eb0a8d8
+  languageName: node
+  linkType: hard
+
+"promiseback@npm:^2.0.2":
+  version: 2.0.3
+  resolution: "promiseback@npm:2.0.3"
+  dependencies:
+    is-callable: "npm:^1.1.5"
+    promise-deferred: "npm:^2.0.3"
+  checksum: 10/39716e64ac75b3a5c58532493f594d4788267ee13e2aeee5c60b448eb17e8f98c8ff4778c5497aed1594e29c428710ae21c83671c87c24b3d2c42f0c359d6e55
   languageName: node
   linkType: hard
 
@@ -42463,10 +42919,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rfc4648@npm:^1.3.0":
-  version: 1.4.0
-  resolution: "rfc4648@npm:1.4.0"
-  checksum: 10/a130355f484a09ead1421c97e8661ccea11b0b4097230604681484066799745fe64a0260b2c5b0e65e9877571bf208ca0fcf4a864449155e3be42c9f1f18ca5b
+"rfc4648@npm:^1.3.0, rfc4648@npm:^1.5.1":
+  version: 1.5.4
+  resolution: "rfc4648@npm:1.5.4"
+  checksum: 10/425ec5a732dad1eed69ebc0217d36e00bd6a3a03dd3da94721bb943d979bb85f4c96e75706437540e726c7cb92ff5c05987ad38b82a1ed9343bb9a6fbfb43224
   languageName: node
   linkType: hard
 
@@ -43123,7 +43579,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.1.1, semver@npm:^7.1.2, semver@npm:^7.1.3, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.2, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.0, semver@npm:^7.6.2":
+"semver@npm:^7.0.0, semver@npm:^7.1.1, semver@npm:^7.1.2, semver@npm:^7.1.3, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.2, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.0, semver@npm:^7.6.2":
   version: 7.7.1
   resolution: "semver@npm:7.7.1"
   bin:
@@ -43634,6 +44090,46 @@ __metadata:
   dependencies:
     nearley: "npm:^2.20.1"
   checksum: 10/73d49712450ccd2b77ec3642e26f73fb7b3ed5b46c416d60714e2b9821e3378c3cf6b44767371d8be42286cfeae63e4c369384ef5bb3eeb42568264cbb330626
+  languageName: node
+  linkType: hard
+
+"snyk-config@npm:^5.2.0":
+  version: 5.3.0
+  resolution: "snyk-config@npm:5.3.0"
+  dependencies:
+    async: "npm:^3.2.2"
+    debug: "npm:^4.3.4"
+    lodash.merge: "npm:^4.6.2"
+    minimist: "npm:^1.2.6"
+  checksum: 10/670a892b293572178b6fbf82dacf24431edd28069ac7a105b3b4cc847df454afd9aba3f4730992fd40bde0a80a0834bb6abf0ca9000195ab06321a69635c62e1
+  languageName: node
+  linkType: hard
+
+"snyk-nodejs-lockfile-parser@npm:^1.58.14":
+  version: 1.58.14
+  resolution: "snyk-nodejs-lockfile-parser@npm:1.58.14"
+  dependencies:
+    "@snyk/dep-graph": "npm:^2.3.0"
+    "@snyk/error-catalog-nodejs-public": "npm:^5.16.0"
+    "@snyk/graphlib": "npm:2.1.9-patch.3"
+    "@yarnpkg/core": "npm:^2.4.0"
+    "@yarnpkg/lockfile": "npm:^1.1.0"
+    dependency-path: "npm:^9.2.8"
+    event-loop-spinner: "npm:^2.0.0"
+    js-yaml: "npm:^4.1.0"
+    lodash.clonedeep: "npm:^4.5.0"
+    lodash.flatmap: "npm:^4.5.0"
+    lodash.isempty: "npm:^4.4.0"
+    lodash.topairs: "npm:^4.3.0"
+    micromatch: "npm:^4.0.8"
+    p-map: "npm:^4.0.0"
+    semver: "npm:^7.6.0"
+    snyk-config: "npm:^5.2.0"
+    tslib: "npm:^1.9.3"
+    uuid: "npm:^8.3.0"
+  bin:
+    parse-nodejs-lockfile: bin/index.js
+  checksum: 10/4a499b8e5eefafbcbf6e9dc9cd9c251777aaf57759eaf56548c3ae9a745a43864aba90e694ef44c3a6162c040895053ec19dea1fbb234d2c33a77209648bfecc
   languageName: node
   linkType: hard
 
@@ -44191,6 +44687,26 @@ __metadata:
   version: 1.0.3
   resolution: "stream-shift@npm:1.0.3"
   checksum: 10/a24c0a3f66a8f9024bd1d579a533a53be283b4475d4e6b4b3211b964031447bdf6532dd1f3c2b0ad66752554391b7c62bd7ca4559193381f766534e723d50242
+  languageName: node
+  linkType: hard
+
+"stream-to-array@npm:~2.3.0":
+  version: 2.3.0
+  resolution: "stream-to-array@npm:2.3.0"
+  dependencies:
+    any-promise: "npm:^1.1.0"
+  checksum: 10/7feaf63b38399b850615e6ffcaa951e96e4c8f46745dbce4b553a94c5dc43966933813747014935a3ff97793e7f30a65270bde19f82b2932871a1879229a77cf
+  languageName: node
+  linkType: hard
+
+"stream-to-promise@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "stream-to-promise@npm:2.2.0"
+  dependencies:
+    any-promise: "npm:~1.3.0"
+    end-of-stream: "npm:~1.1.0"
+    stream-to-array: "npm:~2.3.0"
+  checksum: 10/e4d3253c68dae65c51c5aa1bd657a072267869fd61b57068e74cee7a8e45d67fe154b56918cf546b38cb5be1fa042e632b7267abc9676bb75bba55952d2d57d1
   languageName: node
   linkType: hard
 
@@ -45722,7 +46238,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:2, tslib@npm:2.8.1, tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.2.0, tslib@npm:^2.3.0, tslib@npm:^2.3.1, tslib@npm:^2.4.0, tslib@npm:^2.4.1, tslib@npm:^2.5.0, tslib@npm:^2.6.0, tslib@npm:^2.6.2, tslib@npm:^2.6.3, tslib@npm:^2.8.0, tslib@npm:^2.8.1":
+"tslib@npm:2, tslib@npm:2.8.1, tslib@npm:^2, tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.2.0, tslib@npm:^2.3.0, tslib@npm:^2.3.1, tslib@npm:^2.4.0, tslib@npm:^2.4.1, tslib@npm:^2.5.0, tslib@npm:^2.6.0, tslib@npm:^2.6.2, tslib@npm:^2.6.3, tslib@npm:^2.8.0, tslib@npm:^2.8.1":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10/3e2e043d5c2316461cb54e5c7fe02c30ef6dccb3384717ca22ae5c6b5bc95232a6241df19c622d9c73b809bea33b187f6dbc73030963e29950c2141bc32a79f7
@@ -45736,7 +46252,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^1.11.1, tslib@npm:^1.14.1, tslib@npm:^1.8.1, tslib@npm:^1.9.0, tslib@npm:^1.9.3":
+"tslib@npm:^1.11.1, tslib@npm:^1.13.0, tslib@npm:^1.14.1, tslib@npm:^1.8.1, tslib@npm:^1.9.0, tslib@npm:^1.9.3":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: 10/7dbf34e6f55c6492637adb81b555af5e3b4f9cc6b998fb440dac82d3b42bdc91560a35a5fb75e20e24a076c651438234da6743d139e4feabf0783f3cdfe1dddb
@@ -46198,10 +46714,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici-types@npm:~6.21.0":
-  version: 6.21.0
-  resolution: "undici-types@npm:6.21.0"
-  checksum: 10/ec8f41aa4359d50f9b59fa61fe3efce3477cc681908c8f84354d8567bb3701fafdddf36ef6bff307024d3feb42c837cf6f670314ba37fc8145e219560e473d14
+"undici-types@npm:~6.20.0":
+  version: 6.20.0
+  resolution: "undici-types@npm:6.20.0"
+  checksum: 10/583ac7bbf4ff69931d3985f4762cde2690bb607844c16a5e2fbb92ed312fe4fa1b365e953032d469fa28ba8b224e88a595f0b10a449332f83fa77c695e567dbe
   languageName: node
   linkType: hard
 
@@ -46795,7 +47311,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^11.0.0, uuid@npm:^11.0.2":
+"uuid@npm:^11.0.0, uuid@npm:^11.0.2, uuid@npm:^11.0.3":
   version: 11.0.5
   resolution: "uuid@npm:11.0.5"
   bin:
@@ -47936,6 +48452,7 @@ __metadata:
     fs-extra: "npm:^11.2.0"
     nodemon: "npm:^3.0.1"
     semver: "npm:^7.6.0"
+    snyk-nodejs-lockfile-parser: "npm:^1.58.14"
     yaml: "npm:^2.0.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Unfortunately the recent changes in https://github.com/backstage/backstage/pull/28130 reintroduced the issue previously fixed by https://github.com/backstage/backstage/pull/27727. It turns out that we actually need _two_ ranges present in the lockfile when using the plugin:
* A `backstage:^` range, which allows tools like the Snyk lockfile parser to match packages in `package.json` with entries in the lockfile.
* The corresponding `npm:` range, ensuring that package versions don't get unlocked when translating `backstage:^` ranges during npm pack (in particular when building dist workspaces).

This PR adds a failing test to confirm the issue with lockfile parsing in the current plugin implementation, then resolves the issue by introducing a new resolver to add the appropriate `npm:`-range-based dependencies to packages using `backstage:` ranges.

As part of this change, I've also documented the current architecture of the plugin to aid in future maintenance of this system.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
