### PR TITLE
Search: Add result type and filter extension points to the search plugin

### DIFF
--- a/.changeset/dry-flies-rhyme.md
+++ b/.changeset/dry-flies-rhyme.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-search-react': patch
+'@backstage/plugin-search': patch
+---
+
+Added new extension points to extend search filters `SearchFilterBlueprint` and `SearchFilterResultTypeBlueprint`

--- a/plugins/search-react/report-alpha.api.md
+++ b/plugins/search-react/report-alpha.api.md
@@ -18,6 +18,48 @@ export type BaseSearchResultListItemProps<T = {}> = T & {
 } & Omit<ListItemProps, 'button'>;
 
 // @alpha (undocumented)
+export const SearchFilterBlueprint: ExtensionBlueprint<{
+  kind: 'search-filter';
+  name: undefined;
+  params: SearchFilterBlueprintParams;
+  output: ConfigurableExtensionDataRef<
+    {
+      component: SearchFilterExtensionComponent;
+    },
+    'search.filters.filter',
+    {}
+  >;
+  inputs: {};
+  config: {};
+  configInput: {};
+  dataRefs: {
+    searchFilters: ConfigurableExtensionDataRef<
+      {
+        component: SearchFilterExtensionComponent;
+      },
+      'search.filters.filter',
+      {}
+    >;
+  };
+}>;
+
+// @alpha (undocumented)
+export interface SearchFilterBlueprintParams {
+  // (undocumented)
+  component: SearchFilterExtensionComponent;
+}
+
+// @alpha (undocumented)
+export type SearchFilterExtensionComponent = (
+  props: SearchFilterExtensionComponentProps,
+) => JSX.Element;
+
+// @alpha (undocumented)
+export type SearchFilterExtensionComponentProps = {
+  className: string;
+};
+
+// @alpha (undocumented)
 export const SearchFilterResultTypeBlueprint: ExtensionBlueprint<{
   kind: 'search-filter-result-type';
   name: undefined;

--- a/plugins/search-react/report-alpha.api.md
+++ b/plugins/search-react/report-alpha.api.md
@@ -18,6 +18,43 @@ export type BaseSearchResultListItemProps<T = {}> = T & {
 } & Omit<ListItemProps, 'button'>;
 
 // @alpha (undocumented)
+export const SearchFilterResultTypeBlueprint: ExtensionBlueprint<{
+  kind: 'search-filter-result-type';
+  name: undefined;
+  params: SearchFilterResultTypeBlueprintParams;
+  output: ConfigurableExtensionDataRef<
+    {
+      value: string;
+      name: string;
+      icon: JSX.Element;
+    },
+    'search.filters.result-types.type',
+    {}
+  >;
+  inputs: {};
+  config: {};
+  configInput: {};
+  dataRefs: {
+    resultType: ConfigurableExtensionDataRef<
+      {
+        value: string;
+        name: string;
+        icon: JSX.Element;
+      },
+      'search.filters.result-types.type',
+      {}
+    >;
+  };
+}>;
+
+// @alpha (undocumented)
+export interface SearchFilterResultTypeBlueprintParams {
+  icon: JSX.Element;
+  name: string;
+  value: string;
+}
+
+// @alpha (undocumented)
 export type SearchResultItemExtensionComponent = <
   P extends BaseSearchResultListItemProps,
 >(

--- a/plugins/search-react/src/alpha/blueprints/SearchFilterBlueprint.test.tsx
+++ b/plugins/search-react/src/alpha/blueprints/SearchFilterBlueprint.test.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import {
+  PageBlueprint,
+  createExtensionInput,
+} from '@backstage/frontend-plugin-api';
+import { SearchFilterBlueprint } from './SearchFilterBlueprint';
+import { searchFilterDataRef } from './types';
+import {
+  createExtensionTester,
+  renderInTestApp,
+} from '@backstage/frontend-test-utils';
+
+describe('SearchFilterBlueprint', () => {
+  it('should return an extension', () => {
+    const extension = SearchFilterBlueprint.make({
+      name: 'test',
+      params: {
+        component: props => <p {...props}>test filter</p>,
+      },
+    });
+
+    expect(extension).toMatchInlineSnapshot(`
+      {
+        "$$type": "@backstage/ExtensionDefinition",
+        "T": undefined,
+        "attachTo": {
+          "id": "page:search",
+          "input": "searchFilters",
+        },
+        "configSchema": undefined,
+        "disabled": false,
+        "factory": [Function],
+        "inputs": {},
+        "kind": "search-filter",
+        "name": "test",
+        "output": [
+          [Function],
+        ],
+        "override": [Function],
+        "toString": [Function],
+        "version": "v2",
+      }
+    `);
+  });
+
+  it('should render filter components', async () => {
+    const extension = SearchFilterBlueprint.make({
+      name: 'test',
+      params: {
+        component: props => <p {...props}>Test Filter</p>,
+      },
+    });
+
+    const searchPage = PageBlueprint.makeWithOverrides({
+      name: 'search',
+      inputs: {
+        searchFilters: createExtensionInput([searchFilterDataRef]),
+      },
+      factory(originalFactory, { inputs }) {
+        return originalFactory({
+          defaultPath: '/',
+          loader: async () => {
+            const searchFilters = inputs.searchFilters.map(
+              t => t.get(searchFilterDataRef).component,
+            );
+            return (
+              <div>
+                {searchFilters.map((Component, index) => (
+                  <Component key={index} className="test" />
+                ))}
+              </div>
+            );
+          },
+        });
+      },
+    });
+
+    await expect(
+      renderInTestApp(
+        createExtensionTester(searchPage).add(extension).reactElement(),
+      ).findByText('Test Filter'),
+    ).resolves.toBeInTheDocument();
+  });
+});

--- a/plugins/search-react/src/alpha/blueprints/SearchFilterBlueprint.tsx
+++ b/plugins/search-react/src/alpha/blueprints/SearchFilterBlueprint.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createExtensionBlueprint } from '@backstage/frontend-plugin-api';
+import { searchFilterDataRef, SearchFilterExtensionComponent } from './types';
+
+/** @alpha */
+export interface SearchFilterBlueprintParams {
+  component: SearchFilterExtensionComponent;
+}
+
+/**
+ * @alpha
+ */
+export const SearchFilterBlueprint = createExtensionBlueprint({
+  kind: 'search-filter',
+  attachTo: {
+    id: 'page:search',
+    input: 'searchFilters',
+  },
+  output: [searchFilterDataRef],
+  dataRefs: {
+    searchFilters: searchFilterDataRef,
+  },
+  *factory(params: SearchFilterBlueprintParams) {
+    yield searchFilterDataRef({
+      component: params.component,
+    });
+  },
+});

--- a/plugins/search-react/src/alpha/blueprints/SearchFilterResultTypeBlueprint.test.tsx
+++ b/plugins/search-react/src/alpha/blueprints/SearchFilterResultTypeBlueprint.test.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import {
+  PageBlueprint,
+  createExtensionInput,
+} from '@backstage/frontend-plugin-api';
+import { SearchFilterResultTypeBlueprint } from './SearchFilterResultTypeBlueprint';
+import { searchResultTypeDataRef } from './types';
+import {
+  createExtensionTester,
+  renderInTestApp,
+} from '@backstage/frontend-test-utils';
+
+describe('SearchFilterResultTypeBlueprint', () => {
+  it('should return an extension', () => {
+    const extension = SearchFilterResultTypeBlueprint.make({
+      name: 'test',
+      params: {
+        value: 'test',
+        name: 'Test',
+        icon: <div>Hello</div>,
+      },
+    });
+
+    expect(extension).toMatchInlineSnapshot(`
+      {
+        "$$type": "@backstage/ExtensionDefinition",
+        "T": undefined,
+        "attachTo": {
+          "id": "page:search",
+          "input": "resultTypes",
+        },
+        "configSchema": undefined,
+        "disabled": false,
+        "factory": [Function],
+        "inputs": {},
+        "kind": "search-filter-result-type",
+        "name": "test",
+        "output": [
+          [Function],
+        ],
+        "override": [Function],
+        "toString": [Function],
+        "version": "v2",
+      }
+    `);
+  });
+
+  it('should render result types', async () => {
+    const extension = SearchFilterResultTypeBlueprint.make({
+      name: 'test',
+      params: {
+        value: 'test',
+        name: 'Test Result Type',
+        icon: <div>Hello</div>,
+      },
+    });
+
+    const searchPage = PageBlueprint.makeWithOverrides({
+      name: 'search',
+      inputs: {
+        resultTypes: createExtensionInput([searchResultTypeDataRef]),
+      },
+      factory(originalFactory, { inputs }) {
+        return originalFactory({
+          defaultPath: '/',
+          loader: async () => {
+            const resultTypes = inputs.resultTypes.map(t =>
+              t.get(searchResultTypeDataRef),
+            );
+            return (
+              <div>
+                {resultTypes.map((t, i) => (
+                  <div key={i}>{t.name}</div>
+                ))}
+              </div>
+            );
+          },
+        });
+      },
+    });
+
+    await expect(
+      renderInTestApp(
+        createExtensionTester(searchPage).add(extension).reactElement(),
+      ).findByText('Test Result Type'),
+    ).resolves.toBeInTheDocument();
+  });
+});

--- a/plugins/search-react/src/alpha/blueprints/SearchFilterResultTypeBlueprint.tsx
+++ b/plugins/search-react/src/alpha/blueprints/SearchFilterResultTypeBlueprint.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createExtensionBlueprint } from '@backstage/frontend-plugin-api';
+import { searchResultTypeDataRef } from './types';
+
+/** @alpha */
+export interface SearchFilterResultTypeBlueprintParams {
+  /**
+   * The value of the result type.
+   */
+  value: string;
+  /**
+   * The name of the result type.
+   */
+  name: string;
+  /**
+   * The icon of the result type.
+   */
+  icon: JSX.Element;
+}
+
+/**
+ * @alpha
+ */
+export const SearchFilterResultTypeBlueprint = createExtensionBlueprint({
+  kind: 'search-filter-result-type',
+  attachTo: {
+    id: 'page:search',
+    input: 'resultTypes',
+  },
+  output: [searchResultTypeDataRef],
+  dataRefs: {
+    resultType: searchResultTypeDataRef,
+  },
+  *factory(params: SearchFilterResultTypeBlueprintParams) {
+    yield searchResultTypeDataRef({
+      value: params.value,
+      name: params.name,
+      icon: params.icon,
+    });
+  },
+});

--- a/plugins/search-react/src/alpha/blueprints/index.ts
+++ b/plugins/search-react/src/alpha/blueprints/index.ts
@@ -23,3 +23,8 @@ export {
   type SearchResultItemExtensionComponent,
   type SearchResultItemExtensionPredicate,
 } from './types';
+
+export {
+  SearchFilterResultTypeBlueprint,
+  type SearchFilterResultTypeBlueprintParams,
+} from './SearchFilterResultTypeBlueprint';

--- a/plugins/search-react/src/alpha/blueprints/index.ts
+++ b/plugins/search-react/src/alpha/blueprints/index.ts
@@ -22,9 +22,16 @@ export {
   type BaseSearchResultListItemProps,
   type SearchResultItemExtensionComponent,
   type SearchResultItemExtensionPredicate,
+  type SearchFilterExtensionComponent,
+  type SearchFilterExtensionComponentProps,
 } from './types';
 
 export {
   SearchFilterResultTypeBlueprint,
   type SearchFilterResultTypeBlueprintParams,
 } from './SearchFilterResultTypeBlueprint';
+
+export {
+  SearchFilterBlueprint,
+  type SearchFilterBlueprintParams,
+} from './SearchFilterBlueprint';

--- a/plugins/search-react/src/alpha/blueprints/types.ts
+++ b/plugins/search-react/src/alpha/blueprints/types.ts
@@ -36,13 +36,30 @@ export type SearchResultItemExtensionPredicate = (
   result: SearchResult,
 ) => boolean;
 
+/** @alpha */
 export const searchResultListItemDataRef = createExtensionDataRef<{
   predicate?: SearchResultItemExtensionPredicate;
   component: SearchResultItemExtensionComponent;
 }>().with({ id: 'search.search-result-list-item.item' });
 
+/** @alpha */
 export const searchResultTypeDataRef = createExtensionDataRef<{
   value: string;
   name: string;
   icon: JSX.Element;
 }>().with({ id: 'search.filters.result-types.type' });
+
+/** @alpha */
+export type SearchFilterExtensionComponentProps = {
+  className: string;
+};
+
+/** @alpha */
+export type SearchFilterExtensionComponent = (
+  props: SearchFilterExtensionComponentProps,
+) => JSX.Element;
+
+/** @alpha */
+export const searchFilterDataRef = createExtensionDataRef<{
+  component: SearchFilterExtensionComponent;
+}>().with({ id: 'search.filters.filter' });

--- a/plugins/search-react/src/alpha/blueprints/types.ts
+++ b/plugins/search-react/src/alpha/blueprints/types.ts
@@ -40,3 +40,9 @@ export const searchResultListItemDataRef = createExtensionDataRef<{
   predicate?: SearchResultItemExtensionPredicate;
   component: SearchResultItemExtensionComponent;
 }>().with({ id: 'search.search-result-list-item.item' });
+
+export const searchResultTypeDataRef = createExtensionDataRef<{
+  value: string;
+  name: string;
+  icon: JSX.Element;
+}>().with({ id: 'search.filters.result-types.type' });

--- a/plugins/search/report-alpha.api.md
+++ b/plugins/search/report-alpha.api.md
@@ -12,6 +12,7 @@ import { FrontendPlugin } from '@backstage/frontend-plugin-api';
 import { IconComponent } from '@backstage/core-plugin-api';
 import { default as React_2 } from 'react';
 import { RouteRef } from '@backstage/frontend-plugin-api';
+import { SearchFilterExtensionComponent } from '@backstage/plugin-search-react/alpha';
 import { SearchResultItemExtensionComponent } from '@backstage/plugin-search-react/alpha';
 import { SearchResultItemExtensionPredicate } from '@backstage/plugin-search-react/alpha';
 
@@ -85,6 +86,19 @@ const _default: FrontendPlugin<
               icon: JSX.Element;
             },
             'search.filters.result-types.type',
+            {}
+          >,
+          {
+            singleton: false;
+            optional: false;
+          }
+        >;
+        searchFilters: ExtensionInput<
+          ConfigurableExtensionDataRef<
+            {
+              component: SearchFilterExtensionComponent;
+            },
+            'search.filters.filter',
             {}
           >,
           {
@@ -207,6 +221,19 @@ export const searchPage: ExtensionDefinition<{
           icon: JSX.Element;
         },
         'search.filters.result-types.type',
+        {}
+      >,
+      {
+        singleton: false;
+        optional: false;
+      }
+    >;
+    searchFilters: ExtensionInput<
+      ConfigurableExtensionDataRef<
+        {
+          component: SearchFilterExtensionComponent;
+        },
+        'search.filters.filter',
         {}
       >,
       {

--- a/plugins/search/report-alpha.api.md
+++ b/plugins/search/report-alpha.api.md
@@ -23,6 +23,27 @@ const _default: FrontendPlugin<
   },
   {},
   {
+    'nav-item:search': ExtensionDefinition<{
+      kind: 'nav-item';
+      name: undefined;
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        {
+          title: string;
+          icon: IconComponent;
+          routeRef: RouteRef<undefined>;
+        },
+        'core.nav-item.target',
+        {}
+      >;
+      inputs: {};
+      params: {
+        title: string;
+        icon: IconComponent;
+        routeRef: RouteRef<undefined>;
+      };
+    }>;
     'api:search': ExtensionDefinition<{
       kind: 'api';
       name: undefined;
@@ -113,27 +134,6 @@ const _default: FrontendPlugin<
         defaultPath: string;
         loader: () => Promise<JSX.Element>;
         routeRef?: RouteRef<AnyRouteRefParams> | undefined;
-      };
-    }>;
-    'nav-item:search': ExtensionDefinition<{
-      kind: 'nav-item';
-      name: undefined;
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        {
-          title: string;
-          icon: IconComponent;
-          routeRef: RouteRef<undefined>;
-        },
-        'core.nav-item.target',
-        {}
-      >;
-      inputs: {};
-      params: {
-        title: string;
-        icon: IconComponent;
-        routeRef: RouteRef<undefined>;
       };
     }>;
   }

--- a/plugins/search/report-alpha.api.md
+++ b/plugins/search/report-alpha.api.md
@@ -22,27 +22,6 @@ const _default: FrontendPlugin<
   },
   {},
   {
-    'nav-item:search': ExtensionDefinition<{
-      kind: 'nav-item';
-      name: undefined;
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        {
-          title: string;
-          icon: IconComponent;
-          routeRef: RouteRef<undefined>;
-        },
-        'core.nav-item.target',
-        {}
-      >;
-      inputs: {};
-      params: {
-        title: string;
-        icon: IconComponent;
-        routeRef: RouteRef<undefined>;
-      };
-    }>;
     'api:search': ExtensionDefinition<{
       kind: 'api';
       name: undefined;
@@ -98,6 +77,21 @@ const _default: FrontendPlugin<
             optional: false;
           }
         >;
+        resultTypes: ExtensionInput<
+          ConfigurableExtensionDataRef<
+            {
+              value: string;
+              name: string;
+              icon: JSX.Element;
+            },
+            'search.filters.result-types.type',
+            {}
+          >,
+          {
+            singleton: false;
+            optional: false;
+          }
+        >;
       };
       kind: 'page';
       name: undefined;
@@ -105,6 +99,27 @@ const _default: FrontendPlugin<
         defaultPath: string;
         loader: () => Promise<JSX.Element>;
         routeRef?: RouteRef<AnyRouteRefParams> | undefined;
+      };
+    }>;
+    'nav-item:search': ExtensionDefinition<{
+      kind: 'nav-item';
+      name: undefined;
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        {
+          title: string;
+          icon: IconComponent;
+          routeRef: RouteRef<undefined>;
+        },
+        'core.nav-item.target',
+        {}
+      >;
+      inputs: {};
+      params: {
+        title: string;
+        icon: IconComponent;
+        routeRef: RouteRef<undefined>;
       };
     }>;
   }
@@ -177,6 +192,21 @@ export const searchPage: ExtensionDefinition<{
           component: SearchResultItemExtensionComponent;
         },
         'search.search-result-list-item.item',
+        {}
+      >,
+      {
+        singleton: false;
+        optional: false;
+      }
+    >;
+    resultTypes: ExtensionInput<
+      ConfigurableExtensionDataRef<
+        {
+          value: string;
+          name: string;
+          icon: JSX.Element;
+        },
+        'search.filters.result-types.type',
         {}
       >,
       {

--- a/plugins/search/src/alpha.tsx
+++ b/plugins/search/src/alpha.tsx
@@ -61,7 +61,10 @@ import {
 } from '@backstage/plugin-search-react';
 import { SearchResult } from '@backstage/plugin-search-common';
 import { searchApiRef } from '@backstage/plugin-search-react';
-import { SearchResultListItemBlueprint } from '@backstage/plugin-search-react/alpha';
+import {
+  SearchResultListItemBlueprint,
+  SearchFilterResultTypeBlueprint,
+} from '@backstage/plugin-search-react/alpha';
 
 import { rootRouteRef } from './plugin';
 import { SearchClient } from './apis';
@@ -106,6 +109,9 @@ export const searchPage = PageBlueprint.makeWithOverrides({
   },
   inputs: {
     items: createExtensionInput([SearchResultListItemBlueprint.dataRefs.item]),
+    resultTypes: createExtensionInput([
+      SearchFilterResultTypeBlueprint.dataRefs.resultType,
+    ]),
   },
   factory(originalFactory, { config, inputs }) {
     return originalFactory({
@@ -123,6 +129,10 @@ export const searchPage = PageBlueprint.makeWithOverrides({
             DefaultResultListItem
           );
         };
+
+        const resultTypes = inputs.resultTypes.map(item =>
+          item.get(SearchFilterResultTypeBlueprint.dataRefs.resultType),
+        );
 
         const Component = () => {
           const classes = useSearchPageStyles();
@@ -155,7 +165,7 @@ export const searchPage = PageBlueprint.makeWithOverrides({
                             name: 'Documentation',
                             icon: <DocsIcon />,
                           },
-                        ]}
+                        ].concat(resultTypes)}
                       />
                       <Paper className={classes.filters}>
                         {types.includes('techdocs') && (

--- a/plugins/search/src/alpha.tsx
+++ b/plugins/search/src/alpha.tsx
@@ -64,6 +64,7 @@ import { searchApiRef } from '@backstage/plugin-search-react';
 import {
   SearchResultListItemBlueprint,
   SearchFilterResultTypeBlueprint,
+  SearchFilterBlueprint,
 } from '@backstage/plugin-search-react/alpha';
 
 import { rootRouteRef } from './plugin';
@@ -112,6 +113,9 @@ export const searchPage = PageBlueprint.makeWithOverrides({
     resultTypes: createExtensionInput([
       SearchFilterResultTypeBlueprint.dataRefs.resultType,
     ]),
+    searchFilters: createExtensionInput([
+      SearchFilterBlueprint.dataRefs.searchFilters,
+    ]),
   },
   factory(originalFactory, { config, inputs }) {
     return originalFactory({
@@ -132,6 +136,11 @@ export const searchPage = PageBlueprint.makeWithOverrides({
 
         const resultTypes = inputs.resultTypes.map(item =>
           item.get(SearchFilterResultTypeBlueprint.dataRefs.resultType),
+        );
+
+        const additionalSearchFilters = inputs.searchFilters.map(
+          item =>
+            item.get(SearchFilterBlueprint.dataRefs.searchFilters).component,
         );
 
         const Component = () => {
@@ -203,6 +212,9 @@ export const searchPage = PageBlueprint.makeWithOverrides({
                           name="lifecycle"
                           values={['experimental', 'production']}
                         />
+                        {additionalSearchFilters.map(SearchFilterComponent => (
+                          <SearchFilterComponent className={classes.filter} />
+                        ))}
                       </Paper>
                     </Grid>
                   )}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds two new extension points to the search plugin:
1. A search result type extension to inject additional result types into the existing "Result Type" filter
2. A filter extension to inject additional search filters into the UI.

<img width="326" alt="image" src="https://github.com/user-attachments/assets/45e555eb-c079-4522-b4de-88da44b1ef69" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
