### PR TITLE
chore: prevent collision by default in custom home page

### DIFF
--- a/.changeset/polite-apricots-exercise.md
+++ b/.changeset/polite-apricots-exercise.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-home': patch
+---
+
+Enable collision prevention by default in custom home page.
+
+This change ensures that items in the home page will not collide with each other
+making the user experience better.

--- a/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.tsx
+++ b/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.tsx
@@ -349,7 +349,7 @@ export const CustomHomepageGrid = (props: CustomHomepageGridProps) => {
         compactType={props.compactType}
         style={props.style}
         allowOverlap={props.allowOverlap}
-        preventCollision={props.preventCollision}
+        preventCollision={props.preventCollision ?? true}
         draggableCancel=".overlayGridItem,.widgetSettingsDialog,.disabled"
         containerPadding={props.containerPadding}
         margin={props.containerMargin}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This change ensures that items in the home page will not collide with each other
making the user experience better.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
