### PR TITLE
Fix aws.mainAccount account ID check during fallback in DefaultAwsCredentialsManager

### DIFF
--- a/.changeset/slow-drinks-enjoy.md
+++ b/.changeset/slow-drinks-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration-aws-node': patch
+---
+
+Fixed bug in DefaultAwsCredentialsManager where aws.mainAccount.region has no effect on the STS region used for account ID lookup during credential provider lookup when falling back to the main account, and it does not default to us-east-1

--- a/packages/integration-aws-node/src/DefaultAwsCredentialsManager.test.ts
+++ b/packages/integration-aws-node/src/DefaultAwsCredentialsManager.test.ts
@@ -500,5 +500,21 @@ describe('DefaultAwsCredentialsManager', () => {
         },
       });
     });
+
+    it('passes mainAccount region to fillInAccountId for account ID lookup during fallback', async () => {
+      const region = 'us-west-2';
+      const configWithRegion = new ConfigReader({
+        aws: {
+          mainAccount: {
+            region,
+          },
+        },
+      });
+      const provider =
+        DefaultAwsCredentialsManager.fromConfig(configWithRegion);
+      await provider.getCredentialProvider({ accountId: '123456789012' });
+
+      expect(await stsMock.call(0).thisValue.config.region()).toEqual(region);
+    });
   });
 });

--- a/packages/integration-aws-node/src/DefaultAwsCredentialsManager.test.ts
+++ b/packages/integration-aws-node/src/DefaultAwsCredentialsManager.test.ts
@@ -92,6 +92,18 @@ describe('DefaultAwsCredentialsManager', () => {
     });
 
     stsMock
+      .on(GetCallerIdentityCommand)
+      .callsFake(async (_input, getClient) => {
+        const client = getClient();
+        const region = await client.config.region();
+        if (!region) {
+          throw new Error('Region is missing');
+        }
+        return {
+          Account: '123456789012',
+        };
+      });
+    stsMock
       .on(AssumeRoleCommand, {
         RoleArn: 'arn:aws:iam::111111111111:role/hello',
         RoleSessionName: 'backstage',

--- a/packages/integration-aws-node/src/DefaultAwsCredentialsManager.ts
+++ b/packages/integration-aws-node/src/DefaultAwsCredentialsManager.ts
@@ -175,6 +175,7 @@ export class DefaultAwsCredentialsManager implements AwsCredentialsManager {
       awsConfig.mainAccount,
     );
     const mainAccountCredProvider: AwsCredentialProvider = {
+      stsRegion: awsConfig.mainAccount.region,
       sdkCredentialProvider: mainAccountSdkCredProvider,
     };
 

--- a/packages/integration-aws-node/src/DefaultAwsCredentialsManager.ts
+++ b/packages/integration-aws-node/src/DefaultAwsCredentialsManager.ts
@@ -37,6 +37,7 @@ import { Config } from '@backstage/config';
 
 /**
  * Retrieves the account ID for the given credential provider from STS.
+ * Include the region if present, otherwise use the default region.
  */
 async function fillInAccountId(credProvider: AwsCredentialProvider) {
   if (credProvider.accountId) {
@@ -44,7 +45,7 @@ async function fillInAccountId(credProvider: AwsCredentialProvider) {
   }
 
   const client = new STSClient({
-    region: credProvider.stsRegion,
+    region: credProvider.stsRegion ?? 'us-east-1',
     customUserAgent: 'backstage-aws-credentials-manager',
     credentialDefaultProvider: () => credProvider.sdkCredentialProvider,
   });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Given that:

- there is no entry within `aws.accounts[]` with accountId that matches the query, and 
- the `aws.mainAccount.region` config field is not provided, 

When calling `DefaultAwsCredentialsManager#getCredentialProvider()` with an accountId/arn to lookup a credential provider, 

Then a `Region is missing` error will be returned instead of the expected `There is no AWS integration that matches ${accountId}. Please add a configuration for this AWS account.` error. 

This is confusing when troubleshooting config issues.

This unexpected error comes from sending a GetCallerIdentityCommand to STSClient to retrieve the main account's account ID, but the call fails due to an undefined region being provided to the STSClient. There is no way to provide or configure this region, as `mainAccountCredProvider.stsRegion` is always unset.

There appear to be tests that cover this behavior, but this issue is hidden by the STSClient mock always returning a successful value for GetCallerIdentityCommand calls, even when an undefined region is not provided to the STSClient constructor.

Key changes:

- Set a default region of `us-east-1` when calling STS to check the account ID of the main account when considering whether to fall back to the main account during credential provider lookup. This aligns the behavior with the existing implementation of `getDefaultCredentialsChain()`. If the call to STS completes and confirms that the account id is not the desired one, then the "no AWS integration that matches accountId" error message will be returned as expected.
- Set the region for calling STS from the `aws.mainAccount.region` config field, similar to the existing implementation for reading `aws.accounts[].region` and passing it to `fromNodeProviderChain()` #27028 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
