### PR TITLE
root: switch foreach scripts to --jobs unlimited

### DIFF
--- a/.changeset/orange-icons-sell.md
+++ b/.changeset/orange-icons-sell.md
@@ -2,4 +2,4 @@
 '@backstage/create-app': patch
 ---
 
-Added `-j 2` to `dev` script to help cases where the backend does not start up during local development
+Added `--jobs unlimited` to `dev` script to help cases where the backend does not start up during local development

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "build:plugins-report": "node ./scripts/build-plugins-report",
     "clean": "backstage-cli repo clean",
     "create-plugin": "echo \"use 'yarn new' instead\"",
-    "dev": "yarn workspaces foreach -A --include example-backend --include example-app --parallel -v -i run start",
-    "dev:next": "yarn workspaces foreach -A --include example-backend --include example-app-next --parallel -v -i run start",
+    "dev": "yarn workspaces foreach -A --include example-backend --include example-app --parallel --jobs unlimited -v -i run start",
+    "dev:next": "yarn workspaces foreach -A --include example-backend --include example-app-next --parallel --jobs unlimited -v -i run start",
     "docker-build": "yarn tsc && yarn workspace example-backend build && yarn workspace example-backend build-image",
     "fix": "backstage-cli repo fix --publish",
     "postinstall": "husky || true",
@@ -43,7 +43,7 @@
     "start": "yarn workspace example-app start",
     "start-backend": "yarn workspace example-backend start",
     "start-backend:legacy": "yarn workspace example-backend-legacy start",
-    "start:lighthouse": "yarn workspaces foreach -A --include example-backend --include example-app --parallel -v -i run start",
+    "start:lighthouse": "yarn workspaces foreach -A --include example-backend --include example-app --parallel --jobs unlimited -v -i run start",
     "start:microsite": "cd microsite/ && yarn start",
     "start:next": "yarn workspace example-app-next start",
     "storybook": "yarn ./storybook run storybook",
@@ -84,6 +84,9 @@
     ]
   },
   "prettier": "@backstage/cli/config/prettier",
+  "jest": {
+    "rejectFrontendNetworkRequests": true
+  },
   "resolutions": {
     "@changesets/assemble-release-plan@^6.0.0": "patch:@changesets/assemble-release-plan@npm%3A6.0.0#./.yarn/patches/@changesets-assemble-release-plan-npm-6.0.0-f7b3005037.patch",
     "@material-ui/pickers@^3.2.10": "patch:@material-ui/pickers@npm%3A3.3.11#./.yarn/patches/@material-ui-pickers-npm-3.3.11-1c8f68ea20.patch",
@@ -133,9 +136,6 @@
     "sloc": "^0.3.1",
     "sort-package-json": "^2.8.0",
     "typescript": "~5.2.0"
-  },
-  "jest": {
-    "rejectFrontendNetworkRequests": true
   },
   "packageManager": "yarn@3.8.1",
   "engines": {

--- a/packages/create-app/templates/default-app/package.json.hbs
+++ b/packages/create-app/templates/default-app/package.json.hbs
@@ -6,7 +6,7 @@
     "node": "20 || 22"
   },
   "scripts": {
-    "dev": "yarn workspaces foreach -A --include backend --include app --parallel -j 2 -v -i run start",
+    "dev": "yarn workspaces foreach -A --include backend --include app --parallel --jobs unlimited -v -i run start",
     "start": "yarn workspace app start",
     "start-backend": "yarn workspace backend start",
     "build:backend": "yarn workspace backend build",


### PR DESCRIPTION
🧹, quick followup for #28296, switching to `--jobs` since I find that more informative. I also found `unlimited` to be more semantically correct rather than `2`, and safe in case more packages are added.
