### PR TITLE
Canon - Fix Github action to deploy Canon website

### DIFF
--- a/.github/workflows/sync_canon.yml
+++ b/.github/workflows/sync_canon.yml
@@ -4,7 +4,7 @@ on:
     branches: [master]
 
 jobs:
-  sync-canon-storybook:
+  sync-canon-docs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -26,10 +26,10 @@ jobs:
         with:
           cache-prefix: ${{ runner.os }}-v20.x
 
-      - name: Checkout backstage/canon-storybook
+      - name: Checkout backstage/canon-docs
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          repository: backstage/canon-storybook
+          repository: backstage/canon-docs
           path: canon-external-docs
           token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}
 
@@ -37,6 +37,10 @@ jobs:
         run: |
           git config --global user.email noreply@backstage.io
           git config --global user.name 'Github Canon Docs workflow'
+
+      - name: Install dependencies
+        working-directory: canon-docs
+        run: yarn install
 
       - name: Build Canon Docs
         working-directory: canon-docs


### PR DESCRIPTION
I'm fixing a part of the flow to install dependencies before running `yarn build`. We are also renaming `canon-storybook` repo into `canon-docs`.

To make sure this flow work, we will have to rename `canon-storybook` repo first into `canon-docs`.