### PR TITLE
cfaccess: fallback to identity email when constructing the user profile

### DIFF
--- a/.changeset/fast-seas-hunt.md
+++ b/.changeset/fast-seas-hunt.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-auth-backend-module-cloudflare-access-provider': patch
 ---
 
-Use email from cfIdentity instead of claims when constructing user profile for Service Token support.
+Use the email from `cfIdentity` instead of `claims` when constructing user profile in order to support Cloudflare Service Tokens.

--- a/.changeset/fast-seas-hunt.md
+++ b/.changeset/fast-seas-hunt.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-auth-backend-module-cloudflare-access-provider': patch
 ---
 
-Fallback to email from cfIdentity when constructing user profile for Service Token support.
+Use email from cfIdentity instead of claims when constructing user profile for Service Token support.

--- a/.changeset/fast-seas-hunt.md
+++ b/.changeset/fast-seas-hunt.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-cloudflare-access-provider': patch
+---
+
+Fallback to email from cfIdentity when constructing user profile for Service Token support.

--- a/plugins/auth-backend-module-cloudflare-access-provider/src/authenticator.test.ts
+++ b/plugins/auth-backend-module-cloudflare-access-provider/src/authenticator.test.ts
@@ -18,7 +18,7 @@ import { mockServices } from '@backstage/backend-test-utils';
 import { createCloudflareAccessAuthenticator } from './authenticator';
 
 describe('authenticator', () => {
-  it('createCloudflareAccessAuthenticator works', async () => {
+  it('works for normal users', async () => {
     const auth = createCloudflareAccessAuthenticator({
       cache: mockServices.cache.mock(),
     });
@@ -27,6 +27,27 @@ describe('authenticator', () => {
       {
         cfIdentity: { name: 'Name' } as any,
         claims: { email: 'hello@example.com' } as any,
+        token: 'fake',
+      },
+      {} as any,
+    );
+    expect(profile).toEqual({
+      profile: {
+        displayName: 'Name',
+        email: 'hello@example.com',
+      },
+    });
+  });
+
+  it('works for service tokens', async () => {
+    const auth = createCloudflareAccessAuthenticator({
+      cache: mockServices.cache.mock(),
+    });
+
+    const profile = await auth.defaultProfileTransform(
+      {
+        cfIdentity: { name: 'Name', email: 'hello@example.com' } as any,
+        claims: {} as any,
         token: 'fake',
       },
       {} as any,

--- a/plugins/auth-backend-module-cloudflare-access-provider/src/authenticator.test.ts
+++ b/plugins/auth-backend-module-cloudflare-access-provider/src/authenticator.test.ts
@@ -25,7 +25,7 @@ describe('authenticator', () => {
 
     const profile = await auth.defaultProfileTransform(
       {
-        cfIdentity: { name: 'Name' } as any,
+        cfIdentity: { name: 'Name', email: 'hello@example.com' } as any,
         claims: { email: 'hello@example.com' } as any,
         token: 'fake',
       },

--- a/plugins/auth-backend-module-cloudflare-access-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-cloudflare-access-provider/src/authenticator.ts
@@ -38,7 +38,7 @@ export function createCloudflareAccessAuthenticator(options?: {
     async defaultProfileTransform(result: CloudflareAccessResult) {
       return {
         profile: {
-          email: result.claims.email ?? result.cfIdentity.email,
+          email: result.cfIdentity.email,
           displayName: result.cfIdentity.name,
         },
       };

--- a/plugins/auth-backend-module-cloudflare-access-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-cloudflare-access-provider/src/authenticator.ts
@@ -38,7 +38,7 @@ export function createCloudflareAccessAuthenticator(options?: {
     async defaultProfileTransform(result: CloudflareAccessResult) {
       return {
         profile: {
-          email: result.claims.email,
+          email: result.claims.email ?? result.cfIdentity.email,
           displayName: result.cfIdentity.name,
         },
       };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Noticed this while updating our dependencies and setting up some Service Tokens -- they don't have an `email` in their claims so the current profile transform doesn't work properly.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
