### PR TITLE
Make gitlab:group:ensureExists support path objects

### DIFF
--- a/.changeset/young-forks-grab.md
+++ b/.changeset/young-forks-grab.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gitlab': minor
+---
+
+Updated the path field in the gitlab:group:ensureExists action to accept an array of either strings or objects with name and slug fields.

--- a/.changeset/young-forks-grab.md
+++ b/.changeset/young-forks-grab.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-scaffolder-backend-module-gitlab': minor
+'@backstage/plugin-scaffolder-backend-module-gitlab': patch
 ---
 
-Updated the path field in the gitlab:group:ensureExists action to accept an array of either strings or objects with name and slug fields.
+Updated the path field in the `gitlab:group:ensureExists` action to accept an array of either strings or objects with name and slug fields.

--- a/plugins/scaffolder-backend-module-gitlab/report.api.md
+++ b/plugins/scaffolder-backend-module-gitlab/report.api.md
@@ -14,7 +14,13 @@ export const createGitlabGroupEnsureExistsAction: (options: {
   integrations: ScmIntegrationRegistry;
 }) => TemplateAction<
   {
-    path: string[];
+    path: (
+      | string
+      | {
+          name: string;
+          slug: string;
+        }
+    )[];
     repoUrl: string;
     token?: string | undefined;
   },

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabGroupEnsureExists.examples.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabGroupEnsureExists.examples.ts
@@ -82,4 +82,24 @@ export const examples: TemplateExample[] = [
       ],
     }),
   },
+  {
+    description: 'Create a group nested within another group using objects',
+    example: yaml.stringify({
+      steps: [
+        {
+          id: 'gitlabGroup',
+          name: 'Group',
+          action: 'gitlab:group:ensureExists',
+          input: {
+            repoUrl: 'gitlab.com',
+            path: [
+              { name: 'Group 1', slug: 'group1' },
+              { name: 'Group 2', slug: 'group2' },
+              { name: 'Group 3', slug: 'group3' },
+            ],
+          },
+        },
+      ],
+    }),
+  },
 ];

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabGroupEnsureExists.test.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabGroupEnsureExists.test.ts
@@ -62,7 +62,7 @@ describe('gitlab:group:ensureExists', () => {
 
   const mockContext = createMockActionContext();
 
-  it('should create a new group if it does not exists', async () => {
+  it('should create a new group from string if it does not exists', async () => {
     mockGitlabClient.Groups.search.mockResolvedValue([
       {
         id: 1,
@@ -90,6 +90,45 @@ describe('gitlab:group:ensureExists', () => {
     expect(mockGitlabClient.Groups.create).toHaveBeenCalledWith('bar', 'bar', {
       parentId: 2,
     });
+
+    expect(mockContext.output).toHaveBeenCalledWith('groupId', 3);
+  });
+
+  it('should create a new group from object if it does not exists', async () => {
+    mockGitlabClient.Groups.search.mockResolvedValue([
+      {
+        id: 1,
+        full_path: 'bar',
+      },
+      {
+        id: 2,
+        full_path: 'foo',
+      },
+    ]);
+
+    mockGitlabClient.Groups.create.mockResolvedValue({
+      id: 3,
+      full_path: 'foo/bar',
+    });
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        repoUrl: 'gitlab.com?repo=repo&owner=owner',
+        path: [
+          { name: 'Foo', slug: 'foo' },
+          { name: 'Bar is a nice name', slug: 'bar' },
+        ],
+      },
+    });
+
+    expect(mockGitlabClient.Groups.create).toHaveBeenCalledWith(
+      'Bar is a nice name',
+      'bar',
+      {
+        parentId: 2,
+      },
+    );
 
     expect(mockContext.output).toHaveBeenCalledWith('groupId', 3);
   });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #28392

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
