### PR TITLE
feat(techdocs): add support for AWS S3 retries in publisher

### DIFF
--- a/.changeset/old-phones-rest.md
+++ b/.changeset/old-phones-rest.md
@@ -1,0 +1,6 @@
+---
+'@techdocs/cli': minor
+'@backstage/plugin-techdocs-node': minor
+---
+
+Allow configurable optional retries for publisher AWS S3 operations.

--- a/docs/features/techdocs/cli.md
+++ b/docs/features/techdocs/cli.md
@@ -197,6 +197,7 @@ Options:
   --awsS3sse <AWS SSE>                                          Optional AWS S3 Server Side Encryption.
   --awsS3ForcePathStyle                                         Optional AWS S3 option to force path style.
   --awsBucketRootPath <AWS BUCKET ROOT PATH>                    Optional sub-directory to store files in Amazon S3
+  --awsMaxAttempts <AWS MAX ATTEMPTS>                           Optional maximum number of retries for AWS S3 operations. If not specified, default value of 3 is used.
   --osCredentialId <OPENSTACK SWIFT APPLICATION CREDENTIAL ID>  (Required for OpenStack) specify when --publisher-type openStackSwift
   --osSecret <OPENSTACK SWIFT APPLICATION CREDENTIAL SECRET>    (Required for OpenStack) specify when --publisher-type openStackSwift
   --osAuthUrl <OPENSTACK SWIFT AUTHURL>                         (Required for OpenStack) specify when --publisher-type openStackSwift

--- a/packages/techdocs-cli/cli-report.md
+++ b/packages/techdocs-cli/cli-report.md
@@ -83,6 +83,7 @@ Options:
   --awsS3sse <AWS SSE>
   --awsS3ForcePathStyle
   --awsBucketRootPath <AWS BUCKET ROOT PATH>
+  --awsMaxAttempts <AWS MAX ATTEMPTS>
   --osCredentialId <OPENSTACK SWIFT APPLICATION CREDENTIAL ID>
   --osSecret <OPENSTACK SWIFT APPLICATION CREDENTIAL SECRET>
   --osAuthUrl <OPENSTACK SWIFT AUTHURL>

--- a/packages/techdocs-cli/src/commands/index.ts
+++ b/packages/techdocs-cli/src/commands/index.ts
@@ -197,6 +197,10 @@ export function registerCommands(program: Command) {
       'Optional sub-directory to store files in Amazon S3',
     )
     .option(
+      '--awsMaxAttempts <AWS MAX ATTEMPTS>',
+      'Optional maximum number of retries for AWS S3 operations. If not specified, default value of 3 is used.',
+    )
+    .option(
       '--osCredentialId <OPENSTACK SWIFT APPLICATION CREDENTIAL ID>',
       '(Required for OpenStack) specify when --publisher-type openStackSwift',
     )

--- a/packages/techdocs-cli/src/lib/PublisherConfig.ts
+++ b/packages/techdocs-cli/src/lib/PublisherConfig.ts
@@ -95,6 +95,9 @@ export class PublisherConfig {
         ...(opts.awsS3ForcePathStyle && { s3ForcePathStyle: true }),
         ...(opts.awsS3sse && { sse: opts.awsS3sse }),
         ...(opts.awsProxy && { httpsProxy: opts.awsProxy }),
+        ...(opts.awsMaxAttempts && {
+          maxAttempts: Number(opts.awsMaxAttempts),
+        }),
       },
     };
   }

--- a/plugins/techdocs-node/src/stages/publish/awsS3.ts
+++ b/plugins/techdocs-node/src/stages/publish/awsS3.ts
@@ -164,12 +164,18 @@ export class AwsS3Publish implements PublisherBase {
       'techdocs.publisher.awsS3.s3ForcePathStyle',
     );
 
+    // AWS MAX ATTEMPTS is an optional config. If missing, default value of 3 is used
+    const maxAttempts = config.getOptionalNumber(
+      'techdocs.publisher.awsS3.maxAttempts',
+    );
+
     const storageClient = new S3Client({
       customUserAgent: 'backstage-aws-techdocs-s3-publisher',
       credentialDefaultProvider: () => sdkCredentialProvider,
       ...(region && { region }),
       ...(endpoint && { endpoint }),
       ...(forcePathStyle && { forcePathStyle }),
+      ...(maxAttempts && { maxAttempts }),
       ...(httpsProxy && {
         requestHandler: new NodeHttpHandler({
           httpsAgent: new HttpsProxyAgent({ proxy: httpsProxy }),


### PR DESCRIPTION
This change is to allow a configurable retry in Backstage TechDocs publisher for AWS S3.

It introduces a new possible option for techdocs-cli publish called --awsMaxAttempts. This configuration when specified as a number translates to maxAttempts that is compatible with aws-sdk/client-s3 (JavaScript v3) S3Client class.  
The change will not break existing configuration setups - maxAttempts is optional and fallbacks to already existing defaults if not specified.

This will allow users to increase the number of retries for AWS SDK to perform publishing operations and will be helpful for those with more saturated/weaker networks.

AWS SDK for JavaScript v3 S3Client class details (scroll to the bottom for maxAttempts): https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/s3/
Retry behavior documentation for AWS can be found here: https://docs.aws.amazon.com/sdkref/latest/guide/feature-retry-behavior.html

Changes were tested using yarn with updated code `yarn workspace @techdocs/cli build` and simulating a failing upload to a bucket (to get retries going). Passed settings like `--awsMaxAttempts 4` or `--awsMaxAttempts 10` to the publisher would appear as `"attempts":4` or `"attempts":10` respectively in the metadata from AWS client library. This indicates additional attempts made by the SDK. Not specifying any option would result in a constant default `"attempts":3` as expected.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
