### PR TITLE
Updated docs of Kubernetes configuration docs

### DIFF
--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -578,19 +578,19 @@ view the Kubernetes API docs for your Kubernetes version (e.g.
 
 Overrides for the Kubernetes object types fetched from the cluster. The default object types are:
 
-- pods
-- services
-- configmaps
-- limitranges
-- resourcequotas
-- deployments
-- replicasets
-- horizontalpodautoscalers
-- jobs
-- cronjobs
-- ingresses
-- statefulsets
-- daemonsets
+- `pods`
+- `services`
+- `configmaps`
+- `limitranges`
+- `resourcequotas`
+- `deployments`
+- `replicasets`
+- `horizontalpodautoscalers`
+- `jobs`
+- `cronjobs`
+- `ingresses`
+- `statefulsets`
+- `daemonsets`
 
 You may use this config to override the default object types if you only want a subset of
 the default ones. However, it's currently not supported to fetch object types other


### PR DESCRIPTION
Updated docs of Kubernetes configuration docs maintain design docs as other docs:

![image](https://github.com/user-attachments/assets/c3afc4f0-f32b-4967-b4c0-f7c436917b46)
