### PR TITLE
chore: update getFile in BitbucketServerClient to use REST API path

### DIFF
--- a/.changeset/thick-radios-wink.md
+++ b/.changeset/thick-radios-wink.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-bitbucket-server': patch
+---
+
+Updated the `getFile` method in `BitbucketServerClient` to use `this.config.apiBaseUrl` directly for constructing the API request URL, removing the creation of an unnecessary `URL` object. The method now relies on REST API paths for accessing resources instead of direct access, ensuring better alignment with Bitbucket's API conventions.

--- a/plugins/catalog-backend-module-bitbucket-server/src/lib/BitbucketServerClient.test.ts
+++ b/plugins/catalog-backend-module-bitbucket-server/src/lib/BitbucketServerClient.test.ts
@@ -153,7 +153,7 @@ describe('BitbucketServerClient', () => {
   it('getFile', async () => {
     server.use(
       rest.get(
-        `https://${config.host}/projects/test-project/repos/test-repo/raw/catalog-info.yaml`,
+        `${config.apiBaseUrl}/projects/test-project/repos/test-repo/raw/catalog-info.yaml`,
         (req, res, ctx) => {
           if (
             req.headers.get('authorization') !==

--- a/plugins/catalog-backend-module-bitbucket-server/src/lib/BitbucketServerClient.ts
+++ b/plugins/catalog-backend-module-bitbucket-server/src/lib/BitbucketServerClient.ts
@@ -77,9 +77,8 @@ export class BitbucketServerClient {
     repo: string;
     path: string;
   }): Promise<Response> {
-    const base = new URL(this.config.apiBaseUrl);
     return throttledFetch(
-      `${base.protocol}//${base.host}/projects/${options.projectKey}/repos/${options.repo}/raw/${options.path}`,
+      `${this.config.apiBaseUrl}/projects/${options.projectKey}/repos/${options.repo}/raw/${options.path}`,
       getBitbucketServerRequestOptions(this.config),
     );
   }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR updates the `getFile` method in `BitbucketServerClient` to use REST API paths for constructing request URLs instead of directly referencing the host. In our company, direct access to Bitbucket paths is restricted, and authentication via SSO is enforced. The HTTP access token we use only works for endpoints under `/rest/api...`, making the previous implementation incompatible with our setup.

I noticed that all other endpoints in this client rely on the REST API paths, except for `getFile`, which was directly referencing the host. This change brings consistency across the client and aligns it with REST API standards, ensuring compatibility with environments like ours.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
