### PR TITLE
fix: Techdocs base url should be app.baseUrl

### DIFF
--- a/.changeset/proud-dryers-act.md
+++ b/.changeset/proud-dryers-act.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': major
+---
+
+Changed the base URL in addLinkClickListener from window.location.origin to app.baseUrl for improved path handling. This fixes an issue where Backstage, when running on a subpath, was unable to handle non-Backstage URLs of the same origin correctly.

--- a/.changeset/proud-dryers-act.md
+++ b/.changeset/proud-dryers-act.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-techdocs': major
+'@backstage/plugin-techdocs': patch
 ---
 
 Changed the base URL in addLinkClickListener from window.location.origin to app.baseUrl for improved path handling. This fixes an issue where Backstage, when running on a subpath, was unable to handle non-Backstage URLs of the same origin correctly.

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx
@@ -194,7 +194,9 @@ export const useTechDocsReaderDom = (
         scrollIntoNavigation(),
         copyToClipboard(theme),
         addLinkClickListener({
-          baseUrl: configApi.getString('app.baseUrl'),
+          baseUrl:
+            configApi.getOptionalString('app.baseUrl') ||
+            window.location.origin,
           onClick: (event: MouseEvent, url: string) => {
             // detect if CTRL or META keys are pressed so that links can be opened in a new tab with `window.open`
             const modifierActive = event.ctrlKey || event.metaKey;

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx
@@ -21,7 +21,6 @@ import { useTheme } from '@material-ui/core/styles';
 
 import { CompoundEntityRef } from '@backstage/catalog-model';
 import { configApiRef, useAnalytics, useApi } from '@backstage/core-plugin-api';
-import {} from '@backstage/plugin-catalog-react';
 import { scmIntegrationsApiRef } from '@backstage/integration-react';
 
 import {

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageContent/dom.tsx
@@ -20,7 +20,8 @@ import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { useTheme } from '@material-ui/core/styles';
 
 import { CompoundEntityRef } from '@backstage/catalog-model';
-import { useAnalytics, useApi } from '@backstage/core-plugin-api';
+import { configApiRef, useAnalytics, useApi } from '@backstage/core-plugin-api';
+import {} from '@backstage/plugin-catalog-react';
 import { scmIntegrationsApiRef } from '@backstage/integration-react';
 
 import {
@@ -68,6 +69,7 @@ export const useTechDocsReaderDom = (
 
   const techdocsStorageApi = useApi(techdocsStorageApiRef);
   const scmIntegrationsApi = useApi(scmIntegrationsApiRef);
+  const configApi = useApi(configApiRef);
 
   const { state, path, content: rawPage } = useTechDocsReader();
   const { '*': currPath = '' } = useParams();
@@ -193,7 +195,7 @@ export const useTechDocsReaderDom = (
         scrollIntoNavigation(),
         copyToClipboard(theme),
         addLinkClickListener({
-          baseUrl: window.location.origin,
+          baseUrl: configApi.getString('app.baseUrl'),
           onClick: (event: MouseEvent, url: string) => {
             // detect if CTRL or META keys are pressed so that links can be opened in a new tab with `window.open`
             const modifierActive = event.ctrlKey || event.metaKey;
@@ -258,7 +260,7 @@ export const useTechDocsReaderDom = (
           onLoaded: () => {},
         }),
       ]),
-    [theme, navigate, analytics, entityRef.name],
+    [theme, navigate, analytics, entityRef.name, configApi],
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Changed the base URL in addLinkClickListener from `window.location.origin` to `app.baseUrl`. 
This fixes an issue where Backstage, when running on a subpath, could not handle non-Backstage URLs of the same origin correctly in techdocs leading to 404 issues.

Eg
`app.baseUrl: https://example.com/backstage`
When using `https://example.com/non-backstage` URLs in techdocs. It was generating the final URL as `https://example.com/backstage/<techdocs-url>/https:/non-backstage`. This was happening because techdocs was determining whether the URL is internal or external based on `window.location.origin`. Due to this `https://example.com/non-backstage` was considered an internal route and was causing 404.
Using `app.baseUrl` as base for checking whether URL is internal or external fixed the issue.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
