### PR TITLE
fix(scaffolder): resolve bug in BitbucketRepoBranchPicker crashing the scaffolder

### DIFF
--- a/.changeset/proud-hornets-cheer.md
+++ b/.changeset/proud-hornets-cheer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Fixed a bug in the BitbucketRepoBranchPicker component that crashed the scaffolder

--- a/plugins/scaffolder/src/components/fields/RepoBranchPicker/BitbucketRepoBranchPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoBranchPicker/BitbucketRepoBranchPicker.test.tsx
@@ -26,9 +26,7 @@ import userEvent from '@testing-library/user-event';
 
 describe('BitbucketRepoBranchPicker', () => {
   const scaffolderApiMock: Partial<ScaffolderApi> = {
-    autocomplete: jest
-      .fn()
-      .mockResolvedValue({ results: [{ title: 'branch1' }] }),
+    autocomplete: jest.fn().mockResolvedValue({ results: [{ id: 'branch1' }] }),
   };
 
   it('renders an input field', () => {

--- a/plugins/scaffolder/src/components/fields/RepoBranchPicker/BitbucketRepoBranchPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoBranchPicker/BitbucketRepoBranchPicker.tsx
@@ -66,7 +66,7 @@ export const BitbucketRepoBranchPicker = ({
         provider: 'bitbucket-cloud',
       })
       .then(({ results }) => {
-        setAvailableBranches(results.map(r => r.title!));
+        setAvailableBranches(results.map(r => r.id));
       })
       .catch(() => {
         setAvailableBranches([]);


### PR DESCRIPTION
This PR resolves a bug in the `BitbucketRepoBranchPicker` component that crashed the scaffolder.

This bug seems to have been introduced in #27367, which I was asked to validate, but it seems like I forgot to test out the `BitbucketRepoBranchPicker`. 🤡

Ideally, I think this fix should be released as a hotfix instead of waiting for next month's release since the current `BitbucketRepoBranchPicker` renders every template that uses this component unusable.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
