### PR TITLE
Feature(Scaffolder): Use PermissionsRegistryService

### DIFF
--- a/.changeset/late-moose-care.md
+++ b/.changeset/late-moose-care.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+`permissionRules` option in `createRouter()` is deprecated. Please upgrade to the new backend system and use `coreServices.permissionsRegistry` to add custom rules

--- a/.changeset/lemon-dragons-lick.md
+++ b/.changeset/lemon-dragons-lick.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+Add `scaffolderActionRules`, `createActionPermissionRule`, `scaffolderTemplateRules`, and `createTemplatePermissionRule`

--- a/.changeset/light-dancers-listen.md
+++ b/.changeset/light-dancers-listen.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+'@backstage/plugin-scaffolder-node': minor
+---
+
+Update to use PermissionsRegistryService

--- a/docs/permissions/plugin-authors/03-adding-a-resource-permission-check.md
+++ b/docs/permissions/plugin-authors/03-adding-a-resource-permission-check.md
@@ -135,7 +135,7 @@ export const todoListPermissionResourceRef = createPermissionResourceRef<
   TodoFilter
 >().with({
   pluginId: 'todolist',
-  type: TODO_LIST_RESOURCE_TYPE,
+  resourceType: TODO_LIST_RESOURCE_TYPE,
 });
 
 export const isOwner = createPermissionRule({

--- a/docs/permissions/plugin-authors/03-adding-a-resource-permission-check.md
+++ b/docs/permissions/plugin-authors/03-adding-a-resource-permission-check.md
@@ -141,7 +141,7 @@ export const todoListPermissionResourceRef = createPermissionResourceRef<
 export const isOwner = createPermissionRule({
   name: 'IS_OWNER',
   description: 'Should allow only if the todo belongs to the user',
-  resourceType: todoListPermissionResourceRef,
+  resourceRef: todoListPermissionResourceRef,
   paramsSchema: z.object({
     userId: z.string().describe('User ID to match on the resource'),
   }),

--- a/plugins/scaffolder-backend/report-alpha.api.md
+++ b/plugins/scaffolder-backend/report-alpha.api.md
@@ -9,10 +9,29 @@ import { Conditions } from '@backstage/plugin-permission-node';
 import { JsonObject } from '@backstage/types';
 import { PermissionCondition } from '@backstage/plugin-permission-common';
 import { PermissionCriteria } from '@backstage/plugin-permission-common';
+import { PermissionResourceRef } from '@backstage/plugin-permission-node';
 import { PermissionRule } from '@backstage/plugin-permission-node';
+import { PermissionRuleParams } from '@backstage/plugin-permission-common';
 import { ResourcePermission } from '@backstage/plugin-permission-common';
 import { TemplateEntityStepV1beta3 } from '@backstage/plugin-scaffolder-common';
 import { TemplateParametersV1beta3 } from '@backstage/plugin-scaffolder-common';
+
+// @alpha @deprecated (undocumented)
+export const createActionPermissionRule: <
+  TParams extends PermissionRuleParams = undefined,
+>(
+  rule: PermissionRule<
+    ScaffolderActionPermissionResource,
+    {},
+    'scaffolder-action',
+    TParams
+  >,
+) => PermissionRule<
+  ScaffolderActionPermissionResource,
+  {},
+  'scaffolder-action',
+  TParams
+>;
 
 // @alpha (undocumented)
 export const createScaffolderActionConditionalDecision: (
@@ -26,6 +45,23 @@ export const createScaffolderTemplateConditionalDecision: (
   conditions: PermissionCriteria<PermissionCondition<'scaffolder-template'>>,
 ) => ConditionalPolicyDecision;
 
+// @alpha @deprecated (undocumented)
+export const createTemplatePermissionRule: <
+  TParams extends PermissionRuleParams = undefined,
+>(
+  rule: PermissionRule<
+    ScaffolderTemplatePermissionResource,
+    {},
+    'scaffolder-template',
+    TParams
+  >,
+) => PermissionRule<
+  ScaffolderTemplatePermissionResource,
+  {},
+  'scaffolder-template',
+  TParams
+>;
+
 // @alpha (undocumented)
 const _feature: BackendFeature;
 export default _feature;
@@ -33,10 +69,7 @@ export default _feature;
 // @alpha
 export const scaffolderActionConditions: Conditions<{
   hasActionId: PermissionRule<
-    {
-      action: string;
-      input: JsonObject | undefined;
-    },
+    ScaffolderActionPermissionResource,
     {},
     'scaffolder-action',
     {
@@ -44,10 +77,7 @@ export const scaffolderActionConditions: Conditions<{
     }
   >;
   hasBooleanProperty: PermissionRule<
-    {
-      action: string;
-      input: JsonObject | undefined;
-    },
+    ScaffolderActionPermissionResource,
     {},
     'scaffolder-action',
     {
@@ -56,10 +86,7 @@ export const scaffolderActionConditions: Conditions<{
     }
   >;
   hasNumberProperty: PermissionRule<
-    {
-      action: string;
-      input: JsonObject | undefined;
-    },
+    ScaffolderActionPermissionResource,
     {},
     'scaffolder-action',
     {
@@ -68,10 +95,7 @@ export const scaffolderActionConditions: Conditions<{
     }
   >;
   hasStringProperty: PermissionRule<
-    {
-      action: string;
-      input: JsonObject | undefined;
-    },
+    ScaffolderActionPermissionResource,
     {},
     'scaffolder-action',
     {
@@ -81,10 +105,65 @@ export const scaffolderActionConditions: Conditions<{
   >;
 }>;
 
+// @alpha (undocumented)
+export type ScaffolderActionPermissionResource =
+  | {
+      action: string;
+      input: JsonObject | undefined;
+    }
+  | ScaffolderTemplatePermissionResource;
+
+// @alpha (undocumented)
+export const scaffolderActionPermissionResourceRef: PermissionResourceRef<
+  ScaffolderActionPermissionResource,
+  {},
+  'scaffolder-action',
+  'scaffolder'
+>;
+
+// @alpha (undocumented)
+export const scaffolderActionRules: {
+  hasActionId: PermissionRule<
+    ScaffolderActionPermissionResource,
+    {},
+    'scaffolder-action',
+    {
+      actionId: string;
+    }
+  >;
+  hasBooleanProperty: PermissionRule<
+    ScaffolderActionPermissionResource,
+    {},
+    'scaffolder-action',
+    {
+      key: string;
+      value?: boolean | undefined;
+    }
+  >;
+  hasNumberProperty: PermissionRule<
+    ScaffolderActionPermissionResource,
+    {},
+    'scaffolder-action',
+    {
+      key: string;
+      value?: number | undefined;
+    }
+  >;
+  hasStringProperty: PermissionRule<
+    ScaffolderActionPermissionResource,
+    {},
+    'scaffolder-action',
+    {
+      key: string;
+      value?: string | undefined;
+    }
+  >;
+};
+
 // @alpha
 export const scaffolderTemplateConditions: Conditions<{
   hasTag: PermissionRule<
-    TemplateParametersV1beta3 | TemplateEntityStepV1beta3,
+    ScaffolderTemplatePermissionResource,
     {},
     'scaffolder-template',
     {
@@ -92,6 +171,31 @@ export const scaffolderTemplateConditions: Conditions<{
     }
   >;
 }>;
+
+// @alpha (undocumented)
+export type ScaffolderTemplatePermissionResource =
+  | TemplateEntityStepV1beta3
+  | TemplateParametersV1beta3;
+
+// @alpha (undocumented)
+export const scaffolderTemplatePermissionResourceRef: PermissionResourceRef<
+  ScaffolderTemplatePermissionResource,
+  {},
+  'scaffolder-template',
+  'scaffolder'
+>;
+
+// @alpha (undocumented)
+export const scaffolderTemplateRules: {
+  hasTag: PermissionRule<
+    ScaffolderTemplatePermissionResource,
+    {},
+    'scaffolder-template',
+    {
+      tag: string;
+    }
+  >;
+};
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/scaffolder-backend/report.api.md
+++ b/plugins/scaffolder-backend/report.api.md
@@ -49,6 +49,7 @@ import { Logger } from 'winston';
 import { PermissionEvaluator } from '@backstage/plugin-permission-common';
 import { PermissionRule } from '@backstage/plugin-permission-node';
 import { PermissionRuleParams } from '@backstage/plugin-permission-common';
+import { PermissionsRegistryService } from '@backstage/backend-plugin-api';
 import { PermissionsService } from '@backstage/backend-plugin-api';
 import { RESOURCE_TYPE_SCAFFOLDER_ACTION } from '@backstage/plugin-scaffolder-common/alpha';
 import { RESOURCE_TYPE_SCAFFOLDER_TEMPLATE } from '@backstage/plugin-scaffolder-common/alpha';
@@ -84,7 +85,7 @@ import { ZodTypeDef } from 'zod';
 // @public @deprecated (undocumented)
 export type ActionContext<TInput extends JsonObject> = ActionContext_2<TInput>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type ActionPermissionRuleInput<
   TParams extends PermissionRuleParams = PermissionRuleParams,
 > = PermissionRule<
@@ -579,12 +580,14 @@ export interface RouterOptions {
   lifecycle?: LifecycleService;
   // (undocumented)
   logger: Logger;
-  // (undocumented)
+  // @deprecated (undocumented)
   permissionRules?: Array<
     TemplatePermissionRuleInput | ActionPermissionRuleInput
   >;
   // (undocumented)
   permissions?: PermissionsService;
+  // (undocumented)
+  permissionsRegistry?: PermissionsRegistryService;
   // (undocumented)
   reader: UrlReaderService;
   // (undocumented)
@@ -875,7 +878,7 @@ export type TemplateFilter = TemplateFilter_2;
 // @public @deprecated (undocumented)
 export type TemplateGlobal = TemplateGlobal_2;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type TemplatePermissionRuleInput<
   TParams extends PermissionRuleParams = PermissionRuleParams,
 > = PermissionRule<

--- a/plugins/scaffolder-backend/src/ScaffolderPlugin.ts
+++ b/plugins/scaffolder-backend/src/ScaffolderPlugin.ts
@@ -52,6 +52,17 @@ import {
   createWaitAction,
 } from './scaffolder';
 import { createRouter } from './service/router';
+import {
+  scaffolderActionPermissions,
+  scaffolderPermissions,
+  scaffolderTemplatePermissions,
+} from '@backstage/plugin-scaffolder-common/alpha';
+import {
+  scaffolderActionPermissionResourceRef,
+  scaffolderActionRules,
+  scaffolderTemplatePermissionResourceRef,
+  scaffolderTemplateRules,
+} from './service/rules';
 
 /**
  * Scaffolder plugin
@@ -118,6 +129,7 @@ export const scaffolderPlugin = createBackendPlugin({
         auditor: coreServices.auditor,
         catalogClient: catalogServiceRef,
         events: eventsServiceRef,
+        permissionsRegistry: coreServices.permissionsRegistry,
       },
       async init({
         logger,
@@ -133,6 +145,7 @@ export const scaffolderPlugin = createBackendPlugin({
         permissions,
         events,
         auditor,
+        permissionsRegistry,
       }) {
         const log = loggerToWinstonLogger(logger);
         const integrations = ScmIntegrations.fromConfig(config);
@@ -198,8 +211,23 @@ export const scaffolderPlugin = createBackendPlugin({
           additionalWorkspaceProviders,
           events,
           auditor,
+          permissionsRegistry,
         });
         httpRouter.use(router);
+
+        permissionsRegistry.addPermissions(scaffolderPermissions);
+
+        permissionsRegistry.addResourceType({
+          resourceRef: scaffolderTemplatePermissionResourceRef,
+          permissions: scaffolderTemplatePermissions,
+          rules: Object.values(scaffolderTemplateRules),
+        });
+
+        permissionsRegistry.addResourceType({
+          resourceRef: scaffolderActionPermissionResourceRef,
+          permissions: scaffolderActionPermissions,
+          rules: Object.values(scaffolderActionRules),
+        });
       },
     });
   },

--- a/plugins/scaffolder-backend/src/service/conditionExports.ts
+++ b/plugins/scaffolder-backend/src/service/conditionExports.ts
@@ -14,22 +14,21 @@
  * limitations under the License.
  */
 
-import {
-  RESOURCE_TYPE_SCAFFOLDER_TEMPLATE,
-  RESOURCE_TYPE_SCAFFOLDER_ACTION,
-} from '@backstage/plugin-scaffolder-common/alpha';
 import { createConditionExports } from '@backstage/plugin-permission-node';
-import { scaffolderTemplateRules, scaffolderActionRules } from './rules';
+import {
+  scaffolderActionPermissionResourceRef,
+  scaffolderActionRules,
+  scaffolderTemplatePermissionResourceRef,
+  scaffolderTemplateRules,
+} from './rules';
 
 const templateConditionExports = createConditionExports({
-  pluginId: 'scaffolder',
-  resourceType: RESOURCE_TYPE_SCAFFOLDER_TEMPLATE,
+  resourceRef: scaffolderTemplatePermissionResourceRef,
   rules: scaffolderTemplateRules,
 });
 
 const actionsConditionExports = createConditionExports({
-  pluginId: 'scaffolder',
-  resourceType: RESOURCE_TYPE_SCAFFOLDER_ACTION,
+  resourceRef: scaffolderActionPermissionResourceRef,
   rules: scaffolderActionRules,
 });
 

--- a/plugins/scaffolder-backend/src/service/index.ts
+++ b/plugins/scaffolder-backend/src/service/index.ts
@@ -14,4 +14,18 @@
  * limitations under the License.
  */
 
+export {
+  scaffolderTemplateRules,
+  scaffolderActionRules,
+  scaffolderTemplatePermissionResourceRef,
+  createTemplatePermissionRule,
+  scaffolderActionPermissionResourceRef,
+  createActionPermissionRule,
+} from './rules';
+
+export type {
+  ScaffolderTemplatePermissionResource,
+  ScaffolderActionPermissionResource,
+} from './rules';
+
 export * from './conditionExports';

--- a/plugins/scaffolder-backend/src/service/router.test.ts
+++ b/plugins/scaffolder-backend/src/service/router.test.ts
@@ -40,6 +40,7 @@ import { TaskBroker } from '@backstage/plugin-scaffolder-node';
 import { StorageTaskBroker } from '../scaffolder/tasks/StorageTaskBroker';
 import {
   AuthorizeResult,
+  isPermission,
   PermissionEvaluator,
 } from '@backstage/plugin-permission-common';
 import {
@@ -52,6 +53,10 @@ import { UrlReaders } from '@backstage/backend-defaults/urlReader';
 import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
 import { EventsService } from '@backstage/plugin-events-node';
 import { DatabaseService } from '@backstage/backend-plugin-api';
+import {
+  templateParameterReadPermission,
+  templateStepReadPermission,
+} from '@backstage/plugin-scaffolder-common/alpha';
 
 const mockAccess = jest.fn();
 
@@ -235,14 +240,12 @@ describe('createRouter', () => {
 
       jest
         .spyOn(permissionApi, 'authorizeConditional')
-        .mockImplementation(async () => [
-          {
-            result: AuthorizeResult.ALLOW,
-          },
-          {
-            result: AuthorizeResult.ALLOW,
-          },
-        ]);
+        .mockImplementation(async permissionQueries => {
+          return permissionQueries.map(() => {
+            return { result: AuthorizeResult.ALLOW };
+          });
+        });
+
       jest.spyOn(permissionApi, 'authorize').mockImplementation(async () => [
         {
           result: AuthorizeResult.ALLOW,
@@ -783,14 +786,11 @@ data: {"id":1,"taskId":"a-random-id","type":"completion","createdAt":"","body":{
 
       jest
         .spyOn(permissionApi, 'authorizeConditional')
-        .mockImplementation(async () => [
-          {
-            result: AuthorizeResult.ALLOW,
-          },
-          {
-            result: AuthorizeResult.ALLOW,
-          },
-        ]);
+        .mockImplementation(async permissionQueries => {
+          return permissionQueries.map(() => {
+            return { result: AuthorizeResult.ALLOW };
+          });
+        });
       jest.spyOn(permissionApi, 'authorize').mockImplementation(async () => [
         {
           result: AuthorizeResult.ALLOW,
@@ -860,14 +860,15 @@ data: {"id":1,"taskId":"a-random-id","type":"completion","createdAt":"","body":{
       it('filters parameters that the user is not authorized to see', async () => {
         jest
           .spyOn(permissionApi, 'authorizeConditional')
-          .mockImplementationOnce(async () => [
-            {
-              result: AuthorizeResult.DENY,
-            },
-            {
-              result: AuthorizeResult.ALLOW,
-            },
-          ]);
+          .mockImplementation(async permissionQueries => {
+            return permissionQueries.map(({ permission }) => {
+              if (isPermission(permission, templateParameterReadPermission)) {
+                return { result: AuthorizeResult.DENY };
+              }
+              return { result: AuthorizeResult.ALLOW };
+            });
+          });
+
         const response = await request(app)
           .get(
             '/v2/templates/default/Template/create-react-app-template/parameter-schema',
@@ -884,21 +885,24 @@ data: {"id":1,"taskId":"a-random-id","type":"completion","createdAt":"","body":{
       it('filters parameters that the user is not authorized to see in case of conditional decision', async () => {
         jest
           .spyOn(permissionApi, 'authorizeConditional')
-          .mockImplementationOnce(async () => [
-            {
-              conditions: {
-                resourceType: 'scaffolder-template',
-                rule: 'HAS_TAG',
-                params: { tag: 'parameters-tag' },
-              },
-              pluginId: 'scaffolder',
-              resourceType: 'scaffolder-template',
-              result: AuthorizeResult.CONDITIONAL,
-            },
-            {
-              result: AuthorizeResult.ALLOW,
-            },
-          ]);
+          .mockImplementation(async permissionQueries => {
+            return permissionQueries.map(({ permission }) => {
+              if (isPermission(permission, templateParameterReadPermission)) {
+                return {
+                  conditions: {
+                    resourceType: 'scaffolder-template',
+                    rule: 'HAS_TAG',
+                    params: { tag: 'parameters-tag' },
+                  },
+                  pluginId: 'scaffolder',
+                  resourceType: 'scaffolder-template',
+                  result: AuthorizeResult.CONDITIONAL,
+                };
+              }
+              return { result: AuthorizeResult.ALLOW };
+            });
+          });
+
         const response = await request(app)
           .get(
             '/v2/templates/default/Template/create-react-app-template/parameter-schema',
@@ -950,14 +954,14 @@ data: {"id":1,"taskId":"a-random-id","type":"completion","createdAt":"","body":{
       it('filters steps that the user is not authorized to see', async () => {
         jest
           .spyOn(permissionApi, 'authorizeConditional')
-          .mockImplementation(async () => [
-            {
-              result: AuthorizeResult.ALLOW,
-            },
-            {
-              result: AuthorizeResult.DENY,
-            },
-          ]);
+          .mockImplementation(async permissionQueries => {
+            return permissionQueries.map(({ permission }) => {
+              if (isPermission(permission, templateStepReadPermission)) {
+                return { result: AuthorizeResult.DENY };
+              }
+              return { result: AuthorizeResult.ALLOW };
+            });
+          });
 
         const broker =
           taskBroker.dispatch as jest.Mocked<TaskBroker>['dispatch'];
@@ -1014,26 +1018,28 @@ data: {"id":1,"taskId":"a-random-id","type":"completion","createdAt":"","body":{
       it('filters steps that the user is not authorized to see in case of conditional decision', async () => {
         jest
           .spyOn(permissionApi, 'authorizeConditional')
-          .mockImplementation(async () => [
-            {
-              result: AuthorizeResult.ALLOW,
-            },
-            {
-              conditions: {
-                resourceType: 'scaffolder-template',
-                rule: 'HAS_TAG',
-                params: { tag: 'steps-tag' },
-              },
-              pluginId: 'scaffolder',
-              resourceType: 'scaffolder-template',
-              result: AuthorizeResult.CONDITIONAL,
-            },
-          ]);
+          .mockImplementation(async permissionQueries => {
+            return permissionQueries.map(({ permission }) => {
+              if (isPermission(permission, templateStepReadPermission)) {
+                return {
+                  conditions: {
+                    resourceType: 'scaffolder-template',
+                    rule: 'HAS_TAG',
+                    params: { tag: 'steps-tag' },
+                  },
+                  pluginId: 'scaffolder',
+                  resourceType: 'scaffolder-template',
+                  result: AuthorizeResult.CONDITIONAL,
+                };
+              }
+              return { result: AuthorizeResult.ALLOW };
+            });
+          });
 
         const broker =
           taskBroker.dispatch as jest.Mocked<TaskBroker>['dispatch'];
         const mockTemplate = getMockTemplate();
-        await request(app)
+        const response = await request(app)
           .post('/v2/tasks')
           .send({
             templateRef: stringifyEntityRef({
@@ -1045,6 +1051,8 @@ data: {"id":1,"taskId":"a-random-id","type":"completion","createdAt":"","body":{
               requiredParameter2: 'required-value-2',
             },
           });
+
+        expect(response.status).toEqual(201);
         expect(broker).toHaveBeenCalledWith(
           expect.objectContaining({
             createdBy: 'user:default/mock',

--- a/plugins/scaffolder-backend/src/service/rules.ts
+++ b/plugins/scaffolder-backend/src/service/rules.ts
@@ -14,10 +14,14 @@
  * limitations under the License.
  */
 
-import { makeCreatePermissionRule } from '@backstage/plugin-permission-node';
 import {
-  RESOURCE_TYPE_SCAFFOLDER_TEMPLATE,
+  createPermissionResourceRef,
+  createPermissionRule,
+  makeCreatePermissionRule,
+} from '@backstage/plugin-permission-node';
+import {
   RESOURCE_TYPE_SCAFFOLDER_ACTION,
+  RESOURCE_TYPE_SCAFFOLDER_TEMPLATE,
 } from '@backstage/plugin-scaffolder-common/alpha';
 
 import {
@@ -29,15 +33,38 @@ import { z } from 'zod';
 import { JsonObject, JsonPrimitive } from '@backstage/types';
 import { get } from 'lodash';
 
+/**
+ * @alpha
+ */
+export type ScaffolderTemplatePermissionResource =
+  | TemplateEntityStepV1beta3
+  | TemplateParametersV1beta3;
+
+/**
+ * @alpha
+ */
+export const scaffolderTemplatePermissionResourceRef =
+  createPermissionResourceRef<ScaffolderTemplatePermissionResource, {}>().with({
+    pluginId: 'scaffolder',
+    resourceType: RESOURCE_TYPE_SCAFFOLDER_TEMPLATE,
+  });
+
+/**
+ * @alpha
+ * @deprecated Use `createPermissionRule` directly instead with the resourceRef option.
+ */
 export const createTemplatePermissionRule = makeCreatePermissionRule<
-  TemplateEntityStepV1beta3 | TemplateParametersV1beta3,
+  ScaffolderTemplatePermissionResource,
   {},
   typeof RESOURCE_TYPE_SCAFFOLDER_TEMPLATE
 >();
 
-export const hasTag = createTemplatePermissionRule({
+/**
+ * @alpha
+ */
+export const hasTag = createPermissionRule({
   name: 'HAS_TAG',
-  resourceType: RESOURCE_TYPE_SCAFFOLDER_TEMPLATE,
+  resourceRef: scaffolderTemplatePermissionResourceRef,
   description: `Match parameters or steps with the given tag`,
   paramsSchema: z.object({
     tag: z.string().describe('Name of the tag to match on'),
@@ -48,18 +75,41 @@ export const hasTag = createTemplatePermissionRule({
   toQuery: () => ({}),
 });
 
+/**
+ * @alpha
+ */
+export type ScaffolderActionPermissionResource =
+  | {
+      action: string;
+      input: JsonObject | undefined;
+    }
+  | ScaffolderTemplatePermissionResource;
+
+/**
+ * @alpha
+ */
+export const scaffolderActionPermissionResourceRef =
+  createPermissionResourceRef<ScaffolderActionPermissionResource, {}>().with({
+    pluginId: 'scaffolder',
+    resourceType: RESOURCE_TYPE_SCAFFOLDER_ACTION,
+  });
+
+/**
+ * @alpha
+ * @deprecated Use `createPermissionRule` directly instead with the resourceRef option.
+ */
 export const createActionPermissionRule = makeCreatePermissionRule<
-  {
-    action: string;
-    input: JsonObject | undefined;
-  },
+  ScaffolderActionPermissionResource,
   {},
   typeof RESOURCE_TYPE_SCAFFOLDER_ACTION
 >();
 
-export const hasActionId = createActionPermissionRule({
+/**
+ * @alpha
+ */
+export const hasActionId = createPermissionRule({
   name: 'HAS_ACTION_ID',
-  resourceType: RESOURCE_TYPE_SCAFFOLDER_ACTION,
+  resourceRef: scaffolderActionPermissionResourceRef,
   description: `Match actions with the given actionId`,
   paramsSchema: z.object({
     actionId: z.string().describe('Name of the actionId to match on'),
@@ -70,20 +120,34 @@ export const hasActionId = createActionPermissionRule({
   toQuery: () => ({}),
 });
 
+/**
+ * @alpha
+ */
 export const hasProperty = buildHasProperty({
   name: 'HAS_PROPERTY',
   valueSchema: z.union([z.string(), z.number(), z.boolean(), z.null()]),
   validateProperty: false,
 });
 
+/**
+ * @alpha
+ */
 export const hasBooleanProperty = buildHasProperty({
   name: 'HAS_BOOLEAN_PROPERTY',
   valueSchema: z.boolean(),
 });
+
+/**
+ * @alpha
+ */
 export const hasNumberProperty = buildHasProperty({
   name: 'HAS_NUMBER_PROPERTY',
   valueSchema: z.number(),
 });
+
+/**
+ * @alpha
+ */
 export const hasStringProperty = buildHasProperty({
   name: 'HAS_STRING_PROPERTY',
   valueSchema: z.string(),
@@ -98,10 +162,10 @@ function buildHasProperty<Schema extends z.ZodType<JsonPrimitive>>({
   valueSchema: Schema;
   validateProperty?: boolean;
 }) {
-  return createActionPermissionRule({
+  return createPermissionRule({
     name,
     description: `Allow actions with the specified property`,
-    resourceType: RESOURCE_TYPE_SCAFFOLDER_ACTION,
+    resourceRef: scaffolderActionPermissionResourceRef,
     paramsSchema: z.object({
       key: z
         .string()
@@ -129,7 +193,14 @@ function buildHasProperty<Schema extends z.ZodType<JsonPrimitive>>({
   });
 }
 
+/**
+ * @alpha
+ */
 export const scaffolderTemplateRules = { hasTag };
+
+/**
+ * @alpha
+ */
 export const scaffolderActionRules = {
   hasActionId,
   hasBooleanProperty,


### PR DESCRIPTION
Updates the scaffolder plugin to allow for use of the new PermissionsRegistryService, and restores the ability to add custom rules with the new backend framework.

follow up to #28053

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
