### PR TITLE
Updated Announcements location

### DIFF
--- a/microsite/data/plugins/announcements.yaml
+++ b/microsite/data/plugins/announcements.yaml
@@ -4,7 +4,7 @@ author: procore-oss
 authorUrl: https://github.com/procore-oss
 category: Discovery
 description: Write and share announcements within Backstage.
-documentation: https://github.com/procore-oss/backstage-plugin-announcements/
+documentation: https://github.com/backstage/community-plugins/tree/main/workspaces/announcements/
 iconUrl: /img/plugin-announcements-logo.png
-npmPackageName: '@procore-oss/backstage-plugin-announcements'
+npmPackageName: '@backstage-community/plugin-announcements'
 addedDate: '2022-11-09'


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The Announcements plguin was moved to the Community Plugins repo at the end of last year. This just updates the location to match.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
