### PR TITLE
feat(scaffolder-react): Add output type to `makeFieldSchema`

### DIFF
--- a/.changeset/soft-planets-mate.md
+++ b/.changeset/soft-planets-mate.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-scaffolder': patch
+'@backstage/plugin-scaffolder-react': patch
+---
+
+Add schema output return type to the `makeFieldSchema` function return

--- a/plugins/scaffolder-react/report.api.md
+++ b/plugins/scaffolder-react/report.api.md
@@ -131,6 +131,8 @@ export interface FieldSchema<TReturn, TUiOptions> {
   // (undocumented)
   readonly schema: CustomFieldExtensionSchema;
   // (undocumented)
+  readonly TOutput: TReturn;
+  // (undocumented)
   readonly TProps: FieldExtensionComponentProps<TReturn, TUiOptions>;
   // @deprecated (undocumented)
   readonly type: FieldExtensionComponentProps<TReturn, TUiOptions>;

--- a/plugins/scaffolder-react/src/utils.ts
+++ b/plugins/scaffolder-react/src/utils.ts
@@ -33,6 +33,7 @@ export function makeFieldSchema<
   const { output, uiOptions } = options;
   return {
     TProps: undefined as any,
+    TOutput: undefined as any,
     schema: {
       returnValue: zodToJsonSchema(output(z)) as JSONSchema7,
       uiOptions: uiOptions && (zodToJsonSchema(uiOptions(z)) as JSONSchema7),
@@ -57,4 +58,5 @@ export interface FieldSchema<TReturn, TUiOptions> {
 
   readonly schema: CustomFieldExtensionSchema;
   readonly TProps: FieldExtensionComponentProps<TReturn, TUiOptions>;
+  readonly TOutput: TReturn;
 }

--- a/plugins/scaffolder/src/components/fields/utils.ts
+++ b/plugins/scaffolder/src/components/fields/utils.ts
@@ -53,5 +53,6 @@ export function makeFieldSchemaFromZod<
     type: null as any,
     uiOptionsType: null as any,
     TProps: undefined as any,
+    TOutput: undefined as any,
   };
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds the output type to the `makeFieldSchema` function return. This is particularly useful when your field output is an object type. With this PR you can use the `TOutput` from `makeFieldSchema` return to get the output type so you don't have to separately declare your return schema and import zod. 

### Solution before PR:

```ts
import { makeFieldSchema } from '@backstage/plugin-scaffolder-react';
import { z as zod } from 'zod';

const returnSchema = zod.object({
  employeeId: zod.string().optional(),
  employeeUnit: zod.string().optional(),
});

export const FieldSchema = makeFieldSchema({
  output: () => returnSchema,
  uiOptions: z =>
    z.object({
      firstName: z.string(),
      lastName: z.string(),
    }),
});

export type FieldProps = typeof FieldSchema.TProps;
export type FieldReturnType = zod.infer<typeof returnSchema>;

const test:FieldReturnType = { employeeId: '0', employeeUnit: 'foo' };
```

### Solution after PR:

```ts
import { makeFieldSchema } from '@backstage/plugin-scaffolder-react';

export const FieldSchema = makeFieldSchema({
  output: z => z.object({
    employeeId: z.string().optional(),
    employeeUnit: z.string().optional(),
  }),
  uiOptions: z =>
    z.object({
      firstName: z.string(),
      lastName: z.string(),
    }),
});

export type FieldProps = typeof FieldSchema.TProps;
export type FieldReturnType = typeof FieldSchema.TOutput;

const test:FieldReturnType = { employeeId: '0', employeeUnit: 'foo' };
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
