### PR TITLE
Add support for Entra authentication on Azure Database for PostgreSQL

### DIFF
--- a/.changeset/ninety-pumas-lick.md
+++ b/.changeset/ninety-pumas-lick.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Support `connection.type: azure` in database client to use Microsoft Entra authentication with Azure database for PostgreSQL

--- a/.github/vale/config/vocabularies/Backstage/accept.txt
+++ b/.github/vale/config/vocabularies/Backstage/accept.txt
@@ -301,6 +301,7 @@ pageview
 Pandey
 parallelization
 parseable
+passwordless
 Patrik
 pattison
 Peloton

--- a/docs/getting-started/config/database.md
+++ b/docs/getting-started/config/database.md
@@ -114,9 +114,16 @@ If you want to host your PostgreSQL server in the cloud with passwordless authen
 
 Remove `password` from the connection configuration and set `type` to `azure`.
 
-Optionally set `tokenRenewalOffsetTime`. Entra authentication uses OAuth access tokens with expiration timestamps. By default, the database connector will get a new token 5 minutes before the prior token expires. The value can be a string in the format of '1d', '2 seconds' etc. as supported by the `ms` library or it can be an object with individual units (in plural) as keys, e.g. `{ milliseconds: 2, seconds: 6, minutes: 3 }`.
+Optionally set `tokenCredential` with the following properties. Defaults to `type: 'DefaultAzureCredential', tokenRenewalOffsetTime: 5 minutes` if not specified.
 
-Entra authentication uses `DefaultAzureCredential` under the hood, so it supports [many credential types](https://learn.microsoft.com/azure/developer/javascript/sdk/authentication/credential-chains#use-defaultazurecredential-for-flexibility).
+- Optionally set `type` to `DefaultAzureCredential`, `ClientSecretCredential`, or `ManagedIdentityCredential`.
+  - For `ClientSecretCredential`, also set `tenantId`, `clientId`, and `clientSecret`.
+  - For `ManagedIdentityCredential`, it will use the system-assigned managed identity by default. To use a user-assigned managed identity, set the `clientId` property.
+- Optionally set `tokenRenewalOffsetTime`. The value can be a string in the format of '1d', '2 seconds' etc. as supported by the `ms` library or it can be an object with individual units (in plural) as keys, e.g. `{ milliseconds: 2, seconds: 6, minutes: 3 }`.
+
+Entra authentication uses OAuth access tokens with expiration timestamps. By default, the database connector will get a new token 5 minutes before the prior token expires.
+
+Using `DefaultAzureCredential` by default supports [many credential types](https://learn.microsoft.com/azure/developer/javascript/sdk/authentication/credential-chains#use-defaultazurecredential-for-flexibility), choosing one based on the runtime environment.
 
 Set `user` to the display name of your Entra ID group, service principal, or managed identity. Set it to the user principal name if you're authenticating with a user's credentials.
 
@@ -127,7 +134,9 @@ backend:
     connection:
       # highlight-add-start
       type: azure
-      tokenRenewalOffsetTime: 5min
+      tokenCredential:
+        tokenRenewalOffsetTime: 5 minutes
+        type: DefaultAzureCredential
       # highlight-add-end
       host: ${POSTGRES_HOST}
       port: ${POSTGRES_PORT}

--- a/docs/getting-started/config/database.md
+++ b/docs/getting-started/config/database.md
@@ -106,6 +106,60 @@ When filling these out, you have 2 choices,
 
 If you opt for the second option of replacing the entire string, take care to not commit your `app-config.yaml` to source control. It may contain passwords that you don't want leaked.
 
+## Passwordless PostgreSQL in the Cloud
+
+If you want to host your PostgreSQL server in the cloud with passwordless authentication, you can use Azure Database for PostgreSQL with Microsoft Entra authentication or Google Cloud SQL for PostgreSQL with Cloud IAM.
+
+### Azure with Entra authentication
+
+Remove `password` from the connection configuration and set `type` to `azure`. Optionally set `allowedClockSkewMs`. Entra authentication uses OAuth access tokens with expiration timestamps. By default, the database connector will get a new token 3 minutes (180,000 ms) before the prior token expires. If your server's clock may differ more than that from Azure, you can set another value here.
+
+Entra authentication uses `DefaultAzureCredential` under the hood, so it supports [many credential types](https://learn.microsoft.com/azure/developer/javascript/sdk/authentication/credential-chains#use-defaultazurecredential-for-flexibility).
+
+Set `user` to the display name of your Entra ID group, service principal, or managed identity. Set it to the user principal name if you're authenticating with a user's credentials.
+
+```yaml title="app-config.yaml"
+backend:
+  database:
+    client: pg
+    connection:
+      # highlight-add-start
+      type: azure
+      allowedClockSkewMs: 180000
+      # highlight-add-end
+      host: ${POSTGRES_HOST}
+      port: ${POSTGRES_PORT}
+      user: ${POSTGRES_USER}
+      # highlight-remove-start
+      password: ${POSTGRES_PASSWORD}
+      # highlight-remove-end
+```
+
+### Google with Cloud IAM
+
+Remove `password` from the connection configuration and set `type` to `cloudsql`.
+
+Under the hood, this implements [Automatic IAM Database Authentication](https://github.com/GoogleCloudPlatform/cloud-sql-nodejs-connector?tab=readme-ov-file#automatic-iam-database-authentication).
+
+For an IAM user account, set `user` to the user's email address. For a service account, set `user` to the service account's email without the .gserviceaccount.com domain suffix.
+
+```yaml title="app-config.yaml"
+backend:
+  database:
+    client: pg
+    connection:
+      # highlight-add-start
+      type: cloudsql
+      instance: my-project:region:my-instance
+      # highlight-add-end
+      host: ${POSTGRES_HOST}
+      port: ${POSTGRES_PORT}
+      user: ${POSTGRES_USER}
+      # highlight-remove-start
+      password: ${POSTGRES_PASSWORD}
+      # highlight-remove-end
+```
+
 :::
 
 [Start the Backstage app](../index.md#2-run-the-backstage-app):

--- a/docs/getting-started/config/database.md
+++ b/docs/getting-started/config/database.md
@@ -112,7 +112,9 @@ If you want to host your PostgreSQL server in the cloud with passwordless authen
 
 ### Azure with Entra authentication
 
-Remove `password` from the connection configuration and set `type` to `azure`. Optionally set `allowedClockSkewMs`. Entra authentication uses OAuth access tokens with expiration timestamps. By default, the database connector will get a new token 3 minutes (180,000 ms) before the prior token expires. If your server's clock may differ more than that from Azure, you can set another value here.
+Remove `password` from the connection configuration and set `type` to `azure`.
+
+Optionally set `tokenRenewalOffsetTime`. Entra authentication uses OAuth access tokens with expiration timestamps. By default, the database connector will get a new token 5 minutes before the prior token expires. The value can be a string in the format of '1d', '2 seconds' etc. as supported by the `ms` library or it can be an object with individual units (in plural) as keys, e.g. `{ milliseconds: 2, seconds: 6, minutes: 3 }`.
 
 Entra authentication uses `DefaultAzureCredential` under the hood, so it supports [many credential types](https://learn.microsoft.com/azure/developer/javascript/sdk/authentication/credential-chains#use-defaultazurecredential-for-flexibility).
 
@@ -125,7 +127,7 @@ backend:
     connection:
       # highlight-add-start
       type: azure
-      allowedClockSkewMs: 180000
+      tokenRenewalOffsetTime: 5min
       # highlight-add-end
       host: ${POSTGRES_HOST}
       port: ${POSTGRES_PORT}

--- a/packages/backend-defaults/config.d.ts
+++ b/packages/backend-defaults/config.d.ts
@@ -15,7 +15,6 @@
  */
 
 import { HumanDuration } from '@backstage/types';
-import { AzureTokenCredentialConfig } from './src/entrypoints/database/connectors/postgres';
 
 export interface Config {
   app: {
@@ -429,7 +428,39 @@ export interface Config {
             /**
              * Optional Azure token credential configuration
              */
-            tokenCredential?: AzureTokenCredentialConfig;
+            tokenCredential?: {
+              /**
+               * How early before an access token expires to refresh it with a new one.
+               * Defaults to 5 minutes
+               * Supported formats:
+               * - A string in the format of '1d', '2 seconds' etc. as supported by the `ms`
+               *   library.
+               * - A standard ISO formatted duration string, e.g. 'P2DT6H' or 'PT1M'.
+               * - An object with individual units (in plural) as keys, e.g. `{ days: 2, hours: 6 }`.
+               */
+              tokenRenewalOffsetTime?: string | HumanDuration;
+            } & (
+              | {
+                  type: 'ClientSecretCredential';
+                  clientId: string;
+                  /**
+                   * @visibility secret
+                   */
+                  clientSecret: string;
+                  tenantId: string;
+                }
+              | {
+                  type: 'ManagedIdentityCredential';
+                  /**
+                   * The client ID of a user-assigned managed identity.
+                   * If not provided, the system-assigned managed identity is used.
+                   */
+                  clientId?: string;
+                }
+              | {
+                  type?: undefined | 'DefaultAzureCredential';
+                }
+            );
           }
         | {
             /**

--- a/packages/backend-defaults/config.d.ts
+++ b/packages/backend-defaults/config.d.ts
@@ -426,9 +426,15 @@ export interface Config {
              */
             type: 'azure';
             /**
-             * How many milliseconds before token expiration to refresh the token Defaults to 180,000 (3 minutes)
+             * How early before an access token expires to refresh it with a new one.
+             * Defaults to 5 minutes
+             * Supported formats:
+             * - A string in the format of '1d', '2 seconds' etc. as supported by the `ms`
+             *   library.
+             * - A standard ISO formatted duration string, e.g. 'P2DT6H' or 'PT1M'.
+             * - An object with individual units (in plural) as keys, e.g. `{ days: 2, hours: 6 }`.
              */
-            allowedClockSkewMs?: number;
+            tokenRenewalOffsetTime?: string | HumanDuration;
           }
         | {
             /**

--- a/packages/backend-defaults/config.d.ts
+++ b/packages/backend-defaults/config.d.ts
@@ -422,6 +422,16 @@ export interface Config {
         | string
         | {
             /**
+             * The specific config for Azure database for PostgreSQL with Entra authentication
+             */
+            type: 'azure';
+            /**
+             * How many milliseconds before token expiration to refresh the token Defaults to 180,000 (3 minutes)
+             */
+            allowedClockSkewMs?: number;
+          }
+        | {
+            /**
              * The specific config for cloudsql connections
              */
             type: 'cloudsql';

--- a/packages/backend-defaults/config.d.ts
+++ b/packages/backend-defaults/config.d.ts
@@ -15,6 +15,7 @@
  */
 
 import { HumanDuration } from '@backstage/types';
+import { AzureTokenCredentialConfig } from './src/entrypoints/database/connectors/postgres';
 
 export interface Config {
   app: {
@@ -426,15 +427,9 @@ export interface Config {
              */
             type: 'azure';
             /**
-             * How early before an access token expires to refresh it with a new one.
-             * Defaults to 5 minutes
-             * Supported formats:
-             * - A string in the format of '1d', '2 seconds' etc. as supported by the `ms`
-             *   library.
-             * - A standard ISO formatted duration string, e.g. 'P2DT6H' or 'PT1M'.
-             * - An object with individual units (in plural) as keys, e.g. `{ days: 2, hours: 6 }`.
+             * Optional Azure token credential configuration
              */
-            tokenRenewalOffsetTime?: string | HumanDuration;
+            tokenCredential?: AzureTokenCredentialConfig;
           }
         | {
             /**

--- a/packages/backend-defaults/src/entrypoints/database/connectors/postgres.test.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/postgres.test.ts
@@ -199,7 +199,9 @@ describe('postgres', () => {
           client: 'pg',
           connection: {
             type: 'azure',
-            tokenRenewalOffsetTime: '1 minute',
+            tokenCredential: {
+              tokenRenewalOffsetTime: '1 minute',
+            },
             user: 'user@contoso.com',
             database: 'other_db',
             port: 5423,

--- a/packages/backend-defaults/src/entrypoints/database/connectors/postgres.test.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/postgres.test.ts
@@ -21,7 +21,6 @@ import {
   getPgConnectionConfig,
   parsePgConnectionString,
 } from './postgres';
-import exp from 'node:constants';
 
 jest.mock('@google-cloud/cloud-sql-connector');
 

--- a/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
@@ -181,7 +181,7 @@ export async function buildAzurePgConfig(config: any, sanitizedConfig: any) {
   const configReader = new ConfigReader(config);
   if (configReader.has('connection.tokenCredential.tokenRenewalOffsetTime')) {
     tokenRenewalOffsetMs = durationToMilliseconds(
-      readDurationFromConfig(new ConfigReader(config), {
+      readDurationFromConfig(configReader, {
         key: 'connection.tokenCredential.tokenRenewalOffsetTime',
       }),
     );

--- a/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
@@ -218,7 +218,7 @@ export async function buildAzurePgConfig(config: any, sanitizedConfig: any) {
       default:
         throw new Error(
           `Unknown token credential type: ${
-            (tokenCredentialConfig as any).type
+            (tokenCredentialConfig as any)?.type
           }`,
         );
     }

--- a/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
@@ -165,7 +165,7 @@ export type AzureTokenCredentialConfig = {
       clientId?: string;
     }
   | {
-      type: undefined | 'DefaultAzureCredential';
+      type?: undefined | 'DefaultAzureCredential';
     }
 );
 

--- a/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
@@ -138,6 +138,10 @@ export async function buildCloudSqlConfig(config: any, sanitizedConfig: any) {
   };
 }
 
+/* Note: the following type definition is intentionally duplicated in
+ * /packages/backend-defaults/config.d.ts so the clientSecret property
+ * can be annotated with "@visibility secret" there.
+ */
 export type AzureTokenCredentialConfig = {
   /**
    * How early before an access token expires to refresh it with a new one.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds support for passwordless Entra authentication on Azure Database for PostgreSQL by setting `database.connection.type` to `azure`.

Addresses #27902 and #22535

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
