### PR TITLE
(gitlab integration fix) Do not send If-None-Match and If-Modified-Since for gitlab artifacts urls

### DIFF
--- a/.changeset/plenty-bobcats-drum.md
+++ b/.changeset/plenty-bobcats-drum.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/backend-defaults': minor
+'@backstage/backend-defaults': patch
 ---
 
-Do not send etag or If-Modified-Since headers for gitlab artifact urls
+Do not send `etag` or `If-Modified-Since` headers for gitlab artifact urls

--- a/.changeset/plenty-bobcats-drum.md
+++ b/.changeset/plenty-bobcats-drum.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': minor
+---
+
+Do not send etag or If-Modified-Since headers for gitlab artifact urls


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This pull request fixes https://github.com/backstage/backstage/issues/18123 

This PR introduces introduces two conditions so it doesn't send the `etag` and `if-not-modified` headers on requests to gitlab job artifacts urls.

This is required as due to [gitlab not updating the artifact etag](https://gitlab.com/gitlab-org/gitlab/-/issues/371991)  when the artifact is updated returning a 304 (skip processing)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
