### PR TITLE
Debounce rerender when user resize quickly

### DIFF
--- a/plugins/catalog-react/src/components/CatalogFilterLayout/CatalogFilterLayout.tsx
+++ b/plugins/catalog-react/src/components/CatalogFilterLayout/CatalogFilterLayout.tsx
@@ -23,6 +23,7 @@ import Typography from '@material-ui/core/Typography';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { Theme, useTheme } from '@material-ui/core/styles';
 import FilterListIcon from '@material-ui/icons/FilterList';
+import useDebounce from 'react-use/esm/useDebounce';
 import { catalogReactTranslationRef } from '../../translation';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 
@@ -39,11 +40,23 @@ export const Filters = (props: {
       theme.breakpoints.down(props.options?.drawerBreakpoint ?? 'md'),
     { noSsr: true },
   );
+  const [
+    debouncedIsScreenSmallerThanBreakpoint,
+    setDebouncedIsScreenSmallerThanBreakpoint,
+  ] = useState(isScreenSmallerThanBreakpoint);
+
+  // @ts-ignore
+  const _ = useDebounce(
+    () =>
+      setDebouncedIsScreenSmallerThanBreakpoint(isScreenSmallerThanBreakpoint),
+    300,
+    [isScreenSmallerThanBreakpoint],
+  );
   const theme = useTheme();
   const [filterDrawerOpen, setFilterDrawerOpen] = useState<boolean>(false);
   const { t } = useTranslationRef(catalogReactTranslationRef);
 
-  return isScreenSmallerThanBreakpoint ? (
+  return debouncedIsScreenSmallerThanBreakpoint ? (
     <>
       <Button
         style={{ marginTop: theme.spacing(1), marginLeft: theme.spacing(1) }}

--- a/plugins/catalog-react/src/components/CatalogFilterLayout/CatalogFilterLayout.tsx
+++ b/plugins/catalog-react/src/components/CatalogFilterLayout/CatalogFilterLayout.tsx
@@ -45,11 +45,10 @@ export const Filters = (props: {
     setDebouncedIsScreenSmallerThanBreakpoint,
   ] = useState(isScreenSmallerThanBreakpoint);
 
-  // @ts-ignore
-  const _ = useDebounce(
+  useDebounce(
     () =>
       setDebouncedIsScreenSmallerThanBreakpoint(isScreenSmallerThanBreakpoint),
-    300,
+    200,
     [isScreenSmallerThanBreakpoint],
   );
   const theme = useTheme();


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
When users quickly resize the catalog page window, it causes the <Filter /> component to rerender. Rerendering triggers several unnecessary API calls. This PR adds some delays to prevent unnecessary rerender and API calls.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
