### PR TITLE
chore: fixing changeset package name

### DIFF
--- a/.changeset/bigint-convert.md
+++ b/.changeset/bigint-convert.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/kubernetes-react': patch
+'@backstage/plugin-kubernetes-react': patch
 ---
 
 Fixed bug in string-to-integer conversion to properly handle decimal values with BigInt.


### PR DESCRIPTION
This has broken the [nightly releases](https://github.com/backstage/publishing/actions/runs/12878931745/job/35905614415) and will likely break the release today.