### PR TITLE
backend-defaults: refactor DefaultRootAuditorService

### DIFF
--- a/packages/backend-defaults/report-auditor.api.md
+++ b/packages/backend-defaults/report-auditor.api.md
@@ -13,21 +13,18 @@ import type { HttpAuthService } from '@backstage/backend-plugin-api';
 import type { JsonObject } from '@backstage/types';
 import type { PluginMetadataService } from '@backstage/backend-plugin-api';
 import type { Request as Request_2 } from 'express';
-import type { RootLoggerService } from '@backstage/backend-plugin-api';
 import { ServiceFactory } from '@backstage/backend-plugin-api';
 import * as winston from 'winston';
 
 // @public
-export type AuditorEvent = [
-  eventId: string,
-  meta: {
-    plugin: string;
-    severityLevel: AuditorServiceEventSeverityLevel;
-    actor: AuditorEventActorDetails;
-    meta?: JsonObject;
-    request?: AuditorEventRequest;
-  } & AuditorEventStatus,
-];
+export type AuditorEvent = {
+  plugin: string;
+  eventId: string;
+  severityLevel: AuditorServiceEventSeverityLevel;
+  actor: AuditorEventActorDetails;
+  meta?: JsonObject;
+  request?: AuditorEventRequest;
+} & AuditorEventStatus;
 
 // @public (undocumented)
 export type AuditorEventActorDetails = {
@@ -65,7 +62,7 @@ export type AuditorEventStatus =
     };
 
 // @public
-export const auditorFieldFormat: Format;
+export type AuditorLogFunction = (event: AuditorEvent) => void | Promise<void>;
 
 // @public
 export const auditorServiceFactory: ServiceFactory<
@@ -77,7 +74,7 @@ export const auditorServiceFactory: ServiceFactory<
 // @public
 export class DefaultAuditorService implements AuditorService {
   static create(
-    impl: DefaultRootAuditorService,
+    logFn: AuditorLogFunction,
     deps: {
       auth: AuthService;
       httpAuth: HttpAuthService;
@@ -90,32 +87,25 @@ export class DefaultAuditorService implements AuditorService {
   ): Promise<AuditorServiceEvent>;
 }
 
-// @public (undocumented)
-export const defaultFormatter: Format;
-
-// @public (undocumented)
-export class DefaultRootAuditorService {
-  static create(options?: RootAuditorOptions): DefaultRootAuditorService;
+// @public
+export class WinstonRootAuditorService {
+  static create(
+    options?: WinstonRootAuditorServiceOptions,
+  ): WinstonRootAuditorService;
   // (undocumented)
   forPlugin(deps: {
     auth: AuthService;
     httpAuth: HttpAuthService;
     plugin: PluginMetadataService;
   }): AuditorService;
-  // (undocumented)
-  log(auditorEvent: AuditorEvent): Promise<void>;
 }
 
 // @public
-export type RootAuditorOptions =
-  | {
-      meta?: JsonObject;
-      format?: Format;
-      transports?: winston.transport[];
-    }
-  | {
-      rootLogger: RootLoggerService;
-    };
+export type WinstonRootAuditorServiceOptions = {
+  meta?: JsonObject;
+  format?: Format;
+  transports?: winston.transport[];
+};
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/packages/backend-defaults/src/entrypoints/auditor/DefaultAuditorService.test.ts
+++ b/packages/backend-defaults/src/entrypoints/auditor/DefaultAuditorService.test.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mockServices } from '@backstage/backend-test-utils';
+import { DefaultAuditorService } from './DefaultAuditorService';
+
+const mockDeps = {
+  auth: mockServices.auth.mock(),
+  httpAuth: mockServices.httpAuth.mock(),
+  plugin: {
+    getId: () => 'test',
+  },
+};
+
+describe('DefaultAuditorService', () => {
+  it('creates a auditor instance with default options', () => {
+    const auditor = DefaultAuditorService.create(jest.fn(), mockDeps);
+    expect(auditor).toBeInstanceOf(DefaultAuditorService);
+  });
+
+  it('should log a status "initiated" using createEvent', async () => {
+    const logFn = jest.fn();
+    const auditor = DefaultAuditorService.create(logFn, mockDeps);
+
+    await auditor.createEvent({
+      eventId: 'test-event',
+    });
+
+    expect(logFn).toHaveBeenCalledWith({
+      eventId: 'test-event',
+      status: 'initiated',
+      plugin: 'test',
+      severityLevel: 'low',
+      actor: {},
+    });
+  });
+
+  it('should log a status "succeeded" using createEvent', async () => {
+    const logFn = jest.fn();
+    const auditor = DefaultAuditorService.create(logFn, mockDeps);
+
+    const auditorEvent = await auditor.createEvent({
+      eventId: 'test-event',
+    });
+
+    await auditorEvent.success();
+
+    expect(logFn).toHaveBeenCalledTimes(2);
+    expect(logFn).toHaveBeenLastCalledWith({
+      eventId: 'test-event',
+      status: 'succeeded',
+      plugin: 'test',
+      severityLevel: 'low',
+      actor: {},
+    });
+  });
+
+  it('should log a status "failed"', async () => {
+    const logFn = jest.fn();
+    const auditor = DefaultAuditorService.create(logFn, mockDeps);
+
+    const auditorEvent = await auditor.createEvent({
+      eventId: 'test-event',
+    });
+
+    const error = new Error('error');
+    await auditorEvent.fail({ error });
+
+    expect(logFn).toHaveBeenCalledTimes(2);
+    expect(logFn).toHaveBeenLastCalledWith({
+      eventId: 'test-event',
+      status: 'failed',
+      error: error.toString(),
+      plugin: 'test',
+      severityLevel: 'low',
+      actor: {},
+    });
+  });
+
+  it('should use root meta', async () => {
+    const logFn = jest.fn();
+    const auditor = DefaultAuditorService.create(logFn, mockDeps);
+
+    const auditorEvent = await auditor.createEvent({
+      eventId: 'test-event',
+      meta: {
+        initiated: 'test',
+      },
+    });
+
+    await auditorEvent.success({ meta: { succeeded: 'test' } });
+
+    const error = new Error('error');
+    await auditorEvent.fail({ error, meta: { failed: 'test' } });
+
+    expect(logFn).toHaveBeenCalledTimes(3);
+    expect(logFn).toHaveBeenNthCalledWith(1, {
+      eventId: 'test-event',
+      status: 'initiated',
+      meta: {
+        initiated: 'test',
+      },
+      plugin: 'test',
+      severityLevel: 'low',
+      actor: {},
+    });
+    expect(logFn).toHaveBeenNthCalledWith(2, {
+      eventId: 'test-event',
+      status: 'succeeded',
+      meta: {
+        initiated: 'test',
+        succeeded: 'test',
+      },
+      plugin: 'test',
+      severityLevel: 'low',
+      actor: {},
+    });
+    expect(logFn).toHaveBeenNthCalledWith(3, {
+      eventId: 'test-event',
+      status: 'failed',
+      meta: {
+        initiated: 'test',
+        failed: 'test',
+      },
+      error: error.toString(),
+      plugin: 'test',
+      severityLevel: 'low',
+      actor: {},
+    });
+  });
+});

--- a/packages/backend-defaults/src/entrypoints/auditor/WinstonRootAuditorService.test.ts
+++ b/packages/backend-defaults/src/entrypoints/auditor/WinstonRootAuditorService.test.ts
@@ -15,16 +15,17 @@
  */
 
 import { mockServices } from '@backstage/backend-test-utils';
-import { DefaultAuditorService, DefaultRootAuditorService } from './Auditor';
+import { WinstonRootAuditorService } from './WinstonRootAuditorService';
+import { DefaultAuditorService } from './DefaultAuditorService';
 
-describe('Auditor', () => {
+describe('WinstonRootAuditorService', () => {
   it('creates a auditor instance with default options', () => {
-    const auditor = DefaultRootAuditorService.create();
-    expect(auditor).toBeInstanceOf(DefaultRootAuditorService);
+    const auditor = WinstonRootAuditorService.create();
+    expect(auditor).toBeInstanceOf(WinstonRootAuditorService);
   });
 
   it('creates a child logger', () => {
-    const auditor = DefaultRootAuditorService.create();
+    const auditor = WinstonRootAuditorService.create();
     const childLogger = auditor.forPlugin({
       auth: mockServices.auth.mock(),
       httpAuth: mockServices.httpAuth.mock(),
@@ -38,7 +39,7 @@ describe('Auditor', () => {
   it('should log a status "initiated" using createEvent', async () => {
     const pluginId = 'test-plugin';
 
-    const auditor = DefaultRootAuditorService.create().forPlugin({
+    const auditor = WinstonRootAuditorService.create().forPlugin({
       auth: mockServices.auth.mock(),
       httpAuth: mockServices.httpAuth.mock(),
       plugin: {
@@ -61,7 +62,7 @@ describe('Auditor', () => {
   it('should log a status "succeeded" using createEvent', async () => {
     const pluginId = 'test-plugin';
 
-    const auditor = DefaultRootAuditorService.create().forPlugin({
+    const auditor = WinstonRootAuditorService.create().forPlugin({
       auth: mockServices.auth.mock(),
       httpAuth: mockServices.httpAuth.mock(),
       plugin: {
@@ -88,7 +89,7 @@ describe('Auditor', () => {
   it('should log a status "failed"', async () => {
     const pluginId = 'test-plugin';
 
-    const auditor = DefaultRootAuditorService.create().forPlugin({
+    const auditor = WinstonRootAuditorService.create().forPlugin({
       auth: mockServices.auth.mock(),
       httpAuth: mockServices.httpAuth.mock(),
       plugin: {
@@ -117,7 +118,7 @@ describe('Auditor', () => {
   it('should use root meta', async () => {
     const pluginId = 'test-plugin';
 
-    const auditor = DefaultRootAuditorService.create().forPlugin({
+    const auditor = WinstonRootAuditorService.create().forPlugin({
       auth: mockServices.auth.mock(),
       httpAuth: mockServices.httpAuth.mock(),
       plugin: {

--- a/packages/backend-defaults/src/entrypoints/auditor/WinstonRootAuditorService.ts
+++ b/packages/backend-defaults/src/entrypoints/auditor/WinstonRootAuditorService.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  AuditorService,
+  AuthService,
+  HttpAuthService,
+  PluginMetadataService,
+} from '@backstage/backend-plugin-api';
+import type { JsonObject } from '@backstage/types';
+import type { Format } from 'logform';
+import * as winston from 'winston';
+import { WinstonLogger } from '../rootLogger';
+import { DefaultAuditorService } from './DefaultAuditorService';
+
+/** @public */
+export const defaultFormatter = winston.format.combine(
+  winston.format.timestamp({
+    format: 'YYYY-MM-DD HH:mm:ss',
+  }),
+  winston.format.errors({ stack: true }),
+  winston.format.splat(),
+  winston.format.json(),
+);
+
+/**
+ * Adds `isAuditorEvent` field
+ *
+ * @public
+ */
+export const auditorFieldFormat = winston.format(info => {
+  return { ...info, isAuditorEvent: true };
+})();
+
+/**
+ * Options for creating a {@link WinstonRootAuditorService}.
+ * @public
+ */
+export type WinstonRootAuditorServiceOptions = {
+  meta?: JsonObject;
+  format?: Format;
+  transports?: winston.transport[];
+};
+
+/**
+ * An implementation of the {@link @backstage/backend-plugin-api#AuditorService} that logs events using a separate winston logger.
+ *
+ * @public
+ *
+ * @example
+ * ```ts
+ * export const auditorServiceFactory = createServiceFactory({
+ *   service: coreServices.auditor,
+ *   deps: {
+ *     auth: coreServices.auth,
+ *     httpAuth: coreServices.httpAuth,
+ *     plugin: coreServices.pluginMetadata,
+ *   },
+ *   createRootContext() {
+ *     return WinstonRootAuditorService.create();
+ *   },
+ *   factory({ plugin, auth, httpAuth }, root) {
+ *     return root.forPlugin({ plugin, auth, httpAuth });
+ *   },
+ * });
+ * ```
+ */
+export class WinstonRootAuditorService {
+  private constructor(private readonly winstonLogger: WinstonLogger) {}
+
+  /**
+   * Creates a {@link WinstonRootAuditorService} instance.
+   */
+  static create(
+    options?: WinstonRootAuditorServiceOptions,
+  ): WinstonRootAuditorService {
+    let winstonLogger = WinstonLogger.create({
+      meta: {
+        service: 'backstage',
+      },
+      level: 'info',
+      format: winston.format.combine(
+        auditorFieldFormat,
+        options?.format ?? defaultFormatter,
+      ),
+      transports: options?.transports,
+    });
+
+    if (options?.meta) {
+      winstonLogger = winstonLogger.child(options.meta) as WinstonLogger;
+    }
+
+    return new WinstonRootAuditorService(winstonLogger);
+  }
+
+  forPlugin(deps: {
+    auth: AuthService;
+    httpAuth: HttpAuthService;
+    plugin: PluginMetadataService;
+  }): AuditorService {
+    return DefaultAuditorService.create(
+      e => this.winstonLogger.info(`${e.plugin}.${e.eventId}`, e),
+      deps,
+    );
+  }
+}

--- a/packages/backend-defaults/src/entrypoints/auditor/auditorServiceFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/auditor/auditorServiceFactory.ts
@@ -18,7 +18,7 @@ import {
   coreServices,
   createServiceFactory,
 } from '@backstage/backend-plugin-api';
-import { DefaultRootAuditorService } from './Auditor';
+import { DefaultAuditorService } from './DefaultAuditorService';
 
 /**
  * Plugin-level auditing.
@@ -32,17 +32,16 @@ import { DefaultRootAuditorService } from './Auditor';
 export const auditorServiceFactory = createServiceFactory({
   service: coreServices.auditor,
   deps: {
-    rootLogger: coreServices.rootLogger,
+    logger: coreServices.logger,
     auth: coreServices.auth,
     httpAuth: coreServices.httpAuth,
     plugin: coreServices.pluginMetadata,
   },
-  async createRootContext({ rootLogger }) {
-    const auditor = DefaultRootAuditorService.create({ rootLogger });
-
-    return auditor;
-  },
-  factory({ plugin, auth, httpAuth }, rootAuditor) {
-    return rootAuditor.forPlugin({ auth, httpAuth, plugin });
+  factory({ logger, plugin, auth, httpAuth }) {
+    const auditLogger = logger.child({ isAuditorEvent: true });
+    return DefaultAuditorService.create(
+      event => auditLogger.info(`${event.plugin}.${event.eventId}`, event),
+      { plugin, auth, httpAuth },
+    );
   },
 });

--- a/packages/backend-defaults/src/entrypoints/auditor/index.ts
+++ b/packages/backend-defaults/src/entrypoints/auditor/index.ts
@@ -14,5 +14,15 @@
  * limitations under the License.
  */
 
-export * from './Auditor';
+export type {
+  AuditorEvent,
+  AuditorEventActorDetails,
+  AuditorEventOptions,
+  AuditorEventRequest,
+  AuditorEventStatus,
+  AuditorLogFunction,
+} from './DefaultAuditorService';
+export { DefaultAuditorService } from './DefaultAuditorService';
 export { auditorServiceFactory } from './auditorServiceFactory';
+export { WinstonRootAuditorService } from './WinstonRootAuditorService';
+export type { WinstonRootAuditorServiceOptions } from './WinstonRootAuditorService';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Couple of refactors on top of #26372, piggybacking on changeset from that change.

This splits the `DefaultRootAuditorService` into an explicit `WinstonRootAuditorService` and simply manual wiring within the service factory. In particular I wanted to refactor the `DefaultAuditorService` to remove the coupling to Winston, so the logging is now done via a callback instead. Idea is that the `DefaultAuditorService` takes care for generating the log messages, but is otherwise not opinionated about how they get logged.

👀 @schultzp2020 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
