### PR TITLE
cli: avoid collecting coverage for __fixtures__

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,6 +41,11 @@
     "ext": "ts",
     "watch": "./src"
   },
+  "jest": {
+    "coveragePathIgnorePatterns": [
+      "/__fixtures__/"
+    ]
+  },
   "dependencies": {
     "@backstage/catalog-model": "workspace:^",
     "@backstage/cli-common": "workspace:^",


### PR DESCRIPTION
🧹, fixes current build failures.

The babel coverage transform seems to break the CommonJS compat hoisting. Most likely Node.js isn't able to figure out the named exports with coverage wrapping injected. Not sure whether this is going to be a broader issue yet, but since `node_modules` is already opted out I'd expect this to be mostly a problem for source code in the repo and therefore a bit more limited impact.