### PR TITLE
fix(techdocs): scroll bar retains position after changing page

### DIFF
--- a/.changeset/bright-pets-agree.md
+++ b/.changeset/bright-pets-agree.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Fixed double scrollbar issue that would appear on the Entity TechDocs view page that would stop the page from full scrolling to the top when navigating to a new page

--- a/.changeset/chatty-turkeys-brake.md
+++ b/.changeset/chatty-turkeys-brake.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Added `classNames` prop to the `Page` component

--- a/packages/core-components/src/layout/Page/Page.tsx
+++ b/packages/core-components/src/layout/Page/Page.tsx
@@ -51,7 +51,7 @@ type Props = {
 
 export function Page(props: Props) {
   const { themeId, className, children } = props;
-  const styles = useStyles();
+  const classes = useStyles();
   return (
     <ThemeProvider
       theme={(baseTheme: Theme) => ({
@@ -59,7 +59,7 @@ export function Page(props: Props) {
         page: baseTheme.getPageTheme({ themeId }),
       })}
     >
-      <main className={classNames(styles.root, className)}>{children}</main>
+      <main className={classNames(classes.root, className)}>{children}</main>
     </ThemeProvider>
   );
 }

--- a/packages/core-components/src/layout/Page/Page.tsx
+++ b/packages/core-components/src/layout/Page/Page.tsx
@@ -16,6 +16,7 @@
 
 import React from 'react';
 import { makeStyles, Theme, ThemeProvider } from '@material-ui/core/styles';
+import classNames from 'classnames';
 
 export type PageClassKey = 'root';
 
@@ -44,12 +45,13 @@ const useStyles = makeStyles(
 
 type Props = {
   themeId: string;
+  className?: string;
   children?: React.ReactNode;
 };
 
 export function Page(props: Props) {
-  const { themeId, children } = props;
-  const classes = useStyles();
+  const { themeId, className, children } = props;
+  const styles = useStyles();
   return (
     <ThemeProvider
       theme={(baseTheme: Theme) => ({
@@ -57,7 +59,7 @@ export function Page(props: Props) {
         page: baseTheme.getPageTheme({ themeId }),
       })}
     >
-      <main className={classes.root}>{children}</main>
+      <main className={classNames(styles.root, className)}>{children}</main>
     </ThemeProvider>
   );
 }

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPage/TechDocsReaderPage.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPage/TechDocsReaderPage.tsx
@@ -166,6 +166,16 @@ export const TechDocsReaderPage = (props: TechDocsReaderPageProps) => {
 
   const readerPageTheme = createTheme({
     ...currentTheme,
+    overrides: {
+      // This fixes issues with double scrolls in the TechDocs reader page on EntityPage
+      // @ts-ignore BackstagePage is not in the theme type
+      BackstagePage: {
+        root: {
+          height: 'inherit',
+          overflowY: 'visible',
+        },
+      },
+    },
     ...(props.overrideThemeOptions || {}),
   });
   const { kind, name, namespace } = useRouteRefParams(rootDocsRouteRef);

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPage/TechDocsReaderPage.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPage/TechDocsReaderPage.tsx
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import React, { ReactNode, Children, ReactElement } from 'react';
+import React, { Children, ReactElement, ReactNode } from 'react';
 import { useOutlet } from 'react-router-dom';
 
 import { Page } from '@backstage/core-components';
 import { CompoundEntityRef } from '@backstage/catalog-model';
 import {
-  TECHDOCS_ADDONS_WRAPPER_KEY,
   TECHDOCS_ADDONS_KEY,
+  TECHDOCS_ADDONS_WRAPPER_KEY,
   TechDocsReaderPageProvider,
 } from '@backstage/plugin-techdocs-react';
 
@@ -37,8 +37,13 @@ import {
 } from '@backstage/core-plugin-api';
 
 import { CookieAuthRefreshProvider } from '@backstage/plugin-auth-react';
-import { ThemeOptions } from '@material-ui/core/styles';
-import { createTheme, ThemeProvider, useTheme } from '@material-ui/core/styles';
+import {
+  createTheme,
+  makeStyles,
+  ThemeOptions,
+  ThemeProvider,
+  useTheme,
+} from '@material-ui/core/styles';
 
 /* An explanation for the multiple ways of customizing the TechDocs reader page
 
@@ -117,6 +122,13 @@ are retrieved using the useOutlet hook from React Router.
 NOTE: Render functions are no longer supported in this approach.
 */
 
+const useStyles = makeStyles({
+  readerPage: {
+    height: 'inherit',
+    overflowY: 'visible',
+  },
+});
+
 /**
  * Props for {@link TechDocsReaderLayout}
  * @public
@@ -163,19 +175,10 @@ export type TechDocsReaderPageProps = {
  */
 export const TechDocsReaderPage = (props: TechDocsReaderPageProps) => {
   const currentTheme = useTheme();
+  const classes = useStyles();
 
   const readerPageTheme = createTheme({
     ...currentTheme,
-    overrides: {
-      // This fixes issues with double scrolls in the TechDocs reader page on EntityPage
-      // @ts-ignore BackstagePage is not in the theme type
-      BackstagePage: {
-        root: {
-          height: 'inherit',
-          overflowY: 'visible',
-        },
-      },
-    },
     ...(props.overrideThemeOptions || {}),
   });
   const { kind, name, namespace } = useRouteRefParams(rootDocsRouteRef);
@@ -207,7 +210,6 @@ export const TechDocsReaderPage = (props: TechDocsReaderPageProps) => {
       </ThemeProvider>
     );
   }
-
   // As explained above, a render function is configuration 3 and React element is 2
   return (
     <ThemeProvider theme={readerPageTheme}>
@@ -215,7 +217,7 @@ export const TechDocsReaderPage = (props: TechDocsReaderPageProps) => {
         <TechDocsReaderPageProvider entityRef={entityRef}>
           {({ metadata, entityMetadata, onReady }) => (
             <div className="techdocs-reader-page">
-              <Page themeId="documentation">
+              <Page themeId="documentation" className={classes.readerPage}>
                 {children instanceof Function
                   ? children({
                       entityRef,

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPage/TechDocsReaderPage.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPage/TechDocsReaderPage.tsx
@@ -39,7 +39,7 @@ import {
 import { CookieAuthRefreshProvider } from '@backstage/plugin-auth-react';
 import {
   createTheme,
-  makeStyles,
+  styled,
   ThemeOptions,
   ThemeProvider,
   useTheme,
@@ -122,13 +122,6 @@ are retrieved using the useOutlet hook from React Router.
 NOTE: Render functions are no longer supported in this approach.
 */
 
-const useStyles = makeStyles({
-  readerPage: {
-    height: 'inherit',
-    overflowY: 'visible',
-  },
-});
-
 /**
  * Props for {@link TechDocsReaderLayout}
  * @public
@@ -169,13 +162,20 @@ export type TechDocsReaderPageProps = {
 };
 
 /**
+ * Styled Backstage Page that fills available vertical space
+ */
+const StyledPage = styled(Page)({
+  height: 'inherit',
+  overflowY: 'visible',
+});
+
+/**
  * An addon-aware implementation of the TechDocsReaderPage.
  *
  * @public
  */
 export const TechDocsReaderPage = (props: TechDocsReaderPageProps) => {
   const currentTheme = useTheme();
-  const classes = useStyles();
 
   const readerPageTheme = createTheme({
     ...currentTheme,
@@ -216,18 +216,19 @@ export const TechDocsReaderPage = (props: TechDocsReaderPageProps) => {
       <CookieAuthRefreshProvider pluginId="techdocs">
         <TechDocsReaderPageProvider entityRef={entityRef}>
           {({ metadata, entityMetadata, onReady }) => (
-            <div className="techdocs-reader-page">
-              <Page themeId="documentation" className={classes.readerPage}>
-                {children instanceof Function
-                  ? children({
-                      entityRef,
-                      techdocsMetadataValue: metadata.value,
-                      entityMetadataValue: entityMetadata.value,
-                      onReady,
-                    })
-                  : children}
-              </Page>
-            </div>
+            <StyledPage
+              themeId="documentation"
+              className="techdocs-reader-page"
+            >
+              {children instanceof Function
+                ? children({
+                    entityRef,
+                    techdocsMetadataValue: metadata.value,
+                    entityMetadataValue: entityMetadata.value,
+                    onReady,
+                  })
+                : children}
+            </StyledPage>
           )}
         </TechDocsReaderPageProvider>
       </CookieAuthRefreshProvider>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

As reported in #26662

Override the BackstagePage default styles to avoid a "double scrollbar" situation that stopped the page from fully scrolling to the top of the page when we navigated to a new page


Before (Double Scrollbar)

https://github.com/user-attachments/assets/a703ebb1-6c5c-4630-8dbb-5de53403e704

After 

https://github.com/user-attachments/assets/5aa7b280-1fa1-4c9c-8a44-328eba9b28a7



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
