### PR TITLE
techdocs: add missing alpha entity content route ref

### DIFF
--- a/.changeset/fifty-turtles-count.md
+++ b/.changeset/fifty-turtles-count.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Add missing route ref to the `/alpha` entity content extension.

--- a/plugins/techdocs/src/alpha.tsx
+++ b/plugins/techdocs/src/alpha.tsx
@@ -170,6 +170,7 @@ const techDocsEntityContent = EntityContentBlueprint.makeWithOverrides({
       {
         defaultPath: 'docs',
         defaultTitle: 'TechDocs',
+        routeRef: convertLegacyRouteRef(rootCatalogDocsRouteRef),
         loader: () =>
           import('./Router').then(({ EmbeddedDocsRouter }) =>
             compatWrapper(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

🧹, this can cause crashes since the route ref doesn't end up mounted anywhere.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
