### PR TITLE
backend-app-api: immediately log plugin startup errors

### DIFF
--- a/.changeset/grumpy-crews-sneeze.md
+++ b/.changeset/grumpy-crews-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+The log message written when plugins fail to initialize now includes the error that caused the plugin startup to fail.

--- a/packages/backend-app-api/src/wiring/BackendInitializer.ts
+++ b/packages/backend-app-api/src/wiring/BackendInitializer.ts
@@ -34,7 +34,7 @@ import type {
 } from '../../../backend-plugin-api/src/wiring/types';
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
 import type { InternalServiceFactory } from '../../../backend-plugin-api/src/services/system/types';
-import { ForwardedError, ConflictError } from '@backstage/errors';
+import { ForwardedError, ConflictError, assertError } from '@backstage/errors';
 import {
   instanceMetadataServiceRef,
   featureDiscoveryServiceRef,
@@ -405,8 +405,9 @@ export class BackendInitializer {
           // Once the plugin and all modules have been initialized, we can signal that the plugin has stared up successfully
           const lifecycleService = await this.#getPluginLifecycleImpl(pluginId);
           await lifecycleService.startup();
-        } catch (error) {
-          initLogger.onPluginFailed(pluginId);
+        } catch (error: unknown) {
+          assertError(error);
+          initLogger.onPluginFailed(pluginId, error);
           throw error;
         }
       }),

--- a/packages/backend-app-api/src/wiring/createInitializationLogger.ts
+++ b/packages/backend-app-api/src/wiring/createInitializationLogger.ts
@@ -27,7 +27,7 @@ export function createInitializationLogger(
   rootLogger?: RootLoggerService,
 ): {
   onPluginStarted(pluginId: string): void;
-  onPluginFailed(pluginId: string): void;
+  onPluginFailed(pluginId: string, error: Error): void;
   onAllStarted(): void;
 } {
   const logger = rootLogger?.child({ type: 'initialization' });
@@ -68,14 +68,15 @@ export function createInitializationLogger(
       starting.delete(pluginId);
       started.add(pluginId);
     },
-    onPluginFailed(pluginId: string) {
+    onPluginFailed(pluginId: string, error: Error) {
       starting.delete(pluginId);
       const status =
         starting.size > 0
           ? `, waiting for ${starting.size} other plugins to finish before shutting down the process`
           : '';
       logger?.error(
-        `Plugin '${pluginId}' threw an error during startup${status}`,
+        `Plugin '${pluginId}' threw an error during startup${status}.`,
+        error,
       );
     },
     onAllStarted() {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Goal of this is to make it easier to troubleshoot backend startup errors.

We already log errors once all plugins have been started or failed to start, but I've some environments where the aggregate errors doesn't get properly logged with the causes, hiding the actual errors. More importantly though it's hard to troubleshoot startup errors where the backend startup hangs, since plugin errors will never be logged in that cause.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
