### PR TITLE
make `ldapOrg` config key optional

### DIFF
--- a/.changeset/odd-countries-vanish.md
+++ b/.changeset/odd-countries-vanish.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-ldap': patch
+---
+
+Make `ldapOrg` config key optional

--- a/plugins/catalog-backend-module-ldap/config.d.ts
+++ b/plugins/catalog-backend-module-ldap/config.d.ts
@@ -437,7 +437,7 @@ export interface Config {
       /**
        * LdapOrg provider key
        */
-      ldapOrg: {
+      ldapOrg?: {
         /**
          * Id of the LdapOrg provider
          */


### PR DESCRIPTION
All plugins should have an optional root - this one had just been forgotten.