### PR TITLE
search-backend-module-catalog: filter can be array in config schema

### DIFF
--- a/.changeset/smart-planes-march.md
+++ b/.changeset/smart-planes-march.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend-module-catalog': patch
+---
+
+Allow filter to be an array in config schema

--- a/plugins/search-backend-module-catalog/config.d.ts
+++ b/plugins/search-backend-module-catalog/config.d.ts
@@ -36,7 +36,7 @@ export interface Config {
          *
          * Defaults to no filter, ie indexing all entities.
          */
-        filter?: object;
+        filter?: object | object[];
         /**
          * The number of entities to process at a time. Keep this at a
          * reasonable number to avoid overloading either the catalog or the


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#27277 fixed being able to use an object or an array as the filter, this updates the config schema to allow this as well.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
