### PR TITLE
frontend-plugin-api: allow duplicate route ref IDs

### DIFF
--- a/.changeset/witty-pets-march.md
+++ b/.changeset/witty-pets-march.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': patch
+---
+
+Allow route references to be installed in multiple app instances as long as their name is the same.

--- a/packages/frontend-plugin-api/src/routing/RouteRef.test.ts
+++ b/packages/frontend-plugin-api/src/routing/RouteRef.test.ts
@@ -35,6 +35,7 @@ describe('RouteRef', () => {
 
     internal.setId('some-id');
     expect(String(internal)).toBe('RouteRef{some-id}');
+    internal.setId('some-id'); // Should allow same ID
 
     expect(() => internal.setId('some-other-id')).toThrow(
       "RouteRef was referenced twice as both 'some-id' and 'some-other-id'",

--- a/packages/frontend-plugin-api/src/routing/RouteRef.ts
+++ b/packages/frontend-plugin-api/src/routing/RouteRef.ts
@@ -95,7 +95,7 @@ export class RouteRefImpl implements InternalRouteRef {
     if (!id) {
       throw new Error(`${this.#name} id must be a non-empty string`);
     }
-    if (this.#id) {
+    if (this.#id && this.#id !== id) {
       throw new Error(
         `${this.#name} was referenced twice as both '${this.#id}' and '${id}'`,
       );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Making the use of route refs a bit more flexible in the new system to allowing for some reuse.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
