### PR TITLE
Update TechdocsGeneratorExtensionPoint to use GeneratorBase interface

### DIFF
--- a/.changeset/silver-monkeys-explode.md
+++ b/.changeset/silver-monkeys-explode.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-node': patch
+---
+
+Update TechdocsGeneratorExtensionPoint to use GeneratorBase for improved extensibility.

--- a/plugins/techdocs-node/report.api.md
+++ b/plugins/techdocs-node/report.api.md
@@ -324,7 +324,7 @@ export class TechdocsGenerator implements GeneratorBase {
 // @public
 export interface TechdocsGeneratorExtensionPoint {
   // (undocumented)
-  setTechdocsGenerator(generator: TechdocsGenerator): void;
+  setTechdocsGenerator(generator: GeneratorBase): void;
 }
 
 // @public

--- a/plugins/techdocs-node/src/extensions.ts
+++ b/plugins/techdocs-node/src/extensions.ts
@@ -16,11 +16,11 @@
 import { createExtensionPoint } from '@backstage/backend-plugin-api';
 import { DocsBuildStrategy } from './techdocsTypes';
 import {
+  GeneratorBase,
   PreparerBase,
   PublisherBase,
   PublisherType,
   RemoteProtocol,
-  TechdocsGenerator,
 } from './stages';
 import * as winston from 'winston';
 import { PublisherSettings } from './stages/publish/types';
@@ -51,7 +51,7 @@ export const techdocsBuildsExtensionPoint =
  * @public
  */
 export interface TechdocsGeneratorExtensionPoint {
-  setTechdocsGenerator(generator: TechdocsGenerator): void;
+  setTechdocsGenerator(generator: GeneratorBase): void;
 }
 
 /**


### PR DESCRIPTION
This PR updates the `TechdocsGeneratorExtensionPoint` interface to use the `GeneratorBase` interface for the `setTechdocsGenerator` method instead of the default `TechdocsGenerator` class.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
