### PR TITLE
frontend-plugin-api: add support for multiple attachTos

### DIFF
--- a/.changeset/three-glasses-sell.md
+++ b/.changeset/three-glasses-sell.md
@@ -1,0 +1,6 @@
+---
+'@backstage/frontend-plugin-api': patch
+'@backstage/frontend-app-api': patch
+---
+
+Add support for defining multiple attachment points for extensions and blueprints.

--- a/docs/frontend-system/architecture/20-extensions.md
+++ b/docs/frontend-system/architecture/20-extensions.md
@@ -337,3 +337,21 @@ const routableExtension = createExtension({
   },
 });
 ```
+
+## Multiple attachment points
+
+For some cases it can be useful to attach extensions to multiple parents. An example of this are Scaffolder field extensions or TechDocs addons that are consumed by multiple extensions. Specifying multiple attachments is done by providing an array of attachment points to the `attachTo` property of the extension. Keep in mind that this increases the complexity of your extension tree and should only be done when necessary. The following example shows how to attach our example extension to multiple parents:
+
+```tsx
+const extension = createExtension({
+  name: 'my-extension',
+  attachTo: [
+    { id: 'my-first-parent', input: 'content' },
+    { id: 'my-second-parent', input: 'children' }, // The input names do not need to match
+  ],
+  output: [coreExtensionData.reactElement],
+  factory() {
+    return [coreExtensionData.reactElement(<div>Hello World</div>)];
+  },
+});
+```

--- a/packages/frontend-app-api/src/tree/resolveAppTree.test.ts
+++ b/packages/frontend-app-api/src/tree/resolveAppTree.test.ts
@@ -119,6 +119,84 @@ describe('buildAppTree', () => {
     `);
   });
 
+  it('should create a tree with clones', () => {
+    const tree = resolveAppTree('a', [
+      { ...baseSpec, id: 'a' },
+      { ...baseSpec, id: 'b', attachTo: { id: 'a', input: 'x' } },
+      {
+        ...baseSpec,
+        id: 'c',
+        attachTo: [
+          { id: 'a', input: 'x' },
+          { id: 'b', input: 'x' },
+        ],
+      },
+      {
+        ...baseSpec,
+        id: 'd',
+        attachTo: [
+          { id: 'b', input: 'x' },
+          { id: 'c', input: 'x' },
+        ],
+      },
+    ]);
+
+    expect(Array.from(tree.nodes.keys())).toEqual(['a', 'b', 'c', 'd']);
+
+    expect(JSON.parse(JSON.stringify(tree.root))).toMatchInlineSnapshot(`
+      {
+        "attachments": {
+          "x": [
+            {
+              "attachments": {
+                "x": [
+                  {
+                    "id": "c",
+                  },
+                  {
+                    "id": "d",
+                  },
+                ],
+              },
+              "id": "b",
+            },
+            {
+              "attachments": {
+                "x": [
+                  {
+                    "id": "d",
+                  },
+                ],
+              },
+              "id": "c",
+            },
+          ],
+        },
+        "id": "a",
+      }
+    `);
+    expect(String(tree.root)).toMatchInlineSnapshot(`
+      "<a>
+        x [
+          <b>
+            x [
+              <c />
+              <d />
+            ]
+          </b>
+          <c>
+            x [
+              <d />
+            ]
+          </c>
+        ]
+      </a>"
+    `);
+
+    const orphans = Array.from(tree.orphans).map(String);
+    expect(orphans).toMatchInlineSnapshot(`[]`);
+  });
+
   it('should create a tree out of order', () => {
     const tree = resolveAppTree('b', [
       { ...baseSpec, attachTo: { id: 'b', input: 'x' }, id: 'bx2' },
@@ -239,30 +317,30 @@ describe('buildAppTree', () => {
       ]);
 
       expect(tree.root).toMatchInlineSnapshot(`
-      {
-        "attachments": {
-          "test": [
-            {
-              "attachments": undefined,
-              "id": "b",
-              "output": undefined,
-            },
-          ],
-        },
-        "id": "a",
-        "output": undefined,
-      }
-    `);
+              {
+                "attachments": {
+                  "test": [
+                    {
+                      "attachments": undefined,
+                      "id": "b",
+                      "output": undefined,
+                    },
+                  ],
+                },
+                "id": "a",
+                "output": undefined,
+              }
+          `);
 
       expect(tree.orphans).toMatchInlineSnapshot(`[]`);
 
       expect(String(tree.root)).toMatchInlineSnapshot(`
-      "<a>
-        test [
-          <b />
-        ]
-      </a>"
-    `);
+              "<a>
+                test [
+                  <b />
+                ]
+              </a>"
+          `);
     });
 
     it('should not allow redirects for attachment points that already exist', () => {

--- a/packages/frontend-app-api/src/tree/resolveAppTree.test.ts
+++ b/packages/frontend-app-api/src/tree/resolveAppTree.test.ts
@@ -143,44 +143,16 @@ describe('buildAppTree', () => {
 
     expect(Array.from(tree.nodes.keys())).toEqual(['a', 'b', 'c', 'd']);
 
-    expect(JSON.parse(JSON.stringify(tree.root))).toMatchInlineSnapshot(`
-      {
-        "attachments": {
-          "x": [
-            {
-              "attachments": {
-                "x": [
-                  {
-                    "id": "c",
-                  },
-                  {
-                    "id": "d",
-                  },
-                ],
-              },
-              "id": "b",
-            },
-            {
-              "attachments": {
-                "x": [
-                  {
-                    "id": "d",
-                  },
-                ],
-              },
-              "id": "c",
-            },
-          ],
-        },
-        "id": "a",
-      }
-    `);
     expect(String(tree.root)).toMatchInlineSnapshot(`
       "<a>
         x [
           <b>
             x [
-              <c />
+              <c>
+                x [
+                  <d />
+                ]
+              </c>
               <d />
             ]
           </b>

--- a/packages/frontend-internal/src/wiring/InternalExtensionDefinition.ts
+++ b/packages/frontend-internal/src/wiring/InternalExtensionDefinition.ts
@@ -18,6 +18,7 @@ import {
   AnyExtensionDataRef,
   ApiHolder,
   AppNode,
+  ExtensionAttachToSpec,
   ExtensionDataValue,
   ExtensionDefinition,
   ExtensionDefinitionParameters,
@@ -35,7 +36,7 @@ export const OpaqueExtensionDefinition = OpaqueType.create<{
         readonly kind?: string;
         readonly namespace?: string;
         readonly name?: string;
-        readonly attachTo: { id: string; input: string };
+        readonly attachTo: ExtensionAttachToSpec;
         readonly disabled: boolean;
         readonly configSchema?: PortableSchema<any, any>;
         readonly inputs: {
@@ -66,7 +67,7 @@ export const OpaqueExtensionDefinition = OpaqueType.create<{
         readonly kind?: string;
         readonly namespace?: string;
         readonly name?: string;
-        readonly attachTo: { id: string; input: string };
+        readonly attachTo: ExtensionAttachToSpec;
         readonly disabled: boolean;
         readonly configSchema?: PortableSchema<any, any>;
         readonly inputs: {

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -227,10 +227,7 @@ export interface AppNodeInstance {
 // @public
 export interface AppNodeSpec {
   // (undocumented)
-  readonly attachTo: {
-    id: string;
-    input: string;
-  };
+  readonly attachTo: ExtensionAttachToSpec;
   // (undocumented)
   readonly config?: unknown;
   // (undocumented)
@@ -593,10 +590,7 @@ export type CreateExtensionBlueprintOptions<
   },
 > = {
   kind: TKind;
-  attachTo: {
-    id: string;
-    input: string;
-  };
+  attachTo: ExtensionAttachToSpec;
   disabled?: boolean;
   inputs?: TInputs;
   output: Array<UOutput>;
@@ -680,10 +674,7 @@ export type CreateExtensionOptions<
 > = {
   kind?: TKind;
   name?: TName;
-  attachTo: {
-    id: string;
-    input: string;
-  };
+  attachTo: ExtensionAttachToSpec;
   disabled?: boolean;
   inputs?: TInputs;
   output: Array<UOutput>;
@@ -813,10 +804,7 @@ export interface Extension<TConfig, TConfigInput = TConfig> {
   // (undocumented)
   $$type: '@backstage/Extension';
   // (undocumented)
-  readonly attachTo: {
-    id: string;
-    input: string;
-  };
+  readonly attachTo: ExtensionAttachToSpec;
   // (undocumented)
   readonly configSchema?: PortableSchema<TConfig, TConfigInput>;
   // (undocumented)
@@ -824,6 +812,17 @@ export interface Extension<TConfig, TConfigInput = TConfig> {
   // (undocumented)
   readonly id: string;
 }
+
+// @public (undocumented)
+export type ExtensionAttachToSpec =
+  | {
+      id: string;
+      input: string;
+    }
+  | Array<{
+      id: string;
+      input: string;
+    }>;
 
 // @public (undocumented)
 export interface ExtensionBlueprint<
@@ -834,10 +833,7 @@ export interface ExtensionBlueprint<
   // (undocumented)
   make<TNewName extends string | undefined>(args: {
     name?: TNewName;
-    attachTo?: {
-      id: string;
-      input: string;
-    };
+    attachTo?: ExtensionAttachToSpec;
     disabled?: boolean;
     params: T['params'];
   }): ExtensionDefinition<{
@@ -867,10 +863,7 @@ export interface ExtensionBlueprint<
     },
   >(args: {
     name?: TNewName;
-    attachTo?: {
-      id: string;
-      input: string;
-    };
+    attachTo?: ExtensionAttachToSpec;
     disabled?: boolean;
     inputs?: TExtraInputs & {
       [KName in keyof T['inputs']]?: `Error: Input '${KName &
@@ -1057,10 +1050,7 @@ export type ExtensionDefinition<
   >(
     args: Expand<
       {
-        attachTo?: {
-          id: string;
-          input: string;
-        };
+        attachTo?: ExtensionAttachToSpec;
         disabled?: boolean;
         inputs?: TExtraInputs & {
           [KName in keyof T['inputs']]?: `Error: Input '${KName &

--- a/packages/frontend-plugin-api/src/apis/definitions/AppTreeApi.ts
+++ b/packages/frontend-plugin-api/src/apis/definitions/AppTreeApi.ts
@@ -15,7 +15,12 @@
  */
 
 import { createApiRef } from '@backstage/core-plugin-api';
-import { FrontendPlugin, Extension, ExtensionDataRef } from '../../wiring';
+import {
+  FrontendPlugin,
+  Extension,
+  ExtensionDataRef,
+  ExtensionAttachToSpec,
+} from '../../wiring';
 
 /**
  * The specification for this {@link AppNode} in the {@link AppTree}.
@@ -28,7 +33,7 @@ import { FrontendPlugin, Extension, ExtensionDataRef } from '../../wiring';
  */
 export interface AppNodeSpec {
   readonly id: string;
-  readonly attachTo: { id: string; input: string };
+  readonly attachTo: ExtensionAttachToSpec;
   readonly extension: Extension<unknown, unknown>;
   readonly disabled: boolean;
   readonly config?: unknown;

--- a/packages/frontend-plugin-api/src/wiring/createExtension.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.test.ts
@@ -202,6 +202,20 @@ describe('createExtension', () => {
     });
   });
 
+  it('should create an extension with multiple attachment points', () => {
+    const extension = createExtension({
+      attachTo: [
+        { id: 'root', input: 'default' },
+        { id: 'other', input: 'default' },
+      ],
+      output: [stringDataRef, numberDataRef.optional()],
+      factory: () => [stringDataRef('bar')],
+    });
+    expect(String(extension)).toBe(
+      'ExtensionDefinition{attachTo=root@default+other@default}',
+    );
+  });
+
   it('should create an extension with input', () => {
     const extension = createExtension({
       attachTo: { id: 'root', input: 'default' },

--- a/packages/frontend-plugin-api/src/wiring/createExtension.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.ts
@@ -113,6 +113,11 @@ export type VerifyExtensionFactoryOutput<
   : never;
 
 /** @public */
+export type ExtensionAttachToSpec =
+  | { id: string; input: string }
+  | Array<{ id: string; input: string }>;
+
+/** @public */
 export type CreateExtensionOptions<
   TKind extends string | undefined,
   TName extends string | undefined,
@@ -128,7 +133,7 @@ export type CreateExtensionOptions<
 > = {
   kind?: TKind;
   name?: TName;
-  attachTo: { id: string; input: string };
+  attachTo: ExtensionAttachToSpec;
   disabled?: boolean;
   inputs?: TInputs;
   output: Array<UOutput>;
@@ -183,7 +188,7 @@ export type ExtensionDefinition<
   >(
     args: Expand<
       {
-        attachTo?: { id: string; input: string };
+        attachTo?: ExtensionAttachToSpec;
         disabled?: boolean;
         inputs?: TExtraInputs & {
           [KName in keyof T['inputs']]?: `Error: Input '${KName &
@@ -338,7 +343,12 @@ export function createExtension<
       if (options.name) {
         parts.push(`name=${options.name}`);
       }
-      parts.push(`attachTo=${options.attachTo.id}@${options.attachTo.input}`);
+      parts.push(
+        `attachTo=${[options.attachTo]
+          .flat()
+          .map(a => `${a.id}@${a.input}`)
+          .join('+')}`,
+      );
       return `ExtensionDefinition{${parts.join(',')}}`;
     },
     override(overrideOptions) {

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.test.tsx
@@ -87,7 +87,11 @@ describe('createExtensionBlueprint', () => {
   it('should allow creation of extension blueprints with a generator', () => {
     const TestExtensionBlueprint = createExtensionBlueprint({
       kind: 'test-extension',
-      attachTo: { id: 'test', input: 'default' },
+      // Try multiple attachment points for this one
+      attachTo: [
+        { id: 'test-1', input: 'default' },
+        { id: 'test-2', input: 'default' },
+      ],
       output: [coreExtensionData.reactElement],
       *factory(params: { text: string }) {
         yield coreExtensionData.reactElement(<h1>{params.text}</h1>);
@@ -103,10 +107,10 @@ describe('createExtensionBlueprint', () => {
 
     expect(extension).toEqual({
       $$type: '@backstage/ExtensionDefinition',
-      attachTo: {
-        id: 'test',
-        input: 'default',
-      },
+      attachTo: [
+        { id: 'test-1', input: 'default' },
+        { id: 'test-2', input: 'default' },
+      ],
       configSchema: undefined,
       disabled: false,
       inputs: {},

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
@@ -17,6 +17,7 @@
 import { ApiHolder, AppNode } from '../apis';
 import { Expand } from '@backstage/types';
 import {
+  ExtensionAttachToSpec,
   ExtensionDefinition,
   ResolvedExtensionInputs,
   VerifyExtensionFactoryOutput,
@@ -57,7 +58,7 @@ export type CreateExtensionBlueprintOptions<
   TDataRefs extends { [name in string]: AnyExtensionDataRef },
 > = {
   kind: TKind;
-  attachTo: { id: string; input: string };
+  attachTo: ExtensionAttachToSpec;
   disabled?: boolean;
   inputs?: TInputs;
   output: Array<UOutput>;
@@ -107,7 +108,7 @@ export interface ExtensionBlueprint<
 
   make<TNewName extends string | undefined>(args: {
     name?: TNewName;
-    attachTo?: { id: string; input: string };
+    attachTo?: ExtensionAttachToSpec;
     disabled?: boolean;
     params: T['params'];
   }): ExtensionDefinition<{
@@ -141,7 +142,7 @@ export interface ExtensionBlueprint<
     },
   >(args: {
     name?: TNewName;
-    attachTo?: { id: string; input: string };
+    attachTo?: ExtensionAttachToSpec;
     disabled?: boolean;
     inputs?: TExtraInputs & {
       [KName in keyof T['inputs']]?: `Error: Input '${KName &

--- a/packages/frontend-plugin-api/src/wiring/index.ts
+++ b/packages/frontend-plugin-api/src/wiring/index.ts
@@ -19,6 +19,7 @@ export {
   createExtension,
   type ExtensionDefinition,
   type ExtensionDefinitionParameters,
+  type ExtensionAttachToSpec,
   type CreateExtensionOptions,
   type ResolvedExtensionInput,
   type ResolvedExtensionInputs,

--- a/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.ts
+++ b/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.ts
@@ -16,6 +16,7 @@
 
 import { ApiHolder, AppNode } from '../apis';
 import {
+  ExtensionAttachToSpec,
   ExtensionDefinition,
   ExtensionDefinitionParameters,
   ResolvedExtensionInputs,
@@ -32,7 +33,7 @@ import { OpaqueExtensionDefinition } from '@internal/frontend';
 export interface Extension<TConfig, TConfigInput = TConfig> {
   $$type: '@backstage/Extension';
   readonly id: string;
-  readonly attachTo: { id: string; input: string };
+  readonly attachTo: ExtensionAttachToSpec;
   readonly disabled: boolean;
   readonly configSchema?: PortableSchema<TConfig, TConfigInput>;
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Draft for now while we discuss whether this is needed. This allows for extensions to be cloned through definition of multiple attachment points. The purpose of this is to provide an alternative solution for when extensions are used in multiple parts of the app, for example [scaffolder field extensions](https://github.com/backstage/backstage/blob/78aff31f0dc96399e3783e8f20f8d420b6745a5d/plugins/scaffolder-react/src/next/blueprints/FormFieldBlueprint.tsx#L35-L45) or TechDocs addons. Our current approach is to use Utility APIs for these extensions, but looking into it a bit more I'm not sure that's the best or most intuitive solution.

This also is a bit of a trial of cloning extensions in general, where we could potentially allow for extensions to be cloned through config as well. This PR does not implement that.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
