### PR TITLE
GitlabRepoUrlPicker: Fixes the field in repoUrl that is using the name instead of the path.

### DIFF
--- a/.changeset/smooth-buckets-refuse.md
+++ b/.changeset/smooth-buckets-refuse.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gitlab': patch
+---
+
+fixed bug in GitlabRepoUrlPicker where its passing name instead of path

--- a/plugins/scaffolder-backend-module-gitlab/src/autocomplete/autocomplete.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/autocomplete/autocomplete.ts
@@ -96,7 +96,7 @@ export function createHandleAutocompleteRequest(options: {
 
         return {
           results: response.map(project => ({
-            title: project.name.trim(),
+            title: project.path,
             id: project.id.toString(),
           })),
         };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

fixes #28590 
In the `publish:gitlab:merge-request` action, when using `autocomplete` to get a list of owners and repositories, the repository field is populated with the repository name. This name is then used to construct the URL for querying the GitLab API. If the repository name contains spaces, the URL becomes malformed, resulting in a "Not Found" error.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
