### PR TITLE
add optional description for PluginFeatureFlagConfig

### DIFF
--- a/.changeset/tricky-tips-fix.md
+++ b/.changeset/tricky-tips-fix.md
@@ -1,0 +1,6 @@
+---
+'@backstage/core-plugin-api': patch
+'@backstage/core-app-api': patch
+---
+
+Added optional description field for PluginFeatureFlagConfig.

--- a/docs/plugins/feature-flags.md
+++ b/docs/plugins/feature-flags.md
@@ -19,7 +19,12 @@ import { createPlugin } from '@backstage/core-plugin-api';
 
 export const examplePlugin = createPlugin({
   // ...
-  featureFlags: [{ name: 'show-example-feature' }],
+  featureFlags: [
+    {
+      name: 'show-example-feature',
+      description: 'Enables example feature',
+    },
+  ],
   // ...
 });
 ```

--- a/packages/core-app-api/src/app/AppManager.test.tsx
+++ b/packages/core-app-api/src/app/AppManager.test.tsx
@@ -430,6 +430,10 @@ describe('Integration Test', () => {
             {
               name: 'foo',
             },
+            {
+              name: 'bar',
+              description: 'test',
+            },
           ],
         }),
         // We still support consuming the old feature flag API for a little while longer
@@ -477,6 +481,11 @@ describe('Integration Test', () => {
     expect(storageFlags.registerFlag).toHaveBeenCalledWith({
       name: 'foo',
       pluginId: 'test',
+    });
+    expect(storageFlags.registerFlag).toHaveBeenCalledWith({
+      name: 'bar',
+      pluginId: 'test',
+      description: 'test',
     });
     expect(storageFlags.registerFlag).toHaveBeenCalledWith({
       name: 'old-feature-flag',

--- a/packages/core-app-api/src/app/AppManager.tsx
+++ b/packages/core-app-api/src/app/AppManager.tsx
@@ -94,7 +94,11 @@ import { isProtectedApp } from './isProtectedApp';
 type CompatiblePlugin =
   | BackstagePlugin
   | (Omit<BackstagePlugin, 'getFeatureFlags'> & {
-      output(): Array<{ type: 'feature-flag'; name: string }>;
+      output(): Array<{
+        type: 'feature-flag';
+        name: string;
+        description?: string;
+      }>;
     });
 
 function useConfigLoader(
@@ -337,6 +341,7 @@ DEPRECATION WARNING: React Router Beta is deprecated and support for it will be 
                 featureFlagsApi.registerFlag({
                   name: flag.name,
                   pluginId: plugin.getId(),
+                  description: flag.description,
                 });
               }
             } else {
@@ -345,6 +350,7 @@ DEPRECATION WARNING: React Router Beta is deprecated and support for it will be 
                   featureFlagsApi.registerFlag({
                     name: output.name,
                     pluginId: plugin.getId(),
+                    description: output.description,
                   });
                 }
               }

--- a/packages/core-plugin-api/report.api.md
+++ b/packages/core-plugin-api/report.api.md
@@ -659,6 +659,7 @@ export type PluginConfig<
 // @public
 export type PluginFeatureFlagConfig = {
   name: string;
+  description?: string;
 };
 
 // @public

--- a/packages/core-plugin-api/src/plugin/Plugin.test.tsx
+++ b/packages/core-plugin-api/src/plugin/Plugin.test.tsx
@@ -28,6 +28,13 @@ describe('Plugin Feature Flag', () => {
     expect(
       createPlugin({
         id: 'test',
+        featureFlags: [{ name: 'test', description: 'test' }],
+      }).getFeatureFlags(),
+    ).toEqual([{ name: 'test', description: 'test' }]);
+
+    expect(
+      createPlugin({
+        id: 'test',
       }).getFeatureFlags(),
     ).toEqual([]);
   });

--- a/packages/core-plugin-api/src/plugin/types.ts
+++ b/packages/core-plugin-api/src/plugin/types.ts
@@ -73,6 +73,9 @@ export type BackstagePlugin<
 export type PluginFeatureFlagConfig = {
   /** Feature flag name */
   name: string;
+
+  /** Feature flag description */
+  description?: string;
 };
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Wanted to give descriptions for feature flags registered via `createPlugin`, and be able to see them on the user settings page, just like for flags registered via app.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

![Image 1-24-25 at 11 21 PM](https://github.com/user-attachments/assets/f526f4bf-9c2d-416d-a2f6-09d780204316)
