### PR TITLE
cli: more options for the new command

### DIFF
--- a/.changeset/chilly-glasses-burn.md
+++ b/.changeset/chilly-glasses-burn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Added `--allowedOptions` to `new` command. This is useful for limiting the options shown in the interactive prompt.

--- a/.changeset/chilly-glasses-burn.md
+++ b/.changeset/chilly-glasses-burn.md
@@ -5,3 +5,5 @@
 Added `--allowed-types` to `new` command. This is useful for limiting the type of plugins that can be created. For example, if you only want to create `plugin` and `plugin-react` plugins, you can run `backstage-cli new --allowed-types plugin,plugin-react`.
 
 Added `--skip-install` to `new` command. This is useful for skipping the installation of dependencies after creating a new plugin.
+
+Added `--prefix` to `new` command. This is useful for customizing the prefix of the plugin package name, defined after the scope, which by default is `backstage-plugin-`.

--- a/.changeset/chilly-glasses-burn.md
+++ b/.changeset/chilly-glasses-burn.md
@@ -6,4 +6,4 @@ Added `--allowed-types` to `new` command. This is useful for limiting the type o
 
 Added `--skip-install` to `new` command. This is useful for skipping the installation of dependencies after creating a new plugin.
 
-Added `--prefix` to `new` command. This is useful for customizing the prefix of the plugin package name, defined after the scope, which by default is `backstage-plugin-`.
+Added `--plugin-prefix` to `new` command. This is useful for customizing the prefix of the plugin package name, defined after the scope, which by default is `backstage-plugin-`.

--- a/.changeset/chilly-glasses-burn.md
+++ b/.changeset/chilly-glasses-burn.md
@@ -2,4 +2,6 @@
 '@backstage/cli': patch
 ---
 
-Added `--allowedOptions` to `new` command. This is useful for limiting the options shown in the interactive prompt.
+Added `--allowed-types` to `new` command. This is useful for limiting the type of plugins that can be created. For example, if you only want to create `plugin` and `plugin-react` plugins, you can run `backstage-cli new --allowed-types plugin,plugin-react`.
+
+Added `--skip-install` to `new` command. This is useful for skipping the installation of dependencies after creating a new plugin.

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lint:docs": "node ./scripts/check-docs-quality",
     "lint:peer-deps": "backstage-repo-tools peer-deps",
     "lint:type-deps": "backstage-repo-tools type-deps",
-    "new": "backstage-cli new --scope backstage --prefix plugin --baseVersion 0.0.0 --no-private",
+    "new": "backstage-cli new --scope backstage --plugin-prefix plugin --baseVersion 0.0.0 --no-private",
     "prepare": "husky",
     "prettier:check": "prettier --check .",
     "prettier:fix": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lint:docs": "node ./scripts/check-docs-quality",
     "lint:peer-deps": "backstage-repo-tools peer-deps",
     "lint:type-deps": "backstage-repo-tools type-deps",
-    "new": "backstage-cli new --scope backstage --baseVersion 0.0.0 --no-private",
+    "new": "backstage-cli new --scope backstage --prefix plugin --baseVersion 0.0.0 --no-private",
     "prepare": "husky",
     "prettier:check": "prettier --check .",
     "prettier:fix": "prettier --write .",

--- a/packages/cli/cli-report.md
+++ b/packages/cli/cli-report.md
@@ -183,6 +183,9 @@ Options:
   --npm-registry <URL>
   --baseVersion <version>
   --license <license>
+  --allowed-types <type1,type2>
+  --prefix <prefix>
+  --skip-install
   --no-private
   -h, --help
 ```

--- a/packages/cli/cli-report.md
+++ b/packages/cli/cli-report.md
@@ -184,7 +184,7 @@ Options:
   --baseVersion <version>
   --license <license>
   --allowed-types <type1,type2>
-  --prefix <prefix>
+  --plugin-prefix <prefix>
   --skip-install
   --no-private
   -h, --help

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -270,6 +270,10 @@ export function registerCommands(program: Command) {
       '--license <license>',
       'The license to use for any new packages (default: Apache-2.0)',
     )
+    .option(
+      '--allowedOptions <option1,option2>',
+      'Comma separated list of allowed options shown in the interactive guide',
+    )
     .option('--no-private', 'Do not mark new packages as private')
     .action(lazy(() => import('./new/new'), 'default'));
 

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -271,12 +271,16 @@ export function registerCommands(program: Command) {
       'The license to use for any new packages (default: Apache-2.0)',
     )
     .option(
-      '--allowedOptions <option1,option2>',
-      'Comma separated list of allowed options shown in the interactive guide',
+      '--allowed-types <type1,type2>',
+      'Comma separated list of plugin types that are allowed to be created',
     )
     .option(
       '--prefix <prefix>',
       'The prefix to use for new packages, after the scope (default: backstage-plugin)',
+    )
+    .option(
+      '--skip-install',
+      'Skip the install step after creating the new package',
     )
     .option('--no-private', 'Do not mark new packages as private')
     .action(lazy(() => import('./new/new'), 'default'));

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -274,6 +274,10 @@ export function registerCommands(program: Command) {
       '--allowedOptions <option1,option2>',
       'Comma separated list of allowed options shown in the interactive guide',
     )
+    .option(
+      '--prefix <prefix>',
+      'The prefix to use for new packages, after the scope (default: backstage-plugin)',
+    )
     .option('--no-private', 'Do not mark new packages as private')
     .action(lazy(() => import('./new/new'), 'default'));
 

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -275,8 +275,8 @@ export function registerCommands(program: Command) {
       'Comma separated list of plugin types that are allowed to be created',
     )
     .option(
-      '--prefix <prefix>',
-      'The prefix to use for new packages, after the scope (default: backstage-plugin)',
+      '--plugin-prefix <prefix>',
+      'The prefix to use for new plugin packages, after the scope (default: backstage-plugin)',
     )
     .option(
       '--skip-install',

--- a/packages/cli/src/commands/new/new.ts
+++ b/packages/cli/src/commands/new/new.ts
@@ -42,7 +42,12 @@ function parseOptions(optionStrings: string[]): Record<string, string> {
 }
 
 export default async (opts: OptionValues) => {
-  const factory = await FactoryRegistry.interactiveSelect(opts.select);
+  const allowedOptions = (opts.allowedOptions || undefined)?.split(',');
+
+  const factory = await FactoryRegistry.interactiveSelect(
+    opts.select,
+    allowedOptions,
+  );
 
   const providedOptions = parseOptions(opts.option);
   const options = await FactoryRegistry.populateOptions(

--- a/packages/cli/src/commands/new/new.ts
+++ b/packages/cli/src/commands/new/new.ts
@@ -42,11 +42,11 @@ function parseOptions(optionStrings: string[]): Record<string, string> {
 }
 
 export default async (opts: OptionValues) => {
-  const allowedOptions = (opts.allowedOptions || undefined)?.split(',');
+  const allowedTypes = ((opts.allowedTypes as string) || undefined)?.split(',');
 
   const factory = await FactoryRegistry.interactiveSelect(
     opts.select,
-    allowedOptions,
+    allowedTypes,
   );
 
   const providedOptions = parseOptions(opts.option);
@@ -84,6 +84,7 @@ export default async (opts: OptionValues) => {
       defaultVersion,
       license,
       scope: opts.scope?.replace(/^@/, ''),
+      skipInstall: opts.skipInstall,
       prefix: opts.prefix,
       npmRegistry: opts.npmRegistry,
       private: Boolean(opts.private),

--- a/packages/cli/src/commands/new/new.ts
+++ b/packages/cli/src/commands/new/new.ts
@@ -85,7 +85,7 @@ export default async (opts: OptionValues) => {
       license,
       scope: opts.scope?.replace(/^@/, ''),
       skipInstall: opts.skipInstall,
-      prefix: opts.prefix,
+      pluginPrefix: opts.pluginPrefix,
       npmRegistry: opts.npmRegistry,
       private: Boolean(opts.private),
       createTemporaryDirectory,

--- a/packages/cli/src/commands/new/new.ts
+++ b/packages/cli/src/commands/new/new.ts
@@ -84,6 +84,7 @@ export default async (opts: OptionValues) => {
       defaultVersion,
       license,
       scope: opts.scope?.replace(/^@/, ''),
+      prefix: opts.prefix,
       npmRegistry: opts.npmRegistry,
       private: Boolean(opts.private),
       createTemporaryDirectory,

--- a/packages/cli/src/lib/new/FactoryRegistry.ts
+++ b/packages/cli/src/lib/new/FactoryRegistry.ts
@@ -87,8 +87,8 @@ export class FactoryRegistry {
 
   static async populateOptions(
     factory: AnyFactory,
-    provided: Record<string, string>,
-  ): Promise<Record<string, string>> {
+    provided: Answers,
+  ): Promise<Answers> {
     let currentOptions = provided;
 
     if (factory.optionsDiscovery) {

--- a/packages/cli/src/lib/new/FactoryRegistry.ts
+++ b/packages/cli/src/lib/new/FactoryRegistry.ts
@@ -54,19 +54,25 @@ export class FactoryRegistry {
     Object.values(factories).map(factory => [factory.name, factory]),
   );
 
-  static async interactiveSelect(preselected?: string): Promise<AnyFactory> {
+  static async interactiveSelect(
+    preselected?: string,
+    allowedOptions?: string[],
+  ): Promise<AnyFactory> {
     let selected = preselected;
-
     if (!selected) {
       const answers = await inquirer.prompt<{ name: string }>([
         {
           type: 'list',
           name: 'name',
           message: 'What do you want to create?',
-          choices: Array.from(this.factoryMap.values()).map(factory => ({
-            name: `${factory.name} - ${factory.description}`,
-            value: factory.name,
-          })),
+          choices: Array.from(this.factoryMap.values())
+            .filter(({ name }) =>
+              allowedOptions ? allowedOptions.includes(name) : true,
+            )
+            .map(factory => ({
+              name: `${factory.name} - ${factory.description}`,
+              value: factory.name,
+            })),
         },
       ]);
       selected = answers.name;

--- a/packages/cli/src/lib/new/FactoryRegistry.ts
+++ b/packages/cli/src/lib/new/FactoryRegistry.ts
@@ -56,7 +56,7 @@ export class FactoryRegistry {
 
   static async interactiveSelect(
     preselected?: string,
-    allowedOptions?: string[],
+    allowedTypes?: string[],
   ): Promise<AnyFactory> {
     let selected = preselected;
     if (!selected) {
@@ -67,7 +67,7 @@ export class FactoryRegistry {
           message: 'What do you want to create?',
           choices: Array.from(this.factoryMap.values())
             .filter(({ name }) =>
-              allowedOptions ? allowedOptions.includes(name) : true,
+              allowedTypes ? allowedTypes.includes(name) : true,
             )
             .map(factory => ({
               name: `${factory.name} - ${factory.description}`,

--- a/packages/cli/src/lib/new/factories/backendModule.ts
+++ b/packages/cli/src/lib/new/factories/backendModule.ts
@@ -50,7 +50,7 @@ export const backendModule = createFactory<Options>({
     const name = resolvePackageName({
       baseName: dirName,
       scope: ctx.scope,
-      prefix: ctx.prefix,
+      pluginPrefix: ctx.pluginPrefix,
       plugin: true,
     });
 

--- a/packages/cli/src/lib/new/factories/backendModule.ts
+++ b/packages/cli/src/lib/new/factories/backendModule.ts
@@ -34,6 +34,7 @@ type Options = {
   moduleId: string;
   owner?: string;
   codeOwnersPath?: string;
+  skipInstall?: boolean;
 };
 
 export const backendModule = createFactory<Options>({
@@ -50,6 +51,7 @@ export const backendModule = createFactory<Options>({
     const name = resolvePackageName({
       baseName: dirName,
       scope: ctx.scope,
+      prefix: ctx.prefix,
       plugin: true,
     });
 

--- a/packages/cli/src/lib/new/factories/backendModule.ts
+++ b/packages/cli/src/lib/new/factories/backendModule.ts
@@ -34,7 +34,6 @@ type Options = {
   moduleId: string;
   owner?: string;
   codeOwnersPath?: string;
-  skipInstall?: boolean;
 };
 
 export const backendModule = createFactory<Options>({
@@ -102,10 +101,12 @@ export const backendModule = createFactory<Options>({
       await addCodeownersEntry(`/plugins/${dirName}`, options.owner);
     }
 
-    await Task.forCommand('yarn install', { cwd: targetDir, optional: true });
-    await Task.forCommand('yarn lint --fix', {
-      cwd: targetDir,
-      optional: true,
-    });
+    if (!ctx.skipInstall) {
+      await Task.forCommand('yarn install', { cwd: targetDir, optional: true });
+      await Task.forCommand('yarn lint --fix', {
+        cwd: targetDir,
+        optional: true,
+      });
+    }
   },
 });

--- a/packages/cli/src/lib/new/factories/backendPlugin.ts
+++ b/packages/cli/src/lib/new/factories/backendPlugin.ts
@@ -29,6 +29,7 @@ type Options = {
   id: string;
   owner?: string;
   codeOwnersPath?: string;
+  skipInstall?: boolean;
 };
 
 export const backendPlugin = createFactory<Options>({
@@ -44,6 +45,7 @@ export const backendPlugin = createFactory<Options>({
     const name = resolvePackageName({
       baseName: pluginId,
       scope: ctx.scope,
+      prefix: ctx.prefix,
       plugin: true,
     });
 
@@ -89,10 +91,12 @@ export const backendPlugin = createFactory<Options>({
       await addCodeownersEntry(`/plugins/${id}`, options.owner);
     }
 
-    await Task.forCommand('yarn install', { cwd: targetDir, optional: true });
-    await Task.forCommand('yarn lint --fix', {
-      cwd: targetDir,
-      optional: true,
-    });
+    if (!options.skipInstall) {
+      await Task.forCommand('yarn install', { cwd: targetDir, optional: true });
+      await Task.forCommand('yarn lint --fix', {
+        cwd: targetDir,
+        optional: true,
+      });
+    }
   },
 });

--- a/packages/cli/src/lib/new/factories/backendPlugin.ts
+++ b/packages/cli/src/lib/new/factories/backendPlugin.ts
@@ -44,7 +44,7 @@ export const backendPlugin = createFactory<Options>({
     const name = resolvePackageName({
       baseName: pluginId,
       scope: ctx.scope,
-      prefix: ctx.prefix,
+      pluginPrefix: ctx.pluginPrefix,
       plugin: true,
     });
 

--- a/packages/cli/src/lib/new/factories/backendPlugin.ts
+++ b/packages/cli/src/lib/new/factories/backendPlugin.ts
@@ -29,7 +29,6 @@ type Options = {
   id: string;
   owner?: string;
   codeOwnersPath?: string;
-  skipInstall?: boolean;
 };
 
 export const backendPlugin = createFactory<Options>({
@@ -91,7 +90,7 @@ export const backendPlugin = createFactory<Options>({
       await addCodeownersEntry(`/plugins/${id}`, options.owner);
     }
 
-    if (!options.skipInstall) {
+    if (!ctx.skipInstall) {
       await Task.forCommand('yarn install', { cwd: targetDir, optional: true });
       await Task.forCommand('yarn lint --fix', {
         cwd: targetDir,

--- a/packages/cli/src/lib/new/factories/common/util.test.ts
+++ b/packages/cli/src/lib/new/factories/common/util.test.ts
@@ -25,11 +25,12 @@ describe('resolvePackageName', () => {
     );
   });
 
-  it('should generate correct name for backstage scope', () => {
+  it('should generate correct name with custom prefix', () => {
     expect(
       resolvePackageName({
         baseName: 'test',
         scope: 'backstage',
+        pluginPrefix: 'plugin',
         plugin: true,
       }),
     ).toEqual('@backstage/plugin-test');

--- a/packages/cli/src/lib/new/factories/common/util.ts
+++ b/packages/cli/src/lib/new/factories/common/util.ts
@@ -17,14 +17,13 @@
 export const resolvePackageName = (options: {
   baseName: string;
   scope?: string;
+  prefix?: string;
   plugin: boolean;
 }) => {
-  const { baseName, scope, plugin } = options;
+  const { baseName, scope, plugin, prefix } = options;
   if (scope) {
     if (plugin) {
-      const pluginName = scope.startsWith('backstage')
-        ? 'plugin'
-        : 'backstage-plugin';
+      const pluginName = prefix || 'backstage-plugin';
       return scope.includes('/')
         ? `@${scope}${pluginName}-${baseName}`
         : `@${scope}/${pluginName}-${baseName}`;

--- a/packages/cli/src/lib/new/factories/common/util.ts
+++ b/packages/cli/src/lib/new/factories/common/util.ts
@@ -17,13 +17,13 @@
 export const resolvePackageName = (options: {
   baseName: string;
   scope?: string;
-  prefix?: string;
+  pluginPrefix?: string;
   plugin: boolean;
 }) => {
-  const { baseName, scope, plugin, prefix } = options;
+  const { baseName, scope, plugin, pluginPrefix } = options;
   if (scope) {
     if (plugin) {
-      const pluginName = prefix || 'backstage-plugin';
+      const pluginName = pluginPrefix || 'backstage-plugin';
       return scope.includes('/')
         ? `@${scope}${pluginName}-${baseName}`
         : `@${scope}/${pluginName}-${baseName}`;

--- a/packages/cli/src/lib/new/factories/frontendPlugin.ts
+++ b/packages/cli/src/lib/new/factories/frontendPlugin.ts
@@ -30,7 +30,6 @@ type Options = {
   id: string;
   owner?: string;
   codeOwnersPath?: string;
-  skipInstall?: boolean;
 };
 
 export const frontendPlugin = createFactory<Options>({
@@ -126,7 +125,7 @@ export const frontendPlugin = createFactory<Options>({
       await addCodeownersEntry(`/plugins/${id}`, options.owner);
     }
 
-    if (!options.skipInstall) {
+    if (!ctx.skipInstall) {
       await Task.forCommand('yarn install', { cwd: targetDir, optional: true });
       await Task.forCommand('yarn lint --fix', {
         cwd: targetDir,

--- a/packages/cli/src/lib/new/factories/frontendPlugin.ts
+++ b/packages/cli/src/lib/new/factories/frontendPlugin.ts
@@ -45,7 +45,7 @@ export const frontendPlugin = createFactory<Options>({
     const name = resolvePackageName({
       baseName: id,
       scope: ctx.scope,
-      prefix: ctx.prefix,
+      pluginPrefix: ctx.pluginPrefix,
       plugin: true,
     });
     const extensionName = `${upperFirst(camelCase(id))}Page`;

--- a/packages/cli/src/lib/new/factories/frontendPlugin.ts
+++ b/packages/cli/src/lib/new/factories/frontendPlugin.ts
@@ -30,6 +30,7 @@ type Options = {
   id: string;
   owner?: string;
   codeOwnersPath?: string;
+  skipInstall?: boolean;
 };
 
 export const frontendPlugin = createFactory<Options>({
@@ -45,6 +46,7 @@ export const frontendPlugin = createFactory<Options>({
     const name = resolvePackageName({
       baseName: id,
       scope: ctx.scope,
+      prefix: ctx.prefix,
       plugin: true,
     });
     const extensionName = `${upperFirst(camelCase(id))}Page`;
@@ -124,10 +126,12 @@ export const frontendPlugin = createFactory<Options>({
       await addCodeownersEntry(`/plugins/${id}`, options.owner);
     }
 
-    await Task.forCommand('yarn install', { cwd: targetDir, optional: true });
-    await Task.forCommand('yarn lint --fix', {
-      cwd: targetDir,
-      optional: true,
-    });
+    if (!options.skipInstall) {
+      await Task.forCommand('yarn install', { cwd: targetDir, optional: true });
+      await Task.forCommand('yarn lint --fix', {
+        cwd: targetDir,
+        optional: true,
+      });
+    }
   },
 });

--- a/packages/cli/src/lib/new/factories/nodeLibraryPackage.ts
+++ b/packages/cli/src/lib/new/factories/nodeLibraryPackage.ts
@@ -27,6 +27,7 @@ type Options = {
   id: string;
   owner?: string;
   codeOwnersPath?: string;
+  skipInstall?: boolean;
 };
 
 export const nodeLibraryPackage = createFactory<Options>({
@@ -42,6 +43,7 @@ export const nodeLibraryPackage = createFactory<Options>({
     const name = resolvePackageName({
       baseName: id,
       scope: ctx.scope,
+      prefix: ctx.prefix,
       plugin: false,
     });
 
@@ -69,10 +71,12 @@ export const nodeLibraryPackage = createFactory<Options>({
       await addCodeownersEntry(`/packages/${id}`, options.owner);
     }
 
-    await Task.forCommand('yarn install', { cwd: targetDir, optional: true });
-    await Task.forCommand('yarn lint --fix', {
-      cwd: targetDir,
-      optional: true,
-    });
+    if (!options.skipInstall) {
+      await Task.forCommand('yarn install', { cwd: targetDir, optional: true });
+      await Task.forCommand('yarn lint --fix', {
+        cwd: targetDir,
+        optional: true,
+      });
+    }
   },
 });

--- a/packages/cli/src/lib/new/factories/nodeLibraryPackage.ts
+++ b/packages/cli/src/lib/new/factories/nodeLibraryPackage.ts
@@ -27,7 +27,6 @@ type Options = {
   id: string;
   owner?: string;
   codeOwnersPath?: string;
-  skipInstall?: boolean;
 };
 
 export const nodeLibraryPackage = createFactory<Options>({
@@ -71,7 +70,7 @@ export const nodeLibraryPackage = createFactory<Options>({
       await addCodeownersEntry(`/packages/${id}`, options.owner);
     }
 
-    if (!options.skipInstall) {
+    if (!ctx.skipInstall) {
       await Task.forCommand('yarn install', { cwd: targetDir, optional: true });
       await Task.forCommand('yarn lint --fix', {
         cwd: targetDir,

--- a/packages/cli/src/lib/new/factories/nodeLibraryPackage.ts
+++ b/packages/cli/src/lib/new/factories/nodeLibraryPackage.ts
@@ -42,7 +42,7 @@ export const nodeLibraryPackage = createFactory<Options>({
     const name = resolvePackageName({
       baseName: id,
       scope: ctx.scope,
-      prefix: ctx.prefix,
+      pluginPrefix: ctx.pluginPrefix,
       plugin: false,
     });
 

--- a/packages/cli/src/lib/new/factories/pluginCommon.ts
+++ b/packages/cli/src/lib/new/factories/pluginCommon.ts
@@ -27,7 +27,6 @@ type Options = {
   id: string;
   owner?: string;
   codeOwnersPath?: string;
-  skipInstall?: boolean;
 };
 
 export const pluginCommon = createFactory<Options>({
@@ -71,7 +70,7 @@ export const pluginCommon = createFactory<Options>({
       await addCodeownersEntry(`/plugins/${suffix}`, options.owner);
     }
 
-    if (!options.skipInstall) {
+    if (!ctx.skipInstall) {
       await Task.forCommand('yarn install', { cwd: targetDir, optional: true });
 
       await Task.forCommand('yarn lint --fix', {

--- a/packages/cli/src/lib/new/factories/pluginCommon.ts
+++ b/packages/cli/src/lib/new/factories/pluginCommon.ts
@@ -42,7 +42,7 @@ export const pluginCommon = createFactory<Options>({
     const name = resolvePackageName({
       baseName: suffix,
       scope: ctx.scope,
-      prefix: ctx.prefix,
+      pluginPrefix: ctx.pluginPrefix,
       plugin: true,
     });
 

--- a/packages/cli/src/lib/new/factories/pluginCommon.ts
+++ b/packages/cli/src/lib/new/factories/pluginCommon.ts
@@ -27,6 +27,7 @@ type Options = {
   id: string;
   owner?: string;
   codeOwnersPath?: string;
+  skipInstall?: boolean;
 };
 
 export const pluginCommon = createFactory<Options>({
@@ -42,6 +43,7 @@ export const pluginCommon = createFactory<Options>({
     const name = resolvePackageName({
       baseName: suffix,
       scope: ctx.scope,
+      prefix: ctx.prefix,
       plugin: true,
     });
 
@@ -69,10 +71,13 @@ export const pluginCommon = createFactory<Options>({
       await addCodeownersEntry(`/plugins/${suffix}`, options.owner);
     }
 
-    await Task.forCommand('yarn install', { cwd: targetDir, optional: true });
-    await Task.forCommand('yarn lint --fix', {
-      cwd: targetDir,
-      optional: true,
-    });
+    if (!options.skipInstall) {
+      await Task.forCommand('yarn install', { cwd: targetDir, optional: true });
+
+      await Task.forCommand('yarn lint --fix', {
+        cwd: targetDir,
+        optional: true,
+      });
+    }
   },
 });

--- a/packages/cli/src/lib/new/factories/pluginNode.ts
+++ b/packages/cli/src/lib/new/factories/pluginNode.ts
@@ -27,7 +27,6 @@ type Options = {
   id: string;
   owner?: string;
   codeOwnersPath?: string;
-  skipInstall?: boolean;
 };
 
 export const pluginNode = createFactory<Options>({
@@ -71,7 +70,7 @@ export const pluginNode = createFactory<Options>({
       await addCodeownersEntry(`/plugins/${suffix}`, options.owner);
     }
 
-    if (!options.skipInstall) {
+    if (!ctx.skipInstall) {
       await Task.forCommand('yarn install', { cwd: targetDir, optional: true });
       await Task.forCommand('yarn lint --fix', {
         cwd: targetDir,

--- a/packages/cli/src/lib/new/factories/pluginNode.ts
+++ b/packages/cli/src/lib/new/factories/pluginNode.ts
@@ -27,6 +27,7 @@ type Options = {
   id: string;
   owner?: string;
   codeOwnersPath?: string;
+  skipInstall?: boolean;
 };
 
 export const pluginNode = createFactory<Options>({
@@ -42,6 +43,7 @@ export const pluginNode = createFactory<Options>({
     const name = resolvePackageName({
       baseName: suffix,
       scope: ctx.scope,
+      prefix: ctx.prefix,
       plugin: true,
     });
 
@@ -69,10 +71,12 @@ export const pluginNode = createFactory<Options>({
       await addCodeownersEntry(`/plugins/${suffix}`, options.owner);
     }
 
-    await Task.forCommand('yarn install', { cwd: targetDir, optional: true });
-    await Task.forCommand('yarn lint --fix', {
-      cwd: targetDir,
-      optional: true,
-    });
+    if (!options.skipInstall) {
+      await Task.forCommand('yarn install', { cwd: targetDir, optional: true });
+      await Task.forCommand('yarn lint --fix', {
+        cwd: targetDir,
+        optional: true,
+      });
+    }
   },
 });

--- a/packages/cli/src/lib/new/factories/pluginNode.ts
+++ b/packages/cli/src/lib/new/factories/pluginNode.ts
@@ -42,7 +42,7 @@ export const pluginNode = createFactory<Options>({
     const name = resolvePackageName({
       baseName: suffix,
       scope: ctx.scope,
-      prefix: ctx.prefix,
+      pluginPrefix: ctx.pluginPrefix,
       plugin: true,
     });
 

--- a/packages/cli/src/lib/new/factories/pluginWeb.ts
+++ b/packages/cli/src/lib/new/factories/pluginWeb.ts
@@ -27,7 +27,6 @@ type Options = {
   id: string;
   owner?: string;
   codeOwnersPath?: string;
-  skipInstall?: boolean;
 };
 
 export const pluginWeb = createFactory<Options>({
@@ -71,7 +70,7 @@ export const pluginWeb = createFactory<Options>({
       await addCodeownersEntry(`/plugins/${suffix}`, options.owner);
     }
 
-    if (!options.skipInstall) {
+    if (!ctx.skipInstall) {
       await Task.forCommand('yarn install', { cwd: targetDir, optional: true });
       await Task.forCommand('yarn lint --fix', {
         cwd: targetDir,

--- a/packages/cli/src/lib/new/factories/pluginWeb.ts
+++ b/packages/cli/src/lib/new/factories/pluginWeb.ts
@@ -42,7 +42,7 @@ export const pluginWeb = createFactory<Options>({
     const name = resolvePackageName({
       baseName: suffix,
       scope: ctx.scope,
-      prefix: ctx.prefix,
+      pluginPrefix: ctx.pluginPrefix,
       plugin: true,
     });
 

--- a/packages/cli/src/lib/new/factories/pluginWeb.ts
+++ b/packages/cli/src/lib/new/factories/pluginWeb.ts
@@ -27,6 +27,7 @@ type Options = {
   id: string;
   owner?: string;
   codeOwnersPath?: string;
+  skipInstall?: boolean;
 };
 
 export const pluginWeb = createFactory<Options>({
@@ -42,6 +43,7 @@ export const pluginWeb = createFactory<Options>({
     const name = resolvePackageName({
       baseName: suffix,
       scope: ctx.scope,
+      prefix: ctx.prefix,
       plugin: true,
     });
 
@@ -69,10 +71,12 @@ export const pluginWeb = createFactory<Options>({
       await addCodeownersEntry(`/plugins/${suffix}`, options.owner);
     }
 
-    await Task.forCommand('yarn install', { cwd: targetDir, optional: true });
-    await Task.forCommand('yarn lint --fix', {
-      cwd: targetDir,
-      optional: true,
-    });
+    if (!options.skipInstall) {
+      await Task.forCommand('yarn install', { cwd: targetDir, optional: true });
+      await Task.forCommand('yarn lint --fix', {
+        cwd: targetDir,
+        optional: true,
+      });
+    }
   },
 });

--- a/packages/cli/src/lib/new/factories/scaffolderModule.ts
+++ b/packages/cli/src/lib/new/factories/scaffolderModule.ts
@@ -28,6 +28,7 @@ type Options = {
   id: string;
   owner?: string;
   codeOwnersPath?: string;
+  skipInstall?: boolean;
 };
 
 export const scaffolderModule = createFactory<Options>({
@@ -60,6 +61,7 @@ export const scaffolderModule = createFactory<Options>({
     const name = resolvePackageName({
       baseName: slug,
       scope: ctx.scope,
+      prefix: ctx.prefix,
       plugin: true,
     });
 
@@ -104,10 +106,12 @@ export const scaffolderModule = createFactory<Options>({
       await addCodeownersEntry(`/plugins/${slug}`, options.owner);
     }
 
-    await Task.forCommand('yarn install', { cwd: targetDir, optional: true });
-    await Task.forCommand('yarn lint --fix', {
-      cwd: targetDir,
-      optional: true,
-    });
+    if (!options.skipInstall) {
+      await Task.forCommand('yarn install', { cwd: targetDir, optional: true });
+      await Task.forCommand('yarn lint --fix', {
+        cwd: targetDir,
+        optional: true,
+      });
+    }
   },
 });

--- a/packages/cli/src/lib/new/factories/scaffolderModule.ts
+++ b/packages/cli/src/lib/new/factories/scaffolderModule.ts
@@ -60,7 +60,7 @@ export const scaffolderModule = createFactory<Options>({
     const name = resolvePackageName({
       baseName: slug,
       scope: ctx.scope,
-      prefix: ctx.prefix,
+      pluginPrefix: ctx.pluginPrefix,
       plugin: true,
     });
 

--- a/packages/cli/src/lib/new/factories/scaffolderModule.ts
+++ b/packages/cli/src/lib/new/factories/scaffolderModule.ts
@@ -28,7 +28,6 @@ type Options = {
   id: string;
   owner?: string;
   codeOwnersPath?: string;
-  skipInstall?: boolean;
 };
 
 export const scaffolderModule = createFactory<Options>({
@@ -106,7 +105,7 @@ export const scaffolderModule = createFactory<Options>({
       await addCodeownersEntry(`/plugins/${slug}`, options.owner);
     }
 
-    if (!options.skipInstall) {
+    if (!ctx.skipInstall) {
       await Task.forCommand('yarn install', { cwd: targetDir, optional: true });
       await Task.forCommand('yarn lint --fix', {
         cwd: targetDir,

--- a/packages/cli/src/lib/new/factories/webLibraryPackage.ts
+++ b/packages/cli/src/lib/new/factories/webLibraryPackage.ts
@@ -42,7 +42,7 @@ export const webLibraryPackage = createFactory<Options>({
     const name = resolvePackageName({
       baseName: id,
       scope: ctx.scope,
-      prefix: ctx.prefix,
+      pluginPrefix: ctx.pluginPrefix,
       plugin: false,
     });
 

--- a/packages/cli/src/lib/new/factories/webLibraryPackage.ts
+++ b/packages/cli/src/lib/new/factories/webLibraryPackage.ts
@@ -27,6 +27,7 @@ type Options = {
   id: string;
   owner?: string;
   codeOwnersPath?: string;
+  skipInstall?: boolean;
 };
 
 export const webLibraryPackage = createFactory<Options>({
@@ -42,6 +43,7 @@ export const webLibraryPackage = createFactory<Options>({
     const name = resolvePackageName({
       baseName: id,
       scope: ctx.scope,
+      prefix: ctx.prefix,
       plugin: false,
     });
 
@@ -69,10 +71,12 @@ export const webLibraryPackage = createFactory<Options>({
       await addCodeownersEntry(`/packages/${id}`, options.owner);
     }
 
-    await Task.forCommand('yarn install', { cwd: targetDir, optional: true });
-    await Task.forCommand('yarn lint --fix', {
-      cwd: targetDir,
-      optional: true,
-    });
+    if (!options.skipInstall) {
+      await Task.forCommand('yarn install', { cwd: targetDir, optional: true });
+      await Task.forCommand('yarn lint --fix', {
+        cwd: targetDir,
+        optional: true,
+      });
+    }
   },
 });

--- a/packages/cli/src/lib/new/factories/webLibraryPackage.ts
+++ b/packages/cli/src/lib/new/factories/webLibraryPackage.ts
@@ -27,7 +27,6 @@ type Options = {
   id: string;
   owner?: string;
   codeOwnersPath?: string;
-  skipInstall?: boolean;
 };
 
 export const webLibraryPackage = createFactory<Options>({
@@ -71,7 +70,7 @@ export const webLibraryPackage = createFactory<Options>({
       await addCodeownersEntry(`/packages/${id}`, options.owner);
     }
 
-    if (!options.skipInstall) {
+    if (!ctx.skipInstall) {
       await Task.forCommand('yarn install', { cwd: targetDir, optional: true });
       await Task.forCommand('yarn lint --fix', {
         cwd: targetDir,

--- a/packages/cli/src/lib/new/types.ts
+++ b/packages/cli/src/lib/new/types.ts
@@ -19,6 +19,8 @@ import { Answers, DistinctQuestion } from 'inquirer';
 export interface CreateContext {
   /** The package scope to use for new packages */
   scope?: string;
+  /** The prefix to use for new packages, after the scope */
+  prefix?: string;
   /** The NPM registry to use for new packages */
   npmRegistry?: string;
   /** Whether new packages should be marked as private */
@@ -37,7 +39,7 @@ export interface CreateContext {
   markAsModified(): void;
 }
 
-export type AnyOptions = Record<string, string>;
+export type AnyOptions = Record<string, string | boolean>;
 
 export type Prompt<TOptions extends Answers> = DistinctQuestion<TOptions> & {
   name: string;

--- a/packages/cli/src/lib/new/types.ts
+++ b/packages/cli/src/lib/new/types.ts
@@ -31,6 +31,8 @@ export interface CreateContext {
   defaultVersion: string;
   /** License to use for new packages */
   license: string;
+  /** Whether to skip the install step after creation */
+  skipInstall?: boolean;
 
   /** Creates a temporary directory. This will always be deleted after creation is done. */
   createTemporaryDirectory(name: string): Promise<string>;

--- a/packages/cli/src/lib/new/types.ts
+++ b/packages/cli/src/lib/new/types.ts
@@ -19,8 +19,8 @@ import { Answers, DistinctQuestion } from 'inquirer';
 export interface CreateContext {
   /** The package scope to use for new packages */
   scope?: string;
-  /** The prefix to use for new packages, after the scope */
-  prefix?: string;
+  /** The prefix to use for new plugin packages, after the scope */
+  pluginPrefix?: string;
   /** The NPM registry to use for new packages */
   npmRegistry?: string;
   /** Whether new packages should be marked as private */


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds 3 new options to the cli `new` command:
-  `--plugin-prefix`: custome the prefix of the new plugin, which by default is `backstage-plugin-`.
- `--skip-install`: skips the installation of dependencies after creating a new plugin
- `-allowed-types`: Defines which plugin types should be available in the interactive prompt. This is useful if some types aren't applicable so that adopters could specify the allowed types in their `new` script in their `package.json`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
