### PR TITLE
.github/workflows: add separate build for canon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,10 @@ jobs:
       - name: build all packages
         run: yarn backstage-cli repo build --all
 
+        # For now canon has a custom build script and needs to be built separately
+      - name: build canon
+        run: yarn --cwd packages/canon build
+
       - name: verify type dependencies
         run: yarn lint:type-deps
 

--- a/.github/workflows/deploy_packages.yml
+++ b/.github/workflows/deploy_packages.yml
@@ -110,6 +110,10 @@ jobs:
       - name: build
         run: yarn backstage-cli repo build --all
 
+        # For now canon has a custom build script and needs to be built separately
+      - name: build canon
+        run: yarn --cwd packages/canon build
+
       - name: verify type dependencies
         run: yarn lint:type-deps
 


### PR DESCRIPTION
🧹, we need to build `packages/canon` separately for now due to it having a custom build script that doesn't get picked up by `repo build --all`.
