### PR TITLE
createGitlabProjectMigrateAction returns migration id

### DIFF
--- a/.changeset/heavy-olives-thank.md
+++ b/.changeset/heavy-olives-thank.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gitlab': patch
+---
+
+Action createGitlabProjectMigrateAction writes migration Id to its output

--- a/.changeset/heavy-olives-thank.md
+++ b/.changeset/heavy-olives-thank.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-backend-module-gitlab': patch
 ---
 
-Action createGitlabProjectMigrateAction writes migration Id to its output
+`createGitlabProjectMigrateAction` can now output the `migrationId`

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabProjectMigrate.examples.test.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabProjectMigrate.examples.test.ts
@@ -24,7 +24,9 @@ import yaml from 'yaml';
 
 const mockGitlabClient = {
   Migrations: {
-    create: jest.fn(),
+    create: jest.fn(() => ({
+      id: 0,
+    })),
   },
 };
 

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabProjectMigrate.test.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabProjectMigrate.test.ts
@@ -22,7 +22,9 @@ import { createMockDirectory } from '@backstage/backend-test-utils';
 
 const mockGitlabClient = {
   Migrations: {
-    create: jest.fn(),
+    create: jest.fn(() => ({
+      id: 0,
+    })),
   },
 };
 

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabProjectMigrate.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabProjectMigrate.ts
@@ -89,6 +89,10 @@ export const createGitlabProjectMigrateAction = (options: {
             title: 'URL to the newly imported repo',
             type: 'string',
           },
+          migrationId: {
+            title: 'Id of the migration that imports the project',
+            type: 'number',
+          },
         },
       },
     },
@@ -135,17 +139,21 @@ export const createGitlabProjectMigrateAction = (options: {
       };
 
       try {
-        await api.Migrations.create(sourceConfig, migrationEntity);
+        const { id: migrationId } = await api.Migrations.create(
+          sourceConfig,
+          migrationEntity,
+        );
+
+        ctx.output(
+          'importedRepoUrl',
+          `${destinationHost}/${destinationNamespace}/${destinationSlug}`,
+        );
+        ctx.output('migrationId', migrationId);
       } catch (e: any) {
         throw new InputError(
           `Failed to transfer repo ${sourceFullPath}. Make sure that ${sourceFullPath} exists in ${sourceUrl}, and token has enough rights.\nError: ${e}`,
         );
       }
-
-      ctx.output(
-        'importedRepoUrl',
-        `${destinationHost}/${destinationNamespace}/${destinationSlug}`,
-      );
     },
   });
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The action `createGitlabProjectMigrateAction`, belonging to `scaffolder-backend-module-gitlab`, adds the `migrationId` to its outputs.

Ideally, I wanted to have the project ID in the output, so that future actions could act on the project (e.g.: migrate a project, and then modify its settings, or open an MR). However, the [bulk import API](https://docs.gitlab.com/ee/api/bulk_imports.html) does not return the project ID. Instead, it returns a migration object which has a status. It is unfortunate, but all that subsequent actions can do is poll Gitlab to check if migration has status `finished` (and hopefully, that'll mean that the project is already there).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
