### PR TITLE
Adds createWhenEmpty option to publish:github:pull-request action

### DIFF
--- a/.changeset/hungry-cycles-hide.md
+++ b/.changeset/hungry-cycles-hide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-github': patch
+---
+
+Adds `createWhenEmpty` option to `publish:github:pull-request` action.

--- a/.changeset/hungry-cycles-hide.md
+++ b/.changeset/hungry-cycles-hide.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-scaffolder-backend-module-github': patch
+'@backstage/plugin-scaffolder-backend-module-github': minor
 ---
 
-Adds `createWhenEmpty` option to `publish:github:pull-request` action.
+**BREAKING**: The `remoteUrl` output is no longer required, it can be empty only when using the new `createWhenEmpty` boolean flag.

--- a/.changeset/thick-moose-do.md
+++ b/.changeset/thick-moose-do.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-backend-module-github': patch
 ---
 
-Added oneOf output schema to publish:github:pull-request scaffolder action to allow for non-breaking addition of createWhenEmpty option
+Added `oneOf` output schema to `publish:github:pull-request` scaffolder action to allow for non-breaking addition of `createWhenEmpty` option

--- a/.changeset/thick-moose-do.md
+++ b/.changeset/thick-moose-do.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-github': patch
+---
+
+Added oneOf output schema to publish:github:pull-request scaffolder action to allow for non-breaking addition of createWhenEmpty option

--- a/.changeset/thick-moose-do.md
+++ b/.changeset/thick-moose-do.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-scaffolder-backend-module-github': patch
----
-
-Added `oneOf` output schema to `publish:github:pull-request` scaffolder action to allow for non-breaking addition of `createWhenEmpty` option

--- a/.changeset/wise-cycles-sparkle.md
+++ b/.changeset/wise-cycles-sparkle.md
@@ -3,4 +3,4 @@
 '@backstage/plugin-scaffolder': patch
 ---
 
-Added conditional rendering of oneOf output schemas on the Installed Actions page for scaffolder actions
+Added conditional rendering of `oneOf` output schemas on the Installed Actions page for scaffolder actions

--- a/.changeset/wise-cycles-sparkle.md
+++ b/.changeset/wise-cycles-sparkle.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+'@backstage/plugin-scaffolder': patch
+---
+
+Added conditional rendering of oneOf output schemas on the Installed Actions page for scaffolder actions

--- a/plugins/scaffolder-backend-module-github/report.api.md
+++ b/plugins/scaffolder-backend-module-github/report.api.md
@@ -469,6 +469,7 @@ export const createPublishGithubPullRequestAction: (
     gitAuthorName?: string | undefined;
     gitAuthorEmail?: string | undefined;
     forceEmptyGitAuthor?: boolean | undefined;
+    createWhenEmpty?: boolean | undefined;
   },
   JsonObject
 >;

--- a/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.examples.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.examples.ts
@@ -23,7 +23,7 @@ export const examples: TemplateExample[] = [
       steps: [
         {
           action: 'publish:github:pull-request',
-          name: 'Create a pull reuqest',
+          name: 'Create a pull request',
           input: {
             repoUrl: 'github.com?repo=repo&owner=owner',
             branchName: 'new-app',
@@ -40,7 +40,7 @@ export const examples: TemplateExample[] = [
       steps: [
         {
           action: 'publish:github:pull-request',
-          name: 'Create a pull reuqest with target branch name',
+          name: 'Create a pull request with target branch name',
           input: {
             repoUrl: 'github.com?repo=repo&owner=owner',
             branchName: 'new-app',
@@ -58,7 +58,7 @@ export const examples: TemplateExample[] = [
       steps: [
         {
           action: 'publish:github:pull-request',
-          name: 'Create a pull reuqest as draft',
+          name: 'Create a pull request as draft',
           input: {
             repoUrl: 'github.com?repo=repo&owner=owner',
             branchName: 'new-app',
@@ -76,7 +76,7 @@ export const examples: TemplateExample[] = [
       steps: [
         {
           action: 'publish:github:pull-request',
-          name: 'Create a pull reuqest with target path',
+          name: 'Create a pull request with target path',
           input: {
             repoUrl: 'github.com?repo=repo&owner=owner',
             branchName: 'new-app',
@@ -94,7 +94,7 @@ export const examples: TemplateExample[] = [
       steps: [
         {
           action: 'publish:github:pull-request',
-          name: 'Create a pull reuqest with source path',
+          name: 'Create a pull request with source path',
           input: {
             repoUrl: 'github.com?repo=repo&owner=owner',
             branchName: 'new-app',
@@ -112,7 +112,7 @@ export const examples: TemplateExample[] = [
       steps: [
         {
           action: 'publish:github:pull-request',
-          name: 'Create a pull reuqest',
+          name: 'Create a pull request',
           input: {
             repoUrl: 'github.com?repo=repo&owner=owner',
             branchName: 'new-app',
@@ -130,7 +130,7 @@ export const examples: TemplateExample[] = [
       steps: [
         {
           action: 'publish:github:pull-request',
-          name: 'Create a pull reuqest with reviewers',
+          name: 'Create a pull request with reviewers',
           input: {
             repoUrl: 'github.com?repo=repo&owner=owner',
             branchName: 'new-app',
@@ -148,7 +148,7 @@ export const examples: TemplateExample[] = [
       steps: [
         {
           action: 'publish:github:pull-request',
-          name: 'Create a pull reuqest with team reviewers',
+          name: 'Create a pull request with team reviewers',
           input: {
             repoUrl: 'github.com?repo=repo&owner=owner',
             branchName: 'new-app',
@@ -166,7 +166,7 @@ export const examples: TemplateExample[] = [
       steps: [
         {
           action: 'publish:github:pull-request',
-          name: 'Create a pull reuqest',
+          name: 'Create a pull request',
           input: {
             repoUrl: 'github.com?repo=repo&owner=owner',
             branchName: 'new-app',
@@ -184,7 +184,7 @@ export const examples: TemplateExample[] = [
       steps: [
         {
           action: 'publish:github:pull-request',
-          name: 'Create a pull reuqest',
+          name: 'Create a pull request',
           input: {
             repoUrl: 'github.com?repo=repo&owner=owner',
             branchName: 'new-app',
@@ -203,7 +203,7 @@ export const examples: TemplateExample[] = [
       steps: [
         {
           action: 'publish:github:pull-request',
-          name: 'Create a pull reuqest',
+          name: 'Create a pull request',
           input: {
             repoUrl: 'github.com?repo=repo&owner=owner',
             branchName: 'new-app',
@@ -223,7 +223,7 @@ export const examples: TemplateExample[] = [
       steps: [
         {
           action: 'publish:github:pull-request',
-          name: 'Create a pull reuqest',
+          name: 'Create a pull request',
           input: {
             repoUrl: 'github.com?repo=repo&owner=owner',
             branchName: 'new-app',
@@ -238,12 +238,30 @@ export const examples: TemplateExample[] = [
     }),
   },
   {
+    description: 'Do not create empty pull request',
+    example: yaml.stringify({
+      steps: [
+        {
+          action: 'publish:github:pull-request',
+          name: 'Create a pull request',
+          input: {
+            repoUrl: 'github.com?repo=repo&owner=owner',
+            branchName: 'new-app',
+            title: 'Create my new app',
+            description: 'This PR is really good',
+            createWhenEmpty: false,
+          },
+        },
+      ],
+    }),
+  },
+  {
     description: 'Create a pull request with all parameters',
     example: yaml.stringify({
       steps: [
         {
           action: 'publish:github:pull-request',
-          name: 'Create a pull reuqest',
+          name: 'Create a pull request',
           input: {
             repoUrl: 'github.com?repo=repo&owner=owner',
             branchName: 'new-app',
@@ -259,6 +277,7 @@ export const examples: TemplateExample[] = [
             commitMessage: 'Commit for foo changes',
             gitAuthorName: 'Foo Bar',
             gitAuthorEmail: 'foo@bar.example',
+            createWhenEmpty: true,
           },
         },
       ],

--- a/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.ts
@@ -256,29 +256,53 @@ export const createPublishGithubPullRequestAction = (
             type: 'boolean',
             title: 'Create When Empty',
             description:
-              'Set whether to create pull request when there are no changes to commit. The default value is true',
+              'Set whether to create pull request when there are no changes to commit. The default value is true. If set to false, remoteUrl is no longer a required output.',
           },
         },
       },
       output: {
-        required: [],
-        type: 'object',
-        properties: {
-          targetBranchName: {
-            title: 'Target branch name of the merge request',
-            type: 'string',
+        oneOf: [
+          {
+            required: ['remoteUrl'],
+            type: 'object',
+            properties: {
+              targetBranchName: {
+                title: 'Target branch name of the merge request',
+                type: 'string',
+              },
+              remoteUrl: {
+                type: 'string',
+                title: 'Pull Request URL',
+                description: 'Link to the pull request in Github',
+              },
+              pullRequestNumber: {
+                type: 'number',
+                title: 'Pull Request Number',
+                description: 'The pull request number',
+              },
+            },
           },
-          remoteUrl: {
-            type: 'string',
-            title: 'Pull Request URL',
-            description: 'Link to the pull request in Github',
+          {
+            required: [],
+            type: 'object',
+            properties: {
+              targetBranchName: {
+                title: 'Target branch name of the merge request',
+                type: 'string',
+              },
+              remoteUrl: {
+                type: 'string',
+                title: 'Pull Request URL',
+                description: 'Link to the pull request in Github',
+              },
+              pullRequestNumber: {
+                type: 'number',
+                title: 'Pull Request Number',
+                description: 'The pull request number',
+              },
+            },
           },
-          pullRequestNumber: {
-            type: 'number',
-            title: 'Pull Request Number',
-            description: 'The pull request number',
-          },
-        },
+        ],
       },
     },
     async handler(ctx) {

--- a/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.ts
@@ -145,6 +145,7 @@ export const createPublishGithubPullRequestAction = (
     gitAuthorName?: string;
     gitAuthorEmail?: string;
     forceEmptyGitAuthor?: boolean;
+    createWhenEmpty?: boolean;
   }>({
     id: 'publish:github:pull-request',
     examples,
@@ -251,10 +252,16 @@ export const createPublishGithubPullRequestAction = (
             description:
               'Forces the author to be empty. This is useful when using a Github App, it permit the commit to be verified on Github',
           },
+          createWhenEmpty: {
+            type: 'boolean',
+            title: 'Create When Empty',
+            description:
+              'Set whether to create pull request when there are no changes to commit. The default value is true',
+          },
         },
       },
       output: {
-        required: ['remoteUrl'],
+        required: [],
         type: 'object',
         properties: {
           targetBranchName: {
@@ -293,6 +300,7 @@ export const createPublishGithubPullRequestAction = (
         gitAuthorEmail,
         gitAuthorName,
         forceEmptyGitAuthor,
+        createWhenEmpty,
       } = ctx.input;
 
       const { owner, repo, host } = parseRepoUrl(repoUrl, integrations);
@@ -379,6 +387,7 @@ export const createPublishGithubPullRequestAction = (
           draft,
           update,
           forceFork,
+          createWhenEmpty,
         };
 
         const gitAuthorInfo = {
@@ -416,6 +425,11 @@ export const createPublishGithubPullRequestAction = (
           createOptions.base = targetBranchName;
         }
         const response = await client.createPullRequest(createOptions);
+
+        if (createWhenEmpty === false && !response) {
+          ctx.logger.info('No changes to commit, pull request was not created');
+          return;
+        }
 
         if (!response) {
           throw new GithubResponseError('null response from Github');

--- a/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.ts
@@ -261,48 +261,24 @@ export const createPublishGithubPullRequestAction = (
         },
       },
       output: {
-        oneOf: [
-          {
-            required: ['remoteUrl'],
-            type: 'object',
-            properties: {
-              targetBranchName: {
-                title: 'Target branch name of the merge request',
-                type: 'string',
-              },
-              remoteUrl: {
-                type: 'string',
-                title: 'Pull Request URL',
-                description: 'Link to the pull request in Github',
-              },
-              pullRequestNumber: {
-                type: 'number',
-                title: 'Pull Request Number',
-                description: 'The pull request number',
-              },
-            },
+        required: [],
+        type: 'object',
+        properties: {
+          targetBranchName: {
+            title: 'Target branch name of the merge request',
+            type: 'string',
           },
-          {
-            required: [],
-            type: 'object',
-            properties: {
-              targetBranchName: {
-                title: 'Target branch name of the merge request',
-                type: 'string',
-              },
-              remoteUrl: {
-                type: 'string',
-                title: 'Pull Request URL',
-                description: 'Link to the pull request in Github',
-              },
-              pullRequestNumber: {
-                type: 'number',
-                title: 'Pull Request Number',
-                description: 'The pull request number',
-              },
-            },
+          remoteUrl: {
+            type: 'string',
+            title: 'Pull Request URL',
+            description: 'Link to the pull request in Github',
           },
-        ],
+          pullRequestNumber: {
+            type: 'number',
+            title: 'Pull Request Number',
+            description: 'The pull request number',
+          },
+        },
       },
     },
     async handler(ctx) {

--- a/plugins/scaffolder-backend/report.api.md
+++ b/plugins/scaffolder-backend/report.api.md
@@ -345,6 +345,7 @@ export const createPublishGithubPullRequestAction: (
     gitAuthorName?: string | undefined;
     gitAuthorEmail?: string | undefined;
     forceEmptyGitAuthor?: boolean | undefined;
+    createWhenEmpty?: boolean | undefined;
   },
   JsonObject
 >;

--- a/plugins/scaffolder/src/components/ActionsPage/ActionsPage.test.tsx
+++ b/plugins/scaffolder/src/components/ActionsPage/ActionsPage.test.tsx
@@ -125,6 +125,63 @@ describe('TemplatePage', () => {
     expect(rendered.getByText('Test output')).toBeInTheDocument();
   });
 
+  it('renders action with oneOf output', async () => {
+    scaffolderApiMock.listActions.mockResolvedValue([
+      {
+        id: 'test',
+        description: 'example description',
+        schema: {
+          input: {
+            type: 'object',
+            required: ['foobar'],
+            properties: {
+              foobar: {
+                title: 'Test title',
+                type: 'string',
+              },
+            },
+          },
+          output: {
+            oneOf: [
+              {
+                type: 'object',
+                properties: {
+                  buzz: {
+                    title: 'Test output1',
+                    type: 'string',
+                  },
+                },
+              },
+              {
+                type: 'object',
+                properties: {
+                  buzz: {
+                    title: 'Test output2',
+                    type: 'string',
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+    ]);
+    const rendered = await renderInTestApp(
+      <ApiProvider apis={apis}>
+        <ActionsPage />
+      </ApiProvider>,
+      {
+        mountedRoutes: {
+          '/create/actions': rootRouteRef,
+        },
+      },
+    );
+    expect(rendered.getByText('oneOf')).toBeInTheDocument();
+    expect(rendered.getByText('Test title')).toBeInTheDocument();
+    expect(rendered.getByText('Test output1')).toBeInTheDocument();
+    expect(rendered.getByText('Test output2')).toBeInTheDocument();
+  });
+
   it('renders action with multiple input types', async () => {
     scaffolderApiMock.listActions.mockResolvedValue([
       {

--- a/plugins/scaffolder/src/components/ActionsPage/ActionsPage.tsx
+++ b/plugins/scaffolder/src/components/ActionsPage/ActionsPage.tsx
@@ -340,10 +340,15 @@ export const ActionPageContent = () => {
           return undefined;
         }
 
-        const oneOf = renderTables(
+        const oneOfInput = renderTables(
           'oneOf',
           `${action.id}.input`,
           action.schema?.input?.oneOf,
+        );
+        const oneOfOutput = renderTables(
+          'oneOf',
+          `${action.id}.output`,
+          action.schema?.output?.oneOf,
         );
         return (
           <Box pb={3} key={action.id}>
@@ -374,7 +379,7 @@ export const ActionPageContent = () => {
                 {renderTable(
                   formatRows(`${action.id}.input`, action?.schema?.input),
                 )}
-                {oneOf}
+                {oneOfInput}
               </Box>
             )}
             {action.schema?.output && (
@@ -385,6 +390,7 @@ export const ActionPageContent = () => {
                 {renderTable(
                   formatRows(`${action.id}.output`, action?.schema?.output),
                 )}
+                {oneOfOutput}
               </Box>
             )}
             {action.examples && (


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR expands the functionality of the `publish:github:pull-request` action by connecting the `createWhenEmpty` option from the action's underlying plugin to the action's template parameters.

The behavior of the `createWhenEmpty` option is decribed [here](https://github.com/gr2m/octokit-plugin-create-pull-request#:~:text=By%20default%2C%20a%20pull%20request%20is%20created%2C%20even%20if%20no%20files%20have%20been%20changed.%20To%20prevent%20an%20empty%20pull%20request%2C%20set%20options.createWhenEmpty%20to%20false.%20If%20no%20pull%20request%20has%20been%20created%2C%20octokit.createPullRequest()%20resolves%20with%20null.). 

> By default, a pull request is created, even if no files have been changed. To prevent an empty pull request, set options.createWhenEmpty to false. If no pull request has been created, octokit.createPullRequest() resolves with null.

This option is useful to have available in the use case where a template is called multiple times on a repository, and subsequent invocations of the template would otherwise produce empty pull requests.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
