### PR TITLE
Catalog: retain inspect dialog visibility on page reload

### DIFF
--- a/.changeset/short-keys-heal.md
+++ b/.changeset/short-keys-heal.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-graph': patch
+---
+
+Fixed an issue causing the `CatalogGraphCard` to redraw its content whenever the parent component re-renders, resulting in flickering.

--- a/.changeset/silly-vans-shop.md
+++ b/.changeset/silly-vans-shop.md
@@ -1,6 +1,6 @@
 ---
 '@backstage/plugin-catalog-react': patch
-'@backstage/plugin-catalog': patch
+'@backstage/plugin-catalog': minor
 ---
 
-- The Entity Page now retains the visibility of the Inspect Dialog after a reload. This allows sharing the URL with the dialog open.
+The Entity Page now retains the visibility of the Inspect Dialog after a reload. This allows sharing the URL with the dialog open.

--- a/.changeset/silly-vans-shop.md
+++ b/.changeset/silly-vans-shop.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-catalog-react': patch
+'@backstage/plugin-catalog': patch
+---
+
+- The Entity Page now retains the visibility of the Inspect Dialog after a reload. This allows sharing the URL with the dialog open.

--- a/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.tsx
@@ -28,7 +28,7 @@ import {
 } from '@backstage/plugin-catalog-react';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 import qs from 'qs';
-import React, { MouseEvent, ReactNode, useCallback } from 'react';
+import React, { MouseEvent, ReactNode, useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { catalogGraphRouteRef } from '../../routes';
 import {
@@ -86,7 +86,7 @@ export const CatalogGraphCard = (
   } = props;
 
   const { entity } = useEntity();
-  const entityName = getCompoundEntityRef(entity);
+  const entityName = useMemo(() => getCompoundEntityRef(entity), [entity]);
   const catalogEntityRoute = useRouteRef(entityRouteRef);
   const catalogGraphRoute = useRouteRef(catalogGraphRouteRef);
   const navigate = useNavigate();

--- a/plugins/catalog-react/report.api.md
+++ b/plugins/catalog-react/report.api.md
@@ -685,7 +685,9 @@ export function humanizeEntityRef(
 export function InspectEntityDialog(props: {
   open: boolean;
   entity: Entity;
+  initialTab?: 'overview' | 'ancestry' | 'colocated' | 'json' | 'yaml';
   onClose: () => void;
+  onSelect?: (tab: string) => void;
 }): React_2.JSX.Element | null;
 
 // @public


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Ensure that the visibility of the Inspect Dialog is retained after a page reload, allowing users to share URLs with the dialog open.

https://github.com/user-attachments/assets/88be1d4a-f9ac-46b6-8772-6143f01b4a05

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
