### PR TITLE
[cli] Improve parallelism limits in build-workspace yarn pack

### DIFF
--- a/.changeset/cli-melancholy-in-advance.md
+++ b/.changeset/cli-melancholy-in-advance.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+The packing process when running `build-workspace` with the `--alwaysYarnPack` flag now respects the `BACKSTAGE_CLI_BUILD_PARALLEL` environment variable, defaulting parallel work limits based on CPU availability.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -130,7 +130,6 @@
     "node-libs-browser": "^2.2.1",
     "npm-packlist": "^5.0.0",
     "ora": "^5.3.0",
-    "p-limit": "^3.1.0",
     "p-queue": "^6.6.2",
     "pirates": "^4.0.6",
     "postcss": "^8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4020,7 +4020,6 @@ __metadata:
     nodemon: ^3.0.1
     npm-packlist: ^5.0.0
     ora: ^5.3.0
-    p-limit: ^3.1.0
     p-queue: ^6.6.2
     pirates: ^4.0.6
     postcss: ^8.1.0


### PR DESCRIPTION
## What / Why

Seeing occasional errors like this while running `backstage-cli build-workspace --alwaysYarnPack` in a decently sized monorepo in CI.

```
Repacking @foo/backstage-plugin-bar into dist workspace
➤ YN00ZZ: Calling the "prepack" lifecycle script
undefined:135
    "@types/jest

SyntaxError: Unterminated string in JSON at position 4707 (line 135 column 17) (when parsing /home/runner/work/org/repo/plugins/bar/package.json)
    at JSON.parse (<anonymous>)
    at t.loadFile (/home/runner/work/org/repo/.yarn/releases/yarn-4.6.0.cjs:140:122594)
    at async t.fromFile (/home/runner/work/org/repo/.yarn/releases/yarn-4.6.0.cjs:140:122278)
    at async t.tryFind (/home/runner/work/org/repo/.yarn/releases/yarn-4.6.0.cjs:140:122001)
    at async iE.setup (/home/runner/work/org/repo/.yarn/releases/yarn-4.6.0.cjs:205:9258)
```

Think it makes sense to swap out the hard-coded parallel work limiter in favor of existing utils in the CLI.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
