### PR TITLE
cli: treat static file assets as free from side-effects

### DIFF
--- a/.changeset/fifty-trains-attend.md
+++ b/.changeset/fifty-trains-attend.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Treat static file assets as always being free from side effects in package builds.

--- a/packages/cli/src/lib/builder/plugins.ts
+++ b/packages/cli/src/lib/builder/plugins.ts
@@ -21,7 +21,12 @@ import {
   relative as relativePath,
 } from 'path';
 import { createFilter } from 'rollup-pluginutils';
-import { Plugin, InputOptions, OutputChunk } from 'rollup';
+import {
+  Plugin,
+  InputOptions,
+  OutputChunk,
+  HasModuleSideEffects,
+} from 'rollup';
 
 type ForwardFileImportsOptions = {
   include: Array<string | RegExp> | string | RegExp | null;
@@ -91,6 +96,33 @@ export function forwardFileImports(options: ForwardFileImportsOptions) {
       }
     },
     options(inputOptions) {
+      // We're in control of the config ourselves, so these are just checks to
+      // make sure we don't update the config but forget about the config
+      // overrides here
+      const treeshake = inputOptions.treeshake;
+      if (treeshake !== undefined && typeof treeshake !== 'object') {
+        throw new Error(
+          'Expected treeshake input config to be an object or not set',
+        );
+      }
+      if (treeshake?.moduleSideEffects) {
+        throw new Error('treeshake.moduleSideEffects must not be set');
+      }
+
+      // All external assets are treated as being side-effect free.
+      //
+      // This also works around an apparent bug in rollup where the
+      // `makeAbsoluteExternalsRelative: false` option sometimes caused relative
+      // asset paths to be rewritten with an incorrect path. They are rewritten
+      // in the first place because they are being treated as external by this
+      // plugin, but that seems to be the best way to handle asset files.
+      const moduleSideEffects: HasModuleSideEffects = id => {
+        if (filter(id)) {
+          return false;
+        }
+        return true;
+      };
+
       const origExternal = inputOptions.external;
 
       // We decorate any existing `external` option with our own way of determining
@@ -129,7 +161,11 @@ export function forwardFileImports(options: ForwardFileImportsOptions) {
         return true;
       };
 
-      return { ...inputOptions, external };
+      return {
+        ...inputOptions,
+        external,
+        treeshake: { ...treeshake, moduleSideEffects },
+      };
     },
   } satisfies Plugin;
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes a bug where imports of static assets would sometimes lead to rollup adding extra relative imports of those assets, and also rewrite those import paths to be incorrect, leading to a broken build.

I experimented a bit with trying a different route for excluding the file assets from the build, but marking them as external seems to be the cleanest way still.

Another fix for the broken build bug would be to stop setting `makeAbsoluteExternalsRelative: false` in the rollup config, but that in turn is a fix for #26401. An example of a rewrite that this leads to is for example switching the path `../assets/image.png` to just `./image.png`, where that file is nonexistent. I don't know why these imports are being treated as absolute externals either, and a different fix would be to avoid marking them as such. Couldn't quite find a clean way to do that though.

In the end I think this fix is the way to go, since treating these files as side-effect free is sensible in itself.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
