### PR TITLE
Adding CBA info to the microsite's Community page

### DIFF
--- a/microsite/src/pages/community/community.module.scss
+++ b/microsite/src/pages/community/community.module.scss
@@ -10,7 +10,7 @@
   }
 
   p {
-    text-align: justify;
+    text-align: left;
   }
 }
 

--- a/microsite/src/pages/community/index.tsx
+++ b/microsite/src/pages/community/index.tsx
@@ -134,9 +134,8 @@ const Community = () => {
               and different meetups. To ensure that you have a welcoming
               environment, we follow the{' '}
               <Link to="https://github.com/cncf/foundation/blob/master/code-of-conduct.md">
-              CNCF Code of Conduct
-              </Link>
-              {' '}
+                CNCF Code of Conduct
+              </Link>{' '}
               in everything we do.
             </ContentBlock>
 

--- a/microsite/src/pages/community/index.tsx
+++ b/microsite/src/pages/community/index.tsx
@@ -33,14 +33,14 @@ const Community = () => {
     },
     {
       content: 'Subscribe to the',
-      label: 'Community newsletter',
+      label: 'Community Newsletter',
       link: 'https://info.backstage.spotify.com/newsletter_subscribe',
     },
   ];
 
   const officialInitiatives: ICollectionItem[] = [
     {
-      title: 'Community sessions',
+      title: 'Community Sessions',
       content:
         'Maintainers and adopters meet monthly to share updates, demos, and ideas. You can find recorded session on our YouTube channel!',
       link: 'https://github.com/backstage/community/tree/main/backstage-community-sessions#backstage-community-sessions',
@@ -61,6 +61,13 @@ const Community = () => {
       content:
         'This is a course produced and curated by the Linux Foundation. This course introduces you to Backstage and how to get started with the project.',
       link: 'https://training.linuxfoundation.org/training/introduction-to-backstage-developer-portals-made-easy-lfs142x/',
+      label: 'Learn more',
+    },
+    {
+      title: 'Certified Backstage Associate (CBA)',
+      content:
+        'Designed for IT engineers, developers, platform engineers, and other IT professionals, the CBA proves you have the skills and the mindset to work with Backstage.',
+      link: 'https://www.cncf.io/training/certification/cba/',
       label: 'Learn more',
     },
   ];
@@ -125,11 +132,11 @@ const Community = () => {
             >
               Join the vibrant community around Backstage through social media
               and different meetups. To ensure that you have a welcoming
-              environment, we follow the
+              environment, we follow the{' '}
               <Link to="https://github.com/cncf/foundation/blob/master/code-of-conduct.md">
-                {' '}
-                CNCF Code of Conduct{' '}
+              CNCF Code of Conduct
               </Link>
+              {' '}
               in everything we do.
             </ContentBlock>
 
@@ -159,7 +166,7 @@ const Community = () => {
           <BannerSectionGrid
             header={
               <>
-                <h2 className="text--primary">Offical Backstage initiatives</h2>
+                <h2 className="text--primary">Offical Backstage Initiatives</h2>
 
                 <h1>Stay tuned to the latest developments</h1>
               </>

--- a/microsite/src/pages/demos/demos.module.scss
+++ b/microsite/src/pages/demos/demos.module.scss
@@ -13,7 +13,7 @@
 .banner {
   p {
     flex: 1;
-    text-align: justify;
+    text-align: left;
   }
 
   iframe {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Mainly adding a short description about the Certified Backstage Associate (CBA) certification to the microsite's Community page, along with a link to learn more on the CNCF's site.

While I was in there, I made minor styling tweaks (capitalization in headings, etc.) to make the styling more consistent on the page.

I also changed the text alignment from justified to left-aligned on the Community and Demos pages, to be more consistent with how the text is aligned on the rest of the microsite.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info]
![Screenshot 2025-01-29 at 1 28 21 PM(2)](https://github.com/user-attachments/assets/57ad34c9-1494-4fec-b144-d172f42763a9)
