### PR TITLE
Catalog: Implement EntityContextMenuItemBlueprint to extend the entity page's context menu

### DIFF
--- a/.changeset/smooth-dolls-raise.md
+++ b/.changeset/smooth-dolls-raise.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-catalog-react': minor
+'@backstage/plugin-catalog': minor
+---
+
+Adds `EntityContextMenuItemBlueprint` to enable extending the entity page's context menu

--- a/plugins/catalog-react/report-alpha.api.md
+++ b/plugins/catalog-react/report-alpha.api.md
@@ -209,6 +209,20 @@ export const EntityContentBlueprint: ExtensionBlueprint<{
   };
 }>;
 
+// @alpha (undocumented)
+export const EntityContextMenuItemBlueprint: ExtensionBlueprint<{
+  kind: 'entity-context-menu-item';
+  name: undefined;
+  params: {
+    loader: () => Promise<JSX.Element>;
+  };
+  output: ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>;
+  inputs: {};
+  config: {};
+  configInput: {};
+  dataRefs: never;
+}>;
+
 // @alpha
 export function isOwnerOf(owner: Entity, entity: Entity): boolean;
 

--- a/plugins/catalog-react/src/alpha/blueprints/EntityContextMenuItemBlueprint.test.tsx
+++ b/plugins/catalog-react/src/alpha/blueprints/EntityContextMenuItemBlueprint.test.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { EntityContextMenuItemBlueprint } from './EntityContextMenuItemBlueprint';
+
+describe('EntityContextMenuItemBlueprint', () => {
+  it('should return an extension with sane defaults', () => {
+    const extension = EntityContextMenuItemBlueprint.make({
+      name: 'test',
+      params: {
+        loader: async () => <li>Test!</li>,
+      },
+    });
+
+    expect(extension).toMatchInlineSnapshot(`
+      {
+        "$$type": "@backstage/ExtensionDefinition",
+        "T": undefined,
+        "attachTo": {
+          "id": "page:catalog/entity",
+          "input": "extraContextMenuItems",
+        },
+        "configSchema": undefined,
+        "disabled": false,
+        "factory": [Function],
+        "inputs": {},
+        "kind": "entity-context-menu-item",
+        "name": "test",
+        "output": [
+          [Function],
+        ],
+        "override": [Function],
+        "toString": [Function],
+        "version": "v2",
+      }
+    `);
+  });
+});

--- a/plugins/catalog-react/src/alpha/blueprints/EntityContextMenuItemBlueprint.ts
+++ b/plugins/catalog-react/src/alpha/blueprints/EntityContextMenuItemBlueprint.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ExtensionBoundary,
+  coreExtensionData,
+  createExtensionBlueprint,
+} from '@backstage/frontend-plugin-api';
+
+/** @alpha */
+export const EntityContextMenuItemBlueprint = createExtensionBlueprint({
+  kind: 'entity-context-menu-item',
+  attachTo: { id: 'page:catalog/entity', input: 'extraContextMenuItems' },
+  output: [coreExtensionData.reactElement],
+  *factory(
+    params: {
+      loader: () => Promise<JSX.Element>;
+    },
+    { node },
+  ) {
+    yield coreExtensionData.reactElement(
+      ExtensionBoundary.lazy(node, params.loader),
+    );
+  },
+});

--- a/plugins/catalog-react/src/alpha/blueprints/index.ts
+++ b/plugins/catalog-react/src/alpha/blueprints/index.ts
@@ -15,3 +15,4 @@
  */
 export { EntityCardBlueprint } from './EntityCardBlueprint';
 export { EntityContentBlueprint } from './EntityContentBlueprint';
+export { EntityContextMenuItemBlueprint } from './EntityContextMenuItemBlueprint';

--- a/plugins/catalog/report-alpha.api.md
+++ b/plugins/catalog/report-alpha.api.md
@@ -146,27 +146,6 @@ const _default: FrontendPlugin<
     unregisterRedirect: ExternalRouteRef<undefined>;
   },
   {
-    'nav-item:catalog': ExtensionDefinition<{
-      kind: 'nav-item';
-      name: undefined;
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        {
-          title: string;
-          icon: IconComponent;
-          routeRef: RouteRef<undefined>;
-        },
-        'core.nav-item.target',
-        {}
-      >;
-      inputs: {};
-      params: {
-        title: string;
-        icon: IconComponent;
-        routeRef: RouteRef<undefined>;
-      };
-    }>;
     'api:catalog': ExtensionDefinition<{
       kind: 'api';
       name: undefined;
@@ -837,6 +816,13 @@ const _default: FrontendPlugin<
             optional: false;
           }
         >;
+        extraContextMenuItems: ExtensionInput<
+          ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>,
+          {
+            singleton: false;
+            optional: false;
+          }
+        >;
       };
       kind: 'page';
       name: 'entity';
@@ -844,6 +830,27 @@ const _default: FrontendPlugin<
         defaultPath: string;
         loader: () => Promise<JSX.Element>;
         routeRef?: RouteRef<AnyRouteRefParams> | undefined;
+      };
+    }>;
+    'nav-item:catalog': ExtensionDefinition<{
+      kind: 'nav-item';
+      name: undefined;
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        {
+          title: string;
+          icon: IconComponent;
+          routeRef: RouteRef<undefined>;
+        },
+        'core.nav-item.target',
+        {}
+      >;
+      inputs: {};
+      params: {
+        title: string;
+        icon: IconComponent;
+        routeRef: RouteRef<undefined>;
       };
     }>;
     'search-result-list-item:catalog': ExtensionDefinition<{

--- a/plugins/catalog/report.api.md
+++ b/plugins/catalog/report.api.md
@@ -417,6 +417,8 @@ export interface EntityLayoutProps {
   // (undocumented)
   children?: React_2.ReactNode;
   // (undocumented)
+  extraMenuItems?: JSX.Element[];
+  // (undocumented)
   NotFoundComponent?: React_2.ReactNode;
   parentEntityRelations?: string[];
   // Warning: (ae-forgotten-export) The symbol "EntityContextMenuOptions" needs to be exported by the entry point index.d.ts

--- a/plugins/catalog/src/alpha/pages.tsx
+++ b/plugins/catalog/src/alpha/pages.tsx
@@ -63,6 +63,9 @@ export const catalogEntityPage = PageBlueprint.makeWithOverrides({
       EntityContentBlueprint.dataRefs.filterFunction.optional(),
       EntityContentBlueprint.dataRefs.filterExpression.optional(),
     ]),
+    extraContextMenuItems: createExtensionInput([
+      coreExtensionData.reactElement,
+    ]),
   },
   factory(originalFactory, { inputs }) {
     return originalFactory({
@@ -71,9 +74,13 @@ export const catalogEntityPage = PageBlueprint.makeWithOverrides({
       loader: async () => {
         const { EntityLayout } = await import('../components/EntityLayout');
         const Component = () => {
+          const extraMenuItems = inputs.extraContextMenuItems.map(item =>
+            item.get(coreExtensionData.reactElement),
+          );
+
           return (
             <AsyncEntityProvider {...useEntityFromUrl()}>
-              <EntityLayout>
+              <EntityLayout extraMenuItems={extraMenuItems}>
                 {inputs.contents.map(output => {
                   return (
                     <EntityLayout.Route

--- a/plugins/catalog/src/components/EntityContextMenu/EntityContextMenu.tsx
+++ b/plugins/catalog/src/components/EntityContextMenu/EntityContextMenu.tsx
@@ -61,6 +61,7 @@ interface ExtraContextMenuItem {
 interface EntityContextMenuProps {
   UNSTABLE_extraContextMenuItems?: ExtraContextMenuItem[];
   UNSTABLE_contextMenuOptions?: UnregisterEntityOptions;
+  extraMenuItems?: JSX.Element[];
   onUnregisterEntity: () => void;
   onInspectEntity: () => void;
 }
@@ -69,6 +70,7 @@ export function EntityContextMenu(props: EntityContextMenuProps) {
   const {
     UNSTABLE_extraContextMenuItems,
     UNSTABLE_contextMenuOptions,
+    extraMenuItems,
     onUnregisterEntity,
     onInspectEntity,
   } = props;
@@ -145,6 +147,7 @@ export function EntityContextMenu(props: EntityContextMenuProps) {
       >
         <MenuList autoFocusItem={Boolean(anchorEl)}>
           {extraItems}
+          {extraMenuItems}
           <UnregisterEntity
             unregisterEntityOptions={UNSTABLE_contextMenuOptions}
             isUnregisterAllowed={isAllowed}

--- a/plugins/catalog/src/components/EntityLayout/EntityLayout.tsx
+++ b/plugins/catalog/src/components/EntityLayout/EntityLayout.tsx
@@ -173,6 +173,7 @@ interface EntityContextMenuOptions {
 export interface EntityLayoutProps {
   UNSTABLE_extraContextMenuItems?: ExtraContextMenuItem[];
   UNSTABLE_contextMenuOptions?: EntityContextMenuOptions;
+  extraMenuItems?: JSX.Element[];
   children?: React.ReactNode;
   NotFoundComponent?: React.ReactNode;
   /**
@@ -239,6 +240,7 @@ export const EntityLayout = (props: EntityLayoutProps) => {
   const {
     UNSTABLE_extraContextMenuItems,
     UNSTABLE_contextMenuOptions,
+    extraMenuItems,
     children,
     NotFoundComponent,
     parentEntityRelations,
@@ -354,6 +356,7 @@ export const EntityLayout = (props: EntityLayoutProps) => {
             <EntityContextMenu
               UNSTABLE_extraContextMenuItems={UNSTABLE_extraContextMenuItems}
               UNSTABLE_contextMenuOptions={UNSTABLE_contextMenuOptions}
+              extraMenuItems={extraMenuItems}
               onUnregisterEntity={() => setConfirmationDialogOpen(true)}
               onInspectEntity={() => setSearchParams('inspect')}
             />


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds `EntityContextMenuItemBlueprint` to `@backstage/plugin-catalog-react` to enable extending the entity page's context menu using the new frontend system.

<img width="474" alt="Screenshot 2025-01-29 at 16 59 27" src="https://github.com/user-attachments/assets/37dfeb74-a6c3-425a-832d-b2d842853ee3" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [ x All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
