### PR TITLE
permissions: add resources refs and rule accessor

### DIFF
--- a/.changeset/fresh-bears-thank.md
+++ b/.changeset/fresh-bears-thank.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-node': minor
+---
+
+Added new `catalogEntityPermissionResourceRef` export via the `/alpha` sub-path.

--- a/.changeset/gold-rabbits-change.md
+++ b/.changeset/gold-rabbits-change.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-permission-node': patch
 ---
 
-Added a new `PermissionRuleAccessor` type that encapsulates a lookup function for permission rules, which can be created by the new `PermissionsRegistryService` via the `getRuleAccessor` method. The `createConditionTransformer` and `createConditionAuthorizer` functions have been adapted to receive these accessors as arguments, with their older counterparts being deprecated.
+Added a new `PermissionRuleset` type that encapsulates a lookup function for permission rules, which can be created by the new `PermissionsRegistryService` via the `getPermissionRuleset` method. The `createConditionTransformer` and `createConditionAuthorizer` functions have been adapted to receive these accessors as arguments, with their older counterparts being deprecated.

--- a/.changeset/gold-rabbits-change.md
+++ b/.changeset/gold-rabbits-change.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-permission-node': patch
+---
+
+Added a new `PermissionRuleAccessor` type that encapsulates a lookup function for permission rules, which can be created by the new `PermissionsRegistryService` via the `getRuleAccessor` method. The `createConditionTransformer` and `createConditionAuthorizer` functions have been adapted to receive these accessors as arguments, with their older counterparts being deprecated.

--- a/.changeset/gorgeous-shoes-stare.md
+++ b/.changeset/gorgeous-shoes-stare.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-test-utils': patch
+---
+
+Added the new `getRuleAccessor` method to `mockServices.permissionsRegistry`.

--- a/.changeset/gorgeous-shoes-stare.md
+++ b/.changeset/gorgeous-shoes-stare.md
@@ -2,4 +2,4 @@
 '@backstage/backend-test-utils': patch
 ---
 
-Added the new `getRuleAccessor` method to `mockServices.permissionsRegistry`.
+Added the new `getPermissionRuleset` method to `mockServices.permissionsRegistry`.

--- a/.changeset/hungry-chefs-relax.md
+++ b/.changeset/hungry-chefs-relax.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Updated permission integration to use new permission resource ref.

--- a/.changeset/tidy-forks-pay.md
+++ b/.changeset/tidy-forks-pay.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-permission-node': patch
+---
+
+Added a new `createPermissionResourceRef` utility that encapsulates the constants and types related to a permission resource types. The `createConditionExports` and `createPermissionRule` functions have also been adapted to accept these references as arguments, deprecating their older counterparts.

--- a/.changeset/witty-ducks-cross.md
+++ b/.changeset/witty-ducks-cross.md
@@ -1,0 +1,6 @@
+---
+'@backstage/backend-plugin-api': patch
+'@backstage/backend-defaults': patch
+---
+
+Updated `PermissionsRegistryService` to use `PermissionResourceRef`s and added the `getRuleAccessor` method.

--- a/.changeset/witty-ducks-cross.md
+++ b/.changeset/witty-ducks-cross.md
@@ -3,4 +3,4 @@
 '@backstage/backend-defaults': patch
 ---
 
-Updated `PermissionsRegistryService` to use `PermissionResourceRef`s and added the `getRuleAccessor` method.
+Updated `PermissionsRegistryService` to use `PermissionResourceRef`s and added the `getPermissionRuleset` method.

--- a/docs/permissions/custom-rules.md
+++ b/docs/permissions/custom-rules.md
@@ -24,14 +24,14 @@ yarn --cwd packages/backend add zod @backstage/catalog-model
 ...
 
 import type { Entity } from '@backstage/catalog-model';
-import { createCatalogPermissionRule } from '@backstage/plugin-catalog-backend/alpha';
-import { createConditionFactory } from '@backstage/plugin-permission-node';
+import { catalogEntityPermissionResourceRef } from '@backstage/plugin-catalog-backend/alpha';
+import { createConditionFactory, createPermissionRule } from '@backstage/plugin-permission-node';
 import { z } from 'zod';
 
-export const isInSystemRule = createCatalogPermissionRule({
+export const isInSystemRule = createPermissionRule({
   name: 'IS_IN_SYSTEM',
   description: 'Checks if an entity is part of the system provided',
-  resourceType: 'catalog-entity',
+  resourceRef: catalogEntityPermissionResourceRef,
   paramsSchema: z.object({
     systemRef: z
       .string()
@@ -64,22 +64,22 @@ Still in the `packages/backend/src/extensions/permissionsPolicyExtension.ts` fil
 ```ts title="packages/backend/src/extensions/permissionsPolicyExtension.ts"
 ...
 /* highlight-remove-next-line */
-import { createCatalogPermissionRule } from '@backstage/plugin-catalog-backend/alpha';
+import { catalogEntityPermissionResourceRef } from '@backstage/plugin-catalog-backend/alpha';
 /* highlight-add-next-line */
-import { catalogConditions, createCatalogConditionalDecision, createCatalogPermissionRule } from '@backstage/plugin-catalog-backend/alpha';
+import { catalogEntityPermissionResourceRef, createCatalogConditionalDecision, catalogConditions } from '@backstage/plugin-catalog-backend/alpha';
 /* highlight-remove-next-line */
-import { createConditionFactory } from '@backstage/plugin-permission-node';
+import { createConditionFactory, createPermissionRule } from '@backstage/plugin-permission-node';
 /* highlight-add-next-line */
-import { PermissionPolicy, PolicyQuery, PolicyQueryUser, createConditionFactory } from '@backstage/plugin-permission-node';
+import { createConditionFactory, createPermissionRule, PermissionPolicy, PolicyQuery, PolicyQueryUser } from '@backstage/plugin-permission-node';
 /* highlight-add-start */
 import { AuthorizeResult, PolicyDecision, isResourcePermission } from '@backstage/plugin-permission-common';
 /* highlight-add-end */
 ...
 
-export const isInSystemRule = createCatalogPermissionRule({
+export const isInSystemRule = createPermissionRule({
   name: 'IS_IN_SYSTEM',
   description: 'Checks if an entity is part of the system provided',
-  resourceType: 'catalog-entity',
+  resourceRef: catalogEntityPermissionResourceRef,
   paramsSchema: z.object({
     systemRef: z
       .string()

--- a/docs/permissions/plugin-authors/04-authorizing-access-to-paginated-data.md
+++ b/docs/permissions/plugin-authors/04-authorizing-access-to-paginated-data.md
@@ -100,7 +100,7 @@ import {
 // ...
 
 permissionsRegistry.addResourceType({
-  resourceType: TODO_LIST_RESOURCE_TYPE,
+  resourceRef: todoListPermissionResourceRef,
   /* highlight-remove-next-line */
   permissions: [todoListCreatePermission, todoListUpdatePermission],
   /* highlight-add-next-line */
@@ -129,17 +129,22 @@ import {
 import { add, getAll, getTodo, update } from './todos';
 /* highlight-add-next-line */
 import { add, getAll, getTodo, TodoFilter, update } from './todos';
+/* highlight-add-next-line */
+import { todoListPermissionResourceRef } from './rules';
 import {
   todoListCreatePermission,
   todoListUpdatePermission,
   /* highlight-add-next-line */
   todoListReadPermission,
-} from './permissions';
+} from '@internal/plugin-todo-list-common';
 
 // ...
 
-/* highlight-add-next-line */
-const transformConditions: ConditionTransformer<TodoFilter> = createConditionTransformer(Object.values(rules));
+/* highlight-add-start */
+const transformConditions = createConditionTransformer(
+  permissionsRegistry.getRuleAccessor(todoListPermissionResourceRef)
+);
+/* highlight-add-end */
 
 /* highlight-remove-next-line */
 router.get('/todos', async (_req, res) => {

--- a/docs/permissions/plugin-authors/04-authorizing-access-to-paginated-data.md
+++ b/docs/permissions/plugin-authors/04-authorizing-access-to-paginated-data.md
@@ -142,7 +142,7 @@ import {
 
 /* highlight-add-start */
 const transformConditions = createConditionTransformer(
-  permissionsRegistry.getRuleAccessor(todoListPermissionResourceRef)
+  permissionsRegistry.getPermissionRuleset(todoListPermissionResourceRef)
 );
 /* highlight-add-end */
 

--- a/packages/backend-defaults/src/entrypoints/permissionsRegistry/permissionsRegistryServiceFactory.test.ts
+++ b/packages/backend-defaults/src/entrypoints/permissionsRegistry/permissionsRegistryServiceFactory.test.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  coreServices,
+  createBackendPlugin,
+} from '@backstage/backend-plugin-api';
+import { startTestBackend } from '@backstage/backend-test-utils';
+import { createPermissionResourceRef } from '@backstage/plugin-permission-node';
+import { permissionsRegistryServiceFactory } from './permissionsRegistryServiceFactory';
+
+describe('permissionsRegistryServiceFactory', () => {
+  it('should reject resource refs from other plugins', async () => {
+    await expect(
+      startTestBackend({
+        features: [
+          permissionsRegistryServiceFactory,
+          createBackendPlugin({
+            pluginId: 'test',
+            register(reg) {
+              reg.registerInit({
+                deps: { permissionsRegistry: coreServices.permissionsRegistry },
+                async init({ permissionsRegistry }) {
+                  permissionsRegistry.addResourceType({
+                    resourceRef: createPermissionResourceRef<
+                      unknown,
+                      unknown
+                    >().with({
+                      pluginId: 'other',
+                      resourceType: 'some-resource',
+                    }),
+                    rules: [],
+                  });
+                },
+              });
+            },
+          }),
+        ],
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"Plugin 'test' startup failed; caused by Error: Resource type 'some-resource' belongs to plugin 'other', but was used with plugin 'test'"`,
+    );
+
+    await expect(
+      startTestBackend({
+        features: [
+          permissionsRegistryServiceFactory,
+          createBackendPlugin({
+            pluginId: 'test',
+            register(reg) {
+              reg.registerInit({
+                deps: { permissionsRegistry: coreServices.permissionsRegistry },
+                async init({ permissionsRegistry }) {
+                  permissionsRegistry.getPermissionRuleset(
+                    createPermissionResourceRef<unknown, unknown>().with({
+                      pluginId: 'other',
+                      resourceType: 'some-resource',
+                    }),
+                  );
+                },
+              });
+            },
+          }),
+        ],
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"Plugin 'test' startup failed; caused by Error: Resource type 'some-resource' belongs to plugin 'other', but was used with plugin 'test'"`,
+    );
+  });
+});

--- a/packages/backend-defaults/src/entrypoints/permissionsRegistry/permissionsRegistryServiceFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/permissionsRegistry/permissionsRegistryServiceFactory.ts
@@ -74,8 +74,8 @@ export const permissionsRegistryServiceFactory = createServiceFactory({
         }
         router.addPermissionRules(rules);
       },
-      getRuleAccessor(resourceRef) {
-        return router.getRuleAccessor(resourceRef);
+      getPermissionRuleset(resourceRef) {
+        return router.getPermissionRuleset(resourceRef);
       },
     } satisfies PermissionsRegistryService;
   },

--- a/packages/backend-defaults/src/entrypoints/permissionsRegistry/permissionsRegistryServiceFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/permissionsRegistry/permissionsRegistryServiceFactory.ts
@@ -19,7 +19,18 @@ import {
   coreServices,
   createServiceFactory,
 } from '@backstage/backend-plugin-api';
-import { createPermissionIntegrationRouter } from '@backstage/plugin-permission-node';
+import {
+  PermissionResourceRef,
+  createPermissionIntegrationRouter,
+} from '@backstage/plugin-permission-node';
+
+function assertRefPluginId(ref: PermissionResourceRef, pluginId: string) {
+  if (ref.pluginId !== pluginId) {
+    throw new Error(
+      `Resource type '${ref.resourceType}' belongs to plugin '${ref.pluginId}', but was used with plugin '${pluginId}'`,
+    );
+  }
+}
 
 /**
  * Permission system integration for registering resources and permissions.
@@ -35,9 +46,11 @@ export const permissionsRegistryServiceFactory = createServiceFactory({
   deps: {
     lifecycle: coreServices.lifecycle,
     httpRouter: coreServices.httpRouter,
+    pluginMetadata: coreServices.pluginMetadata,
   },
-  async factory({ httpRouter, lifecycle }) {
+  async factory({ httpRouter, lifecycle, pluginMetadata }) {
     const router = createPermissionIntegrationRouter();
+    const pluginId = pluginMetadata.getId();
 
     httpRouter.use(router);
 
@@ -53,6 +66,7 @@ export const permissionsRegistryServiceFactory = createServiceFactory({
             'Cannot add permission resource types after the plugin has started',
           );
         }
+        assertRefPluginId(resource.resourceRef, pluginId);
         router.addResourceType({
           ...resource,
           resourceType: resource.resourceRef.resourceType,
@@ -75,6 +89,7 @@ export const permissionsRegistryServiceFactory = createServiceFactory({
         router.addPermissionRules(rules);
       },
       getPermissionRuleset(resourceRef) {
+        assertRefPluginId(resourceRef, pluginId);
         return router.getPermissionRuleset(resourceRef);
       },
     } satisfies PermissionsRegistryService;

--- a/packages/backend-defaults/src/entrypoints/permissionsRegistry/permissionsRegistryServiceFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/permissionsRegistry/permissionsRegistryServiceFactory.ts
@@ -15,6 +15,7 @@
  */
 
 import {
+  PermissionsRegistryService,
   coreServices,
   createServiceFactory,
 } from '@backstage/backend-plugin-api';
@@ -52,7 +53,10 @@ export const permissionsRegistryServiceFactory = createServiceFactory({
             'Cannot add permission resource types after the plugin has started',
           );
         }
-        router.addResourceType(resource);
+        router.addResourceType({
+          ...resource,
+          resourceType: resource.resourceRef.resourceType,
+        });
       },
       addPermissions(permissions) {
         if (started) {
@@ -70,6 +74,9 @@ export const permissionsRegistryServiceFactory = createServiceFactory({
         }
         router.addPermissionRules(rules);
       },
-    };
+      getRuleAccessor(resourceRef) {
+        return router.getRuleAccessor(resourceRef);
+      },
+    } satisfies PermissionsRegistryService;
   },
 });

--- a/packages/backend-plugin-api/report.api.md
+++ b/packages/backend-plugin-api/report.api.md
@@ -21,7 +21,7 @@ import { PermissionAttributes } from '@backstage/plugin-permission-common';
 import { PermissionEvaluator } from '@backstage/plugin-permission-common';
 import { PermissionResourceRef } from '@backstage/plugin-permission-node';
 import { PermissionRule } from '@backstage/plugin-permission-node';
-import { PermissionRuleAccessor } from '@backstage/plugin-permission-node';
+import { PermissionRuleset } from '@backstage/plugin-permission-node';
 import { QueryPermissionRequest } from '@backstage/plugin-permission-common';
 import { QueryPermissionResponse } from '@backstage/plugin-permission-common';
 import { Readable } from 'stream';
@@ -475,9 +475,9 @@ export interface PermissionsRegistryService {
       TQuery
     >,
   ): void;
-  getRuleAccessor<TResourceType extends string, TResource, TQuery>(
+  getPermissionRuleset<TResourceType extends string, TResource, TQuery>(
     resourceRef: PermissionResourceRef<TResource, TQuery, TResourceType>,
-  ): PermissionRuleAccessor<TResource, TQuery, TResourceType>;
+  ): PermissionRuleset<TResource, TQuery, TResourceType>;
 }
 
 // @public

--- a/packages/backend-plugin-api/report.api.md
+++ b/packages/backend-plugin-api/report.api.md
@@ -19,7 +19,9 @@ import { Knex } from 'knex';
 import { Permission } from '@backstage/plugin-permission-common';
 import { PermissionAttributes } from '@backstage/plugin-permission-common';
 import { PermissionEvaluator } from '@backstage/plugin-permission-common';
+import { PermissionResourceRef } from '@backstage/plugin-permission-node';
 import { PermissionRule } from '@backstage/plugin-permission-node';
+import { PermissionRuleAccessor } from '@backstage/plugin-permission-node';
 import { QueryPermissionRequest } from '@backstage/plugin-permission-common';
 import { QueryPermissionResponse } from '@backstage/plugin-permission-common';
 import { Readable } from 'stream';
@@ -466,23 +468,34 @@ export interface LoggerService {
 export interface PermissionsRegistryService {
   addPermissionRules(rules: PermissionRule<any, any, string>[]): void;
   addPermissions(permissions: Permission[]): void;
-  addResourceType<const TResourceType extends string, TResource>(
+  addResourceType<const TResourceType extends string, TResource, TQuery>(
     options: PermissionsRegistryServiceAddResourceTypeOptions<
       TResourceType,
-      TResource
+      TResource,
+      TQuery
     >,
   ): void;
+  getRuleAccessor<TResourceType extends string, TResource, TQuery>(
+    resourceRef: PermissionResourceRef<TResource, TQuery, TResourceType>,
+  ): PermissionRuleAccessor<TResource, TQuery, TResourceType>;
 }
 
 // @public
 export type PermissionsRegistryServiceAddResourceTypeOptions<
   TResourceType extends string,
   TResource,
+  TQuery,
 > = {
-  resourceType: TResourceType;
+  resourceRef: PermissionResourceRef<TResource, TQuery, TResourceType>;
   permissions?: Array<Permission>;
-  rules: PermissionRule<TResource, any, NoInfer_2<TResourceType>>[];
-  getResources?(resourceRefs: string[]): Promise<Array<TResource | undefined>>;
+  rules: PermissionRule<
+    NoInfer_2<TResource>,
+    NoInfer_2<TQuery>,
+    NoInfer_2<TResourceType>
+  >[];
+  getResources?(
+    resourceRefs: string[],
+  ): Promise<Array<NoInfer_2<TResource> | undefined>>;
 };
 
 // @public

--- a/packages/backend-plugin-api/src/services/definitions/PermissionsRegistryService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/PermissionsRegistryService.ts
@@ -142,7 +142,7 @@ export interface PermissionsRegistryService {
   ): void;
 
   /**
-   * Returns a lookup function that can be used to look up rules for the provided resource by name.
+   * Returns the set of registered rules for this resource.
    *
    * @remarks
    *

--- a/packages/backend-plugin-api/src/services/definitions/PermissionsRegistryService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/PermissionsRegistryService.ts
@@ -18,7 +18,7 @@ import { Permission } from '@backstage/plugin-permission-common';
 import {
   PermissionResourceRef,
   PermissionRule,
-  PermissionRuleAccessor,
+  PermissionRuleset,
 } from '@backstage/plugin-permission-node';
 
 /**
@@ -148,7 +148,7 @@ export interface PermissionsRegistryService {
    *
    * Primarily intended for use with {@link @backstage/plugin-permission-node#createConditionAuthorizer} and {@link @backstage/plugin-permission-node#createConditionTransformer}.
    */
-  getRuleAccessor<TResourceType extends string, TResource, TQuery>(
+  getPermissionRuleset<TResourceType extends string, TResource, TQuery>(
     resourceRef: PermissionResourceRef<TResource, TQuery, TResourceType>,
-  ): PermissionRuleAccessor<TResource, TQuery, TResourceType>;
+  ): PermissionRuleset<TResource, TQuery, TResourceType>;
 }

--- a/packages/backend-plugin-api/src/services/definitions/PermissionsRegistryService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/PermissionsRegistryService.ts
@@ -15,7 +15,11 @@
  */
 
 import { Permission } from '@backstage/plugin-permission-common';
-import { PermissionRule } from '@backstage/plugin-permission-node';
+import {
+  PermissionResourceRef,
+  PermissionRule,
+  PermissionRuleAccessor,
+} from '@backstage/plugin-permission-node';
 
 /**
  * Prevent use of type parameter from contributing to type inference.
@@ -33,11 +37,12 @@ type NoInfer<T> = T extends infer S ? S : never;
 export type PermissionsRegistryServiceAddResourceTypeOptions<
   TResourceType extends string,
   TResource,
+  TQuery,
 > = {
   /**
-   * The identifier for the resource type.
+   * The {@link @backstage/plugin-permission-node#PermissionResourceRef} that identifies the resource type.
    */
-  resourceType: TResourceType;
+  resourceRef: PermissionResourceRef<TResource, TQuery, TResourceType>;
 
   /**
    * Permissions that are available for this resource type.
@@ -47,7 +52,11 @@ export type PermissionsRegistryServiceAddResourceTypeOptions<
   /**
    * Permission rules that are available for this resource type.
    */
-  rules: PermissionRule<TResource, any, NoInfer<TResourceType>>[];
+  rules: PermissionRule<
+    NoInfer<TResource>,
+    NoInfer<TQuery>,
+    NoInfer<TResourceType>
+  >[];
 
   /**
    * The function used to load associated resources based in the provided
@@ -59,7 +68,9 @@ export type PermissionsRegistryServiceAddResourceTypeOptions<
    * resolve conditional decisions except when requesting resources directly
    * from the plugin.
    */
-  getResources?(resourceRefs: string[]): Promise<Array<TResource | undefined>>;
+  getResources?(
+    resourceRefs: string[],
+  ): Promise<Array<NoInfer<TResource> | undefined>>;
 };
 
 /**
@@ -122,10 +133,22 @@ export interface PermissionsRegistryService {
    * called by the `permission-backend` when authorization conditions relating
    * to this plugin need to be evaluated.
    */
-  addResourceType<const TResourceType extends string, TResource>(
+  addResourceType<const TResourceType extends string, TResource, TQuery>(
     options: PermissionsRegistryServiceAddResourceTypeOptions<
       TResourceType,
-      TResource
+      TResource,
+      TQuery
     >,
   ): void;
+
+  /**
+   * Returns a lookup function that can be used to look up rules for the provided resource by name.
+   *
+   * @remarks
+   *
+   * Primarily intended for use with {@link @backstage/plugin-permission-node#createConditionAuthorizer} and {@link @backstage/plugin-permission-node#createConditionTransformer}.
+   */
+  getRuleAccessor<TResourceType extends string, TResource, TQuery>(
+    resourceRef: PermissionResourceRef<TResource, TQuery, TResourceType>,
+  ): PermissionRuleAccessor<TResource, TQuery, TResourceType>;
 }

--- a/packages/backend-test-utils/src/next/services/mockServices.ts
+++ b/packages/backend-test-utils/src/next/services/mockServices.ts
@@ -489,6 +489,7 @@ export namespace mockServices {
       addPermissionRules: jest.fn(),
       addPermissions: jest.fn(),
       addResourceType: jest.fn(),
+      getRuleAccessor: jest.fn(),
     }));
   }
 

--- a/packages/backend-test-utils/src/next/services/mockServices.ts
+++ b/packages/backend-test-utils/src/next/services/mockServices.ts
@@ -489,7 +489,7 @@ export namespace mockServices {
       addPermissionRules: jest.fn(),
       addPermissions: jest.fn(),
       addResourceType: jest.fn(),
-      getRuleAccessor: jest.fn(),
+      getPermissionRuleset: jest.fn(),
     }));
   }
 

--- a/plugins/catalog-backend/src/permissions/conditionExports.ts
+++ b/plugins/catalog-backend/src/permissions/conditionExports.ts
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 
-import { RESOURCE_TYPE_CATALOG_ENTITY } from '@backstage/plugin-catalog-common/alpha';
 import { createConditionExports } from '@backstage/plugin-permission-node';
 import { permissionRules } from './rules';
+import { catalogEntityPermissionResourceRef } from '@backstage/plugin-catalog-node/alpha';
 
 const { conditions, createConditionalDecision } = createConditionExports({
-  pluginId: 'catalog',
-  resourceType: RESOURCE_TYPE_CATALOG_ENTITY,
+  resourceRef: catalogEntityPermissionResourceRef,
   rules: permissionRules,
 });
 

--- a/plugins/catalog-backend/src/permissions/rules/createPropertyRule.ts
+++ b/plugins/catalog-backend/src/permissions/rules/createPropertyRule.ts
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
+import { catalogEntityPermissionResourceRef } from '@backstage/plugin-catalog-node/alpha';
+import { createPermissionRule } from '@backstage/plugin-permission-node';
 import { get } from 'lodash';
-import { RESOURCE_TYPE_CATALOG_ENTITY } from '@backstage/plugin-catalog-common/alpha';
-import { createCatalogPermissionRule } from './util';
 import { z } from 'zod';
 
 export const createPropertyRule = (propertyType: 'metadata' | 'spec') =>
-  createCatalogPermissionRule({
+  createPermissionRule({
     name: `HAS_${propertyType.toUpperCase()}`,
     description: `Allow entities with the specified ${propertyType} subfield`,
-    resourceType: RESOURCE_TYPE_CATALOG_ENTITY,
+    resourceRef: catalogEntityPermissionResourceRef,
     paramsSchema: z.object({
       key: z
         .string()

--- a/plugins/catalog-backend/src/permissions/rules/hasAnnotation.ts
+++ b/plugins/catalog-backend/src/permissions/rules/hasAnnotation.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { RESOURCE_TYPE_CATALOG_ENTITY } from '@backstage/plugin-catalog-common/alpha';
+import { catalogEntityPermissionResourceRef } from '@backstage/plugin-catalog-node/alpha';
+import { createPermissionRule } from '@backstage/plugin-permission-node';
 import { z } from 'zod';
-import { createCatalogPermissionRule } from './util';
 
 /**
  * A catalog {@link @backstage/plugin-permission-node#PermissionRule} which
@@ -26,10 +26,10 @@ import { createCatalogPermissionRule } from './util';
  *
  * @alpha
  */
-export const hasAnnotation = createCatalogPermissionRule({
+export const hasAnnotation = createPermissionRule({
   name: 'HAS_ANNOTATION',
   description: 'Allow entities with the specified annotation',
-  resourceType: RESOURCE_TYPE_CATALOG_ENTITY,
+  resourceRef: catalogEntityPermissionResourceRef,
   paramsSchema: z.object({
     annotation: z.string().describe('Name of the annotation to match on'),
     value: z

--- a/plugins/catalog-backend/src/permissions/rules/hasLabel.ts
+++ b/plugins/catalog-backend/src/permissions/rules/hasLabel.ts
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-import { RESOURCE_TYPE_CATALOG_ENTITY } from '@backstage/plugin-catalog-common/alpha';
+import { catalogEntityPermissionResourceRef } from '@backstage/plugin-catalog-node/alpha';
+import { createPermissionRule } from '@backstage/plugin-permission-node';
 import { z } from 'zod';
-import { createCatalogPermissionRule } from './util';
 
 /**
  * A catalog {@link @backstage/plugin-permission-node#PermissionRule} which
  * filters for entities with a specified label in its metadata.
  * @alpha
  */
-export const hasLabel = createCatalogPermissionRule({
+export const hasLabel = createPermissionRule({
   name: 'HAS_LABEL',
   description: 'Allow entities with the specified label',
-  resourceType: RESOURCE_TYPE_CATALOG_ENTITY,
+  resourceRef: catalogEntityPermissionResourceRef,
   paramsSchema: z.object({
     label: z.string().describe('Name of the label to match on'),
   }),

--- a/plugins/catalog-backend/src/permissions/rules/isEntityKind.ts
+++ b/plugins/catalog-backend/src/permissions/rules/isEntityKind.ts
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-import { RESOURCE_TYPE_CATALOG_ENTITY } from '@backstage/plugin-catalog-common/alpha';
+import { catalogEntityPermissionResourceRef } from '@backstage/plugin-catalog-node/alpha';
+import { createPermissionRule } from '@backstage/plugin-permission-node';
 import { z } from 'zod';
-import { createCatalogPermissionRule } from './util';
 
 /**
  * A catalog {@link @backstage/plugin-permission-node#PermissionRule} which
  * filters for entities with a specified kind.
  * @alpha
  */
-export const isEntityKind = createCatalogPermissionRule({
+export const isEntityKind = createPermissionRule({
   name: 'IS_ENTITY_KIND',
   description: 'Allow entities matching a specified kind',
-  resourceType: RESOURCE_TYPE_CATALOG_ENTITY,
+  resourceRef: catalogEntityPermissionResourceRef,
   paramsSchema: z.object({
     kinds: z
       .array(z.string())

--- a/plugins/catalog-backend/src/permissions/rules/isEntityOwner.ts
+++ b/plugins/catalog-backend/src/permissions/rules/isEntityOwner.ts
@@ -15,9 +15,9 @@
  */
 
 import { RELATION_OWNED_BY } from '@backstage/catalog-model';
-import { RESOURCE_TYPE_CATALOG_ENTITY } from '@backstage/plugin-catalog-common/alpha';
+import { createPermissionRule } from '@backstage/plugin-permission-node';
 import { z } from 'zod';
-import { createCatalogPermissionRule } from './util';
+import { catalogEntityPermissionResourceRef } from '@backstage/plugin-catalog-node/alpha';
 
 /**
  * A catalog {@link @backstage/plugin-permission-node#PermissionRule} which
@@ -25,10 +25,10 @@ import { createCatalogPermissionRule } from './util';
  *
  * @alpha
  */
-export const isEntityOwner = createCatalogPermissionRule({
+export const isEntityOwner = createPermissionRule({
   name: 'IS_ENTITY_OWNER',
   description: 'Allow entities owned by a specified claim',
-  resourceType: RESOURCE_TYPE_CATALOG_ENTITY,
+  resourceRef: catalogEntityPermissionResourceRef,
   paramsSchema: z.object({
     claims: z
       .array(z.string())

--- a/plugins/catalog-backend/src/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.ts
@@ -561,7 +561,7 @@ export class CatalogBuilder {
       permissionsService,
       permissionsRegistry
         ? createConditionTransformer(
-            permissionsRegistry.getRuleAccessor(
+            permissionsRegistry.getPermissionRuleset(
               catalogEntityPermissionResourceRef,
             ),
           )

--- a/plugins/catalog-node/report-alpha.api.md
+++ b/plugins/catalog-node/report-alpha.api.md
@@ -12,6 +12,7 @@ import { EntityProvider } from '@backstage/plugin-catalog-node';
 import { ExtensionPoint } from '@backstage/backend-plugin-api';
 import { LocationAnalyzer } from '@backstage/plugin-catalog-node';
 import { Permission } from '@backstage/plugin-permission-common';
+import { PermissionResourceRef } from '@backstage/plugin-permission-node';
 import { PermissionRule } from '@backstage/plugin-permission-node';
 import { PermissionRuleParams } from '@backstage/plugin-permission-common';
 import { PlaceholderResolver } from '@backstage/plugin-catalog-node';
@@ -33,6 +34,14 @@ export interface CatalogAnalysisExtensionPoint {
 
 // @alpha (undocumented)
 export const catalogAnalysisExtensionPoint: ExtensionPoint<CatalogAnalysisExtensionPoint>;
+
+// @alpha (undocumented)
+export const catalogEntityPermissionResourceRef: PermissionResourceRef<
+  Entity,
+  EntitiesSearchFilter,
+  'catalog-entity',
+  'catalog'
+>;
 
 // @alpha (undocumented)
 export interface CatalogLocationsExtensionPoint {

--- a/plugins/catalog-node/src/alpha.ts
+++ b/plugins/catalog-node/src/alpha.ts
@@ -21,6 +21,19 @@ import {
 } from '@backstage/backend-plugin-api';
 import { catalogServiceRef as _catalogServiceRef } from './catalogService';
 import { CatalogApi, CatalogClient } from '@backstage/catalog-client';
+import { RESOURCE_TYPE_CATALOG_ENTITY } from '@backstage/plugin-catalog-common/alpha';
+import { createPermissionResourceRef } from '@backstage/plugin-permission-node';
+import { Entity } from '@backstage/catalog-model';
+import { EntitiesSearchFilter } from '@backstage/plugin-catalog-node';
+
+/** @alpha */
+export const catalogEntityPermissionResourceRef = createPermissionResourceRef<
+  Entity,
+  EntitiesSearchFilter
+>().with({
+  pluginId: 'catalog',
+  resourceType: RESOURCE_TYPE_CATALOG_ENTITY,
+});
 
 /**
  * @alpha

--- a/plugins/permission-node/report.api.md
+++ b/plugins/permission-node/report.api.md
@@ -78,9 +78,14 @@ export type ConditionTransformer<TQuery> = (
 ) => PermissionCriteria<TQuery>;
 
 // @public
-export const createConditionAuthorizer: <TResource, TQuery>(
+export function createConditionAuthorizer<TResource>(
+  permissionRuleAccessor: PermissionRuleAccessor<TResource>,
+): (decision: PolicyDecision, resource: TResource | undefined) => boolean;
+
+// @public @deprecated (undocumented)
+export function createConditionAuthorizer<TResource, TQuery>(
   rules: PermissionRule<TResource, TQuery, string>[],
-) => (decision: PolicyDecision, resource: TResource | undefined) => boolean;
+): (decision: PolicyDecision, resource: TResource | undefined) => boolean;
 
 // @public
 export function createConditionExports<
@@ -124,12 +129,15 @@ export const createConditionFactory: <
 ) => (params: TParams) => PermissionCondition<TResourceType, TParams>;
 
 // @public
-export const createConditionTransformer: <
+export function createConditionTransformer<TQuery>(
+  permissionRuleAccessor: PermissionRuleAccessor<any, TQuery>,
+): ConditionTransformer<TQuery>;
+
+// @public @deprecated (undocumented)
+export function createConditionTransformer<
   TQuery,
   TRules extends PermissionRule<any, TQuery, string>[],
->(
-  permissionRules: [...TRules],
-) => ConditionTransformer<TQuery>;
+>(permissionRules: [...TRules]): ConditionTransformer<TQuery>;
 
 // @public
 export function createPermissionIntegrationRouter<
@@ -330,6 +338,13 @@ export type PermissionRule<
   apply(resource: TResource, params: NoInfer_2<TParams>): boolean;
   toQuery(params: NoInfer_2<TParams>): PermissionCriteria<TQuery>;
 };
+
+// @public
+export type PermissionRuleAccessor<
+  TResource = unknown,
+  TQuery = unknown,
+  TResourceType extends string = string,
+> = (name: string) => PermissionRule<TResource, TQuery, TResourceType>;
 
 // @public
 export type PolicyQuery = {

--- a/plugins/permission-node/report.api.md
+++ b/plugins/permission-node/report.api.md
@@ -173,6 +173,9 @@ export function createPermissionIntegrationRouter<
       TResource
     >,
   ): void;
+  getRuleAccessor<TResource, TQuery, TResourceType extends string>(
+    resourceRef: PermissionResourceRef<TResource, TQuery, TResourceType>,
+  ): PermissionRuleAccessor<TResource, TQuery, TResourceType>;
 };
 
 // @public

--- a/plugins/permission-node/report.api.md
+++ b/plugins/permission-node/report.api.md
@@ -83,7 +83,23 @@ export const createConditionAuthorizer: <TResource, TQuery>(
 ) => (decision: PolicyDecision, resource: TResource | undefined) => boolean;
 
 // @public
-export const createConditionExports: <
+export function createConditionExports<
+  TResourceType extends string,
+  TResource,
+  TRules extends Record<string, PermissionRule<TResource, any, TResourceType>>,
+>(options: {
+  resourceRef: PermissionResourceRef<TResource, any, TResourceType>;
+  rules: TRules;
+}): {
+  conditions: Conditions<TRules>;
+  createConditionalDecision: (
+    permission: ResourcePermission<TResourceType>,
+    conditions: PermissionCriteria<PermissionCondition<TResourceType>>,
+  ) => ConditionalPolicyDecision;
+};
+
+// @public @deprecated (undocumented)
+export function createConditionExports<
   TResourceType extends string,
   TResource,
   TRules extends Record<string, PermissionRule<TResource, any, TResourceType>>,
@@ -91,7 +107,7 @@ export const createConditionExports: <
   pluginId: string;
   resourceType: TResourceType;
   rules: TRules;
-}) => {
+}): {
   conditions: Conditions<TRules>;
   createConditionalDecision: (
     permission: ResourcePermission<TResourceType>,
@@ -164,15 +180,48 @@ export type CreatePermissionIntegrationRouterResourceOptions<
   ) => Promise<Array<TResource | undefined>>;
 };
 
+// @public (undocumented)
+export function createPermissionResourceRef<TResource, TQuery>(): {
+  with<TPluginId extends string, TResourceType extends string>(options: {
+    pluginId: TPluginId;
+    resourceType: TResourceType;
+  }): PermissionResourceRef<TResource, TQuery, TResourceType, TPluginId>;
+};
+
 // @public
-export const createPermissionRule: <
+export function createPermissionRule<
+  TResource,
+  TQuery,
+  TResourceType extends string,
+  TParams extends PermissionRuleParams = undefined,
+>(
+  rule: CreatePermissionRuleOptions<TResource, TQuery, TResourceType, TParams>,
+): PermissionRule<TResource, TQuery, TResourceType, TParams>;
+
+// @public @deprecated
+export function createPermissionRule<
   TResource,
   TQuery,
   TResourceType extends string,
   TParams extends PermissionRuleParams = undefined,
 >(
   rule: PermissionRule<TResource, TQuery, TResourceType, TParams>,
-) => PermissionRule<TResource, TQuery, TResourceType, TParams>;
+): PermissionRule<TResource, TQuery, TResourceType, TParams>;
+
+// @public (undocumented)
+export type CreatePermissionRuleOptions<
+  TResource,
+  TQuery,
+  TResourceType extends string,
+  TParams extends PermissionRuleParams = PermissionRuleParams,
+> = {
+  name: string;
+  description: string;
+  resourceRef: PermissionResourceRef<TResource, TQuery, TResourceType>;
+  paramsSchema?: z.ZodSchema<TParams>;
+  apply(resource: TResource, params: NoInfer_2<TParams>): boolean;
+  toQuery(params: NoInfer_2<TParams>): PermissionCriteria<TQuery>;
+};
 
 // @public
 export const isAndCriteria: <T>(
@@ -189,7 +238,7 @@ export const isOrCriteria: <T>(
   criteria: PermissionCriteria<T>,
 ) => criteria is AnyOfCriteria<T>;
 
-// @public
+// @public @deprecated
 export const makeCreatePermissionRule: <
   TResource,
   TQuery,
@@ -252,6 +301,20 @@ export interface PermissionPolicy {
   // (undocumented)
   handle(request: PolicyQuery, user?: PolicyQueryUser): Promise<PolicyDecision>;
 }
+
+// @public (undocumented)
+export type PermissionResourceRef<
+  TResource = unknown,
+  TQuery = unknown,
+  TResourceType extends string = string,
+  TPluginId extends string = string,
+> = {
+  readonly $$type: '@backstage/PermissionResourceRef';
+  readonly pluginId: TPluginId;
+  readonly resourceType: TResourceType;
+  readonly TQuery: TQuery;
+  readonly TResource: TResource;
+};
 
 // @public
 export type PermissionRule<

--- a/plugins/permission-node/report.api.md
+++ b/plugins/permission-node/report.api.md
@@ -203,10 +203,17 @@ export function createPermissionResourceRef<TResource, TQuery>(): {
 export function createPermissionRule<
   TResource,
   TQuery,
+  TQueryOutput extends TQuery,
   TResourceType extends string,
   TParams extends PermissionRuleParams = undefined,
 >(
-  rule: CreatePermissionRuleOptions<TResource, TQuery, TResourceType, TParams>,
+  rule: CreatePermissionRuleOptions<
+    TResource,
+    TQuery,
+    TQueryOutput,
+    TResourceType,
+    TParams
+  >,
 ): PermissionRule<TResource, TQuery, TResourceType, TParams>;
 
 // @public @deprecated
@@ -223,15 +230,16 @@ export function createPermissionRule<
 export type CreatePermissionRuleOptions<
   TResource,
   TQuery,
+  TQueryOutput extends TQuery,
   TResourceType extends string,
-  TParams extends PermissionRuleParams = PermissionRuleParams,
+  TParams extends PermissionRuleParams,
 > = {
   name: string;
   description: string;
   resourceRef: PermissionResourceRef<TResource, TQuery, TResourceType>;
   paramsSchema?: z.ZodSchema<TParams>;
   apply(resource: TResource, params: NoInfer_2<TParams>): boolean;
-  toQuery(params: NoInfer_2<TParams>): PermissionCriteria<TQuery>;
+  toQuery(params: NoInfer_2<TParams>): PermissionCriteria<TQueryOutput>;
 };
 
 // @public

--- a/plugins/permission-node/report.api.md
+++ b/plugins/permission-node/report.api.md
@@ -79,7 +79,7 @@ export type ConditionTransformer<TQuery> = (
 
 // @public
 export function createConditionAuthorizer<TResource>(
-  permissionRuleAccessor: PermissionRuleAccessor<TResource>,
+  permissionRuleset: PermissionRuleset<TResource>,
 ): (decision: PolicyDecision, resource: TResource | undefined) => boolean;
 
 // @public @deprecated (undocumented)
@@ -130,7 +130,7 @@ export const createConditionFactory: <
 
 // @public
 export function createConditionTransformer<TQuery>(
-  permissionRuleAccessor: PermissionRuleAccessor<any, TQuery>,
+  permissionRuleset: PermissionRuleset<any, TQuery>,
 ): ConditionTransformer<TQuery>;
 
 // @public @deprecated (undocumented)
@@ -173,9 +173,9 @@ export function createPermissionIntegrationRouter<
       TResource
     >,
   ): void;
-  getRuleAccessor<TResource, TQuery, TResourceType extends string>(
+  getPermissionRuleset<TResource, TQuery, TResourceType extends string>(
     resourceRef: PermissionResourceRef<TResource, TQuery, TResourceType>,
-  ): PermissionRuleAccessor<TResource, TQuery, TResourceType>;
+  ): PermissionRuleset<TResource, TQuery, TResourceType>;
 };
 
 // @public
@@ -351,11 +351,13 @@ export type PermissionRule<
 };
 
 // @public
-export type PermissionRuleAccessor<
+export type PermissionRuleset<
   TResource = unknown,
   TQuery = unknown,
   TResourceType extends string = string,
-> = (name: string) => PermissionRule<TResource, TQuery, TResourceType>;
+> = {
+  getRuleByName(name: string): PermissionRule<TResource, TQuery, TResourceType>;
+};
 
 // @public
 export type PolicyQuery = {

--- a/plugins/permission-node/src/integration/createConditionExports.ts
+++ b/plugins/permission-node/src/integration/createConditionExports.ts
@@ -23,6 +23,7 @@ import {
 } from '@backstage/plugin-permission-common';
 import { PermissionRule } from '../types';
 import { createConditionFactory } from './createConditionFactory';
+import { PermissionResourceRef } from './createPermissionResourceRef';
 
 /**
  * A utility type for mapping a single {@link PermissionRule} to its
@@ -73,7 +74,25 @@ export type Conditions<
  *
  * @public
  */
-export const createConditionExports = <
+export function createConditionExports<
+  TResourceType extends string,
+  TResource,
+  TRules extends Record<string, PermissionRule<TResource, any, TResourceType>>,
+>(options: {
+  resourceRef: PermissionResourceRef<TResource, any, TResourceType>;
+  rules: TRules;
+}): {
+  conditions: Conditions<TRules>;
+  createConditionalDecision: (
+    permission: ResourcePermission<TResourceType>,
+    conditions: PermissionCriteria<PermissionCondition<TResourceType>>,
+  ) => ConditionalPolicyDecision;
+};
+/**
+ * @public
+ * @deprecated Use the version of `createConditionExports` that accepts a `resourceRef` option instead.
+ */
+export function createConditionExports<
   TResourceType extends string,
   TResource,
   TRules extends Record<string, PermissionRule<TResource, any, TResourceType>>,
@@ -87,8 +106,32 @@ export const createConditionExports = <
     permission: ResourcePermission<TResourceType>,
     conditions: PermissionCriteria<PermissionCondition<TResourceType>>,
   ) => ConditionalPolicyDecision;
-} => {
-  const { pluginId, resourceType, rules } = options;
+};
+export function createConditionExports<
+  TResourceType extends string,
+  TResource,
+  TRules extends Record<string, PermissionRule<TResource, any, TResourceType>>,
+>(
+  options:
+    | {
+        resourceRef: PermissionResourceRef<TResource, any, TResourceType>;
+        rules: TRules;
+      }
+    | {
+        pluginId: string;
+        resourceType: TResourceType;
+        rules: TRules;
+      },
+): {
+  conditions: Conditions<TRules>;
+  createConditionalDecision: (
+    permission: ResourcePermission<TResourceType>,
+    conditions: PermissionCriteria<PermissionCondition<TResourceType>>,
+  ) => ConditionalPolicyDecision;
+} {
+  const { rules } = options;
+  const { pluginId, resourceType } =
+    'resourceRef' in options ? options.resourceRef : options;
 
   return {
     conditions: Object.entries(rules).reduce(
@@ -108,4 +151,4 @@ export const createConditionExports = <
       conditions,
     }),
   };
-};
+}

--- a/plugins/permission-node/src/integration/createConditionFactory.ts
+++ b/plugins/permission-node/src/integration/createConditionFactory.ts
@@ -29,7 +29,7 @@ import { PermissionRule } from '../types';
  * The rule itself defines _how_ to check a given resource, whereas a condition also includes _what_
  * to verify.
  *
- * Plugin authors should generally use the {@link createConditionExports} in order to efficiently
+ * Plugin authors should generally use the {@link (createConditionExports:1)} in order to efficiently
  * create multiple condition factories. This helper should generally only be used to construct
  * condition factories for third-party rules that aren't part of the backend plugin with which
  * they're intended to integrate.

--- a/plugins/permission-node/src/integration/createConditionTransformer.ts
+++ b/plugins/permission-node/src/integration/createConditionTransformer.ts
@@ -20,7 +20,7 @@ import {
   PermissionCondition,
   PermissionCriteria,
 } from '@backstage/plugin-permission-common';
-import { PermissionRule, PermissionRuleAccessor } from '../types';
+import { PermissionRule, PermissionRuleset } from '../types';
 import {
   createGetRule,
   isAndCriteria,
@@ -77,11 +77,11 @@ export type ConditionTransformer<TQuery> = (
  * @public
  */
 export function createConditionTransformer<TQuery>(
-  permissionRuleAccessor: PermissionRuleAccessor<any, TQuery>,
+  permissionRuleset: PermissionRuleset<any, TQuery>,
 ): ConditionTransformer<TQuery>;
 /**
  * @public
- * @deprecated Use the version of `createConditionTransformer` that accepts a `PermissionRuleAccessor` instead.
+ * @deprecated Use the version of `createConditionTransformer` that accepts a `PermissionRuleset` instead.
  */
 export function createConditionTransformer<
   TQuery,
@@ -90,11 +90,11 @@ export function createConditionTransformer<
 export function createConditionTransformer<TQuery>(
   permissionRules:
     | PermissionRule<any, TQuery, string>[]
-    | PermissionRuleAccessor<any, TQuery>,
+    | PermissionRuleset<any, TQuery>,
 ): ConditionTransformer<TQuery> {
   const getRule =
-    typeof permissionRules === 'function'
-      ? permissionRules
+    'getRuleByName' in permissionRules
+      ? (n: string) => permissionRules.getRuleByName(n)
       : createGetRule(permissionRules);
 
   return conditions => mapConditions(conditions, getRule);

--- a/plugins/permission-node/src/integration/createConditionTransformer.ts
+++ b/plugins/permission-node/src/integration/createConditionTransformer.ts
@@ -20,7 +20,7 @@ import {
   PermissionCondition,
   PermissionCriteria,
 } from '@backstage/plugin-permission-common';
-import { PermissionRule } from '../types';
+import { PermissionRule, PermissionRuleAccessor } from '../types';
 import {
   createGetRule,
   isAndCriteria,
@@ -76,13 +76,26 @@ export type ConditionTransformer<TQuery> = (
  *
  * @public
  */
-export const createConditionTransformer = <
+export function createConditionTransformer<TQuery>(
+  permissionRuleAccessor: PermissionRuleAccessor<any, TQuery>,
+): ConditionTransformer<TQuery>;
+/**
+ * @public
+ * @deprecated Use the version of `createConditionTransformer` that accepts a `PermissionRuleAccessor` instead.
+ */
+export function createConditionTransformer<
   TQuery,
   TRules extends PermissionRule<any, TQuery, string>[],
->(
-  permissionRules: [...TRules],
-): ConditionTransformer<TQuery> => {
-  const getRule = createGetRule(permissionRules);
+>(permissionRules: [...TRules]): ConditionTransformer<TQuery>;
+export function createConditionTransformer<TQuery>(
+  permissionRules:
+    | PermissionRule<any, TQuery, string>[]
+    | PermissionRuleAccessor<any, TQuery>,
+): ConditionTransformer<TQuery> {
+  const getRule =
+    typeof permissionRules === 'function'
+      ? permissionRules
+      : createGetRule(permissionRules);
 
   return conditions => mapConditions(conditions, getRule);
-};
+}

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
@@ -39,6 +39,7 @@ import {
   isOrCriteria,
 } from './util';
 import { NotImplementedError } from '@backstage/errors';
+import { PermissionResourceRef } from './createPermissionResourceRef';
 
 const permissionCriteriaSchema: z.ZodSchema<
   PermissionCriteria<PermissionCondition>
@@ -163,10 +164,22 @@ const applyConditions = <TResourceType extends string, TResource>(
  *
  * @public
  */
-export const createConditionAuthorizer = <TResource, TQuery>(
+export function createConditionAuthorizer<TResource>(
+  permissionRuleAccessor: PermissionRuleAccessor<TResource>,
+): (decision: PolicyDecision, resource: TResource | undefined) => boolean;
+/**
+ * @public
+ * @deprecated Use the version of `createConditionAuthorizer` that accepts a `PermissionRuleAccessor` instead.
+ */
+export function createConditionAuthorizer<TResource, TQuery>(
   rules: PermissionRule<TResource, TQuery, string>[],
-) => {
-  const getRule = createGetRule(rules);
+): (decision: PolicyDecision, resource: TResource | undefined) => boolean;
+export function createConditionAuthorizer<TResource, TQuery>(
+  rules:
+    | PermissionRule<TResource, TQuery, string>[]
+    | PermissionRuleAccessor<TResource>,
+): (decision: PolicyDecision, resource: TResource | undefined) => boolean {
+  const getRule = typeof rules === 'function' ? rules : createGetRule(rules);
 
   return (
     decision: PolicyDecision,
@@ -178,7 +191,7 @@ export const createConditionAuthorizer = <TResource, TQuery>(
 
     return decision.result === AuthorizeResult.ALLOW;
   };
-};
+}
 
 /**
  * Options for creating a permission integration router specific

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
@@ -30,7 +30,7 @@ import {
   PermissionCriteria,
   PolicyDecision,
 } from '@backstage/plugin-permission-common';
-import { PermissionRule } from '../types';
+import { PermissionRule, PermissionRuleAccessor } from '../types';
 import {
   NoInfer,
   createGetRule,
@@ -439,6 +439,9 @@ export function createPermissionIntegrationRouter<
       TResource
     >,
   ): void;
+  getRuleAccessor<TResource, TQuery, TResourceType extends string>(
+    resourceRef: PermissionResourceRef<TResource, TQuery, TResourceType>,
+  ): PermissionRuleAccessor<TResource, TQuery, TResourceType>;
 } {
   const store = new PermissionIntegrationMetadataStore();
 
@@ -527,6 +530,13 @@ export function createPermissionIntegrationRouter<
       >,
     ) {
       store.addResourceType(resource);
+    },
+    getRuleAccessor<TResource, TQuery, TResourceType extends string>(
+      resourceRef: PermissionResourceRef<TResource, TQuery, TResourceType>,
+    ): PermissionRuleAccessor<TResource, TQuery, TResourceType> {
+      return store.getRuleMapper(
+        resourceRef.resourceType,
+      ) as PermissionRuleAccessor<TResource, TQuery, TResourceType>;
     },
   });
 }

--- a/plugins/permission-node/src/integration/createPermissionResourceRef.ts
+++ b/plugins/permission-node/src/integration/createPermissionResourceRef.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @public
+ */
+export type PermissionResourceRef<
+  TResource = unknown,
+  TQuery = unknown,
+  TResourceType extends string = string,
+  TPluginId extends string = string,
+> = {
+  readonly $$type: '@backstage/PermissionResourceRef';
+  readonly pluginId: TPluginId;
+  readonly resourceType: TResourceType;
+  readonly TQuery: TQuery;
+  readonly TResource: TResource;
+};
+
+/**
+ * @public
+ */
+export function createPermissionResourceRef<TResource, TQuery>(): {
+  with<TPluginId extends string, TResourceType extends string>(options: {
+    pluginId: TPluginId;
+    resourceType: TResourceType;
+  }): PermissionResourceRef<TResource, TQuery, TResourceType, TPluginId>;
+} {
+  return {
+    with<TPluginId extends string, TResourceType extends string>(options: {
+      pluginId: TPluginId;
+      resourceType: TResourceType;
+    }): PermissionResourceRef<TResource, TQuery, TResourceType, TPluginId> {
+      return {
+        $$type: '@backstage/PermissionResourceRef',
+        pluginId: options.pluginId,
+        resourceType: options.resourceType,
+        TQuery: null as TQuery,
+        TResource: null as TResource,
+      };
+    },
+  };
+}

--- a/plugins/permission-node/src/integration/createPermissionRule.ts
+++ b/plugins/permission-node/src/integration/createPermissionRule.ts
@@ -29,8 +29,9 @@ import { NoInfer } from './util';
 export type CreatePermissionRuleOptions<
   TResource,
   TQuery,
+  TQueryOutput extends TQuery,
   TResourceType extends string,
-  TParams extends PermissionRuleParams = PermissionRuleParams,
+  TParams extends PermissionRuleParams,
 > = {
   name: string;
   description: string;
@@ -54,7 +55,7 @@ export type CreatePermissionRuleOptions<
    * can be used for loading a collection of resources efficiently with conditional criteria already
    * applied.
    */
-  toQuery(params: NoInfer<TParams>): PermissionCriteria<TQuery>;
+  toQuery(params: NoInfer<TParams>): PermissionCriteria<TQueryOutput>;
 };
 
 /**
@@ -65,10 +66,17 @@ export type CreatePermissionRuleOptions<
 export function createPermissionRule<
   TResource,
   TQuery,
+  TQueryOutput extends TQuery,
   TResourceType extends string,
   TParams extends PermissionRuleParams = undefined,
 >(
-  rule: CreatePermissionRuleOptions<TResource, TQuery, TResourceType, TParams>,
+  rule: CreatePermissionRuleOptions<
+    TResource,
+    TQuery,
+    TQueryOutput,
+    TResourceType,
+    TParams
+  >,
 ): PermissionRule<TResource, TQuery, TResourceType, TParams>;
 /**
  * Helper function to ensure that {@link PermissionRule} definitions are typed correctly.
@@ -87,12 +95,19 @@ export function createPermissionRule<
 export function createPermissionRule<
   TResource,
   TQuery,
+  TQueryOutput extends TQuery,
   TResourceType extends string,
   TParams extends PermissionRuleParams = undefined,
 >(
   rule:
     | PermissionRule<TResource, TQuery, TResourceType, TParams>
-    | CreatePermissionRuleOptions<TResource, TQuery, TResourceType, TParams>,
+    | CreatePermissionRuleOptions<
+        TResource,
+        TQuery,
+        TQueryOutput,
+        TResourceType,
+        TParams
+      >,
 ): PermissionRule<TResource, TQuery, TResourceType, TParams> {
   if ('resourceRef' in rule) {
     return { ...rule, resourceType: rule.resourceRef.resourceType };

--- a/plugins/permission-node/src/integration/index.ts
+++ b/plugins/permission-node/src/integration/index.ts
@@ -19,4 +19,8 @@ export * from './createConditionExports';
 export * from './createConditionTransformer';
 export * from './createPermissionIntegrationRouter';
 export * from './createPermissionRule';
+export {
+  createPermissionResourceRef,
+  type PermissionResourceRef,
+} from './createPermissionResourceRef';
 export { isAndCriteria, isOrCriteria, isNotCriteria } from './util';

--- a/plugins/permission-node/src/types.ts
+++ b/plugins/permission-node/src/types.ts
@@ -68,13 +68,11 @@ export type PermissionRule<
 };
 
 /**
- * A function that can be used to look up permission rules by name for a particular resource type.
+ * A set of registered rules for a particular resource type.
  *
  * @remarks
  *
  * Accessed via {@link @backstage/backend-plugin-api#PermissionsRegistryService.getPermissionRuleset}.
- *
- * Will throw an error if a rule with the provided name does not exist.
  *
  * @public
  */
@@ -83,5 +81,12 @@ export type PermissionRuleset<
   TQuery = unknown,
   TResourceType extends string = string,
 > = {
+  /**
+   * Returns a resource permission rule by name.
+   *
+   * @remarks
+   *
+   * Will throw an error if a rule with the provided name does not exist.
+   */
   getRuleByName(name: string): PermissionRule<TResource, TQuery, TResourceType>;
 };

--- a/plugins/permission-node/src/types.ts
+++ b/plugins/permission-node/src/types.ts
@@ -66,3 +66,20 @@ export type PermissionRule<
    */
   toQuery(params: NoInfer<TParams>): PermissionCriteria<TQuery>;
 };
+
+/**
+ * A function that can be used to look up permission rules by name for a particular resource type.
+ *
+ * @remarks
+ *
+ * Accessed via {@link @backstage/backend-plugin-api#PermissionsRegistryService.getRuleAccessor}.
+ *
+ * Will throw an error if a rule with the provided name does not exist.
+ *
+ * @public
+ */
+export type PermissionRuleAccessor<
+  TResource = unknown,
+  TQuery = unknown,
+  TResourceType extends string = string,
+> = (name: string) => PermissionRule<TResource, TQuery, TResourceType>;

--- a/plugins/permission-node/src/types.ts
+++ b/plugins/permission-node/src/types.ts
@@ -72,14 +72,16 @@ export type PermissionRule<
  *
  * @remarks
  *
- * Accessed via {@link @backstage/backend-plugin-api#PermissionsRegistryService.getRuleAccessor}.
+ * Accessed via {@link @backstage/backend-plugin-api#PermissionsRegistryService.getPermissionRuleset}.
  *
  * Will throw an error if a rule with the provided name does not exist.
  *
  * @public
  */
-export type PermissionRuleAccessor<
+export type PermissionRuleset<
   TResource = unknown,
   TQuery = unknown,
   TResourceType extends string = string,
-> = (name: string) => PermissionRule<TResource, TQuery, TResourceType>;
+> = {
+  getRuleByName(name: string): PermissionRule<TResource, TQuery, TResourceType>;
+};


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is on top of #28400, which hasn't been released yet. It fills in the gap identified by @CptnFizzbin in https://github.com/backstage/backstage/pull/28494#issuecomment-2607634349, and adds two new concepts:

- `PermissionResourceRef`: a new ref type that encapsulates the types and constants associated with a permissioned resource that supports conditional decisions.
- `PermissionRuleAccessor`: a callback that can be used to fetch permission rules by name, accessed via the new `permissionsRegistry.getRulesAccessor(...)`.

A bunch of methods have been updated to accept these new types in the permission system, including `createConditionAuthorizer` and `createConditionTransformer`.

No breaking changes here other than compared to #28400. In most places I used overloads to support the old signatures, and deprecated the old variant.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
