### PR TITLE
Allow passing ip type to cloud-sql-connector

### DIFF
--- a/.changeset/pretty-worms-walk.md
+++ b/.changeset/pretty-worms-walk.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Allow passing IP type to use with cloud-sql-connector

--- a/packages/backend-defaults/config.d.ts
+++ b/packages/backend-defaults/config.d.ts
@@ -429,6 +429,10 @@ export interface Config {
              * The instance connection name for the cloudsql instance, e.g. `project:region:instance`
              */
             instance: string;
+            /**
+             * The ip address type to use for the connection. Defaults to 'PUBLIC'
+             */
+            ipAddressType?: 'PUBLIC' | 'PRIVATE' | 'PSC';
           }
         | {
             /**

--- a/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
@@ -107,7 +107,7 @@ export async function buildPgDatabaseConfig(
   const connector = new CloudSqlConnector();
   const clientOpts = await connector.getOptions({
     instanceConnectionName: config.connection.instance,
-    ipType: IpAddressTypes.PUBLIC,
+    ipType: config.connection.ipAddressType ?? IpAddressTypes.PUBLIC,
     authType: AuthTypes.IAM,
   });
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

We do not use public IPs for databases. This will allow us to get rid of the sidecar.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
