### PR TITLE
feat: set lint `--max-warnings` to `-1`

### DIFF
--- a/.changeset/tall-meals-prove.md
+++ b/.changeset/tall-meals-prove.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': minor
+---
+
+Set the max number of warnings to `-1` during linting to enable the gradual adoption of new ESLint rules.

--- a/docs/tooling/cli/03-commands.md
+++ b/docs/tooling/cli/03-commands.md
@@ -189,7 +189,7 @@ Lint a package
 Options:
   --format <format>        Lint report output format (default: "eslint-formatter-friendly")
   --fix                    Attempt to automatically fix violations
-  --max-warnings <number>  Fail if more than this number of warnings. -1 allows warnings. (default: 0)
+  --max-warnings <number>  Fail if more than this number of warnings. -1 allows warnings. (default: -1)
 ```
 
 ## package test

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -177,7 +177,7 @@ export function registerScriptCommand(program: Command) {
     .option('--fix', 'Attempt to automatically fix violations')
     .option(
       '--max-warnings <number>',
-      'Fail if more than this number of warnings. -1 allows warnings. (default: 0)',
+      'Fail if more than this number of warnings. -1 allows warnings. (default: -1)',
     )
     .description('Lint a package')
     .action(lazy(() => import('./lint'), 'default'));

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -30,7 +30,7 @@ export default async (directories: string[], opts: OptionValues) => {
     directories.length ? directories : ['.'],
   );
 
-  const maxWarnings = opts.maxWarnings ?? 0;
+  const maxWarnings = opts.maxWarnings ?? -1;
   const ignoreWarnings = +maxWarnings === -1;
 
   const failed =


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Set the max number of warnings to `-1` during linting to facilitate the gradual adoption of new ESLint rules, such as disallowing global React imports. This came up in a discussion with @Rugvip.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
