### PR TITLE
Gitlab Merge Request: Implement opt-in for automated reviewer assignment (#28641) & fix failing Pull Request Action because of missing licenses(#28587)

### DIFF
--- a/.changeset/few-ducks-cross.md
+++ b/.changeset/few-ducks-cross.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gitlab': patch
+---
+
+Fix automated assignment of reviewers for instances without premium/ultimate license (404). Introduce opt-in flag for automatic reviewer assignment based on approval rules

--- a/plugins/scaffolder-backend-module-gitlab/report.api.md
+++ b/plugins/scaffolder-backend-module-gitlab/report.api.md
@@ -39,11 +39,11 @@ export const createGitlabIssueAction: (options: {
     projectId: number;
     labels?: string | undefined;
     description?: string | undefined;
-    weight?: number | undefined;
     token?: string | undefined;
+    weight?: number | undefined;
     assignees?: number[] | undefined;
-    createdAt?: string | undefined;
     confidential?: boolean | undefined;
+    createdAt?: string | undefined;
     milestoneId?: number | undefined;
     epicId?: number | undefined;
     dueDate?: string | undefined;
@@ -67,8 +67,8 @@ export const createGitlabProjectAccessTokenAction: (options: {
     projectId: string | number;
     name?: string | undefined;
     token?: string | undefined;
-    scopes?: string[] | undefined;
     expiresAt?: string | undefined;
+    scopes?: string[] | undefined;
     accessLevel?: number | undefined;
   },
   {
@@ -82,8 +82,8 @@ export const createGitlabProjectDeployTokenAction: (options: {
 }) => TemplateAction<
   {
     name: string;
-    scopes: string[];
     repoUrl: string;
+    scopes: string[];
     projectId: string | number;
     username?: string | undefined;
     token?: string | undefined;
@@ -124,7 +124,7 @@ export const createGitlabRepoPushAction: (options: {
     sourcePath?: string | undefined;
     targetPath?: string | undefined;
     token?: string | undefined;
-    commitAction?: 'update' | 'delete' | 'create' | undefined;
+    commitAction?: 'update' | 'create' | 'delete' | undefined;
   },
   JsonObject
 >;
@@ -205,11 +205,12 @@ export const createPublishGitlabMergeRequestAction: (options: {
     sourcePath?: string | undefined;
     targetPath?: string | undefined;
     token?: string | undefined;
-    commitAction?: 'auto' | 'update' | 'delete' | 'create' | 'skip' | undefined;
+    commitAction?: 'auto' | 'update' | 'skip' | 'create' | 'delete' | undefined;
     projectid?: string | undefined;
     removeSourceBranch?: boolean | undefined;
     assignee?: string | undefined;
     reviewers?: string[] | undefined;
+    assignReviewersFromApprovalRules?: boolean | undefined;
   },
   JsonObject
 >;
@@ -219,8 +220,8 @@ export const createTriggerGitlabPipelineAction: (options: {
   integrations: ScmIntegrationRegistry;
 }) => TemplateAction<
   {
-    branch: string;
     repoUrl: string;
+    branch: string;
     projectId: number;
     tokenDescription: string;
     token?: string | undefined;
@@ -242,8 +243,8 @@ export const editGitlabIssueAction: (options: {
     title?: string | undefined;
     labels?: string | undefined;
     description?: string | undefined;
-    weight?: number | undefined;
     token?: string | undefined;
+    weight?: number | undefined;
     assignees?: number[] | undefined;
     addLabels?: string | undefined;
     confidential?: boolean | undefined;

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabMergeRequest.test.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabMergeRequest.test.ts
@@ -52,6 +52,11 @@ const mockGitlabClient = {
   },
   MergeRequests: {
     create: jest.fn(async (repoId: string) => {
+      if (repoId === 'owner/repo-without-approval-rule-license') {
+        return {
+          iid: 6,
+        };
+      }
       if (repoId === 'owner/repo-without-approvals') {
         return {
           iid: 5,
@@ -63,6 +68,11 @@ const mockGitlabClient = {
       };
     }),
     show: jest.fn(async (repoId: string, iid: number) => {
+      if (repoId === 'owner/repo-without-approval-rule-license' && iid === 6) {
+        return {
+          iid: 6,
+        };
+      }
       if (repoId === 'owner/repo' && iid === 4) {
         return {
           iid: 4,
@@ -90,6 +100,16 @@ const mockGitlabClient = {
           options.mergerequestIId === 5
         ) {
           return [];
+        }
+        if (
+          repoId === 'owner/repo-without-approval-rule-license' &&
+          options.mergerequestIId === 6
+        ) {
+          throw new Error('Not Found', {
+            cause: {
+              description: '404 Not found',
+            },
+          });
         }
         return [
           {
@@ -608,7 +628,7 @@ describe('createGitLabMergeRequest', () => {
   });
 
   describe('createGitlabMergeRequestWithReviewers', () => {
-    it('no reviewers are set when a no reviewer are passed in options', async () => {
+    it('no dedicated reviewers are set when a no reviewer are passed in options but mr approval reviewers are set when flag activated', async () => {
       const input = {
         repoUrl: 'gitlab.com?repo=repo&owner=owner',
         title: 'Create my new MR',
@@ -617,6 +637,7 @@ describe('createGitLabMergeRequest', () => {
         removeSourceBranch: false,
         targetPath: 'Subdirectory',
         assignee: 'John Smith',
+        assignReviewersFromApprovalRules: true,
       };
       mockDir.setContent({
         [workspacePath]: {
@@ -667,6 +688,7 @@ describe('createGitLabMergeRequest', () => {
         targetPath: 'Subdirectory',
         assignee: 'John Smith',
         reviewers: ['Jane Doe', 'Bob Vance'],
+        assignReviewersFromApprovalRules: true,
       };
       mockDir.setContent({
         [workspacePath]: {
@@ -708,7 +730,53 @@ describe('createGitLabMergeRequest', () => {
       );
     });
 
-    it('reviewer is set correcly when a valid reviewer username is passed in options and no MR rules exist', async () => {
+    it('reviewer is set correcly when a valid reviewer username is passed in options in combination with deactivated approval rules', async () => {
+      const input = {
+        repoUrl: 'gitlab.com?repo=repo&owner=owner',
+        title: 'Create my new MR',
+        branchName: 'new-mr',
+        description: 'This is an important change',
+        removeSourceBranch: false,
+        targetPath: 'Subdirectory',
+        assignee: 'John Smith',
+        reviewers: ['Jane Doe', 'Bob Vance'],
+        assignReviewersFromApprovalRules: false,
+      };
+      mockDir.setContent({
+        [workspacePath]: {
+          source: { 'foo.txt': 'Hello there!' },
+          irrelevant: { 'bar.txt': 'Nothing to see here' },
+        },
+      });
+
+      const ctx = createMockActionContext({ input, workspacePath });
+      await instance.handler(ctx);
+
+      expect(mockGitlabClient.Branches.create).toHaveBeenCalledWith(
+        'owner/repo',
+        'new-mr',
+        'main',
+      );
+      expect(mockGitlabClient.Commits.create).not.toHaveBeenCalled();
+      expect(mockGitlabClient.MergeRequests.create).toHaveBeenCalledWith(
+        'owner/repo',
+        'new-mr',
+        'main',
+        'Create my new MR',
+        {
+          description: 'This is an important change',
+          removeSourceBranch: false,
+          assigneeId: 123,
+          reviewerIds: [456, 234], // Jane Doe and Bob Vance
+        },
+      );
+      expect(
+        mockGitlabClient.MergeRequestApprovals.allApprovalRules,
+      ).not.toHaveBeenCalled();
+      expect(mockGitlabClient.MergeRequests.edit).not.toHaveBeenCalled();
+    });
+
+    it('reviewer is set correctly when a valid reviewer username is passed in options and no MR rules exist and approval rules are activated', async () => {
       const input = {
         repoUrl: 'gitlab.com?repo=repo-without-approvals&owner=owner',
         title: 'Create my new MR',
@@ -718,6 +786,7 @@ describe('createGitLabMergeRequest', () => {
         targetPath: 'Subdirectory',
         assignee: 'John Smith',
         reviewers: ['Jane Doe', 'Bob Vance'],
+        assignReviewersFromApprovalRules: true,
       };
       mockDir.setContent({
         [workspacePath]: {
@@ -755,16 +824,18 @@ describe('createGitLabMergeRequest', () => {
       expect(mockGitlabClient.MergeRequests.edit).not.toHaveBeenCalled();
     });
 
-    it('reviewers are set correcly when valid reviewers username are passed in options', async () => {
+    it('reviewer is set correcly when a valid reviewer username is passed in options and MR rules are not included in the Gitlab license (404)', async () => {
       const input = {
-        repoUrl: 'gitlab.com?repo=repo&owner=owner',
+        repoUrl:
+          'gitlab.com?repo=repo-without-approval-rule-license&owner=owner',
         title: 'Create my new MR',
         branchName: 'new-mr',
         description: 'This is an important change',
         removeSourceBranch: false,
         targetPath: 'Subdirectory',
         assignee: 'John Smith',
-        reviewers: ['Jane Doe', 'John Smith'],
+        reviewers: ['Jane Doe', 'Bob Vance'],
+        assignReviewersFromApprovalRules: true,
       };
       mockDir.setContent({
         [workspacePath]: {
@@ -774,16 +845,17 @@ describe('createGitLabMergeRequest', () => {
       });
 
       const ctx = createMockActionContext({ input, workspacePath });
+      ctx.logger.warn = jest.fn();
       await instance.handler(ctx);
 
       expect(mockGitlabClient.Branches.create).toHaveBeenCalledWith(
-        'owner/repo',
+        'owner/repo-without-approval-rule-license',
         'new-mr',
         'main',
       );
       expect(mockGitlabClient.Commits.create).not.toHaveBeenCalled();
       expect(mockGitlabClient.MergeRequests.create).toHaveBeenCalledWith(
-        'owner/repo',
+        'owner/repo-without-approval-rule-license',
         'new-mr',
         'main',
         'Create my new MR',
@@ -791,9 +863,19 @@ describe('createGitLabMergeRequest', () => {
           description: 'This is an important change',
           removeSourceBranch: false,
           assigneeId: 123,
-          reviewerIds: [456, 123],
+          reviewerIds: [456, 234], // Jane Doe and Bob Vance
         },
       );
+      expect(
+        mockGitlabClient.MergeRequestApprovals.allApprovalRules,
+      ).toHaveBeenCalledWith('owner/repo-without-approval-rule-license', {
+        mergerequestIId: 6,
+      });
+      expect(mockGitlabClient.MergeRequests.edit).not.toHaveBeenCalled();
+      expect(ctx.logger.warn).toHaveBeenCalledWith(
+        'Failed to retrieve approval rules for MR 6: Error: Not Found. Proceeding with MR creation without reviewers from approval rules.',
+      );
+      expect(ctx.output).toHaveBeenCalledWith('targetBranchName', 'main'); // This ensures that the MR scaffolder step finishes successfully and all errors are catched.
     });
 
     it('assignee is not set when a valid assignee username is not passed in options', async () => {

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabMergeRequest.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabMergeRequest.ts
@@ -116,6 +116,7 @@ async function getReviewersFromApprovalRules(
         mergerequestIId: mergeRequest.iid,
       },
     );
+
     return approvalRules
       .filter(rule => rule.eligible_approvers !== undefined)
       .map(rule => {
@@ -472,23 +473,25 @@ which uses additional API calls in order to detect whether to 'create', 'update'
                 repoID,
                 ctx,
               );
-            const eligibleUserIds = new Set([
-              ...reviewersFromApprovalRules,
-              ...(reviewerIds ?? []),
-            ]);
+            if (reviewersFromApprovalRules.length > 0) {
+              const eligibleUserIds = new Set([
+                ...reviewersFromApprovalRules,
+                ...(reviewerIds ?? []),
+              ]);
 
-            mergeRequest = await api.MergeRequests.edit(
-              repoID,
-              mergeRequest.iid,
-              {
-                reviewerIds: Array.from(eligibleUserIds),
-              },
-            );
+              mergeRequest = await api.MergeRequests.edit(
+                repoID,
+                mergeRequest.iid,
+                {
+                  reviewerIds: Array.from(eligibleUserIds),
+                },
+              );
+            }
           } catch (e) {
             ctx.logger.warn(
               `Failed to assign reviewers from approval rules: ${getErrorMessage(
                 e,
-              )}`,
+              )}.`,
             );
           }
         }


### PR DESCRIPTION
## Hey, I just made a Pull Request

In a [previous MR)(#28272) I introduced 
- the option to set dedicated reviewers in the MR Action
- a function to automatically assign reviewers that are retrieved from the approval rules of the Merge Request.

There is one issue and one inconvenience with this function that should be fixed with this PR:

### Implement error handling for automatic assignment of Merge Request reviewers (#28587)
Approval Rules for Merge Requests are a Gitlab Ultimate/Premium feature. The endpoint used for this feature delivers 404 on self-hosted Gitlab instances which leads to the action failing because the error is not properly handled. 

This change outsources the retrieval of the MR reviewers into a separate function and implements a try-catch block to catch errors returned from the Gitlab API. 

### Add opt-in flag for automatic assignment of merge request reviewers based on approval rules (#28641)
The current functionality automatically assigns the **eligible codeowners** as reviewers. The issue points out that this might be a problem for cases where **a lot** of users are assigned as code owners. 
I took the proposal and hid the new functionality behind an opt-in switch.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
