### PR TITLE
feat(scaffolder): experimental flag to wait for task completions

### DIFF
--- a/.changeset/tidy-oranges-allow.md
+++ b/.changeset/tidy-oranges-allow.md
@@ -1,0 +1,12 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+Added experimental flag for scaffolder to wait for running tasks to complete on shutdown
+
+Enabling the `EXPERIMENTAL_gracefulShutdown` flag in the scaffolder config will make the
+scaffolder block the shutdown process until all running tasks have completed. This is useful
+when there is a need to ensure that all tasks have completed before the scaffolder is shut down.
+
+Please note, that the `TaskWorker` `stop` method is now asynchronous and awaited for the
+tasks to complete when the experimental flag is enabled.

--- a/plugins/scaffolder-backend/config.d.ts
+++ b/plugins/scaffolder-backend/config.d.ts
@@ -42,6 +42,11 @@ export interface Config {
     concurrentTasksLimit?: number;
 
     /**
+     * Tries to wait for tasks to finish during SIGTERM before shutting down the TaskWorker.
+     */
+    EXPERIMENTAL_gracefulShutdown?: boolean;
+
+    /**
      * Sets the tasks recoverability on system start up.
      *
      * If not specified, the default value is false.

--- a/plugins/scaffolder-backend/report.api.md
+++ b/plugins/scaffolder-backend/report.api.md
@@ -414,6 +414,7 @@ export type CreateWorkerOptions = {
   concurrentTasksLimit?: number;
   additionalTemplateGlobals?: Record<string, TemplateGlobal_2>;
   permissions?: PermissionEvaluator;
+  gracefulShutdown?: boolean;
 };
 
 // @public
@@ -841,7 +842,7 @@ export class TaskWorker {
   // (undocumented)
   start(): void;
   // (undocumented)
-  stop(): void;
+  stop(): Promise<void>;
 }
 
 // @public @deprecated (undocumented)

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/TaskWorker.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/TaskWorker.ts
@@ -29,6 +29,7 @@ import { Logger } from 'winston';
 import { TemplateActionRegistry } from '../actions';
 import { NunjucksWorkflowRunner } from './NunjucksWorkflowRunner';
 import { WorkflowRunner } from './types';
+import { setTimeout } from 'timers/promises';
 
 /**
  * TaskWorkerOptions
@@ -145,7 +146,7 @@ export class TaskWorker {
   start() {
     (async () => {
       while (!this.stopWorkers) {
-        await new Promise(resolve => setTimeout(resolve, 10000));
+        await setTimeout(10000);
         await this.recoverTasks();
       }
     })();
@@ -164,7 +165,7 @@ export class TaskWorker {
     this.stopWorkers = true;
     if (this.options?.gracefulShutdown) {
       while (this.taskQueue.size > 0) {
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await setTimeout(1000);
       }
     }
   }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Enabling the `EXPERIMENTAL_gracefulShutdown` flag in the scaffolder config will make the scaffolder block the shutdown process until all running tasks have completed. This is useful when there is a need to ensure that all tasks have completed before the scaffolder is shut down.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
