### PR TITLE
feat(scaffolder): use template title for header

### DIFF
--- a/.changeset/yellow-rules-vanish.md
+++ b/.changeset/yellow-rules-vanish.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Use template title for ongoing task page header

--- a/plugins/scaffolder/src/components/OngoingTask/OngoingTask.test.tsx
+++ b/plugins/scaffolder/src/components/OngoingTask/OngoingTask.test.tsx
@@ -17,9 +17,9 @@
 import { OngoingTask } from './OngoingTask';
 import React from 'react';
 import {
+  mockApis,
   renderInTestApp,
   TestApiProvider,
-  mockApis,
 } from '@backstage/test-utils';
 import { scaffolderApiRef } from '@backstage/plugin-scaffolder-react';
 import { act, fireEvent, waitFor, within } from '@testing-library/react';
@@ -30,6 +30,7 @@ import {
 import { rootRouteRef } from '../../routes';
 import { AuthorizeResult } from '@backstage/plugin-permission-common';
 import { SWRConfig } from 'swr';
+import { entityPresentationApiRef } from '@backstage/plugin-catalog-react';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -59,6 +60,8 @@ describe('OngoingTask', () => {
     getTask: jest.fn().mockImplementation(async () => {}),
   };
 
+  const mockEntityPresentationApi = {};
+
   beforeEach(async () => {
     jest.clearAllMocks();
   });
@@ -71,6 +74,7 @@ describe('OngoingTask', () => {
           apis={[
             [scaffolderApiRef, mockScaffolderApi],
             [permissionApiRef, permissionApi || mockApis.permission()],
+            [entityPresentationApiRef, mockEntityPresentationApi],
           ]}
         >
           <OngoingTask />

--- a/plugins/scaffolder/src/components/OngoingTask/OngoingTask.test.tsx
+++ b/plugins/scaffolder/src/components/OngoingTask/OngoingTask.test.tsx
@@ -48,7 +48,10 @@ jest.mock('@backstage/plugin-scaffolder-react', () => ({
     task: {
       spec: {
         steps: [],
-        templateInfo: { entity: { metadata: { name: 'my-template' } } },
+        templateInfo: {
+          entityRef: 'template:default/my-template',
+          entity: { metadata: { name: 'my-template' } },
+        },
       },
     },
   }),
@@ -60,7 +63,11 @@ describe('OngoingTask', () => {
     getTask: jest.fn().mockImplementation(async () => {}),
   };
 
-  const mockEntityPresentationApi = {};
+  const mockEntityPresentationApi = {
+    forEntity: jest.fn().mockReturnValue({
+      promise: new Promise(resolve => resolve({ primaryTitle: 'My template' })),
+    }),
+  };
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -83,6 +90,12 @@ describe('OngoingTask', () => {
       { mountedRoutes: { '/': rootRouteRef } },
     );
   };
+
+  it('should render title', async () => {
+    const rendered = await render();
+    expect(rendered.getByText('My template')).toBeInTheDocument();
+  });
+
   it('should trigger cancel api on "Cancel" click in context menu', async () => {
     const rendered = await render();
     const cancelOptionLabel = 'Cancel';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

using the entity presentation api, use the template title for scaffolder ongoing page header.

closes #28678

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
