### PR TITLE
poc: use case for instance metadata

### DIFF
--- a/packages/app/src/components/devtools/CustomDevToolsPage.tsx
+++ b/packages/app/src/components/devtools/CustomDevToolsPage.tsx
@@ -18,6 +18,7 @@ import {
   ConfigContent,
   ExternalDependenciesContent,
   InfoContent,
+  ListSchedulesContent,
 } from '@backstage/plugin-devtools';
 import { DevToolsLayout } from '@backstage/plugin-devtools';
 import React from 'react';
@@ -31,6 +32,9 @@ const DevToolsPage = () => {
       </DevToolsLayout.Route>
       <DevToolsLayout.Route path="config" title="Config">
         <ConfigContent />
+      </DevToolsLayout.Route>
+      <DevToolsLayout.Route path="scheduler" title="Scheduler">
+        <ListSchedulesContent />
       </DevToolsLayout.Route>
       <DevToolsLayout.Route
         path="external-dependencies"

--- a/packages/backend-defaults/src/entrypoints/scheduler/schedulerServiceFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/schedulerServiceFactory.ts
@@ -19,6 +19,7 @@ import {
   createServiceFactory,
 } from '@backstage/backend-plugin-api';
 import { DefaultSchedulerService } from './lib/DefaultSchedulerService';
+import Router from 'express-promise-router';
 
 /**
  * Scheduling of distributed background tasks.
@@ -35,8 +36,28 @@ export const schedulerServiceFactory = createServiceFactory({
     database: coreServices.database,
     logger: coreServices.logger,
     rootLifecycle: coreServices.rootLifecycle,
+    http: coreServices.httpRouter,
   },
-  async factory({ database, logger, rootLifecycle }) {
-    return DefaultSchedulerService.create({ database, logger, rootLifecycle });
+  async factory({ database, logger, rootLifecycle, http }) {
+    const schedulerService = DefaultSchedulerService.create({
+      database,
+      logger,
+      rootLifecycle,
+    });
+    const router = Router();
+    router.get('/.backstage/scheduler/v1/list', async (_, res) => {
+      res.json(await schedulerService.getScheduledTasks());
+    });
+    http.use(router);
+    schedulerService.scheduleTask({
+      id: 'test',
+      scope: 'local',
+      frequency: { minutes: 1 },
+      fn: async () => {
+        logger.info('Hello from the scheduler!');
+      },
+      timeout: { seconds: 10 },
+    });
+    return schedulerService;
   },
 });

--- a/packages/backend-defaults/src/entrypoints/scheduler/schedulerServiceFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/schedulerServiceFactory.ts
@@ -45,7 +45,7 @@ export const schedulerServiceFactory = createServiceFactory({
       rootLifecycle,
     });
     const router = Router();
-    router.get('/.backstage/scheduler/v1/list', async (_, res) => {
+    router.get('/.backstage/scheduler/v1/tasks', async (_, res) => {
       res.json(await schedulerService.getScheduledTasks());
     });
     http.use(router);

--- a/plugins/devtools-common/src/types.ts
+++ b/plugins/devtools-common/src/types.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { JsonValue } from '@backstage/types';
+import { JsonObject, JsonValue } from '@backstage/types';
 
 /** @public */
 export type Endpoint = {
@@ -68,4 +68,8 @@ export type ConfigError = {
 };
 
 /** @public */
-export type SchedulerResponse = {};
+export type SchedulerResponse = {
+  id: string;
+  scope: string;
+  settings: JsonObject;
+}[];

--- a/plugins/devtools-common/src/types.ts
+++ b/plugins/devtools-common/src/types.ts
@@ -66,3 +66,6 @@ export type ConfigError = {
   messages?: string[];
   stack?: string;
 };
+
+/** @public */
+export type SchedulerResponse = {};

--- a/plugins/devtools/package.json
+++ b/plugins/devtools/package.json
@@ -58,6 +58,7 @@
     "@backstage/frontend-plugin-api": "workspace:^",
     "@backstage/plugin-devtools-common": "workspace:^",
     "@backstage/plugin-permission-react": "workspace:^",
+    "@backstage/types": "workspace:^",
     "@material-ui/core": "^4.9.13",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.57",

--- a/plugins/devtools/src/api/DevToolsApi.ts
+++ b/plugins/devtools/src/api/DevToolsApi.ts
@@ -29,4 +29,5 @@ export interface DevToolsApi {
   getConfig(): Promise<ConfigInfo | undefined>;
   getExternalDependencies(): Promise<ExternalDependency[] | undefined>;
   getInfo(): Promise<DevToolsInfo | undefined>;
+  getScheduleForPlugin(pluginId: string): Promise<any>;
 }

--- a/plugins/devtools/src/api/DevToolsClient.ts
+++ b/plugins/devtools/src/api/DevToolsClient.ts
@@ -22,6 +22,7 @@ import {
 } from '@backstage/plugin-devtools-common';
 import { ResponseError } from '@backstage/errors';
 import { DevToolsApi } from './DevToolsApi';
+import { JsonObject } from '@backstage/types';
 
 export class DevToolsClient implements DevToolsApi {
   private readonly discoveryApi: DiscoveryApi;
@@ -58,6 +59,21 @@ export class DevToolsClient implements DevToolsApi {
 
     const info = await this.get<DevToolsInfo | undefined>(urlSegment);
     return info;
+  }
+
+  public async getScheduleForPlugin(
+    pluginId: string,
+  ): Promise<JsonObject | undefined> {
+    const baseUrl = `${await this.discoveryApi.getBaseUrl(pluginId)}/`;
+    const url = new URL('.backstage/scheduler/v1/', baseUrl);
+
+    const response = await this.fetchApi.fetch(url.toString());
+
+    if (!response.ok) {
+      throw await ResponseError.fromResponse(response);
+    }
+
+    return response.json() as Promise<any>;
   }
 
   private async get<T>(path: string): Promise<T> {

--- a/plugins/devtools/src/components/Content/ListSchedulesContent/ListSchedulesContent.tsx
+++ b/plugins/devtools/src/components/Content/ListSchedulesContent/ListSchedulesContent.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Progress, WarningPanel } from '@backstage/core-components';
+import Box from '@material-ui/core/Box';
+import Paper from '@material-ui/core/Paper';
+import Typography from '@material-ui/core/Typography';
+import {
+  createStyles,
+  makeStyles,
+  Theme,
+  useTheme,
+} from '@material-ui/core/styles';
+import Alert from '@material-ui/lab/Alert';
+import React from 'react';
+import ReactJson from 'react-json-view';
+import { useScheduler } from '../../../hooks';
+import { ConfigError } from '@backstage/plugin-devtools-common';
+import { usePlugins } from '../../../hooks/usePlugins';
+import { SchedulerContent } from '../SchedulerContent';
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    warningStyle: {
+      paddingBottom: theme.spacing(2),
+    },
+    paperStyle: {
+      padding: theme.spacing(2),
+    },
+  }),
+);
+/** @public */
+export const ListSchedulesContent = () => {
+  const classes = useStyles();
+  const theme = useTheme();
+  const { plugins, loading, error } = usePlugins();
+
+  if (loading) {
+    return <Progress />;
+  } else if (error) {
+    return <Alert severity="error">{error.message}</Alert>;
+  }
+
+  if (!plugins) {
+    return <Alert severity="error">Unable to load config</Alert>;
+  }
+
+  return (
+    <Box>
+      {plugins.map(plugin => (
+        <Paper className={classes.paperStyle} key={plugin}>
+          <Typography variant="h6">{plugin}</Typography>
+          <SchedulerContent pluginId={plugin} />
+        </Paper>
+      ))}
+    </Box>
+  );
+};

--- a/plugins/devtools/src/components/Content/ListSchedulesContent/ListSchedulesContent.tsx
+++ b/plugins/devtools/src/components/Content/ListSchedulesContent/ListSchedulesContent.tsx
@@ -60,11 +60,8 @@ export const ListSchedulesContent = () => {
 
   return (
     <Box>
-      {plugins.map(plugin => (
-        <Paper className={classes.paperStyle} key={plugin}>
-          <Typography variant="h6">{plugin}</Typography>
-          <SchedulerContent pluginId={plugin} />
-        </Paper>
+      {plugins.map(pluginId => (
+        <SchedulerContent pluginId={pluginId} key={pluginId} />
       ))}
     </Box>
   );

--- a/plugins/devtools/src/components/Content/ListSchedulesContent/index.ts
+++ b/plugins/devtools/src/components/Content/ListSchedulesContent/index.ts
@@ -14,7 +14,4 @@
  * limitations under the License.
  */
 
-export * from './ConfigContent';
-export * from './InfoContent';
-export * from './ExternalDependenciesContent';
-export * from './ListSchedulesContent';
+export { ListSchedulesContent } from './ListSchedulesContent';

--- a/plugins/devtools/src/components/Content/SchedulerContent/SchedulerContent.tsx
+++ b/plugins/devtools/src/components/Content/SchedulerContent/SchedulerContent.tsx
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Progress, WarningPanel } from '@backstage/core-components';
+import Box from '@material-ui/core/Box';
+import Paper from '@material-ui/core/Paper';
+import Typography from '@material-ui/core/Typography';
+import {
+  createStyles,
+  makeStyles,
+  Theme,
+  useTheme,
+} from '@material-ui/core/styles';
+import Alert from '@material-ui/lab/Alert';
+import React from 'react';
+import ReactJson from 'react-json-view';
+import { useScheduler } from '../../../hooks';
+import { ConfigError } from '@backstage/plugin-devtools-common';
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    warningStyle: {
+      paddingBottom: theme.spacing(2),
+    },
+    paperStyle: {
+      padding: theme.spacing(2),
+    },
+  }),
+);
+
+export const WarningContent = ({ error }: { error: ConfigError }) => {
+  if (!error.messages) {
+    return <Typography>{error.message}</Typography>;
+  }
+
+  const messages = error.messages as string[];
+
+  return (
+    <Box>
+      {messages.map(message => (
+        <Typography>{message}</Typography>
+      ))}
+    </Box>
+  );
+};
+
+/** @public */
+export const SchedulerContent = ({ pluginId }: { pluginId: string }) => {
+  const classes = useStyles();
+  const theme = useTheme();
+  const { schedules, loading, error } = useScheduler(pluginId);
+
+  if (loading) {
+    return <Progress />;
+  } else if (error) {
+    return <Alert severity="error">{error.message}</Alert>;
+  }
+
+  if (!schedules) {
+    return <Alert severity="error">Unable to load config</Alert>;
+  }
+
+  return (
+    <Box>
+      <Paper className={classes.paperStyle}>
+        <ReactJson
+          src={schedules as object}
+          name="schedule"
+          enableClipboard={false}
+          theme={theme.palette.type === 'dark' ? 'chalk' : 'rjv-default'}
+        />
+      </Paper>
+    </Box>
+  );
+};

--- a/plugins/devtools/src/components/Content/SchedulerContent/SchedulerContent.tsx
+++ b/plugins/devtools/src/components/Content/SchedulerContent/SchedulerContent.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Progress, WarningPanel } from '@backstage/core-components';
+import { Progress } from '@backstage/core-components';
 import Box from '@material-ui/core/Box';
 import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
@@ -65,23 +65,34 @@ export const SchedulerContent = ({ pluginId }: { pluginId: string }) => {
 
   if (loading) {
     return <Progress />;
-  } else if (error) {
-    return <Alert severity="error">{error.message}</Alert>;
+  }
+  if (error) {
+    return null;
   }
 
   if (!schedules) {
-    return <Alert severity="error">Unable to load config</Alert>;
+    return <Alert severity="error">Unable to load schedules</Alert>;
   }
 
   return (
     <Box>
       <Paper className={classes.paperStyle}>
-        <ReactJson
-          src={schedules as object}
-          name="schedule"
-          enableClipboard={false}
-          theme={theme.palette.type === 'dark' ? 'chalk' : 'rjv-default'}
-        />
+        <Typography variant="h6">{pluginId}</Typography>
+        <Paper className={classes.paperStyle}>
+          {schedules.map(e => (
+            <>
+              <p>
+                {e.id} | {e.scope}
+              </p>
+              <ReactJson
+                src={e.settings as object}
+                name="schedule"
+                enableClipboard={false}
+                theme={theme.palette.type === 'dark' ? 'chalk' : 'rjv-default'}
+              />
+            </>
+          ))}
+        </Paper>
       </Paper>
     </Box>
   );

--- a/plugins/devtools/src/components/Content/SchedulerContent/index.ts
+++ b/plugins/devtools/src/components/Content/SchedulerContent/index.ts
@@ -14,7 +14,4 @@
  * limitations under the License.
  */
 
-export * from './ConfigContent';
-export * from './InfoContent';
-export * from './ExternalDependenciesContent';
-export * from './ListSchedulesContent';
+export { SchedulerContent } from './SchedulerContent';

--- a/plugins/devtools/src/hooks/index.ts
+++ b/plugins/devtools/src/hooks/index.ts
@@ -17,3 +17,4 @@
 export { useConfig } from './useConfig';
 export { useExternalDependencies } from './useExternalDependencies';
 export { useInfo } from './useInfo';
+export { useScheduler } from './useScheduler';

--- a/plugins/devtools/src/hooks/usePlugins.ts
+++ b/plugins/devtools/src/hooks/usePlugins.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { devToolsApiRef } from '../api';
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
+import useAsync from 'react-use/esm/useAsync';
+import {
+  ConfigInfo,
+  SchedulerResponse,
+} from '@backstage/plugin-devtools-common';
+
+export function usePlugins(): {
+  plugins?: Array<string>;
+  loading: boolean;
+  error?: Error;
+} {
+  const config = useApi(configApiRef);
+  const { value, loading, error } = useAsync(async () => {
+    const response = await fetch(
+      `${config.getString(
+        'backend.baseUrl',
+      )}/.backstage/instanceMetadata/v1/features/installed/`,
+    );
+    if (!response.ok) {
+      throw new Error(`Failed to fetch plugins: ${response.statusText}`);
+    }
+    return ((await response.json()) as any).items
+      .filter((e: { type: string }) => e.type === 'plugin')
+      .map(e => e.pluginId);
+  }, [config]);
+
+  return {
+    plugins: value,
+    loading,
+    error,
+  };
+}

--- a/plugins/devtools/src/hooks/useScheduler.ts
+++ b/plugins/devtools/src/hooks/useScheduler.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { devToolsApiRef } from '../api';
+import { discoveryApiRef, useApi } from '@backstage/core-plugin-api';
+import useAsync from 'react-use/esm/useAsync';
+import {
+  ConfigInfo,
+  SchedulerResponse,
+} from '@backstage/plugin-devtools-common';
+
+export function useScheduler(pluginId: string): {
+  schedules?: SchedulerResponse;
+  loading: boolean;
+  error?: Error;
+} {
+  const discovery = useApi(discoveryApiRef);
+  const { value, loading, error } = useAsync(async () => {
+    const response = await fetch(
+      `${await discovery.getBaseUrl(pluginId)}/.backstage/scheduler/v1/list`,
+    );
+    if (!response.ok) {
+      throw new Error(`Failed to fetch schedules: ${response.statusText}`);
+    }
+    return response.json();
+  }, [discovery, pluginId]);
+
+  return {
+    schedules: value,
+    loading,
+    error,
+  };
+}

--- a/plugins/devtools/src/hooks/useScheduler.ts
+++ b/plugins/devtools/src/hooks/useScheduler.ts
@@ -30,7 +30,7 @@ export function useScheduler(pluginId: string): {
   const discovery = useApi(discoveryApiRef);
   const { value, loading, error } = useAsync(async () => {
     const response = await fetch(
-      `${await discovery.getBaseUrl(pluginId)}/.backstage/scheduler/v1/list`,
+      `${await discovery.getBaseUrl(pluginId)}/.backstage/scheduler/v1/tasks`,
     );
     if (!response.ok) {
       throw new Error(`Failed to fetch schedules: ${response.statusText}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6568,6 +6568,7 @@ __metadata:
     "@backstage/frontend-plugin-api": "workspace:^"
     "@backstage/plugin-devtools-common": "workspace:^"
     "@backstage/plugin-permission-react": "workspace:^"
+    "@backstage/types": "workspace:^"
     "@material-ui/core": ^4.9.13
     "@material-ui/icons": ^4.9.1
     "@material-ui/lab": ^4.0.0-alpha.57


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Quick POC following the discussion of #28129 in the SIG. Goal here is to align on a use case to drive design.

My thinking is that this could be a new DevTools page with the ability to list plugin tasks and for each task, see the last run date, task status, and be able to manually trigger the task. AFAIK those aren't currently supported from the scheduler service interface, so it would be an additional set of steps to add.

<img width="577" alt="Screenshot 2025-02-04 at 10 50 19 PM" src="https://github.com/user-attachments/assets/7dc849a0-ae2b-4171-bf8f-0ee508a2d336" />



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
