### PR TITLE
Export CatalogAutocomplete so it can be used externally

### DIFF
--- a/.changeset/red-hotels-destroy.md
+++ b/.changeset/red-hotels-destroy.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Export CatalogAutocomplete so it can be used externally

--- a/plugins/catalog-react/report.api.md
+++ b/plugins/catalog-react/report.api.md
@@ -6,6 +6,7 @@
 /// <reference types="react" />
 
 import { ApiRef } from '@backstage/core-plugin-api';
+import { AutocompleteProps } from '@material-ui/lab/Autocomplete';
 import { CATALOG_FILTER_EXISTS } from '@backstage/catalog-client';
 import { CatalogApi } from '@backstage/catalog-client';
 import { ComponentEntity } from '@backstage/catalog-model';
@@ -17,6 +18,7 @@ import { IconComponent } from '@backstage/core-plugin-api';
 import { InfoCardVariants } from '@backstage/core-components';
 import { LinkProps } from '@backstage/core-components';
 import { Observable } from '@backstage/types';
+import { OutlinedTextFieldProps } from '@material-ui/core/TextField';
 import { Overrides } from '@material-ui/core/styles/overrides';
 import { PropsWithChildren } from 'react';
 import { default as React_2 } from 'react';
@@ -28,6 +30,7 @@ import { SystemEntity } from '@backstage/catalog-model';
 import { TableColumn } from '@backstage/core-components';
 import { TableOptions } from '@backstage/core-components';
 import { TextFieldProps } from '@material-ui/core/TextField';
+import { TypographyProps } from '@material-ui/core/Typography';
 
 // @public (undocumented)
 export type AllowedEntityFilters<T extends DefaultEntityFilters> = {
@@ -70,6 +73,38 @@ export { CatalogApi };
 
 // @public
 export const catalogApiRef: ApiRef<CatalogApi>;
+
+// @public (undocumented)
+export function CatalogAutocomplete<
+  T,
+  Multiple extends boolean | undefined = undefined,
+  DisableClearable extends boolean | undefined = undefined,
+  FreeSolo extends boolean | undefined = undefined,
+>(
+  props: CatalogAutocompleteProps<T, Multiple, DisableClearable, FreeSolo>,
+): React_2.JSX.Element;
+
+// @public
+export type CatalogAutocompleteProps<
+  T,
+  Multiple extends boolean | undefined = undefined,
+  DisableClearable extends boolean | undefined = undefined,
+  FreeSolo extends boolean | undefined = undefined,
+> = Omit<
+  AutocompleteProps<T, Multiple, DisableClearable, FreeSolo>,
+  'PopperComponent' | 'PaperComponent' | 'popupIcon' | 'renderInput'
+> & {
+  name: string;
+  label?: string;
+  LabelProps?: TypographyProps<'label'>;
+  TextFieldProps?: Omit<OutlinedTextFieldProps, 'variant'>;
+  renderInput?: AutocompleteProps<
+    T,
+    Multiple,
+    DisableClearable,
+    FreeSolo
+  >['renderInput'];
+};
 
 // @public (undocumented)
 export const CatalogFilterLayout: {

--- a/plugins/catalog-react/src/components/CatalogAutocomplete/CatalogAutocomplete.tsx
+++ b/plugins/catalog-react/src/components/CatalogAutocomplete/CatalogAutocomplete.tsx
@@ -124,6 +124,11 @@ const PaperComponent = (props: PaperProps) => (
   <Paper {...props} elevation={8} />
 );
 
+/**
+ * Props for {@link CatalogAutocomplete}
+ *
+ * @public
+ */
 export type CatalogAutocompleteProps<
   T,
   Multiple extends boolean | undefined = undefined,
@@ -145,6 +150,7 @@ export type CatalogAutocompleteProps<
   >['renderInput'];
 };
 
+/** @public */
 export function CatalogAutocomplete<
   T,
   Multiple extends boolean | undefined = undefined,

--- a/plugins/catalog-react/src/components/index.ts
+++ b/plugins/catalog-react/src/components/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+export * from './CatalogAutocomplete';
 export * from './CatalogFilterLayout';
 export * from './DefaultFilters';
 export * from './EntityKindPicker';


### PR DESCRIPTION
## Hey, I just made a Pull Request! 

Export CatalogAutocomplete so it can be used externally

Fixes #28685

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
