### PR TITLE
fix(catalog-backend-module-github): decrease number of repos fetched

### DIFF
--- a/.changeset/green-kings-cheat.md
+++ b/.changeset/green-kings-cheat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+Decreased number of repositories fetched per page by GraphQL query, due to timeouts when running against big organizations.

--- a/plugins/catalog-backend-module-github/src/lib/github.ts
+++ b/plugins/catalog-backend-module-github/src/lib/github.ts
@@ -26,9 +26,9 @@ import {
 } from './defaultTransformers';
 import { withLocations } from './withLocations';
 
+import { LoggerService } from '@backstage/backend-plugin-api';
 import { DeferredEntity } from '@backstage/plugin-catalog-node';
 import { Octokit } from '@octokit/core';
-import { LoggerService } from '@backstage/backend-plugin-api';
 import { throttling } from '@octokit/plugin-throttling';
 // Graphql types
 
@@ -465,7 +465,7 @@ export async function getOrganizationRepositories(
     query repositories($org: String!, $catalogPathRef: String!, $cursor: String) {
       repositoryOwner(login: $org) {
         login
-        repositories(first: 50, after: $cursor) {
+        repositories(first: 30, after: $cursor) {
           nodes {
             name
             catalogInfoFile: object(expression: $catalogPathRef) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR is sort of a continuation of [this issue](https://github.com/backstage/backstage/issues/22318) that was solved in [this PR](https://github.com/backstage/backstage/pull/22523) by the same solution as this PR.

The change I made was to decrease the amount of repositories that are fetched by the `getOrganizationRepositories` query. It was resulting in a timeout on the Github side. After cloning and testing I found out that lowering it from 50 to 40 solves the issue. 

The error I got: 
```
Something went wrong while executing your query. This may be the result of a timeout, or it could be a GitHub bug. Please include `F0B2:197BE6:517000:536DC1:67A35A7C` when reporting this issue.\"}]}","name":"HttpError","plugin":"catalog","request":{"body":"{\"query\":\"\\n    query repositories($org: String!, $catalogPathRef: String!, $cursor: String) {\\n      repositoryOwner(login: $org) {\\n        login\\n        repositories(first: 50, after: $cursor) {\\n          nodes {\\n            name\\n            catalogInfoFile: object(expression: $catalogPathRef) {\\n              __typename\\n              ... on Blob {\\n                id\\n                text\\n              }\\n            }\\n            url\\n            isArchived\\n            isFork\\n            visibility\\n            repositoryTopics(first: 100)...........
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
