### PR TITLE
feat(techdocs): generator timeout config

### DIFF
--- a/.changeset/slow-dots-applaud.md
+++ b/.changeset/slow-dots-applaud.md
@@ -1,0 +1,10 @@
+---
+'@backstage/plugin-techdocs-backend': patch
+'@backstage/plugin-techdocs-node': patch
+---
+
+Support timeout in the techdocs generator
+
+This allows to set a timeout for the techdocs generator to prevent it from running indefinitely.
+The timeout can be configured in the techdocs-backend config with `techdocs.generator.timeout`
+key.

--- a/plugins/techdocs-backend/config.d.ts
+++ b/plugins/techdocs-backend/config.d.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { HumanDuration } from '@backstage/types';
+
 export interface Config {
   /**
    * Configuration options for the techdocs-backend plugin
@@ -44,6 +46,11 @@ export interface Config {
        * Pull the latest docker image
        */
       pullImage?: boolean;
+
+      /**
+       * Generator timeout
+       */
+      timeout?: HumanDuration | string;
 
       /**
        * Override behavior specific to mkdocs.

--- a/plugins/techdocs-backend/package.json
+++ b/plugins/techdocs-backend/package.json
@@ -71,6 +71,7 @@
     "@backstage/plugin-search-backend-module-techdocs": "workspace:^",
     "@backstage/plugin-techdocs-common": "workspace:^",
     "@backstage/plugin-techdocs-node": "workspace:^",
+    "@backstage/types": "workspace:^",
     "@types/express": "^4.17.6",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",

--- a/plugins/techdocs-node/package.json
+++ b/plugins/techdocs-node/package.json
@@ -61,6 +61,7 @@
     "@backstage/integration-aws-node": "workspace:^",
     "@backstage/plugin-search-common": "workspace:^",
     "@backstage/plugin-techdocs-common": "workspace:^",
+    "@backstage/types": "workspace:^",
     "@google-cloud/storage": "^7.0.0",
     "@smithy/node-http-handler": "^3.0.0",
     "@trendyol-js/openstack-swift-sdk": "^0.0.7",

--- a/plugins/techdocs-node/src/stages/generate/DockerContainerRunner.ts
+++ b/plugins/techdocs-node/src/stages/generate/DockerContainerRunner.ts
@@ -17,11 +17,9 @@
 import Docker from 'dockerode';
 import fs from 'fs-extra';
 import { ForwardedError } from '@backstage/errors';
-import { PassThrough } from 'stream';
-import { pipeline as pipelineStream } from 'stream';
+import { PassThrough, pipeline as pipelineStream, Writable } from 'stream';
 import { promisify } from 'util';
 import { TechDocsContainerRunner } from './types';
-import { Writable } from 'stream';
 
 const pipeline = promisify(pipelineStream);
 
@@ -35,8 +33,8 @@ export type UserOptions = {
 export class DockerContainerRunner implements TechDocsContainerRunner {
   private readonly dockerClient: Docker;
 
-  constructor() {
-    this.dockerClient = new Docker();
+  constructor(options?: { timeout?: number }) {
+    this.dockerClient = new Docker(options);
   }
 
   async runContainer(options: {

--- a/plugins/techdocs-node/src/stages/generate/techdocs.test.ts
+++ b/plugins/techdocs-node/src/stages/generate/techdocs.test.ts
@@ -47,12 +47,14 @@ describe('readGeneratorConfig', () => {
       techdocs: {
         generator: {
           runIn: 'local',
+          timeout: { minutes: 5 },
         },
       },
     });
 
     expect(readGeneratorConfig(config, logger)).toEqual({
       runIn: 'local',
+      timeout: 5 * 60 * 1000,
     });
   });
 

--- a/plugins/techdocs-node/src/stages/generate/types.ts
+++ b/plugins/techdocs-node/src/stages/generate/types.ts
@@ -45,6 +45,7 @@ export type GeneratorConfig = {
   omitTechdocsCoreMkdocsPlugin?: boolean;
   legacyCopyReadmeMdToIndexMd?: boolean;
   defaultPlugins?: string[];
+  timeout?: number;
 };
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -8394,6 +8394,7 @@ __metadata:
     "@backstage/plugin-search-backend-module-techdocs": "workspace:^"
     "@backstage/plugin-techdocs-common": "workspace:^"
     "@backstage/plugin-techdocs-node": "workspace:^"
+    "@backstage/types": "workspace:^"
     "@types/express": ^4.17.6
     express: ^4.17.1
     express-promise-router: ^4.1.0
@@ -8470,6 +8471,7 @@ __metadata:
     "@backstage/integration-aws-node": "workspace:^"
     "@backstage/plugin-search-common": "workspace:^"
     "@backstage/plugin-techdocs-common": "workspace:^"
+    "@backstage/types": "workspace:^"
     "@google-cloud/storage": ^7.0.0
     "@smithy/node-http-handler": ^3.0.0
     "@trendyol-js/openstack-swift-sdk": ^0.0.7


### PR DESCRIPTION
## Hey, I just made a Pull Request!

this allows specifying techdocs generator timeout in configuration that prevents techdocs generation to take infinite time in some cases like with huge `plantuml` diagrams and local `mkdocs` renderer.

it does not fix the potential memory leak #27347 but might improve the situation so that sockets get closed in case the generating is blocking the system.

the timeout works both with the default docker generator as well as with the local `mkdocs`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
