### PR TITLE
scaffolder: attach form field extensions to page instead

### DIFF
--- a/.changeset/lazy-apricots-whisper.md
+++ b/.changeset/lazy-apricots-whisper.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+Deprecated the alpha `ScaffolderFormFieldsApi` and `formFieldsApiRef` as these are being replaced with a different solution.

--- a/.changeset/swift-worms-behave.md
+++ b/.changeset/swift-worms-behave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Updated the alpha `page:scaffolder` extension to accept `formFields` input, matching the updated `FormFieldBlueprint`.

--- a/plugins/app-visualizer/report.api.md
+++ b/plugins/app-visualizer/report.api.md
@@ -16,6 +16,27 @@ const visualizerPlugin: FrontendPlugin<
   {},
   {},
   {
+    'nav-item:app-visualizer': ExtensionDefinition<{
+      kind: 'nav-item';
+      name: undefined;
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        {
+          title: string;
+          icon: IconComponent;
+          routeRef: RouteRef<undefined>;
+        },
+        'core.nav-item.target',
+        {}
+      >;
+      inputs: {};
+      params: {
+        title: string;
+        icon: IconComponent;
+        routeRef: RouteRef<undefined>;
+      };
+    }>;
     'page:app-visualizer': ExtensionDefinition<{
       kind: 'page';
       name: undefined;
@@ -44,27 +65,6 @@ const visualizerPlugin: FrontendPlugin<
         defaultPath: string;
         loader: () => Promise<JSX.Element>;
         routeRef?: RouteRef<AnyRouteRefParams> | undefined;
-      };
-    }>;
-    'nav-item:app-visualizer': ExtensionDefinition<{
-      kind: 'nav-item';
-      name: undefined;
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        {
-          title: string;
-          icon: IconComponent;
-          routeRef: RouteRef<undefined>;
-        },
-        'core.nav-item.target',
-        {}
-      >;
-      inputs: {};
-      params: {
-        title: string;
-        icon: IconComponent;
-        routeRef: RouteRef<undefined>;
       };
     }>;
   }

--- a/plugins/catalog-import/report-alpha.api.md
+++ b/plugins/catalog-import/report-alpha.api.md
@@ -18,6 +18,21 @@ const _default: FrontendPlugin<
   },
   {},
   {
+    'api:catalog-import': ExtensionDefinition<{
+      kind: 'api';
+      name: undefined;
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
+    }>;
     'page:catalog-import': ExtensionDefinition<{
       kind: 'page';
       name: undefined;
@@ -46,21 +61,6 @@ const _default: FrontendPlugin<
         defaultPath: string;
         loader: () => Promise<JSX.Element>;
         routeRef?: RouteRef<AnyRouteRefParams> | undefined;
-      };
-    }>;
-    'api:catalog-import': ExtensionDefinition<{
-      kind: 'api';
-      name: undefined;
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        AnyApiFactory,
-        'core.api.factory',
-        {}
-      >;
-      inputs: {};
-      params: {
-        factory: AnyApiFactory;
       };
     }>;
   }

--- a/plugins/devtools/report-alpha.api.md
+++ b/plugins/devtools/report-alpha.api.md
@@ -19,36 +19,6 @@ const _default: FrontendPlugin<
   },
   {},
   {
-    'page:devtools': ExtensionDefinition<{
-      kind: 'page';
-      name: undefined;
-      config: {
-        path: string | undefined;
-      };
-      configInput: {
-        path?: string | undefined;
-      };
-      output:
-        | ConfigurableExtensionDataRef<
-            React_2.JSX.Element,
-            'core.reactElement',
-            {}
-          >
-        | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
-        | ConfigurableExtensionDataRef<
-            RouteRef<AnyRouteRefParams>,
-            'core.routing.ref',
-            {
-              optional: true;
-            }
-          >;
-      inputs: {};
-      params: {
-        defaultPath: string;
-        loader: () => Promise<JSX.Element>;
-        routeRef?: RouteRef<AnyRouteRefParams> | undefined;
-      };
-    }>;
     'nav-item:devtools': ExtensionDefinition<{
       kind: 'nav-item';
       name: undefined;
@@ -83,6 +53,36 @@ const _default: FrontendPlugin<
       inputs: {};
       params: {
         factory: AnyApiFactory;
+      };
+    }>;
+    'page:devtools': ExtensionDefinition<{
+      kind: 'page';
+      name: undefined;
+      config: {
+        path: string | undefined;
+      };
+      configInput: {
+        path?: string | undefined;
+      };
+      output:
+        | ConfigurableExtensionDataRef<
+            React_2.JSX.Element,
+            'core.reactElement',
+            {}
+          >
+        | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
+        | ConfigurableExtensionDataRef<
+            RouteRef<AnyRouteRefParams>,
+            'core.routing.ref',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+      params: {
+        defaultPath: string;
+        loader: () => Promise<JSX.Element>;
+        routeRef?: RouteRef<AnyRouteRefParams> | undefined;
       };
     }>;
   }

--- a/plugins/kubernetes/report-alpha.api.md
+++ b/plugins/kubernetes/report-alpha.api.md
@@ -22,6 +22,21 @@ const _default: FrontendPlugin<
   },
   {},
   {
+    'api:kubernetes': ExtensionDefinition<{
+      kind: 'api';
+      name: undefined;
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
+    }>;
     'page:kubernetes': ExtensionDefinition<{
       kind: 'page';
       name: undefined;
@@ -46,21 +61,6 @@ const _default: FrontendPlugin<
         defaultPath: string;
         loader: () => Promise<JSX.Element>;
         routeRef?: RouteRef<AnyRouteRefParams> | undefined;
-      };
-    }>;
-    'api:kubernetes': ExtensionDefinition<{
-      kind: 'api';
-      name: undefined;
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        AnyApiFactory,
-        'core.api.factory',
-        {}
-      >;
-      inputs: {};
-      params: {
-        factory: AnyApiFactory;
       };
     }>;
     'entity-content:kubernetes/kubernetes': ExtensionDefinition<{

--- a/plugins/scaffolder-react/report-alpha.api.md
+++ b/plugins/scaffolder-react/report-alpha.api.md
@@ -224,7 +224,7 @@ export const formFieldsApi: ExtensionDefinition<{
   };
 }>;
 
-// @alpha (undocumented)
+// @alpha @deprecated (undocumented)
 export const formFieldsApiRef: ApiRef<ScaffolderFormFieldsApi>;
 
 // @alpha (undocumented)
@@ -301,7 +301,7 @@ export type ScaffolderFormDecoratorContext<
   ) => void;
 };
 
-// @alpha (undocumented)
+// @alpha @deprecated (undocumented)
 export interface ScaffolderFormFieldsApi {
   // (undocumented)
   getFormFields(): Promise<FormFieldExtensionData[]>;

--- a/plugins/scaffolder-react/src/next/api/ref.ts
+++ b/plugins/scaffolder-react/src/next/api/ref.ts
@@ -17,7 +17,10 @@
 import { createApiRef } from '@backstage/frontend-plugin-api';
 import { ScaffolderFormFieldsApi } from './types';
 
-/** @alpha */
+/**
+ * @alpha
+ * @deprecated This API is no longer necessary and will be removed
+ */
 export const formFieldsApiRef = createApiRef<ScaffolderFormFieldsApi>({
   id: 'plugin.scaffolder.form-fields',
 });

--- a/plugins/scaffolder-react/src/next/api/types.ts
+++ b/plugins/scaffolder-react/src/next/api/types.ts
@@ -16,7 +16,10 @@
 
 import { FormFieldExtensionData } from '../blueprints';
 
-/** @alpha */
+/**
+ * @alpha
+ * @deprecated This API is no longer necessary and will be removed
+ */
 export interface ScaffolderFormFieldsApi {
   getFormFields(): Promise<FormFieldExtensionData[]>;
 }

--- a/plugins/scaffolder-react/src/next/blueprints/FormFieldBlueprint.tsx
+++ b/plugins/scaffolder-react/src/next/blueprints/FormFieldBlueprint.tsx
@@ -34,7 +34,10 @@ const formFieldExtensionDataRef = createExtensionDataRef<
  * */
 export const FormFieldBlueprint = createExtensionBlueprint({
   kind: 'scaffolder-form-field',
-  attachTo: { id: 'api:scaffolder/form-fields', input: 'formFields' },
+  attachTo: [
+    { id: 'page:scaffolder', input: 'formFields' },
+    { id: 'api:scaffolder/form-fields', input: 'formFields' },
+  ],
   dataRefs: {
     formFieldLoader: formFieldExtensionDataRef,
   },

--- a/plugins/scaffolder/report-alpha.api.md
+++ b/plugins/scaffolder/report-alpha.api.md
@@ -108,8 +108,6 @@ const _default: FrontendPlugin<
       };
     }>;
     'page:scaffolder': ExtensionDefinition<{
-      kind: 'page';
-      name: undefined;
       config: {
         path: string | undefined;
       };
@@ -126,7 +124,21 @@ const _default: FrontendPlugin<
               optional: true;
             }
           >;
-      inputs: {};
+      inputs: {
+        formFields: ExtensionInput<
+          ConfigurableExtensionDataRef<
+            () => Promise<FormField>,
+            'scaffolder.form-field-loader',
+            {}
+          >,
+          {
+            singleton: false;
+            optional: false;
+          }
+        >;
+      };
+      kind: 'page';
+      name: undefined;
       params: {
         defaultPath: string;
         loader: () => Promise<JSX.Element>;

--- a/plugins/scaffolder/src/alpha/extensions.tsx
+++ b/plugins/scaffolder/src/alpha/extensions.tsx
@@ -26,6 +26,7 @@ import {
   discoveryApiRef,
   fetchApiRef,
   identityApiRef,
+  createExtensionInput,
 } from '@backstage/frontend-plugin-api';
 import React from 'react';
 import { rootRouteRef } from '../routes';
@@ -35,12 +36,26 @@ import { scmIntegrationsApiRef } from '@backstage/integration-react';
 import { scaffolderApiRef } from '@backstage/plugin-scaffolder-react';
 import { ScaffolderClient } from '../api';
 
-export const scaffolderPage = PageBlueprint.make({
-  params: {
-    routeRef: convertLegacyRouteRef(rootRouteRef),
-    defaultPath: '/create',
-    loader: () =>
-      import('../components/Router').then(m => compatWrapper(<m.Router />)),
+export const scaffolderPage = PageBlueprint.makeWithOverrides({
+  inputs: {
+    formFields: createExtensionInput([
+      FormFieldBlueprint.dataRefs.formFieldLoader,
+    ]),
+  },
+  factory(originalFactory, { inputs }) {
+    const formFieldLoaders = inputs.formFields.map(i =>
+      i.get(FormFieldBlueprint.dataRefs.formFieldLoader),
+    );
+    return originalFactory({
+      routeRef: convertLegacyRouteRef(rootRouteRef),
+      defaultPath: '/create',
+      loader: () =>
+        import('../components/Router/Router').then(m =>
+          compatWrapper(
+            <m.InternalRouter formFieldLoaders={formFieldLoaders} />,
+          ),
+        ),
+    });
   },
 });
 

--- a/plugins/scaffolder/src/components/Router/Router.tsx
+++ b/plugins/scaffolder/src/components/Router/Router.tsx
@@ -64,6 +64,8 @@ import {
   templateManagementPermission,
 } from '@backstage/plugin-scaffolder-common/alpha';
 import { useApp } from '@backstage/core-plugin-api';
+import { FormField, OpaqueFormField } from '@internal/scaffolder';
+import { useAsync, useMountEffect } from '@react-hookz/web';
 
 /**
  * The Props for the Scaffolder Router
@@ -105,11 +107,16 @@ export type RouterProps = {
 };
 
 /**
- * The Scaffolder Router
+ * Internal router with additional props that aren't available in the public API
+ * for the old frontend system.
  *
- * @public
+ * @internal
  */
-export const Router = (props: PropsWithChildren<RouterProps>) => {
+export const InternalRouter = (
+  props: PropsWithChildren<
+    RouterProps & { formFieldLoaders?: Array<() => Promise<FormField>> }
+  >,
+) => {
   const {
     components: {
       TemplateCardComponent,
@@ -123,13 +130,15 @@ export const Router = (props: PropsWithChildren<RouterProps>) => {
     } = {},
   } = props;
   const outlet = useOutlet() || props.children;
-  const customFieldExtensions =
-    useCustomFieldExtensions<FieldExtensionOptions>(outlet);
+  const customFieldExtensions = useCustomFieldExtensions(outlet);
+  const loadedFieldExtensions = useFormFieldLoaders(props.formFieldLoaders);
+
   const app = useApp();
   const { NotFoundErrorPage } = app.getComponents();
 
   const fieldExtensions = [
     ...customFieldExtensions,
+    ...loadedFieldExtensions,
     ...DEFAULT_SCAFFOLDER_FIELD_EXTENSIONS.filter(
       ({ name }) =>
         !customFieldExtensions.some(
@@ -243,3 +252,26 @@ export const Router = (props: PropsWithChildren<RouterProps>) => {
     </Routes>
   );
 };
+
+/**
+ * The Scaffolder Router
+ *
+ * @public
+ */
+export const Router = (props: PropsWithChildren<RouterProps>) => {
+  return <InternalRouter {...props} />;
+};
+
+function useFormFieldLoaders(
+  formFieldLoaders?: Array<() => Promise<FormField>>,
+) {
+  const [{ result: loadedFieldExtensions }, { execute }] =
+    useAsync(async () => {
+      const loaded = await Promise.all(
+        (formFieldLoaders ?? []).map(loader => loader()),
+      );
+      return loaded.map(f => OpaqueFormField.toInternal(f));
+    }, []);
+  useMountEffect(execute);
+  return loadedFieldExtensions;
+}

--- a/plugins/techdocs/report-alpha.api.md
+++ b/plugins/techdocs/report-alpha.api.md
@@ -31,36 +31,6 @@ const _default: FrontendPlugin<
   },
   {},
   {
-    'page:techdocs': ExtensionDefinition<{
-      kind: 'page';
-      name: undefined;
-      config: {
-        path: string | undefined;
-      };
-      configInput: {
-        path?: string | undefined;
-      };
-      output:
-        | ConfigurableExtensionDataRef<
-            React_2.JSX.Element,
-            'core.reactElement',
-            {}
-          >
-        | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
-        | ConfigurableExtensionDataRef<
-            RouteRef<AnyRouteRefParams>,
-            'core.routing.ref',
-            {
-              optional: true;
-            }
-          >;
-      inputs: {};
-      params: {
-        defaultPath: string;
-        loader: () => Promise<JSX.Element>;
-        routeRef?: RouteRef<AnyRouteRefParams> | undefined;
-      };
-    }>;
     'nav-item:techdocs': ExtensionDefinition<{
       kind: 'nav-item';
       name: undefined;
@@ -110,6 +80,36 @@ const _default: FrontendPlugin<
       inputs: {};
       params: {
         factory: AnyApiFactory;
+      };
+    }>;
+    'page:techdocs': ExtensionDefinition<{
+      kind: 'page';
+      name: undefined;
+      config: {
+        path: string | undefined;
+      };
+      configInput: {
+        path?: string | undefined;
+      };
+      output:
+        | ConfigurableExtensionDataRef<
+            React_2.JSX.Element,
+            'core.reactElement',
+            {}
+          >
+        | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
+        | ConfigurableExtensionDataRef<
+            RouteRef<AnyRouteRefParams>,
+            'core.routing.ref',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+      params: {
+        defaultPath: string;
+        loader: () => Promise<JSX.Element>;
+        routeRef?: RouteRef<AnyRouteRefParams> | undefined;
       };
     }>;
     'search-result-list-item:techdocs': ExtensionDefinition<{


### PR DESCRIPTION
## Hey, I just made a Pull Request!

On top of #28619. Draft for now to align on whether this is how we want to move forward. 👀 @benjdlambert @camilaibs 

I'm a lil bit worried about the implication of multiple parents when it comes to deprecations and redirects, although as seen in this PR it can also be a decent tool for deprecating extensions.

If we're happy with this path I'll also migrate the decorators API and add changesets etc.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
