### PR TITLE
Made gitlab:group:ensureExists action idempotent.

### DIFF
--- a/.changeset/beige-cycles-sit.md
+++ b/.changeset/beige-cycles-sit.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gitlab': patch
+'@backstage/plugin-scaffolder-node-test-utils': patch
+---
+
+Made gitlab:group:ensureExists action idempotent

--- a/.changeset/beige-cycles-sit.md
+++ b/.changeset/beige-cycles-sit.md
@@ -1,6 +1,5 @@
 ---
 '@backstage/plugin-scaffolder-backend-module-gitlab': patch
-'@backstage/plugin-scaffolder-node-test-utils': patch
 ---
 
 Made gitlab:group:ensureExists action idempotent

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabGroupEnsureExists.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabGroupEnsureExists.ts
@@ -90,17 +90,24 @@ export const createGitlabGroupEnsureExistsAction = (options: {
         );
         if (!subGroup) {
           ctx.logger.info(`creating missing group ${fullPath}`);
-          parentId = (
-            await api.Groups.create(
-              name,
-              slug,
-              parentId
-                ? {
-                    parentId: parentId,
-                  }
-                : {},
-            )
-          )?.id;
+
+          parentId = await ctx.checkpoint({
+            key: `ensure.${name}.${slug}.${parentId}`,
+            // eslint-disable-next-line no-loop-func
+            fn: async () => {
+              return (
+                await api.Groups.create(
+                  name,
+                  slug,
+                  parentId
+                    ? {
+                        parentId: parentId,
+                      }
+                    : {},
+                )
+              )?.id;
+            },
+          });
         } else {
           parentId = subGroup.id;
         }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Made gitlab:group:ensureExists action idempotent. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
