### PR TITLE
Allow disabling the header divider on homepage cards

### DIFF
--- a/.changeset/late-hairs-kneel.md
+++ b/.changeset/late-hairs-kneel.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-home-react': patch
+---
+
+Don't render header divider on homepage cards if no title was specified.

--- a/plugins/home-react/src/extensions.tsx
+++ b/plugins/home-react/src/extensions.tsx
@@ -47,7 +47,9 @@ export type RendererProps = { title?: string } & ComponentParts;
 /**
  * @public
  */
-export type CardExtensionProps<T> = ComponentRenderer & { title?: string } & T;
+export type CardExtensionProps<T> = ComponentRenderer & {
+  title?: string;
+} & T;
 
 /**
  * @public
@@ -150,7 +152,7 @@ function CardExtension<T>(props: CardExtensionComponentProps<T>) {
   }
 
   const cardProps = {
-    ...(title && { title }),
+    ...(title && { title, divider: !!title }),
     ...(Settings && !isCustomizable
       ? {
           action: (


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Some homepage cards would like to define their own header for example, so that a title can be set dynamically.

Removing the divider with the divider prop provides a way to put everything in the content area without an extraneous divider above.

The divider is usually not easily visible using the default theme, however customized themes that may use a larger border-radius this divider becomes visible and distracting.

### Default Theme
The divider is visible, but blends into the border, (All content including the "header" is in the content section)
<img width="979" alt="Screenshot 2025-02-06 at 8 59 39 AM" src="https://github.com/user-attachments/assets/37af818b-5cb8-4c74-9d18-b138b1749ba1" />

Homepage Card that uses the title prop, and all content in the content area, no extraneous divider.
<img width="513" alt="Screenshot 2025-02-10 at 9 55 49 AM" src="https://github.com/user-attachments/assets/037121ca-df17-4612-9513-f7c1b749d52b" />

### Modified Theme (border radius)
The divider becomes visible. Note that rather than using the `title` field we are still using the content area because we have a more complex header than a simple title. It is dynamic and has multiple sections

<img width="518" alt="Screenshot 2025-02-06 at 9 00 50 AM" src="https://github.com/user-attachments/assets/fb871244-d652-4e59-b63c-1a76d68e8b4b" />

### Using the noDivider prop from this PR
<img width="665" alt="Screenshot 2025-02-06 at 9 03 37 AM" src="https://github.com/user-attachments/assets/afc4355f-7fb1-4746-862d-f59aed68f576" />


### From the default widgets with and without noDivider
<img width="558" alt="Screenshot 2025-02-10 at 1 22 55 PM" src="https://github.com/user-attachments/assets/528a7c33-344f-4352-9383-0d60b6a3275f" />
<img width="522" alt="Screenshot 2025-02-10 at 1 23 18 PM" src="https://github.com/user-attachments/assets/4bf3582e-0522-4720-a554-d0ca1db09073" />

Verified using `<HomePageRandomJoke noDivider />`

#### :heavy_check_mark: Checklist


<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
