### PR TITLE
feat(catalog-graph): add i18n support for catalog-graph plugin

### DIFF
--- a/.changeset/odd-planes-teach.md
+++ b/.changeset/odd-planes-teach.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-graph': patch
+---
+
+Add i18n support for catalog-graph plugin

--- a/plugins/catalog-graph/report-alpha.api.md
+++ b/plugins/catalog-graph/report-alpha.api.md
@@ -14,6 +14,32 @@ import { ExternalRouteRef } from '@backstage/frontend-plugin-api';
 import { FrontendPlugin } from '@backstage/frontend-plugin-api';
 import { default as React_2 } from 'react';
 import { RouteRef } from '@backstage/frontend-plugin-api';
+import { TranslationRef } from '@backstage/core-plugin-api/alpha';
+
+// @alpha (undocumented)
+export const catalogGraphTranslationRef: TranslationRef<
+  'catalog-graph',
+  {
+    readonly 'catalogGraphCard.viewGraphTitle': 'View graph';
+    readonly 'catalogGraphPage.title': 'Catalog Graph';
+    readonly 'catalogGraphPage.graph.zoomLegendContent': 'Use pinch & zoom to move around the diagram. Click to change active node, shift click to navigate to entity.';
+    readonly 'catalogGraphPage.filterListButtonLabel': 'Filters';
+    readonly 'catalogGraphPage.supportButtonContent': 'Start tracking your component in by adding it to the software catalog.';
+    readonly 'curveFilter.displayName.curveStepBefore': 'Step Before';
+    readonly 'curveFilter.displayName.curveMonotoneX': 'Monotone X';
+    readonly 'curveFilter.selectLabel': 'Curve';
+    readonly 'directionFilter.displayName.leftToRight': 'Left to right';
+    readonly 'directionFilter.displayName.rightToLeft': 'Right to left';
+    readonly 'directionFilter.displayName.topToBottom': 'Top to bottom';
+    readonly 'directionFilter.displayName.bottomToTop': 'Bottom to top';
+    readonly 'directionFilter.selectLabel': 'Direction';
+    readonly 'maxDepthFilter.selectLabel': 'Max Depth';
+    readonly 'maxDepthFilter.inputPlaceholder': '∞ Infinite';
+    readonly 'selectedKindsFilter.selectLabel': 'Kinds';
+    readonly 'selectedKindsFilter.failAlertMessage': 'Failed to load entity kinds';
+    readonly 'selectedRelationsFilter.selectedLabel': 'Relations';
+  }
+>;
 
 // @public (undocumented)
 const _default: FrontendPlugin<

--- a/plugins/catalog-graph/src/alpha.tsx
+++ b/plugins/catalog-graph/src/alpha.tsx
@@ -96,3 +96,5 @@ export default createFrontendPlugin({
   },
   extensions: [CatalogGraphPage, CatalogGraphEntityCard],
 });
+
+export { catalogGraphTranslationRef } from './translation';

--- a/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.tsx
@@ -36,8 +36,10 @@ import {
   Direction,
   EntityNode,
   EntityRelationsGraph,
+  EntityRelationsGraphProps,
 } from '../EntityRelationsGraph';
-import { EntityRelationsGraphProps } from '../EntityRelationsGraph';
+import { useTranslationRef } from '@backstage/frontend-plugin-api';
+import { catalogGraphTranslationRef } from '../../translation';
 
 /** @public */
 export type CatalogGraphCardClassKey = 'card' | 'graph';
@@ -92,6 +94,7 @@ export const CatalogGraphCard = (
   const navigate = useNavigate();
   const classes = useStyles({ height });
   const analytics = useAnalytics();
+  const { t } = useTranslationRef(catalogGraphTranslationRef);
 
   const defaultOnNodeClick = useCallback(
     (node: EntityNode, _: MouseEvent<unknown>) => {
@@ -133,7 +136,7 @@ export const CatalogGraphCard = (
       variant={variant}
       noPadding
       deepLink={{
-        title: 'View graph',
+        title: t('catalogGraphCard.viewGraphTitle'),
         link: catalogGraphUrl,
       }}
     >

--- a/plugins/catalog-graph/src/components/CatalogGraphPage/CatalogGraphPage.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphPage/CatalogGraphPage.tsx
@@ -50,6 +50,8 @@ import { SelectedKindsFilter } from './SelectedKindsFilter';
 import { SelectedRelationsFilter } from './SelectedRelationsFilter';
 import { SwitchFilter } from './SwitchFilter';
 import { useCatalogGraphPage } from './useCatalogGraphPage';
+import { useTranslationRef } from '@backstage/frontend-plugin-api';
+import { catalogGraphTranslationRef } from '../../translation';
 
 /** @public */
 export type CatalogGraphPageClassKey =
@@ -188,11 +190,12 @@ export const CatalogGraphPage = (
     },
     [catalogEntityRoute, navigate, setRootEntityNames, analytics],
   );
+  const { t } = useTranslationRef(catalogGraphTranslationRef);
 
   return (
     <Page themeId="home">
       <Header
-        title="Catalog Graph"
+        title={t('catalogGraphPage.title')}
         subtitle={rootEntityNames.map(e => humanizeEntityRef(e)).join(', ')}
       />
       <Content stretch className={classes.content}>
@@ -203,14 +206,11 @@ export const CatalogGraphPage = (
               selected={showFilters}
               onChange={() => toggleShowFilters()}
             >
-              <FilterListIcon /> Filters
+              <FilterListIcon /> {t('catalogGraphPage.filterListButtonLabel')}
             </ToggleButton>
           }
         >
-          <SupportButton>
-            Start tracking your component in by adding it to the software
-            catalog.
-          </SupportButton>
+          <SupportButton title={t('catalogGraphPage.supportButtonContent')} />
         </ContentHeader>
         <Grid container alignItems="stretch" className={classes.container}>
           {showFilters && (
@@ -247,9 +247,8 @@ export const CatalogGraphPage = (
                 display="block"
                 className={classes.legend}
               >
-                <ZoomOutMap className="icon" /> Use pinch &amp; zoom to move
-                around the diagram. Click to change active node, shift click to
-                navigate to entity.
+                <ZoomOutMap className="icon" />{' '}
+                {t('catalogGraphPage.graph.zoomLegendContent')}
               </Typography>
               <EntityRelationsGraph
                 {...props}

--- a/plugins/catalog-graph/src/components/CatalogGraphPage/CurveFilter.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphPage/CurveFilter.tsx
@@ -14,14 +14,12 @@
  * limitations under the License.
  */
 import { Select, SelectedItems } from '@backstage/core-components';
+import { useTranslationRef } from '@backstage/frontend-plugin-api';
 import Box from '@material-ui/core/Box';
 import React, { useCallback } from 'react';
+import { catalogGraphTranslationRef } from '../../translation';
 
 type Curve = 'curveStepBefore' | 'curveMonotoneX';
-const CURVE_DISPLAY_NAMES: Record<Curve, string> = {
-  curveMonotoneX: 'Monotone X',
-  curveStepBefore: 'Step Before',
-};
 
 export type Props = {
   value: Curve;
@@ -35,11 +33,17 @@ export const CurveFilter = ({ value, onChange }: Props) => {
     (v: SelectedItems) => onChange(v as Curve),
     [onChange],
   );
+  const { t } = useTranslationRef(catalogGraphTranslationRef);
+
+  const CURVE_DISPLAY_NAMES: Record<Curve, string> = {
+    curveMonotoneX: t('curveFilter.displayName.curveMonotoneX'),
+    curveStepBefore: t('curveFilter.displayName.curveStepBefore'),
+  };
 
   return (
     <Box pb={1} pt={1}>
       <Select
-        label="Curve"
+        label={t('curveFilter.selectLabel')}
         selected={value}
         items={curves.map(v => ({
           label: CURVE_DISPLAY_NAMES[v],

--- a/plugins/catalog-graph/src/components/CatalogGraphPage/DirectionFilter.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphPage/DirectionFilter.tsx
@@ -17,13 +17,8 @@ import { Select, SelectedItems } from '@backstage/core-components';
 import Box from '@material-ui/core/Box';
 import React, { useCallback } from 'react';
 import { Direction } from '../EntityRelationsGraph';
-
-const DIRECTION_DISPLAY_NAMES = {
-  [Direction.LEFT_RIGHT]: 'Left to right',
-  [Direction.RIGHT_LEFT]: 'Right to left',
-  [Direction.TOP_BOTTOM]: 'Top to bottom',
-  [Direction.BOTTOM_TOP]: 'Bottom to top',
-};
+import { useTranslationRef } from '@backstage/frontend-plugin-api';
+import { catalogGraphTranslationRef } from '../../translation';
 
 export type Props = {
   value: Direction;
@@ -35,11 +30,19 @@ export const DirectionFilter = ({ value, onChange }: Props) => {
     (v: SelectedItems) => onChange(v as Direction),
     [onChange],
   );
+  const { t } = useTranslationRef(catalogGraphTranslationRef);
+
+  const DIRECTION_DISPLAY_NAMES = {
+    [Direction.LEFT_RIGHT]: t('directionFilter.displayName.leftToRight'),
+    [Direction.RIGHT_LEFT]: t('directionFilter.displayName.rightToLeft'),
+    [Direction.TOP_BOTTOM]: t('directionFilter.displayName.topToBottom'),
+    [Direction.BOTTOM_TOP]: t('directionFilter.displayName.bottomToTop'),
+  };
 
   return (
     <Box pb={1} pt={1}>
       <Select
-        label="Direction"
+        label={t('directionFilter.selectLabel')}
         selected={value}
         items={Object.values(Direction).map(v => ({
           label: DIRECTION_DISPLAY_NAMES[v],

--- a/plugins/catalog-graph/src/components/CatalogGraphPage/MaxDepthFilter.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphPage/MaxDepthFilter.tsx
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { useTranslationRef } from '@backstage/frontend-plugin-api';
 import Box from '@material-ui/core/Box';
 import FormControl from '@material-ui/core/FormControl';
 import IconButton from '@material-ui/core/IconButton';
@@ -22,6 +23,7 @@ import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import ClearIcon from '@material-ui/icons/Clear';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { catalogGraphTranslationRef } from '../../translation';
 
 export type Props = {
   value: number;
@@ -45,6 +47,7 @@ export const MaxDepthFilter = ({ value, onChange }: Props) => {
   const classes = useStyles();
   const onChangeRef = useRef(onChange);
   const [currentValue, setCurrentValue] = useState(value);
+  const { t } = useTranslationRef(catalogGraphTranslationRef);
 
   // Keep a fresh reference to the latest callback
   useEffect(() => {
@@ -78,10 +81,12 @@ export const MaxDepthFilter = ({ value, onChange }: Props) => {
   return (
     <Box pb={1} pt={1}>
       <FormControl variant="outlined" className={classes.formControl}>
-        <Typography variant="button">Max Depth</Typography>
+        <Typography variant="button">
+          {t('maxDepthFilter.selectLabel')}
+        </Typography>
         <OutlinedInput
           type="number"
-          placeholder="∞ Infinite"
+          placeholder={t('maxDepthFilter.inputPlaceholder')}
           value={Number.isFinite(currentValue) ? String(currentValue) : ''}
           onChange={handleChange}
           endAdornment={

--- a/plugins/catalog-graph/src/components/CatalogGraphPage/SelectedKindsFilter.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphPage/SelectedKindsFilter.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { alertApiRef, useApi } from '@backstage/core-plugin-api';
+import { useTranslationRef } from '@backstage/frontend-plugin-api';
 import { catalogApiRef } from '@backstage/plugin-catalog-react';
 import Box from '@material-ui/core/Box';
 import Checkbox from '@material-ui/core/Checkbox';
@@ -27,6 +28,7 @@ import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import Autocomplete from '@material-ui/lab/Autocomplete';
 import React, { useCallback, useEffect, useMemo } from 'react';
 import useAsync from 'react-use/esm/useAsync';
+import { catalogGraphTranslationRef } from '../../translation';
 
 /** @public */
 export type SelectedKindsFilterClassKey = 'formControl';
@@ -49,6 +51,7 @@ export const SelectedKindsFilter = ({ value, onChange }: Props) => {
   const classes = useStyles();
   const alertApi = useApi(alertApiRef);
   const catalogApi = useApi(catalogApiRef);
+  const { t } = useTranslationRef(catalogGraphTranslationRef);
 
   const { error, value: kinds } = useAsync(async () => {
     return await catalogApi
@@ -59,11 +62,11 @@ export const SelectedKindsFilter = ({ value, onChange }: Props) => {
   useEffect(() => {
     if (error) {
       alertApi.post({
-        message: `Failed to load entity kinds`,
+        message: t('selectedKindsFilter.failAlertMessage'),
         severity: 'error',
       });
     }
-  }, [error, alertApi]);
+  }, [error, alertApi, t]);
 
   const normalizedKinds = useMemo(
     () => (kinds ? kinds.map(k => k.toLocaleLowerCase('en-US')) : kinds),
@@ -91,7 +94,9 @@ export const SelectedKindsFilter = ({ value, onChange }: Props) => {
 
   return (
     <Box pb={1} pt={1}>
-      <Typography variant="button">Kinds</Typography>
+      <Typography variant="button">
+        {t('selectedKindsFilter.selectLabel')}
+      </Typography>
       <Autocomplete
         className={classes.formControl}
         multiple

--- a/plugins/catalog-graph/src/components/CatalogGraphPage/SelectedRelationsFilter.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphPage/SelectedRelationsFilter.tsx
@@ -25,6 +25,8 @@ import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import Autocomplete from '@material-ui/lab/Autocomplete';
 import React, { useCallback, useMemo } from 'react';
 import { RelationPairs } from '../EntityRelationsGraph';
+import { useTranslationRef } from '@backstage/frontend-plugin-api';
+import { catalogGraphTranslationRef } from '../../translation';
 
 /** @public */
 export type SelectedRelationsFilterClassKey = 'formControl';
@@ -51,6 +53,7 @@ export const SelectedRelationsFilter = ({
 }: Props) => {
   const classes = useStyles();
   const relations = useMemo(() => relationPairs.flat(), [relationPairs]);
+  const { t } = useTranslationRef(catalogGraphTranslationRef);
 
   const handleChange = useCallback(
     (_: unknown, v: string[]) => {
@@ -65,7 +68,9 @@ export const SelectedRelationsFilter = ({
 
   return (
     <Box pb={1} pt={1}>
-      <Typography variant="button">Relations</Typography>
+      <Typography variant="button">
+        {t('selectedRelationsFilter.selectedLabel')}
+      </Typography>
       <Autocomplete
         className={classes.formControl}
         multiple

--- a/plugins/catalog-graph/src/translation.ts
+++ b/plugins/catalog-graph/src/translation.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createTranslationRef } from '@backstage/core-plugin-api/alpha';
+
+/** @alpha */
+export const catalogGraphTranslationRef = createTranslationRef({
+  id: 'catalog-graph',
+  messages: {
+    catalogGraphCard: {
+      viewGraphTitle: 'View graph',
+    },
+    catalogGraphPage: {
+      title: 'Catalog Graph',
+      filterListButtonLabel: 'Filters',
+      supportButtonContent:
+        'Start tracking your component in by adding it to the software catalog.',
+      graph: {
+        zoomLegendContent: `Use pinch & zoom to move around the diagram. Click to change active node, shift click to navigate to entity.`,
+      },
+    },
+    curveFilter: {
+      selectLabel: 'Curve',
+      displayName: {
+        curveMonotoneX: 'Monotone X',
+        curveStepBefore: 'Step Before',
+      },
+    },
+    directionFilter: {
+      selectLabel: 'Direction',
+      displayName: {
+        leftToRight: 'Left to right',
+        rightToLeft: 'Right to left',
+        topToBottom: 'Top to bottom',
+        bottomToTop: 'Bottom to top',
+      },
+    },
+    maxDepthFilter: {
+      selectLabel: 'Max Depth',
+      inputPlaceholder: '∞ Infinite',
+    },
+    selectedKindsFilter: {
+      selectLabel: 'Kinds',
+      failAlertMessage: 'Failed to load entity kinds',
+    },
+    selectedRelationsFilter: {
+      selectedLabel: 'Relations',
+    },
+  },
+});


### PR DESCRIPTION
## Hey, I just made a Pull Request!

According to #28728 , I created the following i18n translation references for the **catalog-graph** plugin. For the English version it is still the same (as screenshot). But, this PR will enable developers to create translated versions.

<img width="1381" alt="image" src="https://github.com/user-attachments/assets/df20a154-5c26-447f-b86a-e06e110df0e8" />

<img width="1383" alt="image" src="https://github.com/user-attachments/assets/36ab5192-a97b-4f67-8b74-faf9a6ab7d15" />

the translationRef is as following:

```ts
/** @alpha */
export const catalogGraphTranslationRef = createTranslationRef({
  id: 'catalog-graph',
  messages: {
    catalogGraphCard: {
      viewGraphTitle: 'View graph',
    },
    catalogGraphPage: {
      title: 'Catalog Graph',
      filterListButtonLabel: 'Filters',
      supportButtonContent:
        'Start tracking your component in by adding it to the software catalog.',
      graph: {
        zoomLegendContent: `Use pinch & zoom to move around the diagram. Click to change active node, shift click to navigate to entity.`,
      },
    },
    curveFilter: {
      selectLabel: 'Curve',
      displayName: {
        curveMonotoneX: 'Monotone X',
        curveStepBefore: 'Step Before',
      },
    },
    directionFilter: {
      selectLabel: 'Direction',
      displayName: {
        leftToRight: 'Left to right',
        rightToLeft: 'Right to left',
        topToBottom: 'Top to bottom',
        bottomToTop: 'Bottom to top',
      },
    },
    maxDepthFilter: {
      selectLabel: 'Max Depth',
      inputPlaceholder: '∞ Infinite',
    },
    selectedKindsFilter: {
      selectLabel: 'Kinds',
      failAlertMessage: 'Failed to load entity kinds',
    },
    selectedRelationsFilter: {
      selectedLabel: 'Relations',
    },
  },
});
```


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
