### PR TITLE
fix: capturing the correct number of search results in the search ana…

### DIFF
--- a/.changeset/cool-moons-lay.md
+++ b/.changeset/cool-moons-lay.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-react': patch
+---
+
+Capture the number of search results in the search analytics event that correspond to the term entered.

--- a/plugins/search-react/src/context/SearchContext.test.tsx
+++ b/plugins/search-react/src/context/SearchContext.test.tsx
@@ -436,7 +436,7 @@ describe('SearchContext', () => {
       </TestApiProvider>
     );
 
-    it('captures analytics events if enabled in app', async () => {
+    it('captures analytics events for non-empty term', async () => {
       searchApiMock.query
         .mockResolvedValueOnce({
           results: [],
@@ -451,14 +451,13 @@ describe('SearchContext', () => {
           numberOfResults: 1,
         });
 
-      // first api call with empty term
+      // search with empty term
       const { result } = renderHook(() => useSearch(), {
         wrapper: Wrapper,
       });
 
       await waitFor(() => {
-        expect(result.current).toEqual(expect.objectContaining(initialState));
-        expect(searchApiMock.query).toHaveBeenLastCalledWith({
+        expect(searchApiMock.query).toHaveBeenCalledWith({
           term: '',
           types: ['*'],
           filters: {},
@@ -466,13 +465,13 @@ describe('SearchContext', () => {
         expect(analyticsApiMock.captureEvent).not.toHaveBeenCalled();
       });
 
-      // second api call with term 'eva'
+      // search with term 'eva'
       await act(async () => {
         result.current.setTerm('eva');
       });
 
       await waitFor(() => {
-        expect(searchApiMock.query).toHaveBeenLastCalledWith({
+        expect(searchApiMock.query).toHaveBeenCalledWith({
           term: 'eva',
           types: ['*'],
           filters: {},
@@ -489,13 +488,13 @@ describe('SearchContext', () => {
         });
       });
 
-      // third api call with term 'eva.m'
+      // search with new term 'eva.m'
       await act(async () => {
         result.current.setTerm('eva.m');
       });
 
       await waitFor(() => {
-        expect(searchApiMock.query).toHaveBeenLastCalledWith({
+        expect(searchApiMock.query).toHaveBeenCalledWith({
           term: 'eva.m',
           types: ['*'],
           filters: {},

--- a/plugins/search-react/src/context/SearchContext.tsx
+++ b/plugins/search-react/src/context/SearchContext.tsx
@@ -140,7 +140,7 @@ const useSearchContextValue = (
     });
     if (term) {
       analytics.captureEvent('search', term, {
-        value: result.value?.numberOfResults ?? undefined,
+        value: resultSet.numberOfResults,
       });
     }
     return resultSet;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes: #28745

The `search` analytics event was captured with the number of search results received for the previous term.
I have made a change so that the number of search results is the value received for the term entered.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
