### PR TITLE
fix some accidental extra newlines in docs

### DIFF
--- a/docs/features/software-catalog/catalog-customization.md
+++ b/docs/features/software-catalog/catalog-customization.md
@@ -70,9 +70,7 @@ The columns you see in the `CatalogIndexPage` were selected to be a good startin
 Suppose we want to add a new User Email column to the `User` kind in the Catalog. We can do this by overriding the `columns` that we pass into the `CatalogIndexPage` component in our `App.tsx`. First, we need to match the entity kind that we want to override, and then define the columns to show:
 
 ```tsx title="packages/app/src/App.tsx"
-{
-  /* highlight-add-start */
-}
+{/* prettier-ignore */ /* highlight-add-start */}
 const myColumnsFunc: CatalogTableColumnsFunc = entityListContext => {
   if (entityListContext.filters.kind?.value === 'user') {
     return [
@@ -84,9 +82,7 @@ const myColumnsFunc: CatalogTableColumnsFunc = entityListContext => {
 
   return CatalogTable.defaultColumnsFunc(entityListContext);
 };
-{
-  /* highlight-add-end */
-}
+{/* prettier-ignore */ /* highlight-add-end */}
 ```
 
 Then, we can implement the `createUserEmailColumn` function and add it to the list of columns. `field` is used to access the data from the entity, while `render` lets us customize how we display the data:
@@ -391,13 +387,9 @@ export const EntitySecurityTierPicker = () => {
 Now we can add the component to `CatalogIndexPage`:
 
 ```tsx title="packages/app/src/App.tsx"
-{
-  /* highlight-add-start */
-}
+{/* prettier-ignore */ /* highlight-add-start */}
 import { DefaultFilters } from '@backstage/plugin-catalog-react';
-{
-  /* highlight-add-end */
-}
+{/* prettier-ignore */ /* highlight-add-end */}
 
 const routes = (
   <FlatRoutes>

--- a/docs/tutorials/react-router-stable-migration.md
+++ b/docs/tutorials/react-router-stable-migration.md
@@ -181,13 +181,9 @@ It's crucial that you update to `RequirePermission` at the same time as you upda
 When migrating over to React Router v6 stable, you might also see browser console warnings for the `Navigate` component. This will need to be wrapped up in a `Route` component with the `Navigate` component in the `element` prop.
 
 ```tsx
-{
-  /* highlight-remove-next-line */
-}
+{/* prettier-ignore */ /* highlight-remove-next-line */}
 <Navigate key="/" to="catalog" />;
-{
-  /* highlight-add-next-line */
-}
+{/* prettier-ignore */ /* highlight-add-next-line */}
 <Route path="/" element={<Navigate to="catalog" />} />;
 ```
 


### PR DESCRIPTION
Turns out that prettier is VERY adamant about reformatting these particular ones, both on save AND in the precommit hook making them annoying to fix and STAY fixed. Trying out this to see if it still retains the highlighting.

Before:

![image](https://github.com/user-attachments/assets/c390a83b-bafa-4d62-9e54-6296f4540cd5)


No, you actually can't have just one of these at the top of the code block, you need it inside each bracket :)