### PR TITLE
feat(catalog-react): entityOwnerPicker fetches full entities in 'owne…

### DIFF
--- a/.changeset/rich-candles-hang.md
+++ b/.changeset/rich-candles-hang.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': major
+---
+
+OwnerPicker now get's populated with full entities in 'owners-only'-mode

--- a/.changeset/rich-candles-hang.md
+++ b/.changeset/rich-candles-hang.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-react': major
 ---
 
-OwnerPicker now get's populated with full entities in 'owners-only'-mode
+`OwnerPicker` now gets populated with full entities in 'owners-only'-mode

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.test.tsx
@@ -407,24 +407,26 @@ describe('<EntityOwnerPicker mode="owners-only" />', () => {
       expect(screen.getByText('some-owner')).toBeInTheDocument(),
     );
 
-    ['some-owner-2', 'another-owner', 'test-namespace/another-owner-2'].forEach(
-      owner => {
-        expect(screen.getByText(owner)).toBeInTheDocument();
-      },
-    );
+    [
+      'Some Owner 2',
+      'Another Owner',
+      'Another Owner in Another Namespace',
+    ].forEach(owner => {
+      expect(screen.getByText(owner)).toBeInTheDocument();
+    });
 
     expect(mockCatalogApi.getEntityFacets).toHaveBeenCalledTimes(1);
 
     fireEvent.scroll(screen.getByTestId('owner-picker-listbox'));
 
     await waitFor(() =>
-      expect(screen.getByText('some-owner-batch-2')).toBeInTheDocument(),
+      expect(screen.getByText('Some Owner Batch 2')).toBeInTheDocument(),
     );
 
     [
-      'some-owner-2-batch-2',
-      'another-owner-batch-2',
-      'test-namespace/another-owner-2-batch-2',
+      'Some Owner Batch 2',
+      'Another Owner Batch 2',
+      'Another Owner in Another Namespace Batch 2',
     ].forEach(owner => {
       expect(screen.getByText(owner)).toBeInTheDocument();
     });

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/useFacetsEntities.test.ts
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/useFacetsEntities.test.ts
@@ -58,10 +58,26 @@ describe('useFacetsEntities', () => {
   });
 
   it(`should return the owners`, async () => {
+    const entities = [
+      {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'component',
+        metadata: { name: 'e1', namespace: 'default', title: 'E1' },
+      },
+      {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'component',
+        metadata: { name: 'e2', namespace: 'default', title: 'E2' },
+      },
+    ];
     const entityRefs = ['component:default/e1', 'component:default/e2'];
     mockCatalogApi.getEntityFacets.mockResolvedValue(
       facetsFromEntityRefs(entityRefs),
     );
+
+    mockCatalogApi.getEntitiesByRefs.mockResolvedValue({
+      items: entities,
+    });
 
     const { result } = renderHook(() => useFacetsEntities({ enabled: true }));
 
@@ -69,18 +85,7 @@ describe('useFacetsEntities', () => {
     await waitFor(() => {
       expect(result.current[0]).toEqual({
         value: {
-          items: [
-            {
-              apiVersion: 'backstage.io/v1beta1',
-              kind: 'component',
-              metadata: { name: 'e1', namespace: 'default' },
-            },
-            {
-              apiVersion: 'backstage.io/v1beta1',
-              kind: 'component',
-              metadata: { name: 'e2', namespace: 'default' },
-            },
-          ],
+          items: entities,
         },
         loading: false,
       });
@@ -88,6 +93,57 @@ describe('useFacetsEntities', () => {
   });
 
   it(`should return the owners sorted by kind, namespace and name`, async () => {
+    const entities = [
+      {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'group',
+        metadata: { name: 'a', namespace: 'default' },
+        spec: { profile: { displayName: 'A Group' } },
+      },
+      {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'group',
+        metadata: { name: 'd', namespace: 'default' },
+        spec: { profile: { displayName: 'D Group' } },
+      },
+      {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'group',
+        metadata: { name: 'e', namespace: 'default' },
+      },
+      {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'group',
+        metadata: { name: 'team-b', namespace: 'namespace' },
+      },
+      {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'user',
+        metadata: {
+          name: 'a',
+          namespace: 'default',
+        },
+        spec: { profile: { displayName: 'A User' } },
+      },
+      {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'user',
+        metadata: {
+          name: 'b',
+          namespace: 'default',
+        },
+        spec: { profile: { displayName: 'B Group' } },
+      },
+      {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'user',
+        metadata: {
+          name: 'c',
+          namespace: 'default',
+        },
+      },
+    ];
+
     const entityRefs = [
       'group:namespace/team-b',
       'user:default/c',
@@ -102,58 +158,17 @@ describe('useFacetsEntities', () => {
       facetsFromEntityRefs(entityRefs),
     );
 
+    mockCatalogApi.getEntitiesByRefs.mockResolvedValue({
+      items: entities,
+    });
+
     const { result } = renderHook(() => useFacetsEntities({ enabled: true }));
 
     result.current[1]({ text: '' });
     await waitFor(() => {
       expect(result.current[0]).toEqual({
         value: {
-          items: [
-            {
-              apiVersion: 'backstage.io/v1beta1',
-              kind: 'group',
-              metadata: { name: 'a', namespace: 'default' },
-            },
-            {
-              apiVersion: 'backstage.io/v1beta1',
-              kind: 'group',
-              metadata: { name: 'd', namespace: 'default' },
-            },
-            {
-              apiVersion: 'backstage.io/v1beta1',
-              kind: 'group',
-              metadata: { name: 'e', namespace: 'default' },
-            },
-            {
-              apiVersion: 'backstage.io/v1beta1',
-              kind: 'group',
-              metadata: { name: 'team-b', namespace: 'namespace' },
-            },
-            {
-              apiVersion: 'backstage.io/v1beta1',
-              kind: 'user',
-              metadata: {
-                name: 'a',
-                namespace: 'default',
-              },
-            },
-            {
-              apiVersion: 'backstage.io/v1beta1',
-              kind: 'user',
-              metadata: {
-                name: 'b',
-                namespace: 'default',
-              },
-            },
-            {
-              apiVersion: 'backstage.io/v1beta1',
-              kind: 'user',
-              metadata: {
-                name: 'c',
-                namespace: 'default',
-              },
-            },
-          ],
+          items: entities,
         },
         loading: false,
       });
@@ -161,6 +176,33 @@ describe('useFacetsEntities', () => {
   });
 
   it(`should paginate the data accordingly`, async () => {
+    const entities = [
+      {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'group',
+        metadata: { name: 'a', namespace: 'default' },
+      },
+      {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'group',
+        metadata: { name: 'team-b', namespace: 'namespace' },
+      },
+      {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'user',
+        metadata: { name: 'a', namespace: 'default' },
+      },
+      {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'user',
+        metadata: { name: 'b', namespace: 'default' },
+      },
+      {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'user',
+        metadata: { name: 'c', namespace: 'default' },
+      },
+    ];
     const entityRefs = [
       'group:namespace/team-b',
       'user:default/c',
@@ -173,24 +215,17 @@ describe('useFacetsEntities', () => {
       facetsFromEntityRefs(entityRefs),
     );
 
+    mockCatalogApi.getEntitiesByRefs.mockResolvedValue({
+      items: entities,
+    });
+
     const { result } = renderHook(() => useFacetsEntities({ enabled: true }));
 
     result.current[1]({ text: '' }, { limit: 2 });
     await waitFor(() => {
       expect(result.current[0]).toEqual({
         value: {
-          items: [
-            {
-              apiVersion: 'backstage.io/v1beta1',
-              kind: 'group',
-              metadata: { name: 'a', namespace: 'default' },
-            },
-            {
-              apiVersion: 'backstage.io/v1beta1',
-              kind: 'group',
-              metadata: { name: 'team-b', namespace: 'namespace' },
-            },
-          ],
+          items: entities.slice(0, 2),
           cursor: 'eyJ0ZXh0IjoiIiwic3RhcnQiOjJ9',
         },
         loading: false,
@@ -201,28 +236,7 @@ describe('useFacetsEntities', () => {
     await waitFor(() => {
       expect(result.current[0]).toEqual({
         value: {
-          items: [
-            {
-              apiVersion: 'backstage.io/v1beta1',
-              kind: 'group',
-              metadata: { name: 'a', namespace: 'default' },
-            },
-            {
-              apiVersion: 'backstage.io/v1beta1',
-              kind: 'group',
-              metadata: { name: 'team-b', namespace: 'namespace' },
-            },
-            {
-              apiVersion: 'backstage.io/v1beta1',
-              kind: 'user',
-              metadata: { name: 'a', namespace: 'default' },
-            },
-            {
-              apiVersion: 'backstage.io/v1beta1',
-              kind: 'user',
-              metadata: { name: 'b', namespace: 'default' },
-            },
-          ],
+          items: entities.slice(0, 4),
           cursor: 'eyJ0ZXh0IjoiIiwic3RhcnQiOjR9',
         },
         loading: false,
@@ -233,33 +247,7 @@ describe('useFacetsEntities', () => {
     await waitFor(() => {
       expect(result.current[0]).toEqual({
         value: {
-          items: [
-            {
-              apiVersion: 'backstage.io/v1beta1',
-              kind: 'group',
-              metadata: { name: 'a', namespace: 'default' },
-            },
-            {
-              apiVersion: 'backstage.io/v1beta1',
-              kind: 'group',
-              metadata: { name: 'team-b', namespace: 'namespace' },
-            },
-            {
-              apiVersion: 'backstage.io/v1beta1',
-              kind: 'user',
-              metadata: { name: 'a', namespace: 'default' },
-            },
-            {
-              apiVersion: 'backstage.io/v1beta1',
-              kind: 'user',
-              metadata: { name: 'b', namespace: 'default' },
-            },
-            {
-              apiVersion: 'backstage.io/v1beta1',
-              kind: 'user',
-              metadata: { name: 'c', namespace: 'default' },
-            },
-          ],
+          items: entities,
         },
         loading: false,
       });
@@ -267,6 +255,68 @@ describe('useFacetsEntities', () => {
   });
 
   it('should filter the data accordingly', async () => {
+    const entities = [
+      {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'component',
+        metadata: { name: 'spider', namespace: 'default' },
+      },
+      {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'component',
+        metadata: { name: 'a-component', namespace: 'spiders' },
+      },
+      {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'group',
+        metadata: { name: 'spiderman', namespace: 'namespace' },
+      },
+      {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'group',
+        metadata: { name: 'go', namespace: 'spiders' },
+      },
+      {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'group',
+        metadata: {
+          name: 'go',
+          namespace: 'default',
+          title: 'Spider Go Group',
+        },
+      },
+      {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'component',
+        metadata: { name: 'a-component', namespace: 'default' },
+      },
+      {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'spid',
+        metadata: { name: 'lemon', namespace: 'default' },
+      },
+      {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'component',
+        metadata: { name: 'lemon', namespace: 'default' },
+      },
+      {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'component',
+        metadata: { name: 'nade', namespace: 'default' },
+      },
+      {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'user',
+        metadata: { name: 'andersson-john', namespace: 'default' },
+        spec: {
+          profile: {
+            displayName: 'Jöhn Ändersson',
+          },
+        },
+      },
+    ];
+
     const entityRefs = [
       'group:namespace/spiderman',
       'group:spiders/go',
@@ -282,6 +332,10 @@ describe('useFacetsEntities', () => {
     mockCatalogApi.getEntityFacets.mockResolvedValue(
       facetsFromEntityRefs(entityRefs),
     );
+
+    mockCatalogApi.getEntitiesByRefs.mockResolvedValue({
+      items: entities,
+    });
 
     const { result } = renderHook(() => useFacetsEntities({ enabled: true }));
 
@@ -310,6 +364,25 @@ describe('useFacetsEntities', () => {
               apiVersion: 'backstage.io/v1beta1',
               kind: 'group',
               metadata: { name: 'go', namespace: 'spiders' },
+            },
+            {
+              apiVersion: 'backstage.io/v1beta1',
+              kind: 'group',
+              metadata: {
+                name: 'go',
+                namespace: 'default',
+                title: 'Spider Go Group',
+              },
+            },
+            {
+              apiVersion: 'backstage.io/v1beta1',
+              kind: 'user',
+              metadata: { name: 'andersson-john', namespace: 'default' },
+              spec: {
+                profile: {
+                  displayName: 'Jöhn Ändersson',
+                },
+              },
             },
           ],
         },


### PR DESCRIPTION
instead of returning just a partial entity without title / displayName information, fetch the full entity and return that instead so that it works like the 'all'-mode

## Hey, I just made a Pull Request!

Before the EntityOwnerPicker with the 'owners-only'-mode returned just the entity name and that was used for the picker. This PR modifys the functionality so that it fetches the full entity information. 


Before:
https://github.com/user-attachments/assets/d3cccbbf-eaa0-498e-bea5-7e79ff658b04

After:
https://github.com/user-attachments/assets/1b0ccc08-18fe-4457-981d-d661f7dcfa95

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
