### PR TITLE
fix(home): fix home starred entities not using `title` or `displayName`

### DIFF
--- a/.changeset/cyan-needles-hear.md
+++ b/.changeset/cyan-needles-hear.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-home': patch
+---
+
+The starred entities component uses the entity title or display name if it exists

--- a/plugins/home/src/homePageComponents/StarredEntities/Content.test.tsx
+++ b/plugins/home/src/homePageComponents/StarredEntities/Content.test.tsx
@@ -50,7 +50,24 @@ describe('StarredEntitiesContent', () => {
     mockedApi.toggleStarred('component:default/mock-starred-entity-2');
     mockedApi.toggleStarred('component:default/mock-starred-entity-3');
 
-    const mockCatalogApi = catalogApiMock({ entities });
+    const mockCatalogApi = catalogApiMock.mock({
+      getEntitiesByRefs: jest.fn().mockImplementation(async ({ fields }) => {
+        const expectedFields = [
+          'kind',
+          'metadata.namespace',
+          'metadata.name',
+          'spec.type',
+          'metadata.title',
+          'spec.profile.displayName',
+        ];
+        expectedFields.forEach(field => {
+          expect(fields).toContain(field);
+        });
+        return {
+          items: entities,
+        };
+      }),
+    });
 
     const { getByText, queryByText } = await renderInTestApp(
       <TestApiProvider

--- a/plugins/home/src/homePageComponents/StarredEntities/Content.tsx
+++ b/plugins/home/src/homePageComponents/StarredEntities/Content.tsx
@@ -73,7 +73,14 @@ export const Content = ({
     return (
       await catalogApi.getEntitiesByRefs({
         entityRefs: [...starredEntities],
-        fields: ['kind', 'metadata.namespace', 'metadata.name', 'spec.type'],
+        fields: [
+          'kind',
+          'metadata.namespace',
+          'metadata.name',
+          'spec.type',
+          'metadata.title',
+          'spec.profile.displayName',
+        ],
       })
     ).items.filter((e): e is Entity => !!e);
   }, [catalogApi, starredEntities]);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Resolves #28752 and #28161

The starred entities home widget uses entity presentation API via the `<EntityDisplayName/>` component. This will handle what property is best used for display. But the entity you pass needs to have that metadata like `name`, `title`, `displayName` included. The starred entities widget was not fetching the `title` or `displayName` fields so the the entity presentation API was not returning back the correct primary title.

To fix this, I also make make sure to fetch `metadata.title` and `spec.profile.displayName` in the `getEntitiesByRef` call. Example: I added a title property to the `artist-lookup` component.

Before:
<img width="573" alt="image" src="https://github.com/user-attachments/assets/c3afbe09-cdb0-4f9f-b02f-025ef810dbcb" />


After:
<img width="573" alt="image" src="https://github.com/user-attachments/assets/0e18b852-e4d3-403a-890e-96f54b4ac786" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
