### PR TITLE
Fixing small issue that breaks client open API generation

### DIFF
--- a/.changeset/long-cars-raise.md
+++ b/.changeset/long-cars-raise.md
@@ -1,0 +1,5 @@
+---
+'@backstage/repo-tools': minor
+---
+
+Fixing a client generation issue due to a misconfigured lint command.

--- a/packages/repo-tools/src/commands/package/schema/openapi/generate/client.ts
+++ b/packages/repo-tools/src/commands/package/schema/openapi/generate/client.ts
@@ -83,14 +83,15 @@ async function generate(
   );
 
   const parentDirectory = resolve(resolvedOutputDirectory, '..');
+  const indexFile = resolve(parentDirectory, 'index.ts');
 
   await fs.writeFile(
-    resolve(parentDirectory, 'index.ts'),
+    indexFile,
     `// 
     export * from './generated';`,
   );
 
-  await exec(`yarn backstage-cli package lint --fix ${parentDirectory}`, [], {
+  await exec(`yarn backstage-cli package lint --fix ${indexFile}`, [], {
     signal: abortSignal?.signal,
   });
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

There is a small bug in the open API generation code for generating client code. Specifically, a command is trying to run lint on the directory of the generated file instead of just the file itself.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
