### PR TITLE
fix(core-components): Fix misalignment and uppercase text for sidebar dropdown button

### DIFF
--- a/.changeset/hungry-walls-pump.md
+++ b/.changeset/hungry-walls-pump.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Fixed a bug in the SidebarSubmenuItem within the core-components package that caused the dropdown button to be misaligned in the sidebar and the button text to appear in uppercase due to the default <Button> behavior. Also added an example dropdown menu to the app for reference.

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -132,25 +132,6 @@ export const Root = ({ children }: PropsWithChildren<{}>) => (
               to="catalog?filters[kind]=user"
               icon={useApp().getSystemIcon('kind:user')}
             />
-            <SidebarDivider />
-            <SidebarSubmenuItem
-              title="Templates"
-              icon={useApp().getSystemIcon('kind:template')}
-              dropdownItems={[
-                {
-                  title: 'Documentation',
-                  to: 'catalog?filters[kind]=template&filters[type]=documentation',
-                },
-                {
-                  title: 'Service',
-                  to: 'catalog?filters[kind]=template&filters[type]=service',
-                },
-                {
-                  title: 'Website',
-                  to: 'catalog?filters[kind]=template&filters[type]=website',
-                },
-              ]}
-            />
           </SidebarSubmenu>
         </SidebarItem>
         <MyGroupsSidebarItem

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -132,6 +132,25 @@ export const Root = ({ children }: PropsWithChildren<{}>) => (
               to="catalog?filters[kind]=user"
               icon={useApp().getSystemIcon('kind:user')}
             />
+            <SidebarDivider />
+            <SidebarSubmenuItem
+              title="Templates"
+              icon={useApp().getSystemIcon('kind:template')}
+              dropdownItems={[
+                {
+                  title: 'Documentation',
+                  to: 'catalog?filters[kind]=template&filters[type]=documentation',
+                },
+                {
+                  title: 'Service',
+                  to: 'catalog?filters[kind]=template&filters[type]=service',
+                },
+                {
+                  title: 'Website',
+                  to: 'catalog?filters[kind]=template&filters[type]=website',
+                },
+              ]}
+            />
           </SidebarSubmenu>
         </SidebarItem>
         <MyGroupsSidebarItem

--- a/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
+++ b/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
@@ -185,6 +185,10 @@ export const SidebarSubmenuItem = (props: SidebarSubmenuItemProps) => {
               classes.item,
               isActive ? classes.selected : undefined,
             )}
+            style={{
+              textTransform: 'none',
+              justifyContent: 'flex-start',
+            }}
           >
             {Icon && <Icon fontSize="small" />}
             <Typography

--- a/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
+++ b/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
@@ -100,6 +100,10 @@ const useStyles = makeStyles(
         color: theme.palette.navigation.selectedColor,
       },
     },
+    dropdownButton: {
+      textTransform: 'none',
+      justifyContent: 'flex-start',
+    },
     textContent: {
       color: theme.palette.navigation.color,
       paddingLeft: theme.spacing(4),
@@ -183,12 +187,9 @@ export const SidebarSubmenuItem = (props: SidebarSubmenuItemProps) => {
             onTouchStart={e => e.stopPropagation()}
             className={classnames(
               classes.item,
+              classes.dropdownButton,
               isActive ? classes.selected : undefined,
             )}
-            style={{
-              textTransform: 'none',
-              justifyContent: 'flex-start',
-            }}
           >
             {Icon && <Icon fontSize="small" />}
             <Typography


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixed a bug in the `SidebarSubmenuItem` component within the `core-components` package that caused the dropdown button to be misaligned in the sidebar and the button text to appear in uppercase due to the default `<Button>` behavior. Also added an example dropdown button to the 'Home' submenu for reference/example and future UI testing.

Since the `<Button>` component already was modified I added the specific styling directly.

**Before:** 

![Screenshot 2025-02-11 at 13 28 13](https://github.com/user-attachments/assets/e83893e4-e1f3-45b3-b39f-8619cd75d8b6)

The same can be seen in the Storybook sample ([Link](https://backstage.io/storybook/?path=/story/layout-sidebar--sample-scalable-sidebar)):

![image](https://github.com/user-attachments/assets/7c9bbc89-0c0b-4fdc-b754-6484e67ea460)

**After:** 

![image](https://github.com/user-attachments/assets/ff567a65-129c-4ebe-8ba7-c8c5ca5e7185)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
