### PR TITLE
Handle errors during an oauth start stage

### DIFF
--- a/.changeset/new-dryers-cough-2.md
+++ b/.changeset/new-dryers-cough-2.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-oidc-provider': patch
+---
+
+Simplify the `start` method in the `authenticator` to just return the helper promise

--- a/.changeset/new-dryers-cough.md
+++ b/.changeset/new-dryers-cough.md
@@ -1,4 +1,5 @@
 ---
+'@backstage/plugin-auth-backend-module-oidc-provider': patch
 '@backstage/plugin-auth-node': patch
 ---
 

--- a/.changeset/new-dryers-cough.md
+++ b/.changeset/new-dryers-cough.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-node': minor
+---
+
+Fixed a potential issue when using the Backstage's `PassportOAuthAuthenticatorHelper` to implement a custom OAuth Authenticator. The issue occurs during the start stage of the authorization process when the custom `passport.Strategy` calls the `error()` to propagate an error message. Because the `error` function wasn't being set Backstage would throw a `this.error is not a function` error thus hiding the original cause.

--- a/.changeset/new-dryers-cough.md
+++ b/.changeset/new-dryers-cough.md
@@ -1,6 +1,5 @@
 ---
-'@backstage/plugin-auth-backend-module-oidc-provider': patch
 '@backstage/plugin-auth-node': patch
 ---
 
-Fixed a potential issue when using the Backstage's `PassportOAuthAuthenticatorHelper` to implement a custom OAuth Authenticator. The issue occurs during the start stage of the authorization process when the custom `passport.Strategy` calls the `error()` to propagate an error message. Because the `error` function wasn't being set Backstage would throw a `this.error is not a function` error thus hiding the original cause.
+Add an `error` handler to the `strategy` to reject the `executeRedirectStrategy`

--- a/.changeset/new-dryers-cough.md
+++ b/.changeset/new-dryers-cough.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-auth-node': minor
+'@backstage/plugin-auth-node': patch
 ---
 
 Fixed a potential issue when using the Backstage's `PassportOAuthAuthenticatorHelper` to implement a custom OAuth Authenticator. The issue occurs during the start stage of the authorization process when the custom `passport.Strategy` calls the `error()` to propagate an error message. Because the `error` function wasn't being set Backstage would throw a `this.error is not a function` error thus hiding the original cause.

--- a/plugins/auth-backend-module-oidc-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-oidc-provider/src/authenticator.ts
@@ -135,7 +135,7 @@ export const oidcAuthenticator = createOAuthAuthenticator({
 
   async start(input, ctx) {
     const { initializedPrompt, promise } = ctx;
-    const { helper, strategy } = await promise;
+    const { helper } = await promise;
     const options: Record<string, string> = {
       scope: input.scope,
       state: input.state,
@@ -146,15 +146,8 @@ export const oidcAuthenticator = createOAuthAuthenticator({
       options.prompt = prompt;
     }
 
-    return new Promise((resolve, reject) => {
-      strategy.error = reject;
-
-      return helper
-        .start(input, {
-          ...options,
-        })
-        .then(resolve)
-        .catch(reject);
+    return helper.start(input, {
+      ...options,
     });
   },
 

--- a/plugins/auth-backend-module-oidc-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-oidc-provider/src/authenticator.ts
@@ -153,7 +153,8 @@ export const oidcAuthenticator = createOAuthAuthenticator({
         .start(input, {
           ...options,
         })
-        .then(resolve);
+        .then(resolve)
+        .catch(reject);
     });
   },
 

--- a/plugins/auth-node/src/oauth/PassportOAuthAuthenticatorHelper.test.ts
+++ b/plugins/auth-node/src/oauth/PassportOAuthAuthenticatorHelper.test.ts
@@ -26,7 +26,9 @@ class FailureStrategy extends Strategy {
 describe('PassportOAuthAuthenticatorHelper', () => {
   describe('start', () => {
     it('should gracefully handle errors if unable to start', async () => {
-      const helper = PassportOAuthAuthenticatorHelper.from(new FailureStrategy());
+      const helper = PassportOAuthAuthenticatorHelper.from(
+        new FailureStrategy(),
+      );
       await expect(helper.start({} as any, {})).rejects.toThrow(
         'Authentication failed, failure',
       );
@@ -35,7 +37,9 @@ describe('PassportOAuthAuthenticatorHelper', () => {
 
   describe('authenticate', () => {
     it('should gracefully handle errors if unable to authenticate', async () => {
-      const helper = PassportOAuthAuthenticatorHelper.from(new FailureStrategy());
+      const helper = PassportOAuthAuthenticatorHelper.from(
+        new FailureStrategy(),
+      );
       await expect(helper.authenticate({} as any, {})).rejects.toThrow(
         'Authentication failed, failure',
       );

--- a/plugins/auth-node/src/oauth/PassportOAuthAuthenticatorHelper.test.ts
+++ b/plugins/auth-node/src/oauth/PassportOAuthAuthenticatorHelper.test.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Strategy } from 'passport';
+import { PassportOAuthAuthenticatorHelper } from './PassportOAuthAuthenticatorHelper';
+
+class FailureStrategy extends Strategy {
+  public override authenticate(_: any, __: any) {
+    this.error(new Error('failure'));
+  }
+}
+
+describe('PassportOAuthAuthenticatorHelper', () => {
+  describe('start', () => {
+    it('should gracefully handle errors if unable to start', async () => {
+      const helper = PassportOAuthAuthenticatorHelper.from(new FailureStrategy());
+      await expect(helper.start({} as any, {})).rejects.toThrow(
+        'Authentication failed, failure',
+      );
+    });
+  });
+
+  describe('authenticate', () => {
+    it('should gracefully handle errors if unable to authenticate', async () => {
+      const helper = PassportOAuthAuthenticatorHelper.from(new FailureStrategy());
+      await expect(helper.authenticate({} as any, {})).rejects.toThrow(
+        'Authentication failed, failure',
+      );
+    });
+  });
+});

--- a/plugins/auth-node/src/passport/PassportHelpers.ts
+++ b/plugins/auth-node/src/passport/PassportHelpers.ts
@@ -105,8 +105,11 @@ export class PassportHelpers {
      */
     status?: number;
   }> {
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
       const strategy = Object.create(providerStrategy);
+      strategy.error = (error: Error) => {
+        reject(new Error(`Authentication failed, ${error.message ?? ''}`));
+      };
       strategy.redirect = (url: string, status?: number) => {
         resolve({ url, status: status ?? undefined });
       };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Addresses #28746 

Backstage's `PassportOAuthAuthenticatorHelper` doesn't correctly propagate errors during an OAuth start stage. In particular if the underlying `passport.Strategy` calls `error()`.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
