### PR TITLE
feat: add additional props to entity pickers

### DIFF
--- a/.changeset/olive-planes-pay.md
+++ b/.changeset/olive-planes-pay.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-catalog-react': minor
+---
+
+Added `hidden` prop to `EntityTagPicker`, `EntityAutocompletePicker` and `UserListPicker`.
+Added `initialFilter` prop to `EntityTagPicker` to set an initial filter for the picker.
+Added `alwaysKeepFilters` prop to `UserListPicker` to prevent filters from resetting when no entities match the initial filters.

--- a/plugins/catalog-react/report.api.md
+++ b/plugins/catalog-react/report.api.md
@@ -208,6 +208,7 @@ export type EntityAutocompletePickerProps<
   InputProps?: TextFieldProps;
   initialSelectedOptions?: string[];
   filtersForAvailableValues?: Array<keyof T>;
+  hidden?: boolean;
 };
 
 // @public
@@ -580,6 +581,8 @@ export const EntityTagPicker: (
 // @public (undocumented)
 export type EntityTagPickerProps = {
   showCounts?: boolean;
+  initialFilter?: string[];
+  hidden?: boolean;
 };
 
 // @public
@@ -818,12 +821,14 @@ export type UserListFilterKind = 'owned' | 'starred' | 'all';
 // @public (undocumented)
 export const UserListPicker: (
   props: UserListPickerProps,
-) => React_2.JSX.Element;
+) => React_2.JSX.Element | null;
 
 // @public (undocumented)
 export type UserListPickerProps = {
   initialFilter?: UserListFilterKind;
   availableFilters?: UserListFilterKind[];
+  hidden?: boolean;
+  alwaysKeepFilters?: boolean;
 };
 
 // @public (undocumented)

--- a/plugins/catalog-react/src/components/EntityAutocompletePicker/EntityAutocompletePicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityAutocompletePicker/EntityAutocompletePicker.test.tsx
@@ -393,4 +393,22 @@ describe('<EntityAutocompletePicker/>', () => {
       }),
     );
   });
+
+  it("doesn't render when hidden", async () => {
+    const catalogApi = makeMockCatalogApi();
+    render(
+      <TestApiProvider apis={[[catalogApiRef, catalogApi]]}>
+        <MockEntityListContextProvider value={{}}>
+          <EntityAutocompletePicker<EntityFilters>
+            label="Options"
+            path="spec.options"
+            name="options"
+            Filter={EntityOptionFilter}
+            hidden
+          />
+        </MockEntityListContextProvider>
+      </TestApiProvider>,
+    );
+    await waitFor(() => expect(screen.queryByText('Options')).toBeNull());
+  });
 });

--- a/plugins/catalog-react/src/components/EntityAutocompletePicker/EntityAutocompletePicker.tsx
+++ b/plugins/catalog-react/src/components/EntityAutocompletePicker/EntityAutocompletePicker.tsx
@@ -52,6 +52,7 @@ export type EntityAutocompletePickerProps<
   InputProps?: TextFieldProps;
   initialSelectedOptions?: string[];
   filtersForAvailableValues?: Array<keyof T>;
+  hidden?: boolean;
 };
 
 /** @public */
@@ -82,6 +83,7 @@ export function EntityAutocompletePicker<
     InputProps,
     initialSelectedOptions = [],
     filtersForAvailableValues = ['kind'],
+    hidden,
   } = props;
   const classes = useStyles();
 
@@ -146,7 +148,7 @@ export function EntityAutocompletePicker<
     return null;
   }
 
-  return (
+  return hidden ? null : (
     <Box className={classes.root} pb={1} pt={1}>
       <CatalogAutocomplete<string, true>
         multiple

--- a/plugins/catalog-react/src/components/EntityTagPicker/EntityTagPicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityTagPicker/EntityTagPicker.test.tsx
@@ -260,4 +260,36 @@ describe('<EntityTagPicker/>', () => {
       }),
     );
   });
+
+  it('respects the initial filter value', async () => {
+    const updateFilters = jest.fn();
+    await renderInTestApp(
+      <TestApiProvider apis={[[catalogApiRef, catalogApi]]}>
+        <MockEntityListContextProvider
+          value={{
+            updateFilters,
+          }}
+        >
+          <EntityTagPicker initialFilter={['tag3']} />
+        </MockEntityListContextProvider>
+      </TestApiProvider>,
+    );
+
+    await waitFor(() =>
+      expect(updateFilters).toHaveBeenLastCalledWith({
+        tags: new EntityTagFilter(['tag3']),
+      }),
+    );
+  });
+
+  it("doesn't render when hidden", async () => {
+    await renderInTestApp(
+      <TestApiProvider apis={[[catalogApiRef, catalogApi]]}>
+        <MockEntityListContextProvider value={{}}>
+          <EntityTagPicker hidden />
+        </MockEntityListContextProvider>
+      </TestApiProvider>,
+    );
+    await waitFor(() => expect(screen.queryByText('Tags')).toBeNull());
+  });
 });

--- a/plugins/catalog-react/src/components/EntityTagPicker/EntityTagPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityTagPicker/EntityTagPicker.tsx
@@ -27,6 +27,8 @@ export type CatalogReactEntityTagPickerClassKey = 'input';
 /** @public */
 export type EntityTagPickerProps = {
   showCounts?: boolean;
+  initialFilter?: string[];
+  hidden?: boolean;
 };
 
 const useStyles = makeStyles(
@@ -47,6 +49,8 @@ export const EntityTagPicker = (props: EntityTagPickerProps) => {
       Filter={EntityTagFilter}
       showCounts={props.showCounts}
       InputProps={{ className: classes.input }}
+      initialSelectedOptions={props.initialFilter ? props.initialFilter : []}
+      hidden={props.hidden}
     />
   );
 };

--- a/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
@@ -122,11 +122,13 @@ function getFilterGroups(
 export type UserListPickerProps = {
   initialFilter?: UserListFilterKind;
   availableFilters?: UserListFilterKind[];
+  hidden?: boolean;
+  alwaysKeepFilters?: boolean;
 };
 
 /** @public */
 export const UserListPicker = (props: UserListPickerProps) => {
-  const { initialFilter, availableFilters } = props;
+  const { initialFilter, availableFilters, hidden, alwaysKeepFilters } = props;
   const classes = useStyles();
   const configApi = useApi(configApiRef);
   const { t } = useTranslationRef(catalogReactTranslationRef);
@@ -198,11 +200,18 @@ export const UserListPicker = (props: UserListPickerProps) => {
       !loading &&
       !!selectedUserFilter &&
       selectedUserFilter !== 'all' &&
-      filterCounts[selectedUserFilter] === 0
+      filterCounts[selectedUserFilter] === 0 &&
+      !alwaysKeepFilters
     ) {
       setSelectedUserFilter('all');
     }
-  }, [loading, filterCounts, selectedUserFilter, setSelectedUserFilter]);
+  }, [
+    loading,
+    filterCounts,
+    selectedUserFilter,
+    setSelectedUserFilter,
+    alwaysKeepFilters,
+  ]);
 
   useEffect(() => {
     if (!selectedUserFilter) {
@@ -232,7 +241,7 @@ export const UserListPicker = (props: UserListPickerProps) => {
     loading,
   ]);
 
-  return (
+  return hidden ? null : (
     <Card className={classes.root}>
       {filterGroups.map(group => (
         <Fragment key={group.name}>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The UI configuration for the EntityTagPicker, EntityAutocompletePicker, and UserListPicker didn't include an option to hide the UI from users like some of the other pickers. Additionally, the EntityTagPicker didn't include an option to add an initial filter and the UserListPicker assumed that setting the filter to "all" when no matching entities are found is always the desired behavior.

I added addtional props to these components to enhance their functionality.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
