### PR TITLE
microsite: remove unnecessary redirect

### DIFF
--- a/microsite/docusaurus.config.ts
+++ b/microsite/docusaurus.config.ts
@@ -243,10 +243,6 @@ const config: Config = {
             to: '/docs/tooling/cli/overview/',
           },
           {
-            from: '/docs/local-dev/cli-templates/',
-            to: '/docs/tooling/cli/templates/',
-          },
-          {
             from: '/docs/local-dev/linking-local-packages/',
             to: '/docs/tooling/local-dev/linking-local-packages',
           },


### PR DESCRIPTION
🧹, seems to be breaking microsite builds: https://github.com/backstage/backstage/actions/runs/13283954542/job/37088635012

Not quite sure why that is tbh, but the redirect isn't needed to begin with since the old page never existed