### PR TITLE
fix(techdocs): MaxListenersExceededWarning and Caching Issues

### DIFF
--- a/plugins/techdocs-backend/src/cache/cacheMiddleware.test.ts
+++ b/plugins/techdocs-backend/src/cache/cacheMiddleware.test.ts
@@ -56,7 +56,7 @@ describe('createCacheMiddleware', () => {
       invalidate: jest.fn().mockResolvedValue(undefined),
       invalidateMultiple: jest.fn().mockResolvedValue(undefined),
     } as unknown as jest.Mocked<TechDocsCache>;
-    const router = createCacheMiddleware({
+    const router = await createCacheMiddleware({
       logger: mockServices.logger.mock(),
       cache,
     });

--- a/plugins/techdocs-backend/src/cache/cacheMiddleware.test.ts
+++ b/plugins/techdocs-backend/src/cache/cacheMiddleware.test.ts
@@ -56,7 +56,7 @@ describe('createCacheMiddleware', () => {
       invalidate: jest.fn().mockResolvedValue(undefined),
       invalidateMultiple: jest.fn().mockResolvedValue(undefined),
     } as unknown as jest.Mocked<TechDocsCache>;
-    const router = await createCacheMiddleware({
+    const router = createCacheMiddleware({
       logger: mockServices.logger.mock(),
       cache,
     });

--- a/plugins/techdocs-backend/src/cache/cacheMiddleware.ts
+++ b/plugins/techdocs-backend/src/cache/cacheMiddleware.ts
@@ -96,14 +96,13 @@ export const createCacheMiddleware = ({
       };
     }
 
-    const data: CacheData = { chunks: [], writeToCache: true };
     if (requestPathDataMap.has(reqPath)) {
       // If we've already seen this request, remove it from the map. This is
       // to ensure that we don't duplicate the data in the map if multiple
       // requests are made for the same path.
       requestPathDataMap.delete(reqPath);
     }
-    requestPathDataMap.set(reqPath, data);
+    requestPathDataMap.set(reqPath, { chunks: [], writeToCache: true });
 
     // Attempt to retrieve data from the cache.
     const cached = await cache.get(reqPath);
@@ -113,7 +112,7 @@ export const createCacheMiddleware = ({
     // calling next().
     if (cached) {
       logger.debug(`Cache hit for ${reqPath}`);
-      data.writeToCache = false;
+      requestPathDataMap.get(reqPath)!.writeToCache = false;
       realEnd(cached);
       return;
     }

--- a/plugins/techdocs-backend/src/cache/cacheMiddleware.ts
+++ b/plugins/techdocs-backend/src/cache/cacheMiddleware.ts
@@ -46,7 +46,6 @@ export const createCacheMiddleware = ({
   cacheMiddleware.use(async (req, res, next) => {
     const socket = res.socket;
 
-    // Make concrete references to these things.
     const isCacheable = req.path.startsWith('/static/docs/');
     const isGetRequest = req.method === 'GET';
 
@@ -56,6 +55,7 @@ export const createCacheMiddleware = ({
       return;
     }
 
+    // Make concrete references to these things.
     const reqPath = decodeURI(req.path.match(/\/static\/docs\/(.*)$/)![1]);
     const realEnd = socket.end.bind(socket);
     const realWrite = socket.write.bind(socket);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR fixes a bug in the caching middleware that was causing some weirdness with socket events.  Basically, we were adding a new 'close' listener for every single request, which could cause performance issues and eventually hit the listener limit, causing `MaxListenersExceededWarning` messages. I've reworked how we store data associated with sockets. Now, we use a nested Map so we can keep track of data for each request path separately, even if they're using the same socket.  The 'close' listener is now only added once per socket, which solves the listener accumulation problem.  

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
