### PR TITLE
feat(events-backend,events-node) add a parser option to events ingress

### DIFF
--- a/.changeset/ten-impalas-hope.md
+++ b/.changeset/ten-impalas-hope.md
@@ -1,6 +1,6 @@
 ---
-'@backstage/plugin-events-backend': minor
-'@backstage/plugin-events-node': minor
+'@backstage/plugin-events-backend': patch
+'@backstage/plugin-events-node': patch
 ---
 
 add `addHttpPostBodyParser` to events extension to allow body parse customization. This feature will enhance flexibility in handling HTTP POST requests in event-related operations.

--- a/.changeset/ten-impalas-hope.md
+++ b/.changeset/ten-impalas-hope.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-events-backend': minor
+'@backstage/plugin-events-node': minor
+---
+
+add `addHttpPostBodyParser` to events extension to allow body parse customization. This feature will enhance flexibility in handling HTTP POST requests in event-related operations.

--- a/plugins/events-backend/README.md
+++ b/plugins/events-backend/README.md
@@ -140,6 +140,48 @@ export const eventsModuleYourFeature = createBackendModule({
 });
 ```
 
+### Request Body Parse
+
+We need to parse the request body before we can validate it. We have some default parsers but you can provide your own when necessary.
+
+```ts
+import { eventsExtensionPoint } from '@backstage/plugin-events-node/alpha';
+
+// [...]
+
+export const eventsModuleYourFeature = createBackendModule({
+  pluginId: 'events',
+  moduleId: 'your-feature',
+  register(env) {
+    // [...]
+    env.registerInit({
+      deps: {
+        // [...]
+        events: eventsExtensionPoint,
+        // [...]
+      },
+      async init({ /* ... */ events /*, ... */ }) {
+        // [...]
+        events.addHttpPostBodyParser({
+          contentType: 'application/x-www-form-urlencoded',
+          parser: async (req, _topic) => {
+            return {
+              bodyParsed: req.body.toString('utf-8'),
+              bodyBuffer: req.body,
+              encoding: 'utf-8',
+            };
+          },
+        });
+      },
+    });
+  },
+});
+```
+
+We have the following default parsers:
+
+- `application/json`
+
 #### Legacy Backend System
 
 ```ts

--- a/plugins/events-backend/report.api.md
+++ b/plugins/events-backend/report.api.md
@@ -11,6 +11,7 @@ import { EventPublisher } from '@backstage/plugin-events-node';
 import { EventsService } from '@backstage/plugin-events-node';
 import { EventSubscriber } from '@backstage/plugin-events-node';
 import express from 'express';
+import { HttpBodyParser } from '@backstage/plugin-events-node';
 import { HttpPostIngressOptions } from '@backstage/plugin-events-node';
 import { Logger } from 'winston';
 import { LoggerService } from '@backstage/backend-plugin-api';
@@ -57,6 +58,9 @@ export class HttpPostIngressEventPublisher {
     events: EventsService;
     ingresses?: {
       [topic: string]: Omit<HttpPostIngressOptions, 'topic'>;
+    };
+    bodyParsers?: {
+      [contentType: string]: HttpBodyParser;
     };
     logger: LoggerService;
   }): HttpPostIngressEventPublisher;

--- a/plugins/events-backend/src/service/http/HttpPostIngressEventPublisher.ts
+++ b/plugins/events-backend/src/service/http/HttpPostIngressEventPublisher.ts
@@ -103,7 +103,7 @@ export class HttpPostIngressEventPublisher {
 
     router.post(path, async (request, response) => {
       const requestContentType = contentType.parse(request);
-      const bodyParser = this.bodyParsers[requestContentType.type];
+      const bodyParser = this.bodyParsers[requestContentType.type ?? ''];
 
       if (!bodyParser) {
         throw new UnsupportedMediaTypeError(requestContentType.type);
@@ -111,6 +111,7 @@ export class HttpPostIngressEventPublisher {
 
       const { bodyParsed, bodyBuffer, encoding } = await bodyParser(
         request,
+        requestContentType,
         topic,
       );
 

--- a/plugins/events-backend/src/service/http/HttpPostIngressEventPublisher.ts
+++ b/plugins/events-backend/src/service/http/HttpPostIngressEventPublisher.ts
@@ -16,35 +16,18 @@
 
 import { LoggerService } from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
-import { CustomErrorBase } from '@backstage/errors';
 import {
   EventsService,
+  HttpBodyParser,
   HttpPostIngressOptions,
   RequestValidator,
 } from '@backstage/plugin-events-node';
 import contentType from 'content-type';
 import express from 'express';
 import Router from 'express-promise-router';
+import { defaultHttpBodyParsers } from './body-parser';
 import { RequestValidationContextImpl } from './validation';
-
-class UnsupportedCharsetError extends CustomErrorBase {
-  name = 'UnsupportedCharsetError' as const;
-  statusCode = 415 as const;
-
-  constructor(charset: string) {
-    super(`Unsupported charset: ${charset}`);
-  }
-}
-
-class UnsupportedMediaTypeError extends CustomErrorBase {
-  name = 'UnsupportedMediaTypeError' as const;
-  statusCode = 415 as const;
-
-  constructor(mediaType?: string) {
-    super(`Unsupported media type: ${mediaType ?? 'unknown'}`);
-  }
-}
-
+import { UnsupportedMediaTypeError } from './errors';
 /**
  * Publishes events received from their origin (e.g., webhook events from an SCM system)
  * via HTTP POST endpoint and passes the request body as event payload to the registered subscribers.
@@ -57,6 +40,7 @@ export class HttpPostIngressEventPublisher {
     config: Config;
     events: EventsService;
     ingresses?: { [topic: string]: Omit<HttpPostIngressOptions, 'topic'> };
+    bodyParsers?: { [contentType: string]: HttpBodyParser };
     logger: LoggerService;
   }): HttpPostIngressEventPublisher {
     const topics =
@@ -71,7 +55,14 @@ export class HttpPostIngressEventPublisher {
       }
     });
 
-    return new HttpPostIngressEventPublisher(env.events, env.logger, ingresses);
+    const parsers = { ...defaultHttpBodyParsers, ...env.bodyParsers };
+
+    return new HttpPostIngressEventPublisher(
+      env.events,
+      env.logger,
+      ingresses,
+      parsers,
+    );
   }
 
   private constructor(
@@ -79,6 +70,9 @@ export class HttpPostIngressEventPublisher {
     private readonly logger: LoggerService,
     private readonly ingresses: {
       [topic: string]: Omit<HttpPostIngressOptions, 'topic'>;
+    },
+    private readonly bodyParsers: {
+      [contentType: string]: HttpBodyParser;
     },
   ) {}
 
@@ -108,32 +102,17 @@ export class HttpPostIngressEventPublisher {
     const logger = this.logger;
 
     router.post(path, async (request, response) => {
-      const requestBody = request.body;
-      if (!Buffer.isBuffer(requestBody)) {
-        throw new Error(
-          `Failed to retrieve raw body from incoming event for topic ${topic}; not a buffer: ${typeof requestBody}`,
-        );
+      const requestContentType = contentType.parse(request);
+      const bodyParser = this.bodyParsers[requestContentType.type];
+
+      if (!bodyParser) {
+        throw new UnsupportedMediaTypeError(requestContentType.type);
       }
 
-      const bodyBuffer: Buffer = requestBody;
-      const parsedContentType = contentType.parse(request);
-      if (
-        !parsedContentType.type ||
-        parsedContentType.type !== 'application/json'
-      ) {
-        throw new UnsupportedMediaTypeError(parsedContentType.type);
-      }
-
-      const encoding = parsedContentType.parameters.charset ?? 'utf-8';
-      if (!Buffer.isEncoding(encoding)) {
-        throw new UnsupportedCharsetError(encoding);
-      }
-
-      const bodyString = bodyBuffer.toString(encoding);
-      const bodyParsed =
-        parsedContentType.type === 'application/json'
-          ? JSON.parse(bodyString)
-          : bodyString;
+      const { bodyParsed, bodyBuffer, encoding } = await bodyParser(
+        request,
+        topic,
+      );
 
       if (validator) {
         const requestDetails = {

--- a/plugins/events-backend/src/service/http/body-parser/HttpApplicationJsonBodyParser.ts
+++ b/plugins/events-backend/src/service/http/body-parser/HttpApplicationJsonBodyParser.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpBodyParser } from '@backstage/plugin-events-node';
+import contentType from 'content-type';
+import { UnsupportedCharsetError } from '../errors';
+
+export const HttpApplicationJsonBodyParser: HttpBodyParser = async (
+  request,
+  topic,
+) => {
+  const requestBody = request.body;
+  if (!Buffer.isBuffer(requestBody)) {
+    throw new Error(
+      `Failed to retrieve raw body from incoming event for topic ${topic}; not a buffer: ${typeof requestBody}`,
+    );
+  }
+
+  const bodyBuffer: Buffer = requestBody;
+  const parsedContentType = contentType.parse(request);
+
+  const encoding = parsedContentType.parameters.charset ?? 'utf-8';
+  if (!Buffer.isEncoding(encoding)) {
+    throw new UnsupportedCharsetError(encoding);
+  }
+
+  const bodyString = bodyBuffer.toString(encoding);
+  const bodyParsed =
+    parsedContentType.type === 'application/json'
+      ? JSON.parse(bodyString)
+      : bodyString;
+  return { bodyParsed, bodyBuffer, encoding };
+};

--- a/plugins/events-backend/src/service/http/body-parser/HttpApplicationJsonBodyParser.ts
+++ b/plugins/events-backend/src/service/http/body-parser/HttpApplicationJsonBodyParser.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 import { HttpBodyParser } from '@backstage/plugin-events-node';
-import contentType from 'content-type';
 import { UnsupportedCharsetError } from '../errors';
 
 export const HttpApplicationJsonBodyParser: HttpBodyParser = async (
   request,
+  parsedMediaType,
   topic,
 ) => {
   const requestBody = request.body;
@@ -29,16 +29,15 @@ export const HttpApplicationJsonBodyParser: HttpBodyParser = async (
   }
 
   const bodyBuffer: Buffer = requestBody;
-  const parsedContentType = contentType.parse(request);
 
-  const encoding = parsedContentType.parameters.charset ?? 'utf-8';
+  const encoding = parsedMediaType.parameters.charset ?? 'utf-8';
   if (!Buffer.isEncoding(encoding)) {
     throw new UnsupportedCharsetError(encoding);
   }
 
   const bodyString = bodyBuffer.toString(encoding);
   const bodyParsed =
-    parsedContentType.type === 'application/json'
+    parsedMediaType.type === 'application/json'
       ? JSON.parse(bodyString)
       : bodyString;
   return { bodyParsed, bodyBuffer, encoding };

--- a/plugins/events-backend/src/service/http/body-parser/index.ts
+++ b/plugins/events-backend/src/service/http/body-parser/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Backstage Authors
+ * Copyright 2025 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,8 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { HttpBodyParser } from '@backstage/plugin-events-node';
+import { HttpApplicationJsonBodyParser } from './HttpApplicationJsonBodyParser';
 
-export type { HttpPostIngressOptions } from './HttpPostIngressOptions';
-export type { HttpBodyParserOptions } from './HttpBodyParserOptions';
-export * from './validation';
-export * from './body-parser';
+export const defaultHttpBodyParsers: { [contentType: string]: HttpBodyParser } =
+  {
+    'application/json': HttpApplicationJsonBodyParser,
+  };

--- a/plugins/events-backend/src/service/http/errors.ts
+++ b/plugins/events-backend/src/service/http/errors.ts
@@ -32,7 +32,7 @@ export class UnsupportedMediaTypeError extends CustomErrorBase {
     super(
       `Unsupported media type: ${
         mediaType ?? 'unknown'
-      }. You need to provide a custom body parser for this media type using events extension.`,
+      }. You need to provide a custom body parser for this media type using the EventsExtensionPoint.`,
     );
   }
 }

--- a/plugins/events-backend/src/service/http/errors.ts
+++ b/plugins/events-backend/src/service/http/errors.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { CustomErrorBase } from '@backstage/errors';
+
+export class UnsupportedCharsetError extends CustomErrorBase {
+  name = 'UnsupportedCharsetError' as const;
+  statusCode = 415 as const;
+
+  constructor(charset: string) {
+    super(`Unsupported charset: ${charset}`);
+  }
+}
+
+export class UnsupportedMediaTypeError extends CustomErrorBase {
+  name = 'UnsupportedMediaTypeError' as const;
+  statusCode = 415 as const;
+
+  constructor(mediaType?: string) {
+    super(
+      `Unsupported media type: ${
+        mediaType ?? 'unknown'
+      }. You need to provide a custom body parser for this media type using events extension.`,
+    );
+  }
+}

--- a/plugins/events-node/package.json
+++ b/plugins/events-node/package.json
@@ -56,6 +56,7 @@
     "@backstage/errors": "workspace:^",
     "@backstage/types": "workspace:^",
     "@types/express": "^4.17.6",
+    "content-type": "^1.0.5",
     "cross-fetch": "^4.0.0",
     "express": "^4.17.1",
     "uri-template": "^2.0.0"

--- a/plugins/events-node/package.json
+++ b/plugins/events-node/package.json
@@ -55,7 +55,9 @@
     "@backstage/backend-plugin-api": "workspace:^",
     "@backstage/errors": "workspace:^",
     "@backstage/types": "workspace:^",
+    "@types/express": "^4.17.6",
     "cross-fetch": "^4.0.0",
+    "express": "^4.17.1",
     "uri-template": "^2.0.0"
   },
   "devDependencies": {

--- a/plugins/events-node/package.json
+++ b/plugins/events-node/package.json
@@ -55,6 +55,7 @@
     "@backstage/backend-plugin-api": "workspace:^",
     "@backstage/errors": "workspace:^",
     "@backstage/types": "workspace:^",
+    "@types/content-type": "^1.1.8",
     "@types/express": "^4.17.6",
     "content-type": "^1.0.5",
     "cross-fetch": "^4.0.0",

--- a/plugins/events-node/report-alpha.api.md
+++ b/plugins/events-node/report-alpha.api.md
@@ -7,10 +7,13 @@ import { EventBroker } from '@backstage/plugin-events-node';
 import { EventPublisher } from '@backstage/plugin-events-node';
 import { EventSubscriber } from '@backstage/plugin-events-node';
 import { ExtensionPoint } from '@backstage/backend-plugin-api';
+import { HttpBodyParserOptions } from '@backstage/plugin-events-node';
 import { HttpPostIngressOptions } from '@backstage/plugin-events-node';
 
 // @alpha (undocumented)
 export interface EventsExtensionPoint {
+  // (undocumented)
+  addHttpPostBodyParser(options: HttpBodyParserOptions): void;
   // (undocumented)
   addHttpPostIngress(options: HttpPostIngressOptions): void;
   // @deprecated (undocumented)

--- a/plugins/events-node/report.api.md
+++ b/plugins/events-node/report.api.md
@@ -9,6 +9,7 @@ import { AuthService } from '@backstage/backend-plugin-api';
 import { DiscoveryService } from '@backstage/backend-plugin-api';
 import { LifecycleService } from '@backstage/backend-plugin-api';
 import { LoggerService } from '@backstage/backend-plugin-api';
+import { Request as Request_2 } from 'express';
 import { RootConfigService } from '@backstage/backend-plugin-api';
 import { ServiceFactory } from '@backstage/backend-plugin-api';
 import { ServiceRef } from '@backstage/backend-plugin-api';
@@ -109,6 +110,27 @@ export interface EventSubscriber {
   onEvent(params: EventParams): Promise<void>;
   // @deprecated
   supportsEventTopics(): string[];
+}
+
+// @public (undocumented)
+export type HttpBodyParsed = {
+  bodyParsed: any;
+  bodyBuffer: Buffer;
+  encoding: string;
+};
+
+// @public (undocumented)
+export type HttpBodyParser = (
+  request: Request_2,
+  topic: string,
+) => Promise<HttpBodyParsed>;
+
+// @public (undocumented)
+export interface HttpBodyParserOptions {
+  // (undocumented)
+  contentType: string;
+  // (undocumented)
+  parser: HttpBodyParser;
 }
 
 // @public (undocumented)

--- a/plugins/events-node/report.api.md
+++ b/plugins/events-node/report.api.md
@@ -9,6 +9,7 @@ import { AuthService } from '@backstage/backend-plugin-api';
 import { DiscoveryService } from '@backstage/backend-plugin-api';
 import { LifecycleService } from '@backstage/backend-plugin-api';
 import { LoggerService } from '@backstage/backend-plugin-api';
+import { ParsedMediaType } from 'content-type';
 import { Request as Request_2 } from 'express';
 import { RootConfigService } from '@backstage/backend-plugin-api';
 import { ServiceFactory } from '@backstage/backend-plugin-api';
@@ -122,6 +123,7 @@ export type HttpBodyParsed = {
 // @public (undocumented)
 export type HttpBodyParser = (
   request: Request_2,
+  parsedMediaType: ParsedMediaType,
   topic: string,
 ) => Promise<HttpBodyParsed>;
 

--- a/plugins/events-node/src/api/http/HttpBodyParserOptions.ts
+++ b/plugins/events-node/src/api/http/HttpBodyParserOptions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Backstage Authors
+ * Copyright 2025 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,8 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { HttpBodyParser } from './body-parser';
 
-export type { HttpPostIngressOptions } from './HttpPostIngressOptions';
-export type { HttpBodyParserOptions } from './HttpBodyParserOptions';
-export * from './validation';
-export * from './body-parser';
+/**
+ * @public
+ */
+export interface HttpBodyParserOptions {
+  contentType: string;
+  parser: HttpBodyParser;
+}

--- a/plugins/events-node/src/api/http/body-parser/HttpBodyParser.ts
+++ b/plugins/events-node/src/api/http/body-parser/HttpBodyParser.ts
@@ -15,6 +15,7 @@
  */
 
 import { Request } from 'express';
+import { ParsedMediaType } from 'content-type';
 /**
  * @public
  */
@@ -29,5 +30,6 @@ export type HttpBodyParsed = {
  */
 export type HttpBodyParser = (
   request: Request,
+  parsedMediaType: ParsedMediaType,
   topic: string,
 ) => Promise<HttpBodyParsed>;

--- a/plugins/events-node/src/api/http/body-parser/HttpBodyParser.ts
+++ b/plugins/events-node/src/api/http/body-parser/HttpBodyParser.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Backstage Authors
+ * Copyright 2025 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,20 @@
  * limitations under the License.
  */
 
-export type { HttpPostIngressOptions } from './HttpPostIngressOptions';
-export type { HttpBodyParserOptions } from './HttpBodyParserOptions';
-export * from './validation';
-export * from './body-parser';
+import { Request } from 'express';
+/**
+ * @public
+ */
+export type HttpBodyParsed = {
+  bodyParsed: any;
+  bodyBuffer: Buffer;
+  encoding: string;
+};
+
+/**
+ * @public
+ */
+export type HttpBodyParser = (
+  request: Request,
+  topic: string,
+) => Promise<HttpBodyParsed>;

--- a/plugins/events-node/src/api/http/body-parser/index.ts
+++ b/plugins/events-node/src/api/http/body-parser/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Backstage Authors
+ * Copyright 2025 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,8 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-export type { HttpPostIngressOptions } from './HttpPostIngressOptions';
-export type { HttpBodyParserOptions } from './HttpBodyParserOptions';
-export * from './validation';
-export * from './body-parser';
+export * from './HttpBodyParser';

--- a/plugins/events-node/src/extensions.ts
+++ b/plugins/events-node/src/extensions.ts
@@ -19,6 +19,7 @@ import {
   EventBroker,
   EventPublisher,
   EventSubscriber,
+  HttpBodyParserOptions,
   HttpPostIngressOptions,
 } from '@backstage/plugin-events-node';
 
@@ -46,6 +47,8 @@ export interface EventsExtensionPoint {
   ): void;
 
   addHttpPostIngress(options: HttpPostIngressOptions): void;
+
+  addHttpPostBodyParser(options: HttpBodyParserOptions): void;
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -6727,7 +6727,9 @@ __metadata:
     "@backstage/cli": "workspace:^"
     "@backstage/errors": "workspace:^"
     "@backstage/types": "workspace:^"
+    "@types/express": ^4.17.6
     cross-fetch: ^4.0.0
+    express: ^4.17.1
     msw: ^1.0.0
     uri-template: ^2.0.0
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -6727,6 +6727,7 @@ __metadata:
     "@backstage/cli": "workspace:^"
     "@backstage/errors": "workspace:^"
     "@backstage/types": "workspace:^"
+    "@types/content-type": ^1.1.8
     "@types/express": ^4.17.6
     content-type: ^1.0.5
     cross-fetch: ^4.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -6728,6 +6728,7 @@ __metadata:
     "@backstage/errors": "workspace:^"
     "@backstage/types": "workspace:^"
     "@types/express": ^4.17.6
+    content-type: ^1.0.5
     cross-fetch: ^4.0.0
     express: ^4.17.1
     msw: ^1.0.0


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Hey @pjungermann

I open this draft to discuss a solution to #28831
It's not a final version, just an idea to provide a way to override the parse to specific endpoints, like that:
```typescript
export const eventsModuleYourFeature = createBackendModule({
  pluginId: 'events',
  moduleId: 'your-feature',
  register(env) {
    // [...]
    env.registerInit({
      deps: {
        // [...]
        events: eventsExtensionPoint,
        // [...]
      },
      async init({ /* ... */ events /*, ... */ }) {
        // [...]
        events.addHttpPostIngress({
          topic: 'your-topic',
          parser: async (req, _topic) => {
            return {
              bodyParsed: JSON.stringify(req.body),
              bodyBuffer: Buffer.from(JSON.stringify(req.body)),
              encoding: 'utf-8'
            };
          }
        });
      },
    });
  },
});

```

WDYT?  
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
