### PR TITLE
Export getLogMeta from backend-defaults

### DIFF
--- a/.changeset/unlucky-lions-thank.md
+++ b/.changeset/unlucky-lions-thank.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Added export for getLogMeta function to allow customization of logging middleware

--- a/packages/backend-defaults/report-rootHttpRouter.api.md
+++ b/packages/backend-defaults/report-rootHttpRouter.api.md
@@ -15,8 +15,10 @@ import { HelmetOptions } from 'helmet';
 import * as http from 'http';
 import { LifecycleService } from '@backstage/backend-plugin-api';
 import { LoggerService } from '@backstage/backend-plugin-api';
+import { Request as Request_2 } from 'express';
 import { RequestHandler } from 'express';
 import { RequestListener } from 'http';
+import { Response as Response_2 } from 'express';
 import { RootConfigService } from '@backstage/backend-plugin-api';
 import { RootHealthService } from '@backstage/backend-plugin-api';
 import { RootHttpRouterService } from '@backstage/backend-plugin-api';
@@ -65,6 +67,9 @@ export interface ExtendedHttpServer extends http.Server {
 }
 
 // @public
+export function getLogMeta(req: Request_2, res: Response_2): LogMeta;
+
+// @public
 export type HttpServerCertificateOptions =
   | {
       type: 'pem';
@@ -85,6 +90,18 @@ export type HttpServerOptions = {
   https?: {
     certificate: HttpServerCertificateOptions;
   };
+};
+
+// @public
+export type LogMeta = {
+  date: string;
+  method: string;
+  url: string;
+  status: number;
+  httpVersion: string;
+  userAgent?: string;
+  contentLength?: number;
+  referrer?: string;
 };
 
 // @public

--- a/packages/backend-defaults/src/entrypoints/rootHttpRouter/http/MiddlewareFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/rootHttpRouter/http/MiddlewareFactory.ts
@@ -44,7 +44,13 @@ import {
 import { NotImplementedError } from '@backstage/errors';
 import { applyInternalErrorFilter } from './applyInternalErrorFilter';
 
-type LogMeta = {
+/**
+ * Type used to represent the metadata of a log entry.
+ *
+ * @public
+ */
+
+export type LogMeta = {
   date: string;
   method: string;
   url: string;
@@ -55,7 +61,13 @@ type LogMeta = {
   referrer?: string;
 };
 
-function getLogMeta(req: Request, res: Response): LogMeta {
+/**
+ * Returns a log metadata object for a given request and response.
+ *
+ * @public
+ */
+
+export function getLogMeta(req: Request, res: Response): LogMeta {
   const referrer = req.headers.referer ?? req.headers.referrer;
   const userAgent = req.headers['user-agent'];
   const contentLength = Number(res.getHeader('content-length'));

--- a/packages/backend-defaults/src/entrypoints/rootHttpRouter/http/index.ts
+++ b/packages/backend-defaults/src/entrypoints/rootHttpRouter/http/index.ts
@@ -16,7 +16,11 @@
 
 export { readHttpServerOptions } from './config';
 export { createHttpServer } from './createHttpServer';
-export { MiddlewareFactory } from './MiddlewareFactory';
+export {
+  MiddlewareFactory,
+  getLogMeta,
+  type LogMeta,
+} from './MiddlewareFactory';
 export type {
   MiddlewareFactoryErrorOptions,
   MiddlewareFactoryOptions,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added export for getLogMeta function to enable middleware customization.
After getting rid of morgan, this function is needed to implement a custom middleware logger.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
