### PR TITLE
scaffolder: add form decorator support to template editor

### DIFF
--- a/.changeset/eighty-ways-train.md
+++ b/.changeset/eighty-ways-train.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Added support for experimental form decorators when dry-running templates in the template editor.

--- a/plugins/scaffolder/src/alpha/components/TemplateEditorPage/DryRunResults/DryRunResults.test.tsx
+++ b/plugins/scaffolder/src/alpha/components/TemplateEditorPage/DryRunResults/DryRunResults.test.tsx
@@ -21,6 +21,7 @@ import React, { useEffect } from 'react';
 import { scaffolderApiRef } from '@backstage/plugin-scaffolder-react';
 import { DryRunProvider, useDryRun } from '../DryRunContext';
 import { DryRunResults } from './DryRunResults';
+import { formDecoratorsApiRef } from '../../../api';
 
 function DryRunRemote({
   execute,
@@ -50,19 +51,30 @@ function DryRunRemote({
   return null;
 }
 
-const mockScaffolderApi = {
-  dryRun: async () => ({
-    directoryContents: [],
-    log: [],
-    output: {},
-    steps: [],
-  }),
-};
+const mockApis = [
+  [
+    scaffolderApiRef,
+    {
+      dryRun: async () => ({
+        directoryContents: [],
+        log: [],
+        output: {},
+        steps: [],
+      }),
+    },
+  ],
+  [
+    formDecoratorsApiRef,
+    {
+      getFormDecorators: async () => [],
+    },
+  ],
+] as const;
 
 describe('DryRunResults', () => {
   it('renders without exploding', async () => {
     await renderInTestApp(
-      <TestApiProvider apis={[[scaffolderApiRef, mockScaffolderApi]]}>
+      <TestApiProvider apis={mockApis}>
         <DryRunProvider>
           <DryRunResults />
         </DryRunProvider>
@@ -73,7 +85,7 @@ describe('DryRunResults', () => {
 
   it('expands when dry-run result is added and toggles on click, and disappears when results are gone', async () => {
     const { rerender } = await renderInTestApp(
-      <TestApiProvider apis={[[scaffolderApiRef, mockScaffolderApi]]}>
+      <TestApiProvider apis={mockApis}>
         <DryRunProvider>
           <DryRunRemote />
           <DryRunResults />
@@ -85,7 +97,7 @@ describe('DryRunResults', () => {
 
     await act(async () => {
       rerender(
-        <TestApiProvider apis={[[scaffolderApiRef, mockScaffolderApi]]}>
+        <TestApiProvider apis={mockApis}>
           <DryRunProvider>
             <DryRunRemote execute />
             <DryRunResults />
@@ -104,7 +116,7 @@ describe('DryRunResults', () => {
 
     await act(async () => {
       rerender(
-        <TestApiProvider apis={[[scaffolderApiRef, mockScaffolderApi]]}>
+        <TestApiProvider apis={mockApis}>
           <DryRunProvider>
             <DryRunRemote remove />
             <DryRunResults />

--- a/plugins/scaffolder/src/alpha/components/TemplateEditorPage/DryRunResults/DryRunResultsList.test.tsx
+++ b/plugins/scaffolder/src/alpha/components/TemplateEditorPage/DryRunResults/DryRunResultsList.test.tsx
@@ -21,6 +21,7 @@ import React, { useEffect } from 'react';
 import { scaffolderApiRef } from '@backstage/plugin-scaffolder-react';
 import { DryRunProvider, useDryRun } from '../DryRunContext';
 import { DryRunResultsList } from './DryRunResultsList';
+import { formDecoratorsApiRef } from '../../../api';
 
 function DryRunRemote({ execute }: { execute?: number }) {
   const dryRun = useDryRun();
@@ -39,19 +40,30 @@ function DryRunRemote({ execute }: { execute?: number }) {
   return null;
 }
 
-const mockScaffolderApi = {
-  dryRun: async () => ({
-    directoryContents: [],
-    log: [],
-    output: {},
-    steps: [],
-  }),
-};
+const mockApis = [
+  [
+    scaffolderApiRef,
+    {
+      dryRun: async () => ({
+        directoryContents: [],
+        log: [],
+        output: {},
+        steps: [],
+      }),
+    },
+  ],
+  [
+    formDecoratorsApiRef,
+    {
+      getFormDecorators: async () => [],
+    },
+  ],
+] as const;
 
 describe('DryRunResultsList', () => {
   it('renders without exploding', async () => {
     const rendered = await renderInTestApp(
-      <TestApiProvider apis={[[scaffolderApiRef, mockScaffolderApi]]}>
+      <TestApiProvider apis={mockApis}>
         <DryRunProvider>
           <DryRunResultsList />
         </DryRunProvider>
@@ -62,7 +74,7 @@ describe('DryRunResultsList', () => {
 
   it('adds new result items and deletes them', async () => {
     const { rerender } = await renderInTestApp(
-      <TestApiProvider apis={[[scaffolderApiRef, mockScaffolderApi]]}>
+      <TestApiProvider apis={mockApis}>
         <DryRunProvider>
           <DryRunRemote execute={1} />
           <DryRunResultsList />
@@ -75,7 +87,7 @@ describe('DryRunResultsList', () => {
 
     await act(async () => {
       rerender(
-        <TestApiProvider apis={[[scaffolderApiRef, mockScaffolderApi]]}>
+        <TestApiProvider apis={mockApis}>
           <DryRunProvider>
             <DryRunRemote execute={2} />
             <DryRunResultsList />

--- a/plugins/scaffolder/src/alpha/components/TemplateEditorPage/DryRunResults/DryRunResultsView.test.tsx
+++ b/plugins/scaffolder/src/alpha/components/TemplateEditorPage/DryRunResults/DryRunResultsView.test.tsx
@@ -22,6 +22,7 @@ import React, { ReactNode, useEffect } from 'react';
 import { scaffolderApiRef } from '@backstage/plugin-scaffolder-react';
 import { DryRunProvider, useDryRun } from '../DryRunContext';
 import { DryRunResultsView } from './DryRunResultsView';
+import { formDecoratorsApiRef } from '../../../api';
 
 // The <AutoSizer> inside <LogViewer> needs mocking to render in jsdom
 jest.mock('react-virtualized-auto-sizer', () => ({
@@ -68,6 +69,12 @@ describe('DryRunResultsView', () => {
                 },
                 steps: [{ id: 'foo', action: 'foo', name: 'Foo' }],
               }),
+            },
+          ],
+          [
+            formDecoratorsApiRef,
+            {
+              getFormDecorators: async () => [],
             },
           ],
         ]}

--- a/plugins/scaffolder/src/alpha/components/TemplateEditorPage/TemplateEditorPage.test.tsx
+++ b/plugins/scaffolder/src/alpha/components/TemplateEditorPage/TemplateEditorPage.test.tsx
@@ -21,10 +21,14 @@ import { catalogApiRef } from '@backstage/plugin-catalog-react';
 import { scaffolderApiRef } from '@backstage/plugin-scaffolder-react';
 import { TemplateEditorPage } from './TemplateEditorPage';
 import { rootRouteRef } from '../../../routes';
+import { formDecoratorsApiRef } from '../../api';
 
 describe('TemplateEditorPage', () => {
   const catalogApiMock = { getEntities: jest.fn().mockResolvedValue([]) };
   const scaffolderApiMock = {};
+  const formDecoratorsApiMock = {
+    getFormDecorators: jest.fn().mockResolvedValue([]),
+  };
 
   it('Should render without exploding', async () => {
     await renderInTestApp(
@@ -32,6 +36,7 @@ describe('TemplateEditorPage', () => {
         apis={[
           [catalogApiRef, catalogApiMock],
           [scaffolderApiRef, scaffolderApiMock],
+          [formDecoratorsApiRef, formDecoratorsApiMock],
         ]}
       >
         <TemplateEditorPage />
@@ -53,6 +58,7 @@ describe('TemplateEditorPage', () => {
         apis={[
           [catalogApiRef, catalogApiMock],
           [scaffolderApiRef, scaffolderApiMock],
+          [formDecoratorsApiRef, formDecoratorsApiMock],
         ]}
       >
         <TemplateEditorPage />

--- a/plugins/scaffolder/src/alpha/components/TemplateWizardPage/TemplateWizardPage.tsx
+++ b/plugins/scaffolder/src/alpha/components/TemplateWizardPage/TemplateWizardPage.tsx
@@ -91,7 +91,7 @@ export const TemplateWizardPage = (props: TemplateWizardPageProps) => {
   });
 
   const { manifest } = useTemplateParameterSchema(templateRef);
-  const decorators = useFormDecorators({ manifest });
+  const decorators = useFormDecorators();
 
   const { value: editUrl } = useAsync(async () => {
     const data = await catalogApi.getEntityByRef(templateRef);
@@ -108,6 +108,7 @@ export const TemplateWizardPage = (props: TemplateWizardPageProps) => {
     const { formState: values, secrets } = await decorators.run({
       formState: initialValues,
       secrets: contextSecrets,
+      manifest,
     });
 
     const { taskId } = await scaffolderApi.scaffold({

--- a/plugins/scaffolder/src/alpha/hooks/useFormDecorators.test.tsx
+++ b/plugins/scaffolder/src/alpha/hooks/useFormDecorators.test.tsx
@@ -51,7 +51,7 @@ describe('useFormDecorators', () => {
   };
 
   it('should run the form decorators for a given manifest with the correct input', async () => {
-    const renderedHook = renderHook(() => useFormDecorators({ manifest }), {
+    const renderedHook = renderHook(() => useFormDecorators(), {
       wrapper: ({ children }) => (
         <TestApiProvider
           apis={[
@@ -76,6 +76,7 @@ describe('useFormDecorators', () => {
       await result.run({
         formState: {},
         secrets: {},
+        manifest,
       });
 
       expect(mockApiImplementation.test).toHaveBeenCalledWith('hello');
@@ -83,7 +84,7 @@ describe('useFormDecorators', () => {
   });
 
   it('should return existing secrets and formstate', async () => {
-    const renderedHook = renderHook(() => useFormDecorators({ manifest }), {
+    const renderedHook = renderHook(() => useFormDecorators(), {
       wrapper: ({ children }) => (
         <TestApiProvider
           apis={[
@@ -107,6 +108,7 @@ describe('useFormDecorators', () => {
       const { secrets, formState } = await result.run({
         formState: { test: 'formState' },
         secrets: { test: 'hello' },
+        manifest,
       });
 
       expect(secrets).toEqual({ test: 'hello' });
@@ -122,7 +124,7 @@ describe('useFormDecorators', () => {
         setSecrets(state => ({ ...state, new: 'hello' }));
       },
     });
-    const renderedHook = renderHook(() => useFormDecorators({ manifest }), {
+    const renderedHook = renderHook(() => useFormDecorators(), {
       wrapper: ({ children }) => (
         <TestApiProvider
           apis={[
@@ -146,6 +148,7 @@ describe('useFormDecorators', () => {
       const { secrets, formState } = await result.run({
         formState: { test: 'formState' },
         secrets: { test: 'hello' },
+        manifest,
       });
 
       expect(secrets).toEqual({ test: 'hello', new: 'hello' });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds support for running form decorators as part of dry-running templates in the template editor.

Somewhat related to and a partial fix for #26502

I figured the best way to roll these out is to add support for them here, and then start adding them to templates. That'll provide the benefit that secrets get fetched just before the template is run, avoiding potential token expiration issues. We still have a duplicate fetch of secrets in the component ID picker for example, but removing that at this point will break existing templates.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
