### PR TITLE
Expose pages from scaffolder plugin

### DIFF
--- a/.changeset/swift-cows-collect.md
+++ b/.changeset/swift-cows-collect.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': minor
+---
+
+Expose individual pages for usage outside scaffolder plugin

--- a/plugins/scaffolder/report.api.md
+++ b/plugins/scaffolder/report.api.md
@@ -14,6 +14,7 @@ import { createScaffolderLayout as createScaffolderLayout_2 } from '@backstage/p
 import { CustomFieldExtensionSchema as CustomFieldExtensionSchema_2 } from '@backstage/plugin-scaffolder-react';
 import { CustomFieldValidator as CustomFieldValidator_2 } from '@backstage/plugin-scaffolder-react';
 import { DiscoveryApi } from '@backstage/core-plugin-api';
+import { Dispatch } from 'react';
 import { ExternalRouteRef } from '@backstage/core-plugin-api';
 import { FetchApi } from '@backstage/core-plugin-api';
 import { FieldExtensionComponent as FieldExtensionComponent_2 } from '@backstage/plugin-scaffolder-react';
@@ -49,6 +50,7 @@ import { ScaffolderTaskOutput as ScaffolderTaskOutput_2 } from '@backstage/plugi
 import { ScaffolderTaskStatus as ScaffolderTaskStatus_2 } from '@backstage/plugin-scaffolder-react';
 import { ScaffolderUseTemplateSecrets as ScaffolderUseTemplateSecrets_2 } from '@backstage/plugin-scaffolder-react';
 import { ScmIntegrationRegistry } from '@backstage/integration';
+import { SetStateAction } from 'react';
 import { SubRouteRef } from '@backstage/core-plugin-api';
 import { TemplateEntityV1beta3 } from '@backstage/plugin-scaffolder-common';
 import { TemplateGroupFilter } from '@backstage/plugin-scaffolder-react';
@@ -56,6 +58,12 @@ import { TemplateListPageProps } from '@backstage/plugin-scaffolder/alpha';
 import { TemplateParameterSchema as TemplateParameterSchema_2 } from '@backstage/plugin-scaffolder-react';
 import { TemplateWizardPageProps } from '@backstage/plugin-scaffolder/alpha';
 import { z } from 'zod';
+
+// Warning: (ae-forgotten-export) The symbol "ActionsPageProps" needs to be exported by the entry point index.d.ts
+// Warning: (ae-missing-release-tag) "ActionsPage" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const ActionsPage: (props: ActionsPageProps) => React_2.JSX.Element;
 
 // @public @deprecated (undocumented)
 export const createScaffolderFieldExtension: typeof createScaffolderFieldExtension_2;
@@ -186,6 +194,19 @@ export type LayoutTemplate = LayoutTemplate_2;
 
 // @public @deprecated (undocumented)
 export type ListActionsResponse = ListActionsResponse_2;
+
+// Warning: (ae-forgotten-export) The symbol "ListTasksTableProps" needs to be exported by the entry point index.d.ts
+// Warning: (ae-missing-release-tag) "ListTasksTable" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export function ListTasksTable({
+  page,
+  setPage,
+  limit,
+  setLimit,
+  tasks,
+  totalTasks,
+}: Readonly<ListTasksTableProps>): React_2.JSX.Element;
 
 // @public @deprecated (undocumented)
 export type LogEvent = LogEvent_2;

--- a/plugins/scaffolder/report.api.md
+++ b/plugins/scaffolder/report.api.md
@@ -59,11 +59,21 @@ import { TemplateParameterSchema as TemplateParameterSchema_2 } from '@backstage
 import { TemplateWizardPageProps } from '@backstage/plugin-scaffolder/alpha';
 import { z } from 'zod';
 
-// Warning: (ae-forgotten-export) The symbol "ActionsPageProps" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "ActionsPage" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const ActionsPage: (props: ActionsPageProps) => React_2.JSX.Element;
+
+// Warning: (ae-missing-release-tag) "ActionsPageProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type ActionsPageProps = {
+  contextMenu?: {
+    editor?: boolean;
+    tasks?: boolean;
+    create?: boolean;
+  };
+};
 
 // @public @deprecated (undocumented)
 export const createScaffolderFieldExtension: typeof createScaffolderFieldExtension_2;

--- a/plugins/scaffolder/report.api.md
+++ b/plugins/scaffolder/report.api.md
@@ -59,13 +59,9 @@ import { TemplateParameterSchema as TemplateParameterSchema_2 } from '@backstage
 import { TemplateWizardPageProps } from '@backstage/plugin-scaffolder/alpha';
 import { z } from 'zod';
 
-// Warning: (ae-missing-release-tag) "ActionsPage" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
 export const ActionsPage: (props: ActionsPageProps) => React_2.JSX.Element;
 
-// Warning: (ae-missing-release-tag) "ActionsPageProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
 export type ActionsPageProps = {
   contextMenu?: {
@@ -205,9 +201,6 @@ export type LayoutTemplate = LayoutTemplate_2;
 // @public @deprecated (undocumented)
 export type ListActionsResponse = ListActionsResponse_2;
 
-// Warning: (ae-forgotten-export) The symbol "ListTasksTableProps" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "ListTasksTable" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
 export function ListTasksTable({
   page,
@@ -217,6 +210,22 @@ export function ListTasksTable({
   tasks,
   totalTasks,
 }: Readonly<ListTasksTableProps>): React_2.JSX.Element;
+
+// @public (undocumented)
+export interface ListTasksTableProps {
+  // (undocumented)
+  limit: number;
+  // (undocumented)
+  page: number;
+  // (undocumented)
+  setLimit: Dispatch<SetStateAction<number>>;
+  // (undocumented)
+  setPage: Dispatch<SetStateAction<number>>;
+  // (undocumented)
+  tasks?: ScaffolderTask_2[];
+  // (undocumented)
+  totalTasks?: number;
+}
 
 // @public @deprecated (undocumented)
 export type LogEvent = LogEvent_2;

--- a/plugins/scaffolder/src/components/ActionsPage/ActionsPage.tsx
+++ b/plugins/scaffolder/src/components/ActionsPage/ActionsPage.tsx
@@ -414,6 +414,7 @@ export const ActionPageContent = () => {
   );
 };
 
+/** @public */
 export type ActionsPageProps = {
   contextMenu?: {
     editor?: boolean;
@@ -422,6 +423,7 @@ export type ActionsPageProps = {
   };
 };
 
+/** @public */
 export const ActionsPage = (props: ActionsPageProps) => {
   const navigate = useNavigate();
   const editorLink = useRouteRef(editRouteRef);

--- a/plugins/scaffolder/src/components/ActionsPage/index.ts
+++ b/plugins/scaffolder/src/components/ActionsPage/index.ts
@@ -13,5 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 export { ActionsPage } from './ActionsPage';
+export type { ActionsPageProps } from './ActionsPage';

--- a/plugins/scaffolder/src/components/ListTasksPage/ListTasksPage.tsx
+++ b/plugins/scaffolder/src/components/ListTasksPage/ListTasksPage.tsx
@@ -44,7 +44,8 @@ import { useNavigate } from 'react-router-dom';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { scaffolderTranslationRef } from '../../translation';
 
-interface ListTasksTableProps {
+/** @public */
+export interface ListTasksTableProps {
   page: number;
   setPage: Dispatch<SetStateAction<number>>;
   limit: number;
@@ -53,6 +54,7 @@ interface ListTasksTableProps {
   totalTasks?: number;
 }
 
+/** @public */
 export function ListTasksTable({
   page,
   setPage,

--- a/plugins/scaffolder/src/components/ListTasksPage/index.tsx
+++ b/plugins/scaffolder/src/components/ListTasksPage/index.tsx
@@ -13,4 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { ListTasksPage } from './ListTasksPage';
+export { ListTasksTable, ListTasksPage } from './ListTasksPage';

--- a/plugins/scaffolder/src/components/ListTasksPage/index.tsx
+++ b/plugins/scaffolder/src/components/ListTasksPage/index.tsx
@@ -14,3 +14,4 @@
  * limitations under the License.
  */
 export { ListTasksTable, ListTasksPage } from './ListTasksPage';
+export type { ListTasksTableProps } from './ListTasksPage';

--- a/plugins/scaffolder/src/components/index.ts
+++ b/plugins/scaffolder/src/components/index.ts
@@ -21,6 +21,6 @@ export { TemplateTypePicker } from './TemplateTypePicker';
 export type { RouterProps } from './Router';
 export { OngoingTask as TaskPage } from './OngoingTask';
 export { ListTasksTable } from './ListTasksPage';
+export type { ActionsPageProps } from './ActionsPage';
 export { ActionsPage } from './ActionsPage';
-
 export type { ReviewStepProps } from '@backstage/plugin-scaffolder-react';

--- a/plugins/scaffolder/src/components/index.ts
+++ b/plugins/scaffolder/src/components/index.ts
@@ -20,7 +20,7 @@ export { TemplateTypePicker } from './TemplateTypePicker';
 
 export type { RouterProps } from './Router';
 export { OngoingTask as TaskPage } from './OngoingTask';
-export { ListTasksPage } from './ListTasksPage';
+export { ListTasksTable } from './ListTasksPage';
 export { ActionsPage } from './ActionsPage';
 
 export type { ReviewStepProps } from '@backstage/plugin-scaffolder-react';

--- a/plugins/scaffolder/src/components/index.ts
+++ b/plugins/scaffolder/src/components/index.ts
@@ -20,5 +20,7 @@ export { TemplateTypePicker } from './TemplateTypePicker';
 
 export type { RouterProps } from './Router';
 export { OngoingTask as TaskPage } from './OngoingTask';
+export { ListTasksPage } from './ListTasksPage';
+export { ActionsPage } from './ActionsPage';
 
 export type { ReviewStepProps } from '@backstage/plugin-scaffolder-react';

--- a/plugins/scaffolder/src/components/index.ts
+++ b/plugins/scaffolder/src/components/index.ts
@@ -20,6 +20,7 @@ export { TemplateTypePicker } from './TemplateTypePicker';
 
 export type { RouterProps } from './Router';
 export { OngoingTask as TaskPage } from './OngoingTask';
+export type { ListTasksTableProps } from './ListTasksPage';
 export { ListTasksTable } from './ListTasksPage';
 export type { ActionsPageProps } from './ActionsPage';
 export { ActionsPage } from './ActionsPage';

--- a/plugins/scaffolder/src/index.ts
+++ b/plugins/scaffolder/src/index.ts
@@ -36,6 +36,7 @@ export {
   ListTasksTable,
   scaffolderPlugin,
 } from './plugin';
+export type { ActionsPageProps } from './plugin';
 
 export * from './components';
 export * from './deprecated';

--- a/plugins/scaffolder/src/index.ts
+++ b/plugins/scaffolder/src/index.ts
@@ -33,7 +33,7 @@ export {
   RepoBranchPickerFieldExtension,
   ScaffolderPage,
   ActionsPage,
-  ListTasksPage,
+  ListTasksTable,
   scaffolderPlugin,
 } from './plugin';
 

--- a/plugins/scaffolder/src/index.ts
+++ b/plugins/scaffolder/src/index.ts
@@ -32,6 +32,8 @@ export {
   MultiEntityPickerFieldExtension,
   RepoBranchPickerFieldExtension,
   ScaffolderPage,
+  ActionsPage,
+  ListTasksPage,
   scaffolderPlugin,
 } from './plugin';
 

--- a/plugins/scaffolder/src/index.ts
+++ b/plugins/scaffolder/src/index.ts
@@ -36,7 +36,7 @@ export {
   ListTasksTable,
   scaffolderPlugin,
 } from './plugin';
-export type { ActionsPageProps } from './plugin';
+export type { ActionsPageProps, ListTasksTableProps } from './plugin';
 
 export * from './components';
 export * from './deprecated';

--- a/plugins/scaffolder/src/plugin.tsx
+++ b/plugins/scaffolder/src/plugin.tsx
@@ -14,35 +14,6 @@
  * limitations under the License.
  */
 
-import { scmIntegrationsApiRef } from '@backstage/integration-react';
-import {
-  createScaffolderFieldExtension,
-  scaffolderApiRef,
-} from '@backstage/plugin-scaffolder-react';
-import { ScaffolderClient } from './api';
-import {
-  EntityPicker,
-  EntityPickerSchema,
-} from './components/fields/EntityPicker/EntityPicker';
-import { entityNamePickerValidation } from './components/fields/EntityNamePicker';
-import {
-  EntityNamePicker,
-  EntityNamePickerSchema,
-} from './components/fields/EntityNamePicker/EntityNamePicker';
-import {
-  OwnerPicker,
-  OwnerPickerSchema,
-} from './components/fields/OwnerPicker/OwnerPicker';
-import {
-  MultiEntityPicker,
-  MultiEntityPickerSchema,
-  validateMultiEntityPickerValidation,
-} from './components/fields/MultiEntityPicker/MultiEntityPicker';
-import { repoPickerValidation } from './components/fields/RepoUrlPicker';
-import {
-  RepoUrlPicker,
-  RepoUrlPickerSchema,
-} from './components/fields/RepoUrlPicker/RepoUrlPicker';
 import {
   createApiFactory,
   createPlugin,
@@ -51,36 +22,68 @@ import {
   fetchApiRef,
   identityApiRef,
 } from '@backstage/core-plugin-api';
+import { scmIntegrationsApiRef } from '@backstage/integration-react';
 import {
-  OwnedEntityPicker,
-  OwnedEntityPickerSchema,
-} from './components/fields/OwnedEntityPicker/OwnedEntityPicker';
+  createScaffolderFieldExtension,
+  scaffolderApiRef,
+} from '@backstage/plugin-scaffolder-react';
+import { formFieldsApiRef } from '@backstage/plugin-scaffolder-react/alpha';
+import { DefaultScaffolderFormDecoratorsApi } from './alpha/api/FormDecoratorsApi';
+import { formDecoratorsApiRef } from './alpha/api/ref';
+import { ScaffolderClient } from './api';
+import { ActionsPage, ListTasksPage } from './components';
+import { entityNamePickerValidation } from './components/fields/EntityNamePicker';
+import {
+  EntityNamePicker,
+  EntityNamePickerSchema,
+} from './components/fields/EntityNamePicker/EntityNamePicker';
+import {
+  EntityPicker,
+  EntityPickerSchema,
+} from './components/fields/EntityPicker/EntityPicker';
 import {
   EntityTagsPicker,
   EntityTagsPickerSchema,
 } from './components/fields/EntityTagsPicker/EntityTagsPicker';
 import {
-  registerComponentRouteRef,
-  rootRouteRef,
-  viewTechDocRouteRef,
-  selectedTemplateRouteRef,
-  scaffolderTaskRouteRef,
-  scaffolderListTaskRouteRef,
-  actionsRouteRef,
-  editRouteRef,
-  editorRouteRef,
-  customFieldsRouteRef,
-  templateFormRouteRef,
-} from './routes';
+  MultiEntityPicker,
+  MultiEntityPickerSchema,
+  validateMultiEntityPickerValidation,
+} from './components/fields/MultiEntityPicker/MultiEntityPicker';
 import {
   MyGroupsPicker,
   MyGroupsPickerSchema,
 } from './components/fields/MyGroupsPicker/MyGroupsPicker';
+import {
+  OwnedEntityPicker,
+  OwnedEntityPickerSchema,
+} from './components/fields/OwnedEntityPicker/OwnedEntityPicker';
+import {
+  OwnerPicker,
+  OwnerPickerSchema,
+} from './components/fields/OwnerPicker/OwnerPicker';
 import { RepoBranchPicker } from './components/fields/RepoBranchPicker/RepoBranchPicker';
 import { RepoBranchPickerSchema } from './components/fields/RepoBranchPicker/schema';
-import { formDecoratorsApiRef } from './alpha/api/ref';
-import { DefaultScaffolderFormDecoratorsApi } from './alpha/api/FormDecoratorsApi';
-import { formFieldsApiRef } from '@backstage/plugin-scaffolder-react/alpha';
+import { repoPickerValidation } from './components/fields/RepoUrlPicker';
+import {
+  RepoUrlPicker,
+  RepoUrlPickerSchema,
+} from './components/fields/RepoUrlPicker/RepoUrlPicker';
+import {
+  actionsRouteRef,
+  customFieldsRouteRef,
+  editRouteRef,
+  editorRouteRef,
+  registerComponentRouteRef,
+  rootRouteRef,
+  scaffolderListTaskRouteRef,
+  scaffolderTaskRouteRef,
+  selectedTemplateRouteRef,
+  templateFormRouteRef,
+  viewTechDocRouteRef,
+} from './routes';
+
+export { ActionsPage, ListTasksPage };
 
 /**
  * The main plugin export for the scaffolder.

--- a/plugins/scaffolder/src/plugin.tsx
+++ b/plugins/scaffolder/src/plugin.tsx
@@ -31,7 +31,7 @@ import { formFieldsApiRef } from '@backstage/plugin-scaffolder-react/alpha';
 import { DefaultScaffolderFormDecoratorsApi } from './alpha/api/FormDecoratorsApi';
 import { formDecoratorsApiRef } from './alpha/api/ref';
 import { ScaffolderClient } from './api';
-import { ActionsPage, ListTasksTable } from './components';
+import { ActionsPage, ListTasksTable, ActionsPageProps } from './components';
 import { entityNamePickerValidation } from './components/fields/EntityNamePicker';
 import {
   EntityNamePicker,
@@ -87,6 +87,7 @@ import {
  *  Partials exports
  *  @public
  */
+export type { ActionsPageProps };
 export { ActionsPage, ListTasksTable };
 
 /**

--- a/plugins/scaffolder/src/plugin.tsx
+++ b/plugins/scaffolder/src/plugin.tsx
@@ -31,7 +31,7 @@ import { formFieldsApiRef } from '@backstage/plugin-scaffolder-react/alpha';
 import { DefaultScaffolderFormDecoratorsApi } from './alpha/api/FormDecoratorsApi';
 import { formDecoratorsApiRef } from './alpha/api/ref';
 import { ScaffolderClient } from './api';
-import { ActionsPage, ListTasksPage } from './components';
+import { ActionsPage, ListTasksTable } from './components';
 import { entityNamePickerValidation } from './components/fields/EntityNamePicker';
 import {
   EntityNamePicker,
@@ -83,7 +83,11 @@ import {
   viewTechDocRouteRef,
 } from './routes';
 
-export { ActionsPage, ListTasksPage };
+/**
+ *  Partials exports
+ *  @public
+ */
+export { ActionsPage, ListTasksTable };
 
 /**
  * The main plugin export for the scaffolder.

--- a/plugins/scaffolder/src/plugin.tsx
+++ b/plugins/scaffolder/src/plugin.tsx
@@ -31,7 +31,12 @@ import { formFieldsApiRef } from '@backstage/plugin-scaffolder-react/alpha';
 import { DefaultScaffolderFormDecoratorsApi } from './alpha/api/FormDecoratorsApi';
 import { formDecoratorsApiRef } from './alpha/api/ref';
 import { ScaffolderClient } from './api';
-import { ActionsPage, ListTasksTable, ActionsPageProps } from './components';
+import {
+  ActionsPage,
+  ListTasksTable,
+  ActionsPageProps,
+  ListTasksTableProps,
+} from './components';
 import { entityNamePickerValidation } from './components/fields/EntityNamePicker';
 import {
   EntityNamePicker,
@@ -87,7 +92,7 @@ import {
  *  Partials exports
  *  @public
  */
-export type { ActionsPageProps };
+export type { ActionsPageProps, ListTasksTableProps };
 export { ActionsPage, ListTasksTable };
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Scaffolder plugin now exposes "ActionsPage" and "ListTasksPage" for use outside plugin.

Reference: https://github.com/backstage/backstage/issues/28811
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
