### PR TITLE
fix: encode group path for getGroupByPath (#28826)

### DIFF
--- a/.changeset/sour-kids-nail.md
+++ b/.changeset/sour-kids-nail.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend-module-gitlab': patch
 ---
 
-Fix GitlabOrgDiscoveryEntityProvider group path not being encoded causing 404 when using a subgroup in config.group
+Fix `GitlabOrgDiscoveryEntityProvider` group path not being encoded causing 404 when using a subgroup in `config.group`

--- a/.changeset/sour-kids-nail.md
+++ b/.changeset/sour-kids-nail.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-gitlab': patch
+---
+
+Fix GitlabOrgDiscoveryEntityProvider group path not being encoded causing 404 when using a subgroup in config.group

--- a/plugins/catalog-backend-module-gitlab/src/__testUtils__/handlers.ts
+++ b/plugins/catalog-backend-module-gitlab/src/__testUtils__/handlers.ts
@@ -139,17 +139,27 @@ const httpHandlers = [
 // https://docs.gitlab.com/ee/api/groups.html#list-group-details supports encoded path and id
 const httpGroupFindByEncodedPathDynamic = all_groups_response.flatMap(group => [
   // Handler for apiBaseUrl
-  rest.get(`${apiBaseUrl}/groups/${group.full_path}`, (_, res, ctx) => {
-    return res(
-      ctx.json(all_groups_response.find(g => g.full_path === group.full_path)),
-    );
-  }),
+  rest.get(
+    `${apiBaseUrl}/groups/${encodeURIComponent(group.full_path)}`,
+    (_, res, ctx) => {
+      return res(
+        ctx.json(
+          all_groups_response.find(g => g.full_path === group.full_path),
+        ),
+      );
+    },
+  ),
   // Handler for apiSaaSBaseUrl
-  rest.get(`${apiBaseUrlSaas}/groups/${group.full_path}`, (_, res, ctx) => {
-    return res(
-      ctx.json(all_groups_response.find(g => g.full_path === group.full_path)),
-    );
-  }),
+  rest.get(
+    `${apiBaseUrlSaas}/groups/${encodeURIComponent(group.full_path)}`,
+    (_, res, ctx) => {
+      return res(
+        ctx.json(
+          all_groups_response.find(g => g.full_path === group.full_path),
+        ),
+      );
+    },
+  ),
 ]);
 
 const httpGroupFindByIdDynamic = all_groups_response.map(group => {

--- a/plugins/catalog-backend-module-gitlab/src/lib/client.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/client.ts
@@ -174,7 +174,10 @@ export class GitLabClient {
     groupPath: string,
     options?: CommonListOptions,
   ): Promise<GitLabGroup> {
-    return this.nonPagedRequest(`/groups/${groupPath}`, options);
+    return this.nonPagedRequest(
+      `/groups/${encodeURIComponent(groupPath)}`,
+      options,
+    );
   }
 
   async listDescendantGroups(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes the missing encoding of the group path parameter mentioned in #28826.

### Before
Using `publi10/subgroup1` on gitlab.com returns 404 because the path is not encoded.
![grafik](https://github.com/user-attachments/assets/551ffd3a-7cc3-479f-bad9-d53440c568e7)

### After
Path is correctly encoded, groups are loaded.
![grafik](https://github.com/user-attachments/assets/21415e4c-bdf2-42aa-b399-75f08fa883de)
![grafik](https://github.com/user-attachments/assets/c32d0a43-5262-4200-8df1-3325d0c3bf4d)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
