### PR TITLE
Changing the default behaviour of the checkpoint in createMockActionContext. It will reduce the code boilerplate in the tests where checkpoint is used.

### DIFF
--- a/.changeset/six-elephants-rest.md
+++ b/.changeset/six-elephants-rest.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-node-test-utils': patch
+---
+
+Changing the default behaviour of the checkpoint in createMockActionContext. It will reduce the code boilerplate in the tests where checkpoint is used.

--- a/plugins/scaffolder-node-test-utils/src/actions/mockActionContext.ts
+++ b/plugins/scaffolder-node-test-utils/src/actions/mockActionContext.ts
@@ -21,7 +21,7 @@ import {
   mockCredentials,
   mockServices,
 } from '@backstage/backend-test-utils';
-import { JsonObject } from '@backstage/types';
+import { JsonObject, JsonValue } from '@backstage/types';
 import { ActionContext } from '@backstage/plugin-scaffolder-node';
 
 /**
@@ -43,7 +43,12 @@ export const createMockActionContext = <
     output: jest.fn(),
     createTemporaryDirectory: jest.fn(),
     input: {} as TActionInput,
-    checkpoint: jest.fn(),
+    async checkpoint<T extends JsonValue | void>(opts: {
+      key: string;
+      fn: () => Promise<T> | T;
+    }): Promise<T> {
+      return opts.fn();
+    },
     getInitiatorCredentials: () => Promise.resolve(credentials),
     task: {
       id: 'mock-task-id',


### PR DESCRIPTION

## Hey, I just made a Pull Request!

Changing the default behaviour of the checkpoint in createMockActionContext. It will reduce the code boilerplate in the tests where checkpoint is used.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
