### PR TITLE
Update docs on calling catalog in processor/provider

### DIFF
--- a/docs/features/software-catalog/faq.md
+++ b/docs/features/software-catalog/faq.md
@@ -27,7 +27,7 @@ On the user experience side, a Backstage experience without complete organizatio
 
 ## Can I call the catalog itself from inside a processor / provider?
 
-Any backend module, including those that provide processors and entity providers to the catalog, are technically able to get hold of a catalog client via the `catalogServiceRef` from `@backstage/plugin-catalog-node`. However, it is almost never the right thing to do - especially from processors - and we strongly discourage from doing so.
+While it's possible to get hold of a catalog client via the `catalogServiceRef` from `@backstage/plugin-catalog-node`, it's almost never the right thing to do, and we strongly discourage from doing so.
 
 The catalog processing loop is a very high-speed system where your entire catalog cluster collaborates to race through all entities at the highest possible rate. The ideal processor does an absolute minimum of work, and immediately relinquishes control back. Performing asynchronous requests to external systems - including the catalog - from processors, can quickly become overwhelming for that external system and starve their resources if they aren't prepared to deal with very high rates of small requests. It also significantly slows down the procesing loop, when each step needs to wait for responses. This can lead to work "piling up" in the catalog and delays in seeing entities get updated. The [life of an entity](./life-of-an-entity.md) article shows the sequence of events that happen when an entity goes from original ingestion, through processing, and to becoming final entities.
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

> Any backend module, including those that provide processors and entity providers to the catalog, are technically able to get hold of a catalog client via the catalogServiceRef from @backstage/plugin-catalog-node. However, it is almost never the right thing to do - especially from processors - and we strongly discourage from doing so.

Reading this gives me the impression that I shouldn't be calling the catalog from any backend module, _especially from a provider or processor_. I reworded to keep focus on _calling the catalog from within a processor/provider_. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
