### PR TITLE
Fixed path for template

### DIFF
--- a/.changeset/strange-papayas-study.md
+++ b/.changeset/strange-papayas-study.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Corrected path when trying to add dependency to respective `package.json` when using `yarn new` templates

--- a/packages/cli/src/lib/new/execution/installNewPackage.ts
+++ b/packages/cli/src/lib/new/execution/installNewPackage.ts
@@ -30,18 +30,18 @@ export async function installNewPackage(input: PortableTemplateInput) {
     case 'plugin-common-library':
       return; // No installation action needed for library packages
     case 'frontend-plugin':
-      await addDependency(input, 'package/app/package.json');
+      await addDependency(input, 'packages/app/package.json');
       await tryAddFrontendLegacy(input);
       return;
     case 'frontend-plugin-module':
-      await addDependency(input, 'package/app/package.json');
+      await addDependency(input, 'packages/app/package.json');
       return;
     case 'backend-plugin':
-      await addDependency(input, 'package/backend/package.json');
+      await addDependency(input, 'packages/backend/package.json');
       await tryAddBackend(input);
       return;
     case 'backend-plugin-module':
-      await addDependency(input, 'package/backend/package.json');
+      await addDependency(input, 'packages/backend/package.json');
       await tryAddBackend(input);
       return;
     default:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes #28870

Corrected path when trying to add dependency to respective `package.json` when using `yarn new` templates.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
