### PR TITLE
Update techdocs page title

### DIFF
--- a/.changeset/techdocs-four-needles-switch.md
+++ b/.changeset/techdocs-four-needles-switch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Adds the page name of techdoc to the document's title.

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPage/TechDocsReaderPage.test.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPage/TechDocsReaderPage.test.tsx
@@ -17,7 +17,10 @@
 import React from 'react';
 import { scmIntegrationsApiRef } from '@backstage/integration-react';
 
-import { entityRouteRef } from '@backstage/plugin-catalog-react';
+import {
+  entityPresentationApiRef,
+  entityRouteRef,
+} from '@backstage/plugin-catalog-react';
 import {
   mockApis,
   renderInTestApp,
@@ -81,6 +84,16 @@ const techdocsStorageApiMock: jest.Mocked<typeof techdocsStorageApiRef.T> = {
   syncEntityDocs: jest.fn(),
 };
 
+const entityPresentationApiMock: jest.Mocked<
+  typeof entityPresentationApiRef.T
+> = {
+  forEntity: jest.fn().mockReturnValue({
+    snapshot: {
+      primaryTitle: 'Test Entity',
+    },
+  }),
+};
+
 const fetchApiMock = {
   fetch: jest.fn().mockResolvedValue({
     ok: true,
@@ -115,6 +128,7 @@ const Wrapper = ({ children }: { children: React.ReactNode }) => {
         [configApiRef, configApi],
         [techdocsApiRef, techdocsApiMock],
         [techdocsStorageApiRef, techdocsStorageApiMock],
+        [entityPresentationApiRef, entityPresentationApiMock],
       ]}
     >
       {children}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes https://github.com/backstage/backstage/issues/15289. Parses the techdocs subpage content as well as the entity presentation's display name for the documentation entity to come up with a good document title for better accessibility and navigability.

Before:
<img width="1220" alt="Screenshot 2025-02-18 at 12 14 32 AM" src="https://github.com/user-attachments/assets/670bcbed-cecb-4583-9214-96535ceb13e1" />

After:
<img width="1189" alt="Screenshot 2025-02-18 at 12 08 26 AM" src="https://github.com/user-attachments/assets/adc53830-653f-4da2-b4cb-3b0d833acdfe" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
