### PR TITLE
Fix to correctly check gitbeaker exception response for 404

### DIFF
--- a/.changeset/tidy-rice-raise.md
+++ b/.changeset/tidy-rice-raise.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gitlab': patch
+---
+
+Fixed bug in gitlabRepoPush where it was looking in the wrong place in the exception response from gitbeaker when checking if the branch already exists

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.test.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.test.ts
@@ -335,8 +335,10 @@ describe('createGitLabCommit', () => {
   describe('createCommitToBranchThatDoesNotExist', () => {
     it('should create a new branch', async () => {
       mockGitlabClient.Branches.show.mockRejectedValue({
-        response: {
-          statusCode: 404,
+        cause: {
+          response: {
+            status: 404,
+          },
         },
       });
       const input = {

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.ts
@@ -156,7 +156,7 @@ export const createGitlabRepoPushAction = (options: {
         await api.Branches.show(repoID, branchName);
         branchExists = true;
       } catch (e: any) {
-        if (e.response?.statusCode !== 404) {
+        if (e.cause?.response?.status !== 404) {
           throw new InputError(
             `Failed to check status of branch '${branchName}'. Please make sure that branch already exists or Backstage has permissions to create one. ${getErrorMessage(
               e,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updated the if statment in the gitlab repo scaffolder module to correctly find the 404 response code when checking for a branch of the same name already exists.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
