### PR TITLE
fix(core-components): SimpleStepper back button works with activeStep set higher than 0

### DIFF
--- a/.changeset/beige-chairs-suffer.md
+++ b/.changeset/beige-chairs-suffer.md
@@ -2,4 +2,4 @@
 '@backstage/core-components': minor
 ---
 
-SimpleStepper back button now works with activeStep property set higher than 0
+`SimpleStepper` back button now works with `activeStep` property set higher than 0

--- a/.changeset/beige-chairs-suffer.md
+++ b/.changeset/beige-chairs-suffer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': minor
+---
+
+SimpleStepper back button now works with activeStep property set higher than 0

--- a/packages/core-components/src/components/SimpleStepper/SimpleStepper.test.tsx
+++ b/packages/core-components/src/components/SimpleStepper/SimpleStepper.test.tsx
@@ -173,4 +173,32 @@ describe('Stepper', () => {
     fireEvent.click(getTextInSlide(rendered, 2)('Back') as Node);
     expect(rendered.getByText('step1')).toBeInTheDocument();
   });
+
+  it('Handles onBack action properly when activeStep is higher than 0', async () => {
+    const rendered = await renderInTestApp(
+      <Stepper activeStep={2}>
+        <Step title="Step 0" data-testid="step0">
+          <div>step0</div>
+        </Step>
+        <Step title="Step 1" data-testid="step1">
+          <div>step1</div>
+        </Step>
+        <Step title="Step 2" data-testid="step2">
+          <div>step2</div>
+        </Step>
+      </Stepper>,
+    );
+
+    fireEvent.click(getTextInSlide(rendered, 2)('Back') as Node);
+    expect(rendered.getByText('step1')).toBeInTheDocument();
+
+    fireEvent.click(getTextInSlide(rendered, 1)('Back') as Node);
+    expect(rendered.getByText('step0')).toBeInTheDocument();
+
+    fireEvent.click(getTextInSlide(rendered, 0)('Next') as Node);
+    expect(rendered.getByText('step1')).toBeInTheDocument();
+
+    fireEvent.click(getTextInSlide(rendered, 1)('Next') as Node);
+    expect(rendered.getByText('step2')).toBeInTheDocument();
+  });
 });

--- a/packages/core-components/src/components/SimpleStepper/SimpleStepper.tsx
+++ b/packages/core-components/src/components/SimpleStepper/SimpleStepper.tsx
@@ -32,6 +32,7 @@ type InternalState = {
 };
 
 const noop = () => {};
+
 export const VerticalStepperContext = React.createContext<InternalState>({
   stepperLength: 0,
   stepIndex: 0,
@@ -50,7 +51,17 @@ export interface StepperProps {
 export function SimpleStepper(props: PropsWithChildren<StepperProps>) {
   const { children, elevated, onStepChange, activeStep = 0 } = props;
   const [stepIndex, setStepIndex] = useState<number>(activeStep);
-  const [stepHistory, setStepHistory] = useState<number[]>([0]);
+  /*
+  Recreates the stepHistory array based on the activeStep
+  to make sure the handleBack function of the Footer works when activeStep is higher than 0
+  */
+  const inOrderRecreatedStepHistory = Array.from(
+    { length: activeStep + 1 },
+    (_, i) => i,
+  );
+  const [stepHistory, setStepHistory] = useState<number[]>(
+    inOrderRecreatedStepHistory,
+  );
 
   useEffect(() => {
     setStepIndex(activeStep);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes this issue. https://github.com/backstage/backstage/issues/28786

The back button functionality looks at the stepHistory array and uses the pop functionality to determine the previous step it was on. It was always populated by a single 0 entry. This meant that if you don't start at the first step it empties the array and cannot determine the correct previous step anymore. 

This step fixes this issue by populating the stepHistory array with integers in numerical order stopping at the activeStep given. This makes the functionality work for steppers where the flow is in numerical order. It won't take into account if certain steps are skipped. If that is a problem maybe we can opt to add an override options to the stepper so users can figure out the correct initial step history array out for their own use case.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Tests for new functionality and regression tests for bug fixes
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
