### PR TITLE
feat(auth): enable persistency of scopes for Bitbucket Cloud

### DIFF
--- a/.changeset/chatty-days-wonder.md
+++ b/.changeset/chatty-days-wonder.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-bitbucket-provider': patch
+---
+
+Enabled persistency of scopes for Bitbucket Cloud.

--- a/.changeset/serious-guests-tan.md
+++ b/.changeset/serious-guests-tan.md
@@ -2,4 +2,4 @@
 '@backstage/integration-react': patch
 ---
 
-Added scopes `project` and `repository:admin` for Bitbucket Cloud.
+Added scope `project` for Bitbucket Cloud.

--- a/.changeset/serious-guests-tan.md
+++ b/.changeset/serious-guests-tan.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration-react': patch
+---
+
+Added scopes `project` and `repository:admin` for Bitbucket Cloud.

--- a/packages/integration-react/src/api/ScmAuth.test.ts
+++ b/packages/integration-react/src/api/ScmAuth.test.ts
@@ -138,7 +138,7 @@ describe('ScmAuth', () => {
       }),
     ).resolves.toMatchObject({
       token:
-        'account team pullrequest snippet issue project pullrequest:write snippet:write issue:write repository:admin',
+        'account team pullrequest snippet issue project pullrequest:write snippet:write issue:write',
     });
   });
 

--- a/packages/integration-react/src/api/ScmAuth.test.ts
+++ b/packages/integration-react/src/api/ScmAuth.test.ts
@@ -129,7 +129,7 @@ describe('ScmAuth', () => {
     await expect(
       bitbucketAuth.getCredentials({ url: 'http://example.com' }),
     ).resolves.toMatchObject({
-      token: 'account team pullrequest snippet issue',
+      token: 'account team pullrequest snippet issue project',
     });
     await expect(
       bitbucketAuth.getCredentials({
@@ -138,7 +138,7 @@ describe('ScmAuth', () => {
       }),
     ).resolves.toMatchObject({
       token:
-        'account team pullrequest snippet issue pullrequest:write snippet:write issue:write',
+        'account team pullrequest snippet issue project pullrequest:write snippet:write issue:write repository:admin',
     });
   });
 
@@ -195,7 +195,8 @@ describe('ScmAuth', () => {
         },
       }),
     ).resolves.toMatchObject({
-      token: 'account team pullrequest snippet issue snippet:write issue:write',
+      token:
+        'account team pullrequest snippet issue project snippet:write issue:write',
     });
   });
 

--- a/packages/integration-react/src/api/ScmAuth.ts
+++ b/packages/integration-react/src/api/ScmAuth.ts
@@ -239,11 +239,13 @@ export class ScmAuth implements ScmAuthApi {
       'pullrequest',
       'snippet',
       'issue',
+      'project',
     ];
     const repoWriteScopes = options?.scopeMapping?.repoWrite ?? [
       'pullrequest:write',
       'snippet:write',
       'issue:write',
+      'repository:admin',
     ];
     return new ScmAuth('bitbucket', bitbucketAuthApi, host, {
       default: defaultScopes,

--- a/packages/integration-react/src/api/ScmAuth.ts
+++ b/packages/integration-react/src/api/ScmAuth.ts
@@ -245,7 +245,6 @@ export class ScmAuth implements ScmAuthApi {
       'pullrequest:write',
       'snippet:write',
       'issue:write',
-      'repository:admin',
     ];
     return new ScmAuth('bitbucket', bitbucketAuthApi, host, {
       default: defaultScopes,

--- a/plugins/auth-backend-module-bitbucket-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-bitbucket-provider/src/authenticator.ts
@@ -28,6 +28,7 @@ export const bitbucketAuthenticator = createOAuthAuthenticator({
     PassportOAuthAuthenticatorHelper.defaultProfileTransform,
   scopes: {
     required: ['account'],
+    persist: true,
   },
   initialize({ callbackUrl, config }) {
     const clientID = config.getString('clientId');

--- a/plugins/auth-backend-module-bitbucket-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-bitbucket-provider/src/module.test.ts
@@ -73,6 +73,7 @@ describe('authModuleBitbucketProvider', () => {
     expect(decodeOAuthState(startUrl.searchParams.get('state')!)).toEqual({
       env: 'development',
       nonce: decodeURIComponent(nonceCookie.value),
+      scope: 'account',
     });
   });
 });


### PR DESCRIPTION
This PR enables persistency of scopes for Bitbucket Cloud, preventing the OAuth request dialog from popping up every time you want to do something with Bitbucket Cloud.

I wasn't sure whether this was a breaking change since the scaffolder complains about scopes when autocompleting projects and creating repositories if you're missing scopes in `@backstage/integration-react`.

I'm also not 100% sure if I understand how the scopes work: why does it only complain about the scopes as soon as the token gets refreshed (I guess?) and not when initially authenticating? Are the scopes only used for refreshes?

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
