### PR TITLE
fix(notifications): filter null topics

### DIFF
--- a/.changeset/itchy-houses-whisper.md
+++ b/.changeset/itchy-houses-whisper.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications-backend': patch
+---
+
+Fix null topics being returned from notification API

--- a/plugins/notifications-backend/src/database/DatabaseNotificationsStore.test.ts
+++ b/plugins/notifications-backend/src/database/DatabaseNotificationsStore.test.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 import {
+  mockServices,
   TestDatabaseId,
   TestDatabases,
-  mockServices,
 } from '@backstage/backend-test-utils';
 import { DatabaseNotificationsStore } from './DatabaseNotificationsStore';
 import { Knex } from 'knex';
@@ -748,6 +748,7 @@ describe.each(databases.eachSupportedId())(
         await storage.saveNotification(testNotification1);
         await storage.saveNotification(testNotification2);
         await storage.saveBroadcast(testNotification3);
+        await storage.saveNotification(testNotification4); // One without topic
         await storage.saveNotification(otherUserNotification);
 
         const topics = await storage.getTopics({ user });

--- a/plugins/notifications-backend/src/database/DatabaseNotificationsStore.ts
+++ b/plugins/notifications-backend/src/database/DatabaseNotificationsStore.ts
@@ -570,7 +570,9 @@ export class DatabaseNotificationsStore implements NotificationsStore {
       ...options,
       orderField: [{ field: 'topic', order: 'asc' }],
     });
-    const topics = await notificationQuery.distinct(['topic']);
+    const topics = await notificationQuery
+      .whereNotNull('topic')
+      .distinct(['topic']);
     return { topics: topics.map(row => row.topic) };
   }
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

fixes the frontend topic filter when there are notifications without any topic in the database

closes #28902

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
