### PR TITLE
fix(events): increase webhook content limit to 5mb

### DIFF
--- a/.changeset/nasty-lemons-scream.md
+++ b/.changeset/nasty-lemons-scream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-events-backend': patch
+---
+
+Allow webhook content to be 5mb instead the default 100kb

--- a/plugins/events-backend/src/service/http/HttpPostIngressEventPublisher.ts
+++ b/plugins/events-backend/src/service/http/HttpPostIngressEventPublisher.ts
@@ -90,7 +90,7 @@ export class HttpPostIngressEventPublisher {
     [topic: string]: Omit<HttpPostIngressOptions, 'topic'>;
   }): express.Router {
     const router = Router();
-    router.use(express.raw({ type: '*/*' }));
+    router.use(express.raw({ type: '*/*', limit: '5mb' }));
 
     Object.keys(ingresses).forEach(topic =>
       this.addRouteForTopic(router, topic, ingresses[topic].validator),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

the default 100kb is too low for some github webhook content when there are lot of changes to a repository. this change increases the max size of the request to 5mb.

closes #28910

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
