### PR TITLE
catalog-react: align defaultFilter config naming

### DIFF
--- a/plugins/catalog-react/report-alpha.api.md
+++ b/plugins/catalog-react/report-alpha.api.md
@@ -175,7 +175,7 @@ export const EntityCardLayoutBlueprint: ExtensionBlueprint<{
   kind: 'entity-card-layout';
   name: undefined;
   params: {
-    defaultFilter?: string | ((entity: Entity) => boolean) | undefined;
+    filter?: string | ((entity: Entity) => boolean) | undefined;
     loader: () => Promise<
       (props: EntityCardLayoutProps) => React_2.JSX.Element
     >;

--- a/plugins/catalog-react/src/alpha/blueprints/EntityCardLauyoutBlueprint.tsx
+++ b/plugins/catalog-react/src/alpha/blueprints/EntityCardLauyoutBlueprint.tsx
@@ -63,9 +63,9 @@ export const EntityCardLayoutBlueprint = createExtensionBlueprint({
   *factory(
     {
       loader,
-      defaultFilter,
+      filter,
     }: {
-      defaultFilter?:
+      filter?:
         | typeof entityFilterFunctionDataRef.T
         | typeof entityFilterExpressionDataRef.T;
       loader: () => Promise<
@@ -76,10 +76,10 @@ export const EntityCardLayoutBlueprint = createExtensionBlueprint({
   ) {
     if (config.filter) {
       yield entityFilterExpressionDataRef(config.filter);
-    } else if (typeof defaultFilter === 'string') {
-      yield entityFilterExpressionDataRef(defaultFilter);
-    } else if (typeof defaultFilter === 'function') {
-      yield entityFilterFunctionDataRef(defaultFilter);
+    } else if (typeof filter === 'string') {
+      yield entityFilterExpressionDataRef(filter);
+    } else if (typeof filter === 'function') {
+      yield entityFilterFunctionDataRef(filter);
     }
 
     const ExtensionComponent = reactLazy(() =>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Followup for https://github.com/backstage/backstage/pull/28758#discussion_r1962287093

Figured it's best to move to the existing naming for now, and then if we want to move them all over to `defaultFilter` we can do that separately. It would already be a fairly high impact change.

Piggybacking on existing changeset