### PR TITLE
Implement KnexConfigTransformer

### DIFF
--- a/.changeset/light-olives-smile.md
+++ b/.changeset/light-olives-smile.md
@@ -1,0 +1,55 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Expose `DatabaseManager.addConfigTransformer` to register callback functions for altering Knex.Config on Knex.Client creation.
+
+Example:
+
+Before creating an instance of the DatabaseManager (in the databaseServiceFactory) a callback method can be registered,
+The callback is called upon DatabaseClientCreation for the registered connection.type
+
+### Example transformer
+
+```typescript
+export async function myCustomTransformer(
+  config: Knex.Config,
+): Promise<Knex.Config> {
+  if (
+    !config.connection ||
+    typeof config.connection === 'string' ||
+    typeof config.connection === 'function'
+  ) {
+    throw new Error(`myCustomTransformer can not handle this`);
+  }
+  const secret = (config.connection as any).secret;
+  const token = callMyTokenEndpoint(secret);
+  config.connection.password = token;
+  return config;
+}
+```
+
+### Register transformer
+
+```typescript
+//Do this before DatabaseManager.fromConfig()
+DatabaseManager.addConfigTransformer(
+  'pg',
+  'special-authentication',
+  myTokenProvider,
+);
+```
+
+### trigger transformer
+
+```yaml
+...
+backend:
+  ...
+  database:
+    client: pg
+    connection:
+      type: special-authentication
+      secret: ${APPLICATION-CLIENT-ID}
+      ...
+```

--- a/packages/backend-defaults/report-database.api.md
+++ b/packages/backend-defaults/report-database.api.md
@@ -6,6 +6,7 @@
 /// <reference types="node" />
 
 import { DatabaseService } from '@backstage/backend-plugin-api';
+import { Knex } from 'knex';
 import { LifecycleService } from '@backstage/backend-plugin-api';
 import { LoggerService } from '@backstage/backend-plugin-api';
 import { RootConfigService } from '@backstage/backend-plugin-api';
@@ -15,6 +16,11 @@ import { ServiceFactory } from '@backstage/backend-plugin-api';
 
 // @public
 export class DatabaseManager {
+  static addConfigTransformer(
+    client: string,
+    type: string,
+    transformer: KnexConfigTransformer,
+  ): void;
   forPlugin(
     pluginId: string,
     deps: {
@@ -41,6 +47,11 @@ export const databaseServiceFactory: ServiceFactory<
   'plugin',
   'singleton'
 >;
+
+// @public
+export type KnexConfigTransformer = (
+  config: Knex.Config,
+) => Promise<Knex.Config> | Knex.Config;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/packages/backend-defaults/src/entrypoints/database/DatabaseManager.ts
+++ b/packages/backend-defaults/src/entrypoints/database/DatabaseManager.ts
@@ -262,6 +262,14 @@ export class DatabaseManager {
     );
   }
 
+  /**
+   *
+   * Registers a callback to be used for a specific client/type combination
+   *
+   * @param client - the client this transformer should be added to
+   * @param type - the connection.type this transformer is to be triggered for
+   * @param transformer - the callback method performing the transformation
+   */
   static addConfigTransformer(
     client: string,
     type: string,
@@ -272,7 +280,9 @@ export class DatabaseManager {
         pgConnectionTransformers[type] = transformer;
         break;
       default:
-        throw Error(`${client} does not implement connectionTypeTransformers`);
+        throw Error(
+          `KnexConfigTransformer is not implemented for client: ${client}`,
+        );
     }
   }
 

--- a/packages/backend-defaults/src/entrypoints/database/DatabaseManager.ts
+++ b/packages/backend-defaults/src/entrypoints/database/DatabaseManager.ts
@@ -26,9 +26,9 @@ import { Config } from '@backstage/config';
 import { stringifyError } from '@backstage/errors';
 import { Knex } from 'knex';
 import { MysqlConnector } from './connectors/mysql';
-import { PgConnector } from './connectors/postgres';
+import { pgConnectionTransformers, PgConnector } from './connectors/postgres';
 import { Sqlite3Connector } from './connectors/sqlite3';
-import { Connector } from './types';
+import { Connector, KnexConfigTransformer } from './types';
 
 /**
  * Provides a config lookup path for a plugin's config block.
@@ -260,6 +260,20 @@ export class DatabaseManager {
         options,
       ),
     );
+  }
+
+  static addConfigTransformer(
+    client: string,
+    type: string,
+    transformer: KnexConfigTransformer,
+  ) {
+    switch (client) {
+      case 'pg':
+        pgConnectionTransformers[type] = transformer;
+        break;
+      default:
+        throw Error(`${client} does not implement connectionTypeTransformers`);
+    }
   }
 
   private constructor(private readonly impl: DatabaseManagerImpl) {}

--- a/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
@@ -22,14 +22,22 @@ import knexFactory, { Knex } from 'knex';
 import { merge, omit } from 'lodash';
 import limiterFactory from 'p-limit';
 import { Client } from 'pg';
-import { Connector } from '../types';
+import { Connector, KnexConfigTransformer } from '../types';
 import defaultNameOverride from './defaultNameOverride';
 import defaultSchemaOverride from './defaultSchemaOverride';
 import { mergeDatabaseConfig } from './mergeDatabaseConfig';
 import format from 'pg-format';
+import { applyKnexConfigTransformer } from '../transformers/applyKnexConfigTransformer';
+import { cloudsqlTransformer } from '../transformers/cloudsqlTransformer';
 
 // Limits the number of concurrent DDL operations to 1
 const ddlLimiter = limiterFactory(1);
+
+// @TODO: Remove default value (this is just set to prove the cloudsql unit tests pass as is)
+//        Unittest and defaults should be removed
+export const pgConnectionTransformers: Record<string, KnexConfigTransformer> = {
+  cloudsql: cloudsqlTransformer,
+};
 
 /**
  * Creates a knex postgres database connection
@@ -42,6 +50,7 @@ export async function createPgDatabaseClient(
   overrides?: Knex.Config,
 ) {
   const knexConfig = await buildPgDatabaseConfig(dbConfig, overrides);
+
   const database = knexFactory(knexConfig);
 
   const role = dbConfig.getOptionalString('role');
@@ -76,49 +85,7 @@ export async function buildPgDatabaseConfig(
     },
     overrides,
   );
-
-  const sanitizedConfig = JSON.parse(JSON.stringify(config));
-
-  // Trim additional properties from the connection object passed to knex
-  delete sanitizedConfig.connection.type;
-  delete sanitizedConfig.connection.instance;
-
-  if (config.connection.type === 'default' || !config.connection.type) {
-    return sanitizedConfig;
-  }
-
-  if (config.connection.type !== 'cloudsql') {
-    throw new Error(`Unknown connection type: ${config.connection.type}`);
-  }
-
-  if (config.client !== 'pg') {
-    throw new Error('Cloud SQL only supports the pg client');
-  }
-
-  if (!config.connection.instance) {
-    throw new Error('Missing instance connection name for Cloud SQL');
-  }
-
-  const {
-    Connector: CloudSqlConnector,
-    IpAddressTypes,
-    AuthTypes,
-  } = require('@google-cloud/cloud-sql-connector') as typeof import('@google-cloud/cloud-sql-connector');
-  const connector = new CloudSqlConnector();
-  const clientOpts = await connector.getOptions({
-    instanceConnectionName: config.connection.instance,
-    ipType: config.connection.ipAddressType ?? IpAddressTypes.PUBLIC,
-    authType: AuthTypes.IAM,
-  });
-
-  return {
-    ...sanitizedConfig,
-    client: 'pg',
-    connection: {
-      ...sanitizedConfig.connection,
-      ...clientOpts,
-    },
-  };
+  return applyKnexConfigTransformer(config, pgConnectionTransformers);
 }
 
 /**

--- a/packages/backend-defaults/src/entrypoints/database/databaseServiceFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/database/databaseServiceFactory.ts
@@ -20,6 +20,7 @@ import {
 } from '@backstage/backend-plugin-api';
 import { ConfigReader } from '@backstage/config';
 import { DatabaseManager } from './DatabaseManager';
+import { demoTransformer } from './transformers/demoTransformer';
 
 /**
  * Database access and management via `knex`.
@@ -41,6 +42,7 @@ export const databaseServiceFactory = createServiceFactory({
     rootLogger: coreServices.rootLogger,
   },
   async createRootContext({ config, rootLifecycle, rootLogger }) {
+    DatabaseManager.addConfigTransformer('pg', 'noop-demo', demoTransformer);
     return config.getOptional('backend.database')
       ? DatabaseManager.fromConfig(config, { rootLifecycle, rootLogger })
       : DatabaseManager.fromConfig(

--- a/packages/backend-defaults/src/entrypoints/database/index.ts
+++ b/packages/backend-defaults/src/entrypoints/database/index.ts
@@ -19,3 +19,4 @@ export {
   DatabaseManager,
   type DatabaseManagerOptions,
 } from './DatabaseManager';
+export { type KnexConfigTransformer } from './types';

--- a/packages/backend-defaults/src/entrypoints/database/transformers/applyKnexConfigTransformer.test.ts
+++ b/packages/backend-defaults/src/entrypoints/database/transformers/applyKnexConfigTransformer.test.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { KnexConfigTransformer } from '../types';
+import { applyKnexConfigTransformer } from './applyKnexConfigTransformer';
+import { Knex } from 'knex';
+
+describe('createPgDatabaseClient with transformers', () => {
+  const configExistingTransformer = {
+    client: 'pg',
+    connection: {
+      type: 'a-type',
+    },
+  } as Knex.Config;
+  const configMissingTransformer = {
+    client: 'pg',
+    connection: {
+      type: 'no-transformer-for-this-type',
+    },
+  } as Knex.Config;
+  const configDefaultTransformer = {
+    client: 'pg',
+    connection: {
+      type: 'default',
+    },
+  } as Knex.Config;
+  const transformers: Record<string, KnexConfigTransformer> = {
+    'a-type': jest.fn().mockImplementation(a => a),
+  };
+  const typeTransformerMock = transformers['a-type'] as jest.Mock;
+
+  it('calls connection type transformer if connection.type is set', async () => {
+    await applyKnexConfigTransformer(configExistingTransformer, transformers);
+    expect(typeTransformerMock).toHaveBeenCalledTimes(1);
+  });
+  it('throws if connection.type has no transformer', async () => {
+    await expect(
+      async () =>
+        await applyKnexConfigTransformer(
+          configMissingTransformer,
+          transformers,
+        ),
+    ).rejects.toThrow(
+      /No transformer exists for type: no-transformer-for-this-type/,
+    );
+  });
+  it('does not throw when type is default', async () => {
+    expect(
+      async () =>
+        await applyKnexConfigTransformer(
+          configDefaultTransformer,
+          transformers,
+        ),
+    ).not.toThrow();
+  });
+});

--- a/packages/backend-defaults/src/entrypoints/database/transformers/applyKnexConfigTransformer.ts
+++ b/packages/backend-defaults/src/entrypoints/database/transformers/applyKnexConfigTransformer.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Knex } from 'knex';
+import { KnexConfigTransformer } from '../types';
+
+export async function applyKnexConfigTransformer(
+  config: Knex.Config,
+  transformers: Record<string, KnexConfigTransformer>,
+): Promise<Knex.Config> {
+  let sanitizedConfig = JSON.parse(JSON.stringify(config));
+
+  const connectionType = sanitizedConfig.connection
+    ? (sanitizedConfig.connection as any).type
+    : undefined;
+  if (
+    !!sanitizedConfig.connection &&
+    !!connectionType &&
+    connectionType !== 'default'
+  ) {
+    if (!transformers[connectionType]) {
+      throw Error(`No transformer exists for type: ${connectionType}`);
+    }
+    sanitizedConfig = await transformers[connectionType](sanitizedConfig);
+  }
+  if (
+    sanitizedConfig.connection &&
+    typeof sanitizedConfig.connection !== 'string' &&
+    typeof sanitizedConfig.connection !== 'function'
+  ) {
+    // connection.type is not a Knex Configuration Property
+    // It is only used to select potential configuration transformers
+    delete (sanitizedConfig.connection as any).type;
+  }
+
+  return sanitizedConfig;
+}

--- a/packages/backend-defaults/src/entrypoints/database/transformers/cloudsqlTransformer.test.ts
+++ b/packages/backend-defaults/src/entrypoints/database/transformers/cloudsqlTransformer.test.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Knex } from 'knex';
+import { cloudsqlTransformer } from './cloudsqlTransformer';
+
+jest.mock('@google-cloud/cloud-sql-connector');
+
+describe('cloudsqlTransformer', () => {
+  it('should throw with incorrect config', async () => {
+    await expect(
+      cloudsqlTransformer({
+        client: 'pg',
+        connection: {
+          type: 'cloudsql',
+        },
+      } as any as Knex.Config),
+    ).rejects.toThrow(/Missing instance connection name for Cloud SQL/);
+  });
+
+  it('adds the settings from cloud-sql-connector', async () => {
+    const { Connector } = jest.requireMock(
+      '@google-cloud/cloud-sql-connector',
+    ) as jest.Mocked<typeof import('@google-cloud/cloud-sql-connector')>;
+
+    const mockStream = (): any => {};
+    Connector.prototype.getOptions.mockResolvedValue({ stream: mockStream });
+
+    expect(
+      await cloudsqlTransformer({
+        client: 'pg',
+        connection: {
+          type: 'cloudsql',
+          database: 'other_db',
+          user: 'ben@gke.com',
+          instance: 'project:region:instance',
+          port: 5423,
+        },
+      } as any),
+    ).toEqual({
+      client: 'pg',
+      connection: {
+        user: 'ben@gke.com',
+        port: 5423,
+        stream: mockStream,
+        database: 'other_db',
+      },
+    });
+  });
+
+  it('passes default settings to cloud-sql-connector', async () => {
+    const { Connector } = jest.requireMock(
+      '@google-cloud/cloud-sql-connector',
+    ) as jest.Mocked<typeof import('@google-cloud/cloud-sql-connector')>;
+
+    const mockStream = (): any => {};
+    Connector.prototype.getOptions.mockResolvedValue({ stream: mockStream });
+
+    await cloudsqlTransformer({
+      client: 'pg',
+      connection: {
+        type: 'cloudsql',
+        user: 'ben@gke.com',
+        instance: 'project:region:instance',
+        port: 5423,
+      },
+    } as any);
+
+    expect(Connector.prototype.getOptions).toHaveBeenCalledWith({
+      authType: 'IAM',
+      instanceConnectionName: 'project:region:instance',
+      ipType: 'PUBLIC',
+    });
+  });
+
+  it('passes ip settings to cloud-sql-connector', async () => {
+    const { Connector } = jest.requireMock(
+      '@google-cloud/cloud-sql-connector',
+    ) as jest.Mocked<typeof import('@google-cloud/cloud-sql-connector')>;
+
+    const mockStream = (): any => {};
+    Connector.prototype.getOptions.mockResolvedValue({ stream: mockStream });
+
+    await cloudsqlTransformer({
+      client: 'pg',
+      connection: {
+        type: 'cloudsql',
+        user: 'ben@gke.com',
+        instance: 'project:region:instance',
+        ipAddressType: 'PRIVATE',
+        port: 5423,
+      },
+    } as any);
+
+    expect(Connector.prototype.getOptions).toHaveBeenCalledWith({
+      authType: 'IAM',
+      instanceConnectionName: 'project:region:instance',
+      ipType: 'PRIVATE',
+    });
+  });
+});

--- a/packages/backend-defaults/src/entrypoints/database/transformers/cloudsqlTransformer.ts
+++ b/packages/backend-defaults/src/entrypoints/database/transformers/cloudsqlTransformer.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Knex } from 'knex';
+
+interface CloudSqlConnection {
+  type: string;
+  instance: string;
+  ipAddressType: any;
+}
+
+export async function cloudsqlTransformer(
+  config: Knex.Config,
+): Promise<Knex.Config> {
+  const sanitizedConfig = JSON.parse(JSON.stringify(config));
+  if (!config.connection) {
+    throw new Error(`cloudsql config.connection object can not be empty`);
+  } else if (
+    typeof config.connection === 'string' ||
+    typeof config.connection === 'function'
+  ) {
+    throw new Error(
+      `cloudsql config.connection must implement Knex.StaticConnectionConfig`,
+    );
+  }
+  const cloudSqlConnection: CloudSqlConnection = config.connection as any;
+
+  // Trim additional properties from the connection object passed to knex
+  delete sanitizedConfig.connection.type;
+  delete sanitizedConfig.connection.instance;
+
+  if (cloudSqlConnection.type !== 'cloudsql') {
+    throw new Error(`Unknown connection type: ${cloudSqlConnection.type}`);
+  }
+
+  if (config.client !== 'pg') {
+    throw new Error('Cloud SQL only supports the pg client');
+  }
+
+  if (!cloudSqlConnection.instance) {
+    throw new Error('Missing instance connection name for Cloud SQL');
+  }
+
+  const {
+    Connector: CloudSqlConnector,
+    IpAddressTypes,
+    AuthTypes,
+  } = require('@google-cloud/cloud-sql-connector') as typeof import('@google-cloud/cloud-sql-connector');
+  const connector = new CloudSqlConnector();
+  const clientOpts = await connector.getOptions({
+    instanceConnectionName: cloudSqlConnection.instance,
+    ipType: cloudSqlConnection.ipAddressType ?? IpAddressTypes.PUBLIC,
+    authType: AuthTypes.IAM,
+  });
+
+  return {
+    ...sanitizedConfig,
+    client: 'pg',
+    connection: {
+      ...sanitizedConfig.connection,
+      ...clientOpts,
+    },
+  };
+}

--- a/packages/backend-defaults/src/entrypoints/database/transformers/demoTransformer.ts
+++ b/packages/backend-defaults/src/entrypoints/database/transformers/demoTransformer.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Knex } from 'knex';
+
+/**
+ * This demo Transformer converts the Knex.StaticConnectionConfig to a Knex.ConnectionProvider
+ * the Knex.ConnectionProvider return the Knex.StaticConnectionConfig as a Knex.PgConnectionConfig with expirationChecker
+ * It logs the function calls to the console to demonstrate its workings
+ * @param config
+ * @returns
+ */
+export async function demoTransformer(
+  config: Knex.Config,
+): Promise<Knex.Config> {
+  if (!config.connection) {
+    throw new Error(`pg-cluster config.connection object can not be empty`);
+  } else if (
+    typeof config.connection === 'string' ||
+    typeof config.connection === 'function'
+  ) {
+    throw new Error(
+      `noopTransformer: config.connection must implement Knex.StaticConnectionConfig`,
+    );
+  }
+  const copy = (object: Object) => {
+    return JSON.parse(JSON.stringify(object));
+  };
+
+  const transformedConfig: Knex.Config = copy(config);
+  transformedConfig.connection = () => {
+    const connection: Knex.PgConnectionConfig = copy(config.connection || {});
+    console.log(
+      `noopTransformer: configuration provider was called for ${connection.application_name}`,
+    );
+    connection.expirationChecker = () => {
+      console.log(
+        `noopTransformer: expiration checker was called for ${connection.application_name}`,
+      );
+      return false;
+    };
+    return connection;
+  };
+  return transformedConfig;
+}

--- a/packages/backend-defaults/src/entrypoints/database/types.ts
+++ b/packages/backend-defaults/src/entrypoints/database/types.ts
@@ -27,6 +27,11 @@ export interface Connector {
   ): Promise<Knex>;
 }
 
+/**
+ * Transformer callback for Connector {@link DatabaseManager}.
+ *
+ * @public
+ */
 export type KnexConfigTransformer = (
   config: Knex.Config,
 ) => Promise<Knex.Config> | Knex.Config;

--- a/packages/backend-defaults/src/entrypoints/database/types.ts
+++ b/packages/backend-defaults/src/entrypoints/database/types.ts
@@ -26,3 +26,7 @@ export interface Connector {
     },
   ): Promise<Knex>;
 }
+
+export type KnexConfigTransformer = (
+  config: Knex.Config,
+) => Promise<Knex.Config> | Knex.Config;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR Migrates the GoogleCloudSql logic (cloudsql) to a dedicated function in a dedicated file, 
and exposes `DatabaseManager.addConfigTransformer` to register callback functions for altering Knex.Config on Knex.Client creation.

Example:

Before creating an instance of the DatabaseManager (in the databaseServiceFactory) a callback method can be registered,
The callback is called upon DatabaseClientCreation for the registered connection.type

### Example transformer

```typescript
export async function myCustomTransformer(
  config: Knex.Config,
): Promise<Knex.Config> {
  if (
    !config.connection ||
    typeof config.connection === 'string' ||
    typeof config.connection === 'function'
  ) {
    throw new Error(`myCustomTransformer can not handle this`);
  }
  const secret = (config.connection as any).secret;
  const token = callMyTokenEndpoint(secret);
  config.connection.password = token;
  return config;
}
```

### Register transformer

```typescript
//Do this before DatabaseManager.fromConfig()
DatabaseManager.addConfigTransformer(
  'pg',
  'special-authentication',
  myTokenProvider,
);
```

### trigger transformer

```yaml
...
backend:
  ...
  database:
    client: pg
    connection:
      type: special-authentication
      secret: ${APPLICATION-CLIENT-ID}
      ...
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
