### PR TITLE
frontend-plugin-api: add ExtensionBoundary.lazyComponent

### DIFF
--- a/.changeset/tall-falcons-juggle.md
+++ b/.changeset/tall-falcons-juggle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': patch
+---
+
+Added a new `ExtensionBoundary.lazyComponent` helper in addition to the existing `ExtensionBoundary.lazy` helper.

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -964,8 +964,13 @@ export namespace ExtensionBoundary {
   // (undocumented)
   export function lazy(
     appNode: AppNode,
-    lazyElement: () => Promise<JSX.Element>,
+    loader: () => Promise<JSX.Element>,
   ): JSX.Element;
+  // (undocumented)
+  export function lazyComponent<TProps extends {}>(
+    appNode: AppNode,
+    loader: () => Promise<(props: TProps) => JSX.Element>,
+  ): (props: TProps) => JSX.Element;
 }
 
 // @public (undocumented)

--- a/packages/frontend-plugin-api/src/components/ExtensionBoundary.tsx
+++ b/packages/frontend-plugin-api/src/components/ExtensionBoundary.tsx
@@ -96,14 +96,29 @@ export function ExtensionBoundary(props: ExtensionBoundaryProps) {
 export namespace ExtensionBoundary {
   export function lazy(
     appNode: AppNode,
-    lazyElement: () => Promise<JSX.Element>,
+    loader: () => Promise<JSX.Element>,
   ): JSX.Element {
     const ExtensionComponent = reactLazy(() =>
-      lazyElement().then(element => ({ default: () => element })),
+      loader().then(element => ({ default: () => element })),
     );
     return (
       <ExtensionBoundary node={appNode}>
         <ExtensionComponent />
+      </ExtensionBoundary>
+    );
+  }
+
+  export function lazyComponent<TProps extends {}>(
+    appNode: AppNode,
+    loader: () => Promise<(props: TProps) => JSX.Element>,
+  ): (props: TProps) => JSX.Element {
+    const ExtensionComponent = reactLazy(() =>
+      loader().then(Component => ({ default: Component })),
+    ) as unknown as React.ComponentType<TProps>;
+
+    return (props: TProps) => (
+      <ExtensionBoundary node={appNode}>
+        <ExtensionComponent {...props} />
       </ExtensionBoundary>
     );
   }

--- a/plugins/catalog-react/src/alpha/blueprints/EntityCardLauyoutBlueprint.tsx
+++ b/plugins/catalog-react/src/alpha/blueprints/EntityCardLauyoutBlueprint.tsx
@@ -24,7 +24,7 @@ import {
   entityFilterFunctionDataRef,
   defaultEntityCardAreas,
 } from './extensionData';
-import React, { lazy as reactLazy, ComponentProps } from 'react';
+import React from 'react';
 
 /** @alpha */
 export interface EntityCardLayoutProps {
@@ -82,18 +82,8 @@ export const EntityCardLayoutBlueprint = createExtensionBlueprint({
       yield entityFilterFunctionDataRef(defaultFilter);
     }
 
-    const ExtensionComponent = reactLazy(() =>
-      loader().then(component => ({ default: component })),
-    );
-
     yield entityCardLayoutComponentDataRef(
-      (props: ComponentProps<typeof ExtensionComponent>) => {
-        return (
-          <ExtensionBoundary node={node}>
-            <ExtensionComponent {...props} />
-          </ExtensionBoundary>
-        );
-      },
+      ExtensionBoundary.lazyComponent(node, loader),
     );
   },
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Followup for https://github.com/backstage/backstage/pull/28758#discussion_r1962292981

Realized we don't have a helper for lazy components as opposed to elements, but figured that's worth adding.

Catalog change is piggybacking on existing changeset