### PR TITLE
fix: explicitly stringify extra fields passed to the logger service

### DIFF
--- a/.changeset/itchy-schools-camp.md
+++ b/.changeset/itchy-schools-camp.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Explicitly stringify extra logger fields with `JSON.stringify` to prevent `[object Object]` errors.

--- a/packages/backend-defaults/src/entrypoints/rootLogger/WinstonLogger.test.ts
+++ b/packages/backend-defaults/src/entrypoints/rootLogger/WinstonLogger.test.ts
@@ -93,4 +93,21 @@ describe('WinstonLogger', () => {
       expect.any(Function),
     );
   });
+
+  it('gracefully handles fields that contain deeper object structures', () => {
+    const log = jest.fn();
+    const mockTransport = new Transport({ log });
+
+    const logger = WinstonLogger.create({
+      transports: [mockTransport],
+    });
+
+    logger.error('something went wrong', {
+      field: { foo: { bar: { baz: 'qux' } } },
+    });
+
+    expect(log.mock.calls[0][0][MESSAGE]).toContain(
+      `={"foo":{"bar":{"baz":"qux"}}}`,
+    );
+  });
 });

--- a/packages/backend-defaults/src/entrypoints/rootLogger/WinstonLogger.test.ts
+++ b/packages/backend-defaults/src/entrypoints/rootLogger/WinstonLogger.test.ts
@@ -93,28 +93,4 @@ describe('WinstonLogger', () => {
       expect.any(Function),
     );
   });
-
-  it('gracefully handles fields that are not castable to a string', () => {
-    const mockTransport = new Transport({
-      log: jest.fn(),
-      logv: jest.fn(),
-    });
-
-    const logger = WinstonLogger.create({
-      transports: [mockTransport],
-    });
-
-    logger.error('something went wrong', {
-      field: Object.create(null),
-    });
-
-    expect(mockTransport.log).toHaveBeenCalledWith(
-      expect.objectContaining({
-        [MESSAGE]: expect.stringContaining(
-          '[field value not castable to string]',
-        ),
-      }),
-      expect.any(Function),
-    );
-  });
 });

--- a/packages/backend-defaults/src/entrypoints/rootLogger/WinstonLogger.ts
+++ b/packages/backend-defaults/src/entrypoints/rootLogger/WinstonLogger.ts
@@ -151,7 +151,7 @@ export class WinstonLogger implements RootLoggerService {
             let stringValue = '';
 
             try {
-              stringValue = `${value}`;
+              stringValue = JSON.stringify(value);
             } catch (e) {
               stringValue = '[field value not castable to string]';
             }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Serializes the extra fields in the logger service using `JSON.stringify`. This replaces the previous implicit string coercion, preventing unexpected `[object Object]` output when objects are passed as extra fields.

fixes https://github.com/backstage/backstage/issues/28905

```log
[backend]: 2025-02-20T21:57:42.625Z catalog info catalog.entity-fetch isAuditEvent=true eventId="entity-fetch" severityLevel="low" actor={"actorId":"plugin:search","ip":"::1","hostname":"localhost","userAgent":"node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"} request={"url":"/api/catalog/entities?limit=500&filter=metadata.annotations.backstage.io%2Ftechdocs-ref&offset=0","method":"GET"} meta={"queryType":"all","query":{"limit":500,"filter":["metadata.annotations.backstage.io/techdocs-ref"],"offset":0}} status="initiated"
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
