### PR TITLE
feat: add `backend.auditor.severityLogLevelMappings` to map severity levels to log levels

### DIFF
--- a/.changeset/rotten-windows-fly.md
+++ b/.changeset/rotten-windows-fly.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Adds `backend.auditor.severityLogLevelMappings` to map severity levels to log levels.

--- a/docs/backend-system/core-services/auditor.md
+++ b/docs/backend-system/core-services/auditor.md
@@ -151,3 +151,41 @@ To clarify how to utilize the Auditor feature effectively, we recommend explorin
   - It illustrates how to detail various `eventId` values and their corresponding `meta` fields (e.g., `queryType`, `actionType`) for different plugin operations.
 
 These examples provide both a code-level demonstration and a documentation guideline for effectively utilizing the `AuditorService` to manage audit events within your Backstage plugins.
+
+## Severity Log Level Mappings
+
+The Auditor Service provides a way for plugins to log significant events, categorized by their severity. The `severityLogLevelMappings` configuration option enables you to customize how these severity levels are mapped to actual log levels within your Backstage backend, giving you precise control over the verbosity of your audit logs.
+
+### Configuration
+
+The `severityLogLevelMappings` are configured under the `backend.auditor` section of your `app-config.yaml` file. This structure allows you to specify the log level for each severity level supported by the Auditor Service. You can override individual severity levels without changing the entire mapping.
+
+Example configuration:
+
+```yaml
+backend:
+  auditor:
+    severityLogLevelMappings:
+      low: debug
+      medium: info
+      high: warn
+      critical: error
+```
+
+### Severity Levels and Default Mappings
+
+The Auditor Service supports the following severity levels:
+
+- `low`: Represents low-importance events, typically informational or debug-level.
+- `medium`: Represents events of moderate importance, requiring some attention.
+- `high`: Represents high-importance events, potentially indicating a problem or security issue.
+- `critical`: Represents critical events, requiring immediate attention.
+
+By default, these severity levels are mapped to the following log levels:
+
+- `low`: `debug`
+- `medium`: `info`
+- `high`: `info`
+- `critical`: `info`
+
+As a result, medium, high, and critical events are logged as info-level events by default, while low-level events are treated as debug.

--- a/packages/backend-defaults/config.d.ts
+++ b/packages/backend-defaults/config.d.ts
@@ -83,6 +83,32 @@ export interface Config {
         };
 
     /**
+     * Options used by the default auditor service.
+     */
+    auditor?: {
+      /**
+       * Defines how audit event severity levels are mapped to log levels.
+       * This allows you to control the verbosity of audit logs based on the
+       * severity of the event. For example, you might want to log 'low' severity
+       * events as 'debug' messages, while logging 'critical' events as 'error'
+       * messages. Each severity level ('low', 'medium', 'high', 'critical')
+       * can be mapped to one of the standard log levels ('debug', 'info', 'warn', 'error').
+       *
+       * By default, audit events are mapped to log levels as follows:
+       * - `low`: `debug`
+       * - `medium`: `info`
+       * - `high`: `info`
+       * - `critical`: `info`
+       */
+      severityLogLevelMappings?: {
+        low?: 'debug' | 'info' | 'warn' | 'error';
+        medium?: 'debug' | 'info' | 'warn' | 'error';
+        high?: 'debug' | 'info' | 'warn' | 'error';
+        critical?: 'debug' | 'info' | 'warn' | 'error';
+      };
+    };
+
+    /**
      * Options used by the default auth, httpAuth and userInfo services.
      */
     auth?: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds `backend.auditor.severityLogLevelMappings` to map severity levels to log levels.

references https://github.com/backstage/backstage/issues/28905

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
