### PR TITLE
backend-defaults: log low severity audit events as debug

### DIFF
--- a/.changeset/chilled-bugs-draw.md
+++ b/.changeset/chilled-bugs-draw.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+The default auditor service implementation will now log low severity events with `debug` level instead of `info`.

--- a/packages/backend-defaults/src/entrypoints/auditor/auditorServiceFactory.test.ts
+++ b/packages/backend-defaults/src/entrypoints/auditor/auditorServiceFactory.test.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ServiceFactoryTester,
+  mockServices,
+} from '@backstage/backend-test-utils';
+import { auditorServiceFactory } from './auditorServiceFactory';
+
+describe('auditorServiceFactory', () => {
+  it('should log with the appropriate log level', async () => {
+    const mockLogger = mockServices.logger.mock();
+    mockLogger.child.mockReturnValue(mockLogger);
+
+    const auditor = await ServiceFactoryTester.from(auditorServiceFactory, {
+      dependencies: [mockLogger.factory],
+    }).getSubject();
+
+    await auditor.createEvent({
+      eventId: 'test1',
+      severityLevel: 'low',
+    });
+    await auditor.createEvent({
+      eventId: 'test2',
+    });
+    await auditor.createEvent({
+      eventId: 'test3',
+      severityLevel: 'medium',
+    });
+
+    expect(mockLogger.debug).toHaveBeenCalledWith('test.test1', {
+      eventId: 'test1',
+      severityLevel: 'low',
+      actor: {
+        actorId: 'plugin:test',
+      },
+      plugin: 'test',
+      status: 'initiated',
+    });
+    expect(mockLogger.debug).toHaveBeenCalledWith('test.test2', {
+      eventId: 'test2',
+      severityLevel: 'low',
+      actor: {
+        actorId: 'plugin:test',
+      },
+      plugin: 'test',
+      status: 'initiated',
+    });
+    expect(mockLogger.info).toHaveBeenCalledWith('test.test3', {
+      eventId: 'test3',
+      severityLevel: 'medium',
+      actor: {
+        actorId: 'plugin:test',
+      },
+      plugin: 'test',
+      status: 'initiated',
+    });
+  });
+});

--- a/packages/backend-defaults/src/entrypoints/auditor/auditorServiceFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/auditor/auditorServiceFactory.ts
@@ -40,7 +40,14 @@ export const auditorServiceFactory = createServiceFactory({
   factory({ logger, plugin, auth, httpAuth }) {
     const auditLogger = logger.child({ isAuditEvent: true });
     return DefaultAuditorService.create(
-      event => auditLogger.info(`${event.plugin}.${event.eventId}`, event),
+      event => {
+        const message = `${event.plugin}.${event.eventId}`;
+        if (event.severityLevel === 'low') {
+          auditLogger.debug(message, event);
+        } else {
+          auditLogger.info(message, event);
+        }
+      },
       { plugin, auth, httpAuth },
     );
   },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #28905

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
