### PR TITLE
backend-defaults: avoid [object Object] in logs

### DIFF
--- a/.changeset/cold-fishes-doubt.md
+++ b/.changeset/cold-fishes-doubt.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+The default logger implementation will now serialize object meta values to JSON in non-production logs, avoiding `[object Object]` in logs.

--- a/packages/backend-defaults/src/entrypoints/rootLogger/WinstonLogger.test.ts
+++ b/packages/backend-defaults/src/entrypoints/rootLogger/WinstonLogger.test.ts
@@ -117,4 +117,21 @@ describe('WinstonLogger', () => {
       expect.any(Function),
     );
   });
+
+  it('gracefully handles fields that contain deeper object structures', () => {
+    const log = jest.fn();
+    const mockTransport = new Transport({ log });
+
+    const logger = WinstonLogger.create({
+      transports: [mockTransport],
+    });
+
+    logger.error('something went wrong', {
+      field: { foo: { bar: { baz: 'qux' } } },
+    });
+
+    expect(log.mock.calls[0][0][MESSAGE]).toContain(
+      `={"foo":{"bar":{"baz":"qux"}}}`,
+    );
+  });
 });

--- a/packages/backend-defaults/src/entrypoints/rootLogger/WinstonLogger.ts
+++ b/packages/backend-defaults/src/entrypoints/rootLogger/WinstonLogger.ts
@@ -152,6 +152,9 @@ export class WinstonLogger implements RootLoggerService {
 
             try {
               stringValue = `${value}`;
+              if (stringValue === '[object Object]') {
+                stringValue = JSON.stringify(value);
+              }
             } catch (e) {
               stringValue = '[field value not castable to string]';
             }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Additional fix for #28905

Started by implementing serialization via `toString` in some of the values passed in as fields, but it was quite tedious and this really is good enough and will fix all occurrences of this.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
