### PR TITLE
Fix field extension validation not working when field is in dependencies in an array field

### DIFF
--- a/.changeset/fluffy-ghosts-drop.md
+++ b/.changeset/fluffy-ghosts-drop.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+Fix field extension validation not working when field is in dependencies in an array field


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix field extension validation not working when field is in dependencies in an array field

Attempt 2.

Included the test for the case which was affected in the first try

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))