### PR TITLE
docs: Remove node-fetch requirement from doc examples

### DIFF
--- a/docs/features/software-catalog/external-integrations.md
+++ b/docs/features/software-catalog/external-integrations.md
@@ -686,9 +686,8 @@ export class SystemXReaderProcessor implements CatalogProcessor {
 
     try {
       // Use the builtin reader facility to grab data from the
-      // API. If you prefer, you can just use plain fetch here
-      // (from the node-fetch package), or any other method of
-      // your choosing.
+      // API. If you prefer, you can just use plain fetch here,
+      // or any other method of your choosing.
       const response = await this.reader.readUrl(location.target);
       const json = JSON.parse((await response.buffer()).toString());
       // Repeatedly call emit(processingResult.entity(location, <entity>))

--- a/docs/plugins/integrating-search-into-plugins.md
+++ b/docs/plugins/integrating-search-into-plugins.md
@@ -46,7 +46,7 @@ We will use some libraries in the module, so let's add them to your plugin modul
 git checkout -b tutorials/new-faq-snippets-collator
 
 # Install the package containing the interface
-yarn workspace @internal/backstage-plugin-search-backend-module-faq-snippets-collator add node-fetch @backstage/plugin-search-common @backstage/plugin-search-backend-node
+yarn workspace @internal/backstage-plugin-search-backend-module-faq-snippets-collator add @backstage/plugin-search-common @backstage/plugin-search-backend-node
 ```
 
 #### 3. Use Backstage App configuration


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Removes mentions of node-fetch usage from docs, as per ADR014 we don't need it anymore.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
