### PR TITLE
Use correct config definitions in MS related modules

### DIFF
--- a/.changeset/olive-dodos-applaud.md
+++ b/.changeset/olive-dodos-applaud.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-microsoft-provider': patch
+---
+
+Update `auth.microsoft.signIn.resolvers` config def to include the `userIdMatchingUserEntityAnnotation` resolver.

--- a/.changeset/rich-sloths-hang.md
+++ b/.changeset/rich-sloths-hang.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-auth-backend-module-microsoft-provider': patch
+'@backstage/plugin-catalog-backend-module-msgraph': patch
+---
+
+Update `catalog.providers.microsoftGraphOrg.target` config def to be optional as this has a default value.
+Update `auth.microsoft.signIn.resolvers` config def to include the `userIdMatchingUserEntityAnnotation` resolver.

--- a/.changeset/rich-sloths-hang.md
+++ b/.changeset/rich-sloths-hang.md
@@ -1,7 +1,5 @@
 ---
-'@backstage/plugin-auth-backend-module-microsoft-provider': patch
 '@backstage/plugin-catalog-backend-module-msgraph': patch
 ---
 
 Update `catalog.providers.microsoftGraphOrg.target` config def to be optional as this has a default value.
-Update `auth.microsoft.signIn.resolvers` config def to include the `userIdMatchingUserEntityAnnotation` resolver.

--- a/plugins/auth-backend-module-microsoft-provider/config.d.ts
+++ b/plugins/auth-backend-module-microsoft-provider/config.d.ts
@@ -40,6 +40,7 @@ export interface Config {
                   allowedDomains?: string[];
                 }
               | { resolver: 'emailMatchingUserEntityProfileEmail' }
+              | { resolver: 'userIdMatchingUserEntityAnnotation' }
             >;
           };
           sessionDuration?: HumanDuration | string;

--- a/plugins/catalog-backend-module-msgraph/config.d.ts
+++ b/plugins/catalog-backend-module-msgraph/config.d.ts
@@ -32,7 +32,7 @@ export interface Config {
            * The prefix of the target that this matches on, e.g.
            * "https://graph.microsoft.com/v1.0", with no trailing slash.
            */
-          target: string;
+          target?: string;
           /**
            * The auth authority used.
            *


### PR DESCRIPTION
Update `catalog.providers.microsoftGraphOrg.target` config def to be optional as this has a default value.

Update `auth.microsoft.signIn.resolvers` config def to include the `userIdMatchingUserEntityAnnotation` resolver.

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
