### PR TITLE
feat(kubernetes): add support for Kubernetes/Microsoft auth outside of AKS

### DIFF
--- a/.changeset/proud-pigs-sparkle.md
+++ b/.changeset/proud-pigs-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-react': minor
+---
+
+Enables client-side authentication to Kubernetes clusters registered in a custom Microsoft Enterprise App

--- a/plugins/kubernetes-react/config.d.ts
+++ b/plugins/kubernetes-react/config.d.ts
@@ -42,5 +42,20 @@ export interface Config {
         enabled?: boolean;
       };
     };
+    /**
+     * Kubernetes client site authentication config
+     */
+    auth?: {
+      /**
+       * Microsoft Entra Id confg
+       */
+      microsoft?: {
+        /**
+         * Scope to obtain the authentication token
+         * @visibility frontend
+         */
+        scope?: string;
+      };
+    };
   };
 }

--- a/plugins/kubernetes-react/report.api.md
+++ b/plugins/kubernetes-react/report.api.md
@@ -640,9 +640,13 @@ export interface ManifestYamlProps {
 
 // @public (undocumented)
 export class OidcKubernetesAuthProvider implements KubernetesAuthProvider {
-  constructor(providerName: string, authProvider: OpenIdConnectApi);
+  constructor(
+    providerName: string,
+    idTokenProviderApi: OpenIdConnectApi,
+    accessTokenProviderApi?: OAuthApi,
+  );
   // (undocumented)
-  authProvider: OpenIdConnectApi;
+  accessTokenProviderApi?: OAuthApi;
   // (undocumented)
   decorateRequestBodyForAuth(
     requestBody: KubernetesRequestBody,
@@ -651,6 +655,10 @@ export class OidcKubernetesAuthProvider implements KubernetesAuthProvider {
   getCredentials(): Promise<{
     token: string;
   }>;
+  // (undocumented)
+  idTokenProviderApi: OpenIdConnectApi;
+  // (undocumented)
+  microsoftAccessTokenProviderScope: string;
   // (undocumented)
   providerName: string;
 }

--- a/plugins/kubernetes-react/src/hooks/useIsPodExecTerminalSupported.test.ts
+++ b/plugins/kubernetes-react/src/hooks/useIsPodExecTerminalSupported.test.ts
@@ -63,6 +63,11 @@ describe('useIsPodExecTerminalSupported', () => {
       returnValue: false,
       testClusters: [{ authProvider: 'oidc.okta' }],
     },
+    {
+      condition: 'AuthProvider oidc and OidcTokenProvider is microsoft',
+      returnValue: false,
+      testClusters: [{ authProvider: 'oidc.microsoft' }],
+    },
   ])(
     'Should return $returnValue if $condition',
     async ({ testClusters, returnValue }) => {

--- a/plugins/kubernetes-react/src/hooks/useMicrosoftAccessTokenProvider.test.tsx
+++ b/plugins/kubernetes-react/src/hooks/useMicrosoftAccessTokenProvider.test.tsx
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ConfigReader } from '@backstage/core-app-api';
+import { configApiRef } from '@backstage/core-plugin-api';
+import { TestApiProvider } from '@backstage/test-utils';
+import { renderHook } from '@testing-library/react';
+import { PropsWithChildren } from 'react';
+import React from 'react';
+
+import { useMicrosoftAccessTokenProvider } from './useMicrosoftAccessTokenProvider';
+
+describe('useMicrosoftAccessTokenProvider', () => {
+  let microsoftAccessTokenProvider: string;
+
+  const apiWrapper = ({ children }: PropsWithChildren) => (
+    <TestApiProvider
+      apis={[
+        [
+          configApiRef,
+          new ConfigReader({
+            kubernetes: {
+              auth: {
+                microsoft: { scope: microsoftAccessTokenProvider },
+              },
+            },
+          }),
+        ],
+      ]}
+    >
+      {children}
+    </TestApiProvider>
+  );
+
+  it.each([
+    {
+      condition: 'missing config',
+      returnValue: '6dae42f8-4368-4678-94ff-3960e28e3630/user.read',
+    },
+    {
+      condition: 'default',
+      returnValue: '6dae42f8-4368-4678-94ff-3960e28e3630/user.read',
+    },
+    {
+      condition: 'configured',
+      returnValue: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/user.read',
+    },
+  ])('Should return $returnValue if $condition', async ({ returnValue }) => {
+    microsoftAccessTokenProvider = returnValue;
+
+    const { result } = renderHook(() => useMicrosoftAccessTokenProvider(), {
+      wrapper: apiWrapper,
+    });
+
+    expect(result.current).toEqual(returnValue);
+  });
+});
+
+describe('useCustomMicrosoftAccessTokenProvider', () => {
+  let microsoftAccessTokenProvider: string;
+
+  const apiWrapper = ({ children }: PropsWithChildren) => (
+    <TestApiProvider
+      apis={[
+        [
+          configApiRef,
+          new ConfigReader({
+            kubernetes: {
+              auth: {
+                microsoft: {
+                  scope: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/user.read',
+                },
+              },
+            },
+          }),
+        ],
+      ]}
+    >
+      {children}
+    </TestApiProvider>
+  );
+
+  it.each([
+    {
+      condition: 'configured',
+      returnValue: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/user.read',
+    },
+  ])('Should return $returnValue if $condition', async ({ returnValue }) => {
+    microsoftAccessTokenProvider = returnValue;
+
+    const { result } = renderHook(() => useMicrosoftAccessTokenProvider(), {
+      wrapper: apiWrapper,
+    });
+
+    expect(result.current).toEqual(returnValue);
+  });
+});

--- a/plugins/kubernetes-react/src/hooks/useMicrosoftAccessTokenProvider.test.tsx
+++ b/plugins/kubernetes-react/src/hooks/useMicrosoftAccessTokenProvider.test.tsx
@@ -69,7 +69,8 @@ describe('useMicrosoftAccessTokenProvider', () => {
 });
 
 describe('useCustomMicrosoftAccessTokenProvider', () => {
-  let microsoftAccessTokenProvider: string;
+  let microsoftAccessTokenProvider: string =
+    'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/user.read';
 
   const apiWrapper = ({ children }: PropsWithChildren) => (
     <TestApiProvider
@@ -80,7 +81,7 @@ describe('useCustomMicrosoftAccessTokenProvider', () => {
             kubernetes: {
               auth: {
                 microsoft: {
-                  scope: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/user.read',
+                  scope: microsoftAccessTokenProvider,
                 },
               },
             },

--- a/plugins/kubernetes-react/src/hooks/useMicrosoftAccessTokenProvider.ts
+++ b/plugins/kubernetes-react/src/hooks/useMicrosoftAccessTokenProvider.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Backstage Authors
+ * Copyright 2024 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,16 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
 
-export * from './useIsPodDeleteEnabled';
-export * from './useIsPodExecTerminalEnabled';
-export * from './useIsPodExecTerminalSupported';
-export * from './useKubernetesObjects';
-export * from './useCustomResources';
-export * from './PodNamesWithErrors';
-export * from './PodNamesWithMetrics';
-export * from './GroupedResponses';
-export * from './Cluster';
-export * from './usePodMetrics';
-export * from './useMatchingErrors';
-export * from './useMicrosoftAccessTokenProvider';
+/**
+ * Check if conditions for a pod delete call through the proxy endpoint are met
+ *
+ * @internal
+ */
+export const useMicrosoftAccessTokenProvider = (): string => {
+  const configApi = useApi(configApiRef);
+
+  /**
+   * Default: Leverage AKS authorization provider
+   */
+  return (
+    configApi
+      .getOptionalConfig('kubernetes.auth')
+      ?.getOptionalString('microsoft.scope') ??
+    '6dae42f8-4368-4678-94ff-3960e28e3630/user.read'
+  );
+};

--- a/plugins/kubernetes-react/src/kubernetes-auth-provider/KubernetesAuthProviders.test.ts
+++ b/plugins/kubernetes-react/src/kubernetes-auth-provider/KubernetesAuthProviders.test.ts
@@ -49,6 +49,7 @@ describe('KubernetesAuthProviders tests', () => {
       googleAuthApi: new MockAuthApi('googleToken'),
       oidcProviders: {
         okta: new MockAuthApi('oktaToken'),
+        microsoft: new MockAuthApi('microsoftToken'),
       },
     });
   });
@@ -75,6 +76,20 @@ describe('KubernetesAuthProviders tests', () => {
     );
 
     expect(details).toMatchObject({ auth: { oidc: { okta: 'oktaToken' } } });
+  });
+
+  it('adds access token to request body for oidc authProvider', async () => {
+    const details = await kap.decorateRequestBodyForAuth(
+      'oidc.microsoft',
+      requestBody,
+    );
+
+    expect(details).toMatchObject({
+      auth: { oidc: { microsoft: 'microsoftToken' } },
+    });
+    expect(microsoftAuthApi.getAccessToken).toHaveBeenCalledWith(
+      '6dae42f8-4368-4678-94ff-3960e28e3630/user.read',
+    );
   });
 
   it('returns error for unknown authProvider', async () => {

--- a/plugins/kubernetes-react/src/kubernetes-auth-provider/KubernetesAuthProviders.ts
+++ b/plugins/kubernetes-react/src/kubernetes-auth-provider/KubernetesAuthProviders.ts
@@ -71,6 +71,7 @@ export class KubernetesAuthProviders implements KubernetesAuthProvidersApi {
           new OidcKubernetesAuthProvider(
             provider,
             options.oidcProviders![provider],
+            provider === 'microsoft' ? options.microsoftAuthApi : undefined,
           ),
         );
       });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Enable the OIDC client side provider to get authorized from Microsft Entra ID to access Kubernetes clusters provisoned outside of Microsoft Azure Kubernetes Service (AKS).

**example**

```yaml
auth-provider: oidc
oidc-token-provider: microsoft
```

A new field has been added to the `app-config` to allow  the customization of the authorization scope.

```yaml
kubernetes:
  auth:
    microsoft:
      scope: microsoft-entra-application-id/user.read 
``` 

If not configured the access token is retreived using the default [Azure Kubernetes Service AAD Server](https://learn.microsoft.com/en-us/azure/aks/kubelogin-authentication#how-to-use-kubelogin-with-aks) like the AKS Kubernetes provider

https://github.com/backstage/backstage/blob/2bbb4932808c863d3d8a838e13a1a9bd1f9226e7/plugins/kubernetes-react/src/kubernetes-auth-provider/AksKubernetesAuthProvider.ts#L36)

This feature has been tested using a set of AWS Elastic Kubernetes Service clusters (EKS) registered in a custom Microsoft Enterprise App.

### Credits

This feature has been originally developped by @mathstlouis

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
