### PR TITLE
(WIP) feat(catalog): add support for automatically cleaning up locations

### DIFF
--- a/plugins/catalog-backend/config.d.ts
+++ b/plugins/catalog-backend/config.d.ts
@@ -173,6 +173,12 @@ export interface Config {
         };
 
     /**
+     * The strategy to use for locations that return a 404 when fetching the
+     * catalog-info file. The default value is "keep".
+     */
+    locationNotFoundStrategy?: 'keep' | 'delete';
+
+    /**
      * The interval at which the catalog should process its entities.
      * @remarks
      *

--- a/plugins/catalog-backend/src/database/operations/util/deleteLocation.ts
+++ b/plugins/catalog-backend/src/database/operations/util/deleteLocation.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Knex } from 'knex';
+import { StitchingStrategy } from '../../../stitching/types';
+import { DbRefreshStateRow } from '../../tables';
+import { markForStitching } from '../stitcher/markForStitching';
+
+export async function deleteLocation(
+  entityId: string,
+  options: {
+    knex: Knex.Transaction | Knex;
+    strategy: StitchingStrategy;
+  },
+): Promise<void> {
+  const { knex, strategy } = options;
+
+  // Delete the location itself
+  await knex
+    .table<DbRefreshStateRow>('refresh_state')
+    .delete()
+    .where('entity_id', entityId);
+
+  // Retrieve all targets of the location and mark them for stitching
+  const targets = await knex
+    .select({
+      id: 'targets.entity_id',
+    })
+    .from('refresh_state')
+    .leftOuterJoin(
+      'refresh_state_references',
+      'refresh_state_references.source_entity_ref',
+      'refresh_state.entity_ref',
+    )
+    .leftOuterJoin(
+      'refresh_state AS targets',
+      'targets.entity_ref',
+      'refresh_state_references.target_entity_ref',
+    )
+    .where('refresh_state.entity_id', entityId);
+
+  const targetIds = targets.map(r => r.id);
+
+  await markForStitching({
+    knex,
+    strategy,
+    entityIds: targetIds,
+  });
+}


### PR DESCRIPTION
This PR resolves #28638 by introducing a new app config property called `locationNotFoundStrategy`. By setting `locationNotFoundStrategy` to `delete`, locations containing not found errors will be deleted during processing.

In combination with setting `orphanStrategy` to `delete`, this can be useful when you want an entity to be automatically removed after removing the associated repository from your SCM provider.

This PR is marked as WIP because I'm not sure if this is the best way to do it, so feel free to discuss. As soon as a decision has been made, I will add documentation, tests and changesets.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
