### PR TITLE
fix(techdocs): properly clean up tmp files on build failure

### DIFF
--- a/.changeset/swift-rings-switch.md
+++ b/.changeset/swift-rings-switch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-backend': patch
+---
+
+Properly clean up temporary files on build failures


### PR DESCRIPTION
## Hey, I just made a Pull Request!

We've noticed internally that a "memory leak" occurs occasionally on our TechDocs backend containers due to leftover doc files in the tmp dirs which could lead to a `ENOSPC: no space left on device ` error when these files add up before the tmp dir is cleared by the OS.  We narrowed down the issue to the implementation in `DocsBuilder` in scenarios where an error can occur with the docs build process (eg. misconfigured mkdocs or .md errors, publish fails, etc.) resulting in the clean up logic not being triggered. This change ensures clean up is always handled properly in both success and failure scenarios. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
