### PR TITLE
Recreate S3Client before GetObjectCommand.

### DIFF
--- a/plugins/techdocs-node/src/stages/publish/awsS3.ts
+++ b/plugins/techdocs-node/src/stages/publish/awsS3.ts
@@ -484,6 +484,8 @@ export class AwsS3Publish implements PublisherBase {
           assertError(err);
           this.logger.error(err.message);
           reject(new Error(err.message));
+        } finally {
+          storageClient.destroy();
         }
       });
     } catch (e) {
@@ -531,9 +533,13 @@ export class AwsS3Publish implements PublisherBase {
           res.setHeader(headerKey, headerValue);
         }
 
+        res.on('finish', () => {
+          storageClient.destroy();
+        });
         res.send(await streamToBuffer(resp.Body as Readable));
       } catch (err) {
         assertError(err);
+        storageClient.destroy();
         this.logger.warn(
           `TechDocs S3 router failed to serve static files from bucket ${this.bucketName} at key ${filePath}: ${err.message}`,
         );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is a test, based off [comment](https://github.com/aws/aws-sdk-js-v3/issues/3560#issuecomment-1474275964) in this aws github issue [Very slow parallel S3 GetObjectCommand executions (maxSockets)](https://github.com/aws/aws-sdk-js-v3/issues/3560#top). 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
