### PR TITLE
Fix create github environment action got error when I use in GitHub Team plan

### DIFF
--- a/.changeset/old-ladybugs-report.md
+++ b/.changeset/old-ladybugs-report.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-github': patch
+---
+
+Fix createOrUpdateEnvironment not working when optional field of request is not undefine on GitHub Team plan.

--- a/.changeset/old-ladybugs-report.md
+++ b/.changeset/old-ladybugs-report.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-backend-module-github': patch
 ---
 
-Fix createOrUpdateEnvironment not working when optional field of request is not undefine on GitHub Team plan.
+Pass `undefined` to some parameters for `createOrUpdateEnvironment` as these values are not always supported in different plans of GitHub

--- a/plugins/scaffolder-backend-module-github/src/actions/githubEnvironment.examples.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubEnvironment.examples.test.ts
@@ -134,10 +134,10 @@ describe('github:environment:create examples', () => {
       owner: 'owner',
       repo: 'repository',
       environment_name: 'envname',
-      deployment_branch_policy: null,
-      wait_timer: 0,
-      reviewers: null,
-      prevent_self_review: false,
+      deployment_branch_policy: undefined,
+      wait_timer: undefined,
+      reviewers: undefined,
+      prevent_self_review: undefined,
     });
     expect(
       mockOctokit.rest.repos.createDeploymentBranchPolicy,
@@ -171,9 +171,9 @@ describe('github:environment:create examples', () => {
         protected_branches: true,
         custom_branch_policies: false,
       },
-      wait_timer: 0,
-      reviewers: null,
-      prevent_self_review: false,
+      wait_timer: undefined,
+      reviewers: undefined,
+      prevent_self_review: undefined,
     });
 
     expect(
@@ -208,9 +208,9 @@ describe('github:environment:create examples', () => {
         protected_branches: false,
         custom_branch_policies: true,
       },
-      wait_timer: 0,
-      reviewers: null,
-      prevent_self_review: false,
+      wait_timer: undefined,
+      reviewers: undefined,
+      prevent_self_review: undefined,
     });
 
     expect(
@@ -256,10 +256,10 @@ describe('github:environment:create examples', () => {
       owner: 'owner',
       repo: 'repository',
       environment_name: 'envname',
-      deployment_branch_policy: null,
-      wait_timer: 0,
-      reviewers: null,
-      prevent_self_review: false,
+      deployment_branch_policy: undefined,
+      wait_timer: undefined,
+      reviewers: undefined,
+      prevent_self_review: undefined,
     });
 
     expect(
@@ -331,10 +331,10 @@ describe('github:environment:create examples', () => {
       owner: 'owner',
       repo: 'repository',
       environment_name: 'envname',
-      deployment_branch_policy: null,
-      wait_timer: 0,
-      reviewers: null,
-      prevent_self_review: false,
+      deployment_branch_policy: undefined,
+      wait_timer: undefined,
+      reviewers: undefined,
+      prevent_self_review: undefined,
     });
 
     expect(
@@ -386,9 +386,9 @@ describe('github:environment:create examples', () => {
         custom_branch_policies: true,
         protected_branches: false,
       },
-      wait_timer: 0,
-      reviewers: null,
-      prevent_self_review: false,
+      wait_timer: undefined,
+      reviewers: undefined,
+      prevent_self_review: undefined,
     });
 
     expect(
@@ -440,9 +440,9 @@ describe('github:environment:create examples', () => {
         custom_branch_policies: true,
         protected_branches: false,
       },
-      wait_timer: 0,
-      reviewers: null,
-      prevent_self_review: false,
+      wait_timer: undefined,
+      reviewers: undefined,
+      prevent_self_review: undefined,
     });
 
     expect(
@@ -533,10 +533,10 @@ describe('github:environment:create examples', () => {
       owner: 'owner',
       repo: 'repository',
       environment_name: 'envname',
-      deployment_branch_policy: null,
-      wait_timer: 0,
-      reviewers: null,
-      prevent_self_review: false,
+      deployment_branch_policy: undefined,
+      wait_timer: undefined,
+      reviewers: undefined,
+      prevent_self_review: undefined,
     });
 
     expect(
@@ -566,10 +566,10 @@ describe('github:environment:create examples', () => {
       owner: 'owner',
       repo: 'repository',
       environment_name: 'envname',
-      deployment_branch_policy: null,
-      wait_timer: 0,
-      reviewers: null,
-      prevent_self_review: false,
+      deployment_branch_policy: undefined,
+      wait_timer: undefined,
+      reviewers: undefined,
+      prevent_self_review: undefined,
     });
 
     expect(
@@ -603,9 +603,9 @@ describe('github:environment:create examples', () => {
         custom_branch_policies: true,
         protected_branches: false,
       },
-      wait_timer: 0,
-      reviewers: null,
-      prevent_self_review: false,
+      wait_timer: undefined,
+      reviewers: undefined,
+      prevent_self_review: undefined,
     });
 
     expect(
@@ -662,10 +662,10 @@ describe('github:environment:create examples', () => {
       owner: 'owner',
       repo: 'repository',
       environment_name: 'envname',
-      deployment_branch_policy: null,
-      wait_timer: 0,
-      reviewers: null,
-      prevent_self_review: false,
+      deployment_branch_policy: undefined,
+      wait_timer: undefined,
+      reviewers: undefined,
+      prevent_self_review: undefined,
     });
 
     expect(
@@ -715,10 +715,10 @@ describe('github:environment:create examples', () => {
       owner: 'owner',
       repo: 'repository',
       environment_name: 'envname',
-      deployment_branch_policy: null,
-      wait_timer: 0,
-      reviewers: null,
-      prevent_self_review: false,
+      deployment_branch_policy: undefined,
+      wait_timer: undefined,
+      reviewers: undefined,
+      prevent_self_review: undefined,
     });
 
     expect(
@@ -773,9 +773,9 @@ describe('github:environment:create examples', () => {
         custom_branch_policies: false,
         protected_branches: true,
       },
-      wait_timer: 0,
-      reviewers: null,
-      prevent_self_review: false,
+      wait_timer: undefined,
+      reviewers: undefined,
+      prevent_self_review: undefined,
     });
 
     expect(
@@ -804,10 +804,10 @@ describe('github:environment:create examples', () => {
       owner: 'owner',
       repo: 'repository',
       environment_name: 'envname',
-      deployment_branch_policy: null,
-      wait_timer: 0,
-      reviewers: null,
-      prevent_self_review: false,
+      deployment_branch_policy: undefined,
+      wait_timer: undefined,
+      reviewers: undefined,
+      prevent_self_review: undefined,
     });
 
     expect(
@@ -879,10 +879,10 @@ describe('github:environment:create examples', () => {
       owner: 'owner',
       repo: 'repository',
       environment_name: 'envname',
-      deployment_branch_policy: null,
+      deployment_branch_policy: undefined,
       wait_timer: 1000,
-      reviewers: null,
-      prevent_self_review: false,
+      reviewers: undefined,
+      prevent_self_review: undefined,
     });
     expect(
       mockOctokit.rest.repos.createDeploymentBranchPolicy,
@@ -912,9 +912,9 @@ describe('github:environment:create examples', () => {
       owner: 'owner',
       repo: 'repository',
       environment_name: 'envname',
-      deployment_branch_policy: null,
-      wait_timer: 0,
-      reviewers: null,
+      deployment_branch_policy: undefined,
+      wait_timer: undefined,
+      reviewers: undefined,
       prevent_self_review: true,
     });
     expect(
@@ -945,8 +945,8 @@ describe('github:environment:create examples', () => {
       owner: 'owner',
       repo: 'repository',
       environment_name: 'envname',
-      deployment_branch_policy: null,
-      wait_timer: 0,
+      deployment_branch_policy: undefined,
+      wait_timer: undefined,
       reviewers: [
         {
           type: 'User',
@@ -957,7 +957,7 @@ describe('github:environment:create examples', () => {
           id: 2,
         },
       ],
-      prevent_self_review: false,
+      prevent_self_review: undefined,
     });
     expect(
       mockOctokit.rest.repos.createDeploymentBranchPolicy,

--- a/plugins/scaffolder-backend-module-github/src/actions/githubEnvironment.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubEnvironment.test.ts
@@ -147,10 +147,10 @@ describe('github:environment:create', () => {
       owner: 'owner',
       repo: 'repository',
       environment_name: 'envname',
-      deployment_branch_policy: null,
-      reviewers: null,
-      wait_timer: 0,
-      prevent_self_review: false,
+      deployment_branch_policy: undefined,
+      reviewers: undefined,
+      wait_timer: undefined,
+      prevent_self_review: undefined,
     });
   });
 
@@ -176,9 +176,9 @@ describe('github:environment:create', () => {
         protected_branches: true,
         custom_branch_policies: false,
       },
-      reviewers: null,
-      wait_timer: 0,
-      prevent_self_review: false,
+      reviewers: undefined,
+      wait_timer: undefined,
+      prevent_self_review: undefined,
     });
   });
 
@@ -205,9 +205,9 @@ describe('github:environment:create', () => {
         protected_branches: false,
         custom_branch_policies: true,
       },
-      reviewers: null,
-      wait_timer: 0,
-      prevent_self_review: false,
+      reviewers: undefined,
+      wait_timer: undefined,
+      prevent_self_review: undefined,
     });
 
     expect(
@@ -253,9 +253,9 @@ describe('github:environment:create', () => {
         protected_branches: false,
         custom_branch_policies: true,
       },
-      reviewers: null,
-      wait_timer: 0,
-      prevent_self_review: false,
+      reviewers: undefined,
+      wait_timer: undefined,
+      prevent_self_review: undefined,
     });
 
     expect(
@@ -296,10 +296,10 @@ describe('github:environment:create', () => {
       owner: 'owner',
       repo: 'repository',
       environment_name: 'envname',
-      deployment_branch_policy: null,
-      reviewers: null,
-      wait_timer: 0,
-      prevent_self_review: false,
+      deployment_branch_policy: undefined,
+      reviewers: undefined,
+      wait_timer: undefined,
+      prevent_self_review: undefined,
     });
 
     expect(
@@ -345,10 +345,10 @@ describe('github:environment:create', () => {
       owner: 'owner',
       repo: 'repository',
       environment_name: 'envname',
-      deployment_branch_policy: null,
-      reviewers: null,
-      wait_timer: 0,
-      prevent_self_review: false,
+      deployment_branch_policy: undefined,
+      reviewers: undefined,
+      wait_timer: undefined,
+      prevent_self_review: undefined,
     });
 
     expect(
@@ -404,10 +404,32 @@ describe('github:environment:create', () => {
       owner: 'owner',
       repo: 'repository',
       environment_name: 'envname',
-      deployment_branch_policy: null,
-      reviewers: null,
+      deployment_branch_policy: undefined,
+      reviewers: undefined,
       wait_timer: 1000,
-      prevent_self_review: false,
+      prevent_self_review: undefined,
+    });
+  });
+
+  it('should work with wait_timer 0', async () => {
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        waitTimer: 0,
+      },
+    });
+
+    expect(
+      mockOctokit.rest.repos.createOrUpdateEnvironment,
+    ).toHaveBeenCalledWith({
+      owner: 'owner',
+      repo: 'repository',
+      environment_name: 'envname',
+      deployment_branch_policy: undefined,
+      reviewers: undefined,
+      wait_timer: 0,
+      prevent_self_review: undefined,
     });
   });
 
@@ -426,9 +448,9 @@ describe('github:environment:create', () => {
       owner: 'owner',
       repo: 'repository',
       environment_name: 'envname',
-      deployment_branch_policy: null,
-      reviewers: null,
-      wait_timer: 0,
+      deployment_branch_policy: undefined,
+      reviewers: undefined,
+      wait_timer: undefined,
       prevent_self_review: true,
     });
   });
@@ -448,9 +470,9 @@ describe('github:environment:create', () => {
       owner: 'owner',
       repo: 'repository',
       environment_name: 'envname',
-      deployment_branch_policy: null,
-      reviewers: null,
-      wait_timer: 0,
+      deployment_branch_policy: undefined,
+      reviewers: undefined,
+      wait_timer: undefined,
       prevent_self_review: false,
     });
   });
@@ -477,9 +499,9 @@ describe('github:environment:create', () => {
       owner: 'owner',
       repo: 'repository',
       environment_name: 'envname',
-      deployment_branch_policy: null,
-      wait_timer: 0,
-      prevent_self_review: false,
+      deployment_branch_policy: undefined,
+      wait_timer: undefined,
+      prevent_self_review: undefined,
       reviewers: [
         {
           id: 1,

--- a/plugins/scaffolder-backend-module-github/src/actions/githubEnvironment.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubEnvironment.ts
@@ -250,10 +250,10 @@ Wildcard characters will not match \`/\`. For example, to match tags that begin 
         owner: owner,
         repo: repo,
         environment_name: name,
-        deployment_branch_policy: deploymentBranchPolicy ?? null,
-        wait_timer: waitTimer ?? 0,
-        prevent_self_review: preventSelfReview ?? false,
-        reviewers: githubReviewers.length ? githubReviewers : null,
+        deployment_branch_policy: deploymentBranchPolicy ?? undefined,
+        wait_timer: waitTimer ?? undefined,
+        prevent_self_review: preventSelfReview ?? undefined,
+        reviewers: githubReviewers.length ? githubReviewers : undefined,
       });
 
       if (customBranchPolicyNames) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

createOrUpdateEnvironment does not support 'deployment_branch_policy', 'wait_timer', 'reviewers', 'prevent_self_review' on GitHub Team plan.

It seemd that these optional values should be undefined instead of null or 0.

fixes #28977

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))


