### PR TITLE
fix(signals): prevent duplicate connect requests

### DIFF
--- a/.changeset/loud-clocks-obey.md
+++ b/.changeset/loud-clocks-obey.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-signals': patch
+---
+
+Fixed multiple signal connection attempts when there are multiple subscriptions at the same time

--- a/plugins/signals/src/api/SignalClient.ts
+++ b/plugins/signals/src/api/SignalClient.ts
@@ -135,7 +135,7 @@ export class SignalClient implements SignalApi {
   }
 
   private async connect() {
-    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+    if (this.ws && this.ws.readyState !== WebSocket.CLOSED) {
       return;
     }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

the ws state might not be OPEN (but instead CONNECTING) when connect is called thus leading to multiple connect calls being done. it should be sufficient to check that we have the ws instance when starting to connect.

The fix can be verified by adding a small sleep to the `signals-backend` router `handleUpgrade` method and adding `useSignal` to some component used in the frontend. If the connecting takes too long and there are multiple subscriptions, the signal client tries to connect multiple times before this fix.

To reproduce apply this patch, start with `yarn dev`, go to the `My Squad` page and see network tab:
```diff
diff --git a/plugins/org/package.json b/plugins/org/package.json
index 2b5f3b2aad9..166249932b1 100644
--- a/plugins/org/package.json
+++ b/plugins/org/package.json
@@ -58,6 +58,7 @@
     "@backstage/frontend-plugin-api": "workspace:^",
     "@backstage/plugin-catalog-common": "workspace:^",
     "@backstage/plugin-catalog-react": "workspace:^",
+    "@backstage/plugin-signals-react": "workspace:^",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.61",
diff --git a/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx b/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx
index b863bef4822..71d44b6ad6f 100644
--- a/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx
+++ b/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx
@@ -37,8 +37,8 @@ import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
 import Tooltip from '@material-ui/core/Tooltip';
 import {
-  EntityRefLinks,
   catalogApiRef,
+  EntityRefLinks,
   getEntityRelations,
   useEntity,
 } from '@backstage/plugin-catalog-react';
@@ -54,6 +54,7 @@ import GroupIcon from '@material-ui/icons/Group';
 import { LinksGroup } from '../../Meta';
 import { useEntityPermission } from '@backstage/plugin-catalog-react/alpha';
 import { catalogEntityRefreshPermission } from '@backstage/plugin-catalog-common/alpha';
+import { useSignal } from '@backstage/plugin-signals-react';
 
 const CardTitle = (props: { title: string }) => (
   <Box display="flex" alignItems="center">
@@ -74,6 +75,8 @@ export const GroupProfileCard = (props: {
     catalogEntityRefreshPermission,
   );
 
+  const { lastSignal } = useSignal('myplugin:channel');
+
   const refreshEntity = useCallback(async () => {
     await catalogApi.refreshEntity(stringifyEntityRef(group));
     alertApi.post({
diff --git a/plugins/signals-backend/src/service/router.ts b/plugins/signals-backend/src/service/router.ts
index eb1c24f383d..041817931dd 100644
--- a/plugins/signals-backend/src/service/router.ts
+++ b/plugins/signals-backend/src/service/router.ts
@@ -69,6 +69,7 @@ export async function createRouter(
       apiUrl = await discovery.getBaseUrl('signals');
     }
 
+    await new Promise(resolve => setTimeout(resolve, 1000));
     if (!request.url || !apiUrl || !apiUrl.endsWith(request.url)) {
       return;
     }
diff --git a/yarn.lock b/yarn.lock
index 6df31ca4252..0d9d6b6e099 100644
--- a/yarn.lock
+++ b/yarn.lock
@@ -6912,6 +6912,7 @@ __metadata:
     "@backstage/plugin-catalog-react": "workspace:^"
     "@backstage/plugin-permission-common": "workspace:^"
     "@backstage/plugin-permission-react": "workspace:^"
+    "@backstage/plugin-signals-react": "workspace:^"
     "@backstage/test-utils": "workspace:^"
     "@backstage/types": "workspace:^"
     "@material-ui/core": ^4.12.2
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
