### PR TITLE
auth-backend: deprecations everywhere

### DIFF
--- a/.changeset/short-moose-attend.md
+++ b/.changeset/short-moose-attend.md
@@ -1,0 +1,9 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Marked the remaining exports related to `createRouter` and the old backend system as deprecated.
+
+For more information about migrating to the new backend system, see the [migration guide](https://backstage.io/docs/backend-system/building-backends/migrating#the-auth-plugin).
+
+Support for the old backend system will be removed in the next release of this plugin.

--- a/plugins/auth-backend/report.api.md
+++ b/plugins/auth-backend/report.api.md
@@ -121,7 +121,7 @@ export type BitbucketServerOAuthResult = {
   refreshToken?: string;
 };
 
-// @public
+// @public @deprecated
 export class CatalogIdentityClient {
   constructor(options: {
     catalogApi: CatalogApi;
@@ -176,7 +176,7 @@ export type CloudflareAccessResult = {
 // @public @deprecated (undocumented)
 export type CookieConfigurer = CookieConfigurer_2;
 
-// @public
+// @public @deprecated
 export function createAuthProviderIntegration<
   TCreateOptions extends unknown[],
   TResolvers extends {
@@ -190,13 +190,13 @@ export function createAuthProviderIntegration<
   resolvers: Readonly<string extends keyof TResolvers ? never : TResolvers>;
 }>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export function createOriginFilter(config: Config): (origin: string) => boolean;
 
 // @public @deprecated (undocumented)
 export function createRouter(options: RouterOptions): Promise<express.Router>;
 
-// @public
+// @public @deprecated
 export const defaultAuthProviderFactories: {
   [providerId: string]: AuthProviderFactory_2;
 };
@@ -219,7 +219,7 @@ export type GcpIapTokenInfo = GcpIapTokenInfo_2;
 // @public
 export function getDefaultOwnershipEntityRefs(entity: Entity): string[];
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type GithubOAuthResult = {
   fullProfile: Profile;
   params: {
@@ -361,12 +361,12 @@ export const prepareBackstageIdentityResponse: typeof prepareBackstageIdentityRe
 // @public @deprecated (undocumented)
 export type ProfileInfo = ProfileInfo_2;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type ProviderFactories = {
   [s: string]: AuthProviderFactory_2;
 };
 
-// @public
+// @public @deprecated
 export const providers: Readonly<{
   atlassian: Readonly<{
     create: (
@@ -676,7 +676,7 @@ export interface RouterOptions {
   tokenManager?: TokenManager;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type SamlAuthResult = {
   fullProfile: any;
 };

--- a/plugins/auth-backend/src/lib/catalog/CatalogIdentityClient.ts
+++ b/plugins/auth-backend/src/lib/catalog/CatalogIdentityClient.ts
@@ -38,6 +38,7 @@ import {
  * A catalog client tailored for reading out identity data from the catalog.
  *
  * @public
+ * @deprecated Use the provided `AuthResolverContext` instead, see https://backstage.io/docs/auth/identity-resolver#building-custom-resolvers
  */
 export class CatalogIdentityClient {
   private readonly catalogApi: CatalogApi;

--- a/plugins/auth-backend/src/providers/atlassian/provider.ts
+++ b/plugins/auth-backend/src/providers/atlassian/provider.ts
@@ -31,6 +31,7 @@ import { AuthHandler } from '../types';
  * Auth provider integration for Atlassian auth
  *
  * @public
+ * @deprecated Migrate the auth plugin to the new backend system https://backstage.io/docs/backend-system/building-backends/migrating#the-auth-plugin
  */
 export const atlassian = createAuthProviderIntegration({
   create(options?: {

--- a/plugins/auth-backend/src/providers/auth0/provider.ts
+++ b/plugins/auth-backend/src/providers/auth0/provider.ts
@@ -47,6 +47,7 @@ export type Auth0AuthProviderOptions = OAuthProviderOptions & {
  * Auth provider integration for auth0 auth
  *
  * @public
+ * @deprecated Migrate the auth plugin to the new backend system https://backstage.io/docs/backend-system/building-backends/migrating#the-auth-plugin
  */
 export const auth0 = createAuthProviderIntegration({
   create(options?: {

--- a/plugins/auth-backend/src/providers/aws-alb/provider.ts
+++ b/plugins/auth-backend/src/providers/aws-alb/provider.ts
@@ -29,6 +29,7 @@ import { createAuthProviderIntegration } from '../createAuthProviderIntegration'
  * Auth provider integration for AWS ALB auth
  *
  * @public
+ * @deprecated Migrate the auth plugin to the new backend system https://backstage.io/docs/backend-system/building-backends/migrating#the-auth-plugin
  */
 export const awsAlb = createAuthProviderIntegration({
   create(options?: {

--- a/plugins/auth-backend/src/providers/azure-easyauth/provider.ts
+++ b/plugins/auth-backend/src/providers/azure-easyauth/provider.ts
@@ -31,6 +31,7 @@ export type EasyAuthResult = AzureEasyAuthResult;
  * Auth provider integration for Azure EasyAuth
  *
  * @public
+ * @deprecated Migrate the auth plugin to the new backend system https://backstage.io/docs/backend-system/building-backends/migrating#the-auth-plugin
  */
 export const easyAuth = createAuthProviderIntegration({
   create(options?: {

--- a/plugins/auth-backend/src/providers/bitbucket/provider.ts
+++ b/plugins/auth-backend/src/providers/bitbucket/provider.ts
@@ -69,6 +69,7 @@ export type BitbucketPassportProfile = PassportProfile & {
  * Auth provider integration for Bitbucket auth
  *
  * @public
+ * @deprecated Migrate the auth plugin to the new backend system https://backstage.io/docs/backend-system/building-backends/migrating#the-auth-plugin
  */
 export const bitbucket = createAuthProviderIntegration({
   create(options?: {

--- a/plugins/auth-backend/src/providers/cloudflare-access/provider.ts
+++ b/plugins/auth-backend/src/providers/cloudflare-access/provider.ts
@@ -125,6 +125,7 @@ export type CloudflareAccessResult = {
  * Auth provider integration for Cloudflare Access auth
  *
  * @public
+ * @deprecated Migrate the auth plugin to the new backend system https://backstage.io/docs/backend-system/building-backends/migrating#the-auth-plugin
  */
 export const cfAccess = createAuthProviderIntegration({
   create(options: {

--- a/plugins/auth-backend/src/providers/createAuthProviderIntegration.ts
+++ b/plugins/auth-backend/src/providers/createAuthProviderIntegration.ts
@@ -27,6 +27,7 @@ import {
  * supplies built-in sign-in resolvers for the specific provider.
  *
  * @public
+ * @deprecated Migrate the auth plugin to the new backend system https://backstage.io/docs/backend-system/building-backends/migrating#the-auth-plugin
  */
 export function createAuthProviderIntegration<
   TCreateOptions extends unknown[],

--- a/plugins/auth-backend/src/providers/gcp-iap/provider.ts
+++ b/plugins/auth-backend/src/providers/gcp-iap/provider.ts
@@ -27,6 +27,7 @@ import { GcpIapResult } from './types';
  * Auth provider integration for Google Identity-Aware Proxy auth
  *
  * @public
+ * @deprecated Migrate the auth plugin to the new backend system https://backstage.io/docs/backend-system/building-backends/migrating#the-auth-plugin
  */
 export const gcpIap = createAuthProviderIntegration({
   create(options: {

--- a/plugins/auth-backend/src/providers/github/provider.ts
+++ b/plugins/auth-backend/src/providers/github/provider.ts
@@ -25,7 +25,10 @@ import {
 } from '@backstage/plugin-auth-node';
 import { githubAuthenticator } from '@backstage/plugin-auth-backend-module-github-provider';
 
-/** @public */
+/**
+ * @public
+ * @deprecated Migrate the auth plugin to the new backend system https://backstage.io/docs/backend-system/building-backends/migrating#the-auth-plugin
+ */
 export type GithubOAuthResult = {
   fullProfile: PassportProfile;
   params: {
@@ -41,6 +44,7 @@ export type GithubOAuthResult = {
  * Auth provider integration for GitHub auth
  *
  * @public
+ * @deprecated Migrate the auth plugin to the new backend system https://backstage.io/docs/backend-system/building-backends/migrating#the-auth-plugin
  */
 export const github = createAuthProviderIntegration({
   create(options?: {

--- a/plugins/auth-backend/src/providers/gitlab/provider.ts
+++ b/plugins/auth-backend/src/providers/gitlab/provider.ts
@@ -31,6 +31,7 @@ import { gitlabAuthenticator } from '@backstage/plugin-auth-backend-module-gitla
  * Auth provider integration for GitLab auth
  *
  * @public
+ * @deprecated Migrate the auth plugin to the new backend system https://backstage.io/docs/backend-system/building-backends/migrating#the-auth-plugin
  */
 export const gitlab = createAuthProviderIntegration({
   create(options?: {

--- a/plugins/auth-backend/src/providers/google/provider.ts
+++ b/plugins/auth-backend/src/providers/google/provider.ts
@@ -36,6 +36,7 @@ import { AuthHandler } from '../types';
  * Auth provider integration for Google auth
  *
  * @public
+ * @deprecated Migrate the auth plugin to the new backend system https://backstage.io/docs/backend-system/building-backends/migrating#the-auth-plugin
  */
 export const google = createAuthProviderIntegration({
   create(options?: {

--- a/plugins/auth-backend/src/providers/microsoft/provider.ts
+++ b/plugins/auth-backend/src/providers/microsoft/provider.ts
@@ -36,6 +36,7 @@ import {
  * Auth provider integration for Microsoft auth
  *
  * @public
+ * @deprecated Migrate the auth plugin to the new backend system https://backstage.io/docs/backend-system/building-backends/migrating#the-auth-plugin
  */
 export const microsoft = createAuthProviderIntegration({
   create(options?: {

--- a/plugins/auth-backend/src/providers/oauth2-proxy/provider.ts
+++ b/plugins/auth-backend/src/providers/oauth2-proxy/provider.ts
@@ -29,6 +29,7 @@ import {
  * Auth provider integration for oauth2-proxy auth
  *
  * @public
+ * @deprecated Migrate the auth plugin to the new backend system https://backstage.io/docs/backend-system/building-backends/migrating#the-auth-plugin
  */
 export const oauth2Proxy = createAuthProviderIntegration({
   create(options: {

--- a/plugins/auth-backend/src/providers/oauth2/provider.ts
+++ b/plugins/auth-backend/src/providers/oauth2/provider.ts
@@ -31,6 +31,7 @@ import { oauth2Authenticator } from '@backstage/plugin-auth-backend-module-oauth
  * Auth provider integration for generic OAuth2 auth
  *
  * @public
+ * @deprecated Migrate the auth plugin to the new backend system https://backstage.io/docs/backend-system/building-backends/migrating#the-auth-plugin
  */
 export const oauth2 = createAuthProviderIntegration({
   create(options?: {

--- a/plugins/auth-backend/src/providers/oidc/provider.ts
+++ b/plugins/auth-backend/src/providers/oidc/provider.ts
@@ -37,6 +37,7 @@ import {
  * Auth provider integration for generic OpenID Connect auth
  *
  * @public
+ * @deprecated Migrate the auth plugin to the new backend system https://backstage.io/docs/backend-system/building-backends/migrating#the-auth-plugin
  */
 export const oidc = createAuthProviderIntegration({
   create(options?: {

--- a/plugins/auth-backend/src/providers/okta/provider.ts
+++ b/plugins/auth-backend/src/providers/okta/provider.ts
@@ -36,6 +36,7 @@ import {
  * Auth provider integration for Okta auth
  *
  * @public
+ * @deprecated Migrate the auth plugin to the new backend system https://backstage.io/docs/backend-system/building-backends/migrating#the-auth-plugin
  */
 export const okta = createAuthProviderIntegration({
   create(options?: {

--- a/plugins/auth-backend/src/providers/onelogin/provider.ts
+++ b/plugins/auth-backend/src/providers/onelogin/provider.ts
@@ -31,6 +31,7 @@ import { AuthHandler } from '../types';
  * Auth provider integration for OneLogin auth
  *
  * @public
+ * @deprecated Migrate the auth plugin to the new backend system https://backstage.io/docs/backend-system/building-backends/migrating#the-auth-plugin
  */
 export const onelogin = createAuthProviderIntegration({
   create(options?: {

--- a/plugins/auth-backend/src/providers/providers.ts
+++ b/plugins/auth-backend/src/providers/providers.ts
@@ -38,6 +38,7 @@ import { AuthProviderFactory } from '@backstage/plugin-auth-node';
  * All built-in auth provider integrations.
  *
  * @public
+ * @deprecated Migrate the auth plugin to the new backend system https://backstage.io/docs/backend-system/building-backends/migrating#the-auth-plugin
  */
 export const providers = Object.freeze({
   atlassian,
@@ -64,6 +65,7 @@ export const providers = Object.freeze({
  * All auth provider factories that are installed by default.
  *
  * @public
+ * @deprecated Migrate the auth plugin to the new backend system https://backstage.io/docs/backend-system/building-backends/migrating#the-auth-plugin
  */
 export const defaultAuthProviderFactories: {
   [providerId: string]: AuthProviderFactory;

--- a/plugins/auth-backend/src/providers/router.ts
+++ b/plugins/auth-backend/src/providers/router.ts
@@ -34,7 +34,10 @@ import { Minimatch } from 'minimatch';
 import { CatalogAuthResolverContext } from '../lib/resolvers/CatalogAuthResolverContext';
 import { TokenIssuer } from '../identity/types';
 
-/** @public */
+/**
+ * @public
+ * @deprecated Migrate the auth plugin to the new backend system https://backstage.io/docs/backend-system/building-backends/migrating#the-auth-plugin
+ */
 export type ProviderFactories = { [s: string]: AuthProviderFactory };
 
 export function bindProviderRouters(
@@ -145,7 +148,10 @@ export function bindProviderRouters(
   }
 }
 
-/** @public */
+/**
+ * @public
+ * @deprecated this export will be removed
+ */
 export function createOriginFilter(
   config: Config,
 ): (origin: string) => boolean {

--- a/plugins/auth-backend/src/providers/saml/provider.ts
+++ b/plugins/auth-backend/src/providers/saml/provider.ts
@@ -37,7 +37,10 @@ import {
   SignInResolver,
 } from '@backstage/plugin-auth-node';
 
-/** @public */
+/**
+ * @public
+ * @deprecated Migrate the auth plugin to the new backend system https://backstage.io/docs/backend-system/building-backends/migrating#the-auth-plugin
+ */
 export type SamlAuthResult = {
   fullProfile: any;
 };


### PR DESCRIPTION
🧹, one extra round of deprecations. Technically all of these exports are indirectly deprecated already as they're not useful without `createRouter`, which is marked as deprecated. Figured it's best to be very clear here though and give it one more release.