### PR TITLE
auth-backend: move getDefaultOwnershipEntityRefs to resolver context

### DIFF
--- a/.changeset/four-readers-vanish.md
+++ b/.changeset/four-readers-vanish.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-node': patch
+---
+
+Added `AuthResolverContext.resolveOwnershipEntityRefs` as a way of accessing the default ownership resolution logic in sign-in resolvers, replacing `getDefaultOwnershipEntityRefs` from `@backstage/plugin-auth-backend`.

--- a/.changeset/silver-fishes-shop.md
+++ b/.changeset/silver-fishes-shop.md
@@ -1,0 +1,23 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Deprecated `getDefaultOwnershipEntityRefs` in favor of the new `.resolveOwnershipEntityRefs(...)` method in the `AuthResolverContext`.
+
+The following code in a custom sign-in resolver:
+
+```ts
+import { getDefaultOwnershipEntityRefs } from '@backstage/plugin-auth-backend';
+
+// ...
+
+const ent = getDefaultOwnershipEntityRefs(entity);
+```
+
+Can be replaced with the following:
+
+```ts
+const { ownershipEntityRefs: ent } = await ctx.resolveOwnershipEntityRefs(
+  entity,
+);
+```

--- a/docs/auth/identity-resolver.md
+++ b/docs/auth/identity-resolver.md
@@ -298,10 +298,9 @@ of lower-level calls:
 
 ```ts
 // File: packages/backend/src/plugins/auth.ts
-import { getDefaultOwnershipEntityRefs } from '@backstage/plugin-auth-backend';
 
 // ...
-async signInResolver({ profile: { email} }, ctx) {
+async signInResolver({ profile: { email } }, ctx) {
   if (!email) {
     throw new Error('User profile contained no email');
   }
@@ -323,19 +322,19 @@ async signInResolver({ profile: { email} }, ctx) {
   //
   // You might also replace it if you for example want to filter out certain groups.
   //
-  // Note that `getDefaultOwnershipEntityRefs` only includes groups to which the
-  // user has a direct MEMBER_OF relationship. It's perfectly fine to include
-  // groups that the user is transitively part of in the claims array, but the
-  // catalog doesn't currently provide a direct way of accessing this list of
-  // groups.
-  const ownershipRefs = getDefaultOwnershipEntityRefs(entity);
+  // Note that `ctx.resolveOwnershipEntityRefs(...)` by default only includes groups
+  // to which the user has a direct MEMBER_OF relationship.
+  // It's perfectly fine to include groups that the user is transitively part of
+  // in the claims array, but the catalog doesn't currently provide a direct
+  // way of accessing this list of groups.
+  const { ownershipEntityRefs } = await ctx.resolveOwnershipEntityRefs(entity);
 
   // The last step is to issue the token, where we might provide more options in the
   // future.
   return ctx.issueToken({
     claims: {
       sub: stringifyEntityRef(entity),
-      ent: ownershipRefs,
+      ent: ownershipEntityRefs,
     },
   });
 }

--- a/plugins/auth-backend-module-vmware-cloud-provider/src/authenticator.test.ts
+++ b/plugins/auth-backend-module-vmware-cloud-provider/src/authenticator.test.ts
@@ -235,6 +235,7 @@ describe('vmwareCloudAuthenticator', () => {
         signInWithCatalogUser: jest.fn().mockResolvedValue({
           token: 'backstageToken',
         }),
+        resolveOwnershipEntityRefs: jest.fn(),
       };
 
       oAuthState = {
@@ -432,6 +433,7 @@ describe('vmwareCloudAuthenticator', () => {
         signInWithCatalogUser: jest.fn().mockResolvedValue({
           token: 'backstageToken',
         }),
+        resolveOwnershipEntityRefs: jest.fn(),
       };
 
       refreshRequest = {

--- a/plugins/auth-backend/report.api.md
+++ b/plugins/auth-backend/report.api.md
@@ -216,7 +216,7 @@ export type GcpIapResult = GcpIapResult_2;
 // @public @deprecated
 export type GcpIapTokenInfo = GcpIapTokenInfo_2;
 
-// @public
+// @public @deprecated
 export function getDefaultOwnershipEntityRefs(entity: Entity): string[];
 
 // @public (undocumented)

--- a/plugins/auth-backend/src/providers/oidc/provider.test.ts
+++ b/plugins/auth-backend/src/providers/oidc/provider.test.ts
@@ -119,6 +119,7 @@ describe('oidc.create', () => {
         issueToken: jest.fn(),
         findCatalogUser: jest.fn(),
         signInWithCatalogUser: jest.fn(),
+        resolveOwnershipEntityRefs: jest.fn(),
       },
     };
   });

--- a/plugins/auth-node/report.api.md
+++ b/plugins/auth-node/report.api.md
@@ -113,6 +113,9 @@ export type AuthResolverContext = {
   signInWithCatalogUser(
     query: AuthResolverCatalogUserQuery,
   ): Promise<BackstageSignInResult>;
+  resolveOwnershipEntityRefs(entity: Entity): Promise<{
+    ownershipEntityRefs: string[];
+  }>;
 };
 
 // @public

--- a/plugins/auth-node/src/types.ts
+++ b/plugins/auth-node/src/types.ts
@@ -161,6 +161,14 @@ export type AuthResolverContext = {
   signInWithCatalogUser(
     query: AuthResolverCatalogUserQuery,
   ): Promise<BackstageSignInResult>;
+
+  /**
+   * Resolves the ownership entity references for the provided entity.
+   * This will use the `AuthOwnershipResolver` if one is installed, and otherwise fall back to the default resolution logic.
+   */
+  resolveOwnershipEntityRefs(
+    entity: Entity,
+  ): Promise<{ ownershipEntityRefs: string[] }>;
 };
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This gets rid of the `getDefaultOwnershipEntityRefs` export from `auth-backend`. Its logic is still kinda useful though, so figured we mirror the `resolveOwnershipEntityRefs` from `AuthOwnershipResolver` to `AuthResolverContext`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
