### PR TITLE
Fix date parsing and formatting in convertTimeToLocalTimezone function

### DIFF
--- a/.changeset/sweet-maps-invent.md
+++ b/.changeset/sweet-maps-invent.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-unprocessed-entities': patch
+---
+
+Fixed the `convertTimeToLocalTimezone` function in the FailedEntities compoent to correctly parse ISO 8601 date strings and format them as `M/d/yyyy, h:mm:ss a`.

--- a/.changeset/sweet-maps-invent.md
+++ b/.changeset/sweet-maps-invent.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-unprocessed-entities': patch
 ---
 
-Fixed the `convertTimeToLocalTimezone` function in the FailedEntities component to correctly parse ISO 8601 date strings.
+Fixed the `convertTimeToLocalTimezone` function in the FailedEntities component to correctly parse ISO 8601 date strings and set the timezone to the current local timezone.

--- a/.changeset/sweet-maps-invent.md
+++ b/.changeset/sweet-maps-invent.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-unprocessed-entities': patch
 ---
 
-Fixed the `convertTimeToLocalTimezone` function in the FailedEntities compoent to correctly parse ISO 8601 date strings and format them as `M/d/yyyy, h:mm:ss a`.
+Fixed the `convertTimeToLocalTimezone` function in the FailedEntities component to correctly parse ISO 8601 date strings and format them as `M/d/yyyy, h:mm:ss a`.

--- a/.changeset/sweet-maps-invent.md
+++ b/.changeset/sweet-maps-invent.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-unprocessed-entities': patch
 ---
 
-Fixed the `convertTimeToLocalTimezone` function in the FailedEntities component to correctly parse ISO 8601 date strings and format them as `M/d/yyyy, h:mm:ss a`.
+Fixed the `convertTimeToLocalTimezone` function in the FailedEntities component to correctly parse ISO 8601 date strings.

--- a/plugins/catalog-unprocessed-entities/src/components/FailedEntities.tsx
+++ b/plugins/catalog-unprocessed-entities/src/components/FailedEntities.tsx
@@ -94,12 +94,10 @@ const RenderErrorContext = ({
  */
 const convertTimeToLocalTimezone = (strDateTime: string | Date) => {
   const dateTime = DateTime.fromISO(strDateTime.toLocaleString(), {
-    zone: 'UTC',
+    zone: DateTime.local().zoneName,
   });
 
-  const dateTimeLocalTz = dateTime.setZone(DateTime.local().zoneName);
-
-  return dateTimeLocalTz.toFormat('yyyy-MM-dd hh:mm:ss ZZZZ');
+  return dateTime.toFormat('yyyy-MM-dd hh:mm:ss ZZZZ');
 };
 
 export const FailedEntities = () => {

--- a/plugins/catalog-unprocessed-entities/src/components/FailedEntities.tsx
+++ b/plugins/catalog-unprocessed-entities/src/components/FailedEntities.tsx
@@ -93,7 +93,9 @@ const RenderErrorContext = ({
  * easily understand the times.
  */
 const convertTimeToLocalTimezone = (strDateTime: string | Date) => {
-  const dateTime = DateTime.fromISO(strDateTime.toString(), { zone: 'UTC' });
+  const dateTime = DateTime.fromISO(strDateTime.toLocaleString(), {
+    zone: 'UTC',
+  });
 
   const dateTimeLocalTz = dateTime.setZone(DateTime.local().zoneName);
 

--- a/plugins/catalog-unprocessed-entities/src/components/FailedEntities.tsx
+++ b/plugins/catalog-unprocessed-entities/src/components/FailedEntities.tsx
@@ -99,7 +99,7 @@ const convertTimeToLocalTimezone = (strDateTime: string | Date) => {
 
   const dateTimeLocalTz = dateTime.setZone(DateTime.local().zoneName);
 
-  return dateTimeLocalTz.toFormat('M/d/yyyy, h:mm:ss a');
+  return dateTimeLocalTz.toFormat('yyyy-MM-dd hh:mm:ss ZZZZ');
 };
 
 export const FailedEntities = () => {

--- a/plugins/catalog-unprocessed-entities/src/components/FailedEntities.tsx
+++ b/plugins/catalog-unprocessed-entities/src/components/FailedEntities.tsx
@@ -93,17 +93,11 @@ const RenderErrorContext = ({
  * easily understand the times.
  */
 const convertTimeToLocalTimezone = (strDateTime: string | Date) => {
-  const dateTime = DateTime.fromFormat(
-    strDateTime.toLocaleString(),
-    'yyyy-MM-dd hh:mm:ss',
-    {
-      zone: 'UTC',
-    },
-  );
+  const dateTime = DateTime.fromISO(strDateTime.toString(), { zone: 'UTC' });
 
   const dateTimeLocalTz = dateTime.setZone(DateTime.local().zoneName);
 
-  return dateTimeLocalTz.toFormat('yyyy-MM-dd hh:mm:ss ZZZZ');
+  return dateTimeLocalTz.toFormat('M/d/yyyy, h:mm:ss a');
 };
 
 export const FailedEntities = () => {

--- a/plugins/catalog-unprocessed-entities/src/components/FailedEntities.tsx
+++ b/plugins/catalog-unprocessed-entities/src/components/FailedEntities.tsx
@@ -92,7 +92,7 @@ const RenderErrorContext = ({
  * Converts input datetime which lacks timezone info into user's local time so that they can
  * easily understand the times.
  */
-const convertTimeToLocalTimezone = (strDateTime: string | Date) => {
+export const convertTimeToLocalTimezone = (strDateTime: string | Date) => {
   const dateTime = DateTime.fromISO(strDateTime.toLocaleString(), {
     zone: DateTime.local().zoneName,
   });

--- a/plugins/catalog-unprocessed-entities/src/components/FailedEntities.tsx
+++ b/plugins/catalog-unprocessed-entities/src/components/FailedEntities.tsx
@@ -92,12 +92,15 @@ const RenderErrorContext = ({
  * Converts input datetime which lacks timezone info into user's local time so that they can
  * easily understand the times.
  */
-export const convertTimeToLocalTimezone = (strDateTime: string) => {
-  const dateTime = DateTime.fromISO(strDateTime.toLocaleString(), {
+export const convertTimeToLocalTimezone = (dateTime: string | Date) => {
+  const isoDateTime =
+    typeof dateTime === 'string' ? dateTime : dateTime.toISOString();
+
+  const strDateTime = DateTime.fromISO(isoDateTime, {
     zone: DateTime.local().zoneName,
   });
 
-  return dateTime.toFormat('yyyy-MM-dd hh:mm:ss ZZZZ');
+  return strDateTime.toFormat('yyyy-MM-dd hh:mm:ss ZZZZ');
 };
 
 export const FailedEntities = () => {

--- a/plugins/catalog-unprocessed-entities/src/components/FailedEntities.tsx
+++ b/plugins/catalog-unprocessed-entities/src/components/FailedEntities.tsx
@@ -92,7 +92,7 @@ const RenderErrorContext = ({
  * Converts input datetime which lacks timezone info into user's local time so that they can
  * easily understand the times.
  */
-export const convertTimeToLocalTimezone = (strDateTime: string | Date) => {
+export const convertTimeToLocalTimezone = (strDateTime: string) => {
   const dateTime = DateTime.fromISO(strDateTime.toLocaleString(), {
     zone: DateTime.local().zoneName,
   });

--- a/plugins/catalog-unprocessed-entities/src/plugin.test.ts
+++ b/plugins/catalog-unprocessed-entities/src/plugin.test.ts
@@ -29,6 +29,12 @@ describe('components/FailedEntities/convertTimeToLocalTimezone', () => {
     expect(localTime).toBe('2024-09-03 08:15:08 UTC');
   });
 
+  it('should correctly convert a UTC Date object to local time', () => {
+    const utcTime = new Date('2024-09-03T08:15:08.088Z');
+    const localTime = convertTimeToLocalTimezone(utcTime);
+    expect(localTime).toBe('2024-09-03 08:15:08 UTC');
+  });
+
   it('should return "Invalid Date" for an invalid date string', () => {
     const invalidTime = 'invalid-date-string';
     const localTime = convertTimeToLocalTimezone(invalidTime);

--- a/plugins/catalog-unprocessed-entities/src/plugin.test.ts
+++ b/plugins/catalog-unprocessed-entities/src/plugin.test.ts
@@ -29,9 +29,15 @@ describe('components/FailedEntities/convertTimeToLocalTimezone', () => {
     expect(localTime).toBe('2024-09-03 08:15:08 UTC');
   });
 
-  it('should correctly convert a UTC Date object to local time', () => {
-    const utcTime = new Date('2024-09-03T08:15:08.088Z');
-    const localTime = convertTimeToLocalTimezone(utcTime);
-    expect(localTime).toBe('2024-09-03 08:15:08 UTC');
+  it('should return "Invalid Date" for an invalid date string', () => {
+    const invalidTime = 'invalid-date-string';
+    const localTime = convertTimeToLocalTimezone(invalidTime);
+    expect(localTime).toBe('Invalid DateTime');
+  });
+
+  it('should handle empty string input', () => {
+    const emptyString = '';
+    const localTime = convertTimeToLocalTimezone(emptyString);
+    expect(localTime).toBe('Invalid DateTime');
   });
 });

--- a/plugins/catalog-unprocessed-entities/src/plugin.test.ts
+++ b/plugins/catalog-unprocessed-entities/src/plugin.test.ts
@@ -13,10 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { convertTimeToLocalTimezone } from './components/FailedEntities';
 import { catalogUnprocessedEntitiesPlugin } from './plugin';
 
 describe('catalog-unprocessed-entities', () => {
   it('should export plugin', () => {
     expect(catalogUnprocessedEntitiesPlugin).toBeDefined();
+  });
+});
+
+describe('components/FailedEntities/convertTimeToLocalTimezone', () => {
+  it('should correctly a UTC ISO string to local time', () => {
+    const utcTime = '2024-09-03T08:15:08.088Z';
+    const localTime = convertTimeToLocalTimezone(utcTime);
+    expect(localTime).toBe('2024-09-03 08:15:08 UTC');
+  });
+
+  it('should correctly convert a UTC Date object to local time', () => {
+    const utcTime = new Date('2024-09-03T08:15:08.088Z');
+    const localTime = convertTimeToLocalTimezone(utcTime);
+    expect(localTime).toBe('2024-09-03 08:15:08 UTC');
   });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This pull request fixes the  `convertTimeToLocalTimezone` function within the `catalog-unprocessed-entities` plugin, ensuring accurate parsing of ISO 8601 date strings and uses `DateTime.local().zoneName` instead of magic value 'UTC' to accurately set the timezone of the date object based on the local timezone.

Previously, the `convertTimeToLocalTimezone` function was using an incorrect format string for parsing ISO 8601 date strings, resulting in an "Invalid DateTime" error and using `DateTime.local().zoneName` instead 'UTC'. This fix ensures that the input string is correctly parsed and converted to the local timezone. 

#### :heavy_check_mark: Checklist

- [ ] Updated the `convertTimeToLocalTimezone` function to use `DateTime.fromISO` for parsing ISO 8601 date strings.
- [ ] Use the function `DateTime.local().zoneName` to be set as the default zone to make sure the time is formatted in the local timezone
