### PR TITLE
fix(catalog-backend): make catalog.useUrlReadersSearch actually work in 1.36

### DIFF
--- a/.changeset/strange-eels-turn.md
+++ b/.changeset/strange-eels-turn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Correctly use the `catalog.useUrlReadersSearch` config.

--- a/plugins/catalog-backend/src/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.ts
@@ -378,7 +378,7 @@ export class CatalogBuilder {
 
     return [
       new FileReaderProcessor(),
-      new UrlReaderProcessor({ reader, logger }),
+      new UrlReaderProcessor({ reader, logger, config }),
       CodeOwnersProcessor.fromConfig(config, { logger, reader }),
       new AnnotateLocationEntityProcessor({ integrations }),
     ];


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The 1.36 released a new `catalog.useUrlReadersSearch` parameter (introduced in #28379).

Unfortunately the `CatalogBuilder` `getDefaultProcessors` didn't pass the config to the `UrlReaderProcessor` constructor, making the flag useless (defaults to the "legacy" behavior, which is `false`). 

This "bug" seems to have been introduced by mistake in #28790
(see https://github.com/backstage/backstage/pull/28790/files#diff-3320c1fccf36da64786791589cd4f2099717b687b4b45483a35a61e328fd7fbcL384)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
