### PR TITLE
fix(api-docs): Consistent Typography in Entity HasApisCard

### DIFF
--- a/.changeset/smart-pens-change.md
+++ b/.changeset/smart-pens-change.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-api-docs': patch
+---
+
+Use consistent Typography in Entity HasApisCard

--- a/plugins/api-docs/src/components/ApiDefinitionCard/ApiTypeTitle.tsx
+++ b/plugins/api-docs/src/components/ApiDefinitionCard/ApiTypeTitle.tsx
@@ -29,5 +29,9 @@ export const ApiTypeTitle = (props: { apiEntity: ApiEntity }) => {
   const definition = config.getApiDefinitionWidget(apiEntity);
   const type = definition ? definition.title : apiEntity.spec.type;
 
-  return <Typography component="span">{type}</Typography>;
+  return (
+    <Typography component="span" variant="inherit">
+      {type}
+    </Typography>
+  );
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Hey 👋 

I believe it's my smallest MR to date, fixing a small UI issue, with an inconsistent font size in the `EntityProvidedApisCard`, for the "Type" column. I believe the sizing difference was not intentional, as it was changed from a `<span>` 3 years ago, to follow the linter rule.

Notice the "Type" column, where the text was not respecting the table typography.

__Before__
![Screenshot 2025-02-28 at 19 39 06](https://github.com/user-attachments/assets/16c0501c-9312-426d-89d7-e430f5c90db4)
__After__
![Screenshot 2025-02-28 at 19 38 52](https://github.com/user-attachments/assets/9fd51dec-417b-4d4b-9891-4d014eefd52b)

Have a great day!

#### :heavy_check_mark: Checklist

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
