### PR TITLE
notification: Enrich notification settings UI with optional helper messages

### DIFF
--- a/.changeset/tough-brooms-compete.md
+++ b/.changeset/tough-brooms-compete.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications': patch
+---
+
+Added options to supply various helper messages for the user notification settings panel.

--- a/docs/notifications/index.md
+++ b/docs/notifications/index.md
@@ -151,7 +151,7 @@ add the `UserNotificationSettingsCard` to your frontend.
 
 ![Notification Settings](notificationSettings.png)
 
-You can customize the origin names shown in the UI by passing an object where the keys are the origins and the values are the names you want to show in the UI.
+You can customize the origin names shown in the UI by passing an object where the keys are the origins and the values are the names you want to show in the UI. Additionally, helper messages for header of each channel as well as their toggle actions can be supplied and customized. In case more context needs to be provided about the setting, an optional top banner is available when the parameter `helpBannerMessage` is received. For more usage details please refer to the [doc](https://backstage.io/docs/reference/plugin-notifications.usernotificationsettingscard).
 
 Each notification processor will receive its own column in the settings page, where the user can enable or disable notifications from that processor.
 

--- a/plugins/notifications/report-alpha.api.md
+++ b/plugins/notifications/report-alpha.api.md
@@ -18,21 +18,6 @@ const _default: FrontendPlugin<
   },
   {},
   {
-    'api:notifications': ExtensionDefinition<{
-      kind: 'api';
-      name: undefined;
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        AnyApiFactory,
-        'core.api.factory',
-        {}
-      >;
-      inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
-    }>;
     'page:notifications': ExtensionDefinition<{
       kind: 'page';
       name: undefined;
@@ -61,6 +46,21 @@ const _default: FrontendPlugin<
         defaultPath: string;
         loader: () => Promise<JSX.Element>;
         routeRef?: RouteRef<AnyRouteRefParams> | undefined;
+      };
+    }>;
+    'api:notifications': ExtensionDefinition<{
+      kind: 'api';
+      name: undefined;
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {};
+      params: {
+        factory: AnyApiFactory;
       };
     }>;
   }

--- a/plugins/notifications/report-alpha.api.md
+++ b/plugins/notifications/report-alpha.api.md
@@ -18,6 +18,21 @@ const _default: FrontendPlugin<
   },
   {},
   {
+    'api:notifications': ExtensionDefinition<{
+      kind: 'api';
+      name: undefined;
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
+    }>;
     'page:notifications': ExtensionDefinition<{
       kind: 'page';
       name: undefined;
@@ -46,21 +61,6 @@ const _default: FrontendPlugin<
         defaultPath: string;
         loader: () => Promise<JSX.Element>;
         routeRef?: RouteRef<AnyRouteRefParams> | undefined;
-      };
-    }>;
-    'api:notifications': ExtensionDefinition<{
-      kind: 'api';
-      name: undefined;
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        AnyApiFactory,
-        'core.api.factory',
-        {}
-      >;
-      inputs: {};
-      params: {
-        factory: AnyApiFactory;
       };
     }>;
   }

--- a/plugins/notifications/report.api.md
+++ b/plugins/notifications/report.api.md
@@ -208,9 +208,17 @@ export function useNotificationsApi<T>(
     };
 
 // @public (undocumented)
-export const UserNotificationSettingsCard: (props: {
+export const UserNotificationSettingsCard: (
+  props: UserNotificationSettingsCardProps,
+) => React_2.JSX.Element;
+
+// @public (undocumented)
+export type UserNotificationSettingsCardProps = {
   originNames?: Record<string, string>;
-}) => React_2.JSX.Element;
+  channelHeaderHelpMessages?: Record<string, string>;
+  channelToggleHelpMessages?: Record<string, Record<string, string>>;
+  helpBannerMessage?: string;
+};
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/notifications/src/components/UserNotificationSettingsCard/UserNotificationSettingsCard.tsx
+++ b/plugins/notifications/src/components/UserNotificationSettingsCard/UserNotificationSettingsCard.tsx
@@ -24,24 +24,41 @@ import { notificationsApiRef } from '../../api';
 import { useApi } from '@backstage/core-plugin-api';
 import { UserNotificationSettingsPanel } from './UserNotificationSettingsPanel';
 
+/** @public */
+export type UserNotificationSettingsCardProps = {
+  /**
+   * Optional origin plugin display names
+   */
+  originNames?: Record<string, string>;
+  /**
+   * Optional help message for channel headers
+   */
+  channelHeaderHelpMessages?: Record<string, string>;
+  /**
+   * Optional help message for each channel toggle
+   */
+  channelToggleHelpMessages?: Record<string, Record<string, string>>;
+  /**
+   * Optional, text to display in a top banner (could be used for displaying additional context)
+   */
+  helpBannerMessage?: string;
+};
+
 /**
  *
- * @param {Record<string, string>} [props.originNames] - Optional origin plugin display names
- * @param {Record<string, string>} [props.channelHeaderHelpMessages] - Optional help message for channel headers
- * @param {Record<string, Record<string, string>>} [props.channelToggleHelpMessages] - Optional help message for each channel toggle
- * @param {string} [props.helpBannerMessage] - Optional, text to display in a top banner (could be used for displaying additional context)
+ * @param props - Component props (see {@link UserNotificationSettingsCardProps})
  *
  * @example
- * With custom channel header helper messages
- * ```ts
+ * With custom channel header helper messages:
+ * ```tsx
  * <UserNotificationSettingsCard
  *    channelHeaderHelpMessages={{ Web: 'In app notification', Email: 'Email notification' }}
  * />
  * ```
  *
  * @example
- * With custom channel toggle helper messages
- * ```ts
+ * With custom channel toggle helper messages:
+ * ```tsx
  * <UserNotificationSettingsCard
  *    channelToggleHelpMessages={{
  *      'plugin:scaffolder': {
@@ -57,12 +74,9 @@ import { UserNotificationSettingsPanel } from './UserNotificationSettingsPanel';
  *
  * @public
  */
-export const UserNotificationSettingsCard = (props: {
-  originNames?: Record<string, string>;
-  channelHeaderHelpMessages?: Record<string, string>;
-  channelToggleHelpMessages?: Record<string, Record<string, string>>;
-  helpBannerMessage?: string;
-}) => {
+export const UserNotificationSettingsCard = (
+  props: UserNotificationSettingsCardProps,
+) => {
   const [settings, setNotificationSettings] = React.useState<
     NotificationSettings | undefined
   >(undefined);

--- a/plugins/notifications/src/components/UserNotificationSettingsCard/UserNotificationSettingsCard.tsx
+++ b/plugins/notifications/src/components/UserNotificationSettingsCard/UserNotificationSettingsCard.tsx
@@ -16,15 +16,52 @@
 
 import React, { useEffect } from 'react';
 import { ErrorPanel, InfoCard, Progress } from '@backstage/core-components';
+import Box from '@material-ui/core/Box';
+import Alert from '@material-ui/lab/Alert';
 import { useNotificationsApi } from '../../hooks';
 import { NotificationSettings } from '@backstage/plugin-notifications-common';
 import { notificationsApiRef } from '../../api';
 import { useApi } from '@backstage/core-plugin-api';
 import { UserNotificationSettingsPanel } from './UserNotificationSettingsPanel';
 
-/** @public */
+/**
+ *
+ * @param {Record<string, string>} [props.originNames] - Optional origin plugin display names
+ * @param {Record<string, string>} [props.channelHeaderHelpMessages] - Optional help message for channel headers
+ * @param {Record<string, Record<string, string>>} [props.channelToggleHelpMessages] - Optional help message for each channel toggle
+ * @param {string} [props.helpBannerMessage] - Optional, text to display in a top banner (could be used for displaying additional context)
+ *
+ * @example
+ * With custom channel header helper messages
+ * ```ts
+ * <UserNotificationSettingsCard
+ *    channelHeaderHelpMessages={{ Web: 'In app notification', Email: 'Email notification' }}
+ * />
+ * ```
+ *
+ * @example
+ * With custom channel toggle helper messages
+ * ```ts
+ * <UserNotificationSettingsCard
+ *    channelToggleHelpMessages={{
+ *      'plugin:scaffolder': {
+ *         Web: 'Receive in-app notification for supported scaffolder templates',
+ *       },
+ *      'plugin:my-stock-market-plugin': {
+ *         Web: 'Receive in-app notification for stock price alert',
+ *         Email: 'Receive email notification for every stock purchase'
+ *       }
+ *    }}
+ * />
+ * ```
+ *
+ * @public
+ */
 export const UserNotificationSettingsCard = (props: {
   originNames?: Record<string, string>;
+  channelHeaderHelpMessages?: Record<string, string>;
+  channelToggleHelpMessages?: Record<string, Record<string, string>>;
+  helpBannerMessage?: string;
 }) => {
   const [settings, setNotificationSettings] = React.useState<
     NotificationSettings | undefined
@@ -48,16 +85,26 @@ export const UserNotificationSettingsCard = (props: {
   };
 
   return (
-    <InfoCard title="Notification settings" variant="gridItem">
-      {loading && <Progress />}
-      {error && <ErrorPanel title="Failed to load settings" error={error} />}
-      {settings && (
-        <UserNotificationSettingsPanel
-          settings={settings}
-          onChange={onUpdate}
-          originNames={props.originNames}
-        />
+    <Box display="flex" flexDirection="column">
+      {props.helpBannerMessage && (
+        <Box mb={3}>
+          <Alert severity="info">{props.helpBannerMessage}</Alert>
+        </Box>
       )}
-    </InfoCard>
+
+      <InfoCard title="Notification Settings" variant="gridItem">
+        {loading && <Progress />}
+        {error && <ErrorPanel title="Failed to load settings" error={error} />}
+        {settings && (
+          <UserNotificationSettingsPanel
+            settings={settings}
+            onChange={onUpdate}
+            originNames={props.originNames}
+            channelHeaderHelpMessages={props.channelHeaderHelpMessages}
+            channelToggleHelpMessages={props.channelToggleHelpMessages}
+          />
+        )}
+      </InfoCard>
+    </Box>
   );
 };

--- a/plugins/notifications/src/components/UserNotificationSettingsCard/UserNotificationSettingsPanel.tsx
+++ b/plugins/notifications/src/components/UserNotificationSettingsCard/UserNotificationSettingsPanel.tsx
@@ -29,6 +29,8 @@ import TableRow from '@material-ui/core/TableRow';
 import Switch from '@material-ui/core/Switch';
 import { capitalize } from 'lodash';
 import Tooltip from '@material-ui/core/Tooltip';
+import HelpIcon from '@material-ui/icons/Help';
+import Box from '@material-ui/core/Box';
 
 const TableCell = withStyles({
   root: {
@@ -40,8 +42,15 @@ export const UserNotificationSettingsPanel = (props: {
   settings: NotificationSettings;
   onChange: (settings: NotificationSettings) => void;
   originNames?: Record<string, string>;
+  channelHeaderHelpMessages?: Record<string, string>;
+  channelToggleHelpMessages?: Record<string, Record<string, string>>;
 }) => {
-  const { settings, onChange } = props;
+  const {
+    settings,
+    onChange,
+    channelHeaderHelpMessages,
+    channelToggleHelpMessages,
+  } = props;
   const allOrigins = [
     ...new Set(
       settings.channels.flatMap(channel =>
@@ -97,27 +106,48 @@ export const UserNotificationSettingsPanel = (props: {
       <TableHead>
         <TableRow>
           <TableCell>
-            <Typography variant="subtitle1">Origin</Typography>
+            <Box display="flex" flexDirection="row">
+              <Typography variant="subtitle1">Origin</Typography>
+              <Box display="flex" alignItems="center" ml={1}>
+                <Tooltip title="Where the notification is originated from - normally a plugin such as the catalog">
+                  <HelpIcon fontSize="small" />
+                </Tooltip>
+              </Box>
+            </Box>
           </TableCell>
           {settings.channels.map(channel => (
-            <TableCell>
-              <Typography variant="subtitle1">{channel.id}</Typography>
+            <TableCell key={channel.id}>
+              <Box display="flex" flexDirection="row">
+                <Typography variant="subtitle1">{channel.id}</Typography>
+                {channelHeaderHelpMessages?.[channel.id] && (
+                  <Box display="flex" alignItems="center" ml={1}>
+                    <Tooltip title={channelHeaderHelpMessages[channel.id]}>
+                      <HelpIcon fontSize="small" />
+                    </Tooltip>
+                  </Box>
+                )}
+              </Box>
             </TableCell>
           ))}
         </TableRow>
       </TableHead>
       <TableBody>
         {allOrigins.map(origin => (
-          <TableRow>
+          <TableRow key={origin}>
             <TableCell>{formatOriginName(origin)}</TableCell>
             {settings.channels.map(channel => (
-              <TableCell>
+              <TableCell key={channel.id}>
                 <Tooltip
-                  title={`Enable or disable ${channel.id.toLocaleLowerCase(
-                    'en-US',
-                  )} notifications from ${formatOriginName(
-                    origin,
-                  ).toLocaleLowerCase('en-US')}`}
+                  title={
+                    channelToggleHelpMessages?.[origin]?.[
+                      channel.id
+                    ]?.toLocaleLowerCase('en-US') ??
+                    `Enable or disable ${channel.id.toLocaleLowerCase(
+                      'en-US',
+                    )} notifications from ${formatOriginName(
+                      origin,
+                    ).toLocaleLowerCase('en-US')}`
+                  }
                 >
                   <Switch
                     checked={isNotificationsEnabledFor(

--- a/plugins/notifications/src/components/UserNotificationSettingsCard/index.ts
+++ b/plugins/notifications/src/components/UserNotificationSettingsCard/index.ts
@@ -14,3 +14,4 @@
  * limitations under the License.
  */
 export { UserNotificationSettingsCard } from './UserNotificationSettingsCard';
+export type { UserNotificationSettingsCardProps } from './UserNotificationSettingsCard';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When users navigate to the notification settings panel, it will be good to provide some context or explanation on what each toggle does - for example, we can explain that by enabling the email channel for plugin X, it will send emails at a specific event or on a certain interval. This PR enables such customizability by providing the following options on the `UserNotificationSettingsCard` component:
 
- Added a prop `helpBannerMessage` to allow display of a top banner for additional context
- Added a prop `channelHeaderHelpMessages` that adds a help tooltop next to each channel column's header
- Added a prop `channelToggleHelpMessages` that allows customizing the help text displayed when hovering on each channel toggle

An example of enabling all is shown below:


https://github.com/user-attachments/assets/a646ab76-2772-45bc-ada9-0ccf7cd992d8


All of which are optional and if not provided, should safely fallback to the existing behavior (e.g. no banner, help icon, or a consistent helper text for hovering toggles). 

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
