### PR TITLE
scaffolder: use test databases instead of DatabaseManager

### DIFF
--- a/.changeset/little-ways-happen.md
+++ b/.changeset/little-ways-happen.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Fixed a bug where the task count could sometimes be a string instead of a number

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.ts
@@ -262,7 +262,7 @@ export class DatabaseTaskStore implements TaskStore {
       createdAt: parseSqlDateToIsoString(result.created_at),
     }));
 
-    return { tasks, totalTasks: count };
+    return { tasks, totalTasks: Number(count) };
   }
 
   async getTask(taskId: string): Promise<SerializedTask> {

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/StorageTaskBroker.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/StorageTaskBroker.test.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import { DatabaseManager } from '@backstage/backend-common';
-import { ConfigReader } from '@backstage/config';
 import { TaskSpec } from '@backstage/plugin-scaffolder-common';
 import {
   SerializedTaskEvent,
@@ -23,33 +21,29 @@ import {
 } from '@backstage/plugin-scaffolder-node';
 import { DatabaseTaskStore } from './DatabaseTaskStore';
 import { StorageTaskBroker, TaskManager } from './StorageTaskBroker';
-import { mockServices } from '@backstage/backend-test-utils';
+import {
+  TestDatabases,
+  TestDatabaseId,
+  mockServices,
+} from '@backstage/backend-test-utils';
 import { loggerToWinstonLogger } from '../../util/loggerToWinstonLogger';
 
-async function createStore(): Promise<DatabaseTaskStore> {
-  const manager = DatabaseManager.fromConfig(
-    new ConfigReader({
-      backend: {
-        database: {
-          client: 'better-sqlite3',
-          connection: ':memory:',
-        },
-      },
-    }),
-  ).forPlugin('scaffolder');
-
-  return await DatabaseTaskStore.create({
-    database: manager,
-  });
-}
+jest.setTimeout(60_000);
 
 describe('StorageTaskBroker', () => {
-  let storage: DatabaseTaskStore;
-  const fakeSecrets = { backstageToken: 'secret' } as TaskSecrets;
+  // TODO(freben): Rewrite to support more databases - the implementation is correct but the test needs to be adapted
+  const databases = TestDatabases.create({ ids: ['SQLITE_3'] });
 
-  beforeAll(async () => {
-    storage = await createStore();
-  });
+  async function createStore(
+    databaseId: TestDatabaseId,
+  ): Promise<DatabaseTaskStore> {
+    const knex = await databases.init(databaseId);
+    return await DatabaseTaskStore.create({
+      database: knex,
+    });
+  }
+
+  const fakeSecrets = { backstageToken: 'secret' } as TaskSecrets;
 
   const emptyTaskSpec = { spec: { steps: [] } as unknown as TaskSpec };
   const emptyTaskWithFakeSecretsSpec = {
@@ -58,123 +52,159 @@ describe('StorageTaskBroker', () => {
   };
 
   const logger = loggerToWinstonLogger(mockServices.logger.mock());
-  it('should claim a dispatched work item', async () => {
-    const broker = new StorageTaskBroker(storage, logger);
-    await broker.dispatch(emptyTaskSpec);
-    await expect(broker.claim()).resolves.toEqual(
-      expect.any(TaskManager as any),
-    );
-  });
 
-  it('should wait for a dispatched work item', async () => {
-    const broker = new StorageTaskBroker(storage, logger);
-    const promise = broker.claim();
+  it.each(databases.eachSupportedId())(
+    'should claim a dispatched work item',
+    async databaseId => {
+      const storage = await createStore(databaseId);
+      const broker = new StorageTaskBroker(storage, logger);
+      await broker.dispatch(emptyTaskSpec);
+      await expect(broker.claim()).resolves.toEqual(
+        expect.any(TaskManager as any),
+      );
+    },
+  );
 
-    await expect(Promise.race([promise, 'waiting'])).resolves.toBe('waiting');
+  it.each(databases.eachSupportedId())(
+    'should wait for a dispatched work item',
+    async databaseId => {
+      const storage = await createStore(databaseId);
+      const broker = new StorageTaskBroker(storage, logger);
+      const promise = broker.claim();
 
-    await broker.dispatch(emptyTaskSpec);
-    await expect(promise).resolves.toEqual(expect.any(TaskManager as any));
-  });
+      await expect(Promise.race([promise, 'waiting'])).resolves.toBe('waiting');
 
-  it('should dispatch multiple items and claim them in order', async () => {
-    const broker = new StorageTaskBroker(storage, logger);
-    await broker.dispatch({ spec: { steps: [{ id: 'a' }] } as TaskSpec });
-    await broker.dispatch({ spec: { steps: [{ id: 'b' }] } as TaskSpec });
-    await broker.dispatch({ spec: { steps: [{ id: 'c' }] } as TaskSpec });
+      await broker.dispatch(emptyTaskSpec);
+      await expect(promise).resolves.toEqual(expect.any(TaskManager as any));
+    },
+  );
 
-    const taskA = await broker.claim();
-    const taskB = await broker.claim();
-    const taskC = await broker.claim();
-    expect(taskA).toEqual(expect.any(TaskManager as any));
-    expect(taskB).toEqual(expect.any(TaskManager as any));
-    expect(taskC).toEqual(expect.any(TaskManager as any));
-    expect(taskA.spec.steps[0].id).toBe('a');
-    expect(taskB.spec.steps[0].id).toBe('b');
-    expect(taskC.spec.steps[0].id).toBe('c');
-  });
+  it.each(databases.eachSupportedId())(
+    'should dispatch multiple items and claim them in order',
+    async databaseId => {
+      const storage = await createStore(databaseId);
+      const broker = new StorageTaskBroker(storage, logger);
+      await broker.dispatch({ spec: { steps: [{ id: 'a' }] } as TaskSpec });
+      await broker.dispatch({ spec: { steps: [{ id: 'b' }] } as TaskSpec });
+      await broker.dispatch({ spec: { steps: [{ id: 'c' }] } as TaskSpec });
 
-  it('should store secrets', async () => {
-    const broker = new StorageTaskBroker(storage, logger);
-    await broker.dispatch(emptyTaskWithFakeSecretsSpec);
-    const task = await broker.claim();
-    expect(task.secrets).toEqual(fakeSecrets);
-  }, 10000);
+      const taskA = await broker.claim();
+      const taskB = await broker.claim();
+      const taskC = await broker.claim();
+      expect(taskA).toEqual(expect.any(TaskManager as any));
+      expect(taskB).toEqual(expect.any(TaskManager as any));
+      expect(taskC).toEqual(expect.any(TaskManager as any));
+      expect(taskA.spec.steps[0].id).toBe('a');
+      expect(taskB.spec.steps[0].id).toBe('b');
+      expect(taskC.spec.steps[0].id).toBe('c');
+    },
+  );
 
-  it('should complete a task', async () => {
-    const broker = new StorageTaskBroker(storage, logger);
-    const dispatchResult = await broker.dispatch(emptyTaskSpec);
-    const task = await broker.claim();
-    await task.complete('completed');
-    const taskRow = await storage.getTask(dispatchResult.taskId);
-    expect(taskRow.status).toBe('completed');
-  }, 10000);
+  it.each(databases.eachSupportedId())(
+    'should store secrets',
+    async databaseId => {
+      const storage = await createStore(databaseId);
+      const broker = new StorageTaskBroker(storage, logger);
+      await broker.dispatch(emptyTaskWithFakeSecretsSpec);
+      const task = await broker.claim();
+      expect(task.secrets).toEqual(fakeSecrets);
+    },
+  );
 
-  it('should remove secrets after picking up a task', async () => {
-    const broker = new StorageTaskBroker(storage, logger);
-    const dispatchResult = await broker.dispatch(emptyTaskWithFakeSecretsSpec);
-    await broker.claim();
+  it.each(databases.eachSupportedId())(
+    'should complete a task',
+    async databaseId => {
+      const storage = await createStore(databaseId);
+      const broker = new StorageTaskBroker(storage, logger);
+      const dispatchResult = await broker.dispatch(emptyTaskSpec);
+      const task = await broker.claim();
+      await task.complete('completed');
+      const taskRow = await storage.getTask(dispatchResult.taskId);
+      expect(taskRow.status).toBe('completed');
+    },
+  );
 
-    const taskRow = await storage.getTask(dispatchResult.taskId);
-    expect(taskRow.secrets).toBeUndefined();
-  }, 10000);
+  it.each(databases.eachSupportedId())(
+    'should remove secrets after picking up a task',
+    async databaseId => {
+      const storage = await createStore(databaseId);
+      const broker = new StorageTaskBroker(storage, logger);
+      const dispatchResult = await broker.dispatch(
+        emptyTaskWithFakeSecretsSpec,
+      );
+      await broker.claim();
 
-  it('should fail a task', async () => {
-    const broker = new StorageTaskBroker(storage, logger);
-    const dispatchResult = await broker.dispatch(emptyTaskSpec);
-    const task = await broker.claim();
-    await task.complete('failed');
-    const taskRow = await storage.getTask(dispatchResult.taskId);
-    expect(taskRow.status).toBe('failed');
-  });
+      const taskRow = await storage.getTask(dispatchResult.taskId);
+      expect(taskRow.secrets).toBeUndefined();
+    },
+  );
 
-  it('multiple brokers should be able to observe a single task', async () => {
-    const broker1 = new StorageTaskBroker(storage, logger);
-    const broker2 = new StorageTaskBroker(storage, logger);
+  it.each(databases.eachSupportedId())(
+    'should fail a task',
+    async databaseId => {
+      const storage = await createStore(databaseId);
+      const broker = new StorageTaskBroker(storage, logger);
+      const dispatchResult = await broker.dispatch(emptyTaskSpec);
+      const task = await broker.claim();
+      await task.complete('failed');
+      const taskRow = await storage.getTask(dispatchResult.taskId);
+      expect(taskRow.status).toBe('failed');
+    },
+  );
 
-    const { taskId } = await broker1.dispatch(emptyTaskSpec);
+  it.each(databases.eachSupportedId())(
+    'multiple brokers should be able to observe a single task',
+    async databaseId => {
+      const storage = await createStore(databaseId);
+      const broker1 = new StorageTaskBroker(storage, logger);
+      const broker2 = new StorageTaskBroker(storage, logger);
 
-    const logPromise = new Promise<SerializedTaskEvent[]>(resolve => {
-      const observedEvents = new Array<SerializedTaskEvent>();
+      const { taskId } = await broker1.dispatch(emptyTaskSpec);
 
-      const subscription = broker2
-        .event$({ taskId, after: undefined })
-        .subscribe(({ events }) => {
-          observedEvents.push(...events);
-          if (events.some(e => e.type === 'completion')) {
-            resolve(observedEvents);
+      const logPromise = new Promise<SerializedTaskEvent[]>(resolve => {
+        const observedEvents = new Array<SerializedTaskEvent>();
+
+        const subscription = broker2
+          .event$({ taskId, after: undefined })
+          .subscribe(({ events }) => {
+            observedEvents.push(...events);
+            if (events.some(e => e.type === 'completion')) {
+              resolve(observedEvents);
+              subscription.unsubscribe();
+            }
+          });
+      });
+      const task = await broker1.claim();
+      await task.emitLog('log 1');
+      await task.emitLog('log 2');
+      await task.emitLog('log 3');
+      await task.complete('completed');
+
+      const logs = await logPromise;
+      expect(logs.map(l => l.body.message, logger)).toEqual([
+        'log 1',
+        'log 2',
+        'log 3',
+        'Run completed with status: completed',
+      ]);
+
+      const afterLogs = await new Promise<string[]>(resolve => {
+        const subscription = broker2
+          .event$({ taskId, after: logs[1].id })
+          .subscribe(({ events }) => {
+            resolve(events.map(e => e.body.message as string));
             subscription.unsubscribe();
-          }
-        });
-    });
-    const task = await broker1.claim();
-    await task.emitLog('log 1');
-    await task.emitLog('log 2');
-    await task.emitLog('log 3');
-    await task.complete('completed');
+          });
+      });
+      expect(afterLogs).toEqual([
+        'log 3',
+        'Run completed with status: completed',
+      ]);
+    },
+  );
 
-    const logs = await logPromise;
-    expect(logs.map(l => l.body.message, logger)).toEqual([
-      'log 1',
-      'log 2',
-      'log 3',
-      'Run completed with status: completed',
-    ]);
-
-    const afterLogs = await new Promise<string[]>(resolve => {
-      const subscription = broker2
-        .event$({ taskId, after: logs[1].id })
-        .subscribe(({ events }) => {
-          resolve(events.map(e => e.body.message as string));
-          subscription.unsubscribe();
-        });
-    });
-    expect(afterLogs).toEqual([
-      'log 3',
-      'Run completed with status: completed',
-    ]);
-  });
-
-  it('should heartbeat', async () => {
+  it.each(databases.eachSupportedId())('should heartbeat', async databaseId => {
+    const storage = await createStore(databaseId);
     const broker = new StorageTaskBroker(storage, logger);
     const { taskId } = await broker.dispatch(emptyTaskSpec);
     const task = await broker.claim();
@@ -192,106 +222,126 @@ describe('StorageTaskBroker', () => {
     expect.assertions(0);
   });
 
-  it('should be update the status to failed if heartbeat fails', async () => {
-    const broker = new StorageTaskBroker(storage, logger);
-    const { taskId } = await broker.dispatch(emptyTaskSpec);
-    const task = await broker.claim();
+  it.each(databases.eachSupportedId())(
+    'should be update the status to failed if heartbeat fails',
+    async databaseId => {
+      const storage = await createStore(databaseId);
+      const broker = new StorageTaskBroker(storage, logger);
+      const { taskId } = await broker.dispatch(emptyTaskSpec);
+      const task = await broker.claim();
 
-    jest
-      .spyOn((task as any).storage, 'heartbeatTask')
-      .mockRejectedValue(new Error('nah m8'));
+      jest
+        .spyOn((task as any).storage, 'heartbeatTask')
+        .mockRejectedValue(new Error('nah m8'));
 
-    const intervalId = setInterval(() => {
-      broker.vacuumTasks({ timeoutS: 2 });
-    }, 500);
+      const intervalId = setInterval(() => {
+        broker.vacuumTasks({ timeoutS: 2 });
+      }, 500);
 
-    for (;;) {
-      const maybeTask = await storage.getTask(taskId);
-      if (maybeTask.status === 'failed') {
-        break;
+      for (;;) {
+        const maybeTask = await storage.getTask(taskId);
+        if (maybeTask.status === 'failed') {
+          break;
+        }
+        await new Promise(resolve => setTimeout(resolve, 50));
       }
-      await new Promise(resolve => setTimeout(resolve, 50));
-    }
 
-    clearInterval(intervalId);
+      clearInterval(intervalId);
 
-    expect(task.done).toBe(true);
-  });
+      expect(task.done).toBe(true);
+    },
+  );
 
-  it('should list all tasks', async () => {
-    const broker = new StorageTaskBroker(storage, logger);
-    const { taskId } = await broker.dispatch(emptyTaskSpec);
+  it.each(databases.eachSupportedId())(
+    'should list all tasks',
+    async databaseId => {
+      const storage = await createStore(databaseId);
+      const broker = new StorageTaskBroker(storage, logger);
+      const { taskId } = await broker.dispatch(emptyTaskSpec);
 
-    const promise = broker.list();
-    await expect(promise).resolves.toEqual({
-      tasks: expect.arrayContaining([
-        expect.objectContaining({
-          id: taskId,
-        }),
-      ]),
-      totalTasks: 13,
-    });
-  });
+      const promise = broker.list();
+      await expect(promise).resolves.toEqual({
+        tasks: [
+          expect.objectContaining({
+            id: taskId,
+          }),
+        ],
+        totalTasks: 1,
+      });
+    },
+  );
 
-  it('should list only tasks createdBy a specific user', async () => {
-    const broker = new StorageTaskBroker(storage, logger);
-    const { taskId } = await broker.dispatch({
-      spec: { steps: [] } as unknown as TaskSpec,
-      createdBy: 'user:default/foo',
-    });
+  it.each(databases.eachSupportedId())(
+    'should list only tasks createdBy a specific user',
+    async databaseId => {
+      const storage = await createStore(databaseId);
+      const broker = new StorageTaskBroker(storage, logger);
+      const { taskId } = await broker.dispatch({
+        spec: { steps: [] } as unknown as TaskSpec,
+        createdBy: 'user:default/foo',
+      });
 
-    const task = await storage.getTask(taskId);
+      const task = await storage.getTask(taskId);
 
-    const promise = broker.list({
-      filters: { createdBy: ['user:default/foo'] },
-    });
-    await expect(promise).resolves.toEqual({ tasks: [task], totalTasks: 1 });
-  });
+      const promise = broker.list({
+        filters: { createdBy: ['user:default/foo'] },
+      });
+      await expect(promise).resolves.toEqual({ tasks: [task], totalTasks: 1 });
+    },
+  );
 
-  it('should list only tasks with specific status', async () => {
-    const broker = new StorageTaskBroker(storage, logger);
-    const { taskId } = await broker.dispatch({
-      spec: { steps: [] } as unknown as TaskSpec,
-      createdBy: 'user:default/foo',
-    });
+  it.each(databases.eachSupportedId())(
+    'should list only tasks with specific status',
+    async databaseId => {
+      const storage = await createStore(databaseId);
+      const broker = new StorageTaskBroker(storage, logger);
+      const { taskId } = await broker.dispatch({
+        spec: { steps: [] } as unknown as TaskSpec,
+        createdBy: 'user:default/foo',
+      });
 
-    const promise = broker.list({
-      filters: { status: ['open'] },
-    });
-    await expect(promise).resolves.toEqual({
-      tasks: expect.arrayContaining([
-        expect.objectContaining({
-          id: taskId,
-        }),
-      ]),
-      totalTasks: 3,
-    });
-  });
+      const promise = broker.list({
+        filters: { status: ['open'] },
+      });
+      await expect(promise).resolves.toEqual({
+        tasks: [
+          expect.objectContaining({
+            id: taskId,
+          }),
+        ],
+        totalTasks: 1,
+      });
+    },
+  );
 
-  it('should handle checkpoints in task state', async () => {
-    const broker = new StorageTaskBroker(storage, logger);
+  it.each(databases.eachSupportedId())(
+    'should handle checkpoints in task state',
+    async databaseId => {
+      const storage = await createStore(databaseId);
+      const broker = new StorageTaskBroker(storage, logger);
 
-    await broker.dispatch({
-      spec: { steps: [] } as unknown as TaskSpec,
-      createdBy: 'user:default/foo',
-    });
+      await broker.dispatch({
+        spec: { steps: [] } as unknown as TaskSpec,
+        createdBy: 'user:default/foo',
+      });
 
-    const taskA = await broker.claim();
-    await taskA.updateCheckpoint?.({
-      key: 'repo.create',
-      status: 'success',
-      value: 'https://github.com/backstage/backstage.git',
-    });
+      const taskA = await broker.claim();
+      await taskA.updateCheckpoint?.({
+        key: 'repo.create',
+        status: 'success',
+        value: 'https://github.com/backstage/backstage.git',
+      });
 
-    expect(await taskA.getTaskState?.()).toEqual({
-      state: {
-        checkpoints: {
-          'repo.create': {
-            status: 'success',
-            value: 'https://github.com/backstage/backstage.git',
+      expect(await taskA.getTaskState?.()).toEqual({
+        state: {
+          checkpoints: {
+            'repo.create': {
+              status: 'success',
+              value: 'https://github.com/backstage/backstage.git',
+            },
           },
         },
-      },
-    });
-  });
+      });
+    },
+  );
 });


### PR DESCRIPTION
This is on top of #29017.

Just lightly rewrote the tests to use `TestDatabases` instead of the `DatabaseManager` from `@backstage/backend-common`. Ignore whitespace while reviewing. These tests were unfortunately hard coded to only run against sqlite and did not work well with actual databases yet. So I've retained that limitation for now and we can rewrite the tests better in a followup PR. The goal here was to just get rid of backend-common.

Also fixes a small bug in `DatabaseTaskStore` where sometimes the returned count was a string.