### PR TITLE
frontend-plugin-api: add new DialogApi

### DIFF
--- a/.changeset/cuddly-apricots-fetch.md
+++ b/.changeset/cuddly-apricots-fetch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': patch
+---
+
+Added a new Utility API, `DialogApi`, which can be used to show dialogs in the React tree that can collect input from the user.

--- a/.changeset/lucky-ducks-attend.md
+++ b/.changeset/lucky-ducks-attend.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-app': patch
+---
+
+Added implementation of the new `DialogApi`.

--- a/packages/frontend-defaults/src/createApp.test.tsx
+++ b/packages/frontend-defaults/src/createApp.test.tsx
@@ -269,6 +269,7 @@ describe('createApp', () => {
     expect(String(tree.root)).toMatchInlineSnapshot(`
       "<root out=[core.reactElement]>
         apis [
+          <api:app/dialog out=[core.api.factory] />
           <api:app/discovery out=[core.api.factory] />
           <api:app/alert out=[core.api.factory] />
           <api:app/analytics out=[core.api.factory] />
@@ -328,6 +329,7 @@ describe('createApp', () => {
                 elements [
                   <app-root-element:app/oauth-request-dialog out=[core.reactElement] />
                   <app-root-element:app/alert-display out=[core.reactElement] />
+                  <app-root-element:app/dialog-display out=[core.reactElement] />
                 ]
                 signInPage [
                   <sign-in-page:app />

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -782,6 +782,38 @@ export { createTranslationRef };
 
 export { createTranslationResource };
 
+// @public
+export interface DialogApi {
+  show<TResult = {}>(
+    elementOrComponent:
+      | JSX.Element
+      | ((props: {
+          dialog: DialogApiDialog<TResult | undefined>;
+        }) => JSX.Element),
+  ): DialogApiDialog<TResult | undefined>;
+  showModal<TResult = {}>(
+    elementOrComponent:
+      | JSX.Element
+      | ((props: { dialog: DialogApiDialog<TResult> }) => JSX.Element),
+  ): DialogApiDialog<TResult>;
+}
+
+// @public
+export interface DialogApiDialog<TResult = unknown> {
+  close(
+    ...args: undefined extends TResult ? [result?: TResult] : [result: TResult]
+  ): void;
+  result(): Promise<TResult>;
+  update(
+    elementOrComponent:
+      | React.JSX.Element
+      | ((props: { dialog: DialogApiDialog<TResult> }) => JSX.Element),
+  ): void;
+}
+
+// @public
+export const dialogApiRef: ApiRef<DialogApi>;
+
 export { DiscoveryApi };
 
 export { discoveryApiRef };

--- a/packages/frontend-plugin-api/src/apis/definitions/DialogApi.ts
+++ b/packages/frontend-plugin-api/src/apis/definitions/DialogApi.ts
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createApiRef } from '@backstage/core-plugin-api';
+
+/**
+ * A handle for an open dialog that can be used to interact with it.
+ *
+ * @remarks
+ *
+ * Dialogs can be opened using either {@link DialogApi.show} or {@link DialogApi.showModal}.
+ *
+ * @public
+ */
+export interface DialogApiDialog<TResult = unknown> {
+  /**
+   * Closes the dialog with thet provided result.
+   *
+   * @remarks
+   *
+   * If the dialog is a modal dialog a result must always be provided. If it's a regular dialog then passing a result is optional.
+   */
+  close(
+    ...args: undefined extends TResult ? [result?: TResult] : [result: TResult]
+  ): void;
+
+  /**
+   * Replaces the content of the dialog with the provided element or component, causing it to be rerenedered.
+   */
+  update(
+    elementOrComponent:
+      | React.JSX.Element
+      | ((props: { dialog: DialogApiDialog<TResult> }) => JSX.Element),
+  ): void;
+
+  /**
+   * Wait until the dialog is closed and return the result.
+   *
+   * @remarks
+   *
+   * If the dialog is a modal dialog a result will always be returned. If it's a regular dialog then the result may be `undefined`.
+   */
+  result(): Promise<TResult>;
+}
+
+/**
+ * A Utility API for showing dialogs that render in the React tree and return a result.
+ *
+ * @public
+ */
+export interface DialogApi {
+  /**
+   * Opens a modal dialog and returns a handle to it.
+   *
+   * @remarks
+   *
+   * This dialog can be closed by calling the `close` method on the returned handle, optionally providing a result.
+   * The dialog can also be closed by the user by clicking the backdrop or pressing the escape key.
+   *
+   * If the dialog is closed without a result, the result will be `undefined`.
+   *
+   * @example
+   *
+   * ### Example with inline dialog content
+   * ```tsx
+   * const dialog = dialogApi.show<boolean>(
+   *   <DialogContent>
+   *     <DialogTitle>Are you sure?</DialogTitle>
+   *     <DialogActions>
+   *       <Button onClick={() => dialog.close(true)}>Yes</Button>
+   *       <Button onClick={() => dialog.close(false)}>No</Button>
+   *     </DialogActions>
+   *   </DialogContent>
+   * );
+   * const result = await dialog.result();
+   * ```
+   *
+   * @example
+   *
+   * ### Example with separate dialog component
+   * ```tsx
+   * function CustomDialog({ dialog }: { dialog: DialogApiDialog<boolean | undefined> }) {
+   *   return (
+   *     <DialogContent>
+   *       <DialogTitle>Are you sure?</DialogTitle>
+   *       <DialogActions>
+   *         <Button onClick={() => dialog.close(true)}>Yes</Button>
+   *         <Button onClick={() => dialog.close(false)}>No</Button>
+   *       </DialogActions>
+   *     </DialogContent>
+   *   )
+   * }
+   * const result = await dialogApi.show(CustomDialog).result();
+   * ```
+   *
+   * @param elementOrComponent - The element or component to render in the dialog. If a component is provided, it will be provided with a `dialog` prop that contains the dialog handle.
+   * @public
+   */
+  show<TResult = {}>(
+    elementOrComponent:
+      | JSX.Element
+      | ((props: {
+          dialog: DialogApiDialog<TResult | undefined>;
+        }) => JSX.Element),
+  ): DialogApiDialog<TResult | undefined>;
+
+  /**
+   * Opens a modal dialog and returns a handle to it.
+   *
+   * @remarks
+   *
+   * This dialog can not be closed in any other way than calling the `close` method on the returned handle and providing a result.
+   *
+   * @example
+   *
+   * ### Example with inline dialog content
+   * ```tsx
+   * const dialog = dialogApi.showModal<boolean>(
+   *   <DialogContent>
+   *     <DialogTitle>Are you sure?</DialogTitle>
+   *     <DialogActions>
+   *       <Button onClick={() => dialog.close(true)}>Yes</Button>
+   *       <Button onClick={() => dialog.close(false)}>No</Button>
+   *     </DialogActions>
+   *   </DialogContent>
+   * );
+   * const result = await dialog.result();
+   * ```
+   *
+   * @example
+   *
+   * ### Example with separate dialog component
+   * ```tsx
+   * function CustomDialog({ dialog }: { dialog: DialogApiDialog<boolean> }) {
+   *   return (
+   *     <DialogContent>
+   *       <DialogTitle>Are you sure?</DialogTitle>
+   *       <DialogActions>
+   *         <Button onClick={() => dialog.close(true)}>Yes</Button>
+   *         <Button onClick={() => dialog.close(false)}>No</Button>
+   *       </DialogActions>
+   *     </DialogContent>
+   *   )
+   * }
+   * const result = await dialogApi.showModal(CustomDialog).result();
+   * ```
+   *
+   * @param elementOrComponent - The element or component to render in the dialog. If a component is provided, it will be provided with a `dialog` prop that contains the dialog handle.
+   * @public
+   */
+  showModal<TResult = {}>(
+    elementOrComponent:
+      | JSX.Element
+      | ((props: { dialog: DialogApiDialog<TResult> }) => JSX.Element),
+  ): DialogApiDialog<TResult>;
+}
+
+/**
+ * The `ApiRef` of {@link DialogApi}.
+ *
+ * @public
+ */
+export const dialogApiRef = createApiRef<DialogApi>({
+  id: 'core.dialog',
+});

--- a/packages/frontend-plugin-api/src/apis/definitions/DialogApi.ts
+++ b/packages/frontend-plugin-api/src/apis/definitions/DialogApi.ts
@@ -27,7 +27,7 @@ import { createApiRef } from '@backstage/core-plugin-api';
  */
 export interface DialogApiDialog<TResult = unknown> {
   /**
-   * Closes the dialog with thet provided result.
+   * Closes the dialog with that provided result.
    *
    * @remarks
    *

--- a/packages/frontend-plugin-api/src/apis/definitions/index.ts
+++ b/packages/frontend-plugin-api/src/apis/definitions/index.ts
@@ -42,6 +42,7 @@ export * from './FeatureFlagsApi';
 export * from './FetchApi';
 export * from './IconsApi';
 export * from './IdentityApi';
+export * from './DialogApi';
 export * from './OAuthRequestApi';
 export * from './RouteResolutionApi';
 export * from './StorageApi';

--- a/plugins/app/package.json
+++ b/plugins/app/package.json
@@ -43,6 +43,7 @@
     "@backstage/integration-react": "workspace:^",
     "@backstage/plugin-permission-react": "workspace:^",
     "@backstage/theme": "workspace:^",
+    "@backstage/types": "workspace:^",
     "@material-ui/core": "^4.9.13",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.61",

--- a/plugins/app/report.api.md
+++ b/plugins/app/report.api.md
@@ -358,6 +358,21 @@ const appPlugin: FrontendPlugin<
         factory: AnyApiFactory;
       };
     }>;
+    'api:app/dialog': ExtensionDefinition<{
+      kind: 'api';
+      name: 'dialog';
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
+    }>;
     'api:app/discovery': ExtensionDefinition<{
       kind: 'api';
       name: 'discovery';
@@ -694,6 +709,29 @@ const appPlugin: FrontendPlugin<
       };
       kind: 'app-root-element';
       name: 'alert-display';
+      params: {
+        element: JSX.Element | (() => JSX.Element);
+      };
+    }>;
+    'app-root-element:app/dialog-display': ExtensionDefinition<{
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        JSX_2.Element,
+        'core.reactElement',
+        {}
+      >;
+      inputs: {
+        [x: string]: ExtensionInput<
+          AnyExtensionDataRef,
+          {
+            optional: boolean;
+            singleton: boolean;
+          }
+        >;
+      };
+      kind: 'app-root-element';
+      name: 'dialog-display';
       params: {
         element: JSX.Element | (() => JSX.Element);
       };

--- a/plugins/app/src/apis/DefaultDialogApi.ts
+++ b/plugins/app/src/apis/DefaultDialogApi.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DialogApi, DialogApiDialog } from '@backstage/frontend-plugin-api';
+
+export type OnShowDialog = (options: {
+  component: (props: { dialog: DialogApiDialog<any> }) => React.JSX.Element;
+  modal: boolean;
+}) => DialogApiDialog;
+
+/**
+ * Default implementation for the {@link DialogApi}.
+ * @internal
+ */
+export class DefaultDialogApi implements DialogApi {
+  #onShow?: OnShowDialog;
+
+  show<TResult = {}>(
+    elementOrComponent:
+      | JSX.Element
+      | ((props: {
+          dialog: DialogApiDialog<TResult | undefined>;
+        }) => JSX.Element),
+  ): DialogApiDialog<TResult | undefined> {
+    if (!this.#onShow) {
+      throw new Error('Dialog API has not been connected');
+    }
+    return this.#onShow({
+      component:
+        typeof elementOrComponent === 'function'
+          ? elementOrComponent
+          : () => elementOrComponent,
+      modal: false,
+    }) as DialogApiDialog<TResult | undefined>;
+  }
+
+  showModal<TResult = {}>(
+    elementOrComponent:
+      | JSX.Element
+      | ((props: { dialog: DialogApiDialog<TResult> }) => JSX.Element),
+  ): DialogApiDialog<TResult> {
+    if (!this.#onShow) {
+      throw new Error('Dialog API has not been connected');
+    }
+    return this.#onShow({
+      component:
+        typeof elementOrComponent === 'function'
+          ? elementOrComponent
+          : () => elementOrComponent,
+      modal: true,
+    }) as DialogApiDialog<TResult>;
+  }
+
+  connect(onShow: OnShowDialog): void {
+    this.#onShow = onShow;
+  }
+}

--- a/plugins/app/src/defaultApis.ts
+++ b/plugins/app/src/defaultApis.ts
@@ -60,7 +60,7 @@ import {
   atlassianAuthApiRef,
   vmwareCloudAuthApiRef,
 } from '@backstage/core-plugin-api';
-import { ApiBlueprint } from '@backstage/frontend-plugin-api';
+import { ApiBlueprint, dialogApiRef } from '@backstage/frontend-plugin-api';
 import {
   ScmAuth,
   ScmIntegrationsApi,
@@ -70,8 +70,19 @@ import {
   permissionApiRef,
   IdentityPermissionApi,
 } from '@backstage/plugin-permission-react';
+import { DefaultDialogApi } from './apis/DefaultDialogApi';
 
 export const apis = [
+  ApiBlueprint.make({
+    name: 'dialog',
+    params: {
+      factory: createApiFactory({
+        api: dialogApiRef,
+        deps: {},
+        factory: () => new DefaultDialogApi(),
+      }),
+    },
+  }),
   ApiBlueprint.make({
     name: 'discovery',
     params: {

--- a/plugins/app/src/extensions/DialogDisplay.test.tsx
+++ b/plugins/app/src/extensions/DialogDisplay.test.tsx
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderInTestApp } from '@backstage/frontend-test-utils';
+import React, { act, useEffect } from 'react';
+import {
+  AppRootElementBlueprint,
+  DialogApi,
+  DialogApiDialog,
+  dialogApiRef,
+} from '@backstage/frontend-plugin-api';
+import { createDeferred } from '@backstage/types';
+import userEvent from '@testing-library/user-event';
+
+async function withDialogApi<T>(
+  callback: (dialogApi: DialogApi) => Promise<T>,
+) {
+  const deferred = createDeferred<DialogApi>();
+  await renderInTestApp(<div />, {
+    extensions: [
+      AppRootElementBlueprint.makeWithOverrides({
+        name: 'derp',
+        factory(originalFactory, { apis }) {
+          function TestComponent() {
+            useEffect(() => {
+              deferred.resolve(apis.get(dialogApiRef)!);
+            }, []);
+            return <div />;
+          }
+          return originalFactory({ element: <TestComponent /> });
+        },
+      }),
+    ],
+  });
+  return await callback(await deferred);
+}
+
+describe('DialogDisplay', () => {
+  function AutoDialog({
+    dialog,
+    result,
+  }: {
+    dialog: DialogApiDialog<string | undefined>;
+    result?: string;
+  }) {
+    useEffect(() => {
+      if (result) {
+        dialog.close(result);
+      }
+    }, [dialog, result]);
+    return <div />;
+  }
+
+  it('should render a simple dialog', async () => {
+    const result = await withDialogApi(async dialogApi => {
+      const dialog = await act(() => dialogApi.show<string>(<div>Test</div>));
+      dialog.close('test');
+      return dialog.result();
+    });
+    expect(result).toBe('test');
+  });
+
+  it('should allow dialog to be updated', async () => {
+    const result = await withDialogApi(async dialogApi => {
+      const dialog = await act(() => dialogApi.show(AutoDialog));
+
+      setTimeout(async () => {
+        await act(async () => {
+          dialog.update(props => <AutoDialog {...props} result="test2" />);
+        });
+      }, 100);
+
+      return dialog.result();
+    });
+
+    expect(result).toBe('test2');
+  });
+
+  it('should allow dialog to be closed by pressing escape', async () => {
+    const result = await withDialogApi(async dialogApi => {
+      const dialog = await act(() => dialogApi.show(AutoDialog));
+
+      setTimeout(async () => {
+        await userEvent.keyboard('{Escape}');
+      }, 100);
+
+      return dialog.result();
+    });
+
+    expect(result).toBe(undefined);
+  });
+
+  it('should allow a stack of dialogs', async () => {
+    const result = await withDialogApi(async dialogApi => {
+      const dialog1 = await act(() => dialogApi.show(AutoDialog));
+      const dialog2 = await act(() => dialogApi.show(AutoDialog));
+      const dialog3 = await act(() => dialogApi.show(AutoDialog));
+
+      setTimeout(async () => {
+        await act(async () => {
+          dialog3.close('test3');
+          dialog1.close('test1');
+          dialog2.close('test2');
+        });
+      }, 100);
+
+      return Promise.all([
+        dialog1.result(),
+        dialog2.result(),
+        dialog3.result(),
+      ]);
+    });
+
+    expect(result).toEqual(['test1', 'test2', 'test3']);
+  });
+
+  it('should only cancel one dialog at a time', async () => {
+    const result = await withDialogApi(async dialogApi => {
+      const dialog1 = await act(() => dialogApi.show(AutoDialog));
+      const dialog2 = await act(() => dialogApi.show(AutoDialog));
+      const dialog3 = await act(() => dialogApi.show(AutoDialog));
+
+      setTimeout(async () => {
+        await userEvent.keyboard('{Escape}');
+
+        await act(async () => {
+          dialog1.close('test1');
+          dialog2.close('test2');
+          dialog3.close('test3');
+        });
+      }, 100);
+
+      return Promise.all([
+        dialog1.result(),
+        dialog2.result(),
+        dialog3.result(),
+      ]);
+    });
+
+    expect(result).toEqual(['test1', 'test2', undefined]);
+  });
+
+  it('should not allow modal dialog to be closed by pressing escape', async () => {
+    const result = await withDialogApi(async dialogApi => {
+      const dialog = await act(() => dialogApi.showModal(AutoDialog));
+
+      setTimeout(async () => {
+        await userEvent.keyboard('{Escape}');
+
+        setTimeout(async () => {
+          await act(async () => {
+            dialog.close('test');
+          });
+        }, 100);
+      }, 100);
+
+      return dialog.result();
+    });
+
+    expect(result).toBe('test');
+  });
+});

--- a/plugins/app/src/extensions/DialogDisplay.tsx
+++ b/plugins/app/src/extensions/DialogDisplay.tsx
@@ -63,11 +63,13 @@ function DialogDisplay({
           deferred.resolve(result);
           setDialogs(ds => ds.filter(d => d.dialog.id !== id));
         },
-        update(elementOrComponent) {
+        update(ElementOrComponent) {
           const element =
-            typeof elementOrComponent === 'function'
-              ? elementOrComponent({ dialog })
-              : elementOrComponent;
+            typeof ElementOrComponent === 'function' ? (
+              <ElementOrComponent dialog={dialog} />
+            ) : (
+              ElementOrComponent
+            );
           setDialogs(ds =>
             ds.map(d => (d.dialog.id === id ? { dialog, element } : d)),
           );
@@ -76,7 +78,7 @@ function DialogDisplay({
           return deferred;
         },
       };
-      const element = options.component({ dialog });
+      const element = <options.component dialog={dialog} />;
       setDialogs(ds => [...ds, { dialog, element }]);
       return dialog;
     });

--- a/plugins/app/src/extensions/DialogDisplay.tsx
+++ b/plugins/app/src/extensions/DialogDisplay.tsx
@@ -51,7 +51,7 @@ function DialogDisplay({
   const [dialogs, setDialogs] = useState<
     { dialog: DialogState; element: React.JSX.Element }[]
   >([]);
-  // const [state, dispatch] = React.useReducer(dialogReducer)
+
   useEffect(() => {
     dialogApi.connect(options => {
       const id = getDialogId();

--- a/plugins/app/src/extensions/DialogDisplay.tsx
+++ b/plugins/app/src/extensions/DialogDisplay.tsx
@@ -109,9 +109,9 @@ export const dialogDisplayAppRootElement =
     factory(originalFactory, { apis }) {
       const dialogApi = apis.get(dialogApiRef);
       if (!isInternalDialogApi(dialogApi)) {
-        throw new Error(
-          `Invalid dialog API implementation, dialog API has been overridden without also overriding the dialog-display element, got ${dialogApi}`,
-        );
+        return originalFactory({
+          element: <React.Fragment />,
+        });
       }
       return originalFactory({
         element: <DialogDisplay dialogApi={dialogApi} />,

--- a/plugins/app/src/extensions/DialogDisplay.tsx
+++ b/plugins/app/src/extensions/DialogDisplay.tsx
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useEffect, useState } from 'react';
+import {
+  AppRootElementBlueprint,
+  DialogApi,
+  DialogApiDialog,
+  dialogApiRef,
+} from '@backstage/frontend-plugin-api';
+import { createDeferred } from '@backstage/types';
+import { OnShowDialog } from '../apis/DefaultDialogApi';
+import Dialog from '@material-ui/core/Dialog';
+
+let dialogId = 0;
+function getDialogId() {
+  dialogId += 1;
+  return dialogId.toString(36);
+}
+
+type DialogState = DialogApiDialog & {
+  id: string;
+  modal: boolean;
+};
+
+/**
+ * The other half of the default implementation of the {@link DialogApi}.
+ *
+ * This component is responsible for rendering the dialogs in the React tree and managing a stack of dialogs.
+ * It expects the implementation of the {@link DialogApi} to be the `DefaultDialogApi`. If one is replaced the other must be too.
+ * @internal
+ */
+function DialogDisplay({
+  dialogApi,
+}: {
+  dialogApi: DialogApi & { connect(onShow: OnShowDialog): void };
+}) {
+  const [dialogs, setDialogs] = useState<
+    { dialog: DialogState; element: React.JSX.Element }[]
+  >([]);
+  // const [state, dispatch] = React.useReducer(dialogReducer)
+  useEffect(() => {
+    dialogApi.connect(options => {
+      const id = getDialogId();
+      const deferred = createDeferred<unknown>();
+      const dialog: DialogState = {
+        id,
+        modal: options.modal,
+        close(result) {
+          deferred.resolve(result);
+          setDialogs(ds => ds.filter(d => d.dialog.id !== id));
+        },
+        update(elementOrComponent) {
+          const element =
+            typeof elementOrComponent === 'function'
+              ? elementOrComponent({ dialog })
+              : elementOrComponent;
+          setDialogs(ds =>
+            ds.map(d => (d.dialog.id === id ? { dialog, element } : d)),
+          );
+        },
+        async result() {
+          return deferred;
+        },
+      };
+      const element = options.component({ dialog });
+      setDialogs(ds => [...ds, { dialog, element }]);
+      return dialog;
+    });
+  }, [dialogApi]);
+
+  if (dialogs.length > 0) {
+    const lastDialog = dialogs[dialogs.length - 1];
+    return (
+      <Dialog
+        open
+        onClose={() => {
+          if (!lastDialog.dialog.modal) {
+            lastDialog.dialog.close();
+          }
+        }}
+      >
+        {lastDialog.element}
+      </Dialog>
+    );
+  }
+
+  return null;
+}
+
+export const dialogDisplayAppRootElement =
+  AppRootElementBlueprint.makeWithOverrides({
+    name: 'dialog-display',
+    factory(originalFactory, { apis }) {
+      const dialogApi = apis.get(dialogApiRef);
+      if (!isInternalDialogApi(dialogApi)) {
+        throw new Error(
+          `Invalid dialog API implementation, dialog API has been overridden without also overriding the dialog-display element, got ${dialogApi}`,
+        );
+      }
+      return originalFactory({
+        element: <DialogDisplay dialogApi={dialogApi} />,
+      });
+    },
+  });
+
+function isInternalDialogApi(
+  dialogApi?: DialogApi,
+): dialogApi is DialogApi & { connect(onShow: OnShowDialog): void } {
+  if (!dialogApi) {
+    return false;
+  }
+  return 'connect' in dialogApi;
+}

--- a/plugins/app/src/extensions/index.ts
+++ b/plugins/app/src/extensions/index.ts
@@ -25,6 +25,7 @@ export { IconsApi } from './IconsApi';
 export { FeatureFlagsApi } from './FeatureFlagsApi';
 export { TranslationsApi } from './TranslationsApi';
 export { DefaultSignInPage } from './DefaultSignInPage';
+export { dialogDisplayAppRootElement } from './DialogDisplay';
 export {
   DefaultProgressComponent,
   DefaultErrorBoundaryComponent,

--- a/plugins/app/src/plugin.ts
+++ b/plugins/app/src/plugin.ts
@@ -35,6 +35,7 @@ import {
   oauthRequestDialogAppRootElement,
   alertDisplayAppRootElement,
   DefaultSignInPage,
+  dialogDisplayAppRootElement,
 } from './extensions';
 import { apis } from './defaultApis';
 
@@ -62,5 +63,6 @@ export const appPlugin = createFrontendPlugin({
     DefaultSignInPage,
     oauthRequestDialogAppRootElement,
     alertDisplayAppRootElement,
+    dialogDisplayAppRootElement,
   ],
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5099,6 +5099,7 @@ __metadata:
     "@backstage/integration-react": "workspace:^"
     "@backstage/plugin-permission-react": "workspace:^"
     "@backstage/theme": "workspace:^"
+    "@backstage/types": "workspace:^"
     "@material-ui/core": ^4.9.13
     "@material-ui/icons": ^4.9.1
     "@material-ui/lab": ^4.0.0-alpha.61


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds a new Utility API in the new frontend system called `DialogApi`. It's purpose is to be able to show dialogs in the React tree, in particular from code that lives outside of the React tree, for example in even handlers for menu or sidebar items.

The intention of this is to help drive additions like #28673 forward, where we need a way for extensions to render dialogs as part of the react tree that aren't otherwise outputting any React components.

The `show` method shows a regular dialog that can be dismissed by clicking the backdrop or escape, while `showModal` shows a dialog that can only be closed by returning a result. I figured that separating those two use-cases into separate functions ended up being the cleanest API, as I don't really se a big need for additional options, at least not ones that are used frequently. An option would of course be `dialogApi.show({ element: ..., modal: true })`, but it just doesn't look quite as nice when formatted x). Happy to discuss that though, and especially if there are any other options that we think might be needed upfront.

I kept this only in the new frontend system for now to leave a bit more room for iteration and avoid needing to change existing apps.

Two simple examples of the usage of this API, taken from the added docs:

Example with inline dialog content:

```tsx
const dialog = dialogApi.showModal<boolean>(
  <DialogContent>
    <DialogTitle>Are you sure?</DialogTitle>
    <DialogActions>
      <Button onClick={() => dialog.close(true)}>Yes</Button>
      <Button onClick={() => dialog.close(false)}>No</Button>
    </DialogActions>
  </DialogContent>
);
const result = await dialog.result();
```

Example with separate dialog component:

```tsx
function CustomDialog({ dialog }: { dialog: DialogApiDialog<boolean> }) {
  return (
    <DialogContent>
      <DialogTitle>Are you sure?</DialogTitle>
      <DialogActions>
        <Button onClick={() => dialog.close(true)}>Yes</Button>
        <Button onClick={() => dialog.close(false)}>No</Button>
      </DialogActions>
    </DialogContent>
  )
}
const result = await dialogApi.showModal(CustomDialog).result();
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
