### PR TITLE
workflows/deploy_microsite: handle missing gen-api-docs in stable docs

### DIFF
--- a/.github/workflows/deploy_microsite.yml
+++ b/.github/workflows/deploy_microsite.yml
@@ -86,7 +86,8 @@ jobs:
 
       - name: build OpenAPI API docs
         working-directory: microsite
-        run: yarn docusaurus gen-api-docs all
+        # TODO: Remove `|| true` once stable release supports gen-api-docs
+        run: yarn docusaurus gen-api-docs all || true
 
       - name: upload OpenAPI API docs
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4


### PR DESCRIPTION
🧹, stable docs don't support the `get-api-docs` command yet, so we need to ignore errors due to the missing command

FYI @aramissennyeydd 