### PR TITLE
fix(core-components): Avoid Layout Shift for DismissableBanner when using a storageApi with latency (e.g. user-settings-backend)

### DIFF
--- a/.changeset/serious-chefs-provide.md
+++ b/.changeset/serious-chefs-provide.md
@@ -1,0 +1,7 @@
+---
+'@backstage/core-components': patch
+---
+
+Avoid Layout Shift for DismissableBanner when using a storageApi with latency (e.g. user-settings-backend)
+
+Properly handle the `unknown` state of the storageApi. There's a trade-off: this may lead to some Layout Shift if the banner has not been dismissed, but once it has been dismissed, you won't have any.

--- a/.changeset/serious-chefs-provide.md
+++ b/.changeset/serious-chefs-provide.md
@@ -2,6 +2,6 @@
 '@backstage/core-components': patch
 ---
 
-Avoid Layout Shift for DismissableBanner when using a storageApi with latency (e.g. user-settings-backend)
+Avoid Layout Shift for `DismissableBanner` when using a `storageApi` with latency (e.g. `user-settings-backend`)
 
-Properly handle the `unknown` state of the storageApi. There's a trade-off: this may lead to some Layout Shift if the banner has not been dismissed, but once it has been dismissed, you won't have any.
+Properly handle the `unknown` state of the `storageApi`. There's a trade-off: this may lead to some Layout Shift if the banner has not been dismissed, but once it has been dismissed, you won't have any.

--- a/packages/core-components/src/components/DismissableBanner/DismissableBanner.tsx
+++ b/packages/core-components/src/components/DismissableBanner/DismissableBanner.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactNode, useState, useEffect } from 'react';
+import React, { ReactNode, useMemo } from 'react';
 import { useApi, storageApiRef } from '@backstage/core-plugin-api';
 import useObservable from 'react-use/esm/useObservable';
 import classNames from 'classnames';
@@ -107,29 +107,12 @@ export const DismissableBanner = (props: Props) => {
     notificationsStore.snapshot<string[]>('dismissedBanners'),
   );
 
-  const [dismissedBanners, setDismissedBanners] = useState(
-    new Set(observedItems.value ?? []),
-  );
-  const [loadingSettings, setLoadingSettings] = useState(
-    observedItems.presence === 'unknown',
+  const dismissedBanners = useMemo(
+    () => new Set(observedItems.value ?? []),
+    [observedItems.value],
   );
 
-  useEffect(() => {
-    if (observedItems?.presence === 'unknown' || observedItems === undefined) {
-      setLoadingSettings(true);
-    }
-
-    if (observedItems?.value) {
-      const currentValue = observedItems?.value ?? [];
-      setDismissedBanners(new Set(currentValue));
-    }
-    if (
-      observedItems?.presence === 'absent' ||
-      observedItems?.presence === 'present'
-    ) {
-      setLoadingSettings(false);
-    }
-  }, [observedItems]);
+  const loadingSettings = observedItems.presence === 'unknown';
 
   const handleClick = () => {
     notificationsStore.set('dismissedBanners', [...dismissedBanners, id]);

--- a/packages/core-components/src/components/DismissableBanner/DismissableBanner.tsx
+++ b/packages/core-components/src/components/DismissableBanner/DismissableBanner.tsx
@@ -102,18 +102,16 @@ export const DismissableBanner = (props: Props) => {
   const classes = useStyles();
   const storageApi = useApi(storageApiRef);
   const notificationsStore = storageApi.forBucket('notifications');
-  const dismissedBannersSnapshot =
-    notificationsStore.snapshot<string[]>('dismissedBanners');
-
-  const [dismissedBanners, setDismissedBanners] = useState(
-    new Set(dismissedBannersSnapshot.value ?? []),
-  );
-  const [loadingSettings, setLoadingSettings] = useState(
-    dismissedBannersSnapshot.presence === 'unknown',
-  );
-
   const observedItems = useObservable(
     notificationsStore.observe$<string[]>('dismissedBanners'),
+    notificationsStore.snapshot<string[]>('dismissedBanners'),
+  );
+
+  const [dismissedBanners, setDismissedBanners] = useState(
+    new Set(observedItems.value ?? []),
+  );
+  const [loadingSettings, setLoadingSettings] = useState(
+    observedItems.presence === 'unknown',
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Properly handle the `unknown` state of the storageApi, and wait for a value before opening the banner.

There's a tradeoff here: this change may lead to some Layout Shift if the banner has not been dismissed, but once it has been dismissed, you won't have any.

IMO, it's a better user experience than to have a layout shift on every visit of a page, once you have dismissed the banner. This was especially annoying, as if the latency is ~low, you get a flash of information that disappears almost instantly. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
