### PR TITLE
cli: migrate info command do module

### DIFF
--- a/.changeset/sweet-zoos-beam.md
+++ b/.changeset/sweet-zoos-beam.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Internal update to move `info` commands to a separate module.

--- a/packages/cli/cli-report.md
+++ b/packages/cli/cli-report.md
@@ -23,8 +23,8 @@ Commands:
   versions:migrate [options]
   migrate [command]
   build-workspace [options] <workspace-dir> [packages...]
-  create-github-app <github-org>
   info
+  create-github-app <github-org>
   help [command]
 ```
 

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -25,6 +25,7 @@ import {
   registerRepoCommands as registerRepoBuildCommands,
   registerCommands as registerBuildCommands,
 } from '../modules/build';
+import { registerCommands as registerInfoCommands } from '../modules/info';
 import { registerCommands as registerMigrateCommand } from '../modules/migrate';
 
 export function registerRepoCommand(program: Command) {
@@ -214,16 +215,12 @@ export function registerCommands(program: Command) {
   registerScriptCommand(program);
   registerMigrateCommand(program);
   registerBuildCommands(program);
+  registerInfoCommands(program);
 
   program
     .command('create-github-app <github-org>')
     .description('Create new GitHub App in your organization.')
     .action(lazy(() => import('./create-github-app'), 'default'));
-
-  program
-    .command('info')
-    .description('Show helpful information for debugging and reporting bugs')
-    .action(lazy(() => import('./info'), 'default'));
 
   // Notifications for removed commands
   program

--- a/packages/cli/src/modules/config/alpha.ts
+++ b/packages/cli/src/modules/config/alpha.ts
@@ -47,7 +47,8 @@ export default createCliPlugin({
           })
           .help()
           .parse(args);
-        const m = await import('./commands/docs');
+        const m =
+          (await require('./commands/docs')) as typeof import('./commands/docs');
         await m.default(argv);
       },
     });
@@ -66,7 +67,8 @@ export default createCliPlugin({
           })
           .help()
           .parse(args);
-        const m = await import('./commands/print');
+        const m =
+          (await require('./commands/print')) as typeof import('./commands/print');
         await m.default(argv);
       },
     });
@@ -90,7 +92,8 @@ export default createCliPlugin({
           })
           .help()
           .parse(args);
-        const m = await import('./commands/validate');
+        const m =
+          (await require('./commands/validate')) as typeof import('./commands/validate');
         await m.default(argv);
       },
     });

--- a/packages/cli/src/modules/info/alpha.ts
+++ b/packages/cli/src/modules/info/alpha.ts
@@ -13,20 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import yargs from 'yargs';
+import { createCliPlugin } from '../../wiring/factory';
 
-import { CliInitializer } from './wiring/CliInitializer';
-import chalk from 'chalk';
-
-(async () => {
-  console.warn(
-    chalk.yellow(
-      'THIS ENTRYPOINT IS IN ALPHA AND MAY CHANGE IN THE FUTURE - DO NOT USE THIS FOR NORMAL DEVELOPMENT',
-    ),
-  );
-  const initializer = new CliInitializer();
-  initializer.add(import('./modules/info/alpha'));
-  initializer.add(import('./modules/config/alpha'));
-  initializer.add(import('./modules/build/alpha'));
-  initializer.add(import('./modules/migrate/alpha'));
-  await initializer.run();
-})();
+export default createCliPlugin({
+  pluginId: 'info',
+  init: async reg => {
+    reg.addCommand({
+      path: ['info'],
+      description: 'Show helpful information for debugging and reporting bugs',
+      execute: async ({ args }) => {
+        yargs().parse(args);
+        const { default: command } =
+          require('./commands/info') as typeof import('./commands/info');
+        await command();
+      },
+    });
+  },
+});

--- a/packages/cli/src/modules/info/commands/info.ts
+++ b/packages/cli/src/modules/info/commands/info.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2025 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import { version as cliVersion } from '../../package.json';
+import { version as cliVersion } from '../../../../package.json';
 import os from 'os';
-import { runPlain } from '../lib/run';
-import { paths } from '../lib/paths';
-import { Lockfile } from '../lib/versioning';
+import { runPlain } from '../../../lib/run';
+import { paths } from '../../../lib/paths';
+import { Lockfile } from '../../../lib/versioning';
 import fs from 'fs-extra';
 
 export default async () => {

--- a/packages/cli/src/modules/info/index.ts
+++ b/packages/cli/src/modules/info/index.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { lazy } from '../../lib/lazy';
+import { Command } from 'commander';
+
+export function registerCommands(program: Command) {
+  program
+    .command('info')
+    .description('Show helpful information for debugging and reporting bugs')
+    .action(lazy(() => import('./commands/info'), 'default'));
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Migrating the `info` command to module in the CLI. (👀  @aramissennyeydd)

Added a fix for the bare `import(...)`s of CommonJS as well, that ends up crashing at runtime because CommonJS compat is amazing. Situation we're in right now is to use `require` for cjs and `import` for esm, except when we have wrappers that enable `import` like we do in the backend system or the `lazy` helper 🤦 

Btw, not loving yargs for this after trying it a bit more. Might do another one and experiment with the one used in Yarn, https://github.com/arcanis/clipanion. @benjdlambert mentioned that one seems pretty good

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
