### PR TITLE
Add `CatalogApi.getLocations`

### DIFF
--- a/.changeset/yellow-cows-tickle.md
+++ b/.changeset/yellow-cows-tickle.md
@@ -1,0 +1,7 @@
+---
+'@backstage/catalog-client': minor
+'@backstage/plugin-catalog-react': minor
+'@backstage/plugin-catalog-node': minor
+---
+
+Add `getLocations` method to `CatalogApi` and `CatalogClient`. This method calls the [`GET /locations`](https://backstage.io/docs/features/software-catalog/software-catalog-api/#get-locations) endpoint from the catalog backend.

--- a/packages/catalog-client/report-testUtils.api.md
+++ b/packages/catalog-client/report-testUtils.api.md
@@ -16,6 +16,7 @@ import { GetEntityAncestorsRequest } from '@backstage/catalog-client';
 import { GetEntityAncestorsResponse } from '@backstage/catalog-client';
 import { GetEntityFacetsRequest } from '@backstage/catalog-client';
 import { GetEntityFacetsResponse } from '@backstage/catalog-client';
+import { GetLocationsResponse } from '@backstage/catalog-client';
 import { Location as Location_2 } from '@backstage/catalog-client';
 import { QueryEntitiesRequest } from '@backstage/catalog-client';
 import { QueryEntitiesResponse } from '@backstage/catalog-client';
@@ -53,7 +54,7 @@ export class InMemoryCatalogClient implements CatalogApi {
   // (undocumented)
   getLocationByRef(_locationRef: string): Promise<Location_2 | undefined>;
   // (undocumented)
-  getLocations(): Promise<Location_2[]>;
+  getLocations(_request?: {}): Promise<GetLocationsResponse>;
   // (undocumented)
   queryEntities(request?: QueryEntitiesRequest): Promise<QueryEntitiesResponse>;
   // (undocumented)

--- a/packages/catalog-client/report-testUtils.api.md
+++ b/packages/catalog-client/report-testUtils.api.md
@@ -53,6 +53,8 @@ export class InMemoryCatalogClient implements CatalogApi {
   // (undocumented)
   getLocationByRef(_locationRef: string): Promise<Location_2 | undefined>;
   // (undocumented)
+  getLocations(): Promise<Location_2[]>;
+  // (undocumented)
   queryEntities(request?: QueryEntitiesRequest): Promise<QueryEntitiesResponse>;
   // (undocumented)
   refreshEntity(_entityRef: string): Promise<void>;

--- a/packages/catalog-client/report.api.md
+++ b/packages/catalog-client/report.api.md
@@ -62,7 +62,10 @@ export interface CatalogApi {
     locationRef: string,
     options?: CatalogRequestOptions,
   ): Promise<Location_2 | undefined>;
-  getLocations(options?: CatalogRequestOptions): Promise<Location_2[]>;
+  getLocations(
+    request?: {},
+    options?: CatalogRequestOptions,
+  ): Promise<GetLocationsResponse>;
   queryEntities(
     request?: QueryEntitiesRequest,
     options?: CatalogRequestOptions,
@@ -137,7 +140,10 @@ export class CatalogClient implements CatalogApi {
     locationRef: string,
     options?: CatalogRequestOptions,
   ): Promise<Location_2 | undefined>;
-  getLocations(options?: CatalogRequestOptions): Promise<Location_2[]>;
+  getLocations(
+    request?: {},
+    options?: CatalogRequestOptions,
+  ): Promise<GetLocationsResponse>;
   queryEntities(
     request?: QueryEntitiesRequest,
     options?: CatalogRequestOptions,
@@ -250,6 +256,12 @@ export interface GetEntityFacetsResponse {
       count: number;
     }>
   >;
+}
+
+// @public
+export interface GetLocationsResponse {
+  // (undocumented)
+  items: Location_2[];
 }
 
 // @public

--- a/packages/catalog-client/report.api.md
+++ b/packages/catalog-client/report.api.md
@@ -62,6 +62,7 @@ export interface CatalogApi {
     locationRef: string,
     options?: CatalogRequestOptions,
   ): Promise<Location_2 | undefined>;
+  getLocations(options?: CatalogRequestOptions): Promise<Location_2[]>;
   queryEntities(
     request?: QueryEntitiesRequest,
     options?: CatalogRequestOptions,
@@ -136,6 +137,7 @@ export class CatalogClient implements CatalogApi {
     locationRef: string,
     options?: CatalogRequestOptions,
   ): Promise<Location_2 | undefined>;
+  getLocations(options?: CatalogRequestOptions): Promise<Location_2[]>;
   queryEntities(
     request?: QueryEntitiesRequest,
     options?: CatalogRequestOptions,

--- a/packages/catalog-client/src/CatalogClient.test.ts
+++ b/packages/catalog-client/src/CatalogClient.test.ts
@@ -621,19 +621,21 @@ describe('CatalogClient', () => {
     });
 
     it('should return locations from correct endpoint', async () => {
-      const response = await client.getLocations({ token });
-      expect(response).toEqual([
-        {
-          id: '42',
-          type: 'url',
-          target: 'https://example.com',
-        },
-        {
-          id: '43',
-          type: 'url',
-          target: 'https://example.com',
-        },
-      ]);
+      const response = await client.getLocations({}, { token });
+      expect(response).toEqual({
+        items: [
+          {
+            id: '42',
+            type: 'url',
+            target: 'https://example.com',
+          },
+          {
+            id: '43',
+            type: 'url',
+            target: 'https://example.com',
+          },
+        ],
+      });
     });
 
     it('should return empty list with empty result', async () => {
@@ -643,8 +645,8 @@ describe('CatalogClient', () => {
         }),
       );
 
-      const response = await client.getLocations({ token });
-      expect(response).toEqual([]);
+      const response = await client.getLocations({}, { token });
+      expect(response).toEqual({ items: [] });
     });
 
     it('should forward token', async () => {
@@ -657,7 +659,7 @@ describe('CatalogClient', () => {
         }),
       );
 
-      await client.getLocations({ token });
+      await client.getLocations({}, { token });
     });
 
     it('should not forward token if omitted', async () => {

--- a/packages/catalog-client/src/CatalogClient.test.ts
+++ b/packages/catalog-client/src/CatalogClient.test.ts
@@ -24,6 +24,7 @@ import {
   QueryEntitiesResponse,
 } from './types/api';
 import { DiscoveryApi } from './types/discovery';
+import { GetLocations200ResponseInner } from './schema/openapi';
 
 const server = setupServer();
 const token = 'fake-token';
@@ -590,6 +591,86 @@ describe('CatalogClient', () => {
           name: 'missing',
         }),
       ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('getLocations', () => {
+    const defaultResponse = [
+      {
+        data: {
+          id: '42',
+          type: 'url',
+          target: 'https://example.com',
+        },
+      },
+      {
+        data: {
+          id: '43',
+          type: 'url',
+          target: 'https://example.com',
+        },
+      },
+    ] satisfies GetLocations200ResponseInner[];
+
+    beforeEach(() => {
+      server.use(
+        rest.get(`${mockBaseUrl}/locations`, (_, res, ctx) => {
+          return res(ctx.json(defaultResponse));
+        }),
+      );
+    });
+
+    it('should return locations from correct endpoint', async () => {
+      const response = await client.getLocations({ token });
+      expect(response).toEqual([
+        {
+          id: '42',
+          type: 'url',
+          target: 'https://example.com',
+        },
+        {
+          id: '43',
+          type: 'url',
+          target: 'https://example.com',
+        },
+      ]);
+    });
+
+    it('should return empty list with empty result', async () => {
+      server.use(
+        rest.get(`${mockBaseUrl}/locations`, (_, res, ctx) => {
+          return res(ctx.json([]));
+        }),
+      );
+
+      const response = await client.getLocations({ token });
+      expect(response).toEqual([]);
+    });
+
+    it('should forward token', async () => {
+      expect.assertions(1);
+
+      server.use(
+        rest.get(`${mockBaseUrl}/locations`, (req, res, ctx) => {
+          expect(req.headers.get('authorization')).toBe(`Bearer ${token}`);
+          return res(ctx.json(defaultResponse));
+        }),
+      );
+
+      await client.getLocations({ token });
+    });
+
+    it('should not forward token if omitted', async () => {
+      expect.assertions(1);
+
+      server.use(
+        rest.get(`${mockBaseUrl}/locations`, (req, res, ctx) => {
+          expect(req.headers.get('authorization')).toBeNull();
+          return res(ctx.json(defaultResponse));
+        }),
+      );
+
+      await client.getLocations();
     });
   });
 

--- a/packages/catalog-client/src/CatalogClient.ts
+++ b/packages/catalog-client/src/CatalogClient.ts
@@ -76,6 +76,16 @@ export class CatalogClient implements CatalogApi {
   }
 
   /**
+   * {@inheritdoc CatalogApi.getLocations}
+   */
+  async getLocations(options?: CatalogRequestOptions): Promise<Location[]> {
+    const res = await this.requestRequired(
+      await this.apiClient.getLocations({}, options),
+    );
+    return res.map(item => item.data);
+  }
+
+  /**
    * {@inheritdoc CatalogApi.getLocationById}
    */
   async getLocationById(

--- a/packages/catalog-client/src/CatalogClient.ts
+++ b/packages/catalog-client/src/CatalogClient.ts
@@ -36,6 +36,7 @@ import {
   GetEntityAncestorsResponse,
   GetEntityFacetsRequest,
   GetEntityFacetsResponse,
+  GetLocationsResponse,
   Location,
   QueryEntitiesRequest,
   QueryEntitiesResponse,
@@ -78,11 +79,16 @@ export class CatalogClient implements CatalogApi {
   /**
    * {@inheritdoc CatalogApi.getLocations}
    */
-  async getLocations(options?: CatalogRequestOptions): Promise<Location[]> {
+  async getLocations(
+    request?: {},
+    options?: CatalogRequestOptions,
+  ): Promise<GetLocationsResponse> {
     const res = await this.requestRequired(
-      await this.apiClient.getLocations({}, options),
+      await this.apiClient.getLocations(request ?? {}, options),
     );
-    return res.map(item => item.data);
+    return {
+      items: res.map(item => item.data),
+    };
   }
 
   /**

--- a/packages/catalog-client/src/testUtils/InMemoryCatalogClient.ts
+++ b/packages/catalog-client/src/testUtils/InMemoryCatalogClient.ts
@@ -228,6 +228,10 @@ export class InMemoryCatalogClient implements CatalogApi {
     };
   }
 
+  async getLocations(): Promise<Location[]> {
+    throw new NotImplementedError('Method not implemented.');
+  }
+
   async getLocationById(_id: string): Promise<Location | undefined> {
     throw new NotImplementedError('Method not implemented.');
   }

--- a/packages/catalog-client/src/testUtils/InMemoryCatalogClient.ts
+++ b/packages/catalog-client/src/testUtils/InMemoryCatalogClient.ts
@@ -28,6 +28,7 @@ import {
   GetEntityAncestorsResponse,
   GetEntityFacetsRequest,
   GetEntityFacetsResponse,
+  GetLocationsResponse,
   Location,
   QueryEntitiesRequest,
   QueryEntitiesResponse,
@@ -228,7 +229,7 @@ export class InMemoryCatalogClient implements CatalogApi {
     };
   }
 
-  async getLocations(): Promise<Location[]> {
+  async getLocations(_request?: {}): Promise<GetLocationsResponse> {
     throw new NotImplementedError('Method not implemented.');
   }
 

--- a/packages/catalog-client/src/types/api.ts
+++ b/packages/catalog-client/src/types/api.ts
@@ -350,6 +350,15 @@ export type Location = {
 };
 
 /**
+ * The response type for {@link CatalogClient.getLocations}
+ *
+ * @public
+ */
+export interface GetLocationsResponse {
+  items: Location[];
+}
+
+/**
  * The request type for {@link CatalogClient.addLocation}.
  *
  * @public
@@ -593,9 +602,13 @@ export interface CatalogApi {
   /**
    * List locations
    *
+   * @param request - Request parameters
    * @param options - Additional options
    */
-  getLocations(options?: CatalogRequestOptions): Promise<Location[]>;
+  getLocations(
+    request?: {},
+    options?: CatalogRequestOptions,
+  ): Promise<GetLocationsResponse>;
 
   /**
    * Gets a registered location by its ID.

--- a/packages/catalog-client/src/types/api.ts
+++ b/packages/catalog-client/src/types/api.ts
@@ -591,6 +591,13 @@ export interface CatalogApi {
   // Locations
 
   /**
+   * List locations
+   *
+   * @param options - Additional options
+   */
+  getLocations(options?: CatalogRequestOptions): Promise<Location[]>;
+
+  /**
    * Gets a registered location by its ID.
    *
    * @param id - A location ID

--- a/packages/catalog-client/src/types/index.ts
+++ b/packages/catalog-client/src/types/index.ts
@@ -31,6 +31,7 @@ export type {
   GetEntityAncestorsResponse,
   GetEntityFacetsRequest,
   GetEntityFacetsResponse,
+  GetLocationsResponse,
   Location,
   ValidateEntityResponse,
   QueryEntitiesCursorRequest,

--- a/plugins/catalog-node/report-testUtils.api.md
+++ b/plugins/catalog-node/report-testUtils.api.md
@@ -19,6 +19,7 @@ import { GetEntityAncestorsRequest } from '@backstage/catalog-client';
 import { GetEntityAncestorsResponse } from '@backstage/catalog-client';
 import { GetEntityFacetsRequest } from '@backstage/catalog-client';
 import { GetEntityFacetsResponse } from '@backstage/catalog-client';
+import { GetLocationsResponse } from '@backstage/catalog-client';
 import { Location as Location_2 } from '@backstage/catalog-client';
 import { QueryEntitiesRequest } from '@backstage/catalog-client';
 import { QueryEntitiesResponse } from '@backstage/catalog-client';
@@ -75,8 +76,9 @@ export interface CatalogServiceMock extends CatalogService, CatalogApi {
   ): Promise<Location_2 | undefined>;
   // (undocumented)
   getLocations(
+    request?: {},
     options?: CatalogServiceRequestOptions | CatalogRequestOptions,
-  ): Promise<Location_2[]>;
+  ): Promise<GetLocationsResponse>;
   // (undocumented)
   queryEntities(
     request?: QueryEntitiesRequest,

--- a/plugins/catalog-node/report-testUtils.api.md
+++ b/plugins/catalog-node/report-testUtils.api.md
@@ -74,6 +74,10 @@ export interface CatalogServiceMock extends CatalogService, CatalogApi {
     options?: CatalogServiceRequestOptions | CatalogRequestOptions,
   ): Promise<Location_2 | undefined>;
   // (undocumented)
+  getLocations(
+    options?: CatalogServiceRequestOptions | CatalogRequestOptions,
+  ): Promise<Location_2[]>;
+  // (undocumented)
   queryEntities(
     request?: QueryEntitiesRequest,
     options?: CatalogServiceRequestOptions | CatalogRequestOptions,

--- a/plugins/catalog-node/report.api.md
+++ b/plugins/catalog-node/report.api.md
@@ -19,6 +19,7 @@ import { GetEntityAncestorsRequest } from '@backstage/catalog-client';
 import { GetEntityAncestorsResponse } from '@backstage/catalog-client';
 import { GetEntityFacetsRequest } from '@backstage/catalog-client';
 import { GetEntityFacetsResponse } from '@backstage/catalog-client';
+import { GetLocationsResponse } from '@backstage/catalog-client';
 import { JsonValue } from '@backstage/types';
 import { Location as Location_2 } from '@backstage/catalog-client';
 import { LocationEntityV1alpha1 } from '@backstage/catalog-model';
@@ -164,7 +165,10 @@ export interface CatalogService {
     options: CatalogServiceRequestOptions,
   ): Promise<Location_2 | undefined>;
   // (undocumented)
-  getLocations(options: CatalogServiceRequestOptions): Promise<Location_2[]>;
+  getLocations(
+    request: {} | undefined,
+    options: CatalogServiceRequestOptions,
+  ): Promise<GetLocationsResponse>;
   // (undocumented)
   queryEntities(
     request: QueryEntitiesRequest | undefined,

--- a/plugins/catalog-node/report.api.md
+++ b/plugins/catalog-node/report.api.md
@@ -164,6 +164,8 @@ export interface CatalogService {
     options: CatalogServiceRequestOptions,
   ): Promise<Location_2 | undefined>;
   // (undocumented)
+  getLocations(options: CatalogServiceRequestOptions): Promise<Location_2[]>;
+  // (undocumented)
   queryEntities(
     request: QueryEntitiesRequest | undefined,
     options: CatalogServiceRequestOptions,

--- a/plugins/catalog-node/src/catalogService.ts
+++ b/plugins/catalog-node/src/catalogService.ts
@@ -96,6 +96,8 @@ export interface CatalogService {
     options: CatalogServiceRequestOptions,
   ): Promise<GetEntityFacetsResponse>;
 
+  getLocations(options: CatalogServiceRequestOptions): Promise<Location[]>;
+
   getLocationById(
     id: string,
     options: CatalogServiceRequestOptions,
@@ -221,6 +223,12 @@ class DefaultCatalogService implements CatalogService {
       request,
       await this.#getOptions(options),
     );
+  }
+
+  async getLocations(
+    options: CatalogServiceRequestOptions,
+  ): Promise<Location[]> {
+    return this.#catalogApi.getLocations(await this.#getOptions(options));
   }
 
   async getLocationById(

--- a/plugins/catalog-node/src/catalogService.ts
+++ b/plugins/catalog-node/src/catalogService.ts
@@ -35,6 +35,7 @@ import {
   GetEntityAncestorsResponse,
   GetEntityFacetsRequest,
   GetEntityFacetsResponse,
+  GetLocationsResponse,
   Location,
   QueryEntitiesRequest,
   QueryEntitiesResponse,
@@ -96,7 +97,10 @@ export interface CatalogService {
     options: CatalogServiceRequestOptions,
   ): Promise<GetEntityFacetsResponse>;
 
-  getLocations(options: CatalogServiceRequestOptions): Promise<Location[]>;
+  getLocations(
+    request: {} | undefined,
+    options: CatalogServiceRequestOptions,
+  ): Promise<GetLocationsResponse>;
 
   getLocationById(
     id: string,
@@ -226,9 +230,13 @@ class DefaultCatalogService implements CatalogService {
   }
 
   async getLocations(
+    request: {} | undefined,
     options: CatalogServiceRequestOptions,
-  ): Promise<Location[]> {
-    return this.#catalogApi.getLocations(await this.#getOptions(options));
+  ): Promise<GetLocationsResponse> {
+    return this.#catalogApi.getLocations(
+      request,
+      await this.#getOptions(options),
+    );
   }
 
   async getLocationById(

--- a/plugins/catalog-node/src/testUtils/catalogServiceMock.ts
+++ b/plugins/catalog-node/src/testUtils/catalogServiceMock.ts
@@ -95,6 +95,7 @@ export namespace catalogServiceMock {
     removeEntityByUid: jest.fn(),
     refreshEntity: jest.fn(),
     getEntityFacets: jest.fn(),
+    getLocations: jest.fn(),
     getLocationById: jest.fn(),
     getLocationByRef: jest.fn(),
     addLocation: jest.fn(),

--- a/plugins/catalog-node/src/testUtils/types.ts
+++ b/plugins/catalog-node/src/testUtils/types.ts
@@ -27,6 +27,7 @@ import {
   GetEntityAncestorsResponse,
   GetEntityFacetsRequest,
   GetEntityFacetsResponse,
+  GetLocationsResponse,
   Location,
   QueryEntitiesRequest,
   QueryEntitiesResponse,
@@ -91,8 +92,9 @@ export interface CatalogServiceMock extends CatalogService, CatalogApi {
   ): Promise<GetEntityFacetsResponse>;
 
   getLocations(
+    request?: {},
     options?: CatalogServiceRequestOptions | CatalogRequestOptions,
-  ): Promise<Location[]>;
+  ): Promise<GetLocationsResponse>;
 
   getLocationById(
     id: string,

--- a/plugins/catalog-node/src/testUtils/types.ts
+++ b/plugins/catalog-node/src/testUtils/types.ts
@@ -90,6 +90,10 @@ export interface CatalogServiceMock extends CatalogService, CatalogApi {
     options?: CatalogServiceRequestOptions | CatalogRequestOptions,
   ): Promise<GetEntityFacetsResponse>;
 
+  getLocations(
+    options?: CatalogServiceRequestOptions | CatalogRequestOptions,
+  ): Promise<Location[]>;
+
   getLocationById(
     id: string,
     options?: CatalogServiceRequestOptions | CatalogRequestOptions,

--- a/plugins/catalog-react/src/testUtils/catalogApiMock.ts
+++ b/plugins/catalog-react/src/testUtils/catalogApiMock.ts
@@ -94,6 +94,7 @@ export namespace catalogApiMock {
     removeEntityByUid: jest.fn(),
     refreshEntity: jest.fn(),
     getEntityFacets: jest.fn(),
+    getLocations: jest.fn(),
     getLocationById: jest.fn(),
     getLocationByRef: jest.fn(),
     addLocation: jest.fn(),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Fixes #29033 

This PR adds `CatalogApi.getLocations` and its related implementations. This new method calls `GET /locations` on the catalog backend using the generated catalog client.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
