### PR TITLE
fix: Catalog entity page header overflow fix

### DIFF
--- a/.changeset/nice-waves-smoke.md
+++ b/.changeset/nice-waves-smoke.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+fix: resolved an issue in `CatalogEntityPage` where the title overflow caused the right-side icons to extend beyond the Header component.

--- a/packages/core-components/src/layout/Header/Header.tsx
+++ b/packages/core-components/src/layout/Header/Header.tsx
@@ -59,6 +59,7 @@ const useStyles = makeStyles(
     },
     leftItemsBox: {
       maxWidth: '100%',
+      width: '80%', // space for the right items
       flexGrow: 1,
     },
     rightItemsBox: {
@@ -70,6 +71,10 @@ const useStyles = makeStyles(
       wordBreak: 'break-word',
       fontSize: theme.typography.h3.fontSize,
       marginBottom: 0,
+      '& > div > span > span': {
+        display: 'unset',
+        // to fix title overflow issue
+      },
     },
     subtitle: {
       color: theme.page.fontColor,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

fixed `CatalogEntityPage` header where the title overflow caused the right-side icons to extend beyond the Header.
### Before
![image](https://github.com/user-attachments/assets/d4600e64-8f02-4d98-aad4-efac914d1154)

### After fix
![image](https://github.com/user-attachments/assets/8704f44b-9b86-415a-99ed-e41851d513ed)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->
fixes : #28933 
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
