### PR TITLE
fix: update target property in config interface to be optional

### DIFF
--- a/.changeset/nine-frogs-kick.md
+++ b/.changeset/nine-frogs-kick.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-msgraph': patch
+---
+
+Update actual catalog.providers.microsoftGraphOrg.target config def to be optional as this has a default value. Revert the previously mistakenly updated processors config which as it is deprecated.

--- a/.changeset/nine-frogs-kick.md
+++ b/.changeset/nine-frogs-kick.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-catalog-backend-module-msgraph': patch
----
-
-Update actual catalog.providers.microsoftGraphOrg.target config def to be optional as this has a default value. Revert the previously mistakenly updated processors config which as it is deprecated.

--- a/plugins/catalog-backend-module-msgraph/config.d.ts
+++ b/plugins/catalog-backend-module-msgraph/config.d.ts
@@ -32,7 +32,7 @@ export interface Config {
            * The prefix of the target that this matches on, e.g.
            * "https://graph.microsoft.com/v1.0", with no trailing slash.
            */
-          target?: string;
+          target: string;
           /**
            * The auth authority used.
            *
@@ -116,7 +116,7 @@ export interface Config {
              * The prefix of the target that this matches on, e.g.
              * "https://graph.microsoft.com/v1.0", with no trailing slash.
              */
-            target: string;
+            target?: string;
             /**
              * The auth authority used.
              *
@@ -231,7 +231,7 @@ export interface Config {
                * The prefix of the target that this matches on, e.g.
                * "https://graph.microsoft.com/v1.0", with no trailing slash.
                */
-              target: string;
+              target?: string;
               /**
                * The auth authority used.
                *


### PR DESCRIPTION
Make Microsoft Graph Org target config optional and revert deprecated processors config made in this [PR](https://github.com/backstage/backstage/pull/28952).

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
