### PR TITLE
Bug fix: [repo-tools] generate-patch adds incompatible locator

### DIFF
--- a/.changeset/silly-taxis-suffer.md
+++ b/.changeset/silly-taxis-suffer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/repo-tools': patch
+---
+
+Fix issue where generate-patch incorrectly encodes the locator not aligning with result of yarn patch

--- a/packages/repo-tools/src/commands/generate-patch/generate-patch.ts
+++ b/packages/repo-tools/src/commands/generate-patch/generate-patch.ts
@@ -254,12 +254,7 @@ async function generatePatch(
   await fs.writeFile(joinPath(patchDir, name), patch, 'utf8');
 
   const locator = `${ctx.sourcePkg.packageJson.name}@npm:${version}`;
-  return `patch:${encodeURIComponent(locator)}#${posix.join(
-    '.',
-    '.yarn',
-    'patches',
-    name,
-  )}`;
+  return `patch:${locator}#${posix.join('.', '.yarn', 'patches', name)}`;
 }
 
 // Check if an existing resolution entry is a patch, and in that case return the


### PR DESCRIPTION
## Hey, I just made a Pull Request!

## Issue
After applying a patch to your backstage repo, the resulting locator would be inconpatible with third party tooling such as `snyk test`. Looking at the locator, it was encoding characters that were not encoded when using `yarn patch`.

eg.
```diff
- "@backstage/plugin-catalog-backend": "patch:%40backstage%2Fplugin-catalog-backend%40npm%3A1.31.0#.yarn/patches/@backstage-plugin-catalog-backend-1.31.0-4b26b7a3255e3.patch"
+ "@backstage/plugin-catalog-backend": "patch:@backstage/plugin-catalog-backend@npm:1.31.0#.yarn/patches/@backstage-plugin-catalog-backend-1.31.0-4b26b7a3255e3.patch
```

## Changes

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
