### PR TITLE
Introduce a `createFrontendFeatureLoader`

### DIFF
--- a/.changeset/eight-jeans-shop.md
+++ b/.changeset/eight-jeans-shop.md
@@ -1,0 +1,7 @@
+---
+'@backstage/frontend-plugin-api': minor
+'@backstage/frontend-defaults': minor
+'@backstage/frontend-app-api': patch
+---
+
+Introduced a `createFrontendFeatureLoader()` function, as well as a `FrontendFeatureLoader` interface, to gather several frontend plugins, modules or feature loaders in a single exported entrypoint and load them, possibly asynchronously. This new feature, very similar to the `createBackendFeatureLoader()` already available on the backend, supersedes the previous `CreateAppFeatureLoader` type which has been deprecated.

--- a/packages/frontend-app-api/report.api.md
+++ b/packages/frontend-app-api/report.api.md
@@ -8,8 +8,7 @@ import { AppTree } from '@backstage/frontend-plugin-api';
 import { ConfigApi } from '@backstage/core-plugin-api';
 import { ExtensionFactoryMiddleware } from '@backstage/frontend-plugin-api';
 import { ExternalRouteRef } from '@backstage/frontend-plugin-api';
-import { FrontendModule } from '@backstage/frontend-plugin-api';
-import { FrontendPlugin } from '@backstage/frontend-plugin-api';
+import { FrontendFeature as FrontendFeature_2 } from '@backstage/frontend-plugin-api';
 import { RouteRef } from '@backstage/frontend-plugin-api';
 import { SubRouteRef } from '@backstage/frontend-plugin-api';
 
@@ -40,6 +39,6 @@ export function createSpecializedApp(options?: {
   tree: AppTree;
 };
 
-// @public (undocumented)
-export type FrontendFeature = FrontendPlugin | FrontendModule;
+// @public @deprecated (undocumented)
+export type FrontendFeature = FrontendFeature_2;
 ```

--- a/packages/frontend-app-api/src/wiring/types.ts
+++ b/packages/frontend-app-api/src/wiring/types.ts
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 import { RouteRef } from '@backstage/frontend-plugin-api';
-import { FrontendModule, FrontendPlugin } from '@backstage/frontend-plugin-api';
+import { FrontendFeature as PluginApiFrontendFeature } from '@backstage/frontend-plugin-api';
 import { BackstageRouteObject } from '../routing/types';
 
-/** @public  */
-export type FrontendFeature = FrontendPlugin | FrontendModule;
+/** @public
+ * @deprecated Use {@link @backstage/frontend-plugin-api#FrontendFeature} instead.
+ */
+export type FrontendFeature = PluginApiFrontendFeature;
 
 /** @internal */
 export type RouteInfo = {

--- a/packages/frontend-defaults/report.api.md
+++ b/packages/frontend-defaults/report.api.md
@@ -54,8 +54,7 @@ export function createPublicSignInApp(options?: CreateAppOptions): {
 
 // @public (undocumented)
 export function discoverAvailableFeatures(config: Config): {
-  features: FrontendFeature[];
-  featureLoaders?: FrontendFeatureLoader[];
+  features: (FrontendFeature | FrontendFeatureLoader)[];
 };
 
 // @public (undocumented)

--- a/packages/frontend-defaults/report.api.md
+++ b/packages/frontend-defaults/report.api.md
@@ -7,7 +7,8 @@ import { Config } from '@backstage/config';
 import { ConfigApi } from '@backstage/frontend-plugin-api';
 import { CreateAppRouteBinder } from '@backstage/frontend-app-api';
 import { ExtensionFactoryMiddleware } from '@backstage/frontend-plugin-api';
-import { FrontendFeature } from '@backstage/frontend-app-api';
+import { FrontendFeature } from '@backstage/frontend-plugin-api';
+import { FrontendFeatureLoader } from '@backstage/frontend-plugin-api';
 import { JSX as JSX_2 } from 'react';
 import { default as React_2 } from 'react';
 import { ReactNode } from 'react';
@@ -17,7 +18,7 @@ export function createApp(options?: CreateAppOptions): {
   createRoot(): JSX_2.Element;
 };
 
-// @public
+// @public @deprecated
 export interface CreateAppFeatureLoader {
   getLoaderName(): string;
   load(options: { config: ConfigApi }): Promise<{
@@ -38,7 +39,11 @@ export interface CreateAppOptions {
     | ExtensionFactoryMiddleware
     | ExtensionFactoryMiddleware[];
   // (undocumented)
-  features?: (FrontendFeature | CreateAppFeatureLoader)[];
+  features?: (
+    | FrontendFeature
+    | FrontendFeatureLoader
+    | CreateAppFeatureLoader
+  )[];
   loadingComponent?: ReactNode;
 }
 
@@ -50,12 +55,17 @@ export function createPublicSignInApp(options?: CreateAppOptions): {
 // @public (undocumented)
 export function discoverAvailableFeatures(config: Config): {
   features: FrontendFeature[];
+  featureLoaders?: FrontendFeatureLoader[];
 };
 
 // @public (undocumented)
 export function resolveAsyncFeatures(options: {
   config: Config;
-  features?: (FrontendFeature | CreateAppFeatureLoader)[];
+  features?: (
+    | FrontendFeature
+    | FrontendFeatureLoader
+    | CreateAppFeatureLoader
+  )[];
 }): Promise<{
   features: FrontendFeature[];
 }>;

--- a/packages/frontend-defaults/src/createApp.tsx
+++ b/packages/frontend-defaults/src/createApp.tsx
@@ -100,17 +100,11 @@ export function createApp(options?: CreateAppOptions): {
         overrideBaseUrlConfigs(defaultConfigLoaderSync()),
       );
 
-    const {
-      features: discoveredFeatures,
-      featureLoaders: discoveredFeatureLoaders,
-    } = discoverAvailableFeatures(config);
+    const { features: discoveredFeaturesAndLoaders } =
+      discoverAvailableFeatures(config);
     const { features: loadedFeatures } = await resolveAsyncFeatures({
       config,
-      features: [
-        ...discoveredFeatures,
-        ...(discoveredFeatureLoaders ?? []),
-        ...(options?.features ?? []),
-      ],
+      features: [...discoveredFeaturesAndLoaders, ...(options?.features ?? [])],
     });
 
     const app = createSpecializedApp({

--- a/packages/frontend-defaults/src/discovery.test.ts
+++ b/packages/frontend-defaults/src/discovery.test.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { createFrontendPlugin } from '@backstage/frontend-plugin-api';
+import {
+  createFrontendFeatureLoader,
+  createFrontendPlugin,
+} from '@backstage/frontend-plugin-api';
 import { discoverAvailableFeatures } from './discovery';
 import { ConfigReader } from '@backstage/config';
 
@@ -48,6 +51,21 @@ describe('discoverAvailableFeatures', () => {
     });
     expect(discoverAvailableFeatures(config)).toEqual({
       features: [testPlugin],
+    });
+  });
+
+  it('should discover a frontend feature loader', () => {
+    const testLoader = createFrontendFeatureLoader({
+      loader() {
+        return [];
+      },
+    });
+    globalSpy.mockReturnValue({
+      modules: [{ default: testLoader }],
+    });
+    expect(discoverAvailableFeatures(config)).toEqual({
+      features: [],
+      featureLoaders: [testLoader],
     });
   });
 

--- a/packages/frontend-defaults/src/discovery.test.ts
+++ b/packages/frontend-defaults/src/discovery.test.ts
@@ -64,8 +64,7 @@ describe('discoverAvailableFeatures', () => {
       modules: [{ default: testLoader }],
     });
     expect(discoverAvailableFeatures(config)).toEqual({
-      features: [],
-      featureLoaders: [testLoader],
+      features: [testLoader],
     });
   });
 

--- a/packages/frontend-defaults/src/discovery.ts
+++ b/packages/frontend-defaults/src/discovery.ts
@@ -19,6 +19,7 @@ import {
   FrontendFeature,
   FrontendFeatureLoader,
 } from '@backstage/frontend-plugin-api';
+import { isBackstageFeatureLoader } from './resolution';
 
 interface DiscoveryGlobal {
   modules: Array<{ name: string; export?: string; default: unknown }>;
@@ -59,8 +60,7 @@ function readPackageDetectionConfig(config: Config) {
  * @public
  */
 export function discoverAvailableFeatures(config: Config): {
-  features: FrontendFeature[];
-  featureLoaders?: FrontendFeatureLoader[];
+  features: (FrontendFeature | FrontendFeatureLoader)[];
 } {
   const discovered = (
     window as { '__@backstage/discovered__'?: DiscoveryGlobal }
@@ -71,34 +71,20 @@ export function discoverAvailableFeatures(config: Config): {
     return { features: [] };
   }
 
-  const detectedExports = discovered?.modules
-    .filter(({ name }) => {
-      if (detection.exclude?.includes(name)) {
-        return false;
-      }
-      if (detection.include && !detection.include.includes(name)) {
-        return false;
-      }
-      return true;
-    })
-    .map(m => m.default);
-
-  if (detectedExports === undefined) {
-    return {
-      features: [],
-    };
-  }
-
-  const features = detectedExports.filter(isBackstageFeature);
-  const detectedFeatureLoaders = detectedExports.filter(
-    isBackstageFeatureLoader,
-  );
-  const featureLoaders =
-    detectedFeatureLoaders.length > 0 ? detectedFeatureLoaders : undefined;
-
   return {
-    features,
-    featureLoaders,
+    features:
+      discovered?.modules
+        .filter(({ name }) => {
+          if (detection.exclude?.includes(name)) {
+            return false;
+          }
+          if (detection.include && !detection.include.includes(name)) {
+            return false;
+          }
+          return true;
+        })
+        .map(m => m.default)
+        .filter(isFeatureOrLoader) ?? [],
   };
 }
 
@@ -112,13 +98,8 @@ function isBackstageFeature(obj: unknown): obj is FrontendFeature {
   return false;
 }
 
-export function isBackstageFeatureLoader(
+function isFeatureOrLoader(
   obj: unknown,
-): obj is FrontendFeatureLoader {
-  return (
-    obj !== null &&
-    typeof obj === 'object' &&
-    '$$type' in obj &&
-    obj.$$type === '@backstage/FrontendFeatureLoader'
-  );
+): obj is FrontendFeature | FrontendFeatureLoader {
+  return isBackstageFeature(obj) || isBackstageFeatureLoader(obj);
 }

--- a/packages/frontend-defaults/src/resolution.test.ts
+++ b/packages/frontend-defaults/src/resolution.test.ts
@@ -15,7 +15,9 @@
  */
 
 import {
+  createFrontendFeatureLoader,
   createFrontendPlugin,
+  FrontendFeatureLoader,
   PageBlueprint,
 } from '@backstage/frontend-plugin-api';
 import { CreateAppFeatureLoader } from './createApp';
@@ -69,7 +71,7 @@ describe('resolveAsyncFeatures', () => {
     ]);
   });
 
-  it('supports feature loaders', async () => {
+  it('supports deprecated feature loaders', async () => {
     const loader: CreateAppFeatureLoader = {
       getLoaderName() {
         return 'test-loader';
@@ -118,7 +120,7 @@ describe('resolveAsyncFeatures', () => {
     ]);
   });
 
-  it('should propagate errors thrown by feature loaders', async () => {
+  it('should propagate errors thrown by deprecated feature loaders', async () => {
     const loader: CreateAppFeatureLoader = {
       getLoaderName() {
         return 'test-loader';
@@ -135,6 +137,67 @@ describe('resolveAsyncFeatures', () => {
       }),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       `"Failed to read frontend features from loader 'test-loader', TypeError: boom"`,
+    );
+  });
+
+  it('supports feature loaders', async () => {
+    const loader: FrontendFeatureLoader = createFrontendFeatureLoader({
+      async loader({ config: _ }) {
+        return [
+          createFrontendPlugin({
+            id: 'test',
+            extensions: [
+              PageBlueprint.make({
+                params: {
+                  defaultPath: '/',
+                  loader: () => new Promise(() => {}),
+                },
+              }),
+            ],
+          }),
+        ];
+      },
+    });
+
+    const { features } = await resolveAsyncFeatures({
+      config: mockApis.config(),
+      features: [loader],
+    });
+
+    expect(features).toMatchObject([
+      {
+        $$type: '@backstage/FrontendPlugin',
+        id: 'test',
+        version: 'v1',
+        extensions: [
+          {
+            $$type: '@backstage/Extension',
+            id: 'page:test',
+            version: 'v2',
+            attachTo: {
+              id: 'app/routes',
+              input: 'routes',
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should propagate errors thrown by feature loaders', async () => {
+    const loader: FrontendFeatureLoader = createFrontendFeatureLoader({
+      async loader({ config: _ }) {
+        throw new TypeError('boom');
+      },
+    });
+
+    await expect(() =>
+      resolveAsyncFeatures({
+        config: mockApis.config(),
+        features: [loader],
+      }),
+    ).rejects.toThrow(
+      /^Failed to read frontend features from loader created at .*: TypeError: boom$/,
     );
   });
 });

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -708,6 +708,40 @@ export function createExternalRouteRef<
 >;
 
 // @public (undocumented)
+export function createFrontendFeatureLoader(
+  options: CreateFrontendFeatureLoaderOptions,
+): FrontendFeatureLoader;
+
+// @public (undocumented)
+export interface CreateFrontendFeatureLoaderOptions {
+  // (undocumented)
+  loader(deps: { config: ConfigApi }):
+    | Iterable<
+        | FrontendFeature
+        | FrontendFeatureLoader
+        | Promise<{
+            default: FrontendFeature | FrontendFeatureLoader;
+          }>
+      >
+    | Promise<
+        Iterable<
+          | FrontendFeature
+          | FrontendFeatureLoader
+          | Promise<{
+              default: FrontendFeature | FrontendFeatureLoader;
+            }>
+        >
+      >
+    | AsyncIterable<
+        | FrontendFeature
+        | FrontendFeatureLoader
+        | {
+            default: FrontendFeature | FrontendFeatureLoader;
+          }
+      >;
+}
+
+// @public (undocumented)
 export function createFrontendModule<
   TId extends string,
   TExtensions extends readonly ExtensionDefinition[] = [],
@@ -1235,6 +1269,15 @@ export { FeatureFlagState };
 export { FetchApi };
 
 export { fetchApiRef };
+
+// @public (undocumented)
+export type FrontendFeature = FrontendPlugin | FrontendModule;
+
+// @public (undocumented)
+export interface FrontendFeatureLoader {
+  // (undocumented)
+  readonly $$type: '@backstage/FrontendFeatureLoader';
+}
 
 // @public (undocumented)
 export interface FrontendModule {

--- a/packages/frontend-plugin-api/src/wiring/createFrontendFeatureLoader.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createFrontendFeatureLoader.test.ts
@@ -1,0 +1,468 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+// eslint-disable-next-line @backstage/no-relative-monorepo-imports
+import { createApp } from '../../../frontend-defaults/src/createApp';
+import { screen } from '@testing-library/react';
+import { createFrontendPlugin } from './createFrontendPlugin';
+import { JsonObject } from '@backstage/types';
+import { createExtension } from './createExtension';
+import { createExtensionDataRef } from './createExtensionDataRef';
+import { coreExtensionData } from './coreExtensionData';
+import { mockApis, renderWithEffects } from '@backstage/test-utils';
+import { createExtensionInput } from './createExtensionInput';
+import {
+  CreateFrontendFeatureLoaderOptions,
+  InternalFrontendFeatureLoader,
+  createFrontendFeatureLoader,
+  FrontendFeatureLoader,
+} from './createFrontendFeatureLoader';
+import { FrontendFeature } from './types';
+
+const nameExtensionDataRef = createExtensionDataRef<string>().with({
+  id: 'name',
+});
+
+function createTestAppRoot({
+  features,
+  config = {},
+}: {
+  features: (FrontendFeature | FrontendFeatureLoader)[];
+  config: JsonObject;
+}) {
+  return createApp({
+    features: [...features],
+    configLoader: async () => ({ config: mockApis.config({ data: config }) }),
+  }).createRoot();
+}
+
+describe('createFrontendFeatureLoader', () => {
+  it('should create several plugins with only one feature loader', async () => {
+    const featureLoader: FrontendFeatureLoader = createFrontendFeatureLoader({
+      loader({ config }) {
+        const pluginIdPrefix = config.getOptionalString('pluginIdPrefix');
+        const extensionNamePrefix = config.getOptionalString(
+          'extensionNamePrefix',
+        );
+        return [
+          createFrontendPlugin({
+            id: `${pluginIdPrefix}-1`,
+            extensions: [
+              createExtension({
+                name: '1',
+                attachTo: {
+                  id: `${pluginIdPrefix}-output/output`,
+                  input: 'names',
+                },
+                output: [nameExtensionDataRef],
+                factory() {
+                  return [nameExtensionDataRef(`${extensionNamePrefix}-1`)];
+                },
+              }),
+            ],
+          }) as FrontendFeature | FrontendFeatureLoader,
+          createFrontendPlugin({
+            id: `${pluginIdPrefix}-2`,
+            extensions: [
+              createExtension({
+                name: '2',
+                attachTo: {
+                  id: `${pluginIdPrefix}-output/output`,
+                  input: 'names',
+                },
+                output: [nameExtensionDataRef],
+                factory() {
+                  return [nameExtensionDataRef(`${extensionNamePrefix}-2`)];
+                },
+              }),
+            ],
+          }) as FrontendFeature | FrontendFeatureLoader,
+          createFrontendPlugin({
+            id: `${pluginIdPrefix}-output`,
+            extensions: [
+              createExtension({
+                name: 'output',
+                attachTo: { id: 'app', input: 'root' },
+                inputs: {
+                  names: createExtensionInput([nameExtensionDataRef]),
+                },
+                output: [coreExtensionData.reactElement],
+                factory({ inputs }) {
+                  return [
+                    coreExtensionData.reactElement(
+                      React.createElement('span', {}, [
+                        `Names: ${inputs.names
+                          .map(n => n.get(nameExtensionDataRef))
+                          .join(', ')}`,
+                      ]),
+                    ),
+                  ];
+                },
+              }),
+            ],
+          }) as FrontendFeature | FrontendFeatureLoader,
+        ];
+      },
+    } as CreateFrontendFeatureLoaderOptions);
+
+    expect(featureLoader).toBeDefined();
+    expect(String(featureLoader)).toMatch(
+      /^FeatureLoader{description=created at '.*\/packages\/frontend-plugin-api\/src\/wiring\/createFrontendFeatureLoader\.test\.ts:.*'}$/,
+    );
+
+    await renderWithEffects(
+      createTestAppRoot({
+        features: [featureLoader],
+        config: {
+          app: { extensions: [{ 'app/root': false }] },
+          extensionNamePrefix: 'extension',
+          pluginIdPrefix: 'plugin',
+        },
+      }),
+    );
+
+    await expect(
+      screen.findByText('Names: extension-1, extension-2'),
+    ).resolves.toBeInTheDocument();
+  });
+
+  it('should propagate errors thrown by feature loaders', async () => {
+    const featureLoader: FrontendFeature | FrontendFeatureLoader =
+      createFrontendFeatureLoader({
+        async loader(_) {
+          throw new TypeError('boom');
+        },
+      });
+
+    await expect(
+      renderWithEffects(
+        createTestAppRoot({
+          features: [featureLoader],
+          config: {},
+        }),
+      ),
+    ).rejects.toThrow(
+      /^Failed to read frontend features from loader created at '.*\/packages\/frontend-plugin-api\/src\/wiring\/createFrontendFeatureLoader\.test\.ts:.*': TypeError: boom$/,
+    );
+  });
+
+  it('should support loading feature loaders', async () => {
+    const featureLoader: FrontendFeature | FrontendFeatureLoader =
+      createFrontendFeatureLoader({
+        async loader(_) {
+          return [
+            createFrontendFeatureLoader({
+              async *loader(__) {
+                yield createFrontendPlugin({
+                  id: 'plugin-1',
+                  extensions: [
+                    createExtension({
+                      name: '1',
+                      attachTo: {
+                        id: 'plugin-output/output',
+                        input: 'names',
+                      },
+                      output: [nameExtensionDataRef],
+                      factory() {
+                        return [nameExtensionDataRef('extension-1')];
+                      },
+                    }),
+                  ],
+                });
+                yield createFrontendFeatureLoader({
+                  loader: async ___ => [
+                    createFrontendPlugin({
+                      id: 'plugin-2',
+                      extensions: [
+                        createExtension({
+                          name: '2',
+                          attachTo: {
+                            id: 'plugin-output/output',
+                            input: 'names',
+                          },
+                          output: [nameExtensionDataRef],
+                          factory() {
+                            return [nameExtensionDataRef('extension-2')];
+                          },
+                        }),
+                      ],
+                    }),
+                  ],
+                });
+              },
+            }),
+            createFrontendPlugin({
+              id: 'plugin-output',
+              extensions: [
+                createExtension({
+                  name: 'output',
+                  attachTo: { id: 'app', input: 'root' },
+                  inputs: {
+                    names: createExtensionInput([nameExtensionDataRef]),
+                  },
+                  output: [coreExtensionData.reactElement],
+                  factory({ inputs }) {
+                    return [
+                      coreExtensionData.reactElement(
+                        React.createElement('span', {}, [
+                          `Names: ${inputs.names
+                            .map(n => n.get(nameExtensionDataRef))
+                            .join(', ')}`,
+                        ]),
+                      ),
+                    ];
+                  },
+                }),
+              ],
+            }),
+          ];
+        },
+      });
+
+    expect(featureLoader).toBeDefined();
+    expect(String(featureLoader)).toMatch(
+      /^FeatureLoader{description=created at '.*\/packages\/frontend-plugin-api\/src\/wiring\/createFrontendFeatureLoader\.test\.ts:.*'}$/,
+    );
+
+    await renderWithEffects(
+      createTestAppRoot({
+        features: [featureLoader],
+        config: {
+          app: { extensions: [{ 'app/root': false }] },
+        },
+      }),
+    );
+
+    await expect(
+      screen.findByText('Names: extension-1, extension-2'),
+    ).resolves.toBeInTheDocument();
+  });
+
+  it('should guard against infinite recursion of nested feature loaders', async () => {
+    const nestedFeatureLoaderHolder: {
+      loader?: FrontendFeature | FrontendFeatureLoader;
+    } = {};
+    const featureLoader: FrontendFeature | FrontendFeatureLoader =
+      createFrontendFeatureLoader({
+        loader: () =>
+          [
+            nestedFeatureLoaderHolder.loader,
+            createFrontendPlugin({
+              id: 'plugin',
+              extensions: [
+                createExtension({
+                  name: 'output',
+                  attachTo: { id: 'app', input: 'root' },
+                  inputs: {},
+                  output: [coreExtensionData.reactElement],
+                  factory() {
+                    return [
+                      coreExtensionData.reactElement(
+                        React.createElement('span', {}, [`My Content`]),
+                      ),
+                    ];
+                  },
+                }),
+              ],
+            }),
+          ].filter<FrontendFeature | FrontendFeatureLoader>(
+            (f): f is FrontendFeature | FrontendFeatureLoader =>
+              f !== undefined,
+          ),
+      });
+    nestedFeatureLoaderHolder.loader = featureLoader;
+
+    expect(featureLoader).toBeDefined();
+    expect(String(featureLoader)).toMatch(
+      /^FeatureLoader{description=created at '.*\/packages\/frontend-plugin-api\/src\/wiring\/createFrontendFeatureLoader\.test\.ts:.*'}$/,
+    );
+
+    await renderWithEffects(
+      createTestAppRoot({
+        features: [featureLoader],
+        config: {
+          app: { extensions: [{ 'app/root': false }] },
+        },
+      }),
+    );
+  });
+
+  it('should support multiple output formats', async () => {
+    const feature = createFrontendPlugin({
+      id: 'test',
+    });
+    const dynamicFeature = Promise.resolve({ default: feature });
+
+    async function extractResult(f: FrontendFeature | FrontendFeatureLoader) {
+      const internal = f as InternalFrontendFeatureLoader;
+      return internal.loader({ config: mockApis.config() });
+    }
+
+    await expect(
+      extractResult(
+        createFrontendFeatureLoader({
+          loader() {
+            return [feature];
+          },
+        }),
+      ),
+    ).resolves.toEqual([feature]);
+
+    await expect(
+      extractResult(
+        createFrontendFeatureLoader({
+          async loader() {
+            return [feature];
+          },
+        }),
+      ),
+    ).resolves.toEqual([feature]);
+
+    await expect(
+      extractResult(
+        createFrontendFeatureLoader({
+          *loader() {
+            yield feature;
+          },
+        }),
+      ),
+    ).resolves.toEqual([feature]);
+
+    await expect(
+      extractResult(
+        createFrontendFeatureLoader({
+          async *loader() {
+            yield feature;
+          },
+        }),
+      ),
+    ).resolves.toEqual([feature]);
+
+    await expect(
+      extractResult(
+        createFrontendFeatureLoader({
+          loader() {
+            return [dynamicFeature];
+          },
+        }),
+      ),
+    ).resolves.toEqual([feature]);
+
+    await expect(
+      extractResult(
+        createFrontendFeatureLoader({
+          async loader() {
+            return [dynamicFeature];
+          },
+        }),
+      ),
+    ).resolves.toEqual([feature]);
+
+    await expect(
+      extractResult(
+        createFrontendFeatureLoader({
+          *loader() {
+            yield dynamicFeature;
+          },
+        }),
+      ),
+    ).resolves.toEqual([feature]);
+
+    await expect(
+      extractResult(
+        createFrontendFeatureLoader({
+          async *loader() {
+            yield dynamicFeature;
+          },
+        }),
+      ),
+    ).resolves.toEqual([feature]);
+  });
+
+  it('should limit feature loading recursion', async () => {
+    const plugin = createFrontendPlugin({
+      id: 'plugin',
+      extensions: [
+        createExtension({
+          name: 'output',
+          attachTo: { id: 'app', input: 'root' },
+          inputs: {},
+          output: [coreExtensionData.reactElement],
+          factory() {
+            return [
+              coreExtensionData.reactElement(
+                React.createElement('span', {}, [`My Content`]),
+              ),
+            ];
+          },
+        }),
+      ],
+    });
+
+    const featureLoader: FrontendFeature | FrontendFeatureLoader =
+      createFrontendFeatureLoader({
+        loader: () => [
+          createFrontendFeatureLoader({
+            loader: () => [
+              createFrontendFeatureLoader({
+                loader: () => [
+                  createFrontendFeatureLoader({
+                    loader: () => [
+                      createFrontendFeatureLoader({
+                        loader: () => [
+                          createFrontendFeatureLoader({
+                            loader: () => [plugin],
+                          }),
+                        ],
+                      }),
+                    ],
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+      });
+
+    await expect(
+      renderWithEffects(
+        createTestAppRoot({
+          features: [featureLoader],
+          config: {
+            app: { extensions: [{ 'app/root': false }] },
+          },
+        }),
+      ),
+    ).rejects.toThrow(
+      /^Maximum feature loading recursion depth \(5\) reached for the feature loader created at '.*\/packages\/frontend-plugin-api\/src\/wiring\/createFrontendFeatureLoader\.test\.ts:.*'$/,
+    );
+
+    const nestedLoaders = await (
+      featureLoader as InternalFrontendFeatureLoader
+    ).loader({ config: mockApis.config() });
+    await renderWithEffects(
+      createTestAppRoot({
+        features: [nestedLoaders[0]],
+        config: {
+          app: { extensions: [{ 'app/root': false }] },
+        },
+      }),
+    );
+
+    await expect(screen.findByText('My Content')).resolves.toBeInTheDocument();
+  });
+});

--- a/packages/frontend-plugin-api/src/wiring/createFrontendFeatureLoader.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createFrontendFeatureLoader.test.ts
@@ -165,6 +165,22 @@ describe('createFrontendFeatureLoader', () => {
       createFrontendFeatureLoader({
         async loader(_) {
           return [
+            createFrontendPlugin({
+              id: 'plugin-0',
+              extensions: [
+                createExtension({
+                  name: '0',
+                  attachTo: {
+                    id: 'plugin-output/output',
+                    input: 'names',
+                  },
+                  output: [nameExtensionDataRef],
+                  factory() {
+                    return [nameExtensionDataRef('extension-0')];
+                  },
+                }),
+              ],
+            }),
             createFrontendFeatureLoader({
               async *loader(__) {
                 yield createFrontendPlugin({
@@ -248,7 +264,7 @@ describe('createFrontendFeatureLoader', () => {
     );
 
     await expect(
-      screen.findByText('Names: extension-1, extension-2'),
+      screen.findByText('Names: extension-0, extension-1, extension-2'),
     ).resolves.toBeInTheDocument();
   });
 

--- a/packages/frontend-plugin-api/src/wiring/createFrontendFeatureLoader.ts
+++ b/packages/frontend-plugin-api/src/wiring/createFrontendFeatureLoader.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ConfigApi } from '../apis/definitions';
+import { describeParentCallSite } from '../routing/describeParentCallSite';
+import { FrontendFeature } from './types';
+
+/** @public */
+export interface CreateFrontendFeatureLoaderOptions {
+  loader(deps: {
+    config: ConfigApi;
+  }):
+    | Iterable<
+        | FrontendFeature
+        | FrontendFeatureLoader
+        | Promise<{ default: FrontendFeature | FrontendFeatureLoader }>
+      >
+    | Promise<
+        Iterable<
+          | FrontendFeature
+          | FrontendFeatureLoader
+          | Promise<{ default: FrontendFeature | FrontendFeatureLoader }>
+        >
+      >
+    | AsyncIterable<
+        | FrontendFeature
+        | FrontendFeatureLoader
+        | { default: FrontendFeature | FrontendFeatureLoader }
+      >;
+}
+
+/** @public */
+export interface FrontendFeatureLoader {
+  readonly $$type: '@backstage/FrontendFeatureLoader';
+}
+
+/** @internal */
+export interface InternalFrontendFeatureLoader extends FrontendFeatureLoader {
+  readonly version: 'v1';
+  readonly description: string;
+  readonly loader: (deps: {
+    config: ConfigApi;
+  }) => Promise<(FrontendFeature | FrontendFeatureLoader)[]>;
+}
+
+/** @public */
+export function createFrontendFeatureLoader(
+  options: CreateFrontendFeatureLoaderOptions,
+): FrontendFeatureLoader {
+  const description = `created at '${describeParentCallSite()}'`;
+  return {
+    $$type: '@backstage/FrontendFeatureLoader',
+    version: 'v1',
+    description,
+    toString() {
+      return `FeatureLoader{description=${description}}`;
+    },
+    async loader(deps: {
+      config: ConfigApi;
+    }): Promise<(FrontendFeature | FrontendFeatureLoader)[]> {
+      const it = await options.loader(deps);
+      const result = new Array<FrontendFeature | FrontendFeatureLoader>();
+      for await (const item of it) {
+        if (isFeatureOrLoader(item)) {
+          result.push(item);
+        } else if ('default' in item) {
+          result.push(item.default);
+        } else {
+          throw new Error(`Invalid item "${item}"`);
+        }
+      }
+      return result;
+    },
+  } as InternalFrontendFeatureLoader;
+}
+
+/** @internal */
+export function isInternalFrontendFeatureLoader(opaque: {
+  $$type: string;
+}): opaque is InternalFrontendFeatureLoader {
+  if (opaque.$$type === '@backstage/FrontendFeatureLoader') {
+    // Make sure we throw if invalid
+    toInternalFrontendFeatureLoader(opaque as FrontendFeatureLoader);
+    return true;
+  }
+  return false;
+}
+
+/** @internal */
+export function toInternalFrontendFeatureLoader(
+  plugin: FrontendFeatureLoader,
+): InternalFrontendFeatureLoader {
+  const internal = plugin as InternalFrontendFeatureLoader;
+  if (internal.$$type !== '@backstage/FrontendFeatureLoader') {
+    throw new Error(`Invalid plugin instance, bad type '${internal.$$type}'`);
+  }
+  if (internal.version !== 'v1') {
+    throw new Error(
+      `Invalid plugin instance, bad version '${internal.version}'`,
+    );
+  }
+  return internal;
+}
+
+function isFeatureOrLoader(
+  obj: unknown,
+): obj is FrontendFeature | FrontendFeatureLoader {
+  if (obj !== null && typeof obj === 'object' && '$$type' in obj) {
+    return (
+      obj.$$type === '@backstage/FrontendPlugin' ||
+      obj.$$type === '@backstage/FrontendModule' ||
+      obj.$$type === '@backstage/FrontendFeatureLoader'
+    );
+  }
+  return false;
+}

--- a/packages/frontend-plugin-api/src/wiring/index.ts
+++ b/packages/frontend-plugin-api/src/wiring/index.ts
@@ -46,6 +46,11 @@ export {
   type FrontendModule,
   type CreateFrontendModuleOptions,
 } from './createFrontendModule';
+export {
+  createFrontendFeatureLoader,
+  type FrontendFeatureLoader,
+  type CreateFrontendFeatureLoaderOptions,
+} from './createFrontendFeatureLoader';
 export { type Extension } from './resolveExtensionDefinition';
 export {
   type AnyRoutes,
@@ -53,6 +58,7 @@ export {
   type ExtensionDataContainer,
   type FeatureFlagConfig,
   type ExtensionFactoryMiddleware,
+  type FrontendFeature,
 } from './types';
 export {
   type CreateExtensionBlueprintOptions,

--- a/packages/frontend-plugin-api/src/wiring/types.ts
+++ b/packages/frontend-plugin-api/src/wiring/types.ts
@@ -23,6 +23,8 @@ import {
   ExtensionDataValue,
 } from './createExtensionDataRef';
 import { ApiHolder, AppNode } from '../apis';
+import { FrontendModule } from './createFrontendModule';
+import { FrontendPlugin } from './createFrontendPlugin';
 
 /**
  * Feature flag configuration.
@@ -80,3 +82,6 @@ export type ExtensionFactoryMiddleware = (
     config?: JsonObject;
   },
 ) => Iterable<ExtensionDataValue<any, any>>;
+
+/** @public  */
+export type FrontendFeature = FrontendPlugin | FrontendModule;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Introduced a `createFrontendFeatureLoader()` function, as well as a `FrontendFeatureLoader` interface, to gather several frontend plugins, modules or feature loaders in a single exported entrypoint and load them, possibly asynchronously.
This new feature, very similar to the `createBackendFeatureLoader()` already available on the backend, supersedes the previous `CreateAppFeatureLoader` type which has been deprecated.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
