### PR TITLE
chore: Move `createExtensionDataContainer()` to internal, shared location

### DIFF
--- a/packages/frontend-internal/src/wiring/createExtensionDataContainer.ts
+++ b/packages/frontend-internal/src/wiring/createExtensionDataContainer.ts
@@ -16,33 +16,11 @@
 
 import {
   AnyExtensionDataRef,
+  ExtensionDataContainer,
   ExtensionDataRef,
   ExtensionDataValue,
-} from './createExtensionDataRef';
+} from '@backstage/frontend-plugin-api';
 
-/** @public */
-export type ExtensionDataContainer<UExtensionData extends AnyExtensionDataRef> =
-  Iterable<
-    UExtensionData extends ExtensionDataRef<
-      infer IData,
-      infer IId,
-      infer IConfig
-    >
-      ? IConfig['optional'] extends true
-        ? never
-        : ExtensionDataValue<IData, IId>
-      : never
-  > & {
-    get<TId extends UExtensionData['id']>(
-      ref: ExtensionDataRef<any, TId, any>,
-    ): UExtensionData extends ExtensionDataRef<infer IData, TId, infer IConfig>
-      ? IConfig['optional'] extends true
-        ? IData | undefined
-        : IData
-      : never;
-  };
-
-/** @internal */
 export function createExtensionDataContainer<UData extends AnyExtensionDataRef>(
   values: Iterable<
     UData extends ExtensionDataRef<infer IData, infer IId>

--- a/packages/frontend-internal/src/wiring/index.ts
+++ b/packages/frontend-internal/src/wiring/index.ts
@@ -14,5 +14,6 @@
  * limitations under the License.
  */
 
+export { createExtensionDataContainer } from './createExtensionDataContainer';
 export { OpaqueExtensionDefinition } from './InternalExtensionDefinition';
 export { OpaqueFrontendPlugin } from './InternalFrontendPlugin';

--- a/packages/frontend-plugin-api/src/wiring/createExtension.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.ts
@@ -20,10 +20,7 @@ import {
   ResolveInputValueOverrides,
   resolveInputOverrides,
 } from './resolveInputOverrides';
-import {
-  ExtensionDataContainer,
-  createExtensionDataContainer,
-} from './createExtensionDataContainer';
+import { createExtensionDataContainer } from '@internal/frontend';
 import {
   AnyExtensionDataRef,
   ExtensionDataValue,
@@ -32,6 +29,7 @@ import { ExtensionInput } from './createExtensionInput';
 import { z } from 'zod';
 import { createSchemaFromZod } from '../schema/createSchemaFromZod';
 import { OpaqueExtensionDefinition } from '@internal/frontend';
+import { ExtensionDataContainer } from './types';
 
 /**
  * This symbol is used to pass parameter overrides from the extension override to the blueprint factory

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.test.tsx
@@ -28,8 +28,10 @@ import {
 import { createExtensionInput } from './createExtensionInput';
 import { RouteRef } from '../routing';
 import { ExtensionDefinition } from './createExtension';
-import { createExtensionDataContainer } from './createExtensionDataContainer';
-import { OpaqueExtensionDefinition } from '@internal/frontend';
+import {
+  createExtensionDataContainer,
+  OpaqueExtensionDefinition,
+} from '@internal/frontend';
 
 function unused(..._any: any[]) {}
 

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
@@ -30,14 +30,12 @@ import {
   AnyExtensionDataRef,
   ExtensionDataValue,
 } from './createExtensionDataRef';
-import {
-  ExtensionDataContainer,
-  createExtensionDataContainer,
-} from './createExtensionDataContainer';
+import { createExtensionDataContainer } from '@internal/frontend';
 import {
   ResolveInputValueOverrides,
   resolveInputOverrides,
 } from './resolveInputOverrides';
+import { ExtensionDataContainer } from './types';
 
 /**
  * @public

--- a/packages/frontend-plugin-api/src/wiring/index.ts
+++ b/packages/frontend-plugin-api/src/wiring/index.ts
@@ -28,7 +28,6 @@ export {
   createExtensionInput,
   type ExtensionInput,
 } from './createExtensionInput';
-export { type ExtensionDataContainer } from './createExtensionDataContainer';
 export {
   createExtensionDataRef,
   type AnyExtensionDataRef,
@@ -51,6 +50,7 @@ export { type Extension } from './resolveExtensionDefinition';
 export {
   type AnyRoutes,
   type AnyExternalRoutes,
+  type ExtensionDataContainer,
   type ExtensionOverrides,
   type FeatureFlagConfig,
   type FrontendFeature,

--- a/packages/frontend-plugin-api/src/wiring/resolveInputOverrides.ts
+++ b/packages/frontend-plugin-api/src/wiring/resolveInputOverrides.ts
@@ -17,16 +17,14 @@
 import { AppNode } from '../apis';
 import { Expand } from '@backstage/types';
 import { ResolvedExtensionInput } from './createExtension';
-import {
-  ExtensionDataContainer,
-  createExtensionDataContainer,
-} from './createExtensionDataContainer';
+import { createExtensionDataContainer } from '@internal/frontend';
 import {
   AnyExtensionDataRef,
   ExtensionDataRefToValue,
   ExtensionDataValue,
 } from './createExtensionDataRef';
 import { ExtensionInput } from './createExtensionInput';
+import { ExtensionDataContainer } from './types';
 
 /** @public */
 export type ResolveInputValueOverrides<

--- a/packages/frontend-plugin-api/src/wiring/types.ts
+++ b/packages/frontend-plugin-api/src/wiring/types.ts
@@ -16,6 +16,11 @@
 
 import { ExternalRouteRef, RouteRef, SubRouteRef } from '../routing';
 import { ExtensionDefinition } from './createExtension';
+import {
+  AnyExtensionDataRef,
+  ExtensionDataRef,
+  ExtensionDataValue,
+} from './createExtensionDataRef';
 import { FrontendPlugin } from './createFrontendPlugin';
 
 /**
@@ -51,3 +56,25 @@ export interface ExtensionOverrides {
  * @deprecated import from {@link @backstage/frontend-app-api#FrontendFeature} instead
  */
 export type FrontendFeature = FrontendPlugin | ExtensionOverrides;
+
+/** @public */
+export type ExtensionDataContainer<UExtensionData extends AnyExtensionDataRef> =
+  Iterable<
+    UExtensionData extends ExtensionDataRef<
+      infer IData,
+      infer IId,
+      infer IConfig
+    >
+      ? IConfig['optional'] extends true
+        ? never
+        : ExtensionDataValue<IData, IId>
+      : never
+  > & {
+    get<TId extends UExtensionData['id']>(
+      ref: ExtensionDataRef<any, TId, any>,
+    ): UExtensionData extends ExtensionDataRef<infer IData, TId, infer IConfig>
+      ? IConfig['optional'] extends true
+        ? IData | undefined
+        : IData
+      : never;
+  };


### PR DESCRIPTION
## What / Why

Have an upcoming PR where I'd like to introduce the concept of an extension factory middleware.  In order to implement this concept, I need access to `createExtensionDataContainer()` in `@backstage/frontend-app-api`, in addition to where it lives today in `@backstage/frontend-plugin-api`.

This PR lifts and shifts the relevant code to `@internal/frontend` so that it can be inlined in both packages.

#### :heavy_check_mark: Checklist

- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
