### PR TITLE
Hyper link added

### DIFF
--- a/microsite/docusaurus.config.ts
+++ b/microsite/docusaurus.config.ts
@@ -486,7 +486,7 @@ const config: Config = {
           ],
         },
       ],
-      copyright: `<p style="text-align:center"><a href="https://spotify.github.io/">Made with ❤️ at Spotify</a></p><p class="copyright">Copyright © ${new Date().getFullYear()} Backstage Project Authors. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our Trademark Usage page: https://www.linuxfoundation.org/trademark-usage</p>`,
+      copyright: `<p style="text-align:center"><a href="https://spotify.github.io/">Made with ❤️ at Spotify</a></p><p class="copyright">Copyright © ${new Date().getFullYear()} Backstage Project Authors. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our Trademark Usage page: <a href= "https://www.linuxfoundation.org/trademark-usage" />https://www.linuxfoundation.org/trademark-usage</a></p>`,
     },
     algolia: {
       apiKey: '1f0ba86672ccfc3576faa94583e5b318',


### PR DESCRIPTION
The URL  https://www.linuxfoundation.org/trademark-usage  is not clickable, it was a plain text. Changes added to make https://www.linuxfoundation.org/trademark-usage as a hyperlink.

![image](https://github.com/user-attachments/assets/a285e2f4-ee3f-469e-8226-a4d529e1cada)

![image](https://github.com/user-attachments/assets/1f587c0f-3c07-4949-8522-ae066ae3c124)

