### PR TITLE
frontend-plugin-api: sort extension definition in plugin type

### DIFF
--- a/.changeset/stale-frogs-wonder.md
+++ b/.changeset/stale-frogs-wonder.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': patch
+---
+
+The extensions map for plugins created with `createFrontendPlugin` is now sorted alphabetically by ID in the TypeScript type.

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -744,12 +744,7 @@ export function createFrontendPlugin<
 ): FrontendPlugin<
   TRoutes,
   TExternalRoutes,
-  {
-    [KExtension in TExtensions[number] as ResolveExtensionId<
-      KExtension,
-      TId
-    >]: KExtension;
-  }
+  MakeSortedExtensionsMap<TExtensions[number], TId>
 >;
 
 // @public

--- a/packages/frontend-plugin-api/src/wiring/MakeSortedExtensionsMap.ts
+++ b/packages/frontend-plugin-api/src/wiring/MakeSortedExtensionsMap.ts
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ExtensionDefinition } from './createExtension';
+import { ResolveExtensionId } from './resolveExtensionDefinition';
+
+// NOTE: Do not export any utilities in this file. If you want to use them, make a copy and keep them contained.
+
+type CompareChars<A extends string, B extends string> = [A, B] extends [
+  `${infer IAHead}${infer IARest}`,
+  `${infer IBHead}${infer IBRest}`,
+]
+  ? IAHead extends IBHead
+    ? IBRest extends ''
+      ? IARest extends ''
+        ? 'eq'
+        : 'gt'
+      : IARest extends ''
+      ? 'lt'
+      : CompareChars<IARest, IBRest>
+    : `0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz` extends `${string}${IAHead}${string}${IBHead}${string}`
+    ? 'lt'
+    : 'gt'
+  : 'eq';
+
+type CompareStrings<
+  A extends string | undefined,
+  B extends string | undefined,
+> = A extends B
+  ? 'eq'
+  : A extends undefined
+  ? 'lt'
+  : B extends undefined
+  ? 'gt'
+  : CompareChars<A & string, B & string>;
+
+type CompareExtensions<
+  A extends ExtensionDefinition,
+  B extends ExtensionDefinition,
+> = CompareStrings<A['T']['kind'], B['T']['kind']> extends 'eq'
+  ? CompareStrings<A['T']['name'], B['T']['name']>
+  : CompareStrings<A['T']['kind'], B['T']['kind']>;
+
+type SortExtensionsInner<
+  TPivot extends ExtensionDefinition,
+  TRest extends readonly ExtensionDefinition[],
+  TLow extends readonly ExtensionDefinition[],
+  THigh extends readonly ExtensionDefinition[],
+> = TRest extends [
+  infer IHead extends ExtensionDefinition,
+  ...infer IRest extends readonly ExtensionDefinition[],
+]
+  ? CompareExtensions<IHead, TPivot> extends 'lt'
+    ? SortExtensionsInner<TPivot, IRest, [...TLow, IHead], THigh>
+    : SortExtensionsInner<TPivot, IRest, TLow, [...THigh, IHead]>
+  : [low: TLow, high: THigh];
+
+type SortExtensions<T extends readonly ExtensionDefinition[]> = T extends [
+  infer IPivot extends ExtensionDefinition,
+  ...infer IRest extends readonly ExtensionDefinition[],
+]
+  ? SortExtensionsInner<IPivot, IRest, [], []> extends [
+      low: infer ILow extends readonly ExtensionDefinition[],
+      high: infer IHigh extends readonly ExtensionDefinition[],
+    ]
+    ? [...SortExtensions<ILow>, IPivot, ...SortExtensions<IHigh>]
+    : 'invalid SortExtensionsInner'
+  : [];
+
+type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
+  k: infer I,
+) => void
+  ? I
+  : never;
+
+type PopUnion<U> = UnionToIntersection<
+  U extends any ? () => U : never
+> extends () => infer R
+  ? [next: R, rest: Exclude<U, R>]
+  : undefined;
+
+type UnionToArray<U, T = U, TResult extends T[] = []> = PopUnion<U> extends [
+  next: infer INext extends T,
+  rest: infer IRest extends T,
+]
+  ? UnionToArray<IRest, T, [INext, ...TResult]>
+  : TResult;
+
+type ExtensionArrayToMap<
+  T extends ExtensionDefinition[],
+  TId extends string,
+  TOut extends { [KId in string]: ExtensionDefinition } = {},
+> = T extends [
+  infer IHead extends ExtensionDefinition,
+  ...infer IRest extends ExtensionDefinition[],
+]
+  ? ExtensionArrayToMap<
+      IRest,
+      TId,
+      TOut & { [K in ResolveExtensionId<IHead, TId>]: IHead }
+    >
+  : TOut extends infer O
+  ? { [K in keyof O]: O[K] }
+  : never;
+
+// This was added to stability API reports. Before this was added the extensions
+// listed in API reports would be reordered fairly arbitrarily on changes in
+// unrelated packages, which made for a confusing contribution experience. This
+// also makes it slightly easier to find extensions that you're looking for in
+// the API reports.
+//
+// If this causes any type of trouble there is no risk in removing it from a
+// correctness or API stability point of view.
+/** @ignore */
+export type MakeSortedExtensionsMap<
+  UExtensions extends ExtensionDefinition,
+  TId extends string,
+> = ExtensionArrayToMap<SortExtensions<UnionToArray<UExtensions>>, TId>;

--- a/packages/frontend-plugin-api/src/wiring/createFrontendPlugin.ts
+++ b/packages/frontend-plugin-api/src/wiring/createFrontendPlugin.ts
@@ -21,10 +21,10 @@ import {
 import { ExtensionDefinition } from './createExtension';
 import {
   Extension,
-  ResolveExtensionId,
   resolveExtensionDefinition,
 } from './resolveExtensionDefinition';
 import { AnyExternalRoutes, AnyRoutes, FeatureFlagConfig } from './types';
+import { MakeSortedExtensionsMap } from './MakeSortedExtensionsMap';
 
 /** @public */
 export interface FrontendPlugin<
@@ -69,12 +69,7 @@ export function createFrontendPlugin<
 ): FrontendPlugin<
   TRoutes,
   TExternalRoutes,
-  {
-    [KExtension in TExtensions[number] as ResolveExtensionId<
-      KExtension,
-      TId
-    >]: KExtension;
-  }
+  MakeSortedExtensionsMap<TExtensions[number], TId>
 > {
   const extensions = new Array<Extension<any>>();
   const extensionDefinitionsById = new Map<

--- a/plugins/api-docs/report-alpha.api.md
+++ b/plugins/api-docs/report-alpha.api.md
@@ -26,27 +26,6 @@ const _default: FrontendPlugin<
     registerApi: ExternalRouteRef<undefined>;
   },
   {
-    'nav-item:api-docs': ExtensionDefinition<{
-      kind: 'nav-item';
-      name: undefined;
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        {
-          title: string;
-          icon: IconComponent;
-          routeRef: RouteRef<undefined>;
-        },
-        'core.nav-item.target',
-        {}
-      >;
-      inputs: {};
-      params: {
-        title: string;
-        icon: IconComponent;
-        routeRef: RouteRef<undefined>;
-      };
-    }>;
     'api:api-docs/config': ExtensionDefinition<{
       kind: 'api';
       name: 'config';
@@ -62,186 +41,9 @@ const _default: FrontendPlugin<
         factory: AnyApiFactory;
       };
     }>;
-    'page:api-docs': ExtensionDefinition<{
-      config: {
-        initiallySelectedFilter: 'all' | 'owned' | 'starred' | undefined;
-      } & {
-        path: string | undefined;
-      };
-      configInput: {
-        initiallySelectedFilter?: 'all' | 'owned' | 'starred' | undefined;
-      } & {
-        path?: string | undefined;
-      };
-      output:
-        | ConfigurableExtensionDataRef<
-            React_2.JSX.Element,
-            'core.reactElement',
-            {}
-          >
-        | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
-        | ConfigurableExtensionDataRef<
-            RouteRef<AnyRouteRefParams>,
-            'core.routing.ref',
-            {
-              optional: true;
-            }
-          >;
-      inputs: {
-        [x: string]: ExtensionInput<
-          AnyExtensionDataRef,
-          {
-            optional: boolean;
-            singleton: boolean;
-          }
-        >;
-      };
-      kind: 'page';
-      name: undefined;
-      params: {
-        defaultPath: string;
-        loader: () => Promise<JSX.Element>;
-        routeRef?: RouteRef<AnyRouteRefParams> | undefined;
-      };
-    }>;
-    'entity-card:api-docs/has-apis': ExtensionDefinition<{
-      kind: 'entity-card';
-      name: 'has-apis';
-      config: {
-        filter: string | undefined;
-        type: 'full' | 'info' | 'peek' | undefined;
-      };
-      configInput: {
-        filter?: string | undefined;
-        type?: 'full' | 'info' | 'peek' | undefined;
-      };
-      output:
-        | ConfigurableExtensionDataRef<
-            React_2.JSX.Element,
-            'core.reactElement',
-            {}
-          >
-        | ConfigurableExtensionDataRef<
-            (entity: Entity) => boolean,
-            'catalog.entity-filter-function',
-            {
-              optional: true;
-            }
-          >
-        | ConfigurableExtensionDataRef<
-            string,
-            'catalog.entity-filter-expression',
-            {
-              optional: true;
-            }
-          >
-        | ConfigurableExtensionDataRef<
-            EntityCardType,
-            'catalog.entity-card-type',
-            {
-              optional: true;
-            }
-          >;
-      inputs: {};
-      params: {
-        loader: () => Promise<JSX.Element>;
-        filter?: string | ((entity: Entity) => boolean) | undefined;
-        type?: EntityCardType | undefined;
-      };
-    }>;
-    'entity-card:api-docs/definition': ExtensionDefinition<{
-      kind: 'entity-card';
-      name: 'definition';
-      config: {
-        filter: string | undefined;
-        type: 'full' | 'info' | 'peek' | undefined;
-      };
-      configInput: {
-        filter?: string | undefined;
-        type?: 'full' | 'info' | 'peek' | undefined;
-      };
-      output:
-        | ConfigurableExtensionDataRef<
-            React_2.JSX.Element,
-            'core.reactElement',
-            {}
-          >
-        | ConfigurableExtensionDataRef<
-            (entity: Entity) => boolean,
-            'catalog.entity-filter-function',
-            {
-              optional: true;
-            }
-          >
-        | ConfigurableExtensionDataRef<
-            string,
-            'catalog.entity-filter-expression',
-            {
-              optional: true;
-            }
-          >
-        | ConfigurableExtensionDataRef<
-            EntityCardType,
-            'catalog.entity-card-type',
-            {
-              optional: true;
-            }
-          >;
-      inputs: {};
-      params: {
-        loader: () => Promise<JSX.Element>;
-        filter?: string | ((entity: Entity) => boolean) | undefined;
-        type?: EntityCardType | undefined;
-      };
-    }>;
     'entity-card:api-docs/consumed-apis': ExtensionDefinition<{
       kind: 'entity-card';
       name: 'consumed-apis';
-      config: {
-        filter: string | undefined;
-        type: 'full' | 'info' | 'peek' | undefined;
-      };
-      configInput: {
-        filter?: string | undefined;
-        type?: 'full' | 'info' | 'peek' | undefined;
-      };
-      output:
-        | ConfigurableExtensionDataRef<
-            React_2.JSX.Element,
-            'core.reactElement',
-            {}
-          >
-        | ConfigurableExtensionDataRef<
-            (entity: Entity) => boolean,
-            'catalog.entity-filter-function',
-            {
-              optional: true;
-            }
-          >
-        | ConfigurableExtensionDataRef<
-            string,
-            'catalog.entity-filter-expression',
-            {
-              optional: true;
-            }
-          >
-        | ConfigurableExtensionDataRef<
-            EntityCardType,
-            'catalog.entity-card-type',
-            {
-              optional: true;
-            }
-          >;
-      inputs: {};
-      params: {
-        loader: () => Promise<JSX.Element>;
-        filter?: string | ((entity: Entity) => boolean) | undefined;
-        type?: EntityCardType | undefined;
-      };
-    }>;
-    'entity-card:api-docs/provided-apis': ExtensionDefinition<{
-      kind: 'entity-card';
-      name: 'provided-apis';
       config: {
         filter: string | undefined;
         type: 'full' | 'info' | 'peek' | undefined;
@@ -329,6 +131,141 @@ const _default: FrontendPlugin<
         type?: EntityCardType | undefined;
       };
     }>;
+    'entity-card:api-docs/definition': ExtensionDefinition<{
+      kind: 'entity-card';
+      name: 'definition';
+      config: {
+        filter: string | undefined;
+        type: 'full' | 'info' | 'peek' | undefined;
+      };
+      configInput: {
+        filter?: string | undefined;
+        type?: 'full' | 'info' | 'peek' | undefined;
+      };
+      output:
+        | ConfigurableExtensionDataRef<
+            React_2.JSX.Element,
+            'core.reactElement',
+            {}
+          >
+        | ConfigurableExtensionDataRef<
+            (entity: Entity) => boolean,
+            'catalog.entity-filter-function',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-filter-expression',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            EntityCardType,
+            'catalog.entity-card-type',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+        filter?: string | ((entity: Entity) => boolean) | undefined;
+        type?: EntityCardType | undefined;
+      };
+    }>;
+    'entity-card:api-docs/has-apis': ExtensionDefinition<{
+      kind: 'entity-card';
+      name: 'has-apis';
+      config: {
+        filter: string | undefined;
+        type: 'full' | 'info' | 'peek' | undefined;
+      };
+      configInput: {
+        filter?: string | undefined;
+        type?: 'full' | 'info' | 'peek' | undefined;
+      };
+      output:
+        | ConfigurableExtensionDataRef<
+            React_2.JSX.Element,
+            'core.reactElement',
+            {}
+          >
+        | ConfigurableExtensionDataRef<
+            (entity: Entity) => boolean,
+            'catalog.entity-filter-function',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-filter-expression',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            EntityCardType,
+            'catalog.entity-card-type',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+        filter?: string | ((entity: Entity) => boolean) | undefined;
+        type?: EntityCardType | undefined;
+      };
+    }>;
+    'entity-card:api-docs/provided-apis': ExtensionDefinition<{
+      kind: 'entity-card';
+      name: 'provided-apis';
+      config: {
+        filter: string | undefined;
+        type: 'full' | 'info' | 'peek' | undefined;
+      };
+      configInput: {
+        filter?: string | undefined;
+        type?: 'full' | 'info' | 'peek' | undefined;
+      };
+      output:
+        | ConfigurableExtensionDataRef<
+            React_2.JSX.Element,
+            'core.reactElement',
+            {}
+          >
+        | ConfigurableExtensionDataRef<
+            (entity: Entity) => boolean,
+            'catalog.entity-filter-function',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-filter-expression',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            EntityCardType,
+            'catalog.entity-card-type',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+        filter?: string | ((entity: Entity) => boolean) | undefined;
+        type?: EntityCardType | undefined;
+      };
+    }>;
     'entity-card:api-docs/providing-components': ExtensionDefinition<{
       kind: 'entity-card';
       name: 'providing-components';
@@ -372,6 +309,77 @@ const _default: FrontendPlugin<
         loader: () => Promise<JSX.Element>;
         filter?: string | ((entity: Entity) => boolean) | undefined;
         type?: EntityCardType | undefined;
+      };
+    }>;
+    'entity-content:api-docs/apis': ExtensionDefinition<{
+      kind: 'entity-content';
+      name: 'apis';
+      config: {
+        path: string | undefined;
+        title: string | undefined;
+        filter: string | undefined;
+        group: string | false | undefined;
+      };
+      configInput: {
+        filter?: string | undefined;
+        title?: string | undefined;
+        path?: string | undefined;
+        group?: string | false | undefined;
+      };
+      output:
+        | ConfigurableExtensionDataRef<
+            React_2.JSX.Element,
+            'core.reactElement',
+            {}
+          >
+        | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
+        | ConfigurableExtensionDataRef<
+            RouteRef<AnyRouteRefParams>,
+            'core.routing.ref',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-content-title',
+            {}
+          >
+        | ConfigurableExtensionDataRef<
+            (entity: Entity) => boolean,
+            'catalog.entity-filter-function',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-filter-expression',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-content-group',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+        defaultPath: string;
+        defaultTitle: string;
+        defaultGroup?:
+          | (string & {})
+          | 'documentation'
+          | 'development'
+          | 'deployment'
+          | 'observability'
+          | undefined;
+        routeRef?: RouteRef<AnyRouteRefParams> | undefined;
+        filter?: string | ((entity: Entity) => boolean) | undefined;
       };
     }>;
     'entity-content:api-docs/definition': ExtensionDefinition<{
@@ -445,20 +453,37 @@ const _default: FrontendPlugin<
         filter?: string | ((entity: Entity) => boolean) | undefined;
       };
     }>;
-    'entity-content:api-docs/apis': ExtensionDefinition<{
-      kind: 'entity-content';
-      name: 'apis';
+    'nav-item:api-docs': ExtensionDefinition<{
+      kind: 'nav-item';
+      name: undefined;
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        {
+          title: string;
+          icon: IconComponent;
+          routeRef: RouteRef<undefined>;
+        },
+        'core.nav-item.target',
+        {}
+      >;
+      inputs: {};
+      params: {
+        title: string;
+        icon: IconComponent;
+        routeRef: RouteRef<undefined>;
+      };
+    }>;
+    'page:api-docs': ExtensionDefinition<{
       config: {
+        initiallySelectedFilter: 'all' | 'owned' | 'starred' | undefined;
+      } & {
         path: string | undefined;
-        title: string | undefined;
-        filter: string | undefined;
-        group: string | false | undefined;
       };
       configInput: {
-        filter?: string | undefined;
-        title?: string | undefined;
+        initiallySelectedFilter?: 'all' | 'owned' | 'starred' | undefined;
+      } & {
         path?: string | undefined;
-        group?: string | false | undefined;
       };
       output:
         | ConfigurableExtensionDataRef<
@@ -473,47 +498,22 @@ const _default: FrontendPlugin<
             {
               optional: true;
             }
-          >
-        | ConfigurableExtensionDataRef<
-            string,
-            'catalog.entity-content-title',
-            {}
-          >
-        | ConfigurableExtensionDataRef<
-            (entity: Entity) => boolean,
-            'catalog.entity-filter-function',
-            {
-              optional: true;
-            }
-          >
-        | ConfigurableExtensionDataRef<
-            string,
-            'catalog.entity-filter-expression',
-            {
-              optional: true;
-            }
-          >
-        | ConfigurableExtensionDataRef<
-            string,
-            'catalog.entity-content-group',
-            {
-              optional: true;
-            }
           >;
-      inputs: {};
+      inputs: {
+        [x: string]: ExtensionInput<
+          AnyExtensionDataRef,
+          {
+            optional: boolean;
+            singleton: boolean;
+          }
+        >;
+      };
+      kind: 'page';
+      name: undefined;
       params: {
-        loader: () => Promise<JSX.Element>;
         defaultPath: string;
-        defaultTitle: string;
-        defaultGroup?:
-          | (string & {})
-          | 'documentation'
-          | 'development'
-          | 'deployment'
-          | 'observability'
-          | undefined;
+        loader: () => Promise<JSX.Element>;
         routeRef?: RouteRef<AnyRouteRefParams> | undefined;
-        filter?: string | ((entity: Entity) => boolean) | undefined;
       };
     }>;
   }

--- a/plugins/app/report.api.md
+++ b/plugins/app/report.api.md
@@ -29,21 +29,6 @@ const appPlugin: FrontendPlugin<
   {},
   {},
   {
-    'sign-in-page:app': ExtensionDefinition<{
-      kind: 'sign-in-page';
-      name: undefined;
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        ComponentType<SignInPageProps>,
-        'core.sign-in-page.component',
-        {}
-      >;
-      inputs: {};
-      params: {
-        loader: () => Promise<ComponentType<SignInPageProps>>;
-      };
-    }>;
     app: ExtensionDefinition<{
       config: {};
       configInput: {};
@@ -64,21 +49,6 @@ const appPlugin: FrontendPlugin<
       params: never;
       kind: undefined;
       name: undefined;
-    }>;
-    'api:app/app-language': ExtensionDefinition<{
-      kind: 'api';
-      name: 'app-language';
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        AnyApiFactory,
-        'core.api.factory',
-        {}
-      >;
-      inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
     }>;
     'app/layout': ExtensionDefinition<{
       config: {};
@@ -245,226 +215,6 @@ const appPlugin: FrontendPlugin<
       kind: undefined;
       name: 'routes';
     }>;
-    'api:app/app-theme': ExtensionDefinition<{
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        AnyApiFactory,
-        'core.api.factory',
-        {}
-      >;
-      inputs: {
-        themes: ExtensionInput<
-          ConfigurableExtensionDataRef<AppTheme, 'core.theme.theme', {}>,
-          {
-            singleton: false;
-            optional: false;
-          }
-        >;
-      };
-      kind: 'api';
-      name: 'app-theme';
-      params: {
-        factory: AnyApiFactory;
-      };
-    }>;
-    'theme:app/light': ExtensionDefinition<{
-      kind: 'theme';
-      name: 'light';
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<AppTheme, 'core.theme.theme', {}>;
-      inputs: {};
-      params: {
-        theme: AppTheme;
-      };
-    }>;
-    'theme:app/dark': ExtensionDefinition<{
-      kind: 'theme';
-      name: 'dark';
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<AppTheme, 'core.theme.theme', {}>;
-      inputs: {};
-      params: {
-        theme: AppTheme;
-      };
-    }>;
-    'api:app/components': ExtensionDefinition<{
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        AnyApiFactory,
-        'core.api.factory',
-        {}
-      >;
-      inputs: {
-        components: ExtensionInput<
-          ConfigurableExtensionDataRef<
-            {
-              ref: ComponentRef;
-              impl: ComponentType;
-            },
-            'core.component.component',
-            {}
-          >,
-          {
-            singleton: false;
-            optional: false;
-          }
-        >;
-      };
-      kind: 'api';
-      name: 'components';
-      params: {
-        factory: AnyApiFactory;
-      };
-    }>;
-    'api:app/icons': ExtensionDefinition<{
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        AnyApiFactory,
-        'core.api.factory',
-        {}
-      >;
-      inputs: {
-        icons: ExtensionInput<
-          ConfigurableExtensionDataRef<
-            {
-              [x: string]: IconComponent_2;
-            },
-            'core.icons',
-            {}
-          >,
-          {
-            singleton: false;
-            optional: false;
-          }
-        >;
-      };
-      kind: 'api';
-      name: 'icons';
-      params: {
-        factory: AnyApiFactory;
-      };
-    }>;
-    'api:app/feature-flags': ExtensionDefinition<{
-      kind: 'api';
-      name: 'feature-flags';
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        AnyApiFactory,
-        'core.api.factory',
-        {}
-      >;
-      inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
-    }>;
-    'api:app/translations': ExtensionDefinition<{
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        AnyApiFactory,
-        'core.api.factory',
-        {}
-      >;
-      inputs: {
-        translations: ExtensionInput<
-          ConfigurableExtensionDataRef<
-            | TranslationResource<string>
-            | TranslationMessages<
-                string,
-                {
-                  [x: string]: string;
-                },
-                boolean
-              >,
-            'core.translation.translation',
-            {}
-          >,
-          {
-            singleton: false;
-            optional: false;
-          }
-        >;
-      };
-      kind: 'api';
-      name: 'translations';
-      params: {
-        factory: AnyApiFactory;
-      };
-    }>;
-    'app-root-element:app/oauth-request-dialog': ExtensionDefinition<{
-      kind: 'app-root-element';
-      name: 'oauth-request-dialog';
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        JSX_2.Element,
-        'core.reactElement',
-        {}
-      >;
-      inputs: {};
-      params: {
-        element: JSX.Element | (() => JSX.Element);
-      };
-    }>;
-    'app-root-element:app/alert-display': ExtensionDefinition<{
-      config: {
-        transientTimeoutMs: number;
-        anchorOrigin: {
-          horizontal: 'center' | 'left' | 'right';
-          vertical: 'top' | 'bottom';
-        };
-      };
-      configInput: {
-        anchorOrigin?:
-          | {
-              horizontal?: 'center' | 'left' | 'right' | undefined;
-              vertical?: 'top' | 'bottom' | undefined;
-            }
-          | undefined;
-        transientTimeoutMs?: number | undefined;
-      };
-      output: ConfigurableExtensionDataRef<
-        JSX_2.Element,
-        'core.reactElement',
-        {}
-      >;
-      inputs: {
-        [x: string]: ExtensionInput<
-          AnyExtensionDataRef,
-          {
-            optional: boolean;
-            singleton: boolean;
-          }
-        >;
-      };
-      kind: 'app-root-element';
-      name: 'alert-display';
-      params: {
-        element: JSX.Element | (() => JSX.Element);
-      };
-    }>;
-    'api:app/discovery': ExtensionDefinition<{
-      kind: 'api';
-      name: 'discovery';
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        AnyApiFactory,
-        'core.api.factory',
-        {}
-      >;
-      inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
-    }>;
     'api:app/alert': ExtensionDefinition<{
       kind: 'api';
       name: 'alert';
@@ -495,9 +245,9 @@ const appPlugin: FrontendPlugin<
         factory: AnyApiFactory;
       };
     }>;
-    'api:app/error': ExtensionDefinition<{
+    'api:app/app-language': ExtensionDefinition<{
       kind: 'api';
-      name: 'error';
+      name: 'app-language';
       config: {};
       configInput: {};
       output: ConfigurableExtensionDataRef<
@@ -510,9 +260,7 @@ const appPlugin: FrontendPlugin<
         factory: AnyApiFactory;
       };
     }>;
-    'api:app/storage': ExtensionDefinition<{
-      kind: 'api';
-      name: 'storage';
+    'api:app/app-theme': ExtensionDefinition<{
       config: {};
       configInput: {};
       output: ConfigurableExtensionDataRef<
@@ -520,119 +268,24 @@ const appPlugin: FrontendPlugin<
         'core.api.factory',
         {}
       >;
-      inputs: {};
+      inputs: {
+        themes: ExtensionInput<
+          ConfigurableExtensionDataRef<AppTheme, 'core.theme.theme', {}>,
+          {
+            singleton: false;
+            optional: false;
+          }
+        >;
+      };
+      kind: 'api';
+      name: 'app-theme';
       params: {
         factory: AnyApiFactory;
       };
     }>;
-    'api:app/fetch': ExtensionDefinition<{
+    'api:app/atlassian-auth': ExtensionDefinition<{
       kind: 'api';
-      name: 'fetch';
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        AnyApiFactory,
-        'core.api.factory',
-        {}
-      >;
-      inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
-    }>;
-    'api:app/oauth-request': ExtensionDefinition<{
-      kind: 'api';
-      name: 'oauth-request';
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        AnyApiFactory,
-        'core.api.factory',
-        {}
-      >;
-      inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
-    }>;
-    'api:app/google-auth': ExtensionDefinition<{
-      kind: 'api';
-      name: 'google-auth';
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        AnyApiFactory,
-        'core.api.factory',
-        {}
-      >;
-      inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
-    }>;
-    'api:app/microsoft-auth': ExtensionDefinition<{
-      kind: 'api';
-      name: 'microsoft-auth';
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        AnyApiFactory,
-        'core.api.factory',
-        {}
-      >;
-      inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
-    }>;
-    'api:app/github-auth': ExtensionDefinition<{
-      kind: 'api';
-      name: 'github-auth';
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        AnyApiFactory,
-        'core.api.factory',
-        {}
-      >;
-      inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
-    }>;
-    'api:app/okta-auth': ExtensionDefinition<{
-      kind: 'api';
-      name: 'okta-auth';
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        AnyApiFactory,
-        'core.api.factory',
-        {}
-      >;
-      inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
-    }>;
-    'api:app/gitlab-auth': ExtensionDefinition<{
-      kind: 'api';
-      name: 'gitlab-auth';
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        AnyApiFactory,
-        'core.api.factory',
-        {}
-      >;
-      inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
-    }>;
-    'api:app/onelogin-auth': ExtensionDefinition<{
-      kind: 'api';
-      name: 'onelogin-auth';
+      name: 'atlassian-auth';
       config: {};
       configInput: {};
       output: ConfigurableExtensionDataRef<
@@ -675,9 +328,39 @@ const appPlugin: FrontendPlugin<
         factory: AnyApiFactory;
       };
     }>;
-    'api:app/atlassian-auth': ExtensionDefinition<{
+    'api:app/components': ExtensionDefinition<{
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {
+        components: ExtensionInput<
+          ConfigurableExtensionDataRef<
+            {
+              ref: ComponentRef;
+              impl: ComponentType;
+            },
+            'core.component.component',
+            {}
+          >,
+          {
+            singleton: false;
+            optional: false;
+          }
+        >;
+      };
       kind: 'api';
-      name: 'atlassian-auth';
+      name: 'components';
+      params: {
+        factory: AnyApiFactory;
+      };
+    }>;
+    'api:app/discovery': ExtensionDefinition<{
+      kind: 'api';
+      name: 'discovery';
       config: {};
       configInput: {};
       output: ConfigurableExtensionDataRef<
@@ -690,9 +373,173 @@ const appPlugin: FrontendPlugin<
         factory: AnyApiFactory;
       };
     }>;
-    'api:app/vmware-cloud-auth': ExtensionDefinition<{
+    'api:app/error': ExtensionDefinition<{
       kind: 'api';
-      name: 'vmware-cloud-auth';
+      name: 'error';
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
+    }>;
+    'api:app/feature-flags': ExtensionDefinition<{
+      kind: 'api';
+      name: 'feature-flags';
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
+    }>;
+    'api:app/fetch': ExtensionDefinition<{
+      kind: 'api';
+      name: 'fetch';
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
+    }>;
+    'api:app/github-auth': ExtensionDefinition<{
+      kind: 'api';
+      name: 'github-auth';
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
+    }>;
+    'api:app/gitlab-auth': ExtensionDefinition<{
+      kind: 'api';
+      name: 'gitlab-auth';
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
+    }>;
+    'api:app/google-auth': ExtensionDefinition<{
+      kind: 'api';
+      name: 'google-auth';
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
+    }>;
+    'api:app/icons': ExtensionDefinition<{
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {
+        icons: ExtensionInput<
+          ConfigurableExtensionDataRef<
+            {
+              [x: string]: IconComponent_2;
+            },
+            'core.icons',
+            {}
+          >,
+          {
+            singleton: false;
+            optional: false;
+          }
+        >;
+      };
+      kind: 'api';
+      name: 'icons';
+      params: {
+        factory: AnyApiFactory;
+      };
+    }>;
+    'api:app/microsoft-auth': ExtensionDefinition<{
+      kind: 'api';
+      name: 'microsoft-auth';
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
+    }>;
+    'api:app/oauth-request': ExtensionDefinition<{
+      kind: 'api';
+      name: 'oauth-request';
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
+    }>;
+    'api:app/okta-auth': ExtensionDefinition<{
+      kind: 'api';
+      name: 'okta-auth';
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
+    }>;
+    'api:app/onelogin-auth': ExtensionDefinition<{
+      kind: 'api';
+      name: 'onelogin-auth';
       config: {};
       configInput: {};
       output: ConfigurableExtensionDataRef<
@@ -748,6 +595,159 @@ const appPlugin: FrontendPlugin<
       inputs: {};
       params: {
         factory: AnyApiFactory;
+      };
+    }>;
+    'api:app/storage': ExtensionDefinition<{
+      kind: 'api';
+      name: 'storage';
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
+    }>;
+    'api:app/translations': ExtensionDefinition<{
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {
+        translations: ExtensionInput<
+          ConfigurableExtensionDataRef<
+            | TranslationResource<string>
+            | TranslationMessages<
+                string,
+                {
+                  [x: string]: string;
+                },
+                boolean
+              >,
+            'core.translation.translation',
+            {}
+          >,
+          {
+            singleton: false;
+            optional: false;
+          }
+        >;
+      };
+      kind: 'api';
+      name: 'translations';
+      params: {
+        factory: AnyApiFactory;
+      };
+    }>;
+    'api:app/vmware-cloud-auth': ExtensionDefinition<{
+      kind: 'api';
+      name: 'vmware-cloud-auth';
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
+    }>;
+    'app-root-element:app/alert-display': ExtensionDefinition<{
+      config: {
+        transientTimeoutMs: number;
+        anchorOrigin: {
+          horizontal: 'center' | 'left' | 'right';
+          vertical: 'top' | 'bottom';
+        };
+      };
+      configInput: {
+        anchorOrigin?:
+          | {
+              horizontal?: 'center' | 'left' | 'right' | undefined;
+              vertical?: 'top' | 'bottom' | undefined;
+            }
+          | undefined;
+        transientTimeoutMs?: number | undefined;
+      };
+      output: ConfigurableExtensionDataRef<
+        JSX_2.Element,
+        'core.reactElement',
+        {}
+      >;
+      inputs: {
+        [x: string]: ExtensionInput<
+          AnyExtensionDataRef,
+          {
+            optional: boolean;
+            singleton: boolean;
+          }
+        >;
+      };
+      kind: 'app-root-element';
+      name: 'alert-display';
+      params: {
+        element: JSX.Element | (() => JSX.Element);
+      };
+    }>;
+    'app-root-element:app/oauth-request-dialog': ExtensionDefinition<{
+      kind: 'app-root-element';
+      name: 'oauth-request-dialog';
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        JSX_2.Element,
+        'core.reactElement',
+        {}
+      >;
+      inputs: {};
+      params: {
+        element: JSX.Element | (() => JSX.Element);
+      };
+    }>;
+    'sign-in-page:app': ExtensionDefinition<{
+      kind: 'sign-in-page';
+      name: undefined;
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        ComponentType<SignInPageProps>,
+        'core.sign-in-page.component',
+        {}
+      >;
+      inputs: {};
+      params: {
+        loader: () => Promise<ComponentType<SignInPageProps>>;
+      };
+    }>;
+    'theme:app/dark': ExtensionDefinition<{
+      kind: 'theme';
+      name: 'dark';
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<AppTheme, 'core.theme.theme', {}>;
+      inputs: {};
+      params: {
+        theme: AppTheme;
+      };
+    }>;
+    'theme:app/light': ExtensionDefinition<{
+      kind: 'theme';
+      name: 'light';
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<AppTheme, 'core.theme.theme', {}>;
+      inputs: {};
+      params: {
+        theme: AppTheme;
       };
     }>;
   }

--- a/plugins/catalog-unprocessed-entities/report-alpha.api.md
+++ b/plugins/catalog-unprocessed-entities/report-alpha.api.md
@@ -19,6 +19,21 @@ const _default: FrontendPlugin<
   },
   {},
   {
+    'api:catalog-unprocessed-entities': ExtensionDefinition<{
+      kind: 'api';
+      name: undefined;
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
+    }>;
     'nav-item:catalog-unprocessed-entities': ExtensionDefinition<{
       kind: 'nav-item';
       name: undefined;
@@ -38,21 +53,6 @@ const _default: FrontendPlugin<
         title: string;
         icon: IconComponent;
         routeRef: RouteRef<undefined>;
-      };
-    }>;
-    'api:catalog-unprocessed-entities': ExtensionDefinition<{
-      kind: 'api';
-      name: undefined;
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        AnyApiFactory,
-        'core.api.factory',
-        {}
-      >;
-      inputs: {};
-      params: {
-        factory: AnyApiFactory;
       };
     }>;
     'page:catalog-unprocessed-entities': ExtensionDefinition<{

--- a/plugins/catalog/report-alpha.api.md
+++ b/plugins/catalog/report-alpha.api.md
@@ -148,45 +148,9 @@ const _default: FrontendPlugin<
     unregisterRedirect: ExternalRouteRef<undefined>;
   },
   {
-    'nav-item:catalog': ExtensionDefinition<{
-      kind: 'nav-item';
-      name: undefined;
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        {
-          title: string;
-          icon: IconComponent;
-          routeRef: RouteRef<undefined>;
-        },
-        'core.nav-item.target',
-        {}
-      >;
-      inputs: {};
-      params: {
-        title: string;
-        icon: IconComponent;
-        routeRef: RouteRef<undefined>;
-      };
-    }>;
     'api:catalog': ExtensionDefinition<{
       kind: 'api';
       name: undefined;
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        AnyApiFactory,
-        'core.api.factory',
-        {}
-      >;
-      inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
-    }>;
-    'api:catalog/starred-entities': ExtensionDefinition<{
-      kind: 'api';
-      name: 'starred-entities';
       config: {};
       configInput: {};
       output: ConfigurableExtensionDataRef<
@@ -214,91 +178,180 @@ const _default: FrontendPlugin<
         factory: AnyApiFactory;
       };
     }>;
+    'api:catalog/starred-entities': ExtensionDefinition<{
+      kind: 'api';
+      name: 'starred-entities';
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
+    }>;
+    'catalog-filter:catalog/kind': ExtensionDefinition<{
+      config: {
+        initialFilter: string;
+      };
+      configInput: {
+        initialFilter?: string | undefined;
+      };
+      output: ConfigurableExtensionDataRef<
+        JSX_2.Element,
+        'core.reactElement',
+        {}
+      >;
+      inputs: {
+        [x: string]: ExtensionInput<
+          AnyExtensionDataRef,
+          {
+            optional: boolean;
+            singleton: boolean;
+          }
+        >;
+      };
+      kind: 'catalog-filter';
+      name: 'kind';
+      params: {
+        loader: () => Promise<JSX.Element>;
+      };
+    }>;
+    'catalog-filter:catalog/lifecycle': ExtensionDefinition<{
+      kind: 'catalog-filter';
+      name: 'lifecycle';
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        JSX_2.Element,
+        'core.reactElement',
+        {}
+      >;
+      inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+      };
+    }>;
+    'catalog-filter:catalog/list': ExtensionDefinition<{
+      config: {
+        initialFilter: 'all' | 'owned' | 'starred';
+      };
+      configInput: {
+        initialFilter?: 'all' | 'owned' | 'starred' | undefined;
+      };
+      output: ConfigurableExtensionDataRef<
+        JSX_2.Element,
+        'core.reactElement',
+        {}
+      >;
+      inputs: {
+        [x: string]: ExtensionInput<
+          AnyExtensionDataRef,
+          {
+            optional: boolean;
+            singleton: boolean;
+          }
+        >;
+      };
+      kind: 'catalog-filter';
+      name: 'list';
+      params: {
+        loader: () => Promise<JSX.Element>;
+      };
+    }>;
+    'catalog-filter:catalog/mode': ExtensionDefinition<{
+      config: {
+        mode: 'all' | 'owners-only' | undefined;
+      };
+      configInput: {
+        mode?: 'all' | 'owners-only' | undefined;
+      };
+      output: ConfigurableExtensionDataRef<
+        JSX_2.Element,
+        'core.reactElement',
+        {}
+      >;
+      inputs: {
+        [x: string]: ExtensionInput<
+          AnyExtensionDataRef,
+          {
+            optional: boolean;
+            singleton: boolean;
+          }
+        >;
+      };
+      kind: 'catalog-filter';
+      name: 'mode';
+      params: {
+        loader: () => Promise<JSX.Element>;
+      };
+    }>;
+    'catalog-filter:catalog/namespace': ExtensionDefinition<{
+      kind: 'catalog-filter';
+      name: 'namespace';
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        JSX_2.Element,
+        'core.reactElement',
+        {}
+      >;
+      inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+      };
+    }>;
+    'catalog-filter:catalog/processing-status': ExtensionDefinition<{
+      kind: 'catalog-filter';
+      name: 'processing-status';
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        JSX_2.Element,
+        'core.reactElement',
+        {}
+      >;
+      inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+      };
+    }>;
+    'catalog-filter:catalog/tag': ExtensionDefinition<{
+      kind: 'catalog-filter';
+      name: 'tag';
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        JSX_2.Element,
+        'core.reactElement',
+        {}
+      >;
+      inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+      };
+    }>;
+    'catalog-filter:catalog/type': ExtensionDefinition<{
+      kind: 'catalog-filter';
+      name: 'type';
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        JSX_2.Element,
+        'core.reactElement',
+        {}
+      >;
+      inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+      };
+    }>;
     'entity-card:catalog/about': ExtensionDefinition<{
       kind: 'entity-card';
       name: 'about';
-      config: {
-        filter: string | undefined;
-        type: 'full' | 'info' | 'peek' | undefined;
-      };
-      configInput: {
-        filter?: string | undefined;
-        type?: 'full' | 'info' | 'peek' | undefined;
-      };
-      output:
-        | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
-        | ConfigurableExtensionDataRef<
-            (entity: Entity) => boolean,
-            'catalog.entity-filter-function',
-            {
-              optional: true;
-            }
-          >
-        | ConfigurableExtensionDataRef<
-            string,
-            'catalog.entity-filter-expression',
-            {
-              optional: true;
-            }
-          >
-        | ConfigurableExtensionDataRef<
-            EntityCardType,
-            'catalog.entity-card-type',
-            {
-              optional: true;
-            }
-          >;
-      inputs: {};
-      params: {
-        loader: () => Promise<JSX.Element>;
-        filter?: string | ((entity: Entity) => boolean) | undefined;
-        type?: EntityCardType | undefined;
-      };
-    }>;
-    'entity-card:catalog/links': ExtensionDefinition<{
-      kind: 'entity-card';
-      name: 'links';
-      config: {
-        filter: string | undefined;
-        type: 'full' | 'info' | 'peek' | undefined;
-      };
-      configInput: {
-        filter?: string | undefined;
-        type?: 'full' | 'info' | 'peek' | undefined;
-      };
-      output:
-        | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
-        | ConfigurableExtensionDataRef<
-            (entity: Entity) => boolean,
-            'catalog.entity-filter-function',
-            {
-              optional: true;
-            }
-          >
-        | ConfigurableExtensionDataRef<
-            string,
-            'catalog.entity-filter-expression',
-            {
-              optional: true;
-            }
-          >
-        | ConfigurableExtensionDataRef<
-            EntityCardType,
-            'catalog.entity-card-type',
-            {
-              optional: true;
-            }
-          >;
-      inputs: {};
-      params: {
-        loader: () => Promise<JSX.Element>;
-        filter?: string | ((entity: Entity) => boolean) | undefined;
-        type?: EntityCardType | undefined;
-      };
-    }>;
-    'entity-card:catalog/labels': ExtensionDefinition<{
-      kind: 'entity-card';
-      name: 'labels';
       config: {
         filter: string | undefined;
         type: 'full' | 'info' | 'peek' | undefined;
@@ -624,6 +677,88 @@ const _default: FrontendPlugin<
         type?: EntityCardType | undefined;
       };
     }>;
+    'entity-card:catalog/labels': ExtensionDefinition<{
+      kind: 'entity-card';
+      name: 'labels';
+      config: {
+        filter: string | undefined;
+        type: 'full' | 'info' | 'peek' | undefined;
+      };
+      configInput: {
+        filter?: string | undefined;
+        type?: 'full' | 'info' | 'peek' | undefined;
+      };
+      output:
+        | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
+        | ConfigurableExtensionDataRef<
+            (entity: Entity) => boolean,
+            'catalog.entity-filter-function',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-filter-expression',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            EntityCardType,
+            'catalog.entity-card-type',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+        filter?: string | ((entity: Entity) => boolean) | undefined;
+        type?: EntityCardType | undefined;
+      };
+    }>;
+    'entity-card:catalog/links': ExtensionDefinition<{
+      kind: 'entity-card';
+      name: 'links';
+      config: {
+        filter: string | undefined;
+        type: 'full' | 'info' | 'peek' | undefined;
+      };
+      configInput: {
+        filter?: string | undefined;
+        type?: 'full' | 'info' | 'peek' | undefined;
+      };
+      output:
+        | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
+        | ConfigurableExtensionDataRef<
+            (entity: Entity) => boolean,
+            'catalog.entity-filter-function',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            string,
+            'catalog.entity-filter-expression',
+            {
+              optional: true;
+            }
+          >
+        | ConfigurableExtensionDataRef<
+            EntityCardType,
+            'catalog.entity-card-type',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+      params: {
+        loader: () => Promise<JSX.Element>;
+        filter?: string | ((entity: Entity) => boolean) | undefined;
+        type?: EntityCardType | undefined;
+      };
+    }>;
     'entity-content:catalog/overview': ExtensionDefinition<{
       config: {
         path: string | undefined;
@@ -745,160 +880,25 @@ const _default: FrontendPlugin<
         filter?: string | ((entity: Entity) => boolean) | undefined;
       };
     }>;
-    'catalog-filter:catalog/tag': ExtensionDefinition<{
-      kind: 'catalog-filter';
-      name: 'tag';
+    'nav-item:catalog': ExtensionDefinition<{
+      kind: 'nav-item';
+      name: undefined;
       config: {};
       configInput: {};
       output: ConfigurableExtensionDataRef<
-        JSX_2.Element,
-        'core.reactElement',
+        {
+          title: string;
+          icon: IconComponent;
+          routeRef: RouteRef<undefined>;
+        },
+        'core.nav-item.target',
         {}
       >;
       inputs: {};
       params: {
-        loader: () => Promise<JSX.Element>;
-      };
-    }>;
-    'catalog-filter:catalog/kind': ExtensionDefinition<{
-      config: {
-        initialFilter: string;
-      };
-      configInput: {
-        initialFilter?: string | undefined;
-      };
-      output: ConfigurableExtensionDataRef<
-        JSX_2.Element,
-        'core.reactElement',
-        {}
-      >;
-      inputs: {
-        [x: string]: ExtensionInput<
-          AnyExtensionDataRef,
-          {
-            optional: boolean;
-            singleton: boolean;
-          }
-        >;
-      };
-      kind: 'catalog-filter';
-      name: 'kind';
-      params: {
-        loader: () => Promise<JSX.Element>;
-      };
-    }>;
-    'catalog-filter:catalog/type': ExtensionDefinition<{
-      kind: 'catalog-filter';
-      name: 'type';
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        JSX_2.Element,
-        'core.reactElement',
-        {}
-      >;
-      inputs: {};
-      params: {
-        loader: () => Promise<JSX.Element>;
-      };
-    }>;
-    'catalog-filter:catalog/mode': ExtensionDefinition<{
-      config: {
-        mode: 'all' | 'owners-only' | undefined;
-      };
-      configInput: {
-        mode?: 'all' | 'owners-only' | undefined;
-      };
-      output: ConfigurableExtensionDataRef<
-        JSX_2.Element,
-        'core.reactElement',
-        {}
-      >;
-      inputs: {
-        [x: string]: ExtensionInput<
-          AnyExtensionDataRef,
-          {
-            optional: boolean;
-            singleton: boolean;
-          }
-        >;
-      };
-      kind: 'catalog-filter';
-      name: 'mode';
-      params: {
-        loader: () => Promise<JSX.Element>;
-      };
-    }>;
-    'catalog-filter:catalog/namespace': ExtensionDefinition<{
-      kind: 'catalog-filter';
-      name: 'namespace';
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        JSX_2.Element,
-        'core.reactElement',
-        {}
-      >;
-      inputs: {};
-      params: {
-        loader: () => Promise<JSX.Element>;
-      };
-    }>;
-    'catalog-filter:catalog/lifecycle': ExtensionDefinition<{
-      kind: 'catalog-filter';
-      name: 'lifecycle';
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        JSX_2.Element,
-        'core.reactElement',
-        {}
-      >;
-      inputs: {};
-      params: {
-        loader: () => Promise<JSX.Element>;
-      };
-    }>;
-    'catalog-filter:catalog/processing-status': ExtensionDefinition<{
-      kind: 'catalog-filter';
-      name: 'processing-status';
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        JSX_2.Element,
-        'core.reactElement',
-        {}
-      >;
-      inputs: {};
-      params: {
-        loader: () => Promise<JSX.Element>;
-      };
-    }>;
-    'catalog-filter:catalog/list': ExtensionDefinition<{
-      config: {
-        initialFilter: 'all' | 'owned' | 'starred';
-      };
-      configInput: {
-        initialFilter?: 'all' | 'owned' | 'starred' | undefined;
-      };
-      output: ConfigurableExtensionDataRef<
-        JSX_2.Element,
-        'core.reactElement',
-        {}
-      >;
-      inputs: {
-        [x: string]: ExtensionInput<
-          AnyExtensionDataRef,
-          {
-            optional: boolean;
-            singleton: boolean;
-          }
-        >;
-      };
-      kind: 'catalog-filter';
-      name: 'list';
-      params: {
-        loader: () => Promise<JSX.Element>;
+        title: string;
+        icon: IconComponent;
+        routeRef: RouteRef<undefined>;
       };
     }>;
     'page:catalog': ExtensionDefinition<{

--- a/plugins/devtools/report-alpha.api.md
+++ b/plugins/devtools/report-alpha.api.md
@@ -19,6 +19,21 @@ const _default: FrontendPlugin<
   },
   {},
   {
+    'api:devtools': ExtensionDefinition<{
+      kind: 'api';
+      name: undefined;
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
+    }>;
     'nav-item:devtools': ExtensionDefinition<{
       kind: 'nav-item';
       name: undefined;
@@ -38,21 +53,6 @@ const _default: FrontendPlugin<
         title: string;
         icon: IconComponent;
         routeRef: RouteRef<undefined>;
-      };
-    }>;
-    'api:devtools': ExtensionDefinition<{
-      kind: 'api';
-      name: undefined;
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        AnyApiFactory,
-        'core.api.factory',
-        {}
-      >;
-      inputs: {};
-      params: {
-        factory: AnyApiFactory;
       };
     }>;
     'page:devtools': ExtensionDefinition<{

--- a/plugins/kubernetes/report-alpha.api.md
+++ b/plugins/kubernetes/report-alpha.api.md
@@ -37,30 +37,49 @@ const _default: FrontendPlugin<
         factory: AnyApiFactory;
       };
     }>;
-    'page:kubernetes': ExtensionDefinition<{
-      kind: 'page';
-      name: undefined;
-      config: {
-        path: string | undefined;
-      };
-      configInput: {
-        path?: string | undefined;
-      };
-      output:
-        | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
-        | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
-        | ConfigurableExtensionDataRef<
-            RouteRef<AnyRouteRefParams>,
-            'core.routing.ref',
-            {
-              optional: true;
-            }
-          >;
+    'api:kubernetes/auth-providers': ExtensionDefinition<{
+      kind: 'api';
+      name: 'auth-providers';
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
       inputs: {};
       params: {
-        defaultPath: string;
-        loader: () => Promise<JSX.Element>;
-        routeRef?: RouteRef<AnyRouteRefParams> | undefined;
+        factory: AnyApiFactory;
+      };
+    }>;
+    'api:kubernetes/cluster-link-formatter': ExtensionDefinition<{
+      kind: 'api';
+      name: 'cluster-link-formatter';
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
+    }>;
+    'api:kubernetes/proxy': ExtensionDefinition<{
+      kind: 'api';
+      name: 'proxy';
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {};
+      params: {
+        factory: AnyApiFactory;
       };
     }>;
     'entity-content:kubernetes/kubernetes': ExtensionDefinition<{
@@ -130,49 +149,30 @@ const _default: FrontendPlugin<
         filter?: string | ((entity: Entity) => boolean) | undefined;
       };
     }>;
-    'api:kubernetes/proxy': ExtensionDefinition<{
-      kind: 'api';
-      name: 'proxy';
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        AnyApiFactory,
-        'core.api.factory',
-        {}
-      >;
-      inputs: {};
-      params: {
-        factory: AnyApiFactory;
+    'page:kubernetes': ExtensionDefinition<{
+      kind: 'page';
+      name: undefined;
+      config: {
+        path: string | undefined;
       };
-    }>;
-    'api:kubernetes/auth-providers': ExtensionDefinition<{
-      kind: 'api';
-      name: 'auth-providers';
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        AnyApiFactory,
-        'core.api.factory',
-        {}
-      >;
-      inputs: {};
-      params: {
-        factory: AnyApiFactory;
+      configInput: {
+        path?: string | undefined;
       };
-    }>;
-    'api:kubernetes/cluster-link-formatter': ExtensionDefinition<{
-      kind: 'api';
-      name: 'cluster-link-formatter';
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        AnyApiFactory,
-        'core.api.factory',
-        {}
-      >;
+      output:
+        | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
+        | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
+        | ConfigurableExtensionDataRef<
+            RouteRef<AnyRouteRefParams>,
+            'core.routing.ref',
+            {
+              optional: true;
+            }
+          >;
       inputs: {};
       params: {
-        factory: AnyApiFactory;
+        defaultPath: string;
+        loader: () => Promise<JSX.Element>;
+        routeRef?: RouteRef<AnyRouteRefParams> | undefined;
       };
     }>;
   }

--- a/plugins/scaffolder/report-alpha.api.md
+++ b/plugins/scaffolder/report-alpha.api.md
@@ -53,7 +53,9 @@ const _default: FrontendPlugin<
     }>;
   },
   {
-    'api:scaffolder/form-fields': ExtensionDefinition<{
+    'api:scaffolder': ExtensionDefinition<{
+      kind: 'api';
+      name: undefined;
       config: {};
       configInput: {};
       output: ConfigurableExtensionDataRef<
@@ -61,21 +63,7 @@ const _default: FrontendPlugin<
         'core.api.factory',
         {}
       >;
-      inputs: {
-        formFields: ExtensionInput<
-          ConfigurableExtensionDataRef<
-            () => Promise<FormField>,
-            'scaffolder.form-field-loader',
-            {}
-          >,
-          {
-            singleton: false;
-            optional: false;
-          }
-        >;
-      };
-      kind: 'api';
-      name: 'form-fields';
+      inputs: {};
       params: {
         factory: AnyApiFactory;
       };
@@ -105,6 +93,54 @@ const _default: FrontendPlugin<
       name: 'form-decorators';
       params: {
         factory: AnyApiFactory;
+      };
+    }>;
+    'api:scaffolder/form-fields': ExtensionDefinition<{
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {
+        formFields: ExtensionInput<
+          ConfigurableExtensionDataRef<
+            () => Promise<FormField>,
+            'scaffolder.form-field-loader',
+            {}
+          >,
+          {
+            singleton: false;
+            optional: false;
+          }
+        >;
+      };
+      kind: 'api';
+      name: 'form-fields';
+      params: {
+        factory: AnyApiFactory;
+      };
+    }>;
+    'nav-item:scaffolder': ExtensionDefinition<{
+      kind: 'nav-item';
+      name: undefined;
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        {
+          title: string;
+          icon: IconComponent;
+          routeRef: RouteRef<undefined>;
+        },
+        'core.nav-item.target',
+        {}
+      >;
+      inputs: {};
+      params: {
+        title: string;
+        icon: IconComponent;
+        routeRef: RouteRef<undefined>;
       };
     }>;
     'page:scaffolder': ExtensionDefinition<{
@@ -145,27 +181,6 @@ const _default: FrontendPlugin<
         routeRef?: RouteRef<AnyRouteRefParams> | undefined;
       };
     }>;
-    'nav-item:scaffolder': ExtensionDefinition<{
-      kind: 'nav-item';
-      name: undefined;
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        {
-          title: string;
-          icon: IconComponent;
-          routeRef: RouteRef<undefined>;
-        },
-        'core.nav-item.target',
-        {}
-      >;
-      inputs: {};
-      params: {
-        title: string;
-        icon: IconComponent;
-        routeRef: RouteRef<undefined>;
-      };
-    }>;
     'scaffolder-form-field:scaffolder/repo-url-picker': ExtensionDefinition<{
       kind: 'scaffolder-form-field';
       name: 'repo-url-picker';
@@ -179,21 +194,6 @@ const _default: FrontendPlugin<
       inputs: {};
       params: {
         field: () => Promise<FormField>;
-      };
-    }>;
-    'api:scaffolder': ExtensionDefinition<{
-      kind: 'api';
-      name: undefined;
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        AnyApiFactory,
-        'core.api.factory',
-        {}
-      >;
-      inputs: {};
-      params: {
-        factory: AnyApiFactory;
       };
     }>;
   }

--- a/plugins/search/report-alpha.api.md
+++ b/plugins/search/report-alpha.api.md
@@ -23,6 +23,21 @@ const _default: FrontendPlugin<
   },
   {},
   {
+    'api:search': ExtensionDefinition<{
+      kind: 'api';
+      name: undefined;
+      config: {};
+      configInput: {};
+      output: ConfigurableExtensionDataRef<
+        AnyApiFactory,
+        'core.api.factory',
+        {}
+      >;
+      inputs: {};
+      params: {
+        factory: AnyApiFactory;
+      };
+    }>;
     'nav-item:search': ExtensionDefinition<{
       kind: 'nav-item';
       name: undefined;
@@ -42,21 +57,6 @@ const _default: FrontendPlugin<
         title: string;
         icon: IconComponent;
         routeRef: RouteRef<undefined>;
-      };
-    }>;
-    'api:search': ExtensionDefinition<{
-      kind: 'api';
-      name: undefined;
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        AnyApiFactory,
-        'core.api.factory',
-        {}
-      >;
-      inputs: {};
-      params: {
-        factory: AnyApiFactory;
       };
     }>;
     'page:search': ExtensionDefinition<{

--- a/plugins/techdocs/report-alpha.api.md
+++ b/plugins/techdocs/report-alpha.api.md
@@ -32,27 +32,6 @@ const _default: FrontendPlugin<
   },
   {},
   {
-    'nav-item:techdocs': ExtensionDefinition<{
-      kind: 'nav-item';
-      name: undefined;
-      config: {};
-      configInput: {};
-      output: ConfigurableExtensionDataRef<
-        {
-          title: string;
-          icon: IconComponent;
-          routeRef: RouteRef<undefined>;
-        },
-        'core.nav-item.target',
-        {}
-      >;
-      inputs: {};
-      params: {
-        title: string;
-        icon: IconComponent;
-        routeRef: RouteRef<undefined>;
-      };
-    }>;
     'api:techdocs': ExtensionDefinition<{
       kind: 'api';
       name: undefined;
@@ -83,60 +62,15 @@ const _default: FrontendPlugin<
         factory: AnyApiFactory;
       };
     }>;
-    'page:techdocs': ExtensionDefinition<{
-      kind: 'page';
-      name: undefined;
-      config: {
-        path: string | undefined;
-      };
-      configInput: {
-        path?: string | undefined;
-      };
-      output:
-        | ConfigurableExtensionDataRef<
-            React_2.JSX.Element,
-            'core.reactElement',
-            {}
-          >
-        | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
-        | ConfigurableExtensionDataRef<
-            RouteRef<AnyRouteRefParams>,
-            'core.routing.ref',
-            {
-              optional: true;
-            }
-          >;
-      inputs: {};
-      params: {
-        defaultPath: string;
-        loader: () => Promise<JSX.Element>;
-        routeRef?: RouteRef<AnyRouteRefParams> | undefined;
-      };
-    }>;
-    'search-result-list-item:techdocs': ExtensionDefinition<{
-      config: {
-        title: string | undefined;
-        lineClamp: number;
-        asLink: boolean;
-        asListItem: boolean;
-      } & {
-        noTrack: boolean;
-      };
-      configInput: {
-        title?: string | undefined;
-        lineClamp?: number | undefined;
-        asListItem?: boolean | undefined;
-        asLink?: boolean | undefined;
-      } & {
-        noTrack?: boolean | undefined;
-      };
+    'empty-state:techdocs/entity-content': ExtensionDefinition<{
+      config: {};
+      configInput: {};
       output: ConfigurableExtensionDataRef<
+        React_2.JSX.Element,
+        'core.reactElement',
         {
-          predicate?: SearchResultItemExtensionPredicate | undefined;
-          component: SearchResultItemExtensionComponent;
-        },
-        'search.search-result-list-item.item',
-        {}
+          optional: true;
+        }
       >;
       inputs: {
         [x: string]: ExtensionInput<
@@ -147,51 +81,9 @@ const _default: FrontendPlugin<
           }
         >;
       };
-      kind: 'search-result-list-item';
-      name: undefined;
-      params: SearchResultListItemBlueprintParams;
-    }>;
-    'page:techdocs/reader': ExtensionDefinition<{
-      config: {
-        path: string | undefined;
-      };
-      configInput: {
-        path?: string | undefined;
-      };
-      output:
-        | ConfigurableExtensionDataRef<
-            React_2.JSX.Element,
-            'core.reactElement',
-            {}
-          >
-        | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
-        | ConfigurableExtensionDataRef<
-            RouteRef<AnyRouteRefParams>,
-            'core.routing.ref',
-            {
-              optional: true;
-            }
-          >;
-      inputs: {
-        addons: ExtensionInput<
-          ConfigurableExtensionDataRef<
-            TechDocsAddonOptions,
-            'techdocs.addon',
-            {}
-          >,
-          {
-            singleton: false;
-            optional: false;
-          }
-        >;
-      };
-      kind: 'page';
-      name: 'reader';
-      params: {
-        defaultPath: string;
-        loader: () => Promise<JSX.Element>;
-        routeRef?: RouteRef<AnyRouteRefParams> | undefined;
-      };
+      params: never;
+      kind: 'empty-state';
+      name: 'entity-content';
     }>;
     'entity-content:techdocs': ExtensionDefinition<{
       config: {
@@ -289,15 +181,123 @@ const _default: FrontendPlugin<
         filter?: string | ((entity: Entity) => boolean) | undefined;
       };
     }>;
-    'empty-state:techdocs/entity-content': ExtensionDefinition<{
+    'nav-item:techdocs': ExtensionDefinition<{
+      kind: 'nav-item';
+      name: undefined;
       config: {};
       configInput: {};
       output: ConfigurableExtensionDataRef<
-        React_2.JSX.Element,
-        'core.reactElement',
         {
-          optional: true;
-        }
+          title: string;
+          icon: IconComponent;
+          routeRef: RouteRef<undefined>;
+        },
+        'core.nav-item.target',
+        {}
+      >;
+      inputs: {};
+      params: {
+        title: string;
+        icon: IconComponent;
+        routeRef: RouteRef<undefined>;
+      };
+    }>;
+    'page:techdocs': ExtensionDefinition<{
+      kind: 'page';
+      name: undefined;
+      config: {
+        path: string | undefined;
+      };
+      configInput: {
+        path?: string | undefined;
+      };
+      output:
+        | ConfigurableExtensionDataRef<
+            React_2.JSX.Element,
+            'core.reactElement',
+            {}
+          >
+        | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
+        | ConfigurableExtensionDataRef<
+            RouteRef<AnyRouteRefParams>,
+            'core.routing.ref',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+      params: {
+        defaultPath: string;
+        loader: () => Promise<JSX.Element>;
+        routeRef?: RouteRef<AnyRouteRefParams> | undefined;
+      };
+    }>;
+    'page:techdocs/reader': ExtensionDefinition<{
+      config: {
+        path: string | undefined;
+      };
+      configInput: {
+        path?: string | undefined;
+      };
+      output:
+        | ConfigurableExtensionDataRef<
+            React_2.JSX.Element,
+            'core.reactElement',
+            {}
+          >
+        | ConfigurableExtensionDataRef<string, 'core.routing.path', {}>
+        | ConfigurableExtensionDataRef<
+            RouteRef<AnyRouteRefParams>,
+            'core.routing.ref',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {
+        addons: ExtensionInput<
+          ConfigurableExtensionDataRef<
+            TechDocsAddonOptions,
+            'techdocs.addon',
+            {}
+          >,
+          {
+            singleton: false;
+            optional: false;
+          }
+        >;
+      };
+      kind: 'page';
+      name: 'reader';
+      params: {
+        defaultPath: string;
+        loader: () => Promise<JSX.Element>;
+        routeRef?: RouteRef<AnyRouteRefParams> | undefined;
+      };
+    }>;
+    'search-result-list-item:techdocs': ExtensionDefinition<{
+      config: {
+        title: string | undefined;
+        lineClamp: number;
+        asLink: boolean;
+        asListItem: boolean;
+      } & {
+        noTrack: boolean;
+      };
+      configInput: {
+        title?: string | undefined;
+        lineClamp?: number | undefined;
+        asListItem?: boolean | undefined;
+        asLink?: boolean | undefined;
+      } & {
+        noTrack?: boolean | undefined;
+      };
+      output: ConfigurableExtensionDataRef<
+        {
+          predicate?: SearchResultItemExtensionPredicate | undefined;
+          component: SearchResultItemExtensionComponent;
+        },
+        'search.search-result-list-item.item',
+        {}
       >;
       inputs: {
         [x: string]: ExtensionInput<
@@ -308,9 +308,9 @@ const _default: FrontendPlugin<
           }
         >;
       };
-      params: never;
-      kind: 'empty-state';
-      name: 'entity-content';
+      kind: 'search-result-list-item';
+      name: undefined;
+      params: SearchResultListItemBlueprintParams;
     }>;
   }
 >;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Worth it? 😅

Main purpose is to make API reports easier to browse but especially get rid of the flakiness where we currently have where changes in one package can affect the API reports in a another. I think a better fix really would be to implement this with API Extractor instead, i.e. make sure object keys are always sorted, but not quite ready for that adventure. At least if we do that in the future this would be pretty simple to clean up.

Performance wise the `UnionToArray` is a bit slow for large arrays but other operations are fairly fast. A `tsc:full` on this branch takes is `50.11s user 4.63s system 151% cpu 36.150 total`, while before it's `49.69s user 5.56s system 153% cpu 35.908 total`, so no worries there.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
