### PR TITLE
bump to typescript 5.6

### DIFF
--- a/.changeset/brave-wasps-fry.md
+++ b/.changeset/brave-wasps-fry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': minor
+---
+
+Upgraded the TypeScript version in the template to `5.8`.

--- a/.changeset/thin-books-rest.md
+++ b/.changeset/thin-books-rest.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Internal refactor to avoid `expiry-map` dependency.

--- a/.yarn/patches/ast-types-npm-0.14.2-43c4ac4b0d.patch
+++ b/.yarn/patches/ast-types-npm-0.14.2-43c4ac4b0d.patch
@@ -1,0 +1,15 @@
+diff --git a/main.d.ts b/main.d.ts
+index 6b9a8d05d61821a7e7dc831a52a9f7b505bfee42..1010bb5352d975a171a4019768ff6f6f2967c301 100644
+--- a/main.d.ts
++++ b/main.d.ts
+@@ -1,7 +1,7 @@
+-import { ASTNode, Type, AnyType, Field } from "./lib/types";
+-import { NodePath } from "./lib/node-path";
++import { ASTNode, type Type, AnyType, Field } from "./lib/types";
++import { type NodePath } from "./lib/node-path";
+ import { namedTypes } from "./gen/namedTypes";
+-import { builders } from "./gen/builders";
++import { type builders } from "./gen/builders";
+ import { Visitor } from "./gen/visitor";
+ declare const astNodesAreEquivalent: {
+     (a: any, b: any, problemPath?: any): boolean;

--- a/package.json
+++ b/package.json
@@ -103,7 +103,9 @@
     "@material-ui/pickers@^3.3.10": "patch:@material-ui/pickers@npm%3A3.3.11#./.yarn/patches/@material-ui-pickers-npm-3.3.11-1c8f68ea20.patch",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
-    "jest-haste-map@^29.7.0": "patch:jest-haste-map@npm%3A29.7.0#./.yarn/patches/jest-haste-map-npm-29.7.0-e3be419eff.patch"
+    "jest-haste-map@^29.7.0": "patch:jest-haste-map@npm%3A29.7.0#./.yarn/patches/jest-haste-map-npm-29.7.0-e3be419eff.patch",
+    "ast-types@^0.14.1": "patch:ast-types@npm%3A0.14.2#./.yarn/patches/ast-types-npm-0.14.2-43c4ac4b0d.patch",
+    "ast-types@0.14.2": "patch:ast-types@npm%3A0.14.2#./.yarn/patches/ast-types-npm-0.14.2-43c4ac4b0d.patch"
   },
   "dependencies": {
     "@backstage/errors": "workspace:^",
@@ -145,7 +147,7 @@
     "sloc": "^0.3.1",
     "sort-package-json": "^2.8.0",
     "typedoc": "^0.27.6",
-    "typescript": "~5.2.0"
+    "typescript": "~5.6.0"
   },
   "packageManager": "yarn@3.8.1",
   "engines": {

--- a/packages/create-app/templates/default-app/package.json.hbs
+++ b/packages/create-app/templates/default-app/package.json.hbs
@@ -36,7 +36,7 @@
     "@playwright/test": "^1.32.3",
     "node-gyp": "^10.0.0",
     "prettier": "^2.3.2",
-    "typescript": "~5.4.0"
+    "typescript": "~5.8.0"
   },
   "resolutions": {
     "@types/react": "^18",

--- a/plugins/catalog/package.json
+++ b/plugins/catalog/package.json
@@ -79,7 +79,6 @@
     "@mui/utils": "^5.14.15",
     "classnames": "^2.3.1",
     "dataloader": "^2.0.0",
-    "expiry-map": "^2.0.0",
     "history": "^5.0.0",
     "lodash": "^4.17.21",
     "pluralize": "^8.0.0",

--- a/plugins/catalog/src/apis/EntityPresentationApi/DefaultEntityPresentationApi.ts
+++ b/plugins/catalog/src/apis/EntityPresentationApi/DefaultEntityPresentationApi.ts
@@ -28,7 +28,6 @@ import {
 } from '@backstage/plugin-catalog-react';
 import { durationToMilliseconds, HumanDuration } from '@backstage/types';
 import DataLoader from 'dataloader';
-import ExpiryMap from 'expiry-map';
 import ObservableImpl from 'zen-observable';
 import {
   createDefaultRenderer,
@@ -147,6 +146,45 @@ export interface DefaultEntityPresentationApiOptions {
 interface CacheEntry {
   updatedAt: number;
   entity: Entity | undefined;
+}
+
+// Simply expory map for the data loader, which only expects a map that implements set, get, and delete and clear
+export class ExpiryMap<K, V> extends Map<K, V> {
+  #ttlMs: number;
+  #timestamps: Map<K, number> = new Map();
+
+  constructor(ttlMs: number) {
+    super();
+    this.#ttlMs = ttlMs;
+  }
+
+  set(key: K, value: V) {
+    const result = super.set(key, value);
+    this.#timestamps.set(key, Date.now());
+    return result;
+  }
+
+  get(key: K) {
+    if (!this.has(key)) {
+      return undefined;
+    }
+    const timestamp = this.#timestamps.get(key)!;
+    if (Date.now() - timestamp > this.#ttlMs) {
+      this.delete(key);
+      return undefined;
+    }
+    return super.get(key);
+  }
+
+  delete(key: K) {
+    this.#timestamps.delete(key);
+    return super.delete(key);
+  }
+
+  clear() {
+    this.#timestamps.clear();
+    return super.clear();
+  }
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -6437,7 +6437,6 @@ __metadata:
     "@types/react": ^18.0.0
     classnames: ^2.3.1
     dataloader: ^2.0.0
-    expiry-map: ^2.0.0
     history: ^5.0.0
     lodash: ^4.17.21
     pluralize: ^8.0.0
@@ -23279,7 +23278,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ast-types@npm:0.14.2, ast-types@npm:^0.14.1":
+"ast-types@npm:0.14.2":
   version: 0.14.2
   resolution: "ast-types@npm:0.14.2"
   dependencies:
@@ -23303,6 +23302,15 @@ __metadata:
   dependencies:
     tslib: ^2.0.1
   checksum: 21c186da9fdb1d8087b1b7dabbc4059f91aa5a1e593a9776b4393cc1eaa857e741b2dda678d20e34b16727b78fef3ab59cf8f0c75ed1ba649c78fe194e5c114b
+  languageName: node
+  linkType: hard
+
+"ast-types@patch:ast-types@npm%3A0.14.2#./.yarn/patches/ast-types-npm-0.14.2-43c4ac4b0d.patch::locator=root%40workspace%3A.":
+  version: 0.14.2
+  resolution: "ast-types@patch:ast-types@npm%3A0.14.2#./.yarn/patches/ast-types-npm-0.14.2-43c4ac4b0d.patch::version=0.14.2&hash=f42322&locator=root%40workspace%3A."
+  dependencies:
+    tslib: ^2.0.1
+  checksum: 6266562e45466c0d79eee8de68ace0ae4d69968638910cfc153f809632b88b6a4ad44ed33ab7b1e9a3b26ee5f5472bb6be834f380ca533db4a6f8ee1675548fa
   languageName: node
   linkType: hard
 
@@ -29131,15 +29139,6 @@ __metadata:
     jest-message-util: ^29.7.0
     jest-util: ^29.7.0
   checksum: 9257f10288e149b81254a0fda8ffe8d54a7061cd61d7515779998b012579d2b8c22354b0eb901daf0145f347403da582f75f359f4810c007182ad3fb318b5c0c
-  languageName: node
-  linkType: hard
-
-"expiry-map@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "expiry-map@npm:2.0.0"
-  dependencies:
-    map-age-cleaner: ^0.2.0
-  checksum: 9be8662e1a5c1084fb6d0ddc5402658dd06101c330454062b2f5efbf1477259d272e54ec16663d7d12a93d08ed510535781c36acb214696c5bc3a690a02a7a9d
   languageName: node
   linkType: hard
 
@@ -35739,15 +35738,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"map-age-cleaner@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "map-age-cleaner@npm:0.2.0"
-  dependencies:
-    p-defer: ^1.0.0
-  checksum: 13a6810b76b0067efa7f4b0f3dc58b58b4a4b5faa4cae5a0e8d5d59eda04d7074724eee426c9b5890a1d7e14d1e2902a090587acc8e2430198e79ab1556a2dad
-  languageName: node
-  linkType: hard
-
 "map-or-similar@npm:^1.5.0":
   version: 1.5.0
   resolution: "map-or-similar@npm:1.5.0"
@@ -38590,13 +38580,6 @@ __metadata:
   version: 2.0.0
   resolution: "p-cancelable@npm:2.0.0"
   checksum: dbe887e06ec72a918b3f3d41819aa57b5c4248ddf7162477727046bd2775d6e3e52390521198625599198e9bb5d592f3b0064e96fc0940cdf4e01233e2296664
-  languageName: node
-  linkType: hard
-
-"p-defer@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "p-defer@npm:1.0.0"
-  checksum: 4271b935c27987e7b6f229e5de4cdd335d808465604644cb7b4c4c95bef266735859a93b16415af8a41fd663ee9e3b97a1a2023ca9def613dba1bad2a0da0c7b
   languageName: node
   linkType: hard
 
@@ -42767,7 +42750,7 @@ __metadata:
     sloc: ^0.3.1
     sort-package-json: ^2.8.0
     typedoc: ^0.27.6
-    typescript: ~5.2.0
+    typescript: ~5.6.0
   languageName: unknown
   linkType: soft
 
@@ -46019,16 +46002,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~5.2.0":
-  version: 5.2.2
-  resolution: "typescript@npm:5.2.2"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 7912821dac4d962d315c36800fe387cdc0a6298dba7ec171b350b4a6e988b51d7b8f051317786db1094bd7431d526b648aba7da8236607febb26cf5b871d2d3c
-  languageName: node
-  linkType: hard
-
 "typescript@npm:~5.5.0":
   version: 5.5.4
   resolution: "typescript@npm:5.5.4"
@@ -46036,6 +46009,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: b309040f3a1cd91c68a5a58af6b9fdd4e849b8c42d837b2c2e73f9a4f96a98c4f1ed398a9aab576ee0a4748f5690cf594e6b99dbe61de7839da748c41e6d6ca8
+  languageName: node
+  linkType: hard
+
+"typescript@npm:~5.6.0":
+  version: 5.6.3
+  resolution: "typescript@npm:5.6.3"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: ba302f8822777ebefb28b554105f3e074466b671e7444ec6b75dadc008a62f46f373d9e57ceced1c433756d06c8b7dc569a7eefdf3a9573122a49205ff99021a
   languageName: node
   linkType: hard
 
@@ -46049,16 +46032,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@~5.2.0#~builtin<compat/typescript>":
-  version: 5.2.2
-  resolution: "typescript@patch:typescript@npm%3A5.2.2#~builtin<compat/typescript>::version=5.2.2&hash=f3b441"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 0f4da2f15e6f1245e49db15801dbee52f2bbfb267e1c39225afdab5afee1a72839cd86000e65ee9d7e4dfaff12239d28beaf5ee431357fcced15fb08583d72ca
-  languageName: node
-  linkType: hard
-
 "typescript@patch:typescript@~5.5.0#~builtin<compat/typescript>":
   version: 5.5.4
   resolution: "typescript@patch:typescript@npm%3A5.5.4#~builtin<compat/typescript>::version=5.5.4&hash=5adc0c"
@@ -46066,6 +46039,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: fc52962f31a5bcb716d4213bef516885e4f01f30cea797a831205fc9ef12b405a40561c40eae3127ab85ba1548e7df49df2bcdee6b84a94bfbe3a0d7eff16b14
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@~5.6.0#~builtin<compat/typescript>":
+  version: 5.6.3
+  resolution: "typescript@patch:typescript@npm%3A5.6.3#~builtin<compat/typescript>::version=5.6.3&hash=5adc0c"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: ade87bce2363ee963eed0e4ca8a312ea02c81873ebd53609bc3f6dc0a57f6e61ad7e3fb8cbb7f7ab8b5081cbee801b023f7c4823ee70b1c447eae050e6c7622b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Encountered two issues in libraries: `ast-types` and `expires-map`.

For `ast-types` I figured a patch is the best approach, https://github.com/benjamn/ast-types/issues/948 as been open for a long time. We already ship a TS version where this is broken in create-app, so no big impact from patching it here.

For `expires-map` I first tried to switch to `quick-lru`, but it had the exact same issue 😂. Figured a quick lil inline implementation was the way to go instead and got rid of the dep.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
