### PR TITLE
cli: fix typesVersions generation in prepack

### DIFF
--- a/.changeset/kind-waves-impress.md
+++ b/.changeset/kind-waves-impress.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Fixed the package prepack command so that it no longer produces unnecessary `index` entries in the `typesVersions` map, which could cause `/index` to be added when automatically adding imports.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

🧹, I realized the change to write `backstage.features` affected the generated `typesVersions`, producing things like

```json
"typesVersions": {
  "*": {
    "index": [
      "dist/index.d.ts"
    ],
    "alpha": [
      "dist/alpha.d.ts"
    ]
  }
}
```

and

```json
"typesVersions": {
  "*": {
    "*": [
      "dist/index.d.ts"
    ]
  }
}
```

The first example is now instead

```json
"typesVersions": {
  "*": {
    "*": [
      "dist/index.d.ts"
    ],
    "alpha": [
      "dist/alpha.d.ts"
    ]
  }
}
```

while the second is no longer necessary.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
