### PR TITLE
ThrottledOctokit everywhere

### DIFF
--- a/.changeset/dirty-bugs-attend.md
+++ b/.changeset/dirty-bugs-attend.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+Use ThrottledOctokit in GithubMultiOrgEntityProvider and GithubEntityProvider.

--- a/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.test.ts
@@ -38,6 +38,7 @@ import {
 
 jest.mock('../lib/github', () => {
   return {
+    createGraphqlClient: jest.fn(),
     getOrganizationRepositories: jest.fn(),
   };
 });

--- a/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.test.ts
@@ -22,7 +22,7 @@ import {
   DefaultEventsService,
   EventsService,
 } from '@backstage/plugin-events-node';
-import { graphql } from '@octokit/graphql';
+import { createGraphqlClient } from '../lib/github';
 import {
   GithubMultiOrgEntityProvider,
   withLocations,
@@ -30,7 +30,10 @@ import {
 import { LoggerService } from '@backstage/backend-plugin-api';
 import { mockServices } from '@backstage/backend-test-utils';
 
-jest.mock('@octokit/graphql');
+jest.mock('../lib/github', () => ({
+  ...jest.requireActual('../lib/github'),
+  createGraphqlClient: jest.fn(),
+}));
 
 const getAllInstallationsMock = jest.fn();
 jest.mock('@backstage/integration', () => ({
@@ -53,7 +56,7 @@ describe('GithubMultiOrgEntityProvider', () => {
 
     beforeEach(() => {
       mockClient = jest.fn();
-      (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
+      (createGraphqlClient as jest.Mock).mockReturnValue(mockClient);
 
       entityProviderConnection = {
         applyMutation: jest.fn(),
@@ -191,7 +194,7 @@ describe('GithubMultiOrgEntityProvider', () => {
           },
         });
 
-      (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
+      (createGraphqlClient as jest.Mock).mockReturnValue(mockClient);
 
       await entityProvider.read();
 
@@ -479,7 +482,7 @@ describe('GithubMultiOrgEntityProvider', () => {
           },
         });
 
-      (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
+      (createGraphqlClient as jest.Mock).mockReturnValue(mockClient);
 
       const githubCredentialsProvider: GithubCredentialsProvider = {
         getCredentials: mockGetCredentials,
@@ -753,7 +756,7 @@ describe('GithubMultiOrgEntityProvider', () => {
           },
         });
 
-      (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
+      (createGraphqlClient as jest.Mock).mockReturnValue(mockClient);
 
       entityProvider = new GithubMultiOrgEntityProvider({
         id: 'my-id',
@@ -1184,7 +1187,7 @@ describe('GithubMultiOrgEntityProvider', () => {
             },
           });
 
-        (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
+        (createGraphqlClient as jest.Mock).mockReturnValue(mockClient);
 
         await events.publish({
           topic: 'github.installation',
@@ -1316,7 +1319,7 @@ describe('GithubMultiOrgEntityProvider', () => {
             },
           });
 
-        (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
+        (createGraphqlClient as jest.Mock).mockReturnValue(mockClient);
 
         await events.publish({
           topic: 'github.organization',
@@ -1386,7 +1389,7 @@ describe('GithubMultiOrgEntityProvider', () => {
           },
         });
 
-        (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
+        (createGraphqlClient as jest.Mock).mockReturnValue(mockClient);
 
         await events.publish({
           topic: 'github.organization',
@@ -1481,7 +1484,7 @@ describe('GithubMultiOrgEntityProvider', () => {
             },
           });
 
-        (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
+        (createGraphqlClient as jest.Mock).mockReturnValue(mockClient);
 
         await events.publish({
           topic: 'github.organization',
@@ -1806,7 +1809,7 @@ describe('GithubMultiOrgEntityProvider', () => {
             },
           });
 
-        (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
+        (createGraphqlClient as jest.Mock).mockReturnValue(mockClient);
 
         await events.publish({
           topic: 'github.team',
@@ -2000,7 +2003,7 @@ describe('GithubMultiOrgEntityProvider', () => {
             },
           });
 
-        (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
+        (createGraphqlClient as jest.Mock).mockReturnValue(mockClient);
 
         await events.publish({
           topic: 'github.team',
@@ -2179,7 +2182,7 @@ describe('GithubMultiOrgEntityProvider', () => {
             },
           });
 
-        (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
+        (createGraphqlClient as jest.Mock).mockReturnValue(mockClient);
 
         await events.publish({
           topic: 'github.membership',
@@ -2351,7 +2354,7 @@ describe('GithubMultiOrgEntityProvider', () => {
             },
           });
 
-        (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
+        (createGraphqlClient as jest.Mock).mockReturnValue(mockClient);
 
         await events.publish({
           topic: 'github.membership',

--- a/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
@@ -38,7 +38,6 @@ import {
   EntityProviderConnection,
 } from '@backstage/plugin-catalog-node';
 import { EventParams, EventsService } from '@backstage/plugin-events-node';
-import { graphql } from '@octokit/graphql';
 import {
   InstallationCreatedEvent,
   InstallationEvent,
@@ -71,6 +70,7 @@ import {
   ANNOTATION_GITHUB_USER_LOGIN,
 } from '../lib/annotation';
 import {
+  createGraphqlClient,
   getOrganizationsFromUser,
   getOrganizationTeam,
   getOrganizationTeamsFromUsers,
@@ -272,12 +272,13 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
         await this.options.githubCredentialsProvider.getCredentials({
           url: `${this.options.githubUrl}/${org}`,
         });
-      const client = graphql.defaults({
-        baseUrl: this.options.gitHubConfig.apiBaseUrl,
+      const client = createGraphqlClient({
         headers,
+        baseUrl: this.options.gitHubConfig.apiBaseUrl!,
+        logger,
       });
 
-      logger.info(`Reading GitHub users and teams for org: ${org}`);
+      logger.info(`Reading GitHub users for org: ${org}`);
 
       const { users } = await getOrganizationUsers(
         client,
@@ -285,6 +286,8 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
         tokenType,
         this.options.userTransformer,
       );
+
+      logger.info(`Reading GitHub teams for org: ${org}`);
 
       const { teams } = await getOrganizationTeams(
         client,
@@ -418,13 +421,15 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
     }
 
     const org = event.installation.account.login;
+    const logger = this.options.logger;
     const { headers, type: tokenType } =
       await this.options.githubCredentialsProvider.getCredentials({
         url: `${this.options.githubUrl}/${org}`,
       });
-    const client = graphql.defaults({
-      baseUrl: this.options.gitHubConfig.apiBaseUrl,
+    const client = createGraphqlClient({
       headers,
+      baseUrl: this.options.gitHubConfig.apiBaseUrl!,
+      logger,
     });
 
     const { users } = await getOrganizationUsers(
@@ -448,9 +453,10 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
           await this.options.githubCredentialsProvider.getCredentials({
             url: `${this.options.githubUrl}/${userOrg}`,
           });
-        const orgClient = graphql.defaults({
-          baseUrl: this.options.gitHubConfig.apiBaseUrl,
+        const orgClient = createGraphqlClient({
+          baseUrl: this.options.gitHubConfig.apiBaseUrl!,
           headers: orgHeaders,
+          logger,
         });
 
         const { teams: userTeams } = await getOrganizationTeamsFromUsers(
@@ -489,6 +495,7 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
       throw new Error('Not initialized');
     }
 
+    const logger = this.options.logger;
     const userTransformer =
       this.options.userTransformer || defaultUserTransformer;
     const { name, avatar_url: avatarUrl, email, login } = event.membership.user;
@@ -497,9 +504,10 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
       await this.options.githubCredentialsProvider.getCredentials({
         url: `${this.options.githubUrl}/${org}`,
       });
-    const client = graphql.defaults({
-      baseUrl: this.options.gitHubConfig.apiBaseUrl,
+    const client = createGraphqlClient({
       headers,
+      baseUrl: this.options.gitHubConfig.apiBaseUrl!,
+      logger,
     });
 
     const { orgs } = await getOrganizationsFromUser(client, login);
@@ -551,9 +559,10 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
           await this.options.githubCredentialsProvider.getCredentials({
             url: `${this.options.githubUrl}/${userOrg}`,
           });
-        const orgClient = graphql.defaults({
-          baseUrl: this.options.gitHubConfig.apiBaseUrl,
+        const orgClient = createGraphqlClient({
           headers: orgHeaders,
+          baseUrl: this.options.gitHubConfig.apiBaseUrl!,
+          logger,
         });
 
         const { teams } = await getOrganizationTeamsFromUsers(
@@ -584,14 +593,16 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
       throw new Error('Not initialized');
     }
 
+    const logger = this.options.logger;
     const org = event.organization.login;
     const { headers } =
       await this.options.githubCredentialsProvider.getCredentials({
         url: `${this.options.githubUrl}/${org}`,
       });
-    const client = graphql.defaults({
-      baseUrl: this.options.gitHubConfig.apiBaseUrl,
+    const client = createGraphqlClient({
       headers,
+      baseUrl: this.options.gitHubConfig.apiBaseUrl!,
+      logger,
     });
 
     const { name, html_url: url, description, slug } = event.team;
@@ -636,14 +647,16 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
       throw new Error('Not initialized');
     }
 
+    const logger = this.options.logger;
     const org = event.organization.login;
     const { headers, type: tokenType } =
       await this.options.githubCredentialsProvider.getCredentials({
         url: `${this.options.githubUrl}/${org}`,
       });
-    const client = graphql.defaults({
-      baseUrl: this.options.gitHubConfig.apiBaseUrl,
+    const client = createGraphqlClient({
       headers,
+      baseUrl: this.options.gitHubConfig.apiBaseUrl!,
+      logger,
     });
 
     const teamSlug = event.team.slug;
@@ -677,9 +690,10 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
           await this.options.githubCredentialsProvider.getCredentials({
             url: `${this.options.githubUrl}/${userOrg}`,
           });
-        const orgClient = graphql.defaults({
-          baseUrl: this.options.gitHubConfig.apiBaseUrl,
+        const orgClient = createGraphqlClient({
           headers: orgHeaders,
+          baseUrl: this.options.gitHubConfig.apiBaseUrl!,
+          logger,
         });
 
         const { teams } = await getOrganizationTeamsFromUsers(
@@ -749,14 +763,16 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
       return;
     }
 
+    const logger = this.options.logger;
     const org = event.organization.login;
     const { headers } =
       await this.options.githubCredentialsProvider.getCredentials({
         url: `${this.options.githubUrl}/${org}`,
       });
-    const client = graphql.defaults({
-      baseUrl: this.options.gitHubConfig.apiBaseUrl,
+    const client = createGraphqlClient({
       headers,
+      baseUrl: this.options.gitHubConfig.apiBaseUrl!,
+      logger,
     });
 
     const teamSlug = event.team.slug;
@@ -794,9 +810,10 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
           await this.options.githubCredentialsProvider.getCredentials({
             url: `${this.options.githubUrl}/${userOrg}`,
           });
-        const orgClient = graphql.defaults({
-          baseUrl: this.options.gitHubConfig.apiBaseUrl,
+        const orgClient = createGraphqlClient({
+          baseUrl: this.options.gitHubConfig.apiBaseUrl!,
           headers: orgHeaders,
+          logger,
         });
 
         const { teams } = await getOrganizationTeamsFromUsers(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This updates both GitHubEntityProvider and GitHubMultiOrgEntityProvider to use the ThrottledOctokit client like GitHubOrgEntityProvider currently does.  At least in the the case of GitHubMultiOrgEntityProvider, it has resolved issues with secondary rate limits in local testing.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
