### PR TITLE
fix: fs:delete action does not delete files on windows

### DIFF
--- a/.changeset/wicked-dancers-count.md
+++ b/.changeset/wicked-dancers-count.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Fixed bug in fs:delete causing no files to be deleted on windows machines

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/filesystem/delete.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/filesystem/delete.test.ts
@@ -144,4 +144,25 @@ describe('fs:delete', () => {
       expect(fileExists).toBe(false);
     });
   });
+
+  it('should handle windows style file paths', async () => {
+    const files = ['unit-test-a.js', 'unit-test-b.js'];
+
+    files.forEach(file => {
+      const filePath = resolvePath(workspacePath, file);
+      const fileExists = fs.existsSync(filePath);
+      expect(fileExists).toBe(true);
+    });
+
+    await action.handler({
+      ...mockContext,
+      input: { files: files.map(file => `.\\${file}`) },
+    });
+
+    files.forEach(file => {
+      const filePath = resolvePath(workspacePath, file);
+      const fileExists = fs.existsSync(filePath);
+      expect(fileExists).toBe(false);
+    });
+  });
 });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/filesystem/delete.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/filesystem/delete.ts
@@ -53,7 +53,11 @@ export const createFilesystemDeleteAction = () => {
       }
 
       for (const file of ctx.input.files) {
-        const safeFilepath = resolveSafeChildPath(ctx.workspacePath, file);
+        // globby cannot handle backslash file separators
+        const safeFilepath = resolveSafeChildPath(
+          ctx.workspacePath,
+          file,
+        ).replace(/\\/g, '/');
         const resolvedPaths = await globby(safeFilepath, {
           cwd: ctx.workspacePath,
           absolute: true,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Replaces all backslash file separators in fs:delete to forward slashes to be compatible with globby
fixes: #29064 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
