### PR TITLE
frontend-app-api: remove .createRoot

### DIFF
--- a/.changeset/hip-ladybugs-behave.md
+++ b/.changeset/hip-ladybugs-behave.md
@@ -1,0 +1,12 @@
+---
+'@backstage/frontend-app-api': minor
+---
+
+**BREAKING**: The returned object from `createSpecializedApp` no longer contains a `createRoot()` method, and it instead now contains `apis` and `tree`.
+
+You can replace existing usage of `app.createRoot()` with the following:
+
+```ts
+const root = tree.root.instance?.getData(coreExtensionData.reactEleme
+nt);
+```

--- a/.changeset/many-insects-add.md
+++ b/.changeset/many-insects-add.md
@@ -1,0 +1,6 @@
+---
+'@backstage/frontend-defaults': patch
+'@backstage/frontend-test-utils': patch
+---
+
+Internal refactor to match updated `createSpecializedApp`.

--- a/packages/frontend-app-api/report.api.md
+++ b/packages/frontend-app-api/report.api.md
@@ -10,7 +10,6 @@ import { ExtensionDefinition } from '@backstage/frontend-plugin-api';
 import { ExternalRouteRef } from '@backstage/frontend-plugin-api';
 import { FrontendModule } from '@backstage/frontend-plugin-api';
 import { FrontendPlugin } from '@backstage/frontend-plugin-api';
-import { JSX as JSX_2 } from 'react';
 import { RouteRef } from '@backstage/frontend-plugin-api';
 import { SubRouteRef } from '@backstage/frontend-plugin-api';
 
@@ -36,7 +35,6 @@ export function createSpecializedApp(options?: {
   extensionFactoryMiddleware?: ExtensionFactoryMiddleware;
 }): {
   apis: ApiHolder;
-  createRoot(): JSX_2.Element;
   tree: AppTree;
 };
 

--- a/packages/frontend-app-api/src/wiring/createSpecializedApp.test.tsx
+++ b/packages/frontend-app-api/src/wiring/createSpecializedApp.test.tsx
@@ -56,7 +56,7 @@ describe('createSpecializedApp', () => {
       ],
     });
 
-    render(app.createRoot());
+    render(app.tree.root.instance!.getData(coreExtensionData.reactElement));
 
     expect(screen.getByText('Test')).toBeInTheDocument();
   });
@@ -91,7 +91,7 @@ describe('createSpecializedApp', () => {
       ],
     });
 
-    render(app.createRoot());
+    render(app.tree.root.instance!.getData(coreExtensionData.reactElement));
 
     expect(screen.getByText('Test 2')).toBeInTheDocument();
   });
@@ -117,7 +117,7 @@ describe('createSpecializedApp', () => {
       ],
     });
 
-    render(app.createRoot());
+    render(app.tree.root.instance!.getData(coreExtensionData.reactElement));
 
     expect(screen.getByText('Test foo')).toBeInTheDocument();
   });
@@ -163,7 +163,7 @@ describe('createSpecializedApp', () => {
       ],
     });
 
-    render(app.createRoot());
+    render(app.tree.root.instance!.getData(coreExtensionData.reactElement));
 
     expect(screen.getByText('flags:test=a,test=b')).toBeInTheDocument();
 
@@ -307,7 +307,7 @@ describe('createSpecializedApp', () => {
       ],
     });
 
-    render(app.createRoot());
+    render(app.tree.root.instance!.getData(coreExtensionData.reactElement));
 
     expect(mockAnalyticsApi).toHaveBeenCalled();
   });
@@ -339,7 +339,7 @@ describe('createSpecializedApp', () => {
       ],
     });
 
-    render(app.createRoot());
+    render(app.tree.root.instance!.getData(coreExtensionData.reactElement));
 
     expect(screen.getByText('providedApis:config')).toBeInTheDocument();
 
@@ -518,7 +518,7 @@ describe('createSpecializedApp', () => {
         bindRoutes({ bind }) {
           bind(pluginA.externalRoutes, { ext: pluginB.routes.root });
         },
-      }).createRoot(),
+      }).tree.root.instance!.getData(coreExtensionData.reactElement),
     );
 
     expect(screen.getByText('link: /test')).toBeInTheDocument();

--- a/packages/frontend-defaults/src/createApp.tsx
+++ b/packages/frontend-defaults/src/createApp.tsx
@@ -15,7 +15,7 @@
  */
 
 import React, { JSX, ReactNode } from 'react';
-import { ConfigApi } from '@backstage/frontend-plugin-api';
+import { ConfigApi, coreExtensionData } from '@backstage/frontend-plugin-api';
 import { stringifyError } from '@backstage/errors';
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
 import { defaultConfigLoaderSync } from '../../core-app-api/src/app/defaultConfigLoader';
@@ -114,9 +114,13 @@ export function createApp(options?: CreateAppOptions): {
       features: [appPlugin, ...discoveredFeatures, ...providedFeatures],
       bindRoutes: options?.bindRoutes,
       extensionFactoryMiddleware: options?.extensionFactoryMiddleware,
-    }).createRoot();
+    });
 
-    return { default: () => app };
+    const rootEl = app.tree.root.instance!.getData(
+      coreExtensionData.reactElement,
+    );
+
+    return { default: () => rootEl };
   }
 
   return {

--- a/packages/frontend-test-utils/src/app/renderInTestApp.tsx
+++ b/packages/frontend-test-utils/src/app/renderInTestApp.tsx
@@ -201,5 +201,7 @@ export function renderInTestApp(
     ]),
   });
 
-  return render(app.createRoot());
+  return render(
+    app.tree.root.instance!.getData(coreExtensionData.reactElement),
+  );
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Followup to https://github.com/backstage/backstage/pull/29068#discussion_r1985109089

This cleans up the API of `frontend-app-api` a little bit. After the addition of `tree` in the return from `createSpecializedApp` the `createRoot` becomes very unnecessary as it's easy to get access to the app root element from the tree. Given that it's a but more lower level API I think it's good to keep it clean, and it's really `createApp` from `@backstage/frontend-defaults` that is the intended way to create standard apps. Due to that I also think it's alright to ship this as an immediate breaking change, since usage of `createSpecializedApp` should be farily rare and it's easy to replace existing usage.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
