### PR TITLE
frontend-app-api: support array of extension factory middlewares

### DIFF
--- a/.changeset/sixty-ducks-bathe.md
+++ b/.changeset/sixty-ducks-bathe.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': patch
+---
+
+Added new `ExtensionMiddlewareFactory` type.

--- a/packages/frontend-app-api/report.api.md
+++ b/packages/frontend-app-api/report.api.md
@@ -6,7 +6,7 @@
 import { ApiHolder } from '@backstage/core-plugin-api';
 import { AppTree } from '@backstage/frontend-plugin-api';
 import { ConfigApi } from '@backstage/core-plugin-api';
-import { ExtensionDefinition } from '@backstage/frontend-plugin-api';
+import { ExtensionFactoryMiddleware } from '@backstage/frontend-plugin-api';
 import { ExternalRouteRef } from '@backstage/frontend-plugin-api';
 import { FrontendModule } from '@backstage/frontend-plugin-api';
 import { FrontendPlugin } from '@backstage/frontend-plugin-api';
@@ -32,16 +32,13 @@ export function createSpecializedApp(options?: {
   config?: ConfigApi;
   bindRoutes?(context: { bind: CreateAppRouteBinder }): void;
   apis?: ApiHolder;
-  extensionFactoryMiddleware?: ExtensionFactoryMiddleware;
+  extensionFactoryMiddleware?:
+    | ExtensionFactoryMiddleware
+    | ExtensionFactoryMiddleware[];
 }): {
   apis: ApiHolder;
   tree: AppTree;
 };
-
-// @public (undocumented)
-export type ExtensionFactoryMiddleware = Parameters<
-  ExtensionDefinition['override']
->[0]['factory'];
 
 // @public (undocumented)
 export type FrontendFeature =

--- a/packages/frontend-app-api/src/wiring/createSpecializedApp.tsx
+++ b/packages/frontend-app-api/src/wiring/createSpecializedApp.tsx
@@ -30,6 +30,7 @@ import {
   createApiFactory,
   routeResolutionApiRef,
   AppNode,
+  ExtensionFactoryMiddleware,
 } from '@backstage/frontend-plugin-api';
 import {
   AnyApiFactory,
@@ -40,10 +41,16 @@ import {
   identityApiRef,
 } from '@backstage/core-plugin-api';
 import { ApiFactoryRegistry, ApiResolver } from '@backstage/core-app-api';
-import { OpaqueFrontendPlugin } from '@internal/frontend';
+import {
+  createExtensionDataContainer,
+  OpaqueFrontendPlugin,
+} from '@internal/frontend';
 
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
-import { resolveExtensionDefinition } from '../../../frontend-plugin-api/src/wiring/resolveExtensionDefinition';
+import {
+  resolveExtensionDefinition,
+  toInternalExtension,
+} from '../../../frontend-plugin-api/src/wiring/resolveExtensionDefinition';
 
 import { extractRouteInfoFromAppNode } from '../routing/extractRouteInfoFromAppNode';
 
@@ -67,11 +74,7 @@ import { ApiRegistry } from '../../../core-app-api/src/apis/system/ApiRegistry';
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
 import { AppIdentityProxy } from '../../../core-app-api/src/apis/implementations/IdentityApi/AppIdentityProxy';
 import { BackstageRouteObject } from '../routing/types';
-import {
-  ExtensionFactoryMiddleware,
-  FrontendFeature,
-  RouteInfo,
-} from './types';
+import { FrontendFeature, RouteInfo } from './types';
 import { matchRoutes } from 'react-router-dom';
 
 function deduplicateFeatures(
@@ -202,7 +205,9 @@ export function createSpecializedApp(options?: {
   config?: ConfigApi;
   bindRoutes?(context: { bind: CreateAppRouteBinder }): void;
   apis?: ApiHolder;
-  extensionFactoryMiddleware?: ExtensionFactoryMiddleware;
+  extensionFactoryMiddleware?:
+    | ExtensionFactoryMiddleware
+    | ExtensionFactoryMiddleware[];
 }): { apis: ApiHolder; tree: AppTree } {
   const config = options?.config ?? new ConfigReader({}, 'empty-config');
   const features = deduplicateFeatures(options?.features ?? []);
@@ -267,7 +272,11 @@ export function createSpecializedApp(options?: {
   }
 
   // Now instantiate the entire tree, which will skip anything that's already been instantiated
-  instantiateAppNodeTree(tree.root, apis, options?.extensionFactoryMiddleware);
+  instantiateAppNodeTree(
+    tree.root,
+    apis,
+    mergeExtensionFactoryMiddleware(options?.extensionFactoryMiddleware),
+  );
 
   const routeInfo = extractRouteInfoFromAppNode(tree.root);
 
@@ -312,4 +321,38 @@ function createApiHolder(options: {
   ApiResolver.validateFactories(factoryRegistry, factoryRegistry.getAllApis());
 
   return new ApiResolver(factoryRegistry);
+}
+
+function mergeExtensionFactoryMiddleware(
+  middlewares?: ExtensionFactoryMiddleware | ExtensionFactoryMiddleware[],
+): ExtensionFactoryMiddleware | undefined {
+  if (!middlewares) {
+    return undefined;
+  }
+  if (!Array.isArray(middlewares)) {
+    return middlewares;
+  }
+  if (middlewares.length <= 1) {
+    return middlewares[0];
+  }
+  return middlewares.reduce((prev, next) => {
+    if (!prev || !next) {
+      return prev ?? next;
+    }
+    return (orig, ctx) => {
+      const internalExt = toInternalExtension(ctx.node.spec.extension);
+      if (internalExt.version !== 'v2') {
+        return orig();
+      }
+      return next(ctxOverrides => {
+        return createExtensionDataContainer(
+          prev(orig, {
+            node: ctx.node,
+            apis: ctx.apis,
+            config: ctxOverrides?.config ?? ctx.config,
+          }),
+        );
+      }, ctx);
+    };
+  });
 }

--- a/packages/frontend-app-api/src/wiring/types.ts
+++ b/packages/frontend-app-api/src/wiring/types.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ExtensionDefinition, RouteRef } from '@backstage/frontend-plugin-api';
+import { RouteRef } from '@backstage/frontend-plugin-api';
 import { FrontendModule, FrontendPlugin } from '@backstage/frontend-plugin-api';
 import { BackstageRouteObject } from '../routing/types';
 
@@ -31,8 +31,3 @@ export type RouteInfo = {
   routeParents: Map<RouteRef, RouteRef | undefined>;
   routeObjects: BackstageRouteObject[];
 };
-
-/** @public */
-export type ExtensionFactoryMiddleware = Parameters<
-  ExtensionDefinition['override']
->[0]['factory'];

--- a/packages/frontend-defaults/report.api.md
+++ b/packages/frontend-defaults/report.api.md
@@ -5,7 +5,7 @@
 ```ts
 import { ConfigApi } from '@backstage/frontend-plugin-api';
 import { CreateAppRouteBinder } from '@backstage/frontend-app-api';
-import { ExtensionFactoryMiddleware } from '@backstage/frontend-app-api';
+import { ExtensionFactoryMiddleware } from '@backstage/frontend-plugin-api';
 import { FrontendFeature } from '@backstage/frontend-app-api';
 import { JSX as JSX_2 } from 'react';
 import { default as React_2 } from 'react';
@@ -33,7 +33,9 @@ export interface CreateAppOptions {
     config: ConfigApi;
   }>;
   // (undocumented)
-  extensionFactoryMiddleware?: ExtensionFactoryMiddleware;
+  extensionFactoryMiddleware?:
+    | ExtensionFactoryMiddleware
+    | ExtensionFactoryMiddleware[];
   // (undocumented)
   features?: (FrontendFeature | CreateAppFeatureLoader)[];
   loadingComponent?: ReactNode;

--- a/packages/frontend-defaults/src/createApp.tsx
+++ b/packages/frontend-defaults/src/createApp.tsx
@@ -15,7 +15,11 @@
  */
 
 import React, { JSX, ReactNode } from 'react';
-import { ConfigApi, coreExtensionData } from '@backstage/frontend-plugin-api';
+import {
+  ConfigApi,
+  coreExtensionData,
+  ExtensionFactoryMiddleware,
+} from '@backstage/frontend-plugin-api';
 import { stringifyError } from '@backstage/errors';
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
 import { defaultConfigLoaderSync } from '../../core-app-api/src/app/defaultConfigLoader';
@@ -26,7 +30,6 @@ import { ConfigReader } from '@backstage/config';
 import appPlugin from '@backstage/plugin-app';
 import {
   CreateAppRouteBinder,
-  ExtensionFactoryMiddleware,
   FrontendFeature,
   createSpecializedApp,
 } from '@backstage/frontend-app-api';
@@ -66,7 +69,9 @@ export interface CreateAppOptions {
    * If set to "null" then no loading fallback component is rendered.   *
    */
   loadingComponent?: ReactNode;
-  extensionFactoryMiddleware?: ExtensionFactoryMiddleware;
+  extensionFactoryMiddleware?:
+    | ExtensionFactoryMiddleware
+    | ExtensionFactoryMiddleware[];
 }
 
 /**

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -1176,6 +1176,18 @@ export type ExtensionDefinitionParameters = {
 };
 
 // @public (undocumented)
+export type ExtensionFactoryMiddleware = (
+  originalFactory: (contextOverrides?: {
+    config?: JsonObject;
+  }) => ExtensionDataContainer<AnyExtensionDataRef>,
+  context: {
+    node: AppNode;
+    apis: ApiHolder;
+    config?: JsonObject;
+  },
+) => Iterable<ExtensionDataValue<any, any>>;
+
+// @public (undocumented)
 export interface ExtensionInput<
   UExtensionData extends ExtensionDataRef<
     unknown,

--- a/packages/frontend-plugin-api/src/wiring/index.ts
+++ b/packages/frontend-plugin-api/src/wiring/index.ts
@@ -54,6 +54,7 @@ export {
   type ExtensionOverrides,
   type FeatureFlagConfig,
   type FrontendFeature,
+  type ExtensionFactoryMiddleware,
 } from './types';
 export {
   type CreateExtensionBlueprintOptions,

--- a/packages/frontend-plugin-api/src/wiring/types.ts
+++ b/packages/frontend-plugin-api/src/wiring/types.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { JsonObject } from '@backstage/types';
 import { ExternalRouteRef, RouteRef, SubRouteRef } from '../routing';
 import { ExtensionDefinition } from './createExtension';
 import {
@@ -22,6 +23,7 @@ import {
   ExtensionDataValue,
 } from './createExtensionDataRef';
 import { FrontendPlugin } from './createFrontendPlugin';
+import { ApiHolder, AppNode } from '../apis';
 
 /**
  * Feature flag configuration.
@@ -78,3 +80,15 @@ export type ExtensionDataContainer<UExtensionData extends AnyExtensionDataRef> =
         : IData
       : never;
   };
+
+/** @public */
+export type ExtensionFactoryMiddleware = (
+  originalFactory: (contextOverrides?: {
+    config?: JsonObject;
+  }) => ExtensionDataContainer<AnyExtensionDataRef>,
+  context: {
+    node: AppNode;
+    apis: ApiHolder;
+    config?: JsonObject;
+  },
+) => Iterable<ExtensionDataValue<any, any>>;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Followup to https://github.com/backstage/backstage/pull/29068#discussion_r1985152599, kind of. Piggybacking on changesets from there as well. It defines the type separately to be able to skip including the `inputs` for now. I tried adding them and the types end up being wrong due how the types for concrete extensions will be either singleton or not, never both. Probably still worth adding at some point, all that's needed is to use and move `resolveInputOverrides` to `packages/frontend-internal` + fix the types. Figured we can wait with that thought.

Separately I added support for passing multiple middlewares, so that it's a bit easier to keep different middleware separate where that's needed.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
