### PR TITLE
core-compat-api: add entityPage option to convertLegacyApp

### DIFF
--- a/.changeset/gentle-lemons-explain.md
+++ b/.changeset/gentle-lemons-explain.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-test-utils': patch
+---
+
+Added a `initialRouteEntries` option to `renderInTestApp`.

--- a/.changeset/gentle-students-glow.md
+++ b/.changeset/gentle-students-glow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-test-utils': patch
+---
+
+The `renderInTestApp` helper now provides a default mock config with mock values for both `app.baseUrl` and `backend.baseUrl`.

--- a/.changeset/six-taxis-film.md
+++ b/.changeset/six-taxis-film.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-compat-api': patch
+---
+
+Added the `entityPage` option to `convertLegacyApp`, which you can read more about in the [app migration docs](https://backstage.io/docs/frontend-system/building-apps/migrating#entity-pages).

--- a/packages/core-compat-api/package.json
+++ b/packages/core-compat-api/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@backstage/core-plugin-api": "workspace:^",
     "@backstage/frontend-plugin-api": "workspace:^",
+    "@backstage/plugin-catalog-react": "workspace:^",
     "@backstage/version-bridge": "workspace:^",
     "lodash": "^4.17.21"
   },

--- a/packages/core-compat-api/report.api.md
+++ b/packages/core-compat-api/report.api.md
@@ -33,7 +33,13 @@ export function compatWrapper(element: ReactNode): React_2.JSX.Element;
 // @public (undocumented)
 export function convertLegacyApp(
   rootElement: React_2.JSX.Element,
+  options?: ConvertLegacyAppOptions,
 ): (FrontendPlugin | FrontendModule)[];
+
+// @public (undocumented)
+export interface ConvertLegacyAppOptions {
+  entityPage?: React_2.JSX.Element;
+}
 
 // @public (undocumented)
 export function convertLegacyAppOptions(options?: {

--- a/packages/core-compat-api/src/collectEntityPageContents.test.tsx
+++ b/packages/core-compat-api/src/collectEntityPageContents.test.tsx
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ExtensionAttachToSpec } from '@backstage/frontend-plugin-api';
+import { EntityLayout, EntitySwitch, isKind } from '@backstage/plugin-catalog';
+import React from 'react';
+import { collectEntityPageContents } from './collectEntityPageContents';
+import {
+  createComponentExtension,
+  createPlugin,
+} from '@backstage/core-plugin-api';
+// eslint-disable-next-line @backstage/no-relative-monorepo-imports
+import {
+  resolveExtensionDefinition,
+  toInternalExtension,
+} from '../../frontend-plugin-api/src/wiring/resolveExtensionDefinition';
+
+const fooPlugin = createPlugin({
+  id: 'foo',
+});
+
+const FooContent = fooPlugin.provide(
+  createComponentExtension({
+    name: 'FooContent',
+    component: { sync: () => <div>foo content</div> },
+  }),
+);
+const OtherFooContent = fooPlugin.provide(
+  createComponentExtension({
+    name: 'OtherFooContent',
+    component: { sync: () => <div>other foo content</div> },
+  }),
+);
+
+const simpleTestContent = (
+  <EntityLayout>
+    <EntityLayout.Route path="/" title="Overview">
+      <div>overview content</div>
+    </EntityLayout.Route>
+    <EntityLayout.Route path="/foo" title="Foo">
+      <FooContent />
+    </EntityLayout.Route>
+    <EntityLayout.Route path="/bar" title="Bar">
+      <div>bar content</div>
+    </EntityLayout.Route>
+  </EntityLayout>
+);
+
+const otherTestContent = (
+  <EntityLayout>
+    <EntityLayout.Route path="/" title="Overview">
+      <div>other overview content</div>
+    </EntityLayout.Route>
+    <EntityLayout.Route path="/foo" title="Foo">
+      <OtherFooContent />
+    </EntityLayout.Route>
+  </EntityLayout>
+);
+
+function collect(element: React.JSX.Element) {
+  const result = new Array<{
+    id: string;
+    attachTo: ExtensionAttachToSpec;
+  }>();
+
+  collectEntityPageContents(element, {
+    discoverExtension(extension, plugin) {
+      const ext = toInternalExtension(
+        resolveExtensionDefinition(extension, {
+          namespace: plugin?.getId() ?? 'test',
+        }),
+      );
+      result.push({ id: ext.id, attachTo: ext.attachTo });
+    },
+  });
+  return result;
+}
+
+describe('collectEntityPageContents', () => {
+  it('should collect contents from a simple entity page', () => {
+    expect(collect(simpleTestContent)).toMatchInlineSnapshot(`
+      [
+        {
+          "attachTo": {
+            "id": "entity-content:catalog/overview",
+            "input": "cards",
+          },
+          "id": "entity-card:test/discovered-1",
+        },
+        {
+          "attachTo": {
+            "id": "page:catalog/entity",
+            "input": "contents",
+          },
+          "id": "entity-content:foo/discovered-1",
+        },
+        {
+          "attachTo": {
+            "id": "page:catalog/entity",
+            "input": "contents",
+          },
+          "id": "entity-content:test/discovered-2",
+        },
+      ]
+    `);
+  });
+
+  it('should collect contents from an entity page with an entity switch', () => {
+    expect(
+      collect(
+        <EntitySwitch>
+          <EntitySwitch.Case if={isKind('test')}>
+            {simpleTestContent}
+          </EntitySwitch.Case>
+          <EntitySwitch.Case>{otherTestContent}</EntitySwitch.Case>
+        </EntitySwitch>,
+      ),
+    ).toMatchInlineSnapshot(`
+      [
+        {
+          "attachTo": {
+            "id": "entity-content:catalog/overview",
+            "input": "cards",
+          },
+          "id": "entity-card:test/discovered-1",
+        },
+        {
+          "attachTo": {
+            "id": "page:catalog/entity",
+            "input": "contents",
+          },
+          "id": "entity-content:foo/discovered-1",
+        },
+        {
+          "attachTo": {
+            "id": "page:catalog/entity",
+            "input": "contents",
+          },
+          "id": "entity-content:test/discovered-2",
+        },
+        {
+          "attachTo": {
+            "id": "entity-content:catalog/overview",
+            "input": "cards",
+          },
+          "id": "entity-card:test/discovered-2",
+        },
+        {
+          "attachTo": {
+            "id": "page:catalog/entity",
+            "input": "contents",
+          },
+          "id": "entity-content:foo/discovered-3",
+        },
+      ]
+    `);
+  });
+});

--- a/packages/core-compat-api/src/collectEntityPageContents.ts
+++ b/packages/core-compat-api/src/collectEntityPageContents.ts
@@ -74,7 +74,7 @@ function invertFilter(ifFunc?: EntityFilter): EntityFilter {
 export function collectEntityPageContents(
   entityPageElement: React.JSX.Element,
   context: {
-    discoveryExtension(
+    discoverExtension(
       extension: ExtensionDefinition,
       plugin?: LegacyBackstagePlugin,
     ): void;
@@ -94,7 +94,7 @@ export function collectEntityPageContents(
         const mergedIf = allFilters(parentFilter, pageNode.if);
 
         if (pageNode.path === '/') {
-          context.discoveryExtension(
+          context.discoverExtension(
             EntityCardBlueprint.makeWithOverrides({
               name: `discovered-${cardCounter++}`,
               factory(originalFactory, { apis }) {
@@ -109,7 +109,7 @@ export function collectEntityPageContents(
         } else {
           const name = `discovered-${routeCounter++}`;
 
-          context.discoveryExtension(
+          context.discoverExtension(
             EntityContentBlueprint.makeWithOverrides({
               name,
               factory(originalFactory, { apis }) {

--- a/packages/core-compat-api/src/collectEntityPageContents.ts
+++ b/packages/core-compat-api/src/collectEntityPageContents.ts
@@ -99,7 +99,7 @@ export function collectEntityPageContents(
               name: `discovered-${cardCounter++}`,
               factory(originalFactory, { apis }) {
                 return originalFactory({
-                  type: 'full',
+                  type: 'content',
                   filter: mergedIf && (entity => mergedIf(entity, { apis })),
                   loader: () => Promise.resolve(pageNode.children),
                 });

--- a/packages/core-compat-api/src/collectLegacyRoutes.test.tsx
+++ b/packages/core-compat-api/src/collectLegacyRoutes.test.tsx
@@ -57,7 +57,7 @@ describe('collectLegacyRoutes', () => {
 
     expect(
       collected.map(p => ({
-        id: p.id,
+        id: p.$$type === '@backstage/FrontendPlugin' ? p.id : p.pluginId,
         extensions: OpaqueFrontendPlugin.toInternal(p).extensions.map(e => ({
           id: e.id,
           attachTo: e.attachTo,
@@ -177,7 +177,7 @@ describe('collectLegacyRoutes', () => {
 
     expect(
       collected.map(p => ({
-        id: p.id,
+        id: p.$$type === '@backstage/FrontendPlugin' ? p.id : p.pluginId,
         extensions: OpaqueFrontendPlugin.toInternal(p).extensions.map(e => ({
           id: e.id,
           attachTo: e.attachTo,

--- a/packages/core-compat-api/src/collectLegacyRoutes.tsx
+++ b/packages/core-compat-api/src/collectLegacyRoutes.tsx
@@ -270,7 +270,7 @@ export function collectLegacyRoutes(
 
   if (entityPage) {
     collectEntityPageContents(entityPage, {
-      discoveryExtension(extension, plugin) {
+      discoverExtension(extension, plugin) {
         if (!plugin || plugin.getId() === 'catalog') {
           getPluginExtensions(orphanRoutesPlugin).push(extension);
         } else {

--- a/packages/core-compat-api/src/collectLegacyRoutes.tsx
+++ b/packages/core-compat-api/src/collectLegacyRoutes.tsx
@@ -30,6 +30,8 @@ import {
   createFrontendPlugin,
   ApiBlueprint,
   PageBlueprint,
+  FrontendModule,
+  createFrontendModule,
 } from '@backstage/frontend-plugin-api';
 import React, { Children, ReactNode, isValidElement } from 'react';
 import { Route, Routes } from 'react-router-dom';
@@ -38,6 +40,7 @@ import {
   convertLegacyRouteRefs,
 } from './convertLegacyRouteRef';
 import { compatWrapper } from './compatWrapper';
+import { collectEntityPageContents } from './collectEntityPageContents';
 
 /*
 
@@ -102,7 +105,7 @@ function makeRoutingShimExtension(options: {
   });
 }
 
-function visitRouteChildren(options: {
+export function visitRouteChildren(options: {
   children: ReactNode;
   parentExtensionId: string;
   context: {
@@ -157,7 +160,10 @@ function visitRouteChildren(options: {
 /** @internal */
 export function collectLegacyRoutes(
   flatRoutesElement: JSX.Element,
-): FrontendPlugin[] {
+  entityPage?: JSX.Element,
+): (FrontendPlugin | FrontendModule)[] {
+  const output = new Array<FrontendPlugin | FrontendModule>();
+
   const pluginExtensions = new Map<
     LegacyBackstagePlugin,
     ExtensionDefinition[]
@@ -262,20 +268,59 @@ export function collectLegacyRoutes(
     },
   );
 
-  return Array.from(pluginExtensions).map(([plugin, extensions]) =>
-    createFrontendPlugin({
-      id: plugin.getId(),
-      extensions: [
-        ...extensions,
-        ...Array.from(plugin.getApis()).map(factory =>
-          ApiBlueprint.make({
-            name: factory.api.id,
-            params: { factory },
-          }),
-        ),
-      ],
-      routes: convertLegacyRouteRefs(plugin.routes ?? {}),
-      externalRoutes: convertLegacyRouteRefs(plugin.externalRoutes ?? {}),
-    }),
-  );
+  if (entityPage) {
+    collectEntityPageContents(entityPage, {
+      discoveryExtension(extension, plugin) {
+        if (!plugin || plugin.getId() === 'catalog') {
+          getPluginExtensions(orphanRoutesPlugin).push(extension);
+        } else {
+          getPluginExtensions(plugin).push(extension);
+        }
+      },
+    });
+
+    const extensions = new Array<ExtensionDefinition>();
+    visitRouteChildren({
+      children: entityPage,
+      parentExtensionId: `page:catalog/entity`,
+      context: {
+        pluginId: 'catalog',
+        extensions,
+        getUniqueName,
+        discoverPlugin(plugin) {
+          if (plugin.getId() !== 'catalog') {
+            getPluginExtensions(plugin);
+          }
+        },
+      },
+    });
+
+    output.push(
+      createFrontendModule({
+        pluginId: 'catalog',
+        extensions,
+      }),
+    );
+  }
+
+  for (const [plugin, extensions] of pluginExtensions) {
+    output.push(
+      createFrontendPlugin({
+        id: plugin.getId(),
+        extensions: [
+          ...extensions,
+          ...Array.from(plugin.getApis()).map(factory =>
+            ApiBlueprint.make({
+              name: factory.api.id,
+              params: { factory },
+            }),
+          ),
+        ],
+        routes: convertLegacyRouteRefs(plugin.routes ?? {}),
+        externalRoutes: convertLegacyRouteRefs(plugin.externalRoutes ?? {}),
+      }),
+    );
+  }
+
+  return output;
 }

--- a/packages/core-compat-api/src/convertLegacyApp.test.tsx
+++ b/packages/core-compat-api/src/convertLegacyApp.test.tsx
@@ -21,6 +21,16 @@ import { ScoreBoardPage } from '@oriflame/backstage-plugin-score-card';
 import React, { ReactNode } from 'react';
 import { Route } from 'react-router-dom';
 import { convertLegacyApp } from './convertLegacyApp';
+import {
+  createApiFactory,
+  createComponentExtension,
+  createPlugin,
+} from '@backstage/core-plugin-api';
+import { EntityLayout, EntitySwitch, isKind } from '@backstage/plugin-catalog';
+import { renderInTestApp } from '@backstage/frontend-test-utils';
+import { default as catalogPlugin } from '@backstage/plugin-catalog/alpha';
+import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import { catalogApiMock } from '@backstage/plugin-catalog-react/testUtils';
 
 const Root = ({ children }: { children: ReactNode }) => <>{children}</>;
 
@@ -158,5 +168,154 @@ describe('convertLegacyApp', () => {
         id: 'puppetDb',
       }),
     ]);
+  });
+
+  it('should convert entity pages', async () => {
+    const fooPlugin = createPlugin({
+      id: 'foo',
+    });
+
+    const FooContent = fooPlugin.provide(
+      createComponentExtension({
+        name: 'FooContent',
+        component: { sync: () => <div>foo content</div> },
+      }),
+    );
+    const OtherFooContent = fooPlugin.provide(
+      createComponentExtension({
+        name: 'OtherFooContent',
+        component: { sync: () => <div>other foo content</div> },
+      }),
+    );
+
+    const simpleTestContent = (
+      <EntityLayout>
+        <EntityLayout.Route path="/" title="Overview">
+          <div>overview content</div>
+        </EntityLayout.Route>
+        <EntityLayout.Route path="/foo" title="Foo">
+          <FooContent />
+        </EntityLayout.Route>
+        <EntityLayout.Route path="/bar" title="Bar">
+          <div>bar content</div>
+        </EntityLayout.Route>
+      </EntityLayout>
+    );
+
+    const otherTestContent = (
+      <EntityLayout>
+        <EntityLayout.Route path="/" title="Overview">
+          <div>other overview content</div>
+        </EntityLayout.Route>
+        <EntityLayout.Route path="/foo" title="Foo">
+          <OtherFooContent />
+        </EntityLayout.Route>
+      </EntityLayout>
+    );
+
+    const entityPage = (
+      <EntitySwitch>
+        <EntitySwitch.Case if={isKind('test')}>
+          {simpleTestContent}
+        </EntitySwitch.Case>
+        <EntitySwitch.Case>{otherTestContent}</EntitySwitch.Case>
+      </EntitySwitch>
+    );
+
+    const converted = convertLegacyApp(
+      <FlatRoutes>
+        <Route path="/test" element={<div>test</div>} />
+      </FlatRoutes>,
+      { entityPage },
+    );
+
+    const catalogOverride = catalogPlugin.withOverrides({
+      extensions: [
+        catalogPlugin.getExtension('api:catalog').override({
+          params: {
+            factory: createApiFactory(
+              catalogApiRef,
+              catalogApiMock({
+                entities: [
+                  {
+                    apiVersion: 'backstage.io/v1alpha1',
+                    kind: 'test',
+                    metadata: {
+                      name: 'x',
+                    },
+                    spec: {},
+                  },
+                  {
+                    apiVersion: 'backstage.io/v1alpha1',
+                    kind: 'other',
+                    metadata: {
+                      name: 'x',
+                    },
+                    spec: {},
+                  },
+                ],
+              }),
+            ),
+          },
+        }),
+      ],
+    });
+
+    // Overview
+    const renderOverviewTest = await renderInTestApp(<div />, {
+      features: [catalogOverride, ...converted],
+      initialRouteEntries: ['/catalog/default/test/x'],
+    });
+    await expect(
+      renderOverviewTest.findByText('overview content'),
+    ).resolves.toBeInTheDocument();
+    renderOverviewTest.unmount();
+
+    const renderOverviewOther = await renderInTestApp(<div />, {
+      features: [catalogOverride, ...converted],
+      initialRouteEntries: ['/catalog/default/other/x'],
+    });
+    await expect(
+      renderOverviewOther.findByText('other overview content'),
+    ).resolves.toBeInTheDocument();
+    renderOverviewOther.unmount();
+
+    // Foo tab
+    const renderFooTest = await renderInTestApp(<div />, {
+      features: [catalogOverride, ...converted],
+      initialRouteEntries: ['/catalog/default/test/x/foo'],
+    });
+    await expect(
+      renderFooTest.findByText('foo content'),
+    ).resolves.toBeInTheDocument();
+    renderFooTest.unmount();
+
+    const renderFooOther = await renderInTestApp(<div />, {
+      features: [catalogOverride, ...converted],
+      initialRouteEntries: ['/catalog/default/other/x/foo'],
+    });
+    await expect(
+      renderFooOther.findByText('other foo content'),
+    ).resolves.toBeInTheDocument();
+    renderFooOther.unmount();
+
+    // Bar tab
+    const renderBarTest = await renderInTestApp(<div />, {
+      features: [catalogOverride, ...converted],
+      initialRouteEntries: ['/catalog/default/test/x/bar'],
+    });
+    await expect(
+      renderBarTest.findByText('bar content'),
+    ).resolves.toBeInTheDocument();
+    renderBarTest.unmount();
+
+    const renderBarOther = await renderInTestApp(<div />, {
+      features: [catalogOverride, ...converted],
+      initialRouteEntries: ['/catalog/default/other/x/bar'],
+    });
+    await expect(
+      renderBarOther.findByText('other overview content'),
+    ).resolves.toBeInTheDocument(); // /bar does not exist, fall back to rendering overview
+    renderBarOther.unmount();
   });
 });

--- a/packages/core-compat-api/src/convertLegacyApp.ts
+++ b/packages/core-compat-api/src/convertLegacyApp.ts
@@ -86,7 +86,7 @@ export function convertLegacyApp(
   options: ConvertLegacyAppOptions = {},
 ): (FrontendPlugin | FrontendModule)[] {
   if (getComponentData(rootElement, 'core.type') === 'FlatRoutes') {
-    return collectLegacyRoutes(rootElement);
+    return collectLegacyRoutes(rootElement, options?.entityPage);
   }
 
   const appRouterEls = selectChildren(

--- a/packages/core-compat-api/src/convertLegacyApp.ts
+++ b/packages/core-compat-api/src/convertLegacyApp.ts
@@ -59,6 +59,7 @@ function selectChildren(
   });
 }
 
+/** @public */
 export interface ConvertLegacyAppOptions {
   /**
    * By providing an entity page element here it will be split up and converted

--- a/packages/core-compat-api/src/convertLegacyApp.ts
+++ b/packages/core-compat-api/src/convertLegacyApp.ts
@@ -59,9 +59,31 @@ function selectChildren(
   });
 }
 
+export interface ConvertLegacyAppOptions {
+  /**
+   * By providing an entity page element here it will be split up and converted
+   * into individual extensions for the catalog plugin in the new frontend
+   * system.
+   *
+   * In order to use this option the entity page and other catalog extensions
+   * must be removed from the legacy app, and the catalog plugin for the new
+   * frontend system must be installed instead.
+   *
+   * In order for this conversion to work the entity page must be a plain React
+   * element tree without any component wrapping anywhere between the root
+   * element and the `EntityLayout.Route` elements.
+   *
+   * When enabling this conversion you are likely to encounter duplicate entity
+   * page content provided both via the old structure and the new plugins. Any
+   * duplicate content needs to be removed from the old structure.
+   */
+  entityPage?: React.JSX.Element;
+}
+
 /** @public */
 export function convertLegacyApp(
   rootElement: React.JSX.Element,
+  options: ConvertLegacyAppOptions = {},
 ): (FrontendPlugin | FrontendModule)[] {
   if (getComponentData(rootElement, 'core.type') === 'FlatRoutes') {
     return collectLegacyRoutes(rootElement);
@@ -136,7 +158,7 @@ export function convertLegacyApp(
     disabled: true,
   });
 
-  const collectedRoutes = collectLegacyRoutes(routesEl);
+  const collectedRoutes = collectLegacyRoutes(routesEl, options?.entityPage);
 
   return [
     ...collectedRoutes,

--- a/packages/core-compat-api/src/convertLegacyEntityPage.ts
+++ b/packages/core-compat-api/src/convertLegacyEntityPage.ts
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ApiHolder, getComponentData } from '@backstage/core-plugin-api';
+import {
+  createFrontendPlugin,
+  ExtensionDefinition,
+  FrontendModule,
+  FrontendPlugin,
+} from '@backstage/frontend-plugin-api';
+import React from 'react';
+import {
+  EntityCardBlueprint,
+  EntityContentBlueprint,
+} from '@backstage/plugin-catalog-react/alpha';
+
+const ENTITY_SWITCH_KEY = 'core.backstage.entitySwitch';
+const ENTITY_ROUTE_KEY = 'plugin.catalog.entityLayoutRoute';
+
+// Placeholder to make sure internal types here are consitent
+type Entity = { apiVersion: string; kind: string };
+
+type EntityFilter = (entity: Entity, ctx: { apis: ApiHolder }) => boolean;
+type AsyncEntityFilter = (
+  entity: Entity,
+  context: { apis: ApiHolder },
+) => boolean | Promise<boolean>;
+
+function allFilters(
+  ...ifs: (EntityFilter | undefined)[]
+): EntityFilter | undefined {
+  const filtered = ifs.filter(Boolean) as EntityFilter[];
+  if (!filtered.length) {
+    return undefined;
+  }
+  if (filtered.length === 1) {
+    return filtered[0];
+  }
+  return (entity, ctx) => filtered.every(ifFunc => ifFunc(entity, ctx));
+}
+
+function anyFilters(
+  ...ifs: (EntityFilter | undefined)[]
+): EntityFilter | undefined {
+  const filtered = ifs.filter(Boolean) as EntityFilter[];
+  if (!filtered.length) {
+    return undefined;
+  }
+  if (filtered.length === 1) {
+    return filtered[0];
+  }
+  return (entity, ctx) => filtered.some(ifFunc => ifFunc(entity, ctx));
+}
+
+function invertFilter(ifFunc?: EntityFilter): EntityFilter {
+  if (!ifFunc) {
+    return () => true;
+  }
+  return (entity, ctx) => !ifFunc(entity, ctx);
+}
+
+export function convertLegacyEntityPage(
+  entityPageElement: React.JSX.Element,
+): (FrontendModule | FrontendPlugin)[] {
+  let cardCounter = 1;
+  let routeCounter = 1;
+
+  const collected: ExtensionDefinition[] = [];
+
+  function traverse(element: React.ReactNode, parentFilter?: EntityFilter) {
+    if (!React.isValidElement(element)) {
+      return;
+    }
+
+    const pageNode = maybeParseEntityPageNode(element);
+    if (pageNode) {
+      if (pageNode.type === 'route') {
+        const mergedIf = allFilters(parentFilter, pageNode.if);
+
+        if (pageNode.path === '/') {
+          collected.push(
+            EntityCardBlueprint.makeWithOverrides({
+              name: `discovered-entity-cards-${cardCounter++}`,
+              factory(originalFactory, { apis }) {
+                return originalFactory({
+                  type: 'full',
+                  filter: mergedIf && (entity => mergedIf(entity, { apis })),
+                  loader: () => Promise.resolve(pageNode.children),
+                });
+              },
+            }),
+          );
+        } else {
+          collected.push(
+            EntityContentBlueprint.makeWithOverrides({
+              name: `discovered-entity-route-${routeCounter++}`,
+              factory(originalFactory, { apis }) {
+                return originalFactory({
+                  defaultPath: pageNode.path,
+                  defaultTitle: pageNode.title,
+                  filter: mergedIf && (entity => mergedIf(entity, { apis })),
+                  loader: () => Promise.resolve(pageNode.children),
+                });
+              },
+            }),
+          );
+        }
+      }
+      if (pageNode.type === 'switch') {
+        if (pageNode.renderMultipleMatches === 'all') {
+          for (const entityCase of pageNode.cases) {
+            traverse(
+              entityCase.children,
+              allFilters(parentFilter, entityCase.if),
+            );
+          }
+        } else {
+          let previousIf: EntityFilter = () => false;
+          for (const entityCase of pageNode.cases) {
+            const didNotMatchEarlier = invertFilter(previousIf);
+            traverse(
+              entityCase.children,
+              allFilters(parentFilter, entityCase.if, didNotMatchEarlier),
+            );
+            previousIf = anyFilters(previousIf, entityCase.if)!;
+          }
+        }
+      }
+      return;
+    }
+
+    React.Children.forEach(
+      (element.props as { children?: React.ReactNode })?.children,
+      child => {
+        traverse(child, parentFilter);
+      },
+    );
+  }
+
+  traverse(entityPageElement);
+
+  return [
+    createFrontendPlugin({
+      id: 'converted-orphan-entity-content',
+      extensions: collected,
+    }),
+  ];
+}
+
+type EntityRoute = {
+  type: 'route';
+  path: string;
+  title: string;
+  if?: EntityFilter;
+  children: JSX.Element;
+};
+
+type EntitySwitchCase = {
+  if?: EntityFilter;
+  children: React.ReactNode;
+};
+
+type EntitySwitch = {
+  type: 'switch';
+  cases: EntitySwitchCase[];
+  renderMultipleMatches: 'first' | 'all';
+};
+
+function wrapAsyncEntityFilter(
+  asyncFilter?: AsyncEntityFilter,
+): EntityFilter | undefined {
+  if (!asyncFilter) {
+    return asyncFilter;
+  }
+  let loggedError = false;
+  return (entity, ctx) => {
+    const result = asyncFilter(entity, ctx);
+    if (result && typeof result === 'object' && 'then' in result) {
+      if (!loggedError) {
+        // eslint-disable-next-line no-console
+        console.error(
+          `convertLegacyEntityPage does not support async entity filters, skipping filter ${asyncFilter}`,
+        );
+        loggedError = true;
+      }
+      return false;
+    }
+    return result;
+  };
+}
+
+function maybeParseEntityPageNode(
+  element: React.JSX.Element,
+): EntityRoute | EntitySwitch | undefined {
+  if (getComponentData(element, ENTITY_ROUTE_KEY)) {
+    const props = element.props as EntityRoute;
+    return {
+      type: 'route',
+      path: props.path,
+      title: props.title,
+      if: props.if,
+      children: props.children,
+    };
+  }
+
+  const parentProps = element.props as {
+    children?: React.ReactNode;
+    renderMultipleMatches?: 'first' | 'all';
+  };
+
+  const children = React.Children.toArray(parentProps?.children);
+  if (!children.length) {
+    return undefined;
+  }
+
+  const cases = [];
+  for (const child of children) {
+    if (!getComponentData(child, ENTITY_SWITCH_KEY)) {
+      return undefined;
+    }
+    const props = (child as { props: EntitySwitchCase }).props;
+
+    cases.push({
+      if: wrapAsyncEntityFilter(props.if),
+      children: props.children,
+    });
+  }
+  return {
+    type: 'switch',
+    cases,
+    renderMultipleMatches: parentProps?.renderMultipleMatches ?? 'first',
+  };
+}

--- a/packages/core-compat-api/src/index.ts
+++ b/packages/core-compat-api/src/index.ts
@@ -19,6 +19,7 @@ export * from './apis';
 
 export { convertLegacyApp } from './convertLegacyApp';
 export { convertLegacyAppOptions } from './convertLegacyAppOptions';
+export { convertLegacyEntityPage } from './convertLegacyEntityPage';
 export { convertLegacyPlugin } from './convertLegacyPlugin';
 export { convertLegacyPageExtension } from './convertLegacyPageExtension';
 export {

--- a/packages/core-compat-api/src/index.ts
+++ b/packages/core-compat-api/src/index.ts
@@ -17,7 +17,10 @@ export * from './compatWrapper';
 
 export * from './apis';
 
-export { convertLegacyApp } from './convertLegacyApp';
+export {
+  convertLegacyApp,
+  type ConvertLegacyAppOptions,
+} from './convertLegacyApp';
 export { convertLegacyAppOptions } from './convertLegacyAppOptions';
 export { convertLegacyPlugin } from './convertLegacyPlugin';
 export { convertLegacyPageExtension } from './convertLegacyPageExtension';

--- a/packages/core-compat-api/src/index.ts
+++ b/packages/core-compat-api/src/index.ts
@@ -19,7 +19,6 @@ export * from './apis';
 
 export { convertLegacyApp } from './convertLegacyApp';
 export { convertLegacyAppOptions } from './convertLegacyAppOptions';
-export { convertLegacyEntityPage } from './convertLegacyEntityPage';
 export { convertLegacyPlugin } from './convertLegacyPlugin';
 export { convertLegacyPageExtension } from './convertLegacyPageExtension';
 export {

--- a/packages/frontend-test-utils/report.api.md
+++ b/packages/frontend-test-utils/report.api.md
@@ -134,6 +134,7 @@ export type TestAppOptions = {
   config?: JsonObject;
   extensions?: ExtensionDefinition<any>[];
   features?: FrontendFeature[];
+  initialRouteEntries?: string[];
 };
 
 export { withLogCollector };

--- a/packages/frontend-test-utils/src/app/renderInTestApp.tsx
+++ b/packages/frontend-test-utils/src/app/renderInTestApp.tsx
@@ -36,6 +36,11 @@ import {
 } from '@backstage/frontend-plugin-api';
 import appPlugin from '@backstage/plugin-app';
 
+const DEFAULT_MOCK_CONFIG = {
+  app: { baseUrl: 'http://localhost:3000' },
+  backend: { baseUrl: 'http://localhost:7007' },
+};
+
 /**
  * Options to customize the behavior of the test app.
  * @public
@@ -73,6 +78,11 @@ export type TestAppOptions = {
    * Additional features to add to the test app.
    */
   features?: FrontendFeature[];
+
+  /**
+   * Initial route entries to use for the router.
+   */
+  initialRouteEntries?: string[];
 };
 
 const NavItem = (props: {
@@ -150,7 +160,11 @@ export function renderInTestApp(
     }),
     RouterBlueprint.make({
       params: {
-        Component: ({ children }) => <MemoryRouter>{children}</MemoryRouter>,
+        Component: ({ children }) => (
+          <MemoryRouter initialEntries={options?.initialRouteEntries}>
+            {children}
+          </MemoryRouter>
+        ),
       },
     }),
   ];
@@ -197,7 +211,10 @@ export function renderInTestApp(
   const app = createSpecializedApp({
     features,
     config: ConfigReader.fromConfigs([
-      { context: 'render-config', data: options?.config ?? {} },
+      {
+        context: 'render-config',
+        data: options?.config ?? DEFAULT_MOCK_CONFIG,
+      },
     ]),
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4231,6 +4231,7 @@ __metadata:
     "@backstage/frontend-plugin-api": "workspace:^"
     "@backstage/frontend-test-utils": "workspace:^"
     "@backstage/plugin-catalog": "workspace:^"
+    "@backstage/plugin-catalog-react": "workspace:^"
     "@backstage/test-utils": "workspace:^"
     "@backstage/types": "workspace:^"
     "@backstage/version-bridge": "workspace:^"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds support for passing an `entityPage` element as an additional option to `convertLegacyApp`, for example like this:

```tsx
const converted = convertLegacyApp(
  <>
    <AlertDisplay transientTimeoutMs={2500} />
    <OAuthRequestDialog />
    <SignalsDisplay />
    <AppRouter>
      <VisitListener />
      <Root>{routes}</Root>
    </AppRouter>
  </>,
  {
    entityPage,
  },
);
```

Draft for now, needs doc updates, tests, and whatnot.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
