### PR TITLE
add missing parameter from github catalog config definition

### DIFF
--- a/.changeset/large-kings-protect.md
+++ b/.changeset/large-kings-protect.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+Added `validateLocationsExist` to the config definition where it was missing.

--- a/plugins/catalog-backend-module-github/config.d.ts
+++ b/plugins/catalog-backend-module-github/config.d.ts
@@ -72,6 +72,11 @@ export interface Config {
              */
             catalogPath?: string;
             /**
+             * (Optional) Whether to validate locations that exist before emitting them.
+             * Default: `false`.
+             */
+            validateLocationsExist?: boolean;
+            /**
              * (Optional) Filter configuration.
              */
             filters?: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Hello, this PR adds the `validateLocationsExist` parameter to the config definition (`config.d.ts`) for the Github catalog plugin where it is missing. This parameter was added to `config.d.ts` in [this PR](https://github.com/backstage/backstage/commit/785ff247f60ccbdc0bdcf32e9776f59e6613e3c6), however it was only added in one place. The [Github configuration](https://github.com/backstage/backstage/blob/8aa63b60beaab4111f682ce8a21e1a1b7230ee85/plugins/catalog-backend-module-github/src/providers/GithubEntityProviderConfig.ts#L35-L49) can be either a single object or a map and it was previously defined only for the map version.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] ~Added or updated documentation~
- [ ] ~Tests for new functionality and regression tests for bug fixes~
- [ ] ~Screenshots attached (for UI changes)~
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
