### PR TITLE
use all 'Kinds' from system model in search filter

### DIFF
--- a/.changeset/neat-roses-melt.md
+++ b/.changeset/neat-roses-melt.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search': patch
+---
+
+Expand the default kind filter to include all kinds from the System Model.

--- a/plugins/search/src/alpha.tsx
+++ b/plugins/search/src/alpha.tsx
@@ -204,7 +204,17 @@ export const searchPage = PageBlueprint.makeWithOverrides({
                           className={classes.filter}
                           label="Kind"
                           name="kind"
-                          values={['Component', 'Template']}
+                          values={[
+                            'API',
+                            'Component',
+                            'Domain',
+                            'Group',
+                            'Location',
+                            'Resource',
+                            'System',
+                            'Template',
+                            'User',
+                          ]}
                         />
                         <SearchFilter.Checkbox
                           className={classes.filter}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In the search sidebar filters used by default in the [new alpha FE system](https://backstage.io/docs/frontend-system/architecture/index), only 'Component' & 'Template' were included in the Kind dropdown, and the options are not editable. Expanding the supplied Kinds to include all the ones outlined in the [OSS System Model](https://backstage.io/docs/features/software-catalog/system-model#ecosystem-modeling). 

Before:
![Screenshot 2025-03-10 at 4 51 32 PM](https://github.com/user-attachments/assets/96a56df9-8bd3-4479-be41-9248cd65f34e)

After:
![Screenshot 2025-03-10 at 4 49 44 PM](https://github.com/user-attachments/assets/e09ee7d8-96b9-45f6-a1ba-4da7ca3e6b9d)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
