### PR TITLE
notification: count badge on icon

### DIFF
--- a/.changeset/silent-poems-greet.md
+++ b/.changeset/silent-poems-greet.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications': patch
+---
+
+Added an icon badge for notification count that shows even when the sidebar is not pinned.

--- a/plugins/notifications/report.api.md
+++ b/plugins/notifications/report.api.md
@@ -133,6 +133,8 @@ export const NotificationsSidebarItem: (props?: {
   titleCounterEnabled?: boolean;
   snackbarEnabled?: boolean;
   snackbarAutoHideDuration?: number | null;
+  useIconCount?: boolean;
+  useChipCount?: boolean;
   className?: string;
   icon?: IconComponent;
   text?: string;

--- a/plugins/notifications/src/components/NotificationsSideBarItem/NotificationsSideBarItem.tsx
+++ b/plugins/notifications/src/components/NotificationsSideBarItem/NotificationsSideBarItem.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import { useNotificationsApi } from '../../hooks';
 import { Link, SidebarItem } from '@backstage/core-components';
 import NotificationsIcon from '@material-ui/icons/Notifications';
@@ -47,6 +47,8 @@ import MarkAsReadIcon from '@material-ui/icons/CheckCircle';
 import IconButton from '@material-ui/core/IconButton';
 import Chip from '@material-ui/core/Chip';
 import { styled } from '@material-ui/core/styles';
+import { useStyles } from './styles';
+import Typography from '@material-ui/core/Typography';
 
 const StyledMaterialDesignContent = styled(MaterialDesignContent)(
   ({ theme }) => ({
@@ -85,6 +87,8 @@ export const NotificationsSidebarItem = (props?: {
   titleCounterEnabled?: boolean;
   snackbarEnabled?: boolean;
   snackbarAutoHideDuration?: number | null;
+  useIconCount?: boolean;
+  useChipCount?: boolean;
   className?: string;
   icon?: IconComponent;
   text?: string;
@@ -96,6 +100,8 @@ export const NotificationsSidebarItem = (props?: {
     titleCounterEnabled = true,
     snackbarEnabled = true,
     snackbarAutoHideDuration = 10000,
+    useIconCount = true,
+    useChipCount = false,
     icon = NotificationsIcon,
     text = 'Notifications',
     ...restProps
@@ -104,6 +110,8 @@ export const NotificationsSidebarItem = (props?: {
     titleCounterEnabled: true,
     snackbarEnabled: true,
     snackbarAutoHideDuration: 10000,
+    useIconCount: true,
+    useChipCount: false,
   };
 
   const { loading, error, value, retry } = useNotificationsApi(api =>
@@ -256,6 +264,23 @@ export const NotificationsSidebarItem = (props?: {
 
   const count = !error && !!unreadCount ? unreadCount : undefined;
 
+  const classes = useStyles();
+  const Icon = icon;
+  const iconWithCount: IconComponent = useMemo(
+    () => () =>
+      (
+        <div className={classes.iconWrapper}>
+          <Icon />
+          {count && count > 0 && (
+            <Typography variant="body2" className={classes.countBadge}>
+              {count}
+            </Typography>
+          )}
+        </div>
+      ),
+    [Icon, classes, count],
+  );
+
   return (
     <>
       {snackbarEnabled && (
@@ -280,10 +305,12 @@ export const NotificationsSidebarItem = (props?: {
           requestUserPermission();
         }}
         text={text}
-        icon={icon}
+        icon={useIconCount ? iconWithCount : icon}
         {...restProps}
       >
-        {count && <Chip size="small" label={count > 99 ? '99+' : count} />}
+        {count && useChipCount && (
+          <Chip size="small" label={count > 99 ? '99+' : count} />
+        )}
       </SidebarItem>
     </>
   );

--- a/plugins/notifications/src/components/NotificationsSideBarItem/styles.ts
+++ b/plugins/notifications/src/components/NotificationsSideBarItem/styles.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { makeStyles } from '@material-ui/core/styles';
+
+export const useStyles = makeStyles(theme => ({
+  countBadge: {
+    position: 'absolute',
+    top: -6,
+    right: -8,
+    backgroundColor: theme.palette.error.main,
+    color: theme.palette.error.contrastText,
+    borderRadius: '10px',
+    padding: '1px 4px',
+    fontSize: '0.6rem',
+    fontWeight: 'bold',
+    minWidth: '16px',
+    height: '16px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    boxShadow: '0 1px 2px rgba(0,0,0,0.2)',
+    zIndex: 1,
+  },
+  iconWrapper: {
+    position: 'relative',
+    display: 'inline-flex',
+  },
+}));


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

For Notifications, added a red badge on the icon showing the count of unread notifications, so that it will remain visible when the sidbar is not pinned.
![image (1)](https://github.com/user-attachments/assets/48c8d5d3-eb3b-44f9-8923-931541a61b21)

- Added a boolean prop `useChipCount` to enable or disable the pre-existing count to the right that uses a `Chip` element.
- Added a boolean prop `useIconCount` to enable or disable a red badge showing the count over the icon.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
