### PR TITLE
theme: install Canon theme be default

### DIFF
--- a/.changeset/chilled-shrimps-yell.md
+++ b/.changeset/chilled-shrimps-yell.md
@@ -1,0 +1,7 @@
+---
+'@backstage/theme': minor
+---
+
+Added the baseline theme from `@backstage/canon` to `UnifiedThemeProvider`, in addition to the new `cssLinks` and `themeDataAttribute` props.
+
+The intention of this change is to add fowards compatibility with `@backstage/canon` components and ensure that the existing theme and CSS baseline does not interfere with theming in MUI.

--- a/.changeset/unlucky-points-greet.md
+++ b/.changeset/unlucky-points-greet.md
@@ -1,0 +1,11 @@
+---
+'@backstage/cli': patch
+---
+
+Added support for `?raw` query on imports, allowing any module to be imported as a static asset. For example:
+
+```ts
+import cssHref from './styles.css?raw';
+
+console.log(cssHref); // e.g. "/static/styles.123456.css"
+```

--- a/packages/cli/asset-types/asset-types.d.ts
+++ b/packages/cli/asset-types/asset-types.d.ts
@@ -20,6 +20,11 @@
 /// <reference types="react" />
 /// <reference types="react-dom" />
 
+declare module '*?raw' {
+  const src: string;
+  export default src;
+}
+
 declare module '*.bmp' {
   const src: string;
   export default src;

--- a/packages/cli/src/modules/build/lib/bundler/transforms.ts
+++ b/packages/cli/src/modules/build/lib/bundler/transforms.ts
@@ -158,6 +158,13 @@ export const transforms = (options: TransformOptions): Transforms => {
       },
     },
     {
+      resourceQuery: /raw/,
+      type: 'asset/resource',
+      generator: {
+        filename: 'static/[name].[hash:8][ext]',
+      },
+    },
+    {
       test: /\.(eot|woff|woff2|ttf)$/i,
       type: 'asset/resource',
       generator: {
@@ -166,6 +173,7 @@ export const transforms = (options: TransformOptions): Transforms => {
     },
     {
       test: /\.ya?ml$/,
+      resourceQuery: { not: [/raw/] },
       use: require.resolve('yml-loader'),
     },
     {
@@ -177,6 +185,7 @@ export const transforms = (options: TransformOptions): Transforms => {
     },
     {
       test: /\.css$/i,
+      resourceQuery: { not: [/raw/] },
       use: [
         isDev
           ? {

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -38,7 +38,8 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
-    "@mui/material": "^5.12.2"
+    "@mui/material": "^5.12.2",
+    "react-helmet": "6.1.0"
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",

--- a/packages/theme/src/unified/UnifiedThemeProvider.tsx
+++ b/packages/theme/src/unified/UnifiedThemeProvider.tsx
@@ -16,6 +16,7 @@
 
 import React, { ReactNode } from 'react';
 import CssBaseline from '@material-ui/core/CssBaseline';
+import Helmet from 'react-helmet';
 import {
   ThemeProvider,
   StylesProvider,
@@ -29,6 +30,8 @@ import {
 } from '@mui/material/styles';
 import { UnifiedTheme } from './types';
 import { unstable_ClassNameGenerator as ClassNameGenerator } from '@mui/material/className';
+import canonCoreSrc from '@backstage/canon/css/core.css?raw';
+import canonComponetsSrc from '@backstage/canon/css/components.css?raw';
 
 /**
  * Props for {@link UnifiedThemeProvider}.
@@ -39,6 +42,8 @@ export interface UnifiedThemeProviderProps {
   children: ReactNode;
   theme: UnifiedTheme;
   noCssBaseline?: boolean;
+  cssLinks?: string[];
+  themeDataAttribute?: string;
 }
 
 /**
@@ -66,7 +71,13 @@ const generateV4ClassName = createGenerateClassName({
 export function UnifiedThemeProvider(
   props: UnifiedThemeProviderProps,
 ): JSX.Element {
-  const { children, theme, noCssBaseline = false } = props;
+  const {
+    children,
+    theme,
+    noCssBaseline = false,
+    cssLinks = [canonCoreSrc, canonComponetsSrc],
+    themeDataAttribute,
+  } = props;
 
   const v4Theme = theme.getTheme('v4') as Mui4Theme;
   const v5Theme = theme.getTheme('v5') as Mui5Theme;
@@ -96,6 +107,32 @@ export function UnifiedThemeProvider(
       <StyledEngineProvider injectFirst>
         <Mui5Provider theme={v5Theme}>{result}</Mui5Provider>
       </StyledEngineProvider>
+    );
+  }
+
+  if (cssLinks) {
+    result = (
+      <>
+        <Helmet
+          link={cssLinks.map(src => ({
+            type: 'text/css',
+            rel: 'stylesheet',
+            href: src,
+          }))}
+        />
+        {result}
+      </>
+    );
+  }
+
+  const data =
+    themeDataAttribute ?? v5Theme?.palette.mode ?? v4Theme?.palette.type;
+  if (data) {
+    result = (
+      <>
+        <Helmet bodyAttributes={{ 'data-theme': data }} />
+        {result}
+      </>
     );
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8780,6 +8780,7 @@ __metadata:
     "@types/react": ^18.0.0
     react: ^18.0.2
     react-dom: ^18.0.2
+    react-helmet: 6.1.0
     react-router-dom: ^6.3.0
   peerDependencies:
     "@material-ui/core": ^4.12.2


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds the `@backstage/canon` theme as a default theme in `UnifiedThemeProvider`, in addition to adding the `cssLinks` and `themeDataAttribute` props.

It also adds support for `?raw` imports in our WebPack config, as documented here: https://webpack.js.org/guides/asset-modules/#replacing-inline-loader-syntax

One issue I ran into is that `packages/canon/css` is not available on checkout. We'll need to move over be committed to the repo for this to work well, with a CI check to make sure it doesn't go stale.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
