### PR TITLE
fix(techdocs): prevent to throw an error when the SCM provider is not supported

### DIFF
--- a/.changeset/unlucky-carrots-shave.md
+++ b/.changeset/unlucky-carrots-shave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-module-addons-contrib': patch
+---
+
+prevent to throw an error when the SCM provider is not supported

--- a/.changeset/unlucky-carrots-shave.md
+++ b/.changeset/unlucky-carrots-shave.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-techdocs-module-addons-contrib': patch
 ---
 
-prevent to throw an error when the SCM provider is not supported
+Fixed rendering issues in `ReportIssue` addon for unsupported repository types and improved shadow DOM event handling. The addon now properly prevents initialization when encountering unsupported repository types and correctly handles selection events within the shadow DOM.

--- a/plugins/techdocs-module-addons-contrib/src/ReportIssue/IssueLink.tsx
+++ b/plugins/techdocs-module-addons-contrib/src/ReportIssue/IssueLink.tsx
@@ -48,10 +48,7 @@ const getIcon = ({ type }: Repository) => {
 };
 
 const getName = ({ type }: Repository) => {
-  if (type === 'github') {
-    return 'Github';
-  }
-  return 'Gitlab';
+  return type.charAt(0).toLocaleUpperCase('en-US') + type.slice(1);
 };
 
 const getUrl = (repository: Repository, template: ReportIssueTemplate) => {

--- a/plugins/techdocs-module-addons-contrib/src/ReportIssue/ReportIssue.tsx
+++ b/plugins/techdocs-module-addons-contrib/src/ReportIssue/ReportIssue.tsx
@@ -14,39 +14,11 @@
  * limitations under the License.
  */
 
-import React, { useState, useEffect } from 'react';
-
-import { makeStyles, Portal, Paper } from '@material-ui/core';
-
-import { useGitTemplate, useGitRepository } from './hooks';
+import React from 'react';
+import { useGitRepository } from './hooks';
 import { ReportIssueTemplateBuilder } from './types';
-import {
-  PAGE_MAIN_CONTENT_SELECTOR,
-  PAGE_FEEDBACK_LINK_SELECTOR,
-  ADDON_FEEDBACK_CONTAINER_ID,
-  ADDON_FEEDBACK_CONTAINER_SELECTOR,
-} from './constants';
-import { IssueLink } from './IssueLink';
-
-import {
-  useShadowRootElements,
-  useShadowRootSelection,
-} from '@backstage/plugin-techdocs-react';
-
-const useStyles = makeStyles(theme => ({
-  root: {
-    transform: 'translate(-100%, -100%)',
-    position: 'absolute',
-    padding: theme.spacing(1),
-    zIndex: theme.zIndex.tooltip,
-    background: theme.palette.common.white,
-  },
-}));
-
-type Style = {
-  top: string;
-  left: string;
-};
+import { ADDON_ISSUE_REPO_TYPES_SUPPORTED } from './constants';
+import { ReportIssueAddonContent } from './ReportIssueContent';
 
 /**
  * Props customizing the <ReportIssue /> Addon.
@@ -67,101 +39,24 @@ export type ReportIssueProps = {
   templateBuilder?: ReportIssueTemplateBuilder;
 };
 
-/**
- * Show report issue button when text is highlighted
- */
 export const ReportIssueAddon = ({
   debounceTime = 500,
-  templateBuilder: buildTemplate,
+  templateBuilder,
 }: ReportIssueProps) => {
-  const classes = useStyles();
-  const [style, setStyle] = useState<Style>();
-
   const repository = useGitRepository();
 
-  const defaultTemplate = useGitTemplate(debounceTime);
-
-  const selection = useShadowRootSelection(debounceTime);
-
-  const [mainContent, feedbackLink] = useShadowRootElements([
-    PAGE_MAIN_CONTENT_SELECTOR,
-    PAGE_FEEDBACK_LINK_SELECTOR,
-  ]);
-
-  let [feedbackContainer] = useShadowRootElements([
-    ADDON_FEEDBACK_CONTAINER_SELECTOR,
-  ]);
-
-  if (feedbackLink) {
-    feedbackLink.style.display = 'none';
-  }
-
-  // calculates the position of the selected text to be able to set the position of the addon
-  useEffect(() => {
-    if (
-      // todo(backstage/techdocs-core) handle non-repo rendering
-      !repository ||
-      !selection ||
-      !selection?.containsNode(mainContent!, true) ||
-      selection?.containsNode(feedbackContainer!, true)
-    ) {
-      return;
-    }
-
-    const mainContentPosition = mainContent!.getBoundingClientRect();
-    const selectionPosition = selection.getRangeAt(0).getBoundingClientRect();
-
-    // Calculating the distance between the selection's top and the main content's top
-    const distanceFromTop = selectionPosition.top - mainContentPosition.top;
-    const minDistanceFromTop = 50;
-
-    // Defining a base value for 'top'
-    let top = distanceFromTop < minDistanceFromTop ? 101 : distanceFromTop - 16;
-
-    // Checking if the main content is off-screen towards the top
-    if (mainContentPosition.top < 0) {
-      const absMainContentTop = Math.abs(mainContentPosition.top);
-
-      // Adjusting 'top' if the selection is close to the top edge and the main content is off-screen
-      if (distanceFromTop - absMainContentTop < minDistanceFromTop) {
-        top += 89;
-      }
-    }
-
-    setStyle({
-      top: `${top}px`,
-      left: `${selectionPosition.left + selectionPosition.width / 2}px`,
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selection, mainContent, feedbackContainer]);
-
   if (
-    !selection ||
     !repository ||
-    !['github', 'gitlab'].includes(repository.type)
-  )
+    !ADDON_ISSUE_REPO_TYPES_SUPPORTED.includes(repository.type)
+  ) {
     return null;
-
-  if (!feedbackContainer) {
-    feedbackContainer = document.createElement('div');
-    feedbackContainer.setAttribute('id', ADDON_FEEDBACK_CONTAINER_ID);
-    mainContent!.prepend(feedbackContainer);
   }
 
   return (
-    <Portal container={feedbackContainer}>
-      <Paper
-        data-testid="report-issue-addon"
-        className={classes.root}
-        style={style}
-      >
-        <IssueLink
-          repository={repository}
-          template={
-            buildTemplate ? buildTemplate({ selection }) : defaultTemplate
-          }
-        />
-      </Paper>
-    </Portal>
+    <ReportIssueAddonContent
+      debounceTime={debounceTime}
+      templateBuilder={templateBuilder}
+      repository={repository}
+    />
   );
 };

--- a/plugins/techdocs-module-addons-contrib/src/ReportIssue/ReportIssue.tsx
+++ b/plugins/techdocs-module-addons-contrib/src/ReportIssue/ReportIssue.tsx
@@ -102,7 +102,7 @@ export const ReportIssueAddon = ({
       // todo(backstage/techdocs-core) handle non-repo rendering
       !repository ||
       !selection ||
-      !selection.containsNode(mainContent!, true) ||
+      !selection?.containsNode(mainContent!, true) ||
       selection?.containsNode(feedbackContainer!, true)
     ) {
       return;

--- a/plugins/techdocs-module-addons-contrib/src/ReportIssue/ReportIssueContent.tsx
+++ b/plugins/techdocs-module-addons-contrib/src/ReportIssue/ReportIssueContent.tsx
@@ -110,11 +110,7 @@ export const ReportIssueAddonContent = ({
     mainContent!.prepend(feedbackContainer);
   }
 
-  if (
-    !selection ||
-    !selection.containsNode(mainContent, true) ||
-    selection.containsNode(feedbackContainer, true)
-  ) {
+  if (!selection || !selection.containsNode(mainContent, true)) {
     return null;
   }
 

--- a/plugins/techdocs-module-addons-contrib/src/ReportIssue/ReportIssueContent.tsx
+++ b/plugins/techdocs-module-addons-contrib/src/ReportIssue/ReportIssueContent.tsx
@@ -78,7 +78,7 @@ export const ReportIssueAddonContent = ({
     if (
       !selection ||
       !selection.containsNode(mainContent, true) ||
-      selection?.containsNode(feedbackContainer, true)
+      selection.containsNode(feedbackContainer, true)
     ) {
       return;
     }

--- a/plugins/techdocs-module-addons-contrib/src/ReportIssue/ReportIssueContent.tsx
+++ b/plugins/techdocs-module-addons-contrib/src/ReportIssue/ReportIssueContent.tsx
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState, useEffect } from 'react';
+import { makeStyles, Portal, Paper } from '@material-ui/core';
+import { useGitTemplate } from './hooks';
+import {
+  PAGE_MAIN_CONTENT_SELECTOR,
+  PAGE_FEEDBACK_LINK_SELECTOR,
+  ADDON_FEEDBACK_CONTAINER_ID,
+  ADDON_FEEDBACK_CONTAINER_SELECTOR,
+} from './constants';
+import { IssueLink } from './IssueLink';
+import {
+  useShadowRootElements,
+  useShadowRootSelection,
+} from '@backstage/plugin-techdocs-react';
+import { Repository } from './types';
+import { ReportIssueProps } from './ReportIssue';
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    transform: 'translate(-100%, -100%)',
+    position: 'absolute',
+    padding: theme.spacing(1),
+    zIndex: theme.zIndex.tooltip,
+    background: theme.palette.common.white,
+  },
+}));
+
+type Style = {
+  top: string;
+  left: string;
+};
+
+// Props customizing the <ReportIssue /> Addon.
+export type ReportIssueAddonContentProps = ReportIssueProps & {
+  repository: Repository;
+};
+
+export const ReportIssueAddonContent = ({
+  debounceTime,
+  templateBuilder,
+  repository,
+}: ReportIssueAddonContentProps) => {
+  const classes = useStyles();
+  const [style, setStyle] = useState<Style>();
+  const defaultTemplate = useGitTemplate(debounceTime);
+  const selection = useShadowRootSelection(debounceTime);
+
+  const [mainContent, feedbackLink] = useShadowRootElements([
+    PAGE_MAIN_CONTENT_SELECTOR,
+    PAGE_FEEDBACK_LINK_SELECTOR,
+  ]);
+
+  let [feedbackContainer] = useShadowRootElements([
+    ADDON_FEEDBACK_CONTAINER_SELECTOR,
+  ]);
+
+  if (feedbackLink) {
+    feedbackLink.style.display = 'none';
+  }
+
+  useEffect(() => {
+    if (
+      !selection ||
+      !selection.containsNode(mainContent, true) ||
+      selection?.containsNode(feedbackContainer, true)
+    ) {
+      return;
+    }
+
+    const mainContentPosition = mainContent.getBoundingClientRect();
+    const selectionPosition = selection.getRangeAt(0).getBoundingClientRect();
+
+    const distanceFromTop = selectionPosition.top - mainContentPosition.top;
+    const minDistanceFromTop = 50;
+
+    let top = distanceFromTop < minDistanceFromTop ? 101 : distanceFromTop - 16;
+
+    if (mainContentPosition.top < 0) {
+      const absMainContentTop = Math.abs(mainContentPosition.top);
+      if (distanceFromTop - absMainContentTop < minDistanceFromTop) {
+        top += 89;
+      }
+    }
+
+    setStyle({
+      top: `${top}px`,
+      left: `${selectionPosition.left + selectionPosition.width / 2}px`,
+    });
+  }, [selection, mainContent, feedbackContainer]);
+
+  if (!selection) return null;
+
+  if (!feedbackContainer) {
+    feedbackContainer = document.createElement('div');
+    feedbackContainer.setAttribute('id', ADDON_FEEDBACK_CONTAINER_ID);
+    mainContent!.prepend(feedbackContainer);
+  }
+
+  return (
+    <Portal container={feedbackContainer}>
+      <Paper
+        data-testid="report-issue-addon"
+        className={classes.root}
+        style={style}
+      >
+        <IssueLink
+          repository={repository}
+          template={
+            templateBuilder ? templateBuilder({ selection }) : defaultTemplate
+          }
+        />
+      </Paper>
+    </Portal>
+  );
+};

--- a/plugins/techdocs-module-addons-contrib/src/ReportIssue/ReportIssueContent.tsx
+++ b/plugins/techdocs-module-addons-contrib/src/ReportIssue/ReportIssueContent.tsx
@@ -104,12 +104,18 @@ export const ReportIssueAddonContent = ({
     });
   }, [selection, mainContent, feedbackContainer]);
 
-  if (!selection) return null;
-
   if (!feedbackContainer) {
     feedbackContainer = document.createElement('div');
     feedbackContainer.setAttribute('id', ADDON_FEEDBACK_CONTAINER_ID);
     mainContent!.prepend(feedbackContainer);
+  }
+
+  if (
+    !selection ||
+    !selection.containsNode(mainContent, true) ||
+    selection.containsNode(feedbackContainer, true)
+  ) {
+    return null;
   }
 
   return (

--- a/plugins/techdocs-module-addons-contrib/src/ReportIssue/constants.ts
+++ b/plugins/techdocs-module-addons-contrib/src/ReportIssue/constants.ts
@@ -16,6 +16,7 @@
 
 export const ADDON_FEEDBACK_CONTAINER_ID = 'techdocs-report-issue';
 export const ADDON_FEEDBACK_CONTAINER_SELECTOR = `#${ADDON_FEEDBACK_CONTAINER_ID}`;
+export const ADDON_ISSUE_REPO_TYPES_SUPPORTED = ['github', 'gitlab'];
 export const PAGE_EDIT_LINK_SELECTOR = '[title^="Edit this page"]';
 export const PAGE_FEEDBACK_LINK_SELECTOR = '[title^="Leave feedback for"]';
 export const PAGE_MAIN_CONTENT_SELECTOR =


### PR DESCRIPTION
## Hey, I just made a Pull Request!

At present, the plugin lacks support for multiple Source Control Management (SCM) providers within a single Backstage instance when one of these providers is not supported. When encountering an unsupported SCM in the edit_url, the plugin generates an error.

This Pull Request (PR) addresses this issue by dividing the component. The new structure prevents the plugin from loading when the Techdocs are sourced from an unsupported repository. This approach ensures smoother operation and better handling of diverse SCM scenarios within Backstage.

### 🐛 Issue
Error
TypeError

Message
Failed to execute 'containsNode' on 'Selection': parameter 1 is not of type 'Node'.

Stack Trace
TypeError: parameter 1 is not of type 'Node'.
    at https://backstage.example.com/static/module-backstage.b2517ed5.js:618:1729
    at ul (https://backstage.example.com/static/module-react-dom.b4fe5cf3.js:16:24313)
    at Ct (https://backstage.example.com/static/module-react-dom.b4fe5cf3.js:16:42455)
    at qs (https://backstage.example.com/static/module-react-dom.b4fe5cf3.js:16:34578)
    at Ln (https://backstage.example.comstatic/module-react-dom.b4fe5cf3.js:24:1590)
    at MessagePort.Zn (https://backstage.example.comstatic/module-react-dom.b4fe5cf3.js:24:1980)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
