### PR TITLE
core-app-api: make fetch auth middleware of discovery config

### DIFF
--- a/.changeset/early-buses-lick.md
+++ b/.changeset/early-buses-lick.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-app-api': minor
+---
+
+The default auth injection middleware for the `FetchApi` will now also take configuration under `discovery.endpoints` into consideration when deciding whether to include credentials or not.

--- a/packages/core-app-api/src/apis/implementations/FetchApi/IdentityAuthInjectorFetchMiddleware.test.ts
+++ b/packages/core-app-api/src/apis/implementations/FetchApi/IdentityAuthInjectorFetchMiddleware.test.ts
@@ -115,4 +115,49 @@ describe('IdentityAuthInjectorFetchMiddleware', () => {
       ['authorization', 'do-not-clobber'],
     ]);
   });
+
+  describe('.getDiscoveryUrlPrefixes', () => {
+    it('works with no endpoints', () => {
+      const config = new ConfigReader({
+        backend: { baseUrl: 'https://a.com' },
+      });
+      expect(
+        IdentityAuthInjectorFetchMiddleware.getDiscoveryUrlPrefixes(config),
+      ).toEqual([]);
+    });
+
+    it('works with endpoints', () => {
+      const config = new ConfigReader({
+        backend: { baseUrl: 'https://a.com' },
+        discovery: {
+          endpoints: [
+            { target: 'https://b.com', plugins: ['p1'] },
+            { target: 'https://c.com/{{pluginId}}', plugins: ['p2', 'p3'] },
+            { target: { external: 'https://d.com' }, plugins: ['q1'] },
+            {
+              target: { external: 'https://e.com/{{pluginId}}' },
+              plugins: ['q2', 'q3'],
+            },
+            {
+              target: {
+                external: 'https://{{ pluginId   }}.e.com/{{pluginId}}',
+              },
+              plugins: ['q4'],
+            },
+          ],
+        },
+      });
+      expect(
+        IdentityAuthInjectorFetchMiddleware.getDiscoveryUrlPrefixes(config),
+      ).toEqual([
+        'https://b.com',
+        'https://c.com/p2',
+        'https://c.com/p3',
+        'https://d.com',
+        'https://e.com/q2',
+        'https://e.com/q3',
+        'https://q4.e.com/q4',
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This makes the default fetch auth middleware aware of `discovery.endpoints` configuration, including those URLs in the allow list of URLs to include auth for.

I had intended to make the logic available via `IdentityAuthInjectorFetchMiddleware.getDiscoveryUrlPrefixes`, but realized that wasn't exported. Figured it's fine to ship like this and we can consider making it available later. Idea is really for this build-in logic to work pretty much universally anyway.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
