### PR TITLE
module: move misc repo tasks into a maintenance module

### DIFF
--- a/.changeset/wet-penguins-beg.md
+++ b/.changeset/wet-penguins-beg.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': minor
+---
+
+Internal update to move the `clean`, `pre/postpack` and `fix` commands into their own separate module.

--- a/packages/cli/cli-report.md
+++ b/packages/cli/cli-report.md
@@ -200,10 +200,10 @@ Commands:
   start [options]
   build [options]
   test
-  lint [options] [directories...]
   clean
   prepack
   postpack
+  lint [options] [directories...]
   help [command]
 ```
 

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -35,6 +35,10 @@ import {
   registerPackageCommands as registerPackageLintCommands,
   registerRepoCommands as registerRepoLintCommands,
 } from '../modules/lint';
+import {
+  registerPackageCommands as registerMaintenancePackageCommands,
+  registerRepoCommands as registerMaintenanceRepoCommands,
+} from '../modules/maintenance';
 
 export function registerRepoCommand(program: Command) {
   const command = program
@@ -44,30 +48,7 @@ export function registerRepoCommand(program: Command) {
   registerRepoBuildCommands(command);
   registerRepoTestCommands(command);
   registerRepoLintCommands(command);
-
-  command
-    .command('fix')
-    .description('Automatically fix packages in the project')
-    .option(
-      '--publish',
-      'Enable additional fixes that only apply when publishing packages',
-    )
-    .option(
-      '--check',
-      'Fail if any packages would have been changed by the command',
-    )
-    .action(lazy(() => import('./repo/fix'), 'command'));
-
-  command
-    .command('clean')
-    .description('Delete cache and output directories')
-    .action(lazy(() => import('./repo/clean'), 'command'));
-
-  command
-    .command('list-deprecations')
-    .description('List deprecations')
-    .option('--json', 'Output as JSON')
-    .action(lazy(() => import('./repo/list-deprecations'), 'command'));
+  registerMaintenanceRepoCommands(command);
 }
 
 export function registerScriptCommand(program: Command) {
@@ -92,22 +73,8 @@ export function registerScriptCommand(program: Command) {
 
   registerPackageBuildCommands(command);
   registerPackageTestCommands(command);
-
+  registerMaintenancePackageCommands(command);
   registerPackageLintCommands(command);
-  command
-    .command('clean')
-    .description('Delete cache directories')
-    .action(lazy(() => import('./clean/clean'), 'default'));
-
-  command
-    .command('prepack')
-    .description('Prepares a package for packaging before publishing')
-    .action(lazy(() => import('./pack'), 'pre'));
-
-  command
-    .command('postpack')
-    .description('Restores the changes made by the prepack command')
-    .action(lazy(() => import('./pack'), 'post'));
 }
 
 export function registerCommands(program: Command) {
@@ -153,7 +120,6 @@ export function registerCommands(program: Command) {
   registerMigrateCommand(program);
   registerBuildCommands(program);
   registerInfoCommands(program);
-
   program
     .command('create-github-app <github-org>')
     .description('Create new GitHub App in your organization.')

--- a/packages/cli/src/modules/maintenance/alpha.ts
+++ b/packages/cli/src/modules/maintenance/alpha.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Command } from 'commander';
+import { createCliPlugin } from '../../wiring/factory';
+import { lazy } from '../../lib/lazy';
+
+export default createCliPlugin({
+  pluginId: 'maintenance',
+  init: async reg => {
+    reg.addCommand({
+      path: ['package', 'clean'],
+      description: 'Delete cache directories',
+      execute: async ({ args }) => {
+        const command = new Command();
+        const defaultCommand = command.action(
+          lazy(() => import('./commands/package/clean'), 'default'),
+        );
+
+        await defaultCommand.parseAsync(args, { from: 'user' });
+      },
+    });
+
+    reg.addCommand({
+      path: ['package', 'prepack'],
+      description: 'Prepares a package for packaging before publishing',
+      execute: async ({ args }) => {
+        const command = new Command();
+        const defaultCommand = command.action(
+          lazy(() => import('./commands/package/pack'), 'pre'),
+        );
+
+        await defaultCommand.parseAsync(args, { from: 'user' });
+      },
+    });
+
+    reg.addCommand({
+      path: ['package', 'postpack'],
+      description: 'Restores the changes made by the prepack command',
+      execute: async ({ args }) => {
+        const command = new Command();
+        const defaultCommand = command.action(
+          lazy(() => import('./commands/package/pack'), 'post'),
+        );
+
+        await defaultCommand.parseAsync(args, { from: 'user' });
+      },
+    });
+
+    reg.addCommand({
+      path: ['repo', 'fix'],
+      description: 'Automatically fix packages in the project',
+      execute: async ({ args }) => {
+        const command = new Command();
+        const defaultCommand = command
+          .option(
+            '--publish',
+            'Enable additional fixes that only apply when publishing packages',
+          )
+          .option(
+            '--check',
+            'Fail if any packages would have been changed by the command',
+          )
+          .action(lazy(() => import('./commands/repo/fix'), 'command'));
+
+        await defaultCommand.parseAsync(args, { from: 'user' });
+      },
+    });
+
+    reg.addCommand({
+      path: ['repo', 'clean'],
+      description: 'Delete cache and output directories',
+      execute: async ({ args }) => {
+        const command = new Command();
+        const defaultCommand = command.action(
+          lazy(() => import('./commands/repo/clean'), 'command'),
+        );
+
+        await defaultCommand.parseAsync(args, { from: 'user' });
+      },
+    });
+
+    reg.addCommand({
+      path: ['repo', 'list-deprecations'],
+      description: 'List deprecations',
+      execute: async ({ args }) => {
+        const command = new Command();
+        const defaultCommand = command
+          .option('--json', 'Output as JSON')
+          .action(
+            lazy(() => import('./commands/repo/list-deprecations'), 'command'),
+          );
+
+        await defaultCommand.parseAsync(args, { from: 'user' });
+      },
+    });
+  },
+});

--- a/packages/cli/src/modules/maintenance/commands/package/clean.ts
+++ b/packages/cli/src/modules/maintenance/commands/package/clean.ts
@@ -15,7 +15,7 @@
  */
 
 import fs from 'fs-extra';
-import { paths } from '../../lib/paths';
+import { paths } from '../../../../lib/paths';
 
 export default async function clean() {
   await fs.remove(paths.resolveTarget('dist'));

--- a/packages/cli/src/modules/maintenance/commands/package/pack.ts
+++ b/packages/cli/src/modules/maintenance/commands/package/pack.ts
@@ -17,11 +17,11 @@
 import {
   productionPack,
   revertProductionPack,
-} from '../modules/build/lib/packager/productionPack';
-import { paths } from '../lib/paths';
+} from '../../../../modules/build/lib/packager/productionPack';
+import { paths } from '../../../../lib/paths';
 import fs from 'fs-extra';
-import { publishPreflightCheck } from '../lib/publishing';
-import { createTypeDistProject } from '../lib/typeDistProject';
+import { publishPreflightCheck } from '../../../../lib/publishing';
+import { createTypeDistProject } from '../../../../lib/typeDistProject';
 
 export const pre = async () => {
   publishPreflightCheck({

--- a/packages/cli/src/modules/maintenance/commands/repo/clean.ts
+++ b/packages/cli/src/modules/maintenance/commands/repo/clean.ts
@@ -19,7 +19,7 @@ import fs from 'fs-extra';
 import { resolve as resolvePath } from 'path';
 import { promisify } from 'util';
 import { PackageGraph } from '@backstage/cli-node';
-import { paths } from '../../lib/paths';
+import { paths } from '../../../../lib/paths';
 
 const execFile = promisify(execFileCb);
 

--- a/packages/cli/src/modules/maintenance/commands/repo/fix.ts
+++ b/packages/cli/src/modules/maintenance/commands/repo/fix.ts
@@ -24,8 +24,8 @@ import {
 import { OptionValues } from 'commander';
 import fs from 'fs-extra';
 import { resolve as resolvePath, posix, relative as relativePath } from 'path';
-import { paths } from '../../lib/paths';
-import { publishPreflightCheck } from '../../lib/publishing';
+import { paths } from '../../../../lib/paths';
+import { publishPreflightCheck } from '../../../../lib/publishing';
 
 /**
  * A mutable object representing a package.json file with potential fixes.

--- a/packages/cli/src/modules/maintenance/commands/repo/list-deprecations.ts
+++ b/packages/cli/src/modules/maintenance/commands/repo/list-deprecations.ts
@@ -19,7 +19,7 @@ import { ESLint } from 'eslint';
 import { OptionValues } from 'commander';
 import { relative as relativePath } from 'path';
 import { PackageGraph } from '@backstage/cli-node';
-import { paths } from '../../lib/paths';
+import { paths } from '../../../../lib/paths';
 
 export async function command(opts: OptionValues) {
   const packages = await PackageGraph.listTargetPackages();

--- a/packages/cli/src/modules/maintenance/index.ts
+++ b/packages/cli/src/modules/maintenance/index.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Command } from 'commander';
+import { lazy } from '../../lib/lazy';
+
+export function registerPackageCommands(command: Command) {
+  command
+    .command('clean')
+    .description('Delete cache directories')
+    .action(lazy(() => import('./commands/package/clean'), 'default'));
+
+  command
+    .command('prepack')
+    .description('Prepares a package for packaging before publishing')
+    .action(lazy(() => import('./commands/package/pack'), 'pre'));
+
+  command
+    .command('postpack')
+    .description('Restores the changes made by the prepack command')
+    .action(lazy(() => import('./commands/package/pack'), 'post'));
+}
+
+export function registerRepoCommands(command: Command) {
+  command
+    .command('fix')
+    .description('Automatically fix packages in the project')
+    .option(
+      '--publish',
+      'Enable additional fixes that only apply when publishing packages',
+    )
+    .option(
+      '--check',
+      'Fail if any packages would have been changed by the command',
+    )
+    .action(lazy(() => import('./commands/repo/fix'), 'command'));
+
+  command
+    .command('clean')
+    .description('Delete cache and output directories')
+    .action(lazy(() => import('./commands/repo/clean'), 'command'));
+
+  command
+    .command('list-deprecations')
+    .description('List deprecations')
+    .option('--json', 'Output as JSON')
+    .action(lazy(() => import('./commands/repo/list-deprecations'), 'command'));
+}

--- a/packages/cli/src/modules/migrate/commands/packageExports.ts
+++ b/packages/cli/src/modules/migrate/commands/packageExports.ts
@@ -18,7 +18,7 @@ import {
   fixPackageExports,
   readFixablePackages,
   writeFixedPackages,
-} from '../../../commands/repo/fix';
+} from '../../maintenance/commands/repo/fix';
 
 export async function command() {
   console.log(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

One of the last modularization pieces. This one shows a few signs of commands not being in quite the right place as we have cross module imports starting to appear. For packing for example, that could either be a build or maintenance task, and I could see arguments for either way. My goal with this PR is to do the initial migration, moving the commands around afterwards should be straightforward.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
