### PR TITLE
docs(techdocs): update how-to-guide for non-root paths

### DIFF
--- a/docs/features/techdocs/how-to-guides.md
+++ b/docs/features/techdocs/how-to-guides.md
@@ -92,10 +92,11 @@ the source code hosting provider. Notice that instead of the `dir:` prefix, the
 
 Note, just as it's possible to specify a subdirectory with the `dir:` prefix,
 you can also provide a path to a non-root directory inside the repository which
-contains the `mkdocs.yml` file and `docs/` directory.
+contains the `mkdocs.yml` file and `docs/` directory. It is important that it is
+suffixed with a '/' in order for relative path resolution to work consistently.
 
 e.g.
-`url:https://github.com/backstage/backstage/tree/master/plugins/techdocs-backend/examples/documented-component`
+`url:https://github.com/backstage/backstage/tree/master/plugins/techdocs-backend/examples/documented-component/`
 
 ### Why is URL Reader faster than a git clone?
 


### PR DESCRIPTION
This PR updates the Techdocs how-to-guide with an explanation about mandatory suffix for non-root paths. The current documentation for annotation values (https://backstage.io/docs/features/techdocs/how-to-guides/#how-to-understand-techdocs-ref-annotation-values) does not specify using a mandatory trailing slash suffix for url paths that are non-root. Following this documentation can cause confusion for some users. 
A detailed documentation for source location annotation includes the trailing slash suffix (https://backstage.io/docs/features/software-catalog/well-known-annotations/#backstageiosource-location) so this change alligns the annotation value documentation with the more detailed one. 

Although a minor change this might help some first time/initial users.
Relatively relevant bug/issue encountered due to following only the annotation values documentation: https://github.com/backstage/backstage/issues/28814

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
