### PR TITLE
core-plugin-api: avoid using BootErrorPage

### DIFF
--- a/.changeset/brown-dots-shake.md
+++ b/.changeset/brown-dots-shake.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-plugin-api': patch
+---
+
+Failure to lazy load an extension will now always result in an error being thrown to be forwarded to error boundaries, rather than being rendered using the `BootErrorPage` app component.

--- a/packages/core-plugin-api/src/extensions/extensions.tsx
+++ b/packages/core-plugin-api/src/extensions/extensions.tsx
@@ -22,6 +22,7 @@ import { attachComponentData } from './componentData';
 import { Extension, BackstagePlugin } from '../plugin';
 import { PluginErrorBoundary } from './PluginErrorBoundary';
 import { routableExtensionRenderedEvent } from '../analytics/Tracker';
+import { ForwardedError } from '@backstage/errors';
 
 /**
  * Lazy or synchronous retrieving of extension components.
@@ -79,62 +80,51 @@ export function createRoutableExtension<
   return createReactExtension({
     component: {
       lazy: () =>
-        component().then(
-          InnerComponent => {
-            const RoutableExtensionWrapper: any = (props: any) => {
-              const analytics = useAnalytics();
+        component().then(InnerComponent => {
+          const RoutableExtensionWrapper: any = (props: any) => {
+            const analytics = useAnalytics();
 
-              // Validate that the routing is wired up correctly in the App.tsx
-              try {
-                useRouteRef(mountPoint);
-              } catch (error) {
-                if (typeof error === 'object' && error !== null) {
-                  const { message } = error as { message?: unknown };
-                  if (
-                    typeof message === 'string' &&
-                    message.startsWith('No path for ')
-                  ) {
-                    throw new Error(
-                      `Routable extension component with mount point ${mountPoint} was not discovered in the app element tree. ` +
-                        'Routable extension components may not be rendered by other components and must be ' +
-                        'directly available as an element within the App provider component.',
-                    );
-                  }
+            // Validate that the routing is wired up correctly in the App.tsx
+            try {
+              useRouteRef(mountPoint);
+            } catch (error) {
+              if (typeof error === 'object' && error !== null) {
+                const { message } = error as { message?: unknown };
+                if (
+                  typeof message === 'string' &&
+                  message.startsWith('No path for ')
+                ) {
+                  throw new Error(
+                    `Routable extension component with mount point ${mountPoint} was not discovered in the app element tree. ` +
+                      'Routable extension components may not be rendered by other components and must be ' +
+                      'directly available as an element within the App provider component.',
+                  );
                 }
-                throw error;
               }
+              throw error;
+            }
 
-              // This event, never exposed to end-users of the analytics API,
-              // helps inform which extension metadata gets associated with a
-              // navigation event when the route navigated to is a gathered
-              // mountpoint.
-              useEffect(() => {
-                analytics.captureEvent(routableExtensionRenderedEvent, '');
-              }, [analytics]);
+            // This event, never exposed to end-users of the analytics API,
+            // helps inform which extension metadata gets associated with a
+            // navigation event when the route navigated to is a gathered
+            // mountpoint.
+            useEffect(() => {
+              analytics.captureEvent(routableExtensionRenderedEvent, '');
+            }, [analytics]);
 
-              return <InnerComponent {...props} />;
-            };
+            return <InnerComponent {...props} />;
+          };
 
-            const componentName =
-              name ||
-              (InnerComponent as { displayName?: string }).displayName ||
-              InnerComponent.name ||
-              'LazyComponent';
+          const componentName =
+            name ||
+            (InnerComponent as { displayName?: string }).displayName ||
+            InnerComponent.name ||
+            'LazyComponent';
 
-            RoutableExtensionWrapper.displayName = `RoutableExtension(${componentName})`;
+          RoutableExtensionWrapper.displayName = `RoutableExtension(${componentName})`;
 
-            return RoutableExtensionWrapper as T;
-          },
-          error => {
-            const RoutableExtensionWrapper: any = (_: any) => {
-              const app = useApp();
-              const { BootErrorPage } = app.getComponents();
-
-              return <BootErrorPage step="load-chunk" error={error} />;
-            };
-            return RoutableExtensionWrapper;
-          },
-        ),
+          return RoutableExtensionWrapper as T;
+        }),
     },
     data: {
       'core.mountPoint': mountPoint,
@@ -225,7 +215,16 @@ export function createReactExtension<
   if ('lazy' in options.component) {
     const lazyLoader = options.component.lazy;
     Component = lazy(() =>
-      lazyLoader().then(component => ({ default: component })),
+      lazyLoader().then(
+        component => ({ default: component }),
+        error => {
+          const ofExtension = name ? ` of the ${name} extension` : '';
+          throw new ForwardedError(
+            `Failed lazy loading${ofExtension}, try to reload the page`,
+            error,
+          );
+        },
+      ),
     ) as unknown as T;
   } else {
     Component = options.component.sync;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This avoids using the `BootErrorPage`, which tbh I don't know why we needed here in the first place 😁. It now just wraps the error up with a bit of extra context and sends it to the closest error boundary for rendering instead.

The reason for this change is that the new frontend system doesn't expect or support plugins using the `BootErrorPage`, which they are currently doing indirectly with this logic.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
