### PR TITLE
Canon: Build a single css output

### DIFF
--- a/canon-docs/src/app/(docs)/page.mdx
+++ b/canon-docs/src/app/(docs)/page.mdx
@@ -24,8 +24,7 @@ Install Canon using a package manager.
 Import the global CSS file at the root of your application.
 
 ```tsx
-import '@backstage/canon/css/core.css';
-import '@backstage/canon/css/components.css';
+import '@backstage/canon/css/styles.css';
 ```
 
 ### 3. Start building ✨

--- a/packages/canon/.gitignore
+++ b/packages/canon/.gitignore
@@ -2,4 +2,4 @@
 storybook-static
 
 # CSS output
-css
+/css

--- a/packages/canon/.storybook/preview.tsx
+++ b/packages/canon/.storybook/preview.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import type { Preview, ReactRenderer } from '@storybook/react';
 import { withThemeByDataAttribute } from '@storybook/addon-themes';
-
-// Canon specific styles
-import '../src/css/core.css';
-import '../src/css/components.css';
+import '../src/css/styles.css';
 
 const preview: Preview = {
   parameters: {

--- a/packages/canon/scripts/build-css.mjs
+++ b/packages/canon/scripts/build-css.mjs
@@ -31,6 +31,7 @@ const componentsDir = 'src/components';
 const cssFiles = [
   { path: `${cssDir}/core.css`, newName: 'core.css' },
   { path: `${cssDir}/components.css`, newName: 'components.css' },
+  { path: `${cssDir}/styles.css`, newName: 'styles.css' },
 ];
 
 // Components files

--- a/packages/canon/src/css/styles.css
+++ b/packages/canon/src/css/styles.css
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import './core.css';
+@import './components.css';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

To simplify the installation we are providing a single `styles.css` file that you can add to your Backstage instance to install Canon. You can still use `core.css and `components.css` separately if you want to.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
