### PR TITLE
Remove backend-common from permission-node

### DIFF
--- a/.changeset/first-purple-bykors.md
+++ b/.changeset/first-purple-bykors.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-permission-node': minor
+---
+
+**BREAKING** The `ServerPermissionClient` can no longer be instantiated with a `tokenManager` and must instead be instantiated with an `auth` service. If you are still on the legacy backend system, use `createLegacyAuthAdapters()` from `@backstage/backend-common` to create a compatible `auth` service.

--- a/plugins/permission-node/package.json
+++ b/plugins/permission-node/package.json
@@ -56,7 +56,6 @@
     "test": "backstage-cli package test"
   },
   "dependencies": {
-    "@backstage/backend-common": "^0.25.0",
     "@backstage/backend-plugin-api": "workspace:^",
     "@backstage/config": "workspace:^",
     "@backstage/errors": "workspace:^",

--- a/plugins/permission-node/report.api.md
+++ b/plugins/permission-node/report.api.md
@@ -29,7 +29,6 @@ import { PermissionsServiceRequestOptions } from '@backstage/backend-plugin-api'
 import { PolicyDecision } from '@backstage/plugin-permission-common';
 import { QueryPermissionRequest } from '@backstage/plugin-permission-common';
 import { ResourcePermission } from '@backstage/plugin-permission-common';
-import { TokenManager } from '@backstage/backend-common';
 import { z } from 'zod';
 
 // @public
@@ -385,8 +384,7 @@ export class ServerPermissionClient implements PermissionsService {
     config: Config,
     options: {
       discovery: DiscoveryService;
-      tokenManager?: TokenManager;
-      auth?: AuthService;
+      auth: AuthService;
     },
   ): ServerPermissionClient;
 }

--- a/plugins/permission-node/src/ServerPermissionClient.ts
+++ b/plugins/permission-node/src/ServerPermissionClient.ts
@@ -15,10 +15,6 @@
  */
 
 import {
-  TokenManager,
-  createLegacyAuthAdapters,
-} from '@backstage/backend-common';
-import {
   AuthService,
   BackstageCredentials,
   BackstageServicePrincipal,
@@ -53,27 +49,13 @@ export class ServerPermissionClient implements PermissionsService {
     config: Config,
     options: {
       discovery: DiscoveryService;
-      /** @deprecated This option will be removed in the future, provide a the auth option instead */
-      tokenManager?: TokenManager;
-      auth?: AuthService;
+      auth: AuthService;
     },
   ) {
-    const { discovery, tokenManager } = options;
+    const { auth, discovery } = options;
     const permissionClient = new PermissionClient({ discovery, config });
     const permissionEnabled =
       config.getOptionalBoolean('permission.enabled') ?? false;
-
-    if (
-      permissionEnabled &&
-      tokenManager &&
-      (tokenManager as any).isInsecureServerTokenManager
-    ) {
-      throw new Error(
-        'Service-to-service authentication must be configured before enabling permissions. Read more here https://backstage.io/docs/auth/service-to-service-auth',
-      );
-    }
-
-    const { auth } = createLegacyAuthAdapters(options);
 
     return new ServerPermissionClient({
       auth,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7396,7 +7396,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@backstage/plugin-permission-node@workspace:plugins/permission-node"
   dependencies:
-    "@backstage/backend-common": ^0.25.0
     "@backstage/backend-defaults": "workspace:^"
     "@backstage/backend-plugin-api": "workspace:^"
     "@backstage/backend-test-utils": "workspace:^"


### PR DESCRIPTION
## What / Why

I regularly see vulnerabilities in Backstage backend services due to `@backstage/plugin-permission-node`'s dependence on `@backstage/backend-common`, which eventually brings in the offending deps.

Perhaps it's time to remove legacy backend support for the permission framework?  If not in this release, the next release.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
