### PR TITLE
Scaffolder task granular permissions

### DIFF
--- a/.changeset/weak-bags-behave.md
+++ b/.changeset/weak-bags-behave.md
@@ -1,0 +1,11 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+'@backstage/plugin-scaffolder-common': minor
+'@backstage/plugin-scaffolder-react': minor
+'@backstage/plugin-scaffolder-node': minor
+'@backstage/plugin-scaffolder': minor
+---
+
+BREAKING : Added two new scaffolder rules for `scaffolder.task.read` and `scaffolder.task.cancel` to allow for conditional permission policies such as restricting access to tasks and task events based on creators (`hasCreatedBy`) and granting template owners visibility into all runs of their templates (`hasTemplateEntityRefs`).
+
+BREAKING: Removed requirement to have both `scaffolder.task.read` and `scaffolder.task.cancel` permissions to cancel tasks.

--- a/plugins/scaffolder-backend/report-alpha.api.md
+++ b/plugins/scaffolder-backend/report-alpha.api.md
@@ -11,6 +11,8 @@ import { PermissionCondition } from '@backstage/plugin-permission-common';
 import { PermissionCriteria } from '@backstage/plugin-permission-common';
 import { PermissionRule } from '@backstage/plugin-permission-node';
 import { ResourcePermission } from '@backstage/plugin-permission-common';
+import { SerializedTask } from '@backstage/plugin-scaffolder-node';
+import { TaskFilter } from '@backstage/plugin-scaffolder-node';
 import { TemplateEntityStepV1beta3 } from '@backstage/plugin-scaffolder-common';
 import { TemplateParametersV1beta3 } from '@backstage/plugin-scaffolder-common';
 
@@ -18,6 +20,12 @@ import { TemplateParametersV1beta3 } from '@backstage/plugin-scaffolder-common';
 export const createScaffolderActionConditionalDecision: (
   permission: ResourcePermission<'scaffolder-action'>,
   conditions: PermissionCriteria<PermissionCondition<'scaffolder-action'>>,
+) => ConditionalPolicyDecision;
+
+// @alpha (undocumented)
+export const createScaffolderTaskConditionalDecision: (
+  permission: ResourcePermission<'scaffolder-task'>,
+  conditions: PermissionCriteria<PermissionCondition<'scaffolder-task'>>,
 ) => ConditionalPolicyDecision;
 
 // @alpha
@@ -77,6 +85,32 @@ export const scaffolderActionConditions: Conditions<{
     {
       key: string;
       value?: string | undefined;
+    }
+  >;
+}>;
+
+// @alpha
+export const scaffolderTaskConditions: Conditions<{
+  hasCreatedBy: PermissionRule<
+    SerializedTask,
+    {
+      property: TaskFilter['property'];
+      values: any;
+    },
+    'scaffolder-task',
+    {
+      createdBy: string[];
+    }
+  >;
+  hasTemplateEntityRefs: PermissionRule<
+    SerializedTask,
+    {
+      property: TaskFilter['property'];
+      values: any;
+    },
+    'scaffolder-task',
+    {
+      templateEntityRefs: string[];
     }
   >;
 }>;

--- a/plugins/scaffolder-backend/report.api.md
+++ b/plugins/scaffolder-backend/report.api.md
@@ -47,11 +47,13 @@ import { JsonValue } from '@backstage/types';
 import { Knex } from 'knex';
 import { LifecycleService } from '@backstage/backend-plugin-api';
 import { Logger } from 'winston';
+import { PermissionCriteria } from '@backstage/plugin-permission-common';
 import { PermissionEvaluator } from '@backstage/plugin-permission-common';
 import { PermissionRule } from '@backstage/plugin-permission-node';
 import { PermissionRuleParams } from '@backstage/plugin-permission-common';
 import { PermissionsService } from '@backstage/backend-plugin-api';
 import { RESOURCE_TYPE_SCAFFOLDER_ACTION } from '@backstage/plugin-scaffolder-common/alpha';
+import { RESOURCE_TYPE_SCAFFOLDER_TASK } from '@backstage/plugin-scaffolder-common/alpha';
 import { RESOURCE_TYPE_SCAFFOLDER_TEMPLATE } from '@backstage/plugin-scaffolder-common/alpha';
 import { ScaffolderEntitiesProcessor as ScaffolderEntitiesProcessor_2 } from '@backstage/plugin-catalog-backend-module-scaffolder-entity-model';
 import { SchedulerService } from '@backstage/backend-plugin-api';
@@ -65,6 +67,8 @@ import { TaskBrokerDispatchResult as TaskBrokerDispatchResult_2 } from '@backsta
 import { TaskCompletionState as TaskCompletionState_2 } from '@backstage/plugin-scaffolder-node';
 import { TaskContext as TaskContext_2 } from '@backstage/plugin-scaffolder-node';
 import { TaskEventType as TaskEventType_2 } from '@backstage/plugin-scaffolder-node';
+import { TaskFilter } from '@backstage/plugin-scaffolder-node';
+import { TaskFilters } from '@backstage/plugin-scaffolder-node';
 import { TaskRecovery } from '@backstage/plugin-scaffolder-common';
 import { TaskSecrets as TaskSecrets_2 } from '@backstage/plugin-scaffolder-node';
 import { TaskSpec } from '@backstage/plugin-scaffolder-common';
@@ -476,6 +480,7 @@ export class DatabaseTaskStore implements TaskStore {
       order: 'asc' | 'desc';
       field: string;
     }[];
+    permissionFilters?: PermissionCriteria<TaskFilters>;
   }): Promise<{
     tasks: SerializedTask_2[];
     totalTasks?: number;
@@ -562,9 +567,7 @@ export interface RouterOptions {
   // (undocumented)
   logger: Logger;
   // (undocumented)
-  permissionRules?: Array<
-    TemplatePermissionRuleInput | ActionPermissionRuleInput
-  >;
+  permissionRules?: Array<ScaffolderPermissionRuleInput>;
   // (undocumented)
   permissions?: PermissionsService;
   // (undocumented)
@@ -582,6 +585,12 @@ export type RunCommandOptions = ExecuteShellCommandOptions;
 
 // @public @deprecated
 export const ScaffolderEntitiesProcessor: typeof ScaffolderEntitiesProcessor_2;
+
+// @public (undocumented)
+export type ScaffolderPermissionRuleInput =
+  | TemplatePermissionRuleInput
+  | ActionPermissionRuleInput
+  | TaskPermissionRuleInput;
 
 // @public
 const scaffolderPlugin: BackendFeature;
@@ -672,6 +681,19 @@ export class TaskManager implements TaskContext_2 {
         },
   ): Promise<void>;
 }
+
+// @public (undocumented)
+export type TaskPermissionRuleInput<
+  TParams extends PermissionRuleParams = PermissionRuleParams,
+> = PermissionRule<
+  SerializedTask_2,
+  {
+    property: TaskFilter['property'];
+    values: any;
+  },
+  typeof RESOURCE_TYPE_SCAFFOLDER_TASK,
+  TParams
+>;
 
 // @public @deprecated (undocumented)
 export type TaskSecrets = TaskSecrets_2;

--- a/plugins/scaffolder-backend/src/service/conditionExports.ts
+++ b/plugins/scaffolder-backend/src/service/conditionExports.ts
@@ -17,9 +17,14 @@
 import {
   RESOURCE_TYPE_SCAFFOLDER_TEMPLATE,
   RESOURCE_TYPE_SCAFFOLDER_ACTION,
+  RESOURCE_TYPE_SCAFFOLDER_TASK,
 } from '@backstage/plugin-scaffolder-common/alpha';
 import { createConditionExports } from '@backstage/plugin-permission-node';
-import { scaffolderTemplateRules, scaffolderActionRules } from './rules';
+import {
+  scaffolderTemplateRules,
+  scaffolderActionRules,
+  scaffolderTaskRules,
+} from './rules';
 
 const templateConditionExports = createConditionExports({
   pluginId: 'scaffolder',
@@ -31,6 +36,12 @@ const actionsConditionExports = createConditionExports({
   pluginId: 'scaffolder',
   resourceType: RESOURCE_TYPE_SCAFFOLDER_ACTION,
   rules: scaffolderActionRules,
+});
+
+const taskConditionExports = createConditionExports({
+  pluginId: 'scaffolder',
+  resourceType: RESOURCE_TYPE_SCAFFOLDER_TASK,
+  rules: scaffolderTaskRules,
 });
 
 /**
@@ -90,3 +101,17 @@ export const createScaffolderActionConditionalDecision =
  * @alpha
  */
 export const scaffolderActionConditions = actionsConditionExports.conditions;
+
+/**
+ * @alpha
+ */
+export const createScaffolderTaskConditionalDecision =
+  taskConditionExports.createConditionalDecision;
+
+/**
+ * These conditions are used when creating conditional decisions for scaffolder
+ * tasks that are returned by authorization policies.
+ *
+ * @alpha
+ */
+export const scaffolderTaskConditions = taskConditionExports.conditions;

--- a/plugins/scaffolder-backend/src/service/router.test.ts
+++ b/plugins/scaffolder-backend/src/service/router.test.ts
@@ -468,6 +468,32 @@ describe('createRouter', () => {
           order: [{ order: 'desc', field: 'created_at' }],
         });
       });
+      it('disallows users from seeing tasks they do not own', async () => {
+        jest
+          .spyOn(permissionApi, 'authorizeConditional')
+          .mockImplementationOnce(async () => [
+            {
+              conditions: {
+                resourceType: 'scaffolder-task',
+                rule: 'HAS_CREATED_BY',
+                params: { createdBy: ['user'] },
+              },
+              pluginId: 'scaffolder',
+              resourceType: 'scaffolder-task',
+              result: AuthorizeResult.CONDITIONAL,
+            },
+          ]);
+        const response = await request(app).get(`/v2/tasks?createdBy=not-user`);
+        expect(taskBroker.list).toHaveBeenCalledWith({
+          filters: { createdBy: ['not-user'], status: undefined },
+          order: undefined,
+          pagination: { limit: undefined, offset: undefined },
+          permissionFilters: { property: 'createdBy', values: ['user'] },
+        });
+        expect(response.status).toBe(200);
+        expect(response.body.totalTasks).toBe(0);
+        expect(response.body.tasks).toEqual([]);
+      });
     });
 
     describe('GET /v2/tasks/:taskId', () => {
@@ -489,10 +515,89 @@ describe('createRouter', () => {
         expect(response.body.status).toBe('completed');
         expect(response.body.secrets).toBeUndefined();
       });
+      it('disallows users from seeing tasks they do not own', async () => {
+        jest
+          .spyOn(permissionApi, 'authorizeConditional')
+          .mockImplementationOnce(async () => [
+            {
+              conditions: {
+                resourceType: 'scaffolder-task',
+                rule: 'HAS_CREATED_BY',
+                params: { createdBy: ['user'] },
+              },
+              pluginId: 'scaffolder',
+              resourceType: 'scaffolder-task',
+              result: AuthorizeResult.CONDITIONAL,
+            },
+          ]);
+        (taskBroker.get as jest.Mocked<TaskBroker>['get']).mockResolvedValue({
+          id: 'a-random-id',
+          spec: {} as any,
+          status: 'completed',
+          createdAt: '',
+          secrets: {
+            backstageToken: token,
+            __initiatorCredentials: JSON.stringify(credentials),
+          },
+          createdBy: 'not-user',
+        });
+
+        const response = await request(app).get(`/v2/tasks/a-random-id`);
+        expect(taskBroker.get).toHaveBeenCalledWith('a-random-id');
+        expect(response.error).not.toBeFalsy();
+      });
+      it('disallows users from seeing runs of templates they do not own', async () => {
+        jest
+          .spyOn(permissionApi, 'authorizeConditional')
+          .mockImplementationOnce(async () => [
+            {
+              conditions: {
+                resourceType: 'scaffolder-task',
+                rule: 'HAS_TEMPLATE_ENTITY_REFS',
+                params: {
+                  templateEntityRefs: [
+                    'template:deafult/foo',
+                    'template:default/bar',
+                  ],
+                },
+              },
+              pluginId: 'scaffolder',
+              resourceType: 'scaffolder-task',
+              result: AuthorizeResult.CONDITIONAL,
+            },
+          ]);
+        (taskBroker.get as jest.Mocked<TaskBroker>['get']).mockResolvedValue({
+          id: 'a-random-id',
+          spec: {
+            templateInfo: { entityRef: 'template:default/not-foobar' },
+          } as any,
+          status: 'completed',
+          createdAt: '',
+          secrets: {
+            backstageToken: token,
+            __initiatorCredentials: JSON.stringify(credentials),
+          },
+        });
+
+        const response = await request(app).get(`/v2/tasks/a-random-id`);
+        expect(taskBroker.get).toHaveBeenCalledWith('a-random-id');
+        expect(response.error).not.toBeFalsy();
+      });
     });
 
     describe('GET /v2/tasks/:taskId/eventstream', () => {
       it('should return log messages', async () => {
+        (taskBroker.get as jest.Mocked<TaskBroker>['get']).mockResolvedValue({
+          id: 'a-random-id',
+          spec: {} as any,
+          status: 'completed',
+          createdAt: '',
+          secrets: {
+            backstageToken: token,
+            __initiatorCredentials: JSON.stringify(credentials),
+          },
+          createdBy: '',
+        });
         let subscriber: ZenObservable.SubscriptionObserver<any>;
         (
           taskBroker.event$ as jest.Mocked<TaskBroker>['event$']
@@ -572,6 +677,17 @@ data: {"id":1,"taskId":"a-random-id","type":"completion","createdAt":"","body":{
       });
 
       it('should return log messages with after query', async () => {
+        (taskBroker.get as jest.Mocked<TaskBroker>['get']).mockResolvedValue({
+          id: 'a-random-id',
+          spec: {} as any,
+          status: 'completed',
+          createdAt: '',
+          secrets: {
+            backstageToken: token,
+            __initiatorCredentials: JSON.stringify(credentials),
+          },
+          createdBy: '',
+        });
         let subscriber: ZenObservable.SubscriptionObserver<any>;
         (
           taskBroker.event$ as jest.Mocked<TaskBroker>['event$']
@@ -630,6 +746,17 @@ data: {"id":1,"taskId":"a-random-id","type":"completion","createdAt":"","body":{
 
     describe('GET /v2/tasks/:taskId/events', () => {
       it('should return log messages', async () => {
+        (taskBroker.get as jest.Mocked<TaskBroker>['get']).mockResolvedValue({
+          id: 'a-random-id',
+          spec: {} as any,
+          status: 'completed',
+          createdAt: '',
+          secrets: {
+            backstageToken: token,
+            __initiatorCredentials: JSON.stringify(credentials),
+          },
+          createdBy: '',
+        });
         let subscriber: ZenObservable.SubscriptionObserver<any>;
         (
           taskBroker.event$ as jest.Mocked<TaskBroker>['event$']
@@ -685,6 +812,17 @@ data: {"id":1,"taskId":"a-random-id","type":"completion","createdAt":"","body":{
       });
 
       it('should return log messages with after query', async () => {
+        (taskBroker.get as jest.Mocked<TaskBroker>['get']).mockResolvedValue({
+          id: 'a-random-id',
+          spec: {} as any,
+          status: 'completed',
+          createdAt: '',
+          secrets: {
+            backstageToken: token,
+            __initiatorCredentials: JSON.stringify(credentials),
+          },
+          createdBy: '',
+        });
         let subscriber: ZenObservable.SubscriptionObserver<any>;
         (
           taskBroker.event$ as jest.Mocked<TaskBroker>['event$']
@@ -708,6 +846,74 @@ data: {"id":1,"taskId":"a-random-id","type":"completion","createdAt":"","body":{
           after: 10,
         });
         expect(subscriber!.closed).toBe(true);
+      });
+      it('disallows users from seeing events for tasks they do not own', async () => {
+        jest
+          .spyOn(permissionApi, 'authorizeConditional')
+          .mockImplementationOnce(async () => [
+            {
+              conditions: {
+                resourceType: 'scaffolder-task',
+                rule: 'HAS_CREATED_BY',
+                params: { createdBy: ['user'] },
+              },
+              pluginId: 'scaffolder',
+              resourceType: 'scaffolder-task',
+              result: AuthorizeResult.CONDITIONAL,
+            },
+          ]);
+        (taskBroker.get as jest.Mocked<TaskBroker>['get']).mockResolvedValue({
+          id: 'a-random-id',
+          spec: {} as any,
+          status: 'completed',
+          createdAt: '',
+          secrets: {
+            backstageToken: token,
+            __initiatorCredentials: JSON.stringify(credentials),
+          },
+          createdBy: 'not-user',
+        });
+
+        const response = await request(app).get(`/v2/tasks/a-random-id/events`);
+        expect(taskBroker.get).toHaveBeenCalledWith('a-random-id');
+        expect(response.error).not.toBeFalsy();
+      });
+      it('disallows users from seeing runs of templates they do not own', async () => {
+        jest
+          .spyOn(permissionApi, 'authorizeConditional')
+          .mockImplementationOnce(async () => [
+            {
+              conditions: {
+                resourceType: 'scaffolder-task',
+                rule: 'HAS_TEMPLATE_ENTITY_REFS',
+                params: {
+                  templateEntityRefs: [
+                    'template:deafult/foo',
+                    'template:default/bar',
+                  ],
+                },
+              },
+              pluginId: 'scaffolder',
+              resourceType: 'scaffolder-task',
+              result: AuthorizeResult.CONDITIONAL,
+            },
+          ]);
+        (taskBroker.get as jest.Mocked<TaskBroker>['get']).mockResolvedValue({
+          id: 'a-random-id',
+          spec: {
+            templateInfo: { entityRef: 'template:default/not-foobar' },
+          } as any,
+          status: 'completed',
+          createdAt: '',
+          secrets: {
+            backstageToken: token,
+            __initiatorCredentials: JSON.stringify(credentials),
+          },
+        });
+
+        const response = await request(app).get(`/v2/tasks/a-random-id/events`);
+        expect(taskBroker.get).toHaveBeenCalledWith('a-random-id');
+        expect(response.error).not.toBeFalsy();
       });
     });
 
@@ -1270,6 +1476,32 @@ data: {"id":1,"taskId":"a-random-id","type":"completion","createdAt":"","body":{
           totalTasks: 1,
         });
       });
+      it('disallows users from seeing tasks they do not own', async () => {
+        jest
+          .spyOn(permissionApi, 'authorizeConditional')
+          .mockImplementationOnce(async () => [
+            {
+              conditions: {
+                resourceType: 'scaffolder-task',
+                rule: 'HAS_CREATED_BY',
+                params: { createdBy: ['user'] },
+              },
+              pluginId: 'scaffolder',
+              resourceType: 'scaffolder-task',
+              result: AuthorizeResult.CONDITIONAL,
+            },
+          ]);
+        const response = await request(app).get(`/v2/tasks?createdBy=not-user`);
+        expect(taskBroker.list).toHaveBeenCalledWith({
+          filters: { createdBy: ['not-user'], status: undefined },
+          order: undefined,
+          pagination: { limit: undefined, offset: undefined },
+          permissionFilters: { property: 'createdBy', values: ['user'] },
+        });
+        expect(response.status).toBe(200);
+        expect(response.body.totalTasks).toBe(0);
+        expect(response.body.tasks).toEqual([]);
+      });
     });
 
     describe('GET /v2/tasks/:taskId', () => {
@@ -1291,10 +1523,89 @@ data: {"id":1,"taskId":"a-random-id","type":"completion","createdAt":"","body":{
         expect(response.body.status).toBe('completed');
         expect(response.body.secrets).toBeUndefined();
       });
+      it('disallows users from seeing tasks they do not own', async () => {
+        jest
+          .spyOn(permissionApi, 'authorizeConditional')
+          .mockImplementationOnce(async () => [
+            {
+              conditions: {
+                resourceType: 'scaffolder-task',
+                rule: 'HAS_CREATED_BY',
+                params: { createdBy: ['user'] },
+              },
+              pluginId: 'scaffolder',
+              resourceType: 'scaffolder-task',
+              result: AuthorizeResult.CONDITIONAL,
+            },
+          ]);
+        (taskBroker.get as jest.Mocked<TaskBroker>['get']).mockResolvedValue({
+          id: 'a-random-id',
+          spec: {} as any,
+          status: 'completed',
+          createdAt: '',
+          secrets: {
+            backstageToken: token,
+            __initiatorCredentials: JSON.stringify(credentials),
+          },
+          createdBy: 'not-user',
+        });
+
+        const response = await request(app).get(`/v2/tasks/a-random-id`);
+        expect(taskBroker.get).toHaveBeenCalledWith('a-random-id');
+        expect(response.error).not.toBeFalsy();
+      });
+      it('disallows users from seeing runs of templates they do not own', async () => {
+        jest
+          .spyOn(permissionApi, 'authorizeConditional')
+          .mockImplementationOnce(async () => [
+            {
+              conditions: {
+                resourceType: 'scaffolder-task',
+                rule: 'HAS_TEMPLATE_ENTITY_REFS',
+                params: {
+                  templateEntityRefs: [
+                    'template:deafult/foo',
+                    'template:default/bar',
+                  ],
+                },
+              },
+              pluginId: 'scaffolder',
+              resourceType: 'scaffolder-task',
+              result: AuthorizeResult.CONDITIONAL,
+            },
+          ]);
+        (taskBroker.get as jest.Mocked<TaskBroker>['get']).mockResolvedValue({
+          id: 'a-random-id',
+          spec: {
+            templateInfo: { entityRef: 'template:default/not-foobar' },
+          } as any,
+          status: 'completed',
+          createdAt: '',
+          secrets: {
+            backstageToken: token,
+            __initiatorCredentials: JSON.stringify(credentials),
+          },
+        });
+
+        const response = await request(app).get(`/v2/tasks/a-random-id`);
+        expect(taskBroker.get).toHaveBeenCalledWith('a-random-id');
+        expect(response.error).not.toBeFalsy();
+      });
     });
 
     describe('GET /v2/tasks/:taskId/eventstream', () => {
       it('should return log messages', async () => {
+        (taskBroker.get as jest.Mocked<TaskBroker>['get']).mockResolvedValue({
+          id: 'a-random-id',
+          spec: {} as any,
+          status: 'completed',
+          createdAt: '',
+          secrets: {
+            backstageToken: token,
+            __initiatorCredentials: JSON.stringify(credentials),
+          },
+          createdBy: '',
+        });
         let subscriber: ZenObservable.SubscriptionObserver<any>;
         (
           taskBroker.event$ as jest.Mocked<TaskBroker>['event$']
@@ -1374,6 +1685,17 @@ data: {"id":1,"taskId":"a-random-id","type":"completion","createdAt":"","body":{
       });
 
       it('should return log messages with after query', async () => {
+        (taskBroker.get as jest.Mocked<TaskBroker>['get']).mockResolvedValue({
+          id: 'a-random-id',
+          spec: {} as any,
+          status: 'completed',
+          createdAt: '',
+          secrets: {
+            backstageToken: token,
+            __initiatorCredentials: JSON.stringify(credentials),
+          },
+          createdBy: '',
+        });
         let subscriber: ZenObservable.SubscriptionObserver<any>;
         (
           taskBroker.event$ as jest.Mocked<TaskBroker>['event$']
@@ -1428,10 +1750,93 @@ data: {"id":1,"taskId":"a-random-id","type":"completion","createdAt":"","body":{
 
         expect(subscriber!.closed).toBe(true);
       });
+      it('disallows users from seeing events for tasks they do not own', async () => {
+        jest
+          .spyOn(permissionApi, 'authorizeConditional')
+          .mockImplementationOnce(async () => [
+            {
+              conditions: {
+                resourceType: 'scaffolder-task',
+                rule: 'HAS_CREATED_BY',
+                params: { createdBy: ['user'] },
+              },
+              pluginId: 'scaffolder',
+              resourceType: 'scaffolder-task',
+              result: AuthorizeResult.CONDITIONAL,
+            },
+          ]);
+        (taskBroker.get as jest.Mocked<TaskBroker>['get']).mockResolvedValue({
+          id: 'a-random-id',
+          spec: {} as any,
+          status: 'completed',
+          createdAt: '',
+          secrets: {
+            backstageToken: token,
+            __initiatorCredentials: JSON.stringify(credentials),
+          },
+          createdBy: 'not-user',
+        });
+
+        const response = await request(app).get(
+          `/v2/tasks/a-random-id/eventstream`,
+        );
+        expect(taskBroker.get).toHaveBeenCalledWith('a-random-id');
+        expect(response.error).not.toBeFalsy();
+      });
+      it('disallows users from seeing runs of templates they do not own', async () => {
+        jest
+          .spyOn(permissionApi, 'authorizeConditional')
+          .mockImplementationOnce(async () => [
+            {
+              conditions: {
+                resourceType: 'scaffolder-task',
+                rule: 'HAS_TEMPLATE_ENTITY_REFS',
+                params: {
+                  templateEntityRefs: [
+                    'template:deafult/foo',
+                    'template:default/bar',
+                  ],
+                },
+              },
+              pluginId: 'scaffolder',
+              resourceType: 'scaffolder-task',
+              result: AuthorizeResult.CONDITIONAL,
+            },
+          ]);
+        (taskBroker.get as jest.Mocked<TaskBroker>['get']).mockResolvedValue({
+          id: 'a-random-id',
+          spec: {
+            templateInfo: { entityRef: 'template:default/not-foobar' },
+          } as any,
+          status: 'completed',
+          createdAt: '',
+          secrets: {
+            backstageToken: token,
+            __initiatorCredentials: JSON.stringify(credentials),
+          },
+        });
+
+        const response = await request(app).get(
+          `/v2/tasks/a-random-id/eventstream`,
+        );
+        expect(taskBroker.get).toHaveBeenCalledWith('a-random-id');
+        expect(response.error).not.toBeFalsy();
+      });
     });
 
     describe('GET /v2/tasks/:taskId/events', () => {
       it('should return log messages', async () => {
+        (taskBroker.get as jest.Mocked<TaskBroker>['get']).mockResolvedValue({
+          id: 'a-random-id',
+          spec: {} as any,
+          status: 'completed',
+          createdAt: '',
+          secrets: {
+            backstageToken: token,
+            __initiatorCredentials: JSON.stringify(credentials),
+          },
+          createdBy: '',
+        });
         let subscriber: ZenObservable.SubscriptionObserver<any>;
         (
           taskBroker.event$ as jest.Mocked<TaskBroker>['event$']
@@ -1487,6 +1892,17 @@ data: {"id":1,"taskId":"a-random-id","type":"completion","createdAt":"","body":{
       });
 
       it('should return log messages with after query', async () => {
+        (taskBroker.get as jest.Mocked<TaskBroker>['get']).mockResolvedValue({
+          id: 'a-random-id',
+          spec: {} as any,
+          status: 'completed',
+          createdAt: '',
+          secrets: {
+            backstageToken: token,
+            __initiatorCredentials: JSON.stringify(credentials),
+          },
+          createdBy: '',
+        });
         let subscriber: ZenObservable.SubscriptionObserver<any>;
         (
           taskBroker.event$ as jest.Mocked<TaskBroker>['event$']
@@ -1510,6 +1926,74 @@ data: {"id":1,"taskId":"a-random-id","type":"completion","createdAt":"","body":{
           after: 10,
         });
         expect(subscriber!.closed).toBe(true);
+      });
+      it('disallows users from seeing events for tasks they do not own', async () => {
+        jest
+          .spyOn(permissionApi, 'authorizeConditional')
+          .mockImplementationOnce(async () => [
+            {
+              conditions: {
+                resourceType: 'scaffolder-task',
+                rule: 'HAS_CREATED_BY',
+                params: { createdBy: ['user'] },
+              },
+              pluginId: 'scaffolder',
+              resourceType: 'scaffolder-task',
+              result: AuthorizeResult.CONDITIONAL,
+            },
+          ]);
+        (taskBroker.get as jest.Mocked<TaskBroker>['get']).mockResolvedValue({
+          id: 'a-random-id',
+          spec: {} as any,
+          status: 'completed',
+          createdAt: '',
+          secrets: {
+            backstageToken: token,
+            __initiatorCredentials: JSON.stringify(credentials),
+          },
+          createdBy: 'not-user',
+        });
+
+        const response = await request(app).get(`/v2/tasks/a-random-id/events`);
+        expect(taskBroker.get).toHaveBeenCalledWith('a-random-id');
+        expect(response.error).not.toBeFalsy();
+      });
+      it('disallows users from seeing runs of templates they do not own', async () => {
+        jest
+          .spyOn(permissionApi, 'authorizeConditional')
+          .mockImplementationOnce(async () => [
+            {
+              conditions: {
+                resourceType: 'scaffolder-task',
+                rule: 'HAS_TEMPLATE_ENTITY_REFS',
+                params: {
+                  templateEntityRefs: [
+                    'template:deafult/foo',
+                    'template:default/bar',
+                  ],
+                },
+              },
+              pluginId: 'scaffolder',
+              resourceType: 'scaffolder-task',
+              result: AuthorizeResult.CONDITIONAL,
+            },
+          ]);
+        (taskBroker.get as jest.Mocked<TaskBroker>['get']).mockResolvedValue({
+          id: 'a-random-id',
+          spec: {
+            templateInfo: { entityRef: 'template:default/not-foobar' },
+          } as any,
+          status: 'completed',
+          createdAt: '',
+          secrets: {
+            backstageToken: token,
+            __initiatorCredentials: JSON.stringify(credentials),
+          },
+        });
+
+        const response = await request(app).get(`/v2/tasks/a-random-id/events`);
+        expect(taskBroker.get).toHaveBeenCalledWith('a-random-id');
+        expect(response.error).not.toBeFalsy();
       });
     });
 

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -49,6 +49,8 @@ import {
   createConditionAuthorizer,
   createPermissionIntegrationRouter,
   PermissionRule,
+  createConditionTransformer,
+  ConditionTransformer,
 } from '@backstage/plugin-permission-node';
 import {
   TaskSpec,
@@ -60,7 +62,9 @@ import {
 import {
   RESOURCE_TYPE_SCAFFOLDER_ACTION,
   RESOURCE_TYPE_SCAFFOLDER_TEMPLATE,
+  RESOURCE_TYPE_SCAFFOLDER_TASK,
   scaffolderActionPermissions,
+  scaffolderTaskPermissions,
   scaffolderPermissions,
   scaffolderTemplatePermissions,
   taskCancelPermission,
@@ -100,7 +104,11 @@ import {
 import { createDryRunner } from '../scaffolder/dryrun';
 import { StorageTaskBroker } from '../scaffolder/tasks/StorageTaskBroker';
 import { InternalTaskSecrets } from '../scaffolder/tasks/types';
-import { checkPermission } from '../util/checkPermissions';
+import {
+  checkPermission,
+  checkTaskPermission,
+  getAuthorizeConditions,
+} from '../util/checkPermissions';
 import {
   findTemplate,
   getEntityBaseUrl,
@@ -108,12 +116,30 @@ import {
   parseNumberParam,
   parseStringsParam,
 } from './helpers';
-import { scaffolderActionRules, scaffolderTemplateRules } from './rules';
 import { HostDiscovery } from '@backstage/backend-defaults/discovery';
 import {
   convertFiltersToRecord,
   convertGlobalsToRecord,
 } from '../util/templating';
+import {
+  scaffolderActionRules,
+  scaffolderTemplateRules,
+  scaffolderTaskRules,
+} from './rules';
+import {
+  SerializedTask,
+  TaskFilter,
+  TaskFilters,
+} from '@backstage/plugin-scaffolder-node';
+
+/**
+ *
+ * @public
+ */
+export type ScaffolderPermissionRuleInput =
+  | TemplatePermissionRuleInput
+  | ActionPermissionRuleInput
+  | TaskPermissionRuleInput;
 
 /**
  *
@@ -128,7 +154,7 @@ export type TemplatePermissionRuleInput<
   TParams
 >;
 function isTemplatePermissionRuleInput(
-  permissionRule: TemplatePermissionRuleInput | ActionPermissionRuleInput,
+  permissionRule: ScaffolderPermissionRuleInput,
 ): permissionRule is TemplatePermissionRuleInput {
   return permissionRule.resourceType === RESOURCE_TYPE_SCAFFOLDER_TEMPLATE;
 }
@@ -146,9 +172,26 @@ export type ActionPermissionRuleInput<
   TParams
 >;
 function isActionPermissionRuleInput(
-  permissionRule: TemplatePermissionRuleInput | ActionPermissionRuleInput,
+  permissionRule: ScaffolderPermissionRuleInput,
 ): permissionRule is ActionPermissionRuleInput {
   return permissionRule.resourceType === RESOURCE_TYPE_SCAFFOLDER_ACTION;
+}
+
+export type TaskPermissionRuleInput<
+  TParams extends PermissionRuleParams = PermissionRuleParams,
+> = PermissionRule<
+  SerializedTask,
+  {
+    property: TaskFilter['property'];
+    values: any;
+  },
+  typeof RESOURCE_TYPE_SCAFFOLDER_TASK,
+  TParams
+>;
+function isTaskPermissionRuleInput(
+  permissionRule: ScaffolderPermissionRuleInput,
+): permissionRule is TaskPermissionRuleInput {
+  return permissionRule.resourceType === RESOURCE_TYPE_SCAFFOLDER_TASK;
 }
 
 /**
@@ -185,9 +228,7 @@ export interface RouterOptions {
     | CreatedTemplateGlobal[];
   additionalWorkspaceProviders?: Record<string, WorkspaceProvider>;
   permissions?: PermissionsService;
-  permissionRules?: Array<
-    TemplatePermissionRuleInput | ActionPermissionRuleInput
-  >;
+  permissionRules?: Array<ScaffolderPermissionRuleInput>;
   auth?: AuthService;
   httpAuth?: HttpAuthService;
   identity?: IdentityApi;
@@ -445,15 +486,24 @@ export async function createRouter(
   const actionRules: ActionPermissionRuleInput[] = Object.values(
     scaffolderActionRules,
   );
+  const taskRules: TaskPermissionRuleInput[] =
+    Object.values(scaffolderTaskRules);
 
   if (permissionRules) {
     templateRules.push(
       ...permissionRules.filter(isTemplatePermissionRuleInput),
     );
     actionRules.push(...permissionRules.filter(isActionPermissionRuleInput));
+    taskRules.push(...permissionRules.filter(isTaskPermissionRuleInput));
   }
 
-  const isAuthorized = createConditionAuthorizer(Object.values(templateRules));
+  const isTemplateAuthorized = createConditionAuthorizer(
+    Object.values(templateRules),
+  );
+  const isTaskAuthorized = createConditionAuthorizer(Object.values(taskRules));
+
+  const taskTransformConditions: ConditionTransformer<TaskFilters> =
+    createConditionTransformer(Object.values(taskRules));
 
   const permissionIntegrationRouter = createPermissionIntegrationRouter({
     resources: [
@@ -466,6 +516,18 @@ export async function createRouter(
         resourceType: RESOURCE_TYPE_SCAFFOLDER_ACTION,
         permissions: scaffolderActionPermissions,
         rules: actionRules,
+      },
+      {
+        resourceType: RESOURCE_TYPE_SCAFFOLDER_TASK,
+        permissions: scaffolderTaskPermissions,
+        rules: taskRules,
+        getResources: async resourceRefs => {
+          return Promise.all(
+            resourceRefs.map(async taskId => {
+              return await taskBroker.get(taskId);
+            }),
+          );
+        },
       },
     ],
     permissions: scaffolderPermissions,
@@ -680,11 +742,6 @@ export async function createRouter(
 
       try {
         const credentials = await httpAuth.credentials(req);
-        await checkPermission({
-          credentials,
-          permissions: [taskReadPermission],
-          permissionService: permissions,
-        });
 
         if (!taskBroker.list) {
           throw new Error(
@@ -712,6 +769,13 @@ export async function createRouter(
         const limit = parseNumberParam(req.query.limit, 'limit');
         const offset = parseNumberParam(req.query.offset, 'offset');
 
+        const taskPermissionFilters = await getAuthorizeConditions({
+          credentials: credentials,
+          permission: taskReadPermission,
+          permissionService: permissions,
+          transformConditions: taskTransformConditions,
+        });
+
         const tasks = await taskBroker.list({
           filters: {
             createdBy,
@@ -722,6 +786,7 @@ export async function createRouter(
             limit: limit ? limit[0] : undefined,
             offset: offset ? offset[0] : undefined,
           },
+          permissionFilters: taskPermissionFilters,
         });
 
         await auditorEvent?.success();
@@ -746,13 +811,17 @@ export async function createRouter(
 
       try {
         const credentials = await httpAuth.credentials(req);
-        await checkPermission({
-          credentials,
-          permissions: [taskReadPermission],
-          permissionService: permissions,
-        });
 
         const task = await taskBroker.get(taskId);
+
+        await checkTaskPermission({
+          credentials,
+          permission: taskReadPermission,
+          permissionService: permissions,
+          task: task,
+          isTaskAuthorized,
+        });
+
         if (!task) {
           throw new NotFoundError(`Task with id ${taskId} does not exist`);
         }
@@ -782,11 +851,13 @@ export async function createRouter(
 
       try {
         const credentials = await httpAuth.credentials(req);
-        // Requires both read and cancel permissions
-        await checkPermission({
+        const task = await taskBroker.get(taskId);
+        await checkTaskPermission({
           credentials,
-          permissions: [taskCancelPermission, taskReadPermission],
+          permission: taskCancelPermission,
           permissionService: permissions,
+          task: task,
+          isTaskAuthorized,
         });
 
         await taskBroker.cancel?.(taskId);
@@ -814,11 +885,21 @@ export async function createRouter(
 
       try {
         const credentials = await httpAuth.credentials(req);
+        const task = await taskBroker.get(taskId);
+
         // Requires both read and cancel permissions
         await checkPermission({
           credentials,
-          permissions: [taskCreatePermission, taskReadPermission],
+          permissions: [taskCreatePermission],
           permissionService: permissions,
+        });
+
+        await checkTaskPermission({
+          credentials,
+          permission: taskReadPermission,
+          permissionService: permissions,
+          task: task,
+          isTaskAuthorized,
         });
 
         await auditorEvent?.success();
@@ -844,10 +925,14 @@ export async function createRouter(
 
       try {
         const credentials = await httpAuth.credentials(req);
-        await checkPermission({
+        const task = await taskBroker.get(taskId);
+
+        await checkTaskPermission({
           credentials,
-          permissions: [taskReadPermission],
+          permission: taskReadPermission,
           permissionService: permissions,
+          task: task,
+          isTaskAuthorized,
         });
 
         const after =
@@ -916,10 +1001,14 @@ export async function createRouter(
 
       try {
         const credentials = await httpAuth.credentials(req);
-        await checkPermission({
+        const task = await taskBroker.get(taskId);
+
+        await checkTaskPermission({
           credentials,
-          permissions: [taskReadPermission],
+          permission: taskReadPermission,
           permissionService: permissions,
+          task: task,
+          isTaskAuthorized,
         });
 
         const after = Number(req.query.after) || undefined;
@@ -1150,18 +1239,18 @@ export async function createRouter(
     // Authorize parameters
     if (Array.isArray(template.spec.parameters)) {
       template.spec.parameters = template.spec.parameters.filter(step =>
-        isAuthorized(parameterDecision, step),
+        isTemplateAuthorized(parameterDecision, step),
       );
     } else if (
       template.spec.parameters &&
-      !isAuthorized(parameterDecision, template.spec.parameters)
+      !isTemplateAuthorized(parameterDecision, template.spec.parameters)
     ) {
       template.spec.parameters = undefined;
     }
 
     // Authorize steps
     template.spec.steps = template.spec.steps.filter(step =>
-      isAuthorized(stepDecision, step),
+      isTemplateAuthorized(stepDecision, step),
     );
 
     return template;

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -177,6 +177,10 @@ function isActionPermissionRuleInput(
   return permissionRule.resourceType === RESOURCE_TYPE_SCAFFOLDER_ACTION;
 }
 
+/**
+ *
+ * @public
+ */
 export type TaskPermissionRuleInput<
   TParams extends PermissionRuleParams = PermissionRuleParams,
 > = PermissionRule<

--- a/plugins/scaffolder-backend/src/util/checkPermissions.ts
+++ b/plugins/scaffolder-backend/src/util/checkPermissions.ts
@@ -21,12 +21,36 @@ import { NotAllowedError } from '@backstage/errors';
 import {
   AuthorizeResult,
   BasicPermission,
+  PermissionCriteria,
+  PolicyDecision,
+  ResourcePermission,
 } from '@backstage/plugin-permission-common';
+import { ConditionTransformer } from '@backstage/plugin-permission-node';
+import { SerializedTask } from '@backstage/plugin-scaffolder-node';
+import { TaskFilters } from '@backstage/plugin-scaffolder-node';
 
 export type checkPermissionOptions = {
   credentials: BackstageCredentials;
   permissions: BasicPermission[];
   permissionService?: PermissionsService;
+};
+
+export type checkTaskPermissionOptions = {
+  credentials: BackstageCredentials;
+  permission: ResourcePermission;
+  permissionService?: PermissionsService;
+  task: SerializedTask;
+  isTaskAuthorized: (
+    decision: PolicyDecision,
+    resource: SerializedTask | undefined,
+  ) => boolean;
+};
+
+export type authorizeConditionsOptions = {
+  credentials: BackstageCredentials;
+  permission: ResourcePermission;
+  permissionService?: PermissionsService;
+  transformConditions: ConditionTransformer<TaskFilters>;
 };
 
 /**
@@ -51,3 +75,45 @@ export async function checkPermission(options: checkPermissionOptions) {
     }
   }
 }
+
+/**
+ * Does a conditional permission check for scaffolder task reading and cancellation.
+ * Throws 403 error if permission responds with AuthorizeResult.DENY, or does not resolve to true during the conditional rule check
+ * @public
+ */
+export async function checkTaskPermission(options: checkTaskPermissionOptions) {
+  const { permission, permissionService, credentials, task, isTaskAuthorized } =
+    options;
+  if (permissionService) {
+    const [taskDecision] = await permissionService.authorizeConditional(
+      [{ permission: permission }],
+      { credentials },
+    );
+    if (
+      taskDecision.result === AuthorizeResult.DENY ||
+      !isTaskAuthorized(taskDecision, task)
+    ) {
+      throw new NotAllowedError();
+    }
+  }
+}
+
+/** Fetches and transforms authorization conditions into filters, or returns `undefined` if the decision is not conditional.
+ * @public
+ */
+export const getAuthorizeConditions = async (
+  options: authorizeConditionsOptions,
+): Promise<PermissionCriteria<TaskFilters> | undefined> => {
+  const { permission, permissionService, credentials, transformConditions } =
+    options;
+  if (permissionService) {
+    const [taskDecision] = await permissionService.authorizeConditional(
+      [{ permission: permission }],
+      { credentials },
+    );
+    if (taskDecision.result === AuthorizeResult.CONDITIONAL) {
+      return transformConditions(taskDecision.conditions);
+    }
+  }
+  return undefined;
+};

--- a/plugins/scaffolder-common/report-alpha.api.md
+++ b/plugins/scaffolder-common/report-alpha.api.md
@@ -13,6 +13,9 @@ export const actionExecutePermission: ResourcePermission<'scaffolder-action'>;
 export const RESOURCE_TYPE_SCAFFOLDER_ACTION = 'scaffolder-action';
 
 // @alpha
+export const RESOURCE_TYPE_SCAFFOLDER_TASK = 'scaffolder-task';
+
+// @alpha
 export const RESOURCE_TYPE_SCAFFOLDER_TEMPLATE = 'scaffolder-template';
 
 // @alpha
@@ -23,22 +26,26 @@ export const scaffolderPermissions: (
   | BasicPermission
   | ResourcePermission<'scaffolder-action'>
   | ResourcePermission<'scaffolder-template'>
+  | ResourcePermission<'scaffolder-task'>
 )[];
 
 // @alpha
-export const scaffolderTaskPermissions: BasicPermission[];
+export const scaffolderTaskPermissions: (
+  | BasicPermission
+  | ResourcePermission<'scaffolder-task'>
+)[];
 
 // @alpha
 export const scaffolderTemplatePermissions: ResourcePermission<'scaffolder-template'>[];
 
 // @alpha
-export const taskCancelPermission: BasicPermission;
+export const taskCancelPermission: ResourcePermission<'scaffolder-task'>;
 
 // @alpha
 export const taskCreatePermission: BasicPermission;
 
 // @alpha
-export const taskReadPermission: BasicPermission;
+export const taskReadPermission: ResourcePermission<'scaffolder-task'>;
 
 // @alpha
 export const templateManagementPermission: BasicPermission;

--- a/plugins/scaffolder-common/src/permissions.ts
+++ b/plugins/scaffolder-common/src/permissions.ts
@@ -31,6 +31,13 @@ export const RESOURCE_TYPE_SCAFFOLDER_TEMPLATE = 'scaffolder-template';
 export const RESOURCE_TYPE_SCAFFOLDER_ACTION = 'scaffolder-action';
 
 /**
+ * Permission resource type which corresponds to scaffolder tasks
+ *
+ * @alpha
+ */
+export const RESOURCE_TYPE_SCAFFOLDER_TASK = 'scaffolder-task';
+
+/**
  * This permission is used to authorize actions that involve executing
  * an action from a template.
  *
@@ -89,6 +96,7 @@ export const taskReadPermission = createPermission({
   attributes: {
     action: 'read',
   },
+  resourceType: RESOURCE_TYPE_SCAFFOLDER_TASK,
 });
 
 /**
@@ -111,6 +119,7 @@ export const taskCreatePermission = createPermission({
 export const taskCancelPermission = createPermission({
   name: 'scaffolder.task.cancel',
   attributes: {},
+  resourceType: RESOURCE_TYPE_SCAFFOLDER_TASK,
 });
 
 /**

--- a/plugins/scaffolder-node/package.json
+++ b/plugins/scaffolder-node/package.json
@@ -58,6 +58,7 @@
     "@backstage/catalog-model": "workspace:^",
     "@backstage/errors": "workspace:^",
     "@backstage/integration": "workspace:^",
+    "@backstage/plugin-permission-common": "workspace:^",
     "@backstage/plugin-scaffolder-common": "workspace:^",
     "@backstage/types": "workspace:^",
     "@isomorphic-git/pgp-plugin": "^0.0.7",

--- a/plugins/scaffolder-node/report.api.md
+++ b/plugins/scaffolder-node/report.api.md
@@ -10,6 +10,7 @@ import { JsonValue } from '@backstage/types';
 import { Logger } from 'winston';
 import { LoggerService } from '@backstage/backend-plugin-api';
 import { Observable } from '@backstage/types';
+import { PermissionCriteria } from '@backstage/plugin-permission-common';
 import { Schema } from 'jsonschema';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import { ScmIntegrations } from '@backstage/integration';
@@ -402,6 +403,7 @@ export interface TaskBroker {
       order: 'asc' | 'desc';
       field: string;
     }[];
+    permissionFilters?: PermissionCriteria<TaskFilters>;
   }): Promise<{
     tasks: SerializedTask[];
     totalTasks?: number;
@@ -492,6 +494,25 @@ export interface TaskContext {
 
 // @public
 export type TaskEventType = 'completion' | 'log' | 'cancelled' | 'recovered';
+
+// @public
+export type TaskFilter = {
+  property: 'createdBy' | 'templateEntityRefs';
+  values: Array<string> | undefined;
+};
+
+// @public
+export type TaskFilters =
+  | {
+      anyOf: TaskFilter[];
+    }
+  | {
+      allOf: TaskFilter[];
+    }
+  | {
+      not: TaskFilter;
+    }
+  | TaskFilter;
 
 // @public
 export type TaskSecrets = Record<string, string> & {

--- a/plugins/scaffolder-node/src/tasks/index.ts
+++ b/plugins/scaffolder-node/src/tasks/index.ts
@@ -18,6 +18,8 @@ export type {
   TaskSecrets,
   SerializedTask,
   SerializedTaskEvent,
+  TaskFilter,
+  TaskFilters,
   TaskBroker,
   TaskBrokerDispatchOptions,
   TaskBrokerDispatchResult,

--- a/plugins/scaffolder-node/src/tasks/types.ts
+++ b/plugins/scaffolder-node/src/tasks/types.ts
@@ -15,6 +15,7 @@
  */
 
 import { BackstageCredentials } from '@backstage/backend-plugin-api';
+import { PermissionCriteria } from '@backstage/plugin-permission-common';
 import { TaskSpec } from '@backstage/plugin-scaffolder-common';
 import { JsonObject, JsonValue, Observable } from '@backstage/types';
 
@@ -103,6 +104,25 @@ export type TaskBrokerDispatchOptions = {
   secrets?: TaskSecrets;
   createdBy?: string;
 };
+
+/**
+ * TaskFilter
+ * @public
+ */
+export type TaskFilter = {
+  property: 'createdBy' | 'templateEntityRefs';
+  values: Array<string> | undefined;
+};
+
+/**
+ * TaskFilters
+ * @public
+ */
+export type TaskFilters =
+  | { anyOf: TaskFilter[] }
+  | { allOf: TaskFilter[] }
+  | { not: TaskFilter }
+  | TaskFilter;
 
 /**
  * Task
@@ -194,6 +214,7 @@ export interface TaskBroker {
       offset?: number;
     };
     order?: { order: 'asc' | 'desc'; field: string }[];
+    permissionFilters?: PermissionCriteria<TaskFilters>;
   }): Promise<{ tasks: SerializedTask[]; totalTasks?: number }>;
 
   /**

--- a/plugins/scaffolder-react/src/next/components/ScaffolderPageContextMenu/ScaffolderPageContextMenu.tsx
+++ b/plugins/scaffolder-react/src/next/components/ScaffolderPageContextMenu/ScaffolderPageContextMenu.tsx
@@ -29,7 +29,6 @@ import List from '@material-ui/icons/List';
 import MoreVert from '@material-ui/icons/MoreVert';
 import React, { useState } from 'react';
 import { usePermission } from '@backstage/plugin-permission-react';
-import { taskReadPermission } from '@backstage/plugin-scaffolder-common/alpha';
 import { templateManagementPermission } from '@backstage/plugin-scaffolder-common/alpha';
 
 import { scaffolderReactTranslationRef } from '../../../translation';
@@ -61,10 +60,6 @@ export function ScaffolderPageContextMenu(
     props;
   const classes = useStyles();
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement>();
-
-  const { allowed: canReadTasks } = usePermission({
-    permission: taskReadPermission,
-  });
 
   const { allowed: canManageTemplates } = usePermission({
     permission: templateManagementPermission,
@@ -142,7 +137,7 @@ export function ScaffolderPageContextMenu(
               />
             </MenuItem>
           )}
-          {onTasksClicked && canReadTasks && (
+          {onTasksClicked && (
             <MenuItem onClick={onTasksClicked}>
               <ListItemIcon>
                 <List fontSize="small" />

--- a/plugins/scaffolder/src/components/ListTasksPage/ListTasksPage.tsx
+++ b/plugins/scaffolder/src/components/ListTasksPage/ListTasksPage.tsx
@@ -86,14 +86,22 @@ const ListTaskPageContent = (props: MyTaskPageProps) => {
 
   if (error) {
     return (
-      <>
-        <ErrorPanel error={error} />
-        <EmptyState
-          missing="info"
-          title={t('listTaskPage.content.emptyState.title')}
-          description={t('listTaskPage.content.emptyState.description')}
-        />
-      </>
+      <CatalogFilterLayout>
+        <CatalogFilterLayout.Filters>
+          <OwnerListPicker
+            filter={ownerFilter}
+            onSelectOwner={id => setOwnerFilter(id)}
+          />
+        </CatalogFilterLayout.Filters>
+        <CatalogFilterLayout.Content>
+          <ErrorPanel error={error} />
+          <EmptyState
+            missing="info"
+            title={t('listTaskPage.content.emptyState.title')}
+            description={t('listTaskPage.content.emptyState.description')}
+          />
+        </CatalogFilterLayout.Content>
+      </CatalogFilterLayout>
     );
   }
 

--- a/plugins/scaffolder/src/components/OngoingTask/ContextMenu.tsx
+++ b/plugins/scaffolder/src/components/OngoingTask/ContextMenu.tsx
@@ -89,10 +89,12 @@ export const ContextMenu = (props: ContextMenuProps) => {
 
   const { allowed: canCancelTask } = usePermission({
     permission: taskCancelPermission,
+    resourceRef: taskId,
   });
 
   const { allowed: canReadTask } = usePermission({
     permission: taskReadPermission,
+    resourceRef: taskId,
   });
 
   const { allowed: canCreateTask } = usePermission({

--- a/plugins/scaffolder/src/components/OngoingTask/OngoingTask.tsx
+++ b/plugins/scaffolder/src/components/OngoingTask/OngoingTask.tsx
@@ -100,7 +100,6 @@ export const OngoingTask = (props: {
   const [logsVisible, setLogVisibleState] = useState(false);
   const [buttonBarVisible, setButtonBarVisibleState] = useState(true);
 
-  // Used dummy string value for `resourceRef` since `allowed` field will always return `false` if `resourceRef` is `undefined`
   const { allowed: canCancelTask } = usePermission({
     permission: taskCancelPermission,
     resourceRef: taskId,

--- a/plugins/scaffolder/src/components/Router/Router.tsx
+++ b/plugins/scaffolder/src/components/Router/Router.tsx
@@ -59,10 +59,7 @@ import {
   CustomFieldsPage,
 } from '../../alpha/components/TemplateEditorPage';
 import { RequirePermission } from '@backstage/plugin-permission-react';
-import {
-  taskReadPermission,
-  templateManagementPermission,
-} from '@backstage/plugin-scaffolder-common/alpha';
+import { templateManagementPermission } from '@backstage/plugin-scaffolder-common/alpha';
 import { useApp } from '@backstage/core-plugin-api';
 import { FormField, OpaqueFormField } from '@internal/scaffolder';
 import { useAsync, useMountEffect } from '@react-hookz/web';
@@ -180,11 +177,9 @@ export const InternalRouter = (
       <Route
         path={scaffolderTaskRouteRef.path}
         element={
-          <RequirePermission permission={taskReadPermission}>
-            <TaskPageComponent
-              TemplateOutputsComponent={TemplateOutputsComponent}
-            />
-          </RequirePermission>
+          <TaskPageComponent
+            TemplateOutputsComponent={TemplateOutputsComponent}
+          />
         }
       />
       <Route
@@ -228,11 +223,7 @@ export const InternalRouter = (
       />
       <Route
         path={scaffolderListTaskRouteRef.path}
-        element={
-          <RequirePermission permission={taskReadPermission}>
-            <ListTasksPage contextMenu={props.contextMenu} />
-          </RequirePermission>
-        }
+        element={<ListTasksPage contextMenu={props.contextMenu} />}
       />
       <Route
         path={editorRouteRef.path}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Converted the `scaffolder.task.read` and `scaffolder.task.cancel permissions` into resource permissions, and added the following rules:
`hasCreatedBy`: Restricts access to tasks based on task creators; this can be be used by conditional policies to restrict access to tasks to only their owners.
`hasTemplateEntityRefs`: Match tasks with the given template entity refs; this can be used by conditional policies to allow template owners to view all runs of their templates.

Related to: https://github.com/backstage/backstage/issues/27421

Example:
In this example, I have two templates, `template:default/message-logger` owned by `user:default/04kash` and `template:default/sleep-dummy` owned by `user:development/guest`. Both users have run each template once. This is what the task list looks like for each user:

user:default/04kash:

![Screenshot from 2025-03-12 18-22-30](https://github.com/user-attachments/assets/6cc578f7-5c26-4f5b-b514-a6d0109b2fa3)

user:development/guest:

![Screenshot from 2025-03-12 18-22-52](https://github.com/user-attachments/assets/7aea3543-e104-4a0a-96bf-4a4b16dcdc25)

Permission Policy used:
```ts
export class CustomPermissionPolicy implements PermissionPolicy {
  private readonly catalogClient: CatalogClient;

  constructor(catalogClient: CatalogClient) {
    this.catalogClient = catalogClient;
  }

  async getUserOwnedTemplates(userRef: string): Promise<string[]> {
    if (!userRef) return [];

    const response = await this.catalogClient.getEntities({
      filter: {
        kind: ['Template'],
        'relations.ownedBy': [userRef],
      },
    });

    return response.items.map(item => `${item.kind.toLocaleLowerCase()}:${item.metadata.namespace}/${item.metadata.name}`);
}

  async handle(
    request: PolicyQuery,
    user?: PolicyQueryUser,
  ): Promise<PolicyDecision> {
    if (isPermission(request.permission, taskReadPermission)) {
      const userOwnedTemplates = await this.getUserOwnedTemplates(
        user?.info.userEntityRef || '',
      );

      return createScaffolderTaskConditionalDecision(request.permission, {
        anyOf: [
          scaffolderTaskConditions.hasCreatedBy({
            createdBy: user?.info.userEntityRef ? [user?.info.userEntityRef] : [],
          }),
          scaffolderTaskConditions.hasTemplateEntityRefs({
            templateEntityRefs: userOwnedTemplates,
          }),
        ],
      });
    }
    return { result: AuthorizeResult.ALLOW };
  }
}
```


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))