### PR TITLE
feat(gitlab-scaffolder): Support custom commit author email/name

### DIFF
--- a/.changeset/salty-keys-hide.md
+++ b/.changeset/salty-keys-hide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gitlab': minor
+---
+
+feat: Change the commit author name/email in MR action

--- a/plugins/scaffolder-backend-module-gitlab/report.api.md
+++ b/plugins/scaffolder-backend-module-gitlab/report.api.md
@@ -190,6 +190,7 @@ export function createPublishGitlabAction(options: {
 // @public
 export const createPublishGitlabMergeRequestAction: (options: {
   integrations: ScmIntegrationRegistry;
+  config?: Config;
 }) => TemplateAction<
   {
     repoUrl: string;
@@ -206,6 +207,9 @@ export const createPublishGitlabMergeRequestAction: (options: {
     assignee?: string;
     reviewers?: string[];
     assignReviewersFromApprovalRules?: boolean;
+    gitAuthorName?: string;
+    gitAuthorEmail?: string;
+    useCustomGitAuthor?: boolean;
   },
   JsonObject,
   'v1'

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabMergeRequest.examples.test.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabMergeRequest.examples.test.ts
@@ -293,6 +293,7 @@ describe('createGitLabMergeRequest', () => {
             execute_filemode: false,
           },
         ],
+        {},
       );
     });
 
@@ -321,6 +322,7 @@ describe('createGitLabMergeRequest', () => {
             execute_filemode: false,
           },
         ],
+        {},
       );
     });
 
@@ -349,6 +351,7 @@ describe('createGitLabMergeRequest', () => {
             execute_filemode: false,
           },
         ],
+        {},
       );
     });
   });

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabMergeRequest.test.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabMergeRequest.test.ts
@@ -613,6 +613,7 @@ describe('createGitLabMergeRequest', () => {
             execute_filemode: false,
           },
         ]),
+        {},
       );
       expect(mockGitlabClient.MergeRequests.create).toHaveBeenCalledWith(
         'owner/repo',
@@ -962,6 +963,7 @@ describe('createGitLabMergeRequest', () => {
             execute_filemode: false,
           },
         ]),
+        {},
       );
       expect(mockGitlabClient.MergeRequests.create).toHaveBeenCalledWith(
         'owner/repo',
@@ -1014,6 +1016,7 @@ describe('createGitLabMergeRequest', () => {
             execute_filemode: false,
           },
         ],
+        {},
       );
       expect(mockGitlabClient.MergeRequests.create).toHaveBeenCalledWith(
         'owner/repo',
@@ -1064,6 +1067,7 @@ describe('createGitLabMergeRequest', () => {
             execute_filemode: false,
           },
         ],
+        {},
       );
       expect(mockGitlabClient.MergeRequests.create).toHaveBeenCalledWith(
         'owner/repo',
@@ -1119,6 +1123,7 @@ describe('createGitLabMergeRequest', () => {
             execute_filemode: false,
           },
         ]),
+        {},
       );
       expect(mockGitlabClient.MergeRequests.create).toHaveBeenCalledWith(
         'owner/repo',
@@ -1176,6 +1181,7 @@ describe('createGitLabMergeRequest', () => {
             execute_filemode: false,
           },
         ]),
+        {},
       );
       expect(mockGitlabClient.MergeRequests.create).toHaveBeenCalledWith(
         'owner/repo',
@@ -1226,6 +1232,7 @@ describe('createGitLabMergeRequest', () => {
             execute_filemode: false,
           },
         ],
+        {},
       );
       expect(mockGitlabClient.MergeRequests.create).toHaveBeenCalledWith(
         'owner/repo',
@@ -1329,6 +1336,7 @@ describe('createGitLabMergeRequest', () => {
             execute_filemode: false,
           },
         ]),
+        {},
       );
       expect(mockGitlabClient.MergeRequests.create).toHaveBeenCalledWith(
         'owner/repo',
@@ -1383,6 +1391,7 @@ describe('createGitLabMergeRequest', () => {
             execute_filemode: false,
           },
         ],
+        {},
       );
     });
 
@@ -1426,6 +1435,7 @@ describe('createGitLabMergeRequest', () => {
             execute_filemode: false,
           },
         ],
+        {},
       );
     });
 

--- a/plugins/scaffolder-backend/report.api.md
+++ b/plugins/scaffolder-backend/report.api.md
@@ -358,6 +358,7 @@ export const createPublishGitlabAction: typeof createPublishGitlabAction_2;
 // @public @deprecated (undocumented)
 export const createPublishGitlabMergeRequestAction: (options: {
   integrations: ScmIntegrationRegistry;
+  config?: Config;
 }) => TemplateAction_2<
   {
     repoUrl: string;
@@ -374,6 +375,9 @@ export const createPublishGitlabMergeRequestAction: (options: {
     assignee?: string;
     reviewers?: string[];
     assignReviewersFromApprovalRules?: boolean;
+    gitAuthorName?: string;
+    gitAuthorEmail?: string;
+    useCustomGitAuthor?: boolean;
   },
   JsonObject,
   'v1'

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/createBuiltinActions.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/createBuiltinActions.ts
@@ -194,6 +194,7 @@ export const createBuiltinActions = (
     }),
     createPublishGitlabMergeRequestAction({
       integrations,
+      config,
     }),
     createGitlabRepoPushAction({
       integrations,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix #29131.

To avoid a breaking change, a new flag as been added, to overwrite the commit author name and email. It's the opposite of the GitHub PR action, which defaults to setting a custom commit author.

If not set, we get no change to the behaviour: the commit author will be set automatically by Gitlab, using the user associated to the token.

If set, commit author will be set, by decreasing order of priority, by:
- the local parameters (`gitAuthorName`/`gitAuthorEmail`)
- The global config (`scaffolder.defaultAuthor.name`/`scaffolder.defaultAuthor.email`)
- The default Backstage values (`Scaffolder`/`scaffolder@backstage.io`)

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] TODO A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] TODO Added or updated documentation
- [ ] TODO Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
