### PR TITLE
Canon - Fix Button types

### DIFF
--- a/.changeset/chubby-kids-hear.md
+++ b/.changeset/chubby-kids-hear.md
@@ -1,0 +1,5 @@
+---
+'@backstage/canon': patch
+---
+
+Fix Button types that was preventing the use of native attributes like onClick.

--- a/packages/canon/report.api.md
+++ b/packages/canon/report.api.md
@@ -142,22 +142,12 @@ export const buttonPropDefs: {
 };
 
 // @public
-export interface ButtonProps {
-  // (undocumented)
+export interface ButtonProps
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
   children: React.ReactNode;
-  // (undocumented)
-  className?: string;
-  // (undocumented)
-  disabled?: boolean;
-  // (undocumented)
   iconEnd?: IconNames;
-  // (undocumented)
   iconStart?: IconNames;
-  // (undocumented)
   size?: ButtonOwnProps['size'];
-  // (undocumented)
-  style?: React.CSSProperties;
-  // (undocumented)
   variant?: ButtonOwnProps['variant'];
 }
 

--- a/packages/canon/src/components/Button/types.ts
+++ b/packages/canon/src/components/Button/types.ts
@@ -21,13 +21,32 @@ import type { ButtonOwnProps } from './Button.props';
  *
  * @public
  */
-export interface ButtonProps {
+export interface ButtonProps
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
+  /**
+   * The size of the button
+   * @defaultValue 'medium'
+   */
   size?: ButtonOwnProps['size'];
+
+  /**
+   * The visual variant of the button
+   * @defaultValue 'primary'
+   */
   variant?: ButtonOwnProps['variant'];
+
+  /**
+   * The content of the button
+   */
   children: React.ReactNode;
-  className?: string;
-  disabled?: boolean;
+
+  /**
+   * Optional icon to display at the start of the button
+   */
   iconStart?: IconNames;
+
+  /**
+   * Optional icon to display at the end of the button
+   */
   iconEnd?: IconNames;
-  style?: React.CSSProperties;
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Small fix on the Button types that was preventing to use `onClick()`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
