### PR TITLE
docs: fix example location annotations in IncrementalEntityProvider

### DIFF
--- a/.changeset/wide-planets-camp.md
+++ b/.changeset/wide-planets-camp.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-incremental-ingestion': patch
+---
+
+fixed misleading example location annotations in docs

--- a/docs/features/software-catalog/external-integrations.md
+++ b/docs/features/software-catalog/external-integrations.md
@@ -1161,9 +1161,11 @@ export class MyIncrementalEntityProvider
   implements IncrementalEntityProvider<Cursor, Context>
 {
   private readonly token: string;
+  private readonly mySource: string;
 
-  constructor(token: string) {
+  constructor(token: string, mySource: string) {
     this.token = token;
+    this.mySource = mySource;
   }
 
   getProviderName() {
@@ -1181,6 +1183,7 @@ export class MyIncrementalEntityProvider
     cursor: Cursor = { page: 1 },
   ): Promise<EntityIteratorResult<Cursor>> {
     const { apiClient } = context;
+    const location = `${this.getProviderName()}:${mySource}`;
 
     // call your API with the current cursor
     const data = await apiClient.getServices(cursor);
@@ -1200,8 +1203,8 @@ export class MyIncrementalEntityProvider
           name: item.name,
           annotations: {
             // You need to define these, otherwise they'll fail validation
-            [ANNOTATION_LOCATION]: this.getProviderName(),
-            [ANNOTATION_ORIGIN_LOCATION]: this.getProviderName(),
+            [ANNOTATION_LOCATION]: location,
+            [ANNOTATION_ORIGIN_LOCATION]: location,
           },
         },
         spec: {

--- a/docs/features/software-catalog/external-integrations.md
+++ b/docs/features/software-catalog/external-integrations.md
@@ -1157,6 +1157,12 @@ export class MyIncrementalEntityProvider
 The last step is to implement the actual `next` method that will accept the cursor, call the API, process the result and return the result.
 
 ```ts
+import {
+  ANNOTATION_LOCATION,
+  ANNOTATION_ORIGIN_LOCATION,
+} from '@backstage/catalog-model';
+import { IncrementalEntityProvider } from '@backstage/plugin-catalog-backend-module-incremental-ingestion';
+
 export class MyIncrementalEntityProvider
   implements IncrementalEntityProvider<Cursor, Context>
 {
@@ -1183,7 +1189,7 @@ export class MyIncrementalEntityProvider
     cursor: Cursor = { page: 1 },
   ): Promise<EntityIteratorResult<Cursor>> {
     const { apiClient } = context;
-    const location = `${this.getProviderName()}:${mySource}`;
+    const location = `${this.getProviderName()}:${this.mySource}`;
 
     // call your API with the current cursor
     const data = await apiClient.getServices(cursor);

--- a/plugins/catalog-backend-module-incremental-ingestion/README.md
+++ b/plugins/catalog-backend-module-incremental-ingestion/README.md
@@ -211,9 +211,11 @@ The last step is to implement the actual `next` method that will accept the curs
 export class MyIncrementalEntityProvider implements IncrementalEntityProvider<Cursor, Context> {
 
   token: string;
+  mySource: string;
 
-  constructor(token: string) {
+  constructor(token: string, mySource: string) {
     this.token = token;
+    this.mySource = mySource;
   }
 
   getProviderName() {
@@ -230,6 +232,7 @@ export class MyIncrementalEntityProvider implements IncrementalEntityProvider<Cu
 
   async next(context: Context, cursor?: Cursor = { page: 1 }): Promise<EntityIteratorResult<Cursor>> {
     const { apiClient } = context;
+    const location = `${this.getProviderName()}:${mySource}`;
 
     // call your API with the current cursor
     const data = await apiClient.getServices(cursor);
@@ -249,8 +252,8 @@ export class MyIncrementalEntityProvider implements IncrementalEntityProvider<Cu
           name: item.name,
           annotations: {
             // You need to define these, otherwise they'll fail validation
-            [ANNOTATION_LOCATION]: this.getProviderName(),
-            [ANNOTATION_ORIGIN_LOCATION]: this.getProviderName(),
+            [ANNOTATION_LOCATION]: location,
+            [ANNOTATION_ORIGIN_LOCATION]: location,
           }
         }
         spec: {

--- a/plugins/catalog-backend-module-incremental-ingestion/README.md
+++ b/plugins/catalog-backend-module-incremental-ingestion/README.md
@@ -208,6 +208,12 @@ export class MyIncrementalEntityProvider
 The last step is to implement the actual `next` method that will accept the cursor, call the API, process the result and return the result.
 
 ```ts
+import {
+  ANNOTATION_LOCATION,
+  ANNOTATION_ORIGIN_LOCATION,
+} from '@backstage/catalog-model';
+import { IncrementalEntityProvider } from '@backstage/plugin-catalog-backend-module-incremental-ingestion';
+
 export class MyIncrementalEntityProvider implements IncrementalEntityProvider<Cursor, Context> {
 
   token: string;
@@ -232,7 +238,7 @@ export class MyIncrementalEntityProvider implements IncrementalEntityProvider<Cu
 
   async next(context: Context, cursor?: Cursor = { page: 1 }): Promise<EntityIteratorResult<Cursor>> {
     const { apiClient } = context;
-    const location = `${this.getProviderName()}:${mySource}`;
+    const location = `${this.getProviderName()}:${this.mySource}`;
 
     // call your API with the current cursor
     const data = await apiClient.getServices(cursor);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Both `ANNOTATION_LOCATION` and `ANNOTATION_ORIGIN_LOCATION` are expected to be a string location reference, which makes these examples a bit misleading. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
