### PR TITLE
feat(scaffolder-backend-module-github): added `getOctokitClient` helper

### DIFF
--- a/.changeset/tough-baboons-pretend.md
+++ b/.changeset/tough-baboons-pretend.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-github': patch
+---
+
+Added `getOctokitClient` helper

--- a/plugins/scaffolder-backend-module-github/src/actions/gitHelpers.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/gitHelpers.ts
@@ -15,7 +15,7 @@
  */
 
 import { assertError } from '@backstage/errors';
-import { Octokit } from 'octokit';
+import type { Octokit } from 'octokit';
 import { LoggerService } from '@backstage/backend-plugin-api';
 
 type BranchProtectionOptions = {

--- a/plugins/scaffolder-backend-module-github/src/actions/github.examples.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/github.examples.test.ts
@@ -55,6 +55,7 @@ const initRepoAndPushMocked = initRepoAndPush as jest.Mock<
 >;
 
 const mockOctokit = {
+  auth: () => ({ token: 'tokenlols' }),
   rest: {
     users: {
       getByUsername: jest.fn(),
@@ -76,12 +77,8 @@ const mockOctokit = {
     },
   },
 };
-jest.mock('octokit', () => ({
-  Octokit: class {
-    constructor() {
-      return mockOctokit;
-    }
-  },
+jest.mock('../util', () => ({
+  getOctokitClient: () => mockOctokit,
 }));
 
 describe('publish:github', () => {

--- a/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
@@ -55,6 +55,7 @@ const initRepoAndPushMocked = initRepoAndPush as jest.Mock<
 >;
 
 const mockOctokit = {
+  auth: () => ({ token: 'tokenlols' }),
   rest: {
     users: {
       getByUsername: jest.fn(),
@@ -80,12 +81,8 @@ const mockOctokit = {
   },
   request: jest.fn(),
 };
-jest.mock('octokit', () => ({
-  Octokit: class {
-    constructor() {
-      return mockOctokit;
-    }
-  },
+jest.mock('../util', () => ({
+  getOctokitClient: () => mockOctokit,
 }));
 
 describe('publish:github', () => {

--- a/plugins/scaffolder-backend-module-github/src/actions/github.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/github.ts
@@ -20,7 +20,6 @@ import {
   GithubCredentialsProvider,
   ScmIntegrationRegistry,
 } from '@backstage/integration';
-import { Octokit } from 'octokit';
 import {
   createTemplateAction,
   parseRepoUrl,
@@ -29,7 +28,7 @@ import {
   createGithubRepoWithCollaboratorsAndTopics,
   initRepoPushAndProtect,
 } from './helpers';
-import { getOctokitOptions } from '../util';
+import { getOctokitClient } from '../util';
 import * as inputProps from './inputProperties';
 import * as outputProps from './outputProperties';
 import { examples } from './github.examples';
@@ -231,7 +230,7 @@ export function createPublishGithubAction(options: {
         throw new InputError('Invalid repository owner provided in repoUrl');
       }
 
-      const octokitOptions = await getOctokitOptions({
+      const client = await getOctokitClient({
         integrations,
         credentialsProvider: githubCredentialsProvider,
         token: providedToken,
@@ -239,7 +238,7 @@ export function createPublishGithubAction(options: {
         owner,
         repo,
       });
-      const client = new Octokit(octokitOptions);
+      const octokitAuth = await client.auth();
 
       const newRepo = await createGithubRepoWithCollaboratorsAndTopics(
         client,
@@ -274,7 +273,7 @@ export function createPublishGithubAction(options: {
 
       const commitResult = await initRepoPushAndProtect(
         remoteUrl,
-        octokitOptions.auth,
+        octokitAuth.token,
         ctx.workspacePath,
         ctx.input.sourcePath,
         defaultBranch,

--- a/plugins/scaffolder-backend-module-github/src/actions/githubActionsDispatch.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubActionsDispatch.ts
@@ -23,8 +23,7 @@ import {
   createTemplateAction,
   parseRepoUrl,
 } from '@backstage/plugin-scaffolder-node';
-import { Octokit } from 'octokit';
-import { getOctokitOptions } from '../util';
+import { getOctokitClient } from '../util';
 import { examples } from './githubActionsDispatch.examples';
 
 /**
@@ -104,16 +103,14 @@ export function createGithubActionsDispatchAction(options: {
         throw new InputError('Invalid repository owner provided in repoUrl');
       }
 
-      const client = new Octokit(
-        await getOctokitOptions({
-          integrations,
-          host,
-          owner,
-          repo,
-          credentialsProvider: githubCredentialsProvider,
-          token: providedToken,
-        }),
-      );
+      const client = await getOctokitClient({
+        integrations,
+        host,
+        owner,
+        repo,
+        credentialsProvider: githubCredentialsProvider,
+        token: providedToken,
+      });
 
       await client.rest.actions.createWorkflowDispatch({
         owner,

--- a/plugins/scaffolder-backend-module-github/src/actions/githubAutolinks.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubAutolinks.ts
@@ -23,9 +23,8 @@ import {
   createTemplateAction,
   parseRepoUrl,
 } from '@backstage/plugin-scaffolder-node';
-import { Octokit } from 'octokit';
 import { examples } from './githubAutolinks.examples';
-import { getOctokitOptions } from '../util';
+import { getOctokitClient } from '../util';
 
 /**
  * Create an autolink reference for a repository
@@ -97,16 +96,14 @@ export function createGithubAutolinksAction(options: {
         throw new InputError('Invalid repository owner provided in repoUrl');
       }
 
-      const client = new Octokit(
-        await getOctokitOptions({
-          integrations,
-          host,
-          owner,
-          repo,
-          credentialsProvider: githubCredentialsProvider,
-          token,
-        }),
-      );
+      const client = await getOctokitClient({
+        integrations,
+        host,
+        owner,
+        repo,
+        credentialsProvider: githubCredentialsProvider,
+        token,
+      });
 
       await client.rest.repos.createAutolink({
         owner,

--- a/plugins/scaffolder-backend-module-github/src/actions/githubBranchProtection.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubBranchProtection.ts
@@ -22,8 +22,7 @@ import {
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import { examples } from './githubBranchProtection.examples';
 import * as inputProps from './inputProperties';
-import { getOctokitOptions } from '../util';
-import { Octokit } from 'octokit';
+import { getOctokitClient } from '../util';
 import { enableBranchProtectionOnDefaultRepoBranch } from './gitHelpers';
 
 /**
@@ -121,14 +120,13 @@ export function createGithubBranchProtectionAction(options: {
         throw new InputError(`No owner provided for repo ${repoUrl}`);
       }
 
-      const octokitOptions = await getOctokitOptions({
+      const client = await getOctokitClient({
         integrations,
         token: providedToken,
         host,
         owner,
         repo,
       });
-      const client = new Octokit(octokitOptions);
 
       const repository = await client.rest.repos.get({
         owner: owner,

--- a/plugins/scaffolder-backend-module-github/src/actions/githubDeployKey.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubDeployKey.ts
@@ -20,8 +20,7 @@ import {
   parseRepoUrl,
 } from '@backstage/plugin-scaffolder-node';
 import { ScmIntegrationRegistry } from '@backstage/integration';
-import { getOctokitOptions } from '../util';
-import { Octokit } from 'octokit';
+import { getOctokitClient } from '../util';
 import Sodium from 'libsodium-wrappers';
 import { examples } from './githubDeployKey.examples';
 
@@ -116,15 +115,13 @@ export function createGithubDeployKeyAction(options: {
         throw new InputError(`No owner provided for repo ${repoUrl}`);
       }
 
-      const octokitOptions = await getOctokitOptions({
+      const client = await getOctokitClient({
         integrations,
         token: providedToken,
         host,
         owner,
         repo,
       });
-
-      const client = new Octokit(octokitOptions);
 
       await client.rest.repos.createDeployKey({
         owner: owner,

--- a/plugins/scaffolder-backend-module-github/src/actions/githubEnvironment.examples.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubEnvironment.examples.test.ts
@@ -45,12 +45,8 @@ const mockOctokit = {
 const mockCatalogClient: Partial<CatalogApi> = {
   getEntitiesByRefs: jest.fn(),
 };
-jest.mock('octokit', () => ({
-  Octokit: class {
-    constructor() {
-      return mockOctokit;
-    }
-  },
+jest.mock('../util', () => ({
+  getOctokitClient: () => mockOctokit,
 }));
 jest.mock('@backstage/catalog-client', () => ({
   CatalogClient: mockCatalogClient,

--- a/plugins/scaffolder-backend-module-github/src/actions/githubEnvironment.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubEnvironment.ts
@@ -20,8 +20,7 @@ import {
   parseRepoUrl,
 } from '@backstage/plugin-scaffolder-node';
 import { ScmIntegrationRegistry } from '@backstage/integration';
-import { getOctokitOptions } from '../util';
-import { Octokit } from 'octokit';
+import { getOctokitClient } from '../util';
 import Sodium from 'libsodium-wrappers';
 import { examples } from './gitHubEnvironment.examples';
 import { CatalogApi } from '@backstage/catalog-client';
@@ -185,15 +184,13 @@ Wildcard characters will not match \`/\`. For example, to match tags that begin 
         throw new InputError(`No owner provided for repo ${repoUrl}`);
       }
 
-      const octokitOptions = await getOctokitOptions({
+      const client = await getOctokitClient({
         integrations,
         token: providedToken,
         host,
         owner,
         repo,
       });
-
-      const client = new Octokit(octokitOptions);
       const repository = await client.rest.repos.get({
         owner: owner,
         repo: repo,

--- a/plugins/scaffolder-backend-module-github/src/actions/githubIssuesLabel.examples.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubIssuesLabel.examples.test.ts
@@ -25,13 +25,7 @@ import {
 import { createGithubIssuesLabelAction } from './githubIssuesLabel';
 import yaml from 'yaml';
 import { examples } from './githubIssuesLabel.examples';
-import { getOctokitOptions } from '../util';
-
-jest.mock('../util', () => {
-  return {
-    getOctokitOptions: jest.fn(),
-  };
-});
+import { getOctokitClient } from '../util';
 
 const mockOctokit = {
   rest: {
@@ -40,12 +34,9 @@ const mockOctokit = {
     },
   },
 };
-jest.mock('octokit', () => ({
-  Octokit: class {
-    constructor() {
-      return mockOctokit;
-    }
-  },
+
+jest.mock('../util', () => ({
+  getOctokitClient: jest.fn(),
 }));
 
 describe('github:issues:label examples', () => {
@@ -58,7 +49,6 @@ describe('github:issues:label examples', () => {
     },
   });
 
-  const getOctokitOptionsMock = getOctokitOptions as jest.Mock;
   const integrations = ScmIntegrations.fromConfig(config);
   let githubCredentialsProvider: GithubCredentialsProvider;
   let action: TemplateAction<any>;
@@ -66,13 +56,13 @@ describe('github:issues:label examples', () => {
   const mockContext = createMockActionContext();
 
   beforeEach(() => {
-    jest.resetAllMocks();
     githubCredentialsProvider =
       DefaultGithubCredentialsProvider.fromIntegrations(integrations);
     action = createGithubIssuesLabelAction({
       integrations,
       githubCredentialsProvider,
     });
+    getOctokitClient.mockReturnValue(mockOctokit);
   });
 
   afterEach(jest.resetAllMocks);
@@ -90,7 +80,7 @@ describe('github:issues:label examples', () => {
       labels: ['bug'],
     });
 
-    expect(getOctokitOptionsMock.mock.calls[0][0].token).toBeUndefined();
+    expect(getOctokitClient.mock.calls[0][0].token).toBeUndefined();
   });
 
   it('should call the githubApi for adding labels with token', async () => {
@@ -106,7 +96,7 @@ describe('github:issues:label examples', () => {
       labels: ['bug', 'documentation'],
     });
 
-    expect(getOctokitOptionsMock.mock.calls[0][0].token).toEqual(
+    expect(getOctokitClient.mock.calls[0][0].token).toEqual(
       'gph_YourGitHubToken',
     );
   });

--- a/plugins/scaffolder-backend-module-github/src/actions/githubIssuesLabel.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubIssuesLabel.test.ts
@@ -23,13 +23,7 @@ import {
 import { createMockActionContext } from '@backstage/plugin-scaffolder-node-test-utils';
 import { ConfigReader } from '@backstage/config';
 import { TemplateAction } from '@backstage/plugin-scaffolder-node';
-import { getOctokitOptions } from '../util';
-
-jest.mock('../util', () => {
-  return {
-    getOctokitOptions: jest.fn(),
-  };
-});
+import { getOctokitClient } from '../util';
 
 const mockOctokit = {
   rest: {
@@ -38,12 +32,8 @@ const mockOctokit = {
     },
   },
 };
-jest.mock('octokit', () => ({
-  Octokit: class {
-    constructor() {
-      return mockOctokit;
-    }
-  },
+jest.mock('../util', () => ({
+  getOctokitClient: jest.fn(),
 }));
 
 describe('github:issues:label', () => {
@@ -56,7 +46,6 @@ describe('github:issues:label', () => {
     },
   });
 
-  const getOctokitOptionsMock = getOctokitOptions as jest.Mock;
   const integrations = ScmIntegrations.fromConfig(config);
   let githubCredentialsProvider: GithubCredentialsProvider;
   let action: TemplateAction<any>;
@@ -77,6 +66,7 @@ describe('github:issues:label', () => {
       integrations,
       githubCredentialsProvider,
     });
+    getOctokitClient.mockReturnValue(mockOctokit);
   });
 
   it('should call the githubApi for adding labels', async () => {
@@ -87,7 +77,7 @@ describe('github:issues:label', () => {
       issue_number: '1',
       labels: ['label1', 'label2'],
     });
-    expect(getOctokitOptionsMock.mock.calls[0][0].token).toBeUndefined();
+    expect(getOctokitClient.mock.calls[0][0].token).toBeUndefined();
   });
 
   it('should call the githubApi for adding labels with token', async () => {
@@ -101,7 +91,7 @@ describe('github:issues:label', () => {
       issue_number: '1',
       labels: ['label1', 'label2'],
     });
-    expect(getOctokitOptionsMock.mock.calls[0][0].token).toEqual(
+    expect(getOctokitClient.mock.calls[0][0].token).toEqual(
       'gph_YourGitHubToken',
     );
   });

--- a/plugins/scaffolder-backend-module-github/src/actions/githubIssuesLabel.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubIssuesLabel.ts
@@ -23,8 +23,7 @@ import {
   parseRepoUrl,
 } from '@backstage/plugin-scaffolder-node';
 import { assertError, InputError } from '@backstage/errors';
-import { Octokit } from 'octokit';
-import { getOctokitOptions } from '../util';
+import { getOctokitClient } from '../util';
 import { examples } from './githubIssuesLabel.examples';
 
 /**
@@ -89,16 +88,14 @@ export function createGithubIssuesLabelAction(options: {
         throw new InputError('Invalid repository owner provided in repoUrl');
       }
 
-      const client = new Octokit(
-        await getOctokitOptions({
-          integrations,
-          credentialsProvider: githubCredentialsProvider,
-          host,
-          owner,
-          repo,
-          token: providedToken,
-        }),
-      );
+      const client = await getOctokitClient({
+        integrations,
+        credentialsProvider: githubCredentialsProvider,
+        host,
+        owner,
+        repo,
+        token: providedToken,
+      });
 
       try {
         await client.rest.issues.addLabels({

--- a/plugins/scaffolder-backend-module-github/src/actions/githubPagesEnable.examples.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubPagesEnable.examples.test.ts
@@ -30,12 +30,8 @@ const mockOctokit = {
   request: jest.fn(),
 };
 
-jest.mock('octokit', () => ({
-  Octokit: class {
-    constructor() {
-      return mockOctokit;
-    }
-  },
+jest.mock('../util', () => ({
+  getOctokitClient: () => mockOctokit,
 }));
 
 describe('github:pages', () => {

--- a/plugins/scaffolder-backend-module-github/src/actions/githubPagesEnable.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubPagesEnable.test.ts
@@ -28,12 +28,8 @@ const mockOctokit = {
   request: jest.fn(),
 };
 
-jest.mock('octokit', () => ({
-  Octokit: class {
-    constructor() {
-      return mockOctokit;
-    }
-  },
+jest.mock('../util', () => ({
+  getOctokitClient: () => mockOctokit,
 }));
 
 describe('github:pages', () => {

--- a/plugins/scaffolder-backend-module-github/src/actions/githubPagesEnable.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubPagesEnable.ts
@@ -19,13 +19,12 @@ import {
   GithubCredentialsProvider,
   ScmIntegrationRegistry,
 } from '@backstage/integration';
-import { Octokit } from 'octokit';
 import {
   createTemplateAction,
   parseRepoUrl,
 } from '@backstage/plugin-scaffolder-node';
 import { examples } from './githubPagesEnable.examples';
-import { getOctokitOptions } from '../util';
+import { getOctokitClient } from '../util';
 
 /**
  * Creates a new action that enables GitHub Pages for a repository.
@@ -104,7 +103,7 @@ export function createGithubPagesEnableAction(options: {
         throw new InputError('Invalid repository owner provided in repoUrl');
       }
 
-      const octokitOptions = await getOctokitOptions({
+      const client = await getOctokitClient({
         integrations,
         credentialsProvider: githubCredentialsProvider,
         token: providedToken,
@@ -112,7 +111,6 @@ export function createGithubPagesEnableAction(options: {
         owner,
         repo,
       });
-      const client = new Octokit(octokitOptions);
 
       ctx.logger.info(
         `Attempting to enable GitHub Pages for ${owner}/${repo} with "${buildType}" build type, on source branch "${sourceBranch}" and source path "${sourcePath}"`,

--- a/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.examples.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.examples.test.ts
@@ -35,12 +35,8 @@ const mockOctokit = {
   },
 };
 
-jest.mock('octokit', () => ({
-  Octokit: class {
-    constructor() {
-      return mockOctokit;
-    }
-  },
+jest.mock('../util', () => ({
+  getOctokitClient: () => mockOctokit,
 }));
 
 describe('publish:github:pull-request examples', () => {

--- a/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.ts
@@ -25,10 +25,10 @@ import {
   SerializedFile,
   serializeDirectoryContents,
 } from '@backstage/plugin-scaffolder-node';
-import { Octokit } from 'octokit';
+import type { Octokit } from 'octokit';
 import { CustomErrorBase, InputError } from '@backstage/errors';
 import { createPullRequest } from 'octokit-plugin-create-pull-request';
-import { getOctokitOptions } from '../util';
+import { getOctokitClient } from '../util';
 import { examples } from './githubPullRequest.examples';
 import {
   LoggerService,
@@ -48,22 +48,18 @@ export const defaultClientFactory: CreateGithubPullRequestActionOptions['clientF
     repo,
     host = 'github.com',
     token: providedToken,
-  }) => {
-    const octokitOptions = await getOctokitOptions({
-      integrations,
-      credentialsProvider: githubCredentialsProvider,
-      host,
-      owner,
-      repo,
-      token: providedToken,
-    });
-
-    const OctokitPR = Octokit.plugin(createPullRequest);
-    return new OctokitPR({
-      ...octokitOptions,
-      ...{ throttle: { enabled: false } },
-    });
-  };
+  }) =>
+    getOctokitClient(
+      {
+        integrations,
+        credentialsProvider: githubCredentialsProvider,
+        host,
+        owner,
+        repo,
+        token: providedToken,
+      },
+      { pullRequest: true },
+    );
 
 /**
  * The options passed to {@link createPublishGithubPullRequestAction} method

--- a/plugins/scaffolder-backend-module-github/src/actions/githubRepoCreate.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubRepoCreate.ts
@@ -19,13 +19,12 @@ import {
   GithubCredentialsProvider,
   ScmIntegrationRegistry,
 } from '@backstage/integration';
-import { Octokit } from 'octokit';
 import {
   createTemplateAction,
   parseRepoUrl,
 } from '@backstage/plugin-scaffolder-node';
 import { createGithubRepoWithCollaboratorsAndTopics } from './helpers';
-import { getOctokitOptions } from '../util';
+import { getOctokitClient } from '../util';
 import * as inputProps from './inputProperties';
 import * as outputProps from './outputProperties';
 import { examples } from './githubRepoCreate.examples';
@@ -186,7 +185,7 @@ export function createGithubRepoCreateAction(options: {
         throw new InputError('Invalid repository owner provided in repoUrl');
       }
 
-      const octokitOptions = await getOctokitOptions({
+      const client = await getOctokitClient({
         integrations,
         credentialsProvider: githubCredentialsProvider,
         token: providedToken,
@@ -194,7 +193,6 @@ export function createGithubRepoCreateAction(options: {
         owner,
         repo,
       });
-      const client = new Octokit(octokitOptions);
 
       const newRepo = await createGithubRepoWithCollaboratorsAndTopics(
         client,

--- a/plugins/scaffolder-backend-module-github/src/actions/githubRepoPush.examples.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubRepoPush.examples.test.ts
@@ -53,18 +53,15 @@ const initRepoAndPushMocked = initRepoAndPush as jest.Mock<
 >;
 
 const mockOctokit = {
+  auth: () => ({ token: 'tokenlols' }),
   rest: {
     repos: {
       get: jest.fn(),
     },
   },
 };
-jest.mock('octokit', () => ({
-  Octokit: class {
-    constructor() {
-      return mockOctokit;
-    }
-  },
+jest.mock('../util', () => ({
+  getOctokitClient: () => mockOctokit,
 }));
 
 describe('github:repo:push examples', () => {

--- a/plugins/scaffolder-backend-module-github/src/actions/githubRepoPush.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubRepoPush.test.ts
@@ -53,18 +53,15 @@ const initRepoAndPushMocked = initRepoAndPush as jest.Mock<
 >;
 
 const mockOctokit = {
+  auth: () => ({ token: 'tokenlols' }),
   rest: {
     repos: {
       get: jest.fn(),
     },
   },
 };
-jest.mock('octokit', () => ({
-  Octokit: class {
-    constructor() {
-      return mockOctokit;
-    }
-  },
+jest.mock('../util', () => ({
+  getOctokitClient: () => mockOctokit,
 }));
 
 describe('github:repo:push', () => {

--- a/plugins/scaffolder-backend-module-github/src/actions/githubRepoPush.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubRepoPush.ts
@@ -20,13 +20,12 @@ import {
   GithubCredentialsProvider,
   ScmIntegrationRegistry,
 } from '@backstage/integration';
-import { Octokit } from 'octokit';
 import {
   createTemplateAction,
   parseRepoUrl,
 } from '@backstage/plugin-scaffolder-node';
 import { initRepoPushAndProtect } from './helpers';
-import { getOctokitOptions } from '../util';
+import { getOctokitClient } from '../util';
 import * as inputProps from './inputProperties';
 import * as outputProps from './outputProperties';
 import { examples } from './githubRepoPush.examples';
@@ -149,7 +148,7 @@ export function createGithubRepoPushAction(options: {
         throw new InputError('Invalid repository owner provided in repoUrl');
       }
 
-      const octokitOptions = await getOctokitOptions({
+      const client = await getOctokitClient({
         integrations,
         credentialsProvider: githubCredentialsProvider,
         token: providedToken,
@@ -157,8 +156,7 @@ export function createGithubRepoPushAction(options: {
         owner,
         repo,
       });
-
-      const client = new Octokit(octokitOptions);
+      const octokitAuth = await client.auth();
 
       const targetRepo = await client.rest.repos.get({ owner, repo });
 
@@ -167,7 +165,7 @@ export function createGithubRepoPushAction(options: {
 
       const { commitHash } = await initRepoPushAndProtect(
         remoteUrl,
-        octokitOptions.auth,
+        octokitAuth.token,
         ctx.workspacePath,
         ctx.input.sourcePath,
         defaultBranch,

--- a/plugins/scaffolder-backend-module-github/src/actions/githubWebhook.examples.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubWebhook.examples.test.ts
@@ -32,12 +32,8 @@ const mockOctokit = {
     },
   },
 };
-jest.mock('octokit', () => ({
-  Octokit: class {
-    constructor() {
-      return mockOctokit;
-    }
-  },
+jest.mock('../util', () => ({
+  getOctokitClient: () => mockOctokit,
 }));
 
 describe('github:webhook examples', () => {

--- a/plugins/scaffolder-backend-module-github/src/actions/githubWebhook.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubWebhook.ts
@@ -24,8 +24,7 @@ import {
 } from '@backstage/plugin-scaffolder-node';
 import { emitterEventNames } from '@octokit/webhooks';
 import { assertError, InputError } from '@backstage/errors';
-import { Octokit } from 'octokit';
-import { getOctokitOptions } from '../util';
+import { getOctokitClient } from '../util';
 import { examples } from './githubWebhook.examples';
 
 /**
@@ -149,16 +148,14 @@ export function createGithubWebhookAction(options: {
         throw new InputError('Invalid repository owner provided in repoUrl');
       }
 
-      const client = new Octokit(
-        await getOctokitOptions({
-          integrations,
-          credentialsProvider: githubCredentialsProvider,
-          host,
-          owner,
-          repo,
-          token: providedToken,
-        }),
-      );
+      const client = await getOctokitClient({
+        integrations,
+        credentialsProvider: githubCredentialsProvider,
+        host,
+        owner,
+        repo,
+        token: providedToken,
+      });
 
       // If this is a dry run, log and return
       if (ctx.isDryRun) {

--- a/plugins/scaffolder-backend-module-github/src/actions/helpers.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/helpers.ts
@@ -16,7 +16,7 @@
 
 import { Config } from '@backstage/config';
 import { assertError, NotFoundError } from '@backstage/errors';
-import { Octokit } from 'octokit';
+import type { Octokit } from 'octokit';
 
 import {
   getRepoSourceDirectory,

--- a/plugins/scaffolder-backend-module-github/src/autocomplete/autocomplete.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/autocomplete/autocomplete.test.ts
@@ -18,12 +18,6 @@ import { InputError } from '@backstage/errors';
 import { createHandleAutocompleteRequest } from './autocomplete';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 
-jest.mock('../util', () => {
-  return {
-    getOctokitOptions: jest.fn(),
-  };
-});
-
 const mockOctokit = {
   paginate: async (fn: any) => (await fn()).data,
   rest: {
@@ -33,12 +27,9 @@ const mockOctokit = {
     },
   },
 };
-jest.mock('octokit', () => ({
-  Octokit: class {
-    constructor() {
-      return mockOctokit;
-    }
-  },
+
+jest.mock('../util', () => ({
+  getOctokitClient: () => mockOctokit,
 }));
 
 describe('handleAutocompleteRequest', () => {

--- a/plugins/scaffolder-backend-module-github/src/autocomplete/autocomplete.ts
+++ b/plugins/scaffolder-backend-module-github/src/autocomplete/autocomplete.ts
@@ -15,8 +15,7 @@
  */
 
 import { InputError } from '@backstage/errors';
-import { getOctokitOptions } from '../util';
-import { Octokit } from 'octokit';
+import { getOctokitClient } from '../util';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 
 export function createHandleAutocompleteRequest(options: {
@@ -32,12 +31,11 @@ export function createHandleAutocompleteRequest(options: {
     context: Record<string, string>;
   }): Promise<{ results: { title?: string; id: string }[] }> {
     const { integrations } = options;
-    const octokitOptions = await getOctokitOptions({
+    const client = await getOctokitClient({
       integrations,
       token,
       host: context.host ?? 'github.com',
     });
-    const client = new Octokit(octokitOptions);
 
     switch (resource) {
       case 'repositoriesWithOwner': {

--- a/plugins/scaffolder-backend-module-github/src/index.ts
+++ b/plugins/scaffolder-backend-module-github/src/index.ts
@@ -22,4 +22,4 @@
 
 export * from './actions';
 export { githubModule as default } from './module';
-export { getOctokitOptions } from './util';
+export { getOctokitClient, getOctokitOptions } from './util';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Added the `getOctokitClient` helper. This is mostly just a call to `new Octokit()` wrapping the `getOctokitOptions` helper. However I also included a second param to allow opt-in inclusion of the `octokit-plugin-create-pull-request` library.

Benefits:
* code de-deduplucation -- `new Octokit(getOctokitOptions(...))` was copied and pasted repeatedly 
* One file has knowledge of and interfaces with the `octokit` library now
* Simplified unit testing

> [!NOTE]
>
> Since the `repoUrl` usage was deprecated for `getOctokitOptions`, I excluded from the `getOctokitClient` signature.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
