### PR TITLE
Made "gitlab:projectAccessToken:create" action idempotent

### DIFF
--- a/.changeset/olive-mammals-call.md
+++ b/.changeset/olive-mammals-call.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gitlab': patch
+---
+
+Made "gitlab:projectAccessToken:create" action idempotent

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabProjectAccessTokenCreate.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabProjectAccessTokenCreate.ts
@@ -104,21 +104,27 @@ export const createGitlabProjectAccessTokenAction = (options: {
         });
       }
 
-      const response = await api.ProjectAccessTokens.create(
-        projectId,
-        name,
-        scopes as AccessTokenScopes[],
-        expiresAt || DateTime.now().plus({ days: 365 }).toISODate()!,
-        {
-          accessLevel,
+      const projectAccessToken = await ctx.checkpoint({
+        key: `project.access.token.${projectId}.${name}`,
+        fn: async () => {
+          const response = await api.ProjectAccessTokens.create(
+            projectId,
+            name,
+            scopes as AccessTokenScopes[],
+            expiresAt || DateTime.now().plus({ days: 365 }).toISODate()!,
+            {
+              accessLevel,
+            },
+          );
+          return response.token;
         },
-      );
+      });
 
-      if (!response.token) {
+      if (!projectAccessToken) {
         throw new Error('Could not create project access token');
       }
 
-      ctx.output('access_token', response.token);
+      ctx.output('access_token', projectAccessToken);
     },
   });
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Made "gitlab:projectAccessToken:create" action idempotent

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
