### PR TITLE
Made "github:repo:push" action idempotent

### DIFF
--- a/.changeset/odd-seas-switch.md
+++ b/.changeset/odd-seas-switch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-github': patch
+---
+
+Made "github:repo:push" action idempotent

--- a/plugins/scaffolder-backend-module-github/src/actions/githubRepoPush.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubRepoPush.ts
@@ -165,34 +165,40 @@ export function createGithubRepoPushAction(options: {
       const remoteUrl = targetRepo.data.clone_url;
       const repoContentsUrl = `${targetRepo.data.html_url}/blob/${defaultBranch}`;
 
-      const { commitHash } = await initRepoPushAndProtect(
-        remoteUrl,
-        octokitOptions.auth,
-        ctx.workspacePath,
-        ctx.input.sourcePath,
-        defaultBranch,
-        protectDefaultBranch,
-        protectEnforceAdmins,
-        owner,
-        client,
-        repo,
-        requireCodeOwnerReviews,
-        bypassPullRequestAllowances,
-        requiredApprovingReviewCount,
-        restrictions,
-        requiredStatusCheckContexts,
-        requireBranchesToBeUpToDate,
-        requiredConversationResolution,
-        requireLastPushApproval,
-        config,
-        ctx.logger,
-        gitCommitMessage,
-        gitAuthorName,
-        gitAuthorEmail,
-        dismissStaleReviews,
-        requiredCommitSigning,
-        requiredLinearHistory,
-      );
+      const commitHash = await ctx.checkpoint({
+        key: `init.repo.publish.${owner}.${client}.${repo}`,
+        fn: async () => {
+          const { commitHash: hash } = await initRepoPushAndProtect(
+            remoteUrl,
+            octokitOptions.auth,
+            ctx.workspacePath,
+            ctx.input.sourcePath,
+            defaultBranch,
+            protectDefaultBranch,
+            protectEnforceAdmins,
+            owner,
+            client,
+            repo,
+            requireCodeOwnerReviews,
+            bypassPullRequestAllowances,
+            requiredApprovingReviewCount,
+            restrictions,
+            requiredStatusCheckContexts,
+            requireBranchesToBeUpToDate,
+            requiredConversationResolution,
+            requireLastPushApproval,
+            config,
+            ctx.logger,
+            gitCommitMessage,
+            gitAuthorName,
+            gitAuthorEmail,
+            dismissStaleReviews,
+            requiredCommitSigning,
+            requiredLinearHistory,
+          );
+          return hash;
+        },
+      });
 
       ctx.output('remoteUrl', remoteUrl);
       ctx.output('repoContentsUrl', repoContentsUrl);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Made "github:repo:push" action idempotent

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
