### PR TITLE
permission-node: deprecate createPermisisonIntegrationRouter + docs fix

### DIFF
--- a/.changeset/true-papers-visit.md
+++ b/.changeset/true-papers-visit.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-permission-node': patch
+---
+
+Deprecated `createPermissionIntegrationRouter` and related types, which has been replaced by `PermissionRegistryService`. For more information, including how to migrate existing plugins, see the [service docs](https://backstage.io/docs/backend-system/core-services/permissions-registry).

--- a/docs/backend-system/core-services/permissionsRegistry.md
+++ b/docs/backend-system/core-services/permissionsRegistry.md
@@ -1,5 +1,5 @@
 ---
-id: permissions
+id: permissions-registry
 title: Permissions Registry Service
 sidebar_label: Permissions Registry
 description: Documentation for the Permissions Registry service

--- a/microsite/sidebars.ts
+++ b/microsite/sidebars.ts
@@ -450,6 +450,7 @@ export default {
               'backend-system/core-services/lifecycle',
               'backend-system/core-services/logger',
               'backend-system/core-services/permissions',
+              'backend-system/core-services/permissions-registry',
               'backend-system/core-services/plugin-metadata',
               'backend-system/core-services/root-config',
               'backend-system/core-services/root-health',

--- a/plugins/permission-node/report.api.md
+++ b/plugins/permission-node/report.api.md
@@ -138,7 +138,7 @@ export function createConditionTransformer<
   TRules extends PermissionRule<any, TQuery, string>[],
 >(permissionRules: [...TRules]): ConditionTransformer<TQuery>;
 
-// @public
+// @public @deprecated
 export function createPermissionIntegrationRouter<
   TResourceType1 extends string,
   TResource1,
@@ -177,7 +177,7 @@ export function createPermissionIntegrationRouter<
   ): PermissionRuleset<TResource, TQuery, TResourceType>;
 };
 
-// @public
+// @public @deprecated
 export type CreatePermissionIntegrationRouterResourceOptions<
   TResourceType extends string,
   TResource,
@@ -266,7 +266,7 @@ export type MetadataResponse = MetadataResponse_2;
 // @public @deprecated
 export type MetadataResponseSerializedRule = MetadataResponseSerializedRule_2;
 
-// @public
+// @public @deprecated
 export type PermissionIntegrationRouterOptions<
   TResourceType1 extends string = string,
   TResource1 = any,

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
@@ -201,6 +201,7 @@ export function createConditionAuthorizer<TResource, TQuery>(
  * for a particular resource type.
  *
  * @public
+ * @deprecated {@link createPermissionIntegrationRouter} is deprecated
  */
 export type CreatePermissionIntegrationRouterResourceOptions<
   TResourceType extends string,
@@ -223,6 +224,7 @@ export type CreatePermissionIntegrationRouterResourceOptions<
  * permissions and rules from multiple resource types.
  *
  * @public
+ * @deprecated {@link createPermissionIntegrationRouter} is deprecated
  */
 export type PermissionIntegrationRouterOptions<
   TResourceType1 extends string = string,
@@ -410,6 +412,7 @@ class PermissionIntegrationMetadataStore {
  * need to be evaluated.
  *
  * @public
+ * @deprecated use `PermissionRegistryService` instead, see {@link https://backstage.io/docs/backend-system/core-services/permissions-registry#migrating-from-createpermissionintegrationrouter | the migration section in the service docs} for more details.
  */
 export function createPermissionIntegrationRouter<
   TResourceType1 extends string,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

🧹, deprecating `createPermisisonIntegrationRouter` which was replaced by `PermissionRegistryService`. Also fixing the docs for said service, as they had the wrong ID and weren't added to the sidebar.
