### PR TITLE
catalog-react: add operation to default groups

### DIFF
--- a/.changeset/sad-pots-try.md
+++ b/.changeset/sad-pots-try.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Add `operation` to alpha `defaultEntityContentGroups`.

--- a/plugins/catalog-react/report-alpha.api.md
+++ b/plugins/catalog-react/report-alpha.api.md
@@ -99,6 +99,7 @@ export const defaultEntityContentGroups: {
   documentation: string;
   development: string;
   deployment: string;
+  operation: string;
   observability: string;
 };
 

--- a/plugins/catalog-react/src/alpha/blueprints/extensionData.tsx
+++ b/plugins/catalog-react/src/alpha/blueprints/extensionData.tsx
@@ -41,6 +41,7 @@ export const defaultEntityContentGroups = {
   documentation: 'Documentation',
   development: 'Development',
   deployment: 'Deployment',
+  operation: 'Operation',
   observability: 'Observability',
 };
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Felt this was a bit of a gap in the existing default groups. It's like observability in that it's after deployment, but typically for mutating actions.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
