### PR TITLE
Fix code example in proxy tutorial doc for better consistency

### DIFF
--- a/docs/tutorials/using-backstage-proxy-within-plugin.md
+++ b/docs/tutorials/using-backstage-proxy-within-plugin.md
@@ -131,7 +131,7 @@ export class MyAwesomeApiClient implements MyAwesomeApi {
     const proxyUri = `${await this.discoveryApi.getBaseUrl('proxy')}/<your-proxy-uri>`;
 
     const resp = await this.fetchApi.fetch(`${proxyUri}${input}`, init);
-    if (!resp.ok) throw new Error(resp);
+    if (!resp.ok) throw new Error(resp.statusText);
     return await resp.json();
   }
 
@@ -151,8 +151,9 @@ export class MyAwesomeApiClient implements MyAwesomeApi {
   }
 ```
 
-> For more information on the DiscoveryApi check out the
-> [docs](../reference/core-plugin-api.discoveryapi.md)
+> Check out the docs for more information on the
+> [DiscoveryApi](../reference/core-plugin-api.discoveryapi.md) or the
+> [FetchApi](../reference/core-plugin-api.fetchapi.md)
 
 ## Bundling your ApiRef with your plugin
 
@@ -171,6 +172,7 @@ import {
   createRoutableExtension,
   createComponentExtension,
   discoveryApiRef,
+  fetchApiRef,
 } from '@backstage/core-plugin-api';
 
 //...
@@ -182,8 +184,12 @@ export const myCustomPlugin = createPlugin({
   apis: [
     createApiFactory({
       api: myAwesomeApiRef,
-      deps: { discoveryApi: discoveryApiRef },
-      factory: ({ discoveryApi }) => new MyAwesomeApiClient({ discoveryApi }),
+      deps: {
+        discoveryApi: discoveryApiRef,
+        fetchApi: fetchApiRef,
+      },
+      factory: ({ discoveryApi, fetchApi }) =>
+        new MyAwesomeApiClient({ discoveryApi, fetchApi }),
     }),
   ],
 });


### PR DESCRIPTION
## Fixing code example in Proxy tutorial doc

For better consistency, the following changes have been done to the code examples of the proxy tutorial:

* Added missing required usege of `fetchApi` (probably forgotten in #27029)
* Fixed client response thrown error with valid `string` status

#### :heavy_check_mark: Checklist

- [ ] ~A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))~
- [X] Added or updated documentation
- [ ] ~Tests for new functionality and regression tests for bug fixes~
- [ ] ~Screenshots attached (for UI changes)~
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
