### PR TITLE
Updated notes design in how-to-guides docs

### DIFF
--- a/docs/features/search/how-to-guides.md
+++ b/docs/features/search/how-to-guides.md
@@ -173,8 +173,11 @@ Extensions for search results let you customize components used to render search
 
 ### 1. Providing an extension in your plugin package
 
-> Note: You must use the `plugin.provide()` function to make a search item renderer available. Unlike rendering a list in a standard MUI Table or similar, you cannot simply provide
-> a rendering function to the `<SearchResult />` component.
+:::note Note
+
+You must use the `plugin.provide()` function to make a search item renderer available. Unlike rendering a list in a standard MUI Table or similar, you cannot simply provide a rendering function to the `<SearchResult />` component.
+
+:::
 
 Using the example below, you can provide an extension to be used as a search result item:
 


### PR DESCRIPTION
I just made a Pull Request by updating the notes design in `docs/features/search/how-to-guides`

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Before:
![image](https://github.com/user-attachments/assets/7de56db9-d2d6-4e11-bbea-87bcd4834329)

After:
![image](https://github.com/user-attachments/assets/335867d8-92df-4e77-9f23-83ea2cf0d552)

 