### PR TITLE
Added theme change feature to docs page

### DIFF
--- a/microsite/docusaurus.config.ts
+++ b/microsite/docusaurus.config.ts
@@ -344,7 +344,7 @@ const config: Config = {
 
     colorMode: {
       defaultMode: 'dark',
-      disableSwitch: true,
+      disableSwitch: false, // Enable the theme switch
     },
     navbar: {
       logo: {


### PR DESCRIPTION
Added theme change feature to docs page:

Light :


![image](https://github.com/user-attachments/assets/c332f09b-aac4-4d8d-84bd-89187a879269)

Dark:


![image](https://github.com/user-attachments/assets/d1854bbb-0abd-43fc-a698-dbf9d9e8b318)
