### PR TITLE
catalog: Set the default refresh interval to 24hrs

### DIFF
--- a/.changeset/ten-days-slide.md
+++ b/.changeset/ten-days-slide.md
@@ -1,0 +1,15 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Updating the default processing time to be 24 hours. This means that entities will refresh once every ~24 hours, but we encourage the use of the events support for different providers to refresh more often and be reactive to changes outside the refresh loop.
+
+You can override the default processing time by providing the following `app-config.yaml`:
+
+```yaml
+catalog:
+  processingInterval:
+    hours: 1
+```
+
+Be aware that setting this value too low can cause rate limits, and overloading of upstream services as it will try to refresh the entire catalog in that time.

--- a/plugins/catalog-backend/src/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.ts
@@ -865,9 +865,10 @@ export class CatalogBuilder {
     const processingIntervalKey = 'catalog.processingInterval';
 
     if (!config.has(processingIntervalKey)) {
+      // Set default processing interval every 24 hours.
       return createRandomProcessingInterval({
-        minSeconds: 100,
-        maxSeconds: 150,
+        minSeconds: 86400,
+        maxSeconds: 86400 * 1.5,
       });
     }
 


### PR DESCRIPTION
Internally we've had a lot of success increasing the default refresh interval to much longer, giving the processing loop time to breathe.

We're encouraging that you setup events support for providers for example [like this](https://backstage.io/docs/integrations/github/discovery#events-support) to enable push support for updates, and just use the processing interval as a reconcilliation loop.

This should reduce the amount of Rate Limits that Catalogs run into, as it will naturally load balance these refreshes throughout the day.