### PR TITLE
fix(notifications): post process broadcast notification even without signals

### DIFF
--- a/.changeset/wise-suits-protect.md
+++ b/.changeset/wise-suits-protect.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications-backend': patch
+---
+
+Make sure to post process broadcast notifications even without signals support

--- a/plugins/notifications-backend/src/service/router.ts
+++ b/plugins/notifications-backend/src/service/router.ts
@@ -470,8 +470,8 @@ export async function createRouter(
         },
         channel: 'notifications',
       });
-      postProcessNotification(ret, opts);
     }
+    postProcessNotification(ret, opts);
     return notification;
   };
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes issue with broadcast notifications not being post processed when signals backend is missing.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
