### PR TITLE
feat: Scaffolding - create - template - add link to template entity detail

### DIFF
--- a/.changeset/honest-ties-worry.md
+++ b/.changeset/honest-ties-worry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+Scaffolding - Template card - button to show template entity detail

--- a/plugins/home/report.api.md
+++ b/plugins/home/report.api.md
@@ -50,8 +50,7 @@ export const ComponentAccordion: (props: {
   expanded?: boolean;
   Content: () => JSX.Element;
   Actions?: () => JSX.Element;
-  Settings?: () => JSX./** @public */
-  Element;
+  Settings?: () => JSX.Element;
   ContextProvider?: (props: any) => JSX.Element;
 }) => JSX_2.Element;
 

--- a/plugins/scaffolder-react/report-alpha.api.md
+++ b/plugins/scaffolder-react/report-alpha.api.md
@@ -347,6 +347,7 @@ export const scaffolderReactTranslationRef: TranslationRef<
     readonly 'templateCategoryPicker.title': 'Categories';
     readonly 'templateCard.noDescription': 'No description';
     readonly 'templateCard.chooseButtonText': 'Choose';
+    readonly 'cardHeader.detailBtnTitle': 'Show template entity details';
     readonly 'templateOutputs.title': 'Text Output';
   }
 >;

--- a/plugins/scaffolder-react/src/next/components/TemplateCard/CardHeader.tsx
+++ b/plugins/scaffolder-react/src/next/components/TemplateCard/CardHeader.tsx
@@ -15,10 +15,11 @@
  */
 
 import React from 'react';
-import { Theme, makeStyles, useTheme } from '@material-ui/core/styles';
+import { makeStyles, Theme, useTheme } from '@material-ui/core/styles';
 import { ItemCardHeader } from '@backstage/core-components';
 import { TemplateEntityV1beta3 } from '@backstage/plugin-scaffolder-common';
 import { FavoriteEntity } from '@backstage/plugin-catalog-react';
+import { TemplateDetailButton } from './TemplateDetailButton.tsx';
 
 const useStyles = makeStyles<
   Theme,
@@ -66,7 +67,11 @@ export const CardHeader = (props: CardHeaderProps) => {
     <div className={styles.subtitleWrapper}>
       <div>{type}</div>
       <div>
-        <FavoriteEntity entity={props.template} style={{ padding: 0 }} />
+        <TemplateDetailButton template={props.template} />
+        <FavoriteEntity
+          entity={props.template}
+          style={{ padding: 0, marginLeft: 6 }}
+        />
       </div>
     </div>
   );

--- a/plugins/scaffolder-react/src/next/components/TemplateCard/TemplateCard.test.tsx
+++ b/plugins/scaffolder-react/src/next/components/TemplateCard/TemplateCard.test.tsx
@@ -33,6 +33,12 @@ import { permissionApiRef } from '@backstage/plugin-permission-react';
 import { AuthorizeResult } from '@backstage/plugin-permission-common';
 import { SWRConfig } from 'swr';
 
+const mountedRoutes = {
+  mountedRoutes: {
+    '/catalog/:namespace/:kind/:name': entityRouteRef,
+  },
+};
+
 describe('TemplateCard', () => {
   it('should render the card title', async () => {
     const mockTemplate: TemplateEntityV1beta3 = {
@@ -59,6 +65,7 @@ describe('TemplateCard', () => {
       >
         <TemplateCard template={mockTemplate} />
       </TestApiProvider>,
+      mountedRoutes,
     );
 
     expect(getByText('bob')).toBeInTheDocument();
@@ -89,6 +96,7 @@ describe('TemplateCard', () => {
       >
         <TemplateCard template={mockTemplate} />
       </TestApiProvider>,
+      mountedRoutes,
     );
 
     const description = getByText('hello');
@@ -121,6 +129,7 @@ describe('TemplateCard', () => {
       >
         <TemplateCard template={mockTemplate} />
       </TestApiProvider>,
+      mountedRoutes,
     );
 
     expect(getByText('No description')).toBeInTheDocument();
@@ -151,6 +160,7 @@ describe('TemplateCard', () => {
       >
         <TemplateCard template={mockTemplate} />
       </TestApiProvider>,
+      mountedRoutes,
     );
 
     expect(queryByTestId('template-card-separator')).toBeInTheDocument();
@@ -187,6 +197,7 @@ describe('TemplateCard', () => {
       >
         <TemplateCard template={mockTemplate} />
       </TestApiProvider>,
+      mountedRoutes,
     );
 
     for (const tag of mockTemplate.metadata.tags!) {
@@ -227,11 +238,7 @@ describe('TemplateCard', () => {
       >
         <TemplateCard template={mockTemplate} />
       </TestApiProvider>,
-      {
-        mountedRoutes: {
-          '/catalog/:kind/:namespace/:name': entityRouteRef,
-        },
-      },
+      mountedRoutes,
     );
 
     expect(queryByTestId('template-card-separator')).toBeInTheDocument();
@@ -272,11 +279,7 @@ describe('TemplateCard', () => {
       >
         <TemplateCard template={mockTemplate} additionalLinks={[]} />
       </TestApiProvider>,
-      {
-        mountedRoutes: {
-          '/catalog/:kind/:namespace/:name': entityRouteRef,
-        },
-      },
+      mountedRoutes,
     );
 
     expect(queryByTestId('template-card-separator')).toBeInTheDocument();
@@ -321,11 +324,7 @@ describe('TemplateCard', () => {
       >
         <TemplateCard template={mockTemplate} additionalLinks={[]} />
       </TestApiProvider>,
-      {
-        mountedRoutes: {
-          '/catalog/:kind/:namespace/:name': entityRouteRef,
-        },
-      },
+      mountedRoutes,
     );
 
     expect(queryByTestId('template-card-separator')).not.toBeInTheDocument();
@@ -364,17 +363,13 @@ describe('TemplateCard', () => {
       >
         <TemplateCard template={mockTemplate} />
       </TestApiProvider>,
-      {
-        mountedRoutes: {
-          '/catalog/:kind/:namespace/:name': entityRouteRef,
-        },
-      },
+      mountedRoutes,
     );
 
     expect(getByRole('link', { name: /.*my-test-user$/ })).toBeInTheDocument();
     expect(getByRole('link', { name: /.*my-test-user$/ })).toHaveAttribute(
       'href',
-      '/catalog/group/default/my-test-user',
+      '/catalog/default/group/my-test-user',
     );
   });
 
@@ -404,11 +399,7 @@ describe('TemplateCard', () => {
       >
         <TemplateCard template={mockTemplate} onSelected={mockOnSelected} />
       </TestApiProvider>,
-      {
-        mountedRoutes: {
-          '/catalog/:kind/:namespace/:name': entityRouteRef,
-        },
-      },
+      mountedRoutes,
     );
 
     expect(getByRole('button', { name: 'Choose' })).toBeInTheDocument();
@@ -448,11 +439,7 @@ describe('TemplateCard', () => {
           <TemplateCard template={mockTemplate} onSelected={mockOnSelected} />
         </TestApiProvider>
       </SWRConfig>,
-      {
-        mountedRoutes: {
-          '/catalog/:kind/:namespace/:name': entityRouteRef,
-        },
-      },
+      mountedRoutes,
     );
 
     expect(queryByText('Choose')).toBeNull();

--- a/plugins/scaffolder-react/src/next/components/TemplateCard/TemplateDetailButton.tsx
+++ b/plugins/scaffolder-react/src/next/components/TemplateCard/TemplateDetailButton.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import Tooltip from '@material-ui/core/Tooltip';
+import IconButton from '@material-ui/core/IconButton';
+import Typography from '@material-ui/core/Typography';
+import DescriptionIcon from '@material-ui/icons/Description';
+import { Link } from '@backstage/core-components';
+import {
+  entityRouteParams,
+  entityRouteRef,
+} from '@backstage/plugin-catalog-react';
+import { useRouteRef } from '@backstage/core-plugin-api';
+import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
+import { scaffolderReactTranslationRef } from '../../../translation';
+import { useTranslationRef } from '@backstage/frontend-plugin-api';
+
+export interface TemplateDetailButtonProps {
+  template: Entity;
+}
+
+export const TemplateDetailButton = ({
+  template,
+}: TemplateDetailButtonProps) => {
+  const catalogEntityRoute = useRouteRef(entityRouteRef);
+  const { t } = useTranslationRef(scaffolderReactTranslationRef);
+  const entityRef = stringifyEntityRef(template);
+
+  return (
+    <Tooltip id={`tooltip-${entityRef}`} title={t('cardHeader.detailBtnTitle')}>
+      <IconButton
+        aria-label={t('cardHeader.detailBtnTitle')}
+        id={`viewDetail-${entityRef}`}
+        style={{ padding: 0 }}
+        color="inherit"
+      >
+        <Typography component="span">
+          <Link
+            to={catalogEntityRoute(entityRouteParams(template))}
+            style={{ display: 'flex', alignItems: 'center' }}
+          >
+            <DescriptionIcon />
+          </Link>
+        </Typography>
+      </IconButton>
+    </Tooltip>
+  );
+};

--- a/plugins/scaffolder-react/src/translation.ts
+++ b/plugins/scaffolder-react/src/translation.ts
@@ -44,6 +44,9 @@ export const scaffolderReactTranslationRef = createTranslationRef({
       noDescription: 'No description',
       chooseButtonText: 'Choose',
     },
+    cardHeader: {
+      detailBtnTitle: 'Show template entity details',
+    },
     templateOutputs: {
       title: 'Text Output',
     },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I desperately missed a backward link - a fast way - to the entity template. So here it is:

![detail-button](https://github.com/user-attachments/assets/c0fe3d2f-a8a3-49ba-8455-73681be2c84f)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
