### PR TITLE
Made "github:autolinks:create" action idempotent

### DIFF
--- a/.changeset/metal-animals-notice.md
+++ b/.changeset/metal-animals-notice.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-github': patch
+---
+
+Made "github:autolinks:create" action idempotent

--- a/plugins/scaffolder-backend-module-github/src/actions/githubAutolinks.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubAutolinks.ts
@@ -108,15 +108,20 @@ export function createGithubAutolinksAction(options: {
         }),
       );
 
-      await client.rest.repos.createAutolink({
-        owner,
-        repo,
-        key_prefix: keyPrefix,
-        url_template: urlTemplate,
-        is_alphanumeric: isAlphanumeric,
-      });
+      await ctx.checkpoint({
+        key: `create.auto.link.${owner}.${repo}`,
+        fn: async () => {
+          await client.rest.repos.createAutolink({
+            owner,
+            repo,
+            key_prefix: keyPrefix,
+            url_template: urlTemplate,
+            is_alphanumeric: isAlphanumeric,
+          });
 
-      ctx.logger.info(`Autolink reference created successfully`);
+          ctx.logger.info(`Autolink reference created successfully`);
+        },
+      });
     },
   });
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Made "github:autolinks:create" action idempotent

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
