### PR TITLE
[NFS ] Accept custom entity card types

### DIFF
--- a/.changeset/stupid-islands-clap.md
+++ b/.changeset/stupid-islands-clap.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+To give more flexibility in customizing the layout of the entity overview tab, it is now possible to configure custom entity card types via the `app-config.yaml` file or set them when creating a card extension. This means that any string other than `summary`, `info` or `content` will be accepted as the value of a card extension type `config` or `param`. It is up to the layout component to decide whether to validate and use a custom value.

--- a/plugins/api-docs/report-alpha.api.md
+++ b/plugins/api-docs/report-alpha.api.md
@@ -48,11 +48,11 @@ const _default: FrontendPlugin<
       name: 'consumed-apis';
       config: {
         filter: EntityPredicate | undefined;
-        type: 'content' | 'summary' | 'info' | undefined;
+        type: string | undefined;
       };
       configInput: {
         filter?: EntityPredicate | undefined;
-        type?: 'content' | 'summary' | 'info' | undefined;
+        type?: string | undefined;
       };
       output:
         | ConfigurableExtensionDataRef<
@@ -75,7 +75,7 @@ const _default: FrontendPlugin<
             }
           >
         | ConfigurableExtensionDataRef<
-            EntityCardType,
+            string,
             'catalog.entity-card-type',
             {
               optional: true;
@@ -93,11 +93,11 @@ const _default: FrontendPlugin<
       name: 'consuming-components';
       config: {
         filter: EntityPredicate | undefined;
-        type: 'content' | 'summary' | 'info' | undefined;
+        type: string | undefined;
       };
       configInput: {
         filter?: EntityPredicate | undefined;
-        type?: 'content' | 'summary' | 'info' | undefined;
+        type?: string | undefined;
       };
       output:
         | ConfigurableExtensionDataRef<
@@ -120,7 +120,7 @@ const _default: FrontendPlugin<
             }
           >
         | ConfigurableExtensionDataRef<
-            EntityCardType,
+            string,
             'catalog.entity-card-type',
             {
               optional: true;
@@ -138,11 +138,11 @@ const _default: FrontendPlugin<
       name: 'definition';
       config: {
         filter: EntityPredicate | undefined;
-        type: 'content' | 'summary' | 'info' | undefined;
+        type: string | undefined;
       };
       configInput: {
         filter?: EntityPredicate | undefined;
-        type?: 'content' | 'summary' | 'info' | undefined;
+        type?: string | undefined;
       };
       output:
         | ConfigurableExtensionDataRef<
@@ -165,7 +165,7 @@ const _default: FrontendPlugin<
             }
           >
         | ConfigurableExtensionDataRef<
-            EntityCardType,
+            string,
             'catalog.entity-card-type',
             {
               optional: true;
@@ -183,11 +183,11 @@ const _default: FrontendPlugin<
       name: 'has-apis';
       config: {
         filter: EntityPredicate | undefined;
-        type: 'content' | 'summary' | 'info' | undefined;
+        type: string | undefined;
       };
       configInput: {
         filter?: EntityPredicate | undefined;
-        type?: 'content' | 'summary' | 'info' | undefined;
+        type?: string | undefined;
       };
       output:
         | ConfigurableExtensionDataRef<
@@ -210,7 +210,7 @@ const _default: FrontendPlugin<
             }
           >
         | ConfigurableExtensionDataRef<
-            EntityCardType,
+            string,
             'catalog.entity-card-type',
             {
               optional: true;
@@ -228,11 +228,11 @@ const _default: FrontendPlugin<
       name: 'provided-apis';
       config: {
         filter: EntityPredicate | undefined;
-        type: 'content' | 'summary' | 'info' | undefined;
+        type: string | undefined;
       };
       configInput: {
         filter?: EntityPredicate | undefined;
-        type?: 'content' | 'summary' | 'info' | undefined;
+        type?: string | undefined;
       };
       output:
         | ConfigurableExtensionDataRef<
@@ -255,7 +255,7 @@ const _default: FrontendPlugin<
             }
           >
         | ConfigurableExtensionDataRef<
-            EntityCardType,
+            string,
             'catalog.entity-card-type',
             {
               optional: true;
@@ -273,11 +273,11 @@ const _default: FrontendPlugin<
       name: 'providing-components';
       config: {
         filter: EntityPredicate | undefined;
-        type: 'content' | 'summary' | 'info' | undefined;
+        type: string | undefined;
       };
       configInput: {
         filter?: EntityPredicate | undefined;
-        type?: 'content' | 'summary' | 'info' | undefined;
+        type?: string | undefined;
       };
       output:
         | ConfigurableExtensionDataRef<
@@ -300,7 +300,7 @@ const _default: FrontendPlugin<
             }
           >
         | ConfigurableExtensionDataRef<
-            EntityCardType,
+            string,
             'catalog.entity-card-type',
             {
               optional: true;

--- a/plugins/catalog-graph/report-alpha.api.md
+++ b/plugins/catalog-graph/report-alpha.api.md
@@ -45,7 +45,7 @@ const _default: FrontendPlugin<
         height: number | undefined;
       } & {
         filter: EntityPredicate | undefined;
-        type: 'content' | 'summary' | 'info' | undefined;
+        type: string | undefined;
       };
       configInput: {
         height?: number | undefined;
@@ -61,7 +61,7 @@ const _default: FrontendPlugin<
         relationPairs?: [string, string][] | undefined;
       } & {
         filter?: EntityPredicate | undefined;
-        type?: 'content' | 'summary' | 'info' | undefined;
+        type?: string | undefined;
       };
       output:
         | ConfigurableExtensionDataRef<
@@ -84,7 +84,7 @@ const _default: FrontendPlugin<
             }
           >
         | ConfigurableExtensionDataRef<
-            EntityCardType,
+            string,
             'catalog.entity-card-type',
             {
               optional: true;

--- a/plugins/catalog-react/report-alpha.api.md
+++ b/plugins/catalog-react/report-alpha.api.md
@@ -94,6 +94,9 @@ export function convertLegacyEntityContentExtension(
   },
 ): ExtensionDefinition;
 
+// @alpha (undocumented)
+export const defaultEntityCardTypes: readonly ['summary', 'info', 'content'];
+
 // @alpha
 export const defaultEntityContentGroups: {
   documentation: string;
@@ -128,7 +131,7 @@ export const EntityCardBlueprint: ExtensionBlueprint<{
         }
       >
     | ConfigurableExtensionDataRef<
-        EntityCardType,
+        string,
         'catalog.entity-card-type',
         {
           optional: true;
@@ -137,11 +140,11 @@ export const EntityCardBlueprint: ExtensionBlueprint<{
   inputs: {};
   config: {
     filter: EntityPredicate | undefined;
-    type: 'content' | 'summary' | 'info' | undefined;
+    type: string | undefined;
   };
   configInput: {
     filter?: EntityPredicate | undefined;
-    type?: 'content' | 'summary' | 'info' | undefined;
+    type?: string | undefined;
   };
   dataRefs: {
     filterFunction: ConfigurableExtensionDataRef<
@@ -154,16 +157,12 @@ export const EntityCardBlueprint: ExtensionBlueprint<{
       'catalog.entity-filter-expression',
       {}
     >;
-    type: ConfigurableExtensionDataRef<
-      EntityCardType,
-      'catalog.entity-card-type',
-      {}
-    >;
+    type: ConfigurableExtensionDataRef<string, 'catalog.entity-card-type', {}>;
   };
 }>;
 
 // @alpha (undocumented)
-export type EntityCardType = 'summary' | 'info' | 'content';
+export type EntityCardType = (typeof defaultEntityCardTypes)[number] | string;
 
 // @alpha
 export const EntityContentBlueprint: ExtensionBlueprint<{

--- a/plugins/catalog-react/src/alpha/blueprints/EntityCardBlueprint.test.tsx
+++ b/plugins/catalog-react/src/alpha/blueprints/EntityCardBlueprint.test.tsx
@@ -174,12 +174,19 @@ describe('EntityCardBlueprint', () => {
                 ],
               },
               "type": {
-                "enum": [
-                  "summary",
-                  "info",
-                  "content",
+                "anyOf": [
+                  {
+                    "enum": [
+                      "summary",
+                      "info",
+                      "content",
+                    ],
+                    "type": "string",
+                  },
+                  {
+                    "type": "string",
+                  },
                 ],
-                "type": "string",
               },
             },
             "type": "object",

--- a/plugins/catalog-react/src/alpha/blueprints/EntityCardBlueprint.ts
+++ b/plugins/catalog-react/src/alpha/blueprints/EntityCardBlueprint.ts
@@ -23,7 +23,7 @@ import {
   entityFilterFunctionDataRef,
   entityFilterExpressionDataRef,
   entityCardTypeDataRef,
-  entityCardTypes,
+  defaultEntityCardTypes,
   EntityCardType,
 } from './extensionData';
 import { createEntityPredicateSchema } from '../predicates/createEntityPredicateSchema';
@@ -53,7 +53,7 @@ export const EntityCardBlueprint = createExtensionBlueprint({
     schema: {
       filter: z =>
         z.union([z.string(), createEntityPredicateSchema(z)]).optional(),
-      type: z => z.enum(entityCardTypes).optional(),
+      type: z => z.enum(defaultEntityCardTypes).or(z.string()).optional(),
     },
   },
   *factory(

--- a/plugins/catalog-react/src/alpha/blueprints/extensionData.tsx
+++ b/plugins/catalog-react/src/alpha/blueprints/extensionData.tsx
@@ -49,18 +49,11 @@ export const entityContentGroupDataRef = createExtensionDataRef<string>().with({
   id: 'catalog.entity-content-group',
 });
 
-/**
- * @internal
- * Available entity card types
- */
-export const entityCardTypes = [
-  'summary',
-  'info',
-  'content',
-] as const satisfies readonly EntityCardType[];
+/** @alpha */
+export const defaultEntityCardTypes = ['summary', 'info', 'content'] as const;
 
 /** @alpha */
-export type EntityCardType = 'summary' | 'info' | 'content';
+export type EntityCardType = (typeof defaultEntityCardTypes)[number] | string;
 
 /** @internal */
 export const entityCardTypeDataRef =

--- a/plugins/catalog-react/src/alpha/blueprints/index.ts
+++ b/plugins/catalog-react/src/alpha/blueprints/index.ts
@@ -20,5 +20,8 @@ export {
   type EntityContentLayoutProps,
 } from './EntityContentLayoutBlueprint';
 export { EntityHeaderBlueprint } from './EntityHeaderBlueprint';
-export { defaultEntityContentGroups } from './extensionData';
-export type { EntityCardType } from './extensionData';
+export {
+  defaultEntityContentGroups,
+  defaultEntityCardTypes,
+  type EntityCardType,
+} from './extensionData';

--- a/plugins/catalog/report-alpha.api.md
+++ b/plugins/catalog/report-alpha.api.md
@@ -354,11 +354,11 @@ const _default: FrontendPlugin<
       name: 'about';
       config: {
         filter: EntityPredicate | undefined;
-        type: 'content' | 'summary' | 'info' | undefined;
+        type: string | undefined;
       };
       configInput: {
         filter?: EntityPredicate | undefined;
-        type?: 'content' | 'summary' | 'info' | undefined;
+        type?: string | undefined;
       };
       output:
         | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
@@ -377,7 +377,7 @@ const _default: FrontendPlugin<
             }
           >
         | ConfigurableExtensionDataRef<
-            EntityCardType,
+            string,
             'catalog.entity-card-type',
             {
               optional: true;
@@ -395,11 +395,11 @@ const _default: FrontendPlugin<
       name: 'depends-on-components';
       config: {
         filter: EntityPredicate | undefined;
-        type: 'content' | 'summary' | 'info' | undefined;
+        type: string | undefined;
       };
       configInput: {
         filter?: EntityPredicate | undefined;
-        type?: 'content' | 'summary' | 'info' | undefined;
+        type?: string | undefined;
       };
       output:
         | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
@@ -418,7 +418,7 @@ const _default: FrontendPlugin<
             }
           >
         | ConfigurableExtensionDataRef<
-            EntityCardType,
+            string,
             'catalog.entity-card-type',
             {
               optional: true;
@@ -436,11 +436,11 @@ const _default: FrontendPlugin<
       name: 'depends-on-resources';
       config: {
         filter: EntityPredicate | undefined;
-        type: 'content' | 'summary' | 'info' | undefined;
+        type: string | undefined;
       };
       configInput: {
         filter?: EntityPredicate | undefined;
-        type?: 'content' | 'summary' | 'info' | undefined;
+        type?: string | undefined;
       };
       output:
         | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
@@ -459,7 +459,7 @@ const _default: FrontendPlugin<
             }
           >
         | ConfigurableExtensionDataRef<
-            EntityCardType,
+            string,
             'catalog.entity-card-type',
             {
               optional: true;
@@ -477,11 +477,11 @@ const _default: FrontendPlugin<
       name: 'has-components';
       config: {
         filter: EntityPredicate | undefined;
-        type: 'content' | 'summary' | 'info' | undefined;
+        type: string | undefined;
       };
       configInput: {
         filter?: EntityPredicate | undefined;
-        type?: 'content' | 'summary' | 'info' | undefined;
+        type?: string | undefined;
       };
       output:
         | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
@@ -500,7 +500,7 @@ const _default: FrontendPlugin<
             }
           >
         | ConfigurableExtensionDataRef<
-            EntityCardType,
+            string,
             'catalog.entity-card-type',
             {
               optional: true;
@@ -518,11 +518,11 @@ const _default: FrontendPlugin<
       name: 'has-resources';
       config: {
         filter: EntityPredicate | undefined;
-        type: 'content' | 'summary' | 'info' | undefined;
+        type: string | undefined;
       };
       configInput: {
         filter?: EntityPredicate | undefined;
-        type?: 'content' | 'summary' | 'info' | undefined;
+        type?: string | undefined;
       };
       output:
         | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
@@ -541,7 +541,7 @@ const _default: FrontendPlugin<
             }
           >
         | ConfigurableExtensionDataRef<
-            EntityCardType,
+            string,
             'catalog.entity-card-type',
             {
               optional: true;
@@ -559,11 +559,11 @@ const _default: FrontendPlugin<
       name: 'has-subcomponents';
       config: {
         filter: EntityPredicate | undefined;
-        type: 'content' | 'summary' | 'info' | undefined;
+        type: string | undefined;
       };
       configInput: {
         filter?: EntityPredicate | undefined;
-        type?: 'content' | 'summary' | 'info' | undefined;
+        type?: string | undefined;
       };
       output:
         | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
@@ -582,7 +582,7 @@ const _default: FrontendPlugin<
             }
           >
         | ConfigurableExtensionDataRef<
-            EntityCardType,
+            string,
             'catalog.entity-card-type',
             {
               optional: true;
@@ -600,11 +600,11 @@ const _default: FrontendPlugin<
       name: 'has-subdomains';
       config: {
         filter: EntityPredicate | undefined;
-        type: 'content' | 'summary' | 'info' | undefined;
+        type: string | undefined;
       };
       configInput: {
         filter?: EntityPredicate | undefined;
-        type?: 'content' | 'summary' | 'info' | undefined;
+        type?: string | undefined;
       };
       output:
         | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
@@ -623,7 +623,7 @@ const _default: FrontendPlugin<
             }
           >
         | ConfigurableExtensionDataRef<
-            EntityCardType,
+            string,
             'catalog.entity-card-type',
             {
               optional: true;
@@ -641,11 +641,11 @@ const _default: FrontendPlugin<
       name: 'has-systems';
       config: {
         filter: EntityPredicate | undefined;
-        type: 'content' | 'summary' | 'info' | undefined;
+        type: string | undefined;
       };
       configInput: {
         filter?: EntityPredicate | undefined;
-        type?: 'content' | 'summary' | 'info' | undefined;
+        type?: string | undefined;
       };
       output:
         | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
@@ -664,7 +664,7 @@ const _default: FrontendPlugin<
             }
           >
         | ConfigurableExtensionDataRef<
-            EntityCardType,
+            string,
             'catalog.entity-card-type',
             {
               optional: true;
@@ -682,11 +682,11 @@ const _default: FrontendPlugin<
       name: 'labels';
       config: {
         filter: EntityPredicate | undefined;
-        type: 'content' | 'summary' | 'info' | undefined;
+        type: string | undefined;
       };
       configInput: {
         filter?: EntityPredicate | undefined;
-        type?: 'content' | 'summary' | 'info' | undefined;
+        type?: string | undefined;
       };
       output:
         | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
@@ -705,7 +705,7 @@ const _default: FrontendPlugin<
             }
           >
         | ConfigurableExtensionDataRef<
-            EntityCardType,
+            string,
             'catalog.entity-card-type',
             {
               optional: true;
@@ -723,11 +723,11 @@ const _default: FrontendPlugin<
       name: 'links';
       config: {
         filter: EntityPredicate | undefined;
-        type: 'content' | 'summary' | 'info' | undefined;
+        type: string | undefined;
       };
       configInput: {
         filter?: EntityPredicate | undefined;
-        type?: 'content' | 'summary' | 'info' | undefined;
+        type?: string | undefined;
       };
       output:
         | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
@@ -746,7 +746,7 @@ const _default: FrontendPlugin<
             }
           >
         | ConfigurableExtensionDataRef<
-            EntityCardType,
+            string,
             'catalog.entity-card-type',
             {
               optional: true;
@@ -851,7 +851,7 @@ const _default: FrontendPlugin<
               }
             >
           | ConfigurableExtensionDataRef<
-              EntityCardType,
+              string,
               'catalog.entity-card-type',
               {
                 optional: true;

--- a/plugins/org/report-alpha.api.md
+++ b/plugins/org/report-alpha.api.md
@@ -24,11 +24,11 @@ const _default: FrontendPlugin<
       name: 'group-profile';
       config: {
         filter: EntityPredicate | undefined;
-        type: 'content' | 'summary' | 'info' | undefined;
+        type: string | undefined;
       };
       configInput: {
         filter?: EntityPredicate | undefined;
-        type?: 'content' | 'summary' | 'info' | undefined;
+        type?: string | undefined;
       };
       output:
         | ConfigurableExtensionDataRef<
@@ -51,7 +51,7 @@ const _default: FrontendPlugin<
             }
           >
         | ConfigurableExtensionDataRef<
-            EntityCardType,
+            string,
             'catalog.entity-card-type',
             {
               optional: true;
@@ -69,11 +69,11 @@ const _default: FrontendPlugin<
       name: 'members-list';
       config: {
         filter: EntityPredicate | undefined;
-        type: 'content' | 'summary' | 'info' | undefined;
+        type: string | undefined;
       };
       configInput: {
         filter?: EntityPredicate | undefined;
-        type?: 'content' | 'summary' | 'info' | undefined;
+        type?: string | undefined;
       };
       output:
         | ConfigurableExtensionDataRef<
@@ -96,7 +96,7 @@ const _default: FrontendPlugin<
             }
           >
         | ConfigurableExtensionDataRef<
-            EntityCardType,
+            string,
             'catalog.entity-card-type',
             {
               optional: true;
@@ -114,11 +114,11 @@ const _default: FrontendPlugin<
       name: 'ownership';
       config: {
         filter: EntityPredicate | undefined;
-        type: 'content' | 'summary' | 'info' | undefined;
+        type: string | undefined;
       };
       configInput: {
         filter?: EntityPredicate | undefined;
-        type?: 'content' | 'summary' | 'info' | undefined;
+        type?: string | undefined;
       };
       output:
         | ConfigurableExtensionDataRef<
@@ -141,7 +141,7 @@ const _default: FrontendPlugin<
             }
           >
         | ConfigurableExtensionDataRef<
-            EntityCardType,
+            string,
             'catalog.entity-card-type',
             {
               optional: true;
@@ -159,11 +159,11 @@ const _default: FrontendPlugin<
       name: 'user-profile';
       config: {
         filter: EntityPredicate | undefined;
-        type: 'content' | 'summary' | 'info' | undefined;
+        type: string | undefined;
       };
       configInput: {
         filter?: EntityPredicate | undefined;
-        type?: 'content' | 'summary' | 'info' | undefined;
+        type?: string | undefined;
       };
       output:
         | ConfigurableExtensionDataRef<
@@ -186,7 +186,7 @@ const _default: FrontendPlugin<
             }
           >
         | ConfigurableExtensionDataRef<
-            EntityCardType,
+            string,
             'catalog.entity-card-type',
             {
               optional: true;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Similar to: https://github.com/backstage/backstage/pull/28916

To give more flexibility in customizing the layout of the entity overview tab, it is now possible to configure custom entity card types via the `app-config.yaml` file or set them when creating a card extension. This means that any string other than `summary`, `info` or `content` will be accepted as the value of a card extension type `config` or `param`. It is up to the layout component to decide whether to validate and use a custom value.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
