### PR TITLE
Fix for repo lint max-warnings options

### DIFF
--- a/.changeset/every-ties-wink.md
+++ b/.changeset/every-ties-wink.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Fixed an issue causing the `repo lint` command to fail when the `--max-warnings` option was used.

--- a/packages/cli/cli-report.md
+++ b/packages/cli/cli-report.md
@@ -452,6 +452,7 @@ Options:
   --since <ref>
   --successCache
   --successCacheDir <path>
+  --max-warnings <number>
   --fix
   -h, --help
 ```

--- a/packages/cli/src/modules/lint/alpha.ts
+++ b/packages/cli/src/modules/lint/alpha.ts
@@ -76,6 +76,10 @@ export default createCliPlugin({
           '--since <ref>',
           'Only lint packages that changed since the specified ref',
         );
+        command.option(
+          '--max-warnings <number>',
+          'Fail if more than this number of warnings. -1 allows warnings. (default: 0)',
+        );
         command.description('Lint a repository');
         command.action(lazy(() => import('./commands/repo/lint'), 'command'));
 

--- a/packages/cli/src/modules/lint/alpha.ts
+++ b/packages/cli/src/modules/lint/alpha.ts
@@ -38,7 +38,7 @@ export default createCliPlugin({
         );
         command.option(
           '--max-warnings <number>',
-          'Fail if more than this number of warnings. -1 allows warnings. (default: 0)',
+          'Fail if more than this number of warnings. -1 allows warnings. (default: -1)',
         );
         command.description('Lint a package');
         command.action(
@@ -78,7 +78,7 @@ export default createCliPlugin({
         );
         command.option(
           '--max-warnings <number>',
-          'Fail if more than this number of warnings. -1 allows warnings. (default: 0)',
+          'Fail if more than this number of warnings. -1 allows warnings. (default: -1)',
         );
         command.description('Lint a repository');
         command.action(lazy(() => import('./commands/repo/lint'), 'command'));

--- a/packages/cli/src/modules/lint/commands/repo/lint.ts
+++ b/packages/cli/src/modules/lint/commands/repo/lint.ts
@@ -111,6 +111,7 @@ export async function command(opts: OptionValues, cmd: Command): Promise<void> {
       fix: Boolean(opts.fix),
       format: opts.format as string | undefined,
       shouldCache: Boolean(cacheContext),
+      maxWarnings: Number(opts.maxWarnings) || 0,
       successCache: cacheContext?.entries,
       rootDir: paths.targetRoot,
     },
@@ -120,6 +121,7 @@ export async function command(opts: OptionValues, cmd: Command): Promise<void> {
       shouldCache,
       successCache,
       rootDir,
+      maxWarnings,
     }) => {
       const { ESLint } = require('eslint') as typeof import('eslint');
       const crypto = require('crypto') as typeof import('crypto');
@@ -131,7 +133,6 @@ export async function command(opts: OptionValues, cmd: Command): Promise<void> {
       return async ({
         fullDir,
         relativeDir,
-        lintOptions,
         parentHash,
       }): Promise<{
         relativeDir: string;
@@ -199,7 +200,6 @@ export async function command(opts: OptionValues, cmd: Command): Promise<void> {
           await ESLint.outputFixes(results);
         }
 
-        const maxWarnings = lintOptions?.maxWarnings ?? 0;
         const ignoreWarnings = +maxWarnings === -1;
 
         const resultText = formatter.format(results) as string;

--- a/packages/cli/src/modules/lint/commands/repo/lint.ts
+++ b/packages/cli/src/modules/lint/commands/repo/lint.ts
@@ -111,7 +111,7 @@ export async function command(opts: OptionValues, cmd: Command): Promise<void> {
       fix: Boolean(opts.fix),
       format: opts.format as string | undefined,
       shouldCache: Boolean(cacheContext),
-      maxWarnings: Number(opts.maxWarnings) || 0,
+      maxWarnings: opts.maxWarnings ?? -1,
       successCache: cacheContext?.entries,
       rootDir: paths.targetRoot,
     },

--- a/packages/cli/src/modules/lint/index.ts
+++ b/packages/cli/src/modules/lint/index.ts
@@ -62,6 +62,10 @@ export function registerRepoCommands(command: Command) {
       '--successCacheDir <path>',
       'Set the success cache location, (default: node_modules/.cache/backstage-cli)',
     )
+    .option(
+      '--max-warnings <number>',
+      'Fail if more than this number of warnings. -1 allows warnings. (default: 0)',
+    )
     .option('--fix', 'Attempt to automatically fix violations')
     .action(lazy(() => import('./commands/repo/lint'), 'command'));
 }

--- a/packages/cli/src/modules/lint/index.ts
+++ b/packages/cli/src/modules/lint/index.ts
@@ -31,7 +31,7 @@ export function registerPackageCommands(command: Command) {
     .option('--fix', 'Attempt to automatically fix violations')
     .option(
       '--max-warnings <number>',
-      'Fail if more than this number of warnings. -1 allows warnings. (default: 0)',
+      'Fail if more than this number of warnings. -1 allows warnings. (default: -1)',
     )
     .description('Lint a package')
     .action(lazy(() => import('./commands/package/lint'), 'default'));
@@ -64,7 +64,7 @@ export function registerRepoCommands(command: Command) {
     )
     .option(
       '--max-warnings <number>',
-      'Fail if more than this number of warnings. -1 allows warnings. (default: 0)',
+      'Fail if more than this number of warnings. -1 allows warnings. (default: -1)',
     )
     .option('--fix', 'Attempt to automatically fix violations')
     .action(lazy(() => import('./commands/repo/lint'), 'command'));


### PR DESCRIPTION
## Hey, I just made a Pull Request!

It looks like we forgot to specify `--max-warnings` as a valid option of the `repo lint` command.
Fixes #29298

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
