### PR TITLE
feat: Improve Error Handling for Existing Branches in GitLab Actions

### DIFF
--- a/.changeset/gold-bugs-rhyme.md
+++ b/.changeset/gold-bugs-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gitlab': minor
+---
+
+Added additional feedback in case branch is already created

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabMergeRequest.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabMergeRequest.ts
@@ -414,20 +414,39 @@ which uses additional API calls in order to detect whether to 'create', 'update'
               execute_filemode: file.executable,
             }));
 
-      let createBranch: boolean;
-      if (actions.length) {
-        createBranch = true;
-      } else {
-        try {
-          await api.Branches.show(repoID, branchName);
-          createBranch = false;
-          ctx.logger.info(
-            `Using existing branch ${branchName} without modification.`,
-          );
-        } catch (e) {
-          createBranch = true;
+      let createBranch = actions.length > 0;
+
+      try {
+        const branch = await api.Branches.show(repoID, branchName);
+        if (createBranch) {
+          const mergeRequests = await api.MergeRequests.all({
+            projectId: repoID,
+            source_branch: branchName,
+          });
+
+          if (mergeRequests.length > 0) {
+            // If an open MR exists, include the MR link in the error message
+            throw new InputError(
+              `The branch creation failed because the branch already exists at: ${branch.web_url}. Additionally, there is a Merge Request for this branch: ${mergeRequests[0].web_url}`,
+            );
+          } else {
+            // If no open MR, just notify about the existing branch
+            throw new InputError(
+              `The branch creation failed because the branch already exists at: ${branch.web_url}.`,
+            );
+          }
         }
+
+        ctx.logger.info(
+          `Using existing branch ${branchName} without modification.`,
+        );
+      } catch (e) {
+        if (e instanceof InputError) {
+          throw e;
+        }
+        createBranch = true;
       }
+
       if (createBranch) {
         try {
           await api.Branches.create(repoID, branchName, String(targetBranch));
@@ -439,6 +458,7 @@ which uses additional API calls in order to detect whether to 'create', 'update'
           );
         }
       }
+
       await ctx.checkpoint({
         key: `commit.to.${repoID}.${branchName}`,
         fn: async () => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When creating a Merge Request using GitLab actions, if the branch already exists in the target repository, the feedback to the user was minimal. Previously, the message "_Please check that your repo does not already contain a branch named ..._" required the user to manually verify the existence of the branch.

This update improves the user experience by:

- Automatically checking if the branch exists before attempting to create it.
- Providing a direct link to the existing branch in the error message.
- Checking for any open Merge Requests for the branch and including the link if available.

This change enhances the developer workflow by reducing unnecessary manual steps and improving visibility into existing branches and MRs.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
