### PR TITLE
CLI: start command allow multiple require options

### DIFF
--- a/.changeset/thin-snails-judge.md
+++ b/.changeset/thin-snails-judge.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Resolved a problem where the `start` command did not correctly handle multiple `--require` flags, ensuring all specified modules are now properly loaded.

--- a/packages/cli/cli-report.md
+++ b/packages/cli/cli-report.md
@@ -272,7 +272,7 @@ Options:
   --check
   --inspect [host]
   --inspect-brk [host]
-  --require <path>
+  --require <path...>
   --link <path>
   -h, --help
 ```

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -86,7 +86,10 @@ export function registerScriptCommand(program: Command) {
       '--inspect-brk [host]',
       'Enable debugger in Node.js environments, breaking before code starts',
     )
-    .option('--require <path>', 'Add a --require argument to the node process')
+    .option(
+      '--require <path...>',
+      'Add a --require argument to the node process',
+    )
     .option('--link <path>', 'Link an external workspace for module resolution')
     .action(lazy(() => import('./start'), 'command'));
 

--- a/packages/cli/src/lib/runner/runBackend.ts
+++ b/packages/cli/src/lib/runner/runBackend.ts
@@ -39,7 +39,7 @@ export type RunBackendOptions = {
   /** Whether to forward the --inspect-brk flag to the node process */
   inspectBrkEnabled: boolean;
   /** Additional module to require via the --require flag to the node process */
-  require?: string;
+  require?: string | string[];
   /** An external linked workspace to override module resolution towards */
   linkedWorkspace?: string;
 };
@@ -107,7 +107,10 @@ export async function runBackend(options: RunBackendOptions) {
       optionArgs.push(inspect);
     }
     if (options.require) {
-      optionArgs.push(`--require=${options.require}`);
+      const requires = [options.require].flat();
+      for (const r of requires) {
+        optionArgs.push(`--require=${r}`);
+      }
     }
 
     const userArgs = process.argv


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix for the `start` command which was ignoring multiple `--require` options

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
