### PR TITLE
fix(catalog): reset offset on filter change in useEntityList

### DIFF
--- a/.changeset/twenty-forks-cheat.md
+++ b/.changeset/twenty-forks-cheat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Fix offset pagination to reset when updating filters in `useEntityList`

--- a/plugins/catalog-react/src/hooks/useEntityListProvider.test.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.test.tsx
@@ -23,7 +23,7 @@ import {
   identityApiRef,
   storageApiRef,
 } from '@backstage/core-plugin-api';
-import { TestApiProvider, mockApis } from '@backstage/test-utils';
+import { mockApis, TestApiProvider } from '@backstage/test-utils';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import qs from 'qs';
 import React, { PropsWithChildren } from 'react';
@@ -593,6 +593,7 @@ describe(`<EntityListProvider pagination={{ mode: 'offset' }} />`, () => {
       expect(mockCatalogApi.queryEntities).toHaveBeenCalledWith({
         filter: { kind: 'component' },
         limit,
+        offset: 0,
         orderFields,
         fullTextFilter: {
           term: '2',
@@ -620,6 +621,7 @@ describe(`<EntityListProvider pagination={{ mode: 'offset' }} />`, () => {
     expect(mockCatalogApi.queryEntities).toHaveBeenCalledWith({
       filter: { kind: 'component' },
       limit,
+      offset: 0,
       orderFields,
     });
   });
@@ -746,6 +748,7 @@ describe(`<EntityListProvider pagination={{ mode: 'offset' }} />`, () => {
       expect(mockCatalogApi.queryEntities).toHaveBeenNthCalledWith(2, {
         filter: { kind: 'api', 'spec.type': ['service'] },
         limit,
+        offset: 0,
         orderFields,
       });
     });

--- a/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
@@ -379,14 +379,19 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
       // TODO(vinzscam): this is currently causing issues at page reload
       // where the state is not kept. Unfortunately we need to rethink
       // the way filters work in order to fix this.
-      setCursor(undefined);
+      if (paginationMode === 'cursor') {
+        setCursor(undefined);
+      } else if (paginationMode === 'offset') {
+        // Same thing with offset
+        setOffset(0);
+      }
       setRequestedFilters(prevFilters => {
         const newFilters =
           typeof update === 'function' ? update(prevFilters) : update;
         return { ...prevFilters, ...newFilters };
       });
     },
-    [],
+    [paginationMode],
   );
 
   const pageInfo = useMemo(() => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes issue when user has `offset` pagination in use, is already on some other page than 1 and changes the filters. The same fix that was done for the cursor pagination.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
