### PR TITLE
Fixes previous attempt to auto-hide divider

### DIFF
--- a/.changeset/tiny-swans-warn.md
+++ b/.changeset/tiny-swans-warn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-home-react': patch
+---
+
+Fixes auto-hiding of content divider when title not specified

--- a/plugins/home-react/src/extensions.tsx
+++ b/plugins/home-react/src/extensions.tsx
@@ -152,7 +152,8 @@ function CardExtension<T>(props: CardExtensionComponentProps<T>) {
   }
 
   const cardProps = {
-    ...(title && { title, divider: !!title }),
+    divider: !!title,
+    ...(title && { title }),
     ...(Settings && !isCustomizable
       ? {
           action: (


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The divider prop was only being set when title was present, and the default value for divider is true. This unconditionally sets the divider prop.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
