### PR TITLE
Removes domain from being set with cookies in OAuth flows

### DIFF
--- a/plugins/auth-node/src/types.ts
+++ b/plugins/auth-node/src/types.ts
@@ -389,7 +389,7 @@ export type CookieConfigurer = (ctx: {
   /** The origin URL of the app */
   appOrigin: string;
 }) => {
-  domain: string;
+  domain?: string;
   path: string;
   secure: boolean;
   sameSite?: 'none' | 'lax' | 'strict';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This PR fixes #28126, where the domain was set by default and allowed cookies to be shared across subdomains. This PR removes `domain` from the default cookie configurer, which results in the cookie only being usable on the host and not on subdomains.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets)) **TODO**
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
