### PR TITLE
feat: otel bucket configuration

### DIFF
--- a/.changeset/ripe-ducks-own.md
+++ b/.changeset/ripe-ducks-own.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+'@backstage/backend-defaults': patch
+'example-backend-legacy': patch
+'@backstage/plugin-catalog-backend': patch
+---
+
+Support configuration for OpenTelemetry Histogram Buckets on OpenTelemetry histogram metrics

--- a/packages/backend-defaults/config.d.ts
+++ b/packages/backend-defaults/config.d.ts
@@ -697,6 +697,32 @@ export interface Config {
         paths?: string[];
       }>;
     };
+
+    /**
+     * Configuration for the task scheduler
+     */
+    scheduler?: {
+      /**
+       * Defines configuration options for OpenTelemetry metrics
+       */
+      opentelemetry?: {
+        metrics?: {
+          /**
+           * Allows for configuring the default buckets for all histogram metrics or for specific histogram metrics.
+           * Learn more about histograms at https://opentelemetry.io/docs/specs/otel/metrics/data-model/#histogram.
+           *
+           * @remarks
+           *
+           * Configuration for the non 'default' keys will take precedence over 'default'. If no configuration is provided,
+           * falls back to the OpenTelemetry default buckets of [0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000].
+           */
+          histogramBuckets?: {
+            default?: Array<number>;
+            duration?: Array<number>;
+          };
+        };
+      };
+    };
   };
 
   /**

--- a/packages/backend-defaults/report-scheduler.api.md
+++ b/packages/backend-defaults/report-scheduler.api.md
@@ -5,6 +5,7 @@
 ```ts
 import { DatabaseService } from '@backstage/backend-plugin-api';
 import { LoggerService } from '@backstage/backend-plugin-api';
+import { RootConfigService } from '@backstage/backend-plugin-api';
 import { RootLifecycleService } from '@backstage/backend-plugin-api';
 import { SchedulerService } from '@backstage/backend-plugin-api';
 import { ServiceFactory } from '@backstage/backend-plugin-api';
@@ -16,6 +17,7 @@ export class DefaultSchedulerService {
     database: DatabaseService;
     logger: LoggerService;
     rootLifecycle?: RootLifecycleService;
+    config?: RootConfigService;
   }): SchedulerService;
 }
 

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/DefaultSchedulerService.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/DefaultSchedulerService.ts
@@ -17,6 +17,7 @@
 import {
   DatabaseService,
   LoggerService,
+  RootConfigService,
   RootLifecycleService,
   SchedulerService,
 } from '@backstage/backend-plugin-api';
@@ -36,6 +37,7 @@ export class DefaultSchedulerService {
     database: DatabaseService;
     logger: LoggerService;
     rootLifecycle?: RootLifecycleService;
+    config?: RootConfigService;
   }): SchedulerService {
     const databaseFactory = once(async () => {
       const knex = await options.database.getClient();
@@ -63,6 +65,7 @@ export class DefaultSchedulerService {
       databaseFactory,
       options.logger,
       options.rootLifecycle,
+      options.config,
     );
   }
 }

--- a/packages/backend-defaults/src/entrypoints/scheduler/schedulerServiceFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/schedulerServiceFactory.ts
@@ -35,8 +35,14 @@ export const schedulerServiceFactory = createServiceFactory({
     database: coreServices.database,
     logger: coreServices.logger,
     rootLifecycle: coreServices.rootLifecycle,
+    config: coreServices.rootConfig,
   },
-  async factory({ database, logger, rootLifecycle }) {
-    return DefaultSchedulerService.create({ database, logger, rootLifecycle });
+  async factory({ database, logger, rootLifecycle, config }) {
+    return DefaultSchedulerService.create({
+      database,
+      logger,
+      rootLifecycle,
+      config,
+    });
   },
 });

--- a/packages/backend-legacy/src/index.ts
+++ b/packages/backend-legacy/src/index.ts
@@ -87,6 +87,7 @@ function makeCreateEnv(config: Config) {
     const scheduler = DefaultSchedulerService.create({
       logger,
       database,
+      config,
     });
 
     return {

--- a/plugins/catalog-backend/config.d.ts
+++ b/plugins/catalog-backend/config.d.ts
@@ -223,5 +223,29 @@ export interface Config {
      * This flag is temporary and will be enabled by default in future releases.
      */
     useUrlReadersSearch?: boolean;
+
+    /**
+     * Defines configuration options for OpenTelemetry metrics
+     */
+    opentelemetry?: {
+      metrics?: {
+        /**
+         * Allows for configuring the default buckets for all histogram metrics or for specific histogram metrics.
+         * Learn more about histograms at https://opentelemetry.io/docs/specs/otel/metrics/data-model/#histogram.
+         *
+         * @remarks
+         *
+         * Configuration for the non 'default' keys will take precedence over 'default'. If no configuration is provided,
+         * falls back to the OpenTelemetry default buckets of [0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000].
+         */
+        histogramBuckets?: {
+          default?: Array<number>;
+          processingDuration?: Array<number>;
+          processorsDuration?: Array<number>;
+          processingQueueDelay?: Array<number>;
+          stitchingDuration?: Array<number>;
+        };
+      };
+    };
   };
 }

--- a/plugins/catalog-backend/src/stitching/DefaultStitcher.ts
+++ b/plugins/catalog-backend/src/stitching/DefaultStitcher.ts
@@ -30,7 +30,10 @@ import {
   StitchingStrategy,
   stitchingStrategyFromConfig,
 } from './types';
-import { LoggerService } from '@backstage/backend-plugin-api';
+import {
+  LoggerService,
+  RootConfigService,
+} from '@backstage/backend-plugin-api';
 
 type DeferredStitchItem = Awaited<
   ReturnType<typeof getDeferredStitchableEntities>
@@ -61,6 +64,7 @@ export class DefaultStitcher implements Stitcher {
       knex: options.knex,
       logger: options.logger,
       strategy: stitchingStrategyFromConfig(config),
+      config,
     });
   }
 
@@ -68,11 +72,16 @@ export class DefaultStitcher implements Stitcher {
     knex: Knex;
     logger: LoggerService;
     strategy: StitchingStrategy;
+    config?: RootConfigService;
   }) {
     this.knex = options.knex;
     this.logger = options.logger;
     this.strategy = options.strategy;
-    this.tracker = progressTracker(options.knex, options.logger);
+    this.tracker = progressTracker(
+      options.knex,
+      options.logger,
+      options.config,
+    );
   }
 
   async stitch(options: {

--- a/plugins/scaffolder-backend/config.d.ts
+++ b/plugins/scaffolder-backend/config.d.ts
@@ -93,5 +93,27 @@ export interface Config {
      * Default value is 24 hours.
      */
     taskTimeout?: HumanDuration | string;
+
+    /**
+     * Defines configuration options for OpenTelemetry metrics
+     */
+    opentelemetry?: {
+      metrics?: {
+        /**
+         * Allows for configuring the default buckets for all histogram metrics or for specific histogram metrics.
+         * Learn more about histograms at https://opentelemetry.io/docs/specs/otel/metrics/data-model/#histogram.
+         *
+         * @remarks
+         *
+         * Configuration for the non 'default' keys will take precedence over 'default'. If no configuration is provided,
+         * falls back to the OpenTelemetry default buckets of [0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000].
+         */
+        histogramBuckets?: {
+          default?: Array<number>;
+          taskDuration?: Array<number>;
+          stepDuration?: Array<number>;
+        };
+      };
+    };
   };
 }

--- a/plugins/scaffolder-backend/report.api.md
+++ b/plugins/scaffolder-backend/report.api.md
@@ -53,6 +53,7 @@ import { PermissionRuleParams } from '@backstage/plugin-permission-common';
 import { PermissionsService } from '@backstage/backend-plugin-api';
 import { RESOURCE_TYPE_SCAFFOLDER_ACTION } from '@backstage/plugin-scaffolder-common/alpha';
 import { RESOURCE_TYPE_SCAFFOLDER_TEMPLATE } from '@backstage/plugin-scaffolder-common/alpha';
+import { RootConfigService } from '@backstage/backend-plugin-api';
 import { ScaffolderEntitiesProcessor as ScaffolderEntitiesProcessor_2 } from '@backstage/plugin-catalog-backend-module-scaffolder-entity-model';
 import { SchedulerService } from '@backstage/backend-plugin-api';
 import { ScmIntegrationRegistry } from '@backstage/integration';
@@ -403,6 +404,7 @@ export type CreateWorkerOptions = {
   additionalTemplateGlobals?: Record<string, TemplateGlobal_2>;
   permissions?: PermissionEvaluator;
   gracefulShutdown?: boolean;
+  config?: RootConfigService;
 };
 
 // @public

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/TaskWorker.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/TaskWorker.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { AuditorService } from '@backstage/backend-plugin-api';
+import {
+  AuditorService,
+  RootConfigService,
+} from '@backstage/backend-plugin-api';
 import { assertError, stringifyError } from '@backstage/errors';
 import { ScmIntegrations } from '@backstage/integration';
 import { PermissionEvaluator } from '@backstage/plugin-permission-common';
@@ -77,6 +80,7 @@ export type CreateWorkerOptions = {
   additionalTemplateGlobals?: Record<string, TemplateGlobal>;
   permissions?: PermissionEvaluator;
   gracefulShutdown?: boolean;
+  config?: RootConfigService;
 };
 
 /**
@@ -112,6 +116,7 @@ export class TaskWorker {
       additionalTemplateGlobals,
       permissions,
       gracefulShutdown,
+      config,
     } = options;
 
     const workflowRunner = new NunjucksWorkflowRunner({
@@ -123,6 +128,7 @@ export class TaskWorker {
       additionalTemplateFilters,
       additionalTemplateGlobals,
       permissions,
+      config,
     });
 
     return new TaskWorker({

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -397,6 +397,7 @@ export async function createRouter(
         concurrentTasksLimit,
         permissions,
         gracefulShutdown,
+        config,
         ...templateExtensions,
       });
       workers.push(worker);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Resolves https://github.com/backstage/backstage/issues/29339

This PR adds in configuration support for OpenTelemetry for plugins that currently define OpenTelemetry Histogram metrics. This configuration allows for custom defined histogram buckets at the individual histogram level or configuring a default for the plugin.

If no configuration is provided, existing behavior takes place.

I'm well aware this may be over-engineered for the use case, but thought it could be nice to have it configuration based since different adopters might have different buckets/minimums we care about. It also prevents this from introducing any real breaking changes by swapping bucket levels out from under (that may be a surprise for some consumers).

I wanted to get this PR opened to iterate on feedback/ideas before I move forward on further providing screenshots/demos or updating any user facing documentation

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
