### PR TITLE
feat(backend-app-api): add config to permit module failures on startup to not effect the plugin from starting up

### DIFF
--- a/.changeset/eight-toys-feel.md
+++ b/.changeset/eight-toys-feel.md
@@ -1,0 +1,35 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+Added a configuration to permit backend plugin module failures on startup:
+
+```yaml
+backend:
+  ...
+  startup:
+    plugins:
+      plugin-x:
+        modules:
+          module-y:
+            onPluginModuleBootFailure: continue
+```
+
+This configuration permits `plugin-x` with `module-y` to fail on startup. Omitting the
+`onPluginModuleBootFailure` configuration matches the previous behavior, wherein any
+individual plugin module failure is forwarded to the plugin and aborts backend startup.
+
+The default can also be changed, so that continuing on failure is the default
+unless otherwise specified:
+
+```yaml
+backend:
+  startup:
+    default:
+      onPluginModuleBootFailure: continue
+    plugins:
+      catalog:
+        modules:
+          github:
+            onPluginModuleBootFailure: abort
+```

--- a/packages/backend-app-api/config.d.ts
+++ b/packages/backend-app-api/config.d.ts
@@ -34,6 +34,14 @@ export interface Config {
          * `onPluginBootFailure: abort` to be required.
          */
         onPluginBootFailure?: 'continue' | 'abort';
+        /**
+         * The default value for `onPluginModuleBootFailure` if not specified for a particular plugin module.
+         * This defaults to 'abort', which means `onPluginModuleBootFailure: continue` must be specified
+         * for backend startup to continue on plugin module boot failure. This can also be set to
+         * 'continue', which flips the logic for individual plugin modules so that they must be set to
+         * `onPluginModuleBootFailure: abort` to be required.
+         */
+        onPluginModuleBootFailure?: 'continue' | 'abort';
       };
       plugins?: {
         [pluginId: string]: {
@@ -46,6 +54,19 @@ export interface Config {
            * setting).
            */
           onPluginBootFailure?: 'continue' | 'abort';
+          modules?: {
+            [moduleId: string]: {
+              /**
+               * Used to control backend startup behavior when this plugin module fails to boot up. Setting
+               * this to `continue` allows the backend to continue starting up, even if this plugin
+               * module fails. This can enable leaving a crashing plugin installed, but still permit backend
+               * startup, which may help troubleshoot data-dependent issues. Plugin module failures for plugin modules
+               * set to `abort` are fatal (this is the default unless overridden by the `default`
+               * setting).
+               */
+              onPluginModuleBootFailure?: 'continue' | 'abort';
+            };
+          };
         };
       };
     };

--- a/packages/backend-app-api/src/wiring/BackendInitializer.ts
+++ b/packages/backend-app-api/src/wiring/BackendInitializer.ts
@@ -365,17 +365,38 @@ export class BackendInitializer {
             }
             await tree.parallelTopologicalTraversal(
               async ({ moduleId, moduleInit }) => {
-                const moduleDeps = await this.#getInitDeps(
-                  moduleInit.init.deps,
-                  pluginId,
-                  moduleId,
-                );
-                await moduleInit.init.func(moduleDeps).catch(error => {
-                  throw new ForwardedError(
-                    `Module '${moduleId}' for plugin '${pluginId}' startup failed`,
-                    error,
+                const isModuleBootFailurePermitted =
+                  this.#getPluginModuleBootFailurePredicate(
+                    pluginId,
+                    moduleId,
+                    rootConfig,
                   );
-                });
+
+                try {
+                  const moduleDeps = await this.#getInitDeps(
+                    moduleInit.init.deps,
+                    pluginId,
+                    moduleId,
+                  );
+                  await moduleInit.init.func(moduleDeps).catch(error => {
+                    throw new ForwardedError(
+                      `Module '${moduleId}' for plugin '${pluginId}' startup failed`,
+                      error,
+                    );
+                  });
+                } catch (error: unknown) {
+                  assertError(error);
+                  if (isModuleBootFailurePermitted) {
+                    initLogger.onPermittedPluginModuleFailure(
+                      pluginId,
+                      moduleId,
+                      error,
+                    );
+                  } else {
+                    initLogger.onPluginModuleFailed(pluginId, moduleId, error);
+                    throw error;
+                  }
+                }
               },
             );
           }
@@ -648,6 +669,24 @@ export class BackendInitializer {
       ) ?? defaultStartupBootFailureValue;
 
     return pluginStartupBootFailureValue === 'continue';
+  }
+
+  #getPluginModuleBootFailurePredicate(
+    pluginId: string,
+    moduleId: string,
+    config?: Config,
+  ): boolean {
+    const defaultStartupBootFailureValue =
+      config?.getOptionalString(
+        'backend.startup.default.onPluginModuleBootFailure',
+      ) ?? 'abort';
+
+    const pluginModuleStartupBootFailureValue =
+      config?.getOptionalString(
+        `backend.startup.plugins.${pluginId}.modules.${moduleId}.onPluginModuleBootFailure`,
+      ) ?? defaultStartupBootFailureValue;
+
+    return pluginModuleStartupBootFailureValue === 'continue';
   }
 }
 

--- a/packages/backend-app-api/src/wiring/createInitializationLogger.ts
+++ b/packages/backend-app-api/src/wiring/createInitializationLogger.ts
@@ -29,6 +29,12 @@ export function createInitializationLogger(
   onPluginStarted(pluginId: string): void;
   onPluginFailed(pluginId: string, error: Error): void;
   onPermittedPluginFailure(pluginId: string, error: Error): void;
+  onPluginModuleFailed(pluginId: string, moduleId: string, error: Error): void;
+  onPermittedPluginModuleFailure(
+    pluginId: string,
+    moduleId: string,
+    error: Error,
+  ): void;
   onAllStarted(): void;
 } {
   const logger = rootLogger?.child({ type: 'initialization' });
@@ -84,6 +90,26 @@ export function createInitializationLogger(
       starting.delete(pluginId);
       logger?.error(
         `Plugin '${pluginId}' threw an error during startup, but boot failure is permitted for this plugin so startup will continue.`,
+        error,
+      );
+    },
+    onPluginModuleFailed(pluginId: string, moduleId: string, error: Error) {
+      const status =
+        starting.size > 0
+          ? `, waiting for ${starting.size} other plugins to finish before shutting down the process`
+          : '';
+      logger?.error(
+        `Module ${moduleId} in Plugin '${pluginId}' threw an error during startup${status}.`,
+        error,
+      );
+    },
+    onPermittedPluginModuleFailure(
+      pluginId: string,
+      moduleId: string,
+      error: Error,
+    ) {
+      logger?.error(
+        `Module ${moduleId} in Plugin '${pluginId}' threw an error during startup, but boot failure is permitted for this plugin module so startup will continue.`,
         error,
       );
     },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added a `onPluginModuleBootFailure` following the pattern of the `onPluginBootFailure`. This allows an indivdual module to fail without the whole plugin failing. Also followed the config pattern to allow for this to be changed on an individual module level.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
