### PR TITLE
[blog] Fixing a link in the Stash blog post

### DIFF
--- a/microsite/blog/2023-07-08-stash-adopter-post.mdx
+++ b/microsite/blog/2023-07-08-stash-adopter-post.mdx
@@ -10,7 +10,7 @@ author: Taylor Webber, Staff Engineer, Stash
 
 {/* truncate */}
 
-At [Stash](stash.com), our mission is to give people the confidence to invest for a better life. Our app simplifies investing for the middle class who may be less experienced with traditional investing and retirement planning. Our customers trust us with their money, and with that, rely on us to provide a responsive and quality experience that works every time.
+At [Stash](https://www.stash.com), our mission is to give people the confidence to invest for a better life. Our app simplifies investing for the middle class who may be less experienced with traditional investing and retirement planning. Our customers trust us with their money, and with that, rely on us to provide a responsive and quality experience that works every time.
 
 It isn't revolutionary to say that monitoring the health of a software application is critical for ensuring its reliability and performance in service of customers' needs. However, in a distributed architecture like microservices, tracking ownership and monitoring application health across the system quickly becomes complex. The difficulties are further compounded when leveraging multiple SaaS products, which is common in modern development but specifically so for fintechs like Stash that integrate best-of-breed software in novel ways, as we do across our platform.
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Ran into a broken text link in this Adopter Spotlight blog post about the company Stash: https://backstage.io/blog/2023/07/08/stash-adopter-post/  

The current text link is just `stash.com`, so it's being treated as a relative link and 404-ing at: `https://backstage.io/blog/2023/07/08/stash.com`. 

Fixing it by updating the link to the full URL: `https://www.stash.com`.

#### :heavy_check_mark: Checklist

- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
