### PR TITLE
Display entity-ref in GroupProfileCard

### DIFF
--- a/.changeset/real-rings-smoke.md
+++ b/.changeset/real-rings-smoke.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+display entity-ref in GroupProfileCard so groups can easily determine their Group ID

--- a/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx
+++ b/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx
@@ -203,19 +203,17 @@ export const GroupProfileCard = (props: {
                 secondary="Child Groups"
               />
             </ListItem>
-            {stringifyEntityRef(group) && (
-              <ListItem>
-                <ListItemIcon>
-                  <Tooltip title="Group ID">
-                    <PermIdentityIcon />
-                  </Tooltip>
-                </ListItemIcon>
-                <ListItemText
-                  primary={stringifyEntityRef(group)}
-                  secondary="Group ID"
-                />
-              </ListItem>
-            )}
+            <ListItem>
+              <ListItemIcon>
+                <Tooltip title="Entity Ref">
+                  <PermIdentityIcon />
+                </Tooltip>
+              </ListItemIcon>
+              <ListItemText
+                primary={stringifyEntityRef(group)}
+                secondary="Entity Ref"
+              />
+            </ListItem>
             {props?.showLinks && <LinksGroup links={links} />}
           </List>
         </Grid>

--- a/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx
+++ b/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx
@@ -150,6 +150,17 @@ export const GroupProfileCard = (props: {
         </Grid>
         <Grid item md={10} xl={11}>
           <List>
+            <ListItem>
+              <ListItemIcon>
+                <Tooltip title="Entity Ref">
+                  <PermIdentityIcon />
+                </Tooltip>
+              </ListItemIcon>
+              <ListItemText
+                primary={stringifyEntityRef(group)}
+                secondary="Entity Ref"
+              />
+            </ListItem>
             {profile?.email && (
               <ListItem>
                 <ListItemIcon>
@@ -201,17 +212,6 @@ export const GroupProfileCard = (props: {
                   )
                 }
                 secondary="Child Groups"
-              />
-            </ListItem>
-            <ListItem>
-              <ListItemIcon>
-                <Tooltip title="Entity Ref">
-                  <PermIdentityIcon />
-                </Tooltip>
-              </ListItemIcon>
-              <ListItemText
-                primary={stringifyEntityRef(group)}
-                secondary="Entity Ref"
               />
             </ListItem>
             {props?.showLinks && <LinksGroup links={links} />}

--- a/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx
+++ b/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx
@@ -51,6 +51,7 @@ import CachedIcon from '@material-ui/icons/Cached';
 import EditIcon from '@material-ui/icons/Edit';
 import EmailIcon from '@material-ui/icons/Email';
 import GroupIcon from '@material-ui/icons/Group';
+import PermIdentityIcon from '@material-ui/icons/PermIdentity';
 import { LinksGroup } from '../../Meta';
 import { useEntityPermission } from '@backstage/plugin-catalog-react/alpha';
 import { catalogEntityRefreshPermission } from '@backstage/plugin-catalog-common/alpha';
@@ -202,6 +203,19 @@ export const GroupProfileCard = (props: {
                 secondary="Child Groups"
               />
             </ListItem>
+            {stringifyEntityRef(group) && (
+              <ListItem>
+                <ListItemIcon>
+                  <Tooltip title="Group ID">
+                    <PermIdentityIcon />
+                  </Tooltip>
+                </ListItemIcon>
+                <ListItemText
+                  primary={stringifyEntityRef(group)}
+                  secondary="Group ID"
+                />
+              </ListItem>
+            )}
             {props?.showLinks && <LinksGroup links={links} />}
           </List>
         </Grid>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds the entity-ref to the `GroupProfileCard` so that groups can easily identify their Group ID.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))


![GroupProfileCard](https://github.com/user-attachments/assets/249b7ced-078b-49af-88fa-fa0b1545c98b)


