### PR TITLE
add api to retrieve template extensions info from scaffolder-backend

### DIFF
--- a/.changeset/strange-planes-kneel.md
+++ b/.changeset/strange-planes-kneel.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-scaffolder-react': minor
+'@backstage/plugin-scaffolder': minor
+---
+
+add api to retrieve template extensions info from scaffolder-backend

--- a/plugins/scaffolder-react/report.api.md
+++ b/plugins/scaffolder-react/report.api.md
@@ -55,11 +55,8 @@ export type Action = {
   examples?: ActionExample[];
 };
 
-// @public
-export type ActionExample = {
-  description: string;
-  example: string;
-};
+// @public @deprecated
+export type ActionExample = ScaffolderUsageExample;
 
 // @public
 export function createScaffolderFieldExtension<
@@ -169,6 +166,15 @@ export type LayoutTemplate<T = any> = NonNullable<
 export type ListActionsResponse = Array<Action>;
 
 // @public
+export type ListTemplateExtensionsResponse = {
+  filters: Record<string, TemplateFilter>;
+  globals: {
+    functions: Record<string, TemplateGlobalFunction>;
+    values: Record<string, TemplateGlobalValue>;
+  };
+};
+
+// @public
 export type LogEvent = {
   type: 'log' | 'completion' | 'cancelled' | 'recovered';
   body: {
@@ -241,6 +247,7 @@ export interface ScaffolderApi {
     tasks: ScaffolderTask[];
     totalTasks?: number;
   }>;
+  listTemplateExtensions?(): Promise<ListTemplateExtensionsResponse>;
   retry?(taskId: string): Promise<void>;
   scaffold(
     options: ScaffolderScaffoldOptions,
@@ -493,6 +500,13 @@ export type ScaffolderTaskStatus =
   | 'skipped';
 
 // @public
+export type ScaffolderUsageExample = {
+  description?: string;
+  example: string;
+  notes?: string;
+};
+
+// @public
 export interface ScaffolderUseTemplateSecrets {
   // (undocumented)
   secrets: Record<string, string>;
@@ -521,6 +535,33 @@ export type TaskStream = {
     [stepId in string]: ScaffolderStep;
   };
   output?: ScaffolderTaskOutput;
+};
+
+// @public
+export type TemplateFilter = {
+  description?: string;
+  schema?: {
+    input?: JSONSchema7;
+    arguments?: JSONSchema7[];
+    output?: JSONSchema7;
+  };
+  examples?: ScaffolderUsageExample[];
+};
+
+// @public
+export type TemplateGlobalFunction = {
+  description?: string;
+  schema?: {
+    arguments?: JSONSchema7[];
+    output?: JSONSchema7;
+  };
+  examples?: ScaffolderUsageExample[];
+};
+
+// @public
+export type TemplateGlobalValue = {
+  description?: string;
+  value: JsonValue;
 };
 
 // @public (undocumented)

--- a/plugins/scaffolder-react/src/api/types.ts
+++ b/plugins/scaffolder-react/src/api/types.ts
@@ -45,14 +45,23 @@ export type ScaffolderTask = {
 };
 
 /**
- * A single action example
+ * A single scaffolder usage example
  *
  * @public
  */
-export type ActionExample = {
-  description: string;
+export type ScaffolderUsageExample = {
+  description?: string;
   example: string;
+  notes?: string;
 };
+
+/**
+ * A single action example
+ *
+ * @public
+ * @deprecated in favor of ScaffolderUsageExample
+ */
+export type ActionExample = ScaffolderUsageExample;
 
 /**
  * The response shape for a single action in the `listActions` call to the `scaffolder-backend`
@@ -75,6 +84,58 @@ export type Action = {
  * @public
  */
 export type ListActionsResponse = Array<Action>;
+
+/**
+ * The response shape for a single filter in the `listTemplateExtensions` call to the `scaffolder-backend`
+ *
+ * @public
+ */
+export type TemplateFilter = {
+  description?: string;
+  schema?: {
+    input?: JSONSchema7;
+    arguments?: JSONSchema7[];
+    output?: JSONSchema7;
+  };
+  examples?: ScaffolderUsageExample[];
+};
+
+/**
+ * The response shape for a single global function in the `listTemplateExtensions` call to the `scaffolder-backend`
+ *
+ * @public
+ */
+export type TemplateGlobalFunction = {
+  description?: string;
+  schema?: {
+    arguments?: JSONSchema7[];
+    output?: JSONSchema7;
+  };
+  examples?: ScaffolderUsageExample[];
+};
+
+/**
+ * The response shape for a single global value in the `listTemplateExtensions` call to the `scaffolder-backend`
+ *
+ * @public
+ */
+export type TemplateGlobalValue = {
+  description?: string;
+  value: JsonValue;
+};
+
+/**
+ * The response shape for the `listTemplateExtensions` call to the `scaffolder-backend`
+ *
+ * @public
+ */
+export type ListTemplateExtensionsResponse = {
+  filters: Record<string, TemplateFilter>;
+  globals: {
+    functions: Record<string, TemplateGlobalFunction>;
+    values: Record<string, TemplateGlobalValue>;
+  };
+};
 
 /** @public */
 export type ScaffolderOutputLink = {
@@ -235,6 +296,11 @@ export interface ScaffolderApi {
    * Returns a list of all installed actions.
    */
   listActions(): Promise<ListActionsResponse>;
+
+  /**
+   * Returns a structure describing the available templating extensions.
+   */
+  listTemplateExtensions?(): Promise<ListTemplateExtensionsResponse>;
 
   streamLogs(options: ScaffolderStreamLogsOptions): Observable<LogEvent>;
 

--- a/plugins/scaffolder/report.api.md
+++ b/plugins/scaffolder/report.api.md
@@ -25,6 +25,7 @@ import { JSX as JSX_2 } from 'react';
 import { LayoutOptions as LayoutOptions_2 } from '@backstage/plugin-scaffolder-react';
 import { LayoutTemplate as LayoutTemplate_2 } from '@backstage/plugin-scaffolder-react';
 import { ListActionsResponse as ListActionsResponse_2 } from '@backstage/plugin-scaffolder-react';
+import { ListTemplateExtensionsResponse } from '@backstage/plugin-scaffolder-react';
 import { LogEvent as LogEvent_2 } from '@backstage/plugin-scaffolder-react';
 import { Observable } from '@backstage/types';
 import { PathParams } from '@backstage/core-plugin-api';
@@ -560,6 +561,8 @@ export class ScaffolderClient implements ScaffolderApi_2 {
     tasks: ScaffolderTask_2[];
     totalTasks?: number;
   }>;
+  // (undocumented)
+  listTemplateExtensions(): Promise<ListTemplateExtensionsResponse>;
   // (undocumented)
   retry?(taskId: string): Promise<void>;
   // (undocumented)

--- a/plugins/scaffolder/src/api.ts
+++ b/plugins/scaffolder/src/api.ts
@@ -24,6 +24,7 @@ import { ResponseError } from '@backstage/errors';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import {
   ListActionsResponse,
+  ListTemplateExtensionsResponse,
   LogEvent,
   ScaffolderApi,
   ScaffolderDryRunOptions,
@@ -322,6 +323,17 @@ export class ScaffolderClient implements ScaffolderApi {
     }
 
     return await response.json();
+  }
+
+  async listTemplateExtensions(): Promise<ListTemplateExtensionsResponse> {
+    const baseUrl = await this.discoveryApi.getBaseUrl('scaffolder');
+    const response = await this.fetchApi.fetch(
+      `${baseUrl}/v2/template-extensions`,
+    );
+    if (!response.ok) {
+      throw ResponseError.fromResponse(response);
+    }
+    return response.json();
   }
 
   async cancelTask(taskId: string): Promise<void> {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
