### PR TITLE
Fix for duplicate results in queryEntities when using an orderField

### DIFF
--- a/.changeset/famous-tips-raise.md
+++ b/.changeset/famous-tips-raise.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Fix for duplicate results in queryEntities when using an orderField

--- a/.changeset/famous-tips-raise.md
+++ b/.changeset/famous-tips-raise.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend': patch
 ---
 
-Fix for duplicate results in queryEntities when using an orderField
+Fix for duplicate results in `queryEntities` when providing an `orderField` parameter

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
@@ -1970,6 +1970,87 @@ describe('DefaultEntitiesCatalog', () => {
         ).resolves.toEqual(['BB']);
       },
     );
+
+    it.each(databases.eachSupportedId())(
+      'should not return duplicate entities when using orderField, %p',
+      async databaseId => {
+        await createDatabase(databaseId);
+
+        // Create a few test entities with different names to sort by
+        const entities = [
+          {
+            apiVersion: 'a',
+            kind: 'k',
+            metadata: {
+              name: 'a-entity',
+              title: 'A Test Entity',
+              uid: 'uid-a',
+            },
+            spec: {},
+          },
+          {
+            apiVersion: 'a',
+            kind: 'k',
+            metadata: {
+              name: 'b-entity',
+              title: 'B Test Entity',
+              uid: 'uid-b',
+            },
+            spec: {},
+          },
+          {
+            apiVersion: 'a',
+            kind: 'k',
+            metadata: {
+              name: 'c-entity',
+              title: 'C Test Entity',
+              uid: 'uid-c',
+            },
+            spec: {},
+          },
+        ];
+
+        await Promise.all(entities.map(e => addEntityToSearch(e)));
+
+        // Manually insert duplicate search entries for the same entities
+        // I'm not sure exactly how this happens but I have seen it in the real world
+        await knex<DbSearchRow>('search').insert([
+          {
+            entity_id: 'uid-a',
+            key: 'metadata.title',
+            value: 'a test entity',
+            original_value: 'A Test Entity',
+          },
+          {
+            entity_id: 'uid-b',
+            key: 'metadata.title',
+            value: 'b test entity',
+            original_value: 'B Test Entity',
+          },
+        ]);
+
+        const catalog = new DefaultEntitiesCatalog({
+          database: knex,
+          logger: mockServices.logger.mock(),
+          stitcher,
+        });
+
+        // Query with orderField
+        const response = await catalog.queryEntities({
+          orderFields: [{ field: 'metadata.title', order: 'asc' }],
+          credentials: mockCredentials.none(),
+        });
+
+        const resultEntities = entitiesResponseToObjects(response.items);
+
+        // Ensure we get exactly 3 entities back, sorted, with no duplicates
+        expect(resultEntities.map(e => e!.metadata.name)).toEqual([
+          'a-entity',
+          'b-entity',
+          'c-entity',
+        ]);
+      },
+    );
   });
 
   describe('removeEntityByUid', () => {

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -285,6 +285,7 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
 
         if (sortField) {
           inner
+            .distinct()
             .leftOuterJoin('search', qb =>
               qb
                 .on('search.entity_id', 'final_entities.entity_id')

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -273,24 +273,6 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
 
     const sortField = cursor.orderFields.at(0);
 
-    if (sortField) {
-      const duplicateCheck = await this.database('search')
-        .select('entity_id', 'key', 'value')
-        .count('* as count')
-        .where('key', '=', sortField.field)
-        .groupBy('entity_id', 'key', 'value')
-        .having(this.database.raw('count(*) > 1'))
-        .limit(5);
-
-      if (duplicateCheck.length > 0) {
-        this.logger.warn(
-          `Found duplicate search entries for field ${
-            sortField.field
-          }: ${JSON.stringify(duplicateCheck)}`,
-        );
-      }
-    }
-
     // The first part of the query builder is a subquery that applies all of the
     // filtering.
     const dbQuery = this.database.with(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Still not sure exactly why the search table sometimes has duplicate entries for a given key, but this prevents duplicate entities from showing up in the Catalog Table or the Catalog API when a query is made that includes an `orderField` parameter. For example:

`/api/catalog/entities/by-query?limit=25&offset=0&filter=kind%3Dgroup,spec.type%3Dorg&fields=metadata.name&orderField=metadata.name,asc` gives me:
```
{"items":[{"metadata":{"name":"go-to-market"}},{"metadata":{"name":"org.finance"}},{"metadata":{"name":"org.growth"}},{"metadata":{"name":"org.legal-risk"}},{"metadata":{"name":"org.marketing"}},{"metadata":{"name":"org.people"}},{"metadata":{"name":"org.user-voice"}},{"metadata":{"name":"platform"}},{"metadata":{"name":"platform"}},{"metadata":{"name":"product"}},{"metadata":{"name":"product"}},{"metadata":{"name":"product"}},{"metadata":{"name":"product"}},{"metadata":{"name":"product"}},{"metadata":{"name":"product"}},{"metadata":{"name":"product"}},{"metadata":{"name":"product"}},{"metadata":{"name":"product"}},{"metadata":{"name":"security-trust-it"}}],"totalItems":19,"pageInfo":{}}
```

(Note there are 9 entities with the name `product`).

Remove the `orderField` -- `/api/catalog/entities/by-query?limit=25&offset=0&filter=kind%3Dgroup,spec.type%3Dorg&fields=metadata.name` and I get this:

```
{"items":[{"metadata":{"name":"org.people"}},{"metadata":{"name":"org.finance"}},{"metadata":{"name":"org.growth"}},{"metadata":{"name":"org.marketing"}},{"metadata":{"name":"go-to-market"}},{"metadata":{"name":"org.user-voice"}},{"metadata":{"name":"platform"}},{"metadata":{"name":"product"}},{"metadata":{"name":"org.legal-risk"}},{"metadata":{"name":"security-trust-it"}}],"totalItems":10,"pageInfo":{}}
```

I patched `@backstage/plugin-catalog-backend` in my environment with this change plus the following debugging query:

```
    if (sortField) {
      const duplicateCheck = await this.database('search')
        .select('entity_id', 'key', 'value')
        .count('* as count')
        .where('key', '=', sortField.field)
        .groupBy('entity_id', 'key', 'value')
        .having(this.database.raw('count(*) > 1'))
        .limit(5);

      if (duplicateCheck.length > 0) {
        this.logger.warn(`Found duplicate search entries for field ${sortField.field}: ${duplicateCheck}`);
      }
    }
```

And sure enough: `Found duplicate search entries for field metadata.name: [object Object],[object Object],[object Object]`. I'm not really sure if this is expected or not, but I can definitely confirm that adding `distinct()` like this PR does removes the 8 duplicate entity results from both the API and the Catalog Table.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
