### PR TITLE
deps: force transitive update of cpu-features to 0.0.10

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -26304,13 +26304,13 @@ __metadata:
   linkType: hard
 
 "cpu-features@npm:~0.0.9":
-  version: 0.0.9
-  resolution: "cpu-features@npm:0.0.9"
+  version: 0.0.10
+  resolution: "cpu-features@npm:0.0.10"
   dependencies:
     buildcheck: "npm:~0.0.6"
-    nan: "npm:^2.17.0"
+    nan: "npm:^2.19.0"
     node-gyp: "npm:latest"
-  checksum: 10/05a4ec51fff87fcde9ca91021d9a0e73a34eb190b14163f7394757ce2470a85393bc49985915bc0bc0ad7ac1ac79caee21f8626a82b535262d9b7d012f805d64
+  checksum: 10/941b828ffe77582b2bdc03e894c913e2e2eeb5c6043ccb01338c34446d026f6888dc480ecb85e684809f9c3889d245f3648c7907eb61a92bdfc6aed039fcda8d
   languageName: node
   linkType: hard
 
@@ -37759,12 +37759,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nan@npm:^2.17.0, nan@npm:^2.18.0":
-  version: 2.18.0
-  resolution: "nan@npm:2.18.0"
+"nan@npm:^2.18.0, nan@npm:^2.19.0":
+  version: 2.22.2
+  resolution: "nan@npm:2.22.2"
   dependencies:
     node-gyp: "npm:latest"
-  checksum: 10/5520e22c64e2b5b495b1d765d6334c989b848bbe1502fec89c5857cabcc7f9f0474563377259e7574bff1c8a041d3b90e9ffa1f5e15502ffddee7b2550cc26a0
+  checksum: 10/bee49de633650213970596ffbdf036bfe2109ff283a40f7742c3aa6d1fc15b9836f62bfee82192b879f56ab5f9fa9a1e5c58a908a50e5c87d91fb2118ef70827
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When running `yarn install` on a fresh clone using Node.js 22, you may see a native build failure for cpu-features@0.0.9:

```console
➤ YN0008: │ cpu-features@npm:0.0.9 must be rebuilt because its dependency tree changed
➤ YN0009: │ cpu-features@npm:0.0.9 couldn't be built successfully (exit code 1)
```

Errors are:
```
In file included from ../src/binding.cc:3:
../../nan/nan.h:2548:8: error: no matching member function for call to 'SetAccessor'
 2548 |   tpl->SetAccessor(
      |   ~~~~~^~~~~~~~~~~
/Users/bgriggs/Library/Caches/node-gyp/22.14.0/include/node/v8-template.h:1055:8: note: candidate function not viable: no known conversion from 'v8::AccessControl' to 'PropertyAttribute' for 5th argument
 1055 |   void SetAccessor(
      |        ^
 1056 |       Local<Name> name, AccessorNameGetterCallback getter,
 1057 |       AccessorNameSetterCallback setter = nullptr,
 1058 |       Local<Value> data = Local<Value>(), PropertyAttribute attribute = None,
      |                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This happens because that version of `cpu-features` isn’t compatible with Node 22’s V8 API. The package is optional, so it doesn’t actually break the `yarn install`, but the error is noisy and can be misleading.

The issue only shows up on first install (when the native module builds), but it can also be reproduced by running `yarn rebuild`.

This PR updates the `yarn.lock` to pull in cpu-features@0.0.10, which builds cleanly and resolves the build error/warning.

This was the most minimally invasive way to fix the issue without doing a full `yarn.lock` regeneration. Open to exploring a wider update if preferred, but this seemed like the safest low-impact change for now.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
