### PR TITLE
docs: replace Kind examples in Glossary with proper Kinds

### DIFF
--- a/docs/references/glossary.md
+++ b/docs/references/glossary.md
@@ -147,7 +147,7 @@ A popular JSON based token format that is commonly encrypted and/or signed, see 
 
 ## Kind
 
-Classification of an [entity](#Entity) in the Backstage Software Catalog, for example _service_, _database_, and _team_.
+Classification of an [entity](#Entity) in the Backstage Software Catalog, for example _Component_, _Resource_, and _Group_.
 
 ## Kubernetes (CNCF Project)
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

In Glossary, in the definition of Kind, the examples were rather specific Types than Kinds. Updated to typical Kinds.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
