### PR TITLE
Improve readability in observability docs 

### DIFF
--- a/docs/plugins/observability.md
+++ b/docs/plugins/observability.md
@@ -21,7 +21,7 @@ The backend supplies a central logging service,
 [`rootLogger`](../backend-system/core-services/root-logger.md), as well as a plugin
 based logger, [`logger`](../backend-system/core-services/logger.md) from `coreServices`.
 To add additional granularity to your logs, you can create children from the plugin
-based logger, using the `.child()` method and provide is with JSON data. For example,
+based logger, using the `.child()` method and provide it with JSON data. For example,
 if you wanted to log items for a specific span in your plugin, you could do
 
 ```ts


### PR DESCRIPTION
### Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Updated the observability documentation to correct a minor wording issue:

- Changed `provide is with JSON data` to `provide it with JSON data` for better readability.
