### PR TITLE
canon: prop extraction fixes

### DIFF
--- a/.changeset/famous-eggs-dance.md
+++ b/.changeset/famous-eggs-dance.md
@@ -1,0 +1,5 @@
+---
+'@backstage/canon': patch
+---
+
+Internal refactor and fixes to the prop extraction logic for layout components.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Ran into some issue with `<Box width='fit-content'/>` crashing because this logic was expecting values, and also spotted that `customProperties` is somewhat unexpectedly being coerced to string. Refactored to add some more types in the mix for safety, 👀 @cdedreuille

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
