### PR TITLE
fix: mark github webhookSecret as optional

### DIFF
--- a/.changeset/stale-tables-stick.md
+++ b/.changeset/stale-tables-stick.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+Mark GitHub `webhookSecret` config property as optional. A `webhookSecret` is not required when creating a GitHub App.

--- a/packages/integration/config.d.ts
+++ b/packages/integration/config.d.ts
@@ -239,7 +239,7 @@ export interface Config {
          * The secret used for webhooks
          * @visibility secret
          */
-        webhookSecret: string;
+        webhookSecret?: string;
         /**
          * The client ID to use
          */

--- a/packages/integration/report.api.md
+++ b/packages/integration/report.api.md
@@ -647,7 +647,7 @@ export type GiteaIntegrationConfig = {
 export type GithubAppConfig = {
   appId: number;
   privateKey: string;
-  webhookSecret: string;
+  webhookSecret?: string;
   clientId: string;
   clientSecret: string;
   allowedInstallationOwners?: string[];

--- a/packages/integration/src/github/config.ts
+++ b/packages/integration/src/github/config.ts
@@ -92,7 +92,7 @@ export type GithubAppConfig = {
   /**
    * Webhook secret can be configured at https://github.com/organizations/$org/settings/apps/$AppName
    */
-  webhookSecret: string;
+  webhookSecret?: string;
   /**
    * Found at https://github.com/organizations/$org/settings/apps/$AppName
    */
@@ -128,7 +128,7 @@ export function readGithubIntegrationConfig(
     appId: c.getNumber('appId'),
     clientId: c.getString('clientId'),
     clientSecret: c.getString('clientSecret'),
-    webhookSecret: c.getString('webhookSecret'),
+    webhookSecret: c.getOptionalString('webhookSecret'),
     privateKey: c.getString('privateKey'),
     allowedInstallationOwners: c.getOptionalStringArray(
       'allowedInstallationOwners',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
The webhookSecret is not required when creating a GitHub App, we should also not require it in the config. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
