### PR TITLE
fix(discovery): fix bug in event-based discovery for Bitbucket Cloud

### DIFF
--- a/.changeset/tame-worms-do.md
+++ b/.changeset/tame-worms-do.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-bitbucket-cloud': patch
+---
+
+Fixed bug in event-based discovery that caused unnecessary API calls to Bitbucket Cloud

--- a/plugins/catalog-backend-module-bitbucket-cloud/src/providers/BitbucketCloudEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-bitbucket-cloud/src/providers/BitbucketCloudEntityProvider.test.ts
@@ -543,30 +543,10 @@ describe('BitbucketCloudEntityProvider', () => {
 
     server.use(
       rest.get(
-        `https://api.bitbucket.org/2.0/workspaces/test-ws/projects`,
-        (_req, res, ctx) => {
-          const response = {
-            values: [
-              {
-                key: 'TEST',
-              },
-              {
-                key: 'TEST2',
-              },
-            ],
-          };
-          return res(ctx.json(response));
-        },
-      ),
-      rest.get(
         `https://api.bitbucket.org/2.0/workspaces/test-ws/search/code`,
         (req, res, ctx) => {
           const query = req.url.searchParams.get('search_query');
-          if (
-            !query ||
-            !query.includes('repo:test-repo') ||
-            !query.includes('project:TEST')
-          ) {
+          if (!query || !query.includes('repo:test-repo')) {
             return res(ctx.json({ values: [] }));
           }
 
@@ -639,10 +619,6 @@ describe('BitbucketCloudEntityProvider', () => {
     await events.publish(repoPushEventParams);
 
     const addedEntities = [
-      {
-        entity: addedModule,
-        locationKey: 'bitbucketCloud-provider:myProvider',
-      },
       {
         entity: addedModule,
         locationKey: 'bitbucketCloud-provider:myProvider',

--- a/plugins/catalog-backend-module-bitbucket-cloud/src/providers/BitbucketCloudEntityProvider.ts
+++ b/plugins/catalog-backend-module-bitbucket-cloud/src/providers/BitbucketCloudEntityProvider.ts
@@ -326,6 +326,8 @@ export class BitbucketCloudEntityProvider implements EntityProvider {
     const optRepoFilter = repoSlug ? ` repo:${repoSlug}` : '';
     const query = `"${catalogFilename}" path:${catalogPath}${optRepoFilter}`;
 
+    if (repoSlug) return this.processQuery(workspace, query);
+
     const projects = this.client
       .listProjectsByWorkspace(workspace)
       .iterateResults();


### PR DESCRIPTION
This PR fixes a bug in event-based discovery introduced in #26873 that prevents unnecessary API calls to Bitbucket Cloud.

Essentially, for `repo:push` events, it called the endpoint for every project, which isn't necessary.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
