### PR TITLE
Fix default catalog table search

### DIFF
--- a/.changeset/tasty-moments-do.md
+++ b/.changeset/tasty-moments-do.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Fix the default catalog table search behavior by using the catalog table toolbar for all table variations (including when pagination mode is none).

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -49,6 +49,7 @@ import { defaultCatalogTableColumnsFunc } from './defaultCatalogTableColumnsFunc
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { catalogTranslationRef } from '../../alpha/translation';
 import { FavoriteToggleIcon } from '@backstage/core-components';
+import { CatalogTableToolbar } from './CatalogTableToolbar';
 
 /**
  * Props for {@link CatalogTable}.
@@ -251,6 +252,9 @@ export const CatalogTable = (props: CatalogTableProps) => {
       actions={actions}
       subtitle={subtitle}
       emptyContent={emptyContent}
+      components={{
+        Toolbar: CatalogTableToolbar,
+      }}
     />
   );
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes https://github.com/backstage/backstage/issues/29400

Fix the default catalog table search behavior by using the catalog table toolbar for all table variations (including when pagination mode is none). The catalog table toolbar uses a custom `EntitySearchBar` component that knows how to properly filter entities.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
