### PR TITLE
get rid of some docusaurus warnings

### DIFF
--- a/microsite/blog/2022-10-28-backstagecon-kubecon-2022.mdx
+++ b/microsite/blog/2022-10-28-backstagecon-kubecon-2022.mdx
@@ -11,6 +11,8 @@ authorURL: https://www.linkedin.com/in/emmamckeewhite/
 
 What an action-packed and memorable week for the Backstage community meeting up IRL at KubeCon North America 2022 in (unseasonably warm and sunny) Detroit. Let’s see what the community was up to:
 
+{/* truncate */}
+
 ### BackstageCon: A full day of nothing but Backstage
 
 ![BackstageCon group](assets/2022-10-28/groupimage.jpg)

--- a/microsite/docusaurus.config.ts
+++ b/microsite/docusaurus.config.ts
@@ -123,6 +123,11 @@ const config: Config = {
         },
         blog: {
           path: 'blog',
+          // Gets rid of the following:
+          // Warning:  Some blog authors used in "2024-12-18-backstage-wrapped-2024.mdx" are not defined in "authors.yml":
+          // - {"name":"Patrik Oldsberg, Spotify & Ben Lambert, Spotify","key":null,"page":null}
+          // Note that we recommend to declare authors once in a "authors.yml" file and reference them by key in blog posts front matter to avoid author info duplication.
+          onInlineAuthors: 'ignore',
         },
         theme: {
           customCss: 'src/theme/customTheme.scss',


### PR DESCRIPTION
There's still a warning about

```
Warning:  Duplicate routes found!
- Attempting to create page at /docs/next/features/techdocs/addons, but a page already exists at this route.
- Attempting to create page at /docs/features/techdocs/addons, but a page already exists at this route.
```

that I haven't addressed