### PR TITLE
Fixes missing object kind support on gitlab event router

### DIFF
--- a/.changeset/huge-olives-do.md
+++ b/.changeset/huge-olives-do.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-events-backend-module-gitlab': patch
+---
+
+Adds support for `object_kind` field with priority over `event_name` on Gitlab webhook event types

--- a/plugins/events-backend-module-gitlab/src/router/GitlabEventRouter.test.ts
+++ b/plugins/events-backend-module-gitlab/src/router/GitlabEventRouter.test.ts
@@ -21,7 +21,6 @@ describe('GitlabEventRouter', () => {
   const events = new TestEventsService();
   const eventRouter = new GitlabEventRouter({ events: events });
   const topic = 'gitlab';
-  const eventPayload = { event_name: 'test_type', test: 'payload' };
   const metadata = {};
 
   beforeEach(() => {
@@ -36,7 +35,7 @@ describe('GitlabEventRouter', () => {
     expect(events.subscribed[0].topics).toEqual([topic]);
   });
 
-  it('no $.event_name', () => {
+  it('no $.event_name and no $.object_kind', () => {
     eventRouter.onEvent({
       topic,
       eventPayload: { invalid: 'payload' },
@@ -46,11 +45,45 @@ describe('GitlabEventRouter', () => {
     expect(events.published).toEqual([]);
   });
 
-  it('with $.event_name', () => {
+  it('with $.event_name and no $.object_kind', () => {
+    const eventPayload = {
+      event_name: 'type_from_event_name',
+      test: 'payload',
+    };
+
     eventRouter.onEvent({ topic, eventPayload, metadata });
 
     expect(events.published.length).toBe(1);
-    expect(events.published[0].topic).toEqual('gitlab.test_type');
+    expect(events.published[0].topic).toEqual('gitlab.type_from_event_name');
+    expect(events.published[0].eventPayload).toEqual(eventPayload);
+    expect(events.published[0].metadata).toEqual(metadata);
+  });
+
+  it('with $.object_kind and no $.event_name', () => {
+    const eventPayload = {
+      object_kind: 'type_from_object_kind',
+      test: 'payload',
+    };
+
+    eventRouter.onEvent({ topic, eventPayload, metadata });
+
+    expect(events.published.length).toBe(1);
+    expect(events.published[0].topic).toEqual('gitlab.type_from_object_kind');
+    expect(events.published[0].eventPayload).toEqual(eventPayload);
+    expect(events.published[0].metadata).toEqual(metadata);
+  });
+
+  it('with $.event_name and $.object_kind', () => {
+    const eventPayload = {
+      event_name: 'type_from_event_name',
+      object_kind: 'type_from_object_kind',
+      test: 'payload',
+    };
+
+    eventRouter.onEvent({ topic, eventPayload, metadata });
+
+    expect(events.published.length).toBe(1);
+    expect(events.published[0].topic).toEqual('gitlab.type_from_object_kind');
     expect(events.published[0].eventPayload).toEqual(eventPayload);
     expect(events.published[0].metadata).toEqual(metadata);
   });

--- a/plugins/events-backend-module-gitlab/src/router/GitlabEventRouter.ts
+++ b/plugins/events-backend-module-gitlab/src/router/GitlabEventRouter.ts
@@ -40,9 +40,15 @@ export class GitlabEventRouter extends SubTopicEventRouter {
   }
 
   protected determineSubTopic(params: EventParams): string | undefined {
-    if ('event_name' in (params.eventPayload as object)) {
-      const payload = params.eventPayload as { event_name: string };
-      return payload.event_name;
+    if (
+      'object_kind' in (params.eventPayload as object) ||
+      'event_name' in (params.eventPayload as object)
+    ) {
+      const payload = params.eventPayload as {
+        event_name?: string;
+        object_kind?: string;
+      };
+      return payload.object_kind || payload.event_name;
     }
 
     return undefined;


### PR DESCRIPTION
…lab webhook trigger

## Hey, I just made a Pull Request!
Updates the `GitlabEventRouter` to use `object_kind` property sent on Gitlab webhooks along side `event_name`, giving priority to it's value as new webhooks payloads no longer have it defined (e.g. Vulnerability) fixing issue #29418 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
