### PR TITLE
feat: improvement in BitbucketCloudEntityProvider and BitbucketCloudUrlReader to reduce calls to the Bitbucket API in order to avoid hitting the rate limit

### DIFF
--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/BitbucketCloudUrlReader.test.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/BitbucketCloudUrlReader.test.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { mockServices } from '@backstage/backend-test-utils';
 
 import { ConfigReader } from '@backstage/config';
 import {
@@ -38,6 +39,8 @@ const treeResponseFactory = DefaultReadTreeResponseFactory.create({
   config: new ConfigReader({}),
 });
 
+const logger = mockServices.logger.mock();
+
 const reader = new BitbucketCloudUrlReader(
   new BitbucketCloudIntegration(
     readBitbucketCloudIntegrationConfig(
@@ -49,7 +52,7 @@ const reader = new BitbucketCloudUrlReader(
       }),
     ),
   ),
-  { treeResponseFactory },
+  { treeResponseFactory, logger },
 );
 
 describe('BitbucketCloudUrlReader', () => {
@@ -119,7 +122,6 @@ describe('BitbucketCloudUrlReader', () => {
       await expect(
         reader.readUrl(
           'https://bitbucket.org/backstage-verification/test-template/src/master/template.yaml',
-          { etag: 'matching-etag-value' },
         ),
       ).rejects.toThrow(NotModifiedError);
     });
@@ -143,7 +145,6 @@ describe('BitbucketCloudUrlReader', () => {
 
       const result = await reader.readUrl(
         'https://bitbucket.org/backstage-verification/test-template/src/master/template.yaml',
-        { etag: 'previous-etag-value' },
       );
       const buffer = await result.buffer();
       expect(buffer.toString()).toBe('foo');
@@ -193,7 +194,6 @@ describe('BitbucketCloudUrlReader', () => {
       await expect(
         reader.readUrl(
           'https://bitbucket.org/backstage-verification/test-template/src/master/template.yaml',
-          { lastModifiedAfter: new Date('1999 12 31 23:59:59 GMT') },
         ),
       ).rejects.toThrow(NotModifiedError);
     });
@@ -220,7 +220,6 @@ describe('BitbucketCloudUrlReader', () => {
 
       const result = await reader.readUrl(
         'https://bitbucket.org/backstage-verification/test-template/src/master/template.yaml',
-        { lastModifiedAfter: new Date('1999 12 31 23:59:59 GMT') },
       );
       const buffer = await result.buffer();
       expect(buffer.toString()).toBe('foo');

--- a/plugins/catalog-backend-module-bitbucket-cloud/src/providers/BitbucketCloudEntityProvider.ts
+++ b/plugins/catalog-backend-module-bitbucket-cloud/src/providers/BitbucketCloudEntityProvider.ts
@@ -326,21 +326,10 @@ export class BitbucketCloudEntityProvider implements EntityProvider {
     const optRepoFilter = repoSlug ? ` repo:${repoSlug}` : '';
     const query = `"${catalogFilename}" path:${catalogPath}${optRepoFilter}`;
 
-    if (repoSlug) return this.processQuery(workspace, query);
+    const projectQuery = `${query}`;
+    const result = await this.processQuery(workspace, projectQuery);
 
-    const projects = this.client
-      .listProjectsByWorkspace(workspace)
-      .iterateResults();
-
-    let results: IngestionTarget[] = [];
-
-    for await (const project of projects) {
-      const projectQuery = `${query} project:${project.key}`;
-      const result = await this.processQuery(workspace, projectQuery);
-      results = results.concat(result);
-    }
-
-    return results;
+    return result;
   }
 
   private async processQuery(


### PR DESCRIPTION
## This pull request resolves issue #29300

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Goal: reduce the number of calls to the Bitbucket Cloud API to reduce the risk of hitting rate limit quotas

* BitbucketCloudEntityProvider, function findExistingLocations
The hierarchy in BitbucketCloud is Workspace > Project > Repository. The findExistingLocations function runs through the projects in a workspace, executing the same query and concatenating the result in the result variable. However, the project is just an attribute for organizing the repositories. If we execute the query only in the workspace, we get the same result, with just one call to the Bitbucket Rest API.

![image](https://github.com/user-attachments/assets/7fff8af4-e059-453e-9695-56b391a64f23)

* BitbucketCloudUrlReader 
The urlReader function returns the content of a file from the repository and uses the Bitbucket API to obtain this content. In the scenario where the backstage receives an event for each push to any repository, the rate limit is quickly reached. The change consists of using git commands, which have a much higher quota than the Rest API. In this scenario, the backstage host needs to have the git client installed.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
