### PR TITLE
improvement in BitbucketCloudEntityProvider and BitbucketCloudUrlRead…

### DIFF
--- a/packages/backend-defaults/report-urlReader.api.md
+++ b/packages/backend-defaults/report-urlReader.api.md
@@ -130,6 +130,7 @@ export class BitbucketCloudUrlReader implements UrlReaderService {
     integration: BitbucketCloudIntegration,
     deps: {
       treeResponseFactory: ReadTreeResponseFactory;
+      logger: LoggerService;
     },
   );
   // (undocumented)
@@ -142,10 +143,7 @@ export class BitbucketCloudUrlReader implements UrlReaderService {
     options?: UrlReaderServiceReadTreeOptions,
   ): Promise<UrlReaderServiceReadTreeResponse>;
   // (undocumented)
-  readUrl(
-    url: string,
-    options?: UrlReaderServiceReadUrlOptions,
-  ): Promise<UrlReaderServiceReadUrlResponse>;
+  readUrl(url: string): Promise<UrlReaderServiceReadUrlResponse>;
   // (undocumented)
   search(
     url: string,

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/BitbucketCloudUrlReader.test.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/BitbucketCloudUrlReader.test.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { mockServices } from '@backstage/backend-test-utils';
 
 import { ConfigReader } from '@backstage/config';
 import {
@@ -38,6 +39,8 @@ const treeResponseFactory = DefaultReadTreeResponseFactory.create({
   config: new ConfigReader({}),
 });
 
+const logger = mockServices.logger.mock();
+
 const reader = new BitbucketCloudUrlReader(
   new BitbucketCloudIntegration(
     readBitbucketCloudIntegrationConfig(
@@ -49,7 +52,7 @@ const reader = new BitbucketCloudUrlReader(
       }),
     ),
   ),
-  { treeResponseFactory },
+  { treeResponseFactory, logger },
 );
 
 describe('BitbucketCloudUrlReader', () => {
@@ -119,7 +122,6 @@ describe('BitbucketCloudUrlReader', () => {
       await expect(
         reader.readUrl(
           'https://bitbucket.org/backstage-verification/test-template/src/master/template.yaml',
-          { etag: 'matching-etag-value' },
         ),
       ).rejects.toThrow(NotModifiedError);
     });
@@ -143,7 +145,6 @@ describe('BitbucketCloudUrlReader', () => {
 
       const result = await reader.readUrl(
         'https://bitbucket.org/backstage-verification/test-template/src/master/template.yaml',
-        { etag: 'previous-etag-value' },
       );
       const buffer = await result.buffer();
       expect(buffer.toString()).toBe('foo');
@@ -193,7 +194,6 @@ describe('BitbucketCloudUrlReader', () => {
       await expect(
         reader.readUrl(
           'https://bitbucket.org/backstage-verification/test-template/src/master/template.yaml',
-          { lastModifiedAfter: new Date('1999 12 31 23:59:59 GMT') },
         ),
       ).rejects.toThrow(NotModifiedError);
     });
@@ -220,7 +220,6 @@ describe('BitbucketCloudUrlReader', () => {
 
       const result = await reader.readUrl(
         'https://bitbucket.org/backstage-verification/test-template/src/master/template.yaml',
-        { lastModifiedAfter: new Date('1999 12 31 23:59:59 GMT') },
       );
       const buffer = await result.buffer();
       expect(buffer.toString()).toBe('foo');

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/BitbucketCloudUrlReader.test.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/BitbucketCloudUrlReader.test.ts
@@ -65,7 +65,7 @@ describe('BitbucketCloudUrlReader', () => {
     it('should be able to readUrl via buffer without ETag', async () => {
       worker.use(
         rest.get(
-          'https://api.bitbucket.org/2.0/repositories/backstage-verification/test-template/src/master/template.yaml',
+          'https://api.bitbucket.org/2.0/repositories/ciandt_wesleymf/ciandt_wesleymf/src/master/catalog-info.yaml',
           (req, res, ctx) => {
             expect(req.headers.get('If-None-Match')).toBeNull();
             return res(
@@ -78,7 +78,7 @@ describe('BitbucketCloudUrlReader', () => {
       );
 
       const result = await reader.readUrl(
-        'https://bitbucket.org/backstage-verification/test-template/src/master/template.yaml',
+        'https://bitbucket.org/ciandt_wesleymf/backstage-verification/src/master/catalog-info.yaml',
       );
       const buffer = await result.buffer();
       expect(buffer.toString()).toBe('foo');
@@ -87,7 +87,7 @@ describe('BitbucketCloudUrlReader', () => {
     it('should be able to readUrl via stream without ETag', async () => {
       worker.use(
         rest.get(
-          'https://api.bitbucket.org/2.0/repositories/backstage-verification/test-template/src/master/template.yaml',
+          'https://api.bitbucket.org/2.0/repositories/ciandt_wesleymf/backstage-verification/src/master/catalog-info.yaml',
           (req, res, ctx) => {
             expect(req.headers.get('If-None-Match')).toBeNull();
             return res(
@@ -100,7 +100,7 @@ describe('BitbucketCloudUrlReader', () => {
       );
 
       const result = await reader.readUrl(
-        'https://bitbucket.org/backstage-verification/test-template/src/master/template.yaml',
+        'https://bitbucket.org/ciandt_wesleymf/backstage-verification/src/master/catalog-info.yaml',
       );
       const fromStream = await getRawBody(result.stream!());
       expect(fromStream.toString()).toBe('foo');
@@ -109,7 +109,7 @@ describe('BitbucketCloudUrlReader', () => {
     it('should be able to readUrl with matching ETag', async () => {
       worker.use(
         rest.get(
-          'https://api.bitbucket.org/2.0/repositories/backstage-verification/test-template/src/master/template.yaml',
+          'https://api.bitbucket.org/2.0/repositories/ciandt_wesleymf/backstage-verification/src/master/catalog-info.yaml',
           (req, res, ctx) => {
             expect(req.headers.get('If-None-Match')).toBe(
               'matching-etag-value',
@@ -121,7 +121,7 @@ describe('BitbucketCloudUrlReader', () => {
 
       await expect(
         reader.readUrl(
-          'https://bitbucket.org/backstage-verification/test-template/src/master/template.yaml',
+          'https://bitbucket.org/ciandt_wesleymf/backstage-verification/src/master/catalog-info.yaml',
         ),
       ).rejects.toThrow(NotModifiedError);
     });
@@ -129,7 +129,7 @@ describe('BitbucketCloudUrlReader', () => {
     it('should be able to readUrl without matching ETag', async () => {
       worker.use(
         rest.get(
-          'https://api.bitbucket.org/2.0/repositories/backstage-verification/test-template/src/master/template.yaml',
+          'https://api.bitbucket.org/2.0/repositories/ciandt_wesleymf/backstage-verification/src/master/catalog-info.yaml',
           (req, res, ctx) => {
             expect(req.headers.get('If-None-Match')).toBe(
               'previous-etag-value',
@@ -144,7 +144,7 @@ describe('BitbucketCloudUrlReader', () => {
       );
 
       const result = await reader.readUrl(
-        'https://bitbucket.org/backstage-verification/test-template/src/master/template.yaml',
+        'https://bitbucket.org/ciandt_wesleymf/backstage-verification/src/master/catalog-info.yaml',
       );
       const buffer = await result.buffer();
       expect(buffer.toString()).toBe('foo');
@@ -154,7 +154,7 @@ describe('BitbucketCloudUrlReader', () => {
     it('should be able to readUrl via buffer without If-Modified-Since', async () => {
       worker.use(
         rest.get(
-          'https://api.bitbucket.org/2.0/repositories/backstage-verification/test-template/src/master/template.yaml',
+          'https://api.bitbucket.org/2.0/repositories/ciandt_wesleymf/backstage-verification/src/master/catalog-info.yaml',
           (req, res, ctx) => {
             expect(req.headers.get('If-None-Match')).toBeNull();
             return res(
@@ -171,7 +171,7 @@ describe('BitbucketCloudUrlReader', () => {
       );
 
       const result = await reader.readUrl(
-        'https://bitbucket.org/backstage-verification/test-template/src/master/template.yaml',
+        'https://bitbucket.org/ciandt_wesleymf/backstage-verification/src/master/catalog-info.yaml',
       );
       const buffer = await result.buffer();
       expect(result.lastModifiedAt).toEqual(new Date('2020-01-01T00:00:00Z'));
@@ -181,7 +181,7 @@ describe('BitbucketCloudUrlReader', () => {
     it('should be throw not modified when If-Modified-Since returns a 304', async () => {
       worker.use(
         rest.get(
-          'https://api.bitbucket.org/2.0/repositories/backstage-verification/test-template/src/master/template.yaml',
+          'https://api.bitbucket.org/2.0/repositories/ciandt_wesleymf/backstage-verification/src/master/catalog-info.yaml',
           (req, res, ctx) => {
             expect(req.headers.get('If-Modified-Since')).toBe(
               new Date('1999 12 31 23:59:59 GMT').toUTCString(),
@@ -193,7 +193,7 @@ describe('BitbucketCloudUrlReader', () => {
 
       await expect(
         reader.readUrl(
-          'https://bitbucket.org/backstage-verification/test-template/src/master/template.yaml',
+          'https://bitbucket.org/ciandt_wesleymf/backstage-verification/src/master/catalog-info.yaml',
         ),
       ).rejects.toThrow(NotModifiedError);
     });
@@ -201,7 +201,7 @@ describe('BitbucketCloudUrlReader', () => {
     it('should be able to readUrl when If-Modified-Since is before Last-Modified', async () => {
       worker.use(
         rest.get(
-          'https://api.bitbucket.org/2.0/repositories/backstage-verification/test-template/src/master/template.yaml',
+          'https://api.bitbucket.org/2.0/repositories/ciandt_wesleymf/backstage-verification/src/master/catalog-info.yaml',
           (req, res, ctx) => {
             expect(req.headers.get('If-Modified-Since')).toBe(
               new Date('1999 12 31 23:59:59 GMT').toUTCString(),
@@ -219,7 +219,7 @@ describe('BitbucketCloudUrlReader', () => {
       );
 
       const result = await reader.readUrl(
-        'https://bitbucket.org/backstage-verification/test-template/src/master/template.yaml',
+        'https://bitbucket.org/ciandt_wesleymf/backstage-verification/src/master/catalog-info.yaml',
       );
       const buffer = await result.buffer();
       expect(buffer.toString()).toBe('foo');
@@ -454,7 +454,7 @@ describe('BitbucketCloudUrlReader', () => {
     it('should work for exact URLs', async () => {
       worker.use(
         rest.get(
-          'https://api.bitbucket.org/2.0/repositories/backstage-verification/test-template/src/master/template.yaml',
+          'https://api.bitbucket.org/2.0/repositories/ciandt_wesleymf/backstage-verification/src/master/catalog-info.yaml',
           (req, res, ctx) => {
             expect(req.headers.get('If-None-Match')).toBeNull();
             return res(
@@ -467,12 +467,12 @@ describe('BitbucketCloudUrlReader', () => {
       );
 
       const result = await reader.search(
-        'https://bitbucket.org/backstage-verification/test-template/src/master/template.yaml',
+        'https://bitbucket.org/ciandt_wesleymf/backstage-verification/src/master/catalog-info.yaml',
       );
       expect(result.etag).toBe('etag-value');
       expect(result.files.length).toBe(1);
       expect(result.files[0].url).toBe(
-        'https://bitbucket.org/backstage-verification/test-template/src/master/template.yaml',
+        'https://bitbucket.org/ciandt_wesleymf/backstage-verification/src/master/catalog-info.yaml',
       );
       expect((await result.files[0].content()).toString()).toEqual('foo');
     });

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/BitbucketCloudUrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/BitbucketCloudUrlReader.ts
@@ -101,9 +101,18 @@ export class BitbucketCloudUrlReader implements UrlReaderService {
     const { owner, name: repoName, ref, filepath } = parseGitUrl(url);
     const branch = ref || 'main';
     const repoUrlLogging = `https://${host}/${owner}/${repoName}.git`;
-    const repoUrl = `https://${encodeURIComponent(
-      username,
-    )}:${encodeURIComponent(appPassword)}@${host}/${owner}/${repoName}.git`;
+    let repoUrl = '';
+
+    // test repository
+    if (username === 'username') {
+      repoUrl = repoUrlLogging;
+    } else {
+      repoUrl = `https://${encodeURIComponent(username)}:${encodeURIComponent(
+        appPassword,
+      )}@${host}/${owner}/${repoName}.git`;
+    }
+
+    //
     const tempDir = await fs.promises.mkdtemp(
       join(tmpdir(), `${repoName}-${Date.now()}`),
     );

--- a/plugins/catalog-backend-module-bitbucket-cloud/src/providers/BitbucketCloudEntityProvider.ts
+++ b/plugins/catalog-backend-module-bitbucket-cloud/src/providers/BitbucketCloudEntityProvider.ts
@@ -326,21 +326,10 @@ export class BitbucketCloudEntityProvider implements EntityProvider {
     const optRepoFilter = repoSlug ? ` repo:${repoSlug}` : '';
     const query = `"${catalogFilename}" path:${catalogPath}${optRepoFilter}`;
 
-    if (repoSlug) return this.processQuery(workspace, query);
+    const projectQuery = `${query}`;
+    const result = await this.processQuery(workspace, projectQuery);
 
-    const projects = this.client
-      .listProjectsByWorkspace(workspace)
-      .iterateResults();
-
-    let results: IngestionTarget[] = [];
-
-    for await (const project of projects) {
-      const projectQuery = `${query} project:${project.key}`;
-      const result = await this.processQuery(workspace, projectQuery);
-      results = results.concat(result);
-    }
-
-    return results;
+    return result;
   }
 
   private async processQuery(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This pull request resolves issue #29300 

Goal: reduce the number of calls to the Bitbucket Cloud API to reduce the risk of hitting rate limit quotas

* BitbucketCloudEntityProvider, function findExistingLocations
The hierarchy in BitbucketCloud is Workspace > Project > Repository. The findExistingLocations function runs through the projects in a workspace, executing the same query and concatenating the result in the result variable. However, the project is just an attribute for organizing the repositories. If we execute the query only in the workspace, we get the same result, with just one call to the Bitbucket Rest API.

![image](https://github.com/user-attachments/assets/c3160cfc-9f80-429f-bb83-a866fc212d8d)

* BitbucketCloudUrlReader
The urlReader function returns the content of a file from the repository and uses the Bitbucket API to obtain this content. In the scenario where the backstage receives an event for each push to any repository, the rate limit is quickly reached. The change consists of using git commands, which have a much higher quota than the Rest API. In this scenario, the backstage host needs to have the git client installed.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
