### PR TITLE
[docs] add branch naming caveat to github discovery integration

### DIFF
--- a/.changeset/clear-pigs-share.md
+++ b/.changeset/clear-pigs-share.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': minor
+---
+
+Explicitly rejects branch names containing a slash character

--- a/.changeset/clear-pigs-share.md
+++ b/.changeset/clear-pigs-share.md
@@ -2,4 +2,8 @@
 '@backstage/plugin-catalog-backend-module-github': minor
 ---
 
-Explicitly rejects branch names containing a slash character
+**BREAKING**: Explicitly rejects branch names containing a slash character.
+
+The module now rejects any configuration that contains slashes in branch names. The reason for this is that the ingestion will run into downstream problems if they were let through. If you had configuration with a slash in the branch name in `filters.branch`, your application may fail to start up.
+
+If you are affected by this, please move over to using branches that do not have slashes in them.

--- a/docs/integrations/github/discovery.md
+++ b/docs/integrations/github/discovery.md
@@ -152,7 +152,7 @@ If you do so, `default` will be used as provider ID.
   Wildcards cannot be used if the `validateLocationsExist` option is set to `true`.
 - **`filters`** _(optional)_:
   - **`branch`** _(optional)_:
-    String used to filter results based on the branch name.
+    String used to filter results based on the branch name. Branch name cannot have any slash (`/`) characters.
     Defaults to the default Branch of the repository.
   - **`repository`** _(optional)_:
     Regular expression used to filter results based on the repository name.

--- a/plugins/catalog-backend-module-github/src/providers/GithubEntityProviderConfig.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubEntityProviderConfig.test.ts
@@ -311,4 +311,24 @@ describe('readProviderConfigs', () => {
 
     expect(() => readProviderConfigs(config)).toThrow();
   });
+
+  it('throws an error when filters.branch contains a slash', () => {
+    const config = new ConfigReader({
+      catalog: {
+        providers: {
+          github: {
+            invalidBranchUser: {
+              organization: 'test-org',
+              catalogPath: '/*/catalog-info.yaml',
+              filters: {
+                branch: 'test/a',
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(() => readProviderConfigs(config)).toThrow();
+  });
 });

--- a/plugins/catalog-backend-module-github/src/providers/GithubEntityProviderConfig.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubEntityProviderConfig.ts
@@ -104,6 +104,12 @@ function readProviderConfig(
     );
   }
 
+  if (branchPattern?.includes('/')) {
+    throw new Error(
+      'Error while processing GitHub provider config. Slash characters (/) are not allowed in filters.branch',
+    );
+  }
+
   const schedule = config.has('schedule')
     ? readSchedulerServiceTaskScheduleDefinitionFromConfig(
         config.getConfig('schedule'),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] n/a Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

👋 Github, like git itself, allows [slashes in branch names](https://docs.github.com/en/get-started/using-git/dealing-with-special-characters-in-branch-and-tag-names). But the implementation of `GithubDiscoveryProcessor` identifies the catalog path and branch name by [splitting the Location target on slashes](https://github.com/backstage/backstage/blob/6b0cae3fc0665e9d82961fd8e2357f623380c168/plugins/catalog-backend-module-github/src/processors/GithubDiscoveryProcessor.ts#L179).

As a result, it's possible to configure the integration to look for any catalog-info file on the `backstage-poc/main` branch with
```yaml
github:
  invalid:
    organization: example
    catalogPath: /**/catalog-info.yaml
    filters:
      branch: 'backstage-poc/main'
```

And the discovery process will silently discover no files, because it's really looking for

```
branch = backstage-poc
catalogPath = /main/**/catalog-info.yaml
```

I thought a little about how slash-names could be supported, but could not come up with an easy enough, but fully generalizable, solution. So I think there should be documentation to prevent others from going down the rabbit hole I did. 

Thanks!

## Update: validate when reading config
f0c22eb give users a runtime error when using an offending branch name. 