### PR TITLE
microsite: remove node example from OpenAPI docs

### DIFF
--- a/microsite/docusaurus.config.ts
+++ b/microsite/docusaurus.config.ts
@@ -306,11 +306,6 @@ const config: Config = {
     languageTabs: [
       {
         highlight: 'javascript',
-        language: 'nodejs',
-        logoClass: 'nodejs',
-      },
-      {
-        highlight: 'javascript',
         language: 'javascript',
         logoClass: 'javascript',
       },


### PR DESCRIPTION
🧹 the JavaScript example is good enough for both web and node. The node example uses `axios`, let's not encourage that.
