### PR TITLE
export deprecated type to fix e2e

### DIFF
--- a/.changeset/huge-toys-beam.md
+++ b/.changeset/huge-toys-beam.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-import': patch
+---
+
+Expose the `UnpackNestedValue` type as it's been removed from `react-hook-form`

--- a/plugins/catalog-import/report.api.md
+++ b/plugins/catalog-import/report.api.md
@@ -15,13 +15,13 @@ import { FetchApi } from '@backstage/core-plugin-api';
 import { FieldErrors } from 'react-hook-form';
 import { InfoCardVariants } from '@backstage/core-components';
 import { JSX as JSX_2 } from 'react';
+import { NestedValue } from 'react-hook-form';
 import { default as React_2 } from 'react';
 import { RouteRef } from '@backstage/core-plugin-api';
 import { ScmAuthApi } from '@backstage/integration-react';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import { SubmitHandler } from 'react-hook-form';
 import { TextFieldProps } from '@material-ui/core/TextField/TextField';
-import { UnpackNestedValue } from 'react-hook-form';
 import { UseFormProps } from 'react-hook-form';
 import { UseFormReturn } from 'react-hook-form';
 
@@ -360,6 +360,17 @@ export interface StepPrepareCreatePullRequestProps {
     },
   ) => React_2.ReactNode;
 }
+
+// @public @deprecated
+export type UnpackNestedValue<T> = T extends NestedValue<infer U>
+  ? U
+  : T extends Date | FileList | File | Blob
+  ? T
+  : T extends object
+  ? {
+      [K in keyof T]: UnpackNestedValue<T[K]>;
+    }
+  : T;
 
 // Warnings were encountered during analysis:
 //

--- a/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.tsx
+++ b/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.tsx
@@ -27,7 +27,7 @@ import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import React, { useCallback, useEffect, useState } from 'react';
-import { UnpackNestedValue, UseFormReturn } from 'react-hook-form';
+import { NestedValue, UseFormReturn } from 'react-hook-form';
 import useAsync from 'react-use/esm/useAsync';
 import YAML from 'yaml';
 import { AnalyzeResult, catalogImportApiRef } from '../../api';
@@ -55,6 +55,22 @@ type FormData = {
   owner: string;
   useCodeowners: boolean;
 };
+
+/**
+ * Helper for unpacking NestedValue into the underlying type.
+ *
+ * @public
+ * @deprecated This is a copy of the type from react-hook-form, and will be removed in a future release
+ */
+export type UnpackNestedValue<T> = T extends NestedValue<infer U>
+  ? U
+  : T extends Date | FileList | File | Blob
+  ? T
+  : T extends object
+  ? {
+      [K in keyof T]: UnpackNestedValue<T[K]>;
+    }
+  : T;
 
 /**
  * Props for {@link StepPrepareCreatePullRequest}.

--- a/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/index.ts
+++ b/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/index.ts
@@ -23,4 +23,7 @@ export type { PreviewCatalogInfoComponentProps } from './PreviewCatalogInfoCompo
 export { PreviewPullRequestComponent } from './PreviewPullRequestComponent';
 export type { PreviewPullRequestComponentProps } from './PreviewPullRequestComponent';
 export { StepPrepareCreatePullRequest } from './StepPrepareCreatePullRequest';
-export type { StepPrepareCreatePullRequestProps } from './StepPrepareCreatePullRequest';
+export type {
+  StepPrepareCreatePullRequestProps,
+  UnpackNestedValue,
+} from './StepPrepareCreatePullRequest';

--- a/yarn.lock
+++ b/yarn.lock
@@ -40937,11 +40937,11 @@ __metadata:
   linkType: hard
 
 "react-hook-form@npm:^7.12.2":
-  version: 7.53.2
-  resolution: "react-hook-form@npm:7.53.2"
+  version: 7.55.0
+  resolution: "react-hook-form@npm:7.55.0"
   peerDependencies:
     react: ^16.8.0 || ^17 || ^18 || ^19
-  checksum: 37e2dd0e79cd8d3376a7a2cb72ad7b59f0594be499daa898d2c6bec896fc30c2f86e62e8b41bc9d325f77220bd8d76cb31e917f77f1c92ad5740adb1a4cc69e2
+  checksum: ff37fba242c0e94911bf8515bfe1b0670f93bf0ed0c44c923108859244f41da3f0f6dffcf70d570b152ef6b1d56936d943b45fba11c63f21b913fba8f0da862b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The `NestedValue` concept is deprecated and will be removed in the next major release of the library. But they (accidentally?) removed this helper in a minor bump beforehand. To ensure that we don't get premature breakage for customers, let's export the type ourselves until we upgrade the library.

Yes I bumped the yarn.lock entry as well. This is what the e2e sees because it's in-range, and we're already in practice sort of getting to this point anyway.