### PR TITLE
Revert "Fix default catalog table search"

### DIFF
--- a/.changeset/tasty-moments-do.md
+++ b/.changeset/tasty-moments-do.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-catalog': patch
----
-
-Fix the default catalog table search behavior by using the catalog table toolbar for all table variations (including when pagination mode is none).

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -49,7 +49,6 @@ import { defaultCatalogTableColumnsFunc } from './defaultCatalogTableColumnsFunc
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { catalogTranslationRef } from '../../alpha/translation';
 import { FavoriteToggleIcon } from '@backstage/core-components';
-import { CatalogTableToolbar } from './CatalogTableToolbar';
 
 /**
  * Props for {@link CatalogTable}.
@@ -252,9 +251,6 @@ export const CatalogTable = (props: CatalogTableProps) => {
       actions={actions}
       subtitle={subtitle}
       emptyContent={emptyContent}
-      components={{
-        Toolbar: CatalogTableToolbar,
-      }}
     />
   );
 };


### PR DESCRIPTION
Reverts backstage/backstage#29410
Using the `EntitySearchBar` has side effects:
https://github.com/backstage/backstage/pull/28612/files