### PR TITLE
Update refresh_state table column for mysql databases only

### DIFF
--- a/.changeset/chubby-cougars-run.md
+++ b/.changeset/chubby-cougars-run.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+This patch addresses an issue identified in Backstage when configured with a MySQL database. If an entity of type location
+(e..all.yaml) has more than 70 referenced entities, clicking "Refresh" does not update the referenced entities as expected. This occurs because the TEXT type in MySQL has a limit of 65,535 bytes, which is insufficient to store all the referenced entities, causing the refresh operation to fail.

--- a/plugins/catalog-backend/migrations/20250401200503_update_refresh_state_columns.js
+++ b/plugins/catalog-backend/migrations/20250401200503_update_refresh_state_columns.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @param {import('knex').Knex} knex
+ * @returns {Promise<void>}
+ */
+exports.up = async function up(knex) {
+  const isMySQL = knex.client.config.client.includes('mysql');
+  // update the columns to longtext for MySQL
+  if (isMySQL) {
+    await knex.schema.alterTable('refresh_state', table => {
+      table.text('unprocessed_entity', 'longtext').alter();
+      table.text('cache', 'longtext').alter();
+    });
+  }
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ * @returns {Promise<void>}
+ */
+exports.down = async function down(knex) {
+  const isMySQL = knex.client.config.client.includes('mysql');
+  if (isMySQL) {
+    await knex.schema.alterTable('refresh_state', table => {
+      table.text('unprocessed_entity').alter();
+      table.text('cache').alter();
+    });
+  }
+};


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
Hello in this PR i created a new migration to alter the type of unprocessed_entity and cache from text to long longtext in table backstage_plugin_catalog.refresh_state as it was causing issue with the refresh functionality on backstage application with mysql database configuration 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
