### PR TITLE
refactor: consolidate entity route param extraction in catalog-react

### DIFF
--- a/.changeset/dull-masks-occur.md
+++ b/.changeset/dull-masks-occur.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': minor
+---
+
+`entityRouteParams` now also accepts entity refs, and can help with encoding the resulting parameters.

--- a/plugins/catalog-react/report.api.md
+++ b/plugins/catalog-react/report.api.md
@@ -524,10 +524,18 @@ export interface EntityRefPresentationSnapshot {
 }
 
 // @public
-export function entityRouteParams(entity: Entity): {
+export function entityRouteParams(
+  entityOrRef: Entity | CompoundEntityRef | string,
+  options?: EntityRouteParamsOptions,
+): {
   readonly kind: string;
   readonly namespace: string;
   readonly name: string;
+};
+
+// @public
+export type EntityRouteParamsOptions = {
+  encodeParams?: boolean;
 };
 
 // @public

--- a/plugins/catalog-react/src/components/EntityRefLink/EntityRefLink.tsx
+++ b/plugins/catalog-react/src/components/EntityRefLink/EntityRefLink.tsx
@@ -14,16 +14,11 @@
  * limitations under the License.
  */
 
-import {
-  CompoundEntityRef,
-  DEFAULT_NAMESPACE,
-  Entity,
-  parseEntityRef,
-} from '@backstage/catalog-model';
+import { CompoundEntityRef, Entity } from '@backstage/catalog-model';
 import { Link, LinkProps } from '@backstage/core-components';
 import { useRouteRef } from '@backstage/core-plugin-api';
 import { ReactNode, forwardRef } from 'react';
-import { entityRouteRef } from '../../routes';
+import { entityRouteParams, entityRouteRef } from '../../routes';
 import { EntityDisplayName } from '../EntityDisplayName';
 
 /**
@@ -88,33 +83,7 @@ function useEntityRoute(
 ): string {
   const entityRoute = useRouteRef(entityRouteRef);
 
-  let kind;
-  let namespace;
-  let name;
-
-  if (typeof entityRef === 'string') {
-    const parsed = parseEntityRef(entityRef);
-    kind = parsed.kind;
-    namespace = parsed.namespace;
-    name = parsed.name;
-  } else if ('metadata' in entityRef) {
-    kind = entityRef.kind;
-    namespace = entityRef.metadata.namespace;
-    name = entityRef.metadata.name;
-  } else {
-    kind = entityRef.kind;
-    namespace = entityRef.namespace;
-    name = entityRef.name;
-  }
-
-  kind = kind.toLocaleLowerCase('en-US');
-  namespace = namespace?.toLocaleLowerCase('en-US') ?? DEFAULT_NAMESPACE;
-
-  const routeParams = {
-    kind: encodeURIComponent(kind),
-    namespace: encodeURIComponent(namespace),
-    name: encodeURIComponent(name),
-  };
+  const routeParams = entityRouteParams(entityRef, { encodeParams: true });
 
   return entityRoute(routeParams);
 }

--- a/plugins/catalog-react/src/index.ts
+++ b/plugins/catalog-react/src/index.ts
@@ -27,6 +27,7 @@ export * from './apis';
 export * from './components';
 export * from './hooks';
 export * from './filters';
+export type { EntityRouteParamsOptions } from './routes';
 export { entityRouteParams, entityRouteRef } from './routes';
 export * from './types';
 export * from './overridableComponents';

--- a/plugins/catalog-react/src/routes.test.ts
+++ b/plugins/catalog-react/src/routes.test.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { DEFAULT_NAMESPACE, Entity } from '@backstage/catalog-model';
+import {
+  DEFAULT_NAMESPACE,
+  Entity,
+  getCompoundEntityRef,
+} from '@backstage/catalog-model';
 import { entityRouteParams } from './routes';
 
 const entity: Entity = {
@@ -49,9 +53,21 @@ const expectedNamespacedEntityRouteParams = {
 describe('entityRouteParams', () => {
   it.each([
     ['Entity', entity, expectedEntityRouteParams],
+    ['ComponentRef', getCompoundEntityRef(entity), expectedEntityRouteParams],
+    ['string', 'component:Test-Component', expectedEntityRouteParams],
     [
       'namespaced Entity',
       namespacedEntity,
+      expectedNamespacedEntityRouteParams,
+    ],
+    [
+      'namespaced ComponentRef',
+      getCompoundEntityRef(namespacedEntity),
+      expectedNamespacedEntityRouteParams,
+    ],
+    [
+      'namespaced string',
+      'component:Test-Namespace/Test-Namespaced-Component',
       expectedNamespacedEntityRouteParams,
     ],
   ])(

--- a/plugins/catalog-react/src/routes.test.ts
+++ b/plugins/catalog-react/src/routes.test.ts
@@ -77,4 +77,27 @@ describe('entityRouteParams', () => {
       expect(actualRouteParams).toEqual(expectedRouteParams);
     },
   );
+
+  it('should not encode route params by default', () => {
+    const actualRouteParams = entityRouteParams(
+      'Custom Entity:Test Namespace/Test Component',
+    );
+    expect(actualRouteParams).toEqual({
+      kind: 'custom entity',
+      name: 'Test Component',
+      namespace: 'test namespace',
+    });
+  });
+
+  it('should encode route params', () => {
+    const actualRouteParams = entityRouteParams(
+      'Custom Entity:Test Namespace/Test Component',
+      { encodeParams: true },
+    );
+    expect(actualRouteParams).toEqual({
+      kind: 'custom%20entity',
+      name: 'Test%20Component',
+      namespace: 'test%20namespace',
+    });
+  });
 });

--- a/plugins/catalog-react/src/routes.test.ts
+++ b/plugins/catalog-react/src/routes.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DEFAULT_NAMESPACE, Entity } from '@backstage/catalog-model';
+import { entityRouteParams } from './routes';
+
+const entity: Entity = {
+  apiVersion: '1',
+  kind: 'Component',
+  metadata: {
+    name: 'Test-Component',
+  },
+};
+
+const expectedEntityRouteParams = {
+  kind: 'component',
+  name: 'Test-Component',
+  namespace: DEFAULT_NAMESPACE,
+};
+
+const namespacedEntity = {
+  apiVersion: '1',
+  kind: 'Component',
+  metadata: {
+    name: 'Test-Namespaced-Component',
+    namespace: 'Test-Namespace',
+  },
+};
+
+const expectedNamespacedEntityRouteParams = {
+  kind: 'component',
+  name: 'Test-Namespaced-Component',
+  namespace: 'test-namespace',
+};
+
+describe('entityRouteParams', () => {
+  it.each([
+    ['Entity', entity, expectedEntityRouteParams],
+    [
+      'namespaced Entity',
+      namespacedEntity,
+      expectedNamespacedEntityRouteParams,
+    ],
+  ])(
+    'should return correct route params for %s',
+    (_type, entityOrRef, expectedRouteParams) => {
+      const actualRouteParams = entityRouteParams(entityOrRef);
+      expect(actualRouteParams).toEqual(expectedRouteParams);
+    },
+  );
+});

--- a/plugins/catalog-react/src/routes.ts
+++ b/plugins/catalog-react/src/routes.ts
@@ -43,11 +43,20 @@ export const entityRouteRef = getOrCreateGlobalSingleton(
 );
 
 /**
+ * Configurable options for `entityRouteParams`
+ * @public
+ */
+export type EntityRouteParamsOptions = {
+  encodeParams?: boolean;
+};
+
+/**
  * Utility function to get suitable route params for entityRoute, given an
  * @public
  */
 export function entityRouteParams(
   entityOrRef: Entity | CompoundEntityRef | string,
+  options?: EntityRouteParamsOptions,
 ) {
   let kind;
   let namespace;
@@ -70,6 +79,13 @@ export function entityRouteParams(
 
   kind = kind.toLocaleLowerCase('en-US');
   namespace = namespace?.toLocaleLowerCase('en-US') ?? DEFAULT_NAMESPACE;
+
+  const { encodeParams = false } = options || {};
+  if (encodeParams) {
+    kind = encodeURIComponent(kind);
+    namespace = encodeURIComponent(namespace);
+    name = encodeURIComponent(name);
+  }
 
   return {
     kind,

--- a/plugins/catalog-react/src/routes.ts
+++ b/plugins/catalog-react/src/routes.ts
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import { Entity, DEFAULT_NAMESPACE } from '@backstage/catalog-model';
+import {
+  Entity,
+  DEFAULT_NAMESPACE,
+  CompoundEntityRef,
+  parseEntityRef,
+} from '@backstage/catalog-model';
 import { createRouteRef } from '@backstage/core-plugin-api';
 import { getOrCreateGlobalSingleton } from '@backstage/version-bridge';
 
@@ -41,12 +46,34 @@ export const entityRouteRef = getOrCreateGlobalSingleton(
  * Utility function to get suitable route params for entityRoute, given an
  * @public
  */
-export function entityRouteParams(entity: Entity) {
+export function entityRouteParams(
+  entityOrRef: Entity | CompoundEntityRef | string,
+) {
+  let kind;
+  let namespace;
+  let name;
+
+  if (typeof entityOrRef === 'string') {
+    const parsed = parseEntityRef(entityOrRef);
+    kind = parsed.kind;
+    namespace = parsed.namespace;
+    name = parsed.name;
+  } else if ('metadata' in entityOrRef) {
+    kind = entityOrRef.kind;
+    namespace = entityOrRef.metadata.namespace;
+    name = entityOrRef.metadata.name;
+  } else {
+    kind = entityOrRef.kind;
+    namespace = entityOrRef.namespace;
+    name = entityOrRef.name;
+  }
+
+  kind = kind.toLocaleLowerCase('en-US');
+  namespace = namespace?.toLocaleLowerCase('en-US') ?? DEFAULT_NAMESPACE;
+
   return {
-    kind: entity.kind.toLocaleLowerCase('en-US'),
-    namespace:
-      entity.metadata.namespace?.toLocaleLowerCase('en-US') ??
-      DEFAULT_NAMESPACE,
-    name: entity.metadata.name,
+    kind,
+    namespace,
+    name,
   } as const;
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

`entityRouteParams` and `useEntityRoute` both extract entity route parameters for use with an entity route reference.
However, they two methods are different in minor ways.

- `useEntityRoute` will accept an `Entity` or an entity reference, `entityRouteParams` only accepts `Entity`s
- `useEntityRoute` URI encodes route params, `entityRouteParams` does not.
- `entityRouteParams` returns a readonly `const` data structure

In practice, this means routes generated by `useEntityRoute(entity)` and
`useRouteRef(entityRouteRef)(entityRouteParams(entity))` are most likely functionally equivalent, but not strictly
equal. Additionally, you might have to choose to use one or the other based on the data available in scope (entity
references).

This change refactors the two functions to centralize and consolidate similar functionality. It widens
`entityRouteParams` to accept entity references and it allows for configurable URI encoding. The encoding is disabled
by default to preserve backwards compatibility.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
