### PR TITLE
[Catalog] Use a different id for the legacy catalog client ref

### DIFF
--- a/.changeset/few-humans-listen.md
+++ b/.changeset/few-humans-listen.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-node': patch
+---
+
+Use a different ID for the deprecated alpha version of the catalog service, as it has a different type definition and cannot be used interchangeably with the non-alpha version.

--- a/.changeset/rich-ends-throw.md
+++ b/.changeset/rich-ends-throw.md
@@ -1,0 +1,8 @@
+---
+'@backstage/cli': patch
+---
+
+Update the `to do` plugin template to stop using the deprecated catalog alpha service reference.
+If you start seeing the `should create TODO item with catalog information` test failing, you have two options to fix this:
+Update the test to mock the legacy alpha catalog service, or migrate the `TODO` plugin backend to use the new catalog service reference.
+We recommend the second option, see [this](https://github.com/backstage/backstage/pull/29450/files/267115d0436009443ca68ac84e7dcc646c9c938d#diff-47e01aeb12dd55fab9e697f810be21a8d08d39c37df1b078f6d0894f9bad5a1b) pull request for an example of how to do the migration.

--- a/packages/cli/templates/backend-plugin/src/plugin.ts.hbs
+++ b/packages/cli/templates/backend-plugin/src/plugin.ts.hbs
@@ -3,7 +3,7 @@ import {
   createBackendPlugin,
 } from '@backstage/backend-plugin-api';
 import { createRouter } from './router';
-import { catalogServiceRef } from '@backstage/plugin-catalog-node/alpha';
+import { catalogServiceRef } from '@backstage/plugin-catalog-node';
 import { createTodoListService } from './services/TodoListService';
 
 /**
@@ -17,15 +17,13 @@ export const {{pluginVar}} = createBackendPlugin({
     env.registerInit({
       deps: {
         logger: coreServices.logger,
-        auth: coreServices.auth,
         httpAuth: coreServices.httpAuth,
         httpRouter: coreServices.httpRouter,
         catalog: catalogServiceRef,
       },
-      async init({ logger, auth, httpAuth, httpRouter, catalog }) {
+      async init({ logger, httpAuth, httpRouter, catalog }) {
         const todoListService = await createTodoListService({
           logger,
-          auth,
           catalog,
         });
 

--- a/packages/cli/templates/backend-plugin/src/services/TodoListService/createTodoListService.ts
+++ b/packages/cli/templates/backend-plugin/src/services/TodoListService/createTodoListService.ts
@@ -1,6 +1,6 @@
-import { AuthService, LoggerService } from '@backstage/backend-plugin-api';
+import { LoggerService } from '@backstage/backend-plugin-api';
 import { NotFoundError } from '@backstage/errors';
-import { catalogServiceRef } from '@backstage/plugin-catalog-node/alpha';
+import { catalogServiceRef } from '@backstage/plugin-catalog-node';
 import crypto from 'node:crypto';
 import { TodoItem, TodoListService } from './types';
 
@@ -10,11 +10,9 @@ import { TodoItem, TodoListService } from './types';
 // documentation for more information on how to do this:
 // https://backstage.io/docs/backend-system/core-services/database
 export async function createTodoListService({
-  auth,
   logger,
   catalog,
 }: {
-  auth: AuthService;
   logger: LoggerService;
   catalog: typeof catalogServiceRef.T;
 }): Promise<TodoListService> {
@@ -40,13 +38,7 @@ export async function createTodoListService({
         // If you want to make a request using the plugin backend's own identity,
         // you can access it via the `auth.getOwnServiceCredentials()` method.
         // Beware that this bypasses any user permission checks.
-        const { token } = await auth.getPluginRequestToken({
-          onBehalfOf: options.credentials,
-          targetPluginId: 'catalog',
-        });
-        const entity = await catalog.getEntityByRef(input.entityRef, {
-          token,
-        });
+        const entity = await catalog.getEntityByRef(input.entityRef, options);
         if (!entity) {
           throw new NotFoundError(
             `No entity found for ref '${input.entityRef}'`,

--- a/plugins/catalog-node/src/alpha.ts
+++ b/plugins/catalog-node/src/alpha.ts
@@ -40,7 +40,7 @@ export const catalogEntityPermissionResourceRef = createPermissionResourceRef<
  * @deprecated Use {@link @backstage/plugin-catalog-node#catalogServiceRef} instead
  */
 export const catalogServiceRef = createServiceRef<CatalogApi>({
-  id: 'catalog-client',
+  id: 'catalog-client-legacy',
   defaultFactory: async service =>
     createServiceFactory({
       service,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Use a different ID for the deprecated alpha version of the catalog service, as it has a different type definition and cannot be used interchangeably with the non-alpha version.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
