### PR TITLE
Add failure count metric for scaffolder tasks

### DIFF
--- a/.changeset/ten-boxes-knock.md
+++ b/.changeset/ten-boxes-knock.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+Enhance OpenTelemetry metric to track failed scaffolder tasks via `scaffolder.task.failure.count` counter

--- a/docs/tutorials/setup-opentelemetry.md
+++ b/docs/tutorials/setup-opentelemetry.md
@@ -108,6 +108,7 @@ The following metrics are available:
 - `catalog.stitching.queue.delay`: The amount of delay between being scheduled for stitching, and the start of actually being stitched
 - `scaffolder.task.count`: Count of task runs
 - `scaffolder.task.duration`: Duration of a task run
+- `scaffolder.task.failure.count`: Count of failed task runs
 - `scaffolder.step.count`: Count of step runs
 - `scaffolder.step.duration`: Duration of a step runs
 - `backend_tasks.task.runs.count`: Total number of times a task has been run

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
@@ -599,6 +599,13 @@ function scaffoldingTracker() {
     unit: 'seconds',
   });
 
+  const taskFailureCount = meter.createCounter(
+    'scaffolder.task.failure.count',
+    {
+      description: 'Count of failed task runs',
+    },
+  );
+
   async function taskStart(task: TaskContext) {
     await task.emitLog(`Starting up task with ${task.spec.steps.length} steps`);
     const template = task.spec.templateInfo?.entityRef || '';
@@ -654,6 +661,7 @@ function scaffoldingTracker() {
       taskDuration.record(endTime(), {
         result: 'failed',
       });
+      taskFailureCount.add(1, { template, user });
     }
 
     async function markCancelled(step: TaskStep) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

I added a new OpenTelemetry metric to track failed scaffolder tasks. The new metric `scaffolder.task.failure.count` is incremented whenever a task fails. This enables better monitoring and alerting for failed scaffolder tasks in production environments.

The change is minimal and limited to adding the counter in the NunjucksWorkflowRunner and updating it in the markFailed handler. Additionally, the documentation has been updated to mention the new metric.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
  - Changeset: `feat(scaffolder): Add OpenTelemetry metric to track failed scaffolder tasks via scaffolder.task.failure.count counter`
- [x] Added or updated documentation
  - The OpenTelemetry documentation has been updated to list the new metric
- [x] Tests for new functionality and regression tests for bug fixes
  - No new tests required as the change is within the existing metrics framework
- [ ] Screenshots attached (for UI changes)
  - No UI changes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
