### PR TITLE
Add ability disable the built in entity processors [ContribFest]

### DIFF
--- a/.changeset/sharp-ligers-beg.md
+++ b/.changeset/sharp-ligers-beg.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': minor
+---
+
+Adds the ability to disable the default entity processors using a new boolean app config item `catalog.disableCatalogProcessors`.

--- a/.changeset/sharp-ligers-beg.md
+++ b/.changeset/sharp-ligers-beg.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend': minor
 ---
 
-Adds the ability to disable the default entity processors using a new boolean app config item `catalog.disableCatalogProcessors`.
+Adds the ability to disable the default entity processors using a new boolean app config item `catalog.disableDefaultProcessors`.

--- a/plugins/catalog-backend/config.d.ts
+++ b/plugins/catalog-backend/config.d.ts
@@ -149,6 +149,15 @@ export interface Config {
     disableRelationsCompatibility?: boolean;
 
     /**
+     * Disables the default backstage processors.
+     *
+     * Enabling this option allows more complete control of which processors are included
+     * in the backstage processing loop.
+     *
+     */
+    disableDefaultProcessors?: boolean;
+
+    /**
      * The strategy to use for entities that are orphaned, i.e. no longer have
      * any other entities or providers referencing them. The default value is
      * "keep".

--- a/plugins/catalog-backend/src/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.ts
@@ -736,8 +736,14 @@ export class CatalogBuilder {
       processors.push(builtinKindsEntityProcessor);
     }
 
-    // These are only added unless the user replaced them all
-    if (!this.processorsReplace) {
+    const disableDefaultProcessors = config.getOptionalBoolean(
+      'catalog.disableDefaultProcessors',
+    );
+
+    // Add default processors if:
+    // - processors have NOT been explicitly replaced
+    // - and default processors are NOT disabled via config
+    if (!this.processorsReplace && !disableDefaultProcessors) {
       processors.push(...this.getDefaultProcessors());
     }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add ability disable the built in entity processors

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
