### PR TITLE
Gitlab Scaffolder Action - Add a little more context to the commitAction

### DIFF
--- a/.changeset/plenty-coats-rhyme.md
+++ b/.changeset/plenty-coats-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gitlab': patch
+---
+
+Adds more context to the gitlab repo push commitAction for the installed actions section in the scaffolder

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.ts
@@ -89,7 +89,7 @@ export const createGitlabRepoPushAction = (options: {
             type: 'string',
             enum: ['create', 'update', 'delete'],
             description:
-              'The action to be used for git commit. Defaults to create.',
+              'The action to be used for git commit. Defaults to create, but can be set to update or delete',
           },
         },
       },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Somewhat related to #29405 

Adds a little more context to the commitAction in the installed actions section of the scaffolder.

I am not fully sure if we need this or not, when I tested it locally in the backstage repo I get an option to expand the `string` to see the valid enums which I don't see in our version currently `1.37.0` so I am not sure if somewhere in there this is being updated and not really necessary anymore 😅 

Or maybe its fine to just have it anyway so its there at a quick glance

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
