### PR TITLE
cli: fix trailing /* in automatic imports

### DIFF
--- a/.changeset/fluffy-dancers-sneeze.md
+++ b/.changeset/fluffy-dancers-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Avoid trailing `/*` when automatically adding imports for package with multiple entry points.

--- a/packages/cli/src/modules/build/lib/packager/productionPack.ts
+++ b/packages/cli/src/modules/build/lib/packager/productionPack.ts
@@ -166,8 +166,11 @@ async function rewriteEntryPoints(
       if (!pkg.typesVersions) {
         pkg.typesVersions = { '*': {} };
       }
-      const mount = entryPoint.name === 'index' ? '*' : entryPoint.name;
-      pkg.typesVersions['*'][mount] = [`dist/${entryPoint.name}.d.ts`];
+      if (entryPoint.name !== 'index') {
+        pkg.typesVersions['*'][entryPoint.name] = [
+          `dist/${entryPoint.name}.d.ts`,
+        ];
+      }
     }
 
     exp.default = exp.require ?? exp.import;
@@ -217,12 +220,9 @@ async function rewriteEntryPoints(
     }
   }
 
-  // Clean up the typesVersions field if it only contains a wildcard
+  // Make sure package.json is also available in typesVersions if present
   if (pkg.typesVersions?.['*']) {
-    const keys = Object.keys(pkg.typesVersions['*']);
-    if (keys.length === 1 && keys[0] === '*') {
-      delete pkg.typesVersions;
-    }
+    pkg.typesVersions['*']['package.json'] = ['package.json'];
   }
 
   if (pkg.exports) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Followup fix for #29109, the correct format is in fact to not have the separate entry points at all, leaving that to the top-level `types` field. Also throwing in `package.json` while at it, which we have in source but doesn't get sync'd in on prepack.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
