### PR TITLE
Canon docs - Fix sidebar links for TextField

### DIFF
--- a/canon-docs/src/utils/data.ts
+++ b/canon-docs/src/utils/data.ts
@@ -77,11 +77,6 @@ export const components: Page[] = [
     status: 'alpha',
   },
   {
-    title: 'Field',
-    slug: 'field',
-    status: 'alpha',
-  },
-  {
     title: 'Heading',
     slug: 'heading',
     status: 'alpha',
@@ -97,11 +92,6 @@ export const components: Page[] = [
     status: 'alpha',
   },
   {
-    title: 'Input',
-    slug: 'input',
-    status: 'alpha',
-  },
-  {
     title: 'Select',
     slug: 'select',
     status: 'alpha',
@@ -114,6 +104,11 @@ export const components: Page[] = [
   {
     title: 'Text',
     slug: 'text',
+    status: 'alpha',
+  },
+  {
+    title: 'TextField',
+    slug: 'text-field',
     status: 'alpha',
   },
 ];


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The sidebar links were not updated correctly after the move to `TextField`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
