### PR TITLE
proxy-backend support sse connections closing

### DIFF
--- a/.changeset/thin-trams-work.md
+++ b/.changeset/thin-trams-work.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-proxy-backend': patch
 ---
 
-Fixed handling of proxied sse connections when the upstream server closes the connection
+Fixed handling of proxied SSE connections when the upstream server closes the connection

--- a/.changeset/thin-trams-work.md
+++ b/.changeset/thin-trams-work.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-proxy-backend': patch
+---
+
+Fixed handling of proxied sse connections when the upstream server closes the connection

--- a/plugins/proxy-backend/src/service/router.ts
+++ b/plugins/proxy-backend/src/service/router.ts
@@ -214,13 +214,25 @@ export function buildMiddleware(
     ].map(h => h.toLocaleLowerCase()),
   );
 
-  // only forward the allowed headers in backend->client
-  fullConfig.onProxyRes = (proxyRes: http.IncomingMessage) => {
+  fullConfig.onProxyRes = (
+    proxyRes: http.IncomingMessage,
+    _,
+    res: express.Response,
+  ) => {
+    // only forward the allowed headers in backend->client
     const headerNames = Object.keys(proxyRes.headers);
 
     headerNames.forEach(h => {
       if (!responseHeaderAllowList.has(h.toLocaleLowerCase())) {
         delete proxyRes.headers[h];
+      }
+    });
+
+    // handle SSE connections closed by the backend
+    // https://github.com/chimurai/http-proxy-middleware/discussions/765
+    proxyRes.on('close', () => {
+      if (!res.writableEnded) {
+        res.end();
       }
     });
   };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The current proxy-backend plugin allows SSE connections, however does not properly handle situations where the server may close the connection for whatever reason. 

Add config described in https://github.com/chimurai/http-proxy-middleware/discussions/765 to support this behavior



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
