### PR TITLE
Add manifest configuration options

### DIFF
--- a/.changeset/eleven-beans-relax.md
+++ b/.changeset/eleven-beans-relax.md
@@ -1,0 +1,9 @@
+---
+'@backstage/release-manifests': patch
+---
+
+This expands the configurability of `release-manifests` to pave the road for more configuration options in the `cli`.
+
+Specifically it allows the specification of mirrored, proxied, or air-gapped hosts when upgrading across releases when
+working in restricted or heavily governed development environments (common in large enterprises and government
+entities).

--- a/packages/release-manifests/report.api.md
+++ b/packages/release-manifests/report.api.md
@@ -11,6 +11,14 @@ export function getManifestByReleaseLine(
 // @public
 export type GetManifestByReleaseLineOptions = {
   releaseLine: string;
+  fetch?: (
+    url: string,
+    options?: {
+      signal?: AbortSignal;
+    },
+  ) => Promise<Pick<Response, 'ok' | 'status' | 'text' | 'json' | 'url'>>;
+  gitHubRawBaseUrl?: string;
+  versionsBaseUrl?: string;
 };
 
 // @public
@@ -27,6 +35,8 @@ export type GetManifestByVersionOptions = {
       signal?: AbortSignal;
     },
   ) => Promise<Pick<Response, 'status' | 'json' | 'url'>>;
+  gitHubRawBaseUrl?: string;
+  versionsBaseUrl?: string;
 };
 
 // @public


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This expands the configurability of `release-manifests` to pave the road for more configuration options in the `cli`.

Specifically it allows the specification of mirrored, proxied, or air-gapped hosts when upgrading across Backstage releases when working in restricted or heavily governed development environments (common in large enterprises and government
entities).

As a side effect, it makes the specification of custom `fetch` implementations consistent across `getManifestByVersion` and `getManifestByReleaseLine`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
