### PR TITLE
Added labels to scaffolder histogram metrics

### DIFF
--- a/.changeset/legal-loops-push.md
+++ b/.changeset/legal-loops-push.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-backend': patch
 ---
 
-Added `template` and `step` labels for scaffolder historgam metrics: scaffolder_task_duration and scaffolder_step_duration
+Added `template` and `step` labels for scaffolder histogram metrics: `scaffolder_task_duration` and `scaffolder_step_duration`

--- a/.changeset/legal-loops-push.md
+++ b/.changeset/legal-loops-push.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Added `template` and `step` labels for scaffolder historgam metrics: scaffolder_task_duration and scaffolder_step_duration

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
@@ -634,6 +634,7 @@ function scaffoldingTracker() {
 
       taskCount.add(1, { template, user, result: 'ok' });
       taskDuration.record(endTime(), {
+        template,
         result: 'ok',
       });
     }
@@ -652,6 +653,7 @@ function scaffoldingTracker() {
 
       taskCount.add(1, { template, user, result: 'failed' });
       taskDuration.record(endTime(), {
+        template,
         result: 'failed',
       });
     }
@@ -670,6 +672,7 @@ function scaffoldingTracker() {
 
       taskCount.add(1, { template, user, result: 'cancelled' });
       taskDuration.record(endTime(), {
+        template,
         result: 'cancelled',
       });
     }
@@ -714,6 +717,8 @@ function scaffoldingTracker() {
 
       stepCount.add(1, { template, step: step.name, result: 'ok' });
       stepDuration.record(endTime(), {
+        template,
+        step: step.name,
         result: 'ok',
       });
     }
@@ -728,6 +733,8 @@ function scaffoldingTracker() {
 
       stepCount.add(1, { template, step: step.name, result: 'cancelled' });
       stepDuration.record(endTime(), {
+        template,
+        step: step.name,
         result: 'cancelled',
       });
     }
@@ -742,6 +749,8 @@ function scaffoldingTracker() {
 
       stepCount.add(1, { template, step: step.name, result: 'failed' });
       stepDuration.record(endTime(), {
+        template,
+        step: step.name,
         result: 'failed',
       });
     }
@@ -755,6 +764,8 @@ function scaffoldingTracker() {
 
       stepCount.add(1, { template, step: step.name, result: 'skipped' });
       stepDuration.record(endTime(), {
+        template,
+        step: step.name,
         result: 'skipped',
       });
     }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I've added `template` as a label to the scaffolder task_duration histogram metrics
I've added `template` and `step` labels to the scaffolder step_duration histogram metrics

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
<img width="1179" alt="Screenshot 2025-04-08 at 15 07 36" src="https://github.com/user-attachments/assets/48284755-ea4b-48c2-95bf-981e1d428df2" />
