### PR TITLE
[plugin-home]  [plugin-home-react] export ContentModal and make docsLinkTitle prop more flexible

### DIFF
--- a/.changeset/honest-teams-shave.md
+++ b/.changeset/honest-teams-shave.md
@@ -4,6 +4,7 @@
 ---
 
 Export ContentModal from `@backstage/plugin-home-react` so people can use this in other scenarios.
+Renamed `CatalogReactComponentsNameToClassKey` to `PluginHomeComponentsNameToClassKey` in `overridableComponents.ts`
 
 Made QuickStartCard `docsLinkTitle` prop more flexible to allow for any React.JSX.Element instead of just a string.
 Added QuickStartCard prop `additionalContent` which can eventually replace the prop `video`.

--- a/.changeset/honest-teams-shave.md
+++ b/.changeset/honest-teams-shave.md
@@ -7,4 +7,3 @@ Export ContentModal from `@backstage/plugin-home-react` so people can use this i
 
 Made QuickStartCard `docsLinkTitle` prop more flexible to allow for any React.JSX.Element instead of just a string.
 Added QuickStartCard prop `additionalContent` which can eventually replace the prop `video`.
-Remove unused styles.

--- a/.changeset/honest-teams-shave.md
+++ b/.changeset/honest-teams-shave.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-home-react': patch
+'@backstage/plugin-home': patch
+---
+
+Export ContentModal from @backstage/plugin-home-react so people can use this in other scenarios.
+
+Make QuickStartCard docsLinkTitle prop more flexible to allow for any React.JSX.Element instead of just a string

--- a/.changeset/honest-teams-shave.md
+++ b/.changeset/honest-teams-shave.md
@@ -3,8 +3,8 @@
 '@backstage/plugin-home': patch
 ---
 
-Export ContentModal from @backstage/plugin-home-react so people can use this in other scenarios.
+Export ContentModal from `@backstage/plugin-home-react` so people can use this in other scenarios.
 
-Make QuickStartCard docsLinkTitle prop more flexible to allow for any React.JSX.Element instead of just a string.
-Update QuickStartCard prop name from video to additionalContent.
+Made QuickStartCard `docsLinkTitle` prop more flexible to allow for any React.JSX.Element instead of just a string.
+Added QuickStartCard prop `additionalContent` which can eventually replace the prop `video`.
 Remove unused styles.

--- a/.changeset/honest-teams-shave.md
+++ b/.changeset/honest-teams-shave.md
@@ -5,4 +5,6 @@
 
 Export ContentModal from @backstage/plugin-home-react so people can use this in other scenarios.
 
-Make QuickStartCard docsLinkTitle prop more flexible to allow for any React.JSX.Element instead of just a string
+Make QuickStartCard docsLinkTitle prop more flexible to allow for any React.JSX.Element instead of just a string.
+Update QuickStartCard prop name from video to additionalContent.
+Remove unused styles.

--- a/plugins/home-react/report.api.md
+++ b/plugins/home-react/report.api.md
@@ -13,8 +13,8 @@ import { UiSchema } from '@rjsf/utils';
 
 // @public (undocumented)
 export type BackstageOverrides = Overrides & {
-  [Name in keyof CatalogReactComponentsNameToClassKey]?: Partial<
-    StyleRules<CatalogReactComponentsNameToClassKey[Name]>
+  [Name in keyof PluginHomeComponentsNameToClassKey]?: Partial<
+    StyleRules<PluginHomeComponentsNameToClassKey[Name]>
   >;
 };
 
@@ -50,11 +50,6 @@ export type CardSettings = {
 };
 
 // @public (undocumented)
-export type CatalogReactComponentsNameToClassKey = {
-  PluginHomeContentModal: PluginHomeContentModalClassKey;
-};
-
-// @public (undocumented)
 export type ComponentParts = {
   Content: (props?: any) => JSX.Element;
   Actions?: () => JSX.Element;
@@ -85,6 +80,11 @@ export function createCardExtension<T>(options: {
   layout?: CardLayout;
   settings?: CardSettings;
 }): Extension<(props: CardExtensionProps<T>) => JSX_2.Element>;
+
+// @public (undocumented)
+export type PluginHomeComponentsNameToClassKey = {
+  PluginHomeContentModal: PluginHomeContentModalClassKey;
+};
 
 // @public (undocumented)
 export type PluginHomeContentModalClassKey = 'contentModal' | 'linkText';

--- a/plugins/home-react/report.api.md
+++ b/plugins/home-react/report.api.md
@@ -12,9 +12,6 @@ import { StyleRules } from '@material-ui/core/styles/withStyles';
 import { UiSchema } from '@rjsf/utils';
 
 // @public (undocumented)
-export type BackstageContentModalClassKey = 'contentModal' | 'linkText';
-
-// @public (undocumented)
 export type BackstageOverrides = Overrides & {
   [Name in keyof CatalogReactComponentsNameToClassKey]?: Partial<
     StyleRules<CatalogReactComponentsNameToClassKey[Name]>
@@ -54,7 +51,7 @@ export type CardSettings = {
 
 // @public (undocumented)
 export type CatalogReactComponentsNameToClassKey = {
-  BackstageContentModal: BackstageContentModalClassKey;
+  PluginHomeContentModal: PluginHomeContentModalClassKey;
 };
 
 // @public (undocumented)
@@ -88,6 +85,9 @@ export function createCardExtension<T>(options: {
   layout?: CardLayout;
   settings?: CardSettings;
 }): Extension<(props: CardExtensionProps<T>) => JSX_2.Element>;
+
+// @public (undocumented)
+export type PluginHomeContentModalClassKey = 'contentModal' | 'linkText';
 
 // @public (undocumented)
 export type RendererProps = {

--- a/plugins/home-react/report.api.md
+++ b/plugins/home-react/report.api.md
@@ -5,8 +5,21 @@
 ```ts
 import { Extension } from '@backstage/core-plugin-api';
 import { JSX as JSX_2 } from 'react/jsx-runtime';
+import { JSX as JSX_3 } from 'react';
+import { Overrides } from '@material-ui/core/styles/overrides';
 import { RJSFSchema } from '@rjsf/utils';
+import { StyleRules } from '@material-ui/core/styles/withStyles';
 import { UiSchema } from '@rjsf/utils';
+
+// @public (undocumented)
+export type BackstageContentModalClassKey = 'contentModal' | 'linkText';
+
+// @public (undocumented)
+export type BackstageOverrides = Overrides & {
+  [Name in keyof CatalogReactComponentsNameToClassKey]?: Partial<
+    StyleRules<CatalogReactComponentsNameToClassKey[Name]>
+  >;
+};
 
 // @public (undocumented)
 export type CardConfig = {
@@ -40,6 +53,11 @@ export type CardSettings = {
 };
 
 // @public (undocumented)
+export type CatalogReactComponentsNameToClassKey = {
+  BackstageContentModal: BackstageContentModalClassKey;
+};
+
+// @public (undocumented)
 export type ComponentParts = {
   Content: (props?: any) => JSX.Element;
   Actions?: () => JSX.Element;
@@ -50,6 +68,15 @@ export type ComponentParts = {
 // @public (undocumented)
 export type ComponentRenderer = {
   Renderer?: (props: RendererProps) => JSX.Element;
+};
+
+// @public
+export const ContentModal: (props: ContentModalProps) => JSX_2.Element;
+
+// @public
+export type ContentModalProps = {
+  modalContent: JSX_3.Element;
+  linkContent: string | JSX_3.Element;
 };
 
 // @public

--- a/plugins/home-react/src/components/ContentModal.tsx
+++ b/plugins/home-react/src/components/ContentModal.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Backstage Authors
+ * Copyright 2025 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,14 +18,43 @@ import { JSX, useState } from 'react';
 import { Link } from '@backstage/core-components';
 import Modal from '@material-ui/core/Modal';
 import Box from '@material-ui/core/Box';
+import { makeStyles, Theme } from '@material-ui/core/styles';
 
-import { useStyles } from './styles';
+/** @public */
+export type BackstageContentModalClassKey = 'contentModal' | 'linkText';
 
+export const useStyles = makeStyles(
+  (theme: Theme) => ({
+    contentModal: {
+      position: 'absolute',
+      top: '50%',
+      left: '50%',
+      transform: 'translate(-50%, -50%)',
+      width: '80%',
+      height: 'auto',
+    },
+    linkText: {
+      marginBottom: theme.spacing(1.5),
+    },
+  }),
+  { name: 'BackstageContentModal' },
+);
+
+/**
+ * Props customizing the <ContentModal/> component.
+ *
+ * @public
+ */
 export type ContentModalProps = {
   modalContent: JSX.Element;
   linkContent: string | JSX.Element;
 };
 
+/**
+ * A component to expand given content into a full screen modal.
+ *
+ * @public
+ */
 export const ContentModal = (props: ContentModalProps) => {
   const { modalContent, linkContent } = props;
   const styles = useStyles();

--- a/plugins/home-react/src/components/ContentModal.tsx
+++ b/plugins/home-react/src/components/ContentModal.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The Backstage Authors
+ * Copyright 2022 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import Box from '@material-ui/core/Box';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 
 /** @public */
-export type BackstageContentModalClassKey = 'contentModal' | 'linkText';
+export type PluginHomeContentModalClassKey = 'contentModal' | 'linkText';
 
 export const useStyles = makeStyles(
   (theme: Theme) => ({
@@ -37,7 +37,7 @@ export const useStyles = makeStyles(
       marginBottom: theme.spacing(1.5),
     },
   }),
-  { name: 'BackstageContentModal' },
+  { name: 'PluginHomeContentModal' },
 );
 
 /**

--- a/plugins/home-react/src/components/index.ts
+++ b/plugins/home-react/src/components/index.ts
@@ -17,5 +17,5 @@
 export { SettingsModal } from './SettingsModal';
 export { ContentModal } from './ContentModal';
 
-export type { BackstageContentModalClassKey } from './ContentModal';
+export type { PluginHomeContentModalClassKey } from './ContentModal';
 export type { ContentModalProps } from './ContentModal';

--- a/plugins/home-react/src/components/index.ts
+++ b/plugins/home-react/src/components/index.ts
@@ -15,3 +15,7 @@
  */
 
 export { SettingsModal } from './SettingsModal';
+export { ContentModal } from './ContentModal';
+
+export type { BackstageContentModalClassKey } from './ContentModal';
+export type { ContentModalProps } from './ContentModal';

--- a/plugins/home-react/src/index.ts
+++ b/plugins/home-react/src/index.ts
@@ -30,3 +30,4 @@ export type {
   CardSettings,
   CardConfig,
 } from './extensions';
+export * from './overridableComponents';

--- a/plugins/home-react/src/overridableComponents.ts
+++ b/plugins/home-react/src/overridableComponents.ts
@@ -16,11 +16,11 @@
 
 import { Overrides } from '@material-ui/core/styles/overrides';
 import { StyleRules } from '@material-ui/core/styles/withStyles';
-import { BackstageContentModalClassKey } from './';
+import { PluginHomeContentModalClassKey } from './';
 
 /** @public */
 export type CatalogReactComponentsNameToClassKey = {
-  BackstageContentModal: BackstageContentModalClassKey;
+  PluginHomeContentModal: PluginHomeContentModalClassKey;
 };
 
 /** @public */

--- a/plugins/home-react/src/overridableComponents.ts
+++ b/plugins/home-react/src/overridableComponents.ts
@@ -19,18 +19,18 @@ import { StyleRules } from '@material-ui/core/styles/withStyles';
 import { PluginHomeContentModalClassKey } from './';
 
 /** @public */
-export type CatalogReactComponentsNameToClassKey = {
+export type PluginHomeComponentsNameToClassKey = {
   PluginHomeContentModal: PluginHomeContentModalClassKey;
 };
 
 /** @public */
 export type BackstageOverrides = Overrides & {
-  [Name in keyof CatalogReactComponentsNameToClassKey]?: Partial<
-    StyleRules<CatalogReactComponentsNameToClassKey[Name]>
+  [Name in keyof PluginHomeComponentsNameToClassKey]?: Partial<
+    StyleRules<PluginHomeComponentsNameToClassKey[Name]>
   >;
 };
 
 declare module '@backstage/theme' {
   interface OverrideComponentNameToClassKeys
-    extends CatalogReactComponentsNameToClassKey {}
+    extends PluginHomeComponentsNameToClassKey {}
 }

--- a/plugins/home-react/src/overridableComponents.ts
+++ b/plugins/home-react/src/overridableComponents.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Overrides } from '@material-ui/core/styles/overrides';
+import { StyleRules } from '@material-ui/core/styles/withStyles';
+import { BackstageContentModalClassKey } from './';
+
+/** @public */
+export type CatalogReactComponentsNameToClassKey = {
+  BackstageContentModal: BackstageContentModalClassKey;
+};
+
+/** @public */
+export type BackstageOverrides = Overrides & {
+  [Name in keyof CatalogReactComponentsNameToClassKey]?: Partial<
+    StyleRules<CatalogReactComponentsNameToClassKey[Name]>
+  >;
+};
+
+declare module '@backstage/theme' {
+  interface OverrideComponentNameToClassKeys
+    extends CatalogReactComponentsNameToClassKey {}
+}

--- a/plugins/home/report.api.md
+++ b/plugins/home/report.api.md
@@ -194,7 +194,7 @@ export const QuickStartCard: (
 // @public
 export type QuickStartCardProps = {
   modalTitle?: string | JSX_3.Element;
-  docsLinkTitle?: string;
+  docsLinkTitle?: string | React.JSX.Element;
   docsLink?: string;
   video?: JSX_3.Element;
   image: JSX_3.Element;

--- a/plugins/home/report.api.md
+++ b/plugins/home/report.api.md
@@ -196,6 +196,7 @@ export type QuickStartCardProps = {
   modalTitle?: string | JSX_3.Element;
   docsLinkTitle?: string | JSX_3.Element;
   docsLink?: string;
+  video?: JSX_3.Element;
   additionalContent?: JSX_3.Element;
   image: JSX_3.Element;
   cardDescription?: string;

--- a/plugins/home/report.api.md
+++ b/plugins/home/report.api.md
@@ -194,7 +194,7 @@ export const QuickStartCard: (
 // @public
 export type QuickStartCardProps = {
   modalTitle?: string | JSX_3.Element;
-  docsLinkTitle?: string | React.JSX.Element;
+  docsLinkTitle?: string | JSX_3.Element;
   docsLink?: string;
   video?: JSX_3.Element;
   image: JSX_3.Element;

--- a/plugins/home/report.api.md
+++ b/plugins/home/report.api.md
@@ -196,7 +196,7 @@ export type QuickStartCardProps = {
   modalTitle?: string | JSX_3.Element;
   docsLinkTitle?: string | JSX_3.Element;
   docsLink?: string;
-  video?: JSX_3.Element;
+  additionalContent?: JSX_3.Element;
   image: JSX_3.Element;
   cardDescription?: string;
   downloadImage?: JSX_3.Element;

--- a/plugins/home/src/homePageComponents/QuickStart/Content.tsx
+++ b/plugins/home/src/homePageComponents/QuickStart/Content.tsx
@@ -33,8 +33,8 @@ export type QuickStartCardProps = {
   docsLinkTitle?: string | JSX.Element;
   /** The link to docs */
   docsLink?: string;
-  /** The video to play on the card */
-  video?: JSX.Element;
+  /** Additional card content */
+  additionalContent?: JSX.Element;
   /** A quickstart image to display on the card */
   image: JSX.Element;
   /** The card description*/
@@ -78,7 +78,7 @@ export const Content = (props: QuickStartCardProps): JSX.Element => {
           </Link>
         </Grid>
       </Grid>
-      {props.video && props.video}
+      {props.additionalContent && props.additionalContent}
     </>
   );
 };

--- a/plugins/home/src/homePageComponents/QuickStart/Content.tsx
+++ b/plugins/home/src/homePageComponents/QuickStart/Content.tsx
@@ -33,6 +33,8 @@ export type QuickStartCardProps = {
   docsLinkTitle?: string | JSX.Element;
   /** The link to docs */
   docsLink?: string;
+  /** The video to play on the card */
+  video?: JSX.Element;
   /** Additional card content */
   additionalContent?: JSX.Element;
   /** A quickstart image to display on the card */
@@ -78,6 +80,7 @@ export const Content = (props: QuickStartCardProps): JSX.Element => {
           </Link>
         </Grid>
       </Grid>
+      {props.video && props.video}
       {props.additionalContent && props.additionalContent}
     </>
   );

--- a/plugins/home/src/homePageComponents/QuickStart/Content.tsx
+++ b/plugins/home/src/homePageComponents/QuickStart/Content.tsx
@@ -33,7 +33,9 @@ export type QuickStartCardProps = {
   docsLinkTitle?: string | JSX.Element;
   /** The link to docs */
   docsLink?: string;
-  /** The video to play on the card */
+  /** The video to play on the card
+   * @deprecated This will be removed in the future, please use `additionalContent` instead
+   */
   video?: JSX.Element;
   /** Additional card content */
   additionalContent?: JSX.Element;
@@ -80,8 +82,8 @@ export const Content = (props: QuickStartCardProps): JSX.Element => {
           </Link>
         </Grid>
       </Grid>
-      {props.video && props.video}
-      {props.additionalContent && props.additionalContent}
+      {(props.additionalContent && props.additionalContent) ||
+        (props.video && props.video)}
     </>
   );
 };

--- a/plugins/home/src/homePageComponents/QuickStart/Content.tsx
+++ b/plugins/home/src/homePageComponents/QuickStart/Content.tsx
@@ -18,7 +18,7 @@ import { JSX } from 'react';
 import { Link } from '@backstage/core-components';
 import Typography from '@material-ui/core/Typography';
 import Grid from '@material-ui/core/Grid';
-import { ContentModal } from './ContentModal';
+import { ContentModal } from '@backstage/plugin-home-react';
 import { useStyles } from './styles';
 
 /**
@@ -30,7 +30,7 @@ export type QuickStartCardProps = {
   /** The modal link title */
   modalTitle?: string | JSX.Element;
   /** The link to docs title */
-  docsLinkTitle?: string;
+  docsLinkTitle?: string | JSX.Element;
   /** The link to docs */
   docsLink?: string;
   /** The video to play on the card */

--- a/plugins/home/src/homePageComponents/QuickStart/QuickStart.stories.tsx
+++ b/plugins/home/src/homePageComponents/QuickStart/QuickStart.stories.tsx
@@ -18,6 +18,7 @@ import { QuickStartCard } from '../../plugin';
 import { ComponentType, PropsWithChildren } from 'react';
 import { wrapInTestApp } from '@backstage/test-utils';
 import Grid from '@material-ui/core/Grid';
+import OpenInNewIcon from '@material-ui/icons/OpenInNew';
 import ContentImage from './static/backstageSystemModel.png';
 
 export default {
@@ -51,6 +52,33 @@ export const Customized = () => {
         title="Onboarding to the Catalog"
         modalTitle="Onboarding Quick Start"
         docsLinkTitle="Learn more with getting started docs"
+        docsLink="https://backstage.io/docs/getting-started"
+        image={
+          <img
+            src={ContentImage}
+            alt="quick start"
+            width="100%"
+            height="100%"
+          />
+        }
+        cardDescription="Backstage system model will help you create new entities"
+      />
+    </Grid>
+  );
+};
+
+export const CustomDocLink = () => {
+  return (
+    <Grid item xs={12} md={6}>
+      <QuickStartCard
+        title="Onboarding to the Catalog"
+        modalTitle="Onboarding Quick Start"
+        docsLinkTitle={
+          <>
+            <OpenInNewIcon fontSize="small" />
+            Learn more with getting started docs
+          </>
+        }
         docsLink="https://backstage.io/docs/getting-started"
         image={
           <img

--- a/plugins/home/src/homePageComponents/QuickStart/QuickStart.stories.tsx
+++ b/plugins/home/src/homePageComponents/QuickStart/QuickStart.stories.tsx
@@ -62,6 +62,13 @@ export const Customized = () => {
           />
         }
         cardDescription="Backstage system model will help you create new entities"
+        additionalContent={
+          <p>
+            This is a custom description for the Quick Start card. It can be
+            used to provide additional information or context about the Quick
+            Start process.
+          </p>
+        }
       />
     </Grid>
   );

--- a/plugins/home/src/homePageComponents/QuickStart/styles.ts
+++ b/plugins/home/src/homePageComponents/QuickStart/styles.ts
@@ -23,7 +23,8 @@ export type QuickStartCardClassKey =
   | 'contentModal'
   | 'imageSize'
   | 'link'
-  | 'linkText';
+  | 'linkText'
+  | 'videoContainer';
 
 export const useStyles = makeStyles(
   (theme: Theme) => ({
@@ -55,6 +56,12 @@ export const useStyles = makeStyles(
     },
     linkText: {
       marginBottom: theme.spacing(1.5),
+    },
+    videoContainer: {
+      borderRadius: '10px',
+      width: '100%',
+      height: 'auto',
+      background: `${theme.palette.background.default}`,
     },
   }),
   { name: 'HomeQuickStartCard' },

--- a/plugins/home/src/homePageComponents/QuickStart/styles.ts
+++ b/plugins/home/src/homePageComponents/QuickStart/styles.ts
@@ -23,8 +23,7 @@ export type QuickStartCardClassKey =
   | 'contentModal'
   | 'imageSize'
   | 'link'
-  | 'linkText'
-  | 'videoContainer';
+  | 'linkText';
 
 export const useStyles = makeStyles(
   (theme: Theme) => ({
@@ -56,12 +55,6 @@ export const useStyles = makeStyles(
     },
     linkText: {
       marginBottom: theme.spacing(1.5),
-    },
-    videoContainer: {
-      borderRadius: '10px',
-      width: '100%',
-      height: 'auto',
-      background: `${theme.palette.background.default}`,
     },
   }),
   { name: 'HomeQuickStartCard' },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Minor updates to QuickStartCard in `plugin-home`
- export `ContentModal` from `@backstage/plugin-home-react` so people can use this in other scenarios.
- make `QuickStartCard` `docsLinkTitle` prop more flexible to allow for any `React.JSX.Element` instead of just a `string`
- update QuickStartCard prop name from `video` to `additionalContent`.
- remove unused styles.

![Screenshot 2025-04-18 at 3 51 35 PM](https://github.com/user-attachments/assets/65bed122-c017-45ae-8154-da6dd94b0145)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
