### PR TITLE
catalog/bitbucket-cloud: support repo:updated events

### DIFF
--- a/.changeset/calm-toys-occur.md
+++ b/.changeset/calm-toys-occur.md
@@ -1,0 +1,17 @@
+---
+'@backstage/plugin-bitbucket-cloud-common': minor
+---
+
+Update Bitbucket Cloud schema and models.
+
+The latest schema was fetched from Bitbucket Cloud and stored locally.
+Based on the updated schema, the models got regenerated.
+
+**BREAKING:**
+
+Due to the schema changes, the model update includes one breaking change:
+
+- `Account.username` was removed.
+
+Additionally, there were a couple of compatible changes including the addition of
+`BaseCommit.committer` and others.

--- a/.changeset/icy-mugs-glow.md
+++ b/.changeset/icy-mugs-glow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-bitbucket-cloud-common': patch
+---
+
+Add support for `repo:updated` events as `Events.RepoUpdatedEvent`.

--- a/.changeset/lovely-cats-take.md
+++ b/.changeset/lovely-cats-take.md
@@ -1,0 +1,11 @@
+---
+'@backstage/plugin-catalog-backend-module-bitbucket-cloud': patch
+---
+
+Support Bitbucket Cloud's `repo:updated` events at `BitbucketCloudEntityProvider`.
+
+To make use of the new event type, you have to configure your webhook or add a new ones
+that delivers this event type to Backstage similar to `repo:push` before.
+
+Only `repo:updated` events that modify a repository's URL (e.g., due to a name change)
+will cause changes (removing the "old", adding the "new" repository).

--- a/docs/integrations/bitbucketCloud/discovery.md
+++ b/docs/integrations/bitbucketCloud/discovery.md
@@ -12,6 +12,23 @@ The provider will search your Bitbucket Cloud account and register catalog files
 as Location entity and via following processing steps add all contained catalog entities.
 This can be useful as an alternative to static locations or manually adding things to the catalog.
 
+## Event-based Discovery
+
+Supported events for event-based updates:
+
+- [`repo:push`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Push)
+  received as `bitbucket.repo:push`
+- [`repo:updated`](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Updated)
+  received as `bitbucket.repo:updated`
+  - Changes are triggered if the repository slug/name changed, causing a new URL for it.
+
+To receive events, you need to add webhook subscriptions at Bitbucket Cloud.
+Enable the triggers (event types) you want to receive.
+For the entity provider, only the event types above are supported ("Repository Push" and/or "Repository Updated")
+and additional event types will be ignored (e.g., for other use cases/integrations you might have).
+
+For more information on how to set up the event-based discovery, see the installation instructions below.
+
 ## Installation
 
 You will have to add the entity provider in the catalog initialization code of your

--- a/plugins/bitbucket-cloud-common/bitbucket-cloud.oas.json
+++ b/plugins/bitbucket-cloud-common/bitbucket-cloud.oas.json
@@ -634,68 +634,6 @@
         }
       ]
     },
-    "/pullrequests/{selected_user}": {
-      "get": {
-        "tags": ["Pullrequests"],
-        "description": "Returns all pull requests authored by the specified user.\n\nBy default only open pull requests are returned. This can be controlled\nusing the `state` query parameter. To retrieve pull requests that are\nin one of multiple states, repeat the `state` parameter for each\nindividual state.\n\nThis endpoint also supports filtering and sorting of the results. See\n[filtering and sorting](/cloud/bitbucket/rest/intro/#filtering) for more details.",
-        "summary": "List pull requests for a user",
-        "responses": {
-          "200": {
-            "description": "All pull requests authored by the specified user.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/paginated_pullrequests"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "If the specified user does not exist.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/error"
-                }
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "state",
-            "in": "query",
-            "description": "Only return pull requests that are in this state. This parameter can be repeated.",
-            "schema": {
-              "type": "string",
-              "enum": ["OPEN", "MERGED", "DECLINED", "SUPERSEDED"]
-            }
-          }
-        ],
-        "security": [
-          {
-            "oauth2": ["pullrequest"]
-          },
-          {
-            "basic": []
-          },
-          {
-            "api_key": []
-          }
-        ]
-      },
-      "parameters": [
-        {
-          "name": "selected_user",
-          "in": "path",
-          "description": "This can either be the username of the pull request author, the author's UUID\nsurrounded by curly-braces, for example: `{account UUID}`, or the author's Atlassian ID.\n",
-          "required": true,
-          "schema": {
-            "type": "string"
-          }
-        }
-      ]
-    },
     "/repositories": {
       "get": {
         "tags": ["Repositories"],
@@ -2846,13 +2784,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["read:pullrequest:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["pullrequest"]
@@ -2862,6 +2793,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:pullrequest:bitbucket"]
           }
         ]
       }
@@ -2922,6 +2860,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:repository:bitbucket"]
           }
         ]
       }
@@ -3013,6 +2958,13 @@
           {
             "api_key": []
           }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:repository:bitbucket"]
+          }
         ]
       },
       "get": {
@@ -3090,6 +3042,13 @@
           {
             "api_key": []
           }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:repository:bitbucket"]
+          }
         ]
       },
       "delete": {
@@ -3149,6 +3108,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:repository:bitbucket"]
           }
         ]
       }
@@ -3218,6 +3184,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:repository:bitbucket"]
           }
         ]
       },
@@ -3304,6 +3277,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:repository:bitbucket"]
           }
         ]
       }
@@ -3392,6 +3372,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:repository:bitbucket"]
           }
         ]
       },
@@ -3490,6 +3477,13 @@
           {
             "api_key": []
           }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:repository:bitbucket"]
+          }
         ]
       },
       "delete": {
@@ -3559,6 +3553,13 @@
           {
             "api_key": []
           }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:repository:bitbucket"]
+          }
         ]
       }
     },
@@ -3593,6 +3594,15 @@
           }
         },
         "parameters": [
+          {
+            "name": "refname",
+            "in": "query",
+            "description": "If specified, only return commit status objects that were either\ncreated without a refname, or were created with the specified refname\n",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
           {
             "name": "q",
             "in": "query",
@@ -3664,7 +3674,7 @@
     "/repositories/{workspace}/{repo_slug}/commit/{commit}/statuses/build": {
       "post": {
         "tags": ["Commit statuses"],
-        "description": "Creates a new build status against the specified commit.\n\nIf the specified key already exists, the existing status object will\nbe overwritten.\n\nExample:\n\n```\ncurl https://api.bitbucket.org/2.0/repositories/my-workspace/my-repo/commit/e10dae226959c2194f2b07b077c07762d93821cf/statuses/build/           -X POST -u jdoe -H 'Content-Type: application/json'           -d '{\n    \"key\": \"MY-BUILD\",\n    \"state\": \"SUCCESSFUL\",\n    \"description\": \"42 tests passed\",\n    \"url\": \"https://www.example.org/my-build-result\"\n  }'\n```\n\nWhen creating a new commit status, you can use a URI template for the URL.\nTemplates are URLs that contain variable names that Bitbucket will\nevaluate at runtime whenever the URL is displayed anywhere similar to\nparameter substitution in\n[Bitbucket Connect](https://developer.atlassian.com/bitbucket/concepts/context-parameters.html).\nFor example, one could use `https://foo.com/builds/{repository.full_name}`\nwhich Bitbucket will turn into `https://foo.com/builds/foo/bar` at render time.\nThe context variables available are `repository` and `commit`.",
+        "description": "Creates a new build status against the specified commit.\n\nIf the specified key already exists, the existing status object will\nbe overwritten.\n\nExample:\n\n```\ncurl https://api.bitbucket.org/2.0/repositories/my-workspace/my-repo/commit/e10dae226959c2194f2b07b077c07762d93821cf/statuses/build/           -X POST -u jdoe -H 'Content-Type: application/json'           -d '{\n    \"key\": \"MY-BUILD\",\n    \"state\": \"SUCCESSFUL\",\n    \"description\": \"42 tests passed\",\n    \"url\": \"https://www.example.org/my-build-result\"\n  }'\n```\n\nWhen creating a new commit status, you can use a URI template for the URL.\nTemplates are URLs that contain variable names that Bitbucket will\nevaluate at runtime whenever the URL is displayed anywhere similar to\nparameter substitution in\n[Bitbucket Connect](https://developer.atlassian.com/bitbucket/concepts/context-parameters.html).\nFor example, one could use `https://foo.com/builds/{repository.full_name}`\nwhich Bitbucket will turn into `https://foo.com/builds/foo/bar` at render time.\nThe context variables available are `repository` and `commit`.\n\nTo associate a commit status to a pull request, the refname field must be set to the source branch\nof the pull request.\n\nExample:\n```\ncurl https://api.bitbucket.org/2.0/repositories/my-workspace/my-repo/commit/e10dae226959c2194f2b07b077c07762d93821cf/statuses/build/           -X POST -u jdoe -H 'Content-Type: application/json'           -d '{\n    \"key\": \"MY-BUILD\",\n    \"state\": \"SUCCESSFUL\",\n    \"description\": \"42 tests passed\",\n    \"url\": \"https://www.example.org/my-build-result\",\n    \"refname\": \"my-pr-branch\"\n  }'\n```",
         "summary": "Create a build status for a commit",
         "responses": {
           "201": {
@@ -4929,13 +4939,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["read:pipeline:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["pipeline"]
@@ -4945,6 +4948,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:pipeline:bitbucket"]
           }
         ]
       }
@@ -5006,13 +5016,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["read:pipeline:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["pipeline"]
@@ -5022,6 +5025,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:pipeline:bitbucket"]
           }
         ]
       }
@@ -5082,6 +5092,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:pipeline:bitbucket"]
           }
         ]
       },
@@ -5180,6 +5197,13 @@
           {
             "api_key": []
           }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["admin:pipeline:bitbucket"]
+          }
         ]
       }
     },
@@ -5270,6 +5294,13 @@
           {
             "api_key": []
           }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["admin:pipeline:bitbucket"]
+          }
         ]
       },
       "delete": {
@@ -5339,6 +5370,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["admin:pipeline:bitbucket"]
           }
         ]
       }
@@ -5723,6 +5761,13 @@
           {
             "api_key": []
           }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["write:repository:bitbucket"]
+          }
         ]
       },
       "parameters": [
@@ -5833,6 +5878,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:repository:bitbucket"]
           }
         ]
       },
@@ -6085,13 +6137,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["read:pipeline:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["pipeline"]
@@ -6101,6 +6146,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:pipeline:bitbucket"]
           }
         ]
       },
@@ -6190,6 +6242,13 @@
           {
             "api_key": []
           }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["admin:pipeline:bitbucket"]
+          }
         ]
       }
     },
@@ -6250,13 +6309,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["read:pipeline:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["pipeline"]
@@ -6266,6 +6318,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:pipeline:bitbucket"]
           }
         ]
       },
@@ -6327,6 +6386,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["admin:pipeline:bitbucket"]
           }
         ]
       }
@@ -6390,6 +6456,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["admin:pipeline:bitbucket"]
           }
         ]
       }
@@ -7479,15 +7552,8 @@
         "description": "Deletes the specified issue. This requires write access to the\nrepository.",
         "summary": "Delete an issue",
         "responses": {
-          "200": {
-            "description": "The issue object.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/issue"
-                }
-              }
-            }
+          "204": {
+            "description": "Indicates the issue was deleted successfully."
           },
           "403": {
             "description": "When the authenticated user isn't authorized to delete the issue.",
@@ -9314,7 +9380,7 @@
           {
             "state": "Current",
             "scheme": "oauth2",
-            "scopes": ["read:repository:bitbucket", "read:user:bitbucket"]
+            "scopes": ["read:repository:bitbucket"]
           }
         ]
       },
@@ -9342,7 +9408,7 @@
     "/repositories/{workspace}/{repo_slug}/permissions-config/groups/{group_slug}": {
       "delete": {
         "tags": ["Repositories"],
-        "description": "Deletes the repository group permission between the requested repository and group, if one exists.\n\nOnly users with admin permission for the repository may access this resource.",
+        "description": "Deletes the repository group permission between the requested repository and group, if one exists.\n\nOnly users with admin permission for the repository may access this resource.\n\nThe only authentication method supported for this endpoint is via app passwords.",
         "summary": "Delete an explicit group permission for a repository",
         "responses": {
           "204": {
@@ -9471,7 +9537,7 @@
           {
             "state": "Current",
             "scheme": "oauth2",
-            "scopes": ["read:repository:bitbucket", "read:user:bitbucket"]
+            "scopes": ["read:repository:bitbucket"]
           }
         ]
       },
@@ -9708,7 +9774,7 @@
           {
             "state": "Current",
             "scheme": "oauth2",
-            "scopes": ["read:repository:bitbucket", "read:user:bitbucket"]
+            "scopes": ["read:repository:bitbucket"]
           }
         ]
       },
@@ -9866,7 +9932,7 @@
           {
             "state": "Current",
             "scheme": "oauth2",
-            "scopes": ["read:repository:bitbucket", "read:user:bitbucket"]
+            "scopes": ["read:repository:bitbucket"]
           }
         ]
       },
@@ -10005,7 +10071,7 @@
       "get": {
         "tags": ["Pipelines"],
         "summary": "List pipelines",
-        "description": "Find pipelines",
+        "description": "Find pipelines in a repository.\n\nNote that unlike other endpoints in the Bitbucket API, this endpoint utilizes query parameters to allow filtering\nand sorting of returned results. See [query parameters](#api-repositories-workspace-repo-slug-pipelines-get-request-Query%20parameters)\nfor specific details.\n",
         "operationId": "getPipelinesForRepository",
         "parameters": [
           {
@@ -10025,6 +10091,148 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "creator.uuid",
+            "description": "The UUID of the creator of the pipeline to filter by.",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "target.ref_type",
+            "description": "The type of the reference to filter by.",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": ["BRANCH", "TAG", "ANNOTATED_TAG"]
+            }
+          },
+          {
+            "name": "target.ref_name",
+            "description": "The reference name to filter by.",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "target.branch",
+            "description": "The name of the branch to filter by.",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "target.commit.hash",
+            "description": "The revision to filter by.",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "target.selector.pattern",
+            "description": "The pipeline pattern to filter by.",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "target.selector.type",
+            "description": "The type of pipeline to filter by.",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": ["BRANCH", "TAG", "CUSTOM", "PULLREQUESTS", "DEFAULT"]
+            }
+          },
+          {
+            "name": "created_on",
+            "description": "The creation date to filter by.",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "trigger_type",
+            "description": "The trigger type to filter by.",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": ["PUSH", "MANUAL", "SCHEDULED", "PARENT_STEP"]
+            }
+          },
+          {
+            "name": "status",
+            "description": "The pipeline status to filter by.",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "PARSING",
+                "PENDING",
+                "PAUSED",
+                "HALTED",
+                "BUILDING",
+                "ERROR",
+                "PASSED",
+                "FAILED",
+                "STOPPED",
+                "UNKNOWN"
+              ]
+            }
+          },
+          {
+            "name": "sort",
+            "description": "The attribute name to sort on.",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": ["creator.uuid", "created_on", "run_creation_date"]
+            }
+          },
+          {
+            "name": "page",
+            "description": "The page number of elements to retrieve.",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 1,
+              "default": 1
+            }
+          },
+          {
+            "name": "pagelen",
+            "description": "The maximum number of results to return.",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 10
+            }
           }
         ],
         "responses": {
@@ -10039,13 +10247,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["read:pipeline:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["pipeline"]
@@ -10055,6 +10256,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:pipeline:bitbucket"]
           }
         ]
       },
@@ -10134,13 +10342,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["read:pipeline:bitbucket", "write:pipeline:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["pipeline"]
@@ -10150,6 +10351,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:pipeline:bitbucket", "write:pipeline:bitbucket"]
           }
         ]
       }
@@ -10202,13 +10410,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["read:pipeline:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["pipeline"]
@@ -10218,6 +10419,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:pipeline:bitbucket"]
           }
         ]
       },
@@ -10270,13 +10478,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["write:pipeline:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["pipeline:write"]
@@ -10286,6 +10487,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["write:pipeline:bitbucket"]
           }
         ]
       }
@@ -10340,13 +10548,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["write:pipeline:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["pipeline:write"]
@@ -10356,6 +10557,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["write:pipeline:bitbucket"]
           }
         ]
       }
@@ -10417,13 +10625,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["read:pipeline:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["pipeline"]
@@ -10433,6 +10634,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:pipeline:bitbucket"]
           }
         ]
       }
@@ -10494,13 +10702,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["read:pipeline:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["pipeline"]
@@ -10510,6 +10711,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:pipeline:bitbucket"]
           }
         ]
       }
@@ -10561,13 +10769,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["read:pipeline:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["pipeline"]
@@ -10577,6 +10778,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:pipeline:bitbucket"]
           }
         ]
       }
@@ -10647,13 +10855,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["read:pipeline:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["pipeline"]
@@ -10663,6 +10864,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:pipeline:bitbucket"]
           }
         ]
       }
@@ -10725,6 +10933,9 @@
               }
             }
           },
+          "307": {
+            "description": "After the step is completed, the log is moved to long term storage and a redirection to the log file is returned."
+          },
           "404": {
             "description": "A pipeline with the given UUID does not exist, a step with the given UUID does not exist in the pipeline or a log file does not exist for the given step.",
             "content": {
@@ -10746,13 +10957,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["read:pipeline:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["pipeline"]
@@ -10762,6 +10966,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:pipeline:bitbucket"]
           }
         ]
       }
@@ -10823,6 +11034,9 @@
           "200": {
             "description": "The raw log file for the build container or service container."
           },
+          "307": {
+            "description": "After the step is completed, the log is moved to long term storage and a redirection to the log file is returned."
+          },
           "404": {
             "description": "No account, repository, pipeline, step or log exist for the provided path.",
             "content": {
@@ -10834,13 +11048,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["read:pipeline:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["pipeline"]
@@ -10850,6 +11057,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:pipeline:bitbucket"]
           }
         ]
       }
@@ -10912,13 +11126,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["read:pipeline:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["pipeline"]
@@ -10928,6 +11135,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:pipeline:bitbucket"]
           }
         ]
       }
@@ -10990,13 +11204,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["read:pipeline:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["pipeline"]
@@ -11006,6 +11213,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:pipeline:bitbucket"]
           }
         ]
       }
@@ -11077,13 +11291,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["read:pipeline:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["pipeline"]
@@ -11093,6 +11300,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:pipeline:bitbucket"]
           }
         ]
       }
@@ -11157,13 +11371,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["write:pipeline:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["pipeline:write"]
@@ -11173,6 +11380,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["write:pipeline:bitbucket"]
           }
         ]
       }
@@ -11224,6 +11438,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["admin:repository:bitbucket"]
           }
         ]
       },
@@ -11284,6 +11505,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["admin:repository:bitbucket"]
           }
         ]
       }
@@ -11367,6 +11595,13 @@
           {
             "api_key": []
           }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["admin:pipeline:bitbucket"]
+          }
         ]
       }
     },
@@ -11410,6 +11645,14 @@
         "responses": {
           "201": {
             "description": "The created schedule.",
+            "headers": {
+              "Location": {
+                "description": "The URL of the newly created schedule.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -11449,13 +11692,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["read:pipeline:bitbucket", "write:pipeline:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["pipeline:write"]
@@ -11465,6 +11701,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:pipeline:bitbucket", "write:pipeline:bitbucket"]
           }
         ]
       },
@@ -11515,13 +11758,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["read:pipeline:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["pipeline"]
@@ -11531,6 +11767,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:pipeline:bitbucket"]
           }
         ]
       }
@@ -11592,13 +11835,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["read:pipeline:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["pipeline"]
@@ -11608,6 +11844,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:pipeline:bitbucket"]
           }
         ]
       },
@@ -11678,13 +11921,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["read:pipeline:bitbucket", "write:pipeline:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["pipeline:write"]
@@ -11694,6 +11930,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:pipeline:bitbucket", "write:pipeline:bitbucket"]
           }
         ]
       },
@@ -11746,13 +11989,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["write:pipeline:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["pipeline:write"]
@@ -11762,6 +11998,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["write:pipeline:bitbucket"]
           }
         ]
       }
@@ -11823,13 +12066,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["read:pipeline:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["pipeline"]
@@ -11839,6 +12075,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:pipeline:bitbucket"]
           }
         ]
       }
@@ -11891,13 +12134,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["read:pipeline:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["pipeline"]
@@ -11907,6 +12143,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:pipeline:bitbucket"]
           }
         ]
       },
@@ -11978,6 +12221,13 @@
           {
             "api_key": []
           }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["admin:pipeline:bitbucket"]
+          }
         ]
       },
       "delete": {
@@ -12020,13 +12270,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["admin:pipeline:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["pipeline:variable"]
@@ -12036,6 +12279,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["admin:pipeline:bitbucket"]
           }
         ]
       }
@@ -12078,13 +12328,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["read:pipeline:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["pipeline"]
@@ -12094,6 +12337,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:pipeline:bitbucket"]
           }
         ]
       },
@@ -12183,6 +12433,13 @@
           {
             "api_key": []
           }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["admin:pipeline:bitbucket"]
+          }
         ]
       }
     },
@@ -12243,13 +12500,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["read:pipeline:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["pipeline"]
@@ -12259,6 +12509,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:pipeline:bitbucket"]
           }
         ]
       },
@@ -12339,6 +12596,13 @@
           {
             "api_key": []
           }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["admin:pipeline:bitbucket"]
+          }
         ]
       },
       "delete": {
@@ -12390,13 +12654,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["admin:pipeline:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["pipeline:variable"]
@@ -12406,6 +12663,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["admin:pipeline:bitbucket"]
           }
         ]
       }
@@ -12448,13 +12712,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["read:pipeline:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["pipeline"]
@@ -12464,6 +12721,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:pipeline:bitbucket"]
           }
         ]
       },
@@ -12553,6 +12817,13 @@
           {
             "api_key": []
           }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["admin:pipeline:bitbucket"]
+          }
         ]
       }
     },
@@ -12613,13 +12884,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["read:pipeline:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["pipeline"]
@@ -12629,6 +12893,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:pipeline:bitbucket"]
           }
         ]
       },
@@ -12709,6 +12980,13 @@
           {
             "api_key": []
           }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["admin:pipeline:bitbucket"]
+          }
         ]
       },
       "delete": {
@@ -12760,13 +13038,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["admin:pipeline:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["pipeline:variable"]
@@ -12776,6 +13047,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["admin:pipeline:bitbucket"]
           }
         ]
       }
@@ -13034,7 +13312,7 @@
       },
       "post": {
         "tags": ["Pullrequests"],
-        "description": "Creates a new pull request where the destination repository is\nthis repository and the author is the authenticated user.\n\nThe minimum required fields to create a pull request are `title` and\n`source`, specified by a branch name.\n\n```\ncurl https://api.bitbucket.org/2.0/repositories/my-workspace/my-repository/pullrequests \\\n    -u my-username:my-password \\\n    --request POST \\\n    --header 'Content-Type: application/json' \\\n    --data '{\n        \"title\": \"My Title\",\n        \"source\": {\n            \"branch\": {\n                \"name\": \"staging\"\n            }\n        }\n    }'\n```\n\nIf the pull request's `destination` is not specified, it will default\nto the `repository.mainbranch`. To open a pull request to a\ndifferent branch, say from a feature branch to a staging branch,\nspecify a `destination` (same format as the `source`):\n\n```\n{\n    \"title\": \"My Title\",\n    \"source\": {\n        \"branch\": {\n            \"name\": \"my-feature-branch\"\n        }\n    },\n    \"destination\": {\n        \"branch\": {\n            \"name\": \"staging\"\n        }\n    }\n}\n```\n\nReviewers can be specified by adding an array of user objects as the\n`reviewers` property.\n\n```\n{\n    \"title\": \"My Title\",\n    \"source\": {\n        \"branch\": {\n            \"name\": \"my-feature-branch\"\n        }\n    },\n    \"reviewers\": [\n        {\n            \"uuid\": \"{504c3b62-8120-4f0c-a7bc-87800b9d6f70}\"\n        }\n    ]\n}\n```\n\nOther fields:\n\n* `description` - a string\n* `close_source_branch` - boolean that specifies if the source branch should be closed upon merging",
+        "description": "Creates a new pull request where the destination repository is\nthis repository and the author is the authenticated user.\n\nThe minimum required fields to create a pull request are `title` and\n`source`, specified by a branch name.\n\n```\ncurl https://api.bitbucket.org/2.0/repositories/my-workspace/my-repository/pullrequests \\\n    -u my-username:my-password \\\n    --request POST \\\n    --header 'Content-Type: application/json' \\\n    --data '{\n        \"title\": \"My Title\",\n        \"source\": {\n            \"branch\": {\n                \"name\": \"staging\"\n            }\n        }\n    }'\n```\n\nIf the pull request's `destination` is not specified, it will default\nto the `repository.mainbranch`. To open a pull request to a\ndifferent branch, say from a feature branch to a staging branch,\nspecify a `destination` (same format as the `source`):\n\n```\n{\n    \"title\": \"My Title\",\n    \"source\": {\n        \"branch\": {\n            \"name\": \"my-feature-branch\"\n        }\n    },\n    \"destination\": {\n        \"branch\": {\n            \"name\": \"staging\"\n        }\n    }\n}\n```\n\nReviewers can be specified by adding an array of user objects as the\n`reviewers` property.\n\n```\n{\n    \"title\": \"My Title\",\n    \"source\": {\n        \"branch\": {\n            \"name\": \"my-feature-branch\"\n        }\n    },\n    \"reviewers\": [\n        {\n            \"uuid\": \"{504c3b62-8120-4f0c-a7bc-87800b9d6f70}\"\n        }\n    ]\n}\n```\n\nOther fields:\n\n* `description` - a string\n* `close_source_branch` - boolean that specifies if the source branch should be closed upon merging\n* `draft` - boolean that specifies whether the pull request is a draft",
         "summary": "Create a pull request",
         "responses": {
           "201": {
@@ -14385,6 +14663,9 @@
           "202": {
             "description": "In the Location header, the URL to poll for the pull request merge status"
           },
+          "409": {
+            "description": "Unable to merge because one of the refs involved changed while attempting to merge"
+          },
           "555": {
             "description": "If the merge took too long and timed out.\nIn this case the caller should retry the request later",
             "content": {
@@ -14482,6 +14763,9 @@
           },
           "403": {
             "description": "The user making the request does not have permission to the repo and is different from the user who queued the task"
+          },
+          "409": {
+            "description": "Unable to merge because one of the refs involved changed while attempting to merge"
           }
         },
         "security": [
@@ -14970,7 +15254,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/A_pullrequest_comment_task"
+                  "$ref": "#/components/schemas/pullrequest_comment_task"
                 }
               }
             }
@@ -15010,7 +15294,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/A_pullrequest_task_create"
+                "$ref": "#/components/schemas/pullrequest_task_create"
               }
             }
           },
@@ -15125,7 +15409,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/A_pullrequest_comment_task"
+                  "$ref": "#/components/schemas/pullrequest_comment_task"
                 }
               }
             }
@@ -15180,7 +15464,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/A_pullrequest_comment_task"
+                  "$ref": "#/components/schemas/pullrequest_comment_task"
                 }
               }
             }
@@ -15220,7 +15504,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/A_pullrequest_task_update"
+                "$ref": "#/components/schemas/pullrequest_task_update"
               }
             }
           },
@@ -15635,7 +15919,10 @@
                           "merge_strategies": [
                             "merge_commit",
                             "squash",
-                            "fast_forward"
+                            "fast_forward",
+                            "squash_fast_forward",
+                            "rebase_fast_forward",
+                            "rebase_merge"
                           ],
                           "type": "branch",
                           "target": {
@@ -15947,7 +16234,10 @@
                       "merge_strategies": [
                         "merge_commit",
                         "squash",
-                        "fast_forward"
+                        "fast_forward",
+                        "squash_fast_forward",
+                        "rebase_fast_forward",
+                        "rebase_merge"
                       ],
                       "type": "branch",
                       "target": {
@@ -19502,6 +19792,349 @@
         }
       ]
     },
+    "/users/{selected_user}/gpg-keys": {
+      "get": {
+        "tags": ["GPG"],
+        "description": "Returns a paginated list of the user's GPG public keys.\nThe `key` and `subkeys` fields can also be requested from the endpoint.\nSee [Partial Responses](/cloud/bitbucket/rest/intro/#partial-response) for more details.",
+        "summary": "List GPG keys",
+        "responses": {
+          "200": {
+            "description": "A list of the GPG keys associated with the account.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginated_gpg_user_keys"
+                },
+                "examples": {
+                  "response": {
+                    "value": {
+                      "page": 1,
+                      "pagelen": 10,
+                      "size": 1,
+                      "values": [
+                        {
+                          "added_on": "2024-09-24T12:09:33.154081+00:00",
+                          "created_on": "2018-03-20T13:09:04.207005+00:00",
+                          "expires_on": null,
+                          "fingerprint": "h4m26ppxrol7blr7spbc7lhyymokdbnkxd06kzrt",
+                          "key_id": "ymokdbnkxd06kzrt",
+                          "last_used": "2024-09-25T15:18:05.196003+00:00",
+                          "links": {
+                            "self": {
+                              "href": "https://api.bitbucket.org/2.0/users/{d7dd0e2d-3994-4a50-a9ee-d260b6cefdab}/gpg-keys/H4M26PPXROL7BLR7SPBC7LHYYMOKDBNKXD06KZRT"
+                            }
+                          },
+                          "name": "Alice's OpenPGP key",
+                          "owner": {
+                            "display_name": "Mark Adams",
+                            "links": {
+                              "avatar": {
+                                "href": "https://bitbucket.org/account/markadams-atl/avatar/32/"
+                              },
+                              "html": {
+                                "href": "https://bitbucket.org/markadams-atl/"
+                              },
+                              "self": {
+                                "href": "https://api.bitbucket.org/2.0/users/{d7dd0e2d-3994-4a50-a9ee-d260b6cefdab}"
+                              }
+                            },
+                            "type": "user",
+                            "username": "markadams-atl",
+                            "nickname": "markadams-atl",
+                            "uuid": "{d7dd0e2d-3994-4a50-a9ee-d260b6cefdab}"
+                          },
+                          "parent_fingerprint": null,
+                          "type": "gpg_key"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "If the specified user's keys are not accessible to the current user"
+          },
+          "404": {
+            "description": "If the specified user does not exist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "oauth2": ["account"]
+          },
+          {
+            "basic": []
+          },
+          {
+            "api_key": []
+          }
+        ]
+      },
+      "post": {
+        "tags": ["GPG"],
+        "description": "Adds a new GPG public key to the specified user account and returns the resulting key.\n\nExample:\n\n```\n$ curl -X POST -H \"Content-Type: application/json\" -d\n'{\"key\": \"<insert GPG Key>\"}'\nhttps://api.bitbucket.org/2.0/users/{d7dd0e2d-3994-4a50-a9ee-d260b6cefdab}/gpg-keys\n```",
+        "summary": "Add a new GPG key",
+        "responses": {
+          "201": {
+            "description": "The newly created GPG key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GPG_account_key"
+                },
+                "examples": {
+                  "response": {
+                    "value": {
+                      "added_on": "2024-09-24T12:09:33.154081+00:00",
+                      "created_on": "2018-03-20T13:09:04.207005+00:00",
+                      "expires_on": null,
+                      "fingerprint": "h4m26ppxrol7blr7spbc7lhyymokdbnkxd06kzrt",
+                      "key_id": "ymokdbnkxd06kzrt",
+                      "last_used": "2024-09-25T15:18:05.196003+00:00",
+                      "links": {
+                        "self": {
+                          "href": "https://api.bitbucket.org/2.0/users/{d7dd0e2d-3994-4a50-a9ee-d260b6cefdab}/gpg-keys/H4M26PPXROL7BLR7SPBC7LHYYMOKDBNKXD06KZRT"
+                        }
+                      },
+                      "name": "Alice's OpenPGP key",
+                      "owner": {
+                        "display_name": "Mark Adams",
+                        "links": {
+                          "avatar": {
+                            "href": "https://bitbucket.org/account/markadams-atl/avatar/32/"
+                          },
+                          "html": {
+                            "href": "https://bitbucket.org/markadams-atl/"
+                          },
+                          "self": {
+                            "href": "https://api.bitbucket.org/2.0/users/{d7dd0e2d-3994-4a50-a9ee-d260b6cefdab}"
+                          }
+                        },
+                        "type": "user",
+                        "username": "markadams-atl",
+                        "nickname": "markadams-atl",
+                        "uuid": "{d7dd0e2d-3994-4a50-a9ee-d260b6cefdab}"
+                      },
+                      "parent_fingerprint": null,
+                      "type": "gpg_key"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "If the submitted key or related value is invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "If the current user does not have permission to add a key for the specified user"
+          },
+          "404": {
+            "description": "If the specified user does not exist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GPG_account_key"
+              }
+            }
+          },
+          "description": "The new GPG key object."
+        },
+        "security": [
+          {
+            "oauth2": ["account:write"]
+          },
+          {
+            "basic": []
+          },
+          {
+            "api_key": []
+          }
+        ]
+      },
+      "parameters": [
+        {
+          "name": "selected_user",
+          "in": "path",
+          "description": "This can either be an Atlassian Account ID OR the UUID of the account,\nsurrounded by curly-braces, for example: `{account UUID}`.\n",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/users/{selected_user}/gpg-keys/{fingerprint}": {
+      "delete": {
+        "tags": ["GPG"],
+        "description": "Deletes a specific GPG public key from a user's account.",
+        "summary": "Delete a GPG key",
+        "responses": {
+          "204": {
+            "description": "The key has been deleted"
+          },
+          "400": {
+            "description": "If the submitted key or related value is invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "If the current user does not have permission to delete a key for the specified user, or the submitted key is a subkey"
+          },
+          "404": {
+            "description": "If the specified key does not exist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "oauth2": ["account:write"]
+          },
+          {
+            "basic": []
+          },
+          {
+            "api_key": []
+          }
+        ]
+      },
+      "get": {
+        "tags": ["GPG"],
+        "description": "Returns a specific GPG public key belonging to a user.\nThe `key` and `subkeys` fields can also be requested from the endpoint.\nSee [Partial Responses](/cloud/bitbucket/rest/intro/#partial-response) for more details.",
+        "summary": "Get a GPG key",
+        "responses": {
+          "200": {
+            "description": "The specific GPG key matching the user and fingerprint.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GPG_account_key"
+                },
+                "examples": {
+                  "response": {
+                    "value": {
+                      "added_on": "2024-09-24T12:09:33.154081+00:00",
+                      "created_on": "2018-03-20T13:09:04.207005+00:00",
+                      "expires_on": null,
+                      "fingerprint": "h4m26ppxrol7blr7spbc7lhyymokdbnkxd06kzrt",
+                      "key_id": "ymokdbnkxd06kzrt",
+                      "last_used": "2024-09-25T15:18:05.196003+00:00",
+                      "links": {
+                        "self": {
+                          "href": "https://api.bitbucket.org/2.0/users/{d7dd0e2d-3994-4a50-a9ee-d260b6cefdab}/gpg-keys/H4M26PPXROL7BLR7SPBC7LHYYMOKDBNKXD06KZRT"
+                        }
+                      },
+                      "name": "Alice's OpenPGP key",
+                      "owner": {
+                        "display_name": "Mark Adams",
+                        "links": {
+                          "avatar": {
+                            "href": "https://bitbucket.org/account/markadams-atl/avatar/32/"
+                          },
+                          "html": {
+                            "href": "https://bitbucket.org/markadams-atl/"
+                          },
+                          "self": {
+                            "href": "https://api.bitbucket.org/2.0/users/{d7dd0e2d-3994-4a50-a9ee-d260b6cefdab}"
+                          }
+                        },
+                        "type": "user",
+                        "username": "markadams-atl",
+                        "nickname": "markadams-atl",
+                        "uuid": "{d7dd0e2d-3994-4a50-a9ee-d260b6cefdab}"
+                      },
+                      "parent_fingerprint": null,
+                      "type": "gpg_key"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "If the specified user's keys are not accessible to the current user"
+          },
+          "404": {
+            "description": "If the specified user does not exist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "oauth2": ["account"]
+          },
+          {
+            "basic": []
+          },
+          {
+            "api_key": []
+          }
+        ]
+      },
+      "parameters": [
+        {
+          "name": "fingerprint",
+          "in": "path",
+          "description": "A GPG key fingerprint.\n",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "selected_user",
+          "in": "path",
+          "description": "This can either be an Atlassian Account ID OR the UUID of the account,\nsurrounded by curly-braces, for example: `{account UUID}`.\n",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
     "/users/{selected_user}/pipelines_config/variables": {
       "get": {
         "tags": ["Pipelines"],
@@ -20139,7 +20772,7 @@
     },
     "/users/{selected_user}/ssh-keys": {
       "get": {
-        "tags": ["Ssh"],
+        "tags": ["SSH"],
         "description": "Returns a paginated list of the user's SSH public keys.",
         "summary": "List SSH keys",
         "responses": {
@@ -20160,6 +20793,8 @@
                         {
                           "comment": "user@myhost",
                           "created_on": "2018-03-14T13:17:05.196003+00:00",
+                          "expires_on": null,
+                          "fingerprint": "w9tZSiFoZ8oXwS4ZSWrJopGxwvnPIewA6Mo4owAHPrI",
                           "key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKqP3Cr632C2dNhhgKVcon4ldUSAeKiku2yP9O9/bDtY",
                           "label": "",
                           "last_used": "2018-03-20T13:18:05.196003+00:00",
@@ -20223,7 +20858,7 @@
         ]
       },
       "post": {
-        "tags": ["Ssh"],
+        "tags": ["SSH"],
         "description": "Adds a new SSH public key to the specified user account and returns the resulting key.\n\nExample:\n\n```\n$ curl -X POST -H \"Content-Type: application/json\" -d '{\"key\": \"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKqP3Cr632C2dNhhgKVcon4ldUSAeKiku2yP9O9/bDtY user@myhost\"}' https://api.bitbucket.org/2.0/users/{ed08f5e1-605b-4f4a-aee4-6c97628a673e}/ssh-keys\n```",
         "summary": "Add a new SSH key",
         "responses": {
@@ -20239,6 +20874,8 @@
                     "value": {
                       "comment": "user@myhost",
                       "created_on": "2018-03-14T13:17:05.196003+00:00",
+                      "expires_on": null,
+                      "fingerprint": "w9tZSiFoZ8oXwS4ZSWrJopGxwvnPIewA6Mo4owAHPrI",
                       "key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKqP3Cr632C2dNhhgKVcon4ldUSAeKiku2yP9O9/bDtY",
                       "label": "",
                       "last_used": "2018-03-20T13:18:05.196003+00:00",
@@ -20297,6 +20934,17 @@
             }
           }
         },
+        "parameters": [
+          {
+            "name": "expires_on",
+            "in": "query",
+            "description": "The date or date-time of when the key will expire,\nin [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) format.\nExample: `YYYY-MM-DDTHH:mm:ss.sssZ`",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -20333,7 +20981,7 @@
     },
     "/users/{selected_user}/ssh-keys/{key_id}": {
       "delete": {
-        "tags": ["Ssh"],
+        "tags": ["SSH"],
         "description": "Deletes a specific SSH public key from a user's account.",
         "summary": "Delete a SSH key",
         "responses": {
@@ -20377,7 +21025,7 @@
         ]
       },
       "get": {
-        "tags": ["Ssh"],
+        "tags": ["SSH"],
         "description": "Returns a specific SSH public key belonging to a user.",
         "summary": "Get a SSH key",
         "responses": {
@@ -20393,6 +21041,8 @@
                     "value": {
                       "comment": "user@myhost",
                       "created_on": "2018-03-14T13:17:05.196003+00:00",
+                      "expires_on": null,
+                      "fingerprint": "w9tZSiFoZ8oXwS4ZSWrJopGxwvnPIewA6Mo4owAHPrI",
                       "key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKqP3Cr632C2dNhhgKVcon4ldUSAeKiku2yP9O9/bDtY",
                       "label": "",
                       "last_used": "2018-03-20T13:18:05.196003+00:00",
@@ -20454,7 +21104,7 @@
         ]
       },
       "put": {
-        "tags": ["Ssh"],
+        "tags": ["SSH"],
         "description": "Updates a specific SSH public key on a user's account\n\nNote: Only the 'comment' field can be updated using this API. To modify the key or comment values, you must delete and add the key again.\n\nExample:\n\n```\n$ curl -X PUT -H \"Content-Type: application/json\" -d '{\"label\": \"Work key\"}' https://api.bitbucket.org/2.0/users/{ed08f5e1-605b-4f4a-aee4-6c97628a673e}/ssh-keys/{b15b6026-9c02-4626-b4ad-b905f99f763a}\n```",
         "summary": "Update a SSH key",
         "responses": {
@@ -20470,6 +21120,8 @@
                     "value": {
                       "comment": "",
                       "created_on": "2018-03-14T13:17:05.196003+00:00",
+                      "expires_on": null,
+                      "fingerprint": "w9tZSiFoZ8oXwS4ZSWrJopGxwvnPIewA6Mo4owAHPrI",
                       "key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKqP3Cr632C2dNhhgKVcon4ldUSAeKiku2yP9O9/bDtY",
                       "label": "Work key",
                       "last_used": "2018-03-20T13:18:05.196003+00:00",
@@ -21007,7 +21659,7 @@
     "/workspaces/{workspace}/members": {
       "get": {
         "tags": ["Workspaces"],
-        "description": "Returns all members of the requested workspace.",
+        "description": "Returns all members of the requested workspace.\n\nThis endpoint additionally supports [filtering](/cloud/bitbucket/rest/intro/#filtering) by\nemail address, if called by a workspace administrator, integration or workspace access\ntoken. This is done by adding the following query string parameter:\n\n* `q=user.email IN (\"user1@org.com\",\"user2@org.com\")`\n\nWhen filtering by email, you can query up to 90 addresses at a time.\nNote that the query parameter values need to be URL escaped, so the final query string\nshould be:\n\n* `q=user.email%20IN%20(%22user1@org.com%22,%22user2@org.com%22)`\n\nEmail addresses that you filter by (and only these email addresses) can be included in the\nresponse using the `fields` query parameter:\n\n* `&fields=+values.user.email` - add the `email` field to the default `user` response object\n* `&fields=values.user.email,values.user.account_id` - only return user email addresses and\naccount IDs\n\nOnce again, all query parameter values must be URL escaped.",
         "summary": "List users in a workspace",
         "responses": {
           "200": {
@@ -21016,6 +21668,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/paginated_workspace_memberships"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "When more than 90 emails were provided when querying by email.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
                 }
               }
             }
@@ -21046,7 +21708,7 @@
           {
             "state": "Current",
             "scheme": "oauth2",
-            "scopes": ["read:workspace:bitbucket", "read:user:bitbucket"]
+            "scopes": ["read:workspace:bitbucket"]
           }
         ]
       },
@@ -21114,7 +21776,7 @@
           {
             "state": "Current",
             "scheme": "oauth2",
-            "scopes": ["read:workspace:bitbucket", "read:user:bitbucket"]
+            "scopes": ["read:workspace:bitbucket"]
           }
         ]
       },
@@ -21234,7 +21896,7 @@
           {
             "state": "Current",
             "scheme": "oauth2",
-            "scopes": ["read:workspace:bitbucket", "read:user:bitbucket"]
+            "scopes": ["read:workspace:bitbucket"]
           }
         ]
       },
@@ -21368,7 +22030,7 @@
           {
             "state": "Current",
             "scheme": "oauth2",
-            "scopes": ["read:repository:bitbucket", "read:user:bitbucket"]
+            "scopes": ["read:repository:bitbucket"]
           }
         ]
       },
@@ -21487,7 +22149,7 @@
           {
             "state": "Current",
             "scheme": "oauth2",
-            "scopes": ["read:repository:bitbucket", "read:user:bitbucket"]
+            "scopes": ["read:repository:bitbucket"]
           }
         ]
       },
@@ -21631,13 +22293,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["read:pipeline:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["pipeline"]
@@ -21647,6 +22302,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:pipeline:bitbucket"]
           }
         ]
       },
@@ -21719,6 +22381,13 @@
           {
             "api_key": []
           }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["admin:pipeline:bitbucket"]
+          }
         ]
       }
     },
@@ -21770,13 +22439,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["read:pipeline:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["pipeline"]
@@ -21786,6 +22448,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:pipeline:bitbucket"]
           }
         ]
       },
@@ -21849,6 +22518,13 @@
           {
             "api_key": []
           }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["admin:pipeline:bitbucket"]
+          }
         ]
       },
       "delete": {
@@ -21891,13 +22567,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["admin:pipeline:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["pipeline:variable"]
@@ -21907,6 +22576,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["admin:pipeline:bitbucket"]
           }
         ]
       }
@@ -21981,7 +22657,7 @@
             }
           },
           "403": {
-            "description": "The requesting user isn't authorized to create the project.",
+            "description": "The user requesting to create a project does not have the necessary permissions.",
             "content": {
               "application/json": {
                 "schema": {
@@ -23420,7 +24096,7 @@
           {
             "state": "Current",
             "scheme": "oauth2",
-            "scopes": ["read:project:bitbucket", "read:user:bitbucket"]
+            "scopes": ["read:project:bitbucket"]
           }
         ]
       },
@@ -23576,7 +24252,7 @@
           {
             "state": "Current",
             "scheme": "oauth2",
-            "scopes": ["read:project:bitbucket", "read:user:bitbucket"]
+            "scopes": ["read:project:bitbucket"]
           }
         ]
       },
@@ -23812,7 +24488,7 @@
           {
             "state": "Current",
             "scheme": "oauth2",
-            "scopes": ["read:project:bitbucket", "read:user:bitbucket"]
+            "scopes": ["read:project:bitbucket"]
           }
         ]
       },
@@ -23969,7 +24645,7 @@
           {
             "state": "Current",
             "scheme": "oauth2",
-            "scopes": ["read:project:bitbucket", "read:user:bitbucket"]
+            "scopes": ["read:project:bitbucket"]
           }
         ]
       },
@@ -24087,6 +24763,77 @@
           "name": "selected_user_id",
           "in": "path",
           "description": "This can either be the username, the user's UUID surrounded by curly-braces,\nfor example: {account UUID}, or the user's Atlassian ID.\n",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "workspace",
+          "in": "path",
+          "description": "This can either be the workspace ID (slug) or the workspace UUID\nsurrounded by curly-braces, for example: `{workspace UUID}`.\n",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/workspaces/{workspace}/pullrequests/{selected_user}": {
+      "get": {
+        "tags": ["Workspaces", "Pullrequests"],
+        "description": "Returns all workspace pull requests authored by the specified user.\n\nBy default only open pull requests are returned. This can be controlled\nusing the `state` query parameter. To retrieve pull requests that are\nin one of multiple states, repeat the `state` parameter for each\nindividual state.\n\nThis endpoint also supports filtering and sorting of the results. See\n[filtering and sorting](/cloud/bitbucket/rest/intro/#filtering) for more details.",
+        "summary": "List workspace pull requests for a user",
+        "responses": {
+          "200": {
+            "description": "All pull requests authored by the specified user.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginated_pullrequests"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "If the specified user does not exist.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "state",
+            "in": "query",
+            "description": "Only return pull requests that are in this state. This parameter can be repeated.",
+            "schema": {
+              "type": "string",
+              "enum": ["OPEN", "MERGED", "DECLINED", "SUPERSEDED"]
+            }
+          }
+        ],
+        "security": [
+          {
+            "oauth2": ["pullrequest"]
+          },
+          {
+            "basic": []
+          },
+          {
+            "api_key": []
+          }
+        ]
+      },
+      "parameters": [
+        {
+          "name": "selected_user",
+          "in": "path",
+          "description": "This can either be the username of the pull request author, the author's UUID\nsurrounded by curly-braces, for example: `{account UUID}`, or the author's Atlassian ID.\n",
           "required": true,
           "schema": {
             "type": "string"
@@ -24267,13 +25014,6 @@
             }
           }
         },
-        "x-atlassian-oauth2-scopes": [
-          {
-            "state": "Current",
-            "scheme": "oauth2",
-            "scopes": ["read:repository:bitbucket"]
-          }
-        ],
         "security": [
           {
             "oauth2": ["repository"]
@@ -24283,6 +25023,13 @@
           },
           {
             "api_key": []
+          }
+        ],
+        "x-atlassian-oauth2-scopes": [
+          {
+            "state": "Current",
+            "scheme": "oauth2",
+            "scopes": ["read:repository:bitbucket"]
           }
         ]
       }
@@ -24318,6 +25065,10 @@
       "description": "Access the list of download links associated with the repository."
     },
     {
+      "name": "GPG",
+      "description": "The GPG resource allows you to manage GPG keys.\n"
+    },
+    {
       "name": "Issue tracker",
       "description": "The issue resources provide functionality for getting information on\nissues in an issue tracker, creating new issues, updating them and deleting\nthem.\n\nYou can access public issues without authentication, but you can't gain access\nto private repositories' issues. By authenticating, you will get the ability\nto create issues, as well as access to updating data or deleting issues you\nhave access to. Issue Tracker features are not supported for repositories in workspaces administered through admin.atlassian.com.\n"
     },
@@ -24346,16 +25097,16 @@
       "description": "A Git repository is a virtual storage of your project. It\nallows you to save versions of your code, which you can access\nwhen needed. The repo resource allows you to access public repos,\nor repos that belong to a specific workspace.\n"
     },
     {
+      "name": "SSH",
+      "description": "The SSH resource allows you to manage SSH keys.\n"
+    },
+    {
       "name": "Snippets",
       "description": "Snippets allow you share code segments or files with yourself, members of\nyour workspace, or the world.\n\nLike pull requests, repositories and workspaces, the full set of snippets\nis defined by what the current user has access to. This includes all\nsnippets owned by any of the workspaces the user is a member of, or\nsnippets by other users that the current user is either watching or has\n collaborated on (for instance by commenting on it).\n"
     },
     {
       "name": "Source",
       "description": "Browse the source code in the repository and\n                              create new commits by uploading."
-    },
-    {
-      "name": "Ssh",
-      "description": "The SSH resource allows you to manage SSH keys.\n"
     },
     {
       "name": "Teams",
@@ -24378,64 +25129,64 @@
       "description": "A workspace is where you create repositories, collaborate on\nyour code, and organize different streams of work in your Bitbucket\nCloud account. Workspaces replace the use of teams and users in API\ncalls.\n"
     }
   ],
-  "x-revision": "d8aa33b24a80",
+  "x-revision": "877077a77316",
   "x-atlassian-narrative": {
     "documents": [
       {
         "anchor": "authentication",
         "title": "Authentication methods",
         "description": "How to authenticate API actions",
-        "icon": "data:image/svg+xml;base64,b'PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxOTcuNjQ3MyAxODYuODEzOCI+CiAgPGRlZnM+CiAgICA8c3R5bGU+CiAgICAgIC5jbHMtMSB7CiAgICAgICAgaXNvbGF0aW9uOiBpc29sYXRlOwogICAgICB9CgogICAgICAuY2xzLTIgewogICAgICAgIGZpbGw6ICNkZTM1MGI7CiAgICAgIH0KCiAgICAgIC5jbHMtMyB7CiAgICAgICAgZmlsbDogI2ZmNTYzMDsKICAgICAgfQoKICAgICAgLmNscy00IHsKICAgICAgICBmaWxsOiAjZGZlMWU1OwogICAgICAgIG1peC1ibGVuZC1tb2RlOiBtdWx0aXBseTsKICAgICAgfQoKICAgICAgLmNscy01IHsKICAgICAgICBmaWxsOiAjZmFmYmZjOwogICAgICB9CgogICAgICAuY2xzLTYgewogICAgICAgIGZpbGw6ICNlYmVjZjA7CiAgICAgIH0KCiAgICAgIC5jbHMtNyB7CiAgICAgICAgZmlsbDogbm9uZTsKICAgICAgICBzdHJva2U6ICMwMDY1ZmY7CiAgICAgICAgc3Ryb2tlLW1pdGVybGltaXQ6IDEwOwogICAgICAgIHN0cm9rZS13aWR0aDogMnB4OwogICAgICB9CgogICAgICAuY2xzLTggewogICAgICAgIGZpbGw6ICM1ZTZjODQ7CiAgICAgIH0KCiAgICAgIC5jbHMtOSB7CiAgICAgICAgZmlsbDogIzI1Mzg1ODsKICAgICAgfQoKICAgICAgLmNscy0xMCB7CiAgICAgICAgZmlsbDogIzI2ODRmZjsKICAgICAgfQoKICAgICAgLmNscy0xMSB7CiAgICAgICAgZmlsbDogIzAwNjVmZjsKICAgICAgfQogICAgPC9zdHlsZT4KICA8L2RlZnM+CiAgPHRpdGxlPlNlY3VyaXR5IHdpdGggS2V5PC90aXRsZT4KICA8ZyBjbGFzcz0iY2xzLTEiPgogICAgPGcgaWQ9IkxheWVyXzIiIGRhdGEtbmFtZT0iTGF5ZXIgMiI+CiAgICAgIDxnIGlkPSJPYmplY3RzIj4KICAgICAgICA8cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik00Mi4wNjcyLDBoLjYxMTRhOCw4LDAsMCwxLDgsOFYyMy4yMzM4YTAsMCwwLDAsMSwwLDBIMzQuMDY3MmEwLDAsMCwwLDEsMCwwVjhBOCw4LDAsMCwxLDQyLjA2NzIsMFoiLz4KICAgICAgICA8cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik0xMDguMjIsMGguNjExNGE4LDgsMCwwLDEsOCw4VjIzLjIzMzhhMCwwLDAsMCwxLDAsMEgxMDAuMjJhMCwwLDAsMCwxLDAsMFY4QTgsOCwwLDAsMSwxMDguMjIsMFoiLz4KICAgICAgICA8cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik0xNzQuMzcyMiwwaC42MTE0YTgsOCwwLDAsMSw4LDhWMjMuMjMzOGEwLDAsMCwwLDEsMCwwSDE2Ni4zNzIyYTAsMCwwLDAsMSwwLDBWOEE4LDgsMCwwLDEsMTc0LjM3MjIsMFoiLz4KICAgICAgICA8cmVjdCBjbGFzcz0iY2xzLTIiIHg9IjM0LjA2NzIiIHk9IjIzLjIzMzgiIHdpZHRoPSIxNjMuNTgiIGhlaWdodD0iMTYzLjU4Ii8+CiAgICAgICAgPHBhdGggY2xhc3M9ImNscy0yIiBkPSJNNDIuMDY3MiwwSDU5LjI5YTgsOCwwLDAsMSw4LDhWMjMuMjIyOGEwLDAsMCwwLDEsMCwwSDM0LjA2NzJhMCwwLDAsMCwxLDAsMFY4YTgsOCwwLDAsMSw4LThaIi8+CiAgICAgICAgPHBhdGggY2xhc3M9ImNscy0yIiBkPSJNMTA3LjI0NTgsMGgxNy4yMjI4YTgsOCwwLDAsMSw4LDhWMjMuMjIyOGEwLDAsMCwwLDEsMCwwSDk5LjI0NThhMCwwLDAsMCwxLDAsMFY4YTgsOCwwLDAsMSw4LThaIi8+CiAgICAgICAgPHBhdGggY2xhc3M9ImNscy0yIiBkPSJNMTcyLjQyNDQsMGgxNy4yMjI4YTgsOCwwLDAsMSw4LDhWMjMuMjIyOGEwLDAsMCwwLDEsMCwwSDE2NC40MjQ0YTAsMCwwLDAsMSwwLDBWOGE4LDgsMCwwLDEsOC04WiIvPgogICAgICAgIDxyZWN0IGNsYXNzPSJjbHMtMyIgeD0iMTcuNDU1OCIgeT0iMjMuMjMzOCIgd2lkdGg9IjE2My41OCIgaGVpZ2h0PSIxNjMuNTgiLz4KICAgICAgICA8cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik0yNS40NTU4LDBINDIuNjc4NmE4LDgsMCwwLDEsOCw4VjIzLjIyMjhhMCwwLDAsMCwxLDAsMEgxNy40NTU4YTAsMCwwLDAsMSwwLDBWOEE4LDgsMCwwLDEsMjUuNDU1OCwwWiIvPgogICAgICAgIDxwYXRoIGNsYXNzPSJjbHMtMyIgZD0iTTkwLjYzNDQsMGgxNy4yMjI4YTgsOCwwLDAsMSw4LDhWMjMuMjIyOGEwLDAsMCwwLDEsMCwwSDgyLjYzNDRhMCwwLDAsMCwxLDAsMFY4QTgsOCwwLDAsMSw5MC42MzQ0LDBaIi8+CiAgICAgICAgPHBhdGggY2xhc3M9ImNscy0zIiBkPSJNMTU1LjgxMywwaDE3LjIyMjhhOCw4LDAsMCwxLDgsOFYyMy4yMjI4YTAsMCwwLDAsMSwwLDBIMTQ3LjgxM2EwLDAsMCwwLDEsMCwwVjhBOCw4LDAsMCwxLDE1NS44MTMsMFoiLz4KICAgICAgICA8cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik0yNS40NTU4LDBINDIuNjc4NmE4LDgsMCwwLDEsOCw4VjIzLjIyMjhhMCwwLDAsMCwxLDAsMEgxNy40NTU4YTAsMCwwLDAsMSwwLDBWOEE4LDgsMCwwLDEsMjUuNDU1OCwwWiIvPgogICAgICAgIDxwYXRoIGNsYXNzPSJjbHMtMyIgZD0iTTkwLjYzNDQsMGgxNy4yMjI4YTgsOCwwLDAsMSw4LDhWMjMuMjIyOGEwLDAsMCwwLDEsMCwwSDgyLjYzNDRhMCwwLDAsMCwxLDAsMFY4QTgsOCwwLDAsMSw5MC42MzQ0LDBaIi8+CiAgICAgICAgPHBhdGggY2xhc3M9ImNscy0zIiBkPSJNMTU1LjgxMywwaDE3LjIyMjhhOCw4LDAsMCwxLDgsOFYyMy4yMjI4YTAsMCwwLDAsMSwwLDBIMTQ3LjgxM2EwLDAsMCwwLDEsMCwwVjhBOCw4LDAsMCwxLDE1NS44MTMsMFoiLz4KICAgICAgICA8cmVjdCBjbGFzcz0iY2xzLTIiIHg9IjM1Ljc1OTYiIHk9IjU2LjgwNjUiIHdpZHRoPSIzMy4yMjI4IiBoZWlnaHQ9IjE1LjYwMzgiLz4KICAgICAgICA8cmVjdCBjbGFzcz0iY2xzLTIiIHg9IjEzMS4yMDE2IiB5PSIxMzYuOTYxNSIgd2lkdGg9IjMzLjIyMjgiIGhlaWdodD0iMTUuNjAzOCIvPgogICAgICAgIDxwYXRoIGNsYXNzPSJjbHMtNCIgZD0iTTU3LjM3MDksNzEuNjAzNmg3MC43NWE5LDksMCwwLDEsOSw5djM1LjM3NDlhNDQuMzc0OCw0NC4zNzQ4LDAsMCwxLTQ0LjM3NDgsNDQuMzc0OGgwYTQ0LjM3NDgsNDQuMzc0OCwwLDAsMS00NC4zNzQ4LTQ0LjM3NDhWODAuNjAzNkE5LDksMCwwLDEsNTcuMzcwOSw3MS42MDM2WiIvPgogICAgICAgIDxwYXRoIGNsYXNzPSJjbHMtNSIgZD0iTTY2LjM3MSw2Ni42NjE3aDcwLjc1YTksOSwwLDAsMSw5LDl2MzUuMzc0OWE0NC4zNzQ4LDQ0LjM3NDgsMCwwLDEtNDQuMzc0OCw0NC4zNzQ4aDBBNDQuMzc0OCw0NC4zNzQ4LDAsMCwxLDU3LjM3MSwxMTEuMDM2NlY3NS42NjE3YTksOSwwLDAsMSw5LTlaIi8+CiAgICAgICAgPHBhdGggaWQ9Il9SZWN0YW5nbGVfIiBkYXRhLW5hbWU9IiZsdDtSZWN0YW5nbGUmZ3Q7IiBjbGFzcz0iY2xzLTYiIGQ9Ik02MS4zNzEsNjYuNjYxN2g3MC43NWE5LDksMCwwLDEsOSw5djM1LjM3NDlhNDQuMzc0OCw0NC4zNzQ4LDAsMCwxLTQ0LjM3NDgsNDQuMzc0OGgwQTQ0LjM3NDgsNDQuMzc0OCwwLDAsMSw1Mi4zNzEsMTExLjAzNjZWNzUuNjYxN0E5LDksMCwwLDEsNjEuMzcxLDY2LjY2MTdaIi8+CiAgICAgICAgPHBhdGggY2xhc3M9ImNscy03IiBkPSJNOTYuNzQ1OSwxNDcuNzQ0MWEzNi43NDg3LDM2Ljc0ODcsMCwwLDEtMzYuNzA3NC0zNi43MDc0Vjc4LjA1ODRhMy43MzMzLDMuNzMzMywwLDAsMSwzLjcyOS0zLjcyOWg2NS45NTYzYTMuNzMzMywzLjczMzMsMCwwLDEsMy43MjksMy43Mjl2MzIuOTc4NEEzNi43NDg2LDM2Ljc0ODYsMCwwLDEsOTYuNzQ1OSwxNDcuNzQ0MVoiLz4KICAgICAgICA8cGF0aCBjbGFzcz0iY2xzLTQiIGQ9Ik0xMDAuNjg5MywxNjMuMzE2N1YxMTEuMDk3M2EzLjk0NDMsMy45NDQzLDAsMCwwLTcuODg4NywwdjUyLjIyYTIyLjUyNTIsMjIuNTI1MiwwLDAsMC0xOC41NDc5LDIyLjE0YzAsLjQ1Ni4wMTc4LjkwNzguMDQ0NywxLjM1NzFIODIuMjFjLS4wNDE0LS40NDc0LS4wNjg4LS44OTktLjA2ODgtMS4zNTcxYTE0LjYyLDE0LjYyLDAsMCwxLDE0LjU5NzQtMTQuNjA0MWwuMDA2MS4wMDA2LjAwNjgtLjAwMDdBMTQuNjIxMSwxNC42MjExLDAsMCwxLDExMS4zNSwxODUuNDU2NmMwLC40NTgxLS4wMjczLjkxLS4wNjg4LDEuMzU3MWg3LjkxMjhjLjAyNjktLjQ0OTMuMDQ0Ny0uOTAxMS4wNDQ3LTEuMzU3MUEyMi41MjU5LDIyLjUyNTksMCwwLDAsMTAwLjY4OTMsMTYzLjMxNjdaIi8+CiAgICAgICAgPHJlY3QgY2xhc3M9ImNscy0yIiB4PSIxNy40NTU4IiB5PSIzNi40NzAyIiB3aWR0aD0iMzMuMjIyOCIgaGVpZ2h0PSIxNS42MDM4Ii8+CiAgICAgICAgPHJlY3QgY2xhc3M9ImNscy0yIiB4PSIxNy40NTU4IiB5PSIxNTguMTIxNyIgd2lkdGg9IjMzLjIyMjgiIGhlaWdodD0iMTUuNjAzOCIvPgogICAgICAgIDxyZWN0IGNsYXNzPSJjbHMtMiIgeD0iMTQ3LjgxMyIgeT0iMzYuNDcwMiIgd2lkdGg9IjMzLjIyMjgiIGhlaWdodD0iMTUuNjAzOCIvPgogICAgICAgIDxyZWN0IGNsYXNzPSJjbHMtMiIgeD0iMTUwLjA2NDMiIHk9IjE1Ny41NTEzIiB3aWR0aD0iMzMuMjIyOCIgaGVpZ2h0PSIxNS42MDM4Ii8+CiAgICAgICAgPHBhdGggaWQ9Il9QYXRoXyIgZGF0YS1uYW1lPSImbHQ7UGF0aCZndDsiIGNsYXNzPSJjbHMtOCIgZD0iTTEwNy41MjU0LDEwMS4wMDI3YTExLjc3OTQsMTEuNzc5NCwwLDEsMC0xOS44Niw4LjU1NDhBNC4wNDE3LDQuMDQxNywwLDAsMSw4OC44NSwxMTMuNjJsLTIuMTA0LDcuMjY4MWEzLDMsMCwwLDAsMi44ODE3LDMuODM0MmgxMi4yMzcxYTMsMywwLDAsMCwyLjg4MTctMy44MzQybC0yLjA5NTktNy4yNGE0LjA3NDMsNC4wNzQzLDAsMCwxLDEuMTgwOC00LjA5NDVBMTEuNzE3MiwxMS43MTcyLDAsMCwwLDEwNy41MjU0LDEwMS4wMDI3WiIvPgogICAgICAgIDxwYXRoIGNsYXNzPSJjbHMtOSIgZD0iTTEwNC43NDYxLDEyMC44ODc3bC0yLjA5NTktNy4yNGE0LjA3NDQsNC4wNzQ0LDAsMCwxLDEuMTgwOC00LjA5NDUsMTEuNzYyOSwxMS43NjI5LDAsMCwwLTUuMDYtMTkuOTMxMywxMS45MSwxMS45MSwwLDAsMC04Ljc5OCwxMC45OTQ5LDExLjcxODUsMTEuNzE4NSwwLDAsMCwzLjY5MjksOC45NDFBNC4wNDE2LDQuMDQxNiwwLDAsMSw5NC44NSwxMTMuNjJsLTMuMjE0LDExLjEwMjNoMTAuMjI4OEEzLDMsMCwwLDAsMTA0Ljc0NjEsMTIwLjg4NzdaIi8+CiAgICAgICAgPHBhdGggY2xhc3M9ImNscy0xMCIgZD0iTTgxLjc5NzUsMTAwLjMxYTMuOTQzOSwzLjk0MzksMCwwLDAtMy45NDQzLTMuOTQ0M0g0MS4wNDE3YTMuOTQ0MywzLjk0NDMsMCwwLDAsMCw3Ljg4ODdINzcuODUzMkEzLjk0MzksMy45NDM5LDAsMCwwLDgxLjc5NzUsMTAwLjMxWiIvPgogICAgICAgIDxwYXRoIGlkPSJfUGF0aF8yIiBkYXRhLW5hbWU9IiZsdDtQYXRoJmd0OyIgY2xhc3M9ImNscy0xMSIgZD0iTTQxLjA0MTYsMTA0LjI1MzlIOTYuODUzMmEzLjk0NDMsMy45NDQzLDAsMCwwLDAtNy44ODg3SDQxLjA0MTZhMy45NDQzLDMuOTQ0MywwLDAsMCwwLDcuODg4N1oiLz4KICAgICAgICA8cGF0aCBjbGFzcz0iY2xzLTEwIiBkPSJNODEuNzk3NSwxMDAuMzFhMy45NDM5LDMuOTQzOSwwLDAsMC0zLjk0NDMtMy45NDQzSDQxLjA0MTdhMy45NDQzLDMuOTQ0MywwLDAsMCwwLDcuODg4N0g3Ny44NTMyQTMuOTQzOSwzLjk0MzksMCwwLDAsODEuNzk3NSwxMDAuMzFaIi8+CiAgICAgICAgPHBhdGggY2xhc3M9ImNscy0xMCIgZD0iTTIyLjQ5MzIsMTIyLjgwMjlBMjIuNDkyOSwyMi40OTI5LDAsMSwxLDQ0Ljk4NTgsMTAwLjMxLDIyLjUxODUsMjIuNTE4NSwwLDAsMSwyMi40OTMyLDEyMi44MDI5Wm0wLTM3LjA5NzJBMTQuNjA0MiwxNC42MDQyLDAsMSwwLDM3LjA5NzIsMTAwLjMxLDE0LjYyMDcsMTQuNjIwNywwLDAsMCwyMi40OTMyLDg1LjcwNTdaIi8+CiAgICAgIDwvZz4KICAgIDwvZz4KICA8L2c+Cjwvc3ZnPgo='",
-        "body": "\nThe purpose of this section is to describe how to authenticate when making API calls using the Bitbucket REST API.\n\n-----\n\n* [Basic auth](#basic-auth)\n* [Access Tokens](#access-tokens)\n  * [Repository Access Tokens](#repository-access-tokens)\n  * [Project Access Tokens](#project-access-tokens)\n  * [Workspace Access Tokens](#workspace-access-tokens)\n* [App passwords](#app-passwords)\n* [OAuth 2.0](#oauth-2-0)\n  * [Making requests](#making-requests)\n  * [Repository cloning](#repository-cloning)\n  * [Refresh tokens](#refresh-tokens)\n* [Bitbucket OAuth 2.0 Scopes](#bitbucket-oauth-2-0-scopes)\n* [Forge App Scopes](#forge-app-scopes)\n\n---\n\n### Basic auth\n\nBasic HTTP Authentication as per [RFC-2617](https://tools.ietf.org/html/rfc2617) (Digest not supported).\nNote that Basic Auth is available only with username and [app password](https://bitbucket.org/account/settings/app-passwords/) as credentials.\n\n### Access Tokens\n\nAccess Tokens are passwords (or tokens) that provide access to a _single_ repository, project or workspace.\nThese tokens can authenticate with Bitbucket APIs for scripting, CI/CD tools, Bitbucket Cloud-connected apps,\nand Bitbucket Cloud integrations.\n\nAccess Tokens are linked to a repository, project, or workspace, not a user account.\nThe level of access provided by the token is set when a repository, or workspace admin creates it,\nby setting permission scopes.\n\nThere are three types of Access Token:\n\n* **Repository Access Tokens** can connect to a single repository, preventing them from accessing any other repositories or workspaces.\n* **Project Access Tokens** can connect to a single project, providing access to any repositories within the project.\n* **Workspace Access Tokens** can connect to a single workspace and have access to any projects and repositories within that workspace.\n\nWhen using Bitbucket APIs with an Access Token, the token will be treated as the \"user\" in the\nBitbucket UI and Bitbucket logs. This includes when using the Access Token to leave a comment on a pull request,\npush a commit, or merge a pull request. The Bitbucket UI and API responses will show the\nRepository/Project/Workspace Access Token as a user. The username shown in the Bitbucket UI is the Access\nToken _name_, and a custom icon is used to differentiate it from a regular user in the UI.\n\n#### Considerations for using Access Tokens\n\n* After creation, an Access Token can't be viewed or modified. The token's name, created date,\nlast accessed date, and scopes are visible on the repository, project, or workspace **Access Tokens** page.\n* Access Tokens can access a limited set of Bitbucket's permission scopes.\n* Provided you set the correct permission scopes, you can use an Access Token to clone (`repository`)\nand push (`repository:write`) code to the token's repository or the repositories the token can access.\n* You can't use an Access Token to log into the Bitbucket website.\n* Access Tokens don't require two-step verification.\n* You can set permission scopes (specific access rights) for each Access Token.\n* You can't use an Access Token to manipulate or query repository, project, or workspace permissions.\n* Access Tokens are not listed in any repository or workspace permission API response.\n* Access Tokens are deactivated when deleting the resource tied to it (a repository, project, or workspace).\nRepository Access Tokens are also revoked when transferring the repository to another workspace.\n* Any content created by the Access Token will persist after the Access Token has been revoked.\n* Access Tokens can interact with branch restriction APIs, but the token can't be configured as a user with merge access when using branch restrictions.\n\nThere are some APIs which are inaccessible for Access Tokens, these are:\n\n* [Add a repository deploy key](/cloud/bitbucket/rest/api-group-deployments/#api-repositories-workspace-repo-slug-deploy-keys-post)\n* [Update a repository deploy key](/cloud/bitbucket/rest/api-group-deployments/#api-repositories-workspace-repo-slug-deploy-keys-key-id-put)\n* [Delete a repository deploy key](/cloud/bitbucket/rest/api-group-deployments/#api-repositories-workspace-repo-slug-deploy-keys-key-id-delete)\n\n#### Repository Access Tokens\n\nFor details on creating, managing, and using Repository Access Tokens, visit\n[Repository Access Tokens](https://support.atlassian.com/bitbucket-cloud/docs/repository-access-tokens/).\n\nThe available scopes for Repository Access Tokens are:\n\n- [`repository`](#repository)\n- [`repository:write`](#repository-write)\n- [`repository:admin`](#repository-admin)\n- [`repository:delete`](#repository-delete)\n- [`pullrequest`](#pullrequest)\n- [`pullrequest:write`](#pullrequest-write)\n- [`webhook`](#webhook)\n- [`pipeline`](#pipeline)\n- [`pipeline:write`](#pipeline-write)\n- [`pipeline:variable`](#pipeline-variable)\n- [`runner`](#runner)\n- [`runner:write`](#runner-write)\n\n#### Project Access Tokens\n\nFor details on creating, managing, and using Project Access Tokens, visit\n[Project Access Tokens](https://support.atlassian.com/bitbucket-cloud/docs/project-access-tokens/).\n\nThe available scopes for Project Access Tokens are:\n\n- [`project`](#project)\n- [`repository`](#repository)\n- [`repository:write`](#repository-write)\n- [`repository:admin`](#repository-admin)\n- [`repository:delete`](#repository-delete)\n- [`pullrequest`](#pullrequest)\n- [`pullrequest:write`](#pullrequest-write)\n- [`webhook`](#webhook)\n- [`pipeline`](#pipeline)\n- [`pipeline:write`](#pipeline-write)\n- [`pipeline:variable`](#pipeline-variable)\n- [`runner`](#runner)\n- [`runner:write`](#runner-write)\n\n#### Workspace Access Tokens\n\nFor details on creating, managing, and using Workspace Access Tokens, visit\n[Workspace Access Tokens](https://support.atlassian.com/bitbucket-cloud/docs/workspace-access-tokens/).\n\nThe available scopes for Workspace Access Tokens are:\n\n- [`project`](#project)\n- [`project:admin`](#project-admin)\n- [`repository`](#repository)\n- [`repository:write`](#repository-write)\n- [`repository:admin`](#repository-admin)\n- [`repository:delete`](#repository-delete)\n- [`pullrequest`](#pullrequest)\n- [`pullrequest:write`](#pullrequest-write)\n- [`webhook`](#webhook)\n- [`account`](#account)\n- [`pipeline`](#pipeline)\n- [`pipeline:write`](#pipeline-write)\n- [`pipeline:variable`](#pipeline-variable)\n- [`runner`](#runner)\n- [`runner:write`](#runner-write)\n\n### App passwords\n\nApp passwords allow users to make API calls to their Bitbucket account through apps such as Sourcetree.\n\nSome important points about app passwords:\n\n* You cannot view an app password or adjust permissions after you create the app password. Because app passwords are encrypted on our database and cannot be viewed by anyone. They are essentially designed to be disposable. If you need to change the scopes or lost the password just create a new one.\n* You cannot use them to log into your Bitbucket account.\n* You cannot use app passwords to manage team actions.\n\n    App passwords are tied to an individual account's credentials and should not be shared. If you're sharing your app password you're essentially giving direct, authenticated, access to everything that password has been scoped to do with the Bitbucket API's.\n\n* You can use them for API call authentication, even if you don't have two-step verification enabled.\n* You can set permission scopes (specific access rights) for each app password.\n\nFor details on creating, managing, and using App passwords, visit\n[App passwords](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/).\n\n### OAuth 2.0\n\nOur OAuth 2 implementation is merged in with our existing OAuth 1 in\nsuch a way that existing OAuth 1 consumers automatically become\nvalid OAuth 2 clients. The only thing you need to do is edit your\nexisting consumer and configure a callback URL.\n\nOnce that is in place, you'll have the following 2 URLs:\n\n    https://bitbucket.org/site/oauth2/authorize\n    https://bitbucket.org/site/oauth2/access_token\n\nFor obtaining access/bearer tokens, we support three of RFC-6749's grant\nflows, plus a custom Bitbucket flow for exchanging JWT tokens for access tokens.\nNote that Resource Owner Password Credentials Grant (4.3) is no longer supported.\n\n\n#### 1. Authorization Code Grant (4.1)\n\nThe full-blown 3-LO flow. Request authorization from the end user by\nsending their browser to:\n\n    https://bitbucket.org/site/oauth2/authorize?client_id={client_id}&response_type=code\n\nThe callback includes the `?code={}` query parameter that you can swap\nfor an access token:\n\n    $ curl -X POST -u \"client_id:secret\" \\\n      https://bitbucket.org/site/oauth2/access_token \\\n      -d grant_type=authorization_code -d code={code}\n\n\n#### 2. Implicit Grant (4.2)\n\nThis flow is useful for browser-based add-ons that operate without server-side backends.\n\nRequest the end user for authorization by directing the browser to:\n\n    https://bitbucket.org/site/oauth2/authorize?client_id={client_id}&response_type=token\n\nThat will redirect to your preconfigured callback URL with a fragment\ncontaining the access token\n(`#access_token={token}&token_type=bearer`) where your page's js can\npull it out of the URL.\n\n\n#### 3. Client Credentials Grant (4.4)\n\nSomewhat like our existing \"2-LO\" flow for OAuth 1. Obtain an access\ntoken that represents not an end user, but the owner of the\nclient/consumer:\n\n    $ curl -X POST -u \"client_id:secret\" \\\n      https://bitbucket.org/site/oauth2/access_token \\\n      -d grant_type=client_credentials\n\n\n#### 4. Bitbucket Cloud JWT Grant (urn:bitbucket:oauth2:jwt)\n\nIf your Atlassian Connect add-on uses JWT authentication, you can swap a\nJWT for an OAuth access token. The resulting access token represents the\naccount for which the add-on is installed.\n\nMake sure you send the JWT token in the Authorization request header\nusing the \"JWT\" scheme (case sensitive). Note that this custom scheme\nmakes this different from HTTP Basic Auth (and so you cannot use \"curl\n-u\").\n\n    $ curl -X POST -H \"Authorization: JWT {jwt_token}\" \\\n      https://bitbucket.org/site/oauth2/access_token \\\n      -d grant_type=urn:bitbucket:oauth2:jwt\n\n\n#### Making Requests\n\nOnce you have an access token, as per RFC-6750, you can use it in a request in any of\nthe following ways (in decreasing order of desirability):\n\n1. Send it in a request header: `Authorization: Bearer {access_token}`\n2. Include it in a (application/x-www-form-urlencoded) POST body as `access_token={access_token}`\n3. Put it in the query string of a non-POST: `?access_token={access_token}`\n\n\n#### Repository Cloning\n\nSince add-ons will not be able to upload their own SSH keys to clone\nwith, access tokens can be used as Basic HTTP Auth credentials to\nclone securely over HTTPS. This is much like GitHub, yet slightly\ndifferent:\n\n    $ git clone https://x-token-auth:{access_token}@bitbucket.org/user/repo.git\n\nThe literal string `x-token-auth` as a substitute for username is\nrequired (note the difference with GitHub where the actual token is in\nthe username field).\n\n\n#### Refresh Tokens\n\nOur access tokens expire in one hour. When this happens you'll get 401\nresponses.\n\nMost access tokens grant responses (Implicit and JWT excluded). Therefore, you should include a\nrefresh token that can then be used to generate a new access token,\nwithout the need for end user participation:\n\n    $ curl -X POST -u \"client_id:secret\" \\\n      https://bitbucket.org/site/oauth2/access_token \\\n      -d grant_type=refresh_token -d refresh_token={refresh_token}\n\n\n### Bitbucket OAuth 2.0 scopes\n\nBitbucket's API applies a number of privilege scopes to endpoints. In order to access an endpoint, a request will need to have the necessary scopes.\n\nOAuth 2.0 Scopes are applicable for OAuth 2, Access Tokens, and App passwords auth mechanisms as well as Bitbucket Connect apps.\n\nScopes are declared in the descriptor as a list of strings, with each string being the name of a unique scope.\n\nA descriptor lacking the `scopes` element is implicitly assumed to require all scopes and as a result, Bitbucket will require end users authorizing/installing the add-on\nto explicitly accept all scopes.\n\nOur best practice suggests you add only the scopes your add-on needs, but no more than it needs.\n\nInvalid scope strings will cause the descriptor to be rejected and the installation to fail.\n\nThe available scopes are:\n\n- [project](#project)\n- [project:write](#project-write)\n- [project:admin](#project-admin)\n- [repository](#repository)\n- [repository:write](#repository-write)\n- [repository:admin](#repository-admin)\n- [repository:delete](#repository-delete)\n- [pullrequest](#pullrequest)\n- [pullrequest:write](#pullrequest-write)\n- [issue](#issue)\n- [issue:write](#issue-write)\n- [wiki](#wiki)\n- [webhook](#webhook)\n- [snippet](#snippet)\n- [snippet:write](#snippet-write)\n- [email](#email)\n- [account](#account)\n- [account:write](#account-write)\n- [pipeline](#pipeline)\n- [pipeline:write](#pipeline-write)\n- [pipeline:variable](#pipeline-variable)\n- [runner](#runner)\n- [runner:write](#runner-write)\n\n#### project\n\nProvides access to view the project or projects.\nThis scope implies the [`repository`](#repository) scope, giving read access to all the repositories in a project or projects.\n\n#### project:write\n\nThis scope is deprecated, and has been made obsolete by `project:admin`. Please see the deprecation notice [here](/cloud/bitbucket/deprecation-notice-project-write-scope).\n\n#### project:admin\n\nProvides admin access to a project or projects. No distinction is made between public and private projects. This scope doesn't implicitly grant the [`project`](#project) scope or the [`repository:write`](#repository-write) scope on any repositories under the project. It gives access to the admin features of a project only, not direct access to its repositories' contents.\n\n* ability to create the project\n* ability to update the project\n* ability to delete the project\n\n#### repository\n\nProvides read access to a repository or repositories.\nNote that this scope does not give access to a repository's pull requests.\n\n* access to the repo's source code\n* clone over HTTPS\n* access the file browsing API\n* download zip archives of the repo's contents\n* the ability to view and use the issue tracker on any repo (created issues, comment, vote, etc)\n* the ability to view and use the wiki on any repo (create/edit pages)\n\n#### repository:write\n\nProvides write (not admin) access to a repository or repositories. No distinction is made between public and private repositories. This scope implicitly grants the [`repository`](#repository) scope, which does not need to be requested separately.\nThis scope alone does not give access to the pull requests API.\n\n* push access over HTTPS\n* fork repos\n\n#### repository:admin\n\nProvides admin access to a repository or repositories. No distinction is made between public and private repositories. This scope doesn't implicitly grant the [`repository`](#repository) or the [`repository:write`](#repository-write) scopes. It gives access to the admin features of a repo only, not direct access to its contents. This scope can be used or misused to grant read access to other users, who can then clone the repo, but users that need to read and write source code would also request explicit read or write.\nThis scope comes with access to the following functionality:\n\n* View and manipulate committer mappings\n* List and edit deploy keys\n* Ability to delete the repo\n* View and edit repo permissions\n* View and edit branch permissions\n* Import and export the issue tracker\n* Enable and disable the issue tracker\n* List and edit issue tracker version, milestones and components\n* Enable and disable the wiki\n* List and edit default reviewers\n* List and edit repo links (Jira/Bamboo/Custom)\n* List and edit the repository webhooks\n* Initiate a repo ownership transfer\n\n#### repository:delete\n\nProvides access to delete a repository or repositories.\n\n#### pullrequest\n\nProvides read access to pull requests.\nThis scope implies the [`repository`](#repository) scope, giving read access to the pull request's destination repository.\n\n* see and list pull requests\n* create and resolve tasks\n* comment on pull requests\n\n#### pullrequest:write\n\nImplicitly grants the [`pullrequest`](#pullrequest) scope and adds the ability to create, merge and decline pull requests.\nThis scope also implicitly grants the [`repository:write`](#repository-write) scope, giving write access to the pull request's destination repository. This is necessary to allow merging.\n\n* merge pull requests\n* decline pull requests\n* create pull requests\n* approve pull requests\n\n#### issue\n\nAbility to interact with issue trackers the way non-repo members can.\nThis scope doesn't implicitly grant any other scopes and doesn't give implicit access to the repository.\n\n* view, list and search issues\n* create new issues\n* comment on issues\n* watch issues\n* vote for issues\n\n#### issue:write\n\nThis scope implicitly grants the [`issue`](#issue) scope and adds the ability to transition and delete issues.\nThis scope doesn't implicitly grant any other scopes and doesn't give implicit access to the repository.\n\n* transition issues\n* delete issues\n\n#### wiki\n\nProvides access to wikis. This scope provides both read and write access (wikis are always editable by anyone with access to them).\nThis scope doesn't implicitly grant any other scopes and doesn't give implicit access to the repository.\n\n* view wikis\n* create pages\n* edit pages\n* push to wikis\n* clone wikis\n\n#### webhook\n\nGives access to webhooks. This scope is required for any webhook-related operation.\n\nThis scope gives read access to existing webhook subscriptions on all\nresources the authorization mechanism can access, without needing further scopes.\nFor example:\n\n- A client can list all existing webhook subscriptions on a repository. The [`repository`](#repository) scope is not required.\n- Existing webhook subscriptions for the issue tracker on a repo can be retrieved without the [`issue`](#issue) scope. All that is required is the `webhook` scope.\n\nTo create webhooks, the client will need read access to the resource. Such as: for [`issue:created`](#issue-created), the client will need to\nhave both the `webhook` and the [`issue`](#issue) scope.\n\n* list webhook subscriptions on any accessible repository, user, team, or snippet\n* create/update/delete webhook subscriptions.\n\n#### snippet\n\nProvides read access to snippets.\nNo distinction is made between public and private snippets (public snippets are accessible without any form of authentication).\n\n* view any snippet\n* create snippet comments\n\n#### snippet:write\n\nProvides write access to snippets.\nNo distinction is made between public and private snippets (public snippets are accessible without any form of authentication).\nThis scope implicitly grants the [`snippet`](#snippet) scope which does not need to be requested separately.\n\n* create snippets\n* edit snippets\n* delete snippets\n\n#### email\n\nAbility to see the user's primary email address. This should make it easier to use Bitbucket Cloud as a login provider for apps or external applications.\n\n#### account\n\nWhen used for:\n* **user-related APIs** — Gives read-only access to the user's account information.\nNote that this doesn't include any ability to change any of the data. This scope allows you to view the user's:\n  * email addresses\n  * language\n  * location\n  * website\n  * full name\n  * SSH keys\n  * user groups\n* **workspace-related APIs** — Grants access to view the workspace's:\n  * users\n  * user permissions\n  * projects\n\n#### account:write\n\nAbility to change properties on the user's account.\n\n* delete the authorizing user's account\n* manage the user's groups\n* change a user's email addresses\n* change username, display name and avatar\n\n#### pipeline\n\nGives read-only access to pipelines, steps, deployment environments and variables.\n\n#### pipeline:write\n\nGives write access to pipelines. This scope allows a user to:\n* Stop pipelines\n* Rerun failed pipelines\n* Resume halted pipelines\n* Trigger manual pipelines.\n\nThis scope is not needed to trigger a build using a push. Performing a `git push` (or equivalent actions) will trigger the build. The token doing the push only needs the [`repository:write`](#repository-write) scope.\n\nThis doesn't give write access to create variables.\n\n#### pipeline:variable\n\nGives write access to create variables in pipelines at the various levels:\n* Workspace\n* Repository\n* Deployment\n\n#### runner\n\nGives read-only access to pipelines runners setup against a workspace or repository.\n\n#### runner:write\n\nGives write access to create/edit/disable/delete pipelines runners setup against a workspace or repository.\n### Forge app scopes\n\nIn order for a Forge app integration to access Bitbucket API endpoints, it needs to include certain privilege scopes in the app manifest. These are different from Bitbucket OAuth 2.0 scopes.\n\nUnlike OAuth 2.0 scopes, Forge app scopes do not implicitly grant other scopes, for example, `write:repository:bitbucket` does not implicitly grant `read:repository:bitbucket`.\n\nOnly a subset of Bitbucket API endpoints are currently available for Forge app integrations. These will be labeled with Forge app scopes.\n\nOur best practice suggests you only add the scopes your app needs, but no more than it needs.\n\nThe available scopes are:\n\n- [`read:repository:bitbucket`](#read-repository-bitbucket)\n- [`write:repository:bitbucket`](#write-repository-bitbucket)\n- [`admin:repository:bitbucket`](#admin-repository-bitbucket)\n- [`delete:repository:bitbucket`](#delete-repository-bitbucket)\n- [`read:pullrequest:bitbucket`](#read-pullrequest-bitbucket)\n- [`write:pullrequest:bitbucket`](#write-pullrequest-bitbucket)\n- [`read:project:bitbucket`](#read-project-bitbucket)\n- [`admin:project:bitbucket`](#admin-project-bitbucket)\n- [`read:workspace:bitbucket`](#read-workspace-bitbucket)\n- [`read:user:bitbucket`](#read-user-bitbucket)\n- [`read:pipeline:bitbucket`](#read-pipeline-bitbucket)\n- [`write:pipeline:bitbucket`](#write-pipeline-bitbucket)\n- [`admin:pipeline:bitbucket`](#admin-pipeline-bitbucket)\n- [`read:runner:bitbucket`](#read-runner-bitbucket)\n- [`write:runner:bitbucket`](#write-runner-bitbucket)\n\n#### read:repository:bitbucket\n\nAllows viewing of repository data. Note that this scope does not give access to a repository's pull requests.\n* access to the repository's source code\n* access the file browsing API\n* access to certain repository configurations such as branching model, default reviewers, etc.\n\n#### write:repository:bitbucket\n\nAllows modification of repository data. No distinction is made between public and private repositories. This scope does not imply the `read:repository:bitbucket` scope, so you need to request that separately if required. This scope alone does not give access to the pull request API.\n* update/delete source, branches, tags, etc.\n* fork repositories\n\n#### admin:repository:bitbucket\n\nAllows admin activities on repositories. No distinction is made between public and private repositories. This scope does not implicitly grant the `read:repository:bitbucket` or the `write:repository:bitbucket` scopes. It gives access to the admin features of a repository only, not direct access to its contents. This scope does not allow modification of repository permissions. This scope comes with access to the following functionality:\n* create repository\n* view repository permissions\n* view and edit branch restrictions\n* edit branching model settings\n* edit default reviewers\n* view and edit inheritance state for repository settings\n\n#### delete:repository:bitbucket\nAllows deletion of repositories.\n\n#### read:pullrequest:bitbucket\nAllows viewing of pull requests, plus the ability to comment on pull requests.\n\nThis scope does not imply the `read:repository:bitbucket` scope. With this scope, you could retrieve some data specific to the source/destination repositories of a pull request using pull request endpoints, but it does not give access to repository API endpoints.\n\n#### write:pullrequest:bitbucket\nAllows the ability to create, update, approve, decline, and merge pull requests.\n\nThis scope does not imply the `write:repository:bitbucket` scope.\n\n#### read:project:bitbucket\nAllows viewing of project and project permission data.\n\n#### admin:project:bitbucket\nAllows the ability to create, update, and delete project. No distinction is made between public and private projects.\n\nThis scope does not implicitly grant the `read:project:bitbucket` scope or any repository scopes. It gives access to the admin features of a project only, not direct access to its repositories' contents.\n\n#### read:workspace:bitbucket\nAllows viewing of workspace and workspace permission data.\n\n#### read:user:bitbucket\nAllows viewing of user data. This scope is typically required for permission related endpoints.\n\n#### read:pipeline:bitbucket\nAllows read access to all pipeline information (pipelines, steps, caches, artifacts, logs, tests, code-insights).\n\n#### write:pipeline:bitbucket\nAllows running pipelines (i.e., start/stop/create pipeline) and uploading tests/code-insights.\n\nThis scope does not imply the `read:pipeline:bitbucket` scope.\n\n#### admin:pipeline:bitbucket\nAllows admin activities, such as creating pipeline variables.\n\nThis scope does not implicitly grant the `read:pipeline:bitbucket` or the `write:pipeline:bitbucket` scopes.\n\n#### read:runner:bitbucket\nAllows viewing of runners information.\n\n#### write:runner:bitbucket\nAllows runners management.\n\nThis scope does not imply the `read:runners:bitbucket` scope.\n"
+        "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxOTcuNjQ3MyAxODYuODEzOCI+CiAgPGRlZnM+CiAgICA8c3R5bGU+CiAgICAgIC5jbHMtMSB7CiAgICAgICAgaXNvbGF0aW9uOiBpc29sYXRlOwogICAgICB9CgogICAgICAuY2xzLTIgewogICAgICAgIGZpbGw6ICNkZTM1MGI7CiAgICAgIH0KCiAgICAgIC5jbHMtMyB7CiAgICAgICAgZmlsbDogI2ZmNTYzMDsKICAgICAgfQoKICAgICAgLmNscy00IHsKICAgICAgICBmaWxsOiAjZGZlMWU1OwogICAgICAgIG1peC1ibGVuZC1tb2RlOiBtdWx0aXBseTsKICAgICAgfQoKICAgICAgLmNscy01IHsKICAgICAgICBmaWxsOiAjZmFmYmZjOwogICAgICB9CgogICAgICAuY2xzLTYgewogICAgICAgIGZpbGw6ICNlYmVjZjA7CiAgICAgIH0KCiAgICAgIC5jbHMtNyB7CiAgICAgICAgZmlsbDogbm9uZTsKICAgICAgICBzdHJva2U6ICMwMDY1ZmY7CiAgICAgICAgc3Ryb2tlLW1pdGVybGltaXQ6IDEwOwogICAgICAgIHN0cm9rZS13aWR0aDogMnB4OwogICAgICB9CgogICAgICAuY2xzLTggewogICAgICAgIGZpbGw6ICM1ZTZjODQ7CiAgICAgIH0KCiAgICAgIC5jbHMtOSB7CiAgICAgICAgZmlsbDogIzI1Mzg1ODsKICAgICAgfQoKICAgICAgLmNscy0xMCB7CiAgICAgICAgZmlsbDogIzI2ODRmZjsKICAgICAgfQoKICAgICAgLmNscy0xMSB7CiAgICAgICAgZmlsbDogIzAwNjVmZjsKICAgICAgfQogICAgPC9zdHlsZT4KICA8L2RlZnM+CiAgPHRpdGxlPlNlY3VyaXR5IHdpdGggS2V5PC90aXRsZT4KICA8ZyBjbGFzcz0iY2xzLTEiPgogICAgPGcgaWQ9IkxheWVyXzIiIGRhdGEtbmFtZT0iTGF5ZXIgMiI+CiAgICAgIDxnIGlkPSJPYmplY3RzIj4KICAgICAgICA8cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik00Mi4wNjcyLDBoLjYxMTRhOCw4LDAsMCwxLDgsOFYyMy4yMzM4YTAsMCwwLDAsMSwwLDBIMzQuMDY3MmEwLDAsMCwwLDEsMCwwVjhBOCw4LDAsMCwxLDQyLjA2NzIsMFoiLz4KICAgICAgICA8cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik0xMDguMjIsMGguNjExNGE4LDgsMCwwLDEsOCw4VjIzLjIzMzhhMCwwLDAsMCwxLDAsMEgxMDAuMjJhMCwwLDAsMCwxLDAsMFY4QTgsOCwwLDAsMSwxMDguMjIsMFoiLz4KICAgICAgICA8cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik0xNzQuMzcyMiwwaC42MTE0YTgsOCwwLDAsMSw4LDhWMjMuMjMzOGEwLDAsMCwwLDEsMCwwSDE2Ni4zNzIyYTAsMCwwLDAsMSwwLDBWOEE4LDgsMCwwLDEsMTc0LjM3MjIsMFoiLz4KICAgICAgICA8cmVjdCBjbGFzcz0iY2xzLTIiIHg9IjM0LjA2NzIiIHk9IjIzLjIzMzgiIHdpZHRoPSIxNjMuNTgiIGhlaWdodD0iMTYzLjU4Ii8+CiAgICAgICAgPHBhdGggY2xhc3M9ImNscy0yIiBkPSJNNDIuMDY3MiwwSDU5LjI5YTgsOCwwLDAsMSw4LDhWMjMuMjIyOGEwLDAsMCwwLDEsMCwwSDM0LjA2NzJhMCwwLDAsMCwxLDAsMFY4YTgsOCwwLDAsMSw4LThaIi8+CiAgICAgICAgPHBhdGggY2xhc3M9ImNscy0yIiBkPSJNMTA3LjI0NTgsMGgxNy4yMjI4YTgsOCwwLDAsMSw4LDhWMjMuMjIyOGEwLDAsMCwwLDEsMCwwSDk5LjI0NThhMCwwLDAsMCwxLDAsMFY4YTgsOCwwLDAsMSw4LThaIi8+CiAgICAgICAgPHBhdGggY2xhc3M9ImNscy0yIiBkPSJNMTcyLjQyNDQsMGgxNy4yMjI4YTgsOCwwLDAsMSw4LDhWMjMuMjIyOGEwLDAsMCwwLDEsMCwwSDE2NC40MjQ0YTAsMCwwLDAsMSwwLDBWOGE4LDgsMCwwLDEsOC04WiIvPgogICAgICAgIDxyZWN0IGNsYXNzPSJjbHMtMyIgeD0iMTcuNDU1OCIgeT0iMjMuMjMzOCIgd2lkdGg9IjE2My41OCIgaGVpZ2h0PSIxNjMuNTgiLz4KICAgICAgICA8cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik0yNS40NTU4LDBINDIuNjc4NmE4LDgsMCwwLDEsOCw4VjIzLjIyMjhhMCwwLDAsMCwxLDAsMEgxNy40NTU4YTAsMCwwLDAsMSwwLDBWOEE4LDgsMCwwLDEsMjUuNDU1OCwwWiIvPgogICAgICAgIDxwYXRoIGNsYXNzPSJjbHMtMyIgZD0iTTkwLjYzNDQsMGgxNy4yMjI4YTgsOCwwLDAsMSw4LDhWMjMuMjIyOGEwLDAsMCwwLDEsMCwwSDgyLjYzNDRhMCwwLDAsMCwxLDAsMFY4QTgsOCwwLDAsMSw5MC42MzQ0LDBaIi8+CiAgICAgICAgPHBhdGggY2xhc3M9ImNscy0zIiBkPSJNMTU1LjgxMywwaDE3LjIyMjhhOCw4LDAsMCwxLDgsOFYyMy4yMjI4YTAsMCwwLDAsMSwwLDBIMTQ3LjgxM2EwLDAsMCwwLDEsMCwwVjhBOCw4LDAsMCwxLDE1NS44MTMsMFoiLz4KICAgICAgICA8cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik0yNS40NTU4LDBINDIuNjc4NmE4LDgsMCwwLDEsOCw4VjIzLjIyMjhhMCwwLDAsMCwxLDAsMEgxNy40NTU4YTAsMCwwLDAsMSwwLDBWOEE4LDgsMCwwLDEsMjUuNDU1OCwwWiIvPgogICAgICAgIDxwYXRoIGNsYXNzPSJjbHMtMyIgZD0iTTkwLjYzNDQsMGgxNy4yMjI4YTgsOCwwLDAsMSw4LDhWMjMuMjIyOGEwLDAsMCwwLDEsMCwwSDgyLjYzNDRhMCwwLDAsMCwxLDAsMFY4QTgsOCwwLDAsMSw5MC42MzQ0LDBaIi8+CiAgICAgICAgPHBhdGggY2xhc3M9ImNscy0zIiBkPSJNMTU1LjgxMywwaDE3LjIyMjhhOCw4LDAsMCwxLDgsOFYyMy4yMjI4YTAsMCwwLDAsMSwwLDBIMTQ3LjgxM2EwLDAsMCwwLDEsMCwwVjhBOCw4LDAsMCwxLDE1NS44MTMsMFoiLz4KICAgICAgICA8cmVjdCBjbGFzcz0iY2xzLTIiIHg9IjM1Ljc1OTYiIHk9IjU2LjgwNjUiIHdpZHRoPSIzMy4yMjI4IiBoZWlnaHQ9IjE1LjYwMzgiLz4KICAgICAgICA8cmVjdCBjbGFzcz0iY2xzLTIiIHg9IjEzMS4yMDE2IiB5PSIxMzYuOTYxNSIgd2lkdGg9IjMzLjIyMjgiIGhlaWdodD0iMTUuNjAzOCIvPgogICAgICAgIDxwYXRoIGNsYXNzPSJjbHMtNCIgZD0iTTU3LjM3MDksNzEuNjAzNmg3MC43NWE5LDksMCwwLDEsOSw5djM1LjM3NDlhNDQuMzc0OCw0NC4zNzQ4LDAsMCwxLTQ0LjM3NDgsNDQuMzc0OGgwYTQ0LjM3NDgsNDQuMzc0OCwwLDAsMS00NC4zNzQ4LTQ0LjM3NDhWODAuNjAzNkE5LDksMCwwLDEsNTcuMzcwOSw3MS42MDM2WiIvPgogICAgICAgIDxwYXRoIGNsYXNzPSJjbHMtNSIgZD0iTTY2LjM3MSw2Ni42NjE3aDcwLjc1YTksOSwwLDAsMSw5LDl2MzUuMzc0OWE0NC4zNzQ4LDQ0LjM3NDgsMCwwLDEtNDQuMzc0OCw0NC4zNzQ4aDBBNDQuMzc0OCw0NC4zNzQ4LDAsMCwxLDU3LjM3MSwxMTEuMDM2NlY3NS42NjE3YTksOSwwLDAsMSw5LTlaIi8+CiAgICAgICAgPHBhdGggaWQ9Il9SZWN0YW5nbGVfIiBkYXRhLW5hbWU9IiZsdDtSZWN0YW5nbGUmZ3Q7IiBjbGFzcz0iY2xzLTYiIGQ9Ik02MS4zNzEsNjYuNjYxN2g3MC43NWE5LDksMCwwLDEsOSw5djM1LjM3NDlhNDQuMzc0OCw0NC4zNzQ4LDAsMCwxLTQ0LjM3NDgsNDQuMzc0OGgwQTQ0LjM3NDgsNDQuMzc0OCwwLDAsMSw1Mi4zNzEsMTExLjAzNjZWNzUuNjYxN0E5LDksMCwwLDEsNjEuMzcxLDY2LjY2MTdaIi8+CiAgICAgICAgPHBhdGggY2xhc3M9ImNscy03IiBkPSJNOTYuNzQ1OSwxNDcuNzQ0MWEzNi43NDg3LDM2Ljc0ODcsMCwwLDEtMzYuNzA3NC0zNi43MDc0Vjc4LjA1ODRhMy43MzMzLDMuNzMzMywwLDAsMSwzLjcyOS0zLjcyOWg2NS45NTYzYTMuNzMzMywzLjczMzMsMCwwLDEsMy43MjksMy43Mjl2MzIuOTc4NEEzNi43NDg2LDM2Ljc0ODYsMCwwLDEsOTYuNzQ1OSwxNDcuNzQ0MVoiLz4KICAgICAgICA8cGF0aCBjbGFzcz0iY2xzLTQiIGQ9Ik0xMDAuNjg5MywxNjMuMzE2N1YxMTEuMDk3M2EzLjk0NDMsMy45NDQzLDAsMCwwLTcuODg4NywwdjUyLjIyYTIyLjUyNTIsMjIuNTI1MiwwLDAsMC0xOC41NDc5LDIyLjE0YzAsLjQ1Ni4wMTc4LjkwNzguMDQ0NywxLjM1NzFIODIuMjFjLS4wNDE0LS40NDc0LS4wNjg4LS44OTktLjA2ODgtMS4zNTcxYTE0LjYyLDE0LjYyLDAsMCwxLDE0LjU5NzQtMTQuNjA0MWwuMDA2MS4wMDA2LjAwNjgtLjAwMDdBMTQuNjIxMSwxNC42MjExLDAsMCwxLDExMS4zNSwxODUuNDU2NmMwLC40NTgxLS4wMjczLjkxLS4wNjg4LDEuMzU3MWg3LjkxMjhjLjAyNjktLjQ0OTMuMDQ0Ny0uOTAxMS4wNDQ3LTEuMzU3MUEyMi41MjU5LDIyLjUyNTksMCwwLDAsMTAwLjY4OTMsMTYzLjMxNjdaIi8+CiAgICAgICAgPHJlY3QgY2xhc3M9ImNscy0yIiB4PSIxNy40NTU4IiB5PSIzNi40NzAyIiB3aWR0aD0iMzMuMjIyOCIgaGVpZ2h0PSIxNS42MDM4Ii8+CiAgICAgICAgPHJlY3QgY2xhc3M9ImNscy0yIiB4PSIxNy40NTU4IiB5PSIxNTguMTIxNyIgd2lkdGg9IjMzLjIyMjgiIGhlaWdodD0iMTUuNjAzOCIvPgogICAgICAgIDxyZWN0IGNsYXNzPSJjbHMtMiIgeD0iMTQ3LjgxMyIgeT0iMzYuNDcwMiIgd2lkdGg9IjMzLjIyMjgiIGhlaWdodD0iMTUuNjAzOCIvPgogICAgICAgIDxyZWN0IGNsYXNzPSJjbHMtMiIgeD0iMTUwLjA2NDMiIHk9IjE1Ny41NTEzIiB3aWR0aD0iMzMuMjIyOCIgaGVpZ2h0PSIxNS42MDM4Ii8+CiAgICAgICAgPHBhdGggaWQ9Il9QYXRoXyIgZGF0YS1uYW1lPSImbHQ7UGF0aCZndDsiIGNsYXNzPSJjbHMtOCIgZD0iTTEwNy41MjU0LDEwMS4wMDI3YTExLjc3OTQsMTEuNzc5NCwwLDEsMC0xOS44Niw4LjU1NDhBNC4wNDE3LDQuMDQxNywwLDAsMSw4OC44NSwxMTMuNjJsLTIuMTA0LDcuMjY4MWEzLDMsMCwwLDAsMi44ODE3LDMuODM0MmgxMi4yMzcxYTMsMywwLDAsMCwyLjg4MTctMy44MzQybC0yLjA5NTktNy4yNGE0LjA3NDMsNC4wNzQzLDAsMCwxLDEuMTgwOC00LjA5NDVBMTEuNzE3MiwxMS43MTcyLDAsMCwwLDEwNy41MjU0LDEwMS4wMDI3WiIvPgogICAgICAgIDxwYXRoIGNsYXNzPSJjbHMtOSIgZD0iTTEwNC43NDYxLDEyMC44ODc3bC0yLjA5NTktNy4yNGE0LjA3NDQsNC4wNzQ0LDAsMCwxLDEuMTgwOC00LjA5NDUsMTEuNzYyOSwxMS43NjI5LDAsMCwwLTUuMDYtMTkuOTMxMywxMS45MSwxMS45MSwwLDAsMC04Ljc5OCwxMC45OTQ5LDExLjcxODUsMTEuNzE4NSwwLDAsMCwzLjY5MjksOC45NDFBNC4wNDE2LDQuMDQxNiwwLDAsMSw5NC44NSwxMTMuNjJsLTMuMjE0LDExLjEwMjNoMTAuMjI4OEEzLDMsMCwwLDAsMTA0Ljc0NjEsMTIwLjg4NzdaIi8+CiAgICAgICAgPHBhdGggY2xhc3M9ImNscy0xMCIgZD0iTTgxLjc5NzUsMTAwLjMxYTMuOTQzOSwzLjk0MzksMCwwLDAtMy45NDQzLTMuOTQ0M0g0MS4wNDE3YTMuOTQ0MywzLjk0NDMsMCwwLDAsMCw3Ljg4ODdINzcuODUzMkEzLjk0MzksMy45NDM5LDAsMCwwLDgxLjc5NzUsMTAwLjMxWiIvPgogICAgICAgIDxwYXRoIGlkPSJfUGF0aF8yIiBkYXRhLW5hbWU9IiZsdDtQYXRoJmd0OyIgY2xhc3M9ImNscy0xMSIgZD0iTTQxLjA0MTYsMTA0LjI1MzlIOTYuODUzMmEzLjk0NDMsMy45NDQzLDAsMCwwLDAtNy44ODg3SDQxLjA0MTZhMy45NDQzLDMuOTQ0MywwLDAsMCwwLDcuODg4N1oiLz4KICAgICAgICA8cGF0aCBjbGFzcz0iY2xzLTEwIiBkPSJNODEuNzk3NSwxMDAuMzFhMy45NDM5LDMuOTQzOSwwLDAsMC0zLjk0NDMtMy45NDQzSDQxLjA0MTdhMy45NDQzLDMuOTQ0MywwLDAsMCwwLDcuODg4N0g3Ny44NTMyQTMuOTQzOSwzLjk0MzksMCwwLDAsODEuNzk3NSwxMDAuMzFaIi8+CiAgICAgICAgPHBhdGggY2xhc3M9ImNscy0xMCIgZD0iTTIyLjQ5MzIsMTIyLjgwMjlBMjIuNDkyOSwyMi40OTI5LDAsMSwxLDQ0Ljk4NTgsMTAwLjMxLDIyLjUxODUsMjIuNTE4NSwwLDAsMSwyMi40OTMyLDEyMi44MDI5Wm0wLTM3LjA5NzJBMTQuNjA0MiwxNC42MDQyLDAsMSwwLDM3LjA5NzIsMTAwLjMxLDE0LjYyMDcsMTQuNjIwNywwLDAsMCwyMi40OTMyLDg1LjcwNTdaIi8+CiAgICAgIDwvZz4KICAgIDwvZz4KICA8L2c+Cjwvc3ZnPgo=",
+        "body": "\nThe purpose of this section is to describe how to authenticate when making API calls using the Bitbucket REST API.\n\n-----\n\n* [Basic auth](#basic-auth)\n* [Access Tokens](#access-tokens)\n  * [Repository Access Tokens](#repository-access-tokens)\n  * [Project Access Tokens](#project-access-tokens)\n  * [Workspace Access Tokens](#workspace-access-tokens)\n* [App passwords](#app-passwords)\n* [OAuth 2.0](#oauth-2-0)\n  * [Making requests](#making-requests)\n  * [Repository cloning](#repository-cloning)\n  * [Refresh tokens](#refresh-tokens)\n* [Bitbucket OAuth 2.0 Scopes](#bitbucket-oauth-2-0-scopes)\n* [Forge App Scopes](#forge-app-scopes)\n\n---\n\n### Basic auth\n\nBasic HTTP Authentication as per [RFC-2617](https://tools.ietf.org/html/rfc2617) (Digest not supported).\nNote that Basic Auth is available only with username and [app password](https://bitbucket.org/account/settings/app-passwords/) as credentials.\n\n### Access Tokens\n\nAccess Tokens are passwords (or tokens) that provide access to a _single_ repository, project or workspace.\nThese tokens can authenticate with Bitbucket APIs for scripting, CI/CD tools, Bitbucket Cloud-connected apps,\nand Bitbucket Cloud integrations.\n\nAccess Tokens are linked to a repository, project, or workspace, not a user account.\nThe level of access provided by the token is set when a repository, or workspace admin creates it,\nby setting permission scopes.\n\nThere are three types of Access Token:\n\n* **Repository Access Tokens** can connect to a single repository, preventing them from accessing any other repositories or workspaces.\n* **Project Access Tokens** can connect to a single project, providing access to any repositories within the project.\n* **Workspace Access Tokens** can connect to a single workspace and have access to any projects and repositories within that workspace.\n\nWhen using Bitbucket APIs with an Access Token, the token will be treated as the \"user\" in the\nBitbucket UI and Bitbucket logs. This includes when using the Access Token to leave a comment on a pull request,\npush a commit, or merge a pull request. The Bitbucket UI and API responses will show the\nRepository/Project/Workspace Access Token as a user. The username shown in the Bitbucket UI is the Access\nToken _name_, and a custom icon is used to differentiate it from a regular user in the UI.\n\n#### Considerations for using Access Tokens\n\n* After creation, an Access Token can't be viewed or modified. The token's name, created date,\nlast accessed date, and scopes are visible on the repository, project, or workspace **Access Tokens** page.\n* Access Tokens can access a limited set of Bitbucket's permission scopes.\n* Provided you set the correct permission scopes, you can use an Access Token to clone (`repository`)\nand push (`repository:write`) code to the token's repository or the repositories the token can access.\n* You can't use an Access Token to log into the Bitbucket website.\n* Access Tokens don't require two-step verification.\n* You can set permission scopes (specific access rights) for each Access Token.\n* You can't use an Access Token to manipulate or query repository, project, or workspace permissions.\n* Access Tokens are not listed in any repository or workspace permission API response.\n* Access Tokens are deactivated when deleting the resource tied to it (a repository, project, or workspace).\nRepository Access Tokens are also revoked when transferring the repository to another workspace.\n* Any content created by the Access Token will persist after the Access Token has been revoked.\n* Access Tokens can interact with branch restriction APIs, but the token can't be configured as a user with merge access when using branch restrictions.\n\nThere are some APIs which are inaccessible for Access Tokens, these are:\n\n* [Add a repository deploy key](/cloud/bitbucket/rest/api-group-deployments/#api-repositories-workspace-repo-slug-deploy-keys-post)\n* [Update a repository deploy key](/cloud/bitbucket/rest/api-group-deployments/#api-repositories-workspace-repo-slug-deploy-keys-key-id-put)\n* [Delete a repository deploy key](/cloud/bitbucket/rest/api-group-deployments/#api-repositories-workspace-repo-slug-deploy-keys-key-id-delete)\n\n#### Repository Access Tokens\n\nFor details on creating, managing, and using Repository Access Tokens, visit\n[Repository Access Tokens](https://support.atlassian.com/bitbucket-cloud/docs/repository-access-tokens/).\n\nThe available scopes for Repository Access Tokens are:\n\n- [`repository`](#repository)\n- [`repository:write`](#repository-write)\n- [`repository:admin`](#repository-admin)\n- [`repository:delete`](#repository-delete)\n- [`pullrequest`](#pullrequest)\n- [`pullrequest:write`](#pullrequest-write)\n- [`webhook`](#webhook)\n- [`pipeline`](#pipeline)\n- [`pipeline:write`](#pipeline-write)\n- [`pipeline:variable`](#pipeline-variable)\n- [`runner`](#runner)\n- [`runner:write`](#runner-write)\n\n#### Project Access Tokens\n\nFor details on creating, managing, and using Project Access Tokens, visit\n[Project Access Tokens](https://support.atlassian.com/bitbucket-cloud/docs/project-access-tokens/).\n\nThe available scopes for Project Access Tokens are:\n\n- [`project`](#project)\n- [`repository`](#repository)\n- [`repository:write`](#repository-write)\n- [`repository:admin`](#repository-admin)\n- [`repository:delete`](#repository-delete)\n- [`pullrequest`](#pullrequest)\n- [`pullrequest:write`](#pullrequest-write)\n- [`webhook`](#webhook)\n- [`pipeline`](#pipeline)\n- [`pipeline:write`](#pipeline-write)\n- [`pipeline:variable`](#pipeline-variable)\n- [`runner`](#runner)\n- [`runner:write`](#runner-write)\n\n#### Workspace Access Tokens\n\nFor details on creating, managing, and using Workspace Access Tokens, visit\n[Workspace Access Tokens](https://support.atlassian.com/bitbucket-cloud/docs/workspace-access-tokens/).\n\nThe available scopes for Workspace Access Tokens are:\n\n- [`project`](#project)\n- [`project:admin`](#project-admin)\n- [`repository`](#repository)\n- [`repository:write`](#repository-write)\n- [`repository:admin`](#repository-admin)\n- [`repository:delete`](#repository-delete)\n- [`pullrequest`](#pullrequest)\n- [`pullrequest:write`](#pullrequest-write)\n- [`webhook`](#webhook)\n- [`account`](#account)\n- [`pipeline`](#pipeline)\n- [`pipeline:write`](#pipeline-write)\n- [`pipeline:variable`](#pipeline-variable)\n- [`runner`](#runner)\n- [`runner:write`](#runner-write)\n\n### App passwords\n\nApp passwords allow users to make API calls to their Bitbucket account through apps such as Sourcetree.\n\nSome important points about app passwords:\n\n* You cannot view an app password or adjust permissions after you create the app password. Because app passwords are encrypted on our database and cannot be viewed by anyone. They are essentially designed to be disposable. If you need to change the scopes or lost the password just create a new one.\n* You cannot use them to log into your Bitbucket account.\n* You cannot use app passwords to manage team actions.\n\n    App passwords are tied to an individual account's credentials and should not be shared. If you're sharing your app password you're essentially giving direct, authenticated, access to everything that password has been scoped to do with the Bitbucket API's.\n\n* You can use them for API call authentication, even if you don't have two-step verification enabled.\n* You can set permission scopes (specific access rights) for each app password.\n\nFor details on creating, managing, and using App passwords, visit\n[App passwords](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/).\n\n### OAuth 2.0\n\nOur OAuth 2 implementation is merged in with our existing OAuth 1 in\nsuch a way that existing OAuth 1 consumers automatically become\nvalid OAuth 2 clients. The only thing you need to do is edit your\nexisting consumer and configure a callback URL.\n\nOnce that is in place, you'll have the following 2 URLs:\n\n    https://bitbucket.org/site/oauth2/authorize\n    https://bitbucket.org/site/oauth2/access_token\n\nFor obtaining access/bearer tokens, we support three of RFC-6749's grant\nflows, plus a custom Bitbucket flow for exchanging JWT tokens for access tokens.\nNote that Resource Owner Password Credentials Grant (4.3) is no longer supported.\n\n\n#### 1. Authorization Code Grant (4.1)\n\nThe full-blown 3-LO flow. Request authorization from the end user by\nsending their browser to:\n\n    https://bitbucket.org/site/oauth2/authorize?client_id={client_id}&response_type=code\n\nThe callback includes the `?code={}` query parameter that you can swap\nfor an access token:\n\n    $ curl -X POST -u \"client_id:secret\" \\\n      https://bitbucket.org/site/oauth2/access_token \\\n      -d grant_type=authorization_code -d code={code}\n\n\n#### 2. Implicit Grant (4.2)\n\nThis flow is useful for browser-based add-ons that operate without server-side backends.\n\nRequest the end user for authorization by directing the browser to:\n\n    https://bitbucket.org/site/oauth2/authorize?client_id={client_id}&response_type=token\n\nThat will redirect to your preconfigured callback URL with a fragment\ncontaining the access token\n(`#access_token={token}&token_type=bearer`) where your page's js can\npull it out of the URL.\n\n\n#### 3. Client Credentials Grant (4.4)\n\nSomewhat like our existing \"2-LO\" flow for OAuth 1. Obtain an access\ntoken that represents not an end user, but the owner of the\nclient/consumer:\n\n    $ curl -X POST -u \"client_id:secret\" \\\n      https://bitbucket.org/site/oauth2/access_token \\\n      -d grant_type=client_credentials\n\n\n#### 4. Bitbucket Cloud JWT Grant (urn:bitbucket:oauth2:jwt)\n\nIf your Atlassian Connect add-on uses JWT authentication, you can swap a\nJWT for an OAuth access token. The resulting access token represents the\naccount for which the add-on is installed.\n\nMake sure you send the JWT token in the Authorization request header\nusing the \"JWT\" scheme (case sensitive). Note that this custom scheme\nmakes this different from HTTP Basic Auth (and so you cannot use \"curl\n-u\").\n\n    $ curl -X POST -H \"Authorization: JWT {jwt_token}\" \\\n      https://bitbucket.org/site/oauth2/access_token \\\n      -d grant_type=urn:bitbucket:oauth2:jwt\n\n\n#### Making Requests\n\nOnce you have an access token, as per RFC-6750, you can use it in a request in any of\nthe following ways (in decreasing order of desirability):\n\n1. Send it in a request header: `Authorization: Bearer {access_token}`\n2. Include it in a (application/x-www-form-urlencoded) POST body as `access_token={access_token}`\n3. Put it in the query string of a non-POST: `?access_token={access_token}`\n\n\n#### Repository Cloning\n\nSince add-ons will not be able to upload their own SSH keys to clone\nwith, access tokens can be used as Basic HTTP Auth credentials to\nclone securely over HTTPS. This is much like GitHub, yet slightly\ndifferent:\n\n    $ git clone https://x-token-auth:{access_token}@bitbucket.org/user/repo.git\n\nThe literal string `x-token-auth` as a substitute for username is\nrequired (note the difference with GitHub where the actual token is in\nthe username field).\n\n\n#### Refresh Tokens\n\nOur access tokens expire in one hour. When this happens you'll get 401\nresponses.\n\nMost access tokens grant responses (Implicit and JWT excluded). Therefore, you should include a\nrefresh token that can then be used to generate a new access token,\nwithout the need for end user participation:\n\n    $ curl -X POST -u \"client_id:secret\" \\\n      https://bitbucket.org/site/oauth2/access_token \\\n      -d grant_type=refresh_token -d refresh_token={refresh_token}\n\n\n### Bitbucket OAuth 2.0 scopes\n\nBitbucket's API applies a number of privilege scopes to endpoints. In order to access an endpoint, a request will need to have the necessary scopes.\n\nOAuth 2.0 Scopes are applicable for OAuth 2, Access Tokens, and App passwords auth mechanisms as well as Bitbucket Connect apps.\n\nScopes are declared in the descriptor as a list of strings, with each string being the name of a unique scope.\n\nA descriptor lacking the `scopes` element is implicitly assumed to require all scopes and as a result, Bitbucket will require end users authorizing/installing the add-on\nto explicitly accept all scopes.\n\nOur best practice suggests you add only the scopes your add-on needs, but no more than it needs.\n\nInvalid scope strings will cause the descriptor to be rejected and the installation to fail.\n\nThe available scopes are:\n\n- [project](#project)\n- [project:write](#project-write)\n- [project:admin](#project-admin)\n- [repository](#repository)\n- [repository:write](#repository-write)\n- [repository:admin](#repository-admin)\n- [repository:delete](#repository-delete)\n- [pullrequest](#pullrequest)\n- [pullrequest:write](#pullrequest-write)\n- [issue](#issue)\n- [issue:write](#issue-write)\n- [wiki](#wiki)\n- [webhook](#webhook)\n- [snippet](#snippet)\n- [snippet:write](#snippet-write)\n- [email](#email)\n- [account](#account)\n- [account:write](#account-write)\n- [pipeline](#pipeline)\n- [pipeline:write](#pipeline-write)\n- [pipeline:variable](#pipeline-variable)\n- [runner](#runner)\n- [runner:write](#runner-write)\n\n#### project\n\nProvides access to view the project or projects.\nThis scope implies the [`repository`](#repository) scope, giving read access to all the repositories in a project or projects.\n\n#### project:write\n\nThis scope is deprecated, and has been made obsolete by `project:admin`. Please see the deprecation notice [here](/cloud/bitbucket/deprecation-notice-project-write-scope).\n\n#### project:admin\n\nProvides admin access to a project or projects. No distinction is made between public and private projects. This scope doesn't implicitly grant the [`project`](#project) scope or the [`repository:write`](#repository-write) scope on any repositories under the project. It gives access to the admin features of a project only, not direct access to its repositories' contents.\n\n* ability to create the project\n* ability to update the project\n* ability to delete the project\n\n#### repository\n\nProvides read access to a repository or repositories.\nNote that this scope does not give access to a repository's pull requests.\n\n* access to the repo's source code\n* clone over HTTPS\n* access the file browsing API\n* download zip archives of the repo's contents\n* the ability to view and use the issue tracker on any repo (created issues, comment, vote, etc)\n* the ability to view and use the wiki on any repo (create/edit pages)\n\n#### repository:write\n\nProvides write (not admin) access to a repository or repositories. No distinction is made between public and private repositories. This scope implicitly grants the [`repository`](#repository) scope, which does not need to be requested separately.\nThis scope alone does not give access to the pull requests API.\n\n* push access over HTTPS\n* fork repos\n\n#### repository:admin\n\nProvides admin access to a repository or repositories. No distinction is made between public and private repositories. This scope doesn't implicitly grant the [`repository`](#repository) or the [`repository:write`](#repository-write) scopes. It gives access to the admin features of a repo only, not direct access to its contents. This scope can be used or misused to grant read access to other users, who can then clone the repo, but users that need to read and write source code would also request explicit read or write.\nThis scope comes with access to the following functionality:\n\n* View and manipulate committer mappings\n* List and edit deploy keys\n* Ability to delete the repo\n* View and edit repo permissions\n* View and edit branch permissions\n* Import and export the issue tracker\n* Enable and disable the issue tracker\n* List and edit issue tracker version, milestones and components\n* Enable and disable the wiki\n* List and edit default reviewers\n* List and edit repo links (Jira/Bamboo/Custom)\n* List and edit the repository webhooks\n* Initiate a repo ownership transfer\n\n#### repository:delete\n\nProvides access to delete a repository or repositories.\n\n#### pullrequest\n\nProvides read access to pull requests.\nThis scope implies the [`repository`](#repository) scope, giving read access to the pull request's destination repository.\n\n* see and list pull requests\n* create and resolve tasks\n* comment on pull requests\n\n#### pullrequest:write\n\nImplicitly grants the [`pullrequest`](#pullrequest) scope and adds the ability to create, merge and decline pull requests.\nThis scope also implicitly grants the [`repository:write`](#repository-write) scope, giving write access to the pull request's destination repository. This is necessary to allow merging.\n\n* merge pull requests\n* decline pull requests\n* create pull requests\n* approve pull requests\n\n#### issue\n\nAbility to interact with issue trackers the way non-repo members can.\nThis scope doesn't implicitly grant any other scopes and doesn't give implicit access to the repository.\n\n* view, list and search issues\n* create new issues\n* comment on issues\n* watch issues\n* vote for issues\n\n#### issue:write\n\nThis scope implicitly grants the [`issue`](#issue) scope and adds the ability to transition and delete issues.\nThis scope doesn't implicitly grant any other scopes and doesn't give implicit access to the repository.\n\n* transition issues\n* delete issues\n\n#### wiki\n\nProvides access to wikis. This scope provides both read and write access (wikis are always editable by anyone with access to them).\nThis scope doesn't implicitly grant any other scopes and doesn't give implicit access to the repository.\n\n* view wikis\n* create pages\n* edit pages\n* push to wikis\n* clone wikis\n\n#### webhook\n\nGives access to webhooks. This scope is required for any webhook-related operation.\n\nThis scope gives read access to existing webhook subscriptions on all\nresources the authorization mechanism can access, without needing further scopes.\nFor example:\n\n- A client can list all existing webhook subscriptions on a repository. The [`repository`](#repository) scope is not required.\n- Existing webhook subscriptions for the issue tracker on a repo can be retrieved without the [`issue`](#issue) scope. All that is required is the `webhook` scope.\n\nTo create webhooks, the client will need read access to the resource. Such as: for [`issue:created`](#issue-created), the client will need to\nhave both the `webhook` and the [`issue`](#issue) scope.\n\n* list webhook subscriptions on any accessible repository, user, team, or snippet\n* create/update/delete webhook subscriptions.\n\n#### snippet\n\nProvides read access to snippets.\nNo distinction is made between public and private snippets (public snippets are accessible without any form of authentication).\n\n* view any snippet\n* create snippet comments\n\n#### snippet:write\n\nProvides write access to snippets.\nNo distinction is made between public and private snippets (public snippets are accessible without any form of authentication).\nThis scope implicitly grants the [`snippet`](#snippet) scope which does not need to be requested separately.\n\n* create snippets\n* edit snippets\n* delete snippets\n\n#### email\n\nAbility to see the user's primary email address. This should make it easier to use Bitbucket Cloud as a login provider for apps or external applications.\n\n#### account\n\nWhen used for:\n* **user-related APIs** — Gives read-only access to the user's account information.\nNote that this doesn't include any ability to change any of the data. This scope allows you to view the user's:\n  * email addresses\n  * language\n  * location\n  * website\n  * full name\n  * SSH keys\n  * user groups\n* **workspace-related APIs** — Grants access to view the workspace's:\n  * users\n  * user permissions\n  * projects\n\n#### account:write\n\nAbility to change properties on the user's account.\n\n* delete the authorizing user's account\n* manage the user's groups\n* change a user's email addresses\n* change username, display name and avatar\n\n#### pipeline\n\nGives read-only access to pipelines, steps, deployment environments and variables.\n\n#### pipeline:write\n\nGives write access to pipelines. This scope allows a user to:\n* Stop pipelines\n* Rerun failed pipelines\n* Resume halted pipelines\n* Trigger manual pipelines.\n\nThis scope is not needed to trigger a build using a push. Performing a `git push` (or equivalent actions) will trigger the build. The token doing the push only needs the [`repository:write`](#repository-write) scope.\n\nThis doesn't give write access to create variables.\n\n#### pipeline:variable\n\nGives write access to create variables in pipelines at the various levels:\n* Workspace\n* Repository\n* Deployment\n\n#### runner\n\nGives read-only access to pipelines runners setup against a workspace or repository.\n\n#### runner:write\n\nGives write access to create/edit/disable/delete pipelines runners setup against a workspace or repository.\n### Forge app scopes\n\nIn order for a Forge app integration to access Bitbucket API endpoints, it needs to include certain privilege scopes in the app manifest. These are different from Bitbucket OAuth 2.0 scopes.\n\nUnlike OAuth 2.0 scopes, Forge app scopes do not implicitly grant other scopes, for example, `write:repository:bitbucket` does not implicitly grant `read:repository:bitbucket`.\n\nOnly a subset of Bitbucket API endpoints are currently available for Forge app integrations. These will be labeled with Forge app scopes.\n\nOur best practice suggests you only add the scopes your app needs, but no more than it needs.\n\nThe available scopes are:\n\n- [`read:repository:bitbucket`](#read-repository-bitbucket)\n- [`write:repository:bitbucket`](#write-repository-bitbucket)\n- [`admin:repository:bitbucket`](#admin-repository-bitbucket)\n- [`delete:repository:bitbucket`](#delete-repository-bitbucket)\n- [`read:pullrequest:bitbucket`](#read-pullrequest-bitbucket)\n- [`write:pullrequest:bitbucket`](#write-pullrequest-bitbucket)\n- [`read:project:bitbucket`](#read-project-bitbucket)\n- [`admin:project:bitbucket`](#admin-project-bitbucket)\n- [`read:workspace:bitbucket`](#read-workspace-bitbucket)\n- [`read:user:bitbucket`](#read-user-bitbucket)\n- [`read:pipeline:bitbucket`](#read-pipeline-bitbucket)\n- [`write:pipeline:bitbucket`](#write-pipeline-bitbucket)\n- [`admin:pipeline:bitbucket`](#admin-pipeline-bitbucket)\n- [`read:runner:bitbucket`](#read-runner-bitbucket)\n- [`write:runner:bitbucket`](#write-runner-bitbucket)\n\n#### read:repository:bitbucket\n\nAllows viewing of repository data. Note that this scope does not give access to a repository's pull requests.\n* access to the repository's source code\n* access the file browsing API\n* access to certain repository configurations such as branching model, default reviewers, etc.\n\n#### write:repository:bitbucket\n\nAllows modification of repository data. No distinction is made between public and private repositories. This scope does not imply the `read:repository:bitbucket` scope, so you need to request that separately if required. This scope alone does not give access to the pull request API.\n* update/delete source, branches, tags, etc.\n* fork repositories\n\n#### admin:repository:bitbucket\n\nAllows admin activities on repositories. No distinction is made between public and private repositories. This scope does not implicitly grant the `read:repository:bitbucket` or the `write:repository:bitbucket` scopes. It gives access to the admin features of a repository only, not direct access to its contents. This scope does not allow modification of repository permissions. This scope comes with access to the following functionality:\n* create repository\n* view repository permissions\n* view and edit branch restrictions\n* edit branching model settings\n* edit default reviewers\n* view and edit inheritance state for repository settings\n\n#### delete:repository:bitbucket\nAllows deletion of repositories.\n\n#### read:pullrequest:bitbucket\nAllows viewing of pull requests, plus the ability to comment on pull requests.\n\nThis scope does not imply the `read:repository:bitbucket` scope. With this scope, you could retrieve some data specific to the source/destination repositories of a pull request using pull request endpoints, but it does not give access to repository API endpoints.\n\n#### write:pullrequest:bitbucket\nAllows the ability to create, update, approve, decline, and merge pull requests.\n\nThis scope does not imply the `write:repository:bitbucket` scope.\n\n#### read:project:bitbucket\nAllows viewing of project and project permission data.\n\n#### admin:project:bitbucket\nAllows the ability to create, update, and delete project. No distinction is made between public and private projects.\n\nThis scope does not implicitly grant the `read:project:bitbucket` scope or any repository scopes. It gives access to the admin features of a project only, not direct access to its repositories' contents.\n\n#### read:workspace:bitbucket\nAllows viewing of workspace and workspace permission data.\n\n#### read:user:bitbucket\nAllows viewing of data related to the current user.\n\n#### read:pipeline:bitbucket\nAllows read access to all pipeline information (pipelines, steps, caches, artifacts, logs, tests, code-insights).\n\n#### write:pipeline:bitbucket\nAllows running pipelines (i.e., start/stop/create pipeline) and uploading tests/code-insights.\n\nThis scope does not imply the `read:pipeline:bitbucket` scope.\n\n#### admin:pipeline:bitbucket\nAllows admin activities, such as creating pipeline variables.\n\nThis scope does not implicitly grant the `read:pipeline:bitbucket` or the `write:pipeline:bitbucket` scopes.\n\n#### read:runner:bitbucket\nAllows viewing of runners information.\n\n#### write:runner:bitbucket\nAllows runners management.\n\nThis scope does not imply the `read:runners:bitbucket` scope.\n"
       },
       {
         "anchor": "filtering",
         "title": "Filter and sort API objects",
         "description": "Query the 2.0 API for specific objects",
-        "icon": "data:image/svg+xml;base64,b'PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB2aWV3Qm94PSIwIDAgMTk0LjE5MTkgMTQ3LjYwOTIiPgogIDxkZWZzPgogICAgPHN0eWxlPgogICAgICAuY2xzLTEgewogICAgICAgIGlzb2xhdGlvbjogaXNvbGF0ZTsKICAgICAgfQoKICAgICAgLmNscy0yIHsKICAgICAgICBmaWxsOiAjY2ZkNGRiOwogICAgICB9CgogICAgICAuY2xzLTMsIC5jbHMtNCB7CiAgICAgICAgZmlsbDogIzg3NzdkOTsKICAgICAgfQoKICAgICAgLmNscy00IHsKICAgICAgICBtaXgtYmxlbmQtbW9kZTogbXVsdGlwbHk7CiAgICAgIH0KCiAgICAgIC5jbHMtNSB7CiAgICAgICAgZmlsbDogIzAwNjVmZjsKICAgICAgfQoKICAgICAgLmNscy02IHsKICAgICAgICBmaWxsOiAjY2NlMGZmOwogICAgICB9CgogICAgICAuY2xzLTcgewogICAgICAgIGZpbGw6IHVybCgjbGluZWFyLWdyYWRpZW50KTsKICAgICAgfQogICAgPC9zdHlsZT4KICAgIDxsaW5lYXJHcmFkaWVudCBpZD0ibGluZWFyLWdyYWRpZW50IiB4MT0iNDE2LjMwODIiIHkxPSI3NS4wNDc5IiB4Mj0iNTg0Ljg1NTYiIHkyPSI3NS4wNDc5IiBncmFkaWVudFRyYW5zZm9ybT0idHJhbnNsYXRlKC00NDMuOTQ2NyAxMjMuMDY4Nikgcm90YXRlKC0xMy43OTc2KSIgZ3JhZGllbnRVbml0cz0idXNlclNwYWNlT25Vc2UiPgogICAgICA8c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiNmZmYiLz4KICAgICAgPHN0b3Agb2Zmc2V0PSIwLjY5MDgiIHN0b3AtY29sb3I9IiNmZmYiIHN0b3Atb3BhY2l0eT0iMC4xIi8+CiAgICA8L2xpbmVhckdyYWRpZW50PgogIDwvZGVmcz4KICA8dGl0bGU+TWFnbmlmeWluZyBHbGFzczwvdGl0bGU+CiAgPGcgY2xhc3M9ImNscy0xIj4KICAgIDxnIGlkPSJMYXllcl8yIiBkYXRhLW5hbWU9IkxheWVyIDIiPgogICAgICA8ZyBpZD0iT2JqZWN0cyI+CiAgICAgICAgPHBhdGggY2xhc3M9ImNscy0yIiBkPSJNMTMxLjExMjUsOTQuOTMwN2wtOS44ODc4LTUuOTg4OC04LjMyOTIsMTMuNzUxOSw5Ljg4NzgsNS45ODg4YTE1LjYwMywxNS42MDMsMCwwLDEsNS44OCw2LjM4MzVoMGExNS42MDMsMTUuNjAzLDAsMCwwLDUuODgsNi4zODM1bDQwLjExNDMsMjQuMjk2NGExMi44NjY0LDEyLjg2NjQsMCwwLDAsMTcuNjcwOS00LjM0aDBhMTIuODY2NCwxMi44NjY0LDAsMCwwLTQuMzQtMTcuNjcwOUwxNDcuODc0OSw5OS40MzkyYTE1LjYwMywxNS42MDMsMCwwLDAtOC4zODEyLTIuMjU0MmgwQTE1LjYwMywxNS42MDMsMCwwLDEsMTMxLjExMjUsOTQuOTMwN1oiLz4KICAgICAgICA8cGF0aCBpZD0iX1BhdGhfIiBkYXRhLW5hbWU9IiZsdDtQYXRoJmd0OyIgY2xhc3M9ImNscy0zIiBkPSJNMTMxLjExMjUsOTQuOTMwN2wtMy4wMTE4LTEuODI0MkE4LjAzODgsOC4wMzg4LDAsMCwwLDExNy4wNiw5NS44MTc4aDBhOC4wMzg4LDguMDM4OCwwLDAsMCwyLjcxMTMsMTEuMDQwNWwzLjAxMTgsMS44MjQyYTE1LjYwMywxNS42MDMsMCwwLDEsNS44OCw2LjM4MzVoMGExNS42MDMsMTUuNjAzLDAsMCwwLDUuODgsNi4zODM1bDQwLjExNDMsMjQuMjk2NGExMi44NjY0LDEyLjg2NjQsMCwwLDAsMTcuNjcwOS00LjM0aDBhMTIuODY2NCwxMi44NjY0LDAsMCwwLTQuMzQtMTcuNjcwOUwxNDcuODc0OSw5OS40MzkyYTE1LjYwMywxNS42MDMsMCwwLDAtOC4zODEyLTIuMjU0M2gwQTE1LjYwMywxNS42MDMsMCwwLDEsMTMxLjExMjUsOTQuOTMwN1oiLz4KICAgICAgICA8cGF0aCBjbGFzcz0iY2xzLTQiIGQ9Ik0xMzkuMTQzNyw5Ny4xNzkyYTE1LjU5NzMsMTUuNTk3MywwLDAsMS04LjAzMTItMi4yNDg1bC0zLjAxMTgtMS44MjQyQTguMDM4OCw4LjAzODgsMCwwLDAsMTE3LjA2LDk1LjgxNzhoMGE4LjAzODgsOC4wMzg4LDAsMCwwLDIuNzExMywxMS4wNDA1bDMuMDExOCwxLjgyNDJhMTUuNTk3LDE1LjU5NywwLDAsMSw1LjcwNjksNi4wNjQ4LDY3Ljg0ODEsNjcuODQ4MSwwLDAsMCwxMC42NTM2LTE3LjU2ODFaIi8+CiAgICAgICAgPHBhdGggY2xhc3M9ImNscy01IiBkPSJNODMuMjUzNywxMzIuNTU2QTY3LjIzNDgsNjcuMjM0OCwwLDAsMSw5LjcxLDMyLjQyOTUsNjYuNzk3NCw2Ni43OTc0LDAsMCwxLDUxLjE4MzcsMS45NjY2bC4wMDA3LDBBNjYuNzk2Miw2Ni43OTYyLDAsMCwxLDEwMi4wNTEsOS43NTI1aDBBNjcuMjM0Niw2Ny4yMzQ2LDAsMCwxLDgzLjI1MzcsMTMyLjU1NloiLz4KICAgICAgICA8cGF0aCBpZD0iX1BhdGhfMiIgZGF0YS1uYW1lPSImbHQ7UGF0aCZndDsiIGNsYXNzPSJjbHMtNiIgZD0iTTIzLjQzOSw0MC43NDgyQTUxLjE5MDgsNTEuMTkwOCwwLDAsMCwxMTEuMDEsOTMuNzg4OSw1MS4xOTA4LDUxLjE5MDgsMCwwLDAsMjMuNDM5LDQwLjc0ODJaIi8+CiAgICAgICAgPHBhdGggY2xhc3M9ImNscy03IiBkPSJNNzkuNDMzLDExNi45ODJBNTEuMjE2Miw1MS4yMTYyLDAsMCwwLDExOC40MjQxLDY3LjAzN2E0OS4xMzkxLDQ5LjEzOTEsMCwwLDEtNS4wODY3LDIuMjc4OWMtMTUuNzAyOSw1Ljk2MDktMjkuNjg5NSwyLjExLTM2LjQ5ODcuMTMwOC0yMC40MzA3LTUuOTM5LTI0Ljc5LTE3LjM3ODUtMzkuMDQxNC0yNC41ODIzYTQ4LjMwOTIsNDguMzA5MiwwLDAsMC0xNC4wOTM5LTQuNTNjLS4wODYyLjEzOTUtLjE3OTMuMjczLS4yNjQ0LjQxMzVBNTEuMTkwNyw1MS4xOTA3LDAsMCwwLDc5LjQzMywxMTYuOTgyWiIvPgogICAgICA8L2c+CiAgICA8L2c+CiAgPC9nPgo8L3N2Zz4K'",
-        "body": "\nYou can query the 2.0 API for specific objects using a simple language which resembles SQL.\n\nNote that filtering and querying by username has been deprecated, due to privacy changes. \nSee the [announcement](https://developer.atlassian.com/cloud/bitbucket/bitbucket-api-changes-gdpr/#changes-to-querying) \nfor details.\n\n---\n\n* [Supported endpoints](#supported-endpoints)\n* [Operators](#operators)\n* [Data types](#data-types)\n* [Querying](#querying)\n* [Sorting query results](#sorting-query-results)\n\n----\n\n### Supported endpoints\n\nMost 2.0 API resources that return paginated collections of objects support a single, shared, generic querying language that is used to filter down a result set.\n\nThis includes, but is in no way limited to:\n\n    /2.0/repositories/{username}\n    /2.0/repositories/{username}/{slug}/refs\n    /2.0/repositories/{username}/{slug}/refs/branches\n    /2.0/repositories/{username}/{slug}/refs/tags\n    /2.0/repositories/{username}/{slug}/forks\n    /2.0/repositories/{username}/{slug}/src\n    /2.0/repositories/{username}/{slug}/issues\n    /2.0/repositories/{username}/{slug}/pullrequests\n\nFiltering and sorting supports several distinct operators and data types as well as basic features, like logical operators (AND, OR).\nAs examples, the following queries could be used on the issue tracker endpoint (`/2.0/repositories/{workspace}/{slug}/issues/`):\n\n\t(state = \"open\" OR state = \"new\") AND assignee = null\n\treporter.nickname != \"evzijst\" AND priority >= \"major\"\n\t(title ~ \"unicode\" OR content.raw ~ \"unicode\") AND created_on > 2015-10-04T14:00:00-07:00\n\nFilter queries can be added to the URL using the q=<query> query parameter. To sort the response, add sort=<field>. Note that the entire query string is put in the q parameter and hence needs to be URL-encoded as shown in the following example:\n\n\t/2.0/repositories/foo/bar/issues?q=state=\"new\"&sort=-updated_on\n\n\n### Operators\n\nFiltering and sorting supports the following operators:\n\n| Operator | Definition                     | Example                    |\n|----------|--------------------------------|----------------------------|\n| \"=\"      | test for equality              | `nickname = \"evzijst\"`     |\n| \"!=\"     | not equal                      | `is_private != true`       |\n| \"~\"      | case-insensitive text contains | `description ~ \"beef\"`     |\n| \"!~\"     | case-insensitive not contains  | `description !~ \"fubar\"`   |\n| \">\"      | greater than                   | `priority > \"major\"`       |\n| \">=\"     | greater than or equal          | `priority <= \"trivial\"`    |\n| \"<\"      | less than                      | `id < 1234`                |\n| \"<=\"     | less than or equal             | `updated_on <= 2015-03-04` |\n\n### Data types\n\nFiltering and sorting supports the following data types:\n\n| Type         | Description                             | Example       |\n|--------------|-----------------------------------------|---------------|\n| **String**   | any text inside double quotes           | `\"foo\"`       |\n| **Number**   | arbitrary precision integers and floats | `1, -10.302`  |\n| **Null**     | to test for the absence of a value      | `null`        |\n| **boolean**  | the unquoted strings true or false      | `true, false` |\n| **datetime** | an unquoted [ISO-8601][iso-8601] date time string with the timezone offset, milliseconds and entire time component being optional | `2015-03-04T14:08:59.123+02:00`, `2015-03-04T14:08:59` Date time strings are assumed to be in UTC, unless an explicit timezone offset is provided |\n\n[https://en.wikipedia.org/wiki/ISO_8601]: /iso-8601\n\n### Querying\n\nObjects can be filtered based on their properties. In principle, every element in an object's JSON document schema can be used as a filter criterion.\n\nNote that while the array of objects in a paginated response is wrapped in an\nenvelope with a `values` element, this prefix should not be included in the\nquery fields (so use `/2.0/repositories/foo/bar/issues?q=state=\"new\"`, not\n`/2.0/repositories/foo/bar/issues?q=values.state=\"new\"`).\n\n\n### Examples\n\nFields that contain embedded instances of other object types (e.g. owner is an embedded user object, while parent is an embedded repository) can be traversed recursively. For instance:\n\n\tparent.owner.nickname = \"bitbucket\"\n\nTo find pull requests which merge into master, come from a fork of the repo rather than a branch inside the repo, and on which I am a reviewer:\n\n```\nsource.repository.full_name != \"main/repo\" AND state = \"OPEN\" AND reviewers.nickname = \"evzijst\" AND destination.branch.name = \"master\"\n```\n```\n/2.0/repositories/main/repo/pullrequests?q=source.repository.full_name+%21%3D+%22main%2Frepo%22+AND+state+%3D+%22OPEN%22+AND+reviewers.nickname+%3D+%22evzijst%22+AND+destination.branch.name+%3D+%22master%22\n```\n\nTo find new or on-hold issues related to the UI, created or updated in the last day (SF local time), that have not yet been assigned to anyone:\n\n```\n(state = \"new\" OR state = \"on hold\") AND assignee = null AND component = \"UI\" and updated_on > 2015-11-11T00:00:00-07:00\n```\n```\n/2.0/repositories/main/repo/issues?q=%28state+%3D+%22new%22+OR+state+%3D+%22on+hold%22%29+AND+assignee+%3D+null+AND+component+%3D+%22UI%22+and+updated_on+%3E+2015-11-11T00%3A00%3A00-07%3A00\n```\n\nTo find all tags with the string \"2015\" in the name:\n\n```\nname ~ \"2015\"\n```\n```\n/2.0/repositories/{username}/{slug}/refs/tags?q=name+%7E+%222015%22\n```\nOr all my branches:\n\n```\nname ~ \"erik/\"\n```\n```\n/2.0/repositories/{username}/{slug}/refs/?q=name+%7E+%22erik%2F%22\n```\n### Sorting query results\n\nYou can sort result sets using the ?sort=<field> query parameter, available on the same resources that support filtering:\n\n* In principle, every field that can be queried can also be used as a key for sorting.\n* By default the sort order is ascending. To reverse the order, prefix the field name with a hyphen (e.g. ?sort=-updated_on).\n* Only one field can be sorted on. Compound fields (e.g. sort on state first, followed by updated_on) are not supported.\n\n\n"
+        "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB2aWV3Qm94PSIwIDAgMTk0LjE5MTkgMTQ3LjYwOTIiPgogIDxkZWZzPgogICAgPHN0eWxlPgogICAgICAuY2xzLTEgewogICAgICAgIGlzb2xhdGlvbjogaXNvbGF0ZTsKICAgICAgfQoKICAgICAgLmNscy0yIHsKICAgICAgICBmaWxsOiAjY2ZkNGRiOwogICAgICB9CgogICAgICAuY2xzLTMsIC5jbHMtNCB7CiAgICAgICAgZmlsbDogIzg3NzdkOTsKICAgICAgfQoKICAgICAgLmNscy00IHsKICAgICAgICBtaXgtYmxlbmQtbW9kZTogbXVsdGlwbHk7CiAgICAgIH0KCiAgICAgIC5jbHMtNSB7CiAgICAgICAgZmlsbDogIzAwNjVmZjsKICAgICAgfQoKICAgICAgLmNscy02IHsKICAgICAgICBmaWxsOiAjY2NlMGZmOwogICAgICB9CgogICAgICAuY2xzLTcgewogICAgICAgIGZpbGw6IHVybCgjbGluZWFyLWdyYWRpZW50KTsKICAgICAgfQogICAgPC9zdHlsZT4KICAgIDxsaW5lYXJHcmFkaWVudCBpZD0ibGluZWFyLWdyYWRpZW50IiB4MT0iNDE2LjMwODIiIHkxPSI3NS4wNDc5IiB4Mj0iNTg0Ljg1NTYiIHkyPSI3NS4wNDc5IiBncmFkaWVudFRyYW5zZm9ybT0idHJhbnNsYXRlKC00NDMuOTQ2NyAxMjMuMDY4Nikgcm90YXRlKC0xMy43OTc2KSIgZ3JhZGllbnRVbml0cz0idXNlclNwYWNlT25Vc2UiPgogICAgICA8c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiNmZmYiLz4KICAgICAgPHN0b3Agb2Zmc2V0PSIwLjY5MDgiIHN0b3AtY29sb3I9IiNmZmYiIHN0b3Atb3BhY2l0eT0iMC4xIi8+CiAgICA8L2xpbmVhckdyYWRpZW50PgogIDwvZGVmcz4KICA8dGl0bGU+TWFnbmlmeWluZyBHbGFzczwvdGl0bGU+CiAgPGcgY2xhc3M9ImNscy0xIj4KICAgIDxnIGlkPSJMYXllcl8yIiBkYXRhLW5hbWU9IkxheWVyIDIiPgogICAgICA8ZyBpZD0iT2JqZWN0cyI+CiAgICAgICAgPHBhdGggY2xhc3M9ImNscy0yIiBkPSJNMTMxLjExMjUsOTQuOTMwN2wtOS44ODc4LTUuOTg4OC04LjMyOTIsMTMuNzUxOSw5Ljg4NzgsNS45ODg4YTE1LjYwMywxNS42MDMsMCwwLDEsNS44OCw2LjM4MzVoMGExNS42MDMsMTUuNjAzLDAsMCwwLDUuODgsNi4zODM1bDQwLjExNDMsMjQuMjk2NGExMi44NjY0LDEyLjg2NjQsMCwwLDAsMTcuNjcwOS00LjM0aDBhMTIuODY2NCwxMi44NjY0LDAsMCwwLTQuMzQtMTcuNjcwOUwxNDcuODc0OSw5OS40MzkyYTE1LjYwMywxNS42MDMsMCwwLDAtOC4zODEyLTIuMjU0MmgwQTE1LjYwMywxNS42MDMsMCwwLDEsMTMxLjExMjUsOTQuOTMwN1oiLz4KICAgICAgICA8cGF0aCBpZD0iX1BhdGhfIiBkYXRhLW5hbWU9IiZsdDtQYXRoJmd0OyIgY2xhc3M9ImNscy0zIiBkPSJNMTMxLjExMjUsOTQuOTMwN2wtMy4wMTE4LTEuODI0MkE4LjAzODgsOC4wMzg4LDAsMCwwLDExNy4wNiw5NS44MTc4aDBhOC4wMzg4LDguMDM4OCwwLDAsMCwyLjcxMTMsMTEuMDQwNWwzLjAxMTgsMS44MjQyYTE1LjYwMywxNS42MDMsMCwwLDEsNS44OCw2LjM4MzVoMGExNS42MDMsMTUuNjAzLDAsMCwwLDUuODgsNi4zODM1bDQwLjExNDMsMjQuMjk2NGExMi44NjY0LDEyLjg2NjQsMCwwLDAsMTcuNjcwOS00LjM0aDBhMTIuODY2NCwxMi44NjY0LDAsMCwwLTQuMzQtMTcuNjcwOUwxNDcuODc0OSw5OS40MzkyYTE1LjYwMywxNS42MDMsMCwwLDAtOC4zODEyLTIuMjU0M2gwQTE1LjYwMywxNS42MDMsMCwwLDEsMTMxLjExMjUsOTQuOTMwN1oiLz4KICAgICAgICA8cGF0aCBjbGFzcz0iY2xzLTQiIGQ9Ik0xMzkuMTQzNyw5Ny4xNzkyYTE1LjU5NzMsMTUuNTk3MywwLDAsMS04LjAzMTItMi4yNDg1bC0zLjAxMTgtMS44MjQyQTguMDM4OCw4LjAzODgsMCwwLDAsMTE3LjA2LDk1LjgxNzhoMGE4LjAzODgsOC4wMzg4LDAsMCwwLDIuNzExMywxMS4wNDA1bDMuMDExOCwxLjgyNDJhMTUuNTk3LDE1LjU5NywwLDAsMSw1LjcwNjksNi4wNjQ4LDY3Ljg0ODEsNjcuODQ4MSwwLDAsMCwxMC42NTM2LTE3LjU2ODFaIi8+CiAgICAgICAgPHBhdGggY2xhc3M9ImNscy01IiBkPSJNODMuMjUzNywxMzIuNTU2QTY3LjIzNDgsNjcuMjM0OCwwLDAsMSw5LjcxLDMyLjQyOTUsNjYuNzk3NCw2Ni43OTc0LDAsMCwxLDUxLjE4MzcsMS45NjY2bC4wMDA3LDBBNjYuNzk2Miw2Ni43OTYyLDAsMCwxLDEwMi4wNTEsOS43NTI1aDBBNjcuMjM0Niw2Ny4yMzQ2LDAsMCwxLDgzLjI1MzcsMTMyLjU1NloiLz4KICAgICAgICA8cGF0aCBpZD0iX1BhdGhfMiIgZGF0YS1uYW1lPSImbHQ7UGF0aCZndDsiIGNsYXNzPSJjbHMtNiIgZD0iTTIzLjQzOSw0MC43NDgyQTUxLjE5MDgsNTEuMTkwOCwwLDAsMCwxMTEuMDEsOTMuNzg4OSw1MS4xOTA4LDUxLjE5MDgsMCwwLDAsMjMuNDM5LDQwLjc0ODJaIi8+CiAgICAgICAgPHBhdGggY2xhc3M9ImNscy03IiBkPSJNNzkuNDMzLDExNi45ODJBNTEuMjE2Miw1MS4yMTYyLDAsMCwwLDExOC40MjQxLDY3LjAzN2E0OS4xMzkxLDQ5LjEzOTEsMCwwLDEtNS4wODY3LDIuMjc4OWMtMTUuNzAyOSw1Ljk2MDktMjkuNjg5NSwyLjExLTM2LjQ5ODcuMTMwOC0yMC40MzA3LTUuOTM5LTI0Ljc5LTE3LjM3ODUtMzkuMDQxNC0yNC41ODIzYTQ4LjMwOTIsNDguMzA5MiwwLDAsMC0xNC4wOTM5LTQuNTNjLS4wODYyLjEzOTUtLjE3OTMuMjczLS4yNjQ0LjQxMzVBNTEuMTkwNyw1MS4xOTA3LDAsMCwwLDc5LjQzMywxMTYuOTgyWiIvPgogICAgICA8L2c+CiAgICA8L2c+CiAgPC9nPgo8L3N2Zz4K",
+        "body": "\nYou can query the 2.0 API for specific objects using a simple language which resembles SQL.\n\nNote that filtering and querying by username has been deprecated, due to privacy changes. \nSee the [announcement](https://developer.atlassian.com/cloud/bitbucket/bitbucket-api-changes-gdpr/#changes-to-querying) \nfor details.\n\n---\n\n* [Supported endpoints](#supported-endpoints)\n* [Operators](#operators)\n* [Data types](#data-types)\n* [Querying](#querying)\n* [Sorting query results](#sorting-query-results)\n\n----\n\n### Supported endpoints\n\nMost 2.0 API resources that return paginated collections of objects support a single, shared, generic querying language that is used to filter down a result set.\n\nThis includes, but is in no way limited to:\n\n    /2.0/repositories/{username}\n    /2.0/repositories/{username}/{slug}/refs\n    /2.0/repositories/{username}/{slug}/refs/branches\n    /2.0/repositories/{username}/{slug}/refs/tags\n    /2.0/repositories/{username}/{slug}/forks\n    /2.0/repositories/{username}/{slug}/src\n    /2.0/repositories/{username}/{slug}/issues\n    /2.0/repositories/{username}/{slug}/pullrequests\n\nFiltering and sorting supports several distinct operators and data types as well as basic features, like logical operators (AND, OR).\nAs examples, the following queries could be used on the issue tracker endpoint (`/2.0/repositories/{workspace}/{slug}/issues/`):\n\n\t(state = \"open\" OR state = \"new\") AND assignee = null\n\treporter.nickname != \"evzijst\" AND priority >= \"major\"\n\t(title ~ \"unicode\" OR content.raw ~ \"unicode\") AND created_on > 2015-10-04T14:00:00-07:00\n\nFilter queries can be added to the URL using the q=<query> query parameter. To sort the response, add sort=<field>. Note that the entire query string is put in the q parameter and hence needs to be URL-encoded as shown in the following example:\n\n\t/2.0/repositories/foo/bar/issues?q=state=\"new\"&sort=-updated_on\n\n\n### Operators\n\nFiltering and sorting supports the following operators:\n\n| Operator | Definition                     | Example                               |\n|----------|--------------------------------|---------------------------------------|\n| \"=\"      | test for equality              | `nickname = \"evzijst\"`                |\n| \"!=\"     | not equal                      | `is_private != true`                  |\n| \"~\"      | case-insensitive text contains | `description ~ \"beef\"`                |\n| \"!~\"     | case-insensitive not contains  | `description !~ \"fubar\"`              |\n| \">\"      | greater than                   | `priority > \"major\"`                  |\n| \">=\"     | greater than or equal          | `priority <= \"trivial\"`               |\n| \"<\"      | less than                      | `id < 1234`                           |\n| \"<=\"     | less than or equal             | `updated_on <= 2015-03-04`            |\n| \"IN\"     | value present in list          | `state IN (\"OPEN\", \"MERGED\")`         |\n| \"NOT IN\" | value not present in list      | `state NOT IN (\"DECLINED\", \"MERGED\")` |\n\n### Data types\n\nFiltering and sorting supports the following data types:\n\n| Type         | Description                             | Example         |\n|--------------|-----------------------------------------|-----------------|\n| **String**   | any text inside double quotes           | `\"foo\"`         |\n| **Number**   | arbitrary precision integers and floats | `1`, `-10.302`  |\n| **Null**     | to test for the absence of a value      | `null`          |\n| **boolean**  | the unquoted strings true or false      | `true`, `false` |\n| **datetime** | an unquoted [ISO-8601][iso-8601] date time string with the timezone offset, milliseconds and entire time component being optional | `2015-03-04T14:08:59.123+02:00`, `2015-03-04T14:08:59` Date time strings are assumed to be in UTC, unless an explicit timezone offset is provided |\n| **list**     | a comma separated list of values enclosed in parentheses | `(\"a\", \"b\")`, `(1, 2)` |\n\n[iso-8601]: https://en.wikipedia.org/wiki/ISO_8601\n\n### Querying\n\nObjects can be filtered based on their properties. In principle, every element in an object's JSON document schema can be used as a filter criterion.\n\nNote that while the array of objects in a paginated response is wrapped in an\nenvelope with a `values` element, this prefix should not be included in the\nquery fields (so use `/2.0/repositories/foo/bar/issues?q=state=\"new\"`, not\n`/2.0/repositories/foo/bar/issues?q=values.state=\"new\"`).\n\n\n### Examples\n\nFields that contain embedded instances of other object types (e.g. owner is an embedded user object, while parent is an embedded repository) can be traversed recursively. For instance:\n\n\tparent.owner.nickname = \"bitbucket\"\n\nTo find pull requests which merge into master, come from a fork of the repo rather than a branch inside the repo, and on which I am a reviewer:\n\n```\nsource.repository.full_name != \"main/repo\" AND state = \"OPEN\" AND reviewers.nickname = \"evzijst\" AND destination.branch.name = \"master\"\n```\n```\n/2.0/repositories/main/repo/pullrequests?q=source.repository.full_name+%21%3D+%22main%2Frepo%22+AND+state+%3D+%22OPEN%22+AND+reviewers.nickname+%3D+%22evzijst%22+AND+destination.branch.name+%3D+%22master%22\n```\n\nTo find new or on-hold issues related to the UI, created or updated in the last day (SF local time), that have not yet been assigned to anyone:\n\n```\nstate IN (\"new\", \"on hold\") AND assignee = null AND component = \"UI\" and updated_on > 2015-11-11T00:00:00-07:00\n```\n```\n/2.0/repositories/main/repo/issues?q=state%20IN%20%28%22new%22%2C%20%22on%20hold%22%29%20AND%20assignee%20%3D%20null%20AND%20component%20%3D%20%22UI%22%20and%20updated%5Fon%20%3E%202015%2D11%2D11T00%3A00%3A00%2D07%3A00\n```\n\nTo find all tags with the string \"2015\" in the name:\n\n```\nname ~ \"2015\"\n```\n```\n/2.0/repositories/{username}/{slug}/refs/tags?q=name+%7E+%222015%22\n```\nOr all my branches:\n\n```\nname ~ \"erik/\"\n```\n```\n/2.0/repositories/{username}/{slug}/refs/?q=name+%7E+%22erik%2F%22\n```\n### Sorting query results\n\nYou can sort result sets using the ?sort=<field> query parameter, available on the same resources that support filtering:\n\n* In principle, every field that can be queried can also be used as a key for sorting.\n* By default the sort order is ascending. To reverse the order, prefix the field name with a hyphen (e.g. ?sort=-updated_on).\n* Only one field can be sorted on. Compound fields (e.g. sort on state first, followed by updated_on) are not supported.\n\n\n"
       },
       {
         "anchor": "pagination",
         "title": "Pagination",
         "description": "Learn more about pagination",
-        "icon": "data:image/svg+xml;base64,b'PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB2aWV3Qm94PSIwIDAgMjM4LjgyIDE1MS42Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2IyZDRmZjt9LmNscy0ye2ZpbGw6IzRjOWFmZjt9LmNscy0ze2ZpbGw6IzAwNTJjYzt9LmNscy00e29wYWNpdHk6MC42O30uY2xzLTV7ZmlsbDp1cmwoI2xpbmVhci1ncmFkaWVudCk7fS5jbHMtNntmaWxsOnVybCgjbGluZWFyLWdyYWRpZW50LTIpO30uY2xzLTd7ZmlsbDp1cmwoI2xpbmVhci1ncmFkaWVudC0zKTt9LmNscy04e2ZpbGw6dXJsKCNsaW5lYXItZ3JhZGllbnQtNCk7fS5jbHMtOXtmaWxsOnVybCgjbGluZWFyLWdyYWRpZW50LTUpO30uY2xzLTEwLC5jbHMtMTEsLmNscy0xMntmaWxsOm5vbmU7fS5jbHMtMTB7c3Ryb2tlOiMzMzg0ZmY7fS5jbHMtMTAsLmNscy0xMSwuY2xzLTEyLC5jbHMtMTN7c3Ryb2tlLW1pdGVybGltaXQ6MTA7c3Ryb2tlLXdpZHRoOjJweDt9LmNscy0xMXtzdHJva2U6I2ZmYWIwMDt9LmNscy0xMntzdHJva2U6I2ZhZmJmYzt9LmNscy0xM3tmaWxsOiNmZmFiMDA7c3Ryb2tlOiMyNjg0ZmY7fTwvc3R5bGU+PGxpbmVhckdyYWRpZW50IGlkPSJsaW5lYXItZ3JhZGllbnQiIHkxPSI2NS4xNyIgeDI9Ijg2LjM4IiB5Mj0iNjUuMTciIGdyYWRpZW50VW5pdHM9InVzZXJTcGFjZU9uVXNlIj48c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiM0YzlhZmYiLz48c3RvcCBvZmZzZXQ9IjAuMDgiIHN0b3AtY29sb3I9IiM0YzlhZmYiIHN0b3Atb3BhY2l0eT0iMC45NCIvPjxzdG9wIG9mZnNldD0iMC4yNCIgc3RvcC1jb2xvcj0iIzRjOWFmZiIgc3RvcC1vcGFjaXR5PSIwLjc4Ii8+PHN0b3Agb2Zmc2V0PSIwLjQ1IiBzdG9wLWNvbG9yPSIjNGM5YWZmIiBzdG9wLW9wYWNpdHk9IjAuNTMiLz48c3RvcCBvZmZzZXQ9IjAuNTUiIHN0b3AtY29sb3I9IiM0YzlhZmYiIHN0b3Atb3BhY2l0eT0iMC40Ii8+PC9saW5lYXJHcmFkaWVudD48bGluZWFyR3JhZGllbnQgaWQ9ImxpbmVhci1ncmFkaWVudC0yIiB4MT0iMTUyLjQ0IiB5MT0iNjUuMTciIHgyPSIyMzguODIiIHkyPSI2NS4xNyIgeGxpbms6aHJlZj0iI2xpbmVhci1ncmFkaWVudCIvPjxsaW5lYXJHcmFkaWVudCBpZD0ibGluZWFyLWdyYWRpZW50LTMiIHgxPSIxOC44NSIgeTE9IjExOC43OCIgeDI9IjEyNi4wOCIgeTI9IjExLjU2IiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSI+PHN0b3Agb2Zmc2V0PSIwLjA2IiBzdG9wLWNvbG9yPSIjMDA2NWZmIi8+PHN0b3Agb2Zmc2V0PSIwLjE5IiBzdG9wLWNvbG9yPSIjMDA2NWZmIiBzdG9wLW9wYWNpdHk9IjAuOTQiLz48c3RvcCBvZmZzZXQ9IjAuNDYiIHN0b3AtY29sb3I9IiMwMDY1ZmYiIHN0b3Atb3BhY2l0eT0iMC43OCIvPjxzdG9wIG9mZnNldD0iMC44MiIgc3RvcC1jb2xvcj0iIzAwNjVmZiIgc3RvcC1vcGFjaXR5PSIwLjUzIi8+PHN0b3Agb2Zmc2V0PSIxIiBzdG9wLWNvbG9yPSIjMDA2NWZmIiBzdG9wLW9wYWNpdHk9IjAuNCIvPjwvbGluZWFyR3JhZGllbnQ+PGxpbmVhckdyYWRpZW50IGlkPSJsaW5lYXItZ3JhZGllbnQtNCIgeDE9IjExMi43NSIgeTE9IjExOC43OCIgeDI9IjIxOS45NyIgeTI9IjExLjU2IiB4bGluazpocmVmPSIjbGluZWFyLWdyYWRpZW50LTMiLz48bGluZWFyR3JhZGllbnQgaWQ9ImxpbmVhci1ncmFkaWVudC01IiB4MT0iNTAuOTciIHkxPSIxMzMuNjEiIHgyPSIxODcuODYiIHkyPSItMy4yOCIgZ3JhZGllbnRVbml0cz0idXNlclNwYWNlT25Vc2UiPjxzdG9wIG9mZnNldD0iMC42NiIgc3RvcC1jb2xvcj0iIzI1Mzg1OCIvPjxzdG9wIG9mZnNldD0iMC44OCIgc3RvcC1jb2xvcj0iIzI1Mzg1OCIgc3RvcC1vcGFjaXR5PSIwLjgzIi8+PHN0b3Agb2Zmc2V0PSIxIiBzdG9wLWNvbG9yPSIjMjUzODU4IiBzdG9wLW9wYWNpdHk9IjAuNyIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjx0aXRsZT5WaWV3IFZlcnNpb25zPC90aXRsZT48ZyBpZD0iTGF5ZXJfMiIgZGF0YS1uYW1lPSJMYXllciAyIj48ZyBpZD0iU29mdHdhcmUiPjxjaXJjbGUgY2xhc3M9ImNscy0xIiBjeD0iOTQuNTMiIGN5PSIxNDcuOTMiIHI9IjMuNjciLz48Y2lyY2xlIGNsYXNzPSJjbHMtMiIgY3g9IjEwNi45NCIgY3k9IjE0Ny45MyIgcj0iMy42NyIvPjxjaXJjbGUgY2xhc3M9ImNscy0zIiBjeD0iMTE5LjM0IiBjeT0iMTQ3LjkzIiByPSIzLjY3Ii8+PGNpcmNsZSBjbGFzcz0iY2xzLTIiIGN4PSIxMzEuNzUiIGN5PSIxNDcuOTMiIHI9IjMuNjciLz48Y2lyY2xlIGNsYXNzPSJjbHMtMSIgY3g9IjE0NC4xNiIgY3k9IjE0Ny45MyIgcj0iMy42NyIvPjxnIGNsYXNzPSJjbHMtNCI+PHJlY3QgaWQ9Il9SZWN0YW5nbGVfIiBkYXRhLW5hbWU9IiZsdDtSZWN0YW5nbGUmZ3Q7IiBjbGFzcz0iY2xzLTUiIHk9IjI1LjkyIiB3aWR0aD0iODYuMzgiIGhlaWdodD0iNzguNDkiLz48L2c+PGcgY2xhc3M9ImNscy00Ij48cmVjdCBpZD0iX1JlY3RhbmdsZV8yIiBkYXRhLW5hbWU9IiZsdDtSZWN0YW5nbGUmZ3Q7IiBjbGFzcz0iY2xzLTYiIHg9IjE1Mi40NCIgeT0iMjUuOTIiIHdpZHRoPSI4Ni4zOCIgaGVpZ2h0PSI3OC40OSIvPjwvZz48cmVjdCBpZD0iX1JlY3RhbmdsZV8zIiBkYXRhLW5hbWU9IiZsdDtSZWN0YW5nbGUmZ3Q7IiBjbGFzcz0iY2xzLTciIHg9IjE2LjI4IiB5PSIxNC4xMiIgd2lkdGg9IjExMi4zNiIgaGVpZ2h0PSIxMDIuMDkiLz48cmVjdCBpZD0iX1JlY3RhbmdsZV80IiBkYXRhLW5hbWU9IiZsdDtSZWN0YW5nbGUmZ3Q7IiBjbGFzcz0iY2xzLTgiIHg9IjExMC4xOCIgeT0iMTQuMTIiIHdpZHRoPSIxMTIuMzYiIGhlaWdodD0iMTAyLjA5Ii8+PHJlY3QgaWQ9Il9SZWN0YW5nbGVfNSIgZGF0YS1uYW1lPSImbHQ7UmVjdGFuZ2xlJmd0OyIgY2xhc3M9ImNscy05IiB4PSI0Ny42OSIgd2lkdGg9IjE0My40NSIgaGVpZ2h0PSIxMzAuMzQiLz48bGluZSBjbGFzcz0iY2xzLTEwIiB4MT0iNzkuMTYiIHkxPSIxNi4xOCIgeDI9IjExNy4yNCIgeTI9IjE2LjE4Ii8+PGxpbmUgY2xhc3M9ImNscy0xMCIgeDE9IjYyLjkzIiB5MT0iMTYuMTgiIHgyPSI3Mi42IiB5Mj0iMTYuMTgiLz48bGluZSBjbGFzcz0iY2xzLTExIiB4MT0iNzkuMTYiIHkxPSIyNi45NSIgeDI9IjExNy4yNCIgeTI9IjI2Ljk1Ii8+PGxpbmUgY2xhc3M9ImNscy0xMCIgeDE9IjYyLjkzIiB5MT0iMjYuOTUiIHgyPSI3Mi42IiB5Mj0iMjYuOTUiLz48bGluZSBjbGFzcz0iY2xzLTEwIiB4MT0iNzkuMTYiIHkxPSIzNy43MiIgeDI9IjE1MC43IiB5Mj0iMzcuNzIiLz48bGluZSBjbGFzcz0iY2xzLTEwIiB4MT0iNjIuOTMiIHkxPSIzNy43MiIgeDI9IjcyLjYiIHkyPSIzNy43MiIvPjxsaW5lIGNsYXNzPSJjbHMtMTEiIHgxPSIxNTAuNyIgeTE9IjQ4LjQ5IiB4Mj0iMTc1LjU5IiB5Mj0iNDguNDkiLz48bGluZSBjbGFzcz0iY2xzLTEyIiB4MT0iMTEwLjMyIiB5MT0iNDguNDkiIHgyPSIxNDMuMDUiIHkyPSI0OC40OSIvPjxsaW5lIGNsYXNzPSJjbHMtMTEiIHgxPSI3OS4xNiIgeTE9IjQ4LjQ5IiB4Mj0iMTAxLjM3IiB5Mj0iNDguNDkiLz48bGluZSBjbGFzcz0iY2xzLTEwIiB4MT0iNjIuOTMiIHkxPSI0OC40OSIgeDI9IjcyLjYiIHkyPSI0OC40OSIvPjxsaW5lIGNsYXNzPSJjbHMtMTAiIHgxPSI3OS4xNiIgeTE9IjU5LjI2IiB4Mj0iMTUwLjciIHkyPSI1OS4yNiIvPjxsaW5lIGNsYXNzPSJjbHMtMTAiIHgxPSI2Mi45MyIgeTE9IjU5LjI2IiB4Mj0iNzIuNiIgeTI9IjU5LjI2Ii8+PGxpbmUgY2xhc3M9ImNscy0xMCIgeDE9Ijc5LjE2IiB5MT0iNzAuMDMiIHgyPSIxNzUuNTkiIHkyPSI3MC4wMyIvPjxsaW5lIGNsYXNzPSJjbHMtMTAiIHgxPSI2Mi45MyIgeTE9IjcwLjAzIiB4Mj0iNzIuNiIgeTI9IjcwLjAzIi8+PGxpbmUgY2xhc3M9ImNscy0xMSIgeDE9Ijc5LjE2IiB5MT0iODAuNzkiIHgyPSIxMTcuMjQiIHkyPSI4MC43OSIvPjxsaW5lIGNsYXNzPSJjbHMtMTAiIHgxPSI2Mi45MyIgeTE9IjgwLjc5IiB4Mj0iNzIuNiIgeTI9IjgwLjc5Ii8+PGxpbmUgY2xhc3M9ImNscy0xMyIgeDE9Ijc5LjE2IiB5MT0iOTEuNTYiIHgyPSIxNDkuMDYiIHkyPSI5MS41NiIvPjxsaW5lIGNsYXNzPSJjbHMtMTAiIHgxPSI2Mi45MyIgeTE9IjkxLjU2IiB4Mj0iNzIuNiIgeTI9IjkxLjU2Ii8+PGxpbmUgY2xhc3M9ImNscy0xMCIgeDE9IjYyLjkzIiB5MT0iODAuNzkiIHgyPSI3Mi42IiB5Mj0iODAuNzkiLz48bGluZSBjbGFzcz0iY2xzLTEwIiB4MT0iNjIuOTMiIHkxPSI5MS41NiIgeDI9IjcyLjYiIHkyPSI5MS41NiIvPjxsaW5lIGNsYXNzPSJjbHMtMTEiIHgxPSI3OS4xNiIgeTE9IjEwMi4zMyIgeDI9IjExNy4yNCIgeTI9IjEwMi4zMyIvPjxsaW5lIGNsYXNzPSJjbHMtMTAiIHgxPSI2Mi45MyIgeTE9IjEwMi4zMyIgeDI9IjcyLjYiIHkyPSIxMDIuMzMiLz48bGluZSBjbGFzcz0iY2xzLTEwIiB4MT0iMTI1Ljk4IiB5MT0iMTEzLjEiIHgyPSIxNDkuMDYiIHkyPSIxMTMuMSIvPjxsaW5lIGNsYXNzPSJjbHMtMTIiIHgxPSI3OS4xNiIgeTE9IjExMy4xIiB4Mj0iMTE3LjI0IiB5Mj0iMTEzLjEiLz48bGluZSBjbGFzcz0iY2xzLTEwIiB4MT0iNjIuOTMiIHkxPSIxMTMuMSIgeDI9IjcyLjYiIHkyPSIxMTMuMSIvPjwvZz48L2c+PC9zdmc+'",
-        "body": "\nEndpoints that return collections of objects should always apply pagination.\nPaginated collections are always wrapped in the following wrapper object:\n\n```json\n{\n  \"size\": 5421,\n  \"page\": 2,\n  \"pagelen\": 10,\n  \"next\": \"https://api.bitbucket.org/2.0/repositories/pypy/pypy/commits?page=3\",\n  \"previous\": \"https://api.bitbucket.org/2.0/repositories/pypy/pypy/commits?page=1\",\n  \"values\": [\n    ...\n  ]\n}\n```\n\nPagination is often page-bound, with a query parameter page indicating which\npage is to be returned.\n\nHowever, clients are not expected to construct URLs themselves by manipulating\nthe page number query parameter. Instead, the response contains a link to the\nnext page. This link should be treated as an opaque location that is not to be\nconstructed by clients or even assumed to be predictable. The only contract\naround the next link is that it will return the next chunk of results.\n\nLack of a next link in the response indicates the end of the collection.\n\nThe paginated response contains the following fields:\n\n| Field      | Value    |\n|------------|----------|\n| `size`     | Total number of objects in the response. This is an optional element that is not provided in all responses, as it can be expensive to compute. |\n| `page`     | Page number of the current results. This is an optional element that is not provided in all responses. |\n| `pagelen`  | Current number of objects on the existing page. Globally, the minimum length is 10 and the maximum is 100. Some APIs may specify a different default. |\n| `next`     | Link to the next page if it exists. The last page of a collection does not have this value. Use this link to navigate the result set and refrain from constructing your own URLs. |\n| `previous` | Link to previous page if it exists. A collections first page does not have this value. This is an optional element that is not provided in all responses. Some result sets strictly support forward navigation and never provide previous links. Clients must anticipate that backwards navigation is not always available. Use this link to navigate the result set and refrain from constructing your own URLs. |\n| `values`   | The list of objects. This contains at most `pagelen` objects. |\n\nThe link to the next page is included such that you don't have to hardcode or construct any links.  Only values and next are guaranteed (except the last page, which lacks next). This is because the previous and size values can be expensive for some data sets.\n\nIt is important to realize that Bitbucket support both list-based pagination and iterator-based pagination. List-based pagination assumes that the collection is a discrete, immutable, consistently ordered, finite array of objects with a fixed size. Clients navigate a list-based collection by requesting offset-based chunks. In Bitbucket Cloud, list-based responses include the optional size, page, and previous element. The next and previous links typically resemble something like /foo/bar?page=4.\n\nHowever, not all result sets can be treated as immutable and finite – much like how programming languages tend to distinguish between lists and arrays on one hand and iterators or stream on the other. Where an list-based pagination offers random access into any point in a collection, iterator-based pagination can only navigate forward one element at a time. In Bitbucket such iterator-based pagination contains the next link and pagelen elements, but not necessarily anything else. In these cases, the next link's value often contains an unpredictable hash instead of an explicit page number. The commits resource uses iterator-based pagination.\n"
+        "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB2aWV3Qm94PSIwIDAgMjM4LjgyIDE1MS42Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2IyZDRmZjt9LmNscy0ye2ZpbGw6IzRjOWFmZjt9LmNscy0ze2ZpbGw6IzAwNTJjYzt9LmNscy00e29wYWNpdHk6MC42O30uY2xzLTV7ZmlsbDp1cmwoI2xpbmVhci1ncmFkaWVudCk7fS5jbHMtNntmaWxsOnVybCgjbGluZWFyLWdyYWRpZW50LTIpO30uY2xzLTd7ZmlsbDp1cmwoI2xpbmVhci1ncmFkaWVudC0zKTt9LmNscy04e2ZpbGw6dXJsKCNsaW5lYXItZ3JhZGllbnQtNCk7fS5jbHMtOXtmaWxsOnVybCgjbGluZWFyLWdyYWRpZW50LTUpO30uY2xzLTEwLC5jbHMtMTEsLmNscy0xMntmaWxsOm5vbmU7fS5jbHMtMTB7c3Ryb2tlOiMzMzg0ZmY7fS5jbHMtMTAsLmNscy0xMSwuY2xzLTEyLC5jbHMtMTN7c3Ryb2tlLW1pdGVybGltaXQ6MTA7c3Ryb2tlLXdpZHRoOjJweDt9LmNscy0xMXtzdHJva2U6I2ZmYWIwMDt9LmNscy0xMntzdHJva2U6I2ZhZmJmYzt9LmNscy0xM3tmaWxsOiNmZmFiMDA7c3Ryb2tlOiMyNjg0ZmY7fTwvc3R5bGU+PGxpbmVhckdyYWRpZW50IGlkPSJsaW5lYXItZ3JhZGllbnQiIHkxPSI2NS4xNyIgeDI9Ijg2LjM4IiB5Mj0iNjUuMTciIGdyYWRpZW50VW5pdHM9InVzZXJTcGFjZU9uVXNlIj48c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiM0YzlhZmYiLz48c3RvcCBvZmZzZXQ9IjAuMDgiIHN0b3AtY29sb3I9IiM0YzlhZmYiIHN0b3Atb3BhY2l0eT0iMC45NCIvPjxzdG9wIG9mZnNldD0iMC4yNCIgc3RvcC1jb2xvcj0iIzRjOWFmZiIgc3RvcC1vcGFjaXR5PSIwLjc4Ii8+PHN0b3Agb2Zmc2V0PSIwLjQ1IiBzdG9wLWNvbG9yPSIjNGM5YWZmIiBzdG9wLW9wYWNpdHk9IjAuNTMiLz48c3RvcCBvZmZzZXQ9IjAuNTUiIHN0b3AtY29sb3I9IiM0YzlhZmYiIHN0b3Atb3BhY2l0eT0iMC40Ii8+PC9saW5lYXJHcmFkaWVudD48bGluZWFyR3JhZGllbnQgaWQ9ImxpbmVhci1ncmFkaWVudC0yIiB4MT0iMTUyLjQ0IiB5MT0iNjUuMTciIHgyPSIyMzguODIiIHkyPSI2NS4xNyIgeGxpbms6aHJlZj0iI2xpbmVhci1ncmFkaWVudCIvPjxsaW5lYXJHcmFkaWVudCBpZD0ibGluZWFyLWdyYWRpZW50LTMiIHgxPSIxOC44NSIgeTE9IjExOC43OCIgeDI9IjEyNi4wOCIgeTI9IjExLjU2IiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSI+PHN0b3Agb2Zmc2V0PSIwLjA2IiBzdG9wLWNvbG9yPSIjMDA2NWZmIi8+PHN0b3Agb2Zmc2V0PSIwLjE5IiBzdG9wLWNvbG9yPSIjMDA2NWZmIiBzdG9wLW9wYWNpdHk9IjAuOTQiLz48c3RvcCBvZmZzZXQ9IjAuNDYiIHN0b3AtY29sb3I9IiMwMDY1ZmYiIHN0b3Atb3BhY2l0eT0iMC43OCIvPjxzdG9wIG9mZnNldD0iMC44MiIgc3RvcC1jb2xvcj0iIzAwNjVmZiIgc3RvcC1vcGFjaXR5PSIwLjUzIi8+PHN0b3Agb2Zmc2V0PSIxIiBzdG9wLWNvbG9yPSIjMDA2NWZmIiBzdG9wLW9wYWNpdHk9IjAuNCIvPjwvbGluZWFyR3JhZGllbnQ+PGxpbmVhckdyYWRpZW50IGlkPSJsaW5lYXItZ3JhZGllbnQtNCIgeDE9IjExMi43NSIgeTE9IjExOC43OCIgeDI9IjIxOS45NyIgeTI9IjExLjU2IiB4bGluazpocmVmPSIjbGluZWFyLWdyYWRpZW50LTMiLz48bGluZWFyR3JhZGllbnQgaWQ9ImxpbmVhci1ncmFkaWVudC01IiB4MT0iNTAuOTciIHkxPSIxMzMuNjEiIHgyPSIxODcuODYiIHkyPSItMy4yOCIgZ3JhZGllbnRVbml0cz0idXNlclNwYWNlT25Vc2UiPjxzdG9wIG9mZnNldD0iMC42NiIgc3RvcC1jb2xvcj0iIzI1Mzg1OCIvPjxzdG9wIG9mZnNldD0iMC44OCIgc3RvcC1jb2xvcj0iIzI1Mzg1OCIgc3RvcC1vcGFjaXR5PSIwLjgzIi8+PHN0b3Agb2Zmc2V0PSIxIiBzdG9wLWNvbG9yPSIjMjUzODU4IiBzdG9wLW9wYWNpdHk9IjAuNyIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjx0aXRsZT5WaWV3IFZlcnNpb25zPC90aXRsZT48ZyBpZD0iTGF5ZXJfMiIgZGF0YS1uYW1lPSJMYXllciAyIj48ZyBpZD0iU29mdHdhcmUiPjxjaXJjbGUgY2xhc3M9ImNscy0xIiBjeD0iOTQuNTMiIGN5PSIxNDcuOTMiIHI9IjMuNjciLz48Y2lyY2xlIGNsYXNzPSJjbHMtMiIgY3g9IjEwNi45NCIgY3k9IjE0Ny45MyIgcj0iMy42NyIvPjxjaXJjbGUgY2xhc3M9ImNscy0zIiBjeD0iMTE5LjM0IiBjeT0iMTQ3LjkzIiByPSIzLjY3Ii8+PGNpcmNsZSBjbGFzcz0iY2xzLTIiIGN4PSIxMzEuNzUiIGN5PSIxNDcuOTMiIHI9IjMuNjciLz48Y2lyY2xlIGNsYXNzPSJjbHMtMSIgY3g9IjE0NC4xNiIgY3k9IjE0Ny45MyIgcj0iMy42NyIvPjxnIGNsYXNzPSJjbHMtNCI+PHJlY3QgaWQ9Il9SZWN0YW5nbGVfIiBkYXRhLW5hbWU9IiZsdDtSZWN0YW5nbGUmZ3Q7IiBjbGFzcz0iY2xzLTUiIHk9IjI1LjkyIiB3aWR0aD0iODYuMzgiIGhlaWdodD0iNzguNDkiLz48L2c+PGcgY2xhc3M9ImNscy00Ij48cmVjdCBpZD0iX1JlY3RhbmdsZV8yIiBkYXRhLW5hbWU9IiZsdDtSZWN0YW5nbGUmZ3Q7IiBjbGFzcz0iY2xzLTYiIHg9IjE1Mi40NCIgeT0iMjUuOTIiIHdpZHRoPSI4Ni4zOCIgaGVpZ2h0PSI3OC40OSIvPjwvZz48cmVjdCBpZD0iX1JlY3RhbmdsZV8zIiBkYXRhLW5hbWU9IiZsdDtSZWN0YW5nbGUmZ3Q7IiBjbGFzcz0iY2xzLTciIHg9IjE2LjI4IiB5PSIxNC4xMiIgd2lkdGg9IjExMi4zNiIgaGVpZ2h0PSIxMDIuMDkiLz48cmVjdCBpZD0iX1JlY3RhbmdsZV80IiBkYXRhLW5hbWU9IiZsdDtSZWN0YW5nbGUmZ3Q7IiBjbGFzcz0iY2xzLTgiIHg9IjExMC4xOCIgeT0iMTQuMTIiIHdpZHRoPSIxMTIuMzYiIGhlaWdodD0iMTAyLjA5Ii8+PHJlY3QgaWQ9Il9SZWN0YW5nbGVfNSIgZGF0YS1uYW1lPSImbHQ7UmVjdGFuZ2xlJmd0OyIgY2xhc3M9ImNscy05IiB4PSI0Ny42OSIgd2lkdGg9IjE0My40NSIgaGVpZ2h0PSIxMzAuMzQiLz48bGluZSBjbGFzcz0iY2xzLTEwIiB4MT0iNzkuMTYiIHkxPSIxNi4xOCIgeDI9IjExNy4yNCIgeTI9IjE2LjE4Ii8+PGxpbmUgY2xhc3M9ImNscy0xMCIgeDE9IjYyLjkzIiB5MT0iMTYuMTgiIHgyPSI3Mi42IiB5Mj0iMTYuMTgiLz48bGluZSBjbGFzcz0iY2xzLTExIiB4MT0iNzkuMTYiIHkxPSIyNi45NSIgeDI9IjExNy4yNCIgeTI9IjI2Ljk1Ii8+PGxpbmUgY2xhc3M9ImNscy0xMCIgeDE9IjYyLjkzIiB5MT0iMjYuOTUiIHgyPSI3Mi42IiB5Mj0iMjYuOTUiLz48bGluZSBjbGFzcz0iY2xzLTEwIiB4MT0iNzkuMTYiIHkxPSIzNy43MiIgeDI9IjE1MC43IiB5Mj0iMzcuNzIiLz48bGluZSBjbGFzcz0iY2xzLTEwIiB4MT0iNjIuOTMiIHkxPSIzNy43MiIgeDI9IjcyLjYiIHkyPSIzNy43MiIvPjxsaW5lIGNsYXNzPSJjbHMtMTEiIHgxPSIxNTAuNyIgeTE9IjQ4LjQ5IiB4Mj0iMTc1LjU5IiB5Mj0iNDguNDkiLz48bGluZSBjbGFzcz0iY2xzLTEyIiB4MT0iMTEwLjMyIiB5MT0iNDguNDkiIHgyPSIxNDMuMDUiIHkyPSI0OC40OSIvPjxsaW5lIGNsYXNzPSJjbHMtMTEiIHgxPSI3OS4xNiIgeTE9IjQ4LjQ5IiB4Mj0iMTAxLjM3IiB5Mj0iNDguNDkiLz48bGluZSBjbGFzcz0iY2xzLTEwIiB4MT0iNjIuOTMiIHkxPSI0OC40OSIgeDI9IjcyLjYiIHkyPSI0OC40OSIvPjxsaW5lIGNsYXNzPSJjbHMtMTAiIHgxPSI3OS4xNiIgeTE9IjU5LjI2IiB4Mj0iMTUwLjciIHkyPSI1OS4yNiIvPjxsaW5lIGNsYXNzPSJjbHMtMTAiIHgxPSI2Mi45MyIgeTE9IjU5LjI2IiB4Mj0iNzIuNiIgeTI9IjU5LjI2Ii8+PGxpbmUgY2xhc3M9ImNscy0xMCIgeDE9Ijc5LjE2IiB5MT0iNzAuMDMiIHgyPSIxNzUuNTkiIHkyPSI3MC4wMyIvPjxsaW5lIGNsYXNzPSJjbHMtMTAiIHgxPSI2Mi45MyIgeTE9IjcwLjAzIiB4Mj0iNzIuNiIgeTI9IjcwLjAzIi8+PGxpbmUgY2xhc3M9ImNscy0xMSIgeDE9Ijc5LjE2IiB5MT0iODAuNzkiIHgyPSIxMTcuMjQiIHkyPSI4MC43OSIvPjxsaW5lIGNsYXNzPSJjbHMtMTAiIHgxPSI2Mi45MyIgeTE9IjgwLjc5IiB4Mj0iNzIuNiIgeTI9IjgwLjc5Ii8+PGxpbmUgY2xhc3M9ImNscy0xMyIgeDE9Ijc5LjE2IiB5MT0iOTEuNTYiIHgyPSIxNDkuMDYiIHkyPSI5MS41NiIvPjxsaW5lIGNsYXNzPSJjbHMtMTAiIHgxPSI2Mi45MyIgeTE9IjkxLjU2IiB4Mj0iNzIuNiIgeTI9IjkxLjU2Ii8+PGxpbmUgY2xhc3M9ImNscy0xMCIgeDE9IjYyLjkzIiB5MT0iODAuNzkiIHgyPSI3Mi42IiB5Mj0iODAuNzkiLz48bGluZSBjbGFzcz0iY2xzLTEwIiB4MT0iNjIuOTMiIHkxPSI5MS41NiIgeDI9IjcyLjYiIHkyPSI5MS41NiIvPjxsaW5lIGNsYXNzPSJjbHMtMTEiIHgxPSI3OS4xNiIgeTE9IjEwMi4zMyIgeDI9IjExNy4yNCIgeTI9IjEwMi4zMyIvPjxsaW5lIGNsYXNzPSJjbHMtMTAiIHgxPSI2Mi45MyIgeTE9IjEwMi4zMyIgeDI9IjcyLjYiIHkyPSIxMDIuMzMiLz48bGluZSBjbGFzcz0iY2xzLTEwIiB4MT0iMTI1Ljk4IiB5MT0iMTEzLjEiIHgyPSIxNDkuMDYiIHkyPSIxMTMuMSIvPjxsaW5lIGNsYXNzPSJjbHMtMTIiIHgxPSI3OS4xNiIgeTE9IjExMy4xIiB4Mj0iMTE3LjI0IiB5Mj0iMTEzLjEiLz48bGluZSBjbGFzcz0iY2xzLTEwIiB4MT0iNjIuOTMiIHkxPSIxMTMuMSIgeDI9IjcyLjYiIHkyPSIxMTMuMSIvPjwvZz48L2c+PC9zdmc+",
+        "body": "\nEndpoints that return collections of objects should always apply pagination.\nPaginated collections are always wrapped in the following wrapper object:\n\n```json\n{\n  \"size\": 5421,\n  \"page\": 2,\n  \"pagelen\": 10,\n  \"next\": \"https://api.bitbucket.org/2.0/repositories/pypy/pypy/commits?page=3\",\n  \"previous\": \"https://api.bitbucket.org/2.0/repositories/pypy/pypy/commits?page=1\",\n  \"values\": [\n    ...\n  ]\n}\n```\n\nPagination is often page-bound, with a query parameter page indicating which\npage is to be returned.\n\nHowever, clients are not expected to construct URLs themselves by manipulating\nthe page number query parameter. Instead, the response contains a link to the\nnext page. This link should be treated as an opaque location that is not to be\nconstructed by clients or even assumed to be predictable. The only contract\naround the next link is that it will return the next chunk of results.\n\nLack of a next link in the response indicates the end of the collection.\n\nThe paginated response contains the following fields:\n\n| Field      | Value    |\n|------------|----------|\n| `size`     | Total number of objects in the response. This is an optional element that is not provided in all responses, as it can be expensive to compute. |\n| `page`     | Page number of the current results. This is an optional element that is not provided in all responses. |\n| `pagelen`  | Current number of objects on the existing page. Globally, the minimum length is 10 and the maximum is 100. Some APIs may specify a different default. |\n| `next`     | Link to the next page if it exists. The last page of a collection does not have this value. Use this link to navigate the result set and refrain from constructing your own URLs. |\n| `previous` | Link to previous page if it exists. A collections first page does not have this value. This is an optional element that is not provided in all responses. Some result sets strictly support forward navigation and never provide previous links. Clients must anticipate that backwards navigation is not always available. Use this link to navigate the result set and refrain from constructing your own URLs. |\n| `values`   | The list of objects. This contains at most `pagelen` objects. |\n\nThe link to the next page is included such that you don't have to hardcode or construct any links.  Only values and next are guaranteed (except the last page, which lacks next). This is because the previous and size values can be expensive for some data sets.\n\nIt is important to realize that Bitbucket support both list-based pagination and iterator-based pagination. List-based pagination assumes that the collection is a discrete, immutable, consistently ordered, finite array of objects with a fixed size. Clients navigate a list-based collection by requesting offset-based chunks. In Bitbucket Cloud, list-based responses include the optional size, page, and previous element. The the next and previous links typically resemble something like /foo/bar?page=4.\n\nHowever, not all result sets can be treated as immutable and finite – much like how programming languages tend to distinguish between lists and arrays on one hand and iterators or stream on the other. Where an list-based pagination offers random access into any point in a collection, iterator-based pagination can only navigate forward one element at a time. In Bitbucket such iterator-based pagination contains the next link and pagelen elements, but not necessarily anything else. In these cases, the next link's value often contains an unpredictable hash instead of an explicit page number. The commits resource uses iterator-based pagination.\n"
       },
       {
         "anchor": "partial-response",
         "title": "Partial responses",
         "description": "Tweak which fields are returned",
-        "icon": "data:image/svg+xml;base64,b'PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB2aWV3Qm94PSIwIDAgMTYyLjQ0ODcgMjEwLjExMTUiPgogIDxkZWZzPgogICAgPHN0eWxlPgogICAgICAuY2xzLTEgewogICAgICAgIGlzb2xhdGlvbjogaXNvbGF0ZTsKICAgICAgfQoKICAgICAgLmNscy0yLCAuY2xzLTYsIC5jbHMtOCB7CiAgICAgICAgZmlsbDogbm9uZTsKICAgICAgfQoKICAgICAgLmNscy0yLCAuY2xzLTggewogICAgICAgIHN0cm9rZTogIzAwNjVmZjsKICAgICAgICBzdHJva2Utd2lkdGg6IDJweDsKICAgICAgfQoKICAgICAgLmNscy0yIHsKICAgICAgICBzdHJva2UtbGluZWpvaW46IHJvdW5kOwogICAgICB9CgogICAgICAuY2xzLTMgewogICAgICAgIGZpbGw6ICNlN2U4ZWM7CiAgICAgIH0KCiAgICAgIC5jbHMtNCB7CiAgICAgICAgZmlsbDogI2ZmZTM4MDsKICAgICAgfQoKICAgICAgLmNscy01IHsKICAgICAgICBmaWxsOiAjZmZmMGIyOwogICAgICB9CgogICAgICAuY2xzLTYgewogICAgICAgIHN0cm9rZTogI2ZmOTkxZjsKICAgICAgICBzdHJva2Utd2lkdGg6IDEuODE1NnB4OwogICAgICB9CgogICAgICAuY2xzLTYsIC5jbHMtOCB7CiAgICAgICAgc3Ryb2tlLW1pdGVybGltaXQ6IDEwOwogICAgICB9CgogICAgICAuY2xzLTcgewogICAgICAgIG1peC1ibGVuZC1tb2RlOiBtdWx0aXBseTsKICAgICAgICBmaWxsOiB1cmwoI2xpbmVhci1ncmFkaWVudCk7CiAgICAgIH0KCiAgICAgIC5jbHMtOSB7CiAgICAgICAgZmlsbDogI2Y0ZjVmNzsKICAgICAgfQogICAgPC9zdHlsZT4KICAgIDxsaW5lYXJHcmFkaWVudCBpZD0ibGluZWFyLWdyYWRpZW50IiB4MT0iMTEzLjM4MTgiIHkxPSI0OS40MyIgeDI9IjE1My43ODkzIiB5Mj0iOS4wMjI1IiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSI+CiAgICAgIDxzdG9wIG9mZnNldD0iMCIgc3RvcC1jb2xvcj0iI2ZhZmJmYyIvPgogICAgICA8c3RvcCBvZmZzZXQ9IjAuMjc4NiIgc3RvcC1jb2xvcj0iI2VmZjFmMyIvPgogICAgICA8c3RvcCBvZmZzZXQ9IjAuNzY4OCIgc3RvcC1jb2xvcj0iI2QxZDZkZCIvPgogICAgICA8c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiNjMWM3ZDAiLz4KICAgIDwvbGluZWFyR3JhZGllbnQ+CiAgPC9kZWZzPgogIDx0aXRsZT5Eb2N1bWVudCBUYWJsZTwvdGl0bGU+CiAgPGcgY2xhc3M9ImNscy0xIj4KICAgIDxnIGlkPSJMYXllcl8yIiBkYXRhLW5hbWU9IkxheWVyIDIiPgogICAgICA8ZyBpZD0iT2JqZWN0cyI+CiAgICAgICAgPGxpbmUgY2xhc3M9ImNscy0yIiB4MT0iMTcuNDcxIiB5MT0iMTcxLjc1NzMiIHgyPSI3OS4yOTgiIHkyPSIxNzEuNzU3MyIvPgogICAgICAgIDxwb2x5Z29uIGlkPSJfUGF0aF8iIGRhdGEtbmFtZT0iJmx0O1BhdGgmZ3Q7IiBjbGFzcz0iY2xzLTMiIHBvaW50cz0iMTYyLjQ0NSAzOC43MTEgMTYyLjQ0NSAyMTAuMTExIDAgMjEwLjExMSAwIDAgMTIzLjcwNCAwIDE2Mi40MTUgMzguNzExIDE2Mi40NDUgMzguNzExIi8+CiAgICAgICAgPHJlY3QgY2xhc3M9ImNscy00IiB4PSIxOC45MTE3IiB5PSI3OC4xNTQyIiB3aWR0aD0iNDcuODQ4NSIgaGVpZ2h0PSI3OS42NTM3Ii8+CiAgICAgICAgPHJlY3QgY2xhc3M9ImNscy01IiB4PSIxOC45MTE3IiB5PSI1MS42MDMiIHdpZHRoPSIxMjMuNDUyOSIgaGVpZ2h0PSIyNi41NTEyIi8+CiAgICAgICAgPHJlY3QgY2xhc3M9ImNscy02IiB4PSIxOC45MTE3IiB5PSI1MS42MDMiIHdpZHRoPSIxMjMuNDUyOSIgaGVpZ2h0PSIxMDYuMjA0OSIvPgogICAgICAgIDxsaW5lIGNsYXNzPSJjbHMtNiIgeDE9IjY2Ljc2MDEiIHkxPSI1MS42MDMiIHgyPSI2Ni43NjAxIiB5Mj0iMTU3LjgwNzkiLz4KICAgICAgICA8bGluZSBjbGFzcz0iY2xzLTYiIHgxPSI5MS4zMjg0IiB5MT0iNTEuNjAzIiB4Mj0iOTEuMzI4NCIgeTI9IjE1Ny44MDc5Ii8+CiAgICAgICAgPGxpbmUgY2xhc3M9ImNscy02IiB4MT0iMTE1Ljg5NjciIHkxPSI1MS42MDMiIHgyPSIxMTUuODk2NyIgeTI9IjE1Ny44MDc5Ii8+CiAgICAgICAgPGxpbmUgY2xhc3M9ImNscy02IiB4MT0iMTguOTExNyIgeTE9Ijc4LjE1NDIiIHgyPSIxNDIuMzY0NiIgeTI9Ijc4LjE1NDIiLz4KICAgICAgICA8bGluZSBjbGFzcz0iY2xzLTYiIHgxPSIxOC45MTE3IiB5MT0iMTA0LjcwNTUiIHgyPSIxNDIuMzY0NiIgeTI9IjEwNC43MDU1Ii8+CiAgICAgICAgPGxpbmUgY2xhc3M9ImNscy02IiB4MT0iMTguOTExNyIgeTE9IjEzMS4yNTY3IiB4Mj0iMTQyLjM2NDYiIHkyPSIxMzEuMjU2NyIvPgogICAgICAgIDxwb2x5Z29uIGNsYXNzPSJjbHMtNyIgcG9pbnRzPSIxNjIuNDQ1IDM4LjcxMSAxNjIuNDE1IDM4LjcxMSAxMjMuODcyIDAuMTY5IDEyMy44NzIgNTkuOTIxIDE2Mi40NDUgMzkuMTM3IDE2Mi40NDUgMzguNzExIi8+CiAgICAgICAgPGxpbmUgY2xhc3M9ImNscy04IiB4MT0iMTguMzk3MyIgeTE9IjE4MS4zNDQiIHgyPSI3OS4xMTM1IiB5Mj0iMTgxLjM0NCIvPgogICAgICAgIDxsaW5lIGNsYXNzPSJjbHMtOCIgeDE9IjE4LjM5NzMiIHkxPSIxOTAuOTMwNiIgeDI9IjUxLjMwNDkiIHkyPSIxOTAuOTMwNiIvPgogICAgICAgIDxsaW5lIGNsYXNzPSJjbHMtOCIgeDE9IjE4LjM5NzMiIHkxPSIxNzEuNzU3MyIgeDI9Ijc5LjExMzUiIHkyPSIxNzEuNzU3MyIvPgogICAgICAgIDxsaW5lIGNsYXNzPSJjbHMtOCIgeDE9IjE4LjM5NzMiIHkxPSIzNi4xNzA1IiB4Mj0iNzkuMTEzNSIgeTI9IjM2LjE3MDUiLz4KICAgICAgICA8bGluZSBjbGFzcz0iY2xzLTgiIHgxPSIxOC4zOTczIiB5MT0iMjYuNTgzOCIgeDI9Ijc5LjExMzUiIHkyPSIyNi41ODM4Ii8+CiAgICAgICAgPHBvbHlnb24gY2xhc3M9ImNscy05IiBwb2ludHM9IjE2Mi40NDkgMzguNzQyIDEyMy43MDcgMzguNzQyIDEyMy43MDcgMCAxNjIuNDQ5IDM4Ljc0MiIvPgogICAgICA8L2c+CiAgICA8L2c+CiAgPC9nPgo8L3N2Zz4K'",
+        "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB2aWV3Qm94PSIwIDAgMTYyLjQ0ODcgMjEwLjExMTUiPgogIDxkZWZzPgogICAgPHN0eWxlPgogICAgICAuY2xzLTEgewogICAgICAgIGlzb2xhdGlvbjogaXNvbGF0ZTsKICAgICAgfQoKICAgICAgLmNscy0yLCAuY2xzLTYsIC5jbHMtOCB7CiAgICAgICAgZmlsbDogbm9uZTsKICAgICAgfQoKICAgICAgLmNscy0yLCAuY2xzLTggewogICAgICAgIHN0cm9rZTogIzAwNjVmZjsKICAgICAgICBzdHJva2Utd2lkdGg6IDJweDsKICAgICAgfQoKICAgICAgLmNscy0yIHsKICAgICAgICBzdHJva2UtbGluZWpvaW46IHJvdW5kOwogICAgICB9CgogICAgICAuY2xzLTMgewogICAgICAgIGZpbGw6ICNlN2U4ZWM7CiAgICAgIH0KCiAgICAgIC5jbHMtNCB7CiAgICAgICAgZmlsbDogI2ZmZTM4MDsKICAgICAgfQoKICAgICAgLmNscy01IHsKICAgICAgICBmaWxsOiAjZmZmMGIyOwogICAgICB9CgogICAgICAuY2xzLTYgewogICAgICAgIHN0cm9rZTogI2ZmOTkxZjsKICAgICAgICBzdHJva2Utd2lkdGg6IDEuODE1NnB4OwogICAgICB9CgogICAgICAuY2xzLTYsIC5jbHMtOCB7CiAgICAgICAgc3Ryb2tlLW1pdGVybGltaXQ6IDEwOwogICAgICB9CgogICAgICAuY2xzLTcgewogICAgICAgIG1peC1ibGVuZC1tb2RlOiBtdWx0aXBseTsKICAgICAgICBmaWxsOiB1cmwoI2xpbmVhci1ncmFkaWVudCk7CiAgICAgIH0KCiAgICAgIC5jbHMtOSB7CiAgICAgICAgZmlsbDogI2Y0ZjVmNzsKICAgICAgfQogICAgPC9zdHlsZT4KICAgIDxsaW5lYXJHcmFkaWVudCBpZD0ibGluZWFyLWdyYWRpZW50IiB4MT0iMTEzLjM4MTgiIHkxPSI0OS40MyIgeDI9IjE1My43ODkzIiB5Mj0iOS4wMjI1IiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSI+CiAgICAgIDxzdG9wIG9mZnNldD0iMCIgc3RvcC1jb2xvcj0iI2ZhZmJmYyIvPgogICAgICA8c3RvcCBvZmZzZXQ9IjAuMjc4NiIgc3RvcC1jb2xvcj0iI2VmZjFmMyIvPgogICAgICA8c3RvcCBvZmZzZXQ9IjAuNzY4OCIgc3RvcC1jb2xvcj0iI2QxZDZkZCIvPgogICAgICA8c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiNjMWM3ZDAiLz4KICAgIDwvbGluZWFyR3JhZGllbnQ+CiAgPC9kZWZzPgogIDx0aXRsZT5Eb2N1bWVudCBUYWJsZTwvdGl0bGU+CiAgPGcgY2xhc3M9ImNscy0xIj4KICAgIDxnIGlkPSJMYXllcl8yIiBkYXRhLW5hbWU9IkxheWVyIDIiPgogICAgICA8ZyBpZD0iT2JqZWN0cyI+CiAgICAgICAgPGxpbmUgY2xhc3M9ImNscy0yIiB4MT0iMTcuNDcxIiB5MT0iMTcxLjc1NzMiIHgyPSI3OS4yOTgiIHkyPSIxNzEuNzU3MyIvPgogICAgICAgIDxwb2x5Z29uIGlkPSJfUGF0aF8iIGRhdGEtbmFtZT0iJmx0O1BhdGgmZ3Q7IiBjbGFzcz0iY2xzLTMiIHBvaW50cz0iMTYyLjQ0NSAzOC43MTEgMTYyLjQ0NSAyMTAuMTExIDAgMjEwLjExMSAwIDAgMTIzLjcwNCAwIDE2Mi40MTUgMzguNzExIDE2Mi40NDUgMzguNzExIi8+CiAgICAgICAgPHJlY3QgY2xhc3M9ImNscy00IiB4PSIxOC45MTE3IiB5PSI3OC4xNTQyIiB3aWR0aD0iNDcuODQ4NSIgaGVpZ2h0PSI3OS42NTM3Ii8+CiAgICAgICAgPHJlY3QgY2xhc3M9ImNscy01IiB4PSIxOC45MTE3IiB5PSI1MS42MDMiIHdpZHRoPSIxMjMuNDUyOSIgaGVpZ2h0PSIyNi41NTEyIi8+CiAgICAgICAgPHJlY3QgY2xhc3M9ImNscy02IiB4PSIxOC45MTE3IiB5PSI1MS42MDMiIHdpZHRoPSIxMjMuNDUyOSIgaGVpZ2h0PSIxMDYuMjA0OSIvPgogICAgICAgIDxsaW5lIGNsYXNzPSJjbHMtNiIgeDE9IjY2Ljc2MDEiIHkxPSI1MS42MDMiIHgyPSI2Ni43NjAxIiB5Mj0iMTU3LjgwNzkiLz4KICAgICAgICA8bGluZSBjbGFzcz0iY2xzLTYiIHgxPSI5MS4zMjg0IiB5MT0iNTEuNjAzIiB4Mj0iOTEuMzI4NCIgeTI9IjE1Ny44MDc5Ii8+CiAgICAgICAgPGxpbmUgY2xhc3M9ImNscy02IiB4MT0iMTE1Ljg5NjciIHkxPSI1MS42MDMiIHgyPSIxMTUuODk2NyIgeTI9IjE1Ny44MDc5Ii8+CiAgICAgICAgPGxpbmUgY2xhc3M9ImNscy02IiB4MT0iMTguOTExNyIgeTE9Ijc4LjE1NDIiIHgyPSIxNDIuMzY0NiIgeTI9Ijc4LjE1NDIiLz4KICAgICAgICA8bGluZSBjbGFzcz0iY2xzLTYiIHgxPSIxOC45MTE3IiB5MT0iMTA0LjcwNTUiIHgyPSIxNDIuMzY0NiIgeTI9IjEwNC43MDU1Ii8+CiAgICAgICAgPGxpbmUgY2xhc3M9ImNscy02IiB4MT0iMTguOTExNyIgeTE9IjEzMS4yNTY3IiB4Mj0iMTQyLjM2NDYiIHkyPSIxMzEuMjU2NyIvPgogICAgICAgIDxwb2x5Z29uIGNsYXNzPSJjbHMtNyIgcG9pbnRzPSIxNjIuNDQ1IDM4LjcxMSAxNjIuNDE1IDM4LjcxMSAxMjMuODcyIDAuMTY5IDEyMy44NzIgNTkuOTIxIDE2Mi40NDUgMzkuMTM3IDE2Mi40NDUgMzguNzExIi8+CiAgICAgICAgPGxpbmUgY2xhc3M9ImNscy04IiB4MT0iMTguMzk3MyIgeTE9IjE4MS4zNDQiIHgyPSI3OS4xMTM1IiB5Mj0iMTgxLjM0NCIvPgogICAgICAgIDxsaW5lIGNsYXNzPSJjbHMtOCIgeDE9IjE4LjM5NzMiIHkxPSIxOTAuOTMwNiIgeDI9IjUxLjMwNDkiIHkyPSIxOTAuOTMwNiIvPgogICAgICAgIDxsaW5lIGNsYXNzPSJjbHMtOCIgeDE9IjE4LjM5NzMiIHkxPSIxNzEuNzU3MyIgeDI9Ijc5LjExMzUiIHkyPSIxNzEuNzU3MyIvPgogICAgICAgIDxsaW5lIGNsYXNzPSJjbHMtOCIgeDE9IjE4LjM5NzMiIHkxPSIzNi4xNzA1IiB4Mj0iNzkuMTEzNSIgeTI9IjM2LjE3MDUiLz4KICAgICAgICA8bGluZSBjbGFzcz0iY2xzLTgiIHgxPSIxOC4zOTczIiB5MT0iMjYuNTgzOCIgeDI9Ijc5LjExMzUiIHkyPSIyNi41ODM4Ii8+CiAgICAgICAgPHBvbHlnb24gY2xhc3M9ImNscy05IiBwb2ludHM9IjE2Mi40NDkgMzguNzQyIDEyMy43MDcgMzguNzQyIDEyMy43MDcgMCAxNjIuNDQ5IDM4Ljc0MiIvPgogICAgICA8L2c+CiAgICA8L2c+CiAgPC9nPgo8L3N2Zz4K",
         "body": "\nBy default, each endpoint returns the full representation of a resource and in\nsome cases that can be a lot of data. For example, retrieving a list of pull\nrequests can amount to quite a large document.\n\nFor better performance, you can ask the server to only return the fields you\nreally need and to omit unwanted data. To request a partial response and to\nadd or remove specific fields from a response, use the `fields` query\nparameter.\n\n\n### Example\n\nMost API resources embed a substantial list of links pointing to related\nresources. This saves the client from constructing its own URLs, but is\nsomewhat wasteful when the client doesn't need them.\n\nTo significantly reduce the size of the response, use `?fields=-links`:\n\n```json\n$ curl https://api.bitbucket.org/2.0/users/evzijst?fields=-links\n{\n  \"nickname\": \"evzijst\",\n  \"account_status\": \"active\",\n  \"website\": \"\",\n  \"display_name\": \"Erik van Zijst\",\n  \"uuid\": \"{a288a0ab-e13b-43f0-a689-c4ef0a249875}\",\n  \"created_on\": \"2010-07-07T05:16:36+00:00\",\n  \"location\": null,\n  \"type\": \"user\"\n}\n```\n\n### Fields parameter syntax\n\nThe `fields` parameter supports 3 modes of operation:\n\n1. Removal of select fields (e.g. `-links`)\n2. Pulling in additional fields not normally returned by an endpoint, while\n   still getting all the default fields (e.g. `+reviewers`)\n3. Omitting all fields, except those specified (e.g. `owner.display_name`)\n\nThe fields parameter can contain a list of multiple comma-separated field names\n(e.g. `fields=owner.display_name,uuid,links.self.href`). The parameter itself is\nnot repeated.\n\nAs discussed at [Condensed Versus Full Objects](serialization#representations),\nmost objects that are embedded inside other objects (like how `owner` is an\nembedded `user` object in `repository`) appear in \"condensed\" form that omits\nmany fields. The `fields` parameter allows us to pull in additional fields in\nsuch cases.\n\nFor example, the embedded repository object in a pull request does not normally\ncontain its `owner`. To add that in we can use:\n`+values.destination.repository.owner`.\n\n\n### Wildcards\n\nThe asterisk can be used to match all fields on a particular level. For\nexample, removing all entries from the `links` element can be done like this:\n\n```json\n$ curl https://api.bitbucket.org/2.0/users/evzijst?fields=-links.*\n{\n  \"nickname\": \"evzijst\",\n  \"account_status\": \"active\",\n  \"website\": \"\",\n  \"display_name\": \"Erik van Zijst\",\n  \"uuid\": \"{a288a0ab-e13b-43f0-a689-c4ef0a249875}\",\n  \"links\": {},\n  \"created_on\": \"2010-07-07T05:16:36+00:00\",\n  \"location\": null,\n  \"type\": \"user\"\n}\n```\n\nWildcards can be used in combination with exclusion and inclusion. For\ninstance, `-*,+foo,+bar` will remove all elements from the root level and then\nadd in `foo` and `bar`.\n\n\n### URL encoding\n\nBe aware that when using the `+foo.bar` syntax in the query string, that the\n\"+\" must be URL encoded as \"%2B\" and so the URL will be:\n\n```\nhttps://api.bitbucket.org/2.0/repositories/evzijst/interruptingcow?fields=%2Bowner.created_on\n```\n\nWithout URL escaping, \"+\" is interpreted as an encoded space which will not\nmatch any fields.\n\n\n### Field discovery\n\nWhile a resource's `self` URL, as well its \"collection\" URL typically return\nthe full object with all its fields, there are some exceptions for fields that\nare overly verbose or costly to generate.\n\nFor instance, a pull request contains the embedded lists of reviewers and\nparticipants. These fields are included from the `self` URL, but not from the\n`/pullrequests` collections resource, as it would impact performance too much.\n\nTo discover any additional fields that might not be included by default,\n`fields=*` can be used.\n\n\n### More examples\n\nIf we want to get a list of all reviewer nicknames on pull requests I created,\nwe could combine a [filter](filtering) with a partial response. This will omit\nall other data from the response:\n\n```\n/2.0/repositories/bitbucket/bitbucket/pullrequests?fields=values.id,values.reviewers.nickname,values.state&q=author.uuid%3D%22%7Bd301aafa-d676-4ee0-88be-962be7417567%7D%22\n{\n  \"values\": [\n    {\n      \"reviewers\": [\n        {\n          \"nickname\": \"abhin\"\n        },\n        {\n          \"nickname\": \"dtao\"\n        },\n        {\n          \"nickname\": \"csomme\"\n        }\n      ],\n      \"state\": \"OPEN\",\n      \"id\": 11355\n    },\n    {\n      \"reviewers\": [\n        {\n          \"nickname\": \"csomme\"\n        },\n        {\n          \"nickname\": \"abhin\"\n        },\n        {\n          \"nickname\": \"dstevens\"\n        }\n      ],\n      \"state\": \"MERGED\",\n      \"id\": 11347\n    },\n    {\n      \"reviewers\": [\n        {\n          \"nickname\": \"csomme\"\n        },\n        {\n          \"nickname\": \"jmooring\"\n        },\n        {\n          \"nickname\": \"zdavis\"\n        },\n        {\n          \"nickname\": \"flexbox\"\n        }\n      ],\n      \"state\": \"OPEN\",\n      \"id\": 11344\n    }\n  ]\n}\n```\n"
       },
       {
         "anchor": "serialization",
         "title": "Schemas and Serialization",
         "description": "Learn more about object representations",
-        "icon": "data:image/svg+xml;base64,b'PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMjAuNzYyNCAyMDUuNTg2Ij4KICA8ZGVmcz4KICAgIDxzdHlsZT4KICAgICAgLmNscy0xIHsKICAgICAgICBpc29sYXRpb246IGlzb2xhdGU7CiAgICAgIH0KCiAgICAgIC5jbHMtMiwgLmNscy02IHsKICAgICAgICBtaXgtYmxlbmQtbW9kZTogbXVsdGlwbHk7CiAgICAgIH0KCiAgICAgIC5jbHMtMTMsIC5jbHMtMywgLmNscy00LCAuY2xzLTYgewogICAgICAgIGZpbGw6IG5vbmU7CiAgICAgICAgc3Ryb2tlOiAjYzFjN2QwOwogICAgICAgIHN0cm9rZS1saW5lY2FwOiByb3VuZDsKICAgICAgICBzdHJva2UtbWl0ZXJsaW1pdDogMTA7CiAgICAgICAgc3Ryb2tlLXdpZHRoOiAycHg7CiAgICAgIH0KCiAgICAgIC5jbHMtNCB7CiAgICAgICAgc3Ryb2tlLWRhc2hhcnJheTogMy43ODE2IDUuMjk0MzsKICAgICAgfQoKICAgICAgLmNscy01IHsKICAgICAgICBmaWxsOiAjMDA2NWZmOwogICAgICB9CgogICAgICAuY2xzLTYgewogICAgICAgIHN0cm9rZS1kYXNoYXJyYXk6IDMuOTIxOSA1LjQ5MDc7CiAgICAgIH0KCiAgICAgIC5jbHMtNyB7CiAgICAgICAgZmlsbDogIzAwNTJjYzsKICAgICAgfQoKICAgICAgLmNscy04IHsKICAgICAgICBmaWxsOiAjNGM5YWZmOwogICAgICB9CgogICAgICAuY2xzLTkgewogICAgICAgIGZpbGw6ICMwMDQ5YjA7CiAgICAgIH0KCiAgICAgIC5jbHMtMTAgewogICAgICAgIGZpbGw6ICM1N2Q5YTM7CiAgICAgIH0KCiAgICAgIC5jbHMtMTEgewogICAgICAgIGZpbGw6ICM3OWYyYzA7CiAgICAgIH0KCiAgICAgIC5jbHMtMTIgewogICAgICAgIGZpbGw6ICMzNmIzN2U7CiAgICAgIH0KCiAgICAgIC5jbHMtMTMgewogICAgICAgIHN0cm9rZS1kYXNoYXJyYXk6IDMuODY4MSA1LjQxNTQ7CiAgICAgIH0KCiAgICAgIC5jbHMtMTQgewogICAgICAgIGZpbGw6ICM0MjUyNmU7CiAgICAgIH0KCiAgICAgIC5jbHMtMTUgewogICAgICAgIGZpbGw6ICMzNDQ1NjM7CiAgICAgIH0KCiAgICAgIC5jbHMtMTYgewogICAgICAgIGZpbGw6ICM1MDVmNzk7CiAgICAgIH0KICAgIDwvc3R5bGU+CiAgPC9kZWZzPgogIDx0aXRsZT5JbnRlZ3JhdGlvbnM8L3RpdGxlPgogIDxnIGNsYXNzPSJjbHMtMSI+CiAgICA8ZyBpZD0iTGF5ZXJfMiIgZGF0YS1uYW1lPSJMYXllciAyIj4KICAgICAgPGcgaWQ9Ik9iamVjdHMiPgogICAgICAgIDxnIGNsYXNzPSJjbHMtMiI+CiAgICAgICAgICA8Zz4KICAgICAgICAgICAgPGxpbmUgY2xhc3M9ImNscy0zIiB4MT0iNzUuMjExNCIgeTE9IjE4Ny44NTczIiB4Mj0iNzcuMDI0OCIgeTI9IjE4Ny4xMTA5Ii8+CiAgICAgICAgICAgIDxsaW5lIGNsYXNzPSJjbHMtNCIgeDE9IjgxLjkyMDUiIHkxPSIxODUuMDk1NiIgeDI9IjEzOC4yMjEyIiB5Mj0iMTYxLjkyMDMiLz4KICAgICAgICAgICAgPGxpbmUgY2xhc3M9ImNscy0zIiB4MT0iMTQwLjY2OSIgeTE9IjE2MC45MTI2IiB4Mj0iMTQyLjQ4MjQiIHkyPSIxNjAuMTY2MiIvPgogICAgICAgICAgPC9nPgogICAgICAgIDwvZz4KICAgICAgICA8cG9seWdvbiBjbGFzcz0iY2xzLTUiIHBvaW50cz0iMTk0LjUyNiAyNi41NTIgMTc2LjkwMSAzOC4yNDEgMTU5LjI3IDI2LjU1MiAxNzYuOTAxIDE0Ljg3IDE5NC41MjYgMjYuNTUyIi8+CiAgICAgICAgPGxpbmUgY2xhc3M9ImNscy02IiB4MT0iMTgzLjcxMzUiIHkxPSI0My4yMTg4IiB4Mj0iMTgzLjcxMzUiIHkyPSI5Ny44ODMyIi8+CiAgICAgICAgPHBvbHlnb24gY2xhc3M9ImNscy03IiBwb2ludHM9IjE3Ni45MDEgMzguMjQxIDE3Ni45MDEgNTguMTY2IDE1OS4yNyA0Ni40NzcgMTU5LjI3IDI2LjU1MiAxNzYuOTAxIDM4LjI0MSIvPgogICAgICAgIDxwb2x5Z29uIGNsYXNzPSJjbHMtOCIgcG9pbnRzPSIxOTQuNTI2IDI2LjU1MiAxOTQuNTI2IDQ2LjQ3NyAxNzYuOTAxIDU4LjE2NiAxNzYuOTAxIDM4LjI0MSAxOTQuNTI2IDI2LjU1MiIvPgogICAgICAgIDxsaW5lIGNsYXNzPSJjbHMtNiIgeDE9IjQ3Ljk0ODgiIHkxPSI0Mi4yMTg4IiB4Mj0iMTU5LjExNzIiIHkyPSI0Mi4yMTg4Ii8+CiAgICAgICAgPHBvbHlnb24gY2xhc3M9ImNscy01IiBwb2ludHM9IjIyMC43NjIgOTkuNzUyIDE2Ny44MTcgMTM0Ljg2NCAxMTQuODU0IDk5Ljc1MiAxNjcuODE3IDY0LjY1NyAyMjAuNzYyIDk5Ljc1MiIvPgogICAgICAgIDxwb2x5Z29uIGNsYXNzPSJjbHMtOSIgcG9pbnRzPSIxNjcuODE3IDEzNC44NjQgMTY3LjgxNyAxOTQuNzE4IDExNC44NTQgMTU5LjYwNiAxMTQuODU0IDk5Ljc1MiAxNjcuODE3IDEzNC44NjQiLz4KICAgICAgICA8cG9seWdvbiBjbGFzcz0iY2xzLTgiIHBvaW50cz0iMjIwLjc2MiA5OS43NTIgMjIwLjc2MiAxNTkuNjA2IDE2Ny44MTcgMTk0LjcxOCAxNjcuODE3IDEzNC44NjQgMjIwLjc2MiA5OS43NTIiLz4KICAgICAgICA8cG9seWdvbiBjbGFzcz0iY2xzLTEwIiBwb2ludHM9IjExMC41NDEgMjEuNjA0IDc3Ljk0OSA0My4yMTkgNDUuMzQ1IDIxLjYwNCA3Ny45NDkgMCAxMTAuNTQxIDIxLjYwNCIvPgogICAgICAgIDxwb2x5Z29uIGNsYXNzPSJjbHMtMTEiIHBvaW50cz0iMTEwLjU0MSAyMS42MDQgMTEwLjU0MSA1OC40NDkgNzcuOTQ5IDgwLjA2NCA3Ny45NDkgNDMuMjE5IDExMC41NDEgMjEuNjA0Ii8+CiAgICAgICAgPHBvbHlnb24gY2xhc3M9ImNscy01IiBwb2ludHM9IjE0MS4xOSAxNDguMDczIDE2Ny44MTMgMTMwLjQxNyAxOTQuNDQ0IDE0OC4wNzMgMTY3LjgxMyAxNjUuNzE5IDE0MS4xOSAxNDguMDczIi8+CiAgICAgICAgPHBvbHlnb24gY2xhc3M9ImNscy05IiBwb2ludHM9IjE2Ny44MTMgMTMwLjQxNyAxNjcuODEzIDEwMC4zMjEgMTk0LjQ0NCAxMTcuOTc2IDE5NC40NDQgMTQ4LjA3MyAxNjcuODEzIDEzMC40MTciLz4KICAgICAgICA8cG9seWdvbiBjbGFzcz0iY2xzLTgiIHBvaW50cz0iMTQxLjE5IDE0OC4wNzMgMTQxLjE5IDExNy45NzYgMTY3LjgxMyAxMDAuMzIxIDE2Ny44MTMgMTMwLjQxNyAxNDEuMTkgMTQ4LjA3MyIvPgogICAgICAgIDxwb2x5Z29uIGNsYXNzPSJjbHMtMTIiIHBvaW50cz0iNDUuMzQ1IDIxLjYwNCA0NS4zNDUgNDQuOTg0IDU3LjIzMSA1Mi44NjQgNTcuMjMxIDY2LjI5NiA3Ny45NDkgODAuMDY0IDc3Ljk0OSA0My4yMTkgNDUuMzQ1IDIxLjYwNCIvPgogICAgICAgIDxnIGNsYXNzPSJjbHMtMiI+CiAgICAgICAgICA8Zz4KICAgICAgICAgICAgPGxpbmUgY2xhc3M9ImNscy0zIiB4MT0iMjQuNjQzOCIgeTE9Ijg2Ljk1NDQiIHgyPSIyNi4wMTU3IiB5Mj0iODUuNTUzMSIvPgogICAgICAgICAgICA8bGluZSBjbGFzcz0iY2xzLTEzIiB4MT0iMjkuODA0IiB5MT0iODEuNjgzNCIgeDI9IjYwLjM4MTEiIHkyPSI1MC40NDkyIi8+CiAgICAgICAgICAgIDxsaW5lIGNsYXNzPSJjbHMtMyIgeDE9IjYyLjI3NTIiIHkxPSI0OC41MTQzIiB4Mj0iNjMuNjQ3IiB5Mj0iNDcuMTEzIi8+CiAgICAgICAgICA8L2c+CiAgICAgICAgPC9nPgogICAgICAgIDxwb2x5Z29uIGNsYXNzPSJjbHMtNSIgcG9pbnRzPSIzNS4yNTUgODkuNjQ1IDE3LjczNiAxMDEuNDkyIDAgODkuOTYyIDE3LjUyNSA3OC4xMjEgMzUuMjU1IDg5LjY0NSIvPgogICAgICAgIDxwb2x5Z29uIGNsYXNzPSJjbHMtNyIgcG9pbnRzPSIxNy43MzYgMTAxLjQ5MiAxNy45MTUgMTIxLjQxNiAwLjE3OSAxMDkuODg3IDAgODkuOTYyIDE3LjczNiAxMDEuNDkyIi8+CiAgICAgICAgPGxpbmUgY2xhc3M9ImNscy02IiB4MT0iMjAuNTg0OSIgeTE9IjEwNS41MzA1IiB4Mj0iNjUuODc0OSIgeTI9IjE3MS4zNjgxIi8+CiAgICAgICAgPHBvbHlnb24gY2xhc3M9ImNscy04IiBwb2ludHM9IjM1LjI1NSA4OS42NDUgMzUuNDM0IDEwOS41NjkgMTcuOTE1IDEyMS40MTYgMTcuNzM2IDEwMS40OTIgMzUuMjU1IDg5LjY0NSIvPgogICAgICAgIDxwb2x5Z29uIGNsYXNzPSJjbHMtMTQiIHBvaW50cz0iOTIuMzk0IDE3My44MTUgNzQuODc1IDE4NS42NjIgNTcuMTM5IDE3NC4xMzIgNzQuNjY0IDE2Mi4yOTEgOTIuMzk0IDE3My44MTUiLz4KICAgICAgICA8cG9seWdvbiBjbGFzcz0iY2xzLTE1IiBwb2ludHM9Ijc0Ljg3NSAxODUuNjYyIDc1LjA1NCAyMDUuNTg2IDU3LjMxOSAxOTQuMDU3IDU3LjEzOSAxNzQuMTMyIDc0Ljg3NSAxODUuNjYyIi8+CiAgICAgICAgPHBvbHlnb24gY2xhc3M9ImNscy0xNiIgcG9pbnRzPSI5Mi4zOTQgMTczLjgxNSA5Mi41NzQgMTkzLjczOSA3NS4wNTQgMjA1LjU4NiA3NC44NzUgMTg1LjY2MiA5Mi4zOTQgMTczLjgxNSIvPgogICAgICA8L2c+CiAgICA8L2c+CiAgPC9nPgo8L3N2Zz4K'",
+        "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMjAuNzYyNCAyMDUuNTg2Ij4KICA8ZGVmcz4KICAgIDxzdHlsZT4KICAgICAgLmNscy0xIHsKICAgICAgICBpc29sYXRpb246IGlzb2xhdGU7CiAgICAgIH0KCiAgICAgIC5jbHMtMiwgLmNscy02IHsKICAgICAgICBtaXgtYmxlbmQtbW9kZTogbXVsdGlwbHk7CiAgICAgIH0KCiAgICAgIC5jbHMtMTMsIC5jbHMtMywgLmNscy00LCAuY2xzLTYgewogICAgICAgIGZpbGw6IG5vbmU7CiAgICAgICAgc3Ryb2tlOiAjYzFjN2QwOwogICAgICAgIHN0cm9rZS1saW5lY2FwOiByb3VuZDsKICAgICAgICBzdHJva2UtbWl0ZXJsaW1pdDogMTA7CiAgICAgICAgc3Ryb2tlLXdpZHRoOiAycHg7CiAgICAgIH0KCiAgICAgIC5jbHMtNCB7CiAgICAgICAgc3Ryb2tlLWRhc2hhcnJheTogMy43ODE2IDUuMjk0MzsKICAgICAgfQoKICAgICAgLmNscy01IHsKICAgICAgICBmaWxsOiAjMDA2NWZmOwogICAgICB9CgogICAgICAuY2xzLTYgewogICAgICAgIHN0cm9rZS1kYXNoYXJyYXk6IDMuOTIxOSA1LjQ5MDc7CiAgICAgIH0KCiAgICAgIC5jbHMtNyB7CiAgICAgICAgZmlsbDogIzAwNTJjYzsKICAgICAgfQoKICAgICAgLmNscy04IHsKICAgICAgICBmaWxsOiAjNGM5YWZmOwogICAgICB9CgogICAgICAuY2xzLTkgewogICAgICAgIGZpbGw6ICMwMDQ5YjA7CiAgICAgIH0KCiAgICAgIC5jbHMtMTAgewogICAgICAgIGZpbGw6ICM1N2Q5YTM7CiAgICAgIH0KCiAgICAgIC5jbHMtMTEgewogICAgICAgIGZpbGw6ICM3OWYyYzA7CiAgICAgIH0KCiAgICAgIC5jbHMtMTIgewogICAgICAgIGZpbGw6ICMzNmIzN2U7CiAgICAgIH0KCiAgICAgIC5jbHMtMTMgewogICAgICAgIHN0cm9rZS1kYXNoYXJyYXk6IDMuODY4MSA1LjQxNTQ7CiAgICAgIH0KCiAgICAgIC5jbHMtMTQgewogICAgICAgIGZpbGw6ICM0MjUyNmU7CiAgICAgIH0KCiAgICAgIC5jbHMtMTUgewogICAgICAgIGZpbGw6ICMzNDQ1NjM7CiAgICAgIH0KCiAgICAgIC5jbHMtMTYgewogICAgICAgIGZpbGw6ICM1MDVmNzk7CiAgICAgIH0KICAgIDwvc3R5bGU+CiAgPC9kZWZzPgogIDx0aXRsZT5JbnRlZ3JhdGlvbnM8L3RpdGxlPgogIDxnIGNsYXNzPSJjbHMtMSI+CiAgICA8ZyBpZD0iTGF5ZXJfMiIgZGF0YS1uYW1lPSJMYXllciAyIj4KICAgICAgPGcgaWQ9Ik9iamVjdHMiPgogICAgICAgIDxnIGNsYXNzPSJjbHMtMiI+CiAgICAgICAgICA8Zz4KICAgICAgICAgICAgPGxpbmUgY2xhc3M9ImNscy0zIiB4MT0iNzUuMjExNCIgeTE9IjE4Ny44NTczIiB4Mj0iNzcuMDI0OCIgeTI9IjE4Ny4xMTA5Ii8+CiAgICAgICAgICAgIDxsaW5lIGNsYXNzPSJjbHMtNCIgeDE9IjgxLjkyMDUiIHkxPSIxODUuMDk1NiIgeDI9IjEzOC4yMjEyIiB5Mj0iMTYxLjkyMDMiLz4KICAgICAgICAgICAgPGxpbmUgY2xhc3M9ImNscy0zIiB4MT0iMTQwLjY2OSIgeTE9IjE2MC45MTI2IiB4Mj0iMTQyLjQ4MjQiIHkyPSIxNjAuMTY2MiIvPgogICAgICAgICAgPC9nPgogICAgICAgIDwvZz4KICAgICAgICA8cG9seWdvbiBjbGFzcz0iY2xzLTUiIHBvaW50cz0iMTk0LjUyNiAyNi41NTIgMTc2LjkwMSAzOC4yNDEgMTU5LjI3IDI2LjU1MiAxNzYuOTAxIDE0Ljg3IDE5NC41MjYgMjYuNTUyIi8+CiAgICAgICAgPGxpbmUgY2xhc3M9ImNscy02IiB4MT0iMTgzLjcxMzUiIHkxPSI0My4yMTg4IiB4Mj0iMTgzLjcxMzUiIHkyPSI5Ny44ODMyIi8+CiAgICAgICAgPHBvbHlnb24gY2xhc3M9ImNscy03IiBwb2ludHM9IjE3Ni45MDEgMzguMjQxIDE3Ni45MDEgNTguMTY2IDE1OS4yNyA0Ni40NzcgMTU5LjI3IDI2LjU1MiAxNzYuOTAxIDM4LjI0MSIvPgogICAgICAgIDxwb2x5Z29uIGNsYXNzPSJjbHMtOCIgcG9pbnRzPSIxOTQuNTI2IDI2LjU1MiAxOTQuNTI2IDQ2LjQ3NyAxNzYuOTAxIDU4LjE2NiAxNzYuOTAxIDM4LjI0MSAxOTQuNTI2IDI2LjU1MiIvPgogICAgICAgIDxsaW5lIGNsYXNzPSJjbHMtNiIgeDE9IjQ3Ljk0ODgiIHkxPSI0Mi4yMTg4IiB4Mj0iMTU5LjExNzIiIHkyPSI0Mi4yMTg4Ii8+CiAgICAgICAgPHBvbHlnb24gY2xhc3M9ImNscy01IiBwb2ludHM9IjIyMC43NjIgOTkuNzUyIDE2Ny44MTcgMTM0Ljg2NCAxMTQuODU0IDk5Ljc1MiAxNjcuODE3IDY0LjY1NyAyMjAuNzYyIDk5Ljc1MiIvPgogICAgICAgIDxwb2x5Z29uIGNsYXNzPSJjbHMtOSIgcG9pbnRzPSIxNjcuODE3IDEzNC44NjQgMTY3LjgxNyAxOTQuNzE4IDExNC44NTQgMTU5LjYwNiAxMTQuODU0IDk5Ljc1MiAxNjcuODE3IDEzNC44NjQiLz4KICAgICAgICA8cG9seWdvbiBjbGFzcz0iY2xzLTgiIHBvaW50cz0iMjIwLjc2MiA5OS43NTIgMjIwLjc2MiAxNTkuNjA2IDE2Ny44MTcgMTk0LjcxOCAxNjcuODE3IDEzNC44NjQgMjIwLjc2MiA5OS43NTIiLz4KICAgICAgICA8cG9seWdvbiBjbGFzcz0iY2xzLTEwIiBwb2ludHM9IjExMC41NDEgMjEuNjA0IDc3Ljk0OSA0My4yMTkgNDUuMzQ1IDIxLjYwNCA3Ny45NDkgMCAxMTAuNTQxIDIxLjYwNCIvPgogICAgICAgIDxwb2x5Z29uIGNsYXNzPSJjbHMtMTEiIHBvaW50cz0iMTEwLjU0MSAyMS42MDQgMTEwLjU0MSA1OC40NDkgNzcuOTQ5IDgwLjA2NCA3Ny45NDkgNDMuMjE5IDExMC41NDEgMjEuNjA0Ii8+CiAgICAgICAgPHBvbHlnb24gY2xhc3M9ImNscy01IiBwb2ludHM9IjE0MS4xOSAxNDguMDczIDE2Ny44MTMgMTMwLjQxNyAxOTQuNDQ0IDE0OC4wNzMgMTY3LjgxMyAxNjUuNzE5IDE0MS4xOSAxNDguMDczIi8+CiAgICAgICAgPHBvbHlnb24gY2xhc3M9ImNscy05IiBwb2ludHM9IjE2Ny44MTMgMTMwLjQxNyAxNjcuODEzIDEwMC4zMjEgMTk0LjQ0NCAxMTcuOTc2IDE5NC40NDQgMTQ4LjA3MyAxNjcuODEzIDEzMC40MTciLz4KICAgICAgICA8cG9seWdvbiBjbGFzcz0iY2xzLTgiIHBvaW50cz0iMTQxLjE5IDE0OC4wNzMgMTQxLjE5IDExNy45NzYgMTY3LjgxMyAxMDAuMzIxIDE2Ny44MTMgMTMwLjQxNyAxNDEuMTkgMTQ4LjA3MyIvPgogICAgICAgIDxwb2x5Z29uIGNsYXNzPSJjbHMtMTIiIHBvaW50cz0iNDUuMzQ1IDIxLjYwNCA0NS4zNDUgNDQuOTg0IDU3LjIzMSA1Mi44NjQgNTcuMjMxIDY2LjI5NiA3Ny45NDkgODAuMDY0IDc3Ljk0OSA0My4yMTkgNDUuMzQ1IDIxLjYwNCIvPgogICAgICAgIDxnIGNsYXNzPSJjbHMtMiI+CiAgICAgICAgICA8Zz4KICAgICAgICAgICAgPGxpbmUgY2xhc3M9ImNscy0zIiB4MT0iMjQuNjQzOCIgeTE9Ijg2Ljk1NDQiIHgyPSIyNi4wMTU3IiB5Mj0iODUuNTUzMSIvPgogICAgICAgICAgICA8bGluZSBjbGFzcz0iY2xzLTEzIiB4MT0iMjkuODA0IiB5MT0iODEuNjgzNCIgeDI9IjYwLjM4MTEiIHkyPSI1MC40NDkyIi8+CiAgICAgICAgICAgIDxsaW5lIGNsYXNzPSJjbHMtMyIgeDE9IjYyLjI3NTIiIHkxPSI0OC41MTQzIiB4Mj0iNjMuNjQ3IiB5Mj0iNDcuMTEzIi8+CiAgICAgICAgICA8L2c+CiAgICAgICAgPC9nPgogICAgICAgIDxwb2x5Z29uIGNsYXNzPSJjbHMtNSIgcG9pbnRzPSIzNS4yNTUgODkuNjQ1IDE3LjczNiAxMDEuNDkyIDAgODkuOTYyIDE3LjUyNSA3OC4xMjEgMzUuMjU1IDg5LjY0NSIvPgogICAgICAgIDxwb2x5Z29uIGNsYXNzPSJjbHMtNyIgcG9pbnRzPSIxNy43MzYgMTAxLjQ5MiAxNy45MTUgMTIxLjQxNiAwLjE3OSAxMDkuODg3IDAgODkuOTYyIDE3LjczNiAxMDEuNDkyIi8+CiAgICAgICAgPGxpbmUgY2xhc3M9ImNscy02IiB4MT0iMjAuNTg0OSIgeTE9IjEwNS41MzA1IiB4Mj0iNjUuODc0OSIgeTI9IjE3MS4zNjgxIi8+CiAgICAgICAgPHBvbHlnb24gY2xhc3M9ImNscy04IiBwb2ludHM9IjM1LjI1NSA4OS42NDUgMzUuNDM0IDEwOS41NjkgMTcuOTE1IDEyMS40MTYgMTcuNzM2IDEwMS40OTIgMzUuMjU1IDg5LjY0NSIvPgogICAgICAgIDxwb2x5Z29uIGNsYXNzPSJjbHMtMTQiIHBvaW50cz0iOTIuMzk0IDE3My44MTUgNzQuODc1IDE4NS42NjIgNTcuMTM5IDE3NC4xMzIgNzQuNjY0IDE2Mi4yOTEgOTIuMzk0IDE3My44MTUiLz4KICAgICAgICA8cG9seWdvbiBjbGFzcz0iY2xzLTE1IiBwb2ludHM9Ijc0Ljg3NSAxODUuNjYyIDc1LjA1NCAyMDUuNTg2IDU3LjMxOSAxOTQuMDU3IDU3LjEzOSAxNzQuMTMyIDc0Ljg3NSAxODUuNjYyIi8+CiAgICAgICAgPHBvbHlnb24gY2xhc3M9ImNscy0xNiIgcG9pbnRzPSI5Mi4zOTQgMTczLjgxNSA5Mi41NzQgMTkzLjczOSA3NS4wNTQgMjA1LjU4NiA3NC44NzUgMTg1LjY2MiA5Mi4zOTQgMTczLjgxNSIvPgogICAgICA8L2c+CiAgICA8L2c+CiAgPC9nPgo8L3N2Zz4K",
         "body": "\n----\n\n* [Open API Specification](#open-api-specification)\n* [JSON Schema](#json-schema)\n* [Condensed Versus Full Objects](#condensed-versus-full-objects)\n\n____\n\n\n### Open API Specification\n\nBitbucket uses the [Open API Specification](https://openapis.org) (OAI,\nformerly known as Swagger) to describe its APIs. Our OAI specification schema\nis hosted at [https://api.bitbucket.org/swagger.json](https://api.bitbucket.org/swagger.json)\nand serves as the canonical definition and comprehensive declaration of all\navailable endpoints.\n\nThe OAI specification makes writing client applications easier by:\nauto-generating boilerplate code (like data object classes) and dealing with\nauthentication and error handling.\n\nYou can find a comprehensive set of open tools for the OAI specification at:\n[https://github.com/swagger-api](https://github.com/swagger-api).\n\n\n### JSON Schema\n\nBitbucket uses JSON Schema to describe the layout of every type of object\nconsumed or produced by the API. These schemas are collected under the\n`#definitions` element of our swagger.json file.\n\nWhen an endpoint expects an object as part of a POST or PUT, it also expects\nthe object to validate against the JSON schemas. The same applies to objects\nreturned by an endpoint.\n\n\n### Condensed Versus Full Objects\n\nMost objects in Bitbucket come both in \"full\" and \"partial\" representation.\nThe full representation is when all elements are included. This is the layout\nreturned by a resource's `self` location (e.g. `/2.0/repositories/foo/bar`),\nas well as resource collection endpoints (e.g. `/2.0/repositories`).\n\nHowever, Bitbucket objects often embed other objects. For example, a `repository`\nobject embeds a `user` object for its owner. Likewise, a `pullrequest` object\nembeds its `repository` object.\n\nThese related objects are embedded, or inlined, to reduce the \"chatter\" when\nclients make frequent followup API calls to collect information on common,\nrelated information.\n\nEmbedded related objects are typically limited in their fields to avoid such\nobject graphs from becoming too deep and noisy. They often exclude their own\nnested objects in an attempt to strike a balance between performance and\nutility.\n\nAn object's embedded or condensed representation tends to be standardized,\nmeaning the fields included is the same set, regardless of where the object\nwas embedded.\n"
       },
       {
         "anchor": "uri-uuid",
         "title": "URI, UUID, and structures",
         "description": "URL's, UUID's, errors, and timestamps",
-        "icon": "data:image/svg+xml;base64,b'PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB2aWV3Qm94PSIwIDAgMTc5LjI2IDE3Ny42NSI+PGRlZnM+PHN0eWxlPi5jbHMtMXtmaWxsOnVybCgjbGluZWFyLWdyYWRpZW50KTt9LmNscy0ye2ZpbGw6IzA5MWU0Mjt9LmNscy0xMCwuY2xzLTExLC5jbHMtMywuY2xzLTQsLmNscy05e2ZpbGw6bm9uZTt9LmNscy0ze3N0cm9rZTojOTljMWZmO30uY2xzLTMsLmNscy00e3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2Utd2lkdGg6MDt9LmNscy0xMiwuY2xzLTQsLmNscy05e3N0cm9rZTojZTVlOGVjO30uY2xzLTV7ZmlsbDojMzQ0NTYzO30uY2xzLTZ7ZmlsbDojZmY4YjAwO30uY2xzLTd7ZmlsbDojZmZjNDAwO30uY2xzLTh7ZmlsbDojMDA2NWZmO30uY2xzLTEwLC5jbHMtMTEsLmNscy0xMiwuY2xzLTEzLC5jbHMtOXtzdHJva2UtbWl0ZXJsaW1pdDoxMDtzdHJva2Utd2lkdGg6MnB4O30uY2xzLTEwe3N0cm9rZTojZmZhYjAwO30uY2xzLTExLC5jbHMtMTN7c3Ryb2tlOiMwMDY1ZmY7fS5jbHMtMTJ7ZmlsbDojOTljMWZmO30uY2xzLTEze2ZpbGw6I2U1ZThlYzt9PC9zdHlsZT48bGluZWFyR3JhZGllbnQgaWQ9ImxpbmVhci1ncmFkaWVudCIgeDE9IjAuNCIgeTE9IjE3OC4wNSIgeDI9IjE3OC44NSIgeTI9Ii0wLjQiIGdyYWRpZW50VW5pdHM9InVzZXJTcGFjZU9uVXNlIj48c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiMwOTFlNDIiLz48c3RvcCBvZmZzZXQ9IjAuMDciIHN0b3AtY29sb3I9IiMwZDIyNDUiLz48c3RvcCBvZmZzZXQ9IjAuNDkiIHN0b3AtY29sb3I9IiMxZjMyNTMiLz48c3RvcCBvZmZzZXQ9IjAuNzkiIHN0b3AtY29sb3I9IiMyNTM4NTgiLz48L2xpbmVhckdyYWRpZW50PjwvZGVmcz48dGl0bGU+Q29kZTwvdGl0bGU+PGcgaWQ9IkxheWVyXzIiIGRhdGEtbmFtZT0iTGF5ZXIgMiI+PGcgaWQ9IlNvZnR3YXJlIj48cmVjdCBpZD0iX1JlY3RhbmdsZV8iIGRhdGEtbmFtZT0iJmx0O1JlY3RhbmdsZSZndDsiIGNsYXNzPSJjbHMtMSIgd2lkdGg9IjE3OS4yNiIgaGVpZ2h0PSIxNzcuNjUiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik0xNzkuMjYsMjYuNjRIMFY3MS43NUExNjYuNDEsMTY2LjQxLDAsMCwwLDYzLjI0LDU5LjUxYTE4OC40MSwxODguNDEsMCwwLDAsMTcuMzktOC4zNmMxOC40NC05LjQzLDQ4LjM3LTE3LjksOTguNjItMTNabS0xNTkuNDQsMzRoMFptMC0xNC4wOGgwWiIvPjxsaW5lIGNsYXNzPSJjbHMtMyIgeDE9IjE5LjgxIiB5MT0iNDYuNTgiIHgyPSIyNS4wNyIgeTI9IjQ2LjU4Ii8+PGxpbmUgY2xhc3M9ImNscy0zIiB4MT0iMjUuMDciIHkxPSI2MC42NiIgeDI9IjE5LjgxIiB5Mj0iNjAuNjYiLz48bGluZSBjbGFzcz0iY2xzLTMiIHgxPSIxOS44MSIgeTE9Ijc0Ljc0IiB4Mj0iMjUuMDciIHkyPSI3NC43NCIvPjxsaW5lIGNsYXNzPSJjbHMtMyIgeDE9IjI1LjA3IiB5MT0iODguODIiIHgyPSIxOS44MSIgeTI9Ijg4LjgyIi8+PGxpbmUgY2xhc3M9ImNscy0zIiB4MT0iMjUuMDciIHkxPSIxMDIuODkiIHgyPSIxOS44MSIgeTI9IjEwMi44OSIvPjxsaW5lIGNsYXNzPSJjbHMtMyIgeDE9IjI1LjA3IiB5MT0iMTE2Ljk3IiB4Mj0iMTkuODEiIHkyPSIxMTYuOTciLz48bGluZSBjbGFzcz0iY2xzLTMiIHgxPSIyNS4wNyIgeTE9IjEzMS4wNSIgeDI9IjE5LjgxIiB5Mj0iMTMxLjA1Ii8+PGxpbmUgY2xhc3M9ImNscy0zIiB4MT0iMjUuMDciIHkxPSIxNDUuMTMiIHgyPSIxOS44MSIgeTI9IjE0NS4xMyIvPjxsaW5lIGNsYXNzPSJjbHMtMyIgeDE9IjI1LjA3IiB5MT0iMTU5LjIxIiB4Mj0iMTkuODEiIHkyPSIxNTkuMjEiLz48bGluZSBjbGFzcz0iY2xzLTQiIHgxPSI1NS44OSIgeTE9IjEzMS4wNSIgeDI9IjkzLjk5IiB5Mj0iMTMxLjA1Ii8+PGxpbmUgY2xhc3M9ImNscy00IiB4MT0iNTUuODkiIHkxPSIxNDUuMTMiIHgyPSIxMzkuNjciIHkyPSIxNDUuMTMiLz48cmVjdCBjbGFzcz0iY2xzLTUiIHdpZHRoPSIxNzkuMjYiIGhlaWdodD0iMjYuNjQiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9IjEzLjUiIGN5PSIxMi4wOCIgcj0iNS4xMSIvPjxjaXJjbGUgY2xhc3M9ImNscy03IiBjeD0iMzAuMTgiIGN5PSIxMi4wOCIgcj0iNS4xMSIvPjxjaXJjbGUgY2xhc3M9ImNscy04IiBjeD0iNDYuODYiIGN5PSIxMi4wOCIgcj0iNS4xMSIvPjxwYXRoIGNsYXNzPSJjbHMtOSIgZD0iTTc1LjQxLDg4LjgyIi8+PHBhdGggY2xhc3M9ImNscy05IiBkPSJNMzIuODksODguODIiLz48bGluZSBjbGFzcz0iY2xzLTEwIiB4MT0iMzIuODkiIHkxPSI3NC43NCIgeDI9Ijc1LjQxIiB5Mj0iNzQuNzQiLz48bGluZSBjbGFzcz0iY2xzLTExIiB4MT0iMzIuODkiIHkxPSI2MC42NiIgeDI9Ijc1LjQxIiB5Mj0iNjAuNjYiLz48bGluZSBjbGFzcz0iY2xzLTkiIHgxPSIzMi44OSIgeTE9IjQ2LjU4IiB4Mj0iNTUuODkiIHkyPSI0Ni41OCIvPjxsaW5lIGNsYXNzPSJjbHMtMTIiIHgxPSIxOS44MSIgeTE9IjQ2LjU4IiB4Mj0iMjUuMDciIHkyPSI0Ni41OCIvPjxsaW5lIGNsYXNzPSJjbHMtMTIiIHgxPSIxOS44MSIgeTE9IjYwLjY2IiB4Mj0iMjUuMDciIHkyPSI2MC42NiIvPjxsaW5lIGNsYXNzPSJjbHMtMTIiIHgxPSIxOS44MSIgeTE9Ijc0Ljc0IiB4Mj0iMjUuMDciIHkyPSI3NC43NCIvPjxsaW5lIGNsYXNzPSJjbHMtMTIiIHgxPSIxOS44MSIgeTE9Ijg4LjgyIiB4Mj0iMjUuMDciIHkyPSI4OC44MiIvPjxsaW5lIGNsYXNzPSJjbHMtMTIiIHgxPSIxOS44MSIgeTE9IjEwMi44OSIgeDI9IjI1LjA3IiB5Mj0iMTAyLjg5Ii8+PGxpbmUgY2xhc3M9ImNscy0xMiIgeDE9IjE5LjgxIiB5MT0iMTE2Ljk3IiB4Mj0iMjUuMDciIHkyPSIxMTYuOTciLz48bGluZSBjbGFzcz0iY2xzLTEyIiB4MT0iMTkuODEiIHkxPSIxMzEuMDUiIHgyPSIyNS4wNyIgeTI9IjEzMS4wNSIvPjxsaW5lIGNsYXNzPSJjbHMtMTIiIHgxPSIxOS44MSIgeTE9IjE0NS4xMyIgeDI9IjI1LjA3IiB5Mj0iMTQ1LjEzIi8+PGxpbmUgY2xhc3M9ImNscy0xMiIgeDE9IjE5LjgxIiB5MT0iMTU5LjIxIiB4Mj0iMjUuMDciIHkyPSIxNTkuMjEiLz48bGluZSBpZD0iX0xpbmVfIiBkYXRhLW5hbWU9IiZsdDtMaW5lJmd0OyIgY2xhc3M9ImNscy0xMCIgeDE9Ijg0LjI0IiB5MT0iMTE2Ljk3IiB4Mj0iMTU2LjY1IiB5Mj0iMTE2Ljk3Ii8+PHBhdGggY2xhc3M9ImNscy05IiBkPSJNMzIuODksMTE3aDBaIi8+PGxpbmUgY2xhc3M9ImNscy0xMCIgeDE9IjEwMiIgeTE9IjEzMS4wNSIgeDI9IjE2My42MiIgeTI9IjEzMS4wNSIvPjxsaW5lIGNsYXNzPSJjbHMtMTMiIHgxPSI1NS44OSIgeTE9IjEzMS4wNSIgeDI9IjkzLjk5IiB5Mj0iMTMxLjA1Ii8+PGxpbmUgY2xhc3M9ImNscy0xMyIgeDE9IjU1Ljg5IiB5MT0iMTQ1LjEzIiB4Mj0iMTM5LjY3IiB5Mj0iMTQ1LjEzIi8+PGxpbmUgY2xhc3M9ImNscy05IiB4MT0iNzguOSIgeTE9IjE1OS4yMSIgeDI9IjExMy41MSIgeTI9IjE1OS4yMSIvPjxsaW5lIGNsYXNzPSJjbHMtOSIgeDE9IjU5LjYxIiB5MT0iODguODIiIHgyPSI5OS4zMyIgeTI9Ijg4LjgyIi8+PGxpbmUgY2xhc3M9ImNscy05IiB4MT0iNTkuNjEiIHkxPSIxMDIuODkiIHgyPSI5OS4zMyIgeTI9IjEwMi44OSIvPjxjaXJjbGUgY2xhc3M9ImNscy02IiBjeD0iMTMuNSIgY3k9IjEyLjA4IiByPSI1LjExIi8+PGNpcmNsZSBjbGFzcz0iY2xzLTciIGN4PSIzMC4xOCIgY3k9IjEyLjA4IiByPSI1LjExIi8+PGNpcmNsZSBjbGFzcz0iY2xzLTgiIGN4PSI0Ni44NiIgY3k9IjEyLjA4IiByPSI1LjExIi8+PC9nPjwvZz48L3N2Zz4='",
+        "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB2aWV3Qm94PSIwIDAgMTc5LjI2IDE3Ny42NSI+PGRlZnM+PHN0eWxlPi5jbHMtMXtmaWxsOnVybCgjbGluZWFyLWdyYWRpZW50KTt9LmNscy0ye2ZpbGw6IzA5MWU0Mjt9LmNscy0xMCwuY2xzLTExLC5jbHMtMywuY2xzLTQsLmNscy05e2ZpbGw6bm9uZTt9LmNscy0ze3N0cm9rZTojOTljMWZmO30uY2xzLTMsLmNscy00e3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2Utd2lkdGg6MDt9LmNscy0xMiwuY2xzLTQsLmNscy05e3N0cm9rZTojZTVlOGVjO30uY2xzLTV7ZmlsbDojMzQ0NTYzO30uY2xzLTZ7ZmlsbDojZmY4YjAwO30uY2xzLTd7ZmlsbDojZmZjNDAwO30uY2xzLTh7ZmlsbDojMDA2NWZmO30uY2xzLTEwLC5jbHMtMTEsLmNscy0xMiwuY2xzLTEzLC5jbHMtOXtzdHJva2UtbWl0ZXJsaW1pdDoxMDtzdHJva2Utd2lkdGg6MnB4O30uY2xzLTEwe3N0cm9rZTojZmZhYjAwO30uY2xzLTExLC5jbHMtMTN7c3Ryb2tlOiMwMDY1ZmY7fS5jbHMtMTJ7ZmlsbDojOTljMWZmO30uY2xzLTEze2ZpbGw6I2U1ZThlYzt9PC9zdHlsZT48bGluZWFyR3JhZGllbnQgaWQ9ImxpbmVhci1ncmFkaWVudCIgeDE9IjAuNCIgeTE9IjE3OC4wNSIgeDI9IjE3OC44NSIgeTI9Ii0wLjQiIGdyYWRpZW50VW5pdHM9InVzZXJTcGFjZU9uVXNlIj48c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiMwOTFlNDIiLz48c3RvcCBvZmZzZXQ9IjAuMDciIHN0b3AtY29sb3I9IiMwZDIyNDUiLz48c3RvcCBvZmZzZXQ9IjAuNDkiIHN0b3AtY29sb3I9IiMxZjMyNTMiLz48c3RvcCBvZmZzZXQ9IjAuNzkiIHN0b3AtY29sb3I9IiMyNTM4NTgiLz48L2xpbmVhckdyYWRpZW50PjwvZGVmcz48dGl0bGU+Q29kZTwvdGl0bGU+PGcgaWQ9IkxheWVyXzIiIGRhdGEtbmFtZT0iTGF5ZXIgMiI+PGcgaWQ9IlNvZnR3YXJlIj48cmVjdCBpZD0iX1JlY3RhbmdsZV8iIGRhdGEtbmFtZT0iJmx0O1JlY3RhbmdsZSZndDsiIGNsYXNzPSJjbHMtMSIgd2lkdGg9IjE3OS4yNiIgaGVpZ2h0PSIxNzcuNjUiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik0xNzkuMjYsMjYuNjRIMFY3MS43NUExNjYuNDEsMTY2LjQxLDAsMCwwLDYzLjI0LDU5LjUxYTE4OC40MSwxODguNDEsMCwwLDAsMTcuMzktOC4zNmMxOC40NC05LjQzLDQ4LjM3LTE3LjksOTguNjItMTNabS0xNTkuNDQsMzRoMFptMC0xNC4wOGgwWiIvPjxsaW5lIGNsYXNzPSJjbHMtMyIgeDE9IjE5LjgxIiB5MT0iNDYuNTgiIHgyPSIyNS4wNyIgeTI9IjQ2LjU4Ii8+PGxpbmUgY2xhc3M9ImNscy0zIiB4MT0iMjUuMDciIHkxPSI2MC42NiIgeDI9IjE5LjgxIiB5Mj0iNjAuNjYiLz48bGluZSBjbGFzcz0iY2xzLTMiIHgxPSIxOS44MSIgeTE9Ijc0Ljc0IiB4Mj0iMjUuMDciIHkyPSI3NC43NCIvPjxsaW5lIGNsYXNzPSJjbHMtMyIgeDE9IjI1LjA3IiB5MT0iODguODIiIHgyPSIxOS44MSIgeTI9Ijg4LjgyIi8+PGxpbmUgY2xhc3M9ImNscy0zIiB4MT0iMjUuMDciIHkxPSIxMDIuODkiIHgyPSIxOS44MSIgeTI9IjEwMi44OSIvPjxsaW5lIGNsYXNzPSJjbHMtMyIgeDE9IjI1LjA3IiB5MT0iMTE2Ljk3IiB4Mj0iMTkuODEiIHkyPSIxMTYuOTciLz48bGluZSBjbGFzcz0iY2xzLTMiIHgxPSIyNS4wNyIgeTE9IjEzMS4wNSIgeDI9IjE5LjgxIiB5Mj0iMTMxLjA1Ii8+PGxpbmUgY2xhc3M9ImNscy0zIiB4MT0iMjUuMDciIHkxPSIxNDUuMTMiIHgyPSIxOS44MSIgeTI9IjE0NS4xMyIvPjxsaW5lIGNsYXNzPSJjbHMtMyIgeDE9IjI1LjA3IiB5MT0iMTU5LjIxIiB4Mj0iMTkuODEiIHkyPSIxNTkuMjEiLz48bGluZSBjbGFzcz0iY2xzLTQiIHgxPSI1NS44OSIgeTE9IjEzMS4wNSIgeDI9IjkzLjk5IiB5Mj0iMTMxLjA1Ii8+PGxpbmUgY2xhc3M9ImNscy00IiB4MT0iNTUuODkiIHkxPSIxNDUuMTMiIHgyPSIxMzkuNjciIHkyPSIxNDUuMTMiLz48cmVjdCBjbGFzcz0iY2xzLTUiIHdpZHRoPSIxNzkuMjYiIGhlaWdodD0iMjYuNjQiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9IjEzLjUiIGN5PSIxMi4wOCIgcj0iNS4xMSIvPjxjaXJjbGUgY2xhc3M9ImNscy03IiBjeD0iMzAuMTgiIGN5PSIxMi4wOCIgcj0iNS4xMSIvPjxjaXJjbGUgY2xhc3M9ImNscy04IiBjeD0iNDYuODYiIGN5PSIxMi4wOCIgcj0iNS4xMSIvPjxwYXRoIGNsYXNzPSJjbHMtOSIgZD0iTTc1LjQxLDg4LjgyIi8+PHBhdGggY2xhc3M9ImNscy05IiBkPSJNMzIuODksODguODIiLz48bGluZSBjbGFzcz0iY2xzLTEwIiB4MT0iMzIuODkiIHkxPSI3NC43NCIgeDI9Ijc1LjQxIiB5Mj0iNzQuNzQiLz48bGluZSBjbGFzcz0iY2xzLTExIiB4MT0iMzIuODkiIHkxPSI2MC42NiIgeDI9Ijc1LjQxIiB5Mj0iNjAuNjYiLz48bGluZSBjbGFzcz0iY2xzLTkiIHgxPSIzMi44OSIgeTE9IjQ2LjU4IiB4Mj0iNTUuODkiIHkyPSI0Ni41OCIvPjxsaW5lIGNsYXNzPSJjbHMtMTIiIHgxPSIxOS44MSIgeTE9IjQ2LjU4IiB4Mj0iMjUuMDciIHkyPSI0Ni41OCIvPjxsaW5lIGNsYXNzPSJjbHMtMTIiIHgxPSIxOS44MSIgeTE9IjYwLjY2IiB4Mj0iMjUuMDciIHkyPSI2MC42NiIvPjxsaW5lIGNsYXNzPSJjbHMtMTIiIHgxPSIxOS44MSIgeTE9Ijc0Ljc0IiB4Mj0iMjUuMDciIHkyPSI3NC43NCIvPjxsaW5lIGNsYXNzPSJjbHMtMTIiIHgxPSIxOS44MSIgeTE9Ijg4LjgyIiB4Mj0iMjUuMDciIHkyPSI4OC44MiIvPjxsaW5lIGNsYXNzPSJjbHMtMTIiIHgxPSIxOS44MSIgeTE9IjEwMi44OSIgeDI9IjI1LjA3IiB5Mj0iMTAyLjg5Ii8+PGxpbmUgY2xhc3M9ImNscy0xMiIgeDE9IjE5LjgxIiB5MT0iMTE2Ljk3IiB4Mj0iMjUuMDciIHkyPSIxMTYuOTciLz48bGluZSBjbGFzcz0iY2xzLTEyIiB4MT0iMTkuODEiIHkxPSIxMzEuMDUiIHgyPSIyNS4wNyIgeTI9IjEzMS4wNSIvPjxsaW5lIGNsYXNzPSJjbHMtMTIiIHgxPSIxOS44MSIgeTE9IjE0NS4xMyIgeDI9IjI1LjA3IiB5Mj0iMTQ1LjEzIi8+PGxpbmUgY2xhc3M9ImNscy0xMiIgeDE9IjE5LjgxIiB5MT0iMTU5LjIxIiB4Mj0iMjUuMDciIHkyPSIxNTkuMjEiLz48bGluZSBpZD0iX0xpbmVfIiBkYXRhLW5hbWU9IiZsdDtMaW5lJmd0OyIgY2xhc3M9ImNscy0xMCIgeDE9Ijg0LjI0IiB5MT0iMTE2Ljk3IiB4Mj0iMTU2LjY1IiB5Mj0iMTE2Ljk3Ii8+PHBhdGggY2xhc3M9ImNscy05IiBkPSJNMzIuODksMTE3aDBaIi8+PGxpbmUgY2xhc3M9ImNscy0xMCIgeDE9IjEwMiIgeTE9IjEzMS4wNSIgeDI9IjE2My42MiIgeTI9IjEzMS4wNSIvPjxsaW5lIGNsYXNzPSJjbHMtMTMiIHgxPSI1NS44OSIgeTE9IjEzMS4wNSIgeDI9IjkzLjk5IiB5Mj0iMTMxLjA1Ii8+PGxpbmUgY2xhc3M9ImNscy0xMyIgeDE9IjU1Ljg5IiB5MT0iMTQ1LjEzIiB4Mj0iMTM5LjY3IiB5Mj0iMTQ1LjEzIi8+PGxpbmUgY2xhc3M9ImNscy05IiB4MT0iNzguOSIgeTE9IjE1OS4yMSIgeDI9IjExMy41MSIgeTI9IjE1OS4yMSIvPjxsaW5lIGNsYXNzPSJjbHMtOSIgeDE9IjU5LjYxIiB5MT0iODguODIiIHgyPSI5OS4zMyIgeTI9Ijg4LjgyIi8+PGxpbmUgY2xhc3M9ImNscy05IiB4MT0iNTkuNjEiIHkxPSIxMDIuODkiIHgyPSI5OS4zMyIgeTI9IjEwMi44OSIvPjxjaXJjbGUgY2xhc3M9ImNscy02IiBjeD0iMTMuNSIgY3k9IjEyLjA4IiByPSI1LjExIi8+PGNpcmNsZSBjbGFzcz0iY2xzLTciIGN4PSIzMC4xOCIgY3k9IjEyLjA4IiByPSI1LjExIi8+PGNpcmNsZSBjbGFzcz0iY2xzLTgiIGN4PSI0Ni44NiIgY3k9IjEyLjA4IiByPSI1LjExIi8+PC9nPjwvZz48L3N2Zz4=",
         "body": "\nYou should be familiar with REST architecture before writing an integration. Read this overview page to gain a good understanding of Bitbucket's REST implementation.\n\n----\n\n* [URI structure](#uri-structure)\n* [HTTP methods](#http-methods)\n* [UUID](#universally-unique-identifier)\n    * [User object and UUID](#user-object-and-uuid)\n    * [Repository object and UUID](#repository-object-and-uuid)\n    * [Team object and UUID](#team-object-and-uuid)\n* [Standard error responses](#standardized-error-responses)\n* [Standard ISO-8601 timestamps](#standard-iso-8601-timestamps)\n\n----\n\n\n### URI structure\n\nAll Bitbucket Cloud requests start with the `https://api.bitbucket.org/2.0` prefix (for the 2.0 API) and `https://api.bitbucket.org/1.0` prefix (1.0 API).\n\nThe next segment of the URI path depends on the endpoint of the request. For example, using the curl command and the repositories endpoint you can list all the issues on Bitbucket's tutorial repository:\n\n```\ncurl https://api.bitbucket.org/2.0/repositories/tutorials/tutorials.bitbucket.org\n```\nGiven a specific endpoint, you can then drill down to a particular aspect or resource of that endpoint. The issues resource on a repository is an example:\n\n```\ncurl https://api.bitbucket.org/1.0/repositories/tutorials/tutorials.bitbucket.org/issues\n```\n\n#### HTTP methods\n\nA given endpoint or resource has a series of actions (or methods) associated with it. The Bitbucket service supports these standard HTTP methods:\n\n| Call | Description |\n|------|-------------|\n| GET    | Retrieves information. |\n| PUT    | Updates existing information. |\n| POST   | Creates new information. |\n| DELETE | Removes existing information. |\n\nFor example, you can call use the POST action on the issues resource and create an issue on the issue tracker.\n\n**Specifying content length**\n\nYou can get a `411 Length Required` response. If this happens, the API requires a Content-Length header but the client is not sending it. You should add the header yourself, for example using the curl client:\n\n```\ncurl -r PUT --header \"Content-Length: 0\" -u user:app_password https://api.bitbucket.org/1.0/emails/rap@atlassian.com\n```\n\n### Universally Unique Identifier\n\nUUID's provide a single point of recognition for users, teams, and repositories. The UUID is distinct from the username, team name, and repository name fields and remains the same even when those fields change. For example when a user changes their username or moves a repository you will need to modify calls which use those identifiers but not if you are pointing to the UUID.\n\n#### UUID examples and structure\n\nUUID's work with both the 1.0 and 2.0 APIs for the user, team, and repository objects. The following examples the following characters are replacements for curly brackets: `%7B` replaces `{`  and `%7D` replaces `}`. You will see this structure in the following example sections.\n\n#### User object and UUID\n\nWhen you make a call using either the username or the UUID for that user the response is the same.\n\n**Call with username**:\n\n```\ncurl https://api.bitbucket.org/2.0/users/tutorials\n```\n\n***Call with UUID for the user**:\n\n```\ncurl https://api.bitbucket.org/2.0/users/%7Bc788b2da-b7a2-404c-9e26-d3f077557007%7D\n```\n\n**Response**\n```JSON\n{\n    \"username\": \"tutorials\",\n    \"nickname\": \"tutorials\",\n    \"account_status\": \"active\",\n    \"website\": \"https://tutorials.bitbucket.org/\",\n    \"display_name\": \"tutorials account\",\n    \"uuid\": \"{c788b2da-b7a2-404c-9e26-d3f077557007}\",\n    \"links\": {\n        \"self\": {\n            \"href\": \"https://api.bitbucket.org/2.0/users/tutorials\"\n        },\n        \"repositories\": {\n            \"href\": \"https://api.bitbucket.org/2.0/repositories/tutorials\"\n        },\n        \"html\": {\n            \"href\": \"https://bitbucket.org/tutorials\"\n        },\n        \"followers\": {\n            \"href\": \"https://api.bitbucket.org/2.0/users/tutorials/followers\"\n        },\n        \"avatar\": {\n            \"href\": \"https://bitbucket-assetroot.s3.amazonaws.com/c/photos/2013/Nov/25/tutorials-avatar-1563784409-6_avatar.png\"\n        },\n        \"following\": {\n            \"href\": \"https://api.bitbucket.org/2.0/users/tutorials/following\"\n        }\n    },\n    \"created_on\": \"2011-12-20T16:34:07.132459+00:00\",\n    \"location\": \"Santa Monica, CA\",\n    \"type\": \"user\"\n}\n```\n\n#### Repository object and UUID\n\nOnce you have the UUID for a repository you no longer need a username or team name to make the API call so long as you use an empty field. This helps you resolve repositories no matter if the username or team name changes.\n\n**Call with team name (1team) and repository name (moxie)**:\n\n```\ncurl https://api.bitbucket.org/2.0/repositories/1team/moxie\n```\n**Call with UUID and empty field**:\n\n```\ncurl https://api.bitbucket.org/2.0/repositories/%7B%7D/%7B21fa9bf8-b5b2-4891-97ed-d590bad0f871%7D\n```\n\n**Call with UUID and teamname**:\n\n```\ncurl https://api.bitbucket.org/2.0/repositories/1team/%7B21fa9bf8-b5b2-4891-97ed-d590bad0f871%7D\n```\n\n**Response**\n\n```JSON\n{\n    \"created_on\": \"2013-11-08T01:11:03.222520+00:00\",\n    \"description\": \"\",\n    \"fork_policy\": \"allow_forks\",\n    \"full_name\": \"1team/moxie\",\n    \"has_issues\": false,\n    \"has_wiki\": false,\n    \"is_private\": false,\n    \"language\": \"\",\n    \"links\": {\n        \"avatar\": {\n            \"href\": \"https://bitbucket.org/1team/moxie/avatar/32/\"\n        },\n        \"branches\": {\n            \"href\": \"https://api.bitbucket.org/2.0/repositories/1team/moxie/refs/branches\"\n        },\n        \"clone\": [\n            {\n                \"href\": \"https://bitbucket.org/1team/moxie.git\",\n                \"name\": \"https\"\n            },\n            {\n                \"href\": \"ssh://git@bitbucket.org/1team/moxie.git\",\n                \"name\": \"ssh\"\n            }\n        ],\n        \"commits\": {\n            \"href\": \"https://api.bitbucket.org/2.0/repositories/1team/moxie/commits\"\n        },\n        \"downloads\": {\n            \"href\": \"https://api.bitbucket.org/2.0/repositories/1team/moxie/downloads\"\n        },\n        \"forks\": {\n            \"href\": \"https://api.bitbucket.org/2.0/repositories/1team/moxie/forks\"\n        },\n        \"hooks\": {\n            \"href\": \"https://api.bitbucket.org/2.0/repositories/1team/moxie/hooks\"\n        },\n        \"html\": {\n            \"href\": \"https://bitbucket.org/1team/moxie\"\n        },\n        \"pullrequests\": {\n            \"href\": \"https://api.bitbucket.org/2.0/repositories/1team/moxie/pullrequests\"\n        },\n        \"self\": {\n            \"href\": \"https://api.bitbucket.org/2.0/repositories/1team/moxie\"\n        },\n        \"tags\": {\n            \"href\": \"https://api.bitbucket.org/2.0/repositories/1team/moxie/refs/tags\"\n        },\n        \"watchers\": {\n            \"href\": \"https://api.bitbucket.org/2.0/repositories/1team/moxie/watchers\"\n        }\n    },\n    \"name\": \"moxie\",\n    \"owner\": {\n        \"display_name\": \"the team\",\n        \"links\": {\n            \"avatar\": {\n                \"href\": \"https://bitbucket.org/account/1team/avatar/32/\"\n            },\n            \"html\": {\n                \"href\": \"https://bitbucket.org/1team/\"\n            },\n            \"self\": {\n                \"href\": \"https://api.bitbucket.org/2.0/teams/1team\"\n            }\n        },\n        \"type\": \"team\",\n        \"username\": \"1team\",\n        \"uuid\": \"{aa559944-83c9-4963-a9a8-69ac8d9cf5d2}\"\n    },\n    \"project\": {\n        \"key\": \"PROJ\",\n        \"links\": {\n            \"avatar\": {\n                \"href\": \"https://bitbucket.org/account/user/1team/projects/PROJ/avatar/32\"\n            },\n            \"html\": {\n                \"href\": \"https://bitbucket.org/account/user/1team/projects/PROJ\"\n            }\n        },\n        \"name\": \"Untitled project\",\n        \"type\": \"project\",\n        \"uuid\": \"{ab52aaeb-16ad-4fb0-bb1d-47e4f00367ff}\"\n    },\n    \"scm\": \"git\",\n    \"size\": 33348,\n    \"type\": \"repository\",\n    \"updated_on\": \"2013-11-08T01:11:03.263237+00:00\",\n    \"uuid\": \"{21fa9bf8-b5b2-4891-97ed-d590bad0f871}\",\n    \"website\": \"\"\n}\n```\n\n#### Team object and UUID\n\nThis example shows a call for a list of team members using both the team name and with the UUID for the team object. As the call is unauthenticated in the following example the response object will only show members with public profiles. The response is the same in either case.\n\n**Call with teamname**\n\n```\ncurl https://api.bitbucket.org/2.0/teams/1team/members\n```\n**Call with UUID for team object**\n\n```\ncurl https://api.bitbucket.org/2.0/teams/%7Baa559944-83c9-4963-a9a8-69ac8d9cf5d2%7D/members\n```\n\n**Response**\n\n```JSON\n{\n    \"page\": 1,\n    \"pagelen\": 50,\n    \"size\": 2,\n    \"values\": [\n        {\n            \"created_on\": \"2011-12-20T16:34:07.132459+00:00\",\n            \"display_name\": \"tutorials account\",\n            \"links\": {\n                \"avatar\": {\n                    \"href\": \"https://bitbucket.org/account/tutorials/avatar/32/\"\n                },\n                \"followers\": {\n                    \"href\": \"https://api.bitbucket.org/2.0/users/tutorials/followers\"\n                },\n                \"following\": {\n                    \"href\": \"https://api.bitbucket.org/2.0/users/tutorials/following\"\n                },\n                \"hooks\": {\n                    \"href\": \"https://api.bitbucket.org/2.0/users/tutorials/hooks\"\n                },\n                \"html\": {\n                    \"href\": \"https://bitbucket.org/tutorials/\"\n                },\n                \"repositories\": {\n                    \"href\": \"https://api.bitbucket.org/2.0/repositories/tutorials\"\n                },\n                \"self\": {\n                    \"href\": \"https://api.bitbucket.org/2.0/users/tutorials\"\n                },\n                \"snippets\": {\n                    \"href\": \"https://api.bitbucket.org/2.0/snippets/tutorials\"\n                }\n            },\n            \"location\": null,\n            \"type\": \"user\",\n            \"username\": \"tutorials\",\n            \"nickname\": \"tutorials\",\n            \"account_status\": \"active\",\n            \"uuid\": \"{c788b2da-b7a2-404c-9e26-d3f077557007}\",\n            \"website\": \"https://tutorials.bitbucket.org/\"\n        },\n        {\n            \"created_on\": \"2013-12-10T14:44:13+00:00\",\n            \"display_name\": \"Dan Stevens [Atlassian]\",\n            \"links\": {\n                \"avatar\": {\n                    \"href\": \"https://bitbucket.org/account/dans9190/avatar/32/\"\n                },\n                \"followers\": {\n                    \"href\": \"https://api.bitbucket.org/2.0/users/dans9190/followers\"\n                },\n                \"following\": {\n                    \"href\": \"https://api.bitbucket.org/2.0/users/dans9190/following\"\n                },\n                \"hooks\": {\n                    \"href\": \"https://api.bitbucket.org/2.0/users/dans9190/hooks\"\n                },\n                \"html\": {\n                    \"href\": \"https://bitbucket.org/dans9190/\"\n                },\n                \"repositories\": {\n                    \"href\": \"https://api.bitbucket.org/2.0/repositories/dans9190\"\n                },\n                \"self\": {\n                    \"href\": \"https://api.bitbucket.org/2.0/users/dans9190\"\n                },\n                \"snippets\": {\n                    \"href\": \"https://api.bitbucket.org/2.0/snippets/dans9190\"\n                }\n            },\n            \"location\": null,\n            \"type\": \"user\",\n            \"username\": \"dans9190\",\n            \"nickname\": \"dans9190\",\n            \"account_status\": \"active\",\n            \"uuid\": \"{1cd06601-cd0e-4fce-be03-e9ac226978b7}\",\n            \"website\": \"\"\n        }\n    ]\n}\n```\n\n### Standardized error responses\n\nThe 2.0 API standardizes the error response layout. The 2.0 API serves a JSON\nobject along with the appropriate HTTP status code. The JSON object provides a\ndetailed  problem description.\n\n```json\n{\n    \"type\": \"error\",\n    \"error\": {\n        \"message\": \"Bad request\",\n        \"fields\": {\n            \"src\": [\n                \"This field is required.\"\n            ]\n        },\n        \"detail\": \"You must specify a valid source branch when creating a pull request.\",\n        \"id\": \"d23a1cc5178f7637f3d9bf2d13824258\",\n        \"data\": {\n          \"extra\": \"Optional, endpoint-specific data to further augment the error.\"\n        }\n    }\n}\n```\n\nThis object contains an error element which contains the following nested\nelements:\n\n| Element | Description |\n|---------|-------------|\n| message | A short description of the problem. This element is always present. Its value may be localized. |\n| fields  | This optional element is used in response to POST or PUT operations in which clients have provided invalid input. It contains a list of one or more client-provided fields that failed validation. The values may be localized. |\n| detail  | An optional detailed explanation of the failure. Its value may be localized.\n| id      | An optional unique error identifier that identifies the error in Bitbucket's logging system. If you feel you hit a bug in an API and this field is provided, please mention it if you decide to contact support as it will greatly help us narrow down the problem. |\n\n### Standard ISO-8601 timestamps\n\nAll 2.0 APIs use standardized ISO-8601 timestamps. In most cases, our APIs return UTC timestamps and for these, the timezone offset part will be 00:00. In rare cases where the original localized timestamp has significance, the timezone offset may identify the event's original timezone.\n"
       },
       {
         "anchor": "cors-hypermedia",
         "title": "Cors and hypermedia",
         "description": "Learn about resources and linking",
-        "icon": "data:image/svg+xml;base64,b'PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB2aWV3Qm94PSIwIDAgMjM2LjYgMjE4LjQzIj48ZGVmcz48c3R5bGU+LmNscy0xe2lzb2xhdGlvbjppc29sYXRlO30uY2xzLTIsLmNscy0zLC5jbHMtNHtmaWxsOm5vbmU7c3Ryb2tlLWxpbmVjYXA6cm91bmQ7c3Ryb2tlLW1pdGVybGltaXQ6MTA7c3Ryb2tlLXdpZHRoOjExcHg7fS5jbHMtMntzdHJva2U6dXJsKCNsaW5lYXItZ3JhZGllbnQpO30uY2xzLTN7c3Ryb2tlOnVybCgjTmV3X0dyYWRpZW50X1N3YXRjaF8xNCk7fS5jbHMtNHtzdHJva2U6dXJsKCNOZXdfR3JhZGllbnRfU3dhdGNoXzEpO30uY2xzLTV7ZmlsbDojNDI1MjZlO30uY2xzLTZ7ZmlsbDojZmY1NjMwO30uY2xzLTEwLC5jbHMtNywuY2xzLTh7bWl4LWJsZW5kLW1vZGU6bXVsdGlwbHk7fS5jbHMtN3tmaWxsOnVybCgjbGluZWFyLWdyYWRpZW50LTIpO30uY2xzLTh7ZmlsbDp1cmwoI2xpbmVhci1ncmFkaWVudC0zKTt9LmNscy05e2ZpbGw6IzAwNjVmZjt9LmNscy0xMHtmaWxsOnVybCgjbGluZWFyLWdyYWRpZW50LTQpO308L3N0eWxlPjxsaW5lYXJHcmFkaWVudCBpZD0ibGluZWFyLWdyYWRpZW50IiB5MT0iMTY3Ljg3IiB4Mj0iMTkxLjU2IiB5Mj0iMTY3Ljg3IiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSI+PHN0b3Agb2Zmc2V0PSIwIiBzdG9wLWNvbG9yPSIjNTA1Zjc5Ii8+PHN0b3Agb2Zmc2V0PSIxIiBzdG9wLWNvbG9yPSIjMzQ0NTYzIi8+PC9saW5lYXJHcmFkaWVudD48bGluZWFyR3JhZGllbnQgaWQ9Ik5ld19HcmFkaWVudF9Td2F0Y2hfMTQiIHgxPSIxMTIuODMiIHkxPSIxMzEuNzIiIHgyPSIyMzYuNiIgeTI9IjEzMS43MiIgZ3JhZGllbnRVbml0cz0idXNlclNwYWNlT25Vc2UiPjxzdG9wIG9mZnNldD0iMCIgc3RvcC1jb2xvcj0iIzAwNTJjYyIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iIzI2ODRmZiIvPjwvbGluZWFyR3JhZGllbnQ+PGxpbmVhckdyYWRpZW50IGlkPSJOZXdfR3JhZGllbnRfU3dhdGNoXzEiIHgxPSI0NS4wNiIgeTE9Ijg2LjY5IiB4Mj0iMTY4Ljg4IiB5Mj0iODYuNjkiIGdyYWRpZW50VW5pdHM9InVzZXJTcGFjZU9uVXNlIj48c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiNkZTM1MGIiLz48c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiNmZjc0NTIiLz48L2xpbmVhckdyYWRpZW50PjxsaW5lYXJHcmFkaWVudCBpZD0ibGluZWFyLWdyYWRpZW50LTIiIHgxPSIzNDQ3LjkzIiB5MT0iLTkxOC43OSIgeDI9IjM0NTEuNCIgeTI9Ii0xMDMyLjc2IiBncmFkaWVudFRyYW5zZm9ybT0idHJhbnNsYXRlKC01NzIuMzggMzcwNC4yOSkgcm90YXRlKC02NC4zNCkiIGdyYWRpZW50VW5pdHM9InVzZXJTcGFjZU9uVXNlIj48c3RvcCBvZmZzZXQ9IjAuMzEiIHN0b3AtY29sb3I9IiNjMWM3ZDAiIHN0b3Atb3BhY2l0eT0iMCIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iI2MxYzdkMCIvPjwvbGluZWFyR3JhZGllbnQ+PGxpbmVhckdyYWRpZW50IGlkPSJsaW5lYXItZ3JhZGllbnQtMyIgeDE9IjM1MDYuNiIgeTE9Ii03OTYuNjYiIHgyPSIzNTEwLjA3IiB5Mj0iLTkxMC42MyIgeGxpbms6aHJlZj0iI2xpbmVhci1ncmFkaWVudC0yIi8+PGxpbmVhckdyYWRpZW50IGlkPSJsaW5lYXItZ3JhZGllbnQtNCIgeDE9IjM1ODEuNjgiIHkxPSItOTA2LjgyIiB4Mj0iMzU4NS4xNiIgeTI9Ii0xMDIwLjc5IiB4bGluazpocmVmPSIjbGluZWFyLWdyYWRpZW50LTIiLz48L2RlZnM+PHRpdGxlPldlYmhvb2tzPC90aXRsZT48ZyBjbGFzcz0iY2xzLTEiPjxnIGlkPSJMYXllcl8yIiBkYXRhLW5hbWU9IkxheWVyIDIiPjxnIGlkPSJTb2Z0d2FyZSI+PHBhdGggY2xhc3M9ImNscy0yIiBkPSJNMTg2LjA2LDE2Ny44N0gxMTcuNzJBMjcuNTgsMjcuNTgsMCwwLDAsOTIuMjQsMTg1YTQ1LjA2LDQ1LjA2LDAsMSwxLTQxLjY4LTYyLjE5Ii8+PHBhdGggY2xhc3M9ImNscy0zIiBkPSJNMTE4LjMzLDUwLjUybDM0LjE1LDU5LjE4YTI3LjU5LDI3LjU5LDAsMCwwLDI3LjU4LDEzLjUxLDQ1LjA2LDQ1LjA2LDAsMSwxLTMzLDY3LjE5Ii8+PHBhdGggY2xhc3M9ImNscy00IiBkPSJNNTAuNTYsMTY3Ljg3bDM0LjE4LTU5LjE2YTI3LjU5LDI3LjU5LDAsMCwwLTIuMDktMzAuNjQsNDUuMDYsNDUuMDYsMCwxLDEsNzQuNy01Ii8+PHBhdGggY2xhc3M9ImNscy01IiBkPSJNMTg2LjA2LDE5OS42NmEzMS43OSwzMS43OSwwLDEsMSwzMS43OS0zMS43OUEzMS44MiwzMS44MiwwLDAsMSwxODYuMDYsMTk5LjY2WiIvPjxnIGlkPSJfR3JvdXBfIiBkYXRhLW5hbWU9IiZsdDtHcm91cCZndDsiPjxwYXRoIGNsYXNzPSJjbHMtNiIgZD0iTTQ5LjU2LDE5OS42NGEzMS43OSwzMS43OSwwLDEsMSwzMi43Ny0zMC43N0EzMS44MiwzMS44MiwwLDAsMSw0OS41NiwxOTkuNjRaIi8+PC9nPjxwYXRoIGNsYXNzPSJjbHMtNyIgZD0iTTU0LjEyLDE4MC4zNmE1OC45LDU4LjksMCwwLDAtMS41OS0xMS4yN3MtMi4zNS05LjQ0LTcuMzMtMTYuODNhNDMuODksNDMuODksMCwwLDAtMTEuNzMtMTEuMTcsMzEuNzcsMzEuNzcsMCwwLDAsMjkuMjgsNTYuMTNDNTguMjksMTkyLjQ0LDU0LjY4LDE4Ni45LDU0LjEyLDE4MC4zNloiLz48cGF0aCBjbGFzcz0iY2xzLTgiIGQ9Ik0xODkuNjIsMTgwLjM2QTU4LjksNTguOSwwLDAsMCwxODgsMTY5LjA4cy0yLjM1LTkuNDQtNy4zMy0xNi44M0E0My44OSw0My44OSwwLDAsMCwxNjksMTQxLjA4YTMxLjc3LDMxLjc3LDAsMCwwLDI5LjI4LDU2LjEzQzE5My43OSwxOTIuNDQsMTkwLjE4LDE4Ni45LDE4OS42MiwxODAuMzZaIi8+PGcgaWQ9Il9Hcm91cF8yIiBkYXRhLW5hbWU9IiZsdDtHcm91cCZndDsiPjxwYXRoIGNsYXNzPSJjbHMtOSIgZD0iTTg5LjksMzMuNzhhMzIuNDYsMzIuNDYsMCwxLDEsMTEuODgsNDQuMzRBMzIuNDksMzIuNDksMCwwLDEsODkuOSwzMy43OFoiLz48L2c+PHBhdGggY2xhc3M9ImNscy0xMCIgZD0iTTEyMi4yMyw2Ni4xM2E1OC45LDU4LjksMCwwLDAtMS41OS0xMS4yN3MtMi4zNS05LjQ0LTcuMzMtMTYuODNjLTMuMzctNS05LjA2LTkuNzktMTUuNDMtMTMuNDhBMzIuNDQsMzIuNDQsMCwwLDAsMTI4Ljc3LDgwLjZDMTI1LjMxLDc2LjM5LDEyMi43LDcxLjYxLDEyMi4yMyw2Ni4xM1oiLz48L2c+PC9nPjwvZz48L3N2Zz4='",
+        "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB2aWV3Qm94PSIwIDAgMjM2LjYgMjE4LjQzIj48ZGVmcz48c3R5bGU+LmNscy0xe2lzb2xhdGlvbjppc29sYXRlO30uY2xzLTIsLmNscy0zLC5jbHMtNHtmaWxsOm5vbmU7c3Ryb2tlLWxpbmVjYXA6cm91bmQ7c3Ryb2tlLW1pdGVybGltaXQ6MTA7c3Ryb2tlLXdpZHRoOjExcHg7fS5jbHMtMntzdHJva2U6dXJsKCNsaW5lYXItZ3JhZGllbnQpO30uY2xzLTN7c3Ryb2tlOnVybCgjTmV3X0dyYWRpZW50X1N3YXRjaF8xNCk7fS5jbHMtNHtzdHJva2U6dXJsKCNOZXdfR3JhZGllbnRfU3dhdGNoXzEpO30uY2xzLTV7ZmlsbDojNDI1MjZlO30uY2xzLTZ7ZmlsbDojZmY1NjMwO30uY2xzLTEwLC5jbHMtNywuY2xzLTh7bWl4LWJsZW5kLW1vZGU6bXVsdGlwbHk7fS5jbHMtN3tmaWxsOnVybCgjbGluZWFyLWdyYWRpZW50LTIpO30uY2xzLTh7ZmlsbDp1cmwoI2xpbmVhci1ncmFkaWVudC0zKTt9LmNscy05e2ZpbGw6IzAwNjVmZjt9LmNscy0xMHtmaWxsOnVybCgjbGluZWFyLWdyYWRpZW50LTQpO308L3N0eWxlPjxsaW5lYXJHcmFkaWVudCBpZD0ibGluZWFyLWdyYWRpZW50IiB5MT0iMTY3Ljg3IiB4Mj0iMTkxLjU2IiB5Mj0iMTY3Ljg3IiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSI+PHN0b3Agb2Zmc2V0PSIwIiBzdG9wLWNvbG9yPSIjNTA1Zjc5Ii8+PHN0b3Agb2Zmc2V0PSIxIiBzdG9wLWNvbG9yPSIjMzQ0NTYzIi8+PC9saW5lYXJHcmFkaWVudD48bGluZWFyR3JhZGllbnQgaWQ9Ik5ld19HcmFkaWVudF9Td2F0Y2hfMTQiIHgxPSIxMTIuODMiIHkxPSIxMzEuNzIiIHgyPSIyMzYuNiIgeTI9IjEzMS43MiIgZ3JhZGllbnRVbml0cz0idXNlclNwYWNlT25Vc2UiPjxzdG9wIG9mZnNldD0iMCIgc3RvcC1jb2xvcj0iIzAwNTJjYyIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iIzI2ODRmZiIvPjwvbGluZWFyR3JhZGllbnQ+PGxpbmVhckdyYWRpZW50IGlkPSJOZXdfR3JhZGllbnRfU3dhdGNoXzEiIHgxPSI0NS4wNiIgeTE9Ijg2LjY5IiB4Mj0iMTY4Ljg4IiB5Mj0iODYuNjkiIGdyYWRpZW50VW5pdHM9InVzZXJTcGFjZU9uVXNlIj48c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiNkZTM1MGIiLz48c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiNmZjc0NTIiLz48L2xpbmVhckdyYWRpZW50PjxsaW5lYXJHcmFkaWVudCBpZD0ibGluZWFyLWdyYWRpZW50LTIiIHgxPSIzNDQ3LjkzIiB5MT0iLTkxOC43OSIgeDI9IjM0NTEuNCIgeTI9Ii0xMDMyLjc2IiBncmFkaWVudFRyYW5zZm9ybT0idHJhbnNsYXRlKC01NzIuMzggMzcwNC4yOSkgcm90YXRlKC02NC4zNCkiIGdyYWRpZW50VW5pdHM9InVzZXJTcGFjZU9uVXNlIj48c3RvcCBvZmZzZXQ9IjAuMzEiIHN0b3AtY29sb3I9IiNjMWM3ZDAiIHN0b3Atb3BhY2l0eT0iMCIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iI2MxYzdkMCIvPjwvbGluZWFyR3JhZGllbnQ+PGxpbmVhckdyYWRpZW50IGlkPSJsaW5lYXItZ3JhZGllbnQtMyIgeDE9IjM1MDYuNiIgeTE9Ii03OTYuNjYiIHgyPSIzNTEwLjA3IiB5Mj0iLTkxMC42MyIgeGxpbms6aHJlZj0iI2xpbmVhci1ncmFkaWVudC0yIi8+PGxpbmVhckdyYWRpZW50IGlkPSJsaW5lYXItZ3JhZGllbnQtNCIgeDE9IjM1ODEuNjgiIHkxPSItOTA2LjgyIiB4Mj0iMzU4NS4xNiIgeTI9Ii0xMDIwLjc5IiB4bGluazpocmVmPSIjbGluZWFyLWdyYWRpZW50LTIiLz48L2RlZnM+PHRpdGxlPldlYmhvb2tzPC90aXRsZT48ZyBjbGFzcz0iY2xzLTEiPjxnIGlkPSJMYXllcl8yIiBkYXRhLW5hbWU9IkxheWVyIDIiPjxnIGlkPSJTb2Z0d2FyZSI+PHBhdGggY2xhc3M9ImNscy0yIiBkPSJNMTg2LjA2LDE2Ny44N0gxMTcuNzJBMjcuNTgsMjcuNTgsMCwwLDAsOTIuMjQsMTg1YTQ1LjA2LDQ1LjA2LDAsMSwxLTQxLjY4LTYyLjE5Ii8+PHBhdGggY2xhc3M9ImNscy0zIiBkPSJNMTE4LjMzLDUwLjUybDM0LjE1LDU5LjE4YTI3LjU5LDI3LjU5LDAsMCwwLDI3LjU4LDEzLjUxLDQ1LjA2LDQ1LjA2LDAsMSwxLTMzLDY3LjE5Ii8+PHBhdGggY2xhc3M9ImNscy00IiBkPSJNNTAuNTYsMTY3Ljg3bDM0LjE4LTU5LjE2YTI3LjU5LDI3LjU5LDAsMCwwLTIuMDktMzAuNjQsNDUuMDYsNDUuMDYsMCwxLDEsNzQuNy01Ii8+PHBhdGggY2xhc3M9ImNscy01IiBkPSJNMTg2LjA2LDE5OS42NmEzMS43OSwzMS43OSwwLDEsMSwzMS43OS0zMS43OUEzMS44MiwzMS44MiwwLDAsMSwxODYuMDYsMTk5LjY2WiIvPjxnIGlkPSJfR3JvdXBfIiBkYXRhLW5hbWU9IiZsdDtHcm91cCZndDsiPjxwYXRoIGNsYXNzPSJjbHMtNiIgZD0iTTQ5LjU2LDE5OS42NGEzMS43OSwzMS43OSwwLDEsMSwzMi43Ny0zMC43N0EzMS44MiwzMS44MiwwLDAsMSw0OS41NiwxOTkuNjRaIi8+PC9nPjxwYXRoIGNsYXNzPSJjbHMtNyIgZD0iTTU0LjEyLDE4MC4zNmE1OC45LDU4LjksMCwwLDAtMS41OS0xMS4yN3MtMi4zNS05LjQ0LTcuMzMtMTYuODNhNDMuODksNDMuODksMCwwLDAtMTEuNzMtMTEuMTcsMzEuNzcsMzEuNzcsMCwwLDAsMjkuMjgsNTYuMTNDNTguMjksMTkyLjQ0LDU0LjY4LDE4Ni45LDU0LjEyLDE4MC4zNloiLz48cGF0aCBjbGFzcz0iY2xzLTgiIGQ9Ik0xODkuNjIsMTgwLjM2QTU4LjksNTguOSwwLDAsMCwxODgsMTY5LjA4cy0yLjM1LTkuNDQtNy4zMy0xNi44M0E0My44OSw0My44OSwwLDAsMCwxNjksMTQxLjA4YTMxLjc3LDMxLjc3LDAsMCwwLDI5LjI4LDU2LjEzQzE5My43OSwxOTIuNDQsMTkwLjE4LDE4Ni45LDE4OS42MiwxODAuMzZaIi8+PGcgaWQ9Il9Hcm91cF8yIiBkYXRhLW5hbWU9IiZsdDtHcm91cCZndDsiPjxwYXRoIGNsYXNzPSJjbHMtOSIgZD0iTTg5LjksMzMuNzhhMzIuNDYsMzIuNDYsMCwxLDEsMTEuODgsNDQuMzRBMzIuNDksMzIuNDksMCwwLDEsODkuOSwzMy43OFoiLz48L2c+PHBhdGggY2xhc3M9ImNscy0xMCIgZD0iTTEyMi4yMyw2Ni4xM2E1OC45LDU4LjksMCwwLDAtMS41OS0xMS4yN3MtMi4zNS05LjQ0LTcuMzMtMTYuODNjLTMuMzctNS05LjA2LTkuNzktMTUuNDMtMTMuNDhBMzIuNDQsMzIuNDQsMCwwLDAsMTI4Ljc3LDgwLjZDMTI1LjMxLDc2LjM5LDEyMi43LDcxLjYxLDEyMi4yMyw2Ni4xM1oiLz48L2c+PC9nPjwvZz48L3N2Zz4=",
         "body": "\nThis section describes [Cross-origin resource sharing](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) (CORS), what content types we support in requests and responses, and hyperlinking resources in each json responses.\n\n\n----\n\n* [CORS](#cors)\n* [Supported content types](#supported-content-types)\n* [Resource links](#resource-links)\n\n----\n\n### Cors\n\nThe Bitbucket API supports Cross-origin resource sharing to allow requests for restricted resources across domains. For more information you can refer to:\n\n* [Wikipedia article on CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing)\n* [W3C CORS recommendation](https://www.w3.org/TR/cors/)\n\nSending a general request from the api to bitbucket.com:\n\n`curl -i https://api.bitbucket.org -H \"origin: http://bitbucket.com\"`\n\nGives this result:\n\n    HTTP/1.1 302 FOUND\n    Server: nginx/1.6.2\n    Vary: Cookie\n    Cache-Control: max-age=900\n    Content-Type: text/html; charset=utf-8\n    Strict-Transport-Security: max-age=31536000\n    Date: Tue, 21 Jun 2016 17:54:37 GMT\n    Location: http://confluence.atlassian.com/x/IYBGDQ\n    X-Served-By: app-110\n    X-Static-Version: 2c820eb0d2b3\n    ETag: \"d41d8cd98f00b204e9800998ecf8427e\"\n    X-Content-Type-Options: nosniff\n    X-Render-Time: 0.00379920005798\n    Connection: Keep-Alive\n    X-Version: 2c820eb0d2b3\n    X-Frame-Options: SAMEORIGIN\n    X-Request-Count: 383\n    X-Cache-Info: cached\n    Content-Length: 0\n\nSending the same request with the CORS check -X OPTIONS in the call:\n\n`curl -i https://api.bitbucket.org -H \"origin: http://bitbucket.com\" -X OPTIONS`\n\nGives this result:\n\n    HTTP/1.1 302 FOUND\n    Server: nginx/1.6.2\n    Vary: Cookie\n    Cache-Control: max-age=900\n    Content-Type: text/html; charset=utf-8\n    Access-Control-Expose-Headers: Accept-Ranges, Content-Encoding, Content-Length, Content-Type, ETag, Last-Modified\n    Strict-Transport-Security: max-age=31536000\n    Date: Tue, 21 Jun 2016 18:04:30 GMT\n    Access-Control-Max-Age: 86400\n    Location: http://confluence.atlassian.com/x/IYBGDQ\n    X-Served-By: app-111\n    Access-Control-Allow-Origin: *\n    X-Static-Version: 2c820eb0d2b3\n    ETag: \"d41d8cd98f00b204e9800998ecf8427e\"\n    X-Content-Type-Options: nosniff\n    X-Render-Time: 0.00371098518372\n    Connection: keep-alive\n    X-Version: 2c820eb0d2b3\n    X-Frame-Options: SAMEORIGIN\n    X-Request-Count: 357\n    Access-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS\n    Access-Control-Allow-Headers: Accept, Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since, Origin, Range, X-CsrftokenX-Requested-With\n    X-Cache-Info: not cacheable; request wasn't a GET or HEAD\n    Content-Length: 0\n\n\n\n### Supported content types\n\nThe default and primary content type for 2.0 APIs is JSON. This applies both to responses from the server and to the request bodies provided by the client.\n\nUnless documented otherwise, whenever creating a new (POST) or modifying an existing (PUT) object, your client must provide the object's normal representation. Not every object element can be mutated. For example, a repository's created_on date is an auto-generated, immutable field. Your client can omit immutable fields from a request body.\n\nIn some cases, a resource might also accept regular application/x-www-url-form-encoded POST and PUT bodies. Such bodies can be more convenient in scripts and command line usage. Requests bodies can contain contain nested elements or they can be flat (without nested elements). Clients can send flat request bodies as either as application/json or as application/x-www-url-form-encoded. Nested objects always require JSON.\n\n### Resource links\n\nEvery 2.0 object contains a links element that points to related resources or alternate representations. Use links to quickly discover and traverse to related objects. Links serve a \"self-documenting\" function for each endpoint. For example, the following request for a specific user:\n\n\n`$ curl https://api.bitbucket.org/2.0/users/tutorials`\n\n```json\n{\n    \"username\": \"tutorials\",\n    \"nickname\": \"tutorials\",\n    \"account_status\": \"active\",\n    \"website\": \"https://tutorials.bitbucket.org/\",\n    \"display_name\": \"tutorials account\",\n    \"uuid\": \"{c788b2da-b7a2-404c-9e26-d3f077557007}\",\n    \"links\": {\n        \"self\": {\n            \"href\": \"https://api.bitbucket.org/2.0/users/tutorials\"\n        },\n        \"repositories\": {\n            \"href\": \"https://api.bitbucket.org/2.0/repositories/tutorials\"\n        },\n        \"html\": {\n            \"href\": \"https://bitbucket.org/tutorials\"\n        },\n        \"followers\": {\n            \"href\": \"https://api.bitbucket.org/2.0/users/tutorials/followers\"\n        },\n        \"avatar\": {\n            \"href\": \"https://bitbucket-assetroot.s3.amazonaws.com/c/photos/2013/Nov/25/tutorials-avatar-1563784409-6_avatar.png\"\n        },\n        \"following\": {\n            \"href\": \"https://api.bitbucket.org/2.0/users/tutorials/following\"\n        }\n    },\n    \"created_on\": \"2011-12-20T16:34:07.132459+00:00\",\n    \"location\": \"Santa Monica, CA\",\n    \"type\": \"user\"\n}\n```\nLinks can be actual REST API resources or they can be informational. In this example, informative resources include the user's avatar and the HTML URL for the user's Bitbucket account. Your client should avoid hardcoding an API's URL and instead use the URLs returned in API responses.\n\nA link's key is its `rel` (relationship) attribute and it contains a mandatory href element. For example, the following link:\n\n```json\n\"self\": {\n      \"href\": \"https://api.bitbucket.org/api/2.0/users/tutorials\"\n}\n```\n\nThe rel for this link is self and the href is https://api.bitbucket.org/api/2.0/users/tutorials. A single rel key can contain an list (array) of href objects. Your client should anticipate that any rel key can contain one or more href objects.\n\nFinally, links can also contain optional elements. Two common optional elements are the name element and the title element. They are often used to disambiguate links that share the same rel key. In the example below, the repository object that contains a clone link with two href objects. Each object contains the optional name element to clarify its use.\n\n```json\n\"links\": {\n  \"self\": {\n    \"href\": \"https://api.bitbucket.org/2.0/repositories/evzijst/bitbucket\"\n  },\n  \"clone\": [\n    {\n      \"href\": \"https://api.bitbucket.org/evzijst/bitbucket.git\",\n      \"name\": \"https\"\n    },\n    {\n      \"href\": \"ssh://git@bitbucket.org/erik/bitbucket.git\",\n      \"name\": \"ssh\"\n    }\n  ],\n  ...\n}\n```\nLinks can support [URI Templates](https://tools.ietf.org/html/rfc6570); Those that do contain a `\"templated\": \"true\"` element.\n"
       },
       {
         "anchor": "bb-connect",
-        "title": "Atlassian Connect",
-        "description": "Build Bitbucket add-ons with Connect",
-        "icon": "data:image/svg+xml;base64,b'PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB2aWV3Qm94PSIwIDAgMjU3LjMxNjMgMTYyLjU5OTQiPgogIDxkZWZzPgogICAgPHN0eWxlPgogICAgICAuY2xzLTEgewogICAgICAgIGlzb2xhdGlvbjogaXNvbGF0ZTsKICAgICAgfQoKICAgICAgLmNscy0yIHsKICAgICAgICBmaWxsOiAjMzQ0NTYzOwogICAgICB9CgogICAgICAuY2xzLTMgewogICAgICAgIGZpbGw6ICMxZGI5ZDQ7CiAgICAgIH0KCiAgICAgIC5jbHMtNCB7CiAgICAgICAgZmlsbDogIzAwNTdkODsKICAgICAgfQoKICAgICAgLmNscy01LCAuY2xzLTcsIC5jbHMtOSB7CiAgICAgICAgbWl4LWJsZW5kLW1vZGU6IG11bHRpcGx5OwogICAgICB9CgogICAgICAuY2xzLTUgewogICAgICAgIGZpbGw6IHVybCgjTjc1KTsKICAgICAgfQoKICAgICAgLmNscy02IHsKICAgICAgICBmaWxsOiAjMDA2NWZmOwogICAgICB9CgogICAgICAuY2xzLTcgewogICAgICAgIGZpbGw6IHVybCgjTjc1LTIpOwogICAgICB9CgogICAgICAuY2xzLTggewogICAgICAgIGZpbGw6IHVybCgjbGluZWFyLWdyYWRpZW50KTsKICAgICAgfQoKICAgICAgLmNscy05IHsKICAgICAgICBmaWxsOiB1cmwoI043NS0zKTsKICAgICAgfQoKICAgICAgLmNscy0xMCB7CiAgICAgICAgZmlsbDogdXJsKCNUMjAwLVQ3NSk7CiAgICAgIH0KICAgIDwvc3R5bGU+CiAgICA8bGluZWFyR3JhZGllbnQgaWQ9Ik43NSIgeDE9Ii0yMTg5LjU1NiIgeTE9IjI4MDguMjI4NCIgeDI9Ii0yMDkxLjE1NTEiIHkyPSIyODA4LjIyODQiIGdyYWRpZW50VHJhbnNmb3JtPSJtYXRyaXgoMC4xNjgxLCAwLjk4NTgsIDAuOTg1OCwgLTAuMTY4MSwgLTIzNzMuNzM2LCAyNzIyLjEyNzgpIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSI+CiAgICAgIDxzdG9wIG9mZnNldD0iMCIgc3RvcC1jb2xvcj0iI2U1ZThlYyIvPgogICAgICA8c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiNlNWU4ZWMiIHN0b3Atb3BhY2l0eT0iMC4xIi8+CiAgICA8L2xpbmVhckdyYWRpZW50PgogICAgPGxpbmVhckdyYWRpZW50IGlkPSJONzUtMiIgZGF0YS1uYW1lPSJONzUiIHgxPSItMjE2OC41OTQ3IiB5MT0iMjkzNS4wNTU2IiB4Mj0iLTIwNzAuMTkzNyIgeTI9IjI5MzUuMDU1NiIgeGxpbms6aHJlZj0iI043NSIvPgogICAgPGxpbmVhckdyYWRpZW50IGlkPSJsaW5lYXItZ3JhZGllbnQiIHgxPSIxOTAuMzU0NyIgeTE9IjE1OS45NjciIHgyPSIyNTkuOTQ4NyIgeTI9IjkwLjM3MyIgZ3JhZGllbnRVbml0cz0idXNlclNwYWNlT25Vc2UiPgogICAgICA8c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiMzNDQ1NjMiLz4KICAgICAgPHN0b3Agb2Zmc2V0PSIxIiBzdG9wLWNvbG9yPSIjNWU2Yzg0Ii8+CiAgICA8L2xpbmVhckdyYWRpZW50PgogICAgPGxpbmVhckdyYWRpZW50IGlkPSJONzUtMyIgZGF0YS1uYW1lPSJONzUiIHgxPSItMjI1Ny4zOTc3IiB5MT0iMjg4NC4yMjYzIiB4Mj0iLTIxNTguOTk2NyIgeTI9IjI4ODQuMjI2MyIgeGxpbms6aHJlZj0iI043NSIvPgogICAgPGxpbmVhckdyYWRpZW50IGlkPSJUMjAwLVQ3NSIgeDE9IjEyNi4wMjU3IiB5MT0iODUuMTA4IiB4Mj0iMTk1LjYxOTciIHkyPSIxNS41MTQiIGdyYWRpZW50VW5pdHM9InVzZXJTcGFjZU9uVXNlIj4KICAgICAgPHN0b3Agb2Zmc2V0PSIwIiBzdG9wLWNvbG9yPSIjM2RjN2RjIi8+CiAgICAgIDxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iIzljZTNlZSIvPgogICAgPC9saW5lYXJHcmFkaWVudD4KICA8L2RlZnM+CiAgPHRpdGxlPkFkZCBPbiBCbG9ja3MgMjwvdGl0bGU+CiAgPGcgY2xhc3M9ImNscy0xIj4KICAgIDxnIGlkPSJMYXllcl8yIiBkYXRhLW5hbWU9IkxheWVyIDIiPgogICAgICA8ZyBpZD0iT2JqZWN0cyI+CiAgICAgICAgPHJlY3QgaWQ9Il9SZWN0YW5nbGVfIiBkYXRhLW5hbWU9IiZsdDtSZWN0YW5nbGUmZ3Q7IiBjbGFzcz0iY2xzLTIiIHg9IjEyOC42NTgxIiB5PSI4Ny43NDA1IiB3aWR0aD0iNjQuMzI5MSIgaGVpZ2h0PSI3NC44NTkiLz4KICAgICAgICA8cmVjdCBpZD0iX1JlY3RhbmdsZV8yIiBkYXRhLW5hbWU9IiZsdDtSZWN0YW5nbGUmZ3Q7IiBjbGFzcz0iY2xzLTMiIHg9IjY0LjMyOTEiIHk9IjEyLjg4MTUiIHdpZHRoPSI2NC4zMjkxIiBoZWlnaHQ9Ijc0Ljg1OSIvPgogICAgICAgIDxyZWN0IGlkPSJfUmVjdGFuZ2xlXzMiIGRhdGEtbmFtZT0iJmx0O1JlY3RhbmdsZSZndDsiIGNsYXNzPSJjbHMtNCIgeT0iODcuNzQwNSIgd2lkdGg9IjY0LjMyOTEiIGhlaWdodD0iNzQuODU5Ii8+CiAgICAgICAgPHBhdGggY2xhc3M9ImNscy01IiBkPSJNNjQuMzI5MSw4Ny43NEg1OC42NTIzYTYyLjc4NzcsNjIuNzg3NywwLDAsMC0yNC41Njg0LDIwLjc2MjFjLTguMjYwNywxMi4xOTYtNC4zNDM3LDE4LjI0MTUtMTEuNjYzNywzMS42Mzk1QzE2LjUxLDE1MC45Niw4LjA1MSwxNTcuODIsMCwxNjIuNTU2di4wNDM1aDY0LjMyOVoiLz4KICAgICAgICA8cmVjdCBpZD0iX1JlY3RhbmdsZV80IiBkYXRhLW5hbWU9IiZsdDtSZWN0YW5nbGUmZ3Q7IiBjbGFzcz0iY2xzLTYiIHg9IjY0LjMyOTEiIHk9Ijg3Ljc0MDUiIHdpZHRoPSI2NC4zMjkxIiBoZWlnaHQ9Ijc0Ljg1OSIvPgogICAgICAgIDxwYXRoIGNsYXNzPSJjbHMtNyIgZD0iTTE5Mi45ODcyLDg3Ljc0SDE4My4zNDNhNjIuNzg3Nyw2Mi43ODc3LDAsMCwwLTI0LjU2ODQsMjAuNzYyMWMtOC4yNjA3LDEyLjE5Ni00LjM0MzgsMTguMjQxNS0xMS42NjM3LDMxLjYzOTVhNTYuNzI0Niw1Ni43MjQ2LDAsMCwxLTE4LjQ1MjcsMTkuOTF2Mi41NDc0aDY0LjMyOVoiLz4KICAgICAgICA8cmVjdCBjbGFzcz0iY2xzLTgiIHg9IjE5Mi45ODcyIiB5PSI4Ny43NDA1IiB3aWR0aD0iNjQuMzI5MSIgaGVpZ2h0PSI3NC44NTkiLz4KICAgICAgICA8cGF0aCBjbGFzcz0iY2xzLTkiIGQ9Ik0xMjguNjU4MiwxMi44ODE1SDExNi41OUE2MS45NjQ2LDYxLjk2NDYsMCwwLDAsMTAxLjMyMzMsMjguMjE1QzkzLjA2MjUsNDAuNDEwOSw5Ni45Nzk0LDQ2LjQ1NjUsODkuNjYsNTkuODU0NCw4My4wMzE2LDcxLjk4NTcsNzMuMTk3LDc5LjE1MTQsNjQuMzI5MSw4My45MTA4djMuODNoNjQuMzI5MVoiLz4KICAgICAgICA8cmVjdCBjbGFzcz0iY2xzLTEwIiB4PSIxMjguNjU4MSIgeT0iMTIuODgxNSIgd2lkdGg9IjY0LjMyOTEiIGhlaWdodD0iNzQuODU5Ii8+CiAgICAgICAgPHJlY3QgY2xhc3M9ImNscy00IiB4PSIxMC4xNjA1IiB5PSI3NC44NTkiIHdpZHRoPSIyNC43NTM2IiBoZWlnaHQ9IjEyLjg4MTUiLz4KICAgICAgICA8cmVjdCBjbGFzcz0iY2xzLTQiIHg9IjUxLjk1MjMiIHk9Ijc0Ljg1OSIgd2lkdGg9IjI0Ljc1MzYiIGhlaWdodD0iMTIuODgxNSIvPgogICAgICAgIDxyZWN0IGNsYXNzPSJjbHMtNCIgeD0iOTMuNzQ0MSIgeT0iNzQuODU5IiB3aWR0aD0iMjQuNzUzNiIgaGVpZ2h0PSIxMi44ODE1Ii8+CiAgICAgICAgPHJlY3QgY2xhc3M9ImNscy0yIiB4PSIxMzguODE4NiIgeT0iNzQuODU5IiB3aWR0aD0iMjQuNzUzNiIgaGVpZ2h0PSIxMi44ODE1Ii8+CiAgICAgICAgPHJlY3QgY2xhc3M9ImNscy0yIiB4PSIxODAuNjEwNCIgeT0iNzQuODU5IiB3aWR0aD0iMjQuNzUzNiIgaGVpZ2h0PSIxMi44ODE1Ii8+CiAgICAgICAgPHJlY3QgY2xhc3M9ImNscy0yIiB4PSIyMjIuNDAyMiIgeT0iNzQuODU5IiB3aWR0aD0iMjQuNzUzNiIgaGVpZ2h0PSIxMi44ODE1Ii8+CiAgICAgICAgPHJlY3QgY2xhc3M9ImNscy0zIiB4PSI3NC40ODk1IiB3aWR0aD0iMjQuNzUzNiIgaGVpZ2h0PSIxMi44ODE1Ii8+CiAgICAgICAgPHJlY3QgY2xhc3M9ImNscy0zIiB4PSIxMTYuMjgxNCIgd2lkdGg9IjI0Ljc1MzYiIGhlaWdodD0iMTIuODgxNSIvPgogICAgICAgIDxyZWN0IGNsYXNzPSJjbHMtMyIgeD0iMTU4LjA3MzIiIHdpZHRoPSIyNC43NTM2IiBoZWlnaHQ9IjEyLjg4MTUiLz4KICAgICAgPC9nPgogICAgPC9nPgogIDwvZz4KPC9zdmc+Cg=='",
-        "body": "\nYou can use the Atlassian Connect for Bitbucket Cloud to build add-ons which\ncan connect with the Bitbucket UI and your own application set. An add-on could\nbe an integration with another existing service, new features for the Atlassian\napplication, or even a new product that runs within the Atlassian application.\n\nFor complete information see:\n[Atlassian Connect for Bitbucket Cloud](https://developer.atlassian.com/bitbucket/index.html)\n"
+        "title": "Integrating with Bitbucket Cloud",
+        "description": "Build Bitbucket integration with Forge or Atlassian Connect",
+        "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB2aWV3Qm94PSIwIDAgMjU3LjMxNjMgMTYyLjU5OTQiPgogIDxkZWZzPgogICAgPHN0eWxlPgogICAgICAuY2xzLTEgewogICAgICAgIGlzb2xhdGlvbjogaXNvbGF0ZTsKICAgICAgfQoKICAgICAgLmNscy0yIHsKICAgICAgICBmaWxsOiAjMzQ0NTYzOwogICAgICB9CgogICAgICAuY2xzLTMgewogICAgICAgIGZpbGw6ICMxZGI5ZDQ7CiAgICAgIH0KCiAgICAgIC5jbHMtNCB7CiAgICAgICAgZmlsbDogIzAwNTdkODsKICAgICAgfQoKICAgICAgLmNscy01LCAuY2xzLTcsIC5jbHMtOSB7CiAgICAgICAgbWl4LWJsZW5kLW1vZGU6IG11bHRpcGx5OwogICAgICB9CgogICAgICAuY2xzLTUgewogICAgICAgIGZpbGw6IHVybCgjTjc1KTsKICAgICAgfQoKICAgICAgLmNscy02IHsKICAgICAgICBmaWxsOiAjMDA2NWZmOwogICAgICB9CgogICAgICAuY2xzLTcgewogICAgICAgIGZpbGw6IHVybCgjTjc1LTIpOwogICAgICB9CgogICAgICAuY2xzLTggewogICAgICAgIGZpbGw6IHVybCgjbGluZWFyLWdyYWRpZW50KTsKICAgICAgfQoKICAgICAgLmNscy05IHsKICAgICAgICBmaWxsOiB1cmwoI043NS0zKTsKICAgICAgfQoKICAgICAgLmNscy0xMCB7CiAgICAgICAgZmlsbDogdXJsKCNUMjAwLVQ3NSk7CiAgICAgIH0KICAgIDwvc3R5bGU+CiAgICA8bGluZWFyR3JhZGllbnQgaWQ9Ik43NSIgeDE9Ii0yMTg5LjU1NiIgeTE9IjI4MDguMjI4NCIgeDI9Ii0yMDkxLjE1NTEiIHkyPSIyODA4LjIyODQiIGdyYWRpZW50VHJhbnNmb3JtPSJtYXRyaXgoMC4xNjgxLCAwLjk4NTgsIDAuOTg1OCwgLTAuMTY4MSwgLTIzNzMuNzM2LCAyNzIyLjEyNzgpIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSI+CiAgICAgIDxzdG9wIG9mZnNldD0iMCIgc3RvcC1jb2xvcj0iI2U1ZThlYyIvPgogICAgICA8c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiNlNWU4ZWMiIHN0b3Atb3BhY2l0eT0iMC4xIi8+CiAgICA8L2xpbmVhckdyYWRpZW50PgogICAgPGxpbmVhckdyYWRpZW50IGlkPSJONzUtMiIgZGF0YS1uYW1lPSJONzUiIHgxPSItMjE2OC41OTQ3IiB5MT0iMjkzNS4wNTU2IiB4Mj0iLTIwNzAuMTkzNyIgeTI9IjI5MzUuMDU1NiIgeGxpbms6aHJlZj0iI043NSIvPgogICAgPGxpbmVhckdyYWRpZW50IGlkPSJsaW5lYXItZ3JhZGllbnQiIHgxPSIxOTAuMzU0NyIgeTE9IjE1OS45NjciIHgyPSIyNTkuOTQ4NyIgeTI9IjkwLjM3MyIgZ3JhZGllbnRVbml0cz0idXNlclNwYWNlT25Vc2UiPgogICAgICA8c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiMzNDQ1NjMiLz4KICAgICAgPHN0b3Agb2Zmc2V0PSIxIiBzdG9wLWNvbG9yPSIjNWU2Yzg0Ii8+CiAgICA8L2xpbmVhckdyYWRpZW50PgogICAgPGxpbmVhckdyYWRpZW50IGlkPSJONzUtMyIgZGF0YS1uYW1lPSJONzUiIHgxPSItMjI1Ny4zOTc3IiB5MT0iMjg4NC4yMjYzIiB4Mj0iLTIxNTguOTk2NyIgeTI9IjI4ODQuMjI2MyIgeGxpbms6aHJlZj0iI043NSIvPgogICAgPGxpbmVhckdyYWRpZW50IGlkPSJUMjAwLVQ3NSIgeDE9IjEyNi4wMjU3IiB5MT0iODUuMTA4IiB4Mj0iMTk1LjYxOTciIHkyPSIxNS41MTQiIGdyYWRpZW50VW5pdHM9InVzZXJTcGFjZU9uVXNlIj4KICAgICAgPHN0b3Agb2Zmc2V0PSIwIiBzdG9wLWNvbG9yPSIjM2RjN2RjIi8+CiAgICAgIDxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iIzljZTNlZSIvPgogICAgPC9saW5lYXJHcmFkaWVudD4KICA8L2RlZnM+CiAgPHRpdGxlPkFkZCBPbiBCbG9ja3MgMjwvdGl0bGU+CiAgPGcgY2xhc3M9ImNscy0xIj4KICAgIDxnIGlkPSJMYXllcl8yIiBkYXRhLW5hbWU9IkxheWVyIDIiPgogICAgICA8ZyBpZD0iT2JqZWN0cyI+CiAgICAgICAgPHJlY3QgaWQ9Il9SZWN0YW5nbGVfIiBkYXRhLW5hbWU9IiZsdDtSZWN0YW5nbGUmZ3Q7IiBjbGFzcz0iY2xzLTIiIHg9IjEyOC42NTgxIiB5PSI4Ny43NDA1IiB3aWR0aD0iNjQuMzI5MSIgaGVpZ2h0PSI3NC44NTkiLz4KICAgICAgICA8cmVjdCBpZD0iX1JlY3RhbmdsZV8yIiBkYXRhLW5hbWU9IiZsdDtSZWN0YW5nbGUmZ3Q7IiBjbGFzcz0iY2xzLTMiIHg9IjY0LjMyOTEiIHk9IjEyLjg4MTUiIHdpZHRoPSI2NC4zMjkxIiBoZWlnaHQ9Ijc0Ljg1OSIvPgogICAgICAgIDxyZWN0IGlkPSJfUmVjdGFuZ2xlXzMiIGRhdGEtbmFtZT0iJmx0O1JlY3RhbmdsZSZndDsiIGNsYXNzPSJjbHMtNCIgeT0iODcuNzQwNSIgd2lkdGg9IjY0LjMyOTEiIGhlaWdodD0iNzQuODU5Ii8+CiAgICAgICAgPHBhdGggY2xhc3M9ImNscy01IiBkPSJNNjQuMzI5MSw4Ny43NEg1OC42NTIzYTYyLjc4NzcsNjIuNzg3NywwLDAsMC0yNC41Njg0LDIwLjc2MjFjLTguMjYwNywxMi4xOTYtNC4zNDM3LDE4LjI0MTUtMTEuNjYzNywzMS42Mzk1QzE2LjUxLDE1MC45Niw4LjA1MSwxNTcuODIsMCwxNjIuNTU2di4wNDM1aDY0LjMyOVoiLz4KICAgICAgICA8cmVjdCBpZD0iX1JlY3RhbmdsZV80IiBkYXRhLW5hbWU9IiZsdDtSZWN0YW5nbGUmZ3Q7IiBjbGFzcz0iY2xzLTYiIHg9IjY0LjMyOTEiIHk9Ijg3Ljc0MDUiIHdpZHRoPSI2NC4zMjkxIiBoZWlnaHQ9Ijc0Ljg1OSIvPgogICAgICAgIDxwYXRoIGNsYXNzPSJjbHMtNyIgZD0iTTE5Mi45ODcyLDg3Ljc0SDE4My4zNDNhNjIuNzg3Nyw2Mi43ODc3LDAsMCwwLTI0LjU2ODQsMjAuNzYyMWMtOC4yNjA3LDEyLjE5Ni00LjM0MzgsMTguMjQxNS0xMS42NjM3LDMxLjYzOTVhNTYuNzI0Niw1Ni43MjQ2LDAsMCwxLTE4LjQ1MjcsMTkuOTF2Mi41NDc0aDY0LjMyOVoiLz4KICAgICAgICA8cmVjdCBjbGFzcz0iY2xzLTgiIHg9IjE5Mi45ODcyIiB5PSI4Ny43NDA1IiB3aWR0aD0iNjQuMzI5MSIgaGVpZ2h0PSI3NC44NTkiLz4KICAgICAgICA8cGF0aCBjbGFzcz0iY2xzLTkiIGQ9Ik0xMjguNjU4MiwxMi44ODE1SDExNi41OUE2MS45NjQ2LDYxLjk2NDYsMCwwLDAsMTAxLjMyMzMsMjguMjE1QzkzLjA2MjUsNDAuNDEwOSw5Ni45Nzk0LDQ2LjQ1NjUsODkuNjYsNTkuODU0NCw4My4wMzE2LDcxLjk4NTcsNzMuMTk3LDc5LjE1MTQsNjQuMzI5MSw4My45MTA4djMuODNoNjQuMzI5MVoiLz4KICAgICAgICA8cmVjdCBjbGFzcz0iY2xzLTEwIiB4PSIxMjguNjU4MSIgeT0iMTIuODgxNSIgd2lkdGg9IjY0LjMyOTEiIGhlaWdodD0iNzQuODU5Ii8+CiAgICAgICAgPHJlY3QgY2xhc3M9ImNscy00IiB4PSIxMC4xNjA1IiB5PSI3NC44NTkiIHdpZHRoPSIyNC43NTM2IiBoZWlnaHQ9IjEyLjg4MTUiLz4KICAgICAgICA8cmVjdCBjbGFzcz0iY2xzLTQiIHg9IjUxLjk1MjMiIHk9Ijc0Ljg1OSIgd2lkdGg9IjI0Ljc1MzYiIGhlaWdodD0iMTIuODgxNSIvPgogICAgICAgIDxyZWN0IGNsYXNzPSJjbHMtNCIgeD0iOTMuNzQ0MSIgeT0iNzQuODU5IiB3aWR0aD0iMjQuNzUzNiIgaGVpZ2h0PSIxMi44ODE1Ii8+CiAgICAgICAgPHJlY3QgY2xhc3M9ImNscy0yIiB4PSIxMzguODE4NiIgeT0iNzQuODU5IiB3aWR0aD0iMjQuNzUzNiIgaGVpZ2h0PSIxMi44ODE1Ii8+CiAgICAgICAgPHJlY3QgY2xhc3M9ImNscy0yIiB4PSIxODAuNjEwNCIgeT0iNzQuODU5IiB3aWR0aD0iMjQuNzUzNiIgaGVpZ2h0PSIxMi44ODE1Ii8+CiAgICAgICAgPHJlY3QgY2xhc3M9ImNscy0yIiB4PSIyMjIuNDAyMiIgeT0iNzQuODU5IiB3aWR0aD0iMjQuNzUzNiIgaGVpZ2h0PSIxMi44ODE1Ii8+CiAgICAgICAgPHJlY3QgY2xhc3M9ImNscy0zIiB4PSI3NC40ODk1IiB3aWR0aD0iMjQuNzUzNiIgaGVpZ2h0PSIxMi44ODE1Ii8+CiAgICAgICAgPHJlY3QgY2xhc3M9ImNscy0zIiB4PSIxMTYuMjgxNCIgd2lkdGg9IjI0Ljc1MzYiIGhlaWdodD0iMTIuODgxNSIvPgogICAgICAgIDxyZWN0IGNsYXNzPSJjbHMtMyIgeD0iMTU4LjA3MzIiIHdpZHRoPSIyNC43NTM2IiBoZWlnaHQ9IjEyLjg4MTUiLz4KICAgICAgPC9nPgogICAgPC9nPgogIDwvZz4KPC9zdmc+Cg==",
+        "body": "\nYou can use [Forge](https://developer.atlassian.com/cloud/bitbucket/getting-started-with-forge/) \nor [Atlassian Connect](https://developer.atlassian.com/cloud/bitbucket/getting-started-with-connect/) \nto build apps which can connect with the Bitbucket UI and your own application set. An app could\nbe an integration with another existing service, new features for the Atlassian\napplication, or even a new product that runs within the Atlassian application.\n\nFor complete information see:\n[integrating with Bitbucket Cloud](https://developer.atlassian.com/cloud/bitbucket/)\n"
       }
     ]
   },
@@ -24536,17 +25287,17 @@
             "authorizationUrl": "https://bitbucket.org/site/oauth2/authorize",
             "tokenUrl": "https://bitbucket.org/site/oauth2/access_token",
             "scopes": {
-              "email": "Read your account's primary email address",
-              "account": "Read your account information",
-              "account:write": "Read and modify your account information",
-              "team": "Read your team membership information",
-              "team:write": "Read and modify your team membership information",
               "repository": "Read your repositories",
               "repository:write": "Read and modify your repositories",
               "repository:admin": "Administer your repositories",
               "repository:delete": "Delete your repositories",
               "project": "Read your workspace's project settings and read repositories contained within your workspace's projects",
               "project:admin": "Read and modify settings for projects in your workspace",
+              "email": "Read your account's primary email address",
+              "account": "Read your account information",
+              "account:write": "Read and modify your account information",
+              "team": "Read your team membership information",
+              "team:write": "Read and modify your team membership information",
               "pipeline": "Access your repositories' build pipelines",
               "pipeline:write": "Access and rerun your repositories' build pipelines",
               "pipeline:variable": "Access your repositories' build pipelines and configure their variables",
@@ -24572,32 +25323,49 @@
       }
     },
     "schemas": {
-      "A_pull_request_task": {
+      "GPG_account_key": {
         "allOf": [
           {
-            "$ref": "#/components/schemas/task"
+            "$ref": "#/components/schemas/object"
           },
           {
             "type": "object",
             "properties": {
+              "added_on": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "comment": {
+                "type": "string",
+                "description": "The comment parsed from the GPG key (if present)"
+              },
+              "created_on": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "expires_on": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "fingerprint": {
+                "type": "string",
+                "description": "The GPG key fingerprint."
+              },
+              "key": {
+                "type": "string",
+                "description": "The GPG key value in X format."
+              },
+              "key_id": {
+                "type": "string",
+                "description": "The unique identifier for the GPG key"
+              },
+              "last_used": {
+                "type": "string",
+                "format": "date-time"
+              },
               "links": {
                 "type": "object",
                 "properties": {
-                  "html": {
-                    "type": "object",
-                    "title": "Link",
-                    "description": "A link to a resource related to this object.",
-                    "properties": {
-                      "href": {
-                        "type": "string",
-                        "format": "uri"
-                      },
-                      "name": {
-                        "type": "string"
-                      }
-                    },
-                    "additionalProperties": false
-                  },
                   "self": {
                     "type": "object",
                     "title": "Link",
@@ -24615,84 +25383,32 @@
                   }
                 },
                 "additionalProperties": false
+              },
+              "name": {
+                "type": "string",
+                "description": "The user-defined label for the GPG key"
+              },
+              "owner": {
+                "$ref": "#/components/schemas/account"
+              },
+              "parent_fingerprint": {
+                "type": "string",
+                "description": "The fingerprint of the parent key. This value is null unless the current key is a subkey."
+              },
+              "subkeys": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/GPG_account_key"
+                },
+                "minItems": 0,
+                "uniqueItems": true
               }
             },
-            "additionalProperties": false
+            "additionalProperties": true
           }
         ],
-        "title": "Pull Request Task",
-        "description": "A pull request task."
-      },
-      "A_pullrequest_comment_task": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/A_pull_request_task"
-          },
-          {
-            "type": "object",
-            "properties": {
-              "comment": {
-                "$ref": "#/components/schemas/comment"
-              }
-            },
-            "additionalProperties": false
-          }
-        ],
-        "title": "Pull Request Comment Task",
-        "description": "A pullrequest comment task"
-      },
-      "A_pullrequest_task_create": {
-        "type": "object",
-        "title": "Pull Request Task Create",
-        "description": "A pullrequest task create",
-        "properties": {
-          "comment": {
-            "$ref": "#/components/schemas/comment"
-          },
-          "content": {
-            "type": "object",
-            "title": "Task Raw Content",
-            "description": "task raw content",
-            "properties": {
-              "raw": {
-                "type": "string",
-                "description": "The task contents"
-              }
-            },
-            "required": ["raw"],
-            "additionalProperties": false
-          },
-          "pending": {
-            "type": "boolean"
-          }
-        },
-        "required": ["content"],
-        "additionalProperties": false
-      },
-      "A_pullrequest_task_update": {
-        "type": "object",
-        "title": "Pull Request Task Update",
-        "description": "A pullrequest task update",
-        "properties": {
-          "content": {
-            "type": "object",
-            "title": "Task Raw Content",
-            "description": "task raw content",
-            "properties": {
-              "raw": {
-                "type": "string",
-                "description": "The task contents"
-              }
-            },
-            "required": ["raw"],
-            "additionalProperties": false
-          },
-          "state": {
-            "type": "string",
-            "enum": ["RESOLVED", "UNRESOLVED"]
-          }
-        },
-        "additionalProperties": false
+        "title": "GPG Account Key",
+        "description": "Represents a GPG public key for a user."
       },
       "account": {
         "allOf": [
@@ -24711,10 +25427,6 @@
               },
               "links": {
                 "$ref": "#/components/schemas/account_links"
-              },
-              "username": {
-                "type": "string",
-                "pattern": "^[a-zA-Z0-9_\\-]+$"
               },
               "uuid": {
                 "type": "string"
@@ -24812,6 +25524,9 @@
               "author": {
                 "$ref": "#/components/schemas/author"
               },
+              "committer": {
+                "$ref": "#/components/schemas/committer"
+              },
               "date": {
                 "type": "string",
                 "format": "date-time"
@@ -24895,7 +25610,14 @@
                 "description": "Available merge strategies for pull requests targeting this branch.",
                 "items": {
                   "type": "string",
-                  "enum": ["merge_commit", "squash", "fast_forward"]
+                  "enum": [
+                    "merge_commit",
+                    "squash",
+                    "fast_forward",
+                    "squash_fast_forward",
+                    "rebase_fast_forward",
+                    "rebase_merge"
+                  ]
                 }
               }
             },
@@ -25089,6 +25811,23 @@
           {
             "type": "object",
             "properties": {
+              "branch_match_kind": {
+                "type": "string",
+                "description": "Indicates how the restriction is matched against a branch. The default is `glob`.",
+                "enum": ["branching_model", "glob"]
+              },
+              "branch_type": {
+                "type": "string",
+                "description": "Apply the restriction to branches of this type. Active when `branch_match_kind` is `branching_model`. The branch type will be calculated using the branching model configured for the repository.",
+                "enum": [
+                  "feature",
+                  "bugfix",
+                  "release",
+                  "hotfix",
+                  "development",
+                  "production"
+                ]
+              },
               "groups": {
                 "type": "array",
                 "items": {
@@ -25096,14 +25835,72 @@
                 },
                 "minItems": 0
               },
+              "id": {
+                "type": "integer",
+                "description": "The branch restriction status' id."
+              },
+              "kind": {
+                "type": "string",
+                "description": "The type of restriction that is being applied.",
+                "enum": [
+                  "push",
+                  "delete",
+                  "force",
+                  "restrict_merges",
+                  "require_tasks_to_be_completed",
+                  "require_approvals_to_merge",
+                  "require_review_group_approvals_to_merge",
+                  "require_default_reviewer_approvals_to_merge",
+                  "require_no_changes_requested",
+                  "require_passing_builds_to_merge",
+                  "require_commits_behind",
+                  "reset_pullrequest_approvals_on_change",
+                  "smart_reset_pullrequest_approvals",
+                  "reset_pullrequest_changes_requested_on_change",
+                  "require_all_dependencies_merged",
+                  "enforce_merge_checks",
+                  "allow_auto_merge_when_builds_pass",
+                  "require_all_comments_resolved"
+                ]
+              },
+              "links": {
+                "type": "object",
+                "properties": {
+                  "self": {
+                    "type": "object",
+                    "title": "Link",
+                    "description": "A link to a resource related to this object.",
+                    "properties": {
+                      "href": {
+                        "type": "string",
+                        "format": "uri"
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "pattern": {
+                "type": "string",
+                "description": "Apply the restriction to branches that match this pattern. Active when `branch_match_kind` is `glob`. Will be empty when `branch_match_kind` is `branching_model`."
+              },
               "users": {
                 "type": "array",
                 "items": {
                   "$ref": "#/components/schemas/account"
                 },
                 "minItems": 0
+              },
+              "value": {
+                "type": "integer",
+                "description": "Value with kind-specific semantics:\n\n* `require_approvals_to_merge` uses it to require a minimum number of approvals on a PR.\n\n* `require_default_reviewer_approvals_to_merge` uses it to require a minimum number of approvals from default reviewers on a PR.\n\n* `require_passing_builds_to_merge` uses it to require a minimum number of passing builds.\n\n* `require_commits_behind` uses it to require the current branch is up to a maximum number of commits behind it destination."
               }
             },
+            "required": ["kind", "branch_match_kind", "pattern"],
             "additionalProperties": true
           }
         ],
@@ -25393,7 +26190,7 @@
               "state": {
                 "type": "string",
                 "description": "Provides some indication of the status of this commit",
-                "enum": ["STOPPED", "INPROGRESS", "FAILED", "SUCCESSFUL"]
+                "enum": ["FAILED", "INPROGRESS", "STOPPED", "SUCCESSFUL"]
               },
               "updated_on": {
                 "type": "string",
@@ -25413,6 +26210,28 @@
         ],
         "title": "Commit Status",
         "description": "A commit status object."
+      },
+      "committer": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/object"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "raw": {
+                "type": "string",
+                "description": "The raw committer value from the repository. This may be the only value available if the committer does not match a user in Bitbucket."
+              },
+              "user": {
+                "$ref": "#/components/schemas/account"
+              }
+            },
+            "additionalProperties": true
+          }
+        ],
+        "title": "Committer",
+        "description": "The committer of a change in a repository"
       },
       "component": {
         "allOf": [
@@ -25455,20 +26274,6 @@
         ],
         "title": "Component",
         "description": "A component as defined in a repository's issue tracker."
-      },
-      "ddev_report": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/object"
-          },
-          {
-            "additionalProperties": true,
-            "type": "object",
-            "description": "A report for a commit."
-          }
-        ],
-        "x-bb-default-fields": ["uuid", "commitHash"],
-        "x-bb-url": "/rest/2.0/accounts/{target_user.uuid}/repositories/{repository.uuid}/commits/{commitHash}/reports/{uuid}"
       },
       "default_reviewer_and_type": {
         "type": "object",
@@ -25604,28 +26409,6 @@
         "x-bb-batch-max-size": 100,
         "title": "Deployment Environment",
         "description": "A Bitbucket Deployment Environment."
-      },
-      "deployment_environment_lock": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/object"
-          },
-          {
-            "additionalProperties": true,
-            "type": "object",
-            "properties": {
-              "environmentUuid": {
-                "type": "string",
-                "description": "The UUID identifying the environment."
-              }
-            }
-          }
-        ],
-        "x-bb-default-fields": ["*", "lock_opener.*", "owner.*"],
-        "x-bb-batch-url": "/rest/2.0/accounts/{target_user.uuid}/repositories/{repository.uuid}/environments/locks_batch",
-        "x-bb-batch-max-size": 100,
-        "title": "Deployment Environment Lock",
-        "description": "A Bitbucket Deployment Environment Lock."
       },
       "deployment_release": {
         "allOf": [
@@ -25875,148 +26658,6 @@
         "title": "Deployment Variable",
         "description": "A Pipelines deployment variable."
       },
-      "deployments_ddev_deployment_environment": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/object"
-          },
-          {
-            "additionalProperties": true,
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string",
-                "description": "The name of the environment."
-              },
-              "uuid": {
-                "type": "string",
-                "description": "The UUID identifying the environment."
-              }
-            }
-          }
-        ],
-        "x-bb-default-fields": ["uuid"],
-        "x-bb-url": "/rest/2.0/accounts/{target_user.uuid}/repositories/{repository.uuid}/environments/{uuid}",
-        "x-bb-batch-url": "/rest/2.0/accounts/{target_user.uuid}/repositories/{repository.uuid}/environments_batch",
-        "x-bb-batch-max-size": 100,
-        "title": "Deployment Environment",
-        "description": "A Bitbucket Deployment Environment."
-      },
-      "deployments_ddev_deployment_environment_lock": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/object"
-          },
-          {
-            "additionalProperties": true,
-            "type": "object",
-            "properties": {
-              "environmentUuid": {
-                "type": "string",
-                "description": "The UUID identifying the environment."
-              }
-            }
-          }
-        ],
-        "x-bb-default-fields": ["*", "lock_opener.*", "owner.*"],
-        "x-bb-batch-url": "/rest/2.0/accounts/{target_user.uuid}/repositories/{repository.uuid}/environments/locks_batch",
-        "x-bb-batch-max-size": 100,
-        "title": "Deployment Environment Lock",
-        "description": "A Bitbucket Deployment Environment Lock."
-      },
-      "deployments_ddev_paginated_environments": {
-        "title": "Paginated Deployment Environments",
-        "description": "A paged list of environments",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/paginated"
-          },
-          {
-            "type": "object",
-            "properties": {
-              "values": {
-                "type": "array",
-                "minItems": 0,
-                "items": {
-                  "$ref": "#/components/schemas/deployments_ddev_deployment_environment"
-                },
-                "description": "The values of the current page."
-              }
-            }
-          }
-        ]
-      },
-      "deployments_stg_west_deployment_environment": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/object"
-          },
-          {
-            "additionalProperties": true,
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string",
-                "description": "The name of the environment."
-              },
-              "uuid": {
-                "type": "string",
-                "description": "The UUID identifying the environment."
-              }
-            }
-          }
-        ],
-        "x-bb-default-fields": ["uuid"],
-        "x-bb-url": "/rest/2.0/accounts/{target_user.uuid}/repositories/{repository.uuid}/environments/{uuid}",
-        "x-bb-batch-url": "/rest/2.0/accounts/{target_user.uuid}/repositories/{repository.uuid}/environments_batch",
-        "x-bb-batch-max-size": 100,
-        "title": "Deployment Environment",
-        "description": "A Bitbucket Deployment Environment."
-      },
-      "deployments_stg_west_deployment_environment_lock": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/object"
-          },
-          {
-            "additionalProperties": true,
-            "type": "object",
-            "properties": {
-              "environmentUuid": {
-                "type": "string",
-                "description": "The UUID identifying the environment."
-              }
-            }
-          }
-        ],
-        "x-bb-default-fields": ["*", "lock_opener.*", "owner.*"],
-        "x-bb-batch-url": "/rest/2.0/accounts/{target_user.uuid}/repositories/{repository.uuid}/environments/locks_batch",
-        "x-bb-batch-max-size": 100,
-        "title": "Deployment Environment Lock",
-        "description": "A Bitbucket Deployment Environment Lock."
-      },
-      "deployments_stg_west_paginated_environments": {
-        "title": "Paginated Deployment Environments",
-        "description": "A paged list of environments",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/paginated"
-          },
-          {
-            "type": "object",
-            "properties": {
-              "values": {
-                "type": "array",
-                "minItems": 0,
-                "items": {
-                  "$ref": "#/components/schemas/deployments_stg_west_deployment_environment"
-                },
-                "description": "The values of the current page."
-              }
-            }
-          }
-        ]
-      },
       "diffstat": {
         "type": "object",
         "title": "Diff Stat",
@@ -26260,32 +26901,33 @@
             "description": "The event identifier.",
             "enum": [
               "issue:comment_created",
-              "repo:push",
-              "repo:transfer",
-              "pullrequest:changes_request_removed",
-              "pullrequest:comment_updated",
-              "pullrequest:unapproved",
-              "pullrequest:comment_created",
-              "repo:created",
-              "pullrequest:changes_request_created",
-              "repo:imported",
-              "repo:fork",
-              "project:updated",
               "issue:created",
-              "repo:deleted",
               "issue:updated",
+              "project:updated",
+              "pullrequest:approved",
+              "pullrequest:changes_request_created",
+              "pullrequest:changes_request_removed",
+              "pullrequest:comment_created",
+              "pullrequest:comment_deleted",
               "pullrequest:comment_reopened",
+              "pullrequest:comment_resolved",
+              "pullrequest:comment_updated",
+              "pullrequest:created",
+              "pullrequest:fulfilled",
+              "pullrequest:push",
+              "pullrequest:rejected",
+              "pullrequest:unapproved",
               "pullrequest:updated",
               "repo:commit_comment_created",
-              "pullrequest:created",
-              "pullrequest:approved",
-              "pullrequest:rejected",
-              "pullrequest:fulfilled",
-              "pullrequest:comment_resolved",
+              "repo:commit_status_created",
               "repo:commit_status_updated",
-              "repo:updated",
-              "pullrequest:comment_deleted",
-              "repo:commit_status_created"
+              "repo:created",
+              "repo:deleted",
+              "repo:fork",
+              "repo:imported",
+              "repo:push",
+              "repo:transfer",
+              "repo:updated"
             ]
           },
           "label": {
@@ -26771,36 +27413,6 @@
         },
         "additionalProperties": false
       },
-      "jira_project": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/object"
-          },
-          {
-            "additionalProperties": true,
-            "type": "object",
-            "description": "A Jira Project."
-          }
-        ],
-        "x-bb-default-fields": ["type", "cloudId", "id"],
-        "x-bb-detail-fields": ["key", "name", "url", "avatarUrls.*", "site"],
-        "x-bb-url": "/api/{target_user.uuid}/jira/sites/{cloudId}/projects/{id}?atlassian_account_id={user.account_id}"
-      },
-      "jira_site": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/object"
-          },
-          {
-            "additionalProperties": true,
-            "type": "object",
-            "description": "A Jira Site."
-          }
-        ],
-        "x-bb-default-fields": ["type", "cloudId", "cloudUrl", "cloudName"],
-        "x-bb-detail-fields": ["connected"],
-        "x-bb-url": "/api/{target_user.uuid}/jira/sites/{cloudId}?atlassian_account_id={user.account_id}"
-      },
       "link": {
         "type": "object",
         "title": "Link",
@@ -27253,6 +27865,29 @@
                 "type": "array",
                 "items": {
                   "$ref": "#/components/schemas/commit_file"
+                },
+                "minItems": 0,
+                "uniqueItems": true,
+                "description": "The values of the current page."
+              }
+            }
+          }
+        ]
+      },
+      "paginated_gpg_user_keys": {
+        "title": "Paginated GPG User Keys",
+        "description": "A paginated list of GPG keys.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/paginated"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "values": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/GPG_account_key"
                 },
                 "minItems": 0,
                 "uniqueItems": true,
@@ -27954,7 +28589,7 @@
               "values": {
                 "type": "array",
                 "items": {
-                  "$ref": "#/components/schemas/A_pullrequest_comment_task"
+                  "$ref": "#/components/schemas/pullrequest_comment_task"
                 },
                 "minItems": 0,
                 "uniqueItems": true,
@@ -28135,6 +28770,14 @@
                 "format": "date-time",
                 "description": "The timestamp when the Pipeline was completed. This is not set if the pipeline is still in progress."
               },
+              "configuration_sources": {
+                "type": "array",
+                "description": "An ordered list of sources of the pipeline configuration",
+                "minItems": 0,
+                "items": {
+                  "$ref": "#/components/schemas/pipeline_configuration_source"
+                }
+              },
               "created_on": {
                 "type": "string",
                 "format": "date-time",
@@ -28142,6 +28785,9 @@
               },
               "creator": {
                 "$ref": "#/components/schemas/account"
+              },
+              "links": {
+                "$ref": "#/components/schemas/pipelines_pipeline_links"
               },
               "repository": {
                 "$ref": "#/components/schemas/repository"
@@ -28287,6 +28933,22 @@
         ],
         "title": "Pipeline Commit Target",
         "description": "A Bitbucket Pipelines commit target."
+      },
+      "pipeline_configuration_source": {
+        "type": "object",
+        "description": "Information about the source of the pipeline configuration",
+        "properties": {
+          "source": {
+            "type": "string",
+            "description": "Identifier of the configuration source"
+          },
+          "uri": {
+            "type": "string",
+            "format": "uri",
+            "description": "Link to the configuration source view or its immediate content"
+          }
+        },
+        "required": ["source", "uri"]
       },
       "pipeline_error": {
         "allOf": [
@@ -29263,7 +29925,7 @@
         "title": "Pipelines Configuration",
         "description": "The Pipelines configuration for a repository."
       },
-      "pipelines_ddev_pipeline_step": {
+      "pipelines_links_section_href": {
         "allOf": [
           {
             "$ref": "#/components/schemas/object"
@@ -29271,15 +29933,19 @@
           {
             "additionalProperties": true,
             "type": "object",
-            "description": "A step of a Bitbucket pipeline. This represents the actual result of the step execution."
+            "properties": {
+              "href": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link"
+              }
+            }
           }
         ],
-        "x-bb-default-fields": ["uuid"],
-        "x-bb-url": "/rest/1.0/accounts/{target_user.uuid}/repositories/{repository.uuid}/pipelines/{pipeline.uuid}/steps/{uuid}",
-        "x-bb-batch-url": "/rest/1.0/accounts/{target_user.uuid}/repositories/{repository.uuid}/pipelines/steps_batch",
-        "x-bb-batch-max-size": 100
+        "title": "Pipeline Links href",
+        "description": "A links section href"
       },
-      "pipelines_stg_west_pipeline_step": {
+      "pipelines_pipeline_links": {
         "allOf": [
           {
             "$ref": "#/components/schemas/object"
@@ -29287,13 +29953,18 @@
           {
             "additionalProperties": true,
             "type": "object",
-            "description": "A step of a Bitbucket pipeline. This represents the actual result of the step execution."
+            "properties": {
+              "self": {
+                "$ref": "#/components/schemas/pipelines_links_section_href"
+              },
+              "steps": {
+                "$ref": "#/components/schemas/pipelines_links_section_href"
+              }
+            }
           }
         ],
-        "x-bb-default-fields": ["uuid"],
-        "x-bb-url": "/rest/1.0/accounts/{target_user.uuid}/repositories/{repository.uuid}/pipelines/{pipeline.uuid}/steps/{uuid}",
-        "x-bb-batch-url": "/rest/1.0/accounts/{target_user.uuid}/repositories/{repository.uuid}/pipelines/steps_batch",
-        "x-bb-batch-max-size": 100
+        "title": "Pipeline Links",
+        "description": "Links section for a Pipeline."
       },
       "project": {
         "allOf": [
@@ -29627,6 +30298,10 @@
               "destination": {
                 "$ref": "#/components/schemas/pullrequest_endpoint"
               },
+              "draft": {
+                "type": "boolean",
+                "description": "A boolean flag indicating whether the pull request is a draft."
+              },
               "id": {
                 "type": "integer",
                 "description": "The pull request's unique ID. Note that pull request IDs are only unique within their associated repository."
@@ -29953,6 +30628,24 @@
         "title": "Pull Request Comment",
         "description": "A pullrequest comment."
       },
+      "pullrequest_comment_task": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/pullrequest_task"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "comment": {
+                "$ref": "#/components/schemas/comment"
+              }
+            },
+            "additionalProperties": false
+          }
+        ],
+        "title": "Pull Request Comment Task",
+        "description": "A pullrequest comment task"
+      },
       "pullrequest_endpoint": {
         "type": "object",
         "title": "Pull Request Endpoint",
@@ -29970,7 +30663,14 @@
                 "description": "Available merge strategies, when this endpoint is the destination of the pull request.",
                 "items": {
                   "type": "string",
-                  "enum": ["merge_commit", "squash", "fast_forward"]
+                  "enum": [
+                    "merge_commit",
+                    "squash",
+                    "fast_forward",
+                    "squash_fast_forward",
+                    "rebase_fast_forward",
+                    "rebase_merge"
+                  ]
                 }
               },
               "name": {
@@ -30008,12 +30708,19 @@
           "merge_strategy": {
             "type": "string",
             "description": "The merge strategy that will be used to merge the pull request.",
-            "enum": ["merge_commit", "squash", "fast_forward"],
+            "enum": [
+              "merge_commit",
+              "squash",
+              "fast_forward",
+              "squash_fast_forward",
+              "rebase_fast_forward",
+              "rebase_merge"
+            ],
             "default": "merge_commit"
           },
           "message": {
             "type": "string",
-            "description": "The commit message that will be used on the resulting commit."
+            "description": "The commit message that will be used on the resulting commit. Note that the size of the message is limited to 128 KiB."
           },
           "type": {
             "type": "string"
@@ -30021,6 +30728,110 @@
         },
         "required": ["type"],
         "additionalProperties": true
+      },
+      "pullrequest_task": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/task"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "links": {
+                "type": "object",
+                "properties": {
+                  "html": {
+                    "type": "object",
+                    "title": "Link",
+                    "description": "A link to a resource related to this object.",
+                    "properties": {
+                      "href": {
+                        "type": "string",
+                        "format": "uri"
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "self": {
+                    "type": "object",
+                    "title": "Link",
+                    "description": "A link to a resource related to this object.",
+                    "properties": {
+                      "href": {
+                        "type": "string",
+                        "format": "uri"
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ],
+        "title": "Pull Request Task",
+        "description": "A pull request task."
+      },
+      "pullrequest_task_create": {
+        "type": "object",
+        "title": "Pull Request Task Create",
+        "description": "A pullrequest task create",
+        "properties": {
+          "comment": {
+            "$ref": "#/components/schemas/comment"
+          },
+          "content": {
+            "type": "object",
+            "title": "Task Raw Content",
+            "description": "task raw content",
+            "properties": {
+              "raw": {
+                "type": "string",
+                "description": "The task contents"
+              }
+            },
+            "required": ["raw"],
+            "additionalProperties": false
+          },
+          "pending": {
+            "type": "boolean"
+          }
+        },
+        "required": ["content"],
+        "additionalProperties": false
+      },
+      "pullrequest_task_update": {
+        "type": "object",
+        "title": "Pull Request Task Update",
+        "description": "A pullrequest task update",
+        "properties": {
+          "content": {
+            "type": "object",
+            "title": "Task Raw Content",
+            "description": "task raw content",
+            "properties": {
+              "raw": {
+                "type": "string",
+                "description": "The task contents"
+              }
+            },
+            "required": ["raw"],
+            "additionalProperties": false
+          },
+          "state": {
+            "type": "string",
+            "enum": ["RESOLVED", "UNRESOLVED"]
+          }
+        },
+        "additionalProperties": false
       },
       "ref": {
         "type": "object",
@@ -30903,6 +31714,14 @@
           {
             "type": "object",
             "properties": {
+              "expires_on": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "fingerprint": {
+                "type": "string",
+                "description": "The SSH key fingerprint in SHA-256 format."
+              },
               "owner": {
                 "$ref": "#/components/schemas/account"
               }
@@ -30972,20 +31791,6 @@
         ],
         "title": "SSH Key",
         "description": "Base type for representing SSH public keys."
-      },
-      "stg_west_report": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/object"
-          },
-          {
-            "additionalProperties": true,
-            "type": "object",
-            "description": "A report for a commit."
-          }
-        ],
-        "x-bb-default-fields": ["uuid", "commitHash"],
-        "x-bb-url": "/rest/2.0/accounts/{target_user.uuid}/repositories/{repository.uuid}/commits/{commitHash}/reports/{uuid}"
       },
       "subject_types": {
         "type": "object",
@@ -31216,9 +32021,6 @@
               "nickname": {
                 "type": "string",
                 "description": "Account name defined by the owner. Should be used instead of the \"username\" field. Note that \"nickname\" cannot be used in place of \"username\" in URLs and queries, as \"nickname\" is not guaranteed to be unique."
-              },
-              "website": {
-                "type": "string"
               }
             },
             "additionalProperties": true
@@ -31319,32 +32121,33 @@
                   "type": "string",
                   "enum": [
                     "issue:comment_created",
-                    "repo:push",
-                    "repo:transfer",
-                    "pullrequest:changes_request_removed",
-                    "pullrequest:comment_updated",
-                    "pullrequest:unapproved",
-                    "pullrequest:comment_created",
-                    "repo:created",
-                    "pullrequest:changes_request_created",
-                    "repo:imported",
-                    "repo:fork",
-                    "project:updated",
                     "issue:created",
-                    "repo:deleted",
                     "issue:updated",
+                    "project:updated",
+                    "pullrequest:approved",
+                    "pullrequest:changes_request_created",
+                    "pullrequest:changes_request_removed",
+                    "pullrequest:comment_created",
+                    "pullrequest:comment_deleted",
                     "pullrequest:comment_reopened",
+                    "pullrequest:comment_resolved",
+                    "pullrequest:comment_updated",
+                    "pullrequest:created",
+                    "pullrequest:fulfilled",
+                    "pullrequest:push",
+                    "pullrequest:rejected",
+                    "pullrequest:unapproved",
                     "pullrequest:updated",
                     "repo:commit_comment_created",
-                    "pullrequest:created",
-                    "pullrequest:approved",
-                    "pullrequest:rejected",
-                    "pullrequest:fulfilled",
-                    "pullrequest:comment_resolved",
+                    "repo:commit_status_created",
                     "repo:commit_status_updated",
-                    "repo:updated",
-                    "pullrequest:comment_deleted",
-                    "repo:commit_status_created"
+                    "repo:created",
+                    "repo:deleted",
+                    "repo:fork",
+                    "repo:imported",
+                    "repo:push",
+                    "repo:transfer",
+                    "repo:updated"
                   ]
                 },
                 "minItems": 1,
@@ -31395,6 +32198,15 @@
               "created_on": {
                 "type": "string",
                 "format": "date-time"
+              },
+              "forking_mode": {
+                "type": "string",
+                "description": "Controls the rules for forking repositories within this workspace.\n\n* **allow_forks**: unrestricted forking\n* **internal_only**: prevents forking of private repositories outside the workspace or to public repositories\n",
+                "enum": ["allow_forks", "internal_only"]
+              },
+              "is_privacy_enforced": {
+                "type": "boolean",
+                "description": "Indicates whether the workspace enforces private content, or whether it allows public content."
               },
               "is_private": {
                 "type": "boolean",

--- a/plugins/bitbucket-cloud-common/report.api.md
+++ b/plugins/bitbucket-cloud-common/report.api.md
@@ -106,8 +106,6 @@ export namespace Models {
     // (undocumented)
     links?: AccountLinks;
     // (undocumented)
-    username?: string;
-    // (undocumented)
     uuid?: string;
   }
   export interface AccountLinks {
@@ -124,6 +122,8 @@ export namespace Models {
   export interface BaseCommit extends ModelObject {
     // (undocumented)
     author?: Author;
+    // (undocumented)
+    committer?: Committer;
     // (undocumented)
     date?: string;
     // (undocumented)
@@ -163,6 +163,9 @@ export namespace Models {
     readonly MergeCommit: 'merge_commit';
     readonly Squash: 'squash';
     readonly FastForward: 'fast_forward';
+    readonly SquashFastForward: 'squash_fast_forward';
+    readonly RebaseFastForward: 'rebase_fast_forward';
+    readonly RebaseMerge: 'rebase_merge';
   };
   export type BranchMergeStrategiesEnum =
     (typeof BranchMergeStrategiesEnum)[keyof typeof BranchMergeStrategiesEnum];
@@ -195,6 +198,11 @@ export namespace Models {
   // (undocumented)
   export type CommitFileAttributesEnum =
     (typeof CommitFileAttributesEnum)[keyof typeof CommitFileAttributesEnum];
+  export interface Committer extends ModelObject {
+    raw?: string;
+    // (undocumented)
+    user?: Account;
+  }
   export interface Link {
     // (undocumented)
     href?: string;
@@ -416,6 +424,8 @@ export namespace Models {
   export interface Workspace extends ModelObject {
     // (undocumented)
     created_on?: string;
+    forking_mode?: WorkspaceForkingModeEnum;
+    is_privacy_enforced?: boolean;
     is_private?: boolean;
     // (undocumented)
     links?: WorkspaceLinks;
@@ -425,6 +435,12 @@ export namespace Models {
     updated_on?: string;
     uuid?: string;
   }
+  const WorkspaceForkingModeEnum: {
+    readonly AllowForks: 'allow_forks';
+    readonly InternalOnly: 'internal_only';
+  };
+  export type WorkspaceForkingModeEnum =
+    (typeof WorkspaceForkingModeEnum)[keyof typeof WorkspaceForkingModeEnum];
   // (undocumented)
   export interface WorkspaceLinks {
     // (undocumented)

--- a/plugins/bitbucket-cloud-common/report.api.md
+++ b/plugins/bitbucket-cloud-common/report.api.md
@@ -70,6 +70,30 @@ export namespace Events {
     html: Models.Link;
   }
   // (undocumented)
+  export interface RepoChange<T> {
+    // (undocumented)
+    new: T;
+    // (undocumented)
+    old: T;
+  }
+  // (undocumented)
+  export interface RepoChanges {
+    // (undocumented)
+    description?: RepoChange<string>;
+    // (undocumented)
+    full_name?: RepoChange<string>;
+    // (undocumented)
+    language?: RepoChange<string>;
+    // (undocumented)
+    links?: RepoChange<
+      Pick<Models.RepositoryLinks, 'avatar' | 'html' | 'self'>
+    >;
+    // (undocumented)
+    name?: RepoChange<string>;
+    // (undocumented)
+    website?: RepoChange<string>;
+  }
+  // (undocumented)
   export interface RepoEvent {
     // (undocumented)
     actor: Models.Account;
@@ -87,6 +111,11 @@ export namespace Events {
   export interface RepoPushEvent extends RepoEvent {
     // (undocumented)
     push: RepoPush;
+  }
+  // (undocumented)
+  export interface RepoUpdatedEvent extends RepoEvent {
+    // (undocumented)
+    changes: RepoChanges;
   }
 }
 

--- a/plugins/bitbucket-cloud-common/src/events/index.ts
+++ b/plugins/bitbucket-cloud-common/src/events/index.ts
@@ -31,6 +31,29 @@ export namespace Events {
   }
 
   /** @public */
+  export interface RepoUpdatedEvent extends RepoEvent {
+    changes: RepoChanges;
+  }
+
+  /** @public */
+  export interface RepoChanges {
+    description?: RepoChange<string>;
+    full_name?: RepoChange<string>;
+    language?: RepoChange<string>;
+    links?: RepoChange<
+      Pick<Models.RepositoryLinks, 'avatar' | 'html' | 'self'>
+    >;
+    name?: RepoChange<string>;
+    website?: RepoChange<string>;
+  }
+
+  /** @public */
+  export interface RepoChange<T> {
+    new: T;
+    old: T;
+  }
+
+  /** @public */
   export interface RepoPush {
     changes: Change[];
   }

--- a/plugins/bitbucket-cloud-common/src/models/index.ts
+++ b/plugins/bitbucket-cloud-common/src/models/index.ts
@@ -36,7 +36,6 @@ export namespace Models {
     created_on?: string;
     display_name?: string;
     links?: AccountLinks;
-    username?: string;
     uuid?: string;
   }
 
@@ -67,6 +66,7 @@ export namespace Models {
    */
   export interface BaseCommit extends ModelObject {
     author?: Author;
+    committer?: Committer;
     date?: string;
     hash?: string;
     message?: string;
@@ -139,6 +139,9 @@ export namespace Models {
     MergeCommit: 'merge_commit',
     Squash: 'squash',
     FastForward: 'fast_forward',
+    SquashFastForward: 'squash_fast_forward',
+    RebaseFastForward: 'rebase_fast_forward',
+    RebaseMerge: 'rebase_merge',
   } as const;
 
   /**
@@ -194,6 +197,18 @@ export namespace Models {
     (typeof CommitFileAttributesEnum)[keyof typeof CommitFileAttributesEnum];
 
   /**
+   * The committer of a change in a repository
+   * @public
+   */
+  export interface Committer extends ModelObject {
+    /**
+     * The raw committer value from the repository. This may be the only value available if the committer does not match a user in Bitbucket.
+     */
+    raw?: string;
+    user?: Account;
+  }
+
+  /**
    * A link to a resource related to this object.
    * @public
    */
@@ -243,6 +258,28 @@ export namespace Models {
   }
 
   /**
+   * A paginated list of branches.
+   * @public
+   */
+  export interface PaginatedBranches extends Paginated<Branch> {
+    /**
+     * The values of the current page.
+     */
+    values?: Set<Branch>;
+  }
+
+  /**
+   * A paginated list of projects
+   * @public
+   */
+  export interface PaginatedProjects extends Paginated<Project> {
+    /**
+     * The values of the current page.
+     */
+    values?: Set<Project>;
+  }
+
+  /**
    * A paginated list of repositories.
    * @public
    */
@@ -254,17 +291,6 @@ export namespace Models {
   }
 
   /**
-   * A paginated list of projects.
-   * @public
-   */
-  export interface PaginatedProjects extends Paginated<Project> {
-    /**
-     * The values of the current page.
-     */
-    values?: Set<Project>;
-  }
-
-  /**
    * A paginated list of workspaces.
    * @public
    */
@@ -273,17 +299,6 @@ export namespace Models {
      * The values of the current page.
      */
     values?: Set<Workspace>;
-  }
-
-  /**
-   * A paginated list of branches.
-   * @public
-   */
-  export interface PaginatedBranches extends Paginated<Branch> {
-    /**
-     * The values of the current page.
-     */
-    values?: Set<Branch>;
   }
 
   /**
@@ -572,6 +587,17 @@ export namespace Models {
   export interface Workspace extends ModelObject {
     created_on?: string;
     /**
+     * Controls the rules for forking repositories within this workspace.
+     *
+     * * **allow_forks**: unrestricted forking
+     * * **internal_only**: prevents forking of private repositories outside the workspace or to public repositories
+     */
+    forking_mode?: WorkspaceForkingModeEnum;
+    /**
+     * Indicates whether the workspace enforces private content, or whether it allows public content.
+     */
+    is_privacy_enforced?: boolean;
+    /**
      * Indicates whether the workspace is publicly accessible, or whether it is
      * private to the members and consequently only visible to members.
      */
@@ -591,6 +617,28 @@ export namespace Models {
      */
     uuid?: string;
   }
+
+  /**
+   * Controls the rules for forking repositories within this workspace.
+   *
+   * * **allow_forks**: unrestricted forking
+   * * **internal_only**: prevents forking of private repositories outside the workspace or to public repositories
+   * @public
+   */
+  export const WorkspaceForkingModeEnum = {
+    AllowForks: 'allow_forks',
+    InternalOnly: 'internal_only',
+  } as const;
+
+  /**
+   * Controls the rules for forking repositories within this workspace.
+   *
+   * * **allow_forks**: unrestricted forking
+   * * **internal_only**: prevents forking of private repositories outside the workspace or to public repositories
+   * @public
+   */
+  export type WorkspaceForkingModeEnum =
+    (typeof WorkspaceForkingModeEnum)[keyof typeof WorkspaceForkingModeEnum];
 
   /**
    * @public

--- a/plugins/catalog-backend-module-bitbucket-cloud/src/providers/BitbucketCloudEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-bitbucket-cloud/src/providers/BitbucketCloudEntityProvider.test.ts
@@ -123,6 +123,55 @@ describe('BitbucketCloudEntityProvider', () => {
     eventPayload: repoPushEvent,
     metadata: { 'x-event-key': 'repo:push' },
   };
+  const repoUpdatedEvent: Events.RepoUpdatedEvent = {
+    actor: {
+      type: 'user',
+    },
+    repository: {
+      type: 'repository',
+      full_name: 'test-ws/test-repo-new',
+      links: {
+        html: {
+          href: 'https://bitbucket.org/test-ws/test-repo-new',
+        },
+      },
+      workspace: {
+        type: 'workspace',
+        slug: 'test-ws',
+      },
+      project: {
+        type: 'project',
+        key: 'test-project',
+      },
+    },
+    changes: {
+      name: {
+        new: 'test-repo-new',
+        old: 'test-repo-old',
+      },
+      links: {
+        new: {
+          html: {
+            href: 'https://bitbucket.org/test-ws/test-repo-new',
+          },
+        },
+        old: {
+          html: {
+            href: 'https://bitbucket.org/test-ws/test-repo-old',
+          },
+        },
+      },
+      full_name: {
+        new: 'test-ws/test-repo-new',
+        old: 'test-ws/test-repo-old',
+      },
+    },
+  };
+  const repoUpdatedEventParams = {
+    topic: 'bitbucketCloud.repo:updated',
+    eventPayload: repoUpdatedEvent,
+    metadata: { 'x-event-key': 'repo:updated' },
+  };
 
   const createLocationEntity = (
     repoUrl: string,
@@ -698,6 +747,212 @@ describe('BitbucketCloudEntityProvider', () => {
         repository: {
           ...repoPushEventParams.eventPayload.repository,
           full_name: `${repoPushEventParams.eventPayload.repository.workspace.slug}/not-matching`,
+        },
+      },
+    });
+
+    expect(catalogApi.refreshEntity).toHaveBeenCalledTimes(0);
+    expect(entityProviderConnection.applyMutation).toHaveBeenCalledTimes(0);
+  });
+
+  it('update onRepoUpdated', async () => {
+    const oldModule = createLocationEntity(
+      'https://bitbucket.org/test-ws/test-repo-old',
+      'main',
+      'module/catalog-custom.yaml',
+    );
+    const newModule = createLocationEntity(
+      'https://bitbucket.org/test-ws/test-repo-new',
+      'main',
+      'module/catalog-custom.yaml',
+    );
+
+    const auth = mockServices.auth.mock({
+      getPluginRequestToken: async () => ({ token: 'fake-token' }),
+    });
+    const events = DefaultEventsService.create({ logger });
+    const catalogApi = catalogServiceMock.mock({
+      getEntities: async (
+        request: { filter: Record<string, string> },
+        options: { token: string },
+      ): Promise<{ items: Entity[] }> => {
+        if (
+          options.token !== 'fake-token' ||
+          request.filter.kind !== 'Location' ||
+          request.filter['metadata.annotations.bitbucket.org/repo-url'] !==
+            'https://bitbucket.org/test-ws/test-repo-old'
+        ) {
+          return { items: [] };
+        }
+
+        return {
+          items: [oldModule],
+        };
+      },
+    });
+    const provider = BitbucketCloudEntityProvider.fromConfig(defaultConfig, {
+      auth,
+      catalogApi,
+      events,
+      logger,
+      schedule,
+    })[0];
+
+    server.use(
+      rest.get(
+        `https://api.bitbucket.org/2.0/workspaces/test-ws/search/code`,
+        (req, res, ctx) => {
+          const query = req.url.searchParams.get('search_query');
+          if (!query || !query.includes('repo:test-repo-new')) {
+            return res(ctx.json({ values: [] }));
+          }
+
+          const response = {
+            values: [
+              {
+                path_matches: [
+                  {
+                    match: true,
+                    text: 'catalog-custom.yaml',
+                  },
+                ],
+                file: {
+                  type: 'commit_file',
+                  path: 'module/catalog-custom.yaml',
+                  commit: {
+                    repository: {
+                      slug: 'test-repo-new',
+                      project: {
+                        key: 'test-project',
+                      },
+                      mainbranch: {
+                        name: 'main',
+                      },
+                      links: {
+                        html: {
+                          href: 'https://bitbucket.org/test-ws/test-repo-new',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            ],
+          };
+          return res(ctx.json(response));
+        },
+      ),
+    );
+
+    await provider.connect(entityProviderConnection);
+    await events.publish(repoUpdatedEventParams);
+
+    const addedEntities = [
+      {
+        entity: newModule,
+        locationKey: 'bitbucketCloud-provider:myProvider',
+      },
+    ];
+    const removedEntities = [
+      {
+        entity: oldModule,
+        locationKey: 'bitbucketCloud-provider:myProvider',
+      },
+    ];
+
+    expect(entityProviderConnection.refresh).toHaveBeenCalledTimes(0);
+    expect(entityProviderConnection.applyMutation).toHaveBeenCalledTimes(1);
+    expect(entityProviderConnection.applyMutation).toHaveBeenCalledWith({
+      type: 'delta',
+      added: addedEntities,
+      removed: removedEntities,
+    });
+  });
+
+  it('no onRepoUpdated update on non-matching workspace slug', async () => {
+    const auth = mockServices.auth.mock();
+    const catalogApi = catalogServiceMock();
+    jest.spyOn(catalogApi, 'refreshEntity');
+    const events = DefaultEventsService.create({ logger });
+    const provider = BitbucketCloudEntityProvider.fromConfig(defaultConfig, {
+      auth,
+      catalogApi,
+      events,
+      logger,
+      schedule,
+    })[0];
+
+    await provider.connect(entityProviderConnection);
+    await events.publish({
+      ...repoUpdatedEventParams,
+      eventPayload: {
+        ...repoUpdatedEventParams.eventPayload,
+        repository: {
+          ...repoUpdatedEventParams.eventPayload.repository,
+          workspace: {
+            ...repoUpdatedEventParams.eventPayload.repository.workspace,
+            slug: 'not-matching',
+          },
+        },
+      },
+    });
+
+    expect(catalogApi.refreshEntity).toHaveBeenCalledTimes(0);
+    expect(entityProviderConnection.applyMutation).toHaveBeenCalledTimes(0);
+  });
+
+  it('no onRepoUpdated update on non-matching repo slug', async () => {
+    const auth = mockServices.auth.mock();
+    const catalogApi = catalogServiceMock();
+    jest.spyOn(catalogApi, 'refreshEntity');
+    const events = DefaultEventsService.create({ logger });
+    const provider = BitbucketCloudEntityProvider.fromConfig(defaultConfig, {
+      auth,
+      catalogApi,
+      events,
+      logger,
+      schedule,
+    })[0];
+
+    await provider.connect(entityProviderConnection);
+    await events.publish({
+      ...repoUpdatedEventParams,
+      eventPayload: {
+        ...repoUpdatedEventParams.eventPayload,
+        repository: {
+          ...repoUpdatedEventParams.eventPayload.repository,
+          full_name: `${repoUpdatedEventParams.eventPayload.repository.workspace.slug}/not-matching`,
+        },
+      },
+    });
+
+    expect(catalogApi.refreshEntity).toHaveBeenCalledTimes(0);
+    expect(entityProviderConnection.applyMutation).toHaveBeenCalledTimes(0);
+  });
+
+  it('no onRepoUpdated update on non-relevant repo update', async () => {
+    const auth = mockServices.auth.mock();
+    const catalogApi = catalogServiceMock();
+    jest.spyOn(catalogApi, 'refreshEntity');
+    const events = DefaultEventsService.create({ logger });
+    const provider = BitbucketCloudEntityProvider.fromConfig(defaultConfig, {
+      auth,
+      catalogApi,
+      events,
+      logger,
+      schedule,
+    })[0];
+
+    await provider.connect(entityProviderConnection);
+    await events.publish({
+      ...repoUpdatedEventParams,
+      eventPayload: {
+        ...repoUpdatedEventParams.eventPayload,
+        changes: {
+          description: {
+            new: 'New description',
+            old: 'Old description',
+          },
         },
       },
     });

--- a/plugins/catalog-backend-module-bitbucket-cloud/src/providers/BitbucketCloudEntityProvider.ts
+++ b/plugins/catalog-backend-module-bitbucket-cloud/src/providers/BitbucketCloudEntityProvider.ts
@@ -48,6 +48,7 @@ import * as uuid from 'uuid';
 
 const DEFAULT_BRANCH = 'master';
 const TOPIC_REPO_PUSH = 'bitbucketCloud.repo:push';
+const TOPIC_REPO_UPDATED = 'bitbucketCloud.repo:updated';
 
 /** @public */
 export const ANNOTATION_BITBUCKET_CLOUD_REPO_URL = 'bitbucket.org/repo-url';
@@ -186,13 +187,17 @@ export class BitbucketCloudEntityProvider implements EntityProvider {
 
     await this.events.subscribe({
       id: this.getProviderName(),
-      topics: [TOPIC_REPO_PUSH],
+      topics: [TOPIC_REPO_PUSH, TOPIC_REPO_UPDATED],
       onEvent: async params => {
-        if (params.topic !== TOPIC_REPO_PUSH) {
-          return;
+        if (params.topic === TOPIC_REPO_PUSH) {
+          await this.onRepoPush(params.eventPayload as Events.RepoPushEvent);
         }
 
-        await this.onRepoPush(params.eventPayload as Events.RepoPushEvent);
+        if (params.topic === TOPIC_REPO_UPDATED) {
+          await this.onRepoUpdated(
+            params.eventPayload as Events.RepoUpdatedEvent,
+          );
+        }
       },
     });
   }
@@ -217,12 +222,12 @@ export class BitbucketCloudEntityProvider implements EntityProvider {
     );
   }
 
-  private enhanceEvent(event: Events.RepoPushEvent): void {
+  private enhanceEvent(event: Events.RepoEvent): void {
     // add missing slug
     event.repository.slug = event.repository.full_name!.split('/', 2)[1];
   }
 
-  async onRepoPush(event: Events.RepoPushEvent): Promise<void> {
+  private shouldProcessEvent(event: Events.RepoEvent): boolean {
     if (!this.connection) {
       throw new Error('Not initialized');
     }
@@ -230,10 +235,18 @@ export class BitbucketCloudEntityProvider implements EntityProvider {
     this.enhanceEvent(event);
 
     if (event.repository.workspace.slug !== this.config.workspace) {
-      return;
+      return false;
     }
 
     if (!this.matchesFilters(event.repository)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  async onRepoPush(event: Events.RepoPushEvent): Promise<void> {
+    if (!this.shouldProcessEvent(event)) {
       return;
     }
 
@@ -248,12 +261,43 @@ export class BitbucketCloudEntityProvider implements EntityProvider {
     // Hence, we will just trigger a refresh for catalog file(s) within the repository
     // if we get notified about changes there.
 
-    const targets = await this.findCatalogFiles(repoSlug);
-
+    const expected = await this.findCatalogFiles(repoSlug);
     const existing = await this.findExistingLocations(repoUrl);
 
+    await this.updateForChanges(expected, existing);
+  }
+
+  private async onRepoUpdated(event: Events.RepoUpdatedEvent): Promise<void> {
+    if (!this.shouldProcessEvent(event)) {
+      return;
+    }
+
+    // The event is triggered on every change to the repository.
+    // We are only interested in changes that affect the repository URL.
+    // This is the case when the repository name (slug), or the full name changes.
+    if (!event.changes.links?.old.html?.href) {
+      return;
+    }
+
+    const repoSlug = event.repository.slug!;
+    const repoUrl = event.repository.links!.html!.href!;
+    const oldRepoUrl = event.changes.links.old.html.href;
+    this.logger.info(
+      `handle repo:updated event for ${repoUrl}, previous: ${oldRepoUrl}`,
+    );
+
+    const expected = await this.findCatalogFiles(repoSlug);
+    const existing = await this.findExistingLocations(oldRepoUrl);
+
+    await this.updateForChanges(expected, existing);
+  }
+
+  private async updateForChanges(
+    expected: IngestionTarget[],
+    existing: LocationEntity[],
+  ): Promise<void> {
     const added: DeferredEntity[] = this.toDeferredEntities(
-      targets.filter(
+      expected.filter(
         // All Locations are managed by this provider and only have `target`, never `targets`.
         // All URLs (fileUrl, target) are created using `BitbucketCloudEntityProvider.toUrl`.
         // Hence, we can keep the comparison simple and don't need to handle different
@@ -265,7 +309,7 @@ export class BitbucketCloudEntityProvider implements EntityProvider {
     const stillExisting: LocationEntity[] = [];
     const removed: DeferredEntity[] = [];
     existing.forEach(item => {
-      if (targets.find(value => value.fileUrl === item.spec.target)) {
+      if (expected.find(value => value.fileUrl === item.spec.target)) {
         stillExisting.push(item);
       } else {
         removed.push({
@@ -275,14 +319,17 @@ export class BitbucketCloudEntityProvider implements EntityProvider {
       }
     });
 
-    const promises: Promise<void>[] = [
-      this.connection.refresh({
-        keys: stillExisting.map(entity => `url:${entity.spec.target}`),
-      }),
-    ];
+    const promises: Promise<void>[] =
+      stillExisting.length === 0
+        ? []
+        : [
+            this.connection!.refresh({
+              keys: stillExisting.map(entity => `url:${entity.spec.target}`),
+            }),
+          ];
 
     if (added.length > 0 || removed.length > 0) {
-      const connection = this.connection;
+      const connection = this.connection!;
       promises.push(
         connection.applyMutation({
           type: 'delta',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

1. Updates the Bitbucket Cloud schema and models at `@backstage/plugin-bitbucket-cloud-common`. This contains a breaking change within the scope of the package only as documented within the changeset.
2. Adds support for the event type `repo:updated` as `Events.RepoUpdatedEvents` at `@backstage/plugin-bitbucket-cloud-common`.
3. Supports catalog updates based on the `repo:updated` (`bitbucketCloud.repo:updated`) events at `BitbucketCloudEntityProvider`.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
