### PR TITLE
[Catalog - GitLab Provider] fix: Add missing types to config.d.ts

### DIFF
--- a/.changeset/wicked-ideas-cross.md
+++ b/.changeset/wicked-ideas-cross.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-gitlab': patch
+---
+
+fix: Add missing config options to config declaration file

--- a/plugins/catalog-backend-module-gitlab/config.d.ts
+++ b/plugins/catalog-backend-module-gitlab/config.d.ts
@@ -34,10 +34,24 @@ export interface Config {
            */
           group?: string;
           /**
+           * If true, the provider will only ingest users that are part of the configured group.
+           */
+          restrictUsersToGroup?: boolean;
+          /**
            * (Optional) Default branch to read the catalog-info.yaml file.
            * If not set, 'master' will be used.
            */
           branch?: string;
+          /**
+           * If no `branch` is configured and there is no default branch defined at the project as well, this fallback is used
+           * to discover catalog files.
+           * Defaults to: `master`
+           */
+          fallbackBranch?: string;
+          /**
+           * Defaults to `catalog-info.yaml`
+           */
+          catalogFile?: string;
           /**
            * (Optional) The name used for the catalog file.
            * If not set, 'catalog-info.yaml' will be used.
@@ -60,6 +74,26 @@ export interface Config {
            */
           groupPattern?: string;
           /**
+           * Specifies the types of group membership relations that should be included when ingesting data.
+           *
+           * The following values are valid:
+           * - 'DIRECT': Direct members of the group. This is the default relation and is always included.
+           * - 'INHERITED': Members inherited from parent (ascendant) groups.
+           * - 'DESCENDANTS': Members from child (descendant) groups.
+           * - 'SHARED_FROM_GROUPS': Members shared from other groups.
+           *
+           * See: https://docs.gitlab.com/ee/api/graphql/reference/#groupmemberrelation
+           *
+           * If the `relations` array is provided in the app-config.yaml, it should contain any combination of the above values.
+           * The 'DIRECT' relation is automatically included and cannot be excluded, even if not specified.
+           */
+          relations?: string[];
+          /**
+           * Enable org ingestion
+           * Defaults to `false`
+           */
+          orgEnabled?: boolean;
+          /**
            * (Optional) Skip forked repository
            */
           skipForkedRepos?: boolean;
@@ -72,7 +106,12 @@ export interface Config {
            * Should be in the format group/subgroup/repo, with no leading or trailing slashes.
            */
           excludeRepos?: string[];
-
+          /**
+           * If true, users without a seat will be included in the catalog.
+           * Group/Application Access Tokens are still filtered out but you might find service accounts or other users without a seat.
+           * Defaults to `false`
+           */
+          includeUsersWithoutSeat?: boolean;
           /**
            * (Optional) If true, limit by repositories that the current user is a member of.
            * See: https://docs.gitlab.com/api/projects/#list-projects


### PR DESCRIPTION
## Changes
Adds missing types declared in [`plugins/catalog-backend-module-gitlab/src/lib/types.ts`](https://github.com/backstage/backstage/blob/8013013c593ed82c70b7403c3dd8e96d22dce2a3/plugins/catalog-backend-module-gitlab/src/lib/types.ts) to `config.d.ts`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
