### PR TITLE
Advanced Settings changes

### DIFF
--- a/.changeset/rude-towns-occur.md
+++ b/.changeset/rude-towns-occur.md
@@ -1,0 +1,5 @@
+---
+'example-app': patch
+---
+
+The advanced settings switch is not being toggle correctly in some scenarios. The switch's value property was altered by its checked property to apply changes.

--- a/.changeset/rude-towns-occur.md
+++ b/.changeset/rude-towns-occur.md
@@ -2,4 +2,4 @@
 'example-app': patch
 ---
 
-The advanced settings switch is not being toggle correctly in some scenarios. The switch's value property was altered by its checked property to apply changes.
+The advanced settings switch was not toggling correctly in some scenarios. The switch's value property was altered by its checked property to apply changes.

--- a/packages/app/src/components/advancedSettings/AdvancedSettings.tsx
+++ b/packages/app/src/components/advancedSettings/AdvancedSettings.tsx
@@ -47,7 +47,7 @@ export function AdvancedSettings() {
               <ListItemSecondaryAction>
                 <Switch
                   color="primary"
-                  value={value}
+                  checked={value === 'on'}
                   onChange={toggleValue}
                   name="advanced"
                 />


### PR DESCRIPTION

The advanced settings switch was not toggling correctly in some scenarios. The switch's value property was altered by its checked property to apply changes.