### PR TITLE
catalog: couple of fixes for new frontend system

### DIFF
--- a/.changeset/brown-pans-guess.md
+++ b/.changeset/brown-pans-guess.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Fixed the layout of summary cards in the new frontend system, ensuring that the horizontal scroll grid doesn't grow too large as well as tweaked its scrolling parameters.

--- a/.changeset/kind-pianos-fold.md
+++ b/.changeset/kind-pianos-fold.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+The about, links, and labels card now all have the `info` card type by default in the new frontend system.

--- a/.changeset/rare-olives-lay.md
+++ b/.changeset/rare-olives-lay.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Added a new `overview` entity content group for the new frontend system.

--- a/.changeset/wet-towns-laugh.md
+++ b/.changeset/wet-towns-laugh.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+The overview content is now part of the overview group by default in the new frontend system.

--- a/plugins/catalog-react/report-alpha.api.md
+++ b/plugins/catalog-react/report-alpha.api.md
@@ -110,6 +110,7 @@ export function convertLegacyEntityContentExtension(
 
 // @alpha
 export const defaultEntityContentGroups: {
+  overview: string;
   documentation: string;
   development: string;
   deployment: string;

--- a/plugins/catalog-react/src/alpha/blueprints/extensionData.tsx
+++ b/plugins/catalog-react/src/alpha/blueprints/extensionData.tsx
@@ -38,6 +38,7 @@ export const entityFilterExpressionDataRef =
  * Default entity content groups.
  */
 export const defaultEntityContentGroups = {
+  overview: 'Overview',
   documentation: 'Documentation',
   development: 'Development',
   deployment: 'Deployment',

--- a/plugins/catalog/src/alpha/DefaultEntityContentLayout.tsx
+++ b/plugins/catalog/src/alpha/DefaultEntityContentLayout.tsx
@@ -56,6 +56,7 @@ const useStyles = makeStyles<
     minWidth: 0,
   },
   summaryArea: {
+    minWidth: 0,
     margin: theme.spacing(1.5), // To counteract MUI negative grid margin
   },
   summaryCard: {
@@ -145,7 +146,7 @@ export function DefaultEntityContentLayout(props: EntityContentLayoutProps) {
         ) : null}
         {summaryCards.length > 0 ? (
           <div className={classes.summaryArea}>
-            <HorizontalScrollGrid>
+            <HorizontalScrollGrid scrollStep={400} scrollSpeed={100}>
               {summaryCards.map(card => (
                 <div className={classes.summaryCard}>{card.element}</div>
               ))}

--- a/plugins/catalog/src/alpha/entityCards.tsx
+++ b/plugins/catalog/src/alpha/entityCards.tsx
@@ -20,6 +20,7 @@ import { compatWrapper } from '@backstage/core-compat-api';
 export const catalogAboutEntityCard = EntityCardBlueprint.make({
   name: 'about',
   params: {
+    type: 'info',
     loader: async () =>
       import('../components/AboutCard').then(m =>
         compatWrapper(<m.AboutCard variant="gridItem" />),
@@ -30,6 +31,7 @@ export const catalogAboutEntityCard = EntityCardBlueprint.make({
 export const catalogLinksEntityCard = EntityCardBlueprint.make({
   name: 'links',
   params: {
+    type: 'info',
     filter: 'has:links',
     loader: async () =>
       import('../components/EntityLinksCard').then(m =>
@@ -41,6 +43,7 @@ export const catalogLinksEntityCard = EntityCardBlueprint.make({
 export const catalogLabelsEntityCard = EntityCardBlueprint.make({
   name: 'labels',
   params: {
+    type: 'info',
     filter: 'has:labels',
     loader: async () =>
       import('../components/EntityLabelsCard').then(m =>

--- a/plugins/catalog/src/alpha/entityContents.tsx
+++ b/plugins/catalog/src/alpha/entityContents.tsx
@@ -49,6 +49,7 @@ export const catalogOverviewEntityContent =
       return originalFactory({
         defaultPath: '/',
         defaultTitle: 'Overview',
+        defaultGroup: 'overview',
         loader: async () => {
           const LazyDefaultLayoutComponent = reactLazy(() =>
             import('./DefaultEntityContentLayout').then(m => ({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Couple of fixes for the catalog extensions in the new frontend system:

- Summary card layout now shrinks down and scrolls properly, polishing the scrolling a bit too
- There's a new `overview` group used by the Overview content, this ensures it's always listed first.
- The about, links, and labels card are now info cards by default

<img width="1152" alt="image" src="https://github.com/user-attachments/assets/0887f117-9c84-47c0-8b95-e77ac5e2526c" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
