### PR TITLE
Permission: improve request batching

### DIFF
--- a/.changeset/lazy-tires-show.md
+++ b/.changeset/lazy-tires-show.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-permission-backend': minor
+'@backstage/plugin-permission-common': minor
+'@backstage/plugin-permission-node': minor
+---
+
+Fixed an issue causing the `PermissionClient` to exhaust the request body size limit too quickly when making many requests.

--- a/plugins/permission-backend/src/service/router.test.ts
+++ b/plugins/permission-backend/src/service/router.test.ts
@@ -165,11 +165,7 @@ describe('createRouter', () => {
       mockApplyConditions.mockResolvedValueOnce([
         {
           id: '123',
-          result: AuthorizeResult.ALLOW,
-        },
-        {
-          id: '123',
-          result: AuthorizeResult.DENY,
+          result: [AuthorizeResult.ALLOW, AuthorizeResult.DENY],
         },
       ]);
 
@@ -197,6 +193,21 @@ describe('createRouter', () => {
             },
           ],
         });
+
+      expect(mockApplyConditions).toHaveBeenCalledWith(
+        'test-plugin',
+        expect.any(Object),
+        [
+          {
+            conditions: { params: ['abc'], rule: 'test-rule' },
+            id: '123',
+            pluginId: 'test-plugin',
+            resourceRefs: ['resource:1', 'resource:2'],
+            resourceType: 'test-resource-1',
+            result: 'CONDITIONAL',
+          },
+        ],
+      );
 
       expect(response.status).toEqual(200);
 

--- a/plugins/permission-backend/src/service/router.test.ts
+++ b/plugins/permission-backend/src/service/router.test.ts
@@ -881,6 +881,75 @@ describe('createRouter', () => {
           },
         ],
       },
+      {
+        items: [
+          {
+            id: '123',
+            resourceRef: ['resource:1'],
+            permission: {
+              type: 'resource',
+              name: 'test.permission',
+              attributes: {},
+              resourceType: 'test-resource-1',
+            },
+          },
+        ],
+      },
+      {
+        items: [
+          {
+            id: '123',
+            resourceRefs: 'resource:1',
+            permission: {
+              type: 'resource',
+              name: 'test.permission',
+              attributes: {},
+              resourceType: 'test-resource-1',
+            },
+          },
+        ],
+      },
+      {
+        items: [
+          {
+            id: '123',
+            resourceRefs: ['resource:1'],
+            resourceRef: 'resource:1',
+            permission: {
+              type: 'resource',
+              name: 'test.permission',
+              attributes: {},
+              resourceType: 'test-resource-1',
+            },
+          },
+        ],
+      },
+      {
+        items: [
+          {
+            id: '123',
+            resourceRefs: ['resource:1'],
+            permission: {
+              type: 'basic',
+              name: 'test.permission',
+              attributes: {},
+            },
+          },
+        ],
+      },
+      {
+        items: [
+          {
+            id: '123',
+            resourceRef: 'resource:1',
+            permission: {
+              type: 'basic',
+              name: 'test.permission',
+              attributes: {},
+            },
+          },
+        ],
+      },
     ])('returns a 400 error for invalid request %#', async requestBody => {
       const response = await request(app).post('/authorize').send(requestBody);
 

--- a/plugins/permission-backend/src/service/router.test.ts
+++ b/plugins/permission-backend/src/service/router.test.ts
@@ -924,6 +924,20 @@ describe('createRouter', () => {
         items: [
           {
             id: '123',
+            resourceRefs: [],
+            permission: {
+              type: 'resource',
+              name: 'test.permission',
+              attributes: {},
+              resourceType: 'test-resource-1',
+            },
+          },
+        ],
+      },
+      {
+        items: [
+          {
+            id: '123',
             resourceRefs: ['resource:1'],
             resourceRef: 'resource:1',
             permission: {
@@ -965,13 +979,7 @@ describe('createRouter', () => {
       const response = await request(app).post('/authorize').send(requestBody);
 
       expect(response.status).toEqual(400);
-      expect(response.body).toEqual(
-        expect.objectContaining({
-          error: expect.objectContaining({
-            message: expect.stringMatching(/invalid/i),
-          }),
-        }),
-      );
+      expect(response.body.error.name).toEqual('InputError');
     });
 
     it('returns a 500 error if the policy returns a different resourceType', async () => {
@@ -1009,7 +1017,7 @@ describe('createRouter', () => {
       );
     });
 
-    it(`returns a 400 error if the request doesn't contain resourceRef for credentials not issued by a service`, async () => {
+    it(`returns a 400 error if the request doesn't contain resourceRef or resourceRefs for credentials not issued by a service`, async () => {
       policy.handle.mockResolvedValueOnce({
         result: AuthorizeResult.CONDITIONAL,
         pluginId: 'test-plugin',

--- a/plugins/permission-backend/src/service/router.test.ts
+++ b/plugins/permission-backend/src/service/router.test.ts
@@ -154,7 +154,7 @@ describe('createRouter', () => {
       });
     });
 
-    it('calls the permission policy with batched resourceRefs', async () => {
+    it('calls the permission policy with batched resourceRef as an array', async () => {
       policy.handle.mockResolvedValueOnce({
         result: AuthorizeResult.CONDITIONAL,
         pluginId: 'test-plugin',
@@ -181,7 +181,7 @@ describe('createRouter', () => {
                 attributes: {},
                 resourceType: 'test-resource-1',
               },
-              resourceRefs: ['resource:1', 'resource:2'],
+              resourceRef: ['resource:1', 'resource:2'],
             },
             {
               id: '234',
@@ -202,7 +202,7 @@ describe('createRouter', () => {
             conditions: { params: ['abc'], rule: 'test-rule' },
             id: '123',
             pluginId: 'test-plugin',
-            resourceRefs: ['resource:1', 'resource:2'],
+            resourceRef: ['resource:1', 'resource:2'],
             resourceType: 'test-resource-1',
             result: 'CONDITIONAL',
           },
@@ -611,7 +611,7 @@ describe('createRouter', () => {
         });
       });
 
-      it('leaves conditional results without resourceRefs unchanged', async () => {
+      it('leaves conditional results without resourceRef unchanged', async () => {
         policy.handle
           .mockResolvedValueOnce({
             result: AuthorizeResult.CONDITIONAL,
@@ -881,79 +881,7 @@ describe('createRouter', () => {
         items: [
           {
             id: '123',
-            // resource ref should be a string
             resourceRef: ['resource:1'],
-            permission: {
-              type: 'resource',
-              name: 'test.permission',
-              attributes: {},
-              resourceType: 'test-resource-1',
-            },
-          },
-        ],
-      },
-      {
-        items: [
-          {
-            id: '123',
-            resourceRef: ['resource:1'],
-            permission: {
-              type: 'resource',
-              name: 'test.permission',
-              attributes: {},
-              resourceType: 'test-resource-1',
-            },
-          },
-        ],
-      },
-      {
-        items: [
-          {
-            id: '123',
-            resourceRefs: 'resource:1',
-            permission: {
-              type: 'resource',
-              name: 'test.permission',
-              attributes: {},
-              resourceType: 'test-resource-1',
-            },
-          },
-        ],
-      },
-      {
-        items: [
-          {
-            id: '123',
-            resourceRefs: [],
-            permission: {
-              type: 'resource',
-              name: 'test.permission',
-              attributes: {},
-              resourceType: 'test-resource-1',
-            },
-          },
-        ],
-      },
-      {
-        items: [
-          {
-            id: '123',
-            resourceRefs: ['resource:1'],
-            resourceRef: 'resource:1',
-            permission: {
-              type: 'resource',
-              name: 'test.permission',
-              attributes: {},
-              resourceType: 'test-resource-1',
-            },
-          },
-        ],
-      },
-      {
-        items: [
-          {
-            id: '123',
-            resourceRefs: ['resource:1'],
             permission: {
               type: 'basic',
               name: 'test.permission',
@@ -966,16 +894,17 @@ describe('createRouter', () => {
         items: [
           {
             id: '123',
-            resourceRef: 'resource:1',
+            resourceRef: [],
             permission: {
-              type: 'basic',
+              type: 'resource',
               name: 'test.permission',
               attributes: {},
+              resourceType: 'test-resource-1',
             },
           },
         ],
       },
-    ])('returns a 400 error for invalid request %#', async requestBody => {
+    ])('returns a 400 error for invalid request %o', async requestBody => {
       const response = await request(app).post('/authorize').send(requestBody);
 
       expect(response.status).toEqual(400);
@@ -1017,7 +946,7 @@ describe('createRouter', () => {
       );
     });
 
-    it(`returns a 400 error if the request doesn't contain resourceRef or resourceRefs for credentials not issued by a service`, async () => {
+    it(`returns a 400 error if the request doesn't contain resourceRef for credentials not issued by a service`, async () => {
       policy.handle.mockResolvedValueOnce({
         result: AuthorizeResult.CONDITIONAL,
         pluginId: 'test-plugin',

--- a/plugins/permission-backend/src/service/router.ts
+++ b/plugins/permission-backend/src/service/router.ts
@@ -76,19 +76,13 @@ const evaluatePermissionRequestSchema = z.union([
   z.object({
     id: z.string(),
     resourceRef: z.undefined().optional(),
-    resourceRefs: z.undefined().optional(),
     permission: basicPermissionSchema,
   }),
   z.object({
     id: z.string(),
-    resourceRef: z.string().optional(),
-    resourceRefs: z.undefined().optional(),
-    permission: resourcePermissionSchema,
-  }),
-  z.object({
-    id: z.string(),
-    resourceRef: z.undefined().optional(),
-    resourceRefs: z.array(z.string()).nonempty().optional(),
+    resourceRef: z
+      .union([z.string(), z.array(z.string()).nonempty()])
+      .optional(),
     permission: resourcePermissionSchema,
   }),
 ]);
@@ -178,14 +172,6 @@ const handleRequest = async (
             );
           }
 
-          if (request.resourceRefs) {
-            return applyConditionsLoaderFor(decision.pluginId).load({
-              id: request.id,
-              resourceRefs: request.resourceRefs,
-              ...decision,
-            });
-          }
-
           if (!request.resourceRef) {
             return {
               id: request.id,
@@ -265,9 +251,7 @@ export async function createRouter(
         if (
           body.items.some(
             r =>
-              isResourcePermission(r.permission) &&
-              r.resourceRef === undefined &&
-              r.resourceRefs === undefined,
+              isResourcePermission(r.permission) && r.resourceRef === undefined,
           )
         ) {
           throw new InputError(

--- a/plugins/permission-backend/src/service/router.ts
+++ b/plugins/permission-backend/src/service/router.ts
@@ -88,7 +88,7 @@ const evaluatePermissionRequestSchema = z.union([
   z.object({
     id: z.string(),
     resourceRef: z.undefined().optional(),
-    resourceRefs: z.array(z.string()),
+    resourceRefs: z.array(z.string()).nonempty().optional(),
     permission: resourcePermissionSchema,
   }),
 ]);
@@ -265,7 +265,9 @@ export async function createRouter(
         if (
           body.items.some(
             r =>
-              isResourcePermission(r.permission) && r.resourceRef === undefined,
+              isResourcePermission(r.permission) &&
+              r.resourceRef === undefined &&
+              r.resourceRefs === undefined,
           )
         ) {
           throw new InputError(

--- a/plugins/permission-common/config.d.ts
+++ b/plugins/permission-common/config.d.ts
@@ -23,5 +23,10 @@ export interface Config {
      * @visibility frontend
      */
     enabled?: boolean;
+
+    /**
+     * @visibility frontend
+     */
+    EXPERIMENTAL_enableBatchedRequests?: boolean;
   };
 }

--- a/plugins/permission-common/report.api.md
+++ b/plugins/permission-common/report.api.md
@@ -83,7 +83,7 @@ export type EvaluatePermissionRequest = {
   resourceRef?: string;
 };
 
-// @public
+// @public @deprecated
 export type EvaluatePermissionRequestBatch =
   PermissionMessageBatch<EvaluatePermissionRequest>;
 

--- a/plugins/permission-common/src/PermissionClient.test.ts
+++ b/plugins/permission-common/src/PermissionClient.test.ts
@@ -266,16 +266,31 @@ describe('PermissionClient', () => {
     });
 
     it('should include a request body', async () => {
-      await client.authorize([mockAuthorizeConditional]);
+      const basicPermission = createPermission({
+        name: 'test.permission-basic',
+        attributes: {},
+      });
+
+      await client.authorize([
+        { permission: mockPermission, resourceRef: 'foo:bar' },
+        { permission: mockPermission, resourceRef: 'foo:car' },
+        { permission: mockPermission, resourceRef: 'foo:baz' },
+        { permission: basicPermission },
+      ]);
 
       const request = mockAuthorizeHandler.mock.calls[0][0];
 
       expect(request.body).toEqual({
         items: [
-          expect.objectContaining({
+          {
+            id: expect.any(String),
             permission: mockPermission,
-            resourceRefs: ['foo:bar'],
-          }),
+            resourceRefs: ['foo:bar', 'foo:car', 'foo:baz'],
+          },
+          {
+            id: expect.any(String),
+            permission: basicPermission,
+          },
         ],
       });
     });
@@ -447,7 +462,6 @@ describe('PermissionClient', () => {
               name: 'test.permission3',
               attributes: {},
             },
-            resourceRefs: [],
             id: expect.any(String),
           },
           {

--- a/plugins/permission-common/src/PermissionClient.test.ts
+++ b/plugins/permission-common/src/PermissionClient.test.ts
@@ -17,7 +17,10 @@
 import { RestContext, rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { ConfigReader } from '@backstage/config';
-import { PermissionClient } from './PermissionClient';
+import {
+  BatchedAuthorizePermissionRequest,
+  PermissionClient,
+} from './PermissionClient';
 import {
   EvaluatePermissionRequest,
   AuthorizeResult,
@@ -36,10 +39,7 @@ const discovery: DiscoveryApi = {
     return mockBaseUrl;
   },
 };
-const client: PermissionClient = new PermissionClient({
-  discovery,
-  config: new ConfigReader({ permission: { enabled: true } }),
-});
+let client: PermissionClient;
 
 const mockPermission = createPermission({
   name: 'test.permission',
@@ -53,6 +53,13 @@ describe('PermissionClient', () => {
   afterEach(() => server.resetHandlers());
 
   describe('authorize', () => {
+    beforeAll(() => {
+      client = new PermissionClient({
+        discovery,
+        config: new ConfigReader({ permission: { enabled: true } }),
+      });
+    });
+
     const mockAuthorizeConditional = {
       permission: mockPermission,
       resourceRef: 'foo:bar',
@@ -211,7 +218,270 @@ describe('PermissionClient', () => {
     });
   });
 
+  describe('authorize (batched)', () => {
+    beforeAll(() => {
+      client = new PermissionClient({
+        discovery,
+        config: new ConfigReader({
+          permission: {
+            enabled: true,
+            EXPERIMENTAL_enableBatchedRequests: true,
+          },
+        }),
+      });
+    });
+
+    const mockAuthorizeConditional = {
+      permission: mockPermission,
+      resourceRef: 'foo:bar',
+    };
+
+    const mockAuthorizeHandler = jest.fn();
+
+    beforeEach(() => {
+      mockAuthorizeHandler.mockReset();
+      server.use(rest.post(`${mockBaseUrl}/authorize`, mockAuthorizeHandler));
+
+      mockAuthorizeHandler.mockImplementation(
+        (req, res, { json }: RestContext) => {
+          const responses = req.body.items.map(
+            (a: BatchedAuthorizePermissionRequest) => ({
+              id: a.id,
+              result: [AuthorizeResult.ALLOW],
+            }),
+          );
+
+          return res(json({ items: responses }));
+        },
+      );
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should fetch entities from correct endpoint', async () => {
+      await client.authorize([mockAuthorizeConditional]);
+      expect(mockAuthorizeHandler).toHaveBeenCalled();
+    });
+
+    it('should include a request body', async () => {
+      await client.authorize([mockAuthorizeConditional]);
+
+      const request = mockAuthorizeHandler.mock.calls[0][0];
+
+      expect(request.body).toEqual({
+        items: [
+          expect.objectContaining({
+            permission: mockPermission,
+            resourceRefs: ['foo:bar'],
+          }),
+        ],
+      });
+    });
+
+    it('should return the response from the fetch request', async () => {
+      const response = await client.authorize([mockAuthorizeConditional]);
+      expect(response[0]).toEqual(
+        expect.objectContaining({ result: AuthorizeResult.ALLOW }),
+      );
+    });
+
+    it('should not include authorization headers if no token is supplied', async () => {
+      await client.authorize([mockAuthorizeConditional]);
+
+      const request = mockAuthorizeHandler.mock.calls[0][0];
+      expect(request.headers.has('authorization')).toEqual(false);
+    });
+
+    it('should include correctly-constructed authorization header if token is supplied', async () => {
+      await client.authorize([mockAuthorizeConditional], { token });
+
+      const request = mockAuthorizeHandler.mock.calls[0][0];
+      expect(request.headers.get('authorization')).toEqual('Bearer fake-token');
+    });
+
+    it('should forward response errors', async () => {
+      mockAuthorizeHandler.mockImplementationOnce(
+        (_req, res, { status }: RestContext) => {
+          return res(status(401));
+        },
+      );
+      await expect(
+        client.authorize([mockAuthorizeConditional], { token }),
+      ).rejects.toThrow(/request failed with 401/i);
+    });
+
+    it('should reject responses with missing ids', async () => {
+      mockAuthorizeHandler.mockImplementationOnce(
+        (_req, res, { json }: RestContext) => {
+          return res(
+            json({
+              items: [{ id: 'wrong-id', result: [AuthorizeResult.ALLOW] }],
+            }),
+          );
+        },
+      );
+      await expect(
+        client.authorize([mockAuthorizeConditional], { token }),
+      ).rejects.toThrow(/items in response do not match request/i);
+    });
+
+    it('should reject invalid responses', async () => {
+      mockAuthorizeHandler.mockImplementationOnce(
+        (req, res, { json }: RestContext) => {
+          const responses = req.body.items.map(
+            (a: IdentifiedPermissionMessage<EvaluatePermissionRequest>) => ({
+              id: a.id,
+              outcome: AuthorizeResult.ALLOW,
+            }),
+          );
+
+          return res(json({ items: responses }));
+        },
+      );
+      await expect(
+        client.authorize([mockAuthorizeConditional], { token }),
+      ).rejects.toThrow(/invalid_type/i);
+    });
+
+    it('should allow all when permission.enabled is false', async () => {
+      const disabled = new PermissionClient({
+        discovery,
+        config: new ConfigReader({ permission: { enabled: false } }),
+      });
+      const response = await disabled.authorize([mockAuthorizeConditional]);
+      expect(response[0]).toEqual(
+        expect.objectContaining({ result: AuthorizeResult.ALLOW }),
+      );
+      expect(mockAuthorizeHandler).not.toHaveBeenCalled();
+    });
+
+    it('should allow all when permission.enabled is not configured', async () => {
+      const disabled = new PermissionClient({
+        discovery,
+        config: new ConfigReader({}),
+      });
+      const response = await disabled.authorize([mockAuthorizeConditional]);
+      expect(response[0]).toEqual(
+        expect.objectContaining({ result: AuthorizeResult.ALLOW }),
+      );
+      expect(mockAuthorizeHandler).not.toHaveBeenCalled();
+    });
+
+    it('should properly map the permissions', async () => {
+      const mockPermission2 = createPermission({
+        name: 'test.permission2',
+        attributes: {},
+        resourceType: 'foo',
+      });
+
+      const mockPermission3 = createPermission({
+        name: 'test.permission3',
+        attributes: {},
+      });
+
+      mockAuthorizeHandler.mockImplementationOnce(
+        (req, res, { json }: RestContext) => {
+          return res(
+            json({
+              items: [
+                {
+                  id: req.body.items[0].id,
+                  result: [AuthorizeResult.ALLOW, AuthorizeResult.DENY],
+                },
+                {
+                  id: req.body.items[1].id,
+                  result: [AuthorizeResult.DENY],
+                },
+                {
+                  id: req.body.items[2].id,
+                  result: [AuthorizeResult.DENY, AuthorizeResult.ALLOW],
+                },
+              ],
+            }),
+          );
+        },
+      );
+
+      const response = await client.authorize([
+        {
+          permission: mockPermission,
+          resourceRef: 'foo:bar', // allow
+        },
+        {
+          permission: mockPermission3, // deny
+        },
+        {
+          permission: mockPermission,
+          resourceRef: 'foo:car', // deny
+        },
+        {
+          permission: mockPermission3, // deny
+        },
+        {
+          permission: mockPermission2,
+          resourceRef: 'r2', // deny
+        },
+        {
+          permission: mockPermission2,
+          resourceRef: 'r1', // allow
+        },
+      ]);
+
+      expect(mockAuthorizeHandler.mock.calls[0][0].body).toEqual({
+        items: [
+          {
+            permission: {
+              type: 'resource',
+              name: 'test.permission',
+              attributes: {},
+              resourceType: 'foo',
+            },
+            resourceRefs: ['foo:bar', 'foo:car'],
+            id: expect.any(String),
+          },
+          {
+            permission: {
+              type: 'basic',
+              name: 'test.permission3',
+              attributes: {},
+            },
+            resourceRefs: [],
+            id: expect.any(String),
+          },
+          {
+            permission: {
+              type: 'resource',
+              name: 'test.permission2',
+              attributes: {},
+              resourceType: 'foo',
+            },
+            resourceRefs: ['r2', 'r1'],
+            id: expect.any(String),
+          },
+        ],
+      });
+
+      expect(response).toEqual([
+        { result: 'ALLOW' },
+        { result: 'DENY' },
+        { result: 'DENY' },
+        { result: 'DENY' },
+        { result: 'DENY' },
+        { result: 'ALLOW' },
+      ]);
+    });
+  });
+
   describe('authorizeConditional', () => {
+    beforeAll(() => {
+      client = new PermissionClient({
+        discovery,
+        config: new ConfigReader({ permission: { enabled: true } }),
+      });
+    });
+
     const mockResourceAuthorizeConditional = {
       permission: mockPermission,
     };
@@ -420,7 +690,7 @@ describe('PermissionClient', () => {
             }),
           );
 
-          return res(json(responses));
+          return res(json({ items: responses }));
         },
       );
       const disabled = new PermissionClient({

--- a/plugins/permission-common/src/PermissionClient.test.ts
+++ b/plugins/permission-common/src/PermissionClient.test.ts
@@ -285,7 +285,7 @@ describe('PermissionClient', () => {
           {
             id: expect.any(String),
             permission: mockPermission,
-            resourceRefs: ['foo:bar', 'foo:car', 'foo:baz'],
+            resourceRef: ['foo:bar', 'foo:car', 'foo:baz'],
           },
           {
             id: expect.any(String),
@@ -453,7 +453,7 @@ describe('PermissionClient', () => {
               attributes: {},
               resourceType: 'foo',
             },
-            resourceRefs: ['foo:bar', 'foo:car'],
+            resourceRef: ['foo:bar', 'foo:car'],
             id: expect.any(String),
           },
           {
@@ -471,7 +471,7 @@ describe('PermissionClient', () => {
               attributes: {},
               resourceType: 'foo',
             },
-            resourceRefs: ['r2', 'r1'],
+            resourceRef: ['r2', 'r1'],
             id: expect.any(String),
           },
         ],

--- a/plugins/permission-common/src/PermissionClient.ts
+++ b/plugins/permission-common/src/PermissionClient.ts
@@ -62,7 +62,10 @@ const authorizePermissionResponseSchema: z.ZodSchema<AuthorizePermissionResponse
 
 const authorizePermissionResponseBatchSchema = z.object({
   result: z.array(
-    z.literal(AuthorizeResult.ALLOW).or(z.literal(AuthorizeResult.DENY)),
+    z.union([
+      z.literal(AuthorizeResult.ALLOW),
+      z.literal(AuthorizeResult.DENY),
+    ]),
   ),
 });
 

--- a/plugins/permission-common/src/PermissionClient.ts
+++ b/plugins/permission-common/src/PermissionClient.ts
@@ -35,7 +35,6 @@ import { DiscoveryApi } from './types/discovery';
 import {
   AuthorizeRequestOptions,
   BasicPermission,
-  Permission,
   ResourcePermission,
 } from './types/permission';
 import { isResourcePermission } from './permissions';
@@ -270,6 +269,9 @@ export class PermissionClient implements PermissionEvaluator {
   }
 }
 
+/**
+ * @internal
+ */
 export type BatchedAuthorizePermissionRequest = IdentifiedPermissionMessage<
   | {
       permission: BasicPermission;

--- a/plugins/permission-common/src/PermissionClient.ts
+++ b/plugins/permission-common/src/PermissionClient.ts
@@ -213,15 +213,15 @@ export class PermissionClient implements PermissionEvaluator {
           resourceRefs: [],
           id: uuid.v4(),
         };
+
+        if (resourceRef) {
+          request[permission.name].resourceRefs?.push(resourceRef);
+        }
       } else {
         request[permission.name] ||= {
           permission,
           id: uuid.v4(),
         };
-      }
-
-      if (resourceRef) {
-        request[permission.name].resourceRefs?.push(resourceRef);
       }
     }
 

--- a/plugins/permission-common/src/PermissionClient.ts
+++ b/plugins/permission-common/src/PermissionClient.ts
@@ -210,12 +210,12 @@ export class PermissionClient implements PermissionEvaluator {
       if (isResourcePermission(permission)) {
         request[permission.name] ||= {
           permission,
-          resourceRefs: [],
+          resourceRef: [],
           id: uuid.v4(),
         };
 
         if (resourceRef) {
-          request[permission.name].resourceRefs?.push(resourceRef);
+          request[permission.name].resourceRef?.push(resourceRef);
         }
       } else {
         request[permission.name] ||= {
@@ -231,10 +231,15 @@ export class PermissionClient implements PermissionEvaluator {
       options,
     );
 
+    const responsesById = parsedResponse.items.reduce((acc, r) => {
+      acc[r.id] = r;
+      return acc;
+    }, {} as Record<string, (typeof parsedResponse)['items'][number]>);
+
     return queries.map(query => {
       const { id } = request[query.permission.name];
 
-      const item = parsedResponse.items.find(i => i.id === id)!;
+      const item = responsesById[id];
       return {
         result: query.resourceRef ? item.result.shift()! : item.result[0],
       };
@@ -278,7 +283,7 @@ export class PermissionClient implements PermissionEvaluator {
 export type BatchedAuthorizePermissionRequest = IdentifiedPermissionMessage<
   | {
       permission: BasicPermission;
-      resourceRefs?: undefined;
+      resourceRef?: undefined;
     }
-  | { permission: ResourcePermission; resourceRefs: string[] }
+  | { permission: ResourcePermission; resourceRef: string[] }
 >;

--- a/plugins/permission-common/src/index.ts
+++ b/plugins/permission-common/src/index.ts
@@ -21,4 +21,7 @@
  */
 export * from './types';
 export * from './permissions';
-export * from './PermissionClient';
+export {
+  PermissionClient,
+  type PermissionClientRequestOptions,
+} from './PermissionClient';

--- a/plugins/permission-common/src/types/api.ts
+++ b/plugins/permission-common/src/types/api.ts
@@ -176,6 +176,7 @@ export type EvaluatePermissionRequest = {
 /**
  * A batch of requests sent to the permission backend.
  * @public
+ * @deprecated This type is not used and it will be removed in the future
  */
 export type EvaluatePermissionRequestBatch =
   PermissionMessageBatch<EvaluatePermissionRequest>;

--- a/plugins/permission-node/report.api.md
+++ b/plugins/permission-node/report.api.md
@@ -7,6 +7,7 @@ import { AllOfCriteria } from '@backstage/plugin-permission-common';
 import { AnyOfCriteria } from '@backstage/plugin-permission-common';
 import { AuthorizePermissionRequest } from '@backstage/plugin-permission-common';
 import { AuthorizePermissionResponse } from '@backstage/plugin-permission-common';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
 import { AuthService } from '@backstage/backend-plugin-api';
 import { BackstageCredentials } from '@backstage/backend-plugin-api';
 import { BackstageUserIdentity } from '@backstage/plugin-auth-node';
@@ -37,11 +38,20 @@ export type ApplyConditionsRequest = {
 };
 
 // @public
-export type ApplyConditionsRequestEntry = IdentifiedPermissionMessage<{
-  resourceRef: string;
-  resourceType: string;
-  conditions: PermissionCriteria<PermissionCondition>;
-}>;
+export type ApplyConditionsRequestEntry = IdentifiedPermissionMessage<
+  | {
+      resourceRef: string;
+      resourceRefs?: undefined;
+      resourceType: string;
+      conditions: PermissionCriteria<PermissionCondition>;
+    }
+  | {
+      resourceRef?: undefined;
+      resourceRefs: string[];
+      resourceType: string;
+      conditions: PermissionCriteria<PermissionCondition>;
+    }
+>;
 
 // @public
 export type ApplyConditionsResponse = {
@@ -49,8 +59,12 @@ export type ApplyConditionsResponse = {
 };
 
 // @public
-export type ApplyConditionsResponseEntry =
-  IdentifiedPermissionMessage<DefinitivePolicyDecision>;
+export type ApplyConditionsResponseEntry = IdentifiedPermissionMessage<
+  | DefinitivePolicyDecision
+  | {
+      result: Array<AuthorizeResult.ALLOW | AuthorizeResult.DENY>;
+    }
+>;
 
 // @public
 export type Condition<TRule> = TRule extends PermissionRule<

--- a/plugins/permission-node/report.api.md
+++ b/plugins/permission-node/report.api.md
@@ -38,20 +38,11 @@ export type ApplyConditionsRequest = {
 };
 
 // @public
-export type ApplyConditionsRequestEntry = IdentifiedPermissionMessage<
-  | {
-      resourceRef: string;
-      resourceRefs?: undefined;
-      resourceType: string;
-      conditions: PermissionCriteria<PermissionCondition>;
-    }
-  | {
-      resourceRef?: undefined;
-      resourceRefs: string[];
-      resourceType: string;
-      conditions: PermissionCriteria<PermissionCondition>;
-    }
->;
+export type ApplyConditionsRequestEntry = IdentifiedPermissionMessage<{
+  resourceRef: string | string[];
+  resourceType: string;
+  conditions: PermissionCriteria<PermissionCondition>;
+}>;
 
 // @public
 export type ApplyConditionsResponse = {

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
@@ -567,6 +567,101 @@ describe('createPermissionIntegrationRouter', () => {
       });
     });
 
+    describe('batched requests with resourceRefs', () => {
+      let response: Response;
+
+      beforeEach(async () => {
+        const app = express().use(
+          createPermissionIntegrationRouter(mockedOptionResources).use(
+            middleware.error(),
+          ),
+        );
+
+        mockTestRule1Apply.mockReturnValueOnce(true);
+        mockTestRule1Apply.mockReturnValueOnce(false);
+        mockTestRule1Apply.mockReturnValueOnce(false);
+
+        response = await request(app)
+          .post('/.well-known/backstage/permissions/apply-conditions')
+          .send({
+            items: [
+              {
+                id: '123',
+                resourceRefs: [
+                  'default:test/resource-1',
+                  'default:test/resource-2',
+                ],
+                resourceType: 'test-resource',
+                conditions: {
+                  rule: 'test-rule-1',
+                  resourceType: 'test-resource',
+                  params: {
+                    foo: 'a',
+                    bar: 1,
+                  },
+                },
+              },
+              {
+                id: '234',
+                resourceRef: 'default:test/resource-3',
+                resourceType: 'test-resource',
+                conditions: {
+                  rule: 'test-rule-1',
+                  resourceType: 'test-resource',
+                  params: {
+                    foo: 'a',
+                    bar: 1,
+                  },
+                },
+              },
+              {
+                id: '345',
+                resourceRef: 'default:test/resource-2',
+                resourceType: 'test-resource-2',
+                conditions: {
+                  not: {
+                    rule: 'test-rule-1',
+                    resourceType: 'test-resource-2',
+                    params: {
+                      foo: 'a',
+                      bar: 1,
+                    },
+                  },
+                },
+              },
+            ],
+          });
+      });
+
+      it('processes batched requests', () => {
+        expect(response.status).toEqual(200);
+        expect(response.body).toEqual({
+          items: [
+            {
+              id: '123',
+              result: [AuthorizeResult.ALLOW, AuthorizeResult.DENY],
+            },
+            {
+              id: '234',
+              result: AuthorizeResult.DENY,
+            },
+            { id: '345', result: AuthorizeResult.ALLOW },
+          ],
+        });
+      });
+
+      it('calls getResources for all required resources at once', () => {
+        expect(defaultMockedGetResources1).toHaveBeenCalledWith([
+          'default:test/resource-1',
+          'default:test/resource-2',
+          'default:test/resource-3',
+        ]);
+        expect(defaultMockedGetResources2).toHaveBeenCalledWith([
+          'default:test/resource-2',
+        ]);
+      });
+    });
+
     it('returns 400 when called with incorrect resource type', async () => {
       const response = await request(createApp())
         .post('/.well-known/backstage/permissions/apply-conditions')

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
@@ -567,7 +567,7 @@ describe('createPermissionIntegrationRouter', () => {
       });
     });
 
-    describe('batched requests with resourceRefs', () => {
+    describe('batched requests with resourceRef as an array', () => {
       let response: Response;
 
       beforeEach(async () => {
@@ -587,7 +587,7 @@ describe('createPermissionIntegrationRouter', () => {
             items: [
               {
                 id: '123',
-                resourceRefs: [
+                resourceRef: [
                   'default:test/resource-1',
                   'default:test/resource-2',
                 ],

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
@@ -536,11 +536,7 @@ export function createPermissionIntegrationRouter<
           requestedType,
           requests
             .filter(r => r.resourceType === requestedType)
-            .map(i =>
-              typeof i.resourceRef === 'string'
-                ? [i.resourceRef]
-                : i.resourceRefs,
-            )
+            .map(i => i.resourceRefs ?? [i.resourceRef])
             .flat(),
         );
       }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR optimizes the permission framework requests flow by batching requests. This fixes #23303, as the search plugin currently performs result-by-result authorization. When attempting to authorize the catalog search results, search sends: 

```json
[
  {
    "items": [
      {
        "id": "b8c3abdf-2f8a-44ff-ab52-5af9671a92bf",
        "resourceRef": "user:default/sarah.gilroy",
        "permission": {
          "type": "resource",
          "name": "catalog.entity.read",
          "attributes": {
            "action": "read"
          },
          "resourceType": "catalog-entity"
        }
      },
      {
        "id": "6a38049d-de04-46fa-84cf-9861aaebba0f",
        "resourceRef": "group:default/team-c",
        "permission": {
          "type": "resource",
          "name": "catalog.entity.read",
          "attributes": {
            "action": "read"
          },
          "resourceType": "catalog-entity"
        }
      },
      ... // x times depending on the set limit
]
```

if you have a permission policy returning a conditional result, for example containing the following conditional decision:

```js
  if (
    isPermission(request.permission, catalogEntityReadPermission)
  ) {
    return createCatalogConditionalDecision(request.permission, {
      not: catalogConditions.hasMetadata({ key: 'something' }),
    });
  }
```

the permission-backend sends to catalog the resolved value of the permission policy:

```json
  {
    "items": [
      {
        "id": "f2e0b4a1-79ee-41c4-8dcb-9187286d3e74",
        "resourceRef": "location:default/example-systems",
        "resourceType": "catalog-entity",
        "conditions": {
          "not": {
            "rule": "HAS_METADATA",
            "resourceType": "catalog-entity",
            "params": {
              "key": "something"
            }
          }
        }
      },
      {
        "id": "cdef0c2e-2ec3-4284-8204-251b54483f35",
        "resourceRef": "user:default/lucy.sheehan",
        "resourceType": "catalog-entity",
        "conditions": {
          "not": {
            "rule": "HAS_METADATA",
            "resourceType": "catalog-entity",
            "params": {
              "key": "something"
            }
          }
        }
      },
      // ... x times depending on the set limit
]
```

Note that in the request above the resolved value of the permission policy is repeated x times. So if your permission policy is more complex than the one above, the payload limit is exhausted faster.

With the new approach the first request becomes:

```json
  {
    "items": [
      {
        "id": "f9c5bd93-9bc9-455b-89f8-c918e15121e3",
        "resourceRefs": [
          "user:default/colette.brock",
          "user:default/nigel.manning",
          // ...x times depending on the set limit
        ],
        "permission": {
          "type": "resource",
          "name": "catalog.entity.read",
          "attributes": {
            "action": "read"
          },
          "resourceType": "catalog-entity"
        }
      }
    ]
  }
```

The second request:

```json
  {
    "items": [
      {
        "id": "beebd90b-3445-482f-82c4-98220be83d09",
        "resourceRefs": [
          "user:default/colette.brock",
          "user:default/nigel.manning",
          // ...x times depending on the set limit
        ],
        "resourceType": "catalog-entity",
        "conditions": {
          "not": {
            "rule": "HAS_METADATA",
            "resourceType": "catalog-entity",
            "params": {
              "key": "something"
            }
          }
        }
      }
    ]
  }
```

This should avoid exhausting the request body size limit too quickly.
Note that the new batching of requests happens internally within the `PermissionClient`, so no changes are needed to the plugins authorizing the permissions. However, since the new version of `@backstage/plugin-permission-common` needs to be in sync with the new version of `@backstage/plugin-permission-backend`, I have introduced a new `permission.EXPERIMENTAL_enableBatchedRequests` configuration to enable the new batching mode. Eventually, we can enable this feature by default in the future.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
