### PR TITLE
add `backend.trustProxy`

### DIFF
--- a/.changeset/plain-groups-sleep.md
+++ b/.changeset/plain-groups-sleep.md
@@ -1,0 +1,17 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Added an optional `backend.trustProxy` app config value, which sets the
+corresponding [Express.js `trust proxy`](https://expressjs.com/en/guide/behind-proxies.html) setting. This lets
+you easily configure proxy trust without making a custom `configure` callback
+for the `rootHttpRouter` service.
+
+If you already are using a custom `configure` callback, and if that also _does not_ call `applyDefaults()`, you may want to add the following to it:
+
+```ts
+const trustProxy = config.getOptional('backend.trustProxy');
+if (trustProxy !== undefined) {
+  app.set('trust proxy', trustProxy);
+}
+```

--- a/packages/backend-defaults/config.d.ts
+++ b/packages/backend-defaults/config.d.ts
@@ -51,6 +51,19 @@ export interface Config {
       serverShutdownDelay?: string | HumanDuration;
     };
 
+    /**
+     * Corresponds to the Express `trust proxy` setting.
+     *
+     * @see https://expressjs.com/en/guide/behind-proxies.html
+     * @remarks
+     *
+     * This setting is used to determine whether the backend should trust the
+     * `X-Forwarded-*` headers that are set by proxies. This is important for
+     * determining the original client IP address and protocol (HTTP/HTTPS) when
+     * the backend is behind a reverse proxy or load balancer.
+     */
+    trustProxy?: boolean | number | string | string[];
+
     /** Address that the backend should listen to. */
     listen?:
       | string

--- a/packages/backend-defaults/src/entrypoints/rootHttpRouter/rootHttpRouterServiceFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/rootHttpRouter/rootHttpRouterServiceFactory.ts
@@ -87,6 +87,8 @@ const rootHttpRouterServiceFactoryWithOptions = (
       const logger = rootLogger.child({ service: 'rootHttpRouter' });
       const app = express();
 
+      const trustProxy = config.getOptional('backend.trustProxy');
+
       const router = DefaultRootHttpRouter.create({ indexPath });
       const middleware = MiddlewareFactory.create({ config, logger });
       const routes = router.handler();
@@ -111,6 +113,9 @@ const rootHttpRouterServiceFactoryWithOptions = (
         applyDefaults() {
           if (process.env.NODE_ENV === 'development') {
             app.set('json spaces', 2);
+          }
+          if (trustProxy !== undefined) {
+            app.set('trust proxy', trustProxy);
           }
           app.use(middleware.helmet());
           app.use(middleware.cors());


### PR DESCRIPTION
This is off the back of https://github.com/backstage/backstage/pull/28708 . I feel that, whether the rate limiting lands or not, this setting is important and universal enough that it may warrant being added separately either way.

It's a complex type, and I opted to just blankly make it use `getOptional` instead of writing a thorough validation for it, expecting Express to handle it instead.