### PR TITLE
fix: default width option to column factories as auto

### DIFF
--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.test.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.test.tsx
@@ -448,4 +448,34 @@ describe('CatalogTable component', () => {
     const labelCellValue = screen.getByText('generic');
     expect(labelCellValue).toBeInTheDocument();
   });
+  it('should set width: auto for columns by default', async () => {
+    await renderInTestApp(
+      <ApiProvider apis={mockApis}>
+        <MockEntityListContextProvider
+          value={{
+            entities,
+            filters: {
+              kind: {
+                value: 'component',
+                label: 'Component',
+                getCatalogFilters: () => ({ kind: 'component' }),
+                toQueryValue: () => 'component',
+              },
+            },
+          }}
+        >
+          <CatalogTable />
+        </MockEntityListContextProvider>
+      </ApiProvider>,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': entityRouteRef,
+        },
+      },
+    );
+
+    // Get the 'Name' header cell
+    const nameHeader = screen.getByText('Name').closest('th');
+    expect(nameHeader).toHaveStyle({ width: 'auto' });
+  });
 });

--- a/plugins/catalog/src/components/CatalogTable/columns.tsx
+++ b/plugins/catalog/src/components/CatalogTable/columns.tsx
@@ -30,6 +30,7 @@ import { JsonArray } from '@backstage/types';
 export const columnFactories = Object.freeze({
   createNameColumn(options?: {
     defaultKind?: string;
+    width?: string;
   }): TableColumn<CatalogTableRow> {
     function formatContent(entity: Entity): string {
       return (
@@ -44,6 +45,7 @@ export const columnFactories = Object.freeze({
       title: 'Name',
       field: 'resolved.entityRef',
       highlight: true,
+      width: options?.width ?? 'auto',
       customSort({ entity: entity1 }, { entity: entity2 }) {
         // TODO: We could implement this more efficiently by comparing field by field.
         // This has similar issues as above.
@@ -129,13 +131,14 @@ export const columnFactories = Object.freeze({
   createSpecTypeColumn(
     options: {
       hidden: boolean;
+      width?: string;
     } = { hidden: false },
   ): TableColumn<CatalogTableRow> {
     return {
       title: 'Type',
       field: 'entity.spec.type',
       hidden: options.hidden,
-      width: 'auto',
+      width: options?.width ?? 'auto',
     };
   },
   createSpecLifecycleColumn(): TableColumn<CatalogTableRow> {
@@ -183,17 +186,19 @@ export const columnFactories = Object.freeze({
   },
   createTitleColumn(options?: {
     hidden?: boolean;
+    width?: string;
   }): TableColumn<CatalogTableRow> {
     return {
       title: 'Title',
       field: 'entity.metadata.title',
       hidden: options?.hidden,
       searchable: true,
+      width: options?.width ?? 'auto',
     };
   },
   createLabelColumn(
     key: string,
-    options?: { title?: string; defaultValue?: string },
+    options?: { title?: string; defaultValue?: string; width?: string },
   ): TableColumn<CatalogTableRow> {
     function formatContent(keyLabel: string, entity: Entity): string {
       const labels: Record<string, string> | undefined =
@@ -230,7 +235,7 @@ export const columnFactories = Object.freeze({
           </>
         );
       },
-      width: 'auto',
+      width: options?.width ?? 'auto',
     };
   },
   createNamespaceColumn(): TableColumn<CatalogTableRow> {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added width to the options prop as a conditional option that defaults to 'auto' if not set, for columns that had width: auto as well as the name column.

As discussed in #28921 , I would like maintainers to comment on the context behind the different width settings for each column. I thought it best to add the width config in the UI component instead of in the config YAML `app-config.yaml`, unless I am mistaken (still new to the repo), this would be the config file to add any changes. 
     
Before:
![image](https://github.com/user-attachments/assets/c90e1572-8003-41af-95d8-8148ebf6127b)
After:
<img width="1531" alt="image" src="https://github.com/user-attachments/assets/e7a78f82-72c2-48a4-ab73-1e9074603300" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
