### PR TITLE
chore: start building new api reference docs alongside existing build

### DIFF
--- a/.changeset/salty-worlds-float.md
+++ b/.changeset/salty-worlds-float.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': minor
+---
+
+Add .cache directory to shipped gitignore.

--- a/.changeset/six-mangos-yell.md
+++ b/.changeset/six-mangos-yell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/repo-tools': minor
+---
+
+Add support for caching the per-package output from the `package-docs` command.

--- a/.github/workflows/deploy_microsite.yml
+++ b/.github/workflows/deploy_microsite.yml
@@ -80,8 +80,18 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+      # Use the lower-level cache actions for the success cache, so that we can store the cache even on failed builds
+      - name: restore package-docs cache
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: .cache/package-docs
+          key: ${{ runner.os }}-v${{ matrix.node-version }}-package-docs-stable-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-v${{ matrix.node-version }}-package-docs-stable-
+
       - name: build API reference (beta)
         run: yarn backstage-repo-tools package-docs
+        continue-on-error: true
 
       - name: upload API reference (beta)
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -90,6 +100,14 @@ jobs:
           path: type-docs/
           if-no-files-found: error
           retention-days: 1
+
+      # Always save success cache even if there were failures, that way it can be used in re-triggered builds
+      - name: save package-docs cache
+        uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        if: always()
+        with:
+          path: .cache/package-docs
+          key: ${{ runner.os }}-v${{ matrix.node-version }}-package-docs-stable-${{ github.run_id }}
 
       - name: microsite yarn install
         run: yarn install --immutable
@@ -147,8 +165,18 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+      # Use the lower-level cache actions for the success cache, so that we can store the cache even on failed builds
+      - name: restore package-docs cache
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: .cache/package-docs
+          key: ${{ runner.os }}-v${{ matrix.node-version }}-package-docs-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-v${{ matrix.node-version }}-package-docs-
+
       - name: build API reference (beta)
         run: yarn backstage-repo-tools package-docs
+        continue-on-error: true
 
       - name: upload API reference (beta)
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -157,6 +185,14 @@ jobs:
           path: type-docs/
           if-no-files-found: error
           retention-days: 1
+
+      # Always save success cache even if there were failures, that way it can be used in re-triggered builds
+      - name: save package-docs cache
+        uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        if: always()
+        with:
+          path: .cache/package-docs
+          key: ${{ runner.os }}-v${{ matrix.node-version }}-package-docs-${{ github.run_id }}
 
         # Also build and upload storybook
       - name: storybook yarn install

--- a/.github/workflows/deploy_microsite.yml
+++ b/.github/workflows/deploy_microsite.yml
@@ -91,7 +91,6 @@ jobs:
 
       - name: build API reference (beta)
         run: yarn backstage-repo-tools package-docs
-        continue-on-error: true
 
       - name: upload API reference (beta)
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -176,7 +175,6 @@ jobs:
 
       - name: build API reference (beta)
         run: yarn backstage-repo-tools package-docs
-        continue-on-error: true
 
       - name: upload API reference (beta)
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/deploy_microsite.yml
+++ b/.github/workflows/deploy_microsite.yml
@@ -80,6 +80,17 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+      - name: build API reference (beta)
+        run: yarn backstage-repo-tools package-docs
+
+      - name: upload API reference (beta)
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: stable-reference-beta
+          path: type-docs/
+          if-no-files-found: error
+          retention-days: 1
+
       - name: microsite yarn install
         run: yarn install --immutable
         working-directory: microsite
@@ -133,6 +144,17 @@ jobs:
         with:
           name: next-reference
           path: docs/reference/
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: build API reference (beta)
+        run: yarn backstage-repo-tools package-docs
+
+      - name: upload API reference (beta)
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: next-reference-beta
+          path: type-docs/
           if-no-files-found: error
           retention-days: 1
 
@@ -265,8 +287,18 @@ jobs:
           name: storybook
           path: microsite/build/storybook
 
+      - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4
+        with:
+          name: stable-reference-beta
+          path: microsite/build/api/stable/
+
+      - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4
+        with:
+          name: next-reference-beta
+          path: microsite/build/api/next/
+
       - name: Check the build output
-        run: ls microsite/build && ls microsite/build/storybook
+        run: ls microsite/build && ls microsite/build/storybook && ls microsite/build/api/stable && ls microsite/build/api/next
 
       - name: Deploy both microsite and storybook to gh-pages
         uses: JamesIves/github-pages-deploy-action@62fec3add6773ec5dbbf18d2ee4260911aa35cf4 # v4.6.9

--- a/.github/workflows/verify_microsite.yml
+++ b/.github/workflows/verify_microsite.yml
@@ -96,7 +96,6 @@ jobs:
 
       - name: build API reference (beta)
         run: yarn backstage-repo-tools package-docs
-        continue-on-error: true
 
       - name: upload API reference (beta)
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -178,7 +177,6 @@ jobs:
 
       - name: build API reference (beta)
         run: yarn backstage-repo-tools package-docs
-        continue-on-error: true
 
       - name: upload API reference (beta)
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/verify_microsite.yml
+++ b/.github/workflows/verify_microsite.yml
@@ -85,6 +85,15 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+      - name: build API reference (beta)
+        run: yarn backstage-repo-tools package-docs
+
+      - name: upload API reference (beta)
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: stable-reference-beta
+          path: type-docs/
+
       - name: microsite yarn install
         run: yarn install --immutable
         working-directory: microsite
@@ -139,6 +148,15 @@ jobs:
           path: docs/reference/
           if-no-files-found: error
           retention-days: 1
+
+      - name: build API reference (beta)
+        run: yarn backstage-repo-tools package-docs
+
+      - name: upload API reference (beta)
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: next-reference-beta
+          path: type-docs/
 
         # Also build and upload storybook
       - name: storybook yarn install
@@ -271,3 +289,15 @@ jobs:
       - name: build microsite
         run: yarn build
         working-directory: microsite
+
+      - name: download stable reference (beta)
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4
+        with:
+          name: stable-reference-beta
+          path: api/stable/
+
+      - name: download next reference (beta)
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4
+        with:
+          name: next-reference-beta
+          path: api/next/

--- a/.github/workflows/verify_microsite.yml
+++ b/.github/workflows/verify_microsite.yml
@@ -85,14 +85,32 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+      # Use the lower-level cache actions for the success cache, so that we can store the cache even on failed builds
+      - name: restore package-docs cache
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: .cache/package-docs
+          key: ${{ runner.os }}-v${{ matrix.node-version }}-package-docs-stable-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-v${{ matrix.node-version }}-package-docs-stable-
+
       - name: build API reference (beta)
         run: yarn backstage-repo-tools package-docs
+        continue-on-error: true
 
       - name: upload API reference (beta)
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: stable-reference-beta
           path: type-docs/
+
+      # Always save success cache even if there were failures, that way it can be used in re-triggered builds
+      - name: save package-docs cache
+        uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        if: always()
+        with:
+          path: .cache/package-docs
+          key: ${{ runner.os }}-v${{ matrix.node-version }}-package-docs-stable-${{ github.run_id }}
 
       - name: microsite yarn install
         run: yarn install --immutable
@@ -149,14 +167,32 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+      # Use the lower-level cache actions for the success cache, so that we can store the cache even on failed builds
+      - name: restore package-docs cache
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: .cache/package-docs
+          key: ${{ runner.os }}-v${{ matrix.node-version }}-package-docs-next-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-v${{ matrix.node-version }}-package-docs-next-
+
       - name: build API reference (beta)
         run: yarn backstage-repo-tools package-docs
+        continue-on-error: true
 
       - name: upload API reference (beta)
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: next-reference-beta
           path: type-docs/
+
+      # Always save success cache even if there were failures, that way it can be used in re-triggered builds
+      - name: save package-docs cache
+        uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        if: always()
+        with:
+          path: .cache/package-docs
+          key: ${{ runner.os }}-v${{ matrix.node-version }}-package-docs-next-${{ github.run_id }}
 
         # Also build and upload storybook
       - name: storybook yarn install

--- a/packages/create-app/templates/default-app/.gitignore.hbs
+++ b/packages/create-app/templates/default-app/.gitignore.hbs
@@ -52,3 +52,6 @@ site
 
 # E2E test reports
 e2e-test-report/
+
+# Cache
+.cache/

--- a/packages/repo-tools/package.json
+++ b/packages/repo-tools/package.json
@@ -82,7 +82,8 @@
     "portfinder": "^1.0.32",
     "tar": "^6.1.12",
     "ts-morph": "^24.0.0",
-    "yaml-diff-patch": "^2.0.0"
+    "yaml-diff-patch": "^2.0.0",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "workspace:^",

--- a/packages/repo-tools/package.json
+++ b/packages/repo-tools/package.json
@@ -69,6 +69,7 @@
     "commander": "^12.0.0",
     "fs-extra": "^11.2.0",
     "glob": "^8.0.3",
+    "globby": "^11.0.0",
     "is-glob": "^4.0.3",
     "js-yaml": "^4.1.0",
     "just-diff": "^6.0.2",

--- a/packages/repo-tools/src/commands/package-docs/Cache.test.ts
+++ b/packages/repo-tools/src/commands/package-docs/Cache.test.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Lockfile } from '@backstage/cli-node';
+import { PackageDocsCache } from './Cache';
+import { join as joinPath } from 'path';
+import {
+  createMockDirectory,
+  MockDirectory,
+} from '@backstage/backend-test-utils';
+
+describe('PackageDocsCache', () => {
+  let testDir: MockDirectory;
+  beforeEach(async () => {
+    testDir = createMockDirectory();
+  });
+  it('should be able to parse cache files', async () => {
+    const cache = await PackageDocsCache.loadAsync(
+      joinPath(__dirname, 'test-cache'),
+      new Lockfile(),
+    );
+    cache.add('test', 'test');
+  });
+});

--- a/packages/repo-tools/src/commands/package-docs/Cache.ts
+++ b/packages/repo-tools/src/commands/package-docs/Cache.ts
@@ -15,11 +15,12 @@
  */
 import { readFile, writeFile, cp } from 'fs/promises';
 import globby from 'globby';
-import workerPath, { dirname } from 'path';
+import { dirname, join as joinPath, relative } from 'path';
 import crypto from 'crypto';
 import { Lockfile } from '@backstage/cli-node';
 import { paths as cliPaths } from '../../lib/paths';
 import { mkdirp } from 'fs-extra';
+import { z } from 'zod';
 
 const version = '1';
 const CACHE_FILE = 'cache.json';
@@ -31,10 +32,19 @@ interface CacheEntry {
   version: string;
 }
 
+const cacheEntrySchema = z.object({
+  hash: z.string(),
+  packageName: z.string(),
+  restoreTo: z.string(),
+  version: z.string(),
+});
+
 export class PackageDocsCache {
+  // A map of package directory to package hash.
   private keyCache: Map<string, string>;
   constructor(
     private readonly lockfile: Lockfile,
+    // A map of package directory to cache entry.
     private readonly cache: Map<string, CacheEntry>,
     private readonly cacheDir: string,
   ) {
@@ -47,16 +57,21 @@ export class PackageDocsCache {
     const map = new Map<string, CacheEntry>();
     for (const file of cacheFiles) {
       const pkg = dirname(file);
-      const cache = await readFile(workerPath.join(cacheDir, file), 'utf-8');
-      const cacheJson = JSON.parse(cache);
-      map.set(pkg, cacheJson);
+      const cache = await readFile(joinPath(cacheDir, file), 'utf-8');
+      try {
+        const cacheJson = JSON.parse(cache);
+        const parsed = cacheEntrySchema.parse(cacheJson);
+        map.set(pkg, parsed);
+      } catch (e) {
+        console.error(`Skipping unparseable cache file ${file}: ${e}`);
+      }
     }
     return new PackageDocsCache(lockfile, map, cacheDir);
   }
 
   async directoryToName(directory: string) {
     const packageJson = await readFile(
-      workerPath.join(directory, 'package.json'),
+      joinPath(directory, 'package.json'),
       'utf-8',
     );
     return JSON.parse(packageJson).name;
@@ -79,7 +94,7 @@ export class PackageDocsCache {
 
     for (const path of result.sort()) {
       const absPath = cliPaths.resolveTargetRoot(pkg, path);
-      const pathInPackage = workerPath.join(absPath, path);
+      const pathInPackage = joinPath(absPath, path);
       hash.update(pathInPackage);
       hash.update('\0');
       hash.update(await readFile(absPath));
@@ -107,8 +122,8 @@ export class PackageDocsCache {
     }
     const cacheEntry = this.cache.get(pkg);
     const restoreTo = cacheEntry!.restoreTo;
-    const cacheDir = workerPath.join(this.cacheDir, pkg);
-    const contentsDir = workerPath.join(cacheDir, 'contents');
+    const cacheDir = joinPath(this.cacheDir, pkg);
+    const contentsDir = joinPath(cacheDir, 'contents');
 
     const targetDir = cliPaths.resolveTargetRoot(restoreTo);
     await mkdirp(targetDir);
@@ -116,23 +131,17 @@ export class PackageDocsCache {
   }
 
   async write(pkg: string, contentDirectory: string) {
-    const cacheDir = workerPath.join(this.cacheDir, pkg);
-    const contentsDir = workerPath.join(cacheDir, 'contents');
-    await mkdirp(cacheDir);
+    const cacheDir = joinPath(this.cacheDir, pkg);
+    const contentsDir = joinPath(cacheDir, 'contents');
+    await mkdirp(contentsDir);
     const hashString = await this.toKey(pkg);
     await cp(contentDirectory, contentsDir, { recursive: true });
     const cacheEntry: CacheEntry = {
       hash: hashString,
       packageName: await this.directoryToName(pkg),
-      restoreTo: workerPath.relative(
-        cliPaths.resolveTargetRoot(),
-        contentDirectory,
-      ),
+      restoreTo: relative(cliPaths.resolveTargetRoot(), contentDirectory),
       version,
     };
-    await writeFile(
-      workerPath.join(cacheDir, CACHE_FILE),
-      JSON.stringify(cacheEntry),
-    );
+    await writeFile(joinPath(cacheDir, CACHE_FILE), JSON.stringify(cacheEntry));
   }
 }

--- a/packages/repo-tools/src/commands/package-docs/Cache.ts
+++ b/packages/repo-tools/src/commands/package-docs/Cache.ts
@@ -46,7 +46,6 @@ export class PackageDocsCache {
     });
     const map = new Map<string, CacheEntry>();
     for (const file of cacheFiles) {
-      console.log(file);
       const pkg = dirname(file);
       const cache = await readFile(workerPath.join(cacheDir, file), 'utf-8');
       const cacheJson = JSON.parse(cache);
@@ -113,7 +112,6 @@ export class PackageDocsCache {
 
     const targetDir = cliPaths.resolveTargetRoot(restoreTo);
     await mkdirp(targetDir);
-    console.log(contentsDir, targetDir);
     await cp(contentsDir, targetDir, { recursive: true });
   }
 

--- a/packages/repo-tools/src/commands/package-docs/Cache.ts
+++ b/packages/repo-tools/src/commands/package-docs/Cache.ts
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { readFile, writeFile, cp } from 'fs/promises';
+import globby from 'globby';
+import workerPath, { dirname } from 'path';
+import crypto from 'crypto';
+import { Lockfile } from '@backstage/cli-node';
+import { paths as cliPaths } from '../../lib/paths';
+import { mkdirp } from 'fs-extra';
+
+const version = '1';
+const CACHE_FILE = 'cache.json';
+
+interface CacheEntry {
+  hash: string;
+  packageName: string;
+  restoreTo: string;
+  version: string;
+}
+
+export class PackageDocsCache {
+  private keyCache: Map<string, string>;
+  constructor(
+    private readonly lockfile: Lockfile,
+    private readonly cache: Map<string, CacheEntry>,
+    private readonly cacheDir: string,
+  ) {
+    this.keyCache = new Map();
+  }
+  static async loadAsync(cacheDir: string, lockfile: Lockfile) {
+    const cacheFiles = await globby(`**/${CACHE_FILE}`, {
+      cwd: cacheDir,
+    });
+    const map = new Map<string, CacheEntry>();
+    for (const file of cacheFiles) {
+      console.log(file);
+      const pkg = dirname(file);
+      const cache = await readFile(workerPath.join(cacheDir, file), 'utf-8');
+      const cacheJson = JSON.parse(cache);
+      map.set(pkg, cacheJson);
+    }
+    return new PackageDocsCache(lockfile, map, cacheDir);
+  }
+
+  async directoryToName(directory: string) {
+    const packageJson = await readFile(
+      workerPath.join(directory, 'package.json'),
+      'utf-8',
+    );
+    return JSON.parse(packageJson).name;
+  }
+
+  async toKey(pkg: string) {
+    if (this.keyCache.has(pkg)) {
+      return this.keyCache.get(pkg)!;
+    }
+    const name = await this.directoryToName(pkg);
+    const result = await globby('src/**', {
+      gitignore: true,
+      onlyFiles: true,
+      cwd: pkg,
+    });
+
+    const hash = crypto.createHash('sha1');
+    hash.update(version);
+    hash.update('\0');
+
+    for (const path of result.sort()) {
+      const absPath = cliPaths.resolveTargetRoot(pkg, path);
+      const pathInPackage = workerPath.join(absPath, path);
+      hash.update(pathInPackage);
+      hash.update('\0');
+      hash.update(await readFile(absPath));
+      hash.update('\0');
+    }
+    hash.update(this.lockfile.getDependencyTreeHash(name));
+    hash.update('\0');
+    const hashString = hash.digest('hex');
+    this.keyCache.set(pkg, hashString);
+    return hashString;
+  }
+
+  async has(pkg: string) {
+    const cache = this.cache.get(pkg);
+    if (!cache) {
+      return false;
+    }
+    const hashString = await this.toKey(pkg);
+    return cache.hash === hashString;
+  }
+
+  async restore(pkg: string) {
+    if (!this.has(pkg)) {
+      throw new Error(`Cache entry for ${pkg} not found`);
+    }
+    const cacheEntry = this.cache.get(pkg);
+    const restoreTo = cacheEntry!.restoreTo;
+    const cacheDir = workerPath.join(this.cacheDir, pkg);
+    const contentsDir = workerPath.join(cacheDir, 'contents');
+
+    const targetDir = cliPaths.resolveTargetRoot(restoreTo);
+    await mkdirp(targetDir);
+    console.log(contentsDir, targetDir);
+    await cp(contentsDir, targetDir, { recursive: true });
+  }
+
+  async write(pkg: string, contentDirectory: string) {
+    const cacheDir = workerPath.join(this.cacheDir, pkg);
+    const contentsDir = workerPath.join(cacheDir, 'contents');
+    await mkdirp(cacheDir);
+    const hashString = await this.toKey(pkg);
+    await cp(contentDirectory, contentsDir, { recursive: true });
+    const cacheEntry: CacheEntry = {
+      hash: hashString,
+      packageName: await this.directoryToName(pkg),
+      restoreTo: workerPath.relative(
+        cliPaths.resolveTargetRoot(),
+        contentDirectory,
+      ),
+      version,
+    };
+    await writeFile(
+      workerPath.join(cacheDir, CACHE_FILE),
+      JSON.stringify(cacheEntry),
+    );
+  }
+}

--- a/packages/repo-tools/src/commands/package-docs/Cache.ts
+++ b/packages/repo-tools/src/commands/package-docs/Cache.ts
@@ -18,7 +18,7 @@ import globby from 'globby';
 import { dirname, join as joinPath, relative } from 'path';
 import crypto from 'crypto';
 import { Lockfile } from '@backstage/cli-node';
-import { mkdirp } from 'fs-extra';
+import { exists, rm, mkdirp } from 'fs-extra';
 import { z } from 'zod';
 import { CACHE_DIR, CACHE_FILE } from './constants';
 
@@ -140,7 +140,11 @@ export class PackageDocsCache {
   async write(pkg: string, contentDirectory: string) {
     const cacheDir = joinPath(this.baseDirectory, CACHE_DIR, pkg);
     const contentsDir = joinPath(cacheDir, 'contents');
-    await mkdirp(contentsDir);
+    if (await exists(contentsDir)) {
+      await rm(contentsDir, { recursive: true });
+    } else {
+      await mkdirp(contentsDir);
+    }
     const hashString = await this.toKey(pkg);
     await cp(contentDirectory, contentsDir, { recursive: true });
     const cacheEntry: CacheEntry = {

--- a/packages/repo-tools/src/commands/package-docs/command.ts
+++ b/packages/repo-tools/src/commands/package-docs/command.ts
@@ -58,8 +58,6 @@ const HIGHLIGHT_LANGUAGES = [
   'json',
 ];
 
-const CACHE_DIR = '.cache/package-docs';
-
 function getExports(packageJson: any) {
   if (packageJson.exports) {
     return Object.values(packageJson.exports).filter(
@@ -120,9 +118,8 @@ export default async function packageDocs(paths: string[] = [], opts: any) {
     exclude: opts.exclude,
   });
 
-  await mkdirp(CACHE_DIR);
   const cache = await PackageDocsCache.loadAsync(
-    CACHE_DIR,
+    cliPaths.resolveTargetRoot(),
     await Lockfile.load(cliPaths.resolveTargetRoot('yarn.lock')),
   );
 

--- a/packages/repo-tools/src/commands/package-docs/constants.ts
+++ b/packages/repo-tools/src/commands/package-docs/constants.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const CACHE_FILE = 'cache.json';
+export const CACHE_DIR = '.cache/package-docs';

--- a/yarn.lock
+++ b/yarn.lock
@@ -8414,6 +8414,7 @@ __metadata:
     commander: "npm:^12.0.0"
     fs-extra: "npm:^11.2.0"
     glob: "npm:^8.0.3"
+    globby: "npm:^11.0.0"
     is-glob: "npm:^4.0.3"
     js-yaml: "npm:^4.1.0"
     just-diff: "npm:^6.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8429,6 +8429,7 @@ __metadata:
     ts-morph: "npm:^24.0.0"
     typedoc: "npm:^0.27.6"
     yaml-diff-patch: "npm:^2.0.0"
+    zod: "npm:^3.22.4"
   peerDependencies:
     "@microsoft/api-extractor-model": "*"
     "@microsoft/tsdoc": "*"
@@ -48020,9 +48021,9 @@ __metadata:
   linkType: hard
 
 "zod@npm:^3.22.4":
-  version: 3.23.8
-  resolution: "zod@npm:3.23.8"
-  checksum: 10/846fd73e1af0def79c19d510ea9e4a795544a67d5b34b7e1c4d0425bf6bfd1c719446d94cdfa1721c1987d891321d61f779e8236fde517dc0e524aa851a6eff1
+  version: 3.24.4
+  resolution: "zod@npm:3.24.4"
+  checksum: 10/3d545792fa54bb27ee5dbc34a5709e81f603185fcc94c8204b5d95c20dc4c81d870ff9c51f3884a30ef05cdc601449f4c4df254ac4783f0827b1faed7c1cdb48
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In trying to get build times for the microsite down + improving the API docs, we should try to remove the API reports from the docusaurus build process. This starts us down that process by starting to build the new API reports alongside the existing build process for API reports.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
