### PR TITLE
fix: clear all generated files during docsite generation

### DIFF
--- a/.github/workflows/deploy_microsite.yml
+++ b/.github/workflows/deploy_microsite.yml
@@ -231,11 +231,8 @@ jobs:
         run: yarn docusaurus docs:version stable
         working-directory: microsite
 
-      - name: clear API reference
-        run: rm -r docs/reference
-
-      - name: clear OpenAPI reference
-        run: find ./docs -name '*.api.mdx' -type f -delete
+      - name: clear generated docs
+        run: git clean -fd docs/
 
       # Next docs
       - name: checkout master

--- a/.github/workflows/deploy_microsite.yml
+++ b/.github/workflows/deploy_microsite.yml
@@ -232,7 +232,7 @@ jobs:
         working-directory: microsite
 
       - name: clear generated docs
-        run: git clean -fd docs/
+        run: git clean -fdx docs/
 
       # Next docs
       - name: checkout master

--- a/.github/workflows/verify_microsite.yml
+++ b/.github/workflows/verify_microsite.yml
@@ -243,7 +243,7 @@ jobs:
         working-directory: microsite
 
       - name: clear generated docs
-        run: git clean -fd docs/
+        run: git clean -fdx docs/
 
       - name: print directry contents
         run: ls docs/reference

--- a/.github/workflows/verify_microsite.yml
+++ b/.github/workflows/verify_microsite.yml
@@ -245,9 +245,6 @@ jobs:
       - name: clear generated docs
         run: git clean -fdx docs/
 
-      - name: print directry contents
-        run: ls docs/reference
-
       - name: build API reference
         run: yarn build:api-docs
 

--- a/.github/workflows/verify_microsite.yml
+++ b/.github/workflows/verify_microsite.yml
@@ -245,6 +245,9 @@ jobs:
       - name: clear generated docs
         run: git clean -fd docs/
 
+      - name: print directry contents
+        run: ls docs/reference
+
       - name: build API reference
         run: yarn build:api-docs
 

--- a/.github/workflows/verify_microsite.yml
+++ b/.github/workflows/verify_microsite.yml
@@ -242,11 +242,8 @@ jobs:
         run: yarn docusaurus docs:version stable
         working-directory: microsite
 
-      - name: clear API reference
-        run: rm -r docs/reference
-
-      - name: clear OpenAPI reference
-        run: find ./docs -name '*.api.mdx' -type f -delete
+      - name: clear generated docs
+        run: git clean -fd docs/
 
       - name: build API reference
         run: yarn build:api-docs


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Small fix to the docsite pipeline - instead of explicitly removing generated files, we should use git clean to explicitly remove untracked files (the generated content).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
