### PR TITLE
fix safari sidebar overflow

### DIFF
--- a/.changeset/real-sheep-chew.md
+++ b/.changeset/real-sheep-chew.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/core-components': minor
+'@backstage/core-components': patch
 ---
 
-Fix the hidden sidebar's submenu when the sidebar is scrollable
+Fix the hidden sidebar's sub-menu when the sidebar is scrollable

--- a/.changeset/real-sheep-chew.md
+++ b/.changeset/real-sheep-chew.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': minor
+---
+
+Fix the hidden sidebar's submenu when the sidebar is scrollable

--- a/packages/core-components/src/layout/Sidebar/Bar.tsx
+++ b/packages/core-components/src/layout/Sidebar/Bar.tsx
@@ -41,15 +41,21 @@ import { coreComponentsTranslationRef } from '../../translation';
 export type SidebarClassKey = 'drawer' | 'drawerOpen';
 const useStyles = makeStyles<Theme, { sidebarConfig: SidebarConfig }>(
   theme => ({
-    drawer: {
-      display: 'flex',
-      flexFlow: 'column nowrap',
-      alignItems: 'flex-start',
-      position: 'fixed',
+    root: {
       left: 0,
       top: 0,
       bottom: 0,
       zIndex: theme.zIndex.appBar,
+      position: 'fixed',
+    },
+    drawer: {
+      display: 'flex',
+      flexFlow: 'column nowrap',
+      alignItems: 'flex-start',
+      left: 0,
+      top: 0,
+      bottom: 0,
+      position: 'absolute',
       background: theme.palette.navigation.background,
       overflowX: 'hidden',
       msOverflowStyle: 'none',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

fixes #29516

It seems that Webkit has currently [a bug open](https://bugs.webkit.org/show_bug.cgi?id=160953) (the description is a little off, but the bug seems to be the same). After playing around a little bit the bug in Backstage is currently reproducible when the sidebar is getting scrollable (just make the browser horizontally smaller) - exactly at this point the sidebar gets broken. 

After playing around a bit with the CSS and [seeing that](https://stackoverflow.com/a/59656203) on StackOverflow, it seems that on Safari `position: 'fixed'` and `z-index: n` doesn't play well together with `overflow: auto`. Moving `position: 'fixed'` and `z-index` to the root of the `<Bar />` component and changing the drawer to `position: 'absolute'` (which is required to keep it scrollable) seems to fix the problem. 

Edit: Please tell me if there are some visual regression tests in this repo - at least I haven't seen any via Playwright

Before:

![Screenshot 2025-04-14 at 17 23 04](https://github.com/user-attachments/assets/0c89f942-02f1-4541-872a-6dff7f5ba5a4)

After:

![Screenshot 2025-04-14 at 17 22 53](https://github.com/user-attachments/assets/78f5b60e-cc63-4dec-931d-e065066efdbf)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
