### PR TITLE
Add actor to user principal and improve validation in permission-backend

### DIFF
--- a/.changeset/cold-rocks-laugh.md
+++ b/.changeset/cold-rocks-laugh.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-permission-backend': minor
+---
+
+Improved validation for the `/authorize` endpoint when a `resourceRef` is provided alongside a basic permission. Additionally, introduced a clearer error message for cases where users attempt to directly evaluate conditional permissions.

--- a/.changeset/pink-geese-teach.md
+++ b/.changeset/pink-geese-teach.md
@@ -1,5 +1,6 @@
 ---
 '@backstage/backend-defaults': minor
+'@backstage/backend-plugin-api': minor
 '@backstage/backend-test-utils': minor
 ---
 

--- a/.changeset/pink-geese-teach.md
+++ b/.changeset/pink-geese-teach.md
@@ -1,0 +1,6 @@
+---
+'@backstage/backend-defaults': minor
+'@backstage/backend-test-utils': minor
+---
+
+Added `actor` property to `BackstageUserPrincipal` containing the subject of the last service (if any) who performed authentication on behalf of the user.

--- a/packages/backend-defaults/src/entrypoints/auth/DefaultAuthService.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/DefaultAuthService.ts
@@ -68,6 +68,7 @@ export class DefaultAuthService implements AuthService {
           userResult.userEntityRef,
           pluginResult.limitedUserToken,
           this.#getJwtExpiration(pluginResult.limitedUserToken),
+          pluginResult.subject,
         );
       }
       return createCredentialsWithServicePrincipal(pluginResult.subject);

--- a/packages/backend-defaults/src/entrypoints/auth/DefaultAuthService.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/DefaultAuthService.ts
@@ -87,7 +87,6 @@ export class DefaultAuthService implements AuthService {
         userResult.userEntityRef,
         token,
         this.#getJwtExpiration(token),
-        this.pluginId,
       );
     }
 

--- a/packages/backend-defaults/src/entrypoints/auth/DefaultAuthService.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/DefaultAuthService.ts
@@ -87,6 +87,7 @@ export class DefaultAuthService implements AuthService {
         userResult.userEntityRef,
         token,
         this.#getJwtExpiration(token),
+        this.pluginId,
       );
     }
 

--- a/packages/backend-defaults/src/entrypoints/auth/helpers.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/helpers.ts
@@ -51,7 +51,7 @@ export function createCredentialsWithUserPrincipal(
   sub: string,
   token: string,
   expiresAt?: Date,
-  viaSubject?: string,
+  issuedBySubject?: string,
 ): InternalBackstageCredentials<BackstageUserPrincipal> {
   return Object.defineProperty(
     {
@@ -61,7 +61,9 @@ export function createCredentialsWithUserPrincipal(
       principal: {
         type: 'user',
         userEntityRef: sub,
-        ...(viaSubject && { via: { type: 'service', subject: viaSubject } }),
+        ...(issuedBySubject && {
+          issuedBy: { type: 'service', subject: issuedBySubject },
+        }),
       },
     },
     'token',

--- a/packages/backend-defaults/src/entrypoints/auth/helpers.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/helpers.ts
@@ -51,6 +51,7 @@ export function createCredentialsWithUserPrincipal(
   sub: string,
   token: string,
   expiresAt?: Date,
+  viaSubject?: string,
 ): InternalBackstageCredentials<BackstageUserPrincipal> {
   return Object.defineProperty(
     {
@@ -60,6 +61,7 @@ export function createCredentialsWithUserPrincipal(
       principal: {
         type: 'user',
         userEntityRef: sub,
+        ...(viaSubject && { via: { type: 'service', subject: viaSubject } }),
       },
     },
     'token',

--- a/packages/backend-defaults/src/entrypoints/auth/helpers.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/helpers.ts
@@ -51,7 +51,7 @@ export function createCredentialsWithUserPrincipal(
   sub: string,
   token: string,
   expiresAt?: Date,
-  issuedBySubject?: string,
+  actor?: string,
 ): InternalBackstageCredentials<BackstageUserPrincipal> {
   return Object.defineProperty(
     {
@@ -61,8 +61,8 @@ export function createCredentialsWithUserPrincipal(
       principal: {
         type: 'user',
         userEntityRef: sub,
-        ...(issuedBySubject && {
-          issuedBy: { type: 'service', subject: issuedBySubject },
+        ...(actor && {
+          actor: { type: 'service', subject: actor },
         }),
       },
     },

--- a/packages/backend-plugin-api/report.api.md
+++ b/packages/backend-plugin-api/report.api.md
@@ -177,6 +177,7 @@ export interface BackstageUserInfo {
 export type BackstageUserPrincipal = {
   type: 'user';
   userEntityRef: string;
+  actor?: BackstageServicePrincipal;
 };
 
 // @public

--- a/packages/backend-plugin-api/src/services/definitions/AuthService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/AuthService.ts
@@ -45,7 +45,7 @@ export type BackstageUserPrincipal = {
    * of a user. It provides context about the intermediary service that
    * facilitated the authentication.
    */
-  issuedBy?: BackstageServicePrincipal;
+  actor?: BackstageServicePrincipal;
 };
 
 /**

--- a/packages/backend-plugin-api/src/services/definitions/AuthService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/AuthService.ts
@@ -35,6 +35,8 @@ export type BackstageUserPrincipal = {
    * The entity ref of the user entity that this principal represents.
    */
   userEntityRef: string;
+
+  via?: BackstageServicePrincipal;
 };
 
 /**

--- a/packages/backend-plugin-api/src/services/definitions/AuthService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/AuthService.ts
@@ -36,7 +36,16 @@ export type BackstageUserPrincipal = {
    */
   userEntityRef: string;
 
-  via?: BackstageServicePrincipal;
+  /**
+   * The service principal that issued the token on behalf of the user.
+   *
+   * @remarks
+   *
+   * This field is present in scenarios where a backend service acts on behalf
+   * of a user. It provides context about the intermediary service that
+   * facilitated the authentication.
+   */
+  issuedBy?: BackstageServicePrincipal;
 };
 
 /**

--- a/packages/backend-test-utils/report.api.md
+++ b/packages/backend-test-utils/report.api.md
@@ -88,6 +88,11 @@ export namespace mockCredentials {
   }
   export function user(
     userEntityRef?: string,
+    options?: {
+      actor?: {
+        subject: string;
+      };
+    },
   ): BackstageCredentials<BackstageUserPrincipal>;
   export namespace user {
     export function header(userEntityRef?: string): string;
@@ -95,7 +100,14 @@ export namespace mockCredentials {
     export function invalidHeader(): string;
     // (undocumented)
     export function invalidToken(): string;
-    export function token(userEntityRef?: string): string;
+    export function token(
+      userEntityRef?: string,
+      options?: {
+        actor?: {
+          subject: string;
+        };
+      },
+    ): string;
   }
 }
 

--- a/packages/backend-test-utils/src/next/services/MockAuthService.ts
+++ b/packages/backend-test-utils/src/next/services/MockAuthService.ts
@@ -73,11 +73,11 @@ export class MockAuthService implements AuthService {
     }
 
     if (token.startsWith(MOCK_USER_TOKEN_PREFIX)) {
-      const { sub: userEntityRef }: UserTokenPayload = JSON.parse(
+      const { sub: userEntityRef, issuedBy }: UserTokenPayload = JSON.parse(
         token.slice(MOCK_USER_TOKEN_PREFIX.length),
       );
 
-      return mockCredentials.user(userEntityRef);
+      return mockCredentials.user(userEntityRef, { issuedBySubject: issuedBy });
     }
 
     if (token.startsWith(MOCK_USER_LIMITED_TOKEN_PREFIX)) {

--- a/packages/backend-test-utils/src/next/services/MockAuthService.ts
+++ b/packages/backend-test-utils/src/next/services/MockAuthService.ts
@@ -73,11 +73,11 @@ export class MockAuthService implements AuthService {
     }
 
     if (token.startsWith(MOCK_USER_TOKEN_PREFIX)) {
-      const { sub: userEntityRef, issuedBy }: UserTokenPayload = JSON.parse(
+      const { sub: userEntityRef, actor }: UserTokenPayload = JSON.parse(
         token.slice(MOCK_USER_TOKEN_PREFIX.length),
       );
 
-      return mockCredentials.user(userEntityRef, { issuedBySubject: issuedBy });
+      return mockCredentials.user(userEntityRef, { actor });
     }
 
     if (token.startsWith(MOCK_USER_LIMITED_TOKEN_PREFIX)) {

--- a/packages/backend-test-utils/src/next/services/mockCredentials.ts
+++ b/packages/backend-test-utils/src/next/services/mockCredentials.ts
@@ -108,7 +108,7 @@ export namespace mockCredentials {
    */
   export function user(
     userEntityRef: string = DEFAULT_MOCK_USER_ENTITY_REF,
-    options?: { actor?: string },
+    options?: { actor?: { subject: string } },
   ): BackstageCredentials<BackstageUserPrincipal> {
     validateUserEntityRef(userEntityRef);
     return {
@@ -134,14 +134,14 @@ export namespace mockCredentials {
      */
     export function token(
       userEntityRef?: string,
-      options?: { actor?: string },
+      options?: { actor?: { subject: string } },
     ): string {
       if (userEntityRef) {
         validateUserEntityRef(userEntityRef);
         return `${MOCK_USER_TOKEN_PREFIX}${JSON.stringify({
           sub: userEntityRef,
           ...(options?.actor && {
-            actor: options.actor,
+            actor: { subject: options.actor.subject },
           }),
         } satisfies UserTokenPayload)}`;
       }

--- a/packages/backend-test-utils/src/next/services/mockCredentials.ts
+++ b/packages/backend-test-utils/src/next/services/mockCredentials.ts
@@ -55,6 +55,7 @@ function validateUserEntityRef(ref: string) {
  */
 export type UserTokenPayload = {
   sub?: string;
+  issuedBy?: string;
 };
 
 /**
@@ -107,11 +108,18 @@ export namespace mockCredentials {
    */
   export function user(
     userEntityRef: string = DEFAULT_MOCK_USER_ENTITY_REF,
+    options?: { issuedBySubject?: string },
   ): BackstageCredentials<BackstageUserPrincipal> {
     validateUserEntityRef(userEntityRef);
     return {
       $$type: '@backstage/BackstageCredentials',
-      principal: { type: 'user', userEntityRef },
+      principal: {
+        type: 'user',
+        userEntityRef,
+        ...(options?.issuedBySubject && {
+          issuedBy: { type: 'service', subject: options.issuedBySubject },
+        }),
+      },
     };
   }
 
@@ -124,11 +132,17 @@ export namespace mockCredentials {
      * into the token and forwarded to the credentials object when authenticated
      * by the mock auth service.
      */
-    export function token(userEntityRef?: string): string {
+    export function token(
+      userEntityRef?: string,
+      options?: { issuedBySubject?: string },
+    ): string {
       if (userEntityRef) {
         validateUserEntityRef(userEntityRef);
         return `${MOCK_USER_TOKEN_PREFIX}${JSON.stringify({
           sub: userEntityRef,
+          ...(options?.issuedBySubject && {
+            issuedBy: options.issuedBySubject,
+          }),
         } satisfies UserTokenPayload)}`;
       }
       return MOCK_USER_TOKEN;

--- a/packages/backend-test-utils/src/next/services/mockCredentials.ts
+++ b/packages/backend-test-utils/src/next/services/mockCredentials.ts
@@ -55,7 +55,7 @@ function validateUserEntityRef(ref: string) {
  */
 export type UserTokenPayload = {
   sub?: string;
-  issuedBy?: string;
+  actor?: { subject: string };
 };
 
 /**
@@ -108,7 +108,7 @@ export namespace mockCredentials {
    */
   export function user(
     userEntityRef: string = DEFAULT_MOCK_USER_ENTITY_REF,
-    options?: { issuedBySubject?: string },
+    options?: { actor?: string },
   ): BackstageCredentials<BackstageUserPrincipal> {
     validateUserEntityRef(userEntityRef);
     return {
@@ -116,8 +116,8 @@ export namespace mockCredentials {
       principal: {
         type: 'user',
         userEntityRef,
-        ...(options?.issuedBySubject && {
-          issuedBy: { type: 'service', subject: options.issuedBySubject },
+        ...(options?.actor && {
+          actor: { type: 'service', subject: options.actor.subject },
         }),
       },
     };
@@ -134,14 +134,14 @@ export namespace mockCredentials {
      */
     export function token(
       userEntityRef?: string,
-      options?: { issuedBySubject?: string },
+      options?: { actor?: string },
     ): string {
       if (userEntityRef) {
         validateUserEntityRef(userEntityRef);
         return `${MOCK_USER_TOKEN_PREFIX}${JSON.stringify({
           sub: userEntityRef,
-          ...(options?.issuedBySubject && {
-            issuedBy: options.issuedBySubject,
+          ...(options?.actor && {
+            actor: options.actor,
           }),
         } satisfies UserTokenPayload)}`;
       }

--- a/plugins/permission-backend/src/service/router.test.ts
+++ b/plugins/permission-backend/src/service/router.test.ts
@@ -774,6 +774,35 @@ describe('createRouter', () => {
           { id: '123', permission: { attributes: { invalid: 'attribute' } } },
         ],
       },
+      {
+        items: [
+          {
+            id: '123',
+            // basic permission can't have resourceRef
+            resourceRef: 'resource:1',
+            permission: {
+              type: 'basic',
+              name: 'test.permission',
+              attributes: {},
+            },
+          },
+        ],
+      },
+      {
+        items: [
+          {
+            id: '123',
+            // resource ref should be a string
+            resourceRef: ['resource:1'],
+            permission: {
+              type: 'resource',
+              name: 'test.permission',
+              attributes: {},
+              resourceType: 'test-resource-1',
+            },
+          },
+        ],
+      },
     ])('returns a 400 error for invalid request %#', async requestBody => {
       const response = await request(app).post('/authorize').send(requestBody);
 

--- a/plugins/permission-backend/src/service/router.test.ts
+++ b/plugins/permission-backend/src/service/router.test.ts
@@ -596,7 +596,7 @@ describe('createRouter', () => {
         expect(mockApplyConditions).toHaveBeenCalledWith(
           'plugin-1',
           mockCredentials.user('user:default/spiderman', {
-            actor: 'some-service',
+            actor: { subject: 'some-service' },
           }),
           [
             expect.objectContaining({
@@ -611,7 +611,7 @@ describe('createRouter', () => {
         expect(mockApplyConditions).toHaveBeenCalledWith(
           'plugin-2',
           mockCredentials.user('user:default/spiderman', {
-            actor: 'some-service',
+            actor: { subject: 'some-service' },
           }),
           [
             expect.objectContaining({
@@ -729,7 +729,7 @@ describe('createRouter', () => {
 
       function userTokenIssuedByService() {
         return mockCredentials.user.token('user:default/spiderman', {
-          actor: 'some-service',
+          actor: { subject: 'some-service' },
         });
       }
     });

--- a/plugins/permission-backend/src/service/router.test.ts
+++ b/plugins/permission-backend/src/service/router.test.ts
@@ -596,7 +596,7 @@ describe('createRouter', () => {
         expect(mockApplyConditions).toHaveBeenCalledWith(
           'plugin-1',
           mockCredentials.user('user:default/spiderman', {
-            issuedBySubject: 'some-service',
+            actor: 'some-service',
           }),
           [
             expect.objectContaining({
@@ -611,7 +611,7 @@ describe('createRouter', () => {
         expect(mockApplyConditions).toHaveBeenCalledWith(
           'plugin-2',
           mockCredentials.user('user:default/spiderman', {
-            issuedBySubject: 'some-service',
+            actor: 'some-service',
           }),
           [
             expect.objectContaining({
@@ -729,7 +729,7 @@ describe('createRouter', () => {
 
       function userTokenIssuedByService() {
         return mockCredentials.user.token('user:default/spiderman', {
-          issuedBySubject: 'some-service',
+          actor: 'some-service',
         });
       }
     });

--- a/plugins/permission-backend/src/service/router.ts
+++ b/plugins/permission-backend/src/service/router.ts
@@ -209,6 +209,11 @@ export async function createRouter(
     );
   }
 
+  const disabledDefaultAuthPolicy =
+    config.getOptionalBoolean(
+      'backend.auth.dangerouslyDisableDefaultAuthPolicy',
+    ) ?? false;
+
   const permissionIntegrationClient = new PermissionIntegrationClient({
     discovery,
     auth,
@@ -242,7 +247,7 @@ export async function createRouter(
       const body = parseResult.data;
 
       if (
-        auth.isPrincipal(credentials, 'none') ||
+        (auth.isPrincipal(credentials, 'none') && !disabledDefaultAuthPolicy) ||
         (auth.isPrincipal(credentials, 'user') && !credentials.principal.actor)
       ) {
         if (

--- a/plugins/permission-backend/src/service/router.ts
+++ b/plugins/permission-backend/src/service/router.ts
@@ -62,27 +62,33 @@ const attributesSchema: z.ZodSchema<PermissionAttributes> = z.object({
     .optional(),
 });
 
-const permissionSchema = z.union([
-  z.object({
-    type: z.literal('basic'),
-    name: z.string(),
-    attributes: attributesSchema,
-  }),
-  z.object({
-    type: z.literal('resource'),
-    name: z.string(),
-    attributes: attributesSchema,
-    resourceType: z.string(),
-  }),
-]);
+const basicPermissionSchema = z.object({
+  type: z.literal('basic'),
+  name: z.string(),
+  attributes: attributesSchema,
+});
+
+const resourcePermissionSchema = z.object({
+  type: z.literal('resource'),
+  name: z.string(),
+  attributes: attributesSchema,
+  resourceType: z.string(),
+});
 
 const evaluatePermissionRequestSchema: z.ZodSchema<
   IdentifiedPermissionMessage<EvaluatePermissionRequest>
-> = z.object({
-  id: z.string(),
-  resourceRef: z.string().optional(),
-  permission: permissionSchema,
-});
+> = z.union([
+  z.object({
+    id: z.string(),
+    resourceRef: z.undefined().optional(),
+    permission: basicPermissionSchema,
+  }),
+  z.object({
+    id: z.string(),
+    resourceRef: z.string().optional(),
+    permission: resourcePermissionSchema,
+  }),
+]);
 
 const evaluatePermissionRequestBatchSchema: z.ZodSchema<EvaluatePermissionRequestBatch> =
   z.object({

--- a/plugins/permission-backend/src/service/router.ts
+++ b/plugins/permission-backend/src/service/router.ts
@@ -235,6 +235,18 @@ export async function createRouter(
 
       const body = parseResult.data;
 
+      if (
+        !(credentials.principal as BackstageUserPrincipal).issuedBy &&
+        body.items.some(
+          r =>
+            isResourcePermission(r.permission) && r.resourceRef === undefined,
+        )
+      ) {
+        throw new InputError(
+          'Resource permissions require a resourceRef to be set',
+        );
+      }
+
       res.json({
         items: await handleRequest(
           body.items,

--- a/plugins/permission-backend/src/service/router.ts
+++ b/plugins/permission-backend/src/service/router.ts
@@ -236,15 +236,19 @@ export async function createRouter(
       const body = parseResult.data;
 
       if (
-        !(credentials.principal as BackstageUserPrincipal).issuedBy &&
-        body.items.some(
-          r =>
-            isResourcePermission(r.permission) && r.resourceRef === undefined,
-        )
+        auth.isPrincipal(credentials, 'none') ||
+        (auth.isPrincipal(credentials, 'user') && !credentials.principal.actor)
       ) {
-        throw new InputError(
-          'Resource permissions require a resourceRef to be set',
-        );
+        if (
+          body.items.some(
+            r =>
+              isResourcePermission(r.permission) && r.resourceRef === undefined,
+          )
+        ) {
+          throw new InputError(
+            'Resource permissions require a resourceRef to be set. Direct user requests without a resourceRef are not allowed.',
+          );
+        }
       }
 
       res.json({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds `actor` to `BackstageUserPrincipal` which will be populated with the subject of the last service (if any) who performed authentication on behalf of a user.
We are also using this in `permission-backend` to return a clarifying error if the user is directly evaluating conditional permissions.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
