### PR TITLE
move the auth.backstageTokenExpiration key

### DIFF
--- a/.changeset/early-boxes-check.md
+++ b/.changeset/early-boxes-check.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Slight update to the config schema

--- a/plugins/auth-backend/config.d.ts
+++ b/plugins/auth-backend/config.d.ts
@@ -140,11 +140,13 @@ export interface Config {
           callbackUrl?: string;
         };
       };
-      /**
-       * The backstage token expiration.
-       */
-      backstageTokenExpiration?: HumanDuration | string;
     };
+
+    /**
+     * The backstage token expiration.
+     */
+    backstageTokenExpiration?: HumanDuration | string;
+
     /**
      * Additional app origins to allow for authenticating
      */


### PR DESCRIPTION
This was accidentally inside `auth.providers`, instead of just `auth`