### PR TITLE
feat(): Added optional assignees parameter to publish:github:pull-request action

### DIFF
--- a/.changeset/spicy-steaks-swim.md
+++ b/.changeset/spicy-steaks-swim.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-github': patch
+---
+
+Added optional assignees parameter to `publish:github:pull-request` action

--- a/plugins/scaffolder-backend-module-github/report.api.md
+++ b/plugins/scaffolder-backend-module-github/report.api.md
@@ -435,6 +435,7 @@ export const createPublishGithubPullRequestAction: (
     sourcePath?: string;
     token?: string;
     reviewers?: string[];
+    assignees?: string[];
     teamReviewers?: string[];
     commitMessage?: string;
     update?: boolean;

--- a/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.examples.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.examples.test.ts
@@ -32,6 +32,9 @@ const mockOctokit = {
     pulls: {
       requestReviewers: jest.fn(),
     },
+    issues: {
+      addAssignees: jest.fn(),
+    },
   },
 };
 
@@ -61,6 +64,7 @@ describe('publish:github:pull-request examples', () => {
     createPullRequest: jest.Mock;
     rest: {
       pulls: { requestReviewers: jest.Mock };
+      issues: { addAssignees: jest.Mock };
     };
   };
   const mockDir = createMockDirectory();
@@ -89,6 +93,9 @@ describe('publish:github:pull-request examples', () => {
       rest: {
         pulls: {
           requestReviewers: jest.fn(async (_: any) => ({ data: {} })),
+        },
+        issues: {
+          addAssignees: jest.fn(async (_: any) => ({ data: {} })),
         },
       },
     };
@@ -706,6 +713,52 @@ describe('publish:github:pull-request examples', () => {
       pull_number: 123,
       reviewers: ['foobar'],
       team_reviewers: ['team-foo'],
+    });
+
+    expect(mockContext.output).toHaveBeenCalledTimes(3);
+    expect(mockContext.output).toHaveBeenCalledWith('targetBranchName', 'main');
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'remoteUrl',
+      'https://github.com/myorg/myrepo/pull/123',
+    );
+    expect(mockContext.output).toHaveBeenCalledWith('pullRequestNumber', 123);
+  });
+
+  it('Create a pull request with assignees', async () => {
+    const input = yaml.parse(examples[14].example).steps[0].input;
+
+    await action.handler({
+      ...mockContext,
+      workspacePath,
+      input,
+    });
+
+    expect(fakeClient.createPullRequest).toHaveBeenCalledWith({
+      owner: 'owner',
+      repo: 'repo',
+      title: 'Create my new app',
+      body: 'This PR is really good',
+      head: 'new-app',
+      draft: undefined,
+      changes: [
+        {
+          commit: 'Create my new app',
+          files: {
+            'file.txt': {
+              content: Buffer.from('Hello there!').toString('base64'),
+              encoding: 'base64',
+              mode: '100644',
+            },
+          },
+        },
+      ],
+    });
+
+    expect(fakeClient.rest.issues.addAssignees).toHaveBeenCalledWith({
+      owner: 'owner',
+      repo: 'repo',
+      issue_number: 123,
+      assignees: ['foobar'],
     });
 
     expect(mockContext.output).toHaveBeenCalledTimes(3);

--- a/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.examples.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.examples.ts
@@ -283,4 +283,22 @@ export const examples: TemplateExample[] = [
       ],
     }),
   },
+  {
+    description: 'Create a pull request with assignees',
+    example: yaml.stringify({
+      steps: [
+        {
+          action: 'publish:github:pull-request',
+          name: 'Create a pull request with reviewers',
+          input: {
+            repoUrl: 'github.com?repo=repo&owner=owner',
+            branchName: 'new-app',
+            title: 'Create my new app',
+            description: 'This PR is really good',
+            assignees: ['foobar'],
+          },
+        },
+      ],
+    }),
+  },
 ];

--- a/plugins/scaffolder-backend/report.api.md
+++ b/plugins/scaffolder-backend/report.api.md
@@ -339,6 +339,7 @@ export const createPublishGithubPullRequestAction: (
     sourcePath?: string;
     token?: string;
     reviewers?: string[];
+    assignees?: string[];
     teamReviewers?: string[];
     commitMessage?: string;
     update?: boolean;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This resolves https://github.com/backstage/backstage/issues/29536
I've added `assignees` as an optional input for `publish:github:pull-request` action.

The snippet that i've used to test.
```yaml
    - id: publish
      name: Publish
      action: publish:github:pull-request
      input:
        repoUrl: ${{ parameters.repoUrl }}
        title: "Create new project: ${{parameters.name}}"
        branchName: create-${{parameters.name}}
        assignees: ['pmckl']
        description: |
          # New project: ${{parameters.name}}

          ${{ parameters.description if parameters.description }}
        targetPath: ${{ parameters.targetPath if parameters.targetPath else parameters.name }}
```
<img width="340" alt="Screenshot 2025-04-16 at 0 15 31" src="https://github.com/user-attachments/assets/14168a3b-9bff-4200-91b5-3074b51130d1" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
