### PR TITLE
New scaffolder task permission rule: `HAS_TEMPLATE_OWNERS`

### DIFF
--- a/.changeset/weak-bags-behave.md
+++ b/.changeset/weak-bags-behave.md
@@ -7,5 +7,3 @@
 ---
 
 BREAKING : Added two new scaffolder rules for `scaffolder.task.read` and `scaffolder.task.cancel` to allow for conditional permission policies such as restricting access to tasks and task events based on creators (`hasCreatedBy`) and granting template owners visibility into all runs of their templates (`hasTemplateEntityRefs`).
-
-BREAKING: Removed requirement to have both `scaffolder.task.read` and `scaffolder.task.cancel` permissions to cancel tasks.

--- a/.changeset/weak-bags-behave.md
+++ b/.changeset/weak-bags-behave.md
@@ -1,0 +1,11 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+'@backstage/plugin-scaffolder-common': minor
+'@backstage/plugin-scaffolder-react': minor
+'@backstage/plugin-scaffolder-node': minor
+'@backstage/plugin-scaffolder': minor
+---
+
+BREAKING : Added two new scaffolder rules for `scaffolder.task.read` and `scaffolder.task.cancel` to allow for conditional permission policies such as restricting access to tasks and task events based on creators (`hasCreatedBy`) and granting template owners visibility into all runs of their templates (`hasTemplateEntityRefs`).
+
+BREAKING: Removed requirement to have both `scaffolder.task.read` and `scaffolder.task.cancel` permissions to cancel tasks.

--- a/.changeset/weak-bags-behave.md
+++ b/.changeset/weak-bags-behave.md
@@ -6,4 +6,7 @@
 '@backstage/plugin-scaffolder': minor
 ---
 
-BREAKING : Added two new scaffolder rules for `scaffolder.task.read` and `scaffolder.task.cancel` to allow for conditional permission policies such as restricting access to tasks and task events based on creators (`hasCreatedBy`) and granting template owners visibility into all runs of their templates (`hasTemplateEntityRefs`).
+BREAKING :
+
+- Added a new scaffolder rule `hasTemplateOwners` for `scaffolder.task.read` and `scaffolder.task.cancel` to allow for conditional permission policies such as granting template owners visibility into all runs of their templates.
+- Added a new column `template_owner` to the `tasks` table

--- a/docs/features/software-templates/authorizing-scaffolder-template-details.md
+++ b/docs/features/software-templates/authorizing-scaffolder-template-details.md
@@ -176,7 +176,7 @@ class ExamplePermissionPolicy implements PermissionPolicy {
 
 ### Authorizing scaffolder tasks
 
-The scaffolder plugin also exposes permissions that can restrict access to tasks, task logs, task creation, and task cancellation. This can be useful if you want to control who has access to these areas of the scaffolder. You can also restrict access to tasks to only their owners or admin users and allow template owners to view all runs of their templates.
+The scaffolder plugin also exposes permissions that can restrict access to tasks, task logs, task creation, and task cancellation. This can be useful if you want to control who has access to these areas of the scaffolder. You can also restrict access to tasks to allow template owners to view all runs of their templates.
 
 The following is a simple example of how to do this:
 
@@ -205,31 +205,6 @@ import { CatalogClient } from '@backstage/catalog-client';
 /* highlight-add-end */
 
 class ExamplePermissionPolicy implements PermissionPolicy {
-  private readonly catalogClient: CatalogClient;
-
-  constructor(catalogClient: CatalogClient) {
-    this.catalogClient = catalogClient;
-  }
-
-  // Fetches all templates owned by the user from the catalog API.
-  async getUserOwnedTemplates(userRef: string): Promise<string[]> {
-    if (!userRef) return [];
-
-    const response = await this.catalogClient.getEntities({
-      filter: {
-        kind: ['Template'],
-        'relations.ownedBy': [userRef],
-      },
-    });
-
-    return response.items.map(
-      item =>
-        `${item.kind.toLocaleLowerCase()}:${item.metadata.namespace}/${
-          item.metadata.name
-        }`,
-    );
-  }
-
   async handle(
     request: PolicyQuery,
     user?: PolicyQueryUser,
@@ -243,24 +218,15 @@ class ExamplePermissionPolicy implements PermissionPolicy {
         };
       }
 
-      // Retrieve templates that the user owns
-      const userOwnedTemplates = await this.getUserOwnedTemplates(
-        user?.info.userEntityRef || '',
+      // Allow users to read task runs of templates they own
+      return createScaffolderTaskConditionalDecision(
+        request.permission,
+        scaffolderTaskConditions.hasTemplateOwners({
+          templateOwners: user?.info.userEntityRef
+            ? [user?.info.userEntityRef]
+            : [],
+        }),
       );
-
-      // Allow users to read tasks they created or task runs of templates they own
-      return createScaffolderTaskConditionalDecision(request.permission, {
-        anyOf: [
-          scaffolderTaskConditions.hasCreatedBy({
-            createdBy: user?.info.userEntityRef
-              ? [user?.info.userEntityRef]
-              : [],
-          }),
-          scaffolderTaskConditions.hasTemplateEntityRefs({
-            templateEntityRefs: userOwnedTemplates,
-          }),
-        ],
-      });
     }
 
     if (isPermission(request.permission, taskCreatePermission)) {
@@ -278,17 +244,6 @@ class ExamplePermissionPolicy implements PermissionPolicy {
       };
     }
     if (isPermission(request.permission, taskCancelPermission)) {
-      // Allow spiderman to cancel only his tasks
-      if (user?.info.userEntityRef === 'user:default/spiderman') {
-        return createScaffolderTaskConditionalDecision(
-          request.permission,
-          scaffolderTaskConditions.hasCreatedBy({
-            createdBy: user?.info.userEntityRef
-              ? [user?.info.userEntityRef]
-              : [],
-          }),
-        );
-      }
       // Allow admin1 to cancel any task
       if (user?.info.userEntityRef === 'user:default/admin1') {
         return {
@@ -310,7 +265,6 @@ class ExamplePermissionPolicy implements PermissionPolicy {
 
 In the provided example permission policy, we only grant the `spiderman` user permissions to perform/access the following actions/resources:
 
-- Read scaffolder tasks and their associated events/logs for tasks created by `spiderman`.
 - Read scaffolder task runs of templates owned by `spiderman`
 - Cancel ongoing scaffolder tasks created by `spiderman`.
 - Trigger software templates, which effectively creates new scaffolder tasks.
@@ -323,7 +277,6 @@ On the other hand, the `admin1` user is granted:
 
 All other users are granted permissions to perform/access the following actions/resources:
 
-- Read scaffolder tasks and their associated events/logs for tasks created by the user.
 - Read scaffolder task runs of the templates owned by the user
 
 Although the rules exported by the scaffolder are simple, combining them can help you achieve more complex use cases.

--- a/plugins/scaffolder-backend/migrations/20250425170153_template_owner.js
+++ b/plugins/scaffolder-backend/migrations/20250425170153_template_owner.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @ts-check
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function up(knex) {
+  await knex.schema.alterTable('tasks', table => {
+    table
+      .text('template_owner')
+      .nullable()
+      .comment(
+        'An entityRef of the user who the template used to create the task.',
+      );
+  });
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function down(knex) {
+  await knex.schema.alterTable('tasks', table => {
+    table.dropColumn('template_owner');
+  });
+};

--- a/plugins/scaffolder-backend/report-alpha.api.md
+++ b/plugins/scaffolder-backend/report-alpha.api.md
@@ -11,6 +11,8 @@ import { PermissionCondition } from '@backstage/plugin-permission-common';
 import { PermissionCriteria } from '@backstage/plugin-permission-common';
 import { PermissionRule } from '@backstage/plugin-permission-node';
 import { ResourcePermission } from '@backstage/plugin-permission-common';
+import { SerializedTask } from '@backstage/plugin-scaffolder-node';
+import { TaskFilter } from '@backstage/plugin-scaffolder-node';
 import { TemplateEntityStepV1beta3 } from '@backstage/plugin-scaffolder-common';
 import { TemplateParametersV1beta3 } from '@backstage/plugin-scaffolder-common';
 
@@ -18,6 +20,12 @@ import { TemplateParametersV1beta3 } from '@backstage/plugin-scaffolder-common';
 export const createScaffolderActionConditionalDecision: (
   permission: ResourcePermission<'scaffolder-action'>,
   conditions: PermissionCriteria<PermissionCondition<'scaffolder-action'>>,
+) => ConditionalPolicyDecision;
+
+// @alpha (undocumented)
+export const createScaffolderTaskConditionalDecision: (
+  permission: ResourcePermission<'scaffolder-task'>,
+  conditions: PermissionCriteria<PermissionCondition<'scaffolder-task'>>,
 ) => ConditionalPolicyDecision;
 
 // @alpha
@@ -77,6 +85,32 @@ export const scaffolderActionConditions: Conditions<{
     {
       key: string;
       value?: string | undefined;
+    }
+  >;
+}>;
+
+// @alpha
+export const scaffolderTaskConditions: Conditions<{
+  hasCreatedBy: PermissionRule<
+    SerializedTask,
+    {
+      property: TaskFilter['property'];
+      values: any;
+    },
+    'scaffolder-task',
+    {
+      createdBy: string[];
+    }
+  >;
+  hasTemplateEntityRefs: PermissionRule<
+    SerializedTask,
+    {
+      property: TaskFilter['property'];
+      values: any;
+    },
+    'scaffolder-task',
+    {
+      templateEntityRefs: string[];
     }
   >;
 }>;

--- a/plugins/scaffolder-backend/report-alpha.api.md
+++ b/plugins/scaffolder-backend/report-alpha.api.md
@@ -91,7 +91,7 @@ export const scaffolderActionConditions: Conditions<{
 
 // @alpha
 export const scaffolderTaskConditions: Conditions<{
-  hasCreatedBy: PermissionRule<
+  hasTemplateOwners: PermissionRule<
     SerializedTask,
     {
       property: TaskFilter['property'];
@@ -99,18 +99,7 @@ export const scaffolderTaskConditions: Conditions<{
     },
     'scaffolder-task',
     {
-      createdBy: string[];
-    }
-  >;
-  hasTemplateEntityRefs: PermissionRule<
-    SerializedTask,
-    {
-      property: TaskFilter['property'];
-      values: any;
-    },
-    'scaffolder-task',
-    {
-      templateEntityRefs: string[];
+      templateOwners: string[];
     }
   >;
 }>;

--- a/plugins/scaffolder-backend/report.api.md
+++ b/plugins/scaffolder-backend/report.api.md
@@ -47,11 +47,13 @@ import { JsonValue } from '@backstage/types';
 import { Knex } from 'knex';
 import { LifecycleService } from '@backstage/backend-plugin-api';
 import { Logger } from 'winston';
+import { PermissionCriteria } from '@backstage/plugin-permission-common';
 import { PermissionEvaluator } from '@backstage/plugin-permission-common';
 import { PermissionRule } from '@backstage/plugin-permission-node';
 import { PermissionRuleParams } from '@backstage/plugin-permission-common';
 import { PermissionsService } from '@backstage/backend-plugin-api';
 import { RESOURCE_TYPE_SCAFFOLDER_ACTION } from '@backstage/plugin-scaffolder-common/alpha';
+import { RESOURCE_TYPE_SCAFFOLDER_TASK } from '@backstage/plugin-scaffolder-common/alpha';
 import { RESOURCE_TYPE_SCAFFOLDER_TEMPLATE } from '@backstage/plugin-scaffolder-common/alpha';
 import { ScaffolderEntitiesProcessor as ScaffolderEntitiesProcessor_2 } from '@backstage/plugin-catalog-backend-module-scaffolder-entity-model';
 import { SchedulerService } from '@backstage/backend-plugin-api';
@@ -65,6 +67,8 @@ import { TaskBrokerDispatchResult as TaskBrokerDispatchResult_2 } from '@backsta
 import { TaskCompletionState as TaskCompletionState_2 } from '@backstage/plugin-scaffolder-node';
 import { TaskContext as TaskContext_2 } from '@backstage/plugin-scaffolder-node';
 import { TaskEventType as TaskEventType_2 } from '@backstage/plugin-scaffolder-node';
+import { TaskFilter } from '@backstage/plugin-scaffolder-node';
+import { TaskFilters } from '@backstage/plugin-scaffolder-node';
 import { TaskRecovery } from '@backstage/plugin-scaffolder-common';
 import { TaskSecrets as TaskSecrets_2 } from '@backstage/plugin-scaffolder-node';
 import { TaskSpec } from '@backstage/plugin-scaffolder-common';
@@ -476,6 +480,7 @@ export class DatabaseTaskStore implements TaskStore {
       order: 'asc' | 'desc';
       field: string;
     }[];
+    permissionFilters?: PermissionCriteria<TaskFilters>;
   }): Promise<{
     tasks: SerializedTask_2[];
     totalTasks?: number;
@@ -562,9 +567,7 @@ export interface RouterOptions {
   // (undocumented)
   logger: Logger;
   // (undocumented)
-  permissionRules?: Array<
-    TemplatePermissionRuleInput | ActionPermissionRuleInput
-  >;
+  permissionRules?: Array<ScaffolderPermissionRuleInput>;
   // (undocumented)
   permissions?: PermissionsService;
   // (undocumented)
@@ -582,6 +585,12 @@ export type RunCommandOptions = ExecuteShellCommandOptions;
 
 // @public @deprecated
 export const ScaffolderEntitiesProcessor: typeof ScaffolderEntitiesProcessor_2;
+
+// @public (undocumented)
+export type ScaffolderPermissionRuleInput =
+  | TemplatePermissionRuleInput
+  | ActionPermissionRuleInput
+  | TaskPermissionRuleInput;
 
 // @public
 const scaffolderPlugin: BackendFeature;
@@ -672,6 +681,19 @@ export class TaskManager implements TaskContext_2 {
         },
   ): Promise<void>;
 }
+
+// @public (undocumented)
+export type TaskPermissionRuleInput<
+  TParams extends PermissionRuleParams = PermissionRuleParams,
+> = PermissionRule<
+  SerializedTask_2,
+  {
+    property: TaskFilter['property'];
+    values: any;
+  },
+  typeof RESOURCE_TYPE_SCAFFOLDER_TASK,
+  TParams
+>;
 
 // @public @deprecated (undocumented)
 export type TaskSecrets = TaskSecrets_2;

--- a/plugins/scaffolder-backend/report.api.md
+++ b/plugins/scaffolder-backend/report.api.md
@@ -518,6 +518,7 @@ export class DatabaseTaskStore implements TaskStore {
 // @public
 export type DatabaseTaskStoreOptions = {
   database: DatabaseService | Knex;
+  catalog: CatalogApi;
   events?: EventsService;
 };
 

--- a/plugins/scaffolder-backend/report.sql.md
+++ b/plugins/scaffolder-backend/report.sql.md
@@ -33,6 +33,7 @@
 | `spec`              | `text`                     | false    | -          | -                   |
 | `state`             | `text`                     | true     | -          | -                   |
 | `status`            | `text`                     | false    | -          | -                   |
+| `template_owner`    | `text`                     | true     | -          | -                   |
 | `workspace`         | `bytea`                    | true     | -          | -                   |
 
 ### Indices

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.test.ts
@@ -22,8 +22,7 @@ import { ConflictError } from '@backstage/errors';
 import { createMockDirectory } from '@backstage/backend-test-utils';
 import fs from 'fs-extra';
 import { EventsService } from '@backstage/plugin-events-node';
-import { PermissionCriteria } from '@backstage/plugin-permission-common';
-import { TaskFilters } from '@backstage/plugin-scaffolder-node';
+import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
 
 const createStore = async (events?: EventsService) => {
   const manager = DatabaseManager.fromConfig(
@@ -39,6 +38,7 @@ const createStore = async (events?: EventsService) => {
   const store = await DatabaseTaskStore.create({
     database: manager,
     events,
+    catalog: catalogServiceMock.mock(),
   });
   return { store, manager };
 };
@@ -231,73 +231,6 @@ describe('DatabaseTaskStore', () => {
     expect(tasks[0].createdBy).toBe('him');
     expect(tasks[0].status).toBe('open');
     expect(tasks[0].id).toBeDefined();
-  });
-
-  it('should filter tasks based on permissionFilters', async () => {
-    const { store } = await createStore();
-
-    await store.createTask({
-      spec: {
-        templateInfo: { entityRef: 'template:default/three' },
-      } as TaskSpec,
-      createdBy: 'user:default/one',
-    });
-
-    await store.createTask({
-      spec: {
-        templateInfo: { entityRef: 'template:default/four' },
-      } as TaskSpec,
-      createdBy: 'user:default/two',
-    });
-
-    await store.createTask({
-      spec: {
-        templateInfo: { entityRef: 'template:default/one' },
-      } as TaskSpec,
-      createdBy: 'user:default/three',
-    });
-
-    await store.createTask({
-      spec: {
-        templateInfo: { entityRef: 'template:default/two' },
-      } as TaskSpec,
-      createdBy: 'user:default/three',
-    });
-
-    await store.createTask({
-      spec: {
-        templateInfo: { entityRef: 'template:default/three' },
-      } as TaskSpec,
-      createdBy: 'user:default/three',
-    });
-
-    const permissionFilters: PermissionCriteria<TaskFilters> = {
-      anyOf: [
-        {
-          property: 'createdBy',
-          values: ['user:default/one', 'user:default/two'],
-        },
-        {
-          property: 'templateEntityRefs',
-          values: ['template:default/one', 'template:default/two'],
-        },
-      ],
-    };
-
-    const { tasks, totalTasks } = await store.list({
-      permissionFilters: permissionFilters,
-    });
-
-    expect(totalTasks).toBe(4);
-
-    expect(tasks).not.toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          createdBy: 'user:default/three',
-          spec: { templateInfo: { entityRef: 'template:default/three' } },
-        }),
-      ]),
-    );
   });
 
   it('should sent an event to start cancelling the task', async () => {

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.test.ts
@@ -362,6 +362,7 @@ describe('DatabaseTaskStore', () => {
         createdAt: expect.any(String),
         lastHeartbeatAt: null,
         createdBy: 'me',
+        templateOwner: null,
       },
     });
   });
@@ -464,6 +465,7 @@ describe('DatabaseTaskStore', () => {
         createdAt: expect.any(String),
         lastHeartbeatAt: expect.any(String),
         createdBy: 'me',
+        templateOwner: null,
       },
     });
   });

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.ts
@@ -394,7 +394,7 @@ export class DatabaseTaskStore implements TaskStore {
         id: taskId,
         spec: options.spec,
         createdBy: options.createdBy,
-        template_owner: templateOwner,
+        templateOwner: templateOwner,
         status: 'open',
       },
     });

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/StorageTaskBroker.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/StorageTaskBroker.test.ts
@@ -25,6 +25,7 @@ import { DatabaseTaskStore } from './DatabaseTaskStore';
 import { StorageTaskBroker, TaskManager } from './StorageTaskBroker';
 import { mockServices } from '@backstage/backend-test-utils';
 import { loggerToWinstonLogger } from '../../util/loggerToWinstonLogger';
+import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
 
 async function createStore(): Promise<DatabaseTaskStore> {
   const manager = DatabaseManager.fromConfig(
@@ -40,6 +41,7 @@ async function createStore(): Promise<DatabaseTaskStore> {
 
   return await DatabaseTaskStore.create({
     database: manager,
+    catalog: catalogServiceMock.mock(),
   });
 }
 

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/StorageTaskBroker.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/StorageTaskBroker.ts
@@ -28,6 +28,7 @@ import {
   TaskBrokerDispatchOptions,
   TaskCompletionState,
   TaskContext,
+  TaskFilters,
   TaskSecrets,
   TaskStatus,
 } from '@backstage/plugin-scaffolder-node';
@@ -43,6 +44,7 @@ import ObservableImpl from 'zen-observable';
 import { DefaultWorkspaceService, WorkspaceService } from './WorkspaceService';
 import { readDuration } from './helper';
 import { InternalTaskSecrets, TaskStore } from './types';
+import { PermissionCriteria } from '@backstage/plugin-permission-common';
 
 type TaskState = {
   checkpoints: {
@@ -291,6 +293,7 @@ export class StorageTaskBroker implements TaskBroker {
       offset?: number;
     };
     order?: { order: 'asc' | 'desc'; field: string }[];
+    permissionFilters?: PermissionCriteria<TaskFilters>;
   }): Promise<{ tasks: SerializedTask[]; totalTasks?: number }> {
     if (!this.storage.list) {
       throw new Error(

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/TaskWorker.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/TaskWorker.test.ts
@@ -33,6 +33,7 @@ import ObservableImpl from 'zen-observable';
 import waitForExpect from 'wait-for-expect';
 import { mockServices } from '@backstage/backend-test-utils';
 import { loggerToWinstonLogger } from '../../util/loggerToWinstonLogger';
+import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
 
 jest.mock('./NunjucksWorkflowRunner');
 const MockedNunjucksWorkflowRunner =
@@ -52,6 +53,7 @@ async function createStore(): Promise<DatabaseTaskStore> {
   ).forPlugin('scaffolder');
   return await DatabaseTaskStore.create({
     database: manager,
+    catalog: catalogServiceMock.mock(),
   });
 }
 

--- a/plugins/scaffolder-backend/src/service/conditionExports.ts
+++ b/plugins/scaffolder-backend/src/service/conditionExports.ts
@@ -17,9 +17,14 @@
 import {
   RESOURCE_TYPE_SCAFFOLDER_TEMPLATE,
   RESOURCE_TYPE_SCAFFOLDER_ACTION,
+  RESOURCE_TYPE_SCAFFOLDER_TASK,
 } from '@backstage/plugin-scaffolder-common/alpha';
 import { createConditionExports } from '@backstage/plugin-permission-node';
-import { scaffolderTemplateRules, scaffolderActionRules } from './rules';
+import {
+  scaffolderTemplateRules,
+  scaffolderActionRules,
+  scaffolderTaskRules,
+} from './rules';
 
 const templateConditionExports = createConditionExports({
   pluginId: 'scaffolder',
@@ -31,6 +36,12 @@ const actionsConditionExports = createConditionExports({
   pluginId: 'scaffolder',
   resourceType: RESOURCE_TYPE_SCAFFOLDER_ACTION,
   rules: scaffolderActionRules,
+});
+
+const taskConditionExports = createConditionExports({
+  pluginId: 'scaffolder',
+  resourceType: RESOURCE_TYPE_SCAFFOLDER_TASK,
+  rules: scaffolderTaskRules,
 });
 
 /**
@@ -90,3 +101,17 @@ export const createScaffolderActionConditionalDecision =
  * @alpha
  */
 export const scaffolderActionConditions = actionsConditionExports.conditions;
+
+/**
+ * @alpha
+ */
+export const createScaffolderTaskConditionalDecision =
+  taskConditionExports.createConditionalDecision;
+
+/**
+ * These conditions are used when creating conditional decisions for scaffolder
+ * tasks that are returned by authorization policies.
+ *
+ * @alpha
+ */
+export const scaffolderTaskConditions = taskConditionExports.conditions;

--- a/plugins/scaffolder-backend/src/service/router.test.ts
+++ b/plugins/scaffolder-backend/src/service/router.test.ts
@@ -541,6 +541,7 @@ describe.each([
                 status: 'completed',
                 createdAt: '',
                 createdBy: '',
+                templateOwner: '',
               },
             ],
             totalTasks: 1,
@@ -577,6 +578,7 @@ describe.each([
                 status: 'completed',
                 createdAt: '',
                 createdBy: 'user:default/foo',
+                templateOwner: '',
               },
             ],
             totalTasks: 1,
@@ -729,13 +731,13 @@ describe.each([
           expect(headers['content-type']).toBe('text/event-stream');
           expect(responseDataFn).toHaveBeenCalledTimes(2);
           expect(responseDataFn).toHaveBeenCalledWith(`event: log
-  data: {"id":0,"taskId":"a-random-id","type":"log","createdAt":"","body":{"message":"My log message"}}
-  
-  `);
+data: {"id":0,"taskId":"a-random-id","type":"log","createdAt":"","body":{"message":"My log message"}}
+
+`);
           expect(responseDataFn).toHaveBeenCalledWith(`event: completion
-  data: {"id":1,"taskId":"a-random-id","type":"completion","createdAt":"","body":{"message":"Finished!"}}
-  
-  `);
+data: {"id":1,"taskId":"a-random-id","type":"completion","createdAt":"","body":{"message":"Finished!"}}
+
+`);
 
           expect(taskBroker.event$).toHaveBeenCalledTimes(1);
           expect(taskBroker.event$).toHaveBeenCalledWith({
@@ -1474,6 +1476,7 @@ describe.each([
                 status: 'completed',
                 createdAt: '',
                 createdBy: '',
+                templateOwner: '',
               },
             ],
             totalTasks: 1,
@@ -1516,6 +1519,7 @@ describe.each([
                 status: 'completed',
                 createdAt: '',
                 createdBy: 'user:default/foo',
+                templateOwner: '',
               },
             ],
             totalTasks: 1,
@@ -1657,13 +1661,13 @@ describe.each([
           expect(headers['content-type']).toBe('text/event-stream');
           expect(responseDataFn).toHaveBeenCalledTimes(2);
           expect(responseDataFn).toHaveBeenCalledWith(`event: log
-  data: {"id":0,"taskId":"a-random-id","type":"log","createdAt":"","body":{"message":"My log message"}}
-  
-  `);
+data: {"id":0,"taskId":"a-random-id","type":"log","createdAt":"","body":{"message":"My log message"}}
+
+`);
           expect(responseDataFn).toHaveBeenCalledWith(`event: completion
-  data: {"id":1,"taskId":"a-random-id","type":"completion","createdAt":"","body":{"message":"Finished!"}}
-  
-  `);
+data: {"id":1,"taskId":"a-random-id","type":"completion","createdAt":"","body":{"message":"Finished!"}}
+
+`);
 
           expect(taskBroker.event$).toHaveBeenCalledTimes(1);
           expect(taskBroker.event$).toHaveBeenCalledWith({

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -825,7 +825,7 @@ export async function createRouter(
 
         await checkTaskPermission({
           credentials,
-          permission: taskReadPermission,
+          permissions: [taskReadPermission],
           permissionService: permissions,
           task: task,
           isTaskAuthorized,
@@ -861,9 +861,10 @@ export async function createRouter(
       try {
         const credentials = await httpAuth.credentials(req);
         const task = await taskBroker.get(taskId);
+        // Requires both read and cancel permissions
         await checkTaskPermission({
           credentials,
-          permission: taskCancelPermission,
+          permissions: [taskCancelPermission, taskReadPermission],
           permissionService: permissions,
           task: task,
           isTaskAuthorized,
@@ -905,7 +906,7 @@ export async function createRouter(
 
         await checkTaskPermission({
           credentials,
-          permission: taskReadPermission,
+          permissions: [taskReadPermission],
           permissionService: permissions,
           task: task,
           isTaskAuthorized,
@@ -938,7 +939,7 @@ export async function createRouter(
 
         await checkTaskPermission({
           credentials,
-          permission: taskReadPermission,
+          permissions: [taskReadPermission],
           permissionService: permissions,
           task: task,
           isTaskAuthorized,
@@ -1014,7 +1015,7 @@ export async function createRouter(
 
         await checkTaskPermission({
           credentials,
-          permission: taskReadPermission,
+          permissions: [taskReadPermission],
           permissionService: permissions,
           task: task,
           isTaskAuthorized,

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -181,6 +181,10 @@ function isActionPermissionRuleInput(
   return permissionRule.resourceType === RESOURCE_TYPE_SCAFFOLDER_ACTION;
 }
 
+/**
+ *
+ * @public
+ */
 export type TaskPermissionRuleInput<
   TParams extends PermissionRuleParams = PermissionRuleParams,
 > = PermissionRule<

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -378,6 +378,7 @@ export async function createRouter(
     const databaseTaskStore = await DatabaseTaskStore.create({
       database,
       events: eventsService,
+      catalog: catalogClient,
     });
     taskBroker = new StorageTaskBroker(
       databaseTaskStore,

--- a/plugins/scaffolder-backend/src/service/rules.test.ts
+++ b/plugins/scaffolder-backend/src/service/rules.test.ts
@@ -22,8 +22,7 @@ import {
   hasProperty,
   hasStringProperty,
   hasTag,
-  hasCreatedBy,
-  hasTemplateEntityRefs,
+  hasTemplateOwners,
 } from './rules';
 import { createConditionAuthorizer } from '@backstage/plugin-permission-node';
 import { RESOURCE_TYPE_SCAFFOLDER_ACTION } from '@backstage/plugin-scaffolder-common/alpha';
@@ -528,81 +527,7 @@ describe('hasStringProperty', () => {
   });
 });
 
-describe('hasCreatedBy', () => {
-  describe('apply', () => {
-    const task: SerializedTask = {
-      id: 'a-random-id',
-      spec: {} as TaskSpec,
-      status: 'completed',
-      createdAt: '',
-      createdBy: 'user:default/user-1',
-    };
-    it('returns false when createdBy is an empty array', () => {
-      expect(
-        hasCreatedBy.apply(task, {
-          createdBy: [],
-        }),
-      ).toEqual(false);
-    });
-    it('returns false when createdBy is not matched (single user in createdBy)', () => {
-      expect(
-        hasCreatedBy.apply(task, {
-          createdBy: ['not-matched'],
-        }),
-      ).toEqual(false);
-    });
-    it('returns true when createdBy matches (single user in createdBy)', () => {
-      expect(
-        hasCreatedBy.apply(task, {
-          createdBy: ['user:default/user-1'],
-        }),
-      ).toEqual(true);
-    });
-    it('returns false when createdBy is not matched (multiple users in createdBy)', () => {
-      expect(
-        hasCreatedBy.apply(task, {
-          createdBy: [
-            'user:default/user-2',
-            'user:default/user-3',
-            'user:default/user-4',
-          ],
-        }),
-      ).toEqual(false);
-    });
-    it('returns true when createdBy matches (multiple users in createdBy)', () => {
-      expect(
-        hasCreatedBy.apply(task, {
-          createdBy: [
-            'user:default/user-1',
-            'user:default/user-2',
-            'user:default/user-3',
-          ],
-        }),
-      ).toEqual(true);
-    });
-  });
-  describe('toQuery', () => {
-    it('returns the correct query filter with values (single user in createdBy)', () => {
-      expect(
-        hasCreatedBy.toQuery({
-          createdBy: ['user:default/user-1'],
-        }),
-      ).toEqual({ property: 'createdBy', values: ['user:default/user-1'] });
-    });
-  });
-  it('returns the correct query filter with values (multiple users in createdBy)', () => {
-    expect(
-      hasCreatedBy.toQuery({
-        createdBy: ['user:default/user-1', 'user:default/user-2'],
-      }),
-    ).toEqual({
-      property: 'createdBy',
-      values: ['user:default/user-1', 'user:default/user-2'],
-    });
-  });
-});
-
-describe('hasTemplateEntityRefs', () => {
+describe('hasTemplateOwners', () => {
   describe('apply', () => {
     const task: SerializedTask = {
       id: 'a-random-id',
@@ -611,32 +536,33 @@ describe('hasTemplateEntityRefs', () => {
       } as TaskSpec,
       status: 'completed',
       createdAt: '',
+      templateOwner: 'template:default/test-1',
     };
-    it('returns false when templateEntityRefs is an empty array', () => {
+    it('returns false when templateOwners is an empty array', () => {
       expect(
-        hasTemplateEntityRefs.apply(task, {
-          templateEntityRefs: [],
+        hasTemplateOwners.apply(task, {
+          templateOwners: [],
         }),
       ).toEqual(false);
     });
-    it('returns false when templateEntityRef is not matched (single entityRef in templateEntityRefs)', () => {
+    it('returns false when templateOwner is not matched (single entityRef in templateOwners)', () => {
       expect(
-        hasTemplateEntityRefs.apply(task, {
-          templateEntityRefs: ['template:default/not-matched'],
+        hasTemplateOwners.apply(task, {
+          templateOwners: ['template:default/not-matched'],
         }),
       ).toEqual(false);
     });
-    it('returns true when templateEntityRef matches (single entityRef in templateEntityRefs)', () => {
+    it('returns true when templateOwner matches (single entityRef in templateOwners)', () => {
       expect(
-        hasTemplateEntityRefs.apply(task, {
-          templateEntityRefs: ['template:default/test-1'],
+        hasTemplateOwners.apply(task, {
+          templateOwners: ['template:default/test-1'],
         }),
       ).toEqual(true);
     });
-    it('returns false when templateEntityRefs is not matched (multiple entitRefs in templateEntityRefs)', () => {
+    it('returns false when templateOwners is not matched (multiple entitRefs in templateOwners)', () => {
       expect(
-        hasTemplateEntityRefs.apply(task, {
-          templateEntityRefs: [
+        hasTemplateOwners.apply(task, {
+          templateOwners: [
             'template:default/test-2',
             'template:default/test-3',
             'template:default/test-4',
@@ -644,10 +570,10 @@ describe('hasTemplateEntityRefs', () => {
         }),
       ).toEqual(false);
     });
-    it('returns true when templateEntityRefs matches (multiple entityRefs in templateEntityRefs)', () => {
+    it('returns true when templateOwners matches (multiple entityRefs in templateOwners)', () => {
       expect(
-        hasTemplateEntityRefs.apply(task, {
-          templateEntityRefs: [
+        hasTemplateOwners.apply(task, {
+          templateOwners: [
             'template:default/test-2',
             'template:default/test-1',
             'template:default/test-3',
@@ -657,27 +583,24 @@ describe('hasTemplateEntityRefs', () => {
     });
   });
   describe('toQuery', () => {
-    it('returns the correct query filter with values (single entityRef in templateEntityRefs)', () => {
+    it('returns the correct query filter with values (single entityRef in templateOwners)', () => {
       expect(
-        hasTemplateEntityRefs.toQuery({
-          templateEntityRefs: ['template:default/test-1'],
+        hasTemplateOwners.toQuery({
+          templateOwners: ['template:default/test-1'],
         }),
       ).toEqual({
-        property: 'templateEntityRefs',
+        property: 'templateOwners',
         values: ['template:default/test-1'],
       });
     });
   });
   it('returns the correct query filter with values (multiple entityRefs in templateEntityRefs)', () => {
     expect(
-      hasTemplateEntityRefs.toQuery({
-        templateEntityRefs: [
-          'template:default/test-1',
-          'template:default/test-2',
-        ],
+      hasTemplateOwners.toQuery({
+        templateOwners: ['template:default/test-1', 'template:default/test-2'],
       }),
     ).toEqual({
-      property: 'templateEntityRefs',
+      property: 'templateOwners',
       values: ['template:default/test-1', 'template:default/test-2'],
     });
   });

--- a/plugins/scaffolder-backend/src/service/rules.ts
+++ b/plugins/scaffolder-backend/src/service/rules.ts
@@ -142,52 +142,27 @@ export const createTaskPermissionRule = makeCreatePermissionRule<
   typeof RESOURCE_TYPE_SCAFFOLDER_TASK
 >();
 
-export const hasCreatedBy = createTaskPermissionRule({
-  name: 'HAS_CREATED_BY',
-  description: 'Allows tasks created by certain users to be accessible',
+export const hasTemplateOwners = createTaskPermissionRule({
+  name: 'HAS_TEMPLATE_OWNERS',
+  description: 'Match tasks with the given template owners',
   resourceType: RESOURCE_TYPE_SCAFFOLDER_TASK,
   paramsSchema: z.object({
-    createdBy: z
+    templateOwners: z
       .array(z.string())
       .describe(
-        'List of creater entity refs; only tasks created by these users will be viewable',
+        'List of template owners; only tasks related to the templates owned by these users will be viewable',
       ),
   }),
-  apply: (resource, { createdBy }) => {
-    if (!resource.createdBy) {
+  apply: (resource, { templateOwners }) => {
+    if (!resource.templateOwner) {
       return false;
     }
-    return createdBy.includes(resource.createdBy);
+    return templateOwners.includes(resource.templateOwner);
   },
-  toQuery: ({ createdBy }) => {
+  toQuery: ({ templateOwners }) => {
     return {
-      property: 'createdBy' as TaskFilter['property'],
-      values: createdBy,
-    };
-  },
-});
-
-export const hasTemplateEntityRefs = createTaskPermissionRule({
-  name: 'HAS_TEMPLATE_ENTITY_REFS',
-  description: 'Match tasks with the given template entity refs',
-  resourceType: RESOURCE_TYPE_SCAFFOLDER_TASK,
-  paramsSchema: z.object({
-    templateEntityRefs: z
-      .array(z.string())
-      .describe(
-        'List of template entity refs; only tasks related to these templates will be viewable',
-      ),
-  }),
-  apply: (resource, { templateEntityRefs }) => {
-    if (!resource.spec.templateInfo) {
-      return false;
-    }
-    return templateEntityRefs.includes(resource.spec.templateInfo.entityRef);
-  },
-  toQuery: ({ templateEntityRefs }) => {
-    return {
-      property: 'templateEntityRefs' as TaskFilter['property'],
-      values: templateEntityRefs,
+      property: 'templateOwners' as TaskFilter['property'],
+      values: templateOwners,
     };
   },
 });
@@ -199,4 +174,4 @@ export const scaffolderActionRules = {
   hasNumberProperty,
   hasStringProperty,
 };
-export const scaffolderTaskRules = { hasCreatedBy, hasTemplateEntityRefs };
+export const scaffolderTaskRules = { hasTemplateOwners };

--- a/plugins/scaffolder-backend/src/util/checkPermissions.ts
+++ b/plugins/scaffolder-backend/src/util/checkPermissions.ts
@@ -21,12 +21,36 @@ import { NotAllowedError } from '@backstage/errors';
 import {
   AuthorizeResult,
   BasicPermission,
+  PermissionCriteria,
+  PolicyDecision,
+  ResourcePermission,
 } from '@backstage/plugin-permission-common';
+import { ConditionTransformer } from '@backstage/plugin-permission-node';
+import { SerializedTask } from '@backstage/plugin-scaffolder-node';
+import { TaskFilters } from '@backstage/plugin-scaffolder-node';
 
 export type checkPermissionOptions = {
   credentials: BackstageCredentials;
   permissions: BasicPermission[];
   permissionService?: PermissionsService;
+};
+
+export type checkTaskPermissionOptions = {
+  credentials: BackstageCredentials;
+  permission: ResourcePermission;
+  permissionService?: PermissionsService;
+  task: SerializedTask;
+  isTaskAuthorized: (
+    decision: PolicyDecision,
+    resource: SerializedTask | undefined,
+  ) => boolean;
+};
+
+export type authorizeConditionsOptions = {
+  credentials: BackstageCredentials;
+  permission: ResourcePermission;
+  permissionService?: PermissionsService;
+  transformConditions: ConditionTransformer<TaskFilters>;
 };
 
 /**
@@ -51,3 +75,45 @@ export async function checkPermission(options: checkPermissionOptions) {
     }
   }
 }
+
+/**
+ * Does a conditional permission check for scaffolder task reading and cancellation.
+ * Throws 403 error if permission responds with AuthorizeResult.DENY, or does not resolve to true during the conditional rule check
+ * @public
+ */
+export async function checkTaskPermission(options: checkTaskPermissionOptions) {
+  const { permission, permissionService, credentials, task, isTaskAuthorized } =
+    options;
+  if (permissionService) {
+    const [taskDecision] = await permissionService.authorizeConditional(
+      [{ permission: permission }],
+      { credentials },
+    );
+    if (
+      taskDecision.result === AuthorizeResult.DENY ||
+      !isTaskAuthorized(taskDecision, task)
+    ) {
+      throw new NotAllowedError();
+    }
+  }
+}
+
+/** Fetches and transforms authorization conditions into filters, or returns `undefined` if the decision is not conditional.
+ * @public
+ */
+export const getAuthorizeConditions = async (
+  options: authorizeConditionsOptions,
+): Promise<PermissionCriteria<TaskFilters> | undefined> => {
+  const { permission, permissionService, credentials, transformConditions } =
+    options;
+  if (permissionService) {
+    const [taskDecision] = await permissionService.authorizeConditional(
+      [{ permission: permission }],
+      { credentials },
+    );
+    if (taskDecision.result === AuthorizeResult.CONDITIONAL) {
+      return transformConditions(taskDecision.conditions);
+    }
+  }
+  return undefined;
+};

--- a/plugins/scaffolder-common/report-alpha.api.md
+++ b/plugins/scaffolder-common/report-alpha.api.md
@@ -13,6 +13,9 @@ export const actionExecutePermission: ResourcePermission<'scaffolder-action'>;
 export const RESOURCE_TYPE_SCAFFOLDER_ACTION = 'scaffolder-action';
 
 // @alpha
+export const RESOURCE_TYPE_SCAFFOLDER_TASK = 'scaffolder-task';
+
+// @alpha
 export const RESOURCE_TYPE_SCAFFOLDER_TEMPLATE = 'scaffolder-template';
 
 // @alpha
@@ -23,22 +26,26 @@ export const scaffolderPermissions: (
   | BasicPermission
   | ResourcePermission<'scaffolder-action'>
   | ResourcePermission<'scaffolder-template'>
+  | ResourcePermission<'scaffolder-task'>
 )[];
 
 // @alpha
-export const scaffolderTaskPermissions: BasicPermission[];
+export const scaffolderTaskPermissions: (
+  | BasicPermission
+  | ResourcePermission<'scaffolder-task'>
+)[];
 
 // @alpha
 export const scaffolderTemplatePermissions: ResourcePermission<'scaffolder-template'>[];
 
 // @alpha
-export const taskCancelPermission: BasicPermission;
+export const taskCancelPermission: ResourcePermission<'scaffolder-task'>;
 
 // @alpha
 export const taskCreatePermission: BasicPermission;
 
 // @alpha
-export const taskReadPermission: BasicPermission;
+export const taskReadPermission: ResourcePermission<'scaffolder-task'>;
 
 // @alpha
 export const templateManagementPermission: BasicPermission;

--- a/plugins/scaffolder-common/src/permissions.ts
+++ b/plugins/scaffolder-common/src/permissions.ts
@@ -31,6 +31,13 @@ export const RESOURCE_TYPE_SCAFFOLDER_TEMPLATE = 'scaffolder-template';
 export const RESOURCE_TYPE_SCAFFOLDER_ACTION = 'scaffolder-action';
 
 /**
+ * Permission resource type which corresponds to scaffolder tasks
+ *
+ * @alpha
+ */
+export const RESOURCE_TYPE_SCAFFOLDER_TASK = 'scaffolder-task';
+
+/**
  * This permission is used to authorize actions that involve executing
  * an action from a template.
  *
@@ -89,6 +96,7 @@ export const taskReadPermission = createPermission({
   attributes: {
     action: 'read',
   },
+  resourceType: RESOURCE_TYPE_SCAFFOLDER_TASK,
 });
 
 /**
@@ -111,6 +119,7 @@ export const taskCreatePermission = createPermission({
 export const taskCancelPermission = createPermission({
   name: 'scaffolder.task.cancel',
   attributes: {},
+  resourceType: RESOURCE_TYPE_SCAFFOLDER_TASK,
 });
 
 /**

--- a/plugins/scaffolder-node/package.json
+++ b/plugins/scaffolder-node/package.json
@@ -58,6 +58,7 @@
     "@backstage/catalog-model": "workspace:^",
     "@backstage/errors": "workspace:^",
     "@backstage/integration": "workspace:^",
+    "@backstage/plugin-permission-common": "workspace:^",
     "@backstage/plugin-scaffolder-common": "workspace:^",
     "@backstage/types": "workspace:^",
     "@isomorphic-git/pgp-plugin": "^0.0.7",

--- a/plugins/scaffolder-node/report.api.md
+++ b/plugins/scaffolder-node/report.api.md
@@ -10,6 +10,7 @@ import { JsonValue } from '@backstage/types';
 import { Logger } from 'winston';
 import { LoggerService } from '@backstage/backend-plugin-api';
 import { Observable } from '@backstage/types';
+import { PermissionCriteria } from '@backstage/plugin-permission-common';
 import { Schema } from 'jsonschema';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import { ScmIntegrations } from '@backstage/integration';
@@ -402,6 +403,7 @@ export interface TaskBroker {
       order: 'asc' | 'desc';
       field: string;
     }[];
+    permissionFilters?: PermissionCriteria<TaskFilters>;
   }): Promise<{
     tasks: SerializedTask[];
     totalTasks?: number;
@@ -492,6 +494,25 @@ export interface TaskContext {
 
 // @public
 export type TaskEventType = 'completion' | 'log' | 'cancelled' | 'recovered';
+
+// @public
+export type TaskFilter = {
+  property: 'createdBy' | 'templateEntityRefs';
+  values: Array<string> | undefined;
+};
+
+// @public
+export type TaskFilters =
+  | {
+      anyOf: TaskFilter[];
+    }
+  | {
+      allOf: TaskFilter[];
+    }
+  | {
+      not: TaskFilter;
+    }
+  | TaskFilter;
 
 // @public
 export type TaskSecrets = Record<string, string> & {

--- a/plugins/scaffolder-node/report.api.md
+++ b/plugins/scaffolder-node/report.api.md
@@ -357,6 +357,7 @@ export type SerializedTask = {
   spec: TaskSpec;
   status: TaskStatus;
   createdAt: string;
+  templateOwner?: string;
   lastHeartbeatAt?: string;
   createdBy?: string;
   secrets?: TaskSecrets;
@@ -497,7 +498,7 @@ export type TaskEventType = 'completion' | 'log' | 'cancelled' | 'recovered';
 
 // @public
 export type TaskFilter = {
-  property: 'createdBy' | 'templateEntityRefs';
+  property: 'templateOwners';
   values: Array<string> | undefined;
 };
 

--- a/plugins/scaffolder-node/src/tasks/index.ts
+++ b/plugins/scaffolder-node/src/tasks/index.ts
@@ -18,6 +18,8 @@ export type {
   TaskSecrets,
   SerializedTask,
   SerializedTaskEvent,
+  TaskFilter,
+  TaskFilters,
   TaskBroker,
   TaskBrokerDispatchOptions,
   TaskBrokerDispatchResult,

--- a/plugins/scaffolder-node/src/tasks/types.ts
+++ b/plugins/scaffolder-node/src/tasks/types.ts
@@ -15,6 +15,7 @@
  */
 
 import { BackstageCredentials } from '@backstage/backend-plugin-api';
+import { PermissionCriteria } from '@backstage/plugin-permission-common';
 import { TaskSpec } from '@backstage/plugin-scaffolder-common';
 import { JsonObject, JsonValue, Observable } from '@backstage/types';
 
@@ -103,6 +104,25 @@ export type TaskBrokerDispatchOptions = {
   secrets?: TaskSecrets;
   createdBy?: string;
 };
+
+/**
+ * TaskFilter
+ * @public
+ */
+export type TaskFilter = {
+  property: 'createdBy' | 'templateEntityRefs';
+  values: Array<string> | undefined;
+};
+
+/**
+ * TaskFilters
+ * @public
+ */
+export type TaskFilters =
+  | { anyOf: TaskFilter[] }
+  | { allOf: TaskFilter[] }
+  | { not: TaskFilter }
+  | TaskFilter;
 
 /**
  * Task
@@ -194,6 +214,7 @@ export interface TaskBroker {
       offset?: number;
     };
     order?: { order: 'asc' | 'desc'; field: string }[];
+    permissionFilters?: PermissionCriteria<TaskFilters>;
   }): Promise<{ tasks: SerializedTask[]; totalTasks?: number }>;
 
   /**

--- a/plugins/scaffolder-node/src/tasks/types.ts
+++ b/plugins/scaffolder-node/src/tasks/types.ts
@@ -57,6 +57,7 @@ export type SerializedTask = {
   spec: TaskSpec;
   status: TaskStatus;
   createdAt: string;
+  templateOwner?: string;
   lastHeartbeatAt?: string;
   createdBy?: string;
   secrets?: TaskSecrets;
@@ -110,7 +111,7 @@ export type TaskBrokerDispatchOptions = {
  * @public
  */
 export type TaskFilter = {
-  property: 'createdBy' | 'templateEntityRefs';
+  property: 'templateOwners';
   values: Array<string> | undefined;
 };
 

--- a/plugins/scaffolder-react/src/next/components/ScaffolderPageContextMenu/ScaffolderPageContextMenu.tsx
+++ b/plugins/scaffolder-react/src/next/components/ScaffolderPageContextMenu/ScaffolderPageContextMenu.tsx
@@ -29,7 +29,6 @@ import List from '@material-ui/icons/List';
 import MoreVert from '@material-ui/icons/MoreVert';
 import { SyntheticEvent, useState } from 'react';
 import { usePermission } from '@backstage/plugin-permission-react';
-import { taskReadPermission } from '@backstage/plugin-scaffolder-common/alpha';
 import { templateManagementPermission } from '@backstage/plugin-scaffolder-common/alpha';
 
 import { scaffolderReactTranslationRef } from '../../../translation';
@@ -61,10 +60,6 @@ export function ScaffolderPageContextMenu(
     props;
   const classes = useStyles();
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement>();
-
-  const { allowed: canReadTasks } = usePermission({
-    permission: taskReadPermission,
-  });
 
   const { allowed: canManageTemplates } = usePermission({
     permission: templateManagementPermission,
@@ -142,7 +137,7 @@ export function ScaffolderPageContextMenu(
               />
             </MenuItem>
           )}
-          {onTasksClicked && canReadTasks && (
+          {onTasksClicked && (
             <MenuItem onClick={onTasksClicked}>
               <ListItemIcon>
                 <List fontSize="small" />

--- a/plugins/scaffolder/src/components/ListTasksPage/ListTasksPage.tsx
+++ b/plugins/scaffolder/src/components/ListTasksPage/ListTasksPage.tsx
@@ -86,14 +86,22 @@ const ListTaskPageContent = (props: MyTaskPageProps) => {
 
   if (error) {
     return (
-      <>
-        <ErrorPanel error={error} />
-        <EmptyState
-          missing="info"
-          title={t('listTaskPage.content.emptyState.title')}
-          description={t('listTaskPage.content.emptyState.description')}
-        />
-      </>
+      <CatalogFilterLayout>
+        <CatalogFilterLayout.Filters>
+          <OwnerListPicker
+            filter={ownerFilter}
+            onSelectOwner={id => setOwnerFilter(id)}
+          />
+        </CatalogFilterLayout.Filters>
+        <CatalogFilterLayout.Content>
+          <ErrorPanel error={error} />
+          <EmptyState
+            missing="info"
+            title={t('listTaskPage.content.emptyState.title')}
+            description={t('listTaskPage.content.emptyState.description')}
+          />
+        </CatalogFilterLayout.Content>
+      </CatalogFilterLayout>
     );
   }
 

--- a/plugins/scaffolder/src/components/OngoingTask/ContextMenu.tsx
+++ b/plugins/scaffolder/src/components/OngoingTask/ContextMenu.tsx
@@ -89,10 +89,12 @@ export const ContextMenu = (props: ContextMenuProps) => {
 
   const { allowed: canCancelTask } = usePermission({
     permission: taskCancelPermission,
+    resourceRef: taskId,
   });
 
   const { allowed: canReadTask } = usePermission({
     permission: taskReadPermission,
+    resourceRef: taskId,
   });
 
   const { allowed: canCreateTask } = usePermission({

--- a/plugins/scaffolder/src/components/OngoingTask/OngoingTask.test.tsx
+++ b/plugins/scaffolder/src/components/OngoingTask/OngoingTask.test.tsx
@@ -161,20 +161,53 @@ describe('OngoingTask', () => {
     await expect(rendered.findByText('Hide Logs')).resolves.toBeInTheDocument();
   });
 
-  it('should have cancel and start over buttons be disabled without the proper permissions', async () => {
+  it('should render not found error page when user does not have permission to read the task', async () => {
     const permissionApi = mockApis.permission({
       authorize: AuthorizeResult.DENY,
+    });
+
+    await expect(render(permissionApi)).rejects.toThrow(
+      'Reached NotFound Page',
+    );
+  });
+
+  it('should have cancel button be disabled when user has read permission but lacks cancel permission', async () => {
+    const permissionApi = mockApis.permission({
+      authorize: request => {
+        if (request.permission.name === 'scaffolder.task.cancel') {
+          return AuthorizeResult.DENY;
+        }
+        return AuthorizeResult.ALLOW;
+      },
     });
     const rendered = await render(permissionApi);
 
     const { getByTestId } = rendered;
     expect(getByTestId('cancel-button')).toHaveClass('Mui-disabled');
-    expect(getByTestId('start-over-button')).toHaveClass('Mui-disabled');
 
     await act(async () => {
       fireEvent.click(getByTestId('menu-button'));
     });
     expect(getByTestId('cancel-task')).toHaveClass('Mui-disabled');
-    expect(getByTestId('start-over-task')).toHaveClass('Mui-disabled');
+  });
+
+  it('should have start over button be disabled when user has read permission but lacks create permission', async () => {
+    const permissionApi = mockApis.permission({
+      authorize: request => {
+        if (request.permission.name === 'scaffolder.task.create') {
+          return AuthorizeResult.DENY;
+        }
+        return AuthorizeResult.ALLOW;
+      },
+    });
+    const rendered = await render(permissionApi);
+
+    const { getByTestId } = rendered;
+    expect(getByTestId('start-over-button')).toHaveClass('Mui-disabled');
+
+    await act(async () => {
+      fireEvent.click(getByTestId('menu-button'));
+    });
+    expect(getByTestId('start-over-button')).toHaveClass('Mui-disabled');
   });
 });

--- a/plugins/scaffolder/src/components/OngoingTask/OngoingTask.tsx
+++ b/plugins/scaffolder/src/components/OngoingTask/OngoingTask.tsx
@@ -106,7 +106,6 @@ export const OngoingTask = (props: {
   const [logsVisible, setLogVisibleState] = useState(false);
   const [buttonBarVisible, setButtonBarVisibleState] = useState(true);
 
-  // Used dummy string value for `resourceRef` since `allowed` field will always return `false` if `resourceRef` is `undefined`
   const { allowed: canCancelTask } = usePermission({
     permission: taskCancelPermission,
     resourceRef: taskId,

--- a/plugins/scaffolder/src/components/OngoingTask/OngoingTask.tsx
+++ b/plugins/scaffolder/src/components/OngoingTask/OngoingTask.tsx
@@ -41,7 +41,10 @@ import {
   TaskSteps,
 } from '@backstage/plugin-scaffolder-react/alpha';
 import { useAsync } from '@react-hookz/web';
-import { usePermission } from '@backstage/plugin-permission-react';
+import {
+  usePermission,
+  RequirePermission,
+} from '@backstage/plugin-permission-react';
 import {
   taskCancelPermission,
   taskCreatePermission,
@@ -106,10 +109,12 @@ export const OngoingTask = (props: {
   // Used dummy string value for `resourceRef` since `allowed` field will always return `false` if `resourceRef` is `undefined`
   const { allowed: canCancelTask } = usePermission({
     permission: taskCancelPermission,
+    resourceRef: taskId,
   });
 
   const { allowed: canReadTask } = usePermission({
     permission: taskReadPermission,
+    resourceRef: taskId,
   });
 
   const { allowed: canCreateTask } = usePermission({
@@ -204,118 +209,120 @@ export const OngoingTask = (props: {
   const cancelEnabled = !(taskStream.cancelled || taskStream.completed);
 
   return (
-    <Page themeId="website">
-      <Header
-        pageTitleOverride={
-          presentation
-            ? t('ongoingTask.pageTitle.hasTemplateName', {
-                templateName: presentation.primaryTitle,
-              })
-            : t('ongoingTask.pageTitle.noTemplateName')
-        }
-        title={
-          <div>
-            {t('ongoingTask.title')}{' '}
-            <code>{presentation ? presentation.primaryTitle : ''}</code>
-          </div>
-        }
-        subtitle={t('ongoingTask.subtitle', { taskId: taskId as string })}
-      >
-        <ContextMenu
-          cancelEnabled={cancelEnabled}
-          canRetry={canRetry}
-          isRetryableTask={isRetryableTask}
-          logsVisible={logsVisible}
-          buttonBarVisible={buttonBarVisible}
-          onStartOver={startOver}
-          onRetry={triggerRetry}
-          onToggleLogs={setLogVisibleState}
-          onToggleButtonBar={setButtonBarVisibleState}
-          taskId={taskId}
-        />
-      </Header>
-      <Content className={classes.contentWrapper}>
-        {taskStream.error ? (
+    <RequirePermission permission={taskReadPermission} resourceRef={taskId}>
+      <Page themeId="website">
+        <Header
+          pageTitleOverride={
+            presentation
+              ? t('ongoingTask.pageTitle.hasTemplateName', {
+                  templateName: presentation.primaryTitle,
+                })
+              : t('ongoingTask.pageTitle.noTemplateName')
+          }
+          title={
+            <div>
+              {t('ongoingTask.title')}{' '}
+              <code>{presentation ? presentation.primaryTitle : ''}</code>
+            </div>
+          }
+          subtitle={t('ongoingTask.subtitle', { taskId: taskId as string })}
+        >
+          <ContextMenu
+            cancelEnabled={cancelEnabled}
+            canRetry={canRetry}
+            isRetryableTask={isRetryableTask}
+            logsVisible={logsVisible}
+            buttonBarVisible={buttonBarVisible}
+            onStartOver={startOver}
+            onRetry={triggerRetry}
+            onToggleLogs={setLogVisibleState}
+            onToggleButtonBar={setButtonBarVisibleState}
+            taskId={taskId}
+          />
+        </Header>
+        <Content className={classes.contentWrapper}>
+          {taskStream.error ? (
+            <Box paddingBottom={2}>
+              <ErrorPanel
+                error={taskStream.error}
+                titleFormat="markdown"
+                title={taskStream.error.message}
+              />
+            </Box>
+          ) : null}
+
           <Box paddingBottom={2}>
-            <ErrorPanel
-              error={taskStream.error}
-              titleFormat="markdown"
-              title={taskStream.error.message}
+            <TaskSteps
+              steps={steps}
+              activeStep={activeStep}
+              isComplete={taskStream.completed}
+              isError={Boolean(taskStream.error)}
             />
           </Box>
-        ) : null}
 
-        <Box paddingBottom={2}>
-          <TaskSteps
-            steps={steps}
-            activeStep={activeStep}
-            isComplete={taskStream.completed}
-            isError={Boolean(taskStream.error)}
-          />
-        </Box>
+          <Outputs output={taskStream.output} />
 
-        <Outputs output={taskStream.output} />
-
-        {buttonBarVisible ? (
-          <Box paddingBottom={2}>
-            <Paper>
-              <Box padding={2}>
-                <div className={classes.buttonBar}>
-                  <Button
-                    className={classes.cancelButton}
-                    disabled={
-                      !cancelEnabled ||
-                      (cancelStatus !== 'not-executed' && !isRetryableTask) ||
-                      !canCancelTask
-                    }
-                    onClick={triggerCancel}
-                    data-testid="cancel-button"
-                  >
-                    {t('ongoingTask.cancelButtonTitle')}
-                  </Button>
-                  {isRetryableTask && (
+          {buttonBarVisible ? (
+            <Box paddingBottom={2}>
+              <Paper>
+                <Box padding={2}>
+                  <div className={classes.buttonBar}>
                     <Button
-                      className={classes.retryButton}
-                      disabled={cancelEnabled || !canRetry}
-                      onClick={triggerRetry}
-                      data-testid="retry-button"
+                      className={classes.cancelButton}
+                      disabled={
+                        !cancelEnabled ||
+                        (cancelStatus !== 'not-executed' && !isRetryableTask) ||
+                        !canCancelTask
+                      }
+                      onClick={triggerCancel}
+                      data-testid="cancel-button"
                     >
-                      {t('ongoingTask.retryButtonTitle')}
+                      {t('ongoingTask.cancelButtonTitle')}
                     </Button>
-                  )}
-                  <Button
-                    className={classes.logsVisibilityButton}
-                    color="primary"
-                    variant="outlined"
-                    onClick={() => setLogVisibleState(!logsVisible)}
-                  >
-                    {logsVisible
-                      ? t('ongoingTask.hideLogsButtonTitle')
-                      : t('ongoingTask.showLogsButtonTitle')}
-                  </Button>
-                  <Button
-                    variant="contained"
-                    color="primary"
-                    disabled={cancelEnabled || !canStartOver}
-                    onClick={startOver}
-                    data-testid="start-over-button"
-                  >
-                    {t('ongoingTask.startOverButtonTitle')}
-                  </Button>
-                </div>
+                    {isRetryableTask && (
+                      <Button
+                        className={classes.retryButton}
+                        disabled={cancelEnabled || !canRetry}
+                        onClick={triggerRetry}
+                        data-testid="retry-button"
+                      >
+                        {t('ongoingTask.retryButtonTitle')}
+                      </Button>
+                    )}
+                    <Button
+                      className={classes.logsVisibilityButton}
+                      color="primary"
+                      variant="outlined"
+                      onClick={() => setLogVisibleState(!logsVisible)}
+                    >
+                      {logsVisible
+                        ? t('ongoingTask.hideLogsButtonTitle')
+                        : t('ongoingTask.showLogsButtonTitle')}
+                    </Button>
+                    <Button
+                      variant="contained"
+                      color="primary"
+                      disabled={cancelEnabled || !canStartOver}
+                      onClick={startOver}
+                      data-testid="start-over-button"
+                    >
+                      {t('ongoingTask.startOverButtonTitle')}
+                    </Button>
+                  </div>
+                </Box>
+              </Paper>
+            </Box>
+          ) : null}
+
+          {logsVisible ? (
+            <Paper style={{ height: '100%' }}>
+              <Box padding={2} height="100%">
+                <TaskLogStream logs={taskStream.stepLogs} />
               </Box>
             </Paper>
-          </Box>
-        ) : null}
-
-        {logsVisible ? (
-          <Paper style={{ height: '100%' }}>
-            <Box padding={2} height="100%">
-              <TaskLogStream logs={taskStream.stepLogs} />
-            </Box>
-          </Paper>
-        ) : null}
-      </Content>
-    </Page>
+          ) : null}
+        </Content>
+      </Page>
+    </RequirePermission>
   );
 };

--- a/plugins/scaffolder/src/components/Router/Router.tsx
+++ b/plugins/scaffolder/src/components/Router/Router.tsx
@@ -59,10 +59,7 @@ import {
   CustomFieldsPage,
 } from '../../alpha/components/TemplateEditorPage';
 import { RequirePermission } from '@backstage/plugin-permission-react';
-import {
-  taskReadPermission,
-  templateManagementPermission,
-} from '@backstage/plugin-scaffolder-common/alpha';
+import { templateManagementPermission } from '@backstage/plugin-scaffolder-common/alpha';
 import { useApp } from '@backstage/core-plugin-api';
 import { FormField, OpaqueFormField } from '@internal/scaffolder';
 import { useAsync, useMountEffect } from '@react-hookz/web';
@@ -180,11 +177,9 @@ export const InternalRouter = (
       <Route
         path={scaffolderTaskRouteRef.path}
         element={
-          <RequirePermission permission={taskReadPermission}>
-            <TaskPageComponent
-              TemplateOutputsComponent={TemplateOutputsComponent}
-            />
-          </RequirePermission>
+          <TaskPageComponent
+            TemplateOutputsComponent={TemplateOutputsComponent}
+          />
         }
       />
       <Route
@@ -228,11 +223,7 @@ export const InternalRouter = (
       />
       <Route
         path={scaffolderListTaskRouteRef.path}
-        element={
-          <RequirePermission permission={taskReadPermission}>
-            <ListTasksPage contextMenu={props.contextMenu} />
-          </RequirePermission>
-        }
+        element={<ListTasksPage contextMenu={props.contextMenu} />}
       />
       <Route
         path={editorRouteRef.path}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7554,6 +7554,7 @@ __metadata:
     "@backstage/config": "workspace:^"
     "@backstage/errors": "workspace:^"
     "@backstage/integration": "workspace:^"
+    "@backstage/plugin-permission-common": "workspace:^"
     "@backstage/plugin-scaffolder-common": "workspace:^"
     "@backstage/types": "workspace:^"
     "@isomorphic-git/pgp-plugin": "npm:^0.0.7"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

A new scaffolder rule, `hasTemplateOwners`, has been added for the `scaffolder.task.read` and `scaffolder.task.cancel` permissions. This allows for conditional permission policies, such as granting template owners access to all tasks triggered by their templates. Additionally, a new `template_owner` column has been introduced to the `tasks` table, enabling filtering of tasks based on the owner of the template from which the task was triggered.

_**If used independently of the `hasCreatedBy` rule introduced in https://github.com/backstage/backstage/pull/29202, users will only be able to view tasks triggered from templates they own. They will not have access to tasks initiated by templates that are not owned by them. Given this, it would make sense to merge https://github.com/backstage/backstage/pull/29202 before merging this PR.**_ 

Related to: https://github.com/backstage/backstage/issues/27421, https://github.com/backstage/backstage/issues/25616

Example:

In this example, the `Sleep Template` is owned by the guest user and the `Log a message after a specified duration of time` Template is owned by the user 04kash. 04kash triggered a task from the Sleep Template and the guest user triggered a task from the Log Template. Here is what the Task List looks like for both the users:

04kash:
![Screenshot from 2025-04-25 19-40-57](https://github.com/user-attachments/assets/c5aa0601-7c81-4c5c-b4a7-b4f820f8598b)


guest:
![Screenshot from 2025-04-25 19-40-12](https://github.com/user-attachments/assets/5a621066-0afd-413d-9335-0db1cd8ec203)

Permission Policy used:

```ts
export class CustomPermissionPolicy implements PermissionPolicy {
  async handle(
    request: PolicyQuery,
    user?: PolicyQueryUser,
  ): Promise<PolicyDecision> {
    if (isPermission(request.permission, taskReadPermission)) {
      return createScaffolderTaskConditionalDecision(
        request.permission,

        scaffolderTaskConditions.hasTemplateOwners({
          templateOwners: user?.info.userEntityRef ? [user?.info.userEntityRef] : [],
        }),
      );
    }
    return { result: AuthorizeResult.ALLOW };
  }
}
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))