### PR TITLE
Error Handling in Gitlab Repo Push

### DIFF
--- a/.changeset/bumpy-showers-design.md
+++ b/.changeset/bumpy-showers-design.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gitlab': patch
+---
+
+If the commit action is not `create` log a more appropriate error message to the end user advising that the files they're trying to modify might not exist

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.test.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.test.ts
@@ -376,4 +376,75 @@ describe('createGitLabCommit', () => {
       );
     });
   });
+
+  describe('error handling', () => {
+    it('throws appropriate error for create action when commit fails', async () => {
+      const input = {
+        repoUrl: 'gitlab.com?repo=repo&owner=owner',
+        commitMessage: 'Create my new commit',
+        branchName: 'some-branch',
+        commitAction: 'create',
+      };
+      mockDir.setContent({
+        [workspacePath]: {
+          'foo.txt': 'Hello there!',
+        },
+      });
+
+      const ctx = createMockActionContext({ input, workspacePath });
+      mockGitlabClient.Commits.create.mockRejectedValue(
+        new Error('Commit failed'),
+      );
+
+      await expect(instance.handler(ctx)).rejects.toThrow(
+        'Committing the changes to some-branch failed. Please check that none of the files created by the template already exists. Error: Commit failed',
+      );
+    });
+
+    it('throws appropriate error for update action when commit fails', async () => {
+      const input = {
+        repoUrl: 'gitlab.com?repo=repo&owner=owner',
+        commitMessage: 'Update my commit',
+        branchName: 'some-branch',
+        commitAction: 'update',
+      };
+      mockDir.setContent({
+        [workspacePath]: {
+          'foo.txt': 'Hello there!',
+        },
+      });
+
+      const ctx = createMockActionContext({ input, workspacePath });
+      mockGitlabClient.Commits.create.mockRejectedValue(
+        new Error('Commit failed'),
+      );
+
+      await expect(instance.handler(ctx)).rejects.toThrow(
+        "Modifying the files in some-branch failed. Please verify that all files you're trying to modify exist in the repository. Error: Commit failed",
+      );
+    });
+
+    it('throws appropriate error for delete action when commit fails', async () => {
+      const input = {
+        repoUrl: 'gitlab.com?repo=repo&owner=owner',
+        commitMessage: 'Delete my commit',
+        branchName: 'some-branch',
+        commitAction: 'delete',
+      };
+      mockDir.setContent({
+        [workspacePath]: {
+          'foo.txt': 'Hello there!',
+        },
+      });
+
+      const ctx = createMockActionContext({ input, workspacePath });
+      mockGitlabClient.Commits.create.mockRejectedValue(
+        new Error('Commit failed'),
+      );
+
+      await expect(instance.handler(ctx)).rejects.toThrow(
+        "Modifying the files in some-branch failed. Please verify that all files you're trying to modify exist in the repository. Error: Commit failed",
+      );
+    });
+  });
 });

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.test.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.test.ts
@@ -420,7 +420,7 @@ describe('createGitLabCommit', () => {
       );
 
       await expect(instance.handler(ctx)).rejects.toThrow(
-        "Modifying the files in some-branch failed. Please verify that all files you're trying to modify exist in the repository. Error: Commit failed",
+        "Committing the changes to some-branch failed. Please verify that all files you're trying to modify exist in the repository. Error: Commit failed",
       );
     });
 
@@ -443,7 +443,7 @@ describe('createGitLabCommit', () => {
       );
 
       await expect(instance.handler(ctx)).rejects.toThrow(
-        "Modifying the files in some-branch failed. Please verify that all files you're trying to modify exist in the repository. Error: Commit failed",
+        "Committing the changes to some-branch failed. Please verify that all files you're trying to modify exist in the repository. Error: Commit failed",
       );
     });
   });

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.ts
@@ -203,6 +203,13 @@ export const createGitlabRepoPushAction = (options: {
         ctx.output('projectPath', repoID);
         ctx.output('commitHash', commitId);
       } catch (e) {
+        if (commitAction !== 'create') {
+          throw new InputError(
+            `Modifying the files in ${branchName} failed. Please verify that all files you're trying to modify exist in the repository. ${getErrorMessage(
+              e,
+            )}`,
+          );
+        }
         throw new InputError(
           `Committing the changes to ${branchName} failed. Please check that none of the files created by the template already exists. ${getErrorMessage(
             e,

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.ts
@@ -205,7 +205,7 @@ export const createGitlabRepoPushAction = (options: {
       } catch (e) {
         if (commitAction !== 'create') {
           throw new InputError(
-            `Modifying the files in ${branchName} failed. Please verify that all files you're trying to modify exist in the repository. ${getErrorMessage(
+            `Committing the changes to ${branchName} failed. Please verify that all files you're trying to modify exist in the repository. ${getErrorMessage(
               e,
             )}`,
           );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Hey Team! 👋 

An attempt at making the error messages a bit more clear for the end user when using 'update' or 'delete' I noticed if I use 'update' and try to add a file from the skeleton that doesn't exist in the repo it will throw:

```text
Committing the changes to adding-catalog-info-file failed. Please check that none of the files created by the template already exists. GitbeakerRequestError: Bad Request
```

Which can be a bit misleading if you're trying to update a file (or delete one). I've not used the `commitAction: 'delete'` before so I'm not sure if it would have a similar problem but I would imagine it would.

I also added some tests for the error handling parts, if this is OTT or not really useful please let me know? Also happy to change the approach but just wanted to try and keep it simple for now as I think later on we will move to not using `Gitbeaker` anymore so it will probably change? 💭 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
