### PR TITLE
Move `templateExtensions` to `templatingExtensions`

### DIFF
--- a/.changeset/shiny-symbols-grow.md
+++ b/.changeset/shiny-symbols-grow.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+'@backstage/plugin-scaffolder-react': patch
+'@backstage/plugin-scaffolder': patch
+---
+
+Fixing a bug where the name for `templatingExtensions` was incorrect

--- a/plugins/scaffolder-backend/src/service/router.test.ts
+++ b/plugins/scaffolder-backend/src/service/router.test.ts
@@ -360,10 +360,10 @@ describe.each([
         });
       });
 
-      describe('GET /v2/template-extensions', () => {
+      describe('GET /v2/temlating-extensions', () => {
         it('lists template filters and globals', async () => {
           const response = await request(app)
-            .get('/v2/template-extensions')
+            .get('/v2/temlating-extensions')
             .send();
           expect(response.status).toEqual(200);
           const integrations = ScmIntegrations.fromConfig(config);

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -1115,7 +1115,7 @@ export async function createRouter(
 
       res.status(200).json({ results });
     })
-    .get('/v2/template-extensions', async (_req, res) => {
+    .get('/v2/templating-extensions', async (_req, res) => {
       res.status(200).json({
         filters: {
           ...extractFilterMetadata(createDefaultFilters({ integrations })),

--- a/plugins/scaffolder-react/report.api.md
+++ b/plugins/scaffolder-react/report.api.md
@@ -166,7 +166,7 @@ export type LayoutTemplate<T = any> = NonNullable<
 export type ListActionsResponse = Array<Action>;
 
 // @public
-export type ListTemplateExtensionsResponse = {
+export type ListTemplatingExtensionsResponse = {
   filters: Record<string, TemplateFilter>;
   globals: {
     functions: Record<string, TemplateGlobalFunction>;
@@ -247,7 +247,7 @@ export interface ScaffolderApi {
     tasks: ScaffolderTask[];
     totalTasks?: number;
   }>;
-  listTemplateExtensions?(): Promise<ListTemplateExtensionsResponse>;
+  listTemplatingExtensions?(): Promise<ListTemplatingExtensionsResponse>;
   retry?(taskId: string): Promise<void>;
   scaffold(
     options: ScaffolderScaffoldOptions,

--- a/plugins/scaffolder-react/src/api/types.ts
+++ b/plugins/scaffolder-react/src/api/types.ts
@@ -129,7 +129,7 @@ export type TemplateGlobalValue = {
  *
  * @public
  */
-export type ListTemplateExtensionsResponse = {
+export type ListTemplatingExtensionsResponse = {
   filters: Record<string, TemplateFilter>;
   globals: {
     functions: Record<string, TemplateGlobalFunction>;
@@ -300,7 +300,7 @@ export interface ScaffolderApi {
   /**
    * Returns a structure describing the available templating extensions.
    */
-  listTemplateExtensions?(): Promise<ListTemplateExtensionsResponse>;
+  listTemplatingExtensions?(): Promise<ListTemplatingExtensionsResponse>;
 
   streamLogs(options: ScaffolderStreamLogsOptions): Observable<LogEvent>;
 

--- a/plugins/scaffolder/report.api.md
+++ b/plugins/scaffolder/report.api.md
@@ -25,7 +25,7 @@ import { JSX as JSX_2 } from 'react/jsx-runtime';
 import { LayoutOptions as LayoutOptions_2 } from '@backstage/plugin-scaffolder-react';
 import { LayoutTemplate as LayoutTemplate_2 } from '@backstage/plugin-scaffolder-react';
 import { ListActionsResponse as ListActionsResponse_2 } from '@backstage/plugin-scaffolder-react';
-import { ListTemplateExtensionsResponse } from '@backstage/plugin-scaffolder-react';
+import { ListTemplatingExtensionsResponse } from '@backstage/plugin-scaffolder-react';
 import { LogEvent as LogEvent_2 } from '@backstage/plugin-scaffolder-react';
 import { Observable } from '@backstage/types';
 import { PathParams } from '@backstage/core-plugin-api';
@@ -561,7 +561,7 @@ export class ScaffolderClient implements ScaffolderApi_2 {
     totalTasks?: number;
   }>;
   // (undocumented)
-  listTemplateExtensions(): Promise<ListTemplateExtensionsResponse>;
+  listTemplatingExtensions(): Promise<ListTemplatingExtensionsResponse>;
   // (undocumented)
   retry?(taskId: string): Promise<void>;
   // (undocumented)

--- a/plugins/scaffolder/src/api.ts
+++ b/plugins/scaffolder/src/api.ts
@@ -24,7 +24,7 @@ import { ResponseError } from '@backstage/errors';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import {
   ListActionsResponse,
-  ListTemplateExtensionsResponse,
+  ListTemplatingExtensionsResponse,
   LogEvent,
   ScaffolderApi,
   ScaffolderDryRunOptions,
@@ -325,7 +325,7 @@ export class ScaffolderClient implements ScaffolderApi {
     return await response.json();
   }
 
-  async listTemplateExtensions(): Promise<ListTemplateExtensionsResponse> {
+  async listTemplatingExtensions(): Promise<ListTemplatingExtensionsResponse> {
     const baseUrl = await this.discoveryApi.getBaseUrl('scaffolder');
     const response = await this.fetchApi.fetch(
       `${baseUrl}/v2/template-extensions`,


### PR DESCRIPTION
Gonna ship this as a patch release, as we probably got the name a little bit wrong in the release yesterday.