### PR TITLE
fix(scaffolder): make EntityPicker display consistent between dropdown and selected value

### DIFF
--- a/.changeset/entity-picker-display-fix.md
+++ b/.changeset/entity-picker-display-fix.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder': patch
 ---
 
-Fixed EntityPicker display inconsistency between dropdown options and selected value by using primaryTitle from entity presentation for both.
+Fixed `EntityPicker` display inconsistency between dropdown options and selected value.

--- a/.changeset/entity-picker-display-fix.md
+++ b/.changeset/entity-picker-display-fix.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Fixed EntityPicker display inconsistency between dropdown options and selected value by using primaryTitle from entity presentation for both.

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.test.tsx
@@ -812,4 +812,97 @@ describe('<EntityPicker />', () => {
       expect(onChange).toHaveBeenCalledWith(undefined);
     });
   });
+
+  describe('rendering consistency', () => {
+    beforeEach(() => {
+      uiSchema = { 'ui:options': {} };
+      props = {
+        onChange,
+        schema,
+        required,
+        uiSchema,
+        rawErrors,
+        formData: 'group:default/team-a',
+      } as unknown as FieldProps<string>;
+    });
+
+    it('renders consistent entity display between dropdown and selected value', async () => {
+      // Mock the presentation API to return specific values for testing
+      const mockEntityPresentation = {
+        entityRef: 'group:default/team-a',
+        primaryTitle: 'Team A',
+      };
+
+      // Create a catalog API that includes the specific test entity
+      const testCatalogApi = catalogApiMock.mock({
+        getEntities: jest.fn().mockResolvedValue({
+          items: [makeEntity('Group', 'default', 'team-a')],
+        }),
+      });
+
+      // Create mock entity presentation mapping
+      const entityRefToPresentation = new Map();
+      entityRefToPresentation.set(
+        'group:default/team-a',
+        mockEntityPresentation,
+      );
+
+      const renderResult = await renderInTestApp(
+        <TestApiProvider
+          apis={[
+            [catalogApiRef, testCatalogApi],
+            [
+              entityPresentationApiRef,
+              {
+                forEntity: jest.fn().mockReturnValue({
+                  snapshot: mockEntityPresentation,
+                  promise: Promise.resolve(mockEntityPresentation),
+                }),
+              },
+            ],
+          ]}
+        >
+          <EntityPicker {...props} />
+        </TestApiProvider>,
+      );
+
+      // Wait for the entity data to load and be processed
+      // This is needed because the EntityPicker uses useAsync
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      // Force a re-render to apply the mocked data
+      renderResult.rerender(
+        <TestApiProvider
+          apis={[
+            [catalogApiRef, testCatalogApi],
+            [
+              entityPresentationApiRef,
+              {
+                forEntity: jest.fn().mockReturnValue({
+                  snapshot: mockEntityPresentation,
+                  promise: Promise.resolve(mockEntityPresentation),
+                }),
+              },
+            ],
+          ]}
+        >
+          <EntityPicker {...props} formData="group:default/team-a" />
+        </TestApiProvider>,
+      );
+
+      // Force update to complete
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      // Verify the selected value shows the correct display
+      const input = screen.getByRole('textbox');
+      expect(input).toHaveValue('Team A');
+
+      // Open the dropdown
+      fireEvent.mouseDown(input);
+
+      // Check if dropdown shows the same representation
+      const option = await screen.findByText('Team A');
+      expect(option).toBeInTheDocument();
+    });
+  });
 });

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
@@ -201,7 +201,7 @@ export const EntityPicker = (props: EntityPickerProps) => {
           typeof option === 'string'
             ? option
             : entities?.entityRefToPresentation.get(stringifyEntityRef(option))
-                ?.entityRef!
+                ?.primaryTitle || stringifyEntityRef(option)
         }
         autoSelect
         freeSolo={allowArbitraryValues}


### PR DESCRIPTION
This PR fixes an inconsistency in the EntityPicker component where the dropdown options and the selected value were rendered differently.