### PR TITLE
chore(typos): fix various code typos

### DIFF
--- a/.changeset/early-colts-accept.md
+++ b/.changeset/early-colts-accept.md
@@ -1,0 +1,6 @@
+---
+'@backstage/backend-dynamic-feature-service': patch
+---
+
+Fixed various typos.
+`FrontendRemoteResolver`'s misspelled `getAdditionaRemoteInfo` has been deprecated. Use the correct spelling `getAdditionalRemoteInfo` instead.

--- a/.changeset/short-teeth-juggle.md
+++ b/.changeset/short-teeth-juggle.md
@@ -1,0 +1,49 @@
+---
+'@backstage/plugin-scaffolder-backend-module-bitbucket-server': patch
+'@backstage/plugin-scaffolder-backend-module-bitbucket-cloud': patch
+'@backstage/plugin-catalog-backend-module-backstage-openapi': patch
+'@backstage/plugin-scaffolder-backend-module-bitbucket': patch
+'@backstage/plugin-search-backend-module-elasticsearch': patch
+'@backstage/plugin-catalog-backend-module-github-org': patch
+'@backstage/plugin-scaffolder-backend-module-gerrit': patch
+'@backstage/plugin-scaffolder-backend-module-github': patch
+'@backstage/plugin-scaffolder-backend-module-gitlab': patch
+'@backstage/plugin-catalog-backend-module-msgraph': patch
+'@backstage/plugin-catalog-backend-module-gitlab': patch
+'@backstage/plugin-catalog-backend-module-logs': patch
+'@backstage/plugin-catalog-backend-module-aws': patch
+'@backstage/frontend-plugin-api': patch
+'@backstage/backend-plugin-api': patch
+'@backstage/plugin-kubernetes-backend': patch
+'@backstage/plugin-kubernetes-cluster': patch
+'@backstage/plugin-scaffolder-backend': patch
+'@backstage/backend-defaults': patch
+'@backstage/frontend-app-api': patch
+'@backstage/plugin-kubernetes-common': patch
+'@backstage/plugin-permission-common': patch
+'@backstage/backend-app-api': patch
+'@backstage/core-compat-api': patch
+'@backstage/core-components': patch
+'@backstage/plugin-kubernetes-react': patch
+'@backstage/plugin-scaffolder-react': patch
+'@backstage/plugin-techdocs-backend': patch
+'@backstage/plugin-kubernetes-node': patch
+'@backstage/plugin-scaffolder-node': patch
+'@backstage/config-loader': patch
+'@backstage/plugin-techdocs-react': patch
+'@backstage/plugin-catalog-graph': patch
+'@backstage/plugin-techdocs-node': patch
+'@backstage/plugin-auth-backend': patch
+'@backstage/repo-tools': patch
+'@backstage/plugin-auth-react': patch
+'@backstage/plugin-kubernetes': patch
+'@backstage/plugin-scaffolder': patch
+'@backstage/plugin-api-docs': patch
+'@backstage/plugin-techdocs': patch
+'@backstage/canon': patch
+'@backstage/cli': patch
+'@backstage/plugin-home': patch
+'@backstage/plugin-org': patch
+---
+
+Removed various typos

--- a/packages/backend-app-api/src/wiring/BackendInitializer.ts
+++ b/packages/backend-app-api/src/wiring/BackendInitializer.ts
@@ -472,7 +472,7 @@ export class BackendInitializer {
 
     const rootLifecycleService = await this.#getRootLifecycleImpl();
 
-    // Root services like the health one need to immediatelly be notified of the shutdown
+    // Root services like the health one need to immediately be notified of the shutdown
     await rootLifecycleService.beforeShutdown();
 
     // Get all plugins.

--- a/packages/backend-defaults/src/entrypoints/auth/DefaultAuthService.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/DefaultAuthService.ts
@@ -151,7 +151,7 @@ export class DefaultAuthService implements AuthService {
     }
 
     // check whether a plugin support the new auth system
-    // by checking the public keys endpoint existance.
+    // by checking the public keys endpoint existence.
     switch (type) {
       // TODO: Check whether the principal is ourselves
       case 'service':

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/GerritUrlReader.test.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/GerritUrlReader.test.ts
@@ -412,7 +412,7 @@ describe.skip('GerritUrlReader', () => {
         gerritProcessor.readTree(shaTreeUrl, { etag: sha }),
       ).rejects.toThrow(NotModifiedError);
     });
-    it('can fetch files for a specifc sha.', async () => {
+    it('can fetch files for a specific sha.', async () => {
       const response = await gerritProcessorWithGitiles.readTree(
         `https://gerrit.com/gitiles/app/web/+/${sha}/`,
       );

--- a/packages/backend-dynamic-feature-service/report.api.md
+++ b/packages/backend-dynamic-feature-service/report.api.md
@@ -230,6 +230,9 @@ export type FrontendRemoteResolver = {
   getRemoteEntryType?: (
     manifestContent: JsonObject,
   ) => 'manifest' | 'javascript';
+  getAdditionalRemoteInfo?: (
+    manifestContent: JsonObject,
+  ) => AdditionalRemoteInfo;
   getAdditionaRemoteInfo?: (
     manifestContent: JsonObject,
   ) => AdditionalRemoteInfo;

--- a/packages/backend-dynamic-feature-service/src/features/__fixtures__/node_modules/@backstage/backend-plugin-api/package.json
+++ b/packages/backend-dynamic-feature-service/src/features/__fixtures__/node_modules/@backstage/backend-plugin-api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/backend-plugin-api",
   "version": "0.0.0",
-  "description": "dummy backstage package that should be skipped by the ComonJSLoduleLoader",
+  "description": "dummy backstage package that should be skipped by the CommonJSModuleLoader",
   "main": "index.js",
   "dependencies": {}
 }

--- a/packages/backend-dynamic-feature-service/src/features/features.test.ts
+++ b/packages/backend-dynamic-feature-service/src/features/features.test.ts
@@ -558,7 +558,7 @@ Require stack:
             for: () => ({
               assetsPathFromPackage: 'dist-alternate',
               getRemoteEntryType: () => 'javascript',
-              getAdditionaRemoteInfo: manifest => ({
+              getAdditionalRemoteInfo: manifest => ({
                 type: (manifest as any).metaData.remoteEntry.type,
               }),
               overrideExposedModules: exposedModules =>

--- a/packages/backend-dynamic-feature-service/src/loader/CommonJSModuleLoader.ts
+++ b/packages/backend-dynamic-feature-service/src/loader/CommonJSModuleLoader.ts
@@ -68,7 +68,7 @@ export class CommonJSModuleLoader implements ModuleLoader {
       return filtered;
     };
 
-    // The whole piece of code below is a way to accomodate the limitations of
+    // The whole piece of code below is a way to accommodate the limitations of
     // the current `resolvePackagePath` implementation, which cannot be provided
     // some custom locations where it should find the assets of some given packages.
     //
@@ -104,7 +104,7 @@ export class CommonJSModuleLoader implements ModuleLoader {
         mod?.path &&
         !dynamicPluginsPaths.some(p => mod.path.startsWith(p));
 
-      // If not, we don't need the dedicated specfic case below.
+      // If not, we don't need the dedicated specific case below.
       if (!resolvingPackageJsonFromBackstageApplication) {
         throw errorToThrow;
       }
@@ -133,7 +133,7 @@ export class CommonJSModuleLoader implements ModuleLoader {
       }
 
       // If a custom resolution is provided, use it.
-      // This allows accomodating alternate ways to package dynamic plugins:
+      // This allows accommodating alternate ways to package dynamic plugins:
       // static plugin package wrapped inside a distinct dynamic plugin package for example.
       if (this.options.customResolveDynamicPackage) {
         const resolvedPath = this.options.customResolveDynamicPackage(

--- a/packages/backend-dynamic-feature-service/src/server/frontendRemotesServer.ts
+++ b/packages/backend-dynamic-feature-service/src/server/frontendRemotesServer.ts
@@ -37,7 +37,7 @@ export type AdditionalRemoteInfo = Omit<RemoteInfo, 'name' | 'entry'>;
  * */
 export type FrontendRemoteResolver = {
   /**
-   * Relative path to the module federation assets folder from thr root folder of the plugin package.
+   * Relative path to the module federation assets folder from the root folder of the plugin package.
    * Default value is `dist`.
    */
   assetsPathFromPackage?: string;
@@ -58,6 +58,14 @@ export type FrontendRemoteResolver = {
 
   /**
    * Additional module federation fields, which might be required if the remote entry type is 'javascript'.
+   */
+  getAdditionalRemoteInfo?: (
+    manifestContent: JsonObject,
+  ) => AdditionalRemoteInfo;
+
+  /**
+   * Additional module federation fields, which might be required if the remote entry type is 'javascript'.
+   * @deprecated Use `getAdditionalRemoteInfo` instead.
    */
   getAdditionaRemoteInfo?: (
     manifestContent: JsonObject,

--- a/packages/backend-dynamic-feature-service/src/server/router.ts
+++ b/packages/backend-dynamic-feature-service/src/server/router.ts
@@ -121,8 +121,10 @@ export async function createRouter({
       }
 
       const getAdditionalRemoteInfo =
+        providedResolver?.getAdditionalRemoteInfo ??
         providedResolver?.getAdditionaRemoteInfo ??
-        defaultResolver.getAdditionaRemoteInfo;
+        defaultResolver.getAdditionalRemoteInfo ??
+        defaultResolver?.getAdditionaRemoteInfo;
       const getRemoteEntryType =
         providedResolver?.getRemoteEntryType ??
         defaultResolver.getRemoteEntryType;

--- a/packages/backend-plugin-api/src/services/definitions/HttpAuthService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/HttpAuthService.ts
@@ -93,7 +93,7 @@ export interface HttpAuthService {
        *
        * Normally you do not have to specify this option, because the default
        * behavior is to extract the credentials from the request that
-       * corresponded to the given respnse.
+       * corresponded to the given response.
        */
       credentials?: BackstageCredentials;
     },

--- a/packages/backend-plugin-api/src/services/definitions/UrlReaderService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/UrlReaderService.ts
@@ -110,7 +110,7 @@ export type UrlReaderServiceReadUrlOptions = {
    * @remarks
    *
    * By default all URL Readers will use the integrations config which is supplied
-   * when creating the Readers. Sometimes it might be desireable to use the already
+   * when creating the Readers. Sometimes it might be desirable to use the already
    * created URLReaders but with a different token, maybe that's supplied by the user
    * at runtime.
    */
@@ -209,7 +209,7 @@ export type UrlReaderServiceReadTreeOptions = {
    * @remarks
    *
    * By default all URL Readers will use the integrations config which is supplied
-   * when creating the Readers. Sometimes it might be desireable to use the already
+   * when creating the Readers. Sometimes it might be desirable to use the already
    * created URLReaders but with a different token, maybe that's supplied by the user
    * at runtime.
    */
@@ -323,7 +323,7 @@ export type UrlReaderServiceSearchOptions = {
    * @remarks
    *
    * By default all URL Readers will use the integrations config which is supplied
-   * when creating the Readers. Sometimes it might be desireable to use the already
+   * when creating the Readers. Sometimes it might be desirable to use the already
    * created URLReaders but with a different token, maybe that's supplied by the user
    * at runtime.
    */

--- a/packages/canon/src/components/Select/types.ts
+++ b/packages/canon/src/components/Select/types.ts
@@ -84,7 +84,7 @@ export interface SelectProps {
   onValueChange?: (value: string) => void;
 
   /**
-   * Callbak that is called when the select field is opened or closed
+   * Callback that is called when the select field is opened or closed
    */
   onOpenChange?: (open: boolean) => void;
 

--- a/packages/cli/config/jestCachingModuleLoader.js
+++ b/packages/cli/config/jestCachingModuleLoader.js
@@ -19,8 +19,8 @@ const { default: JestRuntime } = require('jest-runtime');
 const scriptTransformCache = new Map();
 
 module.exports = class CachingJestRuntime extends JestRuntime {
-  constructor(config, ...restAgs) {
-    super(config, ...restAgs);
+  constructor(config, ...restArgs) {
+    super(config, ...restArgs);
     this.allowLoadAsEsm = config.extensionsToTreatAsEsm.includes('.mts');
   }
 

--- a/packages/cli/src/modules/migrate/commands/versions/bump.test.ts
+++ b/packages/cli/src/modules/migrate/commands/versions/bump.test.ts
@@ -131,10 +131,10 @@ const lockfileMock = `${HEADER}
 
 // Avoid flakes by comparing sorted log lines. File system access is async, which leads to the log line order being indeterministic
 const expectLogsToMatch = (
-  recievedLogs: String[],
+  receivedLogs: String[],
   expected: String[],
 ): void => {
-  expect(recievedLogs.filter(Boolean).sort()).toEqual(expected.sort());
+  expect(receivedLogs.filter(Boolean).sort()).toEqual(expected.sort());
 };
 
 describe('bump', () => {

--- a/packages/cli/src/modules/migrate/commands/versions/migrate.test.ts
+++ b/packages/cli/src/modules/migrate/commands/versions/migrate.test.ts
@@ -51,8 +51,8 @@ jest.mock('../../../../lib/run', () => {
   };
 });
 
-function expectLogsToMatch(recievedLogs: String[], expected: String[]): void {
-  expect(recievedLogs.filter(Boolean).sort()).toEqual(expected.sort());
+function expectLogsToMatch(receivedLogs: String[], expected: String[]): void {
+  expect(receivedLogs.filter(Boolean).sort()).toEqual(expected.sort());
 }
 
 describe('versions:migrate', () => {
@@ -169,7 +169,7 @@ describe('versions:migrate', () => {
     });
   });
 
-  it('should replace the occurences of the moved package in files inside the correct package', async () => {
+  it('should replace the occurrences of the moved package in files inside the correct package', async () => {
     mockDir.setContent({
       'package.json': JSON.stringify({
         workspaces: {
@@ -259,7 +259,7 @@ describe('versions:migrate', () => {
     );
   });
 
-  it('should replaces the occurences of changed packages, and is careful', async () => {
+  it('should replaces the occurrences of changed packages, and is careful', async () => {
     mockDir.setContent({
       'package.json': JSON.stringify({
         workspaces: {

--- a/packages/cli/src/modules/start/commands/repo/start.ts
+++ b/packages/cli/src/modules/start/commands/repo/start.ts
@@ -69,7 +69,7 @@ export async function findTargetPackages(
 
   const packages = await PackageGraph.listTargetPackages();
 
-  // Priorotize plugin options, so that the `start` script can contain a list of packages,
+  // Prioritize plugin options, so that the `start` script can contain a list of packages,
   // but make them easy to override by running for example `yarn start --plugin catalog`
   for (const pluginId of pluginIds) {
     const matchingPackages = packages.filter(pkg => {

--- a/packages/config-loader/src/sources/RemoteConfigSource.ts
+++ b/packages/config-loader/src/sources/RemoteConfigSource.ts
@@ -147,7 +147,7 @@ export class RemoteConfigSource implements ConfigSource {
     if (rawData === undefined) {
       /**
        * This error message is/was coupled to the implementation and with refactoring it is no longer truly accurate
-       * This behavior is also inconsistent with {@link FileConfigSource}, which doesn't error on unparseable or empty
+       * This behavior is also inconsistent with {@link FileConfigSource}, which doesn't error on unparsable or empty
        * content
        *
        * Preserving to not make a breaking change

--- a/packages/config-loader/src/sources/types.ts
+++ b/packages/config-loader/src/sources/types.ts
@@ -78,7 +78,7 @@ export interface ConfigSource {
 }
 
 /**
- * A custom function to be used for substitution withing configuration files.
+ * A custom function to be used for substitution within configuration files.
  *
  * @remarks
  *

--- a/packages/core-compat-api/src/collectEntityPageContents.ts
+++ b/packages/core-compat-api/src/collectEntityPageContents.ts
@@ -30,7 +30,7 @@ import { normalizeRoutePath } from './normalizeRoutePath';
 const ENTITY_SWITCH_KEY = 'core.backstage.entitySwitch';
 const ENTITY_ROUTE_KEY = 'plugin.catalog.entityLayoutRoute';
 
-// Placeholder to make sure internal types here are consitent
+// Placeholder to make sure internal types here are consistent
 type Entity = { apiVersion: string; kind: string };
 
 type EntityFilter = (entity: Entity, ctx: { apis: ApiHolder }) => boolean;

--- a/packages/core-components/src/components/AutoLogout/AutoLogout.tsx
+++ b/packages/core-components/src/components/AutoLogout/AutoLogout.tsx
@@ -42,7 +42,7 @@ type AutoLogoutTrackableEvent = EventsType;
 export type AutoLogoutProps = {
   /**
    * Enable/disable the AutoLogoutMechanism.
-   * defauls to true.
+   * defaults to true.
    */
   enabled?: boolean;
   /**

--- a/packages/core-components/src/components/Chip/Chip.stories.tsx
+++ b/packages/core-components/src/components/Chip/Chip.stories.tsx
@@ -58,7 +58,7 @@ export default {
 export const Default = (args: ChipProps) => <Chip {...args} />;
 Default.args = defaultArgs;
 
-export const Deleteable = (args: ChipProps) => (
+export const Deletable = (args: ChipProps) => (
   <Chip {...args} onDelete={() => ({})} />
 );
-Deleteable.args = defaultArgs;
+Deletable.args = defaultArgs;

--- a/packages/core-components/src/hooks/useQueryParamState.ts
+++ b/packages/core-components/src/hooks/useQueryParamState.ts
@@ -58,7 +58,7 @@ type SetQueryParams<T> = (params: T) => void;
 
 export function useQueryParamState<T>(
   stateName: string,
-  /** @deprecated Don't configure a custom debouceTime */
+  /** @deprecated Don't configure a custom debounceTime */
   debounceTime: number = 250,
 ): [T | undefined, SetQueryParams<T>] {
   const [searchParams, setSearchParams] = useSearchParams();

--- a/packages/frontend-app-api/src/wiring/createSpecializedApp.test.tsx
+++ b/packages/frontend-app-api/src/wiring/createSpecializedApp.test.tsx
@@ -244,7 +244,7 @@ describe('createSpecializedApp', () => {
     `);
   });
 
-  it('should intitialize the APIs in the correct order to allow for overrides', () => {
+  it('should initialize the APIs in the correct order to allow for overrides', () => {
     const mockAnalyticsApi = jest.fn(() => ({ captureEvent: jest.fn() }));
 
     const app = createSpecializedApp({

--- a/packages/frontend-app-api/src/wiring/createSpecializedApp.tsx
+++ b/packages/frontend-app-api/src/wiring/createSpecializedApp.tsx
@@ -195,7 +195,7 @@ class RouteResolutionApiProxy implements RouteResolutionApi {
 
 /**
  * Creates an empty app without any default features. This is a low-level API is
- * intended for use in tests or specialized setups. Typically wou want to use
+ * intended for use in tests or specialized setups. Typically you want to use
  * `createApp` from `@backstage/frontend-defaults` instead.
  *
  * @public

--- a/packages/frontend-plugin-api/src/wiring/createExtension.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.test.ts
@@ -669,7 +669,7 @@ describe('createExtension', () => {
         },
       });
 
-      const overriden = testExtension.override({
+      const overridden = testExtension.override({
         config: {
           schema: {
             bar: z => z.string().default('hello'),
@@ -684,12 +684,12 @@ describe('createExtension', () => {
         },
       });
 
-      expect(createExtensionTester(overriden).get(stringDataRef)).toBe(
+      expect(createExtensionTester(overridden).get(stringDataRef)).toBe(
         'foo-boom-override-hello',
       );
 
       expect(
-        createExtensionTester(overriden, {
+        createExtensionTester(overridden, {
           config: { foo: 'hello', bar: 'world' },
         }).get(stringDataRef),
       ).toBe('foo-hello-override-world');

--- a/packages/repo-tools/src/commands/index.ts
+++ b/packages/repo-tools/src/commands/index.ts
@@ -187,7 +187,7 @@ export function registerCommands(program: Command) {
     )
     .option(
       '-o, --omit-messages <messageCodes>',
-      'select some message code to be omited on the API Extractor (comma separated values i.e ae-cyclic-inherit-doc,ae-missing-getter )',
+      'select some message code to be omitted on the API Extractor (comma separated values i.e ae-cyclic-inherit-doc,ae-missing-getter )',
     )
     .option(
       '--validate-release-tags',

--- a/plugins/api-docs/README-alpha.md
+++ b/plugins/api-docs/README-alpha.md
@@ -77,12 +77,12 @@ To link that a component provides or consumes an API, see the [`providesApis`](h
        # Shows a table of components that provides a particular api
        - entity-card:api-docs/providing-components:
            config:
-             # Presenting the card ony for entites of kind api
+             # Presenting the card only for entities of kind api
              filter: kind:api
        # Shows a table of components that consumes a particular api
        - entity-card:api-docs/consuming-components:
            config:
-             # Presenting the card ony for entites of kind api
+             # Presenting the card only for entities of kind api
              filter: kind:api
        # Enabling some contents
        # The contents will be displayed in the same order it appears in this setting list
@@ -285,7 +285,7 @@ export default createFrontendModule({
   pluginId: 'api-docs',
   extensions: [
     createPageExtension({
-      // Ommitting name since we are overriding a plugin index page
+      // Omitting name since we are overriding a plugin index page
       // It's up to you whether to use the original default path or not, but links that are hardcoded to the default path won't work if you change it
       defaultPath: '/api-docs',
       // Associating the page with a different route ref may result in the sidebar item or external plugin route pointing to an unreachable page
@@ -370,7 +370,7 @@ export default createFrontendModule({
     createEntityCardExtension({
       // Name is necessary so the system knows that this extension will override the default 'has-apis' entity card extension provided by the 'api-docs' plugin
       name: 'has-apis',
-      // Returing a custom card component
+      // Returning a custom card component
       loader: () =>
         import('./components').then(m => <m.MyCustomHasApisEntityCard />),
     }),
@@ -443,7 +443,7 @@ export default createFrontendModule({
     createEntityCardExtension({
       // Name is necessary so the system knows that this extension will override the default 'definition' entity card extension provided by the 'api-docs' plugin
       name: 'definition',
-      // Returing a custom card component
+      // Returning a custom card component
       loader: () =>
         import('./components').then(m => <m.MyCustomApiDefinitionEntityCard />),
     }),
@@ -516,7 +516,7 @@ export default createFrontendModule({
     createEntityCardExtension({
       // Name is necessary so the system knows that this extension will override the default 'provided-apis' entity card extension provided by the 'api-docs' plugin
       name: 'provided-apis',
-      // Returing a custom card component
+      // Returning a custom card component
       loader: () =>
         import('./components').then(m => <m.MyCustomProvidedApisEntityCard />),
     }),
@@ -589,7 +589,7 @@ export default createFrontendModule({
     createEntityCardExtension({
       // Name is necessary so the system knows that this extension will override the default 'consumed-apis' entity card extension provided by the 'api-docs' plugin
       name: 'consumed-apis',
-      // Returing a custom card component
+      // Returning a custom card component
       loader: () =>
         import('./components').then(m => <m.MyCustomConsumedApisEntityCard />),
     }),
@@ -662,7 +662,7 @@ export default createFrontendModule({
     createEntityCardExtension({
       // Name is necessary so the system knows that this extension will override the default 'providing-components' entity card extension provided by the 'api-docs' plugin
       name: 'providing-components',
-      // Returing a custom card component
+      // Returning a custom card component
       loader: () =>
         import('./components').then(m => (
           <m.MyCustomProvidingComponentsEntityCard />
@@ -737,7 +737,7 @@ export default createFrontendModule({
     createEntityCardExtension({
       // Name is necessary so the system knows that this extension will override the default 'consuming-components' entity card extension provided by the 'api-docs' plugin
       name: 'consuming-components',
-      // Returing a custom card component
+      // Returning a custom card component
       loader: () =>
         import('./components').then(m => (
           <m.MyCustomConsumingComponentsEntityCard />
@@ -906,7 +906,7 @@ export default createFrontendModule({
     createEntityContentExtension({
       // Name is necessary so the system knows that this extension will override the default 'apis' entity content extension provided by the 'api-docs' plugin
       name: 'apis',
-      // Returing a custom content component
+      // Returning a custom content component
       loader: () =>
         import('./components').then(m => <m.MyCustomApisEntityContent />),
     }),
@@ -935,7 +935,7 @@ This is an example with a made-up renderer for SQL schemas:
 ```tsx
 import {
   createFrontendModule,
-  createApiExtenion,
+  createApiExtension,
   createApiFactory,
 } from '@backstage/frontend-plugin-api';
 import { ApiEntity } from '@backstage/catalog-model';
@@ -949,7 +949,7 @@ import { SqlRenderer } from '...';
 export default createFrontendModule({
   pluginId: 'api-docs',
   extensions: [
-    createApiExtenion({
+    createApiExtension({
       factory: createApiFactory({
         api: apiDocsConfigRef,
         deps: {},
@@ -989,7 +989,7 @@ Override the config api to configure a [`requestInterceptor` for Swagger UI](htt
 ```tsx
 import {
   createFrontendModule,
-  createApiExtenion,
+  createApiExtension,
   createApiFactory,
 } from '@backstage/frontend-plugin-api';
 import {
@@ -1002,7 +1002,7 @@ import { ApiEntity } from '@backstage/catalog-model';
 export default createFrontendModule({
   pluginId: 'api-docs',
   extensions: [
-    createApiExtenion({
+    createApiExtension({
       factory: createApiFactory({
         api: apiDocsConfigRef,
         deps: {},
@@ -1051,7 +1051,7 @@ If you want to limit the HTTP methods available for the `Try It Out` feature of 
 ```tsx
 import {
   createFrontendModule,
-  createApiExtenion,
+  createApiExtension,
   createApiFactory,
 } from '@backstage/frontend-plugin-api';
 import {
@@ -1064,7 +1064,7 @@ import { ApiEntity } from '@backstage/catalog-model';
 export default createFrontendModule({
   pluginId: 'api-docs',
   extensions: [
-    createApiExtenion({
+    createApiExtension({
       factory: createApiFactory({
         api: apiDocsConfigRef,
         deps: {},

--- a/plugins/api-docs/src/alpha.tsx
+++ b/plugins/api-docs/src/alpha.tsx
@@ -74,7 +74,7 @@ const apiDocsConfigApi = ApiBlueprint.make({
 const apiDocsExplorerPage = PageBlueprint.makeWithOverrides({
   config: {
     schema: {
-      // Ommiting columns and actions for now as their types are too complex to map to zod
+      // Omitting columns and actions for now as their types are too complex to map to zod
       initiallySelectedFilter: z =>
         z.enum(['owned', 'starred', 'all']).optional(),
     },
@@ -98,7 +98,7 @@ const apiDocsExplorerPage = PageBlueprint.makeWithOverrides({
 const apiDocsHasApisEntityCard = EntityCardBlueprint.make({
   name: 'has-apis',
   params: {
-    // Ommiting configSchema for now
+    // Omitting configSchema for now
     // We are skipping variants and columns are too complex to map to zod
     // See: https://github.com/backstage/backstage/pull/22619#discussion_r1477333252
     filter: entity => {
@@ -132,7 +132,7 @@ const apiDocsDefinitionEntityCard = EntityCardBlueprint.make({
 const apiDocsConsumedApisEntityCard = EntityCardBlueprint.make({
   name: 'consumed-apis',
   params: {
-    // Ommiting configSchema for now
+    // Omitting configSchema for now
     // We are skipping variants and columns are too complex to map to zod
     // See: https://github.com/backstage/backstage/pull/22619#discussion_r1477333252
     filter: 'kind:component',
@@ -146,7 +146,7 @@ const apiDocsConsumedApisEntityCard = EntityCardBlueprint.make({
 const apiDocsProvidedApisEntityCard = EntityCardBlueprint.make({
   name: 'provided-apis',
   params: {
-    // Ommiting configSchema for now
+    // Omitting configSchema for now
     // We are skipping variants and columns are too complex to map to zod
     // See: https://github.com/backstage/backstage/pull/22619#discussion_r1477333252
     filter: 'kind:component',
@@ -160,7 +160,7 @@ const apiDocsProvidedApisEntityCard = EntityCardBlueprint.make({
 const apiDocsConsumingComponentsEntityCard = EntityCardBlueprint.make({
   name: 'consuming-components',
   params: {
-    // Ommiting configSchema for now
+    // Omitting configSchema for now
     // We are skipping variants
     // See: https://github.com/backstage/backstage/pull/22619#discussion_r1477333252
     filter: 'kind:api',
@@ -174,7 +174,7 @@ const apiDocsConsumingComponentsEntityCard = EntityCardBlueprint.make({
 const apiDocsProvidingComponentsEntityCard = EntityCardBlueprint.make({
   name: 'providing-components',
   params: {
-    // Ommiting configSchema for now
+    // Omitting configSchema for now
     // We are skipping variants
     // See: https://github.com/backstage/backstage/pull/22619#discussion_r1477333252
     filter: 'kind:api',

--- a/plugins/auth-backend/src/identity/TokenFactory.ts
+++ b/plugins/auth-backend/src/identity/TokenFactory.ts
@@ -52,7 +52,7 @@ export interface BackstageTokenPayload {
   sub: string;
 
   /**
-   * The entity refs that the user claims ownership througg
+   * The entity refs that the user claims ownership through
    */
   ent: string[];
 

--- a/plugins/auth-react/src/hooks/useCookieAuthRefresh/useCookieAuthRefresh.tsx
+++ b/plugins/auth-react/src/hooks/useCookieAuthRefresh/useCookieAuthRefresh.tsx
@@ -57,7 +57,7 @@ export function useCookieAuthRefresh(options: {
     if (!response.ok) {
       // If we get a 404 from the cookie endpoint we assume that it does not
       // exist and cookie auth is not needed. For all active tabs we don't
-      // schedule another refresh for the forseeable future, but new tabs will
+      // schedule another refresh for the foreseeable future, but new tabs will
       // still check if cookie auth has been added to the deployment.
       // TODO(Rugvip): Once the legacy backend system is no longer supported we should remove this check
       if (response.status === 404) {

--- a/plugins/catalog-backend-module-aws/src/processors/AwsEKSClusterProcessor.ts
+++ b/plugins/catalog-backend-module-aws/src/processors/AwsEKSClusterProcessor.ts
@@ -49,10 +49,10 @@ export class AwsEKSClusterProcessor implements CatalogProcessor {
       clusterEntityTransformer?: EksClusterEntityTransformer;
     },
   ): AwsEKSClusterProcessor {
-    const awsCredentaislManager =
+    const awsCredentialsManager =
       DefaultAwsCredentialsManager.fromConfig(configRoot);
     return new AwsEKSClusterProcessor({
-      credentialsManager: awsCredentaislManager,
+      credentialsManager: awsCredentialsManager,
       ...options,
     });
   }

--- a/plugins/catalog-backend-module-backstage-openapi/src/InternalOpenApiDocumentationProvider.ts
+++ b/plugins/catalog-backend-module-backstage-openapi/src/InternalOpenApiDocumentationProvider.ts
@@ -295,7 +295,7 @@ export class InternalOpenApiDocumentationProvider implements EntityProvider {
     // Overwrite baseConfig with options from config file.
     const mergedConfig = lodash.merge(baseConfig, configToMerge);
 
-    // Overwite mergedConfig with requiredConfig (i.e., spec.type and spec.definition) to avoid bad configuration.
+    // Overwrite mergedConfig with requiredConfig (i.e., spec.type and spec.definition) to avoid bad configuration.
     const documentationEntity = lodash.merge(
       mergedConfig,
       requiredConfig,

--- a/plugins/catalog-backend-module-github-org/src/index.ts
+++ b/plugins/catalog-backend-module-github-org/src/index.ts
@@ -26,7 +26,7 @@ export {
 } from './module';
 /**
  *
- * TODO(djamaile): GithubMultiOrgEntityProvider should be mirgated over to this module.
+ * TODO(djamaile): GithubMultiOrgEntityProvider should be migrated over to this module.
  * Afterwards, mark it as deprecated in catalog-backend-module-github and export them there from this module.
  */
 export {

--- a/plugins/catalog-backend-module-gitlab/src/lib/types.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/types.ts
@@ -256,7 +256,7 @@ export type GitlabProviderConfig = {
   membership?: boolean;
 
   /**
-   * Optional comma seperated list of topics to filter projects by, as specified in the GitLab API documentation:
+   * Optional comma separated list of topics to filter projects by, as specified in the GitLab API documentation:
    * https://docs.gitlab.com/api/projects/#list-projects
    */
   topics?: string;

--- a/plugins/catalog-backend-module-logs/catalog-info.yaml
+++ b/plugins/catalog-backend-module-logs/catalog-info.yaml
@@ -3,7 +3,7 @@ kind: Component
 metadata:
   name: backstage-plugin-catalog-backend-module-logs
   title: '@backstage/plugin-catalog-backend-module-logs'
-  description: A module that subscribes to catalog releated events and logs them.
+  description: A module that subscribes to catalog related events and logs them.
 spec:
   lifecycle: experimental
   type: backstage-backend-plugin-module

--- a/plugins/catalog-backend-module-logs/package.json
+++ b/plugins/catalog-backend-module-logs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-catalog-backend-module-logs",
   "version": "0.1.10-next.0",
-  "description": "A module that subscribes to catalog releated events and logs them.",
+  "description": "A module that subscribes to catalog related events and logs them.",
   "backstage": {
     "role": "backend-plugin-module",
     "pluginId": "catalog",

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/client.test.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/client.test.ts
@@ -326,7 +326,7 @@ describe('MicrosoftGraphClient', () => {
 
   it('should load organization', async () => {
     worker.use(
-      rest.get('https://example.com/organization/tentant-id', (_, res, ctx) =>
+      rest.get('https://example.com/organization/tenant-id', (_, res, ctx) =>
         res(
           ctx.status(200),
           ctx.json({
@@ -336,7 +336,7 @@ describe('MicrosoftGraphClient', () => {
       ),
     );
 
-    const organization = await client.getOrganization('tentant-id');
+    const organization = await client.getOrganization('tenant-id');
 
     expect(organization).toEqual({ displayName: 'Example' });
   });

--- a/plugins/catalog-graph/README-alpha.md
+++ b/plugins/catalog-graph/README-alpha.md
@@ -184,7 +184,7 @@ app:
   extensions:
     # this is the extension id and it follows the naming pattern bellow:
     # <extension-kind>/<plugin-namespace>:<extension-name>
-    # example disbaling the graph card extension
+    # example disabling the graph card extension
     - entity-card:catalog-graph/relations: false
 ```
 
@@ -212,7 +212,7 @@ export default createFrontendModule({
       configSchema: createSchemaFromZod(z =>
         z.object({
           filter: z.string().optional(),
-          // Ommitting the rest of default configs for simplicity in this example
+          // Omitting the rest of default configs for simplicity in this example
         }),
       ),
       loader: () =>
@@ -283,7 +283,7 @@ app:
   extensions:
     # this is the extension id and it follows the naming pattern bellow:
     # <extension-kind>/<plugin-namespace>:<extension-name>
-    # example disbaling the graph page extension
+    # example disabling the graph page extension
     - page:catalog-graph: false
 ```
 
@@ -305,12 +305,12 @@ export default createFrontendModule({
   pluginId: 'catalog-graph',
   extensions: [
     createPageExtension({
-      // Ommiting name since it is an index page
+      // Omitting name since it is an index page
       defaultPath: '/catalog-graph',
       routeRef: convertLegacyRouteRef(catalogGraphRouteRef),
       createSchemaFromZod(z => z.object({
         path: z.string().default('/catalog-graph')
-        // Ommitting the rest of default configs for simplicity in this example
+        // Omitting the rest of default configs for simplicity in this example
       })),
       loader: () => import('./components').then(m => <m.CustomEntityRelationsPage />)
     })

--- a/plugins/home/README.md
+++ b/plugins/home/README.md
@@ -170,7 +170,7 @@ Available home page properties that are used for homepage widgets are:
 To define settings that the users can change for your component, you should define the `layout` and `settings`
 properties. The `settings.schema` object should follow
 [react-jsonschema-form](https://rjsf-team.github.io/react-jsonschema-form/docs/) definition and the type of the schema
-must be `object`. As well, the `uiSchema` can be defined if a certain UI style needs to be applied fo any of the defined
+must be `object`. As well, the `uiSchema` can be defined if a certain UI style needs to be applied for any of the defined
 properties. More documentation [here](https://rjsf-team.github.io/react-jsonschema-form/docs/api-reference/uiSchema).
 
 If you want to hide the card title, you can do it by setting a `name` and leaving the `title` empty.

--- a/plugins/home/src/api/VisitsStorageApi.ts
+++ b/plugins/home/src/api/VisitsStorageApi.ts
@@ -125,7 +125,7 @@ export class VisitsStorageApi implements VisitsApi {
 
   private async retrieveAll(): Promise<Array<Visit>> {
     const storageKey = await this.getStorageKey();
-    // Handles for case when snapshot is and is not referenced per storaged type used
+    // Handles for case when snapshot is and is not referenced per storage type used
     const snapshot = this.storageApi.snapshot<Array<Visit>>(storageKey);
     if (snapshot?.presence !== 'unknown') {
       return snapshot?.value ?? [];

--- a/plugins/home/src/api/VisitsWebStorageApi.test.ts
+++ b/plugins/home/src/api/VisitsWebStorageApi.test.ts
@@ -39,7 +39,7 @@ describe('VisitsWebStorageApi.create()', () => {
     jest.clearAllMocks();
   });
 
-  it('instantiates with only identitiyApi', () => {
+  it('instantiates with only identityApi', () => {
     const api = VisitsWebStorageApi.create({
       identityApi: mockIdentityApi,
       errorApi: mockErrorApi,

--- a/plugins/home/src/homePageComponents/Toolkit/Toolkit.stories.tsx
+++ b/plugins/home/src/homePageComponents/Toolkit/Toolkit.stories.tsx
@@ -43,7 +43,7 @@ export const Default = () => {
   );
 };
 
-export const InAccordian = () => {
+export const InAccordion = () => {
   const ExpandedComponentAccordion = (props: any) => (
     <ComponentAccordion expanded {...props} />
   );

--- a/plugins/kubernetes-common/src/types.ts
+++ b/plugins/kubernetes-common/src/types.ts
@@ -72,7 +72,7 @@ export interface ClusterAttributes {
    */
   name: string;
   /**
-   * Human-readable name for the cluster, to be dispayed in UIs.
+   * Human-readable name for the cluster, to be displayed in UIs.
    */
   title?: string;
   /**

--- a/plugins/kubernetes-node/src/types/types.ts
+++ b/plugins/kubernetes-node/src/types/types.ts
@@ -78,7 +78,7 @@ export interface ClusterDetails {
    */
   name: string;
   /**
-   * Human-readable name for the cluster, to be dispayed in UIs.
+   * Human-readable name for the cluster, to be displayed in UIs.
    */
   title?: string;
   url: string;

--- a/plugins/kubernetes-react/src/kubernetes-auth-provider/KubernetesAuthProviders.test.ts
+++ b/plugins/kubernetes-react/src/kubernetes-auth-provider/KubernetesAuthProviders.test.ts
@@ -85,7 +85,7 @@ describe('KubernetesAuthProviders tests', () => {
     );
   });
 
-  it('returns error for missconfigured oidc authProvider', async () => {
+  it('returns error for misconfigured oidc authProvider', async () => {
     await expect(
       kap.decorateRequestBodyForAuth('oidc.random', requestBody),
     ).rejects.toThrow(

--- a/plugins/org/README-alpha.md
+++ b/plugins/org/README-alpha.md
@@ -130,7 +130,7 @@ export default createFrontendModule({
       name: 'group-profile',
       // By default, this card will show up only for groups
       filter: 'kind:group'
-      // Returing a custom card component
+      // Returning a custom card component
       loader: () =>
         import('./components').then(m => <m.MyCustomGroupProfileEntityCard />),
     }),
@@ -182,7 +182,7 @@ export default createFrontendModule({
       name: 'members-list',
       // By default, this card will show up only for groups
       filter: 'kind:group'
-      // Returing a custom card component
+      // Returning a custom card component
       loader: () =>
         import('./components').then(m => <m.MyCustomMembersListEntityCard />),
     }),
@@ -234,7 +234,7 @@ export default createFrontendModule({
       name: 'ownership',
       // By default, this card will show up only for groups or users
       filter: 'kind:group,user'
-      // Returing a custom card component
+      // Returning a custom card component
       loader: () =>
         import('./components').then(m => <m.MyCustomOwnershipEntityCard />),
     }),
@@ -286,7 +286,7 @@ export default createFrontendModule({
       name: 'user-profile',
       // By default, this card will show up only for groups or users
       filter: 'kind:user'
-      // Returing a custom card component
+      // Returning a custom card component
       loader: () =>
         import('./components').then(m => <m.MyCustomOwnershipEntityCard />),
     }),

--- a/plugins/permission-common/src/PermissionClient.test.ts
+++ b/plugins/permission-common/src/PermissionClient.test.ts
@@ -310,7 +310,7 @@ describe('PermissionClient', () => {
       ).rejects.toThrow(/request failed with 401/i);
     });
 
-    it('should handle reponses with rules with no params', async () => {
+    it('should handle responses with rules with no params', async () => {
       mockPolicyDecisionHandler.mockImplementationOnce(
         (req, res, { json }: RestContext) => {
           const responses = req.body.items.map(

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloud.examples.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloud.examples.ts
@@ -126,7 +126,7 @@ export const examples: TemplateExample[] = [
   },
   {
     description:
-      'Initializes a Bitbucket Cloud repository with all proporties being set',
+      'Initializes a Bitbucket Cloud repository with all properties being set',
     example: yaml.stringify({
       steps: [
         {

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPullRequest.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPullRequest.ts
@@ -82,7 +82,7 @@ const createPullRequest = async (opts: {
       data,
     );
   } catch (e) {
-    throw new Error(`Unable to create pull-reqeusts, ${e}`);
+    throw new Error(`Unable to create pull-requests, ${e}`);
   }
 
   if (response.status !== 201) {

--- a/plugins/scaffolder-backend-module-bitbucket-server/src/actions/bitbucketServerPullRequest.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-server/src/actions/bitbucketServerPullRequest.ts
@@ -96,7 +96,7 @@ const createPullRequest = async (opts: {
       data,
     );
   } catch (e) {
-    throw new Error(`Unable to create pull-reqeusts, ${e}`);
+    throw new Error(`Unable to create pull-requests, ${e}`);
   }
 
   if (response.status !== 201) {

--- a/plugins/scaffolder-backend-module-bitbucket/src/actions/bitbucket.examples.ts
+++ b/plugins/scaffolder-backend-module-bitbucket/src/actions/bitbucket.examples.ts
@@ -178,7 +178,7 @@ export const examples: TemplateExample[] = [
   },
   {
     description:
-      'Initializes a Bitbucket repository with all proporties being set',
+      'Initializes a Bitbucket repository with all properties being set',
     example: yaml.stringify({
       steps: [
         {

--- a/plugins/scaffolder-backend-module-gerrit/src/actions/gerrit.examples.ts
+++ b/plugins/scaffolder-backend-module-gerrit/src/actions/gerrit.examples.ts
@@ -136,7 +136,7 @@ export const examples: TemplateExample[] = [
   },
   {
     description:
-      'Initializes a Gerrit repository with all proporties being set',
+      'Initializes a Gerrit repository with all properties being set',
     example: yaml.stringify({
       steps: [
         {

--- a/plugins/scaffolder-backend-module-github/src/actions/github.examples.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/github.examples.test.ts
@@ -121,7 +121,7 @@ describe('publish:github', () => {
       githubCredentialsProvider,
     });
 
-    // restore real implmentation
+    // restore real implementation
     (entityRefToName as jest.Mock).mockImplementation(
       realFamiliarizeEntityName,
     );

--- a/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
@@ -125,7 +125,7 @@ describe('publish:github', () => {
       githubCredentialsProvider,
     });
 
-    // restore real implmentation
+    // restore real implementation
     (entityRefToName as jest.Mock).mockImplementation(
       realFamiliarizeEntityName,
     );

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlab.examples.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlab.examples.ts
@@ -69,7 +69,7 @@ export const examples: TemplateExample[] = [
     }),
   },
   {
-    description: 'Initializes a GitLab repository with aditional settings.',
+    description: 'Initializes a GitLab repository with additional settings.',
     example: yaml.stringify({
       steps: [
         {

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabMergeRequest.test.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabMergeRequest.test.ts
@@ -418,7 +418,7 @@ describe('createGitLabMergeRequest', () => {
   });
 
   describe('createGitLabMergeRequestWithAssignee', () => {
-    it('assignee is set correcly when a valid assignee username is passed in options', async () => {
+    it('assignee is set correctly when a valid assignee username is passed in options', async () => {
       const input = {
         repoUrl: 'gitlab.com?repo=repo&owner=owner',
         title: 'Create my new MR',
@@ -678,7 +678,7 @@ describe('createGitLabMergeRequest', () => {
       );
     });
 
-    it('reviewer is set correcly when a valid reviewer username is passed in options in combination with MR approval rules', async () => {
+    it('reviewer is set correctly when a valid reviewer username is passed in options in combination with MR approval rules', async () => {
       const input = {
         repoUrl: 'gitlab.com?repo=repo&owner=owner',
         title: 'Create my new MR',
@@ -730,7 +730,7 @@ describe('createGitLabMergeRequest', () => {
       );
     });
 
-    it('reviewer is set correcly when a valid reviewer username is passed in options in combination with deactivated approval rules', async () => {
+    it('reviewer is set correctly when a valid reviewer username is passed in options in combination with deactivated approval rules', async () => {
       const input = {
         repoUrl: 'gitlab.com?repo=repo&owner=owner',
         title: 'Create my new MR',
@@ -824,7 +824,7 @@ describe('createGitLabMergeRequest', () => {
       expect(mockGitlabClient.MergeRequests.edit).not.toHaveBeenCalled();
     });
 
-    it('reviewer is set correcly when a valid reviewer username is passed in options and MR rules are not included in the Gitlab license (404)', async () => {
+    it('reviewer is set correctly when a valid reviewer username is passed in options and MR rules are not included in the Gitlab license (404)', async () => {
       const input = {
         repoUrl:
           'gitlab.com?repo=repo-without-approval-rule-license&owner=owner',
@@ -875,7 +875,7 @@ describe('createGitLabMergeRequest', () => {
       expect(ctx.logger.warn).toHaveBeenCalledWith(
         'Failed to retrieve approval rules for MR 6: Error: Not Found. Proceeding with MR creation without reviewers from approval rules.',
       );
-      expect(ctx.output).toHaveBeenCalledWith('targetBranchName', 'main'); // This ensures that the MR scaffolder step finishes successfully and all errors are catched.
+      expect(ctx.output).toHaveBeenCalledWith('targetBranchName', 'main'); // This ensures that the MR scaffolder step finishes successfully and all errors are caught.
     });
 
     it('assignee is not set when a valid assignee username is not passed in options', async () => {
@@ -1144,7 +1144,7 @@ describe('createGitLabMergeRequest', () => {
       mockDir.setContent({
         [workspacePath]: {
           source: { 'foo.txt': 'Hello there!', 'auto.txt': 'File exist' },
-          irrevelant: {},
+          irrelevant: {},
         },
       });
 

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabMergeRequest.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabMergeRequest.ts
@@ -317,7 +317,7 @@ which uses additional API calls in order to detect whether to 'create', 'update'
         }
       }
 
-      let reviewerIds: number[] | undefined = undefined; // Explicitly set to undefined. Strangely, passing an empty array to the API will result the other options being undefined also being explicity passed to the Gitlab API call (e.g. assigneeId)
+      let reviewerIds: number[] | undefined = undefined; // Explicitly set to undefined. Strangely, passing an empty array to the API will result the other options being undefined also being explicitly passed to the Gitlab API call (e.g. assigneeId)
       if (reviewers !== undefined) {
         reviewerIds = (
           await Promise.all(

--- a/plugins/scaffolder-backend-module-gitlab/src/util.test.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/util.test.ts
@@ -351,7 +351,7 @@ describe('checkEpicScope', () => {
 });
 
 describe('convertDate', () => {
-  it('should convert a valid input date with miliseconds to an ISO string', () => {
+  it('should convert a valid input date with milliseconds to an ISO string', () => {
     const inputDate = '1970-01-01T12:00:00.000Z';
     const defaultDate = '1978-10-09T12:00:00Z';
 

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/catalog/register.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/catalog/register.test.ts
@@ -250,7 +250,7 @@ describe('catalog:register', () => {
     );
   });
 
-  it('should not return entityRef if there are no entites', async () => {
+  it('should not return entityRef if there are no entities', async () => {
     catalogClient.addLocation
       .mockResolvedValueOnce({
         location: null as any,

--- a/plugins/scaffolder-node/src/scm/git.test.ts
+++ b/plugins/scaffolder-node/src/scm/git.test.ts
@@ -137,13 +137,13 @@ describe('Git', () => {
     it('should call isomorphic-git with the correct arguments', async () => {
       const git = Git.fromAuth({});
       const dir = 'mockdirectory';
-      const message = 'Inital Commit';
+      const message = 'Initial Commit';
       const author = {
         name: 'author',
         email: 'test@backstage.io',
       };
       const committer = {
-        name: 'comitter',
+        name: 'committer',
         email: 'test@backstage.io',
       };
       const signingKey = 'test-signing-key';
@@ -414,7 +414,7 @@ describe('Git', () => {
         email: 'test@backstage.io',
       };
       const committer = {
-        name: 'comitter',
+        name: 'committer',
         email: 'test@backstage.io',
       };
       const theirs = 'master';

--- a/plugins/scaffolder-react/src/hooks/useCustomFieldExtensions.ts
+++ b/plugins/scaffolder-react/src/hooks/useCustomFieldExtensions.ts
@@ -51,7 +51,7 @@ export const useCustomFieldExtensions = <
       }),
   );
 
-  // This should really be a different type moving foward, but we do this to keep type compatibility.
+  // This should really be a different type moving forward, but we do this to keep type compatibility.
   // should probably also move the defaults into the API eventually too, but that will come with the move
   // to the new frontend system.
   const blueprintsToLegacy: FieldExtensionOptions[] = blueprintFields?.map(

--- a/plugins/scaffolder-react/src/next/components/Stepper/utils.test.ts
+++ b/plugins/scaffolder-react/src/next/components/Stepper/utils.test.ts
@@ -65,7 +65,7 @@ describe('hasErrors', () => {
       otherThing: {},
       someName: {
         __errors: [
-          'Accepts alphanumeric values along with _(underscore) and -(hypen) as special characters',
+          'Accepts alphanumeric values along with _(underscore) and -(hyphen) as special characters',
         ],
         addError: jest.fn(),
       },

--- a/plugins/scaffolder-react/src/next/components/TemplateGroups/TemplateGroups.test.tsx
+++ b/plugins/scaffolder-react/src/next/components/TemplateGroups/TemplateGroups.test.tsx
@@ -44,7 +44,7 @@ describe('TemplateGroups', () => {
   });
 
   it('should use the error api if there is an error with the retrieval of entitylist', async () => {
-    const mockError = new Error('tings went poop');
+    const mockError = new Error('things went poop');
     (useEntityList as jest.Mock).mockReturnValue({
       error: mockError,
     });

--- a/plugins/scaffolder-react/src/next/components/Workflow/Workflow.test.tsx
+++ b/plugins/scaffolder-react/src/next/components/Workflow/Workflow.test.tsx
@@ -108,7 +108,7 @@ describe('<Workflow />', () => {
       </ApiProvider>,
     );
 
-    // Test template title is overriden
+    // Test template title is overridden
     expect(getByRole('heading', { level: 2 }).innerHTML).toBe(
       'Different title than template',
     );

--- a/plugins/scaffolder/src/alpha/components/TemplateEditorPage/CustomFieldPlayground.tsx
+++ b/plugins/scaffolder/src/alpha/components/TemplateEditorPage/CustomFieldPlayground.tsx
@@ -57,7 +57,7 @@ const useStyles = makeStyles(
   { name: 'ScaffolderCustomFieldExtensionsPlaygroud' },
 );
 
-export const CustomFieldPlaygroud = ({
+export const CustomFieldPlayground = ({
   fieldExtensions = [],
 }: {
   fieldExtensions?: FieldExtensionOptions<any, any>[];

--- a/plugins/scaffolder/src/alpha/components/TemplateEditorPage/TemplateEditorToolbar.tsx
+++ b/plugins/scaffolder/src/alpha/components/TemplateEditorPage/TemplateEditorToolbar.tsx
@@ -37,7 +37,7 @@ import { FieldExtensionOptions } from '@backstage/plugin-scaffolder-react';
 
 import { ActionPageContent } from '../../../components/ActionsPage/ActionsPage';
 import { scaffolderTranslationRef } from '../../../translation';
-import { CustomFieldPlaygroud } from './CustomFieldPlaygroud';
+import { CustomFieldPlayground } from './CustomFieldPlayground';
 import { TemplatingExtensionsPageContent } from '../../../components/TemplatingExtensionsPage/TemplatingExtensionsPage';
 
 const useStyles = makeStyles(
@@ -128,7 +128,7 @@ export function TemplateEditorToolbar(props: {
           open={showFieldsDrawer}
           onClose={() => setShowFieldsDrawer(false)}
         >
-          <CustomFieldPlaygroud fieldExtensions={fieldExtensions} />
+          <CustomFieldPlayground fieldExtensions={fieldExtensions} />
         </Drawer>
         <Drawer
           classes={{ paper: classes.paper }}

--- a/plugins/scaffolder/src/alpha/components/TemplateEditorPage/TemplateFormPreviewer.tsx
+++ b/plugins/scaffolder/src/alpha/components/TemplateEditorPage/TemplateFormPreviewer.tsx
@@ -177,7 +177,7 @@ export const TemplateFormPreviewer = ({
         )
         .catch(e =>
           alertApi.post({
-            message: `Error loading exisiting templates: ${e.message}`,
+            message: `Error loading existing templates: ${e.message}`,
             severity: 'error',
           }),
         ),

--- a/plugins/scaffolder/src/components/FileBrowser/FileBrowser.test.tsx
+++ b/plugins/scaffolder/src/components/FileBrowser/FileBrowser.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { FileEntry, parseFileEntires } from './FileBrowser';
+import { FileEntry, parseFileEntries } from './FileBrowser';
 
 function dir(path: string, ...children: FileEntry[]): FileEntry {
   return {
@@ -33,62 +33,62 @@ function file(path: string): FileEntry {
   };
 }
 
-describe('parseFileEntires', () => {
+describe('parseFileEntries', () => {
   it('parses an empty list', () => {
-    expect(parseFileEntires([])).toEqual([]);
+    expect(parseFileEntries([])).toEqual([]);
   });
 
   it('parses a single file', () => {
-    expect(parseFileEntires(['a.txt'])).toEqual([file('a.txt')]);
-    expect(parseFileEntires(['a/b.txt'])).toEqual([dir('a', file('a/b.txt'))]);
-    expect(parseFileEntires(['a/b/c.txt'])).toEqual([
+    expect(parseFileEntries(['a.txt'])).toEqual([file('a.txt')]);
+    expect(parseFileEntries(['a/b.txt'])).toEqual([dir('a', file('a/b.txt'))]);
+    expect(parseFileEntries(['a/b/c.txt'])).toEqual([
       dir('a', dir('a/b', file('a/b/c.txt'))),
     ]);
   });
 
   it('parses multiple files', () => {
-    expect(parseFileEntires(['a.txt', 'b.txt'])).toEqual([
+    expect(parseFileEntries(['a.txt', 'b.txt'])).toEqual([
       file('a.txt'),
       file('b.txt'),
     ]);
-    expect(parseFileEntires(['a.txt', 'a/b.txt'])).toEqual([
+    expect(parseFileEntries(['a.txt', 'a/b.txt'])).toEqual([
       dir('a', file('a/b.txt')),
       file('a.txt'),
     ]);
-    expect(parseFileEntires(['a.txt', 'a/b.txt', 'a/c.txt'])).toEqual([
+    expect(parseFileEntries(['a.txt', 'a/b.txt', 'a/c.txt'])).toEqual([
       dir('a', file('a/b.txt'), file('a/c.txt')),
       file('a.txt'),
     ]);
-    expect(parseFileEntires(['a.txt', 'a/b/c.txt', 'a/b/d.txt'])).toEqual([
+    expect(parseFileEntries(['a.txt', 'a/b/c.txt', 'a/b/d.txt'])).toEqual([
       dir('a', dir('a/b', file('a/b/c.txt'), file('a/b/d.txt'))),
       file('a.txt'),
     ]);
   });
 
   it('throws an error on invalid filenames', () => {
-    expect(() => parseFileEntires([''])).toThrow(`Invalid path part: ''`);
-    expect(() => parseFileEntires(['/'])).toThrow(`Invalid path part: ''`);
-    expect(() => parseFileEntires(['a/'])).toThrow(`Invalid path part: ''`);
-    expect(() => parseFileEntires(['/a.txt'])).toThrow(`Invalid path part: ''`);
-    expect(() => parseFileEntires(['a//a.txt'])).toThrow(
+    expect(() => parseFileEntries([''])).toThrow(`Invalid path part: ''`);
+    expect(() => parseFileEntries(['/'])).toThrow(`Invalid path part: ''`);
+    expect(() => parseFileEntries(['a/'])).toThrow(`Invalid path part: ''`);
+    expect(() => parseFileEntries(['/a.txt'])).toThrow(`Invalid path part: ''`);
+    expect(() => parseFileEntries(['a//a.txt'])).toThrow(
       `Invalid path part: ''`,
     );
   });
 
   it('throws an error on conflicting directory and filenames', () => {
-    expect(() => parseFileEntires(['a', 'a'])).toThrow(
+    expect(() => parseFileEntries(['a', 'a'])).toThrow(
       `Duplicate filename at 'a'`,
     );
-    expect(() => parseFileEntires(['a', 'a/b'])).toThrow(
+    expect(() => parseFileEntries(['a', 'a/b'])).toThrow(
       `Duplicate filename at 'a'`,
     );
-    expect(() => parseFileEntires(['a/b', 'a'])).toThrow(
+    expect(() => parseFileEntries(['a/b', 'a'])).toThrow(
       `Duplicate filename at 'a'`,
     );
-    expect(() => parseFileEntires(['a/b', 'a/b/c'])).toThrow(
+    expect(() => parseFileEntries(['a/b', 'a/b/c'])).toThrow(
       `Duplicate filename at 'a/b'`,
     );
-    expect(() => parseFileEntires(['a/b/c', 'a/b/c'])).toThrow(
+    expect(() => parseFileEntries(['a/b/c', 'a/b/c'])).toThrow(
       `Duplicate filename at 'a/b/c'`,
     );
   });

--- a/plugins/scaffolder/src/components/FileBrowser/FileBrowser.tsx
+++ b/plugins/scaffolder/src/components/FileBrowser/FileBrowser.tsx
@@ -42,7 +42,7 @@ export type FileEntry =
       children: FileEntry[];
     };
 
-export function parseFileEntires(paths: string[]): FileEntry[] {
+export function parseFileEntries(paths: string[]): FileEntry[] {
   const root: FileEntry = {
     type: 'directory',
     name: '',
@@ -122,7 +122,7 @@ export function FileBrowser(props: FileBrowserProps) {
   const classes = useStyles();
 
   const fileTree = useMemo(
-    () => parseFileEntires(props.filePaths),
+    () => parseFileEntries(props.filePaths),
     [props.filePaths],
   );
 

--- a/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.test.tsx
@@ -188,7 +188,7 @@ describe('<MultiEntityPicker />', () => {
       });
     });
 
-    it('search for entitities containing an specific key', async () => {
+    it('search for entities containing an specific key', async () => {
       const uiSchemaWithBoolean = {
         'ui:options': {
           catalogFilter: [

--- a/plugins/scaffolder/src/components/fields/RepoBranchPicker/BitbucketRepoBranchPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoBranchPicker/BitbucketRepoBranchPicker.test.tsx
@@ -113,7 +113,7 @@ describe('BitbucketRepoBranchPicker', () => {
       </TestApiProvider>,
     );
 
-    // Open the Autcomplete dropdown
+    // Open the Autocomplete dropdown
     const input = getByRole('textbox');
     await userEvent.click(input);
 

--- a/plugins/scaffolder/src/components/fields/RepoBranchPicker/GitHubRepoBranchPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoBranchPicker/GitHubRepoBranchPicker.test.tsx
@@ -113,7 +113,7 @@ describe('GitHubRepoBranchPicker', () => {
       </TestApiProvider>,
     );
 
-    // Open the Autcomplete dropdown
+    // Open the Autocomplete dropdown
     const input = getByRole('textbox');
     await userEvent.click(input);
 

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/BitbucketRepoPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/BitbucketRepoPicker.test.tsx
@@ -200,7 +200,7 @@ describe('BitbucketRepoPicker', () => {
         </TestApiProvider>,
       );
 
-      // Open the Autcomplete dropdown
+      // Open the Autocomplete dropdown
       const workspaceInput = getAllByRole('textbox')[0];
       await userEvent.click(workspaceInput);
 
@@ -230,7 +230,7 @@ describe('BitbucketRepoPicker', () => {
         </TestApiProvider>,
       );
 
-      // Open the Autcomplete dropdown
+      // Open the Autocomplete dropdown
       const projectInput = getAllByRole('textbox')[1];
       await userEvent.click(projectInput);
 

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/GithubRepoPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/GithubRepoPicker.test.tsx
@@ -132,7 +132,7 @@ describe('GithubRepoPicker', () => {
         </TestApiProvider>,
       );
 
-      // Open the Autcomplete dropdown
+      // Open the Autocomplete dropdown
       const ownerInput = getAllByRole('textbox')[0];
       await userEvent.click(ownerInput);
 

--- a/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngine.ts
+++ b/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngine.ts
@@ -518,7 +518,7 @@ export class ElasticSearchSearchEngine implements SearchEngine {
       const service =
         config.getOptionalString('service') ?? requestSigner.service;
       if (service !== 'es' && service !== 'aoss')
-        throw new Error(`Unrecognized serivce type: ${service}`);
+        throw new Error(`Unrecognized service type: ${service}`);
       return {
         provider: 'aws',
         node: config.getString('node'),

--- a/plugins/search-backend-module-elasticsearch/src/module.ts
+++ b/plugins/search-backend-module-elasticsearch/src/module.ts
@@ -72,7 +72,7 @@ export default createBackendModule({
         const baseConfig = config.getOptional(baseKey);
         if (!baseConfig) {
           logger.warn(
-            'No configuration found under "search.elasticsearch" key.  Skipping search engine inititalization.',
+            'No configuration found under "search.elasticsearch" key.  Skipping search engine initialization.',
           );
           return;
         }

--- a/plugins/techdocs-backend/src/service/CachedEntityLoader.test.ts
+++ b/plugins/techdocs-backend/src/service/CachedEntityLoader.test.ts
@@ -70,7 +70,7 @@ describe('CachedEntityLoader', () => {
     expect(catalog.getEntityByRef).not.toHaveBeenCalled();
   });
 
-  it('does not cache missing entites', async () => {
+  it('does not cache missing entities', async () => {
     const catalog = catalogServiceMock({ entities: [] });
     cache.get.mockResolvedValue(undefined);
 

--- a/plugins/techdocs-node/src/stages/generate/DockerContainerRunner.ts
+++ b/plugins/techdocs-node/src/stages/generate/DockerContainerRunner.ts
@@ -80,7 +80,7 @@ export class DockerContainerRunner implements TechDocsContainerRunner {
           } else if (!stream) {
             reject(
               new Error(
-                'Unexpeected error: no stream returned from Docker while pulling image',
+                'Unexpected error: no stream returned from Docker while pulling image',
               ),
             );
           } else {

--- a/plugins/techdocs-react/src/context.test.tsx
+++ b/plugins/techdocs-react/src/context.test.tsx
@@ -53,7 +53,7 @@ const mockEntityMetadata: Entity = {
 };
 
 const mockTechDocsMetadata: TechDocsMetadata = {
-  site_name: 'test-componnet',
+  site_name: 'test-component',
   site_description: 'this is a test component',
 };
 

--- a/plugins/techdocs/src/home/components/Grids/EntityListDocsGrid.test.tsx
+++ b/plugins/techdocs/src/home/components/Grids/EntityListDocsGrid.test.tsx
@@ -77,7 +77,7 @@ describe('Entity List Docs Grid', () => {
     [starredEntitiesApiRef, new MockStarredEntitiesApi()],
   );
 
-  it('should render all entitites without filtering', async () => {
+  it('should render all entities without filtering', async () => {
     await renderInTestApp(
       <ApiProvider apis={apiRegistry}>
         <MockEntityListContextProvider value={{ entities: entities }}>

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPage/context.test.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPage/context.test.tsx
@@ -44,7 +44,7 @@ const mockEntityMetadata: Entity = {
 };
 
 const mockTechDocsMetadata: TechDocsMetadata = {
-  site_name: 'test-componnet',
+  site_name: 'test-component',
   site_description: 'this is a test component',
 };
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix many typos, in code, comments, CLI help,  examples, JSDocs...

Some typos in docs/microsite have already been fixed in #29666.

I used the [typos](https://github.com/crate-ci/typos?tab=readme-ov-file) CLI to identify most typos.

This PR does not include the `typos.toml` config or any CI, as there are still a dozen files with false-positives, and the choice for a code typo linter may probably need a decision record.

### Bug fixes / API changes

- ~~`core-components`: `TableFiltersClassKey` had an invalid type value `heder`, while the code used `header`~~
  - ~~I've added to force the resolution of `core-components`, to avoid a type conflict between the versions.~~
  - Removed from this PR.
- `backend-dynamic-feature-service`: deprecated `getAdditionaRemoteInfo`, replaced by `getAdditionalRemoteInfo`. Deprecated one is used as a fallback.
- A few error messages / logs changed

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
