### PR TITLE
authentication.md docs: fix SignInPage GitHub‑auth example (modify existing component instead of adding a second)

### DIFF
--- a/docs/getting-started/config/authentication.md
+++ b/docs/getting-started/config/authentication.md
@@ -60,8 +60,8 @@ Search for `const app = createApp({` in this file, and replace:
 
 ```tsx title="packages/app/src/App.tsx"
 components: {
-    SignInPage: props => <SignInPage {...props} auto providers={['guest']} />,
-  },
+  SignInPage: props => <SignInPage {...props} auto providers={['guest']} />,
+},
 ```
 
 with

--- a/docs/getting-started/config/authentication.md
+++ b/docs/getting-started/config/authentication.md
@@ -56,7 +56,15 @@ Open `packages/app/src/App.tsx` and below the last `import` line, add:
 import { githubAuthApiRef } from '@backstage/core-plugin-api';
 ```
 
-Search for `const app = createApp({` in this file, and below `apis,` add:
+Search for `const app = createApp({` in this file, and replace:
+
+```tsx title="packages/app/src/App.tsx"
+components: {
+    SignInPage: props => <SignInPage {...props} auto providers={['guest']} />,
+  },
+```
+
+with
 
 ```tsx title="packages/app/src/App.tsx"
 components: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The current docs show how to *add* a new `SignInPage` for GitHub authentication, but a `SignInPage` component already exists in every freshly‑scaffolded Backstage app.  
Creating a second one produces a duplicate‑child runtime error.  
This PR updates the **“Add sign‑in option to the frontend”** section to instruct users to **edit the existing `SignInPage`** and replace the `providers={['guest']}` line with the GitHub provider object.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([Developer Certificate of Origin](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
