### PR TITLE
integration - Added missing `organizations` property to `azure` section

### DIFF
--- a/.changeset/breezy-hotels-deny.md
+++ b/.changeset/breezy-hotels-deny.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+Added missing `organizations` property to `azure` section in `config.d.ts` file

--- a/packages/integration/config.d.ts
+++ b/packages/integration/config.d.ts
@@ -51,12 +51,13 @@ export interface Config {
 
       /**
        * The credentials to use for requests. If multiple credentials are specified the first one that matches the organization is used.
-       * If not organization matches the first credential without an organization is used.
+       * If no organization matches the first credential without an organization is used.
        *
        * If no credentials are specified at all, either a default credential (for Azure DevOps) or anonymous access (for Azure DevOps Server) is used.
        * @deepVisibility secret
        */
       credentials?: {
+        organizations?: string[];
         clientId?: string;
         clientSecret?: string;
         tenantId?: string;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added missing `organizations` property to `azure` section in `config.d.ts` file,

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
