### PR TITLE
fix(useEntityListProvider): adjust the EntityListProvider to fix (#18710)

### DIFF
--- a/.changeset/pretty-seas-hug.md
+++ b/.changeset/pretty-seas-hug.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Add filter handling for user and group types to fix EntityOwnerPicker for users/groups

--- a/.changeset/pretty-seas-hug.md
+++ b/.changeset/pretty-seas-hug.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-react': patch
 ---
 
-Add filter handling for user and group types to fix EntityOwnerPicker for users/groups
+Fixed an issue causing entities of kind user and group to be empty when an owner was selected

--- a/plugins/catalog-react/src/hooks/useEntityListProvider.test.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.test.tsx
@@ -32,6 +32,7 @@ import { catalogApiRef } from '../api';
 import { MockStarredEntitiesApi, starredEntitiesApiRef } from '../apis';
 import {
   EntityKindFilter,
+  EntityOwnerFilter,
   EntityTextFilter,
   EntityTypeFilter,
   EntityUserFilter,
@@ -298,6 +299,48 @@ describe('<EntityListProvider />', () => {
 
     expect(result.current.pageInfo).toBeUndefined();
   });
+
+  it('should omit owners filter when kind is "user"', async () => {
+    const { result } = renderHook(() => useEntityList(), {
+      wrapper: createWrapper({ pagination }),
+    });
+
+    act(() => {
+      result.current.updateFilters({
+        kind: new EntityKindFilter('user', 'User'),
+        owners: new EntityOwnerFilter(['user:default/guest']),
+      });
+    });
+
+    await waitFor(() => {
+      expect(mockCatalogApi.getEntities).toHaveBeenCalled();
+    });
+
+    expect(mockCatalogApi.getEntities).toHaveBeenCalledWith({
+      filter: { kind: 'user' },
+    });
+  });
+
+  it('should omit owners filter when kind is "group"', async () => {
+    const { result } = renderHook(() => useEntityList(), {
+      wrapper: createWrapper({ pagination }),
+    });
+
+    act(() => {
+      result.current.updateFilters({
+        kind: new EntityKindFilter('group', 'Group'),
+        owners: new EntityOwnerFilter(['group:default/team-a']),
+      });
+    });
+
+    await waitFor(() => {
+      expect(mockCatalogApi.getEntities).toHaveBeenCalled();
+    });
+
+    expect(mockCatalogApi.getEntities).toHaveBeenCalledWith({
+      filter: { kind: 'group' },
+    });
+  });
 });
 
 describe('<EntityListProvider pagination />', () => {
@@ -552,6 +595,52 @@ describe('<EntityListProvider pagination />', () => {
         });
       });
     });
+
+    it('should omit owners filter when kind is "user"', async () => {
+      const { result } = renderHook(() => useEntityList(), {
+        wrapper: createWrapper({ pagination }),
+      });
+
+      act(() => {
+        result.current.updateFilters({
+          kind: new EntityKindFilter('user', 'User'),
+          owners: new EntityOwnerFilter(['user:default/guest']),
+        });
+      });
+
+      await waitFor(() => {
+        expect(mockCatalogApi.queryEntities).toHaveBeenCalled();
+      });
+
+      expect(mockCatalogApi.queryEntities).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filter: { kind: 'user' },
+        }),
+      );
+    });
+
+    it('should omit owners filter when kind is "group"', async () => {
+      const { result } = renderHook(() => useEntityList(), {
+        wrapper: createWrapper({ pagination }),
+      });
+
+      act(() => {
+        result.current.updateFilters({
+          kind: new EntityKindFilter('group', 'Group'),
+          owners: new EntityOwnerFilter(['group:default/team-a']),
+        });
+      });
+
+      await waitFor(() => {
+        expect(mockCatalogApi.queryEntities).toHaveBeenCalled();
+      });
+
+      expect(mockCatalogApi.queryEntities).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filter: { kind: 'group' },
+        }),
+      );
+    });
   });
 });
 
@@ -800,5 +889,51 @@ describe(`<EntityListProvider pagination={{ mode: 'offset' }} />`, () => {
     await waitFor(() => {
       expect(result.current.error).toBeDefined();
     });
+  });
+
+  it('should omit owners filter when kind is "user"', async () => {
+    const { result } = renderHook(() => useEntityList(), {
+      wrapper: createWrapper({ pagination }),
+    });
+
+    act(() => {
+      result.current.updateFilters({
+        kind: new EntityKindFilter('user', 'User'),
+        owners: new EntityOwnerFilter(['user:default/guest']),
+      });
+    });
+
+    await waitFor(() => {
+      expect(mockCatalogApi.queryEntities).toHaveBeenCalled();
+    });
+
+    expect(mockCatalogApi.queryEntities).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filter: { kind: 'user' },
+      }),
+    );
+  });
+
+  it('should omit owners filter when kind is "group"', async () => {
+    const { result } = renderHook(() => useEntityList(), {
+      wrapper: createWrapper({ pagination }),
+    });
+
+    act(() => {
+      result.current.updateFilters({
+        kind: new EntityKindFilter('group', 'Group'),
+        owners: new EntityOwnerFilter(['group:default/team-a']),
+      });
+    });
+
+    await waitFor(() => {
+      expect(mockCatalogApi.queryEntities).toHaveBeenCalled();
+    });
+
+    expect(mockCatalogApi.queryEntities).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filter: { kind: 'group' },
+      }),
+    );
   });
 });

--- a/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
@@ -241,7 +241,13 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
   // based on the requested filters changing.
   const [{ loading, error }, refresh] = useAsyncFn(
     async () => {
-      const compacted = compact(Object.values(requestedFilters));
+      const kindValue =
+        requestedFilters.kind?.value?.toLocaleLowerCase('en-US');
+      const effectiveFilters =
+        kindValue === 'user' || kindValue === 'group'
+          ? { ...requestedFilters, owners: undefined }
+          : requestedFilters;
+      const compacted = compact(Object.values(effectiveFilters));
 
       const queryParams = Object.keys(requestedFilters).reduce(
         (params, key) => {

--- a/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
@@ -243,11 +243,11 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
     async () => {
       const kindValue =
         requestedFilters.kind?.value?.toLocaleLowerCase('en-US');
-      const effectiveFilters =
+      const adjustedFilters =
         kindValue === 'user' || kindValue === 'group'
           ? { ...requestedFilters, owners: undefined }
           : requestedFilters;
-      const compacted = compact(Object.values(effectiveFilters));
+      const compacted = compact(Object.values(adjustedFilters));
 
       const queryParams = Object.keys(requestedFilters).reduce(
         (params, key) => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR fixes the bug described in the issue #18710
Based on the discussion in my previous [PR](https://github.com/backstage/backstage/pull/28561) I adjusted the useEntityListProvider to set the owners to undefined for the "user" & "group" kind. This fixes the bug without touching the state management.

https://github.com/user-attachments/assets/6b7748af-78e1-4766-9f40-e1b5148a06c2

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

