### PR TITLE
Updated AwsS3UrlReader to support VPCE URLs

### DIFF
--- a/.changeset/sixty-chicken-look.md
+++ b/.changeset/sixty-chicken-look.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Fixed the AwsS3UrlReader host regex and host to allow S3 reading from AWS virtual private cloud endpoint (VPCE) URLs

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.test.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.test.ts
@@ -126,6 +126,19 @@ describe('parseUrl', () => {
       bucket: 'my.bucket-3',
       region: 'us-west-2',
     });
+    expect(
+      parseUrl(
+        'https://bucket.vpce-id.s3.us-west-2.vpce.amazonaws.com/my.bucket-3/a/puppy.jpg',
+        {
+          host: 'bucket.vpce-id.s3.us-west-2.vpce.amazonaws.com',
+          s3ForcePathStyle: true,
+        },
+      ),
+    ).toEqual({
+      path: 'a/puppy.jpg',
+      bucket: 'my.bucket-3',
+      region: 'us-west-2',
+    });
   });
 
   it('supports all non-aws formats', () => {

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.ts
@@ -79,7 +79,7 @@ export function parseUrl(
   if (
     config.host === 'amazonaws.com' ||
     config.host === 'amazonaws.com.cn' ||
-    config.host.endsWith('vpce.amazonaws.com')
+    config.host.endsWith('.vpce.amazonaws.com')
   ) {
     const match = host.match(
       /^(?:([a-z0-9.-]+)\.)?s3(?:[.-]([a-z0-9-]+))?\.(vpce\.)?amazonaws\.com(\.cn)?$/,

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.ts
@@ -79,7 +79,7 @@ export function parseUrl(
   if (
     config.host === 'amazonaws.com' ||
     config.host === 'amazonaws.com.cn' ||
-    config.host.endsWith('vpce.amazonaws.com')
+    /^(bucket|accesspoint|control)\.vpce-([a-z0-9-]+)\.s3\.([a-z0-9-]+)\.vpce.amazonaws\.com?$/.test(config.host)
   ) {
     const match = host.match(
       /^(?:([a-z0-9.-]+)\.)?s3(?:[.-]([a-z0-9-]+))?\.(vpce\.)?amazonaws\.com(\.cn)?$/,

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.ts
@@ -79,7 +79,7 @@ export function parseUrl(
   if (
     config.host === 'amazonaws.com' ||
     config.host === 'amazonaws.com.cn' ||
-    /^(bucket|accesspoint|control)\.vpce-([a-z0-9-]+)\.s3\.([a-z0-9-]+)\.vpce\.amazonaws\.com?$/.test(config.host)
+    /^(bucket|accesspoint|control)\.vpce-([a-z0-9-]+)\.s3\.([a-z0-9-]+)\.vpce\.amazonaws\.com$/.test(config.host)
   ) {
     const match = host.match(
       /^(?:([a-z0-9.-]+)\.)?s3(?:[.-]([a-z0-9-]+))?\.(vpce\.)?amazonaws\.com(\.cn)?$/,

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.ts
@@ -79,7 +79,7 @@ export function parseUrl(
   if (
     config.host === 'amazonaws.com' ||
     config.host === 'amazonaws.com.cn' ||
-    /^(bucket|accesspoint|control)\.vpce-([a-z0-9-]+)\.s3\.([a-z0-9-]+)\.vpce\.amazonaws\.com?$/.test(config.host)
+    /^(bucket|accesspoint|control)\.vpce-([a-z0-9-]+)\.s3\.([a-z0-9-]+)\.vpce.amazonaws\.com?$/.test(config.host)
   ) {
     const match = host.match(
       /^(?:([a-z0-9.-]+)\.)?s3(?:[.-]([a-z0-9-]+))?\.(vpce\.)?amazonaws\.com(\.cn)?$/,

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.ts
@@ -79,7 +79,7 @@ export function parseUrl(
   if (
     config.host === 'amazonaws.com' ||
     config.host === 'amazonaws.com.cn' ||
-    /^(bucket|accesspoint|control)\.vpce-([a-z0-9-]+)\.s3\.([a-z0-9-]+)\.vpce.amazonaws\.com?$/.test(config.host)
+    config.host.endsWith('vpce.amazonaws.com')
   ) {
     const match = host.match(
       /^(?:([a-z0-9.-]+)\.)?s3(?:[.-]([a-z0-9-]+))?\.(vpce\.)?amazonaws\.com(\.cn)?$/,

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.ts
@@ -79,7 +79,7 @@ export function parseUrl(
   if (
     config.host === 'amazonaws.com' ||
     config.host === 'amazonaws.com.cn' ||
-    /^(bucket|accesspoint|control)\.vpce-([a-z0-9-]+)\.s3\.([a-z0-9-]+)\.vpce\.amazonaws\.com$/.test(config.host)
+    /^(bucket|accesspoint|control)\.vpce-([a-z0-9-]+)\.s3\.([a-z0-9-]+)\.vpce\.amazonaws\.com?$/.test(config.host)
   ) {
     const match = host.match(
       /^(?:([a-z0-9.-]+)\.)?s3(?:[.-]([a-z0-9-]+))?\.(vpce\.)?amazonaws\.com(\.cn)?$/,

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.ts
@@ -59,6 +59,8 @@ export const DEFAULT_REGION = 'us-east-1';
  * The region can also be on the old form: https://s3-(region).amazonaws.com/(bucket)/(key)
  * Virtual hosted style URLs: https://(bucket).s3.(region).amazonaws.com/(key)
  * See https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#path-style-access
+ * Virtual private cloud endpoint URLs: https://bucket.(vpce-id).s3.(region).vpce.amazonaws.com/(bucket)/(key)
+ * See https://docs.aws.amazon.com/AmazonS3/latest/userguide/privatelink-interface-endpoints.html#accessing-bucket-and-aps-from-interface-endpoints
  */
 export function parseUrl(
   url: string,
@@ -74,9 +76,13 @@ export function parseUrl(
   const host = parsedUrl.host;
 
   // Treat Amazon hosted separately because it has special region logic
-  if (config.host === 'amazonaws.com' || config.host === 'amazonaws.com.cn') {
+  if (
+    config.host === 'amazonaws.com' ||
+    config.host === 'amazonaws.com.cn' ||
+    config.host.endsWith('vpce.amazonaws.com')
+  ) {
     const match = host.match(
-      /^(?:([a-z0-9.-]+)\.)?s3(?:[.-]([a-z0-9-]+))?\.amazonaws\.com(\.cn)?$/,
+      /^(?:([a-z0-9.-]+)\.)?s3(?:[.-]([a-z0-9-]+))?\.(vpce\.)?amazonaws\.com(\.cn)?$/,
     );
     if (!match) {
       throw new Error(`Invalid AWS S3 URL ${url}`);

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.ts
@@ -79,7 +79,7 @@ export function parseUrl(
   if (
     config.host === 'amazonaws.com' ||
     config.host === 'amazonaws.com.cn' ||
-    /^(bucket|accesspoint|control)\.vpce-([a-z0-9-]+)\.s3\.([a-z0-9-]+)\.vpce.amazonaws\.com?$/.test(config.host)
+    /^(bucket|accesspoint|control)\.vpce-([a-z0-9-]+)\.s3\.([a-z0-9-]+)\.vpce\.amazonaws\.com?$/.test(config.host)
   ) {
     const match = host.match(
       /^(?:([a-z0-9.-]+)\.)?s3(?:[.-]([a-z0-9-]+))?\.(vpce\.)?amazonaws\.com(\.cn)?$/,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updated `AwsS3UrlReader` to support [AWS virtual private cloud endpoint (VPCE) URLs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/privatelink-interface-endpoints.html#accessing-bucket-and-aps-from-interface-endpoints).

This is tangentially related to issue [#16941](https://github.com/backstage/backstage/issues/16941) where region cannot be manually set due to `DEFAULT_REGION = 'us-east-1'` being hardcoded in `AwsS3UrlReader`, but since VPCEs contain a region in their URL and are hosted by AWS, it should fall into this code block.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
