### PR TITLE
Fix Canon DataTable.Pagination to count issue.

### DIFF
--- a/.changeset/open-ghosts-fix.md
+++ b/.changeset/open-ghosts-fix.md
@@ -1,0 +1,5 @@
+---
+'@backstage/canon': patch
+---
+
+Fixed an issue with Canon's DataTable.Pagination component showing the wrong number for the "to" count.

--- a/packages/canon/src/components/DataTable/Pagination/DataTablePagination.tsx
+++ b/packages/canon/src/components/DataTable/Pagination/DataTablePagination.tsx
@@ -32,6 +32,12 @@ const DataTablePagination = forwardRef(
     const { table } = useDataTable();
     const pageIndex = table?.getState().pagination.pageIndex;
     const pageSize = table?.getState().pagination.pageSize;
+    const rowCount = table?.getRowCount();
+    const fromCount = (pageIndex ?? 0) * (pageSize ?? 10) + 1;
+    const toCount = Math.min(
+      ((pageIndex ?? 0) + 1) * (pageSize ?? 10),
+      rowCount,
+    );
 
     return (
       <div
@@ -63,9 +69,7 @@ const DataTablePagination = forwardRef(
           )}
         </div>
         <div className="canon-DataTablePagination--right">
-          <Text variant="body">{`${(pageIndex ?? 0) * (pageSize ?? 10) + 1} - ${
-            ((pageIndex ?? 0) + 1) * (pageSize ?? 10)
-          } of ${table?.getRowCount()}`}</Text>
+          <Text variant="body">{`${fromCount} - ${toCount} of ${rowCount}`}</Text>
           <IconButton
             variant="secondary"
             size="small"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes an issue where the pagination component would not consider the row count when calculating the `from - to of totalCount` string. This would result in strings like `21-30 of 24`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
