### PR TITLE
docs(home): Update default for preventCollision prop

### DIFF
--- a/.changeset/tidy-paths-count.md
+++ b/.changeset/tidy-paths-count.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-home': patch
+---
+
+docs: Update default for `preventCollision` prop

--- a/plugins/home/src/components/CustomHomepage/types.ts
+++ b/plugins/home/src/components/CustomHomepage/types.ts
@@ -95,7 +95,7 @@ export type CustomHomepageGridProps = {
   allowOverlap?: boolean;
   /**
    * Controls if widgets can collide with each other. If true, grid items won't change position when being dragged over.
-   * @defaultValue false
+   * @defaultValue true
    */
   preventCollision?: boolean;
 };


### PR DESCRIPTION
## Hey :wave:

#28397 changed the default value for the `CustomHomepage`'s `preventCollision` prop, but the JSDocs were not updated, which was misleading.

#### :heavy_check_mark: Checklist

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
