### PR TITLE
improve LDAP missing metadata.name error message

### DIFF
--- a/.changeset/deep-ties-move.md
+++ b/.changeset/deep-ties-move.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-ldap': patch
+---
+
+Improves error reporting for missing metadata.name in LDAP catalog provider.

--- a/plugins/catalog-backend-module-ldap/src/ldap/read.test.ts
+++ b/plugins/catalog-backend-module-ldap/src/ldap/read.test.ts
@@ -988,6 +988,34 @@ describe('defaultUserTransformer', () => {
       },
     });
   });
+
+  it('throws and includes message when uid (metadata.name) is missing', async () => {
+    const config: UserConfig = {
+      dn: 'ddd',
+      options: {},
+      map: {
+        rdn: 'uid',
+        name: 'uid',
+        displayName: 'cn',
+        email: 'mail',
+        memberOf: 'memberOf',
+      },
+      set: {},
+    };
+
+    const entry = searchEntry({
+      description: ['description-value'],
+      cn: ['cn-value'],
+      mail: ['mail-value'],
+      memberOf: ['x', 'y', 'z'],
+    });
+
+    await expect(
+      defaultUserTransformer(DefaultLdapVendor, config, entry),
+    ).rejects.toThrow(
+      "User syncing failed: missing 'uid' attribute, consider applying a user filter to skip processing users with incomplete data.",
+    );
+  });
 });
 
 describe('defaultGroupTransformer', () => {
@@ -1072,6 +1100,38 @@ describe('defaultGroupTransformer', () => {
         profile: { displayName: 'cn-value', email: 'mail-value' },
       },
     });
+  });
+
+  it('throws and includes message when cn (metadata.name) is missing', async () => {
+    const config: GroupConfig = {
+      dn: 'ddd',
+      options: {},
+      map: {
+        rdn: 'cn',
+        name: 'cn',
+        displayName: 'cn',
+        email: 'mail',
+        description: 'description',
+        type: 'type',
+        members: 'members',
+        memberOf: 'memberOf',
+      },
+    };
+
+    const entry = searchEntry({
+      description: ['description-value'],
+      mail: ['mail-value'],
+      avatarUrl: ['avatarUrl-value'],
+      memberOf: ['x', 'y', 'z'],
+      entryDN: ['dn-value'],
+      entryUUID: ['uuid-value'],
+    });
+
+    await expect(
+      defaultGroupTransformer(DefaultLdapVendor, config, entry),
+    ).rejects.toThrow(
+      "Group syncing failed: missing 'cn' attribute, consider applying a group filter to skip processing groups with incomplete data.",
+    );
   });
 });
 

--- a/plugins/catalog-backend-module-ldap/src/ldap/read.ts
+++ b/plugins/catalog-backend-module-ldap/src/ldap/read.ts
@@ -34,6 +34,7 @@ import { LdapVendor } from './vendors';
 import { GroupTransformer, UserTransformer } from './types';
 import { mapStringAttr } from './util';
 import { LoggerService } from '@backstage/backend-plugin-api';
+import { InputError } from '@backstage/errors';
 
 /**
  * The default implementation of the transformation from an LDAP entry to a
@@ -70,6 +71,13 @@ export async function defaultUserTransformer(
   mapStringAttr(entry, vendor, map.name, v => {
     entity.metadata.name = v;
   });
+
+  if (!entity.metadata.name) {
+    throw new InputError(
+      `User syncing failed: missing '${map.name}' attribute, consider applying a user filter to skip processing users with incomplete data.`,
+    );
+  }
+
   mapStringAttr(entry, vendor, map.description, v => {
     entity.metadata.description = v;
   });
@@ -180,6 +188,13 @@ export async function defaultGroupTransformer(
   mapStringAttr(entry, vendor, map.name, v => {
     entity.metadata.name = v;
   });
+
+  if (!entity.metadata.name) {
+    throw new InputError(
+      `Group syncing failed: missing '${map.name}' attribute, consider applying a group filter to skip processing groups with incomplete data.`,
+    );
+  }
+
   mapStringAttr(entry, vendor, map.description, v => {
     entity.metadata.description = v;
   });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Currently, the LDAP catalog provider stops after receiving this error for a user:

`"LdapOrgEntityProvider:default refresh failed, TypeError: Malformed entity envelope, TypeError: /metadata/name must NOT have fewer than 1 characters - limit: 1 Malformed entity envelope, TypeError: /metadata/name must NOT have fewer than 1 characters - limit: 1"`

This PR adds a more informative error message that clearly explains the problem and recommends a solution.

The new error message looks like:
`"Error: LDAP search at DN \"ou=users,dc=example,dc=org\" failed; caused by Error: Transform function threw an exception, InputError: User syncing failed: missing 'uid' attribute, consider applying a user filter to skip processing users with incomplete data.`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
