### PR TITLE
notifications-slack-module: use user email if slack annotation is missing

### DIFF
--- a/.changeset/spotty-doors-design.md
+++ b/.changeset/spotty-doors-design.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications-backend-module-slack': patch
+---
+
+Added email-based Slack User ID lookup if `metadata.annotations.slack.com/bot-notify` is missing from user entity


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Uses Slack's user id lookup via email if the user entity is missing `metadata.annotations.slack.com/bot-notify`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
