### PR TITLE
Add optional title to CustomizableHomepageGrid and improve example app with feature flag

### DIFF
--- a/.changeset/petite-pants-accept.md
+++ b/.changeset/petite-pants-accept.md
@@ -1,5 +1,4 @@
 ---
-'example-app': minor
 '@backstage/plugin-home': minor
 ---
 

--- a/.changeset/petite-pants-accept.md
+++ b/.changeset/petite-pants-accept.md
@@ -1,0 +1,6 @@
+---
+'example-app': minor
+'@backstage/plugin-home': minor
+---
+
+Add optional title prop to CustomizableHomepageGrid and enhance example app homepage to support customizable layout based on a feature flag

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -27,7 +27,7 @@ import {
   RELATION_PROVIDES_API,
 } from '@backstage/catalog-model';
 import { createApp } from '@backstage/app-defaults';
-import { AppRouter, FlatRoutes } from '@backstage/core-app-api';
+import { AppRouter, FeatureFlagged, FlatRoutes } from '@backstage/core-app-api';
 import {
   AlertDisplay,
   OAuthRequestDialog,
@@ -66,7 +66,6 @@ import AlarmIcon from '@material-ui/icons/Alarm';
 import { Navigate, Route } from 'react-router-dom';
 import { apis } from './apis';
 import { entityPage } from './components/catalog/EntityPage';
-import { homePage } from './components/home/HomePage';
 import { Root } from './components/Root';
 import { DelayingComponentFieldExtension } from './components/scaffolder/customScaffolderExtensions';
 import { defaultPreviewTemplate } from './components/scaffolder/defaultPreviewTemplate';
@@ -84,6 +83,8 @@ import {
   NotificationsPage,
   UserNotificationSettingsCard,
 } from '@backstage/plugin-notifications';
+import { CustomizableHomePage } from './components/home/CustomizableHomePage';
+import { homePage } from './components/home/HomePage';
 
 const app = createApp({
   apis,
@@ -95,6 +96,11 @@ const app = createApp({
     {
       name: 'scaffolder-next-preview',
       description: 'Preview the new Scaffolder Next',
+      pluginId: '',
+    },
+    {
+      name: 'customizable-home-page-preview',
+      description: 'Makes the home page customizable',
       pluginId: '',
     },
   ],
@@ -115,10 +121,20 @@ const app = createApp({
 const routes = (
   <FlatRoutes>
     <Route path="/" element={<Navigate to="catalog" />} />
+
     {/* TODO(rubenl): Move this to / once its more mature and components exist */}
-    <Route path="/home" element={<HomepageCompositionRoot />}>
-      {homePage}
-    </Route>
+
+    <FeatureFlagged with="customizable-home-page-preview">
+      <Route path="/home" element={<HomepageCompositionRoot />}>
+        <CustomizableHomePage />
+      </Route>
+    </FeatureFlagged>
+    <FeatureFlagged without="customizable-home-page-preview">
+      <Route path="/home" element={<HomepageCompositionRoot />}>
+        {homePage}
+      </Route>
+    </FeatureFlagged>
+
     <Route
       path="/catalog"
       element={<CatalogIndexPage pagination={{ mode: 'offset', limit: 20 }} />}

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -84,7 +84,7 @@ import {
   UserNotificationSettingsCard,
 } from '@backstage/plugin-notifications';
 import { CustomizableHomePage } from './components/home/CustomizableHomePage';
-import { homePage } from './components/home/HomePage';
+import { HomePage } from './components/home/HomePage';
 
 const app = createApp({
   apis,
@@ -131,7 +131,7 @@ const routes = (
     </FeatureFlagged>
     <FeatureFlagged without="customizable-home-page-preview">
       <Route path="/home" element={<HomepageCompositionRoot />}>
-        {homePage}
+        <HomePage />
       </Route>
     </FeatureFlagged>
 

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -98,11 +98,6 @@ const app = createApp({
       description: 'Preview the new Scaffolder Next',
       pluginId: '',
     },
-    {
-      name: 'customizable-home-page-preview',
-      description: 'Makes the home page customizable',
-      pluginId: '',
-    },
   ],
   components: {
     SignInPage: props => {

--- a/packages/app/src/components/home/CustomizableHomePage.tsx
+++ b/packages/app/src/components/home/CustomizableHomePage.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Page, Content } from '@backstage/core-components';
+import { Page, Content, Header } from '@backstage/core-components';
 import {
   HomePageCompanyLogo,
   TemplateBackstageLogo,
@@ -23,11 +23,39 @@ import {
   HomePageRandomJoke,
   HomePageTopVisited,
   HomePageRecentlyVisited,
+  WelcomeTitle,
+  HeaderWorldClock,
+  ClockConfig,
 } from '@backstage/plugin-home';
 import { HomePageSearchBar } from '@backstage/plugin-search';
 import Grid from '@material-ui/core/Grid';
 
 import { tools, useLogoStyles } from './shared';
+
+const clockConfigs: ClockConfig[] = [
+  {
+    label: 'NYC',
+    timeZone: 'America/New_York',
+  },
+  {
+    label: 'UTC',
+    timeZone: 'UTC',
+  },
+  {
+    label: 'STO',
+    timeZone: 'Europe/Stockholm',
+  },
+  {
+    label: 'TYO',
+    timeZone: 'Asia/Tokyo',
+  },
+];
+
+const timeFormat: Intl.DateTimeFormatOptions = {
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+};
 
 const defaultConfig = [
   {
@@ -73,6 +101,12 @@ export const CustomizableHomePage = () => {
   return (
     <Page themeId="home">
       <Content>
+        <Header title={<WelcomeTitle />} pageTitleOverride="Home">
+          <HeaderWorldClock
+            clockConfigs={clockConfigs}
+            customTimeFormat={timeFormat}
+          />
+        </Header>
         <Grid container justifyContent="center">
           <HomePageCompanyLogo
             className={container}

--- a/packages/app/src/components/home/CustomizableHomePage.tsx
+++ b/packages/app/src/components/home/CustomizableHomePage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Backstage Authors
+ * Copyright 2025 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,16 +15,19 @@
  */
 import { Page, Content } from '@backstage/core-components';
 import {
+  HomePageCompanyLogo,
+  TemplateBackstageLogo,
   HomePageStarredEntities,
+  HomePageToolkit,
   CustomHomepageGrid,
   HomePageRandomJoke,
   HomePageTopVisited,
   HomePageRecentlyVisited,
 } from '@backstage/plugin-home';
 import { HomePageSearchBar } from '@backstage/plugin-search';
-// import { Grid } from '@material-ui/core';
+import Grid from '@material-ui/core/Grid';
 
-// import { tools } from './shared';
+import { tools, useLogoStyles } from './shared';
 
 const defaultConfig = [
   {
@@ -65,26 +68,23 @@ const defaultConfig = [
 ];
 
 export const CustomizableHomePage = () => {
-  // const { svg, path, container } = useLogoStyles();
+  const { svg, path, container } = useLogoStyles();
 
   return (
     <Page themeId="home">
       <Content>
-        {/* <Grid container justifyContent="center">
+        <Grid container justifyContent="center">
           <HomePageCompanyLogo
             className={container}
             logo={<TemplateBackstageLogo classes={{ svg, path }} />}
           />
-        </Grid> */}
+        </Grid>
 
-        <CustomHomepageGrid
-          config={defaultConfig}
-          title="Your Dashboard"
-          containerPadding={[0, 0]}
-        >
+        <CustomHomepageGrid config={defaultConfig}>
           <HomePageSearchBar />
           <HomePageRecentlyVisited />
           <HomePageTopVisited />
+          <HomePageToolkit tools={tools} />
           <HomePageStarredEntities />
           <HomePageRandomJoke />
         </CustomHomepageGrid>

--- a/packages/app/src/components/home/CustomizableHomePage.tsx
+++ b/packages/app/src/components/home/CustomizableHomePage.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Page, Content, Header } from '@backstage/core-components';
+import { Page, Content } from '@backstage/core-components';
 import {
   HomePageCompanyLogo,
   TemplateBackstageLogo,
@@ -23,39 +23,11 @@ import {
   HomePageRandomJoke,
   HomePageTopVisited,
   HomePageRecentlyVisited,
-  WelcomeTitle,
-  HeaderWorldClock,
-  ClockConfig,
 } from '@backstage/plugin-home';
 import { HomePageSearchBar } from '@backstage/plugin-search';
 import Grid from '@material-ui/core/Grid';
 
 import { tools, useLogoStyles } from './shared';
-
-const clockConfigs: ClockConfig[] = [
-  {
-    label: 'NYC',
-    timeZone: 'America/New_York',
-  },
-  {
-    label: 'UTC',
-    timeZone: 'UTC',
-  },
-  {
-    label: 'STO',
-    timeZone: 'Europe/Stockholm',
-  },
-  {
-    label: 'TYO',
-    timeZone: 'Asia/Tokyo',
-  },
-];
-
-const timeFormat: Intl.DateTimeFormatOptions = {
-  hour: '2-digit',
-  minute: '2-digit',
-  hour12: false,
-};
 
 const defaultConfig = [
   {
@@ -101,12 +73,6 @@ export const CustomizableHomePage = () => {
   return (
     <Page themeId="home">
       <Content>
-        <Header title={<WelcomeTitle />} pageTitleOverride="Home">
-          <HeaderWorldClock
-            clockConfigs={clockConfigs}
-            customTimeFormat={timeFormat}
-          />
-        </Header>
         <Grid container justifyContent="center">
           <HomePageCompanyLogo
             className={container}

--- a/packages/app/src/components/home/CustomizableHomePage.tsx
+++ b/packages/app/src/components/home/CustomizableHomePage.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Page, Content } from '@backstage/core-components';
+import {
+  HomePageStarredEntities,
+  CustomHomepageGrid,
+  HomePageRandomJoke,
+  HomePageTopVisited,
+  HomePageRecentlyVisited,
+} from '@backstage/plugin-home';
+import { HomePageSearchBar } from '@backstage/plugin-search';
+// import { Grid } from '@material-ui/core';
+
+// import { tools } from './shared';
+
+const defaultConfig = [
+  {
+    component: 'HomePageSearchBar',
+    x: 0,
+    y: 0,
+    width: 24,
+    height: 2,
+  },
+  {
+    component: 'HomePageRecentlyVisited',
+    x: 0,
+    y: 1,
+    width: 5,
+    height: 4,
+  },
+  {
+    component: 'HomePageTopVisited',
+    x: 5,
+    y: 1,
+    width: 5,
+    height: 4,
+  },
+  {
+    component: 'HomePageStarredEntities',
+    x: 0,
+    y: 2,
+    width: 6,
+    height: 4,
+  },
+  {
+    component: 'HomePageToolkit',
+    x: 6,
+    y: 6,
+    width: 4,
+    height: 4,
+  },
+];
+
+export const CustomizableHomePage = () => {
+  // const { svg, path, container } = useLogoStyles();
+
+  return (
+    <Page themeId="home">
+      <Content>
+        {/* <Grid container justifyContent="center">
+          <HomePageCompanyLogo
+            className={container}
+            logo={<TemplateBackstageLogo classes={{ svg, path }} />}
+          />
+        </Grid> */}
+
+        <CustomHomepageGrid
+          config={defaultConfig}
+          title="Your Dashboard"
+          containerPadding={[0, 0]}
+        >
+          <HomePageSearchBar />
+          <HomePageRecentlyVisited />
+          <HomePageTopVisited />
+          <HomePageStarredEntities />
+          <HomePageRandomJoke />
+        </CustomHomepageGrid>
+      </Content>
+    </Page>
+  );
+};

--- a/packages/app/src/components/home/HomePage.tsx
+++ b/packages/app/src/components/home/HomePage.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Page, Content } from '@backstage/core-components';
+import { Page, Content, Header } from '@backstage/core-components';
 import {
   HomePageCompanyLogo,
   TemplateBackstageLogo,
@@ -22,6 +22,9 @@ import {
   HomePageToolkit,
   HomePageTopVisited,
   HomePageRecentlyVisited,
+  WelcomeTitle,
+  HeaderWorldClock,
+  ClockConfig,
 } from '@backstage/plugin-home';
 import { HomePageSearchBar } from '@backstage/plugin-search';
 import { SearchContextProvider } from '@backstage/plugin-search-react';
@@ -43,6 +46,31 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
+const clockConfigs: ClockConfig[] = [
+  {
+    label: 'NYC',
+    timeZone: 'America/New_York',
+  },
+  {
+    label: 'UTC',
+    timeZone: 'UTC',
+  },
+  {
+    label: 'STO',
+    timeZone: 'Europe/Stockholm',
+  },
+  {
+    label: 'TYO',
+    timeZone: 'Asia/Tokyo',
+  },
+];
+
+const timeFormat: Intl.DateTimeFormatOptions = {
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+};
+
 export const HomePage = () => {
   const classes = useStyles();
   const { svg, path, container } = useLogoStyles();
@@ -50,6 +78,12 @@ export const HomePage = () => {
   return (
     <SearchContextProvider>
       <Page themeId="home">
+        <Header title={<WelcomeTitle />} pageTitleOverride="Home">
+          <HeaderWorldClock
+            clockConfigs={clockConfigs}
+            customTimeFormat={timeFormat}
+          />
+        </Header>
         <Content>
           <Grid container justifyContent="center" spacing={2}>
             <HomePageCompanyLogo

--- a/packages/app/src/components/home/HomePage.tsx
+++ b/packages/app/src/components/home/HomePage.tsx
@@ -14,101 +14,78 @@
  * limitations under the License.
  */
 
+import { Page, Content } from '@backstage/core-components';
 import {
-  ClockConfig,
-  CustomHomepageGrid,
-  HeaderWorldClock,
   HomePageCompanyLogo,
-  HomePageRandomJoke,
+  TemplateBackstageLogo,
   HomePageStarredEntities,
   HomePageToolkit,
   HomePageTopVisited,
   HomePageRecentlyVisited,
-  WelcomeTitle,
 } from '@backstage/plugin-home';
-import { Content, Header, Page } from '@backstage/core-components';
 import { HomePageSearchBar } from '@backstage/plugin-search';
-import HomeIcon from '@material-ui/icons/Home';
+import { SearchContextProvider } from '@backstage/plugin-search-react';
+import Grid from '@material-ui/core/Grid';
+import { makeStyles } from '@material-ui/core/styles';
 
-const clockConfigs: ClockConfig[] = [
-  {
-    label: 'NYC',
-    timeZone: 'America/New_York',
-  },
-  {
-    label: 'UTC',
-    timeZone: 'UTC',
-  },
-  {
-    label: 'STO',
-    timeZone: 'Europe/Stockholm',
-  },
-  {
-    label: 'TYO',
-    timeZone: 'Asia/Tokyo',
-  },
-];
+import { tools, useLogoStyles } from './shared';
 
-const timeFormat: Intl.DateTimeFormatOptions = {
-  hour: '2-digit',
-  minute: '2-digit',
-  hour12: false,
+const useStyles = makeStyles(theme => ({
+  searchBarInput: {
+    maxWidth: '60vw',
+    margin: 'auto',
+    backgroundColor: theme.palette.background.paper,
+    borderRadius: '50px',
+    boxShadow: theme.shadows[1],
+  },
+  searchBarOutline: {
+    borderStyle: 'none',
+  },
+}));
+
+export const HomePage = () => {
+  const classes = useStyles();
+  const { svg, path, container } = useLogoStyles();
+
+  return (
+    <SearchContextProvider>
+      <Page themeId="home">
+        <Content>
+          <Grid container justifyContent="center" spacing={2}>
+            <HomePageCompanyLogo
+              className={container}
+              logo={<TemplateBackstageLogo classes={{ svg, path }} />}
+            />
+            <Grid container item xs={12} justifyContent="center">
+              <HomePageSearchBar
+                InputProps={{
+                  classes: {
+                    root: classes.searchBarInput,
+                    notchedOutline: classes.searchBarOutline,
+                  },
+                }}
+                placeholder="Search"
+              />
+            </Grid>
+            <Grid container item xs={12}>
+              <Grid item xs={12} md={6}>
+                <HomePageTopVisited />
+              </Grid>
+              <Grid item xs={12} md={6}>
+                <HomePageRecentlyVisited />
+              </Grid>
+            </Grid>
+            <Grid container item xs={12}>
+              <Grid item xs={7}>
+                <HomePageStarredEntities />
+              </Grid>
+              <Grid item xs={5}>
+                <HomePageToolkit tools={tools} />
+              </Grid>
+            </Grid>
+          </Grid>
+        </Content>
+      </Page>
+    </SearchContextProvider>
+  );
 };
-
-const defaultConfig = [
-  {
-    component: 'CompanyLogo',
-    x: 0,
-    y: 0,
-    width: 12,
-    height: 1,
-    movable: false,
-    resizable: false,
-    deletable: false,
-  },
-  {
-    component: 'WelcomeTitle',
-    x: 0,
-    y: 1,
-    width: 12,
-    height: 1,
-  },
-  {
-    component: 'HomePageSearchBar',
-    x: 0,
-    y: 2,
-    width: 12,
-    height: 2,
-  },
-];
-
-export const homePage = (
-  <Page themeId="home">
-    <Header title={<WelcomeTitle />} pageTitleOverride="Home">
-      <HeaderWorldClock
-        clockConfigs={clockConfigs}
-        customTimeFormat={timeFormat}
-      />
-    </Header>
-    <Content>
-      <CustomHomepageGrid config={defaultConfig}>
-        <HomePageSearchBar />
-        <HomePageRandomJoke />
-        <HomePageStarredEntities />
-        <HomePageCompanyLogo />
-        <WelcomeTitle />
-        <HomePageToolkit
-          tools={[
-            {
-              url: 'https://backstage.io',
-              label: 'Backstage Homepage',
-              icon: <HomeIcon />,
-            },
-          ]}
-        />
-        <HomePageTopVisited />
-        <HomePageRecentlyVisited />
-      </CustomHomepageGrid>
-    </Content>
-  </Page>
-);

--- a/packages/app/src/components/home/shared.tsx
+++ b/packages/app/src/components/home/shared.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TemplateBackstageLogoIcon } from '@backstage/plugin-home';
+import { makeStyles } from '@material-ui/core/styles';
+
+export const useLogoStyles = makeStyles(theme => ({
+  container: {
+    margin: theme.spacing(5, 0),
+  },
+  svg: {
+    width: 'auto',
+    height: 100,
+  },
+  path: {
+    fill: '#7df3e1',
+  },
+}));
+
+export const tools = [
+  {
+    url: 'https://backstage.io/docs',
+    label: 'Docs',
+    icon: <TemplateBackstageLogoIcon />,
+  },
+  {
+    url: 'https://github.com/backstage/backstage',
+    label: 'GitHub',
+    icon: <TemplateBackstageLogoIcon />,
+  },
+  {
+    url: 'https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md',
+    label: 'Contributing',
+    icon: <TemplateBackstageLogoIcon />,
+  },
+  {
+    url: 'https://backstage.io/plugins',
+    label: 'Plugins Directory',
+    icon: <TemplateBackstageLogoIcon />,
+  },
+  {
+    url: 'https://github.com/backstage/backstage/issues/new/choose',
+    label: 'Submit New Issue',
+    icon: <TemplateBackstageLogoIcon />,
+  },
+];

--- a/plugins/home/README.md
+++ b/plugins/home/README.md
@@ -107,6 +107,9 @@ export const homePage = (
 );
 ```
 
+> [!NOTE]
+> You can provide a title to the grid by passing it as a prop: `<CustomHomepageGrid title="Your Dashboard" />`. This will be displayed as a header above the grid layout.
+
 ### Creating Customizable Components
 
 The custom home page can use the default components created by using the default `createCardExtension` method but if you

--- a/plugins/home/report.api.md
+++ b/plugins/home/report.api.md
@@ -89,6 +89,7 @@ export const CustomHomepageGrid: (
 export type CustomHomepageGridProps = {
   children?: ReactNode;
   config?: LayoutConfiguration[];
+  title?: string;
   rowHeight?: number;
   breakpoints?: Record<Breakpoint, number>;
   cols?: Record<Breakpoint, number>;

--- a/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.tsx
+++ b/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.tsx
@@ -321,7 +321,7 @@ export const CustomHomepageGrid = (props: CustomHomepageGridProps) => {
 
   return (
     <>
-      <ContentHeader title="">
+      <ContentHeader title={props.title}>
         <CustomHomepageButtons
           editMode={editMode}
           numWidgets={widgets.length}

--- a/plugins/home/src/components/CustomHomepage/types.ts
+++ b/plugins/home/src/components/CustomHomepage/types.ts
@@ -46,6 +46,10 @@ export type CustomHomepageGridProps = {
    */
   config?: LayoutConfiguration[];
   /**
+   * Title displayed in the header of the grid. If not provided, no title will be shown.
+   */
+  title?: string;
+  /**
    * Height of grid row in pixels.
    * @defaultValue 60
    */


### PR DESCRIPTION
## Add optional title to CustomizableHomepageGrid and improve example app with feature flag

This PR introduces two minor enhancements:

### Optional title prop for CustomizableHomepageGrid:

The title element was previously hardcoded as an empty string. This change makes the title prop optional, maintaining existing behavior by default. However, it allows customization by passing a value like:

`<CustomHomepageGrid config={defaultConfig} title="My Dashboard" />
`

This displays the provided title as shown in the screenshot:
![image](https://github.com/user-attachments/assets/49ffe3e9-3f47-435f-892d-1a8b95cfc752)


### Enhanced example app homepage with feature flag:
Following @ahhhndre's recommendation (based on the [demo site](https://github.com/backstage/demo/blob/f8f53d1dd324d3166e63552d2f8cc0588e7b1093/packages/app/src/App.tsx#L121-L130)), the example app now uses a customizable-home-page-preview feature flag. This allows /home to toggle between the default static homepage and the customizable homepage. This setup is useful for developing and testing features without impacting the default experience.

![image](https://github.com/user-attachments/assets/9d47363d-3d1b-4ec2-82d1-6fd9804427f3)

This feature flag changes the home page in /home, the next screenshot shows both options:
![image](https://github.com/user-attachments/assets/7421a86e-4fbf-4708-9ada-31216c01dddb)
![image](https://github.com/user-attachments/assets/9e4b1089-4694-4d79-86cf-066e9c9a8abe)



