### PR TITLE
auth-backend: add omitIdentityTokenOwnershipClaim flag

### DIFF
--- a/.changeset/angry-sites-fold.md
+++ b/.changeset/angry-sites-fold.md
@@ -1,0 +1,30 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Added the configuration flag `auth.omitIdentityTokenOwnershipClaim` that causes issued user tokens to no longer contain the `ent` claim that represents the ownership references of the user.
+
+The benefit of this new flag is that issued user tokens will be much smaller in
+size, but they will no longer be self-contained. This means that any consumers
+of the token that require access to the ownership claims now need to call the
+`/api/auth/v1/userinfo` endpoint instead. Within the Backstage ecosystem this is
+done automatically, as clients will still receive the full set of claims during
+authentication, while plugin backends will need to use the `UserInfoService`
+which already calls the user info endpoint if necessary.
+
+When enabling this flag, it is important that any custom sign-in resolvers directly return the result of the sign-in method. For example, the following would not work:
+
+```ts
+const { token } = await ctx.issueToken({
+  claims: { sub: entityRef, ent: [entityRef] },
+});
+return { token }; // WARNING: This will not work with the flag enabled
+```
+
+Instead, the sign-in resolver should directly return the result:
+
+```ts
+return ctx.issueToken({
+  claims: { sub: entityRef, ent: [entityRef] },
+});
+```

--- a/.changeset/famous-cities-stand.md
+++ b/.changeset/famous-cities-stand.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-auth-node': patch
+---
+
+Added the `identity` property to `BackstageSignInResult`.
+
+The `prepareBackstageIdentityResponse` function will now also forward the `identity` to the response if present in the provided sign-in result.

--- a/plugins/auth-backend/config.d.ts
+++ b/plugins/auth-backend/config.d.ts
@@ -43,6 +43,15 @@ export interface Config {
      */
     identityTokenAlgorithm?: string;
 
+    /**
+     * Whether to omit the entity ownership references (`ent`) claim from the
+     * identity token. If this is enabled the `ent` claim will only be available
+     * via the user info endpoint and the `UserInfoService`.
+     *
+     * Defaults to `false`.
+     */
+    omitIdentityTokenOwnershipClaim?: boolean;
+
     /** To control how to store JWK data in auth-backend */
     keyStore?: {
       provider?: 'database' | 'memory' | 'firestore' | 'static';

--- a/plugins/auth-backend/package.json
+++ b/plugins/auth-backend/package.json
@@ -69,6 +69,7 @@
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@backstage/plugin-auth-backend-module-google-provider": "workspace:^",
+    "@backstage/plugin-auth-backend-module-guest-provider": "workspace:^",
     "@types/cookie-parser": "^1.4.2",
     "@types/express": "^4.17.6",
     "@types/express-session": "^1.17.2",

--- a/plugins/auth-backend/src/authPlugin.test.ts
+++ b/plugins/auth-backend/src/authPlugin.test.ts
@@ -17,6 +17,8 @@
 import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
 import request from 'supertest';
 import { authPlugin } from './authPlugin';
+import authModuleGuestProvider from '@backstage/plugin-auth-backend-module-guest-provider';
+import { authServiceFactory } from '@backstage/backend-defaults/auth';
 
 describe('authPlugin', () => {
   it('should provide an OpenID configuration', async () => {
@@ -40,6 +42,127 @@ describe('authPlugin', () => {
     expect(res.body).toMatchObject({
       claims_supported: ['sub', 'ent'],
       issuer: `http://localhost:${server.port()}/api/auth`,
+    });
+  });
+
+  describe('mock provider', () => {
+    const mockProvidersConfig = {
+      environment: 'test',
+      providers: {
+        guest: {
+          dangerouslyAllowOutsideDevelopment: true,
+          userEntityRef: 'user:default/tester',
+          ownershipEntityRefs: [
+            'group:default/testers',
+            'group:default/testers2',
+          ],
+        },
+      },
+    };
+
+    const expectedIdentity = {
+      type: 'user',
+      userEntityRef: 'user:default/tester',
+      ownershipEntityRefs: ['group:default/testers', 'group:default/testers2'],
+    };
+
+    it('should return tokens with all identity claims by default', async () => {
+      const { server } = await startTestBackend({
+        features: [
+          authPlugin,
+          authModuleGuestProvider,
+          authServiceFactory,
+          mockServices.rootConfig.factory({
+            data: {
+              app: {
+                baseUrl: 'http://localhost',
+              },
+              auth: {
+                ...mockProvidersConfig,
+              },
+            },
+          }),
+        ],
+      });
+
+      const refreshRes = await request(server).post('/api/auth/guest/refresh');
+      expect(refreshRes.status).toBe(200);
+      expect(refreshRes.body).toMatchObject({
+        backstageIdentity: {
+          expiresInSeconds: expect.any(Number),
+          identity: expectedIdentity,
+          token: expect.any(String),
+        },
+        profile: {},
+      });
+
+      const token = refreshRes.body.backstageIdentity.token;
+      const decoded = JSON.parse(atob(token.split('.')[1]));
+      expect(decoded.sub).toEqual(expectedIdentity.userEntityRef);
+      expect(decoded.ent).toEqual(expectedIdentity.ownershipEntityRefs);
+
+      const userInfoRes = await request(server)
+        .get('/api/auth/v1/userinfo')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(userInfoRes.status).toBe(200);
+      expect(userInfoRes.body).toMatchObject({
+        claims: {
+          sub: expectedIdentity.userEntityRef,
+          ent: expectedIdentity.ownershipEntityRefs,
+          exp: expect.any(Number),
+        },
+      });
+    });
+
+    it('should omit ownership claims from the token when the config is set', async () => {
+      const { server } = await startTestBackend({
+        features: [
+          authPlugin,
+          authModuleGuestProvider,
+          authServiceFactory,
+          mockServices.rootConfig.factory({
+            data: {
+              app: {
+                baseUrl: 'http://localhost',
+              },
+              auth: {
+                omitIdentityTokenOwnershipClaim: true,
+                ...mockProvidersConfig,
+              },
+            },
+          }),
+        ],
+      });
+
+      const refreshRes = await request(server).post('/api/auth/guest/refresh');
+      expect(refreshRes.status).toBe(200);
+      expect(refreshRes.body).toMatchObject({
+        backstageIdentity: {
+          expiresInSeconds: expect.any(Number),
+          identity: expectedIdentity,
+          token: expect.any(String),
+        },
+        profile: {},
+      });
+
+      const token = refreshRes.body.backstageIdentity.token;
+      const decoded = JSON.parse(atob(token.split('.')[1]));
+      expect(decoded.sub).toEqual(expectedIdentity.userEntityRef);
+      expect(decoded.ent).toBeUndefined();
+
+      const userInfoRes = await request(server)
+        .get('/api/auth/v1/userinfo')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(userInfoRes.status).toBe(200);
+      expect(userInfoRes.body).toMatchObject({
+        claims: {
+          sub: expectedIdentity.userEntityRef,
+          ent: expectedIdentity.ownershipEntityRefs,
+          exp: expect.any(Number),
+        },
+      });
     });
   });
 });

--- a/plugins/auth-backend/src/identity/StaticTokenIssuer.test.ts
+++ b/plugins/auth-backend/src/identity/StaticTokenIssuer.test.ts
@@ -83,7 +83,7 @@ describe('StaticTokenIssuer', () => {
       options,
       staticKeyStore as unknown as StaticKeyStore,
     );
-    const token = await issuer.issueToken({
+    const { token } = await issuer.issueToken({
       claims: {
         sub: entityRef,
         ent: [entityRef],

--- a/plugins/auth-backend/src/identity/TokenFactory.test.ts
+++ b/plugins/auth-backend/src/identity/TokenFactory.test.ts
@@ -60,13 +60,18 @@ describe('TokenFactory', () => {
     });
 
     await expect(factory.listPublicKeys()).resolves.toEqual({ keys: [] });
-    const token = await factory.issueToken({
+    const { token, identity } = await factory.issueToken({
       claims: {
         sub: entityRef,
         ent: [entityRef],
         'x-fancy-claim': 'my special claim',
         aud: 'this value will be overridden',
       },
+    });
+    expect(identity).toEqual({
+      type: 'user',
+      userEntityRef: entityRef,
+      ownershipEntityRefs: [entityRef],
     });
 
     const { keys } = await factory.listPublicKeys();
@@ -137,10 +142,10 @@ describe('TokenFactory', () => {
       userInfoDatabaseHandler: mockUserInfoDatabaseHandler,
     });
 
-    const token1 = await factory.issueToken({
+    const { token: token1 } = await factory.issueToken({
       claims: { sub: entityRef },
     });
-    const token2 = await factory.issueToken({
+    const { token: token2 } = await factory.issueToken({
       claims: { sub: entityRef },
     });
     expect(jwtKid(token1)).toBe(jwtKid(token2));
@@ -159,7 +164,7 @@ describe('TokenFactory', () => {
       keys: [],
     });
 
-    const token3 = await factory.issueToken({
+    const { token: token3 } = await factory.issueToken({
       claims: { sub: entityRef },
     });
     expect(jwtKid(token3)).not.toBe(jwtKid(token2));
@@ -236,7 +241,7 @@ describe('TokenFactory', () => {
       userInfoDatabaseHandler: mockUserInfoDatabaseHandler,
     });
 
-    const token = await factory.issueToken({
+    const { token } = await factory.issueToken({
       claims: { sub: entityRef, ent: [entityRef] },
     });
 

--- a/plugins/auth-backend/src/identity/types.ts
+++ b/plugins/auth-backend/src/identity/types.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { TokenParams } from '@backstage/plugin-auth-node';
+import {
+  BackstageUserIdentity,
+  TokenParams,
+} from '@backstage/plugin-auth-node';
 
 /** Represents any form of serializable JWK */
 export interface AnyJWK extends Record<string, string> {
@@ -31,7 +34,9 @@ export type TokenIssuer = {
   /**
    * Issues a new ID Token
    */
-  issueToken(params: TokenParams): Promise<string>;
+  issueToken(
+    params: TokenParams,
+  ): Promise<{ token: string; identity?: BackstageUserIdentity }>;
 
   /**
    * List all public keys that are currently being used to sign tokens, or have been used

--- a/plugins/auth-backend/src/lib/resolvers/CatalogAuthResolverContext.ts
+++ b/plugins/auth-backend/src/lib/resolvers/CatalogAuthResolverContext.ts
@@ -77,8 +77,7 @@ export class CatalogAuthResolverContext implements AuthResolverContext {
   ) {}
 
   async issueToken(params: TokenParams) {
-    const token = await this.tokenIssuer.issueToken(params);
-    return { token };
+    return await this.tokenIssuer.issueToken(params);
   }
 
   async findCatalogUser(query: AuthResolverCatalogUserQuery) {
@@ -147,13 +146,12 @@ export class CatalogAuthResolverContext implements AuthResolverContext {
       entity,
     );
 
-    const token = await this.tokenIssuer.issueToken({
+    return await this.tokenIssuer.issueToken({
       claims: {
         sub: stringifyEntityRef(entity),
         ent: ownershipEntityRefs,
       },
     });
-    return { token };
   }
 
   async resolveOwnershipEntityRefs(

--- a/plugins/auth-backend/src/service/router.ts
+++ b/plugins/auth-backend/src/service/router.ts
@@ -101,6 +101,11 @@ export async function createRouter(
         tokenFactoryAlgorithm ??
         config.getOptionalString('auth.identityTokenAlgorithm'),
       userInfoDatabaseHandler,
+      omitClaimsFromToken: config.getOptionalBoolean(
+        'auth.omitIdentityTokenOwnershipClaim',
+      )
+        ? ['ent']
+        : [],
     });
   }
 

--- a/plugins/auth-node/report.api.md
+++ b/plugins/auth-node/report.api.md
@@ -104,9 +104,7 @@ export type AuthResolverCatalogUserQuery =
 
 // @public
 export type AuthResolverContext = {
-  issueToken(params: TokenParams): Promise<{
-    token: string;
-  }>;
+  issueToken(params: TokenParams): Promise<BackstageSignInResult>;
   findCatalogUser(query: AuthResolverCatalogUserQuery): Promise<{
     entity: Entity;
   }>;
@@ -126,6 +124,7 @@ export interface BackstageIdentityResponse extends BackstageSignInResult {
 
 // @public
 export interface BackstageSignInResult {
+  identity?: BackstageUserIdentity;
   token: string;
 }
 

--- a/plugins/auth-node/src/identity/prepareBackstageIdentityResponse.test.ts
+++ b/plugins/auth-node/src/identity/prepareBackstageIdentityResponse.test.ts
@@ -44,6 +44,30 @@ describe('prepareBackstageIdentityResponse', () => {
     });
   });
 
+  it('uses the identity in the result if present', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(5000);
+
+    const token = mkToken({ sub: 'k:ns/n', ent: ['k:ns/o'], exp: 1005 });
+    expect(
+      prepareBackstageIdentityResponse({
+        token,
+        identity: {
+          type: 'user',
+          userEntityRef: 'k:ns/other',
+          ownershipEntityRefs: ['k:ns/group1', 'k:ns/group2'],
+        },
+      }),
+    ).toEqual({
+      token,
+      expiresInSeconds: 1000,
+      identity: {
+        type: 'user',
+        userEntityRef: 'k:ns/other',
+        ownershipEntityRefs: ['k:ns/group1', 'k:ns/group2'],
+      },
+    });
+  });
+
   it('should reject tokens without subject', () => {
     const token = mkToken({});
     expect(() =>

--- a/plugins/auth-node/src/identity/prepareBackstageIdentityResponse.ts
+++ b/plugins/auth-node/src/identity/prepareBackstageIdentityResponse.ts
@@ -57,7 +57,7 @@ export function prepareBackstageIdentityResponse(
   return {
     ...result,
     expiresInSeconds: exp,
-    identity: {
+    identity: result.identity ?? {
       type: 'user',
       userEntityRef: sub,
       ownershipEntityRefs: ent,

--- a/plugins/auth-node/src/types.ts
+++ b/plugins/auth-node/src/types.ts
@@ -34,6 +34,12 @@ export interface BackstageSignInResult {
    * The token used to authenticate the user within Backstage.
    */
   token: string;
+
+  /**
+   * Identity information to pass to the client rather than using the
+   * information that's embeeded in the token.
+   */
+  identity?: BackstageUserIdentity;
 }
 
 /**
@@ -141,7 +147,7 @@ export type AuthResolverContext = {
   /**
    * Issues a Backstage token using the provided parameters.
    */
-  issueToken(params: TokenParams): Promise<{ token: string }>;
+  issueToken(params: TokenParams): Promise<BackstageSignInResult>;
 
   /**
    * Finds a single user in the catalog using the provided query.

--- a/yarn.lock
+++ b/yarn.lock
@@ -5286,6 +5286,7 @@ __metadata:
     "@backstage/config": "workspace:^"
     "@backstage/errors": "workspace:^"
     "@backstage/plugin-auth-backend-module-google-provider": "workspace:^"
+    "@backstage/plugin-auth-backend-module-guest-provider": "workspace:^"
     "@backstage/plugin-auth-node": "workspace:^"
     "@backstage/plugin-catalog-node": "workspace:^"
     "@backstage/types": "workspace:^"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This continues the work from #24729 by adding a flag that removes the `ent` claim from issued user tokens. It also adds an `identity` property to sign-in results in order to be able to forward claims to the frontend.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
