### PR TITLE
Corrects command in catalog external integrations doc.

### DIFF
--- a/docs/features/software-catalog/external-integrations.md
+++ b/docs/features/software-catalog/external-integrations.md
@@ -70,7 +70,7 @@ putting all extensions like this in a backend module package of their own in the
 `plugins` folder of your Backstage repo:
 
 ```sh
-yarn new --select backend-module --option pluginId=catalog
+yarn new --select backend-plugin-module --option pluginId=catalog
 ```
 
 The class will have this basic structure:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes the `yarn new` CLI command in the [software-catalog](https://backstage.io/docs/features/software-catalog/external-integrations) docs so that it works when creating a the plugin module.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
