### PR TITLE
fix(kubernetes-backend): Changed logging of cluster details to debug level

### DIFF
--- a/.changeset/dull-doodles-trade.md
+++ b/.changeset/dull-doodles-trade.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Changed logging of cluster details to debug to minimise log clutter.

--- a/plugins/kubernetes-backend/src/service/KubernetesBuilder.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesBuilder.ts
@@ -488,7 +488,7 @@ export class KubernetesBuilder {
   ) {
     const clusterDetails = await clusterSupplier.getClusters(options);
 
-    this.env.logger.info(
+    this.env.logger.debug(
       `action=loadClusterDetails numOfClustersLoaded=${clusterDetails.length}`,
     );
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Changed the logging of loaded cluster details to debug.

This was probably not intended to be info logs, since this spams our logs with +20000 lines per hour.

So I choose to change it to debug instead of removing it completely, so it can be used when developing and debugging.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
