### PR TITLE
docs(events-backend-module-github): correct install instructions

### DIFF
--- a/.changeset/slick-brooms-start.md
+++ b/.changeset/slick-brooms-start.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-events-backend-module-github': patch
+---
+
+Correct README installation instructions.

--- a/plugins/events-backend-module-github/README.md
+++ b/plugins/events-backend-module-github/README.md
@@ -27,16 +27,14 @@ Please find all possible webhook event types at the
 yarn --cwd packages/backend add @backstage/plugin-events-backend-module-github
 ```
 
-### Event Router
-
 ```ts
 // packages/backend/src/index.ts
-import { eventsModuleGithubEventRouter } from '@backstage/plugin-events-backend-module-github/alpha';
-// ...
-backend.add(eventsModuleGithubEventRouter);
+backend.add(import('@backstage/plugin-events-backend-module-github'));
 ```
 
-#### Legacy Backend System
+### Legacy Backend System
+
+#### Event Router
 
 ```ts
 // packages/backend/src/plugins/events.ts
@@ -44,16 +42,7 @@ const eventRouter = new GithubEventRouter({ events: env.events });
 await eventRouter.subscribe();
 ```
 
-### Signature Validator
-
-```ts
-// packages/backend/src/index.ts
-import { eventsModuleGithubWebhook } from '@backstage/plugin-events-backend-module-github/alpha';
-// ...
-backend.add(eventsModuleGithubWebhook);
-```
-
-#### Legacy Backend System
+#### Signature Validator
 
 Add the signature validator for the topic `github`:
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Just encountered this while upgrading to 1.38.

The `/alpha` exports have been removed in #29598 and the default exports a backend feature loader directly.

So now instead of adding in the backend the event router _and_ the signature validator, we just have to do a single `backend.add(import('@backstage/plugin-events-backend-module-github'));`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] ~A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))~
- [X] Added or updated documentation
- [X] ~Tests for new functionality and regression tests for bug fixes~
- [X] ~Screenshots attached (for UI changes)~
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
