### PR TITLE
.github/ISSUE_TEMPLATE: fix triage label

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug.yaml
+++ b/.github/ISSUE_TEMPLATE/01_bug.yaml
@@ -2,7 +2,7 @@ name: '🪲 Report a bug'
 description: 'Report a bug that you have encountered'
 labels:
   - type:bug
-  - status:needs-triage
+  - needs:triage
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/02_documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/02_documentation.yaml
@@ -3,7 +3,7 @@ description: 'Report an issue in the Backstage documentation'
 labels:
   - domain:docs
   - type:documentation
-  - status:needs-triage
+  - needs:triage
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/03_suggestion.yaml
+++ b/.github/ISSUE_TEMPLATE/03_suggestion.yaml
@@ -2,7 +2,7 @@ name: '💡 Suggest a change'
 description: 'Suggest an idea for a new feature or change to Backstage'
 labels:
   - type:suggestion
-  - status:needs-triage
+  - needs:triage
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/04_maintenance.yaml
+++ b/.github/ISSUE_TEMPLATE/04_maintenance.yaml
@@ -2,7 +2,7 @@ name: '🚧 Track a maintenance task'
 description: 'Track a maintenance task'
 labels:
   - type:maintenance
-  - status:needs-triage
+  - needs:triage
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/05_other.yaml
+++ b/.github/ISSUE_TEMPLATE/05_other.yaml
@@ -1,5 +1,7 @@
 name: '❓ Other'
 description: 'Something not captured by any other template'
+labels:
+  - needs:triage
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
🧹, followup for #29677, templates were using the wrong initial triage label