### PR TITLE
Let fs:delete wildcard patterns match paths that start with "."

### DIFF
--- a/.changeset/sad-taxes-bake.md
+++ b/.changeset/sad-taxes-bake.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Fixed bug in fs:delete that prevented wildcard patterns from matching paths starting with "."

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/filesystem/delete.examples.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/filesystem/delete.examples.ts
@@ -48,4 +48,19 @@ export const examples: TemplateExample[] = [
       ],
     }),
   },
+  {
+    description: 'Delete all files in workspace',
+    example: yaml.stringify({
+      steps: [
+        {
+          action: 'fs:delete',
+          id: 'deleteFiles',
+          name: 'Delete files',
+          input: {
+            files: ['**'],
+          },
+        },
+      ],
+    }),
+  },
 ];

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/filesystem/delete.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/filesystem/delete.test.ts
@@ -40,8 +40,14 @@ describe('fs:delete', () => {
       [workspacePath]: {
         'unit-test-a.js': 'hello',
         'unit-test-b.js': 'world',
-        'a-folder': {
-          'unit-test-in-a-folder.js2': 'content',
+        '.dotfile': 'content',
+        '.dotdir': {
+          '.dotfile': 'content',
+          'reg-file.js': 'content',
+        },
+        regdir: {
+          '.dotfile': 'content',
+          'reg-file.js': 'content',
         },
       },
     });
@@ -157,6 +163,64 @@ describe('fs:delete', () => {
     await action.handler({
       ...mockContext,
       input: { files: files.map(file => `.\\${file}`) },
+    });
+
+    files.forEach(file => {
+      const filePath = resolvePath(workspacePath, file);
+      const fileExists = fs.existsSync(filePath);
+      expect(fileExists).toBe(false);
+    });
+  });
+
+  it('. pattern should match nested and hidden files', async () => {
+    const files = [
+      'unit-test-a.js',
+      'unit-test-b.js',
+      '.dotfile',
+      '.dotdir/.dotfile',
+      '.dotdir/reg-file.js',
+      'regdir/.dotfile',
+      'regdir/reg-file.js',
+    ];
+
+    files.forEach(file => {
+      const filePath = resolvePath(workspacePath, file);
+      const fileExists = fs.existsSync(filePath);
+      expect(fileExists).toBe(true);
+    });
+
+    await action.handler({
+      ...mockContext,
+      input: { files: ['.'] },
+    });
+
+    files.forEach(file => {
+      const filePath = resolvePath(workspacePath, file);
+      const fileExists = fs.existsSync(filePath);
+      expect(fileExists).toBe(false);
+    });
+  });
+
+  it('** pattern should match nested and hidden files', async () => {
+    const files = [
+      'unit-test-a.js',
+      'unit-test-b.js',
+      '.dotfile',
+      '.dotdir/.dotfile',
+      '.dotdir/reg-file.js',
+      'regdir/.dotfile',
+      'regdir/reg-file.js',
+    ];
+
+    files.forEach(file => {
+      const filePath = resolvePath(workspacePath, file);
+      const fileExists = fs.existsSync(filePath);
+      expect(fileExists).toBe(true);
+    });
+
+    await action.handler({
+      ...mockContext,
+      input: { files: ['**'] },
     });
 
     files.forEach(file => {

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/filesystem/delete.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/filesystem/delete.ts
@@ -61,6 +61,7 @@ export const createFilesystemDeleteAction = () => {
         const resolvedPaths = await globby(safeFilepath, {
           cwd: ctx.workspacePath,
           absolute: true,
+          dot: true,
         });
 
         for (const filepath of resolvedPaths) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#28777 added wildcard support to fs:delete but changed its behavior. globby's default options prevent it from matching entries that begin with a period. This PR adds the `dot: true` option to globby to restore the previous behavior.

### References:
https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#dot
https://github.com/micromatch/picomatch#matching-behavior-vs-bash

### Example:
```
    - id: delete
      name: Refresh Workspace
      action: fs:delete
      input:
        files:
        - "."
```

Before [scaffolder-backend 1.30.0](https://github.com/backstage/backstage/blob/master/plugins/scaffolder-backend/CHANGELOG.md#1300) this would recursively delete all files in the workspace. After 1.30.0, that pattern no longer matched dotfiles or paths that start with `.` such as:

```
.circleci/config.yml
.github/CODEOWNERS
.github/workflows/labels.yml
.gitignore
```

Those files and directories would remain in the workspace and be actioned by subsequent steps, breaking the template.

With this change, "." as the pattern works like it did before.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
