### PR TITLE
.github/workflows: add issue label automation

### DIFF
--- a/.github/workflows/automate_issue_labels.yml
+++ b/.github/workflows/automate_issue_labels.yml
@@ -1,0 +1,19 @@
+name: Automate issue labels
+on:
+  issues:
+    types:
+      - labeled
+
+jobs:
+  stale:
+    permissions:
+      issues: write
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Remove needs:triage label
+        uses: actions-ecosystem/action-remove-labels@v1
+        if: ${{ startsWith(github.event.label.name, 'priority:') || ( startsWith(github.event.label.name, 'needs:') && github.event.label.name != 'needs:triage' ) }}
+        with:
+          labels: needs:triage


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds a new workflow with a tiny bit of automation around issue labels. If any `priority:*` or `needs:*` label is added other than `needs:triage`, the `needs:triage` label is removed.