### PR TITLE
OWNERS.md: add new distinct areas for maintainer team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,28 +7,50 @@
 *                                                 @backstage/maintainers @backstage/reviewers
 yarn.lock                                         @backstage/maintainers @backstage-service
 */yarn.lock                                       @backstage/maintainers @backstage-service
+/.changeset                                       @backstage/operations-maintainers
 /.changeset/*.md
+/.github                                          @backstage/operations-maintainers
 /beps/0001-notifications-system                   @backstage/maintainers @backstage/notifications-maintainers
 /docs                                             @backstage/maintainers @backstage/documentation-maintainers
 /docs/assets/search                               @backstage/search-maintainers
-/docs/features/search                             @backstage/search-maintainers
+/docs/auth                                        @backstage/auth-maintainers
+/docs/backend-system                              @backstage/framework-maintainers
+/docs/deployment                                  @backstage/tooling-maintainers
 /docs/dls                                         @backstage/design-system-maintainers
+/docs/features/search                             @backstage/search-maintainers
 /docs/features/techdocs                           @backstage/techdocs-maintainers
+/docs/permissions                                 @backstage/permission-maintainers
 /docs/plugins/integrating-search-into-plugins.md  @backstage/search-maintainers
+/docs/releases                                    @backstage/operations-maintainers
+/docs/tooling                                     @backstage/tooling-maintainers
 /microsite                                        @backstage/documentation-maintainers
 /microsite/data/plugins                           @backstage/maintainers
-/packages/cli/src/commands/onboard                @backstage/sharks
+/packages                                         @backstage/framework-maintainers
 /packages/backend-openapi-utils                   @backstage/maintainers @backstage/reviewers @backstage/openapi-tooling-maintainers
 /packages/canon                                   @backstage/design-system-maintainers
+/packages/catalog-client                          @backstage/catalog-maintainers
+/packages/catalog-model                           @backstage/catalog-maintainers
+/packages/cli                                     @backstage/tooling-maintainers
+/packages/cli-*                                   @backstage/tooling-maintainers
+/packages/cli/src/commands/onboard                @backstage/sharks
+/packages/e2e-test                                @backstage/operations-maintainers
+/packages/eslint-plugin                           @backstage/tooling-maintainers
+/packages/release-manifests                       @backstage/operations-maintainers
+/packages/repo-tools                              @backstage/tooling-maintainers
 /packages/techdocs-cli                            @backstage/techdocs-maintainers
 /packages/techdocs-cli-embedded-app               @backstage/techdocs-maintainers
+/packages/yarn-plugin                             @backstage/tooling-maintainers
+/plugins/app                                      @backstage/framework-maintainers
+/plugins/app-*                                    @backstage/framework-maintainers
+/plugins/auth                                     @backstage/auth-maintainers
+/plugins/auth-*                                   @backstage/auth-maintainers
 /plugins/api-docs                                 @backstage/maintainers @backstage/reviewers @backstage/sda-se-reviewers
 /plugins/bitbucket-cloud-common                   @backstage/maintainers @backstage/reviewers @pjungermann
 /plugins/catalog                                  @backstage/maintainers @backstage/reviewers @backstage/catalog-maintainers
 /plugins/catalog-*                                @backstage/maintainers @backstage/reviewers @backstage/catalog-maintainers
 /plugins/catalog-backend-module-aws               @backstage/maintainers @backstage/reviewers @backstage/catalog-maintainers @pjungermann
 /plugins/catalog-backend-module-bitbucket-cloud   @backstage/maintainers @backstage/reviewers @backstage/catalog-maintainers @pjungermann
-/plugins/catalog-backend-module-backstage-openapi      @backstage/maintainers @backstage/reviewers @backstage/openapi-tooling-maintainers
+/plugins/catalog-backend-module-backstage-openapi @backstage/maintainers @backstage/reviewers @backstage/openapi-tooling-maintainers
 /plugins/catalog-backend-module-msgraph           @backstage/maintainers @backstage/reviewers @backstage/catalog-maintainers @pjungermann
 /plugins/catalog-backend-module-puppetdb          @backstage/maintainers @backstage/reviewers @backstage/catalog-maintainers
 /plugins/catalog-graph                            @backstage/maintainers @backstage/reviewers @backstage/catalog-maintainers @backstage/sda-se-reviewers
@@ -55,6 +77,8 @@ yarn.lock                                         @backstage/maintainers @backst
 /plugins/user-settings                            @backstage/maintainers @backstage/reviewers @backstage/sda-se-reviewers
 /plugins/user-settings-backend                    @backstage/maintainers @backstage/reviewers @backstage/sda-se-reviewers
 /plugins/user-settings-common                     @backstage/maintainers @backstage/reviewers @backstage/sda-se-reviewers
+
+/scripts                                          @backstage/operations-maintainers
 
 /packages/backend-plugin-api/src/services/definitions/AuditorService.ts   @backstage/maintainers @backstage/auditor-maintainers
 /packages/backend-defaults/src/entrypoints/auditor                        @backstage/maintainers @backstage/auditor-maintainers

--- a/.github/ISSUE_TEMPLATE/.common.yaml
+++ b/.github/ISSUE_TEMPLATE/.common.yaml
@@ -42,6 +42,7 @@ body:
         - Events System
         - Home
         - Kubernetes Plugin
+        - Management of this repository
         - Microsite
         - Notifications
         - OpenAPI Tooling

--- a/.github/ISSUE_TEMPLATE/01_bug.yaml
+++ b/.github/ISSUE_TEMPLATE/01_bug.yaml
@@ -58,6 +58,7 @@ body:
         - Events System
         - Home
         - Kubernetes Plugin
+        - Management of this repository
         - Microsite
         - Notifications
         - OpenAPI Tooling

--- a/.github/ISSUE_TEMPLATE/02_documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/02_documentation.yaml
@@ -37,6 +37,7 @@ body:
         - Events System
         - Home
         - Kubernetes Plugin
+        - Management of this repository
         - Microsite
         - Notifications
         - OpenAPI Tooling

--- a/.github/ISSUE_TEMPLATE/03_suggestion.yaml
+++ b/.github/ISSUE_TEMPLATE/03_suggestion.yaml
@@ -50,6 +50,7 @@ body:
         - Events System
         - Home
         - Kubernetes Plugin
+        - Management of this repository
         - Microsite
         - Notifications
         - OpenAPI Tooling

--- a/.github/ISSUE_TEMPLATE/04_maintenance.yaml
+++ b/.github/ISSUE_TEMPLATE/04_maintenance.yaml
@@ -48,6 +48,7 @@ body:
         - Events System
         - Home
         - Kubernetes Plugin
+        - Management of this repository
         - Microsite
         - Notifications
         - OpenAPI Tooling

--- a/.github/advanced-issue-labeler.yml
+++ b/.github/advanced-issue-labeler.yml
@@ -9,8 +9,8 @@ policy:
             keys: ['Auth']
           - name: 'area:catalog'
             keys: ['Catalog']
-          - name: 'area:core'
-            keys: ['Core Framework', 'CLI Tooling']
+          - name: 'area:framework'
+            keys: ['Core Framework']
           - name: 'area:design-system'
             keys: ['Design System']
           - name: 'area:documentation'
@@ -25,6 +25,8 @@ policy:
             keys: ['Notifications']
           - name: 'area:openapi-tooling'
             keys: ['OpenAPI Tooling']
+          - name: 'area:operations'
+            keys: ['Management of this repository']
           - name: 'area:permission'
             keys: ['Permission Framework']
           - name: 'area:search'
@@ -33,6 +35,8 @@ policy:
             keys: ['Software Templates']
           - name: 'area:techdocs'
             keys: ['TechDocs']
+          - name: 'area:tooling'
+            keys: ['CLI Tooling']
       - id: ['integration']
         block-list: []
         label:

--- a/LABELS.md
+++ b/LABELS.md
@@ -39,19 +39,21 @@ These labels indicate which part of Backstage an issue or pull request relates t
 - `area:auditor` - Auditor service and it's use in plugins.
 - `area:auth` - Authentication and 3rd party authorization.
 - `area:catalog` - The Catalog plugin and the Software Catalog model and integrations.
-- `area:core` - The core Backstage framework.
 - `area:design-system` - The Canon design system and library.
 - `area:documentation` - Documentation for adopters, users, and developers.
 - `area:events` - The Events system and integrations for other plugins.
+- `area:framework` - The core Backstage framework.
 - `area:home` - The Home plugin and the main page of the Backstage site.
 - `area:kubernetes` - The Kubernetes plugin and integrations for other plugins.
 - `area:microsite` - The microsite at [backstage.io](https://backstage.io), excluding the documentation.
 - `area:notifications` - The Notifications plugin and integrations for other plugins.
 - `area:openapi-tooling` - The OpenAPI tooling it's use in plugins.
+- `area:operations` - The management and operations of the main Backstage repository.
 - `area:permission` - The Permissions system and permission integrations from other plugins.
 - `area:scaffolder` - The Scaffolder plugin that powers Software Templates.
 - `area:search` - The Search plugin and search integrations for other plugins.
 - `area:techdocs` - The TechDocs plugin.
+- `area:tooling` - The Backstage CLI and repository tooling.
 
 ## Integration Labels - `integration:*`
 

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -15,6 +15,21 @@ Team: @backstage/maintainers
 
 These are the separate project areas of Backstage, each with their own project area maintainers
 
+### Auth
+
+Team: @backstage/auth-maintainers
+
+Scope: The Backstage auth plugin and modules, as well as client-side implementations.
+
+| Name                 | Organization | Team          | GitHub                                          | Discord         |
+| -------------------- | ------------ | ------------- | ----------------------------------------------- | --------------- |
+| Ben Lambert          | Spotify      | Cubic Belugas | [benjdlambert](https://github.com/benjdlambert) | `blam#2159`     |
+| Camila Loiola        | Spotify      | Cubic Belugas | [camilaibs](http://github.com/camilaibs)        | `camilal#0226`  |
+| Fredrik Adelöw       | Spotify      | Cubic Belugas | [freben](https://github.com/freben)             | `freben#3926`   |
+| Mihai Tabara         | Spotify      | Cubic Belugas | [MihaiTabara](http://github.com/MihaiTabara)    | `mihait#3107`   |
+| Patrik Oldsberg      | Spotify      | Cubic Belugas | [Rugvip](https://github.com/Rugvip)             | `Rugvip#0019`   |
+| Vincenzo Scamporlino | Spotify      | Cubic Belugas | [vinzscam](http://github.com/vinzscam)          | `vinzscam#6944` |
+
 ### Catalog
 
 Team: @backstage/catalog-maintainers
@@ -40,6 +55,21 @@ Scope: The Backstage design system, component library, as well as surrounding to
 | ------------------- | ------------ | ------------- | --------------------------------------------- | ------------- |
 | Charles de Dreuille | Spotify      |               | [cdedreuille](https://github.com/cdedreuille) | `cdedreuille` |
 | Patrik Oldsberg     | Spotify      | Cubic Belugas | [Rugvip](https://github.com/Rugvip)           | `Rugvip`      |
+
+### Framework
+
+Team: @backstage/framework-maintainers
+
+Scope: The Backstage core framework, including all revisions of the frontend and backend systems, as well as the App plugin.
+
+| Name                 | Organization | Team          | GitHub                                          | Discord         |
+| -------------------- | ------------ | ------------- | ----------------------------------------------- | --------------- |
+| Ben Lambert          | Spotify      | Cubic Belugas | [benjdlambert](https://github.com/benjdlambert) | `blam#2159`     |
+| Camila Loiola        | Spotify      | Cubic Belugas | [camilaibs](http://github.com/camilaibs)        | `camilal#0226`  |
+| Fredrik Adelöw       | Spotify      | Cubic Belugas | [freben](https://github.com/freben)             | `freben#3926`   |
+| Mihai Tabara         | Spotify      | Cubic Belugas | [MihaiTabara](http://github.com/MihaiTabara)    | `mihait#3107`   |
+| Patrik Oldsberg      | Spotify      | Cubic Belugas | [Rugvip](https://github.com/Rugvip)             | `Rugvip#0019`   |
+| Vincenzo Scamporlino | Spotify      | Cubic Belugas | [vinzscam](http://github.com/vinzscam)          | `vinzscam#6944` |
 
 ### Helm Charts
 
@@ -75,6 +105,36 @@ Scope: The Kubernetes plugin and the base it provides for other plugins to build
 | Name           | Organization | Team | GitHub                                   | Discord      |
 | -------------- | ------------ | ---- | ---------------------------------------- | ------------ |
 | Matthew Clarke | Spotify      |      | [mclarke47](http://github.com/mclarke47) | mclarke#0725 |
+
+### Microsite
+
+Team: @backstage/microsite-maintainers
+
+Scope: The microsite at [backstage.io](https://backstage.io), excluding the documentation.
+
+| Name                 | Organization | Team          | GitHub                                          | Discord         |
+| -------------------- | ------------ | ------------- | ----------------------------------------------- | --------------- |
+| Patrik Oldsberg      | Spotify      | Cubic Belugas | [Rugvip](https://github.com/Rugvip)             | `Rugvip#0019`   |
+| Ben Lambert          | Spotify      | Cubic Belugas | [benjdlambert](https://github.com/benjdlambert) | `blam#2159`     |
+| Camila Loiola        | Spotify      | Cubic Belugas | [camilaibs](http://github.com/camilaibs)        | `camilal#0226`  |
+| Fredrik Adelöw       | Spotify      | Cubic Belugas | [freben](https://github.com/freben)             | `freben#3926`   |
+| Mihai Tabara         | Spotify      | Cubic Belugas | [MihaiTabara](http://github.com/MihaiTabara)    | `mihait#3107`   |
+| Vincenzo Scamporlino | Spotify      | Cubic Belugas | [vinzscam](http://github.com/vinzscam)          | `vinzscam#6944` |
+
+### Operations
+
+Team: @backstage/operations-maintainers
+
+Scope: The management and operation of the main Backstage repository and release process, along with the surrounding tooling.
+
+| Name                 | Organization | Team          | GitHub                                          | Discord         |
+| -------------------- | ------------ | ------------- | ----------------------------------------------- | --------------- |
+| Ben Lambert          | Spotify      | Cubic Belugas | [benjdlambert](https://github.com/benjdlambert) | `blam#2159`     |
+| Camila Loiola        | Spotify      | Cubic Belugas | [camilaibs](http://github.com/camilaibs)        | `camilal#0226`  |
+| Fredrik Adelöw       | Spotify      | Cubic Belugas | [freben](https://github.com/freben)             | `freben#3926`   |
+| Mihai Tabara         | Spotify      | Cubic Belugas | [MihaiTabara](http://github.com/MihaiTabara)    | `mihait#3107`   |
+| Patrik Oldsberg      | Spotify      | Cubic Belugas | [Rugvip](https://github.com/Rugvip)             | `Rugvip#0019`   |
+| Vincenzo Scamporlino | Spotify      | Cubic Belugas | [vinzscam](http://github.com/vinzscam)          | `vinzscam#6944` |
 
 ### Permission Framework
 
@@ -116,6 +176,21 @@ Scope: The TechDocs plugin and related tooling
 | Jackson Chen    | Spotify      | ProTean | [PeaWarrior](https://github.com/PeaWarrior)       | `jacksonc#3322`    |
 | John Philip     | Spotify      | ProTean | [johnphilip283](https://github.com/johnphilip283) | `john_philip#2399` |
 | Sydney Achinger | Spotify      | ProTean | [squid-ney](https://github.com/squid-ney)         | -                  |
+
+### Tooling
+
+Team: @backstage/tooling-maintainers
+
+Scope: All published Backstage CLI tools in the main `backstage` repository that do not belong to other areas, including `@backstage/cli` and `@backstage/repo-tools`.
+
+| Name                 | Organization | Team          | GitHub                                          | Discord         |
+| -------------------- | ------------ | ------------- | ----------------------------------------------- | --------------- |
+| Patrik Oldsberg      | Spotify      | Cubic Belugas | [Rugvip](https://github.com/Rugvip)             | `Rugvip#0019`   |
+| Ben Lambert          | Spotify      | Cubic Belugas | [benjdlambert](https://github.com/benjdlambert) | `blam#2159`     |
+| Camila Loiola        | Spotify      | Cubic Belugas | [camilaibs](http://github.com/camilaibs)        | `camilal#0226`  |
+| Fredrik Adelöw       | Spotify      | Cubic Belugas | [freben](https://github.com/freben)             | `freben#3926`   |
+| Mihai Tabara         | Spotify      | Cubic Belugas | [MihaiTabara](http://github.com/MihaiTabara)    | `mihait#3107`   |
+| Vincenzo Scamporlino | Spotify      | Cubic Belugas | [vinzscam](http://github.com/vinzscam)          | `vinzscam#6944` |
 
 ## Incubating Project Areas
 

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -106,21 +106,6 @@ Scope: The Kubernetes plugin and the base it provides for other plugins to build
 | -------------- | ------------ | ---- | ---------------------------------------- | ------------ |
 | Matthew Clarke | Spotify      |      | [mclarke47](http://github.com/mclarke47) | mclarke#0725 |
 
-### Microsite
-
-Team: @backstage/microsite-maintainers
-
-Scope: The microsite at [backstage.io](https://backstage.io), excluding the documentation.
-
-| Name                 | Organization | Team          | GitHub                                          | Discord         |
-| -------------------- | ------------ | ------------- | ----------------------------------------------- | --------------- |
-| Patrik Oldsberg      | Spotify      | Cubic Belugas | [Rugvip](https://github.com/Rugvip)             | `Rugvip#0019`   |
-| Ben Lambert          | Spotify      | Cubic Belugas | [benjdlambert](https://github.com/benjdlambert) | `blam#2159`     |
-| Camila Loiola        | Spotify      | Cubic Belugas | [camilaibs](http://github.com/camilaibs)        | `camilal#0226`  |
-| Fredrik Adelöw       | Spotify      | Cubic Belugas | [freben](https://github.com/freben)             | `freben#3926`   |
-| Mihai Tabara         | Spotify      | Cubic Belugas | [MihaiTabara](http://github.com/MihaiTabara)    | `mihait#3107`   |
-| Vincenzo Scamporlino | Spotify      | Cubic Belugas | [vinzscam](http://github.com/vinzscam)          | `vinzscam#6944` |
-
 ### Operations
 
 Team: @backstage/operations-maintainers

--- a/packages/app-defaults/catalog-info.yaml
+++ b/packages/app-defaults/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: production
   type: backstage-web-library
-  owner: maintainers
+  owner: framework-maintainers

--- a/packages/app-next-example-plugin/catalog-info.yaml
+++ b/packages/app-next-example-plugin/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-frontend-plugin
-  owner: maintainers
+  owner: framework-maintainers

--- a/packages/app-next/catalog-info.yaml
+++ b/packages/app-next/catalog-info.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-frontend
-  owner: maintainers
+  owner: framework-maintainers

--- a/packages/app/catalog-info.yaml
+++ b/packages/app/catalog-info.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-frontend
-  owner: maintainers
+  owner: framework-maintainers

--- a/packages/backend-app-api/catalog-info.yaml
+++ b/packages/backend-app-api/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-node-library
-  owner: maintainers
+  owner: framework-maintainers

--- a/packages/backend-defaults/catalog-info.yaml
+++ b/packages/backend-defaults/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-node-library
-  owner: maintainers
+  owner: framework-maintainers

--- a/packages/backend-dev-utils/catalog-info.yaml
+++ b/packages/backend-dev-utils/catalog-info.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-node-library
-  owner: maintainers
+  owner: framework-maintainers

--- a/packages/backend-dynamic-feature-service/catalog-info.yaml
+++ b/packages/backend-dynamic-feature-service/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-node-library
-  owner: maintainers
+  owner: framework-maintainers

--- a/packages/backend-plugin-api/catalog-info.yaml
+++ b/packages/backend-plugin-api/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-node-library
-  owner: maintainers
+  owner: framework-maintainers

--- a/packages/backend-test-utils/catalog-info.yaml
+++ b/packages/backend-test-utils/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-node-library
-  owner: maintainers
+  owner: framework-maintainers

--- a/packages/backend/catalog-info.yaml
+++ b/packages/backend/catalog-info.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-backend
-  owner: maintainers
+  owner: framework-maintainers

--- a/packages/catalog-client/catalog-info.yaml
+++ b/packages/catalog-client/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: production
   type: backstage-common-library
-  owner: maintainers
+  owner: catalog-maintainers

--- a/packages/catalog-model/catalog-info.yaml
+++ b/packages/catalog-model/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: production
   type: backstage-common-library
-  owner: maintainers
+  owner: catalog-maintainers

--- a/packages/cli-common/catalog-info.yaml
+++ b/packages/cli-common/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-node-library
-  owner: maintainers
+  owner: tooling-maintainers

--- a/packages/cli-node/catalog-info.yaml
+++ b/packages/cli-node/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-node-library
-  owner: maintainers
+  owner: tooling-maintainers

--- a/packages/cli/catalog-info.yaml
+++ b/packages/cli/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-cli
-  owner: maintainers
+  owner: tooling-maintainers

--- a/packages/codemods/catalog-info.yaml
+++ b/packages/codemods/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-cli
-  owner: maintainers
+  owner: framework-maintainers

--- a/packages/config-loader/catalog-info.yaml
+++ b/packages/config-loader/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: production
   type: backstage-node-library
-  owner: maintainers
+  owner: framework-maintainers

--- a/packages/config/catalog-info.yaml
+++ b/packages/config/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: production
   type: backstage-common-library
-  owner: maintainers
+  owner: framework-maintainers

--- a/packages/core-app-api/catalog-info.yaml
+++ b/packages/core-app-api/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: production
   type: backstage-web-library
-  owner: maintainers
+  owner: framework-maintainers

--- a/packages/core-compat-api/catalog-info.yaml
+++ b/packages/core-compat-api/catalog-info.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-web-library
-  owner: maintainers
+  owner: framework-maintainers

--- a/packages/core-components/catalog-info.yaml
+++ b/packages/core-components/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-web-library
-  owner: maintainers
+  owner: framework-maintainers

--- a/packages/core-plugin-api/catalog-info.yaml
+++ b/packages/core-plugin-api/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: production
   type: backstage-web-library
-  owner: maintainers
+  owner: framework-maintainers

--- a/packages/create-app/catalog-info.yaml
+++ b/packages/create-app/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-cli
-  owner: maintainers
+  owner: framework-maintainers

--- a/packages/dev-utils/catalog-info.yaml
+++ b/packages/dev-utils/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: production
   type: backstage-web-library
-  owner: maintainers
+  owner: framework-maintainers

--- a/packages/e2e-test-utils/catalog-info.yaml
+++ b/packages/e2e-test-utils/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-node-library
-  owner: maintainers
+  owner: framework-maintainers

--- a/packages/e2e-test/catalog-info.yaml
+++ b/packages/e2e-test/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-cli
-  owner: maintainers
+  owner: operations-maintainers

--- a/packages/errors/catalog-info.yaml
+++ b/packages/errors/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: production
   type: backstage-common-library
-  owner: maintainers
+  owner: framework-maintainers

--- a/packages/frontend-app-api/catalog-info.yaml
+++ b/packages/frontend-app-api/catalog-info.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-web-library
-  owner: maintainers
+  owner: framework-maintainers

--- a/packages/frontend-defaults/catalog-info.yaml
+++ b/packages/frontend-defaults/catalog-info.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-web-library
-  owner: maintainers
+  owner: framework-maintainers

--- a/packages/frontend-dynamic-feature-loader/catalog-info.yaml
+++ b/packages/frontend-dynamic-feature-loader/catalog-info.yaml
@@ -3,8 +3,9 @@ kind: Component
 metadata:
   name: backstage-frontend-dynamic-feature-loader
   title: '@backstage/frontend-dynamic-feature-loader'
-  description: Backstage frontend feature loader to load new frontend system plugins exposed as module federation remotes.
+  description: Backstage frontend feature loader to load new frontend system
+    plugins exposed as module federation remotes.
 spec:
   lifecycle: experimental
   type: backstage-web-library
-  owner: maintainers
+  owner: framework-maintainers

--- a/packages/frontend-internal/catalog-info.yaml
+++ b/packages/frontend-internal/catalog-info.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-web-library
-  owner: maintainers
+  owner: framework-maintainers

--- a/packages/frontend-plugin-api/catalog-info.yaml
+++ b/packages/frontend-plugin-api/catalog-info.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-web-library
-  owner: maintainers
+  owner: framework-maintainers

--- a/packages/frontend-test-utils/catalog-info.yaml
+++ b/packages/frontend-test-utils/catalog-info.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-web-library
-  owner: maintainers
+  owner: framework-maintainers

--- a/packages/integration-aws-node/catalog-info.yaml
+++ b/packages/integration-aws-node/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-node-library
-  owner: maintainers
+  owner: framework-maintainers

--- a/packages/integration-react/catalog-info.yaml
+++ b/packages/integration-react/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: production
   type: backstage-web-library
-  owner: maintainers
+  owner: framework-maintainers

--- a/packages/integration/catalog-info.yaml
+++ b/packages/integration/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: production
   type: backstage-common-library
-  owner: maintainers
+  owner: framework-maintainers

--- a/packages/opaque-internal/catalog-info.yaml
+++ b/packages/opaque-internal/catalog-info.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-common-library
-  owner: maintainers
+  owner: framework-maintainers

--- a/packages/release-manifests/catalog-info.yaml
+++ b/packages/release-manifests/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-common-library
-  owner: maintainers
+  owner: operations-maintainers

--- a/packages/repo-tools/catalog-info.yaml
+++ b/packages/repo-tools/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-cli
-  owner: maintainers
+  owner: tooling-maintainers

--- a/packages/scaffolder-internal/catalog-info.yaml
+++ b/packages/scaffolder-internal/catalog-info.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-web-library
-  owner: maintainers
+  owner: framework-maintainers

--- a/packages/test-utils/catalog-info.yaml
+++ b/packages/test-utils/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: production
   type: backstage-web-library
-  owner: maintainers
+  owner: framework-maintainers

--- a/packages/theme/catalog-info.yaml
+++ b/packages/theme/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-web-library
-  owner: maintainers
+  owner: framework-maintainers

--- a/packages/types/catalog-info.yaml
+++ b/packages/types/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: production
   type: backstage-common-library
-  owner: maintainers
+  owner: framework-maintainers

--- a/packages/version-bridge/catalog-info.yaml
+++ b/packages/version-bridge/catalog-info.yaml
@@ -4,9 +4,8 @@ metadata:
   name: backstage-version-bridge
   title: '@backstage/version-bridge'
   description: >-
-    Utilities used by @backstage packages to support multiple concurrent
-    versions
+    Utilities used by @backstage packages to support multiple concurrent versions
 spec:
   lifecycle: production
   type: backstage-web-library
-  owner: maintainers
+  owner: framework-maintainers

--- a/packages/yarn-plugin/catalog-info.yaml
+++ b/packages/yarn-plugin/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-node-library
-  owner: maintainers
+  owner: tooling-maintainers

--- a/plugins/app-backend/catalog-info.yaml
+++ b/plugins/app-backend/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-backend-plugin
-  owner: maintainers
+  owner: framework-maintainers

--- a/plugins/app-node/catalog-info.yaml
+++ b/plugins/app-node/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-node-library
-  owner: maintainers
+  owner: framework-maintainers

--- a/plugins/app-visualizer/catalog-info.yaml
+++ b/plugins/app-visualizer/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-frontend-plugin
-  owner: maintainers
+  owner: framework-maintainers

--- a/plugins/app/catalog-info.yaml
+++ b/plugins/app/catalog-info.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-frontend-plugin
-  owner: maintainers
+  owner: framework-maintainers

--- a/plugins/auth-backend-module-atlassian-provider/catalog-info.yaml
+++ b/plugins/auth-backend-module-atlassian-provider/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-backend-plugin-module
-  owner: maintainers
+  owner: auth-maintainers

--- a/plugins/auth-backend-module-auth0-provider/catalog-info.yaml
+++ b/plugins/auth-backend-module-auth0-provider/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-backend-plugin-module
-  owner: maintainers
+  owner: auth-maintainers

--- a/plugins/auth-backend-module-aws-alb-provider/catalog-info.yaml
+++ b/plugins/auth-backend-module-aws-alb-provider/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-backend-plugin-module
-  owner: maintainers
+  owner: auth-maintainers

--- a/plugins/auth-backend-module-azure-easyauth-provider/catalog-info.yaml
+++ b/plugins/auth-backend-module-azure-easyauth-provider/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-backend-plugin-module
-  owner: maintainers
+  owner: auth-maintainers

--- a/plugins/auth-backend-module-bitbucket-provider/catalog-info.yaml
+++ b/plugins/auth-backend-module-bitbucket-provider/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-backend-plugin-module
-  owner: maintainers
+  owner: auth-maintainers

--- a/plugins/auth-backend-module-bitbucket-server-provider/catalog-info.yaml
+++ b/plugins/auth-backend-module-bitbucket-server-provider/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-backend-plugin-module
-  owner: maintainers
+  owner: auth-maintainers

--- a/plugins/auth-backend-module-cloudflare-access-provider/catalog-info.yaml
+++ b/plugins/auth-backend-module-cloudflare-access-provider/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-backend-plugin-module
-  owner: maintainers
+  owner: auth-maintainers

--- a/plugins/auth-backend-module-gcp-iap-provider/catalog-info.yaml
+++ b/plugins/auth-backend-module-gcp-iap-provider/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-backend-plugin-module
-  owner: maintainers
+  owner: auth-maintainers

--- a/plugins/auth-backend-module-github-provider/catalog-info.yaml
+++ b/plugins/auth-backend-module-github-provider/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-backend-plugin-module
-  owner: maintainers
+  owner: auth-maintainers

--- a/plugins/auth-backend-module-gitlab-provider/catalog-info.yaml
+++ b/plugins/auth-backend-module-gitlab-provider/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-backend-plugin-module
-  owner: maintainers
+  owner: auth-maintainers

--- a/plugins/auth-backend-module-google-provider/catalog-info.yaml
+++ b/plugins/auth-backend-module-google-provider/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-backend-plugin-module
-  owner: maintainers
+  owner: auth-maintainers

--- a/plugins/auth-backend-module-guest-provider/catalog-info.yaml
+++ b/plugins/auth-backend-module-guest-provider/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-backend-plugin-module
-  owner: maintainers
+  owner: auth-maintainers

--- a/plugins/auth-backend-module-microsoft-provider/catalog-info.yaml
+++ b/plugins/auth-backend-module-microsoft-provider/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-backend-plugin-module
-  owner: maintainers
+  owner: auth-maintainers

--- a/plugins/auth-backend-module-oauth2-provider/catalog-info.yaml
+++ b/plugins/auth-backend-module-oauth2-provider/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-backend-plugin-module
-  owner: maintainers
+  owner: auth-maintainers

--- a/plugins/auth-backend-module-oauth2-proxy-provider/catalog-info.yaml
+++ b/plugins/auth-backend-module-oauth2-proxy-provider/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-backend-plugin-module
-  owner: maintainers
+  owner: auth-maintainers

--- a/plugins/auth-backend-module-oidc-provider/catalog-info.yaml
+++ b/plugins/auth-backend-module-oidc-provider/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-backend-plugin-module
-  owner: maintainers
+  owner: auth-maintainers

--- a/plugins/auth-backend-module-okta-provider/catalog-info.yaml
+++ b/plugins/auth-backend-module-okta-provider/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-backend-plugin-module
-  owner: maintainers
+  owner: auth-maintainers

--- a/plugins/auth-backend-module-onelogin-provider/catalog-info.yaml
+++ b/plugins/auth-backend-module-onelogin-provider/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-backend-plugin-module
-  owner: maintainers
+  owner: auth-maintainers

--- a/plugins/auth-backend-module-pinniped-provider/catalog-info.yaml
+++ b/plugins/auth-backend-module-pinniped-provider/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-backend-plugin-module
-  owner: maintainers
+  owner: auth-maintainers

--- a/plugins/auth-backend-module-vmware-cloud-provider/catalog-info.yaml
+++ b/plugins/auth-backend-module-vmware-cloud-provider/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-backend-plugin-module
-  owner: maintainers
+  owner: auth-maintainers

--- a/plugins/auth-backend/catalog-info.yaml
+++ b/plugins/auth-backend/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-backend-plugin
-  owner: maintainers
+  owner: auth-maintainers

--- a/plugins/auth-node/catalog-info.yaml
+++ b/plugins/auth-node/catalog-info.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-node-library
-  owner: maintainers
+  owner: auth-maintainers

--- a/plugins/auth-react/catalog-info.yaml
+++ b/plugins/auth-react/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   lifecycle: experimental
   type: backstage-web-library
-  owner: maintainers
+  owner: auth-maintainers


### PR DESCRIPTION
This proposes a couple of new project areas that assigns ownership to existing parts of the project currently owned by the core maintainers. The new areas are Auth, Framework, Microsite, Operations, and Tooling. See the changes in `OWNERS.md` for what the proposed scope of each of them is, and `.github/CODEOWNERS` for code ownership. Additionally, the `@backstage/operations-maintainers` team would have the necessary access to perform releases.

There are a couple of purposes of this change:
- Carve out important areas of the project and assigning them a name and scope, in order to make it easier to communicate around them and prioritize work.
- Move more direct code ownership away from the immediate @backstage/maintainers team and instead use the broader team and Spotify that the maintainers are part of in order to include the entire team and better reflect reality.
- Create more areas of opportunity for new project area maintainers to be onboarded into existing parts of the projects that was previously owned only by the core maintainers. Please reach out if you are interested in being a maintainer of any of these new areas! 🙏