### PR TITLE
fix slack notification processor attachment blocks

### DIFF
--- a/.changeset/crazy-chefs-sin.md
+++ b/.changeset/crazy-chefs-sin.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications-backend-module-slack': patch
+---
+
+Fix slack notification processor to handle a notification with an empty description

--- a/plugins/notifications-backend-module-slack/src/lib/SlackNotificationProcessor.test.ts
+++ b/plugins/notifications-backend-module-slack/src/lib/SlackNotificationProcessor.test.ts
@@ -158,6 +158,10 @@ describe('SlackNotificationProcessor', () => {
           blocks: [
             {
               type: 'section',
+              text: {
+                text: 'No description provided',
+                type: 'mrkdwn',
+              },
               accessory: {
                 type: 'button',
                 text: {
@@ -229,6 +233,10 @@ describe('SlackNotificationProcessor', () => {
             blocks: [
               {
                 type: 'section',
+                text: {
+                  text: 'No description provided',
+                  type: 'mrkdwn',
+                },
                 accessory: {
                   type: 'button',
                   text: {

--- a/plugins/notifications-backend-module-slack/src/lib/util.ts
+++ b/plugins/notifications-backend-module-slack/src/lib/util.ts
@@ -46,12 +46,10 @@ export function toSlackBlockKit(payload: NotificationPayload): KnownBlock[] {
   return [
     {
       type: 'section',
-      ...(description && {
-        text: {
-          type: 'mrkdwn',
-          text: description ?? 'No description provided',
-        },
-      }),
+      text: {
+        type: 'mrkdwn',
+        text: description ?? 'No description provided',
+      },
       accessory: {
         type: 'button',
         text: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

A `section` block requires that either a `text` or `fields` item be included (see [docs](https://api.slack.com/reference/block-kit/blocks#section)). Since we were already defaulting the `payload.description`, this change simply ensures that the text portion of the block is specified (with tests updated accordingly).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))