### PR TITLE
Fix: renderInTestApp act warnings

### DIFF
--- a/.changeset/ninety-donkeys-shop.md
+++ b/.changeset/ninety-donkeys-shop.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-app-api': patch
+---
+
+Fixed an issue causing `OAuthRequestDialog` to re-render on mount.

--- a/packages/core-app-api/src/apis/implementations/OAuthRequestApi/OAuthRequestManager.test.ts
+++ b/packages/core-app-api/src/apis/implementations/OAuthRequestApi/OAuthRequestManager.test.ts
@@ -34,12 +34,12 @@ describe('OAuthRequestManager', () => {
 
     expect(reqSpy).toHaveBeenCalledTimes(0);
     await 'a tick';
-    expect(reqSpy).toHaveBeenCalledTimes(2);
+    expect(reqSpy).toHaveBeenCalledTimes(1);
     expect(reqSpy).toHaveBeenLastCalledWith([]);
 
     const req = requester(new Set(['my-scope']));
 
-    expect(reqSpy).toHaveBeenCalledTimes(3);
+    expect(reqSpy).toHaveBeenCalledTimes(2);
     expect(reqSpy).toHaveBeenLastCalledWith([
       expect.objectContaining({
         reject: expect.any(Function),
@@ -51,7 +51,7 @@ describe('OAuthRequestManager', () => {
       'not yet',
     );
 
-    const [request] = reqSpy.mock.calls[2][0];
+    const [request] = reqSpy.mock.calls[1][0];
     request.trigger();
 
     await expect(req).resolves.toBe('hello');

--- a/packages/core-app-api/src/apis/implementations/OAuthRequestApi/OAuthRequestManager.ts
+++ b/packages/core-app-api/src/apis/implementations/OAuthRequestApi/OAuthRequestManager.ts
@@ -22,7 +22,7 @@ import {
 } from '@backstage/core-plugin-api';
 import { Observable } from '@backstage/types';
 import { OAuthPendingRequests, PendingRequest } from './OAuthPendingRequests';
-import { BehaviorSubject } from '../../../lib/subjects';
+import { PublishSubject } from '../../../lib/subjects';
 
 /**
  * The OAuthRequestManager is an implementation of the OAuthRequestApi.
@@ -34,7 +34,7 @@ import { BehaviorSubject } from '../../../lib/subjects';
  * @public
  */
 export class OAuthRequestManager implements OAuthRequestApi {
-  private readonly subject = new BehaviorSubject<PendingOAuthRequest[]>([]);
+  private readonly subject = new PublishSubject<PendingOAuthRequest[]>();
   private currentRequests: PendingOAuthRequest[] = [];
   private handlerCount = 0;
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I've noticed that all our tests using `renderInTestApp` from `@backstage/frontend-test-utils` are flooded with the following warnings:

```
   Warning: An update to OAuthRequestDialog inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
```    

this is caused by the `BehaviorSubject` inside `OAuthRequestManager` which causes the re-render of `OAuthRequestDialog` on mount. Since the component is globally mounted, I don't think `BehaviorSubject` is necessary. I'm happy to fix the problem internally in `OAuthRequestDialog` if there are other use cases for `BehaviorSubject` that I may have missed.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
