### PR TITLE
.github/workflows/automate_stale: separate stale rules for needs:repro

### DIFF
--- a/.github/workflows/automate_stale.yml
+++ b/.github/workflows/automate_stale.yml
@@ -19,8 +19,8 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
-        id: stale
+      - name: Stale check - base
+        uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           stale-issue-message: >
             This issue has been automatically marked as stale because it has not had
@@ -40,3 +40,19 @@ jobs:
           exempt-pr-labels: after vacations,no stale
           stale-pr-label: stale
           operations-per-run: 100
+
+      - name: Stale check - bugs without repro
+        uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
+        with:
+          stale-issue-message: >
+            This bug report has been automatically marked as stale because it has not had
+            recent activity and does not have valid steps to reproduce. It will be closed
+            if no further activity occurs. If the PR was closed and you want it re-opened,
+            let us know and we'll re-open the PR so that you can continue the contribution!
+          days-before-stale: 30
+          days-before-close: 7
+          days-before-pr-stale: -1
+          exempt-issue-labels: after vacations,no stale
+          only-labels: type:bug,needs:repro
+          stale-issue-label: stale
+          operations-per-run: 50


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The intention of this is to add a separate stale interval and message for bug reports with the `needs:repro` label.