### PR TITLE
cli: add separate type for command context and try forwarding to clipanion command

### DIFF
--- a/packages/cli/src/modules/config/alpha.ts
+++ b/packages/cli/src/modules/config/alpha.ts
@@ -102,13 +102,13 @@ export default createCliPlugin({
       path: ['config', 'check'],
       description:
         'Validate that the given configuration loads and matches schema',
-      execute: async ({ args, info }) => {
+      execute: async ctx => {
         const { ValidateCommand } =
           require('./commands/validate') as typeof import('./commands/validate');
         ValidateCommand.usage = ClipanionCommand.Usage({
-          description: info.description,
+          description: ctx.info.description,
         });
-        runExit({ binaryName: info.usage }, ValidateCommand, args);
+        runExit({ binaryName: ctx.info.usage }, ValidateCommand, ctx.args, ctx);
       },
     });
 

--- a/packages/cli/src/modules/config/commands/validate.ts
+++ b/packages/cli/src/modules/config/commands/validate.ts
@@ -16,7 +16,8 @@
 
 import { OptionValues } from 'commander';
 import { loadCliConfig } from '../lib/config';
-import { Command, Option } from 'clipanion';
+import { BaseContext, Command, Option } from 'clipanion';
+import { BackstageCommandContext } from '../../../wiring/types';
 
 export default async (opts: OptionValues) => {
   await loadCliConfig({
@@ -29,7 +30,9 @@ export default async (opts: OptionValues) => {
   });
 };
 
-export class ValidateCommand extends Command {
+export class ValidateCommand extends Command<
+  BackstageCommandContext & BaseContext
+> {
   package = Option.String('--package', {
     description: 'Only load config schema that applies to the given package',
   });

--- a/packages/cli/src/wiring/types.ts
+++ b/packages/cli/src/wiring/types.ts
@@ -15,24 +15,32 @@
  */
 import { CommandRegistry } from './CommandRegistry';
 
-export interface BackstageCommand {
+export interface BackstageCommandContext {
+  /**
+   * The arguments passed to the command
+   */
+  args: string[];
+  /**
+   * General information relevant to the command
+   */
+  info: {
+    /**
+     * The usage string of the current command, for example: "backstage-cli repo test"
+     */
+    usage: string;
+    /**
+     * The description provided for the command
+     */
+    description: string;
+  };
+}
+
+export type BackstageCommand = {
   path: string[];
   description: string;
   deprecated?: boolean;
-  execute: (context: {
-    args: string[];
-    info: {
-      /**
-       * The usage string of the current command, for example: "backstage-cli repo test"
-       */
-      usage: string;
-      /**
-       * The description provided for the command
-       */
-      description: string;
-    };
-  }) => Promise<void>;
-}
+  execute(context: BackstageCommandContext): Promise<void>;
+};
 
 export interface CliFeature {
   $$type: '@backstage/CliFeature';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Seeing what it looks like to wrap things up in an explicit command context type and forwarding to Clipanion

On top of #29745