### PR TITLE
hopefully fix ci flakiness in kubernetes backend

### DIFF
--- a/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.test.ts
@@ -333,6 +333,8 @@ describe('KubernetesFanOutHandler', () => {
   });
 
   beforeEach(() => {
+    // Fake timers helps prevent k8s internals from firing after test teardown
+    jest.useFakeTimers();
     jest.resetAllMocks();
 
     fetchObjectsForService.mockImplementation((params: ObjectFetchParams) =>


### PR DESCRIPTION
In all honesty I'm still not 100% sure about the cause here. It _seems_ that after upgrading to the new kubernetes client library, it behaves differently in terms of timings and how it fires off work. So our code got called after the end of the test.

Maybe there's somewhere that an extra await or explicit teardown is needed. But we need to get rid of the CI flake too because it's being fairly troublesome.