### PR TITLE
Canon - Fix - Clicking Select label moves focus to trigger.

### DIFF
--- a/.changeset/floppy-days-tell.md
+++ b/.changeset/floppy-days-tell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/canon': patch
+---
+
+For improved a11y, clicking a Select component label now focuses the Select trigger element.

--- a/.changeset/floppy-days-tell.md
+++ b/.changeset/floppy-days-tell.md
@@ -2,4 +2,4 @@
 '@backstage/canon': patch
 ---
 
-For improved a11y, clicking a Select component label now focuses the Select trigger element.
+For improved a11y, clicking a Select component label now focuses the Select trigger element, and the TextField component's label is now styled to indicate it's interactive.

--- a/packages/canon/css/components.css
+++ b/packages/canon/css/components.css
@@ -836,6 +836,11 @@
   font-weight: var(--canon-font-weight-regular);
   color: var(--canon-fg-primary);
   margin-bottom: var(--canon-space-1_5);
+  cursor: pointer;
+}
+
+.canon-SelectLabel[data-disabled] {
+  cursor: default;
 }
 
 .canon-SelectDescription {

--- a/packages/canon/css/components.css
+++ b/packages/canon/css/components.css
@@ -543,6 +543,11 @@
   font-weight: var(--canon-font-weight-regular);
   color: var(--canon-fg-primary);
   margin-bottom: var(--canon-space-1_5);
+  cursor: pointer;
+}
+
+.canon-TextFieldLabel[data-disabled] {
+  cursor: default;
 }
 
 .canon-TextFieldDescription {

--- a/packages/canon/css/select.css
+++ b/packages/canon/css/select.css
@@ -10,6 +10,11 @@
   font-weight: var(--canon-font-weight-regular);
   color: var(--canon-fg-primary);
   margin-bottom: var(--canon-space-1_5);
+  cursor: pointer;
+}
+
+.canon-SelectLabel[data-disabled] {
+  cursor: default;
 }
 
 .canon-SelectDescription {

--- a/packages/canon/css/styles.css
+++ b/packages/canon/css/styles.css
@@ -10060,6 +10060,11 @@
   font-weight: var(--canon-font-weight-regular);
   color: var(--canon-fg-primary);
   margin-bottom: var(--canon-space-1_5);
+  cursor: pointer;
+}
+
+.canon-SelectLabel[data-disabled] {
+  cursor: default;
 }
 
 .canon-SelectDescription {

--- a/packages/canon/css/styles.css
+++ b/packages/canon/css/styles.css
@@ -9767,6 +9767,11 @@
   font-weight: var(--canon-font-weight-regular);
   color: var(--canon-fg-primary);
   margin-bottom: var(--canon-space-1_5);
+  cursor: pointer;
+}
+
+.canon-TextFieldLabel[data-disabled] {
+  cursor: default;
 }
 
 .canon-TextFieldDescription {

--- a/packages/canon/css/textfield.css
+++ b/packages/canon/css/textfield.css
@@ -10,6 +10,11 @@
   font-weight: var(--canon-font-weight-regular);
   color: var(--canon-fg-primary);
   margin-bottom: var(--canon-space-1_5);
+  cursor: pointer;
+}
+
+.canon-TextFieldLabel[data-disabled] {
+  cursor: default;
 }
 
 .canon-TextFieldDescription {

--- a/packages/canon/src/components/Select/Select.styles.css
+++ b/packages/canon/src/components/Select/Select.styles.css
@@ -26,6 +26,10 @@
   font-weight: var(--canon-font-weight-regular);
   color: var(--canon-fg-primary);
   margin-bottom: var(--canon-space-1_5);
+  cursor: pointer;
+}
+.canon-SelectLabel[data-disabled] {
+  cursor: default;
 }
 
 .canon-SelectDescription {

--- a/packages/canon/src/components/Select/Select.tsx
+++ b/packages/canon/src/components/Select/Select.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { forwardRef, useId } from 'react';
+import { forwardRef, useCallback, useId, useRef, MouseEvent } from 'react';
 import { Select as SelectPrimitive } from '@base-ui-components/react/select';
 import { Icon } from '../Icon';
 import clsx from 'clsx';
@@ -45,10 +45,27 @@ export const Select = forwardRef<HTMLDivElement, SelectProps>((props, ref) => {
   const descriptionId = useId();
   const errorId = useId();
 
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const handleLabelClick = useCallback(
+    (e: MouseEvent<HTMLLabelElement>) => {
+      if (!props.disabled && triggerRef.current) {
+        e.preventDefault();
+        triggerRef.current.focus();
+      }
+    },
+    [props.disabled],
+  );
+
   return (
     <div className={clsx('canon-Select', className)} style={style} ref={ref}>
       {label && (
-        <label className="canon-SelectLabel" htmlFor={selectId}>
+        <label
+          className="canon-SelectLabel"
+          htmlFor={selectId}
+          onClick={handleLabelClick}
+          data-disabled={props.disabled ? true : undefined}
+        >
           {label}
           {required && (
             <span aria-hidden="true" className="canon-SelectRequired">
@@ -59,6 +76,7 @@ export const Select = forwardRef<HTMLDivElement, SelectProps>((props, ref) => {
       )}
       <SelectPrimitive.Root {...rest}>
         <SelectPrimitive.Trigger
+          ref={triggerRef}
           id={selectId}
           className="canon-SelectTrigger"
           data-size={responsiveSize}

--- a/packages/canon/src/components/TextField/TextField.styles.css
+++ b/packages/canon/src/components/TextField/TextField.styles.css
@@ -26,6 +26,10 @@
   font-weight: var(--canon-font-weight-regular);
   color: var(--canon-fg-primary);
   margin-bottom: var(--canon-space-1_5);
+  cursor: pointer;
+}
+.canon-TextFieldLabel[data-disabled] {
+  cursor: default;
 }
 
 .canon-TextFieldDescription {

--- a/packages/canon/src/components/TextField/TextField.tsx
+++ b/packages/canon/src/components/TextField/TextField.tsx
@@ -32,6 +32,7 @@ export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(
       error,
       required,
       style,
+      disabled,
       ...rest
     } = props;
 
@@ -50,7 +51,11 @@ export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(
         ref={ref}
       >
         {label && (
-          <label className="canon-TextFieldLabel" htmlFor={inputId}>
+          <label
+            className="canon-TextFieldLabel"
+            htmlFor={inputId}
+            data-disabled={disabled}
+          >
             {label}
             {required && (
               <span aria-hidden="true" className="canon-TextFieldRequired">
@@ -70,6 +75,7 @@ export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(
           })}
           data-invalid={error}
           required={required}
+          disabled={disabled}
           {...rest}
         />
         {description && (


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When a Select component label is clicked, focus should move to the associated trigger element. This PR adds this behavior, for improved a11y. It also updates the label styling of the TextField component, so the cursor better indicates that the label is interactive.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
