### PR TITLE
Added "New" ribbon option to SidebarItem

### DIFF
--- a/.changeset/tall-mammals-care.md
+++ b/.changeset/tall-mammals-care.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': minor
+---
+
+Added `newRibbon` option to `SidebarItem` and `SidebarSubmenuItem` for easier recognition of new features

--- a/packages/core-components/src/layout/Sidebar/Items.tsx
+++ b/packages/core-components/src/layout/Sidebar/Items.tsx
@@ -33,6 +33,7 @@ import ArrowDropDown from '@material-ui/icons/ArrowDropDown';
 import ArrowDropUp from '@material-ui/icons/ArrowDropUp';
 import ArrowRightIcon from '@material-ui/icons/ArrowRight';
 import SearchIcon from '@material-ui/icons/Search';
+import NewReleasesIcon from '@material-ui/icons/NewReleases';
 import classnames from 'classnames';
 import type { Location } from 'history';
 
@@ -73,6 +74,7 @@ import { SidebarSubmenu, SidebarSubmenuProps } from './SidebarSubmenu';
 import { SidebarSubmenuItemProps } from './SidebarSubmenuItem';
 import { isLocationMatch } from './utils';
 import Button from '@material-ui/core/Button';
+import { NewRibbon } from './NewRibbon';
 
 /** @public */
 export type SidebarItemClassKey =
@@ -105,6 +107,8 @@ const makeSidebarStyles = (sidebarConfig: SidebarConfig) =>
         alignItems: 'center',
         height: 48,
         cursor: 'pointer',
+        position: 'relative',
+        overflow: 'hidden',
       },
       buttonItem: {
         background: 'none',
@@ -276,6 +280,7 @@ type SidebarItemBaseProps = {
   disableHighlight?: boolean;
   className?: string;
   noTrack?: boolean;
+  newRibbon?: boolean;
   onClick?: (ev: MouseEvent) => void;
 };
 
@@ -383,6 +388,7 @@ const SidebarItemBase = forwardRef<
     disableHighlight = false,
     onClick,
     noTrack,
+    newRibbon,
     children,
     className,
     ...navLinkProps
@@ -411,7 +417,7 @@ const SidebarItemBase = forwardRef<
       color="secondary"
       variant="dot"
       overlap="circular"
-      invisible={!hasNotifications}
+      invisible={!hasNotifications && !newRibbon}
       className={classnames({ [classes.closedItemIcon]: !isOpen })}
     >
       {displayItemIcon}
@@ -432,6 +438,7 @@ const SidebarItemBase = forwardRef<
           {text}
         </Typography>
       )}
+      {newRibbon && <NewRibbon />}
       <div className={classes.secondaryAction}>{children}</div>
     </>
   );

--- a/packages/core-components/src/layout/Sidebar/NewRibbon.tsx
+++ b/packages/core-components/src/layout/Sidebar/NewRibbon.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles(theme => ({
+  newRibbon: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    textAlign: 'center',
+    transform: 'translateY(-100%) translateX(35%) rotate(45deg)',
+    backgroundColor: theme.palette.navigation.indicator,
+    color: 'black',
+    transformOrigin: 'bottom left',
+    padding: '0 0.9lh',
+  },
+}));
+
+export const NewRibbon = () => {
+  const classes = useStyles();
+
+  return <div className={classes.newRibbon}>NEW</div>;
+};

--- a/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
+++ b/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
@@ -28,6 +28,7 @@ import { SidebarItemWithSubmenuContext } from './config';
 import { isLocationMatch } from './utils';
 import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
+import { NewRibbon } from './NewRibbon';
 
 /** @public */
 export type SidebarSubmenuItemClassKey =
@@ -59,6 +60,7 @@ const useStyles = makeStyles(
       position: 'relative',
       background: 'none',
       border: 'none',
+      overflow: 'hidden',
     },
     itemContainer: {
       width: '100%',
@@ -148,6 +150,7 @@ export type SidebarSubmenuItemProps = {
   dropdownItems?: SidebarSubmenuItemDropdownItem[];
   exact?: boolean;
   initialShowDropdown?: boolean;
+  newRibbon?: boolean;
 };
 
 /**
@@ -156,7 +159,15 @@ export type SidebarSubmenuItemProps = {
  * @public
  */
 export const SidebarSubmenuItem = (props: SidebarSubmenuItemProps) => {
-  const { title, subtitle, to, icon: Icon, dropdownItems, exact } = props;
+  const {
+    title,
+    subtitle,
+    to,
+    icon: Icon,
+    dropdownItems,
+    exact,
+    newRibbon,
+  } = props;
   const classes = useStyles();
   const { setIsHoveredOn } = useContext(SidebarItemWithSubmenuContext);
   const closeSubmenu = () => {
@@ -275,6 +286,7 @@ export const SidebarSubmenuItem = (props: SidebarSubmenuItemProps) => {
               </Typography>
             )}
           </Typography>
+          {newRibbon && <NewRibbon />}
         </Link>
       </Tooltip>
     </Box>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added `newRibbon` option to `SidebarItem` and `SidebarSubmenuItem` for easier recognition of new features.

Adding it because I wasn't able to get the desired effect on my own Backstage instance 😅.
Let me know if it makes sense.
Also, additional feedback is welcome.

I tried to make it work on both collapsed and open sidebar as well as submenus

![image](https://github.com/user-attachments/assets/a801ba91-7bfd-465a-99e9-3199bd02f64d)
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
