### PR TITLE
add note about visibility of entity-fetch audit events in logs

### DIFF
--- a/.changeset/every-bottles-grow.md
+++ b/.changeset/every-bottles-grow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+"Added a note clarifying that `entity-fetch` audit events are not visible by default in the logs and are only displayed when the log severity level is adjusted."

--- a/plugins/catalog-backend/README.md
+++ b/plugins/catalog-backend/README.md
@@ -94,7 +94,8 @@ The Catalog backend emits audit events for various operations. Events are groupe
 **Entity Events:**
 
 - **`entity-fetch`**: Retrieves entities.
-- **Note:** By default, `entity-fetch` audit events are not visible in the log output. This is because these events are classified with a severity level of "low", which maps to the "debug" log level. The default log level in Backstage is "info", so debug-level events (severity "low") are filtered out. To see `entity-fetch` events in the logs, adjust the Auditor Service configuration by setting `backend.auditor.severityLogLevelMappings.low` to `info` in your `app-config.yaml`. For more information, refer to the [Auditor Service documentation on severity levels and default mappings](https://backstage.io/docs/backend-system/core-services/auditor/#severity-levels-and-default-mappings).
+- **Note:** By default, "low" severity audit events like `entity-fetch` aren't logged because they map to the "debug" level, while Backstage defaults to "info" level logging. To see `entity-fetch` events, update your `app-config.yaml` by setting `backend.auditor.severityLogLevelMappings.low: info`. See the [Auditor Service documentation](https://backstage.io/docs/backend-system/core-services/auditor/#severity-levels-and-default-mappings) for details on severity mappings.
+
 
   Filter on `queryType`.
 

--- a/plugins/catalog-backend/README.md
+++ b/plugins/catalog-backend/README.md
@@ -94,6 +94,7 @@ The Catalog backend emits audit events for various operations. Events are groupe
 **Entity Events:**
 
 - **`entity-fetch`**: Retrieves entities.
+- **Note:** By default, `entity-fetch` audit events are not visible in the log output. This is because these events are classified with a severity level of "low", which maps to the "debug" log level. The default log level in Backstage is "info", so debug-level events (severity "low") are filtered out. To see `entity-fetch` events in the logs, adjust the Auditor Service configuration by setting `backend.auditor.severityLogLevelMappings.low` to `info` in your `app-config.yaml`. For more information, refer to the [Auditor Service documentation on severity levels and default mappings](https://backstage.io/docs/backend-system/core-services/auditor/#severity-levels-and-default-mappings).
 
   Filter on `queryType`.
 

--- a/plugins/catalog-backend/README.md
+++ b/plugins/catalog-backend/README.md
@@ -96,7 +96,6 @@ The Catalog backend emits audit events for various operations. Events are groupe
 - **`entity-fetch`**: Retrieves entities.
 - **Note:** By default, "low" severity audit events like `entity-fetch` aren't logged because they map to the "debug" level, while Backstage defaults to "info" level logging. To see `entity-fetch` events, update your `app-config.yaml` by setting `backend.auditor.severityLogLevelMappings.low: info`. See the [Auditor Service documentation](https://backstage.io/docs/backend-system/core-services/auditor/#severity-levels-and-default-mappings) for details on severity mappings.
 
-
   Filter on `queryType`.
 
   - **`all`**: Fetching all entities. (GET `/entities`)


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR updates the Audit Events section of the @backstage/plugin-catalog-backend README to clarify why the entity-fetch audit events do not appear in log output with the default Auditor Service configuration. It adds a note explaining the default severity level of entity-fetch events and how to adjust the configuration to log these events. A reference link to the official Backstage documentation on Auditor Service severity levels is also included for further details.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
