### PR TITLE
Fields@uidesc

### DIFF
--- a/.changeset/violet-breads-obey.md
+++ b/.changeset/violet-breads-obey.md
@@ -1,0 +1,9 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+EntityPicker: prefer ui:description over schema description
+MultiEntityPicker: use ScaffolderField wrapper component and prefer ui:description over schema description
+OwnedEntityPicker: description consistency during load
+RepoUrlPicker += consistent RJSF description handling
+SecretInput += consistent RJSF description handling

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
@@ -185,7 +185,7 @@ export const EntityPicker = (props: EntityPickerProps) => {
   return (
     <ScaffolderField
       rawErrors={rawErrors}
-      rawDescription={description}
+      rawDescription={uiSchema['ui:description'] ?? description}
       required={required}
       disabled={isDisabled}
       errors={errors}

--- a/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.test.tsx
@@ -30,6 +30,7 @@ import { MultiEntityPickerProps } from './schema';
 import { ScaffolderRJSFFieldProps as FieldProps } from '@backstage/plugin-scaffolder-react';
 import { DefaultEntityPresentationApi } from '@backstage/plugin-catalog';
 import { catalogApiMock } from '@backstage/plugin-catalog-react/testUtils';
+import { merge, set } from 'lodash';
 
 const makeEntity = (kind: string, namespace: string, name: string): Entity => ({
   apiVersion: 'scaffolder.backstage.io/v1beta3',
@@ -845,6 +846,61 @@ describe('<MultiEntityPicker />', () => {
         'user:default/user-a',
         'group:default/squad-b',
       ]);
+    });
+  });
+
+  describe.each([
+    {
+      from: 'default',
+    },
+    {
+      from: 'schema',
+      descriptionPath: 'schema.description',
+    },
+    {
+      from: 'ui options',
+      descriptionPath: 'uiSchema[ui:description]',
+    },
+  ])('MultiEntityPicker description: $from', ({ from, descriptionPath }) => {
+    const customDescription = 'Custom MultiEntityPicker description';
+
+    it(`Presents ${from} description`, async () => {
+      uiSchema = {
+        'ui:options': {
+          catalogFilter: [
+            {
+              kind: ['Group'],
+              'metadata.name': 'test-entity',
+            },
+            {
+              kind: ['User'],
+              'metadata.name': 'test-entity',
+            },
+          ],
+        },
+      };
+      const override = {};
+      if (descriptionPath) {
+        set(override, descriptionPath, customDescription);
+      }
+      props = merge(
+        {
+          onChange,
+          schema,
+          required: true,
+          uiSchema,
+          rawErrors,
+          formData,
+        },
+        override,
+      ) as unknown as FieldProps<any>;
+
+      const { queryByText } = await renderInTestApp(
+        <Wrapper>
+          <MultiEntityPicker {...props} />
+        </Wrapper>,
+      );
+      expect(queryByText(customDescription) === null).toBe(!descriptionPath);
     });
   });
 });

--- a/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.tsx
@@ -30,7 +30,6 @@ import {
   EntityRefPresentationSnapshot,
 } from '@backstage/plugin-catalog-react';
 import TextField from '@material-ui/core/TextField';
-import FormControl from '@material-ui/core/FormControl';
 import Autocomplete, {
   AutocompleteChangeReason,
 } from '@material-ui/lab/Autocomplete';
@@ -44,6 +43,7 @@ import {
   MultiEntityPickerFilterQuery,
 } from './schema';
 import { VirtualizedListbox } from '../VirtualizedListbox';
+import { ScaffolderField } from '@backstage/plugin-scaffolder-react/alpha';
 
 export { MultiEntityPickerSchema } from './schema';
 
@@ -60,6 +60,7 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
     rawErrors,
     formData,
     idSchema,
+    errors,
   } = props;
 
   const catalogFilter = buildCatalogFilter(uiSchema);
@@ -144,10 +145,12 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
   }, [entities, onChange, required, allowArbitraryValues]);
 
   return (
-    <FormControl
-      margin="normal"
+    <ScaffolderField
+      rawErrors={rawErrors}
+      rawDescription={uiSchema['ui:description'] ?? description}
       required={required}
-      error={rawErrors?.length > 0 && !formData}
+      disabled={isDisabled}
+      errors={errors}
     >
       <Autocomplete
         multiple
@@ -182,7 +185,6 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
             label={title}
             disabled={isDisabled}
             margin="dense"
-            helperText={description}
             FormHelperTextProps={{
               margin: 'dense',
               style: { marginLeft: 0 },
@@ -197,7 +199,7 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
         )}
         ListboxComponent={VirtualizedListbox}
       />
-    </FormControl>
+    </ScaffolderField>
   );
 };
 

--- a/plugins/scaffolder/src/components/fields/OwnedEntityPicker/OwnedEntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/OwnedEntityPicker/OwnedEntityPicker.tsx
@@ -24,6 +24,7 @@ import { OwnedEntityPickerProps } from './schema';
 import { EntityPickerProps } from '../EntityPicker/schema';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { scaffolderTranslationRef } from '../../../translation';
+import { MarkdownContent } from '@backstage/core-components';
 
 export { OwnedEntityPickerSchema } from './schema';
 
@@ -59,7 +60,11 @@ export const OwnedEntityPicker = (props: OwnedEntityPickerProps) => {
             {...params}
             label={title}
             margin="dense"
-            helperText={description}
+            helperText={
+              <MarkdownContent
+                content={uiSchema['ui:description'] ?? description}
+              />
+            }
             FormHelperTextProps={{ margin: 'dense', style: { marginLeft: 0 } }}
             variant="outlined"
             required={required}

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
@@ -35,6 +35,7 @@ import { RepoUrlPickerRepoName } from './RepoUrlPickerRepoName';
 import { RepoUrlPickerFieldSchema } from './schema';
 import { RepoUrlPickerState } from './types';
 import { parseRepoPickerUrl, serializeRepoPickerUrl } from './utils';
+import { MarkdownContent } from '@backstage/core-components';
 
 export { RepoUrlPickerSchema } from './schema';
 
@@ -166,6 +167,9 @@ export const RepoUrlPicker = (
 
   const hostType =
     (state.host && integrationApi.byHost(state.host)?.type) ?? null;
+
+  const description = uiSchema['ui:description'] ?? schema.description;
+
   return (
     <>
       {schema.title && (
@@ -174,8 +178,10 @@ export const RepoUrlPicker = (
           <Divider />
         </Box>
       )}
-      {schema.description && (
-        <Typography variant="body1">{schema.description}</Typography>
+      {description && (
+        <Typography variant="body1">
+          <MarkdownContent content={description} />
+        </Typography>
       )}
       <RepoUrlPickerHost
         host={state.host}

--- a/plugins/scaffolder/src/components/fields/SecretInput/SecretInput.tsx
+++ b/plugins/scaffolder/src/components/fields/SecretInput/SecretInput.tsx
@@ -26,12 +26,13 @@ export const SecretInput = (props: ScaffolderRJSFFieldProps) => {
     disabled,
     errors,
     required,
+    uiSchema,
   } = props;
 
   return (
     <ScaffolderField
       rawErrors={rawErrors}
-      rawDescription={description}
+      rawDescription={uiSchema['ui:description'] ?? description}
       disabled={disabled}
       errors={errors}
       required={required}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Modifications to scaffolder fields to respect `ui:description` in manner consistent with RJSF OOTB fields.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
