### PR TITLE
Canon - Pin Base UI version

### DIFF
--- a/.changeset/mean-parents-build.md
+++ b/.changeset/mean-parents-build.md
@@ -1,0 +1,5 @@
+---
+'@backstage/canon': patch
+---
+
+Pin version of @base-ui-components/react

--- a/.changeset/mean-parents-build.md
+++ b/.changeset/mean-parents-build.md
@@ -2,4 +2,4 @@
 '@backstage/canon': patch
 ---
 
-Pin version of @base-ui-components/react
+Pin version of @base-ui-components/react.

--- a/packages/canon/package.json
+++ b/packages/canon/package.json
@@ -41,7 +41,7 @@
     "test": "backstage-cli package test"
   },
   "dependencies": {
-    "@base-ui-components/react": "^1.0.0-alpha.7",
+    "@base-ui-components/react": "1.0.0-alpha.7",
     "@remixicon/react": "^4.6.0",
     "@tanstack/react-table": "^8.21.3",
     "clsx": "^2.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3800,7 +3800,7 @@ __metadata:
   resolution: "@backstage/canon@workspace:packages/canon"
   dependencies:
     "@backstage/cli": "workspace:^"
-    "@base-ui-components/react": "npm:^1.0.0-alpha.7"
+    "@base-ui-components/react": "npm:1.0.0-alpha.7"
     "@remixicon/react": "npm:^4.6.0"
     "@storybook/addon-essentials": "npm:^8.6.12"
     "@storybook/addon-interactions": "npm:^8.6.12"
@@ -8859,7 +8859,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@base-ui-components/react@npm:^1.0.0-alpha.7":
+"@base-ui-components/react@npm:1.0.0-alpha.7":
   version: 1.0.0-alpha.7
   resolution: "@base-ui-components/react@npm:1.0.0-alpha.7"
   dependencies:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Canon is built on Base UI primitives, but Base UI is still in alpha and does not follow semantic versioning. This means that breaking changes can appear in non-major dependency versions. As Canon does not currently depend on a specific version of Base UI, any project that consumes Canon that also installs a later version of Base UI could end up using a version of Base UI that Canon does not support, resulting in unexpected behaviour or bugs. To try and avoid this scenario, this PR pins the version of Base UI to the one that Canon has been developed against, meaning that Canon will install that version of Base UI rather than inheriting another if it is also in use elsewhere, and ensuring that the components all work as expected

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
