### PR TITLE
Filter-out unrelated schemas for frontend plugin module federation remotes

### DIFF
--- a/.changeset/clean-geese-heal.md
+++ b/.changeset/clean-geese-heal.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Only keep relevant schemas when collecting and compiling the configuration schemas of a frontend plugin built as a module federation remote.

--- a/.changeset/yummy-kiwis-end.md
+++ b/.changeset/yummy-kiwis-end.md
@@ -1,0 +1,5 @@
+---
+'@backstage/config-loader': patch
+---
+
+Allow filtering the traversed dependencies when collecting the configuration schemas

--- a/packages/cli/src/modules/build/lib/bundler/moduleFederation.ts
+++ b/packages/cli/src/modules/build/lib/bundler/moduleFederation.ts
@@ -81,3 +81,27 @@ export async function getModuleFederationOptions(
     exposes,
   };
 }
+
+export function buildModuleFederationHostDependencyFilter(
+  packageJson: BackstagePackageJson,
+  moduleFederationOptions?: ModuleFederationOptions,
+) {
+  if (moduleFederationOptions?.mode !== 'remote') {
+    return undefined;
+  }
+
+  return (depName: string) => {
+    if (packageJson.backstage?.pluginPackages?.includes(depName)) {
+      return true;
+    }
+
+    // reject all backstage core dependencies: the schemas would be
+    // brought by the main frontend application (== the module federation host)
+    if (depName.startsWith('@backstage/')) {
+      return false;
+    }
+
+    // all other packages should be included in the schema of the plugin module federation remote.
+    return true;
+  };
+}

--- a/packages/config-loader/report.api.md
+++ b/packages/config-loader/report.api.md
@@ -188,6 +188,7 @@ export type LoadConfigSchemaOptions = (
   | {
       dependencies: string[];
       packagePaths?: string[];
+      filterDependencies?: (depName: string) => boolean;
     }
   | {
       serialized: JsonObject;

--- a/packages/config-loader/src/schema/collect.ts
+++ b/packages/config-loader/src/schema/collect.ts
@@ -43,6 +43,7 @@ const req =
 export async function collectConfigSchemas(
   packageNames: string[],
   packagePaths: string[],
+  filterDependencies: (depName: string) => boolean = () => true,
 ): Promise<ConfigSchemaPackageEntry[]> {
   const schemas = new Array<ConfigSchemaPackageEntry>();
   const tsSchemaPaths = new Array<{ packageName: string; path: string }>();
@@ -141,9 +142,9 @@ export async function collectConfigSchemas(
     }
 
     await Promise.all(
-      depNames.map(depName =>
-        processItem({ name: depName, parentPath: pkgPath }),
-      ),
+      depNames
+        .filter(filterDependencies)
+        .map(depName => processItem({ name: depName, parentPath: pkgPath })),
     );
   }
 

--- a/packages/config-loader/src/schema/load.ts
+++ b/packages/config-loader/src/schema/load.ts
@@ -37,6 +37,7 @@ export type LoadConfigSchemaOptions =
       | {
           dependencies: string[];
           packagePaths?: string[];
+          filterDependencies?: (depName: string) => boolean;
         }
       | {
           serialized: JsonObject;
@@ -73,6 +74,7 @@ export async function loadConfigSchema(
     schemas = await collectConfigSchemas(
       options.dependencies,
       options.packagePaths ?? [],
+      options.filterDependencies,
     );
   } else {
     const { serialized } = options;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Filter-out unrelated schemas for frontend plugin built as a module federation remote.
We should not include the schemas of all the core backstage packages in the configuration schema of the plugin.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
