### PR TITLE
core-{app,plugin}-api: add support for JSX in translation messages

### DIFF
--- a/.changeset/cool-bikes-push.md
+++ b/.changeset/cool-bikes-push.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-app-api': patch
+---
+
+Updated `I18nextTranslationApi` to support interpolation with the new `jsx` format.

--- a/.changeset/wicked-dingos-stand.md
+++ b/.changeset/wicked-dingos-stand.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-plugin-api': patch
+---
+
+Added a new `jsx` interpolation format to `TranslationsApi`. If any of the interpolations in the default translation message uses the `jsx` format, the translation function will always return a `ReactNode`.

--- a/docs/plugins/internationalization.md
+++ b/docs/plugins/internationalization.md
@@ -147,6 +147,43 @@ export const myPluginTranslationRef = createTranslationRef({
 });
 ```
 
+#### React Nodes
+
+In addition to the default formats that `i18next` supports, you can also use the `jsx` format to specify that an interpolated value is a `ReactNode`.
+
+For example, you might define the following messages:
+
+```ts title="define the message"
+export const myPluginTranslationRef = createTranslationRef({
+  id: 'plugin.my-plugin',
+  messages: {
+    entityPage: {
+      redirect:
+        'The entity you are looking for has been moved to {{link, jsx}}.',
+      newLocation: 'new location',
+    },
+  },
+});
+```
+
+Which can be used within a component like this:
+
+```tsx title="use within a component"
+const { t } = useTranslationRef(myPluginTranslationRef);
+
+return (
+  <div>
+    {t('entityPage.redirect', {
+      link: <a href="/new-location">{t('entityPage.newLocation')}</a>,
+    })}
+  </div>
+);
+```
+
+Note that whenever you use the `jsx` format in a message, the return value from the `t` function will be a `ReactNode`.
+
+When overriding a message you must always keep the `jsx` format for any interpolated values that use it in the original message.
+
 ## For an application developer overwrite plugin messages
 
 Step 1: Create translation resources

--- a/packages/core-app-api/src/apis/implementations/TranslationApi/I18nextTranslationApi.test.tsx
+++ b/packages/core-app-api/src/apis/implementations/TranslationApi/I18nextTranslationApi.test.tsx
@@ -23,6 +23,7 @@ import {
 import { Observable } from '@backstage/types';
 import { AppLanguageSelector } from '../AppLanguageApi';
 import { I18nextTranslationApi } from './I18nextTranslationApi';
+import { render } from '@testing-library/react';
 
 const plainRef = createTranslationRef({
   id: 'plain',
@@ -537,6 +538,57 @@ describe('I18nextTranslationApi', () => {
       expect(snapshot.t('derpWithCount', { count: 1 })).toBe('1 derp');
       expect(snapshot.t('derpWithCount', { count: 2 })).toBe('2 derps');
       expect(snapshot.t('derpWithCount', { count: 0 })).toBe('0 derps');
+    });
+
+    it('should support jsx formatting', () => {
+      const snapshot = snapshotWithMessages({
+        jsx: '{{ hello, jsx }}, {{ world, jsx }}!',
+      });
+
+      expect(
+        render(
+          snapshot.t('jsx', {
+            replace: {
+              hello: <h1>Hello</h1>,
+              world: <h6>World</h6>,
+            },
+          }),
+        ).container.textContent,
+      ).toBe('Hello, World!');
+
+      expect(
+        render(
+          snapshot.t('jsx', {
+            hello: <h1>world</h1>,
+            world: <h6>hello</h6>,
+          }),
+        ).container.textContent,
+      ).toBe('world, hello!');
+    });
+
+    it('should support jsx formatting with nested interpolations', () => {
+      const snapshot = snapshotWithMessages({
+        message: '$t(foo), $t(bar)',
+        foo: 'foo={{ foo, jsx }}',
+        bar: 'bar={{ bar, jsx }}',
+      });
+
+      expect(
+        render(
+          snapshot.t('message', {
+            foo: (
+              <div>
+                f<span>oo</span>
+              </div>
+            ),
+            bar: (
+              <div>
+                <b>b</b>a<span>r</span>
+              </div>
+            ),
+          }),
+        ).container.textContent,
+      ).toBe('foo=foo, bar=bar');
     });
   });
 });

--- a/packages/core-plugin-api/src/apis/definitions/TranslationApi.test.ts
+++ b/packages/core-plugin-api/src/apis/definitions/TranslationApi.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { ReactNode } from 'react';
 import { TranslationFunction } from './TranslationApi';
 
 function unused(..._any: any[]) {}
@@ -171,24 +172,28 @@ describe('TranslationFunction', () => {
       datetime: '{{x, dateTime}}';
       relativeTimeOptions: '{{x, relativeTime(quarter)}}';
       list: '{{x, list}}';
+      jsx: '{{x, jsx}}';
+      jsxNested: '$t(jsx)';
     }>;
     expect(f).toBeDefined();
 
-    f('none', { replace: { x: 'x' } });
-    f('number', { x: 1 });
+    f('none', { replace: { x: 'x' } }) satisfies string;
+    f('number', { x: 1 }) satisfies string;
     f('number', {
       replace: { x: 1 },
       formatParams: { x: { minimumFractionDigits: 2 } },
-    });
-    f('numberOptions', { x: 1 });
-    f('currency', { replace: { x: 1 } });
-    f('datetime', { x: new Date() });
-    f('relativeTimeOptions', { replace: { x: 1 } });
+    }) satisfies string;
+    f('numberOptions', { x: 1 }) satisfies string;
+    f('currency', { replace: { x: 1 } }) satisfies string;
+    f('datetime', { x: new Date() }) satisfies string;
+    f('relativeTimeOptions', { replace: { x: 1 } }) satisfies string;
     f('relativeTimeOptions', {
       replace: { x: 1 },
       formatParams: { x: { style: 'short' } },
-    });
-    f('list', { replace: { x: ['a', 'b', 'c'] } });
+    }) satisfies string;
+    f('list', { replace: { x: ['a', 'b', 'c'] } }) satisfies string;
+    f('jsx', { replace: { x: '' } }) satisfies ReactNode;
+    f('jsxNested', { replace: { x: '' } }) satisfies ReactNode;
     // @ts-expect-error
     f('none', { x: 1 });
     // @ts-expect-error
@@ -208,6 +213,10 @@ describe('TranslationFunction', () => {
     });
     // @ts-expect-error
     f('list', { x: [1, 2, 3] });
+    // @ts-expect-error
+    f('jsx', { x: Symbol('not-a-node') });
+    // @ts-expect-error
+    f('jsxNested', { x: Symbol('not-a-node') });
   });
 
   it('should support nesting', () => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Did a quick spike to try out this way of adding support for JSX in translation interpolations. This is an alternative to the implementation in #27193.

The tl;dr of the design is that there's a new `jsx` interpolation format that expects a `ReactNode` and will cause the returned result to be a `ReactNode` as well.

There's a bit of an issue when it comes to communicating support for React nodes in any given message, explained by this part in the new docs:

> When overriding a message you must always keep the `jsx` format for any interpolated values that use it in the original message.

This is of course fairly easy to miss, and there might be an expectation that adding `jsx` to an existing message that doesn't already use it is going to magically do something. Then again that wouldn't really be a reasonable thing for someone overriding messages to do, since you don't control the provided replacements anyway. In the end I think this might actually be the best we can do, since something like the `Trans` component used in #27193 doesn't have a way to communicate support for `ReactNode`s at all.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
