### PR TITLE
Support passing additional properties to OpenAPI server generator

### DIFF
--- a/.changeset/cool-colts-float.md
+++ b/.changeset/cool-colts-float.md
@@ -1,0 +1,5 @@
+---
+'@backstage/repo-tools': patch
+---
+
+Support passing additional properties to OpenAPI server generator

--- a/packages/repo-tools/src/commands/index.ts
+++ b/packages/repo-tools/src/commands/index.ts
@@ -56,6 +56,10 @@ function registerPackageCommand(program: Command) {
     .description(
       'Additional properties that can be passed to @openapitools/openapi-generator-cli',
     )
+    .option('--server-additional-properties [properties]')
+    .description(
+      'Additional properties that can be passed to @openapitools/openapi-generator-cli',
+    )
     .option('--watch')
     .description('Watch the OpenAPI spec for changes and regenerate on save.')
     .action(lazy(() => import('./package/schema/openapi/generate'), 'command'));

--- a/packages/repo-tools/src/commands/package/schema/openapi/generate/index.ts
+++ b/packages/repo-tools/src/commands/package/schema/openapi/generate/index.ts
@@ -51,7 +51,7 @@ export async function command(opts: OptionValues) {
       );
     }
     if (opts.server) {
-      promises.push(generateServer(options));
+      promises.push(generateServer(options, opts.serverAdditionalProperties));
     }
     await Promise.all(promises);
   };

--- a/packages/repo-tools/src/commands/package/schema/openapi/generate/server.ts
+++ b/packages/repo-tools/src/commands/package/schema/openapi/generate/server.ts
@@ -30,6 +30,7 @@ import { resolvePackagePath } from '@backstage/backend-plugin-api';
 import {
   getPathToCurrentOpenApiSpec,
   getRelativePathToFile,
+  toGeneratorAdditionalProperties,
 } from '../../../../../lib/openapi/helpers';
 
 async function generateSpecFile() {
@@ -70,7 +71,7 @@ export const createOpenApiRouter = async (
   const indexFile = join(schemaDir, '..', 'index.ts');
   await fs.writeFile(
     indexFile,
-    `// 
+    `//
     export * from './generated';`,
   );
 
@@ -82,7 +83,10 @@ export const createOpenApiRouter = async (
   }
 }
 
-async function generate(abortSignal?: AbortController) {
+async function generate(
+  serverAdditionalProperties?: string,
+  abortSignal?: AbortController,
+) {
   const resolvedOpenapiPath = await getPathToCurrentOpenApiSpec();
   const resolvedOutputDirectory = await getRelativePathToFile(OUTPUT_PATH);
 
@@ -92,6 +96,10 @@ async function generate(abortSignal?: AbortController) {
     resolve(resolvedOutputDirectory, '.openapi-generator-ignore'),
     OPENAPI_IGNORE_FILES.join('\n'),
   );
+
+  const additionalProperties = toGeneratorAdditionalProperties({
+    initialValue: serverAdditionalProperties,
+  });
 
   await exec(
     'node',
@@ -111,6 +119,9 @@ async function generate(abortSignal?: AbortController) {
       ),
       '--generator-key',
       'v3.0',
+      additionalProperties
+        ? `--additional-properties=${additionalProperties}`
+        : '',
     ],
     {
       maxBuffer: Number.MAX_VALUE,
@@ -147,15 +158,18 @@ async function generate(abortSignal?: AbortController) {
   await generateSpecFile();
 }
 
-export async function command({
-  abortSignal,
-  isWatch = false,
-}: {
-  abortSignal?: AbortController;
-  isWatch?: boolean;
-}): Promise<void> {
+export async function command(
+  {
+    abortSignal,
+    isWatch = false,
+  }: {
+    abortSignal?: AbortController;
+    isWatch?: boolean;
+  },
+  serverAdditionalProperties?: string,
+): Promise<void> {
   try {
-    await generate(abortSignal);
+    await generate(serverAdditionalProperties, abortSignal);
     console.log(chalk.green('Generated server files.'));
   } catch (err) {
     if (err.name === 'AbortError') {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Support passing additional properties to OpenAPI server generator similar to client. This allows one to for example, force snake case fields.

Verified using: `backstage-repo-tools package schema openapi generate --server --server-additional-properties modelPropertyNaming=snake_case,paramNaming=snake_case`

Confirmed casing was as expected.

I set it to a patch change as its small, but let me know if it should be minor since it exposes a "feature".

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
