### PR TITLE
NFS: Fix issue with `UnregisterEntityDialog` not being able to access `routeRefs` in `DialogApi.show`

### DIFF
--- a/.changeset/yellow-beans-eat.md
+++ b/.changeset/yellow-beans-eat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Fix for missing `routeRef` when using `core-plugin-api` in a dialog context

--- a/plugins/catalog/src/alpha/contextMenuItems.tsx
+++ b/plugins/catalog/src/alpha/contextMenuItems.tsx
@@ -37,6 +37,7 @@ import {
 import { rootRouteRef, unregisterRedirectRouteRef } from '../routes';
 import { catalogEntityDeletePermission } from '@backstage/plugin-catalog-common/alpha';
 import { useEffect } from 'react';
+import { compatWrapper } from '@backstage/core-compat-api';
 
 export const copyEntityUrlContextMenuItem = EntityContextMenuItemBlueprint.make(
   {
@@ -99,6 +100,7 @@ export const unregisterEntityContextMenuItem =
         const dialogApi = useApi(dialogApiRef);
         const navigate = useNavigate();
         const catalogRoute = useRouteRef(rootRouteRef);
+
         const { t } = useTranslationRef(catalogTranslationRef);
         const unregisterRedirectRoute = useRouteRef(unregisterRedirectRouteRef);
         const unregisterPermission = useEntityPermission(
@@ -109,21 +111,23 @@ export const unregisterEntityContextMenuItem =
           title: t('entityContextMenu.unregisterMenuTitle'),
           disabled: !unregisterPermission.allowed,
           onClick: async () => {
-            dialogApi.showModal(({ dialog }: { dialog: DialogApiDialog }) => (
-              <UnregisterEntityDialog
-                open
-                entity={entity}
-                onClose={() => dialog.close()}
-                onConfirm={() => {
-                  dialog.close();
-                  navigate(
-                    unregisterRedirectRoute
-                      ? unregisterRedirectRoute()
-                      : catalogRoute(),
-                  );
-                }}
-              />
-            ));
+            dialogApi.showModal(({ dialog }: { dialog: DialogApiDialog }) =>
+              compatWrapper(
+                <UnregisterEntityDialog
+                  open
+                  entity={entity}
+                  onClose={() => dialog.close()}
+                  onConfirm={() => {
+                    dialog.close();
+                    navigate(
+                      unregisterRedirectRoute
+                        ? unregisterRedirectRoute()
+                        : catalogRoute(),
+                    );
+                  }}
+                />,
+              ),
+            );
           },
         };
       },


### PR DESCRIPTION
The `compatWrapper` is not used here when we use `DialogApi.show` as they're rendered outside of the original extension context.

Not sure if this is the right fix or if we should be pushing this to the `DialogApi` implementation instead.