### PR TITLE
[catalog]: Support disabling one form of relationships from `ldap` module

### DIFF
--- a/.changeset/yellow-rats-argue.md
+++ b/.changeset/yellow-rats-argue.md
@@ -1,0 +1,38 @@
+---
+'@backstage/plugin-catalog-backend-module-ldap': patch
+---
+
+Added the ability to configure disabling one side of the relations tree with LDAP.
+
+Groups have a `member` attribute and users have a `memberOf` attribute, however these often can drift out of sync, leaving weird states in the Catalog as we collate these results together and deduplicate them.
+
+You can chose to optionally disable one side of these relationships, or even both by providing config in `app-config.yaml` under either the `GroupConfig` or `UserConfig`:
+
+```yaml
+catalog:
+  providers:
+    ldapOrg:
+      default:
+        target: ldaps://ds.example.net
+        bind:
+          dn: uid=ldap-reader-user,ou=people,ou=example,dc=example,dc=net
+          secret: ${LDAP_SECRET}
+        users:
+          - dn: ou=people,ou=example,dc=example,dc=net
+            options:
+              filter: (uid=*)
+            parsing:
+              # this defaults to false, to disable use the following:
+              skipMemberOf: true
+        groups:
+          - dn: ou=access,ou=groups,ou=example,dc=example,dc=net
+            options:
+              filter: (&(objectClass=some-group-class)(!(groupType=email)))
+            map:
+              description: l
+            set:
+              metadata.customField: 'hello'
+            parsing:
+              # this defaults to false, to disable use the following:
+              skipMember: true
+```

--- a/.changeset/yellow-rats-argue.md
+++ b/.changeset/yellow-rats-argue.md
@@ -4,9 +4,9 @@
 
 Added the ability to configure disabling one side of the relations tree with LDAP.
 
-Groups have a `member` attribute and users have a `memberOf` attribute, however these often can drift out of sync, leaving weird states in the Catalog as we collate these results together and deduplicate them.
+Groups have a `member` attribute and users have a `memberOf` attribute, however these can drift out of sync in some LDAP installations, leaving weird states in the Catalog as we collate these results together and deduplicate them.
 
-You can chose to optionally disable one side of these relationships, or even both by providing config in `app-config.yaml` under either the `GroupConfig` or `UserConfig`:
+You can chose to optionally disable one side of these relationships, or even both by setting the respective mapping to `null` in your `app-config.yaml` for your groups and/or users:
 
 ```yaml
 catalog:
@@ -21,9 +21,9 @@ catalog:
           - dn: ou=people,ou=example,dc=example,dc=net
             options:
               filter: (uid=*)
-            parsing:
-              # this defaults to false, to disable use the following:
-              skipMemberOf: true
+            map:
+              # this ensures that outgoing memberships from users is ignored
+              memberOf: null
         groups:
           - dn: ou=access,ou=groups,ou=example,dc=example,dc=net
             options:
@@ -32,7 +32,7 @@ catalog:
               description: l
             set:
               metadata.customField: 'hello'
-            parsing:
-              # this defaults to false, to disable use the following:
-              skipMember: true
+            map:
+              # this ensures that outgoing memberships from groups is ignored
+              members: null
 ```

--- a/plugins/catalog-backend-module-ldap/config.d.ts
+++ b/plugins/catalog-backend-module-ldap/config.d.ts
@@ -94,6 +94,17 @@ export interface Config {
                   };
             };
             /**
+             * Additional parsing config
+             */
+            parsing?: {
+              /**
+               * Whether to skip the memberOf attribute on the users to power the relations of users and groups
+               *
+               * @default false
+               */
+              skipMemberOf?: boolean;
+            };
+            /**
              * JSON paths (on a.b.c form) and hard coded values to set on those
              * paths.
              *
@@ -172,6 +183,17 @@ export interface Config {
                     pageSize?: number;
                     pagePause?: boolean;
                   };
+            };
+            /**
+             * Additional parsing config
+             */
+            parsing?: {
+              /**
+               * Whether to skip the memberOf attribute on the users to power the relations of users and groups
+               *
+               * @default false
+               */
+              skipMemberOf?: boolean;
             };
             /**
              * JSON paths (on a.b.c form) and hard coded values to set on those
@@ -257,6 +279,17 @@ export interface Config {
                     pageSize?: number;
                     pagePause?: boolean;
                   };
+            };
+            /**
+             * Additional parsing config
+             */
+            parsing?: {
+              /**
+               * Whether to skip the member attributes on the groups to power the relations of users and groups
+               *
+               * @default false
+               */
+              skipMembers?: boolean;
             };
             /**
              * JSON paths (on a.b.c form) and hard coded values to set on those
@@ -347,6 +380,17 @@ export interface Config {
                     pageSize?: number;
                     pagePause?: boolean;
                   };
+            };
+            /**
+             * Additional parsing config
+             */
+            parsing?: {
+              /**
+               * Whether to skip the member attributes on the groups to power the relations of users and groups
+               *
+               * @default false
+               */
+              skipMembers?: boolean;
             };
             /**
              * JSON paths (on a.b.c form) and hard coded values to set on those
@@ -509,6 +553,17 @@ export interface Config {
                       };
                 };
                 /**
+                 * Additional parsing config
+                 */
+                parsing?: {
+                  /**
+                   * Whether to skip the memberOf attribute on the users to power the relations of users and groups
+                   *
+                   * @default false
+                   */
+                  skipMemberOf?: boolean;
+                };
+                /**
                  * JSON paths (on a.b.c form) and hard coded values to set on those
                  * paths.
                  *
@@ -587,6 +642,17 @@ export interface Config {
                         pageSize?: number;
                         pagePause?: boolean;
                       };
+                };
+                /**
+                 * Additional parsing config
+                 */
+                parsing?: {
+                  /**
+                   * Whether to skip the memberOf attribute on the users to power the relations of users and groups
+                   *
+                   * @default false
+                   */
+                  skipMemberOf?: boolean;
                 };
                 /**
                  * JSON paths (on a.b.c form) and hard coded values to set on those
@@ -672,6 +738,17 @@ export interface Config {
                         pageSize?: number;
                         pagePause?: boolean;
                       };
+                };
+                /**
+                 * Additional parsing config
+                 */
+                parsing?: {
+                  /**
+                   * Whether to skip the member attributes on the groups to power the relations of users and groups
+                   *
+                   * @default false
+                   */
+                  skipMembers?: boolean;
                 };
                 /**
                  * JSON paths (on a.b.c form) and hard coded values to set on those
@@ -762,6 +839,17 @@ export interface Config {
                         pageSize?: number;
                         pagePause?: boolean;
                       };
+                };
+                /**
+                 * Additional parsing config
+                 */
+                parsing?: {
+                  /**
+                   * Whether to skip the member attributes on the groups to power the relations of users and groups
+                   *
+                   * @default false
+                   */
+                  skipMembers?: boolean;
                 };
                 /**
                  * JSON paths (on a.b.c form) and hard coded values to set on those
@@ -922,11 +1010,21 @@ export interface Config {
                   };
             };
             /**
+             * Additional parsing config
+             */
+            parsing?: {
+              /**
+               * Whether to skip the memberOf attribute on the users to power the relations of users and groups
+               *
+               * @default false
+               */
+              skipMemberOf?: boolean;
+            };
+            /**
              * JSON paths (on a.b.c form) and hard coded values to set on those
              * paths.
              *
              * This can be useful for example if you want to hard code a
-             * namespace or similar on the generated entities.
              */
             set?: { [key: string]: JsonValue };
             /**
@@ -1006,6 +1104,18 @@ export interface Config {
                   };
             };
             /**
+             * Additional parsing config
+             */
+            parsing?: {
+              /**
+               * Whether to skip the member attributes on the groups to power the relations of users and groups
+               *
+               * @default false
+               */
+              skipMembers?: boolean;
+            };
+            /**
+             * @default false
              * JSON paths (on a.b.c form) and hard coded values to set on those
              * paths.
              *

--- a/plugins/catalog-backend-module-ldap/config.d.ts
+++ b/plugins/catalog-backend-module-ldap/config.d.ts
@@ -94,17 +94,6 @@ export interface Config {
                   };
             };
             /**
-             * Additional parsing config
-             */
-            parsing?: {
-              /**
-               * Whether to skip the memberOf attribute on the users to power the relations of users and groups
-               *
-               * @default false
-               */
-              skipMemberOf?: boolean;
-            };
-            /**
              * JSON paths (on a.b.c form) and hard coded values to set on those
              * paths.
              *
@@ -152,7 +141,7 @@ export interface Config {
                * The name of the attribute that shall be used for the values of
                * the spec.memberOf field of the entity. Defaults to "memberOf".
                */
-              memberOf?: string;
+              memberOf?: string | null;
             };
           }
         | Array<{
@@ -185,17 +174,6 @@ export interface Config {
                   };
             };
             /**
-             * Additional parsing config
-             */
-            parsing?: {
-              /**
-               * Whether to skip the memberOf attribute on the users to power the relations of users and groups
-               *
-               * @default false
-               */
-              skipMemberOf?: boolean;
-            };
-            /**
              * JSON paths (on a.b.c form) and hard coded values to set on those
              * paths.
              *
@@ -243,7 +221,7 @@ export interface Config {
                * The name of the attribute that shall be used for the values of
                * the spec.memberOf field of the entity. Defaults to "memberOf".
                */
-              memberOf?: string;
+              memberOf?: string | null;
             };
           }>;
 
@@ -281,17 +259,6 @@ export interface Config {
                   };
             };
             /**
-             * Additional parsing config
-             */
-            parsing?: {
-              /**
-               * Whether to skip the member attributes on the groups to power the relations of users and groups
-               *
-               * @default false
-               */
-              skipMembers?: boolean;
-            };
-            /**
              * JSON paths (on a.b.c form) and hard coded values to set on those
              * paths.
              *
@@ -344,12 +311,12 @@ export interface Config {
                * The name of the attribute that shall be used for the values of
                * the spec.parent field of the entity. Defaults to "memberOf".
                */
-              memberOf?: string;
+              memberOf?: string | null;
               /**
                * The name of the attribute that shall be used for the values of
                * the spec.children field of the entity. Defaults to "member".
                */
-              members?: string;
+              members?: string | null;
             };
           }
         | Array<{
@@ -382,17 +349,6 @@ export interface Config {
                   };
             };
             /**
-             * Additional parsing config
-             */
-            parsing?: {
-              /**
-               * Whether to skip the member attributes on the groups to power the relations of users and groups
-               *
-               * @default false
-               */
-              skipMembers?: boolean;
-            };
-            /**
              * JSON paths (on a.b.c form) and hard coded values to set on those
              * paths.
              *
@@ -445,12 +401,12 @@ export interface Config {
                * The name of the attribute that shall be used for the values of
                * the spec.parent field of the entity. Defaults to "memberOf".
                */
-              memberOf?: string;
+              memberOf?: string | null;
               /**
                * The name of the attribute that shall be used for the values of
                * the spec.children field of the entity. Defaults to "member".
                */
-              members?: string;
+              members?: string | null;
             };
           }>;
       /**
@@ -553,17 +509,6 @@ export interface Config {
                       };
                 };
                 /**
-                 * Additional parsing config
-                 */
-                parsing?: {
-                  /**
-                   * Whether to skip the memberOf attribute on the users to power the relations of users and groups
-                   *
-                   * @default false
-                   */
-                  skipMemberOf?: boolean;
-                };
-                /**
                  * JSON paths (on a.b.c form) and hard coded values to set on those
                  * paths.
                  *
@@ -611,7 +556,7 @@ export interface Config {
                    * The name of the attribute that shall be used for the values of
                    * the spec.memberOf field of the entity. Defaults to "memberOf".
                    */
-                  memberOf?: string;
+                  memberOf?: string | null;
                 };
               }
             | Array<{
@@ -643,17 +588,7 @@ export interface Config {
                         pagePause?: boolean;
                       };
                 };
-                /**
-                 * Additional parsing config
-                 */
-                parsing?: {
-                  /**
-                   * Whether to skip the memberOf attribute on the users to power the relations of users and groups
-                   *
-                   * @default false
-                   */
-                  skipMemberOf?: boolean;
-                };
+
                 /**
                  * JSON paths (on a.b.c form) and hard coded values to set on those
                  * paths.
@@ -702,7 +637,7 @@ export interface Config {
                    * The name of the attribute that shall be used for the values of
                    * the spec.memberOf field of the entity. Defaults to "memberOf".
                    */
-                  memberOf?: string;
+                  memberOf?: string | null;
                 };
               }>;
 
@@ -740,17 +675,6 @@ export interface Config {
                       };
                 };
                 /**
-                 * Additional parsing config
-                 */
-                parsing?: {
-                  /**
-                   * Whether to skip the member attributes on the groups to power the relations of users and groups
-                   *
-                   * @default false
-                   */
-                  skipMembers?: boolean;
-                };
-                /**
                  * JSON paths (on a.b.c form) and hard coded values to set on those
                  * paths.
                  *
@@ -803,12 +727,12 @@ export interface Config {
                    * The name of the attribute that shall be used for the values of
                    * the spec.parent field of the entity. Defaults to "memberOf".
                    */
-                  memberOf?: string;
+                  memberOf?: string | null;
                   /**
                    * The name of the attribute that shall be used for the values of
                    * the spec.children field of the entity. Defaults to "member".
                    */
-                  members?: string;
+                  members?: string | null;
                 };
               }
             | Array<{
@@ -841,17 +765,6 @@ export interface Config {
                       };
                 };
                 /**
-                 * Additional parsing config
-                 */
-                parsing?: {
-                  /**
-                   * Whether to skip the member attributes on the groups to power the relations of users and groups
-                   *
-                   * @default false
-                   */
-                  skipMembers?: boolean;
-                };
-                /**
                  * JSON paths (on a.b.c form) and hard coded values to set on those
                  * paths.
                  *
@@ -904,12 +817,12 @@ export interface Config {
                    * The name of the attribute that shall be used for the values of
                    * the spec.parent field of the entity. Defaults to "memberOf".
                    */
-                  memberOf?: string;
+                  memberOf?: string | null;
                   /**
                    * The name of the attribute that shall be used for the values of
                    * the spec.children field of the entity. Defaults to "member".
                    */
-                  members?: string;
+                  members?: string | null;
                 };
               }>;
 
@@ -1010,17 +923,6 @@ export interface Config {
                   };
             };
             /**
-             * Additional parsing config
-             */
-            parsing?: {
-              /**
-               * Whether to skip the memberOf attribute on the users to power the relations of users and groups
-               *
-               * @default false
-               */
-              skipMemberOf?: boolean;
-            };
-            /**
              * JSON paths (on a.b.c form) and hard coded values to set on those
              * paths.
              *
@@ -1067,7 +969,7 @@ export interface Config {
                * The name of the attribute that shall be used for the values of
                * the spec.memberOf field of the entity. Defaults to "memberOf".
                */
-              memberOf?: string;
+              memberOf?: string | null;
             };
           };
 
@@ -1102,17 +1004,6 @@ export interface Config {
                     pageSize?: number;
                     pagePause?: boolean;
                   };
-            };
-            /**
-             * Additional parsing config
-             */
-            parsing?: {
-              /**
-               * Whether to skip the member attributes on the groups to power the relations of users and groups
-               *
-               * @default false
-               */
-              skipMembers?: boolean;
             };
             /**
              * @default false
@@ -1168,12 +1059,12 @@ export interface Config {
                * The name of the attribute that shall be used for the values of
                * the spec.parent field of the entity. Defaults to "memberOf".
                */
-              memberOf?: string;
+              memberOf?: string | null;
               /**
                * The name of the attribute that shall be used for the values of
                * the spec.children field of the entity. Defaults to "member".
                */
-              members?: string;
+              members?: string | null;
             };
           };
           /**

--- a/plugins/catalog-backend-module-ldap/report.api.md
+++ b/plugins/catalog-backend-module-ldap/report.api.md
@@ -52,6 +52,9 @@ export function defaultUserTransformer(
 export type GroupConfig = {
   dn: string;
   options: SearchOptions;
+  parsing?: {
+    skipMembers?: boolean;
+  };
   set?: {
     [path: string]: JsonValue;
   };
@@ -249,6 +252,9 @@ export type TLSConfig = {
 export type UserConfig = {
   dn: string;
   options: SearchOptions;
+  parsing?: {
+    skipMemberOf?: boolean;
+  };
   set?: {
     [path: string]: JsonValue;
   };

--- a/plugins/catalog-backend-module-ldap/report.api.md
+++ b/plugins/catalog-backend-module-ldap/report.api.md
@@ -52,9 +52,6 @@ export function defaultUserTransformer(
 export type GroupConfig = {
   dn: string;
   options: SearchOptions;
-  parsing?: {
-    skipMembers?: boolean;
-  };
   set?: {
     [path: string]: JsonValue;
   };
@@ -66,8 +63,8 @@ export type GroupConfig = {
     displayName: string;
     email?: string;
     picture?: string;
-    memberOf: string;
-    members: string;
+    memberOf: string | null;
+    members: string | null;
   };
 };
 
@@ -252,9 +249,6 @@ export type TLSConfig = {
 export type UserConfig = {
   dn: string;
   options: SearchOptions;
-  parsing?: {
-    skipMemberOf?: boolean;
-  };
   set?: {
     [path: string]: JsonValue;
   };
@@ -265,7 +259,7 @@ export type UserConfig = {
     displayName: string;
     email: string;
     picture?: string;
-    memberOf: string;
+    memberOf: string | null;
   };
 };
 

--- a/plugins/catalog-backend-module-ldap/src/ldap/config.ts
+++ b/plugins/catalog-backend-module-ldap/src/ldap/config.ts
@@ -90,6 +90,12 @@ export type UserConfig = {
   // Only the scope, filter, attributes, and paged fields are supported. The
   // default is scope "one" and attributes "*" and "+".
   options: SearchOptions;
+
+  // Additional parsing config
+  parsing?: {
+    // Whether to skip the memberOf attribute on the users to power the relations of users and groups
+    skipMemberOf?: boolean;
+  };
   // JSON paths (on a.b.c form) and hard coded values to set on those paths
   set?: { [path: string]: JsonValue };
   // Mappings from well known entity fields, to LDAP attribute names
@@ -129,6 +135,12 @@ export type GroupConfig = {
   // The search options to use.
   // Only the scope, filter, attributes, and paged fields are supported.
   options: SearchOptions;
+
+  // Additional parsing config
+  parsing?: {
+    // Whether to skip the members attribute on the groups to power the relations of users and groups
+    skipMembers?: boolean;
+  };
   // JSON paths (on a.b.c form) and hard coded values to set on those paths
   set?: { [path: string]: JsonValue };
   // Mappings from well known entity fields, to LDAP attribute names

--- a/plugins/catalog-backend-module-ldap/src/ldap/config.ts
+++ b/plugins/catalog-backend-module-ldap/src/ldap/config.ts
@@ -91,11 +91,6 @@ export type UserConfig = {
   // default is scope "one" and attributes "*" and "+".
   options: SearchOptions;
 
-  // Additional parsing config
-  parsing?: {
-    // Whether to skip the memberOf attribute on the users to power the relations of users and groups
-    skipMemberOf?: boolean;
-  };
   // JSON paths (on a.b.c form) and hard coded values to set on those paths
   set?: { [path: string]: JsonValue };
   // Mappings from well known entity fields, to LDAP attribute names
@@ -136,11 +131,6 @@ export type GroupConfig = {
   // Only the scope, filter, attributes, and paged fields are supported.
   options: SearchOptions;
 
-  // Additional parsing config
-  parsing?: {
-    // Whether to skip the members attribute on the groups to power the relations of users and groups
-    skipMembers?: boolean;
-  };
   // JSON paths (on a.b.c form) and hard coded values to set on those paths
   set?: { [path: string]: JsonValue };
   // Mappings from well known entity fields, to LDAP attribute names

--- a/plugins/catalog-backend-module-ldap/src/ldap/config.ts
+++ b/plugins/catalog-backend-module-ldap/src/ldap/config.ts
@@ -120,7 +120,7 @@ export type UserConfig = {
     picture?: string;
     // The name of the attribute that shall be used for the values of the
     // spec.memberOf field of the entity. Defaults to "memberOf".
-    memberOf: string;
+    memberOf: string | null;
   };
 };
 
@@ -168,10 +168,10 @@ export type GroupConfig = {
     picture?: string;
     // The name of the attribute that shall be used for the values of the
     // spec.parent field of the entity. Defaults to "memberOf".
-    memberOf: string;
+    memberOf: string | null;
     // The name of the attribute that shall be used for the values of the
     // spec.children field of the entity. Defaults to "member".
-    members: string;
+    members: string | null;
   };
 };
 

--- a/plugins/catalog-backend-module-ldap/src/ldap/read.test.ts
+++ b/plugins/catalog-backend-module-ldap/src/ldap/read.test.ts
@@ -235,9 +235,7 @@ describe('readLdapUsers', () => {
       {
         dn: 'ddd',
         options: {},
-        parsing: {
-          skipMemberOf: true,
-        },
+
         map: {
           rdn: 'uid',
           name: 'uid',
@@ -245,7 +243,7 @@ describe('readLdapUsers', () => {
           displayName: 'cn',
           email: 'mail',
           picture: 'avatarUrl',
-          memberOf: 'memberOf',
+          memberOf: null,
         },
       },
     ];
@@ -799,9 +797,6 @@ describe('readLdapGroups', () => {
       {
         dn: 'ddd',
         options: {},
-        parsing: {
-          skipMembers: true,
-        },
         map: {
           rdn: 'cn',
           name: 'cn',
@@ -811,7 +806,7 @@ describe('readLdapGroups', () => {
           picture: 'avatarUrl',
           type: 'tt',
           memberOf: 'memberOf',
-          members: 'member',
+          members: null,
         },
       },
     ];

--- a/plugins/catalog-backend-module-ldap/src/ldap/read.ts
+++ b/plugins/catalog-backend-module-ldap/src/ldap/read.ts
@@ -143,9 +143,12 @@ export async function readLdapUsers(
         return;
       }
 
-      mapReferencesAttr(user, vendor, map.memberOf, (myDn, vs) => {
-        ensureItems(userMemberOf, myDn, vs);
-      });
+      if (!cfg.parsing?.skipMemberOf) {
+        mapReferencesAttr(user, vendor, map.memberOf, (myDn, vs) => {
+          ensureItems(userMemberOf, myDn, vs);
+        });
+      }
+
       entities.push(entity);
     });
   }
@@ -277,9 +280,12 @@ export async function readLdapGroups(
       mapReferencesAttr(entry, vendor, map.memberOf, (myDn, vs) => {
         ensureItems(groupMemberOf, myDn, vs);
       });
-      mapReferencesAttr(entry, vendor, map.members, (myDn, vs) => {
-        ensureItems(groupMember, myDn, vs);
-      });
+
+      if (!cfg.parsing?.skipMembers) {
+        mapReferencesAttr(entry, vendor, map.members, (myDn, vs) => {
+          ensureItems(groupMember, myDn, vs);
+        });
+      }
 
       groups.push(entity);
     });

--- a/plugins/catalog-backend-module-ldap/src/ldap/read.ts
+++ b/plugins/catalog-backend-module-ldap/src/ldap/read.ts
@@ -143,11 +143,9 @@ export async function readLdapUsers(
         return;
       }
 
-      if (!cfg.parsing?.skipMemberOf) {
-        mapReferencesAttr(user, vendor, map.memberOf, (myDn, vs) => {
-          ensureItems(userMemberOf, myDn, vs);
-        });
-      }
+      mapReferencesAttr(user, vendor, map.memberOf, (myDn, vs) => {
+        ensureItems(userMemberOf, myDn, vs);
+      });
 
       entities.push(entity);
     });
@@ -281,11 +279,9 @@ export async function readLdapGroups(
         ensureItems(groupMemberOf, myDn, vs);
       });
 
-      if (!cfg.parsing?.skipMembers) {
-        mapReferencesAttr(entry, vendor, map.members, (myDn, vs) => {
-          ensureItems(groupMember, myDn, vs);
-        });
-      }
+      mapReferencesAttr(entry, vendor, map.members, (myDn, vs) => {
+        ensureItems(groupMember, myDn, vs);
+      });
 
       groups.push(entity);
     });
@@ -355,7 +351,7 @@ export async function readLdapOrg(
 function mapReferencesAttr(
   entry: SearchEntry,
   vendor: LdapVendor,
-  attributeName: string | undefined,
+  attributeName: string | undefined | null,
   setter: (sourceDn: string, targets: string[]) => void,
 ) {
   if (attributeName) {


### PR DESCRIPTION
Groups have a `member` attribute and users have a `memberOf` attribute, however these often can drift out of sync, leaving weird states in the Catalog as we collate these results together and deduplicate them.

You can chose to optionally disable one side of these relationships, or even both by providing config in `app-config.yaml` under either the `GroupConfig` or `UserConfig`: