### PR TITLE
fix(GithubUrlReader): use token from options to fetch repoDetails

### DIFF
--- a/.changeset/warm-cases-bathe.md
+++ b/.changeset/warm-cases-bathe.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+The `GithubUrlReader` will now use the token from `options` when fetching repo details

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/GithubUrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/GithubUrlReader.ts
@@ -154,7 +154,7 @@ export class GithubUrlReader implements UrlReaderService {
     url: string,
     options?: UrlReaderServiceReadTreeOptions,
   ): Promise<UrlReaderServiceReadTreeResponse> {
-    const repoDetails = await this.getRepoDetails(url);
+    const repoDetails = await this.getRepoDetails(url, options);
     const commitSha = repoDetails.commitSha;
 
     if (options?.etag && options.etag === commitSha) {
@@ -212,7 +212,7 @@ export class GithubUrlReader implements UrlReaderService {
       }
     }
 
-    const repoDetails = await this.getRepoDetails(url);
+    const repoDetails = await this.getRepoDetails(url, options);
     const commitSha = repoDetails.commitSha;
 
     if (options?.etag && options.etag === commitSha) {
@@ -320,7 +320,10 @@ export class GithubUrlReader implements UrlReaderService {
     }));
   }
 
-  private async getRepoDetails(url: string): Promise<{
+  private async getRepoDetails(
+    url: string,
+    options?: { token?: string },
+  ): Promise<{
     commitSha: string;
     repo: {
       archive_url: string;
@@ -330,9 +333,7 @@ export class GithubUrlReader implements UrlReaderService {
     const parsed = parseGitUrl(url);
     const { ref, full_name } = parsed;
 
-    const credentials = await this.deps.credentialsProvider.getCredentials({
-      url,
-    });
+    const credentials = await this.getCredentials(url, options);
     const { headers } = credentials;
 
     const commitStatus: GhCombinedCommitStatusResponse = await this.fetchJson(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The GithubUrlReader is not currently using the `token` supplied via `options` when making calls to fetch commit details or the repository's default branch. We were seeing rate limit errors in Scaffolder Tasks (`fetch:template` action) due to our Backstage GH integration token running out of rate limit. However, we always pass the user's OAuth token to the `fetch:template` action so we should be using that token wherever possible.

This change updates the two API calls to use the provided token when available, otherwise falling back to the token provided via the `GithubCredentialsProvider`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
