### PR TITLE
Canon - Refactor TextField to use Field

### DIFF
--- a/.changeset/wise-cobras-sink.md
+++ b/.changeset/wise-cobras-sink.md
@@ -1,0 +1,5 @@
+---
+'@backstage/canon': patch
+---
+
+Use the Field component from Base UI within the TextField.

--- a/packages/canon/css/components.css
+++ b/packages/canon/css/components.css
@@ -544,6 +544,7 @@
   color: var(--canon-fg-primary);
   margin-bottom: var(--canon-space-1_5);
   cursor: pointer;
+  margin-right: auto;
 }
 
 .canon-TextFieldLabel[data-disabled] {

--- a/packages/canon/css/styles.css
+++ b/packages/canon/css/styles.css
@@ -9768,6 +9768,7 @@
   color: var(--canon-fg-primary);
   margin-bottom: var(--canon-space-1_5);
   cursor: pointer;
+  margin-right: auto;
 }
 
 .canon-TextFieldLabel[data-disabled] {

--- a/packages/canon/css/textfield.css
+++ b/packages/canon/css/textfield.css
@@ -11,6 +11,7 @@
   color: var(--canon-fg-primary);
   margin-bottom: var(--canon-space-1_5);
   cursor: pointer;
+  margin-right: auto;
 }
 
 .canon-TextFieldLabel[data-disabled] {

--- a/packages/canon/src/components/TextField/TextField.styles.css
+++ b/packages/canon/src/components/TextField/TextField.styles.css
@@ -26,6 +26,7 @@
   font-weight: var(--canon-font-weight-regular);
   color: var(--canon-fg-primary);
   margin-bottom: var(--canon-space-1_5);
+  margin-right: auto;
   cursor: pointer;
 }
 .canon-TextFieldLabel[data-disabled] {

--- a/packages/canon/src/components/TextField/TextField.tsx
+++ b/packages/canon/src/components/TextField/TextField.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { useId, forwardRef } from 'react';
-import { Input } from '@base-ui-components/react/input';
+import { Field } from '@base-ui-components/react/field';
+import { forwardRef } from 'react';
 import { useResponsiveValue } from '../../hooks/useResponsiveValue';
 import clsx from 'clsx';
 
@@ -39,56 +39,41 @@ export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(
     // Get the responsive value for the variant
     const responsiveSize = useResponsiveValue(size);
 
-    // Generate unique IDs for accessibility
-    const inputId = useId();
-    const descriptionId = useId();
-    const errorId = useId();
-
     return (
-      <div
+      <Field.Root
         className={clsx('canon-TextField', className)}
+        disabled={disabled}
+        invalid={!!error}
         style={style}
         ref={ref}
       >
         {label && (
-          <label
-            className="canon-TextFieldLabel"
-            htmlFor={inputId}
-            data-disabled={disabled}
-          >
+          <Field.Label className="canon-TextFieldLabel">
             {label}
             {required && (
               <span aria-hidden="true" className="canon-TextFieldRequired">
                 (Required)
               </span>
             )}
-          </label>
+          </Field.Label>
         )}
-        <Input
-          id={inputId}
+        <Field.Control
           className="canon-TextFieldInput"
           data-size={responsiveSize}
-          aria-labelledby={label ? inputId : undefined}
-          aria-describedby={clsx({
-            [descriptionId]: description,
-            [errorId]: error,
-          })}
-          data-invalid={error}
           required={required}
-          disabled={disabled}
           {...rest}
         />
         {description && (
-          <p className="canon-TextFieldDescription" id={descriptionId}>
+          <Field.Description className="canon-TextFieldDescription">
             {description}
-          </p>
+          </Field.Description>
         )}
         {error && (
-          <p className="canon-TextFieldError" id={errorId} role="alert">
+          <Field.Error className="canon-TextFieldError" role="alert" forceShow>
             {error}
-          </p>
+          </Field.Error>
         )}
-      </div>
+      </Field.Root>
     );
   },
 );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Precursor to https://github.com/backstage/backstage/pull/29820.

Refactors the TextField component to use the Field component from Base UI in order to ensure the full range of documented `data-*` attributes are available for consumers to build upon

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
