### PR TITLE
[DOCS] Adds small addition to the PG docker-compose about timezones

### DIFF
--- a/docs/getting-started/config/database.md
+++ b/docs/getting-started/config/database.md
@@ -153,6 +153,9 @@ services:
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: <secret>
+      # If you want to set a timezone you can use the following environment variables, this is handy when trying to figure out when scheduled tasks will run!
+      # TZ: Europe/Stockholm
+      # PGTZ: Europe/Stockholm
     ports:
       - 5432:5432
 ```


### PR DESCRIPTION
## Hey, I just made a Pull Request!

a small yet useful addition to the docker-compose being able to setup a timezone for the DB locally so you don't have to do any mental mathematics about timezones 🫨 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
