### PR TITLE
feat(techdocs): add support for external documentation

### DIFF
--- a/plugins/catalog/package.json
+++ b/plugins/catalog/package.json
@@ -72,6 +72,7 @@
     "@backstage/plugin-scaffolder-common": "workspace:^",
     "@backstage/plugin-search-common": "workspace:^",
     "@backstage/plugin-search-react": "workspace:^",
+    "@backstage/plugin-techdocs-common": "workspace:^",
     "@backstage/types": "workspace:^",
     "@backstage/version-bridge": "workspace:^",
     "@material-ui/core": "^4.12.2",

--- a/plugins/catalog/src/components/AboutCard/AboutCard.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutCard.tsx
@@ -66,10 +66,11 @@ import { taskCreatePermission } from '@backstage/plugin-scaffolder-common/alpha'
 import { usePermission } from '@backstage/plugin-permission-react';
 import { catalogTranslationRef } from '../../alpha/translation';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
-
-const TECHDOCS_ANNOTATION = 'backstage.io/techdocs-ref';
-
-const TECHDOCS_EXTERNAL_ANNOTATION = 'backstage.io/techdocs-entity';
+import {
+  TECHDOCS_ANNOTATION,
+  TECHDOCS_EXTERNAL_ANNOTATION,
+  TECHDOCS_REDIRECT_ANNOTATION,
+} from '@backstage/plugin-techdocs-common';
 
 const useStyles = makeStyles({
   gridItemCard: {
@@ -148,6 +149,25 @@ export function AboutCard(props: AboutCardProps) {
     }
   }
 
+  let techdocsHref: string | undefined;
+  if (viewTechdocLink) {
+    if (techdocsRef) {
+      techdocsHref = viewTechdocLink({
+        namespace: techdocsRef.namespace || DEFAULT_NAMESPACE,
+        kind: techdocsRef.kind,
+        name: techdocsRef.name,
+      });
+    } else {
+      techdocsHref = entity.metadata.annotations?.[TECHDOCS_ANNOTATION]
+        ? viewTechdocLink({
+            namespace: entity.metadata.namespace || DEFAULT_NAMESPACE,
+            kind: entity.kind,
+            name: entity.metadata.name,
+          })
+        : entity.metadata.annotations?.[TECHDOCS_REDIRECT_ANNOTATION];
+    }
+  }
+
   const viewInSource: IconLinkVerticalProps = {
     label: t('aboutCard.viewSource'),
     disabled: !entitySourceLocation,
@@ -156,25 +176,9 @@ export function AboutCard(props: AboutCardProps) {
   };
   const viewInTechDocs: IconLinkVerticalProps = {
     label: t('aboutCard.viewTechdocs'),
-    disabled:
-      !(
-        entity.metadata.annotations?.[TECHDOCS_ANNOTATION] ||
-        entity.metadata.annotations?.[TECHDOCS_EXTERNAL_ANNOTATION]
-      ) || !viewTechdocLink,
+    disabled: !techdocsHref,
     icon: <DocsIcon />,
-    href:
-      viewTechdocLink &&
-      (techdocsRef
-        ? viewTechdocLink({
-            namespace: techdocsRef.namespace || DEFAULT_NAMESPACE,
-            kind: techdocsRef.kind,
-            name: techdocsRef.name,
-          })
-        : viewTechdocLink({
-            namespace: entity.metadata.namespace || DEFAULT_NAMESPACE,
-            kind: entity.kind,
-            name: entity.metadata.name,
-          })),
+    href: techdocsHref,
   };
 
   const subHeaderLinks = [viewInSource, viewInTechDocs];

--- a/plugins/techdocs-common/src/constants.ts
+++ b/plugins/techdocs-common/src/constants.ts
@@ -18,3 +18,6 @@
 export const TECHDOCS_ANNOTATION = 'backstage.io/techdocs-ref';
 /** @public */
 export const TECHDOCS_EXTERNAL_ANNOTATION = 'backstage.io/techdocs-entity';
+/** @public */
+export const TECHDOCS_REDIRECT_ANNOTATION =
+  'backstage.io/techdocs-redirect-ref';

--- a/plugins/techdocs-common/src/constants.ts
+++ b/plugins/techdocs-common/src/constants.ts
@@ -19,5 +19,5 @@ export const TECHDOCS_ANNOTATION = 'backstage.io/techdocs-ref';
 /** @public */
 export const TECHDOCS_EXTERNAL_ANNOTATION = 'backstage.io/techdocs-entity';
 /** @public */
-export const TECHDOCS_REDIRECT_ANNOTATION =
+export const TECHDOCS_LINKED_DOCS_ANNOTATION ='backstage.io/techdocs-external-ref';
   'backstage.io/techdocs-redirect-ref';

--- a/yarn.lock
+++ b/yarn.lock
@@ -6468,6 +6468,7 @@ __metadata:
     "@backstage/plugin-scaffolder-common": "workspace:^"
     "@backstage/plugin-search-common": "workspace:^"
     "@backstage/plugin-search-react": "workspace:^"
+    "@backstage/plugin-techdocs-common": "workspace:^"
     "@backstage/test-utils": "workspace:^"
     "@backstage/types": "workspace:^"
     "@backstage/version-bridge": "workspace:^"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add an annotation for the external documentation reference on the techdocs entity. Now, on the entity card, if that annotation is present, the URL will be loaded in a new window

In reference to issue #28791

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
