### PR TITLE
Support custom components in the New frontend Application navigation bar, and use it in the Notifications plugin

### DIFF
--- a/.changeset/rotten-hornets-fold.md
+++ b/.changeset/rotten-hornets-fold.md
@@ -1,0 +1,7 @@
+---
+'@backstage/frontend-plugin-api': minor
+'@backstage/plugin-app': minor
+---
+
+Add support for custom React components in the navigation bar of the new frontend application.
+A new type of blueprint (`NavComponentBlueprint`) is available for plugins to implement the whole menu item as a React component, and then displayed by the new frontend application alongside simple navigation bar items.

--- a/.changeset/tired-humans-stop.md
+++ b/.changeset/tired-humans-stop.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications': minor
+---
+
+Complete the new frontend implementation of the Notifications plugins by supporting the custom menu item in the navigation bar.

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -1387,6 +1387,40 @@ export { identityApiRef };
 export { microsoftAuthApiRef };
 
 // @public
+export const NavComponentBlueprint: ExtensionBlueprint<{
+  kind: 'nav-component';
+  name: undefined;
+  params: {
+    Component: ComponentType<any>;
+    routeRef: RouteRef<AnyRouteRefParams>;
+    args?: Record<string, any>;
+  };
+  output: ConfigurableExtensionDataRef<
+    {
+      Component: ComponentType<any>;
+      routeRef: RouteRef<AnyRouteRefParams>;
+      args?: Record<string, any>;
+    },
+    'core.nav-component.target',
+    {}
+  >;
+  inputs: {};
+  config: {};
+  configInput: {};
+  dataRefs: {
+    target: ConfigurableExtensionDataRef<
+      {
+        Component: ComponentType<any>;
+        routeRef: RouteRef<AnyRouteRefParams>;
+        args?: Record<string, any>;
+      },
+      'core.nav-component.target',
+      {}
+    >;
+  };
+}>;
+
+// @public
 export const NavItemBlueprint: ExtensionBlueprint<{
   kind: 'nav-item';
   name: undefined;

--- a/packages/frontend-plugin-api/src/blueprints/NavComponentBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/NavComponentBlueprint.test.tsx
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { createExtensionTester } from '@backstage/frontend-test-utils';
+import { createRouteRef } from '../routing';
+import { NavComponentBlueprint } from './NavComponentBlueprint';
+
+describe('NavComponentBlueprint', () => {
+  const mockRouteRef = createRouteRef();
+  const MockComponent = () => undefined;
+
+  it('should return an extension with sensible defaults', () => {
+    const extension = NavComponentBlueprint.make({
+      params: {
+        Component: MockComponent,
+        routeRef: mockRouteRef,
+      },
+    });
+
+    expect(extension).toMatchInlineSnapshot(`
+      {
+        "$$type": "@backstage/ExtensionDefinition",
+        "T": undefined,
+        "attachTo": {
+          "id": "app/nav",
+          "input": "components",
+        },
+        "configSchema": {
+          "parse": [Function],
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "additionalProperties": false,
+            "properties": {
+              "args": {
+                "additionalProperties": {},
+                "type": "object",
+              },
+            },
+            "type": "object",
+          },
+        },
+        "disabled": false,
+        "factory": [Function],
+        "inputs": {},
+        "kind": "nav-component",
+        "name": undefined,
+        "output": [
+          [Function],
+        ],
+        "override": [Function],
+        "toString": [Function],
+        "version": "v2",
+      }
+    `);
+  });
+
+  it('should return the correct extension data', () => {
+    const extension = NavComponentBlueprint.make({
+      params: {
+        Component: MockComponent,
+        routeRef: mockRouteRef,
+        args: {
+          anArgument: 'argValue',
+        },
+      },
+    });
+
+    const tester = createExtensionTester(extension);
+    expect(tester.get(NavComponentBlueprint.dataRefs.target)).toEqual({
+      Component: MockComponent,
+      routeRef: mockRouteRef,
+      args: {
+        anArgument: 'argValue',
+      },
+    });
+  });
+
+  it('should allow overriding of the args using config', () => {
+    const extension = NavComponentBlueprint.make({
+      params: {
+        Component: MockComponent,
+        routeRef: mockRouteRef,
+      },
+    });
+
+    const tester = createExtensionTester(extension, {
+      config: { args: { anArgument: 'argumentValue' } },
+    });
+
+    const extensionTarget = tester.get(NavComponentBlueprint.dataRefs.target);
+    expect(extensionTarget).toEqual({
+      Component: MockComponent,
+      routeRef: mockRouteRef,
+      args: { anArgument: 'argumentValue' },
+    });
+  });
+});

--- a/packages/frontend-plugin-api/src/blueprints/NavComponentBlueprint.ts
+++ b/packages/frontend-plugin-api/src/blueprints/NavComponentBlueprint.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AnyRouteRefParams, RouteRef } from '../routing';
+import { createExtensionBlueprint, createExtensionDataRef } from '../wiring';
+import { ComponentType } from 'react';
+
+const targetDataRef = createExtensionDataRef<{
+  Component: ComponentType<any>;
+  routeRef: RouteRef<AnyRouteRefParams>;
+  args?: Record<string, any>;
+}>().with({ id: 'core.nav-component.target' });
+
+/**
+ * Creates extensions that make up the custom items of the nav bar.
+ *
+ * @public
+ */
+export const NavComponentBlueprint = createExtensionBlueprint({
+  kind: 'nav-component',
+  attachTo: { id: 'app/nav', input: 'components' },
+  output: [targetDataRef],
+  dataRefs: {
+    target: targetDataRef,
+  },
+  factory: (
+    {
+      Component,
+      routeRef,
+      args,
+    }: {
+      Component: ComponentType<any>;
+      routeRef: RouteRef<AnyRouteRefParams>;
+      args?: Record<string, any>;
+    },
+    { config },
+  ) => [
+    targetDataRef({
+      Component,
+      routeRef,
+      args: config.args ?? args,
+    }),
+  ],
+  config: {
+    schema: {
+      args: z => z.record(z.any()).optional(),
+    },
+  },
+});

--- a/packages/frontend-plugin-api/src/blueprints/index.ts
+++ b/packages/frontend-plugin-api/src/blueprints/index.ts
@@ -19,6 +19,7 @@ export { AppRootElementBlueprint } from './AppRootElementBlueprint';
 export { AppRootWrapperBlueprint } from './AppRootWrapperBlueprint';
 export { IconBundleBlueprint } from './IconBundleBlueprint';
 export { NavItemBlueprint } from './NavItemBlueprint';
+export { NavComponentBlueprint } from './NavComponentBlueprint';
 export { NavLogoBlueprint } from './NavLogoBlueprint';
 export { PageBlueprint } from './PageBlueprint';
 export { RouterBlueprint } from './RouterBlueprint';

--- a/plugins/app/report.api.md
+++ b/plugins/app/report.api.md
@@ -100,6 +100,21 @@ const appPlugin: FrontendPlugin<
             optional: false;
           }
         >;
+        components: ExtensionInput<
+          ConfigurableExtensionDataRef<
+            {
+              Component: ComponentType<any>;
+              routeRef: RouteRef<AnyRouteRefParams>;
+              args?: Record<string, any>;
+            },
+            'core.nav-component.target',
+            {}
+          >,
+          {
+            singleton: false;
+            optional: false;
+          }
+        >;
         logos: ExtensionInput<
           ConfigurableExtensionDataRef<
             {

--- a/plugins/app/src/extensions/AppNav.tsx
+++ b/plugins/app/src/extensions/AppNav.tsx
@@ -21,6 +21,7 @@ import {
   useRouteRef,
   NavItemBlueprint,
   NavLogoBlueprint,
+  NavComponentBlueprint,
 } from '@backstage/frontend-plugin-api';
 import { makeStyles } from '@material-ui/core/styles';
 import {
@@ -80,11 +81,23 @@ const SidebarNavItem = (
   return <SidebarItem to={link()} icon={Icon} text={title} />;
 };
 
+const SidebarNavComponent = (
+  props: (typeof NavComponentBlueprint.dataRefs.target)['T'],
+) => {
+  const { Component, routeRef, args } = props;
+  const link = useRouteRef(routeRef);
+  if (!link) {
+    return null;
+  }
+  return <Component to={link()} {...args} />;
+};
+
 export const AppNav = createExtension({
   name: 'nav',
   attachTo: { id: 'app/layout', input: 'nav' },
   inputs: {
     items: createExtensionInput([NavItemBlueprint.dataRefs.target]),
+    components: createExtensionInput([NavComponentBlueprint.dataRefs.target]),
     logos: createExtensionInput([NavLogoBlueprint.dataRefs.logoElements], {
       singleton: true,
       optional: true,
@@ -101,7 +114,13 @@ export const AppNav = createExtension({
         {inputs.items.map((item, index) => (
           <SidebarNavItem
             {...item.get(NavItemBlueprint.dataRefs.target)}
-            key={index}
+            key={`item-${index}`}
+          />
+        ))}
+        {inputs.components.map((ci, index) => (
+          <SidebarNavComponent
+            {...ci.get(NavComponentBlueprint.dataRefs.target)}
+            key={`component-${index}`}
           />
         ))}
       </Sidebar>,

--- a/plugins/notifications/report-alpha.api.md
+++ b/plugins/notifications/report-alpha.api.md
@@ -4,9 +4,12 @@
 
 ```ts
 import { AnyApiFactory } from '@backstage/frontend-plugin-api';
+import { AnyExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { AnyRouteRefParams } from '@backstage/frontend-plugin-api';
+import { ComponentType } from 'react';
 import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { ExtensionDefinition } from '@backstage/frontend-plugin-api';
+import { ExtensionInput } from '@backstage/frontend-plugin-api';
 import { FrontendPlugin } from '@backstage/frontend-plugin-api';
 import { JSX as JSX_2 } from 'react';
 import { RouteRef } from '@backstage/frontend-plugin-api';
@@ -31,6 +34,53 @@ const _default: FrontendPlugin<
       inputs: {};
       params: {
         factory: AnyApiFactory;
+      };
+    }>;
+    'nav-component:notifications': ExtensionDefinition<{
+      config: {
+        webNotificationsEnabled: boolean | undefined;
+        titleCounterEnabled: boolean | undefined;
+        snackbarEnabled: boolean | undefined;
+        snackbarAutoHideDuration: number | undefined;
+        className: string | undefined;
+        text: string | undefined;
+        disableHighlight: boolean | undefined;
+        noTrack: boolean | undefined;
+      };
+      configInput: {
+        text?: string | undefined;
+        className?: string | undefined;
+        noTrack?: boolean | undefined;
+        disableHighlight?: boolean | undefined;
+        webNotificationsEnabled?: boolean | undefined;
+        titleCounterEnabled?: boolean | undefined;
+        snackbarEnabled?: boolean | undefined;
+        snackbarAutoHideDuration?: number | undefined;
+      };
+      output: ConfigurableExtensionDataRef<
+        {
+          Component: ComponentType<any>;
+          routeRef: RouteRef<AnyRouteRefParams>;
+          args?: Record<string, any>;
+        },
+        'core.nav-component.target',
+        {}
+      >;
+      inputs: {
+        [x: string]: ExtensionInput<
+          AnyExtensionDataRef,
+          {
+            optional: boolean;
+            singleton: boolean;
+          }
+        >;
+      };
+      kind: 'nav-component';
+      name: undefined;
+      params: {
+        Component: ComponentType<any>;
+        routeRef: RouteRef<AnyRouteRefParams>;
+        args?: Record<string, any>;
       };
     }>;
     'page:notifications': ExtensionDefinition<{

--- a/plugins/notifications/src/alpha.tsx
+++ b/plugins/notifications/src/alpha.tsx
@@ -16,6 +16,7 @@
 
 import {
   ApiBlueprint,
+  NavComponentBlueprint,
   PageBlueprint,
   createApiFactory,
   createFrontendPlugin,
@@ -29,6 +30,7 @@ import {
   convertLegacyRouteRefs,
 } from '@backstage/core-compat-api';
 import { NotificationsClient, notificationsApiRef } from './api';
+import { NotificationsSidebarItem } from './components';
 
 const page = PageBlueprint.make({
   params: {
@@ -52,12 +54,34 @@ const api = ApiBlueprint.make({
   },
 });
 
+const navBarComponent = NavComponentBlueprint.makeWithOverrides({
+  config: {
+    schema: {
+      webNotificationsEnabled: z => z.boolean().optional(),
+      titleCounterEnabled: z => z.boolean().optional(),
+      snackbarEnabled: z => z.boolean().optional(),
+      snackbarAutoHideDuration: z => z.number().optional(),
+      className: z => z.string().optional(),
+      text: z => z.string().optional(),
+      disableHighlight: z => z.boolean().optional(),
+      noTrack: z => z.boolean().optional(),
+    },
+  },
+  factory(originalFactory, context) {
+    return originalFactory({
+      Component: (props: Parameters<typeof NotificationsSidebarItem>[0]) =>
+        compatWrapper(<NotificationsSidebarItem {...props} />),
+      routeRef: convertLegacyRouteRef(rootRouteRef),
+      args: context.config,
+    });
+  },
+});
+
 /** @alpha */
 export default createFrontendPlugin({
   pluginId: 'notifications',
   routes: convertLegacyRouteRefs({
     root: rootRouteRef,
   }),
-  // TODO(Rugvip): Nav item (i.e. NotificationsSidebarItem) currently needs to be installed manually
-  extensions: [page, api],
+  extensions: [page, api, navBarComponent],
 });

--- a/plugins/notifications/src/alpha.tsx
+++ b/plugins/notifications/src/alpha.tsx
@@ -24,6 +24,7 @@ import {
 } from '@backstage/frontend-plugin-api';
 import { rootRouteRef } from './routes';
 import {
+  compatWrapper,
   convertLegacyRouteRef,
   convertLegacyRouteRefs,
 } from '@backstage/core-compat-api';
@@ -34,9 +35,9 @@ const page = PageBlueprint.make({
     defaultPath: '/notifications',
     routeRef: convertLegacyRouteRef(rootRouteRef),
     loader: () =>
-      import('./components/NotificationsPage').then(m => (
-        <m.NotificationsPage />
-      )),
+      import('./components/NotificationsPage').then(m =>
+        compatWrapper(<m.NotificationsPage />),
+      ),
   },
 });
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This pull request add support for custom react components in the navigation bar of the new frontend Application: a new type of blueprint is provided: `NavComponentBlueprint`.
It also builds on top of this new support to complete the new frontend implementation of the Notifications plugin, and display the `NotificationsSidebarItem` as a configurable navigation bar item.

https://github.com/user-attachments/assets/cbbdaf52-de37-46c0-85ef-460b3a79fafa

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
