### PR TITLE
[Notifications] format user entity ref mentions to be Slack compatible

### DIFF
--- a/.changeset/true-trains-tie.md
+++ b/.changeset/true-trains-tie.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-notifications-backend-module-slack': patch
+---
+
+Notifications which mention user entity refs are now replaced with Slack compatible mentions.
+
+Example: `Welcome <@user:default/billy>!` -> `Welcome <@U123456890>!`

--- a/plugins/notifications-backend-module-slack/src/lib/SlackNotificationProcessor.test.ts
+++ b/plugins/notifications-backend-module-slack/src/lib/SlackNotificationProcessor.test.ts
@@ -543,4 +543,127 @@ describe('SlackNotificationProcessor', () => {
       expect(slack.chat.postMessage).not.toHaveBeenCalled();
     });
   });
+
+  describe('when replacing user entity refs with Slack IDs', () => {
+    const createBaseMessage = (text: string) => ({
+      channel: 'U12345678',
+      text: 'notification',
+      attachments: [
+        {
+          color: '#00A699',
+          blocks: [
+            {
+              type: 'section',
+              text: {
+                type: 'mrkdwn',
+                text,
+              },
+              accessory: {
+                type: 'button',
+                text: {
+                  type: 'plain_text',
+                  text: 'View More',
+                },
+                action_id: 'button-action',
+              },
+            },
+            {
+              type: 'context',
+              elements: [
+                {
+                  type: 'plain_text',
+                  text: 'Severity: normal',
+                  emoji: true,
+                },
+                {
+                  type: 'plain_text',
+                  text: 'Topic: N/A',
+                  emoji: true,
+                },
+              ],
+            },
+          ],
+          fallback: 'notification',
+        },
+      ],
+    });
+
+    it('should replace user entity refs with Slack compatible mentions', async () => {
+      const slack = new WebClient();
+      const processor = SlackNotificationProcessor.fromConfig(config, {
+        auth,
+        discovery,
+        logger,
+        catalog: catalogServiceMock({
+          entities: DEFAULT_ENTITIES_RESPONSE.items,
+        }),
+        slack,
+      })[0];
+
+      await processor.postProcess(
+        {
+          origin: 'plugin',
+          id: '1234',
+          user: 'user:default/mock',
+          created: new Date(),
+          payload: {
+            title: 'notification',
+            description:
+              'Hello <@user:default/mock> and <@user:default/mock-without-slack-annotation>',
+          },
+        },
+        {
+          recipients: { type: 'entity', entityRef: 'user:default/mock' },
+          payload: {
+            title: 'notification',
+            description:
+              'Hello <@user:default/mock> and <@user:default/mock-without-slack-annotation>',
+          },
+        },
+      );
+
+      expect(slack.chat.postMessage).toHaveBeenCalledWith(
+        createBaseMessage(
+          'Hello <@U12345678> and <@user:default/mock-without-slack-annotation>',
+        ),
+      );
+    });
+
+    it('should handle text without user entity refs', async () => {
+      const slack = new WebClient();
+      const processor = SlackNotificationProcessor.fromConfig(config, {
+        auth,
+        discovery,
+        logger,
+        catalog: catalogServiceMock({
+          entities: DEFAULT_ENTITIES_RESPONSE.items,
+        }),
+        slack,
+      })[0];
+
+      await processor.postProcess(
+        {
+          origin: 'plugin',
+          id: '1234',
+          user: 'user:default/mock',
+          created: new Date(),
+          payload: {
+            title: 'notification',
+            description: 'Hello world',
+          },
+        },
+        {
+          recipients: { type: 'entity', entityRef: 'user:default/mock' },
+          payload: {
+            title: 'notification',
+            description: 'Hello world',
+          },
+        },
+      );
+
+      expect(slack.chat.postMessage).toHaveBeenCalledWith(
+        createBaseMessage('Hello world'),
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Replaces mentioned user entity refs in the notifications payload with Slack compatible mentions.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
