### PR TITLE
fix(feat): Shell command built from environment values

### DIFF
--- a/packages/repo-tools/src/commands/package-docs/command.ts
+++ b/packages/repo-tools/src/commands/package-docs/command.ts
@@ -158,23 +158,22 @@ export default async function packageDocs(paths: string[] = [], opts: any) {
     }
   }
 
-  const { stdout, stderr } = await execAsync(
-    [
-      cliPaths.resolveTargetRoot('node_modules/.bin/typedoc'),
-      '--entryPointStrategy',
-      'merge',
-      ...generatedPackageDirs.flatMap(pkg => [
-        '--entryPoints',
-        `dist-types/${pkg}/docs.json`,
-      ]),
-      ...HIGHLIGHT_LANGUAGES.flatMap(e => ['--highlightLanguages', e]),
-      '--out',
-      cliPaths.resolveTargetRoot('type-docs'),
-    ].join(' '),
-    {
-      cwd: cliPaths.targetRoot,
-    },
-  );
+  const typedocPath = cliPaths.resolveTargetRoot('node_modules/.bin/typedoc');
+  const args = [
+    '--entryPointStrategy',
+    'merge',
+    ...generatedPackageDirs.flatMap(pkg => [
+      '--entryPoints',
+      `dist-types/${pkg}/docs.json`,
+    ]),
+    ...HIGHLIGHT_LANGUAGES.flatMap(e => ['--highlightLanguages', e]),
+    '--out',
+    cliPaths.resolveTargetRoot('type-docs'),
+  ];
+
+  const { stdout, stderr } = await execAsync(typedocPath, args, {
+    cwd: cliPaths.targetRoot,
+  });
 
   console.log(stdout);
   console.error(stderr);


### PR DESCRIPTION
https://github.com/backstage/backstage/blob/f4e628639d6ed793181d871c5b1815c98fcc2a13/packages/repo-tools/src/commands/package-docs/command.ts#L162-L173

fix the issue the dynamically constructed shell command should be replaced with a safer approach that avoids shell interpretation. Specifically, the `execFile` or `execFileSync` method should be used, which allows passing the command and its arguments as separate parameters. This ensures that the arguments are not interpreted by the shell, mitigating the risk of injection attacks.

The changes involve:
1. Replacing the `execAsync` call with `execFileAsync` (or equivalent) and passing the command and arguments separately.
2. Extracting the dynamic parts of the command (e.g., `generatedPackageDirs` and `HIGHLIGHT_LANGUAGES`) into an array of arguments.
3. Ensuring that all paths and arguments are properly sanitized and validated before being passed to the command.

This shell command depends on an uncontrolled 
https://github.com/backstage/backstage/blob/f4e628639d6ed793181d871c5b1815c98fcc2a13/packages/cli-common/src/paths.ts#L121-L122

https://github.com/backstage/backstage/blob/f4e628639d6ed793181d871c5b1815c98fcc2a13/packages/cli-common/src/paths.ts#L167-L167

Dynamically constructing a shell command with values from the local environment, such as file paths, may inadvertently change the meaning of the shell command. Such changes can occur when an environment value contains characters that the shell interprets in a special way, for instance quotes and spaces. This can result in the shell command misbehaving, or even allowing a malicious user to execute arbitrary commands on the system.

## References
[Command Injection](https://www.owasp.org/index.php/Command_Injection)
[CWE-78](https://cwe.mitre.org/data/definitions/78.html)
[CWE-88](https://cwe.mitre.org/data/definitions/88.html)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
