### PR TITLE
feat(home): add entity presentation api to home page widgets

### DIFF
--- a/.changeset/dry-shirts-film.md
+++ b/.changeset/dry-shirts-film.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-home': patch
+---
+
+Added the Catalog presentation API to the HomePageRecentlyVisited and HomePageTopVisited components

--- a/plugins/home/src/components/VisitList/ItemName.tsx
+++ b/plugins/home/src/components/VisitList/ItemName.tsx
@@ -18,15 +18,27 @@ import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import { Visit } from '../../api/VisitsApi';
 import { Link } from '@backstage/core-components';
+import { EntityRefLink } from '@backstage/plugin-catalog-react';
 
-const useStyles = makeStyles(_theme => ({
+const useStyles = makeStyles(theme => ({
   name: {
     marginLeft: '0.8rem',
     marginRight: '0.8rem',
+    fontSize: theme.typography.body1.fontSize,
   },
 }));
 export const ItemName = ({ visit }: { visit: Visit }) => {
   const classes = useStyles();
+
+  if (visit.entityRef)
+    return (
+      <EntityRefLink
+        entityRef={visit.entityRef}
+        className={classes.name}
+        hideIcon
+        disableTooltip
+      />
+    );
 
   return (
     <Typography


### PR DESCRIPTION
This PR adds the entity presentation API to the `HomePageRecentlyVisited` and `HomePageTopVisited` components, contributing to #20955.

<img width="236" alt="Scherm­afbeelding 2025-05-07 om 15 28 13" src="https://github.com/user-attachments/assets/e0334a68-3baf-4944-a833-1be6ae6ad3bf" />

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
