### PR TITLE
Pass queryOptions to ElasticSearchSearchEngine

### DIFF
--- a/.changeset/grumpy-phones-kiss.md
+++ b/.changeset/grumpy-phones-kiss.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend-module-elasticsearch': patch
+---
+
+Fixed an issue where the `search.elasticsearch.queryOptions` config were not picked up by the `ElasticSearchSearchEngine`.

--- a/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngine.ts
+++ b/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngine.ts
@@ -192,6 +192,9 @@ export class ElasticSearchSearchEngine implements SearchEngine {
       config.getOptional<ElasticSearchHighlightOptions>(
         'search.elasticsearch.highlightOptions',
       ),
+      config.getOptional<ElasticSearchQueryConfig>(
+        'search.elasticsearch.queryOptions',
+      ),
     );
 
     for (const indexTemplate of this.readIndexTemplateConfig(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

It looks like `ElasticSearchSearchEngine` wasn't picking up `search.elasticsearch.queryOptions`.
Closes #27339

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
