### PR TITLE
Canon - Styling fixes for field clear button

### DIFF
--- a/.changeset/chatty-months-grow.md
+++ b/.changeset/chatty-months-grow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/canon': patch
+---
+
+Use correct colour token for TextField clear button icon and prevent layout shift as it is hidden or shown.

--- a/.changeset/chatty-months-grow.md
+++ b/.changeset/chatty-months-grow.md
@@ -2,4 +2,4 @@
 '@backstage/canon': patch
 ---
 
-Use correct colour token for TextField clear button icon, prevent layout shift whenever it is hidden or shown and properly size focus area around it. Also stop leading icon shrinking when used together.
+Use correct colour token for TextField clear button icon, prevent layout shift whenever it is hidden or shown and properly size focus area around it. Also stop leading icon shrinking when used together with clear button.

--- a/.changeset/chatty-months-grow.md
+++ b/.changeset/chatty-months-grow.md
@@ -2,4 +2,4 @@
 '@backstage/canon': patch
 ---
 
-Use correct colour token for TextField clear button icon and prevent layout shift as it is hidden or shown.
+Use correct colour token for TextField clear button icon, prevent layout shift whenever it is hidden or shown and properly size focus area around it. Also stop leading icon shrinking when used together.

--- a/packages/canon/css/components.css
+++ b/packages/canon/css/components.css
@@ -581,6 +581,7 @@
   width: 1.5rem;
   height: 1.5rem;
   color: var(--canon-fg-primary);
+  flex-shrink: 0;
   display: block;
 }
 

--- a/packages/canon/css/components.css
+++ b/packages/canon/css/components.css
@@ -608,11 +608,12 @@
 }
 
 .canon-TextFieldClearButton {
-  padding: 0 0 0 var(--canon-space-1);
+  margin-left: var(--canon-space-1);
   vertical-align: middle;
   color: var(--canon-fg-primary);
   background: none;
   border: none;
+  padding: 0;
   display: none;
 }
 

--- a/packages/canon/css/components.css
+++ b/packages/canon/css/components.css
@@ -594,7 +594,12 @@
   cursor: inherit;
   background: none;
   border: none;
+  padding: 0;
   transition: border-color .2s ease-in-out, outline-color .2s ease-in-out;
+}
+
+.canon-TextFieldInput:not([data-filled]):has( + .canon-TextFieldClearButton) {
+  padding-right: 1.25rem;
 }
 
 .canon-TextFieldInput[type="search"]::-webkit-search-cancel-button, .canon-TextFieldInput[type="search"]::-webkit-search-decoration {
@@ -604,6 +609,7 @@
 .canon-TextFieldClearButton {
   padding: 0 0 0 var(--canon-space-1);
   vertical-align: middle;
+  color: var(--canon-fg-primary);
   background: none;
   border: none;
   display: none;

--- a/packages/canon/css/styles.css
+++ b/packages/canon/css/styles.css
@@ -9832,11 +9832,12 @@
 }
 
 .canon-TextFieldClearButton {
-  padding: 0 0 0 var(--canon-space-1);
+  margin-left: var(--canon-space-1);
   vertical-align: middle;
   color: var(--canon-fg-primary);
   background: none;
   border: none;
+  padding: 0;
   display: none;
 }
 

--- a/packages/canon/css/styles.css
+++ b/packages/canon/css/styles.css
@@ -9818,7 +9818,12 @@
   cursor: inherit;
   background: none;
   border: none;
+  padding: 0;
   transition: border-color .2s ease-in-out, outline-color .2s ease-in-out;
+}
+
+.canon-TextFieldInput:not([data-filled]):has( + .canon-TextFieldClearButton) {
+  padding-right: 1.25rem;
 }
 
 .canon-TextFieldInput[type="search"]::-webkit-search-cancel-button, .canon-TextFieldInput[type="search"]::-webkit-search-decoration {
@@ -9828,6 +9833,7 @@
 .canon-TextFieldClearButton {
   padding: 0 0 0 var(--canon-space-1);
   vertical-align: middle;
+  color: var(--canon-fg-primary);
   background: none;
   border: none;
   display: none;

--- a/packages/canon/css/styles.css
+++ b/packages/canon/css/styles.css
@@ -9805,6 +9805,7 @@
   width: 1.5rem;
   height: 1.5rem;
   color: var(--canon-fg-primary);
+  flex-shrink: 0;
   display: block;
 }
 

--- a/packages/canon/css/textfield.css
+++ b/packages/canon/css/textfield.css
@@ -61,7 +61,12 @@
   cursor: inherit;
   background: none;
   border: none;
+  padding: 0;
   transition: border-color .2s ease-in-out, outline-color .2s ease-in-out;
+}
+
+.canon-TextFieldInput:not([data-filled]):has( + .canon-TextFieldClearButton) {
+  padding-right: 1.25rem;
 }
 
 .canon-TextFieldInput[type="search"]::-webkit-search-cancel-button, .canon-TextFieldInput[type="search"]::-webkit-search-decoration {
@@ -71,6 +76,7 @@
 .canon-TextFieldClearButton {
   padding: 0 0 0 var(--canon-space-1);
   vertical-align: middle;
+  color: var(--canon-fg-primary);
   background: none;
   border: none;
   display: none;

--- a/packages/canon/css/textfield.css
+++ b/packages/canon/css/textfield.css
@@ -48,6 +48,7 @@
   width: 1.5rem;
   height: 1.5rem;
   color: var(--canon-fg-primary);
+  flex-shrink: 0;
   display: block;
 }
 

--- a/packages/canon/css/textfield.css
+++ b/packages/canon/css/textfield.css
@@ -75,11 +75,12 @@
 }
 
 .canon-TextFieldClearButton {
-  padding: 0 0 0 var(--canon-space-1);
+  margin-left: var(--canon-space-1);
   vertical-align: middle;
   color: var(--canon-fg-primary);
   background: none;
   border: none;
+  padding: 0;
   display: none;
 }
 

--- a/packages/canon/src/components/TextField/TextField.stories.tsx
+++ b/packages/canon/src/components/TextField/TextField.stories.tsx
@@ -130,7 +130,7 @@ export const WithOnClear: Story = {
     ...WithLabel.args,
     placeholder: 'Search...',
     type: 'search',
-    onClear: () => null,
+    onClear: () => console.log('Cleared!'),
   },
 };
 

--- a/packages/canon/src/components/TextField/TextField.styles.css
+++ b/packages/canon/src/components/TextField/TextField.styles.css
@@ -78,6 +78,11 @@
   width: 100%;
   height: 100%;
   cursor: inherit;
+  padding: 0;
+}
+
+.canon-TextFieldInput:not([data-filled]):has(+ .canon-TextFieldClearButton) {
+  padding-right: 1.25rem;
 }
 
 .canon-TextFieldInput[type='search']::-webkit-search-cancel-button,
@@ -91,6 +96,7 @@
   background: none;
   border: none;
   vertical-align: middle;
+  color: var(--canon-fg-primary);
 }
 
 .canon-TextFieldInput[data-filled] + .canon-TextFieldClearButton {

--- a/packages/canon/src/components/TextField/TextField.styles.css
+++ b/packages/canon/src/components/TextField/TextField.styles.css
@@ -93,7 +93,8 @@
 
 .canon-TextFieldClearButton {
   display: none;
-  padding: 0 0 0 var(--canon-space-1);
+  padding: 0;
+  margin-left: var(--canon-space-1);
   background: none;
   border: none;
   vertical-align: middle;

--- a/packages/canon/src/components/TextField/TextField.styles.css
+++ b/packages/canon/src/components/TextField/TextField.styles.css
@@ -65,6 +65,7 @@
   width: 1.5rem;
   height: 1.5rem;
   color: var(--canon-fg-primary);
+  flex-shrink: 0;
 }
 
 .canon-TextFieldInput {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I spotted a couple of problems with the new clear button added to the TextField in https://github.com/backstage/backstage/pull/29820. Firstly, it did not use the correct colour token and therefore was not visible in dark mode. Secondly, for fields without a fixed width, the field would grow/shrink in size as the button was shown or hidden. Both of these issues have been rectified here

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
