### PR TITLE
Notifications Email Module - Enable endpoint configuration for SES

### DIFF
--- a/.changeset/moody-women-itch.md
+++ b/.changeset/moody-women-itch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications-backend-module-email': patch
+---
+
+Enable the ability to configure the endpoint for the SES connection used in the notifications email module. This enables the configuration of alternate endpoints as required, for example for local testing or alternative stacks.

--- a/plugins/notifications-backend-module-email/config.d.ts
+++ b/plugins/notifications-backend-module-email/config.d.ts
@@ -65,6 +65,10 @@ export interface Config {
                */
               accountId?: string;
               /**
+               * AWS endpoint to use, defaults to standard AWS endpoint based on region
+               */
+              endpoint?: string;
+              /**
                * AWS region to use
                */
               region?: string;

--- a/plugins/notifications-backend-module-email/src/processor/transports/ses.ts
+++ b/plugins/notifications-backend-module-email/src/processor/transports/ses.ts
@@ -30,6 +30,7 @@ export const createSesTransport = async (
       apiVersion: config.getOptionalString('apiVersion') ?? '2010-12-01',
       credentials: credentials.sdkCredentialProvider,
       region: config.getOptionalString('region'),
+      endpoint: config.getOptionalString('endpoint'),
     },
   ]);
   return createTransport({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Enable the ability to configure the endpoint for the SES connection used in the notifications email module. This enables the configuration of alternate endpoints as required, for example for local testing or alternative stacks.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
