### PR TITLE
Fix missing edges in the catalog-graph plugin

### DIFF
--- a/.changeset/some-horses-ask.md
+++ b/.changeset/some-horses-ask.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-graph': patch
+---
+
+Fix rendering of missing relations

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/useEntityRelationNodesAndEdges.test.ts
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/useEntityRelationNodesAndEdges.test.ts
@@ -34,6 +34,17 @@ const useEntityRelationGraph = useEntityRelationGraphMocked as jest.Mock<
   ReturnType<typeof useEntityRelationGraphMocked>
 >;
 
+/*
+  This is the full test graph:
+  - b:d/c -> k:d/a1 (ownerOf)
+  - b:d/c -> b:d/c1 (hasPart)
+  - k:d/a1 -> b:d/c (ownedBy)
+  - k:d/a1 -> b:d/c1 (ownedBy)
+  - b:d/c1 -> b:d/c (partOf)
+  - b:d/c1 -> k:d/a1 (ownerOf)
+  - b:d/c1 -> b:d/c2 (hasPart)
+  - b:d/c2 -> b:d/c1 (partOf)
+*/
 const entities: { [ref: string]: Entity } = {
   'b:d/c': {
     apiVersion: 'a',
@@ -236,6 +247,12 @@ describe('useEntityRelationNodesAndEdges', () => {
       {
         from: 'b:d/c1',
         label: 'visible',
+        relations: [RELATION_OWNER_OF, RELATION_OWNED_BY],
+        to: 'k:d/a1',
+      },
+      {
+        from: 'b:d/c1',
+        label: 'visible',
         relations: [RELATION_HAS_PART, RELATION_PART_OF],
         to: 'b:d/c2',
       },
@@ -305,8 +322,38 @@ describe('useEntityRelationNodesAndEdges', () => {
       {
         from: 'b:d/c1',
         label: 'visible',
+        relations: [RELATION_PART_OF],
+        to: 'b:d/c',
+      },
+      {
+        from: 'b:d/c1',
+        label: 'visible',
+        relations: [RELATION_OWNER_OF],
+        to: 'k:d/a1',
+      },
+      {
+        from: 'b:d/c1',
+        label: 'visible',
         relations: [RELATION_HAS_PART],
         to: 'b:d/c2',
+      },
+      {
+        from: 'b:d/c2',
+        label: 'visible',
+        relations: [RELATION_PART_OF],
+        to: 'b:d/c1',
+      },
+      {
+        from: 'k:d/a1',
+        label: 'visible',
+        relations: [RELATION_OWNED_BY],
+        to: 'b:d/c',
+      },
+      {
+        from: 'k:d/a1',
+        label: 'visible',
+        relations: [RELATION_OWNED_BY],
+        to: 'b:d/c1',
       },
     ]);
   });
@@ -545,6 +592,12 @@ describe('useEntityRelationNodesAndEdges', () => {
       },
       {
         from: 'b:d/c1',
+        label: 'visible',
+        relations: ['ownerOf', 'ownedBy'],
+        to: 'k:d/a1',
+      },
+      {
+        from: 'b:d/c',
         label: 'visible',
         relations: ['ownerOf', 'ownedBy'],
         to: 'k:d/a1',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The catalog-graph has a hook called `useEntityRelationNodesAndEdges` which creates the nodes and edges for a set of entities. The current mechanism is incorrect and non-deterministic. It has a set `visitedNodes` so that it doesn't visit nodes more than once while traversing - this part is correct. However, it also uses this set to look for edges to be created or not, which causes graphs to be incomplete and the result depending on the order of the entities.

The PR replaces the `visitedNodes` check, with a check that ensures the edge doesn't already exist before creating it, so that it creates edges to nodes that _have_ been visited, which is correct.

Some tests needed to be updated, and the change feels very reasonable IMO.

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
