### PR TITLE
remove explicit tag fetching

### DIFF
--- a/.github/workflows/sync_version-packages.yml
+++ b/.github/workflows/sync_version-packages.yml
@@ -24,9 +24,6 @@ jobs:
           fetch-tags: true
           token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}
 
-      - name: Fetch tags # See https://github.com/actions/checkout/issues/2041
-        run: git fetch --tags
-
       - name: Install Dependencies
         run: yarn --immutable
       - name: Create Release Pull Request


### PR DESCRIPTION
Attempt to undo https://github.com/backstage/backstage/pull/28715 because https://github.com/actions/checkout/issues/2041#issuecomment-2766377359 claims that runners now use a version of git that does the right thing. [Recent runs](https://github.com/backstage/backstage/actions/runs/14936392728/job/41964701450#step:5:21) seem to confirm that that git version is indeed in use.