### PR TITLE
CODEOWNERS: joint ownership of /microsite/static

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,6 +25,7 @@ yarn.lock                                         @backstage/maintainers @backst
 /docs/tooling                                     @backstage/tooling-maintainers
 /microsite                                        @backstage/documentation-maintainers
 /microsite/data/plugins                           @backstage/maintainers
+/microsite/static                                 @backstage/maintainers @backstage/documentation-maintainers
 /packages                                         @backstage/framework-maintainers
 /packages/backend-openapi-utils                   @backstage/maintainers @backstage/reviewers @backstage/openapi-tooling-maintainers
 /packages/canon                                   @backstage/design-system-maintainers


### PR DESCRIPTION
🧹, hit this as part of https://github.com/backstage/backstage/pull/29561, plugin listing updates often include changes to the static assets.