### PR TITLE
feat: add a react 17 deprecation warning

### DIFF
--- a/.changeset/fluffy-lands-stand.md
+++ b/.changeset/fluffy-lands-stand.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': minor
+---
+
+Add a warning for React 17 deprecation that triggers when frontend packages and plugins start.

--- a/.changeset/fluffy-lands-stand.md
+++ b/.changeset/fluffy-lands-stand.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/cli': minor
+'@backstage/cli': patch
 ---
 
 Add a warning for React 17 deprecation that triggers when frontend packages and plugins start.

--- a/packages/cli/src/modules/start/commands/package/start/startFrontend.ts
+++ b/packages/cli/src/modules/start/commands/package/start/startFrontend.ts
@@ -22,6 +22,7 @@ import {
 } from '../../../../build/lib/bundler';
 import { paths } from '../../../../../lib/paths';
 import { BackstagePackageJson } from '@backstage/cli-node';
+import { hasReactDomClient } from '../../../../build/lib/bundler/hasReactDomClient';
 
 interface StartAppOptions {
   verifyVersions?: boolean;
@@ -39,6 +40,12 @@ export async function startFrontend(options: StartAppOptions) {
   const packageJson = (await readJson(
     resolvePath(options.targetDir ?? paths.targetDir, 'package.json'),
   )) as BackstagePackageJson;
+
+  if (!hasReactDomClient()) {
+    console.warn(
+      'React 17 is now deprecated! Please follow the Backstage migration guide to update to React 18: https://backstage.io/docs/tutorials/react18-migration/',
+    );
+  }
 
   const waitForExit = await serveBundle({
     entry: options.entry,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds a warning for React 17 deprecation that triggers when frontend packages and plugins start.

The easiest way I found to test this was by creating a new Backstage app and then patching @backstage/cli with the changes.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
