### PR TITLE
update `refresh_state_references.id` to big int

### DIFF
--- a/.changeset/tough-heads-knock.md
+++ b/.changeset/tough-heads-knock.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Update `refresh_state_references.id` to be a big int

--- a/plugins/catalog-backend/migrations/20250514000000_refresh_state_references_big_increments.js
+++ b/plugins/catalog-backend/migrations/20250514000000_refresh_state_references_big_increments.js
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @param {import('knex').Knex} knex
+ * @returns {Promise<void>}
+ */
+exports.up = async function up(knex) {
+  if (knex.client.config.client.includes('pg')) {
+    await knex.schema.raw(
+      `ALTER TABLE refresh_state_references ALTER COLUMN id TYPE bigint;`,
+    );
+    await knex.schema.raw(
+      `ALTER SEQUENCE refresh_state_references_id_seq AS bigint MAXVALUE 9223372036854775807;`,
+    );
+  } else if (knex.client.config.client.includes('mysql')) {
+    await knex.schema.raw(
+      `ALTER TABLE refresh_state_references MODIFY id bigint AUTO_INCREMENT;`,
+    );
+  }
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ * @returns {Promise<void>}
+ */
+exports.down = async function down(knex) {
+  if (knex.client.config.client.includes('pg')) {
+    await knex.schema.raw(
+      `ALTER SEQUENCE refresh_state_references_id_seq AS integer MAXVALUE 2147483647;`,
+    );
+    await knex.schema.raw(
+      `ALTER TABLE refresh_state_references ALTER COLUMN id TYPE integer;`,
+    );
+  } else if (knex.client.config.client.includes('mysql')) {
+    await knex.schema.raw(
+      `ALTER TABLE refresh_state_references MODIFY id integer AUTO_INCREMENT;`,
+    );
+  }
+};

--- a/plugins/catalog-backend/report.sql.md
+++ b/plugins/catalog-backend/report.sql.md
@@ -8,7 +8,7 @@
 ## Sequences
 
 - `location_update_log_id_seq` (bigint)
-- `refresh_state_references_id_seq` (integer)
+- `refresh_state_references_id_seq` (bigint)
 
 ## Table `final_entities`
 
@@ -93,12 +93,12 @@
 
 ## Table `refresh_state_references`
 
-| Column              | Type      | Nullable | Max Length | Default                                                |
-| ------------------- | --------- | -------- | ---------- | ------------------------------------------------------ |
-| `id`                | `integer` | false    | -          | `nextval('refresh_state_references_id_seq'::regclass)` |
-| `source_entity_ref` | `text`    | true     | -          | -                                                      |
-| `source_key`        | `text`    | true     | -          | -                                                      |
-| `target_entity_ref` | `text`    | false    | -          | -                                                      |
+| Column              | Type     | Nullable | Max Length | Default                                                |
+| ------------------- | -------- | -------- | ---------- | ------------------------------------------------------ |
+| `id`                | `bigint` | false    | -          | `nextval('refresh_state_references_id_seq'::regclass)` |
+| `source_entity_ref` | `text`   | true     | -          | -                                                      |
+| `source_key`        | `text`   | true     | -          | -                                                      |
+| `target_entity_ref` | `text`   | false    | -          | -                                                      |
 
 ### Indices
 

--- a/plugins/catalog-backend/src/database/DefaultProviderDatabase.test.ts
+++ b/plugins/catalog-backend/src/database/DefaultProviderDatabase.test.ts
@@ -610,16 +610,18 @@ describe('DefaultProviderDatabase', () => {
         );
         let references = await knex<DbRefreshStateReferencesRow>(
           'refresh_state_references',
-        ).select();
+        )
+          .select()
+          .orderBy('id');
         expect(references).toEqual([
           {
-            id: 1,
+            id: expect.anything(),
             source_key: 'lols',
             source_entity_ref: null,
             target_entity_ref: 'component:default/a',
           },
           {
-            id: 2,
+            id: expect.anything(),
             source_key: 'lols',
             source_entity_ref: null,
             target_entity_ref: 'component:default/b',
@@ -670,16 +672,18 @@ describe('DefaultProviderDatabase', () => {
         );
         references = await knex<DbRefreshStateReferencesRow>(
           'refresh_state_references',
-        ).select();
+        )
+          .select()
+          .orderBy('id');
         expect(references).toEqual([
           {
-            id: 2,
+            id: expect.anything(),
             source_key: 'lols',
             source_entity_ref: null,
             target_entity_ref: 'component:default/b',
           },
           {
-            id: 3,
+            id: expect.anything(),
             source_key: 'lols',
             source_entity_ref: null,
             target_entity_ref: 'component:default/a',


### PR DESCRIPTION
This does put an exclusive lock on the table while changing the type and it rewrites the entire table when doing so since the data type is wider than what was there before.

However, since it's a primary column, doing it entirely without blocking is quite involved. It's interesting to note that this column is currently unused in code, and mostly there as a best practice. Also in even the largest of installations this table is a few tens of megabytes and takes a handful of seconds to update. Therefore I judged this in-place simpler solution as a reasonable balance.