### PR TITLE
Fix git filtering bitbucket pull request scaffolder

### DIFF
--- a/.changeset/honest-moles-bet.md
+++ b/.changeset/honest-moles-bet.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-scaffolder-backend-module-bitbucket-server': patch
+'@backstage/plugin-scaffolder-backend-module-bitbucket-cloud': patch
+'@backstage/plugin-scaffolder-node': patch
+---
+
+Update pull request creation filter to include .gitignore files in the created pull request

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPullRequest.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPullRequest.ts
@@ -23,6 +23,7 @@ import {
   addFiles,
   cloneRepo,
   parseRepoUrl,
+  filterGitFiles,
 } from '@backstage/plugin-scaffolder-node';
 import { Config } from '@backstage/config';
 import fs from 'fs-extra';
@@ -413,9 +414,7 @@ export function createPublishBitbucketCloudPullRequestAction(options: {
         // copy files
         fs.cpSync(sourceDir, tempDir, {
           recursive: true,
-          filter: path => {
-            return !(path.indexOf('.git') > -1);
-          },
+          filter: filterGitFiles,
         });
 
         await addFiles({

--- a/plugins/scaffolder-backend-module-bitbucket-server/src/actions/bitbucketServerPullRequest.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-server/src/actions/bitbucketServerPullRequest.ts
@@ -26,6 +26,7 @@ import {
   addFiles,
   cloneRepo,
   parseRepoUrl,
+  filterGitFiles,
 } from '@backstage/plugin-scaffolder-node';
 import { Config } from '@backstage/config';
 import fs from 'fs-extra';
@@ -453,9 +454,7 @@ export function createPublishBitbucketServerPullRequestAction(options: {
         // copy files
         fs.cpSync(sourceDir, tempDir, {
           recursive: true,
-          filter: path => {
-            return !(path.indexOf('.git') > -1);
-          },
+          filter: filterGitFiles,
         });
 
         await addFiles({

--- a/plugins/scaffolder-node/src/actions/index.ts
+++ b/plugins/scaffolder-node/src/actions/index.ts
@@ -33,4 +33,4 @@ export {
   createBranch,
   cloneRepo,
 } from './gitHelpers';
-export { parseRepoUrl, getRepoSourceDirectory } from './util';
+export { parseRepoUrl, getRepoSourceDirectory, filterGitFiles } from './util';

--- a/plugins/scaffolder-node/src/actions/util.test.ts
+++ b/plugins/scaffolder-node/src/actions/util.test.ts
@@ -244,4 +244,26 @@ describe('scaffolder action utils', () => {
       });
     });
   });
+
+  describe('filterGitFiles', () => {
+    it('should filter .git directory and its contents but keep other files', () => {
+      // Import the function to test
+      const { filterGitFiles } = require('./util');
+
+      // Should filter out .git directory
+      expect(filterGitFiles('.git')).toBe(false);
+
+      // Should filter out .git directory in subdirectories
+      expect(filterGitFiles('subdir/.git')).toBe(false);
+
+      // Should filter out files inside .git directory
+      expect(filterGitFiles('.git/config')).toBe(false);
+      expect(filterGitFiles('subdir/.git/config')).toBe(false);
+
+      // Should keep .gitignore and other non-.git-directory files
+      expect(filterGitFiles('.gitignore')).toBe(true);
+      expect(filterGitFiles('src/components/GitHubIcon.js')).toBe(true);
+      expect(filterGitFiles('.github/workflows/ci.yml')).toBe(true);
+    });
+  });
 });

--- a/plugins/scaffolder-node/src/actions/util.ts
+++ b/plugins/scaffolder-node/src/actions/util.ts
@@ -186,3 +186,12 @@ export const parseSchemas = (
     outputSchema: action.schema.output,
   };
 };
+
+/**
+ * Filter function to exclude the .git directory and its contents
+ * while keeping other files like .gitignore
+ * @public
+ */
+export function filterGitFiles(path: string): boolean {
+  return !(path.endsWith('.git') || path.includes('.git/'));
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updated the bitbucket pull request actions to allow for the submission of `.gitignore` files.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
