### PR TITLE
Updated branch restrictions value data type to string due to failures

### DIFF
--- a/.changeset/true-tools-play.md
+++ b/.changeset/true-tools-play.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-bitbucket-cloud': patch
+---
+
+Fix `bitbucketCloudBranchRestrictions` API calls to accept null to prevent 400 errors for some branch restriction kinds defined.

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudBranchRestriction.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudBranchRestriction.ts
@@ -30,7 +30,7 @@ const createBitbucketCloudBranchRestriction = async (opts: {
   branchMatchKind?: string;
   branchType?: string;
   pattern?: string;
-  value?: number;
+  value?: number | null;
   users?: { uuid: string; type: string }[];
   groups?: { slug: string; type: string }[];
   authorization: {
@@ -84,7 +84,7 @@ export function createBitbucketCloudBranchRestrictionAction(options: {
     branchMatchKind?: string;
     branchType?: string;
     pattern?: string;
-    value?: number;
+    value?: number | null;
     users?: { uuid: string }[];
     groups?: { slug: string }[];
     token?: string;

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/inputProperties.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/inputProperties.ts
@@ -213,6 +213,7 @@ const restriction = {
     description:
       'The value of the restriction. This field is required when kind is one of require_approvals_to_merge / require_default_reviewer_approvals_to_merge / require_passing_builds_to_merge / require_commits_behind.',
     type: 'number',
+    nullable: true,
   },
   users: {
     title: 'users',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR fixes a type mismatch with the Bitbucket API, where certain fields were expected to accept `null`, but TypeScript's `number` type does not allow it. To resolve this, I updated the types to accept null as well, which aligns with the API's behavior.

Additionally, I addressed issues with merge check restrictions that were causing `400 Bad Request` errors due to incorrect or unsupported values. The affected restrictions are:

- `require_default_reviewer_approvals_to_merge`
- `require_no_changes_requested`
- `require_passing_builds_to_merge`
- `require_commits_behind`
- `reset_pullrequest_approvals_on_change`
- `smart_reset_pullrequest_approvals`
- `reset_pullrequest_changes_requested_on_change`
- `require_all_dependencies_merged`
- `enforce_merge_checks`
- `allow_auto_merge_when_builds_pass`

These changes ensure smoother interaction with the Bitbucket API.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
