### PR TITLE
remove padding from k8s content

### DIFF
--- a/.changeset/slick-cameras-bet.md
+++ b/.changeset/slick-cameras-bet.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes': patch
+---
+
+Removed the kubernetes content padding to avoid double padding on k8s entity page

--- a/plugins/kubernetes/src/KubernetesContent.tsx
+++ b/plugins/kubernetes/src/KubernetesContent.tsx
@@ -64,7 +64,7 @@ export const KubernetesContent = ({
 
   return (
     <Page themeId="tool">
-      <Content>
+      <Content noPadding>
         <RequireKubernetesPermissions>
           <DetectedErrorsContext.Provider
             value={[...detectedErrors.values()].flat()}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

When adding the k8s content to an entity page there is a double padding, One from entityPage content and a second one from the kubernetes page content

This PR removes the K8s padding
| before k8 padding | entityPage padding |
| --- | --- |
| ![Screenshot 2025-05-15 at 23 08 04](https://github.com/user-attachments/assets/5fc1cb43-9fbe-4d50-91e3-b8f92252a0a4) | ![Screenshot 2025-05-15 at 23 08 22](https://github.com/user-attachments/assets/688356cd-6a52-4808-a5a1-a53e335ccb03) |

|after just entityPage padding|
|---|
|![Screenshot 2025-05-16 at 10 37 24](https://github.com/user-attachments/assets/74d68ed2-daaf-475a-86fd-5a4541ad225b)|


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
