### PR TITLE
Add truncate prop to Text and Heading

### DIFF
--- a/.changeset/witty-weeks-boil.md
+++ b/.changeset/witty-weeks-boil.md
@@ -1,0 +1,5 @@
+---
+'@backstage/canon': patch
+---
+
+Add new truncate prop to Text and Heading components in Canon.

--- a/canon-docs/src/app/(docs)/components/heading/page.mdx
+++ b/canon-docs/src/app/(docs)/components/heading/page.mdx
@@ -62,6 +62,22 @@ appearance of the heading.
 </Flex>`}
 />
 
+### Truncate
+
+The `Heading` component has a `truncate` prop that can be used to truncate the
+heading.
+
+<Snippet
+  py={2}
+  open
+  preview={<HeadingSnippet story="Truncate" />}
+  code={`<Heading style={{ maxWidth: '400px' }} truncate>
+    A man looks at a painting in a museum and says, “Brothers and sisters I
+    have none, but that man&apos;s father is my father's son.” Who is
+    in the painting?
+  </Heading>`}
+/>
+
 ### Responsive
 
 You can also use the `variant` prop to change the appearance of the text based

--- a/canon-docs/src/app/(docs)/components/heading/props.ts
+++ b/canon-docs/src/app/(docs)/components/heading/props.ts
@@ -12,6 +12,10 @@ export const headingPropDefs: Record<string, PropDef> = {
     values: ['ReactNode'],
     responsive: false,
   },
+  truncate: {
+    type: 'boolean',
+    default: 'false',
+  },
   ...classNamePropDefs,
   ...stylePropDefs,
 };

--- a/canon-docs/src/app/(docs)/components/text/page.mdx
+++ b/canon-docs/src/app/(docs)/components/text/page.mdx
@@ -102,6 +102,21 @@ appearance of the text.
   </Flex>`}
 />
 
+### Truncate
+
+The `Text` component has a `truncate` prop that can be used to truncate the
+text.
+
+<Snippet
+  open
+  preview={<TextSnippet story="Truncate" />}
+  code={`<Text weight="regular" style={{ maxWidth: '600px' }} truncate>
+    A man looks at a painting in a museum and says, “Brothers and sisters I
+    have none, but that man&apos;s father is my father&apos;s son.” Who is
+    in the painting?
+  </Text>`}
+/>
+
 ### Responsive
 
 You can also use the `variant` prop to change the appearance of the text based

--- a/canon-docs/src/app/(docs)/components/text/props.ts
+++ b/canon-docs/src/app/(docs)/components/text/props.ts
@@ -16,6 +16,10 @@ export const textPropDefs: Record<string, PropDef> = {
     values: ['regular', 'bold'],
     responsive: true,
   },
+  truncate: {
+    type: 'boolean',
+    default: 'false',
+  },
   ...childrenPropDefs,
   ...classNamePropDefs,
   ...stylePropDefs,

--- a/packages/canon/css/components.css
+++ b/packages/canon/css/components.css
@@ -403,6 +403,12 @@
   color: var(--canon-fg-success);
 }
 
+.canon-Text[data-truncate] {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
 .canon-Heading {
   font-family: var(--canon-font-regular);
   color: var(--canon-fg-primary);
@@ -439,6 +445,12 @@
 .canon-Heading[data-variant="title5"] {
   font-size: var(--canon-font-size-5);
   font-weight: var(--canon-font-weight-bold);
+}
+
+.canon-Heading[data-truncate] {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 }
 
 .canon-IconButton {

--- a/packages/canon/css/heading.css
+++ b/packages/canon/css/heading.css
@@ -35,3 +35,9 @@
   font-size: var(--canon-font-size-5);
   font-weight: var(--canon-font-weight-bold);
 }
+
+.canon-Heading[data-truncate] {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}

--- a/packages/canon/css/styles.css
+++ b/packages/canon/css/styles.css
@@ -9627,6 +9627,12 @@
   color: var(--canon-fg-success);
 }
 
+.canon-Text[data-truncate] {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
 .canon-Heading {
   font-family: var(--canon-font-regular);
   color: var(--canon-fg-primary);
@@ -9663,6 +9669,12 @@
 .canon-Heading[data-variant="title5"] {
   font-size: var(--canon-font-size-5);
   font-weight: var(--canon-font-weight-bold);
+}
+
+.canon-Heading[data-truncate] {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 }
 
 .canon-IconButton {

--- a/packages/canon/css/text.css
+++ b/packages/canon/css/text.css
@@ -51,3 +51,9 @@
 .canon-Text[data-color="success"] {
   color: var(--canon-fg-success);
 }
+
+.canon-Text[data-truncate] {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}

--- a/packages/canon/report.api.md
+++ b/packages/canon/report.api.md
@@ -627,6 +627,8 @@ export interface HeadingProps {
   // (undocumented)
   style?: React.CSSProperties;
   // (undocumented)
+  truncate?: boolean;
+  // (undocumented)
   variant?:
     | 'display'
     | 'title1'
@@ -1249,6 +1251,8 @@ export interface TextProps {
       >;
   // (undocumented)
   style?: CSSProperties;
+  // (undocumented)
+  truncate?: boolean;
   // (undocumented)
   variant?:
     | 'subtitle'

--- a/packages/canon/src/components/Heading/Heading.stories.tsx
+++ b/packages/canon/src/components/Heading/Heading.stories.tsx
@@ -50,6 +50,14 @@ export const AllVariants: Story = {
   ),
 };
 
+export const Truncate: Story = {
+  args: {
+    ...Title1.args,
+    truncate: true,
+    style: { maxWidth: '400px' },
+  },
+};
+
 export const Responsive: Story = {
   args: {
     variant: {

--- a/packages/canon/src/components/Heading/Heading.tsx
+++ b/packages/canon/src/components/Heading/Heading.tsx
@@ -27,6 +27,7 @@ export const Heading = forwardRef<HTMLHeadingElement, HeadingProps>(
       children,
       variant = 'title1',
       as = 'h1',
+      truncate,
       className,
       ...restProps
     } = props;
@@ -47,6 +48,7 @@ export const Heading = forwardRef<HTMLHeadingElement, HeadingProps>(
         ref={ref}
         className={clsx('canon-Heading', className)}
         data-variant={responsiveVariant}
+        data-truncate={truncate}
         {...restProps}
       >
         {children}

--- a/packages/canon/src/components/Heading/styles.css
+++ b/packages/canon/src/components/Heading/styles.css
@@ -51,3 +51,9 @@
   font-size: var(--canon-font-size-5);
   font-weight: var(--canon-font-weight-bold);
 }
+
+.canon-Heading[data-truncate] {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/packages/canon/src/components/Heading/types.ts
+++ b/packages/canon/src/components/Heading/types.ts
@@ -33,6 +33,7 @@ export interface HeadingProps {
         >
       >;
   as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+  truncate?: boolean;
   className?: string;
   style?: React.CSSProperties;
 }

--- a/packages/canon/src/components/Text/Text.stories.tsx
+++ b/packages/canon/src/components/Text/Text.stories.tsx
@@ -78,6 +78,13 @@ export const AllColors: Story = {
   ),
 };
 
+export const Truncate: Story = {
+  args: {
+    ...Default.args,
+    truncate: true,
+  },
+};
+
 export const Responsive: Story = {
   args: {
     ...Default.args,

--- a/packages/canon/src/components/Text/Text.tsx
+++ b/packages/canon/src/components/Text/Text.tsx
@@ -30,6 +30,7 @@ export const Text = forwardRef<HTMLParagraphElement, TextProps>(
       color = 'primary',
       style,
       className,
+      truncate,
       ...restProps
     } = props;
 
@@ -45,6 +46,7 @@ export const Text = forwardRef<HTMLParagraphElement, TextProps>(
         data-variant={responsiveVariant}
         data-weight={responsiveWeight}
         data-color={responsiveColor}
+        data-truncate={truncate}
         style={style}
         {...restProps}
       >

--- a/packages/canon/src/components/Text/styles.css
+++ b/packages/canon/src/components/Text/styles.css
@@ -67,3 +67,9 @@
 .canon-Text[data-color='success'] {
   color: var(--canon-fg-success);
 }
+
+.canon-Text[data-truncate] {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/packages/canon/src/components/Text/types.ts
+++ b/packages/canon/src/components/Text/types.ts
@@ -39,6 +39,7 @@ export interface TextProps {
           'primary' | 'secondary' | 'danger' | 'warning' | 'success'
         >
       >;
+  truncate?: boolean;
   className?: string;
   style?: CSSProperties;
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds a `truncate` prop to `Text` and `Heading` to make sure your text stays in a single line with ellipsis at the end.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
