### PR TITLE
Canon - Improve the way we treat custom render on Text and Heading

### DIFF
--- a/.changeset/puny-garlics-bathe.md
+++ b/.changeset/puny-garlics-bathe.md
@@ -1,0 +1,5 @@
+---
+'@backstage/canon': minor
+---
+
+We are modifying the way we treat custom render using 'useRender()' under the hood from BaseUI.

--- a/packages/canon/css/components.css
+++ b/packages/canon/css/components.css
@@ -447,6 +447,26 @@
   font-weight: var(--canon-font-weight-bold);
 }
 
+.canon-Heading[data-color="primary"] {
+  color: var(--canon-fg-primary);
+}
+
+.canon-Heading[data-color="secondary"] {
+  color: var(--canon-fg-secondary);
+}
+
+.canon-Heading[data-color="danger"] {
+  color: var(--canon-fg-danger);
+}
+
+.canon-Heading[data-color="warning"] {
+  color: var(--canon-fg-warning);
+}
+
+.canon-Heading[data-color="success"] {
+  color: var(--canon-fg-success);
+}
+
 .canon-Heading[data-truncate] {
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/packages/canon/css/components.css
+++ b/packages/canon/css/components.css
@@ -455,18 +455,6 @@
   color: var(--canon-fg-secondary);
 }
 
-.canon-Heading[data-color="danger"] {
-  color: var(--canon-fg-danger);
-}
-
-.canon-Heading[data-color="warning"] {
-  color: var(--canon-fg-warning);
-}
-
-.canon-Heading[data-color="success"] {
-  color: var(--canon-fg-success);
-}
-
 .canon-Heading[data-truncate] {
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/packages/canon/css/heading.css
+++ b/packages/canon/css/heading.css
@@ -36,6 +36,26 @@
   font-weight: var(--canon-font-weight-bold);
 }
 
+.canon-Heading[data-color="primary"] {
+  color: var(--canon-fg-primary);
+}
+
+.canon-Heading[data-color="secondary"] {
+  color: var(--canon-fg-secondary);
+}
+
+.canon-Heading[data-color="danger"] {
+  color: var(--canon-fg-danger);
+}
+
+.canon-Heading[data-color="warning"] {
+  color: var(--canon-fg-warning);
+}
+
+.canon-Heading[data-color="success"] {
+  color: var(--canon-fg-success);
+}
+
 .canon-Heading[data-truncate] {
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/packages/canon/css/heading.css
+++ b/packages/canon/css/heading.css
@@ -44,18 +44,6 @@
   color: var(--canon-fg-secondary);
 }
 
-.canon-Heading[data-color="danger"] {
-  color: var(--canon-fg-danger);
-}
-
-.canon-Heading[data-color="warning"] {
-  color: var(--canon-fg-warning);
-}
-
-.canon-Heading[data-color="success"] {
-  color: var(--canon-fg-success);
-}
-
 .canon-Heading[data-truncate] {
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/packages/canon/css/styles.css
+++ b/packages/canon/css/styles.css
@@ -9671,6 +9671,26 @@
   font-weight: var(--canon-font-weight-bold);
 }
 
+.canon-Heading[data-color="primary"] {
+  color: var(--canon-fg-primary);
+}
+
+.canon-Heading[data-color="secondary"] {
+  color: var(--canon-fg-secondary);
+}
+
+.canon-Heading[data-color="danger"] {
+  color: var(--canon-fg-danger);
+}
+
+.canon-Heading[data-color="warning"] {
+  color: var(--canon-fg-warning);
+}
+
+.canon-Heading[data-color="success"] {
+  color: var(--canon-fg-success);
+}
+
 .canon-Heading[data-truncate] {
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/packages/canon/css/styles.css
+++ b/packages/canon/css/styles.css
@@ -9679,18 +9679,6 @@
   color: var(--canon-fg-secondary);
 }
 
-.canon-Heading[data-color="danger"] {
-  color: var(--canon-fg-danger);
-}
-
-.canon-Heading[data-color="warning"] {
-  color: var(--canon-fg-warning);
-}
-
-.canon-Heading[data-color="success"] {
-  color: var(--canon-fg-success);
-}
-
 .canon-Heading[data-truncate] {
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/packages/canon/report.api.md
+++ b/packages/canon/report.api.md
@@ -625,15 +625,7 @@ export interface HeadingProps
   color?:
     | 'primary'
     | 'secondary'
-    | 'danger'
-    | 'warning'
-    | 'success'
-    | Partial<
-        Record<
-          Breakpoint,
-          'primary' | 'secondary' | 'danger' | 'warning' | 'success'
-        >
-      >;
+    | Partial<Record<Breakpoint, 'primary' | 'secondary'>>;
   // (undocumented)
   style?: React.CSSProperties;
   // (undocumented)

--- a/packages/canon/report.api.md
+++ b/packages/canon/report.api.md
@@ -613,17 +613,27 @@ export interface GridProps extends SpaceProps {
 
 // @public (undocumented)
 export const Heading: ForwardRefExoticComponent<
-  HeadingProps & RefAttributes<HTMLHeadingElement>
+  Omit<HeadingProps, 'ref'> & RefAttributes<HTMLHeadingElement>
 >;
 
 // @public (undocumented)
-export interface HeadingProps {
-  // (undocumented)
-  as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
-  // (undocumented)
-  children: React.ReactNode;
+export interface HeadingProps
+  extends Omit<useRender.ComponentProps<'h1'>, 'color'> {
   // (undocumented)
   className?: string;
+  // (undocumented)
+  color?:
+    | 'primary'
+    | 'secondary'
+    | 'danger'
+    | 'warning'
+    | 'success'
+    | Partial<
+        Record<
+          Breakpoint,
+          'primary' | 'secondary' | 'danger' | 'warning' | 'success'
+        >
+      >;
   // (undocumented)
   style?: React.CSSProperties;
   // (undocumented)
@@ -1208,7 +1218,7 @@ export interface TableCellTextProps
 
 // @public (undocumented)
 const Text_2: ForwardRefExoticComponent<
-  TextProps & RefAttributes<HTMLParagraphElement>
+  Omit<TextProps, 'ref'> & RefAttributes<HTMLParagraphElement>
 >;
 export { Text_2 as Text };
 
@@ -1231,9 +1241,8 @@ export interface TextFieldProps
 }
 
 // @public (undocumented)
-export interface TextProps {
-  // (undocumented)
-  children: ReactNode;
+export interface TextProps
+  extends Omit<useRender.ComponentProps<'p'>, 'color'> {
   // (undocumented)
   className?: string;
   // (undocumented)

--- a/packages/canon/src/components/Heading/Heading.stories.tsx
+++ b/packages/canon/src/components/Heading/Heading.stories.tsx
@@ -50,6 +50,21 @@ export const AllVariants: Story = {
   ),
 };
 
+export const AllColors: Story = {
+  args: {
+    ...Default.args,
+  },
+  render: args => (
+    <Flex gap="4" direction="column">
+      <Heading color="primary" {...args} />
+      <Heading color="secondary" {...args} />
+      <Heading color="danger" {...args} />
+      <Heading color="warning" {...args} />
+      <Heading color="success" {...args} />
+    </Flex>
+  ),
+};
+
 export const Truncate: Story = {
   args: {
     ...Title1.args,
@@ -67,13 +82,6 @@ export const Responsive: Story = {
   },
 };
 
-export const CustomTag: Story = {
-  args: {
-    variant: 'title5',
-    as: 'h2',
-  },
-};
-
 export const WrappedInLink: Story = {
   args: {
     ...Default.args,
@@ -85,6 +93,13 @@ export const WrappedInLink: Story = {
       </a>
     ),
   ],
+};
+
+export const CustomRender: Story = {
+  args: {
+    ...Default.args,
+    render: <h4 />,
+  },
 };
 
 export const Playground: Story = {

--- a/packages/canon/src/components/Heading/Heading.stories.tsx
+++ b/packages/canon/src/components/Heading/Heading.stories.tsx
@@ -58,9 +58,6 @@ export const AllColors: Story = {
     <Flex gap="4" direction="column">
       <Heading color="primary" {...args} />
       <Heading color="secondary" {...args} />
-      <Heading color="danger" {...args} />
-      <Heading color="warning" {...args} />
-      <Heading color="success" {...args} />
     </Flex>
   ),
 };

--- a/packages/canon/src/components/Heading/Heading.tsx
+++ b/packages/canon/src/components/Heading/Heading.tsx
@@ -14,46 +14,41 @@
  * limitations under the License.
  */
 
-import { forwardRef } from 'react';
+import { forwardRef, useRef } from 'react';
 import clsx from 'clsx';
 import { useResponsiveValue } from '../../hooks/useResponsiveValue';
-
+import { useRender } from '@base-ui-components/react/use-render';
 import type { HeadingProps } from './types';
 
 /** @public */
 export const Heading = forwardRef<HTMLHeadingElement, HeadingProps>(
   (props, ref) => {
     const {
-      children,
       variant = 'title1',
-      as = 'h1',
+      color = 'primary',
       truncate,
       className,
+      render = <h1 />,
       ...restProps
     } = props;
 
-    // Get the responsive value for the variant
     const responsiveVariant = useResponsiveValue(variant);
+    const responsiveColor = useResponsiveValue(color);
+    const internalRef = useRef<HTMLElement | null>(null);
 
-    // Determine the component to render based on the variant
-    let Component = as;
-    if (variant === 'title2') Component = 'h2';
-    if (variant === 'title3') Component = 'h3';
-    if (variant === 'title4') Component = 'h4';
-    if (variant === 'title5') Component = 'h5';
-    if (as) Component = as;
+    const { renderElement } = useRender({
+      render,
+      props: {
+        className: clsx('canon-Heading', className),
+        ['data-variant']: responsiveVariant,
+        ['data-color']: responsiveColor,
+        ['data-truncate']: truncate,
+        ...restProps,
+      },
+      refs: [ref, internalRef],
+    });
 
-    return (
-      <Component
-        ref={ref}
-        className={clsx('canon-Heading', className)}
-        data-variant={responsiveVariant}
-        data-truncate={truncate}
-        {...restProps}
-      >
-        {children}
-      </Component>
-    );
+    return renderElement();
   },
 );
 

--- a/packages/canon/src/components/Heading/styles.css
+++ b/packages/canon/src/components/Heading/styles.css
@@ -60,18 +60,6 @@
   color: var(--canon-fg-secondary);
 }
 
-.canon-Heading[data-color='danger'] {
-  color: var(--canon-fg-danger);
-}
-
-.canon-Heading[data-color='warning'] {
-  color: var(--canon-fg-warning);
-}
-
-.canon-Heading[data-color='success'] {
-  color: var(--canon-fg-success);
-}
-
 .canon-Heading[data-truncate] {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/packages/canon/src/components/Heading/styles.css
+++ b/packages/canon/src/components/Heading/styles.css
@@ -52,6 +52,26 @@
   font-weight: var(--canon-font-weight-bold);
 }
 
+.canon-Heading[data-color='primary'] {
+  color: var(--canon-fg-primary);
+}
+
+.canon-Heading[data-color='secondary'] {
+  color: var(--canon-fg-secondary);
+}
+
+.canon-Heading[data-color='danger'] {
+  color: var(--canon-fg-danger);
+}
+
+.canon-Heading[data-color='warning'] {
+  color: var(--canon-fg-warning);
+}
+
+.canon-Heading[data-color='success'] {
+  color: var(--canon-fg-success);
+}
+
 .canon-Heading[data-truncate] {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/packages/canon/src/components/Heading/types.ts
+++ b/packages/canon/src/components/Heading/types.ts
@@ -15,10 +15,11 @@
  */
 
 import { Breakpoint } from '../../types';
+import type { useRender } from '@base-ui-components/react/use-render';
 
 /** @public */
-export interface HeadingProps {
-  children: React.ReactNode;
+export interface HeadingProps
+  extends Omit<useRender.ComponentProps<'h1'>, 'color'> {
   variant?:
     | 'display'
     | 'title1'
@@ -32,7 +33,18 @@ export interface HeadingProps {
           'display' | 'title1' | 'title2' | 'title3' | 'title4' | 'title5'
         >
       >;
-  as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+  color?:
+    | 'primary'
+    | 'secondary'
+    | 'danger'
+    | 'warning'
+    | 'success'
+    | Partial<
+        Record<
+          Breakpoint,
+          'primary' | 'secondary' | 'danger' | 'warning' | 'success'
+        >
+      >;
   truncate?: boolean;
   className?: string;
   style?: React.CSSProperties;

--- a/packages/canon/src/components/Heading/types.ts
+++ b/packages/canon/src/components/Heading/types.ts
@@ -36,15 +36,7 @@ export interface HeadingProps
   color?:
     | 'primary'
     | 'secondary'
-    | 'danger'
-    | 'warning'
-    | 'success'
-    | Partial<
-        Record<
-          Breakpoint,
-          'primary' | 'secondary' | 'danger' | 'warning' | 'success'
-        >
-      >;
+    | Partial<Record<Breakpoint, 'primary' | 'secondary'>>;
   truncate?: boolean;
   className?: string;
   style?: React.CSSProperties;

--- a/packages/canon/src/components/Text/Text.stories.tsx
+++ b/packages/canon/src/components/Text/Text.stories.tsx
@@ -108,6 +108,13 @@ export const WrappedInLink: Story = {
   ],
 };
 
+export const CustomRender: Story = {
+  args: {
+    ...Default.args,
+    render: <span />,
+  },
+};
+
 export const Playground: Story = {
   render: () => (
     <Flex gap="4" direction="column">

--- a/packages/canon/src/components/Text/Text.tsx
+++ b/packages/canon/src/components/Text/Text.tsx
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import { forwardRef } from 'react';
+import { forwardRef, useRef } from 'react';
 import { useResponsiveValue } from '../../hooks/useResponsiveValue';
+import { useRender } from '@base-ui-components/react/use-render';
 import clsx from 'clsx';
 
 import type { TextProps } from './types';
@@ -24,13 +25,12 @@ import type { TextProps } from './types';
 export const Text = forwardRef<HTMLParagraphElement, TextProps>(
   (props, ref) => {
     const {
-      children,
       variant = 'body',
       weight = 'regular',
       color = 'primary',
-      style,
       className,
       truncate,
+      render = <p />,
       ...restProps
     } = props;
 
@@ -38,21 +38,22 @@ export const Text = forwardRef<HTMLParagraphElement, TextProps>(
     const responsiveVariant = useResponsiveValue(variant);
     const responsiveWeight = useResponsiveValue(weight);
     const responsiveColor = useResponsiveValue(color);
+    const internalRef = useRef<HTMLElement | null>(null);
 
-    return (
-      <p
-        ref={ref}
-        className={clsx('canon-Text', className)}
-        data-variant={responsiveVariant}
-        data-weight={responsiveWeight}
-        data-color={responsiveColor}
-        data-truncate={truncate}
-        style={style}
-        {...restProps}
-      >
-        {children}
-      </p>
-    );
+    const { renderElement } = useRender({
+      render,
+      props: {
+        className: clsx('canon-Text', className),
+        ['data-variant']: responsiveVariant,
+        ['data-weight']: responsiveWeight,
+        ['data-color']: responsiveColor,
+        ['data-truncate']: truncate,
+        ...restProps,
+      },
+      refs: [ref, internalRef],
+    });
+
+    return renderElement();
   },
 );
 

--- a/packages/canon/src/components/Text/types.ts
+++ b/packages/canon/src/components/Text/types.ts
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-import type { CSSProperties, ReactNode } from 'react';
+import type { CSSProperties } from 'react';
 import type { Breakpoint } from '../../types';
+import type { useRender } from '@base-ui-components/react/use-render';
 
 /** @public */
-export interface TextProps {
-  children: ReactNode;
+export interface TextProps
+  extends Omit<useRender.ComponentProps<'p'>, 'color'> {
   variant?:
     | 'subtitle'
     | 'body'


### PR DESCRIPTION
## Hey, I just made a Pull Request!

We are improving the way we handle custom render using BaseUI useRender() function under the hood.

You will now be able to do something like this:
```tsx
<Text render={<span />}>Hello world</Text>
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
