### PR TITLE
feat: add sidebar popper submenu type

### DIFF
--- a/.changeset/nine-kiwis-study.md
+++ b/.changeset/nine-kiwis-study.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/core-components': minor
+'@backstage/core-components': patch
 ---
 
 This adds a `subMenuType` property to the `subMenuOptions` prop on the sidebar to choose a different submenu rendering layout. The types to choose from are `default` and `popper`. The `default` type keeps the original submenu layout, whilst the `popper` type allow the submenu to render as a Material UI Popper component, anchored near the menu item containing the submenu, for easier accessibility.

--- a/.changeset/nine-kiwis-study.md
+++ b/.changeset/nine-kiwis-study.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': minor
+---
+
+This adds a `subMenuType` property to the `subMenuOptions` prop on the sidebar to choose a different submenu rendering layout. The types to choose from are `default` and `popper`. The `default` type keeps the original submenu layout, whilst the `popper` type allow the submenu to render as a Material UI Popper component, anchored near the menu item containing the submenu, for easier accessibility.

--- a/.github/vale/config/vocabularies/Backstage/accept.txt
+++ b/.github/vale/config/vocabularies/Backstage/accept.txt
@@ -540,3 +540,4 @@ scrollable
 severities
 intellij
 tsconfig
+submenu

--- a/packages/core-components/report-alpha.api.md
+++ b/packages/core-components/report-alpha.api.md
@@ -23,10 +23,10 @@ export const coreComponentsTranslationRef: TranslationRef<
     readonly 'signIn.title': 'Sign In';
     readonly 'signIn.loginFailed': 'Login failed';
     readonly 'signIn.customProvider.title': 'Custom User';
+    readonly 'signIn.customProvider.continue': 'Continue';
     readonly 'signIn.customProvider.subtitle': 'Enter your own User ID and credentials.\n This selection will not be stored.';
     readonly 'signIn.customProvider.userId': 'User ID';
     readonly 'signIn.customProvider.tokenInvalid': 'Token is not a valid OpenID Connect JWT Token';
-    readonly 'signIn.customProvider.continue': 'Continue';
     readonly 'signIn.customProvider.idToken': 'ID Token (optional)';
     readonly 'signIn.guestProvider.title': 'Guest';
     readonly 'signIn.guestProvider.enter': 'Enter';

--- a/packages/core-components/report-alpha.api.md
+++ b/packages/core-components/report-alpha.api.md
@@ -23,10 +23,10 @@ export const coreComponentsTranslationRef: TranslationRef<
     readonly 'signIn.title': 'Sign In';
     readonly 'signIn.loginFailed': 'Login failed';
     readonly 'signIn.customProvider.title': 'Custom User';
-    readonly 'signIn.customProvider.continue': 'Continue';
     readonly 'signIn.customProvider.subtitle': 'Enter your own User ID and credentials.\n This selection will not be stored.';
     readonly 'signIn.customProvider.userId': 'User ID';
     readonly 'signIn.customProvider.tokenInvalid': 'Token is not a valid OpenID Connect JWT Token';
+    readonly 'signIn.customProvider.continue': 'Continue';
     readonly 'signIn.customProvider.idToken': 'ID Token (optional)';
     readonly 'signIn.guestProvider.title': 'Guest';
     readonly 'signIn.guestProvider.enter': 'Enter';

--- a/packages/core-components/report.api.md
+++ b/packages/core-components/report.api.md
@@ -1285,7 +1285,7 @@ export interface StructuredMetadataTableProps {
 export type SubmenuOptions = {
   drawerWidthClosed?: number;
   drawerWidthOpen?: number;
-  subMenuType: 'default' | 'popper';
+  subMenuType?: 'default' | 'popper';
 };
 
 // Warning: (ae-forgotten-export) The symbol "SubvalueCellProps" needs to be exported by the entry point index.d.ts

--- a/packages/core-components/report.api.md
+++ b/packages/core-components/report.api.md
@@ -1285,6 +1285,7 @@ export interface StructuredMetadataTableProps {
 export type SubmenuOptions = {
   drawerWidthClosed?: number;
   drawerWidthOpen?: number;
+  subMenuType: 'default' | 'popper';
 };
 
 // Warning: (ae-forgotten-export) The symbol "SubvalueCellProps" needs to be exported by the entry point index.d.ts

--- a/packages/core-components/src/layout/Sidebar/Items.tsx
+++ b/packages/core-components/src/layout/Sidebar/Items.tsx
@@ -47,11 +47,12 @@ import {
   useContext,
   useMemo,
   useState,
-  MouseEvent,
   ChangeEvent,
   ReactElement,
   createElement,
+  TouchEvent,
 } from 'react';
+import type { MouseEvent } from 'react';
 
 import {
   Link,
@@ -510,9 +511,18 @@ const SidebarItemWithSubmenu = ({
   const isSmallScreen = useMediaQuery((theme: Theme) =>
     theme.breakpoints.down('sm'),
   );
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const [popperKey, setPopperKey] = useState(0);
 
-  const handleMouseEnter = () => {
+  const handleMouseEnter = (
+    e:
+      | MouseEvent<HTMLDivElement, globalThis.MouseEvent>
+      | TouchEvent<HTMLDivElement>,
+  ) => {
     setIsHoveredOn(true);
+    if (e.currentTarget instanceof HTMLElement) {
+      setAnchorEl(e.currentTarget);
+    }
   };
   const handleMouseLeave = () => {
     setIsHoveredOn(false);
@@ -538,6 +548,9 @@ const SidebarItemWithSubmenu = ({
       value={{
         isHoveredOn,
         setIsHoveredOn,
+        anchorEl,
+        popperKey,
+        setPopperKey,
       }}
     >
       <div

--- a/packages/core-components/src/layout/Sidebar/SidebarSubmenu.tsx
+++ b/packages/core-components/src/layout/Sidebar/SidebarSubmenu.tsx
@@ -150,9 +150,11 @@ export const SidebarSubmenu = (props: SidebarSubmenuProps) => {
         }}
       >
         <Paper>
-          <Typography variant="h5" component="div" className={classes.title}>
-            {props.title}
-          </Typography>
+          {props.title && (
+            <Typography variant="h5" component="div" className={classes.title}>
+              {props.title}
+            </Typography>
+          )}
           {props.children}
         </Paper>
       </Popper>

--- a/packages/core-components/src/layout/Sidebar/SidebarSubmenu.tsx
+++ b/packages/core-components/src/layout/Sidebar/SidebarSubmenu.tsx
@@ -26,6 +26,8 @@ import {
   SubmenuConfig,
 } from './config';
 import { useSidebarOpenState } from './SidebarOpenStateContext';
+import Paper from '@material-ui/core/Paper';
+import Popper from '@material-ui/core/Popper';
 
 /** @public */
 export type SidebarSubmenuClassKey = 'root' | 'drawer' | 'drawerOpen' | 'title';
@@ -120,12 +122,42 @@ export const SidebarSubmenu = (props: SidebarSubmenuProps) => {
     : sidebarConfig.drawerWidthClosed;
   const classes = useStyles({ left, submenuConfig });
 
-  const { isHoveredOn } = useContext(SidebarItemWithSubmenuContext);
-  const [isSubmenuOpen, setIsSubmenuOpen] = useState(false);
+  const { isHoveredOn, anchorEl } = useContext(SidebarItemWithSubmenuContext);
+  const [isSubmenuOpen, setIsSubmenuOpen] = useState(true);
 
   useEffect(() => {
     setIsSubmenuOpen(isHoveredOn);
   }, [isHoveredOn]);
+
+  if (submenuConfig.subMenuType === 'popper') {
+    return (
+      <Popper
+        open={isHoveredOn}
+        anchorEl={anchorEl}
+        placement="right-start"
+        transition
+        style={{
+          width: submenuConfig.drawerWidthOpen,
+        }}
+        modifiers={{
+          flip: {
+            enabled: true,
+          },
+          preventOverflow: {
+            enabled: true,
+            boundariesElement: 'viewport',
+          },
+        }}
+      >
+        <Paper>
+          <Typography variant="h5" component="div" className={classes.title}>
+            {props.title}
+          </Typography>
+          {props.children}
+        </Paper>
+      </Popper>
+    );
+  }
 
   return (
     <Box

--- a/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
+++ b/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
@@ -158,7 +158,10 @@ export type SidebarSubmenuItemProps = {
 export const SidebarSubmenuItem = (props: SidebarSubmenuItemProps) => {
   const { title, subtitle, to, icon: Icon, dropdownItems, exact } = props;
   const classes = useStyles();
-  const { setIsHoveredOn } = useContext(SidebarItemWithSubmenuContext);
+  const { setIsHoveredOn, setPopperKey } = useContext(
+    SidebarItemWithSubmenuContext,
+  );
+
   const closeSubmenu = () => {
     setIsHoveredOn(false);
   };
@@ -170,8 +173,16 @@ export const SidebarSubmenuItem = (props: SidebarSubmenuItemProps) => {
     props.initialShowDropdown ?? false,
   );
   const handleClickDropdown = () => {
+    // Force rerender of popper to recalculate position with dropdown items
+    /* Note: The setPopperKey state update should be run before setShowDropDown to 
+       ensure the popper is rerendered before the dropdown items are shown.
+       This avoids a flicker effect when the dropdown items are displayed,
+       and the popper disappearing when navigating back previous submenu items.
+    */
+    setPopperKey(prevKey => prevKey + 1);
     setShowDropDown(!showDropDown);
   };
+
   if (dropdownItems !== undefined) {
     dropdownItems.some(item => {
       const resolvedPath = resolvePath(item.to);

--- a/packages/core-components/src/layout/Sidebar/config.ts
+++ b/packages/core-components/src/layout/Sidebar/config.ts
@@ -30,7 +30,7 @@ export type SidebarOptions = {
 export type SubmenuOptions = {
   drawerWidthClosed?: number;
   drawerWidthOpen?: number;
-  subMenuType: 'default' | 'popper';
+  subMenuType?: 'default' | 'popper';
 };
 
 /** @internal */

--- a/packages/core-components/src/layout/Sidebar/config.ts
+++ b/packages/core-components/src/layout/Sidebar/config.ts
@@ -30,6 +30,7 @@ export type SidebarOptions = {
 export type SubmenuOptions = {
   drawerWidthClosed?: number;
   drawerWidthOpen?: number;
+  subMenuType: 'default' | 'popper';
 };
 
 /** @internal */
@@ -83,12 +84,14 @@ export type SubmenuConfig = {
   drawerWidthClosed: number;
   drawerWidthOpen: number;
   defaultOpenDelayMs: number;
+  subMenuType: 'default' | 'popper';
 };
 
-export const submenuConfig = {
+export const submenuConfig: SubmenuConfig = {
   drawerWidthClosed: 0,
   drawerWidthOpen: 202,
   defaultOpenDelayMs: sidebarConfig.defaultOpenDelayMs + 200,
+  subMenuType: 'default',
 };
 
 export const makeSidebarSubmenuConfig = (
@@ -114,10 +117,17 @@ export const SidebarConfigContext = createContext<SidebarConfigContextType>({
 export type SidebarItemWithSubmenuContextType = {
   isHoveredOn: boolean;
   setIsHoveredOn: Dispatch<SetStateAction<boolean>>;
+  anchorEl: HTMLElement | null;
+  popperKey: number;
+  setPopperKey: Dispatch<SetStateAction<number>>;
 };
 
 export const SidebarItemWithSubmenuContext =
   createContext<SidebarItemWithSubmenuContextType>({
     isHoveredOn: false,
     setIsHoveredOn: () => {},
+    anchorEl: null,
+    // State to force re-render of popper to recalculate position for dropdown items
+    popperKey: 0,
+    setPopperKey: () => {},
   });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds a `subMenuType` property to the `subMenuOptions` prop on the sidebar to choose a different submenu rendering layout. The types to choose from are `default` and `popper`. The `default` type keeps the original submenu layout, whilst the `popper` type allow the submenu to render as a Material UI Popper component, anchored near the menu item containing the submenu, for easier accessibility.

![msedge_Y0VHfEkRHc](https://github.com/user-attachments/assets/a33fff0c-9659-4b55-bf61-3e68ccf8f167)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
