### PR TITLE
Added a `variant` prop to the `WelcomeTitle` component

### DIFF
--- a/.changeset/many-beans-write.md
+++ b/.changeset/many-beans-write.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-home': patch
+---
+
+Added a `variant` prop to the `WelcomeTitle` component making it work with the Customizable Home page feature. Adding it like this `<WelcomeTitle variant='h1' />` to the list of items under `CustomHomepageGrid` will allow it to render with a size that works well.

--- a/packages/app/src/components/home/CustomizableHomePage.tsx
+++ b/packages/app/src/components/home/CustomizableHomePage.tsx
@@ -28,6 +28,7 @@ import { HomePageSearchBar } from '@backstage/plugin-search';
 import Grid from '@material-ui/core/Grid';
 
 import { tools, useLogoStyles } from './shared';
+import { WelcomeTitle } from '@backstage/plugin-home';
 
 const defaultConfig = [
   {
@@ -81,6 +82,7 @@ export const CustomizableHomePage = () => {
         </Grid>
 
         <CustomHomepageGrid config={defaultConfig}>
+          <WelcomeTitle variant="h1" />
           <HomePageSearchBar />
           <HomePageRecentlyVisited />
           <HomePageTopVisited />

--- a/plugins/home/src/homePageComponents/WelcomeTitle/WelcomeTitle.tsx
+++ b/plugins/home/src/homePageComponents/WelcomeTitle/WelcomeTitle.tsx
@@ -23,13 +23,18 @@ import Typography from '@material-ui/core/Typography';
 import { useEffect, useMemo } from 'react';
 import useAsync from 'react-use/esm/useAsync';
 import { getTimeBasedGreeting } from './timeUtil';
+import { Variant } from '@material-ui/core/styles/createTypography';
 
 /** @public */
 export type WelcomeTitleLanguageProps = {
   language?: string[];
+  variant?: Variant | 'inherit';
 };
 
-export const WelcomeTitle = ({ language }: WelcomeTitleLanguageProps) => {
+export const WelcomeTitle = ({
+  language,
+  variant,
+}: WelcomeTitleLanguageProps) => {
   const identityApi = useApi(identityApiRef);
   const alertApi = useApi(alertApiRef);
   const greeting = useMemo(() => getTimeBasedGreeting(language), [language]);
@@ -49,7 +54,7 @@ export const WelcomeTitle = ({ language }: WelcomeTitleLanguageProps) => {
 
   return (
     <Tooltip title={greeting.language}>
-      <Typography component="span" variant="inherit">{`${greeting.greeting}${
+      <Typography component="span" variant={variant}>{`${greeting.greeting}${
         profile?.displayName ? `, ${profile?.displayName}` : ''
       }!`}</Typography>
     </Tooltip>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added a `variant` prop to the `WelcomeTitle` component making it work with the Customizable Home page feature. Adding it like this `<WelcomeTitle variant='h1' />` to the list of items under `CustomHomepageGrid` will allow it to render with a size that works well.

| Before    | After |
| -------- | ------- |
| ![Screenshot 2025-05-19 at 4 28 05 PM](https://github.com/user-attachments/assets/90669f4b-5e69-4be5-9f3c-a86a73dc0143)  | ![Screenshot 2025-05-19 at 4 28 16 PM](https://github.com/user-attachments/assets/7b637a5d-47da-4b58-80db-993e39e1ea36)    |

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
