### PR TITLE
example-app - Root Sidebar Clean Up

### DIFF
--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -17,14 +17,9 @@
 import { PropsWithChildren } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import HomeIcon from '@material-ui/icons/Home';
-import RuleIcon from '@material-ui/icons/AssignmentTurnedIn';
-import MapIcon from '@material-ui/icons/MyLocation';
-import LayersIcon from '@material-ui/icons/Layers';
-import PlaylistPlayIcon from '@material-ui/icons/PlaylistPlay';
 import CreateComponentIcon from '@material-ui/icons/AddCircleOutline';
 import SearchIcon from '@material-ui/icons/Search';
 import MenuIcon from '@material-ui/icons/Menu';
-import MoneyIcon from '@material-ui/icons/MonetizationOn';
 import LogoFull from './LogoFull';
 import LogoIcon from './LogoIcon';
 import {
@@ -48,10 +43,11 @@ import {
 } from '@backstage/core-components';
 import { MyGroupsSidebarItem } from '@backstage/plugin-org';
 import { SearchModal } from '../search/SearchModal';
-import Score from '@material-ui/icons/Score';
 import { useApp } from '@backstage/core-plugin-api';
 import BuildIcon from '@material-ui/icons/Build';
 import { NotificationsSidebarItem } from '@backstage/plugin-notifications';
+import UpdateIcon from '@material-ui/icons/Update';
+import CategoryIcon from '@material-ui/icons/Category';
 
 const useSidebarLogoStyles = makeStyles({
   root: {
@@ -93,7 +89,8 @@ export const Root = ({ children }: PropsWithChildren<{}>) => (
       <SidebarDivider />
       <SidebarGroup label="Menu" icon={<MenuIcon />}>
         {/* Global nav, not org-specific */}
-        <SidebarItem icon={HomeIcon} to="catalog" text="Home">
+        <SidebarItem icon={HomeIcon} to="home" text="Home" />
+        <SidebarItem icon={CategoryIcon} to="/" text="Catalog">
           <SidebarSubmenu title="Catalog">
             <SidebarSubmenuItem
               title="Domains"
@@ -149,26 +146,20 @@ export const Root = ({ children }: PropsWithChildren<{}>) => (
           to="docs"
           text="Docs"
         />
-        <SidebarItem icon={PlaylistPlayIcon} to="playlist" text="Playlists" />
-        <SidebarItem icon={LayersIcon} to="explore" text="Explore" />
         <SidebarItem icon={CreateComponentIcon} to="create" text="Create..." />
         {/* End global nav */}
         <SidebarDivider />
         <SidebarScrollWrapper>
-          <SidebarItem icon={MapIcon} to="tech-radar" text="Tech Radar" />
-          <SidebarItem icon={RuleIcon} to="lighthouse" text="Lighthouse" />
           <SidebarItem
-            icon={MoneyIcon}
-            to="cost-insights"
-            text="Cost Insights"
+            icon={UpdateIcon}
+            to="catalog-unprocessed-entities"
+            text="Unprocessed Entities"
           />
-          <SidebarItem icon={Score} to="score-board" text="Score board" />
         </SidebarScrollWrapper>
-        <SidebarDivider />
-        <SidebarDivider />
-        <NotificationsSidebarItem />
       </SidebarGroup>
       <SidebarSpace />
+      <SidebarDivider />
+      <NotificationsSidebarItem />
       <SidebarDivider />
       <SidebarGroup
         label="Settings"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Did some clean up of the Root sidebar to better reflect the installed plugins. This adds a entry for the Home plugin and moved the Catalog to a dedicated item but still default this as the first page at start up. Also added an entry for the Unprocessed Entities plugin as it is installed but there was no easy way to get to it. Finally cleaned up the Notifications item to be closer to the bottom and remove the extra divider line.

No changeset as we don't ship the example-app. 👍 

| Before  | After  |
|---|---|
|  ![Screenshot 2025-05-20 at 7 39 45 AM](https://github.com/user-attachments/assets/77cf3292-a7dc-494f-831c-eb484f6e2d40) | ![Screenshot 2025-05-20 at 7 40 29 AM](https://github.com/user-attachments/assets/3e86cfe6-f9f2-4421-898f-b9d73c13eee5)  |

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
