### PR TITLE
[Docs] Kubernetes - Catalog cluster locator `dependsOn`

### DIFF
--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -203,6 +203,28 @@ or the
 [`AwsEKSClusterProcessor`](https://backstage.io/docs/reference/plugin-catalog-backend-module-aws.awseksclusterprocessor/)
 to automatically update the set of clusters tracked by Backstage.
 
+For this method to work any entity that would be using this `Resource` to help drive the Kubernetes details in the Catalog's Entity pages needs to have a `dependsOn` relationship setup. Here's a quick example:
+
+```yaml
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    backstage.io/kubernetes-id: dice-roller
+    backstage.io/kubernetes-namespace: default
+  name: dice-roller
+  description: It rolls dice
+  tags:
+    - go
+spec:
+  type: service
+  lifecycle: production
+  owner: guest
+  dependsOn: ['resource:my-cluster']
+```
+
+This example assumes it's using the default namespace, if that's not the case for you then make sure to include it like this: `resource:my-namespace/my-cluster`.
+
 #### `config`
 
 This cluster locator method will read cluster information from your app-config


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added details regarding the need for a `dependsOn` relationship needed to use the Catalog cluster locator method. 

As this isn't documented anywhere it's often a spot of confusion when trying to use this.

Related code: https://github.com/backstage/backstage/blob/5cc0ca32e1a2f62420d3bccf209f7d428e8765d9/plugins/kubernetes-backend/src/service-locator/CatalogRelationServiceLocator.ts#L57-L68

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
