### PR TITLE
fix: error message not showing outside of watch mode

### DIFF
--- a/.changeset/good-paths-act.md
+++ b/.changeset/good-paths-act.md
@@ -1,0 +1,5 @@
+---
+'@backstage/repo-tools': patch
+---
+
+Fix an issue where errors were not printed to console when running `backstage-repo-tools schema openapi generate` without the `--watch` flag.

--- a/packages/repo-tools/src/commands/package/schema/openapi/generate/index.ts
+++ b/packages/repo-tools/src/commands/package/schema/openapi/generate/index.ts
@@ -95,6 +95,7 @@ export async function command(opts: OptionValues) {
     try {
       await sharedCommand();
     } catch (err) {
+      console.error(chalk.red('Error: ', err));
       process.exit(1);
     }
   }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

@freben - missed this when creating the watch mode in #25539.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
