### PR TITLE
[Docs] Debugging - Updated to add `experimentalNetworking` flag for VS Code

### DIFF
--- a/docs/tooling/local-dev/debugging.md
+++ b/docs/tooling/local-dev/debugging.md
@@ -65,7 +65,8 @@ In your `.vscode/launch.json`, add a new entry with the following,
       "runtimeExecutable": "yarn", // Specifies the runtime to execute the application. In this case, it uses `yarn` to run the script.
       "args": ["start", "--inspect"], // Arguments passed to the `yarn` command. Here, it runs `yarn start` with the `--inspect` flag to enable debugging.
       "skipFiles": ["<node_internals>/**"], // Tells the debugger to skip stepping into Node.js internal files during debugging.
-      "console": "integratedTerminal" // Specifies that the debugger should use the integrated terminal for input/output.
+      "console": "integratedTerminal", // Specifies that the debugger should use the integrated terminal for input/output.
+      "experimentalNetworking": "off" // Since Node.js 22.15.0 an additional parameter --experimental-network-inspection is added but currently not supported by Yarn
     }
   ]
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updated to add `experimentalNetworking` flag for VS Code `launch.json`. Since Node 22.15.0 an additional parameter `--experimental-network-inspection` is added but currently not supported by Yarn and will prevent you from being able to launch the debugger without this flag.

Reference where the solution was found: https://github.com/microsoft/vscode-js-debug/issues/2220

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
