### PR TITLE
Added note design to search engine docs

### DIFF
--- a/docs/features/search/search-engines.md
+++ b/docs/features/search/search-engines.md
@@ -91,7 +91,10 @@ search:
       fragmentDelimiter: ' ... ' # Delimiter string used to concatenate fragments. Defaults to " ... ".
 ```
 
-**Note:** the highlight search term feature uses `ts_headline` which has been known to potentially impact performance. You only need this minimal config to disable it should you have issues:
+:::note Note 
+The highlight search term feature uses `ts_headline` which has been known to potentially impact performance. You only need this minimal config to disable it should you have issues:
+
+:::
 
 ```yaml
 search:

--- a/docs/features/search/search-engines.md
+++ b/docs/features/search/search-engines.md
@@ -92,7 +92,7 @@ search:
 ```
 
 :::note Note 
-The highlight search term feature uses `ts_headline` which has been known to potentially impact performance. You only need this minimal config to disable it should you have issues:
+The highlight search term feature uses `ts_headline` which has been known to potentially impact performance. You only need this minimal config to disable it should you have issues.
 
 :::
 

--- a/docs/features/search/search-engines.md
+++ b/docs/features/search/search-engines.md
@@ -92,6 +92,7 @@ search:
 ```
 
 :::note Note 
+
 The highlight search term feature uses `ts_headline` which has been known to potentially impact performance. You only need this minimal config to disable it should you have issues.
 
 :::


### PR DESCRIPTION
I have added note design changes to search engine docs

current Page:
![image](https://github.com/user-attachments/assets/fb967d14-2376-47bc-b31e-ad43eb24c31b)


After change :
![image](https://github.com/user-attachments/assets/eedf87a0-cf62-4023-8fa6-3217257efc7a)
