### PR TITLE
fix: add missing highlight language

### DIFF
--- a/.changeset/grumpy-dryers-act.md
+++ b/.changeset/grumpy-dryers-act.md
@@ -1,0 +1,5 @@
+---
+'@backstage/repo-tools': patch
+---
+
+Add missing highlight language for the `package-docs` command.

--- a/packages/repo-tools/src/commands/package-docs/command.ts
+++ b/packages/repo-tools/src/commands/package-docs/command.ts
@@ -56,6 +56,7 @@ const HIGHLIGHT_LANGUAGES = [
   'diff',
   'js',
   'json',
+  'docker',
 ];
 
 function getExports(packageJson: any) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Caused by #29573, looks like a missing highlight language was added while that branch was still out of date :/

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
