### PR TITLE
updated search engine docs note

### DIFF
--- a/docs/features/search/search-engines.md
+++ b/docs/features/search/search-engines.md
@@ -91,7 +91,11 @@ search:
       fragmentDelimiter: ' ... ' # Delimiter string used to concatenate fragments. Defaults to " ... ".
 ```
 
-**Note:** the highlight search term feature uses `ts_headline` which has been known to potentially impact performance. You only need this minimal config to disable it should you have issues:
+:::note Note 
+
+The highlight search term feature uses `ts_headline` which has been known to potentially impact performance. You only need this minimal config to disable it should you have issues.
+
+:::
 
 ```yaml
 search:


### PR DESCRIPTION
I have added note design changes to search engine docs

current Page:
![image](https://github.com/user-attachments/assets/7e07efbd-f274-41c3-a931-e07daa931e2f)

After change :
![image](https://github.com/user-attachments/assets/45c53e42-f1c9-4e83-861a-64a505a8a0a9)