### PR TITLE
feat(catalog-model): add support for status field

### DIFF
--- a/.changeset/social-words-check.md
+++ b/.changeset/social-words-check.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-model': minor
+---
+
+added support to be able to use the `status`field in entities

--- a/packages/catalog-model/src/entity/policies/NoForeignRootFieldsEntityPolicy.test.ts
+++ b/packages/catalog-model/src/entity/policies/NoForeignRootFieldsEntityPolicy.test.ts
@@ -25,6 +25,15 @@ describe('NoForeignRootFieldsEntityPolicy', () => {
     data = yaml.parse(`
       apiVersion: backstage.io/v1alpha1
       kind: Component
+      status:
+        items:
+          - type: backstage.io/catalog-processing
+            level: error
+            message: 'NotFoundError: File not found'
+            error:
+              name: NotFoundError
+              message: File not found
+              stack: Error stack
       metadata:
         uid: e01199ab-08cc-44c2-8e19-5c29ded82521
         etag: lsndfkjsndfkjnsdfkjnsd==

--- a/packages/catalog-model/src/entity/policies/NoForeignRootFieldsEntityPolicy.ts
+++ b/packages/catalog-model/src/entity/policies/NoForeignRootFieldsEntityPolicy.ts
@@ -17,7 +17,7 @@
 import { EntityPolicy } from './types';
 import { Entity } from '../Entity';
 
-const defaultKnownFields = ['apiVersion', 'kind', 'metadata', 'spec'];
+const defaultKnownFields = ['apiVersion', 'kind', 'status', 'metadata', 'spec'];
 
 /**
  * Ensures that there are no foreign root fields in the entity.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

https://github.com/backstage/backstage/issues/30033

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
