### PR TITLE
fix: Backstage ESlint rules signifiant speedup

### DIFF
--- a/.changeset/fluffy-bobcats-tell.md
+++ b/.changeset/fluffy-bobcats-tell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/eslint-plugin': patch
+---
+
+Fix custom rules package scanning performance.

--- a/packages/eslint-plugin/rules/no-undeclared-imports.js
+++ b/packages/eslint-plugin/rules/no-undeclared-imports.js
@@ -319,6 +319,7 @@ module.exports = {
         if (importsToAdd.length > 0) {
           addMissingImports(importsToAdd, packages, localPkg);
 
+          packages.clearCache();
           // This switches all import directives back to the original import.
           for (const added of importsToAdd) {
             context.report({
@@ -336,6 +337,7 @@ module.exports = {
           removeInlineImports(importsToInline, localPkg);
           addForwardedInlineImports(importsToInline, localPkg);
 
+          packages.clearCache();
           for (const inlined of importsToInline) {
             context.report({
               node: inlined.node,
@@ -350,8 +352,6 @@ module.exports = {
           }
           importsToInline.length = 0;
         }
-
-        packages.clearCache();
       },
       ...visitImports(context, (node, imp) => {
         // We leave checking of type imports to the repo-tools check,


### PR DESCRIPTION
## :wave:

### Context & Problem

While I was trying to improve my ESLint config, I noticed with `TIMING=1` that the slowest rule was taking an order of magnitude more than the other - and that it was a `@backstage/` one!

`TIMING=all yarn backstage-cli repo lint --fix`:
Rule                                                   | Time (ms) | Relative
:------------------------------------------------------|----------:|--------:
@backstage/no-forbidden-package-imports                | 12962.237 |    69.0%
@typescript-eslint/no-redeclare                        |   932.467 |     5.0%
@backstage/no-undeclared-imports                       |   685.183 |     3.6%
@backstage/no-relative-monorepo-imports                |   564.529 |     3.0%
notice/notice                                          |   339.391 |     1.8%
... | ... | ...

### Cause

- `manypkg.getPackagesSync()` is not superfast (scanning files...)
- `clearCache` was called to aggressively in `no-undeclared-import`
- cached only for 5s, while most runs are longer than that

### Solution

- `clearCache` in `no-undeclared-import` only when actions are taken
- Longer caching (5s -> 30s)
  - I believe it's a good balance between general speed and needing to reload ESlint server when working locally 

> In an earlier solution, I replaced `manypkg.getPackagesSync()` with a custom implementation that was faster, but more specialized.
> I believe it will be too much of a maintenance burden, and that performance optimizations be carried upstream (which already supports multiple tools), or by overriding the [scanning tools](https://github.com/Thinkmill/manypkg/tree/main/packages/tools/src).
> The current improvements are already significant, and have less risks.


### Quick benchmark

On the backstage/backstage repository:

**Before:**:
```
Benchmark old: yarn backstage-cli repo lint --fix
  Time (mean ± σ):     32.125 s ±  2.680 s    [User: 120.888 s, System: 38.496 s]
  Range (min … max):   29.555 s … 35.659 s    5 runs
```

Rule                                                   | Time (ms) | Relative
:------------------------------------------------------|----------:|--------:
@backstage/no-forbidden-package-imports                | 12962.237 |    69.0%
@typescript-eslint/no-redeclare                        |   932.467 |     5.0%
@backstage/no-undeclared-imports                       |   685.183 |     3.6%
@backstage/no-relative-monorepo-imports                |   564.529 |     3.0%
notice/notice                                          |   339.391 |     1.8%
... | ... | ...

**After:**
```
Benchmark 1: yarn backstage-cli repo lint --fix
  Time (mean ± σ):     20.434 s ±  1.533 s    [User: 94.206 s, System: 8.612 s]
  Range (min … max):   18.759 s … 22.589 s    5 runs
```

Rule                                                   | Time (ms) | Relative
:------------------------------------------------------|----------:|--------:
@typescript-eslint/no-redeclare                        |  1195.297 |    15.5%
@backstage/no-relative-monorepo-imports                |   612.720 |     8.0%
@backstage/no-undeclared-imports                       |   585.354 |     7.6%



<details><summary>**(Reverted) Custom scanning of workspaces**</summary>
<p>


```
hyperfine --warmup 1  --runs 5 'yarn backstage-cli repo lint --fix'
Benchmark 1: yarn backstage-cli repo lint --fix
  Time (mean ± σ):     17.220 s ±  1.862 s    [User: 86.202 s, System: 7.654 s]
  Range (min … max):   15.660 s … 19.939 s    5 runs
```

Rule                                                   | Time (ms) | Relative
:------------------------------------------------------|----------:|--------:
@typescript-eslint/no-redeclare                        |  1197.588 |    22.7%
... | ... | ...
@backstage/no-forbidden-package-imports                |    30.434 |     0.6%
... | ... | ...
@backstage/no-relative-monorepo-imports                |     3.866 |     0.1%
... | ... | ...
</p>
</details> 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
