### PR TITLE
[Catalog] GitLab Org SAAS - Ingest Users from Sub Groups

### DIFF
--- a/.changeset/major-heads-scream.md
+++ b/.changeset/major-heads-scream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-gitlab': minor
+---
+
+Changing default saas discovery to include members from subgroups of the root group

--- a/.changeset/major-heads-scream.md
+++ b/.changeset/major-heads-scream.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend-module-gitlab': minor
 ---
 
-Changing default SAAS discovery to include members from subgroups of the root group
+Breaking: User and Group discovery will default to ingesting all users in sub groups that belong to the specified root group in config. Disable setting config `restrictUsersToGroup: true`.

--- a/.changeset/major-heads-scream.md
+++ b/.changeset/major-heads-scream.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend-module-gitlab': minor
 ---
 
-Breaking: User and Group discovery will default to ingesting all users in sub groups that belong to the specified root group in config. Disable setting config `restrictUsersToGroup: true`.
+**BREAKING CHANGE**: User and Group discovery will default to ingesting all users in sub groups that belong to the specified root group in config. Disable by setting `restrictUsersToGroup: true` in app-config under your module settings.

--- a/.changeset/major-heads-scream.md
+++ b/.changeset/major-heads-scream.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend-module-gitlab': minor
 ---
 
-Changing default saas discovery to include members from subgroups of the root group
+Changing default SAAS discovery to include members from subgroups of the root group

--- a/plugins/catalog-backend-module-gitlab/src/__testUtils__/handlers.ts
+++ b/plugins/catalog-backend-module-gitlab/src/__testUtils__/handlers.ts
@@ -89,6 +89,14 @@ const httpHandlers = [
     },
   ),
 
+  rest.get(`${apiBaseUrlSaas}/groups/456/members/all`, (_req, res, ctx) => {
+    return res(ctx.json(all_saas_users_response));
+  }),
+
+  rest.get(`${apiBaseUrlSaas}/groups/1/members/all`, (_req, res, ctx) => {
+    return res(ctx.json(all_saas_users_response));
+  }),
+
   /**
    * Users REST endpoint mocks
    */

--- a/plugins/catalog-backend-module-gitlab/src/__testUtils__/handlers.ts
+++ b/plugins/catalog-backend-module-gitlab/src/__testUtils__/handlers.ts
@@ -30,7 +30,6 @@ import {
   some_endpoint,
   unhealthy_endpoint,
   userID,
-  all_saas_group_with_subgroups_members,
   all_saas_subgroup_1_members,
   all_saas_subgroup_2_members,
   group_with_subgroups_response,

--- a/plugins/catalog-backend-module-gitlab/src/__testUtils__/mocks.ts
+++ b/plugins/catalog-backend-module-gitlab/src/__testUtils__/mocks.ts
@@ -796,6 +796,30 @@ export const config_org_group_restrictUsers_true_selfHosted = {
     },
   },
 };
+
+export const config_org_group_with_subgroups_sass = {
+  integrations: {
+    gitlab: [
+      {
+        host: 'gitlab.com',
+        apiBaseUrl: 'https://gitlab.com/api/v4',
+        token: '1234',
+      },
+    ],
+  },
+  catalog: {
+    providers: {
+      gitlab: {
+        'test-id': {
+          host: 'gitlab.com',
+          group: 'group1',
+          orgEnabled: true,
+          skipForkedRepos: true,
+        },
+      },
+    },
+  },
+};
 /**
  * GitLab API responses
  */
@@ -1021,6 +1045,71 @@ export const all_saas_users_response: MockObject[] = [
     created_at: '2023-07-19T08:58:34.984Z',
     expires_at: null,
     id: 36,
+    username: 'testusernoseat1',
+    name: 'Test User No Seat 1',
+    state: 'active',
+    avatar_url: 'https://secure.gravatar.com/',
+    web_url: 'https://gitlab.com/testusernoseat1',
+    email: 'testusernoseat1@example.com',
+    group_saml_identity: {
+      provider: 'group_saml',
+      extern_uid: '60',
+      saml_provider_id: 1,
+    },
+    is_using_seat: false,
+    membership_state: 'active',
+  },
+];
+
+// Only test user 1
+export const all_saas_group_with_subgroups_members: MockObject[] = [
+  {
+    access_level: 30,
+    created_at: '2023-07-17T08:58:34.984Z',
+    expires_at: null,
+    id: 12,
+    username: 'testuser1',
+    name: 'Test User 1',
+    state: 'active',
+    avatar_url: 'https://secure.gravatar.com/',
+    web_url: 'https://gitlab.com/testuser1',
+    email: 'testuser1@example.com',
+    group_saml_identity: {
+      provider: 'group_saml',
+      extern_uid: '50',
+      saml_provider_id: 1,
+    },
+    is_using_seat: true,
+    membership_state: 'active',
+  },
+];
+
+// Only test user 1
+export const all_saas_subgroup_1_members: MockObject[] = [
+  {
+    access_level: 30,
+    created_at: '2023-07-17T08:58:34.984Z',
+    expires_at: null,
+    id: 12,
+    username: 'testuser1',
+    name: 'Test User 1',
+    state: 'active',
+    avatar_url: 'https://secure.gravatar.com/',
+    web_url: 'https://gitlab.com/testuser1',
+    email: 'testuser1@example.com',
+    group_saml_identity: {
+      provider: 'group_saml',
+      extern_uid: '51',
+      saml_provider_id: 1,
+    },
+    is_using_seat: true,
+    membership_state: 'active',
+  },
+  {
+    access_level: 30,
+    created_at: '2023-07-17T08:58:34.984Z',
+    expires_at: null,
+    id: 33,
     username: 'testuser3',
     name: 'Test User 3',
     state: 'active',
@@ -1032,7 +1121,49 @@ export const all_saas_users_response: MockObject[] = [
       extern_uid: '53',
       saml_provider_id: 1,
     },
-    is_using_seat: false,
+    is_using_seat: true,
+    membership_state: 'active',
+  },
+];
+
+// Only test user 2
+export const all_saas_subgroup_2_members: MockObject[] = [
+  {
+    access_level: 30,
+    created_at: '2023-07-19T08:58:34.984Z',
+    expires_at: null,
+    id: 34,
+    username: 'testuser2',
+    name: 'Test User 2',
+    state: 'active',
+    avatar_url: 'https://secure.gravatar.com/',
+    web_url: 'https://gitlab.com/testuser2',
+    email: 'testuser2@example.com',
+    group_saml_identity: {
+      provider: 'group_saml',
+      extern_uid: '52',
+      saml_provider_id: 1,
+    },
+    is_using_seat: true,
+    membership_state: 'active',
+  },
+  {
+    access_level: 30,
+    created_at: '2023-07-17T08:58:34.984Z',
+    expires_at: null,
+    id: 44,
+    username: 'testuser4',
+    name: 'Test User 4',
+    state: 'active',
+    avatar_url: 'https://secure.gravatar.com/',
+    web_url: 'https://gitlab.com/testuser4',
+    email: 'testuser4@example.com',
+    group_saml_identity: {
+      provider: 'group_saml',
+      extern_uid: '54',
+      saml_provider_id: 1,
+    },
+    is_using_seat: true,
     membership_state: 'active',
   },
 ];
@@ -1073,6 +1204,21 @@ export const all_groups_response: GitLabGroup[] = [
     name: 'subgroup1',
     description: '',
     full_path: 'group1/subgroup1',
+  },
+  {
+    id: 7,
+    name: 'subgroup2',
+    description: '',
+    full_path: 'group1/subgroup2',
+  },
+];
+
+export const group_with_subgroups_response: GitLabGroup[] = [
+  {
+    id: 1,
+    name: 'group1',
+    description: 'description1',
+    full_path: 'group1',
   },
 ];
 
@@ -2183,6 +2329,58 @@ export const expected_full_org_scan_entities_saas: MockObject[] = [
     },
     locationKey: 'GitlabOrgDiscoveryEntityProvider:test-id',
   },
+  {
+    entity: {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'User',
+      metadata: {
+        annotations: {
+          'backstage.io/managed-by-location':
+            'url:https://gitlab.com/testuser4',
+          'backstage.io/managed-by-origin-location':
+            'url:https://gitlab.com/testuser4',
+          'gitlab.com/user-login': 'https://gitlab.com/testuser4',
+          'gitlab.com/saml-external-uid': '54',
+        },
+        name: 'testuser4',
+      },
+      spec: {
+        memberOf: [],
+        profile: {
+          displayName: 'Test User 4',
+          email: 'testuser4@example.com',
+          picture: 'https://secure.gravatar.com/',
+        },
+      },
+    },
+    locationKey: 'GitlabOrgDiscoveryEntityProvider:test-id',
+  },
+  {
+    entity: {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'User',
+      metadata: {
+        annotations: {
+          'backstage.io/managed-by-location':
+            'url:https://gitlab.com/testuser3',
+          'backstage.io/managed-by-origin-location':
+            'url:https://gitlab.com/testuser3',
+          'gitlab.com/user-login': 'https://gitlab.com/testuser3',
+          'gitlab.com/saml-external-uid': '53',
+        },
+        name: 'testuser3',
+      },
+      spec: {
+        memberOf: [],
+        profile: {
+          displayName: 'Test User 3',
+          email: 'testuser3@example.com',
+          picture: 'https://secure.gravatar.com/',
+        },
+      },
+    },
+    locationKey: 'GitlabOrgDiscoveryEntityProvider:test-id',
+  },
 ];
 
 export const expected_full_org_scan_entities_includeUsersWithoutSeat_saas: MockObject[] =
@@ -2233,6 +2431,58 @@ export const expected_full_org_scan_entities_includeUsersWithoutSeat_saas: MockO
           profile: {
             displayName: 'Test User 2',
             email: 'testuser2@example.com',
+            picture: 'https://secure.gravatar.com/',
+          },
+        },
+      },
+      locationKey: 'GitlabOrgDiscoveryEntityProvider:test-id',
+    },
+    {
+      entity: {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'User',
+        metadata: {
+          annotations: {
+            'backstage.io/managed-by-location':
+              'url:https://gitlab.com/testusernoseat1',
+            'backstage.io/managed-by-origin-location':
+              'url:https://gitlab.com/testusernoseat1',
+            'gitlab.com/user-login': 'https://gitlab.com/testusernoseat1',
+            'gitlab.com/saml-external-uid': '60',
+          },
+          name: 'testusernoseat1',
+        },
+        spec: {
+          memberOf: [],
+          profile: {
+            displayName: 'Test User No Seat 1',
+            email: 'testusernoseat1@example.com',
+            picture: 'https://secure.gravatar.com/',
+          },
+        },
+      },
+      locationKey: 'GitlabOrgDiscoveryEntityProvider:test-id',
+    },
+    {
+      entity: {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'User',
+        metadata: {
+          annotations: {
+            'backstage.io/managed-by-location':
+              'url:https://gitlab.com/testuser4',
+            'backstage.io/managed-by-origin-location':
+              'url:https://gitlab.com/testuser4',
+            'gitlab.com/user-login': 'https://gitlab.com/testuser4',
+            'gitlab.com/saml-external-uid': '54',
+          },
+          name: 'testuser4',
+        },
+        spec: {
+          memberOf: [],
+          profile: {
+            displayName: 'Test User 4',
+            email: 'testuser4@example.com',
             picture: 'https://secure.gravatar.com/',
           },
         },

--- a/plugins/catalog-backend-module-gitlab/src/__testUtils__/mocks.ts
+++ b/plugins/catalog-backend-module-gitlab/src/__testUtils__/mocks.ts
@@ -1020,7 +1020,7 @@ export const all_saas_users_response: MockObject[] = [
     access_level: 30,
     created_at: '2023-07-19T08:58:34.984Z',
     expires_at: null,
-    id: 34,
+    id: 36,
     username: 'testuser3',
     name: 'Test User 3',
     state: 'active',

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.test.ts
@@ -303,7 +303,7 @@ describe('GitlabOrgDiscoveryEntityProvider - refresh', () => {
     });
   });
 
-  // This should return all members of the SaaS Root group (group1) -> expected_full_org_scan_entities_saas
+  // This should return all members of the SaaS Root group (group1) and any subgroups -> expected_full_org_scan_entities_saas
   it('SaaS: should get all saas root group users when restrictUsersToGroup is not set', async () => {
     const config = new ConfigReader(mock.config_org_group_saas);
     const schedule = new PersistingTaskRunner();
@@ -334,7 +334,7 @@ describe('GitlabOrgDiscoveryEntityProvider - refresh', () => {
     });
   });
 
-  // This should return all members of the SaaS Root group (group1) -> expected_full_org_scan_entities_saas
+  // This should return all members of the SaaS Root group (group1) and any subgroups -> expected_full_org_scan_entities_saas
   it('SaaS: should get all saas root group users when restrictUsersToGroup is false', async () => {
     const config = new ConfigReader(
       mock.config_org_group_restrictUsers_false_saas,

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.ts
@@ -359,7 +359,7 @@ export class GitlabOrgDiscoveryEntityProvider implements EntityProvider {
     }
 
     let groups;
-    let users;
+    const allUsers = [];
 
     // Self-hosted: Fetch the users either from the defined group (restrictUsersToGroup) or fetch all users from the GitLab instance
     // SaaS: Fetch the users from the defined group (restrictUsersToGroup) or fetch all users from the root group.
@@ -367,13 +367,15 @@ export class GitlabOrgDiscoveryEntityProvider implements EntityProvider {
       groups = (await this.gitLabClient.listDescendantGroups(this.config.group))
         .items;
       groups.push(await this.gitLabClient.getGroupByPath(this.config.group)); // adds the parent group for #26554
-      users = paginated<GitLabUser>(
-        options =>
-          this.gitLabClient.listGroupMembers(this.config.group, options), // calls /groups/<groupId>/members
-        {
-          page: 1,
-          per_page: 100,
-        },
+      allUsers.push(
+        paginated<GitLabUser>(
+          options =>
+            this.gitLabClient.listGroupMembers(this.config.group, options), // calls /groups/<groupId>/members
+          {
+            page: 1,
+            per_page: 100,
+          },
+        ),
       );
     } else if (
       this.gitLabClient.isSelfManaged() &&
@@ -387,35 +389,46 @@ export class GitlabOrgDiscoveryEntityProvider implements EntityProvider {
           all_available: true,
         },
       );
-      users = paginated<GitLabUser>(
-        options => this.gitLabClient.listUsers(options), // calls /users?
-        { page: 1, per_page: 100, active: true },
+      allUsers.push(
+        paginated<GitLabUser>(
+          options => this.gitLabClient.listUsers(options), // calls /users?
+          { page: 1, per_page: 100, active: true },
+        ),
       );
     }
     // SaaS: Fetch the users from the defined group (restrictUsersToGroup) or fetch all users from the root group.
     else {
-      groups = (await this.gitLabClient.listDescendantGroups(this.config.group))
-        .items;
+      const descendantGroups = (
+        await this.gitLabClient.listDescendantGroups(this.config.group)
+      ).items;
+      groups = descendantGroups;
 
       groups.push(await this.gitLabClient.getGroupByPath(this.config.group)); // adds the parent group for #26554
 
       const rootGroupSplit = this.config.group.split('/');
-      const groupPath = this.config.restrictUsersToGroup
-        ? this.config.group
-        : rootGroupSplit[0];
 
-      users = paginated<GitLabUser>(
-        options =>
-          this.gitLabClient.listSaaSUsers(
-            groupPath,
-            options,
-            this.config.includeUsersWithoutSeat,
+      const groupPaths = this.config.restrictUsersToGroup
+        ? [this.config.group]
+        : [rootGroupSplit[0], ...descendantGroups.map(g => g.id)];
+
+      // Fetch users group and descendant groups
+      for (const group of groupPaths) {
+        logger.debug(`Fetching users for group: ${group}`);
+        allUsers.push(
+          paginated<GitLabUser>(
+            options =>
+              this.gitLabClient.listSaaSUsers(
+                String(group),
+                options,
+                this.config.includeUsersWithoutSeat,
+              ),
+            {
+              page: 1,
+              per_page: 100,
+            },
           ),
-        {
-          page: 1,
-          per_page: 100,
-        },
-      );
+        );
+      }
     }
 
     const idMappedUser: { [userId: number]: GitLabUser } = {};
@@ -430,16 +443,23 @@ export class GitlabOrgDiscoveryEntityProvider implements EntityProvider {
       matches: [],
     };
 
-    for await (const user of users) {
-      userRes.scanned++;
+    for (const users of allUsers) {
+      // Iterate through paginated users
+      for await (const user of users) {
+        // Skip if user already processed and do not count it as scanned
+        if (user.id in idMappedUser) {
+          continue; // Skip if user already processed
+        }
+        userRes.scanned++;
 
-      if (!this.shouldProcessUser(user)) {
-        logger.debug(`Skipped user: ${user.username}`);
-        continue;
+        if (!this.shouldProcessUser(user)) {
+          logger.debug(`Skipped user: ${user.username}`);
+          continue;
+        }
+
+        idMappedUser[user.id] = user;
+        userRes.matches.push(user);
       }
-
-      idMappedUser[user.id] = user;
-      userRes.matches.push(user);
     }
 
     for await (const group of groups) {

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.ts
@@ -409,7 +409,7 @@ export class GitlabOrgDiscoveryEntityProvider implements EntityProvider {
 
       const groupPaths = this.config.restrictUsersToGroup
         ? [this.config.group]
-        : [rootGroupSplit[0], ...descendantGroups.map(g => g.id)];
+        : [rootGroupSplit[0], ...descendantGroups.map(g => `${g.id}`)];
 
       // Fetch users group and descendant groups
       for (const group of groupPaths) {
@@ -418,7 +418,7 @@ export class GitlabOrgDiscoveryEntityProvider implements EntityProvider {
           paginated<GitLabUser>(
             options =>
               this.gitLabClient.listSaaSUsers(
-                String(group),
+                group,
                 options,
                 this.config.includeUsersWithoutSeat,
               ),


### PR DESCRIPTION
## Current Status
The current behaviour of GitLab org ingestion is that will bring in all the users within the group specified, and also the sub groups of the specified parent group, as long as members from the specified group are also in the sub group.

This feels sub-optimal, and does not work for Saas setups where everyone belongs to a single group.

## Change
When using Saas GitLab (gitlab.com), and you specify a group in the config, then all the sub groups and their users will be ingested into the Software Catalog and modelled appropriately.

> [!NOTE]  
> This change can cause more users to be ingested into Backstage without altering pre-existing gitlab config.
> 
> You can use the existing `restrictUsersToGroup` option to turn off this behaviour.

Using the following setup
```yaml
catalog:
  providers:
    gitlab:
      default:
        host: gitlab.com
        orgEnabled: true
        group: group-name-here
        relations:
          - DIRECT # Default
        schedule:
          frequency: { seconds: 30 }
          timeout: { minutes: 3 }
        restrictUsersToGroup: false # pre-existing - defaults to false
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
