### PR TITLE
validate plugin and module ids

### DIFF
--- a/.changeset/itchy-sites-cheer.md
+++ b/.changeset/itchy-sites-cheer.md
@@ -1,0 +1,8 @@
+---
+'@backstage/backend-plugin-api': minor
+'@backstage/backend-app-api': minor
+'@backstage/config-loader': patch
+'@backstage/config': patch
+---
+
+Now plugin and module Ids needs to be a valid config keys

--- a/docs/backend-system/architecture/08-naming-patterns.md
+++ b/docs/backend-system/architecture/08-naming-patterns.md
@@ -12,10 +12,10 @@ As a rule, all names should be camel case, with the exceptions of plugin and mod
 
 ### Plugins
 
-| Description | Pattern           | Examples                              |
-| ----------- | ----------------- | ------------------------------------- |
-| export      | `<camelId>Plugin` | `catalogPlugin`, `userSettingsPlugin` |
-| ID          | `'<kebab-id>'`    | `'catalog'`, `'user-settings'`        |
+| Description | Pattern           | Examples                              | Notes                                                                 |
+| ----------- | ----------------- | ------------------------------------- | --------------------------------------------------------------------- |
+| export      | `<camelId>Plugin` | `catalogPlugin`, `userSettingsPlugin` |                                                                       |
+| ID          | `'<kebab-id>'`    | `'catalog'`, `'user-settings'`        | letters, digits, dashes, and underscores only, starting with a letter |
 
 Example:
 
@@ -28,10 +28,10 @@ export const userSettingsPlugin = createBackendPlugin({
 
 ### Modules
 
-| Description | Pattern                      | Examples                            |
-| ----------- | ---------------------------- | ----------------------------------- |
-| export      | `<pluginId>Module<ModuleId>` | `catalogModuleGithubEntityProvider` |
-| ID          | `'<module-id>'`              | `'github-entity-provider'`          |
+| Description | Pattern                      | Examples                            | Notes                                                                 |
+| ----------- | ---------------------------- | ----------------------------------- | --------------------------------------------------------------------- |
+| export      | `<pluginId>Module<ModuleId>` | `catalogModuleGithubEntityProvider` |                                                                       |
+| ID          | `'<module-id>'`              | `'github-entity-provider'`          | letters, digits, dashes, and underscores only, starting with a letter |
 
 Example:
 

--- a/packages/backend-app-api/src/wiring/BackendInitializer.test.ts
+++ b/packages/backend-app-api/src/wiring/BackendInitializer.test.ts
@@ -774,7 +774,7 @@ describe('BackendInitializer', () => {
     const init = new BackendInitializer([]);
     init.add(
       createBackendPlugin({
-        pluginId: 'test-1',
+        pluginId: 'test-t1',
         register(reg) {
           reg.registerInit({
             deps: {},
@@ -787,7 +787,7 @@ describe('BackendInitializer', () => {
     );
     init.add(
       createBackendPlugin({
-        pluginId: 'test-2',
+        pluginId: 'test-t2',
         register(reg) {
           reg.registerInit({
             deps: {},
@@ -804,10 +804,10 @@ describe('BackendInitializer', () => {
     await expect(result).rejects.toMatchObject({
       errors: [
         expect.objectContaining({
-          message: "Plugin 'test-1' startup failed; caused by Error: NOPE A",
+          message: "Plugin 'test-t1' startup failed; caused by Error: NOPE A",
         }),
         expect.objectContaining({
-          message: "Plugin 'test-2' startup failed; caused by Error: NOPE B",
+          message: "Plugin 'test-t2' startup failed; caused by Error: NOPE B",
         }),
       ],
     });
@@ -1015,6 +1015,53 @@ describe('BackendInitializer', () => {
     );
     await expect(init.start()).rejects.toThrow(
       "Service or extension point dependencies of module 'test-mod' for plugin 'test' are missing for the following ref(s): serviceRef{a}",
+    );
+  });
+  it('should reject plugins with invalid pluginId', async () => {
+    const init = new BackendInitializer(baseFactories);
+    init.add(
+      createBackendPlugin({
+        pluginId: 'test:invalid&id',
+        register(reg) {
+          reg.registerInit({
+            deps: {},
+            async init() {},
+          });
+        },
+      }),
+    );
+    await expect(init.start()).rejects.toThrow(
+      "Invalid pluginId 'test:invalid&id', must match the pattern /^[a-z][a-z0-9]*(?:[-_][a-z][a-z0-9]*)*$/i (letters, digits, dashes, and underscores only, starting with a letter)",
+    );
+  });
+
+  it('should reject modules with invalid moduleId', async () => {
+    const init = new BackendInitializer(baseFactories);
+    init.add(
+      createBackendPlugin({
+        pluginId: 'test',
+        register(reg) {
+          reg.registerInit({
+            deps: {},
+            async init() {},
+          });
+        },
+      }),
+    );
+    init.add(
+      createBackendModule({
+        pluginId: 'test',
+        moduleId: 'invalid:module&id',
+        register(reg) {
+          reg.registerInit({
+            deps: {},
+            async init() {},
+          });
+        },
+      }),
+    );
+    await expect(init.start()).rejects.toThrow(
+      "Invalid moduleId 'invalid:module&id' for plugin 'test', must match the pattern /^[a-z][a-z0-9]*(?:[-_][a-z][a-z0-9]*)*$/i (letters, digits, dashes, and underscores only, starting with a letter)",
     );
   });
 

--- a/packages/backend-plugin-api/src/wiring/createBackendModule.ts
+++ b/packages/backend-plugin-api/src/wiring/createBackendModule.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { CONFIG_KEY_PART_PATTERN } from '@backstage/config';
 import { BackendFeature } from '../types';
 import {
   BackendModuleRegistrationPoints,
@@ -55,6 +56,12 @@ export function createBackendModule(
   options: CreateBackendModuleOptions,
 ): BackendFeature {
   function getRegistrations() {
+    if (!CONFIG_KEY_PART_PATTERN.test(options.moduleId)) {
+      throw new Error(
+        `Invalid moduleId '${options.moduleId}' for plugin '${options.pluginId}', must match the pattern ${CONFIG_KEY_PART_PATTERN} (letters, digits, dashes, and underscores only, starting with a letter)`,
+      );
+    }
+
     const extensionPoints: InternalBackendPluginRegistration['extensionPoints'] =
       [];
     let init: InternalBackendModuleRegistration['init'] | undefined = undefined;

--- a/packages/backend-plugin-api/src/wiring/createBackendPlugin.ts
+++ b/packages/backend-plugin-api/src/wiring/createBackendPlugin.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { CONFIG_KEY_PART_PATTERN } from '@backstage/config';
 import { BackendFeature } from '../types';
 import {
   BackendPluginRegistrationPoints,
@@ -49,6 +50,12 @@ export function createBackendPlugin(
   options: CreateBackendPluginOptions,
 ): BackendFeature {
   function getRegistrations() {
+    if (!CONFIG_KEY_PART_PATTERN.test(options.pluginId)) {
+      throw new Error(
+        `Invalid pluginId '${options.pluginId}', must match the pattern ${CONFIG_KEY_PART_PATTERN} (letters, digits, dashes, and underscores only, starting with a letter)`,
+      );
+    }
+
     const extensionPoints: InternalBackendPluginRegistration['extensionPoints'] =
       [];
     let init: InternalBackendPluginRegistration['init'] | undefined = undefined;

--- a/packages/config-loader/src/sources/EnvConfigSource.ts
+++ b/packages/config-loader/src/sources/EnvConfigSource.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { AppConfig } from '@backstage/config';
+import { AppConfig, CONFIG_KEY_PART_PATTERN } from '@backstage/config';
 import { assertError } from '@backstage/errors';
 import { JsonObject } from '@backstage/types';
 import { AsyncConfigSourceGenerator, ConfigSource } from './types';
@@ -83,9 +83,6 @@ export class EnvConfigSource implements ConfigSource {
 }
 
 const ENV_PREFIX = 'APP_CONFIG_';
-
-// Update the same pattern in config package if this is changed
-const CONFIG_KEY_PART_PATTERN = /^[a-z][a-z0-9]*(?:[-_][a-z][a-z0-9]*)*$/i;
 
 /**
  * Read runtime configuration from the environment.

--- a/packages/config/src/constants.ts
+++ b/packages/config/src/constants.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2025 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,18 +15,14 @@
  */
 
 /**
- * Config API used by Backstage core, backend, and CLI
+ * The pattern that config keys must match.
  *
- * @packageDocumentation
+ * @remarks
+ * keys must only contain the letters `a` through `z` and digits, in groups separated by
+ * dashes or underscores. Additionally, the very first character of each such group
+ * must be a letter, not a digit
+ *
+ * @public
  */
-
-export type {
-  JsonArray,
-  JsonObject,
-  JsonPrimitive,
-  JsonValue,
-} from './deprecatedTypes';
-export { readDurationFromConfig } from './readDurationFromConfig';
-export { ConfigReader } from './reader';
-export type { AppConfig, Config } from './types';
-export { CONFIG_KEY_PART_PATTERN } from './constants';
+export const CONFIG_KEY_PART_PATTERN =
+  /^[a-z][a-z0-9]*(?:[-_][a-z][a-z0-9]*)*$/i;

--- a/packages/config/src/reader.ts
+++ b/packages/config/src/reader.ts
@@ -17,8 +17,7 @@
 import { JsonValue, JsonObject } from '@backstage/types';
 import { AppConfig, Config } from './types';
 
-// Update the same pattern in config-loader package if this is changed
-const CONFIG_KEY_PART_PATTERN = /^[a-z][a-z0-9]*(?:[-_][a-z][a-z0-9]*)*$/i;
+import { CONFIG_KEY_PART_PATTERN } from './constants';
 
 function isObject(value: JsonValue | undefined): value is JsonObject {
   return typeof value === 'object' && value !== null && !Array.isArray(value);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

With the introduction of `onPluginModuleBootFailure` cofiguration is expecrted that module and plugin ids are valid config keys

Here we are adding an early validation to make it clear instead of failing on the configuration read

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
