### PR TITLE
chore: update to node 22 and 24

### DIFF
--- a/.changeset/fifty-walls-argue.md
+++ b/.changeset/fifty-walls-argue.md
@@ -1,0 +1,15 @@
+---
+'@backstage/plugin-scaffolder-backend-module-rails': patch
+'@backstage/plugin-kubernetes-cluster': patch
+'@backstage/plugin-scaffolder-backend': patch
+'@techdocs/cli': patch
+'@backstage/cli-common': patch
+'@backstage/create-app': patch
+'@backstage/repo-tools': patch
+'@backstage/codemods': patch
+'@backstage/cli': patch
+---
+
+Updated to Node 22 and 24
+
+Bumped dev dependencies `@types/node` to 22

--- a/.github/workflows/api-breaking-changes.yml
+++ b/.github/workflows/api-breaking-changes.yml
@@ -29,13 +29,13 @@ jobs:
       - name: setup-node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20.x
+          node-version: 22.x
           registry-url: https://registry.npmjs.org/
 
       - name: yarn install
         uses: backstage/actions/yarn-install@b3c1841fd69e1658ac631afafd0fb140a2309024 # v0.6.17
         with:
-          cache-prefix: linux-v20
+          cache-prefix: linux-v22
 
       - name: breaking changes check
         run: |

--- a/.github/workflows/ci-noop.yml
+++ b/.github/workflows/ci-noop.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x]
 
     name: Verify ${{ matrix.node-version }}
     steps:
@@ -35,7 +35,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x]
 
     name: Test ${{ matrix.node-version }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x]
 
     env:
       CI: true
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x]
 
     env:
       CI: true
@@ -157,7 +157,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x]
 
     name: Test ${{ matrix.node-version }}
     services:

--- a/.github/workflows/deploy_docker-image.yml
+++ b/.github/workflows/deploy_docker-image.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/deploy_microsite.yml
+++ b/.github/workflows/deploy_microsite.yml
@@ -58,16 +58,16 @@ jobs:
         with:
           ref: refs/tags/${{ steps.find-release.outputs.result }}
 
-      - name: Use Node.js 20.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20.x
+          node-version: 22.x
           registry-url: https://registry.npmjs.org/ # Needed for auth
 
       - name: yarn install
         uses: backstage/actions/yarn-install@b3c1841fd69e1658ac631afafd0fb140a2309024 # v0.6.17
         with:
-          cache-prefix: ${{ runner.os }}-v20.x
+          cache-prefix: ${{ runner.os }}-v22.x
 
       - name: build API reference
         run: yarn build:api-docs
@@ -142,16 +142,16 @@ jobs:
       - name: checkout master
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Use Node.js 20.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20.x
+          node-version: 22.x
           registry-url: https://registry.npmjs.org/ # Needed for auth
 
       - name: yarn install
         uses: backstage/actions/yarn-install@b3c1841fd69e1658ac631afafd0fb140a2309024 # v0.6.17
         with:
-          cache-prefix: ${{ runner.os }}-v20.x
+          cache-prefix: ${{ runner.os }}-v22.x
 
       - name: build API reference
         run: yarn build:api-docs
@@ -250,10 +250,10 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Use Node.js 20.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20.x
+          node-version: 22.x
           registry-url: https://registry.npmjs.org/ # Needed for auth
 
       # Stable docs

--- a/.github/workflows/deploy_packages.yml
+++ b/.github/workflows/deploy_packages.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x]
 
     services:
       postgres17:
@@ -147,7 +147,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/sync_canon.yml
+++ b/.github/workflows/sync_canon.yml
@@ -15,16 +15,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Use Node.js 20.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20.x
+          node-version: 22.x
           registry-url: https://registry.npmjs.org/ # Needed for auth
 
       - name: yarn install
         uses: backstage/actions/yarn-install@b3c1841fd69e1658ac631afafd0fb140a2309024 # v0.6.17
         with:
-          cache-prefix: ${{ runner.os }}-v20.x
+          cache-prefix: ${{ runner.os }}-v22.x
 
       - name: Checkout backstage/canon-docs
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/sync_release-manifest.yml
+++ b/.github/workflows/sync_release-manifest.yml
@@ -18,16 +18,16 @@ jobs:
           # 'v' prefix is added here for the tag, we keep it out of the manifest logic
           ref: v${{ github.event.client_payload.version }}
 
-      - name: Use Node.js 20.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20.x
+          node-version: 22.x
           registry-url: https://registry.npmjs.org/ # Needed for auth
 
       - name: yarn install
         uses: backstage/actions/yarn-install@b3c1841fd69e1658ac631afafd0fb140a2309024 # v0.6.17
         with:
-          cache-prefix: ${{ runner.os }}-v20.x
+          cache-prefix: ${{ runner.os }}-v22.x
 
       - name: Build yarn plugin
         working-directory: packages/yarn-plugin

--- a/.github/workflows/sync_snyk-github-issues.yml
+++ b/.github/workflows/sync_snyk-github-issues.yml
@@ -18,15 +18,15 @@ jobs:
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Use Node.js 20.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20.x
+          node-version: 22.x
           registry-url: https://registry.npmjs.org/ # Needed for auth
       - name: yarn install
         uses: backstage/actions/yarn-install@b3c1841fd69e1658ac631afafd0fb140a2309024 # v0.6.17
         with:
-          cache-prefix: ${{ runner.os }}-v20.x
+          cache-prefix: ${{ runner.os }}-v22.x
 
       - name: Create Snyk report
         uses: snyk/actions/node@cdb760004ba9ea4d525f2e043745dfe85bb9077e # master

--- a/.github/workflows/verify_accessibility.yml
+++ b/.github/workflows/verify_accessibility.yml
@@ -25,14 +25,14 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Use Node.js 20.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20.x
+          node-version: 22.x
       - name: yarn install
         uses: backstage/actions/yarn-install@b3c1841fd69e1658ac631afafd0fb140a2309024 # v0.6.17
         with:
-          cache-prefix: ${{ runner.os }}-v20.x
+          cache-prefix: ${{ runner.os }}-v22.x
       - name: run Lighthouse CI
         run: |
           yarn dlx @lhci/cli@0.11.x autorun

--- a/.github/workflows/verify_e2e-linux-noop.yml
+++ b/.github/workflows/verify_e2e-linux-noop.yml
@@ -24,7 +24,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x]
 
     name: E2E Linux ${{ matrix.node-version }}
     steps:

--- a/.github/workflows/verify_e2e-linux.yml
+++ b/.github/workflows/verify_e2e-linux.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x]
 
     env:
       CI: true

--- a/.github/workflows/verify_e2e-techdocs.yml
+++ b/.github/workflows/verify_e2e-techdocs.yml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x]
 
     env:
       CI: true

--- a/.github/workflows/verify_e2e-windows-noop.yml
+++ b/.github/workflows/verify_e2e-windows-noop.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x]
 
     name: E2E Windows ${{ matrix.node-version }}
     steps:

--- a/.github/workflows/verify_e2e-windows.yml
+++ b/.github/workflows/verify_e2e-windows.yml
@@ -24,7 +24,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x]
 
     env:
       CI: true

--- a/.github/workflows/verify_microsite.yml
+++ b/.github/workflows/verify_microsite.yml
@@ -63,16 +63,16 @@ jobs:
         with:
           ref: refs/tags/${{ steps.find-release.outputs.result }}
 
-      - name: Use Node.js 20.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20.x
+          node-version: 22.x
           registry-url: https://registry.npmjs.org/ # Needed for auth
 
       - name: yarn install
         uses: backstage/actions/yarn-install@b3c1841fd69e1658ac631afafd0fb140a2309024 # v0.6.17
         with:
-          cache-prefix: ${{ runner.os }}-v20.x
+          cache-prefix: ${{ runner.os }}-v22.x
 
       - name: build API reference
         run: yarn build:api-docs
@@ -144,16 +144,16 @@ jobs:
       - name: checkout master
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Use Node.js 20.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20.x
+          node-version: 22.x
           registry-url: https://registry.npmjs.org/ # Needed for auth
 
       - name: yarn install
         uses: backstage/actions/yarn-install@b3c1841fd69e1658ac631afafd0fb140a2309024 # v0.6.17
         with:
-          cache-prefix: ${{ runner.os }}-v20.x
+          cache-prefix: ${{ runner.os }}-v22.x
 
       - name: build API reference
         run: yarn build:api-docs
@@ -246,10 +246,10 @@ jobs:
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Use Node.js 20.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20.x
+          node-version: 22.x
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.9'

--- a/.github/workflows/verify_microsite_accessibility.yml
+++ b/.github/workflows/verify_microsite_accessibility.yml
@@ -21,10 +21,10 @@ jobs:
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Use Node.js 20.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20.x
+          node-version: 22.x
 
       - name: top-level install
         run: yarn install --immutable

--- a/.github/workflows/verify_storybook.yml
+++ b/.github/workflows/verify_storybook.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [20.x]
+        node-version: [22.x]
 
     name: Storybook
     steps:

--- a/.github/workflows/verify_windows.yml
+++ b/.github/workflows/verify_windows.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x]
 
     env:
       CI: true

--- a/canon-docs/package.json
+++ b/canon-docs/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@types/mdx": "^2.0.13",
-    "@types/node": "^20",
+    "@types/node": "^22",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "eslint": "^8",

--- a/contrib/.devcontainer/Dockerfile
+++ b/contrib/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/typescript-node:20
+FROM mcr.microsoft.com/devcontainers/typescript-node:22
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install chromium \

--- a/contrib/docker/frontend-with-nginx/Dockerfile.dockerbuild
+++ b/contrib/docker/frontend-with-nginx/Dockerfile.dockerbuild
@@ -35,7 +35,7 @@
 
 
 
-FROM node:20-buster AS build
+FROM node:22-buster AS build
 
 RUN mkdir /app
 COPY . /app

--- a/contrib/docker/minimal-hardened-image/Dockerfile
+++ b/contrib/docker/minimal-hardened-image/Dockerfile
@@ -23,7 +23,7 @@ RUN --mount=type=cache,target=/home/nonroot/.cache/pip,uid=65532,gid=65532 \
 # Build Node environment in a separate builder stage
 FROM cgr.dev/chainguard/wolfi-base:latest as node-builder
 
-ENV NODE_VERSION="20=~20.11"
+ENV NODE_VERSION="22=~22.16"
 ENV NODE_ENV=production
 
 RUN --mount=type=cache,target=/var/cache/apk,sharing=locked,uid=65532,gid=65532 \

--- a/contrib/docs/tutorials/flightcontrol-deployment.md
+++ b/contrib/docs/tutorials/flightcontrol-deployment.md
@@ -23,7 +23,7 @@ The following two code snippets demonstrate this method. The first block of code
 # yarn build:backend
 #
 # Once the commands have been run, you can build the image using `yarn build-image`
-FROM node:20-bookworm-slim as build
+FROM node:22-bookworm-slim as build
 
 USER node
 WORKDIR /app
@@ -38,7 +38,7 @@ RUN yarn tsc
 # The configuration files here should match the one you use inside the Dockerfile below.
 RUN yarn build:backend --config ../../app-config.yaml
 
-FROM node:20-bookworm-slim
+FROM node:22-bookworm-slim
 
 # Install isolate-vm dependencies, these are needed by the @backstage/plugin-scaffolder-backend.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -53,7 +53,7 @@ Once the host build is complete, we are ready to build our image. The following
 `Dockerfile` is included when creating a new app with `@backstage/create-app`:
 
 ```dockerfile
-FROM node:20-bookworm-slim
+FROM node:22-bookworm-slim
 
 # Set Python interpreter for `node-gyp` to use
 ENV PYTHON=/usr/bin/python3
@@ -178,7 +178,7 @@ the repo root:
 
 ```dockerfile
 # Stage 1 - Create yarn install skeleton layer
-FROM node:20-bookworm-slim AS packages
+FROM node:22-bookworm-slim AS packages
 
 WORKDIR /app
 COPY backstage.json package.json yarn.lock ./
@@ -193,7 +193,7 @@ COPY plugins plugins
 RUN find packages \! -name "package.json" -mindepth 2 -maxdepth 2 -exec rm -rf {} \+
 
 # Stage 2 - Install dependencies and build packages
-FROM node:20-bookworm-slim AS build
+FROM node:22-bookworm-slim AS build
 
 # Set Python interpreter for `node-gyp` to use
 ENV PYTHON=/usr/bin/python3
@@ -231,7 +231,7 @@ RUN mkdir packages/backend/dist/skeleton packages/backend/dist/bundle \
     && tar xzf packages/backend/dist/bundle.tar.gz -C packages/backend/dist/bundle
 
 # Stage 3 - Build the actual backend image and install production dependencies
-FROM node:20-bookworm-slim
+FROM node:22-bookworm-slim
 
 # Set Python interpreter for `node-gyp` to use
 ENV PYTHON=/usr/bin/python3

--- a/docs/tooling/cli/02-build-system.md
+++ b/docs/tooling/cli/02-build-system.md
@@ -417,7 +417,7 @@ The following is an example of a `Dockerfile` that can be used to package the
 output of building a package with role `'backend'` into an image:
 
 ```Dockerfile
-FROM node:20-bookworm-slim
+FROM node:22-bookworm-slim
 WORKDIR /app
 
 COPY yarn.lock package.json packages/backend/dist/skeleton.tar.gz ./

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "@techdocs/cli": "workspace:*",
     "@types/cacheable-request": "^8.3.6",
     "@types/memjs": "^1.3.3",
-    "@types/node": "^20.16.0",
+    "@types/node": "^22.15.0",
     "@types/webpack": "^5.28.0",
     "array-to-table": "^1.0.1",
     "command-exists": "^1.2.9",
@@ -155,6 +155,6 @@
   },
   "packageManager": "yarn@4.8.1",
   "engines": {
-    "node": "20 || 22"
+    "node": "20 || 22 || 24"
   }
 }

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -9,7 +9,7 @@
 #
 # Once the commands have been run, you can build the image using `yarn build-image`
 
-FROM node:20-bookworm-slim
+FROM node:22-bookworm-slim
 
 # Install sqlite3 dependencies. You can skip this if you don't use sqlite3 in the image,
 # in which case you should also move better-sqlite3 to "devDependencies" in package.json.

--- a/packages/cli-common/package.json
+++ b/packages/cli-common/package.json
@@ -36,6 +36,6 @@
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",
-    "@types/node": "^20.16.0"
+    "@types/node": "^22.15.0"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -189,7 +189,7 @@
     "@types/fs-extra": "^11.0.0",
     "@types/http-proxy": "^1.17.4",
     "@types/inquirer": "^8.1.3",
-    "@types/node": "^20.16.0",
+    "@types/node": "^22.15.0",
     "@types/npm-packlist": "^3.0.0",
     "@types/recursive-readdir": "^2.2.0",
     "@types/rollup-plugin-peer-deps-external": "^2.2.0",

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -52,6 +52,6 @@
   "devDependencies": {
     "@backstage/cli": "workspace:^",
     "@types/jscodeshift": "^0.12.0",
-    "@types/node": "^20.16.0"
+    "@types/node": "^22.15.0"
   }
 }

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -58,7 +58,7 @@
     "@types/command-exists": "^1.2.0",
     "@types/fs-extra": "^11.0.0",
     "@types/inquirer": "^8.1.3",
-    "@types/node": "^20.16.0",
+    "@types/node": "^22.15.0",
     "@types/recursive-readdir": "^2.2.0",
     "msw": "^2.0.0",
     "nodemon": "^3.0.1"

--- a/packages/create-app/templates/default-app/packages/backend/Dockerfile
+++ b/packages/create-app/templates/default-app/packages/backend/Dockerfile
@@ -12,7 +12,7 @@
 # Alternatively, there is also a multi-stage Dockerfile documented here:
 # https://backstage.io/docs/deployment/docker#multi-stage-build
 
-FROM node:20-bookworm-slim
+FROM node:22-bookworm-slim
 
 # Set Python interpreter for `node-gyp` to use
 ENV PYTHON=/usr/bin/python3

--- a/packages/e2e-test/package.json
+++ b/packages/e2e-test/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@backstage/cli": "workspace:^",
     "@types/fs-extra": "^11.0.0",
-    "@types/node": "^20.16.0",
+    "@types/node": "^22.15.0",
     "nodemon": "^3.0.1"
   }
 }

--- a/packages/repo-tools/package.json
+++ b/packages/repo-tools/package.json
@@ -90,7 +90,7 @@
     "@backstage/cli": "workspace:^",
     "@backstage/types": "workspace:^",
     "@types/is-glob": "^4.0.2",
-    "@types/node": "^20.16.0",
+    "@types/node": "^22.15.0",
     "@types/prettier": "^2.0.0",
     "typedoc": "^0.28.0"
   },

--- a/packages/techdocs-cli/package.json
+++ b/packages/techdocs-cli/package.json
@@ -62,7 +62,7 @@
     "@types/commander": "^2.12.2",
     "@types/fs-extra": "^11.0.0",
     "@types/http-proxy": "^1.17.4",
-    "@types/node": "^20.16.0",
+    "@types/node": "^22.15.0",
     "@types/serve-handler": "^6.1.0",
     "@types/webpack-env": "^1.15.3",
     "find-process": "^1.4.5",

--- a/plugins/kubernetes-cluster/package.json
+++ b/plugins/kubernetes-cluster/package.json
@@ -78,7 +78,7 @@
     "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^16.0.0",
-    "@types/node": "^20.16.0",
+    "@types/node": "^22.15.0",
     "@types/react": "^18.0.0",
     "react": "^18.0.2",
     "react-dom": "^18.0.2",

--- a/plugins/scaffolder-backend-module-rails/package.json
+++ b/plugins/scaffolder-backend-module-rails/package.json
@@ -59,7 +59,7 @@
     "@backstage/plugin-scaffolder-node-test-utils": "workspace:^",
     "@types/command-exists": "^1.2.0",
     "@types/fs-extra": "^11.0.0",
-    "@types/node": "^20.16.0",
+    "@types/node": "^22.15.0",
     "jest-when": "^3.1.0"
   }
 }

--- a/plugins/scaffolder-backend/package.json
+++ b/plugins/scaffolder-backend/package.json
@@ -95,7 +95,7 @@
     "fs-extra": "^11.2.0",
     "globby": "^11.0.0",
     "isbinaryfile": "^5.0.0",
-    "isolated-vm": "^5.0.1",
+    "isolated-vm": "^6.0.0",
     "jsonschema": "^1.5.0",
     "knex": "^3.0.0",
     "lodash": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3877,7 +3877,7 @@ __metadata:
   resolution: "@backstage/cli-common@workspace:packages/cli-common"
   dependencies:
     "@backstage/cli": "workspace:^"
-    "@types/node": "npm:^20.16.0"
+    "@types/node": "npm:^22.15.0"
   languageName: unknown
   linkType: soft
 
@@ -3960,7 +3960,7 @@ __metadata:
     "@types/http-proxy": "npm:^1.17.4"
     "@types/inquirer": "npm:^8.1.3"
     "@types/jest": "npm:^29.5.11"
-    "@types/node": "npm:^20.16.0"
+    "@types/node": "npm:^22.15.0"
     "@types/npm-packlist": "npm:^3.0.0"
     "@types/recursive-readdir": "npm:^2.2.0"
     "@types/rollup-plugin-peer-deps-external": "npm:^2.2.0"
@@ -4077,7 +4077,7 @@ __metadata:
     "@backstage/cli": "workspace:^"
     "@backstage/cli-common": "workspace:^"
     "@types/jscodeshift": "npm:^0.12.0"
-    "@types/node": "npm:^20.16.0"
+    "@types/node": "npm:^22.15.0"
     chalk: "npm:^4.0.0"
     commander: "npm:^12.0.0"
     jscodeshift: "npm:^0.16.0"
@@ -4451,7 +4451,7 @@ __metadata:
     "@types/command-exists": "npm:^1.2.0"
     "@types/fs-extra": "npm:^11.0.0"
     "@types/inquirer": "npm:^8.1.3"
-    "@types/node": "npm:^20.16.0"
+    "@types/node": "npm:^22.15.0"
     "@types/recursive-readdir": "npm:^2.2.0"
     chalk: "npm:^4.0.0"
     commander: "npm:^12.0.0"
@@ -6860,7 +6860,7 @@ __metadata:
     "@testing-library/dom": "npm:^10.0.0"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^16.0.0"
-    "@types/node": "npm:^20.16.0"
+    "@types/node": "npm:^22.15.0"
     "@types/react": "npm:^18.0.0"
     cronstrue: "npm:^2.2.0"
     js-yaml: "npm:^4.0.0"
@@ -7659,7 +7659,7 @@ __metadata:
     "@backstage/types": "workspace:^"
     "@types/command-exists": "npm:^1.2.0"
     "@types/fs-extra": "npm:^11.0.0"
-    "@types/node": "npm:^20.16.0"
+    "@types/node": "npm:^22.15.0"
     command-exists: "npm:^1.2.9"
     fs-extra: "npm:^11.0.0"
     jest-when: "npm:^3.1.0"
@@ -7747,7 +7747,7 @@ __metadata:
     fs-extra: "npm:^11.2.0"
     globby: "npm:^11.0.0"
     isbinaryfile: "npm:^5.0.0"
-    isolated-vm: "npm:^5.0.1"
+    isolated-vm: "npm:^6.0.0"
     jsonschema: "npm:^1.5.0"
     knex: "npm:^3.0.0"
     lodash: "npm:^4.17.21"
@@ -8716,7 +8716,7 @@ __metadata:
     "@stoplight/spectral-runtime": "npm:^1.1.2"
     "@stoplight/types": "npm:^14.0.0"
     "@types/is-glob": "npm:^4.0.2"
-    "@types/node": "npm:^20.16.0"
+    "@types/node": "npm:^22.15.0"
     "@types/prettier": "npm:^2.0.0"
     "@useoptic/openapi-utilities": "npm:^0.55.0"
     chalk: "npm:^4.0.0"
@@ -19385,7 +19385,7 @@ __metadata:
     "@types/commander": "npm:^2.12.2"
     "@types/fs-extra": "npm:^11.0.0"
     "@types/http-proxy": "npm:^1.17.4"
-    "@types/node": "npm:^20.16.0"
+    "@types/node": "npm:^22.15.0"
     "@types/serve-handler": "npm:^6.1.0"
     "@types/webpack-env": "npm:^1.15.3"
     commander: "npm:^12.0.0"
@@ -20647,12 +20647,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:>=12, @types/node@npm:>=12.0.0, @types/node@npm:>=13.7.0, @types/node@npm:>=18.0.0, @types/node@npm:^22.0.0":
-  version: 22.13.10
-  resolution: "@types/node@npm:22.13.10"
+"@types/node@npm:*, @types/node@npm:>=12, @types/node@npm:>=12.0.0, @types/node@npm:>=13.7.0, @types/node@npm:>=18.0.0, @types/node@npm:^22.0.0, @types/node@npm:^22.15.0":
+  version: 22.15.28
+  resolution: "@types/node@npm:22.15.28"
   dependencies:
-    undici-types: "npm:~6.20.0"
-  checksum: 10/57dc6a5e0110ca9edea8d7047082e649fa7fa813f79e4a901653b9174141c622f4336435648baced5b38d9f39843f404fa2d8d7a10981610da26066bc8caab48
+    undici-types: "npm:~6.21.0"
+  checksum: 10/82ee399642729755f09aa59284f4ecf155451a39d268fd1c1f464aed9e1107842753cecab2058ad5f322a5487e534c1d7abe50801106f8844e74f0d1463dddc3
   languageName: node
   linkType: hard
 
@@ -20693,7 +20693,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^20.1.1, @types/node@npm:^20.16.0":
+"@types/node@npm:^20.1.1":
   version: 20.17.30
   resolution: "@types/node@npm:20.17.30"
   dependencies:
@@ -28165,7 +28165,7 @@ __metadata:
     "@backstage/create-app": "workspace:^"
     "@backstage/errors": "workspace:^"
     "@types/fs-extra": "npm:^11.0.0"
-    "@types/node": "npm:^20.16.0"
+    "@types/node": "npm:^22.15.0"
     chalk: "npm:^4.0.0"
     commander: "npm:^12.0.0"
     cross-fetch: "npm:^4.0.0"
@@ -33700,13 +33700,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"isolated-vm@npm:^5.0.1":
-  version: 5.0.4
-  resolution: "isolated-vm@npm:5.0.4"
+"isolated-vm@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "isolated-vm@npm:6.0.0"
   dependencies:
     node-gyp: "npm:latest"
     prebuild-install: "npm:^7.1.2"
-  checksum: 10/f48e69ecf907645711d0a372cb6adb28cf72499e34b6e008ed597994bfd90d41dd11dc478a41fc21a25aaef424ab5a95a372286e4daf7f61e231d028c0fd64ec
+  checksum: 10/18f9cf96fbc6870102ce4bbad0188558c2bf35d27f112e3d486aa55d51edd4935a0f28e9eb4e7e0d1bc78e3d30180517a2c07f1eca37b8ed4dd4a5a65e136024
   languageName: node
   linkType: hard
 
@@ -43724,7 +43724,7 @@ __metadata:
     "@types/cacheable-request": "npm:^8.3.6"
     "@types/global-agent": "npm:^2.1.3"
     "@types/memjs": "npm:^1.3.3"
-    "@types/node": "npm:^20.16.0"
+    "@types/node": "npm:^22.15.0"
     "@types/webpack": "npm:^5.28.0"
     "@useoptic/optic": "npm:^1.0.0"
     array-to-table: "npm:^1.0.1"
@@ -47276,10 +47276,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici-types@npm:~6.20.0":
-  version: 6.20.0
-  resolution: "undici-types@npm:6.20.0"
-  checksum: 10/583ac7bbf4ff69931d3985f4762cde2690bb607844c16a5e2fbb92ed312fe4fa1b365e953032d469fa28ba8b224e88a595f0b10a449332f83fa77c695e567dbe
+"undici-types@npm:~6.21.0":
+  version: 6.21.0
+  resolution: "undici-types@npm:6.21.0"
+  checksum: 10/ec8f41aa4359d50f9b59fa61fe3efce3477cc681908c8f84354d8567bb3701fafdddf36ef6bff307024d3feb42c837cf6f670314ba37fc8145e219560e473d14
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updated engines and node types to 22. Node.js 24, on the other hand, is generally faster than Node.js 22 due to improvements in the V8 engine and other core features. Specifically, Node.js 24 uses V8 version 13.6, which provides performance improvements and also includes enhanced security checks and lifecycle script hardening. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
