### PR TITLE
Export function for creating `rootLogger`

### DIFF
--- a/packages/backend-defaults/src/entrypoints/rootLogger/index.ts
+++ b/packages/backend-defaults/src/entrypoints/rootLogger/index.ts
@@ -14,5 +14,8 @@
  * limitations under the License.
  */
 
-export { rootLoggerServiceFactory } from './rootLoggerServiceFactory';
+export {
+  createRootLogger,
+  rootLoggerServiceFactory,
+} from './rootLoggerServiceFactory';
 export { WinstonLogger, type WinstonLoggerOptions } from './WinstonLogger';


### PR DESCRIPTION
Backstage docs currently recommend duplicating the `rootLoggerServiceFactory.ts` code if they want to override the service: https://backstage.io/docs/backend-system/core-services/root-logger/#configuring-the-service

However, in some cases it would be preferable to reuse the existing logic so that you don't miss any upstream changes to the default `rootLogger` implementation.

For example, if you wanted to add additional attributes to the `rootLogger`:

```ts
import { createBackend } from '@backstage/backend-defaults';
import {
  createServiceFactory,
  coreServices,
} from '@backstage/backend-plugin-api';
import { createRootLogger } from '@backstage/backend-defaults/rootLogger';

const backend = createBackend();

backend.add(
  createServiceFactory({
    service: coreServices.rootLogger,
    deps: {
      config: coreServices.rootConfig,
    },
    async factory({ config }) {
      const logger = await createRootLogger({ config });
      return logger.child({ someKey: 'some-value' });
    },
  }),
);
```

This PR implements the above `createRootLogger()` function and exports it from the `@backstage/backend-defaults` package. The existing logic for creating the default `rootLogger` is moved to this function, and the `rootLoggerServiceFactory` simply calls `createRootLogger()`.

---

Right now this is just a proposal. There are some implementation details I'm struggling to work through (see code comments). However, overall I think a strategy like this would be a good way to reduce the amount of code duplication required to override the default `rootLogger` implementation.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
