### PR TITLE
cli: remove FORCE_REACT_DEVELOPMENT

### DIFF
--- a/.changeset/ripe-squids-sink.md
+++ b/.changeset/ripe-squids-sink.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+The experimental `FORCE_REACT_DEVELOPMENT` flag has been removed.

--- a/packages/cli/src/modules/build/lib/bundler/config.ts
+++ b/packages/cli/src/modules/build/lib/bundler/config.ts
@@ -15,8 +15,7 @@
  */
 
 import { BundlingOptions, ModuleFederationOptions } from './types';
-import { resolve as resolvePath, dirname } from 'path';
-import chalk from 'chalk';
+import { resolve as resolvePath } from 'path';
 import webpack from 'webpack';
 
 import { BundlingPaths } from './paths';
@@ -345,47 +344,6 @@ export async function createConfig(
 
   const mode = isDev ? 'development' : 'production';
   const optimization = optimizationConfig(options);
-
-  if (
-    mode === 'production' &&
-    process.env.EXPERIMENTAL_MODULE_FEDERATION &&
-    process.env.FORCE_REACT_DEVELOPMENT
-  ) {
-    console.log(
-      chalk.yellow(
-        `⚠️  WARNING: Forcing react and react-dom into development mode. This build should not be used in production.`,
-      ),
-    );
-
-    const reactPackageDirs = [
-      `${dirname(require.resolve('react/package.json'))}/`,
-      `${dirname(require.resolve('react-dom/package.json'))}/`,
-    ];
-
-    // Don't define process.env.NODE_ENV with value matching config.mode. If we
-    // don't set this to false, webpack will define the value of
-    // process.env.NODE_ENV for us, and the definition below will be ignored.
-    optimization.nodeEnv = false;
-
-    // Instead, provide a custom definition which always uses "development" if
-    // the module is part of `react` or `react-dom`, and `config.mode` otherwise.
-    plugins.push(
-      new bundler.DefinePlugin({
-        'process.env.NODE_ENV': rspack
-          ? // FIXME: see also https://github.com/web-infra-dev/rspack/issues/5606
-            JSON.stringify(mode)
-          : webpack.DefinePlugin.runtimeValue(({ module }) => {
-              if (
-                reactPackageDirs.some(val => module.resource.startsWith(val))
-              ) {
-                return '"development"';
-              }
-
-              return `"${mode}"`;
-            }),
-      }),
-    );
-  }
 
   return {
     mode,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I suggest we remove the `FORCE_REACT_DEVELOPMENT` flag. Afaik it's not in use and it doesn't support Rspack.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
