### PR TITLE
cli: use @module-federation/enhanced/rspack

### DIFF
--- a/.changeset/mean-tigers-rush.md
+++ b/.changeset/mean-tigers-rush.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Switched to using the `ModuleFederationPlugin` from `@module-federation/enhanced/rspack` for Rspack, rather than the built-in one.

--- a/packages/cli/src/modules/build/lib/bundler/config.ts
+++ b/packages/cli/src/modules/build/lib/bundler/config.ts
@@ -231,8 +231,8 @@ export async function createConfig(
     const isRemote = options.moduleFederation?.mode === 'remote';
 
     const AdaptedModuleFederationPlugin = rspack
-      ? (rspack.container
-          .ModuleFederationPlugin as unknown as typeof ModuleFederationPlugin)
+      ? (require('@module-federation/enhanced/rspack')
+          .ModuleFederationPlugin as typeof ModuleFederationPlugin)
       : ModuleFederationPlugin;
 
     const exposes = options.moduleFederation?.exposes


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Realized we're not using the latest MF 2.0 implementation for Rspack, see https://rspack.rs/guide/features/module-federation#module-federation-v20. Since we already have it as a dep for WebPack I think we might as well use it for Rspack too.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
