### PR TITLE
cli: remove BACKSTAGE_CLI_EXPERIMENTAL_BUILD_CACHE

### DIFF
--- a/.changeset/fresh-brooms-follow.md
+++ b/.changeset/fresh-brooms-follow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+The `BACKSTAGE_CLI_EXPERIMENTAL_BUILD_CACHE` flag has been removed. Existing users are encouraged to switch to `EXPERIMENTAL_RSPACK` instead.

--- a/packages/cli/src/modules/build/lib/bundler/config.ts
+++ b/packages/cli/src/modules/build/lib/bundler/config.ts
@@ -39,8 +39,6 @@ import { hasReactDomClient } from './hasReactDomClient';
 import { createWorkspaceLinkingPlugins } from './linkWorkspaces';
 import { ConfigInjectingHtmlWebpackPlugin } from './ConfigInjectingHtmlWebpackPlugin';
 
-const BUILD_CACHE_ENV_VAR = 'BACKSTAGE_CLI_EXPERIMENTAL_BUILD_CACHE';
-
 export function resolveBaseUrl(
   config: Config,
   moduleFederation?: ModuleFederationOptions,
@@ -389,8 +387,6 @@ export async function createConfig(
     );
   }
 
-  const withCache = yn(process.env[BUILD_CACHE_ENV_VAR], { default: false });
-
   return {
     mode,
     profile: false,
@@ -473,13 +469,5 @@ export async function createConfig(
       }),
     },
     plugins,
-    ...(withCache && {
-      cache: {
-        type: 'filesystem',
-        buildDependencies: {
-          config: [__filename],
-        },
-      },
-    }),
   };
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I don't think this flag is very useful anymore and if anything nudges users in the wrong direction.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
