### PR TITLE
cli: disable caching Jest module loader for node

### DIFF
--- a/.changeset/slow-impalas-wear.md
+++ b/.changeset/slow-impalas-wear.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Only use the caching Jest module loader for frontend packages in order to avoid breaking real ESM module imports.

--- a/packages/cli/config/jest.js
+++ b/packages/cli/config/jest.js
@@ -212,6 +212,11 @@ function getRoleConfig(role, pkgJson) {
   if (FRONTEND_ROLES.includes(role)) {
     return {
       testEnvironment: require.resolve('jest-environment-jsdom'),
+      // The caching module loader is only used to speed up frontend tests,
+      // as it breaks real dynamic imports of ESM modules.
+      runtime: envOptions.oldTests
+        ? undefined
+        : require.resolve('./jestCachingModuleLoader'),
       transform,
     };
   }
@@ -256,10 +261,6 @@ async function getProjectConfig(targetPath, extraConfig, extraOptions) {
 
     // A bit more opinionated
     testMatch: [`**/*.test.{${SRC_EXTS.join(',')}}`],
-
-    runtime: envOptions.oldTests
-      ? undefined
-      : require.resolve('./jestCachingModuleLoader'),
 
     transformIgnorePatterns: [`/node_modules/(?:${transformIgnorePattern})/`],
     ...getRoleConfig(pkgJson.backstage?.role, pkgJson),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes the `Test environment has been torn down` flaky test issue, like this one: https://github.com/backstage/backstage/actions/runs/15364676304/job/43236105338?pr=30098

Turns out it happens when you get the same dynamic ESM imports happening again on the same worker, and it could be reproduced reliably with `--runInBand`. Bit more context here: https://github.com/jestjs/jest/issues/10944#issuecomment-781523091

Still a bit interesting that caching the script of the importing (!) module breaks things in this way, but I don't think it's worth digging into too much. Fix is to simply not use the caching module loader for node packages. I do think it's still worth keeping it for frontend packages as it's a pretty decent performance boost and there's no risk of that issue there since dynamic imports are transpiled rather than left as is.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
