### PR TITLE
(canon)fix: use full menu width for combobox menu filter input.

### DIFF
--- a/.changeset/tired-readers-share.md
+++ b/.changeset/tired-readers-share.md
@@ -1,0 +1,5 @@
+---
+'@backstage/canon': patch
+---
+
+The filter input in menu comboboxes should now always use the full width of the menu it's in.

--- a/packages/canon/css/components.css
+++ b/packages/canon/css/components.css
@@ -871,6 +871,7 @@
   border: none;
   border-bottom: 1px solid var(--canon-border);
   background-color: var(--canon-bg-surface-1);
+  width: 100%;
   height: 32px;
   color: var(--canon-fg-primary);
   line-height: 140%;

--- a/packages/canon/css/menu.css
+++ b/packages/canon/css/menu.css
@@ -94,6 +94,7 @@
   border: none;
   border-bottom: 1px solid var(--canon-border);
   background-color: var(--canon-bg-surface-1);
+  width: 100%;
   height: 32px;
   color: var(--canon-fg-primary);
   line-height: 140%;

--- a/packages/canon/css/styles.css
+++ b/packages/canon/css/styles.css
@@ -10095,6 +10095,7 @@
   border: none;
   border-bottom: 1px solid var(--canon-border);
   background-color: var(--canon-bg-surface-1);
+  width: 100%;
   height: 32px;
   color: var(--canon-fg-primary);
   line-height: 140%;

--- a/packages/canon/src/components/Menu/Menu.styles.css
+++ b/packages/canon/src/components/Menu/Menu.styles.css
@@ -93,6 +93,7 @@
 
 .canon-SubmenuComboboxSearch {
   padding-inline: var(--canon-space-3);
+  width: 100%;
   height: 32px;
   border: none;
   border-bottom: 1px solid var(--canon-border);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When rendering a combobox menu component, the filter input in the top would sometimes not occupy the full width of the menu. This happened e.g. if options with longer text were included in the combobox. This PR adds a minute style fix to fix this issue.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
