### PR TITLE
fix(cli): merge eslint reports when using json format

### DIFF
--- a/.changeset/three-boats-sort.md
+++ b/.changeset/three-boats-sort.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+fix: merge eslint reports when using json format

--- a/packages/cli/src/modules/lint/commands/repo/lint.ts
+++ b/packages/cli/src/modules/lint/commands/repo/lint.ts
@@ -220,6 +220,7 @@ export async function command(opts: OptionValues, cmd: Command): Promise<void> {
   });
 
   const outputSuccessCache = [];
+  const jsonResults = [];
 
   let errorOutput = '';
 
@@ -238,7 +239,11 @@ export async function command(opts: OptionValues, cmd: Command): Promise<void> {
       // dump of all warnings that might be irrelevant
       if (resultText) {
         if (opts.outputFile) {
-          errorOutput += `${resultText}\n`;
+          if (opts.format === 'json') {
+            jsonResults.push(resultText);
+          } else {
+            errorOutput += `${resultText}\n`;
+          }
         } else {
           console.log();
           console.log(resultText.trimStart());
@@ -247,6 +252,14 @@ export async function command(opts: OptionValues, cmd: Command): Promise<void> {
     } else if (sha) {
       outputSuccessCache.push(sha);
     }
+  }
+
+  if (opts.format === 'json') {
+    let mergedJsonResults: any[] = [];
+    for (const jsonResult of jsonResults) {
+      mergedJsonResults = mergedJsonResults.concat(JSON.parse(jsonResult));
+    }
+    errorOutput = JSON.stringify(mergedJsonResults, null, 2);
   }
 
   if (opts.outputFile && errorOutput) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR fixes https://github.com/backstage/backstage/issues/30103. It merges multiple eslint json reports into a single output file.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
