### PR TITLE
Add a standard `toString` on credentials objects

### DIFF
--- a/.changeset/gentle-llamas-press.md
+++ b/.changeset/gentle-llamas-press.md
@@ -1,0 +1,6 @@
+---
+'@backstage/backend-defaults': patch
+'@backstage/backend-test-utils': minor
+---
+
+Add a standard `toString` on credentials objects

--- a/packages/backend-defaults/src/entrypoints/auth/helpers.test.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/helpers.test.ts
@@ -82,33 +82,62 @@ describe('credentials', () => {
     ).not.toMatch(/my-token/);
   });
 
-  it('should have a serializable form', () => {
-    expect(
-      String(createCredentialsWithServicePrincipal('my-service')),
-    ).toMatchInlineSnapshot(
-      `"{"$$type":"@backstage/BackstageCredentials","type":"service","subject":"my-service"}"`,
+  it('should have a serializable form both as strings and as JSON', () => {
+    const simpleService = createCredentialsWithServicePrincipal('my-service');
+    expect(String(simpleService)).toMatchInlineSnapshot(
+      `"backstageCredentials{servicePrincipal{my-service}}"`,
     );
-    expect(
-      String(
-        createCredentialsWithUserPrincipal('user:default/mock', 'my-token'),
-      ),
-    ).toMatchInlineSnapshot(
-      `"{"$$type":"@backstage/BackstageCredentials","type":"user","userEntityRef":"user:default/mock"}"`,
+    expect(JSON.stringify(simpleService)).toMatchInlineSnapshot(
+      `"{"$$type":"@backstage/BackstageCredentials","version":"v1","principal":{"type":"service","subject":"my-service"}}"`,
     );
-    expect(
-      String(
-        createCredentialsWithUserPrincipal(
-          'user:default/mock',
-          'my-token',
-          undefined,
-          'my-actor',
-        ),
-      ),
-    ).toMatchInlineSnapshot(
-      `"{"$$type":"@backstage/BackstageCredentials","type":"user","userEntityRef":"user:default/mock","actor":{"type":"service","subject":"my-actor"}}"`,
+
+    const serviceWithAccessRestrictions = createCredentialsWithServicePrincipal(
+      'my-service',
+      undefined,
+      {
+        permissionNames: ['perm'],
+        permissionAttributes: {
+          action: ['read'],
+        },
+      },
     );
-    expect(String(createCredentialsWithNonePrincipal())).toMatchInlineSnapshot(
-      `"{"$$type":"@backstage/BackstageCredentials","type":"none"}"`,
+    expect(String(serviceWithAccessRestrictions)).toMatchInlineSnapshot(
+      `"backstageCredentials{servicePrincipal{my-service,accessRestrictions=cXWOJgUirHkHNZIowUi/YO5nwEwhTicC38iXi2XTYCk}}"`,
+    );
+    expect(JSON.stringify(serviceWithAccessRestrictions)).toMatchInlineSnapshot(
+      `"{"$$type":"@backstage/BackstageCredentials","version":"v1","principal":{"type":"service","subject":"my-service","accessRestrictions":{"permissionNames":["perm"],"permissionAttributes":{"action":["read"]}}}}"`,
+    );
+
+    const simpleUser = createCredentialsWithUserPrincipal(
+      'user:default/mock',
+      'my-token',
+    );
+    expect(String(simpleUser)).toMatchInlineSnapshot(
+      `"backstageCredentials{userPrincipal{user:default/mock}}"`,
+    );
+    expect(JSON.stringify(simpleUser)).toMatchInlineSnapshot(
+      `"{"$$type":"@backstage/BackstageCredentials","version":"v1","principal":{"type":"user","userEntityRef":"user:default/mock"}}"`,
+    );
+
+    const userWithActor = createCredentialsWithUserPrincipal(
+      'user:default/mock',
+      'my-token',
+      undefined,
+      'my-actor',
+    );
+    expect(String(userWithActor)).toMatchInlineSnapshot(
+      `"backstageCredentials{userPrincipal{user:default/mock,actor={servicePrincipal{my-actor}}}}"`,
+    );
+    expect(JSON.stringify(userWithActor)).toMatchInlineSnapshot(
+      `"{"$$type":"@backstage/BackstageCredentials","version":"v1","principal":{"type":"user","userEntityRef":"user:default/mock","actor":{"type":"service","subject":"my-actor"}}}"`,
+    );
+
+    const none = createCredentialsWithNonePrincipal();
+    expect(String(none)).toMatchInlineSnapshot(
+      `"backstageCredentials{nonePrincipal}"`,
+    );
+    expect(JSON.stringify(none)).toMatchInlineSnapshot(
+      `"{"$$type":"@backstage/BackstageCredentials","version":"v1","principal":{"type":"none"}}"`,
     );
   });
 });

--- a/packages/backend-defaults/src/entrypoints/auth/helpers.test.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/helpers.test.ts
@@ -42,6 +42,23 @@ describe('credentials', () => {
       },
     });
 
+    expect(
+      createCredentialsWithUserPrincipal(
+        'user:default/mock',
+        'my-token',
+        undefined,
+        'my-actor',
+      ),
+    ).toEqual({
+      $$type: '@backstage/BackstageCredentials',
+      version: 'v1',
+      principal: {
+        type: 'user',
+        userEntityRef: 'user:default/mock',
+        actor: { type: 'service', subject: 'my-actor' },
+      },
+    });
+
     expect(createCredentialsWithNonePrincipal()).toEqual({
       $$type: '@backstage/BackstageCredentials',
       version: 'v1',
@@ -63,5 +80,35 @@ describe('credentials', () => {
         createCredentialsWithUserPrincipal('user:default/mock', 'my-token'),
       ),
     ).not.toMatch(/my-token/);
+  });
+
+  it('should have a serializable form', () => {
+    expect(
+      String(createCredentialsWithServicePrincipal('my-service')),
+    ).toMatchInlineSnapshot(
+      `"{"$$type":"@backstage/BackstageCredentials","type":"service","subject":"my-service"}"`,
+    );
+    expect(
+      String(
+        createCredentialsWithUserPrincipal('user:default/mock', 'my-token'),
+      ),
+    ).toMatchInlineSnapshot(
+      `"{"$$type":"@backstage/BackstageCredentials","type":"user","userEntityRef":"user:default/mock"}"`,
+    );
+    expect(
+      String(
+        createCredentialsWithUserPrincipal(
+          'user:default/mock',
+          'my-token',
+          undefined,
+          'my-actor',
+        ),
+      ),
+    ).toMatchInlineSnapshot(
+      `"{"$$type":"@backstage/BackstageCredentials","type":"user","userEntityRef":"user:default/mock","actor":{"type":"service","subject":"my-actor"}}"`,
+    );
+    expect(String(createCredentialsWithNonePrincipal())).toMatchInlineSnapshot(
+      `"{"$$type":"@backstage/BackstageCredentials","type":"none"}"`,
+    );
   });
 });

--- a/packages/backend-defaults/src/entrypoints/auth/helpers.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/helpers.ts
@@ -28,23 +28,31 @@ export function createCredentialsWithServicePrincipal(
   token?: string,
   accessRestrictions?: BackstagePrincipalAccessRestrictions,
 ): InternalBackstageCredentials<BackstageServicePrincipal> {
-  return Object.defineProperty(
-    {
-      $$type: '@backstage/BackstageCredentials',
-      version: 'v1',
-      principal: {
+  const result = {
+    $$type: '@backstage/BackstageCredentials',
+    version: 'v1',
+    principal: {
+      type: 'service',
+      subject: sub,
+      accessRestrictions,
+    },
+  } as const;
+  Object.defineProperty(result, 'token', {
+    enumerable: false,
+    configurable: true,
+    value: token,
+  });
+  Object.defineProperty(result, 'toString', {
+    enumerable: false,
+    configurable: true,
+    value: () =>
+      JSON.stringify({
+        $$type: '@backstage/BackstageCredentials',
         type: 'service',
         subject: sub,
-        accessRestrictions,
-      },
-    },
-    'token',
-    {
-      enumerable: false,
-      configurable: true,
-      value: token,
-    },
-  );
+      }),
+  });
+  return result;
 }
 
 export function createCredentialsWithUserPrincipal(
@@ -53,36 +61,57 @@ export function createCredentialsWithUserPrincipal(
   expiresAt?: Date,
   actor?: string,
 ): InternalBackstageCredentials<BackstageUserPrincipal> {
-  return Object.defineProperty(
-    {
-      $$type: '@backstage/BackstageCredentials',
-      version: 'v1',
-      expiresAt,
-      principal: {
+  const result = {
+    $$type: '@backstage/BackstageCredentials',
+    version: 'v1',
+    expiresAt,
+    principal: {
+      type: 'user',
+      userEntityRef: sub,
+      ...(actor && {
+        actor: { type: 'service', subject: actor } as const,
+      }),
+    },
+  } as const;
+  Object.defineProperty(result, 'token', {
+    enumerable: false,
+    configurable: true,
+    value: token,
+  });
+  Object.defineProperty(result, 'toString', {
+    enumerable: false,
+    configurable: true,
+    value: () =>
+      JSON.stringify({
+        $$type: '@backstage/BackstageCredentials',
         type: 'user',
         userEntityRef: sub,
         ...(actor && {
           actor: { type: 'service', subject: actor },
         }),
-      },
-    },
-    'token',
-    {
-      enumerable: false,
-      configurable: true,
-      value: token,
-    },
-  );
+      }),
+  });
+  return result;
 }
 
 export function createCredentialsWithNonePrincipal(): InternalBackstageCredentials<BackstageNonePrincipal> {
-  return {
+  const result = {
     $$type: '@backstage/BackstageCredentials',
     version: 'v1',
     principal: {
       type: 'none',
     },
-  };
+  } as const;
+  Object.defineProperty(result, 'toString', {
+    enumerable: false,
+    configurable: true,
+    value: () =>
+      JSON.stringify({
+        $$type: '@backstage/BackstageCredentials',
+        type: 'none',
+      }),
+  });
+  return result;
 }
 
 export function toInternalBackstageCredentials(

--- a/packages/backend-test-utils/src/services/mockCredentials.test.ts
+++ b/packages/backend-test-utils/src/services/mockCredentials.test.ts
@@ -173,12 +173,12 @@ describe('mockCredentials', () => {
 
   it('should have a serializable form', () => {
     expect(String(mockCredentials.service('my-service'))).toMatchInlineSnapshot(
-      `"{"$$type":"@backstage/MockBackstageCredentials","type":"service","subject":"my-service"}"`,
+      `"mockCredentials{servicePrincipal{my-service}}"`,
     );
     expect(
       String(mockCredentials.user('user:default/mock')),
     ).toMatchInlineSnapshot(
-      `"{"$$type":"@backstage/MockBackstageCredentials","type":"user","userEntityRef":"user:default/mock"}"`,
+      `"mockCredentials{userPrincipal{user:default/mock}}"`,
     );
     expect(
       String(
@@ -187,10 +187,10 @@ describe('mockCredentials', () => {
         }),
       ),
     ).toMatchInlineSnapshot(
-      `"{"$$type":"@backstage/MockBackstageCredentials","type":"user","userEntityRef":"user:default/mock","actor":{"type":"service","subject":"my-actor"}}"`,
+      `"mockCredentials{userPrincipal{user:default/mock,actor={my-actor}}}"`,
     );
     expect(String(mockCredentials.none())).toMatchInlineSnapshot(
-      `"{"$$type":"@backstage/MockBackstageCredentials","type":"none"}"`,
+      `"mockCredentials{nonePrincipal}"`,
     );
   });
 });

--- a/packages/backend-test-utils/src/services/mockCredentials.test.ts
+++ b/packages/backend-test-utils/src/services/mockCredentials.test.ts
@@ -170,4 +170,27 @@ describe('mockCredentials', () => {
       "Invalid user entity reference 'wrong', expected <kind>:<namespace>/<name>",
     );
   });
+
+  it('should have a serializable form', () => {
+    expect(String(mockCredentials.service('my-service'))).toMatchInlineSnapshot(
+      `"{"$$type":"@backstage/MockBackstageCredentials","type":"service","subject":"my-service"}"`,
+    );
+    expect(
+      String(mockCredentials.user('user:default/mock')),
+    ).toMatchInlineSnapshot(
+      `"{"$$type":"@backstage/MockBackstageCredentials","type":"user","userEntityRef":"user:default/mock"}"`,
+    );
+    expect(
+      String(
+        mockCredentials.user('user:default/mock', {
+          actor: { subject: 'my-actor' },
+        }),
+      ),
+    ).toMatchInlineSnapshot(
+      `"{"$$type":"@backstage/MockBackstageCredentials","type":"user","userEntityRef":"user:default/mock","actor":{"type":"service","subject":"my-actor"}}"`,
+    );
+    expect(String(mockCredentials.none())).toMatchInlineSnapshot(
+      `"{"$$type":"@backstage/MockBackstageCredentials","type":"none"}"`,
+    );
+  });
 });

--- a/packages/backend-test-utils/src/services/mockCredentials.ts
+++ b/packages/backend-test-utils/src/services/mockCredentials.ts
@@ -76,10 +76,20 @@ export namespace mockCredentials {
    * Creates a mocked credentials object for a unauthenticated principal.
    */
   export function none(): BackstageCredentials<BackstageNonePrincipal> {
-    return {
+    const result = {
       $$type: '@backstage/BackstageCredentials',
       principal: { type: 'none' },
-    };
+    } as const;
+    Object.defineProperty(result, 'toString', {
+      enumerable: false,
+      configurable: true,
+      value: () =>
+        JSON.stringify({
+          $$type: '@backstage/MockBackstageCredentials',
+          type: 'none',
+        }),
+    });
+    return result;
   }
 
   /**
@@ -111,24 +121,35 @@ export namespace mockCredentials {
     options?: { actor?: { subject: string } },
   ): BackstageCredentials<BackstageUserPrincipal> {
     validateUserEntityRef(userEntityRef);
-    return Object.defineProperty(
-      {
-        $$type: '@backstage/BackstageCredentials',
-        principal: {
+    const result = {
+      $$type: '@backstage/BackstageCredentials',
+      principal: {
+        type: 'user',
+        userEntityRef,
+        ...(options?.actor && {
+          actor: { type: 'service', subject: options.actor.subject } as const,
+        }),
+      },
+    } as const;
+    Object.defineProperty(result, 'toString', {
+      enumerable: false,
+      configurable: true,
+      value: () =>
+        JSON.stringify({
+          $$type: '@backstage/MockBackstageCredentials',
           type: 'user',
           userEntityRef,
           ...(options?.actor && {
             actor: { type: 'service', subject: options.actor.subject },
           }),
-        },
-      },
-      'token',
-      {
-        enumerable: false,
-        configurable: true,
-        value: user.token(),
-      },
-    );
+        }),
+    });
+    Object.defineProperty(result, 'token', {
+      enumerable: false,
+      configurable: true,
+      value: user.token(),
+    });
+    return result;
   }
 
   /**
@@ -231,14 +252,25 @@ export namespace mockCredentials {
     subject: string = DEFAULT_MOCK_SERVICE_SUBJECT,
     accessRestrictions?: BackstagePrincipalAccessRestrictions,
   ): BackstageCredentials<BackstageServicePrincipal> {
-    return {
+    const result = {
       $$type: '@backstage/BackstageCredentials',
       principal: {
         type: 'service',
         subject,
         ...(accessRestrictions ? { accessRestrictions } : {}),
       },
-    };
+    } as const;
+    Object.defineProperty(result, 'toString', {
+      enumerable: false,
+      configurable: true,
+      value: () =>
+        JSON.stringify({
+          $$type: '@backstage/MockBackstageCredentials',
+          type: 'service',
+          subject,
+        }),
+    });
+    return result;
   }
 
   /**

--- a/packages/backend-test-utils/src/services/mockCredentials.ts
+++ b/packages/backend-test-utils/src/services/mockCredentials.ts
@@ -80,14 +80,13 @@ export namespace mockCredentials {
       $$type: '@backstage/BackstageCredentials',
       principal: { type: 'none' },
     } as const;
-    Object.defineProperty(result, 'toString', {
-      enumerable: false,
-      configurable: true,
-      value: () =>
-        JSON.stringify({
-          $$type: '@backstage/MockBackstageCredentials',
-          type: 'none',
-        }),
+    Object.defineProperties(result, {
+      toString: {
+        enumerable: false,
+        configurable: true,
+        writable: true,
+        value: () => `mockCredentials{nonePrincipal}`,
+      },
     });
     return result;
   }
@@ -131,23 +130,20 @@ export namespace mockCredentials {
         }),
       },
     } as const;
-    Object.defineProperty(result, 'toString', {
-      enumerable: false,
-      configurable: true,
-      value: () =>
-        JSON.stringify({
-          $$type: '@backstage/MockBackstageCredentials',
-          type: 'user',
-          userEntityRef,
-          ...(options?.actor && {
-            actor: { type: 'service', subject: options.actor.subject },
-          }),
-        }),
-    });
-    Object.defineProperty(result, 'token', {
-      enumerable: false,
-      configurable: true,
-      value: user.token(),
+    Object.defineProperties(result, {
+      toString: {
+        enumerable: false,
+        configurable: true,
+        value: () =>
+          `mockCredentials{userPrincipal{${userEntityRef}${
+            options?.actor ? `,actor={${options.actor.subject}}` : ''
+          }}}`,
+      },
+      token: {
+        enumerable: false,
+        configurable: true,
+        value: user.token(),
+      },
     });
     return result;
   }
@@ -260,15 +256,17 @@ export namespace mockCredentials {
         ...(accessRestrictions ? { accessRestrictions } : {}),
       },
     } as const;
-    Object.defineProperty(result, 'toString', {
-      enumerable: false,
-      configurable: true,
-      value: () =>
-        JSON.stringify({
-          $$type: '@backstage/MockBackstageCredentials',
-          type: 'service',
-          subject,
-        }),
+    Object.defineProperties(result, {
+      toString: {
+        enumerable: false,
+        configurable: true,
+        value: () =>
+          `mockCredentials{servicePrincipal{${subject}${
+            accessRestrictions
+              ? `,accessRestrictions=${JSON.stringify(accessRestrictions)}`
+              : ''
+          }}}`,
+      },
     });
     return result;
   }


### PR DESCRIPTION
This is useful when cache-keying, or wanting to log a string form, or track credentials of actors in a database, etc. One such example is techdocs caching reads [here](https://github.com/backstage/backstage/blob/a58e48e983224686a9ef7862d6b29976dd202732/plugins/techdocs-backend/src/service/CachedEntityLoader.ts#L44), which is currently based on a token which blocks migration of this code to using credentials and the `CacheService` instead of `CacheApi`.

This also at the same time adds tests that check the JSON stringified form of credentials, to make visible the fact that these might be sent across the wire or persisted.