### PR TITLE
fix(repo-tools): remove const object from modelEnum template files

### DIFF
--- a/.changeset/fair-doors-bathe.md
+++ b/.changeset/fair-doors-bathe.md
@@ -2,4 +2,4 @@
 '@backstage/repo-tools': patch
 ---
 
-Remove exported `const` objects from the `modelEnum` template files for the server and client, as they were causing issues when defining `enum` schemas
+Fixed a bug where linting would fail with the generated clients when defining top-level `enum` schema values.

--- a/.changeset/fair-doors-bathe.md
+++ b/.changeset/fair-doors-bathe.md
@@ -1,0 +1,5 @@
+---
+'@backstage/repo-tools': patch
+---
+
+Remove exported `const` objects from the `modelEnum` template files for the server and client, as they were causing issues when defining `enum` schemas

--- a/packages/repo-tools/templates/typescript-backstage-client/modelEnum.mustache
+++ b/packages/repo-tools/templates/typescript-backstage-client/modelEnum.mustache
@@ -18,14 +18,3 @@ export enum {{classname}} {
   */
 export type {{classname}} = {{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}} | {{/-last}}{{/enumVars}}{{/allowableValues}};
 
-/**
-  * @public
-  */
-export const {{classname}} = {
-{{#allowableValues}}
-{{#enumVars}}
-    {{name}}: {{{value}}} as {{classname}}{{^-last}},{{/-last}}
-{{/enumVars}}
-{{/allowableValues}}
-};
-{{/stringEnums}}

--- a/packages/repo-tools/templates/typescript-backstage-server/modelEnum.mustache
+++ b/packages/repo-tools/templates/typescript-backstage-server/modelEnum.mustache
@@ -18,14 +18,3 @@ export enum {{classname}} {
   */
 export type {{classname}} = {{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}} | {{/-last}}{{/enumVars}}{{/allowableValues}};
 
-/**
-  * @public
-  */
-export const {{classname}} = {
-{{#allowableValues}}
-{{#enumVars}}
-    {{name}}: {{{value}}} as {{classname}}{{^-last}},{{/-last}}
-{{/enumVars}}
-{{/allowableValues}}
-};
-{{/stringEnums}}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR updates the repo-tools modelEnum template files for the server and client to no longer export a const object.

See [Discord Thread](https://discord.com/channels/687207715902193673/1379480958062952672) for more information.

This was causing issues when defining the following OpenAPI enum schema. The generated files were trying to export both a `Status` type and a `Status` object:

```yaml
components:
  schemas:
    Status:
      type: string
      description: Status of the result
      enum:
        - fail
        - skip
        - pass
        - warn
        - error
        - summary
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
