### PR TITLE
scaffolder-backend-module-notifications - Removed `octokit` dependency

### DIFF
--- a/.changeset/open-bottles-attack.md
+++ b/.changeset/open-bottles-attack.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-notifications': patch
+---
+
+Removed `octokit` dependency as it was not being used

--- a/plugins/scaffolder-backend-module-notifications/package.json
+++ b/plugins/scaffolder-backend-module-notifications/package.json
@@ -37,7 +37,6 @@
     "@backstage/plugin-notifications-common": "workspace:^",
     "@backstage/plugin-notifications-node": "workspace:^",
     "@backstage/plugin-scaffolder-node": "workspace:^",
-    "octokit": "^3.0.0",
     "yaml": "^2.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7653,7 +7653,6 @@ __metadata:
     "@backstage/plugin-notifications-node": "workspace:^"
     "@backstage/plugin-scaffolder-node": "workspace:^"
     "@backstage/plugin-scaffolder-node-test-utils": "workspace:^"
-    octokit: "npm:^3.0.0"
     yaml: "npm:^2.0.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Removed `octokit` dependency as it was not being used

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
