### PR TITLE
fix: prevent oauth and integration token merge

### DIFF
--- a/.changeset/wise-frogs-talk.md
+++ b/.changeset/wise-frogs-talk.md
@@ -1,0 +1,6 @@
+---
+'@backstage/backend-defaults': patch
+'@backstage/integration': patch
+---
+
+Fixed bug where the GitLab user token and GitLab integration token were being merged together

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/GitlabUrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/GitlabUrlReader.ts
@@ -340,10 +340,7 @@ export class GitlabUrlReader implements UrlReaderService {
       );
     }
     // Default to the old behavior of assuming the url is for a file
-    return getGitLabFileFetchUrl(target, {
-      ...this.integration.config,
-      ...(token && { token }),
-    });
+    return getGitLabFileFetchUrl(target, this.integration.config, token);
   }
 
   // convert urls of the form:

--- a/packages/integration/report.api.md
+++ b/packages/integration/report.api.md
@@ -588,6 +588,7 @@ export function getGitilesAuthenticationUrl(
 export function getGitLabFileFetchUrl(
   url: string,
   config: GitLabIntegrationConfig,
+  token?: string,
 ): Promise<string>;
 
 // @public

--- a/packages/integration/src/gitlab/core.ts
+++ b/packages/integration/src/gitlab/core.ts
@@ -40,8 +40,9 @@ import {
 export async function getGitLabFileFetchUrl(
   url: string,
   config: GitLabIntegrationConfig,
+  token?: string,
 ): Promise<string> {
-  const projectID = await getProjectId(url, config);
+  const projectID = await getProjectId(url, config, token);
   return buildProjectUrl(url, projectID, config).toString();
 }
 
@@ -113,6 +114,7 @@ export function buildProjectUrl(
 export async function getProjectId(
   target: string,
   config: GitLabIntegrationConfig,
+  token?: string,
 ): Promise<number> {
   const url = new URL(target);
 
@@ -143,7 +145,7 @@ export async function getProjectId(
 
     const response = await fetch(
       repoIDLookup.toString(),
-      getGitLabRequestOptions(config),
+      getGitLabRequestOptions(config, token),
     );
 
     const data = await response.json();


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR fixes a bug where the GitLab user token and GitLab integration token were being merged together. 
Relates to: https://github.com/backstage/backstage/issues/30079


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
