### PR TITLE
[Catalog] Add optional `value` to `HAS_LABEL` permission rule

### DIFF
--- a/plugins/catalog-backend/src/permissions/rules/hasLabel.test.ts
+++ b/plugins/catalog-backend/src/permissions/rules/hasLabel.test.ts
@@ -73,6 +73,50 @@ describe('hasLabel permission rule', () => {
         ),
       ).toEqual(true);
     });
+
+    it('returns false when specified label has different than expected value', () => {
+      expect(
+        hasLabel.apply(
+          {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'Component',
+            metadata: {
+              name: 'test-component',
+              labels: {
+                someLabel: 'foo',
+                'backstage.io/testLabel': 'bar',
+              },
+            },
+          },
+          {
+            label: 'backstage.io/testLabel',
+            value: 'baz',
+          },
+        ),
+      ).toEqual(false);
+    });
+
+    it('returns true when specified label has expected value', () => {
+      expect(
+        hasLabel.apply(
+          {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'Component',
+            metadata: {
+              name: 'test-component',
+              labels: {
+                someLabel: 'foo',
+                'backstage.io/testLabel': 'bar',
+              },
+            },
+          },
+          {
+            label: 'backstage.io/testLabel',
+            value: 'bar',
+          },
+        ),
+      ).toEqual(true);
+    });
   });
 
   describe('toQuery', () => {
@@ -83,6 +127,18 @@ describe('hasLabel permission rule', () => {
         }),
       ).toEqual({
         key: 'metadata.labels.backstage.io/testlabel',
+      });
+    });
+
+    it('returns an appropriate catalog-backend filter with values', () => {
+      expect(
+        hasLabel.toQuery({
+          label: 'backstage.io/testLabel',
+          value: 'foo',
+        }),
+      ).toEqual({
+        key: 'metadata.labels.backstage.io/testLabel',
+        values: ['foo'],
       });
     });
   });

--- a/plugins/catalog-backend/src/permissions/rules/hasLabel.ts
+++ b/plugins/catalog-backend/src/permissions/rules/hasLabel.ts
@@ -29,10 +29,18 @@ export const hasLabel = createPermissionRule({
   resourceRef: catalogEntityPermissionResourceRef,
   paramsSchema: z.object({
     label: z.string().describe('Name of the label to match on'),
+    value: z.string().optional().describe('Value of the label to match on'),
   }),
-  apply: (resource, { label }) =>
-    !!resource.metadata.labels?.hasOwnProperty(label),
-  toQuery: ({ label }) => ({
-    key: `metadata.labels.${label}`,
-  }),
+  apply: (resource, { label, value }) =>
+    !!resource.metadata.labels?.hasOwnProperty(label) &&
+    (value === undefined ? true : resource.metadata.labels?.[label] === value),
+  toQuery: ({ label, value }) =>
+    value === undefined
+      ? {
+          key: `metadata.labels.${label}`,
+        }
+      : {
+          key: `metadata.labels.${label}`,
+          values: [value],
+        },
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Noticed the `HAS_LABEL` permission rule wasn't as useful as the very similar `HAS_ANNOTATION` permission rule. This PR brings the former in line with the latter.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
