### PR TITLE
Patch release of #30045

### DIFF
--- a/.changeset/grumpy-dryers-act.md
+++ b/.changeset/grumpy-dryers-act.md
@@ -1,5 +1,0 @@
----
-'@backstage/repo-tools': patch
----
-
-Add missing highlight language for the `package-docs` command.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.39.0",
+  "version": "1.39.1",
   "backstage": {
     "cli": {
       "new": {

--- a/packages/repo-tools/CHANGELOG.md
+++ b/packages/repo-tools/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/repo-tools
 
+## 0.13.4
+
+### Patch Changes
+
+- 209c679: Add missing highlight language for the `package-docs` command.
+
 ## 0.13.3
 
 ### Patch Changes

--- a/packages/repo-tools/package.json
+++ b/packages/repo-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/repo-tools",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "description": "CLI for Backstage repo tooling ",
   "backstage": {
     "role": "cli"


### PR DESCRIPTION
This release fixes an issue with the documentation at https://backstage.io, and does not need to be adopted in end user projects.