### PR TITLE
remove some usages of the old alpha catalog service

### DIFF
--- a/.changeset/khaki-swans-invite.md
+++ b/.changeset/khaki-swans-invite.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-notifications-backend-module-email': patch
+'@backstage/plugin-notifications-backend': patch
+---
+
+Internal changes to switch to the non-alpha `catalogServiceRef`

--- a/.changeset/some-llamas-go.md
+++ b/.changeset/some-llamas-go.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-bitbucket-cloud': minor
+---
+
+**BREAKING**: `BitbucketCloudEntityProvider` now accepts a `CatalogService` instead of a `CatalogApi`.

--- a/plugins/catalog-backend-module-bitbucket-cloud/report.api.md
+++ b/plugins/catalog-backend-module-bitbucket-cloud/report.api.md
@@ -5,7 +5,7 @@
 ```ts
 import { AuthService } from '@backstage/backend-plugin-api';
 import { BackendFeature } from '@backstage/backend-plugin-api';
-import { CatalogApi } from '@backstage/catalog-client';
+import { CatalogService } from '@backstage/plugin-catalog-node';
 import { Config } from '@backstage/config';
 import { EntityProvider } from '@backstage/plugin-catalog-node';
 import { EntityProviderConnection } from '@backstage/plugin-catalog-node';
@@ -23,7 +23,7 @@ export class BitbucketCloudEntityProvider implements EntityProvider {
     config: Config,
     options: {
       auth: AuthService;
-      catalogApi: CatalogApi;
+      catalog: CatalogService;
       events: EventsService;
       logger: LoggerService;
       schedule?: SchedulerServiceTaskRunner;

--- a/plugins/catalog-backend-module-bitbucket-cloud/src/module/catalogModuleBitbucketCloudEntityProvider.ts
+++ b/plugins/catalog-backend-module-bitbucket-cloud/src/module/catalogModuleBitbucketCloudEntityProvider.ts
@@ -18,10 +18,8 @@ import {
   coreServices,
   createBackendModule,
 } from '@backstage/backend-plugin-api';
-import {
-  catalogProcessingExtensionPoint,
-  catalogServiceRef,
-} from '@backstage/plugin-catalog-node/alpha';
+import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
+import { catalogServiceRef } from '@backstage/plugin-catalog-node';
 import { eventsServiceRef } from '@backstage/plugin-events-node';
 import { BitbucketCloudEntityProvider } from '../providers/BitbucketCloudEntityProvider';
 
@@ -35,8 +33,8 @@ export const catalogModuleBitbucketCloudEntityProvider = createBackendModule({
     env.registerInit({
       deps: {
         auth: coreServices.auth,
-        catalog: catalogProcessingExtensionPoint,
-        catalogApi: catalogServiceRef,
+        catalogProcessing: catalogProcessingExtensionPoint,
+        catalog: catalogServiceRef,
         config: coreServices.rootConfig,
         events: eventsServiceRef,
         logger: coreServices.logger,
@@ -44,8 +42,8 @@ export const catalogModuleBitbucketCloudEntityProvider = createBackendModule({
       },
       async init({
         auth,
+        catalogProcessing,
         catalog,
-        catalogApi,
         config,
         events,
         logger,
@@ -53,13 +51,13 @@ export const catalogModuleBitbucketCloudEntityProvider = createBackendModule({
       }) {
         const providers = BitbucketCloudEntityProvider.fromConfig(config, {
           auth,
-          catalogApi,
+          catalog,
           events,
           logger,
           scheduler,
         });
 
-        catalog.addEntityProvider(providers);
+        catalogProcessing.addEntityProvider(providers);
       },
     });
   },

--- a/plugins/catalog-backend-module-bitbucket-cloud/src/providers/BitbucketCloudEntityProvider.ts
+++ b/plugins/catalog-backend-module-bitbucket-cloud/src/providers/BitbucketCloudEntityProvider.ts
@@ -20,7 +20,6 @@ import {
   SchedulerService,
   SchedulerServiceTaskRunner,
 } from '@backstage/backend-plugin-api';
-import { CatalogApi } from '@backstage/catalog-client';
 import { LocationEntity } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
 import {
@@ -33,6 +32,7 @@ import {
   Models,
 } from '@backstage/plugin-bitbucket-cloud-common';
 import {
+  CatalogService,
   DeferredEntity,
   EntityProvider,
   EntityProviderConnection,
@@ -68,7 +68,7 @@ interface IngestionTarget {
  */
 export class BitbucketCloudEntityProvider implements EntityProvider {
   private readonly auth: AuthService;
-  private readonly catalogApi: CatalogApi;
+  private readonly catalog: CatalogService;
   private readonly client: BitbucketCloudClient;
   private readonly config: BitbucketCloudEntityProviderConfig;
   private readonly events: EventsService;
@@ -81,7 +81,7 @@ export class BitbucketCloudEntityProvider implements EntityProvider {
     config: Config,
     options: {
       auth: AuthService;
-      catalogApi: CatalogApi;
+      catalog: CatalogService;
       events: EventsService;
       logger: LoggerService;
       schedule?: SchedulerServiceTaskRunner;
@@ -113,7 +113,7 @@ export class BitbucketCloudEntityProvider implements EntityProvider {
 
       return new BitbucketCloudEntityProvider(
         options.auth,
-        options.catalogApi,
+        options.catalog,
         providerConfig,
         options.events,
         integration,
@@ -125,7 +125,7 @@ export class BitbucketCloudEntityProvider implements EntityProvider {
 
   private constructor(
     auth: AuthService,
-    catalogApi: CatalogApi,
+    catalog: CatalogService,
     config: BitbucketCloudEntityProviderConfig,
     events: EventsService,
     integration: BitbucketCloudIntegration,
@@ -133,7 +133,7 @@ export class BitbucketCloudEntityProvider implements EntityProvider {
     taskRunner: SchedulerServiceTaskRunner,
   ) {
     this.auth = auth;
-    this.catalogApi = catalogApi;
+    this.catalog = catalog;
     this.client = BitbucketCloudClient.fromConfig(integration.config);
     this.config = config;
     this.events = events;
@@ -350,13 +350,11 @@ export class BitbucketCloudEntityProvider implements EntityProvider {
     filter[`metadata.annotations.${ANNOTATION_BITBUCKET_CLOUD_REPO_URL}`] =
       repoUrl;
 
-    const { token } = await this.auth.getPluginRequestToken({
-      onBehalfOf: await this.auth.getOwnServiceCredentials(),
-      targetPluginId: 'catalog',
-    });
-
-    return this.catalogApi
-      .getEntities({ filter }, { token })
+    return this.catalog
+      .getEntities(
+        { filter },
+        { credentials: await this.auth.getOwnServiceCredentials() },
+      )
       .then(result => result.items) as Promise<LocationEntity[]>;
   }
 

--- a/plugins/notifications-backend-module-email/src/module.ts
+++ b/plugins/notifications-backend-module-email/src/module.ts
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   coreServices,
   createBackendModule,
 } from '@backstage/backend-plugin-api';
-import { catalogServiceRef } from '@backstage/plugin-catalog-node/alpha';
+import { catalogServiceRef } from '@backstage/plugin-catalog-node';
 import { notificationsProcessingExtensionPoint } from '@backstage/plugin-notifications-node';
 import { NotificationsEmailProcessor } from './processor';
 import {

--- a/plugins/notifications-backend-module-email/src/processor/NotificationsEmailProcessor.ts
+++ b/plugins/notifications-backend-module-email/src/processor/NotificationsEmailProcessor.ts
@@ -25,7 +25,7 @@ import {
 } from '@backstage/backend-plugin-api';
 import { Config, readDurationFromConfig } from '@backstage/config';
 import { durationToMilliseconds } from '@backstage/types';
-import { CATALOG_FILTER_EXISTS, CatalogApi } from '@backstage/catalog-client';
+import { CATALOG_FILTER_EXISTS } from '@backstage/catalog-client';
 import {
   getProcessorFiltersFromConfig,
   Notification,
@@ -39,6 +39,7 @@ import {
   createStreamTransport,
 } from './transports';
 import { UserEntity } from '@backstage/catalog-model';
+import { CatalogService } from '@backstage/plugin-catalog-node';
 import { compact } from 'lodash';
 import { DefaultAwsCredentialsManager } from '@backstage/integration-aws-node';
 import { NotificationTemplateRenderer } from '../extensions';
@@ -62,7 +63,7 @@ export class NotificationsEmailProcessor implements NotificationProcessor {
   constructor(
     private readonly logger: LoggerService,
     private readonly config: Config,
-    private readonly catalog: CatalogApi,
+    private readonly catalog: CatalogService,
     private readonly auth: AuthService,
     private readonly cache?: CacheService,
     private readonly templateRenderer?: NotificationTemplateRenderer,
@@ -152,10 +153,6 @@ export class NotificationsEmailProcessor implements NotificationProcessor {
         return cached;
       }
 
-      const { token } = await this.auth.getPluginRequestToken({
-        onBehalfOf: await this.auth.getOwnServiceCredentials(),
-        targetPluginId: 'catalog',
-      });
       const entities = await this.catalog.getEntities(
         {
           filter: [
@@ -163,7 +160,7 @@ export class NotificationsEmailProcessor implements NotificationProcessor {
           ],
           fields: ['spec.profile.email'],
         },
-        { token },
+        { credentials: await this.auth.getOwnServiceCredentials() },
       );
       const ret = compact([
         ...new Set(
@@ -188,11 +185,9 @@ export class NotificationsEmailProcessor implements NotificationProcessor {
       return cached;
     }
 
-    const { token } = await this.auth.getPluginRequestToken({
-      onBehalfOf: await this.auth.getOwnServiceCredentials(),
-      targetPluginId: 'catalog',
+    const entity = await this.catalog.getEntityByRef(entityRef, {
+      credentials: await this.auth.getOwnServiceCredentials(),
     });
-    const entity = await this.catalog.getEntityByRef(entityRef, { token });
     const ret: string[] = [];
     if (entity) {
       const userEntity = entity as UserEntity;

--- a/plugins/notifications-backend/package.json
+++ b/plugins/notifications-backend/package.json
@@ -40,7 +40,6 @@
   },
   "dependencies": {
     "@backstage/backend-plugin-api": "workspace:^",
-    "@backstage/catalog-client": "workspace:^",
     "@backstage/catalog-model": "workspace:^",
     "@backstage/config": "workspace:^",
     "@backstage/errors": "workspace:^",

--- a/plugins/notifications-backend/src/plugin.ts
+++ b/plugins/notifications-backend/src/plugin.ts
@@ -25,7 +25,7 @@ import {
   notificationsProcessingExtensionPoint,
   NotificationsProcessingExtensionPoint,
 } from '@backstage/plugin-notifications-node';
-import { catalogServiceRef } from '@backstage/plugin-catalog-node/alpha';
+import { catalogServiceRef } from '@backstage/plugin-catalog-node';
 
 class NotificationsProcessingExtensionPointImpl
   implements NotificationsProcessingExtensionPoint

--- a/plugins/notifications-backend/src/service/getUsersForEntityRef.test.ts
+++ b/plugins/notifications-backend/src/service/getUsersForEntityRef.test.ts
@@ -28,25 +28,25 @@ describe('getUsersForEntityRef', () => {
     await expect(
       getUsersForEntityRef(null, [], {
         auth: mockServices.auth(),
-        catalogClient: catalogServiceMock(),
+        catalog: catalogServiceMock(),
       }),
     ).resolves.toEqual([]);
   });
 
   it('should resolve users without calling catalog', async () => {
-    const catalogClient = catalogServiceMock();
-    jest.spyOn(catalogClient, 'getEntitiesByRefs');
+    const catalog = catalogServiceMock();
+    jest.spyOn(catalog, 'getEntitiesByRefs');
     await expect(
       getUsersForEntityRef(['user:foo', 'user:ignored'], ['user:ignored'], {
         auth: mockServices.auth(),
-        catalogClient,
+        catalog,
       }),
     ).resolves.toEqual(['user:foo']);
-    expect(catalogClient.getEntitiesByRefs).not.toHaveBeenCalled();
+    expect(catalog.getEntitiesByRefs).not.toHaveBeenCalled();
   });
 
   it('should resolve group entities to users', async () => {
-    const catalogClient = catalogServiceMock({
+    const catalog = catalogServiceMock({
       entities: [
         {
           apiVersion: 'backstage.io/v1alpha1',
@@ -91,14 +91,14 @@ describe('getUsersForEntityRef', () => {
         ['user:default/ignored'],
         {
           auth: mockServices.auth(),
-          catalogClient,
+          catalog,
         },
       ),
     ).resolves.toEqual(['user:default/foo', 'user:default/bar']);
   });
 
   it('should resolve user owner of entity from entity ref', async () => {
-    const catalogClient = catalogServiceMock({
+    const catalog = catalogServiceMock({
       entities: [
         {
           apiVersion: 'backstage.io/v1alpha1',
@@ -119,13 +119,13 @@ describe('getUsersForEntityRef', () => {
     await expect(
       getUsersForEntityRef('component:default/test_component', [], {
         auth: mockServices.auth(),
-        catalogClient,
+        catalog,
       }),
     ).resolves.toEqual(['user:default/foo']);
   });
 
   it('should resolve group owner of entity from entity ref', async () => {
-    const catalogClient = catalogServiceMock({
+    const catalog = catalogServiceMock({
       entities: [
         {
           apiVersion: 'backstage.io/v1alpha1',
@@ -159,7 +159,7 @@ describe('getUsersForEntityRef', () => {
     await expect(
       getUsersForEntityRef('component:default/test_component', [], {
         auth: mockServices.auth(),
-        catalogClient,
+        catalog,
       }),
     ).resolves.toEqual(['user:default/foo']);
   });

--- a/plugins/notifications-backend/src/service/router.ts
+++ b/plugins/notifications-backend/src/service/router.ts
@@ -23,7 +23,7 @@ import {
   TopicGetOptions,
 } from '../database';
 import { v4 as uuid } from 'uuid';
-import { CatalogApi } from '@backstage/catalog-client';
+import { CatalogService } from '@backstage/plugin-catalog-node';
 import {
   NotificationProcessor,
   NotificationSendOptions,
@@ -63,7 +63,7 @@ export interface RouterOptions {
   httpAuth: HttpAuthService;
   userInfo: UserInfoService;
   signals?: SignalsService;
-  catalog: CatalogApi;
+  catalog: CatalogService;
   processors?: NotificationProcessor[];
 }
 
@@ -672,7 +672,7 @@ export async function createRouter(
         users = await getUsersForEntityRef(
           entityRef,
           recipients.excludeEntityRef ?? [],
-          { auth, catalogClient: catalog },
+          { auth, catalog },
         );
       } catch (e) {
         throw new InputError('Failed to resolve notification receivers', e);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7082,7 +7082,6 @@ __metadata:
     "@backstage/backend-defaults": "workspace:^"
     "@backstage/backend-plugin-api": "workspace:^"
     "@backstage/backend-test-utils": "workspace:^"
-    "@backstage/catalog-client": "workspace:^"
     "@backstage/catalog-model": "workspace:^"
     "@backstage/cli": "workspace:^"
     "@backstage/config": "workspace:^"


### PR DESCRIPTION
There are very few left; one is in the scaffolder and that's being addressed, and one in techdocs that currently needs https://github.com/backstage/backstage/pull/30127