### PR TITLE
cli: add backstage.pluginId templating

### DIFF
--- a/.changeset/stupid-goats-teach.md
+++ b/.changeset/stupid-goats-teach.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Added `backstage.pluginId` field in `package.json` to all default plugin package templates for the `new` command.

--- a/packages/cli/templates/backend-plugin-module/package.json.hbs
+++ b/packages/cli/templates/backend-plugin-module/package.json.hbs
@@ -9,7 +9,8 @@
     "types": "dist/index.d.ts"
   },
   "backstage": {
-    "role": "backend-plugin-module"
+    "role": "backend-plugin-module",
+    "pluginId": "{{pluginId}}"
   },
   "scripts": {
     "start": "backstage-cli package start",

--- a/packages/cli/templates/backend-plugin/package.json.hbs
+++ b/packages/cli/templates/backend-plugin/package.json.hbs
@@ -8,7 +8,8 @@
     "types": "dist/index.d.ts"
   },
   "backstage": {
-    "role": "backend-plugin"
+    "role": "backend-plugin",
+    "pluginId": "{{pluginId}}"
   },
   "scripts": {
     "start": "backstage-cli package start",

--- a/packages/cli/templates/frontend-plugin/package.json.hbs
+++ b/packages/cli/templates/frontend-plugin/package.json.hbs
@@ -8,7 +8,8 @@
     "types": "dist/index.d.ts"
   },
   "backstage": {
-    "role": "frontend-plugin"
+    "role": "frontend-plugin",
+    "pluginId": "{{pluginId}}"
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/cli/templates/plugin-common-library/package.json.hbs
+++ b/packages/cli/templates/plugin-common-library/package.json.hbs
@@ -10,7 +10,8 @@
     "types": "dist/index.d.ts"
   },
   "backstage": {
-    "role": "common-library"
+    "role": "common-library",
+    "pluginId": "{{pluginId}}"
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/cli/templates/plugin-node-library/package.json.hbs
+++ b/packages/cli/templates/plugin-node-library/package.json.hbs
@@ -9,7 +9,8 @@
     "types": "dist/index.d.ts"
   },
   "backstage": {
-    "role": "node-library"
+    "role": "node-library",
+    "pluginId": "{{pluginId}}"
   },
   "scripts": {
     "build": "backstage-cli package build",

--- a/packages/cli/templates/plugin-web-library/package.json.hbs
+++ b/packages/cli/templates/plugin-web-library/package.json.hbs
@@ -9,7 +9,8 @@
     "types": "dist/index.d.ts"
   },
   "backstage": {
-    "role": "web-library"
+    "role": "web-library",
+    "pluginId": "{{pluginId}}"
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/cli/templates/scaffolder-backend-module/package.json.hbs
+++ b/packages/cli/templates/scaffolder-backend-module/package.json.hbs
@@ -9,7 +9,8 @@
     "types": "dist/index.d.ts"
   },
   "backstage": {
-    "role": "backend-plugin-module"
+    "role": "backend-plugin-module",
+    "pluginId": "scaffolder"
   },
   "scripts": {
     "start": "backstage-cli package start",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Spotted this gap, given the new `repo start` command we really want to start encouraging this. Thinking we may add a warning to the CLI as well and weave this into the regular `fix` command instead of `fix --publish`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
