### PR TITLE
Migrate typography to canon in search

### DIFF
--- a/.changeset/open-clocks-swim.md
+++ b/.changeset/open-clocks-swim.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-search-react': patch
+'@backstage/plugin-search': patch
+---
+
+added backstage/canon to migrate MUI Typography components to Canon Text

--- a/plugins/search-react/package.json
+++ b/plugins/search-react/package.json
@@ -56,6 +56,7 @@
     "test": "backstage-cli package test"
   },
   "dependencies": {
+    "@backstage/canon": "workspace:^",
     "@backstage/core-components": "workspace:^",
     "@backstage/core-plugin-api": "workspace:^",
     "@backstage/frontend-plugin-api": "workspace:^",

--- a/plugins/search-react/src/components/DefaultResultListItem/DefaultResultListItem.test.tsx
+++ b/plugins/search-react/src/components/DefaultResultListItem/DefaultResultListItem.test.tsx
@@ -19,23 +19,9 @@ import { renderInTestApp } from '@backstage/test-utils';
 import FindInPageIcon from '@material-ui/icons/FindInPage';
 import { DefaultResultListItem } from './DefaultResultListItem';
 
-describe('DefaultResultListItem', () => {
-  beforeAll(() => {
-    Object.defineProperty(window, 'matchMedia', {
-      writable: true,
-      value: jest.fn().mockImplementation(query => ({
-        matches: false,
-        media: query,
-        onchange: null,
-        addListener: jest.fn(),
-        removeListener: jest.fn(),
-        addEventListener: jest.fn(),
-        removeEventListener: jest.fn(),
-        dispatchEvent: jest.fn(),
-      })),
-    });
-  });
+jest.mock('@backstage/canon/src/hooks/useMediaQuery');
 
+describe('DefaultResultListItem', () => {
   const result = {
     title: 'title',
     text: 'text',

--- a/plugins/search-react/src/components/DefaultResultListItem/DefaultResultListItem.test.tsx
+++ b/plugins/search-react/src/components/DefaultResultListItem/DefaultResultListItem.test.tsx
@@ -20,6 +20,22 @@ import FindInPageIcon from '@material-ui/icons/FindInPage';
 import { DefaultResultListItem } from './DefaultResultListItem';
 
 describe('DefaultResultListItem', () => {
+  beforeAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation(query => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
+  });
+
   const result = {
     title: 'title',
     text: 'text',

--- a/plugins/search-react/src/components/DefaultResultListItem/DefaultResultListItem.tsx
+++ b/plugins/search-react/src/components/DefaultResultListItem/DefaultResultListItem.tsx
@@ -24,7 +24,7 @@ import { HighlightedSearchResultText } from '../HighlightedSearchResultText';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
 import Box from '@material-ui/core/Box';
-import Typography from '@material-ui/core/Typography';
+import { Text } from '@backstage/canon';
 import { Link } from '@backstage/core-components';
 
 /**
@@ -75,17 +75,7 @@ export const DefaultResultListItemComponent = ({
           </Link>
         }
         secondary={
-          <Typography
-            component="span"
-            style={{
-              display: '-webkit-box',
-              WebkitBoxOrient: 'vertical',
-              WebkitLineClamp: lineClamp,
-              overflow: 'hidden',
-            }}
-            color="textSecondary"
-            variant="body2"
-          >
+          <Text variant="body" color="secondary">
             {highlight?.fields.text ? (
               <HighlightedSearchResultText
                 text={highlight.fields.text}
@@ -95,7 +85,7 @@ export const DefaultResultListItemComponent = ({
             ) : (
               result.text
             )}
-          </Typography>
+          </Text>
         }
       />
       {secondaryAction && <Box alignItems="flex-end">{secondaryAction}</Box>}

--- a/plugins/search-react/src/components/DefaultResultListItem/DefaultResultListItem.tsx
+++ b/plugins/search-react/src/components/DefaultResultListItem/DefaultResultListItem.tsx
@@ -75,7 +75,16 @@ export const DefaultResultListItemComponent = ({
           </Link>
         }
         secondary={
-          <Text variant="body" color="secondary">
+          <Text
+            variant="body"
+            style={{
+              display: '-webkit-box',
+              WebkitBoxOrient: 'vertical',
+              WebkitLineClamp: lineClamp,
+              overflow: 'hidden',
+            }}
+            color="secondary"
+          >
             {highlight?.fields.text ? (
               <HighlightedSearchResultText
                 text={highlight.fields.text}

--- a/plugins/search-react/src/components/SearchResult/SearchResult.test.tsx
+++ b/plugins/search-react/src/components/SearchResult/SearchResult.test.tsx
@@ -31,22 +31,11 @@ jest.mock('../../context', () => ({
   }),
 }));
 
+jest.mock('@backstage/canon/src/hooks/useMediaQuery');
+
 describe('SearchResult', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    Object.defineProperty(window, 'matchMedia', {
-      writable: true,
-      value: jest.fn().mockImplementation(query => ({
-        matches: false,
-        media: query,
-        onchange: null,
-        addListener: jest.fn(),
-        removeListener: jest.fn(),
-        addEventListener: jest.fn(),
-        removeEventListener: jest.fn(),
-        dispatchEvent: jest.fn(),
-      })),
-    });
   });
 
   it('Progress rendered on Loading state', async () => {

--- a/plugins/search-react/src/components/SearchResult/SearchResult.test.tsx
+++ b/plugins/search-react/src/components/SearchResult/SearchResult.test.tsx
@@ -34,6 +34,19 @@ jest.mock('../../context', () => ({
 describe('SearchResult', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation(query => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
   });
 
   it('Progress rendered on Loading state', async () => {

--- a/plugins/search-react/src/components/SearchResultGroup/SearchResultGroup.test.tsx
+++ b/plugins/search-react/src/components/SearchResultGroup/SearchResultGroup.test.tsx
@@ -63,6 +63,19 @@ describe('SearchResultGroup', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation(queryValue => ({
+        matches: false,
+        media: queryValue,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
   });
 
   it('Renders without exploding', async () => {

--- a/plugins/search-react/src/components/SearchResultGroup/SearchResultGroup.test.tsx
+++ b/plugins/search-react/src/components/SearchResultGroup/SearchResultGroup.test.tsx
@@ -41,6 +41,8 @@ const query = jest.fn().mockResolvedValue({ results: [] });
 const searchApiMock = { query };
 const analyticsApiMock = mockApis.analytics();
 
+jest.mock('@backstage/canon/src/hooks/useMediaQuery');
+
 describe('SearchResultGroup', () => {
   const results = [
     {
@@ -63,19 +65,6 @@ describe('SearchResultGroup', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    Object.defineProperty(window, 'matchMedia', {
-      writable: true,
-      value: jest.fn().mockImplementation(queryValue => ({
-        matches: false,
-        media: queryValue,
-        onchange: null,
-        addListener: jest.fn(),
-        removeListener: jest.fn(),
-        addEventListener: jest.fn(),
-        removeEventListener: jest.fn(),
-        dispatchEvent: jest.fn(),
-      })),
-    });
   });
 
   it('Renders without exploding', async () => {

--- a/plugins/search-react/src/components/SearchResultList/SearchResultList.test.tsx
+++ b/plugins/search-react/src/components/SearchResultList/SearchResultList.test.tsx
@@ -54,6 +54,19 @@ describe('SearchResultList', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation(queryValue => ({
+        matches: false,
+        media: queryValue,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
   });
 
   it('Renders without exploding', async () => {

--- a/plugins/search-react/src/extensions.test.tsx
+++ b/plugins/search-react/src/extensions.test.tsx
@@ -88,6 +88,22 @@ const createExtension = (
 };
 
 describe('extensions', () => {
+  beforeAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation(query => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
+  });
+
   it('renders without exploding', async () => {
     await renderInTestApp(
       <TestApiProvider apis={[[analyticsApiRef, analyticsApiMock]]}>

--- a/plugins/search/package.json
+++ b/plugins/search/package.json
@@ -58,6 +58,7 @@
     "test": "backstage-cli package test"
   },
   "dependencies": {
+    "@backstage/canon": "workspace:^",
     "@backstage/core-compat-api": "workspace:^",
     "@backstage/core-components": "workspace:^",
     "@backstage/core-plugin-api": "workspace:^",

--- a/plugins/search/src/components/SearchType/SearchType.Accordion.test.tsx
+++ b/plugins/search/src/components/SearchType/SearchType.Accordion.test.tsx
@@ -44,6 +44,8 @@ jest.mock('@backstage/plugin-search-react', () => ({
   }),
 }));
 
+jest.mock('@backstage/canon/src/hooks/useMediaQuery');
+
 describe('SearchType.Accordion', () => {
   const configApiMock = mockApis.config({
     data: {
@@ -68,19 +70,6 @@ describe('SearchType.Accordion', () => {
     searchApiMock.query.mockResolvedValue({
       results: [],
       numberOfResults: 1234,
-    });
-    Object.defineProperty(window, 'matchMedia', {
-      writable: true,
-      value: jest.fn().mockImplementation(query => ({
-        matches: false,
-        media: query,
-        onchange: null,
-        addListener: jest.fn(),
-        removeListener: jest.fn(),
-        addEventListener: jest.fn(),
-        removeEventListener: jest.fn(),
-        dispatchEvent: jest.fn(),
-      })),
     });
   });
 

--- a/plugins/search/src/components/SearchType/SearchType.Accordion.test.tsx
+++ b/plugins/search/src/components/SearchType/SearchType.Accordion.test.tsx
@@ -69,6 +69,19 @@ describe('SearchType.Accordion', () => {
       results: [],
       numberOfResults: 1234,
     });
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation(query => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
   });
 
   const Wrapper = ({ children }: { children: ReactNode }) => {

--- a/plugins/search/src/components/SearchType/SearchType.Accordion.tsx
+++ b/plugins/search/src/components/SearchType/SearchType.Accordion.tsx
@@ -28,11 +28,11 @@ import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
 import { makeStyles } from '@material-ui/core/styles';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
-import Typography from '@material-ui/core/Typography';
 import AllIcon from '@material-ui/icons/FontDownload';
 import useAsync from 'react-use/esm/useAsync';
 import { useTranslationRef } from '@backstage/frontend-plugin-api';
 import { searchTranslationRef } from '../../translation';
+import { Text } from '@backstage/canon';
 
 const useStyles = makeStyles(theme => ({
   icon: {
@@ -147,9 +147,7 @@ export const SearchTypeAccordion = (props: SearchTypeAccordionProps) => {
 
   return (
     <Box>
-      <Typography variant="body2" component="h2">
-        {name}
-      </Typography>
+      <Text variant="body">{name}</Text>
       <Accordion
         className={classes.accordion}
         expanded={expanded}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8174,6 +8174,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@backstage/plugin-search-react@workspace:plugins/search-react"
   dependencies:
+    "@backstage/canon": "workspace:^"
     "@backstage/cli": "workspace:^"
     "@backstage/core-app-api": "workspace:^"
     "@backstage/core-components": "workspace:^"
@@ -8216,6 +8217,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@backstage/plugin-search@workspace:plugins/search"
   dependencies:
+    "@backstage/canon": "workspace:^"
     "@backstage/cli": "workspace:^"
     "@backstage/core-app-api": "workspace:^"
     "@backstage/core-compat-api": "workspace:^"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In the Search plugin and its child components, all Typography components should be migrated to use Heading or Text components from Canon. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
