### PR TITLE
Canon - Fix heading variants

### DIFF
--- a/.changeset/forty-seas-worry.md
+++ b/.changeset/forty-seas-worry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/canon': patch
+---
+
+Fix styling for the title4 prop on the Heading component in Canon.

--- a/canon-docs/src/app/(docs)/components/heading/page.mdx
+++ b/canon-docs/src/app/(docs)/components/heading/page.mdx
@@ -59,6 +59,7 @@ appearance of the heading.
     <Heading variant="title2">Title 2</Heading>
     <Heading variant="title3">Title 3</Heading>
     <Heading variant="title4">Title 4</Heading>
+    <Heading variant="title5">Title 5</Heading>
 </Flex>`}
 />
 
@@ -76,6 +77,17 @@ heading.
     have none, but that man&apos;s father is my father's son.” Who is
     in the painting?
   </Heading>`}
+/>
+
+### Custom render
+
+You can also use the `render` prop to render the heading as a different element.
+
+<Snippet
+  py={2}
+  open
+  preview={<HeadingSnippet story="CustomRender" />}
+  code={`<Heading render={<h4 />}>Custom render</Heading>`}
 />
 
 ### Responsive

--- a/canon-docs/src/app/(docs)/components/text/page.mdx
+++ b/canon-docs/src/app/(docs)/components/text/page.mdx
@@ -117,6 +117,16 @@ text.
   </Text>`}
 />
 
+### Custom render
+
+You can also use the `render` prop to render the text as a different element.
+
+<Snippet
+  open
+  preview={<TextSnippet story="CustomRender" />}
+  code={`<Text render={<span />}>Custom render</Text>`}
+/>
+
 ### Responsive
 
 You can also use the `variant` prop to change the appearance of the text based

--- a/packages/canon/css/components.css
+++ b/packages/canon/css/components.css
@@ -515,7 +515,7 @@
 }
 
 .canon-Heading[data-variant="title4"] {
-  font-size: var(--canon-font-size-title4);
+  font-size: var(--canon-font-size-6);
   font-weight: var(--canon-font-weight-bold);
 }
 

--- a/packages/canon/css/heading.css
+++ b/packages/canon/css/heading.css
@@ -27,7 +27,7 @@
 }
 
 .canon-Heading[data-variant="title4"] {
-  font-size: var(--canon-font-size-title4);
+  font-size: var(--canon-font-size-6);
   font-weight: var(--canon-font-weight-bold);
 }
 

--- a/packages/canon/css/styles.css
+++ b/packages/canon/css/styles.css
@@ -9739,7 +9739,7 @@
 }
 
 .canon-Heading[data-variant="title4"] {
-  font-size: var(--canon-font-size-title4);
+  font-size: var(--canon-font-size-6);
   font-weight: var(--canon-font-weight-bold);
 }
 

--- a/packages/canon/src/components/Heading/Heading.stories.tsx
+++ b/packages/canon/src/components/Heading/Heading.stories.tsx
@@ -46,6 +46,7 @@ export const AllVariants: Story = {
       <Heading variant="title2">Title 2</Heading>
       <Heading variant="title3">Title 3</Heading>
       <Heading variant="title4">Title 4</Heading>
+      <Heading variant="title5">Title 5</Heading>
     </Flex>
   ),
 };

--- a/packages/canon/src/components/Heading/styles.css
+++ b/packages/canon/src/components/Heading/styles.css
@@ -43,7 +43,7 @@
 }
 
 .canon-Heading[data-variant='title4'] {
-  font-size: var(--canon-font-size-title4);
+  font-size: var(--canon-font-size-6);
   font-weight: var(--canon-font-weight-bold);
 }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

We had a bug on the `title4` props that was not using the right CSS token. I also updated the doc to add some missing elements on `Heading` + `Text`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
