### PR TITLE
Canon - Add min-width: 0; to the Flex components

### DIFF
--- a/.changeset/deep-moments-love.md
+++ b/.changeset/deep-moments-love.md
@@ -1,0 +1,5 @@
+---
+'@backstage/canon': patch
+---
+
+Add min-width: 0; by default on every Flex components in Canon to help support truncated texts inside flex elements.

--- a/packages/canon/css/components.css
+++ b/packages/canon/css/components.css
@@ -186,6 +186,7 @@
 }
 
 .canon-Flex {
+  min-width: 0;
   display: flex;
 }
 

--- a/packages/canon/css/flex.css
+++ b/packages/canon/css/flex.css
@@ -1,3 +1,4 @@
 .canon-Flex {
+  min-width: 0;
   display: flex;
 }

--- a/packages/canon/css/styles.css
+++ b/packages/canon/css/styles.css
@@ -9410,6 +9410,7 @@
 }
 
 .canon-Flex {
+  min-width: 0;
   display: flex;
 }
 

--- a/packages/canon/src/components/Flex/Flex.stories.tsx
+++ b/packages/canon/src/components/Flex/Flex.stories.tsx
@@ -16,6 +16,7 @@
 
 import type { Meta, StoryObj } from '@storybook/react';
 import { Flex } from './Flex';
+import { Text } from '../Text';
 
 const meta = {
   title: 'Layout/Flex',
@@ -140,6 +141,27 @@ export const LargeGap: Story = {
       <DecorativeBox />
       <DecorativeBox />
       <DecorativeBox />
+    </Flex>
+  ),
+};
+
+export const WithTextTruncate: Story = {
+  render: () => (
+    <Flex direction="row" gap="8">
+      <Flex>
+        <Text truncate>
+          A man looks at a painting in a museum and says, “Brothers and sisters
+          I have none, but that man&apos;s father is my father&apos;s son.” Who
+          is in the painting?
+        </Text>
+      </Flex>
+      <Flex>
+        <Text truncate>
+          A man looks at a painting in a museum and says, “Brothers and sisters
+          I have none, but that man&apos;s father is my father&apos;s son.” Who
+          is in the painting?
+        </Text>
+      </Flex>
     </Flex>
   ),
 };

--- a/packages/canon/src/components/Flex/styles.css
+++ b/packages/canon/src/components/Flex/styles.css
@@ -16,4 +16,7 @@
 
 .canon-Flex {
   display: flex;
+
+  /* This helps when using `truncate` on text inside a flex container */
+  min-width: 0;
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

To avoid content to overflow incorrectly when placing truncated texts inside `Flex` components, we are adding `min-width: 0;` as a default options on every `Flex` components.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
