### PR TITLE
home - Fixed the `WelcomeTitle` to properly default to the previous value of `inherit`

### DIFF
--- a/.changeset/spicy-rivers-notice.md
+++ b/.changeset/spicy-rivers-notice.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-home': patch
+---
+
+Fixed the `WelcomeTitle` to properly default to the previous value of `inherit`

--- a/plugins/home/src/homePageComponents/WelcomeTitle/WelcomeTitle.tsx
+++ b/plugins/home/src/homePageComponents/WelcomeTitle/WelcomeTitle.tsx
@@ -33,7 +33,7 @@ export type WelcomeTitleLanguageProps = {
 
 export const WelcomeTitle = ({
   language,
-  variant,
+  variant = 'inherit',
 }: WelcomeTitleLanguageProps) => {
   const identityApi = useApi(identityApiRef);
   const alertApi = useApi(alertApiRef);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixed the `WelcomeTitle` to properly default to the previous value of `inherit`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
