### PR TITLE
Feat/optimize catalog api fields

### DIFF
--- a/plugins/catalog-react/src/hooks/useEntityListProvider.test.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.test.tsx
@@ -1110,8 +1110,11 @@ describe('Field optimization', () => {
   });
 
   it('should request necessary fields for paginated requests', async () => {
+    // Clear mocks before this test to avoid interference from other tests
+    jest.clearAllMocks();
+
     const { result } = renderHook(() => useEntityList(), {
-      wrapper: createWrapper({ pagination: { kind: 'offset', limit: 20 } }),
+      wrapper: createWrapper({ pagination: { mode: 'offset', limit: 20 } }),
     });
 
     act(() => {
@@ -1125,7 +1128,12 @@ describe('Field optimization', () => {
     });
 
     // Verify that paginated API calls also include the fields parameter
-    expect(mockCatalogApi.queryEntities).toHaveBeenCalledWith(
+    // Use the most recent call since other tests might have made calls before
+    const lastCall =
+      mockCatalogApi.queryEntities.mock.calls[
+        mockCatalogApi.queryEntities.mock.calls.length - 1
+      ];
+    expect(lastCall[0]).toEqual(
       expect.objectContaining({
         filter: { kind: 'component' },
         fields: expectedCatalogTableFields,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### 🎯 Summary

This PR implements the optimization proposed in issue [#30175](https://github.com/backstage/backstage/issues/30175) to improve `/catalog` page performance by implementing field selection in catalog API requests. Currently, the catalog table fetches complete entity objects but only displays ~13 specific fields, resulting in unnecessary network overhead and slower page loads.

**Resolves:** #30175

### 🔧 What Changed

**Location**: `plugins/catalog-react/src/hooks/useEntityListProvider.tsx`

- ✅ Added `getCatalogTableFields()` function that defines the minimal set of fields needed for catalog table display
- ✅ Updated all catalog API calls (`getEntities`, `queryEntities`) to include the `fields` parameter
- ✅ Implemented for both paginated and non-paginated requests
- ✅ Added comprehensive test coverage to validate field optimization

**API calls now include**:
```typescript
const response = await catalogApi.getEntities({
  filter: backendFilter,
  fields: getCatalogTableFields(), // 🎯 Only fetch necessary fields
});
```

### 📊 Performance Impact

As detailed in [issue #30175](https://github.com/backstage/backstage/issues/30175):

- **Bandwidth Reduction**: 60-75% smaller response payloads
- **Faster Page Loads**: Especially noticeable with 500+ entities
- **Network Efficiency**: Critical for mobile users and limited connectivity
- **Backend Optimization**: Reduced serialization overhead

**Example**: For 500 entities, transfer size drops from ~1-2.5MB to ~400-600KB

### 🧪 Testing

Added 5 comprehensive tests in the "Field optimization" test suite:

1. ✅ **should only request necessary fields for catalog table** - Validates only required fields are requested
2. ✅ **should request necessary fields for paginated requests** - Ensures paginated calls include field selection  
3. ✅ **should include relations field for table entity processing** - Verifies critical `relations` field
4. ✅ **should include all metadata fields used by default columns** - Confirms metadata completeness
5. ✅ **should include spec fields used by table columns** - Validates spec field coverage

### 🔗 References

- **Related Issue**: [#30175 - Optimize Catalog API requests by limiting fields for better performance](https://github.com/backstage/backstage/issues/30175)
- **Official Documentation**: [Field Selection in Backstage Catalog API](https://backstage.io/docs/features/software-catalog/retrieving-entities#field-selection)

### 💡 Technical Details

**Fields included** (conservative approach):
- `kind`, `metadata.name`, `metadata.namespace`, `metadata.title`
- `metadata.description`, `metadata.tags`, `metadata.labels`, `metadata.annotations`  
- `spec.type`, `spec.lifecycle`, `spec.targets`, `spec.target`, `relations`

**Backward Compatibility**: ✅ Zero breaking changes - uses existing API capabilities

This implementation addresses all the acceptance criteria defined in [issue #30175](https://github.com/backstage/backstage/issues/30175).

---

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation (TSDoc comments in code)
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (N/A - backend optimization)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

### 🎉 Result

The catalog table now loads significantly faster while maintaining exactly the same functionality and user experience. This optimization scales particularly well for organizations with large entity catalogs, delivering the benefits outlined in the original issue.