### PR TITLE
added adornment option

### DIFF
--- a/.changeset/mean-files-camp.md
+++ b/.changeset/mean-files-camp.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': minor
+---
+
+Added `adornment` option to `SidebarItem` and `SidebarSubmenuItem` for easier addition of secondary components like ribbons

--- a/packages/core-components/src/layout/Sidebar/Items.tsx
+++ b/packages/core-components/src/layout/Sidebar/Items.tsx
@@ -105,6 +105,8 @@ const makeSidebarStyles = (sidebarConfig: SidebarConfig) =>
         alignItems: 'center',
         height: 48,
         cursor: 'pointer',
+        position: 'relative',
+        overflow: 'hidden',
       },
       buttonItem: {
         background: 'none',
@@ -154,6 +156,7 @@ const makeSidebarStyles = (sidebarConfig: SidebarConfig) =>
         alignItems: 'center',
         justifyContent: 'center',
         lineHeight: '0',
+        flexShrink: 0,
       },
       searchRoot: {
         marginBottom: 12,
@@ -276,6 +279,7 @@ type SidebarItemBaseProps = {
   disableHighlight?: boolean;
   className?: string;
   noTrack?: boolean;
+  adornment?: React.ReactNode;
   onClick?: (ev: MouseEvent) => void;
 };
 
@@ -383,6 +387,7 @@ const SidebarItemBase = forwardRef<
     disableHighlight = false,
     onClick,
     noTrack,
+    adornment,
     children,
     className,
     ...navLinkProps
@@ -432,6 +437,7 @@ const SidebarItemBase = forwardRef<
           {text}
         </Typography>
       )}
+      {adornment}
       <div className={classes.secondaryAction}>{children}</div>
     </>
   );

--- a/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
+++ b/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
@@ -59,6 +59,7 @@ const useStyles = makeStyles(
       position: 'relative',
       background: 'none',
       border: 'none',
+      overflow: 'hidden',
     },
     itemContainer: {
       width: '100%',
@@ -148,6 +149,7 @@ export type SidebarSubmenuItemProps = {
   dropdownItems?: SidebarSubmenuItemDropdownItem[];
   exact?: boolean;
   initialShowDropdown?: boolean;
+  adornment?: React.ReactNode;
 };
 
 /**
@@ -156,7 +158,15 @@ export type SidebarSubmenuItemProps = {
  * @public
  */
 export const SidebarSubmenuItem = (props: SidebarSubmenuItemProps) => {
-  const { title, subtitle, to, icon: Icon, dropdownItems, exact } = props;
+  const {
+    title,
+    subtitle,
+    to,
+    icon: Icon,
+    dropdownItems,
+    exact,
+    adornment,
+  } = props;
   const classes = useStyles();
   const { setIsHoveredOn } = useContext(SidebarItemWithSubmenuContext);
   const closeSubmenu = () => {
@@ -209,6 +219,7 @@ export const SidebarSubmenuItem = (props: SidebarSubmenuItemProps) => {
                 </Typography>
               )}
             </Typography>
+            {adornment}
             {showDropDown ? (
               <ArrowDropUpIcon className={classes.dropdownArrow} />
             ) : (
@@ -275,6 +286,7 @@ export const SidebarSubmenuItem = (props: SidebarSubmenuItemProps) => {
               </Typography>
             )}
           </Typography>
+          {adornment}
         </Link>
       </Tooltip>
     </Box>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added `adornemnt` option to `SidebarItem` and `SidebarSubmenuItem`

Adding it because I wasn't able to get the desired effect on my own Backstage instance 😅.
Let me know if it makes sense.
Also, additional feedback is welcome.

I tried to make it work on submenus as well

![image](https://github.com/user-attachments/assets/31244ac2-9678-461b-8a85-ca0d336c7140)
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
