### PR TITLE
Fix missing import for `createServiceFactory` in backend plugin API example

### DIFF
--- a/docs/backend-system/core-services/root-health.md
+++ b/docs/backend-system/core-services/root-health.md
@@ -12,7 +12,11 @@ The Root Health service provides some health check endpoints for the backend. By
 The following example shows how you can override the root health service implementation.
 
 ```ts
-import { RootHealthService, coreServices } from '@backstage/backend-plugin-api';
+import {
+  RootHealthService,
+  coreServices,
+  createServiceFactory
+} from '@backstage/backend-plugin-api';
 
 const backend = createBackend();
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This pull request fixes a small issue in the documentation example for [Root Health Service](https://backstage.io/docs/backend-system/core-services/root-health). The example was missing the import for createServiceFactory, which is used later in the code.

### Error info

If I write the code as described in the document, I will receive such an error：

```
backend.add(
        ^


ReferenceError: createServiceFactory is not defined
    at Object.<anonymous> (xxx/packages/backend/src/index.ts:30:9)
    at Module._compile (node:internal/modules/cjs/loader:1529:14)
    at Module._compile (xxx/node_modules/pirates/lib/index.js:129:24)
    at Module._extensions..js (node:internal/modules/cjs/loader:1613:10)
    at Object.newLoader [as .ts] (xxx/node_modules/pirates/lib/index.js:134:7)
    at Module.load (node:internal/modules/cjs/loader:1275:32)
    at Module._load (node:internal/modules/cjs/loader:1096:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:164:12)
    at node:internal/main/run_main_module:28:49

Node.js v20.19.2
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
