### PR TITLE
fix: loosen regex requirements for config keys

### DIFF
--- a/.changeset/dry-hornets-stop.md
+++ b/.changeset/dry-hornets-stop.md
@@ -1,0 +1,6 @@
+---
+'@backstage/config-loader': patch
+'@backstage/config': patch
+---
+
+Loosen the requirements for a key to be considered valid config.

--- a/packages/config-loader/src/sources/EnvConfigSource.ts
+++ b/packages/config-loader/src/sources/EnvConfigSource.ts
@@ -85,7 +85,7 @@ export class EnvConfigSource implements ConfigSource {
 const ENV_PREFIX = 'APP_CONFIG_';
 
 // Update the same pattern in config package if this is changed
-const CONFIG_KEY_PART_PATTERN = /^[a-z][a-z0-9]*(?:[-_][a-z][a-z0-9]*)*$/i;
+const CONFIG_KEY_PART_PATTERN = /^[\w-_]+$/i;
 
 /**
  * Read runtime configuration from the environment.

--- a/packages/config-loader/src/sources/EnvConfigSource.ts
+++ b/packages/config-loader/src/sources/EnvConfigSource.ts
@@ -85,7 +85,7 @@ export class EnvConfigSource implements ConfigSource {
 const ENV_PREFIX = 'APP_CONFIG_';
 
 // Update the same pattern in config package if this is changed
-const CONFIG_KEY_PART_PATTERN = /^[\w-_]+$/i;
+const CONFIG_KEY_PART_PATTERN = /^[a-z][a-z0-9]*(?:[-_][a-z0-9]+)*$/i;
 
 /**
  * Read runtime configuration from the environment.

--- a/packages/config/src/reader.test.ts
+++ b/packages/config/src/reader.test.ts
@@ -171,6 +171,7 @@ describe('ConfigReader', () => {
     expect(config.getOptionalString('x_x')).toBeUndefined();
     expect(config.getOptionalString('x-X')).toBeUndefined();
     expect(config.getOptionalString('x0')).toBeUndefined();
+    expect(config.getOptionalString('x-2')).toBeUndefined();
     expect(config.getOptionalString('X-x2')).toBeUndefined();
     expect(config.getOptionalString('x0_x0')).toBeUndefined();
     expect(config.getOptionalString('x_x-x_x')).toBeUndefined();

--- a/packages/config/src/reader.ts
+++ b/packages/config/src/reader.ts
@@ -18,7 +18,7 @@ import { JsonValue, JsonObject } from '@backstage/types';
 import { AppConfig, Config } from './types';
 
 // Update the same pattern in config-loader package if this is changed
-const CONFIG_KEY_PART_PATTERN = /^[a-z][a-z0-9]*(?:[-_][a-z][a-z0-9]*)*$/i;
+const CONFIG_KEY_PART_PATTERN = /^[\w-_]+$/i;
 
 function isObject(value: JsonValue | undefined): value is JsonObject {
   return typeof value === 'object' && value !== null && !Array.isArray(value);

--- a/packages/config/src/reader.ts
+++ b/packages/config/src/reader.ts
@@ -18,7 +18,7 @@ import { JsonValue, JsonObject } from '@backstage/types';
 import { AppConfig, Config } from './types';
 
 // Update the same pattern in config-loader package if this is changed
-const CONFIG_KEY_PART_PATTERN = /^[\w-_]+$/i;
+const CONFIG_KEY_PART_PATTERN = /^[a-z][a-z0-9]*(?:[-_][a-z0-9]+)*$/i;
 
 function isObject(value: JsonValue | undefined): value is JsonObject {
   return typeof value === 'object' && value !== null && !Array.isArray(value);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Related to the test failure in #28129, `test-1` became an invalid plugin ID once #28621 merged, tying plugin ID to a config key value. Let's loosen the config key allowed values to support more expansive values.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
