### PR TITLE
fix: force broadcast notification user field to be null always

### DIFF
--- a/.changeset/two-waves-worry.md
+++ b/.changeset/two-waves-worry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications-backend': patch
+---
+
+Notifications API will now return user as null always for broadcast notifications

--- a/plugins/notifications-backend/src/database/DatabaseNotificationsStore.test.ts
+++ b/plugins/notifications-backend/src/database/DatabaseNotificationsStore.test.ts
@@ -228,6 +228,13 @@ describe.each(databases.eachSupportedId())(
         ]);
       });
 
+      it('should return null value for user for broadcast notifications', async () => {
+        await storage.saveBroadcast({ ...testNotification1, read: new Date() });
+        const notifications = await storage.getNotifications({ user });
+        expect(notifications).toHaveLength(1);
+        expect(notifications[0].user).toBeNull();
+      });
+
       it('should return read notifications for user', async () => {
         await storage.saveNotification(testNotification1);
         await storage.saveBroadcast(testNotification2);
@@ -298,7 +305,7 @@ describe.each(databases.eachSupportedId())(
           user: otherUser,
         });
         expect(otherUserNotifications.map(idOnly)).toEqual([id0, id2]);
-        expect(otherUserNotifications[1].user).toBe(otherUser);
+        expect(otherUserNotifications[1].user).toBeNull();
       });
 
       it('should allow searching for notifications', async () => {
@@ -635,7 +642,7 @@ describe.each(databases.eachSupportedId())(
         expect(notification?.user).toBeNull();
         await storage.markRead({ ids: [id1], user });
         notification = await storage.getNotification({ id: id1, user });
-        expect(notification?.user).toBe(user);
+        expect(notification?.user).toBeNull();
 
         const otherNotification = await storage.getNotification({
           id: id1,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Related discussion https://discord.com/channels/687207715902193673/1382282442291019816

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
