### PR TITLE
Case-insensitive match organization on Github events.

### DIFF
--- a/.changeset/rich-tires-battle.md
+++ b/.changeset/rich-tires-battle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': minor
+---
+
+GitHub organization now matches in a case-insensitive manner when processing events.

--- a/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.ts
@@ -323,7 +323,13 @@ export class GithubEntityProvider implements EntityProvider, EventSubscriber {
   }
 
   private async onPush(event: PushEvent) {
-    if (this.config.organization !== event.organization?.login) {
+    const configOrganization = this.config.organization;
+    const eventOrganization = event.organization?.login;
+
+    if (
+      configOrganization.toLocaleLowerCase('en-US') !==
+      eventOrganization?.toLocaleLowerCase('en-US')
+    ) {
       this.logger.debug(
         `skipping push event from organization ${event.organization?.login}`,
       );
@@ -406,7 +412,13 @@ export class GithubEntityProvider implements EntityProvider, EventSubscriber {
   }
 
   private async onRepoChange(event: RepositoryEvent) {
-    if (this.config.organization !== event.organization?.login) {
+    const configOrganization = this.config.organization;
+    const eventOrganization = event.organization?.login;
+
+    if (
+      configOrganization.toLocaleLowerCase('en-US') !==
+      eventOrganization?.toLocaleLowerCase('en-US')
+    ) {
       this.logger.debug(
         `skipping repository event from organization ${event.organization?.login}`,
       );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

GitHub events are processed as long as the `organization` name is a case-insensitive match to the configured value.

GitHub organization names are case-insensitive. A user should be able to configure `catalog.providers.github.providerId.organization` as `Backstage`, `backstage`, `BackStage`, etc. and events should still be processed. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] (N/A) Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
