### PR TITLE
cleanup: package-docs fixes for docsite

### DIFF
--- a/.changeset/mean-lemons-dream.md
+++ b/.changeset/mean-lemons-dream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/repo-tools': minor
+---
+
+Clear output directory before running `package-docs` and skip all internal packages.

--- a/packages/repo-tools/src/commands/package-docs/command.ts
+++ b/packages/repo-tools/src/commands/package-docs/command.ts
@@ -132,10 +132,6 @@ export default async function packageDocs(paths: string[] = [], opts: any) {
     recursive: true,
     force: true,
   });
-  await rm(cliPaths.resolveTargetRoot('dist-types'), {
-    recursive: true,
-    force: true,
-  });
   const selectedPackageDirs = await resolvePackagePaths({
     paths,
     include: opts.include,

--- a/packages/repo-tools/src/commands/package-docs/command.ts
+++ b/packages/repo-tools/src/commands/package-docs/command.ts
@@ -22,6 +22,7 @@ import pLimit from 'p-limit';
 import { mkdirp } from 'fs-extra';
 import { PackageDocsCache } from './Cache';
 import { Lockfile } from '@backstage/cli-node';
+import { glob } from 'glob';
 
 const limit = pLimit(8);
 
@@ -113,6 +114,20 @@ async function generateDocJson(pkg: string) {
 
 export default async function packageDocs(paths: string[] = [], opts: any) {
   console.warn('!!! This is an experimental command !!!');
+
+  const existingDocsJsonPaths = glob.sync(
+    cliPaths.resolveTargetRoot('dist-types/**/docs.json'),
+  );
+  if (existingDocsJsonPaths.length > 0) {
+    console.warn(
+      `!!! Deleting all ${existingDocsJsonPaths.length} existing docs.json files !!!`,
+    );
+
+    for (const path of existingDocsJsonPaths) {
+      await rm(path, { force: true });
+    }
+  }
+  console.warn('!!! Deleting existing docs output !!!');
   await rm(cliPaths.resolveTargetRoot('type-docs'), {
     recursive: true,
     force: true,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Hide all `@internal` packages in the Typedocs output and ensure that we aren't using previously cached output between runs.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
