### PR TITLE
Add validateLocationsExist option for the BitbucketServer entity provider

### DIFF
--- a/.changeset/fifty-sides-begin.md
+++ b/.changeset/fifty-sides-begin.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-bitbucket-server': minor
+---
+
+Add validateLocationsExist option to avoid generating locations for catalog-info.yaml files that do not exist in the source repository.

--- a/docs/integrations/bitbucketServer/discovery.md
+++ b/docs/integrations/bitbucketServer/discovery.md
@@ -66,6 +66,7 @@ catalog:
           projectKey: '^apis-.*$' # optional; RegExp
           repoSlug: '^service-.*$' # optional; RegExp
           skipArchivedRepos: true # optional; boolean
+        validateLocationsExist: false # optional; boolean
         schedule: # same options as in SchedulerServiceTaskScheduleDefinition
           # supports cron, ISO duration, "human duration" as used in code
           frequency: { minutes: 30 }
@@ -86,6 +87,10 @@ catalog:
     Regular expression used to filter results based on the repo slug.
   - **`skipArchivedRepos`** _(optional)_:
     Boolean flag to filter out archived repositories.
+- **`validateLocationsExist`** _(optional)_:
+  Defaults to `false`.
+  Whether to validate locations that exist before emitting them.
+  This option avoids generating locations for catalog info files that do not exist in the source repository.
 - **`schedule`**:
   - **`frequency`**:
     How often you want the task to run. The system does its best to avoid overlapping invocations.

--- a/plugins/catalog-backend-module-bitbucket-server/config.d.ts
+++ b/plugins/catalog-backend-module-bitbucket-server/config.d.ts
@@ -52,6 +52,11 @@ export interface Config {
               skipArchivedRepos?: boolean;
             };
             /**
+             * (Optional) Whether to validate locations that exist before emitting them.
+             * Default: `false`.
+             */
+            validateLocationsExist?: boolean;
+            /**
              * (Optional) TaskScheduleDefinition for the refresh.
              */
             schedule?: SchedulerServiceTaskScheduleDefinitionConfig;
@@ -83,6 +88,11 @@ export interface Config {
                  */
                 skipArchivedRepos?: boolean;
               };
+              /**
+               * (Optional) Whether to validate locations that exist before emitting them.
+               * Default: `false`.
+               */
+              validateLocationsExist?: boolean;
               /**
                * (Optional) TaskScheduleDefinition for the refresh.
                */

--- a/plugins/catalog-backend-module-bitbucket-server/src/lib/BitbucketServerClient.ts
+++ b/plugins/catalog-backend-module-bitbucket-server/src/lib/BitbucketServerClient.ts
@@ -70,8 +70,11 @@ export class BitbucketServerClient {
     repo: string;
     path: string;
   }): Promise<Response> {
+    const normalizedPath = options.path.startsWith('/')
+      ? options.path.substring(1)
+      : options.path;
     return fetch(
-      `${this.config.apiBaseUrl}/projects/${options.projectKey}/repos/${options.repo}/raw/${options.path}`,
+      `${this.config.apiBaseUrl}/projects/${options.projectKey}/repos/${options.repo}/raw/${normalizedPath}`,
       getBitbucketServerRequestOptions(this.config),
     );
   }

--- a/plugins/catalog-backend-module-bitbucket-server/src/providers/BitbucketServerEntityProviderConfig.test.ts
+++ b/plugins/catalog-backend-module-bitbucket-server/src/providers/BitbucketServerEntityProviderConfig.test.ts
@@ -49,6 +49,8 @@ describe('readProviderConfigs', () => {
         repoSlug: undefined,
         skipArchivedRepos: undefined,
       },
+      schedule: undefined,
+      validateLocationsExist: false,
     });
   });
 
@@ -89,6 +91,8 @@ describe('readProviderConfigs', () => {
         repoSlug: undefined,
         skipArchivedRepos: undefined,
       },
+      schedule: undefined,
+      validateLocationsExist: false,
     });
     expect(providerConfigs[1]).toEqual({
       id: 'secondaryProvider',
@@ -99,6 +103,8 @@ describe('readProviderConfigs', () => {
         repoSlug: undefined,
         skipArchivedRepos: undefined,
       },
+      schedule: undefined,
+      validateLocationsExist: false,
     });
     expect(providerConfigs[2]).toEqual({
       id: 'thirdProvider',
@@ -109,6 +115,7 @@ describe('readProviderConfigs', () => {
         repoSlug: undefined,
         skipArchivedRepos: undefined,
       },
+      validateLocationsExist: false,
       schedule: {
         frequency: { minutes: 30 },
         timeout: {
@@ -147,6 +154,36 @@ describe('readProviderConfigs', () => {
         repoSlug: /.*/,
         skipArchivedRepos: true,
       },
+      schedule: undefined,
+      validateLocationsExist: false,
+    });
+  });
+
+  it('single simple provider config with validateLocationsExist', () => {
+    const config = new ConfigReader({
+      catalog: {
+        providers: {
+          bitbucketServer: {
+            host: 'bitbucket.mycompany.com',
+            validateLocationsExist: true,
+          },
+        },
+      },
+    });
+    const providerConfigs = readProviderConfigs(config);
+
+    expect(providerConfigs).toHaveLength(1);
+    expect(providerConfigs[0]).toEqual({
+      id: 'default',
+      catalogPath: '/catalog-info.yaml',
+      host: 'bitbucket.mycompany.com',
+      filters: {
+        projectKey: undefined,
+        repoSlug: undefined,
+        skipArchivedRepos: undefined,
+      },
+      schedule: undefined,
+      validateLocationsExist: true,
     });
   });
 });

--- a/plugins/catalog-backend-module-bitbucket-server/src/providers/BitbucketServerEntityProviderConfig.ts
+++ b/plugins/catalog-backend-module-bitbucket-server/src/providers/BitbucketServerEntityProviderConfig.ts
@@ -32,6 +32,7 @@ export type BitbucketServerEntityProviderConfig = {
     repoSlug?: RegExp;
     skipArchivedRepos?: boolean;
   };
+  validateLocationsExist: boolean;
   schedule?: SchedulerServiceTaskScheduleDefinition;
 };
 
@@ -66,7 +67,8 @@ function readProviderConfig(
   const skipArchivedReposFlag = config.getOptionalBoolean(
     'filters.skipArchivedRepos',
   );
-
+  const validateLocationsExistFlag =
+    config?.getOptionalBoolean('validateLocationsExist') ?? false;
   const schedule = config.has('schedule')
     ? readSchedulerServiceTaskScheduleDefinitionFromConfig(
         config.getConfig('schedule'),
@@ -82,6 +84,7 @@ function readProviderConfig(
       repoSlug: repoSlugPattern ? new RegExp(repoSlugPattern) : undefined,
       skipArchivedRepos: skipArchivedReposFlag,
     },
+    validateLocationsExist: validateLocationsExistFlag,
     schedule,
   };
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Introduce a `validateLocationsExist` option within the BitbucketServer entity provider. If enabled, this setting will prevent the generation of locations for `catalog-info.yaml` files that are absent in the source repository, thereby avoiding numerous 404 errors on the backend when attempting to retrieve the nonexistent `catalog-info.yaml` files.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
