### PR TITLE
export vendor types for testing custom transformers

### DIFF
--- a/.changeset/empty-actors-relax.md
+++ b/.changeset/empty-actors-relax.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-ldap': patch
+---
+
+Export LDAP vendor types and instances for testing custom transformers

--- a/plugins/catalog-backend-module-ldap/report.api.md
+++ b/plugins/catalog-backend-module-ldap/report.api.md
@@ -275,4 +275,14 @@ export type VendorConfig = {
   dnAttributeName?: string;
   uuidAttributeName?: string;
 };
+
+// @public
+export const vendors: {
+  readonly activeDirectory: LdapVendor;
+  readonly aeDir: LdapVendor;
+  readonly freeIpa: LdapVendor;
+  readonly googleLdap: LdapVendor;
+  readonly lldap: LdapVendor;
+  readonly default: LdapVendor;
+};
 ```

--- a/plugins/catalog-backend-module-ldap/src/ldap/index.ts
+++ b/plugins/catalog-backend-module-ldap/src/ldap/index.ts
@@ -13,6 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {
+  ActiveDirectoryVendor,
+  AEDirVendor,
+  DefaultLdapVendor,
+  FreeIpaVendor,
+  GoogleLdapVendor,
+  LdapVendor,
+  LLDAPVendor,
+} from './vendors';
 
 export { LdapClient } from './client';
 export { mapStringAttr } from './util';
@@ -37,3 +46,16 @@ export {
   readLdapOrg,
 } from './read';
 export type { GroupTransformer, UserTransformer } from './types';
+/**
+ * An LDAP Vendor types.
+ *
+ * @public
+ */
+export const vendors = {
+  activeDirectory: ActiveDirectoryVendor as LdapVendor,
+  aeDir: AEDirVendor as LdapVendor,
+  freeIpa: FreeIpaVendor as LdapVendor,
+  googleLdap: GoogleLdapVendor as LdapVendor,
+  lldap: LLDAPVendor as LdapVendor,
+  default: DefaultLdapVendor as LdapVendor,
+} as const;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Exports LDAP vendor types and instances from the module's public API to enable 
proper testing of custom LDAP transformers.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
