### PR TITLE
feat(scaffolder-github): Allow file deletion in pull requests

### DIFF
--- a/.changeset/social-insects-cheat.md
+++ b/.changeset/social-insects-cheat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-github': patch
+---
+
+Added support for deleting files

--- a/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubPullRequest.ts
@@ -27,7 +27,10 @@ import {
 } from '@backstage/plugin-scaffolder-node';
 import { Octokit } from 'octokit';
 import { CustomErrorBase, InputError } from '@backstage/errors';
-import { createPullRequest } from 'octokit-plugin-create-pull-request';
+import {
+  createPullRequest,
+  DELETE_FILE,
+} from 'octokit-plugin-create-pull-request';
 import { getOctokitOptions } from '../util';
 import { examples } from './githubPullRequest.examples';
 import {
@@ -143,6 +146,15 @@ export const createPublishGithubPullRequestAction = (
           z.string({
             description: 'The name for the branch',
           }),
+        deletionMarker: z =>
+          z
+            .string({
+              description: 'Contents of files that will be deleted',
+            })
+            .min(33, {
+              message: 'deletion marker must be at least 33 characters long',
+            })
+            .optional(),
         targetBranchName: z =>
           z
             .string({
@@ -269,6 +281,7 @@ export const createPublishGithubPullRequestAction = (
       const {
         repoUrl,
         branchName,
+        deletionMarker,
         targetBranchName,
         title,
         description,
@@ -323,24 +336,32 @@ export const createPublishGithubPullRequestAction = (
         file: SerializedFile,
       ): 'utf-8' | 'base64' => (file.symlink ? 'utf-8' : 'base64');
 
+      const encodedDeletionMarker =
+        deletionMarker && Buffer.from(deletionMarker).toString('base64');
       const files = Object.fromEntries(
-        directoryContents.map(file => [
-          targetPath ? path.posix.join(targetPath, file.path) : file.path,
-          {
-            // See the properties of tree items
-            // in https://docs.github.com/en/rest/reference/git#trees
-            mode: determineFileMode(file),
-            // Always use base64 encoding where possible to avoid doubling a binary file in size
-            // due to interpreting a binary file as utf-8 and sending github
-            // the utf-8 encoded content. Symlinks are kept as utf-8 to avoid them
-            // being formatted as a series of scrambled characters
-            //
-            // For example, the original gradle-wrapper.jar is 57.8k in https://github.com/kennethzfeng/pull-request-test/pull/5/files.
-            // Its size could be doubled to 98.3K (See https://github.com/kennethzfeng/pull-request-test/pull/4/files)
-            encoding: determineFileEncoding(file),
-            content: file.content.toString(determineFileEncoding(file)),
-          },
-        ]),
+        directoryContents.map(file => {
+          const content = file.content.toString(determineFileEncoding(file));
+
+          return [
+            targetPath ? path.posix.join(targetPath, file.path) : file.path,
+            content === encodedDeletionMarker
+              ? DELETE_FILE
+              : {
+                  // See the properties of tree items
+                  // in https://docs.github.com/en/rest/reference/git#trees
+                  mode: determineFileMode(file),
+                  // Always use base64 encoding where possible to avoid doubling a binary file in size
+                  // due to interpreting a binary file as utf-8 and sending github
+                  // the utf-8 encoded content. Symlinks are kept as utf-8 to avoid them
+                  // being formatted as a series of scrambled characters
+                  //
+                  // For example, the original gradle-wrapper.jar is 57.8k in https://github.com/kennethzfeng/pull-request-test/pull/5/files.
+                  // Its size could be doubled to 98.3K (See https://github.com/kennethzfeng/pull-request-test/pull/4/files)
+                  encoding: determineFileEncoding(file),
+                  content,
+                },
+          ];
+        }),
       );
 
       // If this is a dry run, log and return


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This adds the ability to delete files in GitHub pull requests. Files are marked for deletion based on file contents being set to a user-supplied sentinel value. The implementation of this is a bit odd/unexpected. The _why_ is explained below in the "background" section. 

To delete a file, you need to set its contents to a special "deletion marker" (read: sentinel value). I made the minimum length of this 33 characters since UUID's are 32 characters and some files only contain UUID's and that's a perfectly valid file contents. I didn't go with empty file contents since some files are intentionally left empty. So if you have a file that contains this sentinel value, it will be deleted in the pull request.

### Background - Why Implement it this way?

The implementation is bit odd, because of the way Backstage handles pull requests. Backstage currently only does something similar to a "sparse checkout" of the files that you plan to change. This means the absence of a file does not mean it should be deleted. So I needed a way to know a file that exists  on disk should be deleted. I went with "magic" file contents. **I'm open to other suggestions**, but this is the best thing I came up with at the time.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
