### PR TITLE
fix: hide pagination query params if pagination mode is set to none

### DIFF
--- a/.changeset/open-seas-ring.md
+++ b/.changeset/open-seas-ring.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-react': patch
 ---
 
-fix: hide pagination query params if pagination mode is set to none
+hide pagination `queryparams` if pagination mode is set to none

--- a/.changeset/open-seas-ring.md
+++ b/.changeset/open-seas-ring.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+fix: hide pagination query params if pagination mode is set to none

--- a/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
@@ -346,7 +346,11 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
           ignoreQueryPrefix: true,
         });
         const newParams = qs.stringify(
-          { ...oldParams, filters: queryParams, cursor, offset, limit },
+          {
+            ...oldParams,
+            filters: queryParams,
+            ...(paginationMode === 'none' ? {} : { cursor, limit, offset }),
+          },
           { addQueryPrefix: true, arrayFormat: 'repeat' },
         );
         const newUrl = `${window.location.pathname}${newParams}`;


### PR DESCRIPTION
When entity list pagination is not enabled, there should be no `limit`, `cursor` or `offset` in the url query parameters since they are not used and have no effect.

We stumbled across the problem in our E2E tests, where we check the URL including query parameters. With pagination deactivated, the query parameters make no sense anyway.