### PR TITLE
`mcp-actions`: Use `output` instead of `structuredOutput` for the time being

### DIFF
--- a/plugins/mcp-actions-backend/src/plugin.test.ts
+++ b/plugins/mcp-actions-backend/src/plugin.test.ts
@@ -116,17 +116,6 @@ describe('Mcp Backend', () => {
           type: 'object',
         },
         name: 'make-greeting',
-        outputSchema: {
-          $schema: 'http://json-schema.org/draft-07/schema#',
-          additionalProperties: false,
-          properties: {
-            greeting: {
-              type: 'string',
-            },
-          },
-          required: ['greeting'],
-          type: 'object',
-        },
       },
     ]);
   });
@@ -170,17 +159,6 @@ describe('Mcp Backend', () => {
           type: 'object',
         },
         name: 'make-greeting',
-        outputSchema: {
-          $schema: 'http://json-schema.org/draft-07/schema#',
-          additionalProperties: false,
-          properties: {
-            greeting: {
-              type: 'string',
-            },
-          },
-          required: ['greeting'],
-          type: 'object',
-        },
       },
     ]);
   });

--- a/plugins/mcp-actions-backend/src/services/McpService.test.ts
+++ b/plugins/mcp-actions-backend/src/services/McpService.test.ts
@@ -88,17 +88,6 @@ describe('McpService', () => {
           type: 'object',
         },
         name: 'mock-action',
-        outputSchema: {
-          $schema: 'http://json-schema.org/draft-07/schema#',
-          additionalProperties: false,
-          properties: {
-            output: {
-              type: 'string',
-            },
-          },
-          required: ['output'],
-          type: 'object',
-        },
       },
     ]);
   });
@@ -155,7 +144,16 @@ describe('McpService', () => {
       }),
     );
 
-    expect(result.structuredContent).toEqual({ output: 'test' });
+    expect(result.content).toEqual([
+      {
+        type: 'text',
+        text: [
+          '```json',
+          JSON.stringify({ output: 'test' }, null, 2),
+          '```',
+        ].join('\n'),
+      },
+    ]);
   });
 
   it('should return an error when the action is not found', async () => {

--- a/plugins/mcp-actions-backend/src/services/McpService.ts
+++ b/plugins/mcp-actions-backend/src/services/McpService.ts
@@ -48,7 +48,9 @@ export class McpService {
       return {
         tools: actions.map(action => ({
           inputSchema: action.schema.input,
-          outputSchema: action.schema.output,
+          // todo(blam): this is unfortunately not supported by most clients yet.
+          // When this is provided you need to provide structuredContent instead.
+          // outputSchema: action.schema.output,
           name: action.name,
           description: action.description,
           annotations: {
@@ -77,10 +79,17 @@ export class McpService {
       });
 
       return {
-        // all actions need to be defined with an structured output,
-        // so we can return the output using this format rather than
-        // just text.
-        structuredContent: output,
+        // todo(blam): unfortunately structuredContent is not supported by most clients yet.
+        // so the validation for the output happens in the default actions registry
+        // and we return it as json text instead for now.
+        content: [
+          {
+            type: 'text',
+            text: ['```json', JSON.stringify(output, null, 2), '```'].join(
+              '\n',
+            ),
+          },
+        ],
       };
     });
 


### PR DESCRIPTION
See the comments in the code for why we need to avoid this for now.