### PR TITLE
docs(search): replaced plain note with styled ::note block for clarity

### DIFF
--- a/docs/features/search/search-engines.md
+++ b/docs/features/search/search-engines.md
@@ -91,7 +91,10 @@ search:
       fragmentDelimiter: ' ... ' # Delimiter string used to concatenate fragments. Defaults to " ... ".
 ```
 
-**Note:** the highlight search term feature uses `ts_headline` which has been known to potentially impact performance. You only need this minimal config to disable it should you have issues:
+:::note Note
+The highlight search term feature uses `ts_headline` which has been known to potentially impact performance. You only need this minimal config to disable it should you have issues:
+
+:::
 
 ```yaml
 search:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Updated the search engine documentation to replace a plain `**Note:**` markdown block with a properly styled `::note` directive for improved readability and consistency across Backstage docs.

### 📘 Before:
