### PR TITLE
Filter out unregister-entity contextMenuItem on datasets

### DIFF
--- a/.changeset/fair-insects-agree.md
+++ b/.changeset/fair-insects-agree.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog': patch
 ---
 
-fix: hide the unregister-entity menu item on dataset
+fix: hide the unregister-entity menu item on datasets

--- a/.changeset/fair-insects-agree.md
+++ b/.changeset/fair-insects-agree.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+fix: hide the unregister-entity menu item on dataset

--- a/plugins/catalog/src/alpha/contextMenuItems.tsx
+++ b/plugins/catalog/src/alpha/contextMenuItems.tsx
@@ -95,6 +95,9 @@ export const unregisterEntityContextMenuItem =
     name: 'unregister-entity',
     params: {
       icon: <CancelIcon fontSize="small" />,
+      filter: entity => {
+        return Boolean(entity.spec?.type !== 'dataset');
+      },
       useProps: () => {
         const { entity } = useEntity();
         const dialogApi = useApi(dialogApiRef);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In the NFS, updates the unregister-entity menu item to not appear on entities with the type 'dataset'. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
