### PR TITLE
docs: Fix MCP backend token subject

### DIFF
--- a/.changeset/rich-eagles-rule.md
+++ b/.changeset/rich-eagles-rule.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-mcp-actions-backend': patch
+---
+
+Fixed the example in the README for generating a static token by adding a subject field

--- a/plugins/mcp-actions-backend/README.md
+++ b/plugins/mcp-actions-backend/README.md
@@ -89,6 +89,7 @@ backend:
       - type: static
         options:
           token: ${MCP_TOKEN}
+          subject: mcp-clients
         accessRestrictions:
           - plugin: mcp-actions
           - plugin: catalog


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When I followed the setup instructions in the `mcp-actions-backend` plugin I got this error:

```
Error: Missing required config value at 'backend.auth.externalAccess[0].options.subject' in 'app-config.local.yaml'
```

Adding a `subject` fixed the issue, this PR updates the README accordingly.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
