### PR TITLE
 Fix: Consistent Casing for Category Filter Display

### DIFF
--- a/microsite/data/plugins/kong-service-manager.yaml
+++ b/microsite/data/plugins/kong-service-manager.yaml
@@ -2,7 +2,7 @@
 title: VeeCode Kong Service Manager
 author: VeeCode Platform
 authorUrl: https://platform.vee.codes/
-category: api-manager
+category: API Manager
 description: The Kong Service Manager plugin provides information about the kong service, a list of the routes it has and also offers the possibility of manipulating plugins without leaving the backstage.
 documentation: https://platform.vee.codes/plugin/kong-service-manager/
 iconUrl: https://veecode-platform.github.io/support/imgs/logo_3.svg


### PR DESCRIPTION
 **Issue**
Some categories like "api-manager" were displayed in lowercase or kebab-case while others used Proper Case (e.g., API Management, App Delivery).

 **Fix**
Updated the display text to ensure all category labels follow Proper Case (e.g., API Manager), regardless of how the category key is stored (e.g., kebab-case or camelCase). This improves visual consistency in the filter list UI.

 **Checklist**
 
 A changeset describing the change and affected packages.

 UI text display normalized

 All commits have a Signed-off-by line

📸 Screenshot Before:
![Api manager before](https://github.com/user-attachments/assets/e25e3c18-b1d2-4b9a-aee5-2bb630f51ce3)


📸 Screenshot After:
![Api manager after](https://github.com/user-attachments/assets/d72bd554-b29e-473b-917d-c06e9da0e470)

