### PR TITLE
fix: Gitlab auth issue

### DIFF
--- a/.changeset/tired-bats-attend.md
+++ b/.changeset/tired-bats-attend.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration-react': patch
+---
+
+Separated gitlab `write_repository` scope to pass checks in `RefreshingAuthSessionManager`

--- a/.changeset/tired-bats-attend.md
+++ b/.changeset/tired-bats-attend.md
@@ -2,4 +2,4 @@
 '@backstage/integration-react': patch
 ---
 
-Separated gitlab `write_repository` scope to pass checks in `RefreshingAuthSessionManager`
+Separated gitlab `write_repository` and `api` scope to pass checks in `RefreshingAuthSessionManager`

--- a/packages/integration-react/src/api/ScmAuth.ts
+++ b/packages/integration-react/src/api/ScmAuth.ts
@@ -173,7 +173,7 @@ export class ScmAuth implements ScmAuthApi {
     const host = options?.host ?? 'gitlab.com';
     return new ScmAuth('gitlab', gitlabAuthApi, host, {
       default: ['read_user', 'read_api', 'read_repository'],
-      repoWrite: ['write_repository api'],
+      repoWrite: ['write_repository', 'api'],
     });
   }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Previously, when using GitLab SCM authentication in the scaffolder, tokens were not reused as expected. This was caused by the scope check failing because the `repoWrite` scopes `api` and `write_repository` were combined into a single space-separated string instead of two separate string.

As a result, users were repeatedly prompted to authenticate, even when an existing token with the correct scopes was available and not expired.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
