### PR TITLE
Fix(footer): open Linux Foundation trademark link in new tab

### DIFF
--- a/microsite/docusaurus.config.ts
+++ b/microsite/docusaurus.config.ts
@@ -480,7 +480,7 @@ const config: Config = {
           ],
         },
       ],
-      copyright: `<p style="text-align:center"><a href="https://spotify.github.io/">Made with ❤️ at Spotify</a></p><p class="copyright">Copyright © ${new Date().getFullYear()} Backstage Project Authors. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our Trademark Usage page: <a href="https://www.linuxfoundation.org/trademark-usage" />https://www.linuxfoundation.org/trademark-usage</a></p>`,
+      copyright: `<p style="text-align:center"><a href="https://spotify.github.io/">Made with ❤️ at Spotify</a></p><p class="copyright">Copyright © ${new Date().getFullYear()} Backstage Project Authors. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our Trademark Usage page: <a href="https://www.linuxfoundation.org/trademark-usage" target="blank"  />https://www.linuxfoundation.org/trademark-usage</a></p>`,
     },
     algolia: {
       apiKey: '60d2643a9c6306463f15f8c3556e7f2e', // Owned by @Rugvip


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updated the Linux Foundation trademark link in the footer to open in a new tab using `target="_blank"` and `rel="noopener noreferrer"` for better user experience and security.

#### :heavy_check_mark: Checklist

- [x] Changeset not required (minor external link behavior fix)
- [x] Link opens in new tab as expected

