### PR TITLE
feat(catalog): make content header of `CatalogIndexPage` customizable

### DIFF
--- a/.changeset/long-jeans-fail.md
+++ b/.changeset/long-jeans-fail.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': minor
+---
+
+Added support for customizing the content header of `CatalogIndexPage`

--- a/docs/features/software-catalog/catalog-customization.md
+++ b/docs/features/software-catalog/catalog-customization.md
@@ -416,6 +416,29 @@ const routes = (
 
 The same method can be used to customize the _default_ filters with a different interface - for such usage, the generic argument isn't needed since the filter shape remains the same as the default.
 
+## Customize Content Header
+
+The `CatalogIndexPage` comes with a default content header, but you may want to customize it:
+
+```tsx title="packages/app/src/App.tsx"
+import { DismissableBanner } from '@backstage/core-components';
+
+<Route
+  path="/catalog"
+  element={
+    <CatalogIndexPage
+      contentHeader={
+        <DismissableBanner
+          id="repository_migration_notice"
+          variant="info"
+          message="We're currently migrating repositories to a new provider. Your entities might be temporarily missing from the catalog."
+        />
+      }
+    />
+  }
+/>;
+```
+
 ## Advanced Customization
 
 For those where none of the above fits their needs you can take the option of creating a fully custom `CatalogIndexPage`.

--- a/plugins/catalog/report.api.md
+++ b/plugins/catalog/report.api.md
@@ -231,6 +231,8 @@ export interface DefaultCatalogPageProps {
   // (undocumented)
   columns?: TableColumn<CatalogTableRow>[] | CatalogTableColumnsFunc;
   // (undocumented)
+  contentHeader?: ReactNode;
+  // (undocumented)
   emptyContent?: ReactNode;
   // (undocumented)
   filters?: ReactNode;

--- a/plugins/catalog/src/components/CatalogPage/DefaultCatalogContentHeader.tsx
+++ b/plugins/catalog/src/components/CatalogPage/DefaultCatalogContentHeader.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ContentHeader,
+  CreateButton,
+  SupportButton,
+} from '@backstage/core-components';
+import { useRouteRef } from '@backstage/core-plugin-api';
+import { createComponentRouteRef } from '../../routes';
+import { catalogTranslationRef } from '../../alpha/translation';
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import { catalogEntityCreatePermission } from '@backstage/plugin-catalog-common/alpha';
+import { usePermission } from '@backstage/plugin-permission-react';
+
+export function DefaultCatalogContentHeader() {
+  const createComponentLink = useRouteRef(createComponentRouteRef);
+  const { allowed } = usePermission({
+    permission: catalogEntityCreatePermission,
+  });
+  const { t } = useTranslationRef(catalogTranslationRef);
+
+  return (
+    <ContentHeader title="">
+      {allowed && (
+        <CreateButton
+          title={t('indexPage.createButtonTitle')}
+          to={createComponentLink && createComponentLink()}
+        />
+      )}
+      <SupportButton>{t('indexPage.supportButtonContent')}</SupportButton>
+    </ContentHeader>
+  );
+}

--- a/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.test.tsx
+++ b/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.test.tsx
@@ -16,7 +16,11 @@
 
 import { QueryEntitiesInitialRequest } from '@backstage/catalog-client';
 import { RELATION_OWNED_BY } from '@backstage/catalog-model';
-import { TableColumn, TableProps } from '@backstage/core-components';
+import {
+  DismissableBanner,
+  TableColumn,
+  TableProps,
+} from '@backstage/core-components';
 import { identityApiRef, storageApiRef } from '@backstage/core-plugin-api';
 import {
   catalogApiRef,
@@ -365,5 +369,24 @@ describe('DefaultCatalogPage', () => {
     ).toBeInTheDocument();
     fireEvent.click(button);
     expect(screen.getByRole('presentation')).toBeVisible();
+  }, 20_000);
+
+  it('should render the custom content header passed as prop', async () => {
+    const customContentHeader = (
+      <DismissableBanner
+        id="repository_migration_notice"
+        variant="info"
+        message="We're currently migrating repositories to a new provider. Your entities might be temporarily missing from the catalog."
+      />
+    );
+    await renderWrapped(
+      <DefaultCatalogPage contentHeader={customContentHeader} />,
+    );
+
+    await expect(
+      screen.findByText(
+        "We're currently migrating repositories to a new provider. Your entities might be temporarily missing from the catalog.",
+      ),
+    ).resolves.toBeInTheDocument();
   }, 20_000);
 });

--- a/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.tsx
@@ -16,14 +16,11 @@
 
 import {
   Content,
-  ContentHeader,
-  CreateButton,
   PageWithHeader,
-  SupportButton,
   TableColumn,
   TableProps,
 } from '@backstage/core-components';
-import { configApiRef, useApi, useRouteRef } from '@backstage/core-plugin-api';
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
 import {
   CatalogFilterLayout,
   DefaultFilters,
@@ -33,44 +30,36 @@ import {
   UserListFilterKind,
 } from '@backstage/plugin-catalog-react';
 import { ReactNode } from 'react';
-import { createComponentRouteRef } from '../../routes';
 import { CatalogTable, CatalogTableRow } from '../CatalogTable';
 import { catalogTranslationRef } from '../../alpha/translation';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { CatalogTableColumnsFunc } from '../CatalogTable/types';
-import { catalogEntityCreatePermission } from '@backstage/plugin-catalog-common/alpha';
-import { usePermission } from '@backstage/plugin-permission-react';
+import { DefaultCatalogContentHeader } from './DefaultCatalogContentHeader';
 
 /** @internal */
 export type BaseCatalogPageProps = {
   filters: ReactNode;
   content?: ReactNode;
   pagination?: EntityListPagination;
+  contentHeader?: ReactNode;
 };
 
 /** @internal */
 export function BaseCatalogPage(props: BaseCatalogPageProps) {
-  const { filters, content = <CatalogTable />, pagination } = props;
+  const {
+    filters,
+    content = <CatalogTable />,
+    pagination,
+    contentHeader = <DefaultCatalogContentHeader />,
+  } = props;
   const orgName =
     useApi(configApiRef).getOptionalString('organization.name') ?? 'Backstage';
-  const createComponentLink = useRouteRef(createComponentRouteRef);
   const { t } = useTranslationRef(catalogTranslationRef);
-  const { allowed } = usePermission({
-    permission: catalogEntityCreatePermission,
-  });
 
   return (
     <PageWithHeader title={t('indexPage.title', { orgName })} themeId="home">
       <Content>
-        <ContentHeader title="">
-          {allowed && (
-            <CreateButton
-              title={t('indexPage.createButtonTitle')}
-              to={createComponentLink && createComponentLink()}
-            />
-          )}
-          <SupportButton>{t('indexPage.supportButtonContent')}</SupportButton>
-        </ContentHeader>
+        {contentHeader}
         <EntityListProvider pagination={pagination}>
           <CatalogFilterLayout>
             <CatalogFilterLayout.Filters>{filters}</CatalogFilterLayout.Filters>
@@ -98,6 +87,7 @@ export interface DefaultCatalogPageProps {
   filters?: ReactNode;
   initiallySelectedNamespaces?: string[];
   pagination?: EntityListPagination;
+  contentHeader?: ReactNode;
 }
 
 export function DefaultCatalogPage(props: DefaultCatalogPageProps) {
@@ -112,6 +102,7 @@ export function DefaultCatalogPage(props: DefaultCatalogPageProps) {
     ownerPickerMode,
     filters,
     initiallySelectedNamespaces,
+    contentHeader,
   } = props;
 
   return (
@@ -135,6 +126,7 @@ export function DefaultCatalogPage(props: DefaultCatalogPageProps) {
         />
       }
       pagination={pagination}
+      contentHeader={contentHeader}
     />
   );
 }


### PR DESCRIPTION
This PR makes the content header of `CatalogIndexPage` customizable, allowing for replacing the default content header with something entirely different:

<img width="1280" alt="Scherm­afbeelding 2025-06-20 om 16 46 56" src="https://github.com/user-attachments/assets/e2574f3c-bca7-44f4-9ace-d91a50ab2fe1" />

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
