### PR TITLE
Canon - Placeholder support for TextField

### DIFF
--- a/.changeset/silent-vans-tie.md
+++ b/.changeset/silent-vans-tie.md
@@ -1,0 +1,5 @@
+---
+'@backstage/canon': patch
+---
+
+Added placeholder prop to TextField component.

--- a/packages/canon/report.api.md
+++ b/packages/canon/report.api.md
@@ -1299,6 +1299,7 @@ export interface TextFieldProps
   extends TextFieldProps_2,
     Omit<FieldLabelProps, 'htmlFor' | 'id'> {
   icon?: ReactNode;
+  placeholder?: string;
   size?: 'small' | 'medium' | Partial<Record<Breakpoint, 'small' | 'medium'>>;
 }
 

--- a/packages/canon/src/components/TextField/TextField.stories.tsx
+++ b/packages/canon/src/components/TextField/TextField.stories.tsx
@@ -40,7 +40,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     name: 'url',
-    defaultValue: 'Enter a URL',
+    placeholder: 'Enter a URL',
     style: {
       maxWidth: '300px',
     },
@@ -97,7 +97,7 @@ export const Disabled: Story = {
 export const WithIcon: Story = {
   args: {
     ...Default.args,
-    defaultValue: 'Search...',
+    placeholder: 'Search...',
     icon: <Icon name="search" />,
   },
 };

--- a/packages/canon/src/components/TextField/TextField.tsx
+++ b/packages/canon/src/components/TextField/TextField.tsx
@@ -39,6 +39,7 @@ export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(
       isRequired,
       'aria-label': ariaLabel,
       'aria-labelledby': ariaLabelledBy,
+      placeholder,
       ...rest
     } = props;
 
@@ -84,6 +85,7 @@ export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(
           <Input
             className="canon-TextFieldInput"
             {...(icon && { 'data-icon': true })}
+            placeholder={placeholder}
           />
         </div>
         <FieldError className="canon-TextFieldError" />

--- a/packages/canon/src/components/TextField/types.ts
+++ b/packages/canon/src/components/TextField/types.ts
@@ -33,4 +33,9 @@ export interface TextFieldProps
    * @defaultValue 'medium'
    */
   size?: 'small' | 'medium' | Partial<Record<Breakpoint, 'small' | 'medium'>>;
+
+  /**
+   * Text to display in the input when it has no value
+   */
+  placeholder?: string;
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Support for setting placeholder text for a text field was inadvertently removed in https://github.com/backstage/backstage/pull/30286, this PR just adds it back

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
