### PR TITLE
Added support for `{org}.visualstudio.com` domains used by Azure DevOps

### DIFF
--- a/.changeset/calm-knives-glow.md
+++ b/.changeset/calm-knives-glow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+Added support for `{org}.visualstudio.com` domains used by Azure DevOps

--- a/packages/integration/src/azure/AzureUrl.test.ts
+++ b/packages/integration/src/azure/AzureUrl.test.ts
@@ -198,4 +198,53 @@ describe('AzureUrl', () => {
       ),
     ).toThrow('Azure URL must point to a git repository');
   });
+
+  it('should work with the old visualstudio long URL', () => {
+    const url = AzureUrl.fromRepoUrl(
+      'https://my-org.visualstudio.com/my-project/_git/my-repo',
+    );
+
+    expect(url.getOwner()).toBe('my-org');
+    expect(url.getProject()).toBe('my-project');
+    expect(url.getRepo()).toBe('my-repo');
+    expect(url.getRef()).toBeUndefined();
+    expect(url.getPath()).toBeUndefined();
+  });
+
+  it('should work with the old visualstudio long URL form with a path', () => {
+    const url = AzureUrl.fromRepoUrl(
+      'https://my-org.visualstudio.com/my-project/_git/my-repo?path=%2Ftest.yaml',
+    );
+
+    expect(url.getOwner()).toBe('my-org');
+    expect(url.getProject()).toBe('my-project');
+    expect(url.getRepo()).toBe('my-repo');
+    expect(url.getRef()).toBeUndefined();
+    expect(url.getPath()).toBe('/test.yaml');
+
+    expect(url.toRepoUrl()).toBe(
+      'https://my-org.visualstudio.com/my-project/_git/my-repo?path=%2Ftest.yaml',
+    );
+    expect(url.toFileUrl()).toBe(
+      'https://my-org.visualstudio.com/my-project/_apis/git/repositories/my-repo/items?api-version=6.0&path=%2Ftest.yaml',
+    );
+    expect(url.toArchiveUrl()).toBe(
+      'https://my-org.visualstudio.com/my-project/_apis/git/repositories/my-repo/items?recursionLevel=full&download=true&api-version=6.0&scopePath=%2Ftest.yaml',
+    );
+    expect(url.toCommitsUrl()).toBe(
+      'https://my-org.visualstudio.com/my-project/_apis/git/repositories/my-repo/commits?api-version=6.0',
+    );
+  });
+
+  it('should work with the old visualstudio long URL form with a path and ref', () => {
+    const url = AzureUrl.fromRepoUrl(
+      'https://my-org.visualstudio.com/my-project/_git/my-repo?path=%2Ffolder&version=GBtest-branch',
+    );
+
+    expect(url.getOwner()).toBe('my-org');
+    expect(url.getProject()).toBe('my-project');
+    expect(url.getRepo()).toBe('my-repo');
+    expect(url.getRef()).toBe('test-branch');
+    expect(url.getPath()).toBe('/folder');
+  });
 });

--- a/packages/integration/src/azure/AzureUrl.ts
+++ b/packages/integration/src/azure/AzureUrl.ts
@@ -30,7 +30,11 @@ export class AzureUrl {
     let repo;
 
     const parts = url.pathname.split('/').map(part => decodeURIComponent(part));
-    if (parts[2] === '_git') {
+    if (url.host.includes('visualstudio.com') && parts[2] === '_git') {
+      owner = url.host.split('.')[0];
+      project = parts[1];
+      repo = parts[3];
+    } else if (parts[2] === '_git') {
       owner = parts[1];
       project = repo = parts[3];
     } else if (parts[3] === '_git') {
@@ -98,7 +102,9 @@ export class AzureUrl {
    */
   toRepoUrl(): string {
     let url;
-    if (this.#project === this.#repo) {
+    if (this.#origin.includes('visualstudio.com')) {
+      url = this.#baseUrl(this.#project, '_git', this.#repo);
+    } else if (this.#project === this.#repo) {
       url = this.#baseUrl(this.#owner, '_git', this.#repo);
     } else {
       url = this.#baseUrl(this.#owner, this.#project, '_git', this.#repo);
@@ -126,15 +132,28 @@ export class AzureUrl {
       );
     }
 
-    const url = this.#baseUrl(
-      this.#owner,
-      this.#project,
-      '_apis',
-      'git',
-      'repositories',
-      this.#repo,
-      'items',
-    );
+    let url;
+    if (this.#origin.includes('visualstudio.com')) {
+      url = this.#baseUrl(
+        this.#project,
+        '_apis',
+        'git',
+        'repositories',
+        this.#repo,
+        'items',
+      );
+    } else {
+      url = this.#baseUrl(
+        this.#owner,
+        this.#project,
+        '_apis',
+        'git',
+        'repositories',
+        this.#repo,
+        'items',
+      );
+    }
+
     url.searchParams.set('api-version', '6.0');
     url.searchParams.set('path', this.#path);
 
@@ -151,15 +170,28 @@ export class AzureUrl {
    * Throws an error if the URL does not point to a repo.
    */
   toArchiveUrl(): string {
-    const url = this.#baseUrl(
-      this.#owner,
-      this.#project,
-      '_apis',
-      'git',
-      'repositories',
-      this.#repo,
-      'items',
-    );
+    let url;
+    if (this.#origin.includes('visualstudio.com')) {
+      url = this.#baseUrl(
+        this.#project,
+        '_apis',
+        'git',
+        'repositories',
+        this.#repo,
+        'items',
+      );
+    } else {
+      url = this.#baseUrl(
+        this.#owner,
+        this.#project,
+        '_apis',
+        'git',
+        'repositories',
+        this.#repo,
+        'items',
+      );
+    }
+
     url.searchParams.set('recursionLevel', 'full');
     url.searchParams.set('download', 'true');
     url.searchParams.set('api-version', '6.0');
@@ -180,15 +212,28 @@ export class AzureUrl {
    * Throws an error if the URL does not point to a commit.
    */
   toCommitsUrl(): string {
-    const url = this.#baseUrl(
-      this.#owner,
-      this.#project,
-      '_apis',
-      'git',
-      'repositories',
-      this.#repo,
-      'commits',
-    );
+    let url;
+    if (this.#origin.includes('visualstudio.com')) {
+      url = this.#baseUrl(
+        this.#project,
+        '_apis',
+        'git',
+        'repositories',
+        this.#repo,
+        'commits',
+      );
+    } else {
+      url = this.#baseUrl(
+        this.#owner,
+        this.#project,
+        '_apis',
+        'git',
+        'repositories',
+        this.#repo,
+        'commits',
+      );
+    }
+
     url.searchParams.set('api-version', '6.0');
 
     if (this.#ref) {

--- a/packages/integration/src/azure/DefaultAzureDevOpsCredentialsProvider.test.ts
+++ b/packages/integration/src/azure/DefaultAzureDevOpsCredentialsProvider.test.ts
@@ -445,5 +445,26 @@ describe('DefaultAzureDevOpsCredentialProvider', () => {
         });
       });
     });
+    describe('Azure DevOps (visualstudio.com)', () => {
+      it('Should return a token when a credential with the same organization is specified', async () => {
+        const provider = buildProvider([
+          {
+            host: 'org1.visualstudio.com',
+            credentials: [
+              {
+                organizations: ['org1'],
+                personalAccessToken: 'pat',
+              },
+            ],
+          },
+        ]);
+
+        const credentials = provider.getCredentials({
+          url: 'https://org1.visualstudio.com/project1',
+        });
+
+        expect(credentials).toBeDefined();
+      });
+    });
   });
 });

--- a/packages/integration/src/azure/DefaultAzureDevOpsCredentialsProvider.ts
+++ b/packages/integration/src/azure/DefaultAzureDevOpsCredentialsProvider.ts
@@ -110,6 +110,18 @@ export class DefaultAzureDevOpsCredentialsProvider
     return undefined;
   }
 
+  private forVisualstudioOrganization(
+    url: URL,
+  ): AzureDevOpsCredentialsProvider | undefined {
+    const parts = url.host.split('.');
+    if (url.host.includes('visualstudio.com') && parts.length > 0) {
+      // url format: https://{organization}.visualstudio.com
+      return this.providers.get(`${url.host}/${parts[0]}`);
+    }
+
+    return undefined;
+  }
+
   private forHost(url: URL): AzureDevOpsCredentialsProvider | undefined {
     return this.providers.get(url.host);
   }
@@ -121,6 +133,7 @@ export class DefaultAzureDevOpsCredentialsProvider
     const provider =
       this.forAzureDevOpsOrganization(url) ??
       this.forAzureDevOpsServerOrganization(url) ??
+      this.forVisualstudioOrganization(url) ??
       this.forHost(url);
 
     if (provider === undefined) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added support for `{org}.visualstudio.com` domains used by Azure DevOps. With this change you will be able to import entities into the Catalog via static configuration or the Catalog Import plugin.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
