### PR TITLE
Fix Error Message in StepInitAnalyzeUrl.tsx

### DIFF
--- a/.changeset/stupid-donuts-sit.md
+++ b/.changeset/stupid-donuts-sit.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-import': patch
+---
+
+Fixed bug with error message since ResponseError is now thrown from CatalogClient

--- a/plugins/catalog-import/src/components/StepInitAnalyzeUrl/StepInitAnalyzeUrl.tsx
+++ b/plugins/catalog-import/src/components/StepInitAnalyzeUrl/StepInitAnalyzeUrl.tsx
@@ -130,7 +130,7 @@ export const StepInitAnalyzeUrl = (props: StepInitAnalyzeUrlProps) => {
           }
         }
       } catch (e: any) {
-        setError(e?.data?.error?.message ?? e.message);
+        setError(e?.body?.error?.message ?? e.message);
         setSubmitted(false);
       }
     },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Due to this change https://github.com/backstage/backstage/commit/22fad0d4519aedd03164b9ed1dcf16662083c8f7 to fix error responses in CatalogClient, this broke error messaging in catalog-import. `data` is not a property in ResponseError so we need to switch `e?.data?.error?.message` to `e?.body?.error?.message` as that is what is set in the ResponseError constructor.

Currently:
![image](https://github.com/user-attachments/assets/f107e7e4-2feb-4822-8919-eb25f5a59a64)

After fix:
![image](https://github.com/user-attachments/assets/c3a54b21-274c-488d-b873-649ef9125d80)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
