### PR TITLE
fix: Add optional config for ses mail options with sourceArn, etc.

### DIFF
--- a/.changeset/tender-wolves-strive.md
+++ b/.changeset/tender-wolves-strive.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications-backend-module-email': patch
+---
+
+Add optional config for ses mail options with SourceArn, FromArn, ConfigurationSetName

--- a/.changeset/tender-wolves-strive.md
+++ b/.changeset/tender-wolves-strive.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-notifications-backend-module-email': patch
 ---
 
-Add optional config for ses mail options with SourceArn, FromArn, ConfigurationSetName
+Add optional config for `ses` mail options with `sourceArn`, `fromArn`, `configurationSetName`

--- a/plugins/notifications-backend-module-email/README.md
+++ b/plugins/notifications-backend-module-email/README.md
@@ -79,6 +79,11 @@ notifications:
       # Who to send email for broadcast notifications
       broadcastConfig:
         receiver: 'users'
+      # Optional SES config
+      # sesConfig:
+      #   SourceArn: 'arn:aws:ses:us-west-2:123456789012:identity/example.com'
+      #   FromArn: 'arn:aws:ses:us-west-2:123456789012:identity/example.com'
+      #   ConfigurationSetName: 'custom-config'
       # How many emails to send concurrently, defaults to 2
       concurrencyLimit: 10
       # How much to throttle between emails, defaults to 100ms

--- a/plugins/notifications-backend-module-email/README.md
+++ b/plugins/notifications-backend-module-email/README.md
@@ -81,9 +81,9 @@ notifications:
         receiver: 'users'
       # Optional SES config
       # sesConfig:
-      #   SourceArn: 'arn:aws:ses:us-west-2:123456789012:identity/example.com'
-      #   FromArn: 'arn:aws:ses:us-west-2:123456789012:identity/example.com'
-      #   ConfigurationSetName: 'custom-config'
+      #   sourceArn: 'arn:aws:ses:us-west-2:123456789012:identity/example.com'
+      #   fromArn: 'arn:aws:ses:us-west-2:123456789012:identity/example.com'
+      #   configurationSetName: 'custom-config'
       # How many emails to send concurrently, defaults to 2
       concurrencyLimit: 10
       # How much to throttle between emails, defaults to 100ms

--- a/plugins/notifications-backend-module-email/config.d.ts
+++ b/plugins/notifications-backend-module-email/config.d.ts
@@ -132,6 +132,23 @@ export interface Config {
            */
           receiverEmails?: string[];
         };
+        /**
+         * Optional SES config for mail options. Allows for delegated sender
+         */
+        sesConfig?: {
+          /**
+           * ARN of the identity to use as the source of the email
+           */
+          SourceArn?: string;
+          /**
+           * ARN of the identity to use for the "From"/sender address of the email
+           */
+          FromArn?: string;
+          /**
+           * Name of the configuration set to use when sending email via ses
+           */
+          ConfigurationSetName?: string;
+        };
         cache?: {
           /**
            * Email cache TTL, defaults to 1 hour

--- a/plugins/notifications-backend-module-email/config.d.ts
+++ b/plugins/notifications-backend-module-email/config.d.ts
@@ -139,15 +139,15 @@ export interface Config {
           /**
            * ARN of the identity to use as the source of the email
            */
-          SourceArn?: string;
+          sourceArn?: string;
           /**
            * ARN of the identity to use for the "From"/sender address of the email
            */
-          FromArn?: string;
+          fromArn?: string;
           /**
            * Name of the configuration set to use when sending email via ses
            */
-          ConfigurationSetName?: string;
+          configurationSetName?: string;
         };
         cache?: {
           /**

--- a/plugins/notifications-backend-module-email/src/processor/NotificationsEmailProcessor.test.ts
+++ b/plugins/notifications-backend-module-email/src/processor/NotificationsEmailProcessor.test.ts
@@ -458,9 +458,9 @@ describe('NotificationsEmailProcessor', () => {
             sender: 'backstage@backstage.io',
             replyTo: 'no-reply@backstage.io',
             sesConfig: {
-              SourceArn:
+              sourceArn:
                 'arn:aws:ses:us-west-2:123456789012:identity/example.com',
-              FromArn:
+              fromArn:
                 'arn:aws:ses:us-west-2:123456789012:identity/example.com',
             },
           },

--- a/plugins/notifications-backend-module-email/src/processor/NotificationsEmailProcessor.test.ts
+++ b/plugins/notifications-backend-module-email/src/processor/NotificationsEmailProcessor.test.ts
@@ -442,4 +442,62 @@ describe('NotificationsEmailProcessor', () => {
       to: 'mock@backstage.io',
     });
   });
+
+  it('should send email with ses config', async () => {
+    const SES_SENDMAIL_CONFIG = {
+      app: {
+        baseUrl: 'https://example.org',
+      },
+      notifications: {
+        processors: {
+          email: {
+            transportConfig: {
+              transport: 'ses',
+              region: 'us-west-2',
+            },
+            sender: 'backstage@backstage.io',
+            replyTo: 'no-reply@backstage.io',
+            sesConfig: {
+              SourceArn: 'arn:aws:ses:us-west-2:123456789012:identity/example.com',
+              FromArn: 'arn:aws:ses:us-west-2:123456789012:identity/example.com',
+            }
+          },
+        },
+      },
+    };
+    (createTransport as jest.Mock).mockReturnValue(mockTransport);
+    const processor = new NotificationsEmailProcessor(
+      logger,
+      mockServices.rootConfig({ data: SES_SENDMAIL_CONFIG }),
+      catalogServiceMock({ entities: [ DEFAULT_ENTITIES_RESPONSE.items[ 0 ] ] }),
+      auth,
+    );
+
+    await processor.postProcess(
+      {
+        origin: 'plugin',
+        id: '1234',
+        user: 'user:default/mock',
+        created: new Date(),
+        payload: { title: 'notification' },
+      },
+      {
+        recipients: { type: 'entity', entityRef: 'user:default/mock' },
+        payload: { title: 'notification' },
+      },
+    );
+
+    expect(sendmailMock).toHaveBeenCalledWith({
+      from: 'backstage@backstage.io',
+      html: '<p><a href="https://example.org/notifications">https://example.org/notifications</a></p>',
+      replyTo: 'no-reply@backstage.io',
+      subject: 'notification',
+      text: 'https://example.org/notifications',
+      to: 'mock@backstage.io',
+      ses: {
+        SourceArn: 'arn:aws:ses:us-west-2:123456789012:identity/example.com',
+        FromArn: 'arn:aws:ses:us-west-2:123456789012:identity/example.com',
+      }
+    });
+  });
 });

--- a/plugins/notifications-backend-module-email/src/processor/NotificationsEmailProcessor.test.ts
+++ b/plugins/notifications-backend-module-email/src/processor/NotificationsEmailProcessor.test.ts
@@ -458,9 +458,11 @@ describe('NotificationsEmailProcessor', () => {
             sender: 'backstage@backstage.io',
             replyTo: 'no-reply@backstage.io',
             sesConfig: {
-              SourceArn: 'arn:aws:ses:us-west-2:123456789012:identity/example.com',
-              FromArn: 'arn:aws:ses:us-west-2:123456789012:identity/example.com',
-            }
+              SourceArn:
+                'arn:aws:ses:us-west-2:123456789012:identity/example.com',
+              FromArn:
+                'arn:aws:ses:us-west-2:123456789012:identity/example.com',
+            },
           },
         },
       },
@@ -469,7 +471,7 @@ describe('NotificationsEmailProcessor', () => {
     const processor = new NotificationsEmailProcessor(
       logger,
       mockServices.rootConfig({ data: SES_SENDMAIL_CONFIG }),
-      catalogServiceMock({ entities: [ DEFAULT_ENTITIES_RESPONSE.items[ 0 ] ] }),
+      catalogServiceMock({ entities: [DEFAULT_ENTITIES_RESPONSE.items[0]] }),
       auth,
     );
 
@@ -497,7 +499,7 @@ describe('NotificationsEmailProcessor', () => {
       ses: {
         SourceArn: 'arn:aws:ses:us-west-2:123456789012:identity/example.com',
         FromArn: 'arn:aws:ses:us-west-2:123456789012:identity/example.com',
-      }
+      },
     });
   });
 });

--- a/plugins/notifications-backend-module-email/src/processor/NotificationsEmailProcessor.ts
+++ b/plugins/notifications-backend-module-email/src/processor/NotificationsEmailProcessor.ts
@@ -52,6 +52,7 @@ export class NotificationsEmailProcessor implements NotificationProcessor {
   private readonly transportConfig: Config;
   private readonly sender: string;
   private readonly replyTo?: string;
+  private readonly sesConfig?: Config;
   private readonly cacheTtl: number;
   private readonly concurrencyLimit: number;
   private readonly throttleInterval: number;
@@ -76,6 +77,7 @@ export class NotificationsEmailProcessor implements NotificationProcessor {
       emailProcessorConfig.getOptionalConfig('broadcastConfig');
     this.sender = emailProcessorConfig.getString('sender');
     this.replyTo = emailProcessorConfig.getOptionalString('replyTo');
+    this.sesConfig = emailProcessorConfig.getOptionalConfig('sesConfig');
     this.concurrencyLimit =
       emailProcessorConfig.getOptionalNumber('concurrencyLimit') ?? 2;
     this.throttleInterval = emailProcessorConfig.has('throttleInterval')
@@ -292,6 +294,22 @@ export class NotificationsEmailProcessor implements NotificationProcessor {
     return contentParts.join('\n\n');
   }
 
+  private async getSesOptions() {
+    if (!this.sesConfig) {
+      return undefined;
+    }
+    const ses: Record<string, string> = {};
+    const sourceArn = this.sesConfig.getOptionalString('SourceArn');
+    const fromArn = this.sesConfig.getOptionalString('FromArn');
+    const configurationSetName = this.sesConfig.getOptionalString('ConfigurationSetName');
+
+    if (sourceArn) ses.SourceArn = sourceArn;
+    if (fromArn) ses.FromArn = fromArn;
+    if (configurationSetName) ses.ConfigurationSetName = configurationSetName;
+
+    return Object.keys(ses).length > 0 ? ses : undefined;
+  }
+
   private async sendPlainEmail(notification: Notification, emails: string[]) {
     const mailOptions = {
       from: this.sender,
@@ -299,6 +317,7 @@ export class NotificationsEmailProcessor implements NotificationProcessor {
       html: this.getHtmlContent(notification),
       text: this.getTextContent(notification),
       replyTo: this.replyTo,
+      ses: await this.getSesOptions()
     };
 
     await this.sendMails(mailOptions, emails);
@@ -316,6 +335,7 @@ export class NotificationsEmailProcessor implements NotificationProcessor {
       html: await this.templateRenderer?.getHtml?.(notification),
       text: await this.templateRenderer?.getText?.(notification),
       replyTo: this.replyTo,
+      ses: await this.getSesOptions(),
     };
 
     await this.sendMails(mailOptions, emails);

--- a/plugins/notifications-backend-module-email/src/processor/NotificationsEmailProcessor.ts
+++ b/plugins/notifications-backend-module-email/src/processor/NotificationsEmailProcessor.ts
@@ -299,10 +299,10 @@ export class NotificationsEmailProcessor implements NotificationProcessor {
       return undefined;
     }
     const ses: Record<string, string> = {};
-    const sourceArn = this.sesConfig.getOptionalString('SourceArn');
-    const fromArn = this.sesConfig.getOptionalString('FromArn');
+    const sourceArn = this.sesConfig.getOptionalString('sourceArn');
+    const fromArn = this.sesConfig.getOptionalString('fromArn');
     const configurationSetName = this.sesConfig.getOptionalString(
-      'ConfigurationSetName',
+      'configurationSetName',
     );
 
     if (sourceArn) ses.SourceArn = sourceArn;

--- a/plugins/notifications-backend-module-email/src/processor/NotificationsEmailProcessor.ts
+++ b/plugins/notifications-backend-module-email/src/processor/NotificationsEmailProcessor.ts
@@ -301,7 +301,9 @@ export class NotificationsEmailProcessor implements NotificationProcessor {
     const ses: Record<string, string> = {};
     const sourceArn = this.sesConfig.getOptionalString('SourceArn');
     const fromArn = this.sesConfig.getOptionalString('FromArn');
-    const configurationSetName = this.sesConfig.getOptionalString('ConfigurationSetName');
+    const configurationSetName = this.sesConfig.getOptionalString(
+      'ConfigurationSetName',
+    );
 
     if (sourceArn) ses.SourceArn = sourceArn;
     if (fromArn) ses.FromArn = fromArn;
@@ -317,7 +319,7 @@ export class NotificationsEmailProcessor implements NotificationProcessor {
       html: this.getHtmlContent(notification),
       text: this.getTextContent(notification),
       replyTo: this.replyTo,
-      ses: await this.getSesOptions()
+      ses: await this.getSesOptions(),
     };
 
     await this.sendMails(mailOptions, emails);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added optional config values in `@backstage/plugin-notifications-backend-module-email` to allow SES to send emails from delegated sender. Added optional config `sesConfig` with optional `sourceArn`, `fromArn`, and `configurationSetName` keys. If provided, adds `ses` on mail options.

- https://nodemailer.com/transports/ses
- https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-client-ses/Interface/SendRawEmailRequest/

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
