### PR TITLE
fix: incremental burstLength check

### DIFF
--- a/.changeset/fancy-nails-call.md
+++ b/.changeset/fancy-nails-call.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-incremental-ingestion': patch
+---
+
+Fixed bug in IncrementalIngestionEngine by adding burstLength check when a burst completes

--- a/.changeset/fancy-nails-call.md
+++ b/.changeset/fancy-nails-call.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend-module-incremental-ingestion': patch
 ---
 
-Fixed bug in IncrementalIngestionEngine by adding burstLength check when a burst completes
+Fixed bug in `IncrementalIngestionEngine` by adding `burstLength` check when a burst completes

--- a/plugins/catalog-backend-module-incremental-ingestion/src/engine/IncrementalIngestionEngine.test.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/engine/IncrementalIngestionEngine.test.ts
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { IncrementalIngestionEngine } from './IncrementalIngestionEngine';
+import { IterationEngineOptions } from '../types';
+import { performance } from 'perf_hooks';
+
+jest.setTimeout(60_000);
+
+describe('IncrementalIngestionEngine - Burst Length', () => {
+  const createMockProvider = () => ({
+    getProviderName: jest.fn().mockReturnValue('test-provider'),
+    next: jest.fn(),
+    around: jest.fn(),
+  });
+
+  const createMockManager = () =>
+    ({
+      getLastMark: jest.fn().mockResolvedValue(null),
+      createMark: jest.fn().mockResolvedValue(undefined),
+      createMarkEntities: jest.fn().mockResolvedValue(undefined),
+      computeRemoved: jest.fn().mockResolvedValue({ total: 0, removed: [] }),
+    } as any);
+
+  const createMockConnection = () =>
+    ({
+      applyMutation: jest.fn().mockResolvedValue(undefined),
+      refresh: jest.fn().mockResolvedValue(undefined),
+    } as any);
+
+  const createMockLogger = () =>
+    ({
+      info: jest.fn(),
+      debug: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      child: jest.fn().mockReturnThis(),
+    } as any);
+
+  it('should respect burst length and stop burst when time limit exceeded', async () => {
+    const mockProvider = createMockProvider();
+    const mockManager = createMockManager();
+    const mockConnection = createMockConnection();
+    const mockLogger = createMockLogger();
+
+    const options: IterationEngineOptions = {
+      provider: mockProvider,
+      manager: mockManager,
+      connection: mockConnection,
+      burstLength: { milliseconds: 100 }, // Short burst length for testing
+      restLength: { minutes: 1 },
+      logger: mockLogger,
+      ready: Promise.resolve(),
+    };
+
+    const engine = new IncrementalIngestionEngine(options);
+
+    let callCount = 0;
+    mockProvider.around.mockImplementation(async fn => {
+      await fn({});
+    });
+
+    // Mock provider.next to return multiple batches that never complete
+    // Each call takes some time to simulate real processing
+    mockProvider.next.mockImplementation(async () => {
+      callCount++;
+      // Add a small delay to ensure we exceed burst length
+      await new Promise(resolve => setTimeout(resolve, 30));
+      return {
+        done: false, // Never done - would continue forever without burst length
+        entities: [
+          {
+            entity: {
+              kind: 'Component',
+              metadata: { name: `test-component-${callCount}` },
+            },
+          },
+        ],
+        cursor: `cursor-${callCount}`,
+      };
+    });
+
+    const signal = new AbortController().signal;
+    const start = performance.now();
+
+    const result = await engine.ingestOneBurst('test-ingestion', signal);
+
+    const duration = performance.now() - start;
+
+    // Verify that the burst was stopped due to time limit, not completion
+    expect(result).toBe(false); // Should return false since provider never returned done
+    expect(duration).toBeGreaterThanOrEqual(100); // Should have run for at least the burst length
+    expect(mockProvider.next).toHaveBeenCalledTimes(callCount);
+    expect(callCount).toBeGreaterThan(1); // Should have made multiple calls before stopping
+
+    // Verify the correct log message was called
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      expect.stringContaining('burst exceeded length of 100 milliseconds'),
+    );
+  });
+
+  it('should complete burst normally when provider returns done before burst length', async () => {
+    const mockProvider = createMockProvider();
+    const mockManager = createMockManager();
+    const mockConnection = createMockConnection();
+    const mockLogger = createMockLogger();
+
+    const options: IterationEngineOptions = {
+      provider: mockProvider,
+      manager: mockManager,
+      connection: mockConnection,
+      burstLength: { seconds: 10 }, // Long burst length
+      restLength: { minutes: 1 },
+      logger: mockLogger,
+      ready: Promise.resolve(),
+    };
+
+    const engine = new IncrementalIngestionEngine(options);
+
+    mockProvider.around.mockImplementation(async fn => {
+      await fn({});
+    });
+
+    // Mock provider.next to return done after first call
+    mockProvider.next.mockResolvedValueOnce({
+      done: true,
+      entities: [
+        {
+          entity: {
+            kind: 'Component',
+            metadata: { name: 'test-component-1' },
+          },
+        },
+      ],
+      cursor: 'final-cursor',
+    });
+
+    const signal = new AbortController().signal;
+    const result = await engine.ingestOneBurst('test-ingestion', signal);
+
+    // Should return true when provider indicates done
+    expect(result).toBe(true);
+    expect(mockProvider.next).toHaveBeenCalledTimes(1);
+
+    // Should NOT log the burst exceeded message
+    expect(mockLogger.info).not.toHaveBeenCalledWith(
+      expect.stringContaining('burst exceeded length of'),
+    );
+
+    // Should log burst initiation and completion
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      "incremental-engine: Ingestion 'test-ingestion' burst initiated",
+    );
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "incremental-engine: Ingestion 'test-ingestion' burst complete",
+      ),
+    );
+  });
+});

--- a/plugins/catalog-backend-module-incremental-ingestion/src/engine/IncrementalIngestionEngine.test.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/engine/IncrementalIngestionEngine.test.ts
@@ -103,12 +103,13 @@ describe('IncrementalIngestionEngine - Burst Length', () => {
     // Verify that the burst was stopped due to time limit, not completion
     expect(result).toBe(false); // Should return false since provider never returned done
     expect(duration).toBeGreaterThanOrEqual(100); // Should have run for at least the burst length
+    expect(duration).toBeLessThan(200); // But not too much longer (allowing for timing variance)
     expect(mockProvider.next).toHaveBeenCalledTimes(callCount);
     expect(callCount).toBeGreaterThan(1); // Should have made multiple calls before stopping
 
-    // Verify the correct log message was called
+    // Verify that burst was terminated due to time limit (not normal completion)
     expect(mockLogger.info).toHaveBeenCalledWith(
-      expect.stringContaining('burst exceeded length of 100 milliseconds'),
+      expect.stringContaining('burst ending after'),
     );
   });
 
@@ -157,7 +158,7 @@ describe('IncrementalIngestionEngine - Burst Length', () => {
 
     // Should NOT log the burst exceeded message
     expect(mockLogger.info).not.toHaveBeenCalledWith(
-      expect.stringContaining('burst exceeded length of'),
+      expect.stringContaining('burst ending after'),
     );
 
     // Should log burst initiation and completion

--- a/plugins/catalog-backend-module-incremental-ingestion/src/engine/IncrementalIngestionEngine.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/engine/IncrementalIngestionEngine.ts
@@ -27,6 +27,7 @@ import { HumanDuration } from '@backstage/types';
 
 export class IncrementalIngestionEngine implements IterationEngine {
   private readonly restLength: Duration;
+  private readonly burstLength: HumanDuration;
   private readonly backoff: HumanDuration[];
   private readonly lastStarted: Gauge;
   private readonly lastCompleted: Gauge;
@@ -38,6 +39,7 @@ export class IncrementalIngestionEngine implements IterationEngine {
 
     this.manager = options.manager;
     this.restLength = Duration.fromObject(options.restLength);
+    this.burstLength = options.burstLength;
     this.backoff = options.backoff ?? [
       { minutes: 1 },
       { minutes: 5 },
@@ -246,6 +248,16 @@ export class IncrementalIngestionEngine implements IterationEngine {
           cursor: next?.cursor,
         });
         if (signal.aborted || next.done) {
+          break;
+        } else if (
+          performance.now() - start >
+          Duration.fromObject(this.burstLength).as('milliseconds')
+        ) {
+          this.options.logger.info(
+            `incremental-engine: Ingestion '${id}' burst exceeded length of ${Duration.fromObject(
+              this.burstLength,
+            ).toHuman()}.`,
+          );
           break;
         } else {
           next = await this.options.provider.next(context, next.cursor);

--- a/plugins/catalog-backend-module-incremental-ingestion/src/engine/IncrementalIngestionEngine.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/engine/IncrementalIngestionEngine.ts
@@ -27,7 +27,7 @@ import { HumanDuration } from '@backstage/types';
 
 export class IncrementalIngestionEngine implements IterationEngine {
   private readonly restLength: Duration;
-  private readonly burstLength: HumanDuration;
+  private readonly burstLength: Duration;
   private readonly backoff: HumanDuration[];
   private readonly lastStarted: Gauge;
   private readonly lastCompleted: Gauge;
@@ -39,7 +39,7 @@ export class IncrementalIngestionEngine implements IterationEngine {
 
     this.manager = options.manager;
     this.restLength = Duration.fromObject(options.restLength);
-    this.burstLength = options.burstLength;
+    this.burstLength = Duration.fromObject(options.burstLength);
     this.backoff = options.backoff ?? [
       { minutes: 1 },
       { minutes: 5 },
@@ -251,12 +251,10 @@ export class IncrementalIngestionEngine implements IterationEngine {
           break;
         } else if (
           performance.now() - start >
-          Duration.fromObject(this.burstLength).as('milliseconds')
+          this.burstLength.as('milliseconds')
         ) {
           this.options.logger.info(
-            `incremental-engine: Ingestion '${id}' burst exceeded length of ${Duration.fromObject(
-              this.burstLength,
-            ).toHuman()}.`,
+            `incremental-engine: Ingestion '${id}' burst exceeded length of ${this.burstLength.toHuman()}.`,
           );
           break;
         } else {

--- a/plugins/catalog-backend-module-incremental-ingestion/src/engine/IncrementalIngestionEngine.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/engine/IncrementalIngestionEngine.ts
@@ -254,7 +254,7 @@ export class IncrementalIngestionEngine implements IterationEngine {
           this.burstLength.as('milliseconds')
         ) {
           this.options.logger.info(
-            `incremental-engine: Ingestion '${id}' burst exceeded length of ${this.burstLength.toHuman()}.`,
+            `incremental-engine: Ingestion '${id}' burst ending after ${this.burstLength.toHuman()}.`,
           );
           break;
         } else {

--- a/plugins/catalog-backend-module-incremental-ingestion/src/types.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/types.ts
@@ -188,6 +188,7 @@ export interface IterationEngineOptions {
   manager: IncrementalIngestionDatabaseManager;
   provider: IncrementalEntityProvider<unknown, unknown>;
   restLength: HumanDuration;
+  burstLength: HumanDuration;
   ready: Promise<void>;
   backoff?: IncrementalEntityProviderOptions['backoff'];
   rejectRemovalsAbovePercentage?: number;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

The IncrementalIngestionEngine did not support burstLength for making API calls in a burst, meaning Incremental Entity Providers did burst API calls until the last cursor of data without respecting the burstLength. This PR adds a burstLength check after one burst completes to ensure the bursting stops once the burstLength has passed. Also added a new test file (IncrementalIngestionEngine.test.ts) to test this functionality.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
