### PR TITLE
Fix a blocking behavior of the dynamic plugin scanner on MacOS/

### DIFF
--- a/.changeset/eighty-parrots-jump.md
+++ b/.changeset/eighty-parrots-jump.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-dynamic-feature-service': patch
+---
+
+Fix a blocking behavior of the dynamic plugin scanner on MacOS.

--- a/packages/backend-dynamic-feature-service/src/scanner/plugin-scanner-watcher.test.ts
+++ b/packages/backend-dynamic-feature-service/src/scanner/plugin-scanner-watcher.test.ts
@@ -124,7 +124,7 @@ describe('plugin-scanner', () => {
         ]);
       });
 
-      expect(logger.logs).toEqual<Logs>({
+      expect(logger.logs).toMatchObject<Logs>({
         infos: expect.arrayContaining([
           {
             message: `rootDirectory changed (addDir - ${path.resolve(

--- a/packages/backend-dynamic-feature-service/src/scanner/plugin-scanner.ts
+++ b/packages/backend-dynamic-feature-service/src/scanner/plugin-scanner.ts
@@ -236,7 +236,7 @@ export class PluginScanner {
         this.rootDirectoryWatcher = chokidar
           .watch(this._rootDirectory, {
             ignoreInitial: true,
-            followSymlinks: true,
+            followSymlinks: false,
             depth: 1,
             disableGlobbing: true,
           })


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR fixes a platform-specific blocking bug that occurs only on MacOS, when running Backstage locally with the dynamic plugins enabled. It also fixes unit tests accordingly. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
