### PR TITLE
fix: auditor log length for scaffolder audits 

### DIFF
--- a/.changeset/smooth-lies-yell.md
+++ b/.changeset/smooth-lies-yell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+Implement max length for scaffolder auditor audit logging with default of 256

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -200,6 +200,8 @@ catalog:
         - allow: [Template]
 
 scaffolder:
+  auditor:
+    maxLength: 256
   # Use to customize default commit author info used when new components are created
   defaultAuthor:
     name: Scaffolder

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -271,6 +271,7 @@ export async function createRouter(
       integrations,
       logger,
       auditor,
+      config,
       workingDirectory,
       concurrentTasksLimit,
       permissions,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added ability to limit the length on audit fields for scaffolder parameters.
This solves issues where using dataUrl fields for file uploads storing huge amounts of data (entire file as a dataurl).

Set a default of 256 length, but added config in allow a change/override this default behaviour.

```yaml
scaffolder:
  auditor:
    maxLength: 256
```

#### :heavy_check_mark: Checklist

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation (Added in main config file)
- [] Tests for new functionality and regression tests for bug fixes
- [] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

I ran api docs but it just produced the exact same file (no api changes).

There are no tests currently for any `parameter` checking, i can investigate further to add more if needed?

https://github.com/backstage/backstage/issues/29838

Remade from #30354