### PR TITLE
fix: Add support for spaces format to Confluence on-prem

### DIFF
--- a/.changeset/ripe-actors-boil.md
+++ b/.changeset/ripe-actors-boil.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-confluence-to-markdown': patch
+---
+
+Added support for new url format for on-prem links and clean code

--- a/plugins/scaffolder-backend-module-confluence-to-markdown/README.md
+++ b/plugins/scaffolder-backend-module-confluence-to-markdown/README.md
@@ -106,7 +106,7 @@ spec:
       properties:
         confluenceUrls:
           type: array
-          description: Urls for Confluence doc to be converted to markdown. In format <CONFLUENCE_BASE_URL>/display/<SPACEKEY>/<PAGE+TITLE> or <CONFLUENCE_BASE_URL>/spaces/<SPACEKEY>/pages/<PAGEID>/<PAGE+TITLE> for Confluence cloud
+          description: Urls for Confluence doc to be converted to markdown. In format <CONFLUENCE_BASE_URL>/display/<SPACEKEY>/<PAGE+TITLE> or <CONFLUENCE_BASE_URL>/spaces/<SPACEKEY>/pages/<PAGEID>/<PAGE+TITLE>
           items:
             type: string
           ui:options:

--- a/plugins/scaffolder-backend-module-confluence-to-markdown/src/actions/confluence/helpers.ts
+++ b/plugins/scaffolder-backend-module-confluence-to-markdown/src/actions/confluence/helpers.ts
@@ -205,6 +205,7 @@ export const createConfluenceVariables = (url: string) => {
       'The Url format for Confluence is incorrect. Acceptable format is `<CONFLUENCE_BASE_URL>/display/<SPACEKEY>/<PAGE+TITLE>` or `<CONFLUENCE_BASE_URL>/spaces/<SPACEKEY>/pages/<PAGEID>/<PAGE+TITLE>`',
     );
   }
+
   titleWithSpaces = title?.replace(/\+/g, ' ');
   return { spacekey, title, titleWithSpaces };
 };

--- a/plugins/scaffolder-backend-module-confluence-to-markdown/src/actions/confluence/helpers.ts
+++ b/plugins/scaffolder-backend-module-confluence-to-markdown/src/actions/confluence/helpers.ts
@@ -183,27 +183,28 @@ export const getAndWriteAttachments = async (
   return productArr;
 };
 
-export const createConfluenceVariables = (url) => {
-  let spacekey, title, titleWithSpaces = "";
+export const createConfluenceVariables = (url: string) => {
+  let spacekey;
+  let title;
+  let titleWithSpaces = '';
   const params = new URL(url);
-  const pathParts = params.pathname.split("/").filter(Boolean);
+  const pathParts = params.pathname.split('/').filter(Boolean);
 
-  if (pathParts.includes("display")) {
+  if (pathParts.includes('display')) {
     // /display/<SPACEKEY>/<TITLE>
-    const idx = pathParts.indexOf("display");
+    const idx = pathParts.indexOf('display');
     spacekey = pathParts[idx + 1];
     title = pathParts[idx + 2];
-  } else if (pathParts.includes("spaces")) {
+  } else if (pathParts.includes('spaces')) {
     // /spaces/<SPACEKEY>/pages/<PAGEID>/<TITLE>
-    const idx = pathParts.indexOf("spaces");
+    const idx = pathParts.indexOf('spaces');
     spacekey = pathParts[idx + 1];
     title = pathParts[pathParts.length - 1];
   } else {
-    throw new errors.InputError(
-      "The Url format for Confluence is incorrect. Acceptable format is `<CONFLUENCE_BASE_URL>/display/<SPACEKEY>/<PAGE+TITLE>` or `<CONFLUENCE_BASE_URL>/spaces/<SPACEKEY>/pages/<PAGEID>/<PAGE+TITLE>` for Confluence cloud"
+    throw new Error(
+      'The Url format for Confluence is incorrect. Acceptable format is `<CONFLUENCE_BASE_URL>/display/<SPACEKEY>/<PAGE+TITLE>` or `<CONFLUENCE_BASE_URL>/spaces/<SPACEKEY>/pages/<PAGEID>/<PAGE+TITLE>`',
     );
   }
-
-  titleWithSpaces = title?.replace(/\+/g, " ");
+  titleWithSpaces = title?.replace(/\+/g, ' ');
   return { spacekey, title, titleWithSpaces };
 };

--- a/plugins/scaffolder-backend-module-confluence-to-markdown/src/actions/confluence/helpers.ts
+++ b/plugins/scaffolder-backend-module-confluence-to-markdown/src/actions/confluence/helpers.ts
@@ -15,7 +15,7 @@
  */
 
 import { Config } from '@backstage/config';
-import { ResponseError, ConflictError, InputError } from '@backstage/errors';
+import { ResponseError, ConflictError } from '@backstage/errors';
 import fs from 'fs-extra';
 import { Readable } from 'stream';
 

--- a/plugins/scaffolder-backend-module-confluence-to-markdown/src/actions/confluence/helpers.ts
+++ b/plugins/scaffolder-backend-module-confluence-to-markdown/src/actions/confluence/helpers.ts
@@ -183,31 +183,27 @@ export const getAndWriteAttachments = async (
   return productArr;
 };
 
-export const createConfluenceVariables = (url: string) => {
-  let spacekey: string | undefined = undefined;
-  let title: string | undefined = undefined;
-  let titleWithSpaces: string | undefined = '';
+export const createConfluenceVariables = (url) => {
+  let spacekey, title, titleWithSpaces = "";
   const params = new URL(url);
-  if (params.pathname.split('/')[1] === 'display') {
-    // https://confluence.example.com/display/SPACEKEY/Page+Title
-    spacekey = params.pathname.split('/')[2];
-    title = params.pathname.split('/')[3];
-    titleWithSpaces = title?.replace(/\+/g, ' ');
-    return { spacekey, title, titleWithSpaces };
-  } else if (params.pathname.split('/')[2] === 'display') {
-    // https://confluence.example.com/prefix/display/SPACEKEY/Page+Title
-    spacekey = params.pathname.split('/')[3];
-    title = params.pathname.split('/')[4];
-    titleWithSpaces = title?.replace(/\+/g, ' ');
-    return { spacekey, title, titleWithSpaces };
-  } else if (params.pathname.split('/')[2] === 'spaces') {
-    // https://example.atlassian.net/wiki/spaces/SPACEKEY/pages/1234567/Page+Title
-    spacekey = params.pathname.split('/')[3];
-    title = params.pathname.split('/')[6];
-    titleWithSpaces = title?.replace(/\+/g, ' ');
-    return { spacekey, title, titleWithSpaces };
+  const pathParts = params.pathname.split("/").filter(Boolean);
+
+  if (pathParts.includes("display")) {
+    // /display/<SPACEKEY>/<TITLE>
+    const idx = pathParts.indexOf("display");
+    spacekey = pathParts[idx + 1];
+    title = pathParts[idx + 2];
+  } else if (pathParts.includes("spaces")) {
+    // /spaces/<SPACEKEY>/pages/<PAGEID>/<TITLE>
+    const idx = pathParts.indexOf("spaces");
+    spacekey = pathParts[idx + 1];
+    title = pathParts[pathParts.length - 1];
+  } else {
+    throw new errors.InputError(
+      "The Url format for Confluence is incorrect. Acceptable format is `<CONFLUENCE_BASE_URL>/display/<SPACEKEY>/<PAGE+TITLE>` or `<CONFLUENCE_BASE_URL>/spaces/<SPACEKEY>/pages/<PAGEID>/<PAGE+TITLE>` for Confluence cloud"
+    );
   }
-  throw new InputError(
-    'The Url format for Confluence is incorrect. Acceptable format is `<CONFLUENCE_BASE_URL>/display/<SPACEKEY>/<PAGE+TITLE>` or `<CONFLUENCE_BASE_URL>/spaces/<SPACEKEY>/pages/<PAGEID>/<PAGE+TITLE>` for Confluence cloud',
-  );
+
+  titleWithSpaces = title?.replace(/\+/g, " ");
+  return { spacekey, title, titleWithSpaces };
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

From [this](https://github.com/backstage/backstage/pull/28230#discussion_r1926642762) issue I saw that Confluence have [updated the url format](https://support.atlassian.com/confluence/kb/the-differences-between-various-url-formats-for-a-confluence-page/) (at the bottom) to be with "spaces", also for on-prem which we use.

I could probably just have made yet another if block, but I wanted to make it cleaner :)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
