### PR TITLE
Fix duplicate route warning for TechDocs Addons documentation in microsite

### DIFF
--- a/docs/features/techdocs/addons--new.md
+++ b/docs/features/techdocs/addons--new.md
@@ -1,5 +1,5 @@
 ---
-id: addons
+id: addons--new
 title: TechDocs Addons
 description: How to find, use, or create TechDocs Addons.
 ---

--- a/microsite/sidebars.ts
+++ b/microsite/sidebars.ts
@@ -238,7 +238,7 @@ export default {
           'features/techdocs/techdocs-overview',
           'features/techdocs/getting-started',
           'features/techdocs/concepts',
-          'features/techdocs/addons',
+          'features/techdocs/addons--new',
           'features/techdocs/architecture',
           'features/techdocs/extensions',
           'features/techdocs/creating-and-publishing',


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/66b22e75-2bb6-4bc7-bef3-37dc389f550a)


This PR resolves a Docusaurus routing warning caused by two Markdown files (`addons.md` and `addons--new.md`) using the same `id: addons` in their frontmatter. This resulted in both files attempting to generate the same route (`/docs/addons`), leading to non-deterministic routing behavior.

## Changes

- Updated the `id` in `addon-new.md` to `addons--new`