### PR TITLE
Adding Additional options to Microsoft-Provider auth-plugin

### DIFF
--- a/.changeset/curly-rules-stand.md
+++ b/.changeset/curly-rules-stand.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-microsoft-provider': patch
+---
+
+Added config options: apiEndPoint, authorizationURL, and apiGraphVersion for dependency passport-microsoft

--- a/docs/auth/microsoft/provider.md
+++ b/docs/auth/microsoft/provider.md
@@ -85,6 +85,10 @@ The Microsoft provider is a structure with three mandatory configuration keys:
 - `additionalScopes` (optional): List of scopes for the App Registration, to be requested in addition to the required ones.
 - `skipUserProfile` (optional): If true, skips loading the user profile even if the `User.Read` scope is present. This is a performance optimization during login and can be used with resolvers that only needs the email address in `spec.profile.email` obtained when the `email` OAuth2 scope is present.
 - `sessionDuration` (optional): Lifespan of the user session.
+- `authorizationURL` (optional): Set the OAuth2 authorization endpoint. Defaults to `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/authorize`
+- `apiEntryPoint` (optional): Set the root URL for the [Microsoft Graph Endpoint](https://learn.microsoft.com/en-us/graph/deployments#app-registration-and-token-service-root-endpoints). Defaults to `https://graph.microsoft.com`.
+- `graphApiVersion` (optional): Microsoft Graph API Version. Defaults to `v1.0`.
+- tokenURL (optional): Set the OAuth2 token endpoint. Defaults to `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`.
 
 ### Resolvers
 

--- a/plugins/auth-backend-module-microsoft-provider/config.d.ts
+++ b/plugins/auth-backend-module-microsoft-provider/config.d.ts
@@ -22,6 +22,8 @@ export interface Config {
       /** @visibility frontend */
       microsoft?: {
         [authEnv: string]: {
+          apiEntryPoint?: string;
+          authorizationURL?: string;
           clientId: string;
           tenantId: string;
           /**
@@ -31,6 +33,7 @@ export interface Config {
           domainHint?: string;
           callbackUrl?: string;
           additionalScopes?: string | string[];
+          graphApiVersion?: string;
           skipUserProfile?: boolean;
           signIn?: {
             resolvers: Array<

--- a/plugins/auth-backend-module-microsoft-provider/config.d.ts
+++ b/plugins/auth-backend-module-microsoft-provider/config.d.ts
@@ -34,6 +34,7 @@ export interface Config {
           callbackUrl?: string;
           additionalScopes?: string | string[];
           graphApiVersion?: string;
+          tokenURL?: string;
           skipUserProfile?: boolean;
           signIn?: {
             resolvers: Array<

--- a/plugins/auth-backend-module-microsoft-provider/package.json
+++ b/plugins/auth-backend-module-microsoft-provider/package.json
@@ -39,6 +39,7 @@
     "express": "^4.18.2",
     "jose": "^5.0.0",
     "passport-microsoft": "^2.1.0",
+    "passport-oauth2": "^1.6.1",
     "zod": "^3.22.4"
   },
   "devDependencies": {
@@ -49,6 +50,7 @@
     "@backstage/plugin-auth-backend": "workspace:^",
     "@backstage/types": "workspace:^",
     "@types/passport-microsoft": "^2.1.0",
+    "@types/passport-oauth2": "^1.4.15",
     "msw": "^1.0.0",
     "supertest": "^7.0.0"
   },

--- a/plugins/auth-backend-module-microsoft-provider/package.json
+++ b/plugins/auth-backend-module-microsoft-provider/package.json
@@ -38,7 +38,7 @@
     "@backstage/plugin-auth-node": "workspace:^",
     "express": "^4.18.2",
     "jose": "^5.0.0",
-    "passport-microsoft": "^1.0.0",
+    "passport-microsoft": "^2.1.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {
@@ -48,7 +48,7 @@
     "@backstage/config": "workspace:^",
     "@backstage/plugin-auth-backend": "workspace:^",
     "@backstage/types": "workspace:^",
-    "@types/passport-microsoft": "^1.0.0",
+    "@types/passport-microsoft": "^2.1.0",
     "msw": "^1.0.0",
     "supertest": "^7.0.0"
   },

--- a/plugins/auth-backend-module-microsoft-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-microsoft-provider/src/authenticator.ts
@@ -41,19 +41,27 @@ export const microsoftAuthenticator = createOAuthAuthenticator({
     },
   },
   initialize({ callbackUrl, config }) {
+    const apiEntryPoint = config.getOptionalString('apiEntryPoint');
+    const authorizationURL = config.getOptionalString('authorizationURL');
     const clientId = config.getString('clientId');
     const clientSecret = config.getString('clientSecret');
+    const graphApiVersion = config.getOptionalString('graphApiVersion');
     const tenantId = config.getString('tenantId');
+    const tokenURL = config.getOptionalString('tokenURL');
     const domainHint = config.getOptionalString('domainHint');
     const skipUserProfile =
       config.getOptionalBoolean('skipUserProfile') ?? false;
 
     const strategy = new ExtendedMicrosoftStrategy(
       {
+        apiEntryPoint: apiEntryPoint,
+        authorizationURL: authorizationURL,
         clientID: clientId,
         clientSecret: clientSecret,
         callbackURL: callbackUrl,
+        graphApiVersion: graphApiVersion,
         tenant: tenantId,
+        tokenURL: tokenURL,
       },
       (
         accessToken: string,

--- a/plugins/auth-backend-module-microsoft-provider/src/strategy.ts
+++ b/plugins/auth-backend-module-microsoft-provider/src/strategy.ts
@@ -23,14 +23,14 @@ import {
 import { VerifyFunction } from 'passport-oauth2';
 
 export class ExtendedMicrosoftStrategy extends MicrosoftStrategy {
-  private _apiEntryPoint: string;
-  private _graphApiVersion: string;
+  private apiEntryPoint: string;
+  private graphApiVersion: string;
   private shouldSkipUserProfile = false;
 
   constructor(config: MicrosoftStrategyOptions, verify: VerifyFunction) {
     super(config, verify);
-    this._apiEntryPoint = config.apiEntryPoint || 'https://graph.microsoft.com';
-    this._graphApiVersion = config.graphApiVersion || 'v1.0';
+    this.apiEntryPoint = config.apiEntryPoint || 'https://graph.microsoft.com';
+    this.graphApiVersion = config.graphApiVersion || 'v1.0';
   }
 
   public setSkipUserProfile(shouldSkipUserProfile: boolean): void {
@@ -72,8 +72,8 @@ export class ExtendedMicrosoftStrategy extends MicrosoftStrategy {
         .map(s => s.toLocaleLowerCase('en-US'))
         .some(s =>
           [
-            `${this._apiEntryPoint}/user.read`,
-            `${this._apiEntryPoint}/user.read.all`,
+            `${this.apiEntryPoint}/user.read`,
+            `${this.apiEntryPoint}/user.read.all`,
             'user.read',
             'user.read.all',
           ].includes(s),
@@ -107,7 +107,7 @@ export class ExtendedMicrosoftStrategy extends MicrosoftStrategy {
   ): Promise<string | undefined> {
     try {
       const res = await fetch(
-        `${this._apiEntryPoint}/${this._graphApiVersion}/me/photos/${size}/$value`,
+        `${this.apiEntryPoint}/${this.graphApiVersion}/me/photos/${size}/$value`,
         {
           headers: {
             Authorization: `Bearer ${accessToken}`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4975,10 +4975,12 @@ __metadata:
     "@backstage/plugin-auth-node": "workspace:^"
     "@backstage/types": "workspace:^"
     "@types/passport-microsoft": "npm:^2.1.0"
+    "@types/passport-oauth2": "npm:^1.4.15"
     express: "npm:^4.18.2"
     jose: "npm:^5.0.0"
     msw: "npm:^1.0.0"
     passport-microsoft: "npm:^2.1.0"
+    passport-oauth2: "npm:^1.6.1"
     supertest: "npm:^7.0.0"
     zod: "npm:^3.22.4"
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -4974,11 +4974,11 @@ __metadata:
     "@backstage/plugin-auth-backend": "workspace:^"
     "@backstage/plugin-auth-node": "workspace:^"
     "@backstage/types": "workspace:^"
-    "@types/passport-microsoft": "npm:^1.0.0"
+    "@types/passport-microsoft": "npm:^2.1.0"
     express: "npm:^4.18.2"
     jose: "npm:^5.0.0"
     msw: "npm:^1.0.0"
-    passport-microsoft: "npm:^1.0.0"
+    passport-microsoft: "npm:^2.1.0"
     supertest: "npm:^7.0.0"
     zod: "npm:^3.22.4"
   languageName: unknown
@@ -21979,12 +21979,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/passport-microsoft@npm:^1.0.0":
-  version: 1.0.3
-  resolution: "@types/passport-microsoft@npm:1.0.3"
+"@types/passport-microsoft@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@types/passport-microsoft@npm:2.1.0"
   dependencies:
     "@types/passport-oauth2": "npm:*"
-  checksum: 10/68e9204e90b4a195a1476cfc966d5165febcbb60948a9e98e5dab66f9080a69a2d5f76473a09aed26e00e776038ae63852e44889adb6e45a1851365ca10e5060
+  checksum: 10/711e67ed40bc47a1469d84fcb220e02be040166d8c6ceed97ad77aa647bef1ff0597f48e38fee44d8f576c5b188bc5c5fa7060cd5b527bf450fd99d03565303d
   languageName: node
   linkType: hard
 
@@ -41831,12 +41831,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"passport-microsoft@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "passport-microsoft@npm:1.1.0"
+"passport-microsoft@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "passport-microsoft@npm:2.1.0"
   dependencies:
     passport-oauth2: "npm:1.8.0"
-  checksum: 10/4c18d4074308ca5da67b08b2b9eee97dae017e7c9e62dedb21875f25ced9fd959218977bd1c8cfd6067ce081e9764bbe2541696e09e6e1464e72c699165fc07f
+  checksum: 10/42dd445ff06021dc0138e731655dbbf6e31ee3ed49d34f2e2ff8d05979dfca66a3e0107a964fee4911ac2dc7be7ed14a007f5e36d64c260416fa12be55090a0b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request to Use Backstage with Government Cloud!

We are using the government versions of Microsoft Azure, and we need to pass in the government urls (login.microsoftonline.us and graph.microsoft.us). We have patched backstage on our end, but we figure it would be nice to get this to everyone who uses Backstage (and also simplify our build process a bit). Just so you know, when I say we patched backstage on our end, I mean that I hacked the javascript modules with sed scripts in the Dockerfile. So this isn't exactly what we have deployed--it should be loads nicer.

Really all this does is make it so that we can use the microsoft-provider backend module.  I also configured (I think) the configSchema to reflect these additional options.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

I did not add any new testing for this, I'm hoping the existing test works, but I'm having tests that are failing on the master branch with node v20.19.3.

***update*** I'm checking that we are testing for "new functionality." The justification is that these variables are optional, and should not change anything, so the microsoft-provider test should have exactly the same result as before. If you would prefer a test of some sort, then please request it.