### PR TITLE
Patch release of #30345

### DIFF
--- a/.changeset/stupid-donuts-sit.md
+++ b/.changeset/stupid-donuts-sit.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-catalog-import': patch
----
-
-Fixed bug with error message since ResponseError is now thrown from CatalogClient

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.40.1",
+  "version": "1.40.2",
   "backstage": {
     "cli": {
       "new": {

--- a/packages/app-next/CHANGELOG.md
+++ b/packages/app-next/CHANGELOG.md
@@ -1,5 +1,12 @@
 # example-app-next
 
+## 0.0.26
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-import@0.13.2
+
 ## 0.0.25
 
 ### Patch Changes

--- a/packages/app-next/package.json
+++ b/packages/app-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-app-next",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "backstage": {
     "role": "frontend"
   },

--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # example-app
 
+## 0.2.112
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage/plugin-catalog-import@0.13.2
+
 ## 0.2.111
 
 ### Patch Changes

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-app",
-  "version": "0.2.111",
+  "version": "0.2.112",
   "backstage": {
     "role": "frontend"
   },

--- a/plugins/catalog-import/CHANGELOG.md
+++ b/plugins/catalog-import/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/plugin-catalog-import
 
+## 0.13.2
+
+### Patch Changes
+
+- 00da6d6: Fixed bug with error message since ResponseError is now thrown from CatalogClient
+
 ## 0.13.1
 
 ### Patch Changes

--- a/plugins/catalog-import/package.json
+++ b/plugins/catalog-import/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-catalog-import",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "A Backstage plugin the helps you import entities into your catalog",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
This release fixes an issue where the `catalog-import` plugin didn't render error messages from the backend properly.