### PR TITLE
Fix (techdocs-node): Fix `parseReferenceAnnotation` missing annotation error message to include annotation name

### DIFF
--- a/.changeset/whole-buckets-fix.md
+++ b/.changeset/whole-buckets-fix.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-node': patch
+---
+
+Updated the error message thrown by parseReferenceAnnotation to reflect the annotation value passed as an argument rather than in correctly assuming location.

--- a/plugins/techdocs-node/src/helpers.test.ts
+++ b/plugins/techdocs-node/src/helpers.test.ts
@@ -113,9 +113,12 @@ describe('parseReferenceAnnotation', () => {
   });
 
   it('should throw error without annotation', () => {
+    const logMsgRegex = new RegExp(
+      `No ${TECHDOCS_ANNOTATION} annotation provided`,
+    );
     expect(() => {
       parseReferenceAnnotation(TECHDOCS_ANNOTATION, entityBase);
-    }).toThrow(/No location annotation/);
+    }).toThrow(logMsgRegex);
   });
 
   it('should throw error with bad annotation', () => {

--- a/plugins/techdocs-node/src/helpers.ts
+++ b/plugins/techdocs-node/src/helpers.ts
@@ -52,7 +52,7 @@ export const parseReferenceAnnotation = (
   const annotation = entity.metadata.annotations?.[annotationName];
   if (!annotation) {
     throw new InputError(
-      `No location annotation provided in entity: ${entity.metadata.name}`,
+      `No ${annotationName} annotation provided in entity: ${entity.metadata.name}`,
     );
   }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `parseReferenceAnnotation` accepts an annotation name and an error will be thrown IF that annotation is not found. However the error message _does not_ include the annotation name argument, rather it is simply:
```
No location annotation provided in entity
```

Having the error message reflect the annotation argument will give a lot more context when these are found ( which is most likely to happen while going through logs debugging an issue)

When this error message was found in the debug log, it was confusing as it looked to indicate an annotation named `location` was missing, however it was actually the `backstage.io/techdocs-ref` annotation.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
