### PR TITLE
docs(search): Fixed incorrect ElasticSearch query config

### DIFF
--- a/docs/features/search/search-engines.md
+++ b/docs/features/search/search-engines.md
@@ -267,7 +267,7 @@ Fuzziness allows you to define the maximum Levenshtein distance, AUTO is the def
 ```yaml
 search:
   elasticsearch:
-    queryConfig:
+    queryOptions:
       fuzziness: AUTO
       prefixLength: 3;
 ```


### PR DESCRIPTION
I noticed the documentation for ES search does not match the [actual code](https://github.com/backstage/backstage/blob/9f67ede0651a187ed890df3de4caee941e078c95/plugins/search-backend-module-elasticsearch/config.d.ts#L50-L70). (`queryConfig` vs `queryOptions`)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
