### PR TITLE
Canon - Update Heading & Text types 

### DIFF
--- a/.changeset/seven-sloths-kick.md
+++ b/.changeset/seven-sloths-kick.md
@@ -1,0 +1,5 @@
+---
+'@backstage/canon': patch
+---
+
+Update return types for Heading & Text components for React 19.

--- a/packages/canon/report.api.md
+++ b/packages/canon/report.api.md
@@ -917,11 +917,14 @@ export interface GridProps extends SpaceProps {
 }
 
 // @public (undocumented)
-export const Heading: <T extends ElementType = 'h1'>(
-  props: HeadingProps<T> & {
-    ref?: React.Ref<any>;
-  },
-) => React.ReactElement | null;
+export const Heading: {
+  <T extends ElementType = 'h1'>(
+    props: HeadingProps<T> & {
+      ref?: React.ComponentPropsWithRef<T>['ref'];
+    },
+  ): React.ReactElement<HeadingProps<T>, T>;
+  displayName: string;
+};
 
 // @public (undocumented)
 export type HeadingOwnProps = {
@@ -1576,11 +1579,14 @@ export interface TabsRootWithoutOrientation
   > {}
 
 // @public (undocumented)
-const Text_2: <T extends ElementType = 'p'>(
-  props: TextProps<T> & {
-    ref?: React.Ref<any>;
-  },
-) => React.ReactElement | null;
+const Text_2: {
+  <T extends ElementType = 'p'>(
+    props: TextProps<T> & {
+      ref?: React.ComponentPropsWithRef<T>['ref'];
+    },
+  ): React.ReactElement<TextProps<T>, T>;
+  displayName: string;
+};
 export { Text_2 as Text };
 
 // @public (undocumented)

--- a/packages/canon/src/components/Heading/Heading.tsx
+++ b/packages/canon/src/components/Heading/Heading.tsx
@@ -54,10 +54,11 @@ function HeadingComponent<T extends ElementType = 'h1'>(
 HeadingComponent.displayName = 'Heading';
 
 /** @public */
-export const Heading = forwardRef(HeadingComponent) as <
-  T extends ElementType = 'h1',
->(
-  props: HeadingProps<T> & { ref?: React.Ref<any> },
-) => React.ReactElement | null;
+export const Heading = forwardRef(HeadingComponent) as {
+  <T extends ElementType = 'h1'>(
+    props: HeadingProps<T> & { ref?: React.ComponentPropsWithRef<T>['ref'] },
+  ): React.ReactElement<HeadingProps<T>, T>;
+  displayName: string;
+};
 
-(Heading as any).displayName = 'Heading';
+Heading.displayName = 'Heading';

--- a/packages/canon/src/components/Text/Text.tsx
+++ b/packages/canon/src/components/Text/Text.tsx
@@ -56,8 +56,11 @@ function TextComponent<T extends ElementType = 'p'>(
 TextComponent.displayName = 'Text';
 
 /** @public */
-export const Text = forwardRef(TextComponent) as <T extends ElementType = 'p'>(
-  props: TextProps<T> & { ref?: React.Ref<any> },
-) => React.ReactElement | null;
+export const Text = forwardRef(TextComponent) as {
+  <T extends ElementType = 'p'>(
+    props: TextProps<T> & { ref?: React.ComponentPropsWithRef<T>['ref'] },
+  ): React.ReactElement<TextProps<T>, T>;
+  displayName: string;
+};
 
-(Text as any).displayName = 'Text';
+Text.displayName = 'Text';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The types in their current form don't appear to be entirely suitable for React 19 and above which causes some issues elsewhere in the docs site. I think this is because the default type for `ReactElement` has changed from `ReactElement<any>` to `ReactElement<unknown>` as detailed [here](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#changes-to-the-reactelement-typescript-type). This PR updates the types for both elements to be a bit more prescriptive to hopefully resolve this issue without introducing any other regressions.

Both the Heading and Text components are receiving a lot of attention at the moment so expect further changes to come following this.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
