### PR TITLE
Remove 'allowedHosts' from publish:github action

### DIFF
--- a/.changeset/sweet-donkeys-swim.md
+++ b/.changeset/sweet-donkeys-swim.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Removed deprecated 'allowedHosts' field from GitHub Publish action input in default template files to fix validation errors with strict Zod validation.

--- a/.github/vale/config/vocabularies/Backstage/accept.txt
+++ b/.github/vale/config/vocabularies/Backstage/accept.txt
@@ -10,6 +10,7 @@ Airbrakes
 ajv
 Alaria
 Alef
+allowedHosts
 allowlisted
 Anddddd
 Apdex
@@ -103,6 +104,8 @@ deliverables
 denormalized
 dependabot
 deps
+dequeue
+dequeueing
 deserialization
 destructured
 destructuring
@@ -112,8 +115,6 @@ devcontainer
 devcontainers
 devops
 devs
-dequeue
-dequeueing
 dialogs
 disambiguator
 discoverability
@@ -151,8 +152,8 @@ FireHydrant
 Firekube
 Firestore
 Fiverr
-Flightcontrol
 flightcontrol
+Flightcontrol
 Francesco
 Frontside
 Gaurav
@@ -176,8 +177,8 @@ Hackathons
 haproxy
 hardcoded
 hardcoding
-Harness
 harness
+Harness
 Helidon
 Henneke
 Heroku
@@ -200,9 +201,10 @@ Indal
 indexable
 ingestors
 inlined
-inlining
 inlinehilite
+inlining
 integrator's
+intellij
 interop
 interoperate
 iterable
@@ -313,8 +315,8 @@ OpenSearch
 OpenShift
 openssl
 orgs
-Overridable
 overridable
+Overridable
 padding
 paddings
 pagerduty
@@ -381,10 +383,10 @@ retryable
 reusability
 Reusability
 roadmaps
-rollbar
-rollout
 Roboto
+rollbar
 Rollbar
+rollout
 Rollup
 routable
 Routable
@@ -400,9 +402,10 @@ sanitization
 scaffolded
 scaffolder
 Scaffolder
-scrollbar
 SCM
 SCMs
+scrollable
+scrollbar
 sdks
 seb
 semlas
@@ -410,14 +413,15 @@ semver
 sendmail
 serializable
 Serverless
+severities
 shoutout
 SIG
 signoff
 SIGs
 siloed
 Sinon
-snackbars
 snackbar
+snackbars
 Snyk
 Sonarqube
 sourcemaps
@@ -488,6 +492,7 @@ transpiled
 transpiler
 transpilers
 truthy
+tsconfig
 TSDoc
 typeahead
 ui
@@ -538,7 +543,3 @@ zod
 Zolotusky
 zoomable
 zsh
-scrollable
-severities
-intellij
-tsconfig

--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -727,7 +727,6 @@ spec:
       name: Publish
       action: publish:github
       input:
-        allowedHosts: ['github.com']
         description: 'This is {{ parameters.name }}'
         repoUrl: '{{ parameters.repoUrl }}'
 

--- a/docs/features/software-templates/adding-templates.md
+++ b/docs/features/software-templates/adding-templates.md
@@ -68,7 +68,6 @@ spec:
       name: Publish
       action: publish:github
       input:
-        allowedHosts: ['github.com']
         description: This is ${{ parameters.name }}
         repoUrl: ${{ parameters.repoUrl }}
         defaultBranch: 'main'

--- a/docs/features/software-templates/migrating-from-v1beta2-to-v1beta3.md
+++ b/docs/features/software-templates/migrating-from-v1beta2-to-v1beta3.md
@@ -79,7 +79,6 @@ writing nice `yaml` files that just work.
 spec:
   steps:
       input:
-        allowedHosts: ['github.com']
         # highlight-remove-next-line
         description: 'This is {{ parameters.name }}'
         # highlight-add-next-line

--- a/docs/features/software-templates/writing-templates.md
+++ b/docs/features/software-templates/writing-templates.md
@@ -79,7 +79,6 @@ spec:
       name: Publish
       action: publish:github
       input:
-        allowedHosts: ['github.com']
         description: This is ${{ parameters.name }}
         repoUrl: ${{ parameters.repoUrl }}
         defaultBranch: 'main'
@@ -505,7 +504,6 @@ spec:
       name: Publish
       action: publish:github
       input:
-        allowedHosts: ['github.com']
         description: This is ${{ parameters.name }}
         repoUrl: ${{ parameters.repoUrl }}
         # here's where the secret can be used

--- a/packages/create-app/templates/default-app/examples/template/template.yaml
+++ b/packages/create-app/templates/default-app/examples/template/template.yaml
@@ -54,7 +54,6 @@ spec:
       name: Publish
       action: publish:github
       input:
-        allowedHosts: ['github.com']
         description: This is ${{ parameters.name }}
         repoUrl: ${{ parameters.repoUrl }}
         defaultBranch: 'main'

--- a/plugins/scaffolder/src/alpha/components/TemplateEditorPage/TemplateEditorToolbarTemplatesMenu.test.tsx
+++ b/plugins/scaffolder/src/alpha/components/TemplateEditorPage/TemplateEditorToolbarTemplatesMenu.test.tsx
@@ -99,7 +99,6 @@ describe('TemplateEditorToolbarTemplatesMenu', () => {
               name: 'Publish',
               action: 'publish:github',
               input: {
-                allowedHosts: ['github.com'],
                 description: 'This is ${{ parameters.component_id }}',
                 repoUrl: '${{ parameters.repoUrl }}',
               },
@@ -205,7 +204,6 @@ describe('TemplateEditorToolbarTemplatesMenu', () => {
               name: 'Publish',
               action: 'publish:github',
               input: {
-                allowedHosts: ['github.com'],
                 description: 'This is ${{ parameters.component_id }}',
                 repoUrl: '${{ parameters.repoUrl }}',
               },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR removes `allowedHosts: ['github.com']` from `publish:github` action template examples. Using Zod for validation with the template can cause an error when this field is present.

```txt
InputError: Invalid input passed to action publish:github, instance is not allowed to have the additional property "allowedHosts"
```

For more context see discussion on this [discord thread](https://discord.com/channels/687207715902193673/1385602370829946960) 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
