### PR TITLE
fix(scaffolder): Scroll to top when navigating template form steps

### DIFF
--- a/.changeset/loud-turtles-mate.md
+++ b/.changeset/loud-turtles-mate.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+Scroll to the top of the page when navigating between steps in template forms.

--- a/plugins/scaffolder-react/src/next/components/Stepper/Stepper.test.tsx
+++ b/plugins/scaffolder-react/src/next/components/Stepper/Stepper.test.tsx
@@ -672,6 +672,40 @@ describe('Stepper', () => {
     );
   });
 
+  it('should scroll the first main element to top when activeStep changes', async () => {
+    const manifest: TemplateParameterSchema = {
+      steps: [
+        { title: 'Step 1', schema: { properties: {} } },
+        { title: 'Step 2', schema: { properties: {} } },
+      ],
+      title: 'Scroll Test',
+    };
+
+    // Render a main element in the document for the Stepper to find
+    const main = document.createElement('main');
+    document.body.appendChild(main);
+    const scrollToMock = jest.fn();
+    main.scrollTo = scrollToMock;
+
+    // Render Stepper as usual (do not pass container)
+    const { getByRole, unmount } = await renderInTestApp(
+      <SecretsContextProvider>
+        <Stepper manifest={manifest} extensions={[]} onCreate={jest.fn()} />
+      </SecretsContextProvider>,
+    );
+
+    // Click next to change the activeStep
+    await act(async () => {
+      fireEvent.click(getByRole('button', { name: 'Next' }));
+    });
+
+    expect(scrollToMock).toHaveBeenCalledWith({ top: 0, behavior: 'auto' });
+
+    // Clean up
+    document.body.removeChild(main);
+    unmount();
+  });
+
   describe('Scaffolder Layouts', () => {
     it('should render the step in the scaffolder layout', async () => {
       const ScaffolderLayout: LayoutTemplate = ({ properties }) => (

--- a/plugins/scaffolder-react/src/next/components/Stepper/Stepper.tsx
+++ b/plugins/scaffolder-react/src/next/components/Stepper/Stepper.tsx
@@ -37,6 +37,7 @@ import { merge } from 'lodash';
 import {
   ComponentType,
   useCallback,
+  useEffect,
   useMemo,
   useState,
   type ReactNode,
@@ -217,6 +218,13 @@ export const Stepper = (stepperProps: StepperProps) => {
     },
     [validation, analytics],
   );
+
+  useEffect(() => {
+    const main = document.querySelector('main');
+    if (main) {
+      main.scrollTo({ top: 0, behavior: 'auto' });
+    }
+  }, [activeStep]);
 
   const mergedUiSchema = merge({}, propUiSchema, currentStep?.uiSchema);
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Currently when navigating between form steps your scroll position stays the same as you navigate between steps. So if your template has a lot of fields, and you press "Next" when you go to the next step you are still at the bottom of the form and you need to manually scroll up. You may not even know the next step has changed!

This PR scrolls to the top of the content when you navigate between steps in the template form.

Before:


https://github.com/user-attachments/assets/8ea8dea9-fa2e-4465-990a-9dbe9677f545

After:

https://github.com/user-attachments/assets/645a4d2b-a29d-4a0b-b648-6ad3634d65f


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
