### PR TITLE
Fix duplicate slash in `renderInTestApp` routing

### DIFF
--- a/.changeset/yellow-spies-rescue.md
+++ b/.changeset/yellow-spies-rescue.md
@@ -2,4 +2,4 @@
 '@backstage/frontend-test-utils': patch
 ---
 
-Update route path for index route in `renderInTestApp` util to fix duplicate slash and ensure any nested routing behaves correctly.
+Update route path for index route in `renderInTestApp` to fix duplicate slash and ensure any nested routing behaves correctly.

--- a/.changeset/yellow-spies-rescue.md
+++ b/.changeset/yellow-spies-rescue.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/frontend-test-utils': patch
+'@backstage/plugin-app': patch
 ---
 
-Update route path for index route in `renderInTestApp` to fix duplicate slash and ensure any nested routing behaves correctly.
+Remove trailing slashes in the `AppRoutes` extension to ensure any nested routing behaves correctly.

--- a/.changeset/yellow-spies-rescue.md
+++ b/.changeset/yellow-spies-rescue.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-test-utils': patch
+---
+
+Update route path for index route in `renderInTestApp` util to fix duplicate slash and ensure any nested routing behaves correctly.

--- a/packages/frontend-test-utils/src/app/renderInTestApp.test.tsx
+++ b/packages/frontend-test-utils/src/app/renderInTestApp.test.tsx
@@ -21,6 +21,7 @@ import {
   TestApiProvider,
 } from '@backstage/frontend-test-utils';
 import { analyticsApiRef, useAnalytics } from '@backstage/frontend-plugin-api';
+import { Routes, Route } from 'react-router-dom';
 import { renderInTestApp } from './renderInTestApp';
 
 describe('renderInTestApp', () => {
@@ -64,5 +65,19 @@ describe('renderInTestApp', () => {
         }),
       ]),
     );
+  });
+
+  it('should support setting different locations in the history stack', async () => {
+    renderInTestApp(
+      <Routes>
+        <Route path="/" element={<h1>Index Page</h1>} />
+        <Route path="/second-page" element={<h1>Second Page</h1>} />
+      </Routes>,
+      {
+        initialRouteEntries: ['/second-page'],
+      },
+    );
+
+    expect(screen.getByText('Second Page')).toBeInTheDocument();
   });
 });

--- a/packages/frontend-test-utils/src/app/renderInTestApp.tsx
+++ b/packages/frontend-test-utils/src/app/renderInTestApp.tsx
@@ -154,7 +154,7 @@ export function renderInTestApp(
       factory: () => {
         return [
           coreExtensionData.reactElement(element),
-          coreExtensionData.routePath('/'),
+          coreExtensionData.routePath(''),
         ];
       },
     }),

--- a/packages/frontend-test-utils/src/app/renderInTestApp.tsx
+++ b/packages/frontend-test-utils/src/app/renderInTestApp.tsx
@@ -154,7 +154,7 @@ export function renderInTestApp(
       factory: () => {
         return [
           coreExtensionData.reactElement(element),
-          coreExtensionData.routePath(''),
+          coreExtensionData.routePath('/'),
         ];
       },
     }),

--- a/plugins/app/src/extensions/AppRoutes.tsx
+++ b/plugins/app/src/extensions/AppRoutes.tsx
@@ -42,7 +42,9 @@ export const AppRoutes = createExtension({
 
       const element = useRoutes([
         ...inputs.routes.map(route => ({
-          path: `${route.get(coreExtensionData.routePath)}/*`,
+          path: `${route
+            .get(coreExtensionData.routePath)
+            .replace(/\/$/, '')}/*`,
           element: route.get(coreExtensionData.reactElement),
         })),
         {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `renderInTestApp` util currently registers the element you pass in with a route path of `/`
https://github.com/backstage/backstage/blob/f78a03b57baf0ff50f95a458a556cc4036065b3f/packages/frontend-test-utils/src/app/renderInTestApp.tsx#L157

This is then passed into the AppRoutes extension as an input which also appends a `/*` to the end
https://github.com/backstage/backstage/blob/2b939c8ffac2c675621215a29901368be0299b67/plugins/app/src/extensions/AppRoutes.tsx#L45

This means that the route mounted in the test is `//*` rather than `/*` as you might expect. This causes problems with route matching, as React Router removes duplicate slashes from patterns when determining matches meaning that most paths can never be matched.

In order to resolve this, I think the correct course of action would be to set an empty route path in the test util and leave the existing behaviour in the AppRoutes extension as it is, resulting in the test element being served on `/*` as expected. That is what I have implemented in this PR.

I've also written a test that fails with the old behaviour to try and prevent a regression in future.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
