### PR TITLE
Added title description for proxying docs

### DIFF
--- a/docs/plugins/proxying.md
+++ b/docs/plugins/proxying.md
@@ -4,6 +4,8 @@ title: Proxying
 description: Documentation on Proxying
 ---
 
+This page describes how to configure and use the built-in HTTP proxy functionality in your Backstage backend.
+
 ## Overview
 
 The Backstage backend comes packaged with a basic HTTP proxy, that can aid in


### PR DESCRIPTION
Added title description for proxying docs like other :


example :

![image](https://github.com/user-attachments/assets/bdd89087-85a9-4fd3-ba10-0eb6ad0b0b00)


updated:

![image](https://github.com/user-attachments/assets/20a69fc2-835a-42e5-a2d5-3769fd0c0efa)
