### PR TITLE
Add optional `platform` input to sentry:project:create action

### DIFF
--- a/.changeset/green-facts-wink.md
+++ b/.changeset/green-facts-wink.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-sentry': patch
+---
+
+Add optional input to sentry:project:create to set the new Sentry project's platform

--- a/plugins/scaffolder-backend-module-sentry/report.api.md
+++ b/plugins/scaffolder-backend-module-sentry/report.api.md
@@ -16,6 +16,7 @@ export function createSentryCreateProjectAction(options: {
     teamSlug: string;
     name: string;
     slug?: string | undefined;
+    platform?: string | undefined;
     authToken?: string | undefined;
   },
   {

--- a/plugins/scaffolder-backend-module-sentry/src/actions/createProject.examples.test.ts
+++ b/plugins/scaffolder-backend-module-sentry/src/actions/createProject.examples.test.ts
@@ -43,6 +43,7 @@ describe('sentry:project:create action', () => {
     teamSlug: string;
     name: string;
     slug?: string;
+    platform?: string;
     authToken?: string;
   }> =>
     createMockActionContext({
@@ -56,12 +57,14 @@ describe('sentry:project:create action', () => {
       },
     });
 
-  it(`should ${examples[0].description}`, async () => {
+  it(`should ${examples[0].description} ${
+    yaml.parse(examples[0].example).steps[2].name
+  }`, async () => {
     expect.assertions(3);
 
     let input;
     try {
-      input = yaml.parse(examples[0].example).steps[1].input;
+      input = yaml.parse(examples[0].example).steps[2].input;
     } catch (error) {
       console.error('Failed to parse YAML:', error);
     }
@@ -97,7 +100,9 @@ describe('sentry:project:create action', () => {
     });
   });
 
-  it(`should ${examples[0].description}`, async () => {
+  it(`should ${examples[0].description} ${
+    yaml.parse(examples[0].example).steps[0].name
+  }`, async () => {
     expect.assertions(3);
 
     let input;
@@ -122,6 +127,51 @@ describe('sentry:project:create action', () => {
           await expect(request.json()).resolves.toEqual({
             name: 'Scaffolded project A',
             slug: 'scaff-proj-a',
+          });
+          return HttpResponse.json(
+            { detail: 'project creation mocked result' },
+            { status: 201 },
+          );
+        },
+      ),
+    );
+
+    await action.handler({
+      ...actionContext,
+      input: {
+        ...actionContext.input,
+        ...input,
+      },
+    });
+  });
+
+  it(`should ${examples[0].description}  ${
+    yaml.parse(examples[0].example).steps[1].name
+  }`, async () => {
+    expect.assertions(3);
+
+    let input;
+    try {
+      input = yaml.parse(examples[0].example).steps[1].input;
+    } catch (error) {
+      console.error('Failed to parse YAML:', error);
+    }
+
+    const action = createSentryCreateProjectAction(createScaffolderConfig());
+    const actionContext = getActionContext();
+    actionContext.input = { ...actionContext.input, platform: 'platform-a' };
+
+    worker.use(
+      http.post(
+        `https://sentry.io/api/0/teams/${input.organizationSlug}/${input.teamSlug}/projects/`,
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
+            `Bearer c25711beb516e1e910d2ede554dc1bf725654ef3c75e5a9106de9aec13d5de85`,
+          );
+          expect(request.headers.get('Content-Type')).toBe(`application/json`);
+          await expect(request.json()).resolves.toEqual({
+            name: 'Scaffolded project A',
+            platform: 'platform-a',
           });
           return HttpResponse.json(
             { detail: 'project creation mocked result' },

--- a/plugins/scaffolder-backend-module-sentry/src/actions/createProject.examples.ts
+++ b/plugins/scaffolder-backend-module-sentry/src/actions/createProject.examples.ts
@@ -38,7 +38,20 @@ export const examples: TemplateExample[] = [
         {
           id: 'create-sentry-project',
           action: 'sentry:project:create',
-          name: 'Create a Sentry project without providing a project slug.',
+          name: 'Create a Sentry project with provided platform.',
+          input: {
+            organizationSlug: 'my-org',
+            teamSlug: 'team-a',
+            name: 'Scaffolded project A',
+            platform: 'platform-a',
+            authToken:
+              'c25711beb516e1e910d2ede554dc1bf725654ef3c75e5a9106de9aec13d5de85',
+          },
+        },
+        {
+          id: 'create-sentry-project',
+          action: 'sentry:project:create',
+          name: 'Create a Sentry project without optional parameters.',
           input: {
             organizationSlug: 'my-org',
             teamSlug: 'team-b',

--- a/plugins/scaffolder-backend-module-sentry/src/actions/createProject.ts
+++ b/plugins/scaffolder-backend-module-sentry/src/actions/createProject.ts
@@ -54,6 +54,12 @@ export function createSentryCreateProjectAction(options: { config: Config }) {
                 'Optional slug for the new project. If not provided a slug is generated from the name',
             })
             .optional(),
+        platform: z =>
+          z
+            .string({
+              description: 'Optional sentry platform for the new project. ',
+            })
+            .optional(),
         authToken: z =>
           z
             .string({
@@ -64,7 +70,8 @@ export function createSentryCreateProjectAction(options: { config: Config }) {
       },
     },
     async handler(ctx) {
-      const { organizationSlug, teamSlug, name, slug, authToken } = ctx.input;
+      const { organizationSlug, teamSlug, name, slug, platform, authToken } =
+        ctx.input;
 
       const body: any = {
         name: name,
@@ -72,6 +79,10 @@ export function createSentryCreateProjectAction(options: { config: Config }) {
 
       if (slug) {
         body.slug = slug;
+      }
+
+      if (platform) {
+        body.platform = platform;
       }
 
       const token = authToken


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This closes #30486 by adding a optional input to the `sentry:project:create` action which sends the platform specified in the input to the Sentry REST API for creating a new project.

This will allow the action to create a specific (e.g. javascript, python, etc) project instead of only generic ones 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
