### PR TITLE
Remove double padding on k8s entity page 

### DIFF
--- a/.changeset/slick-cameras-bet.md
+++ b/.changeset/slick-cameras-bet.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes': patch
+---
+
+Removed the kubernetes content padding to avoid double padding on k8s entity page

--- a/plugins/kubernetes/src/KubernetesContent.tsx
+++ b/plugins/kubernetes/src/KubernetesContent.tsx
@@ -64,7 +64,7 @@ export const KubernetesContent = ({
 
   return (
     <Page themeId="tool">
-      <Content>
+      <Content noPadding>
         <RequireKubernetesPermissions>
           <DetectedErrorsContext.Provider
             value={[...detectedErrors.values()].flat()}

--- a/plugins/kubernetes/src/KubernetesContent.tsx
+++ b/plugins/kubernetes/src/KubernetesContent.tsx
@@ -29,12 +29,7 @@ import {
   DetectedError,
   detectErrors,
 } from '@backstage/plugin-kubernetes-common';
-import {
-  Content,
-  EmptyState,
-  Page,
-  Progress,
-} from '@backstage/core-components';
+import { EmptyState, Progress } from '@backstage/core-components';
 import { RequireKubernetesPermissions } from './RequireKubernetesPermissions';
 
 type KubernetesContentProps = {
@@ -63,93 +58,87 @@ export const KubernetesContent = ({
       : new Map<string, DetectedError[]>();
 
   return (
-    <Page themeId="tool">
-      <Content noPadding>
-        <RequireKubernetesPermissions>
-          <DetectedErrorsContext.Provider
-            value={[...detectedErrors.values()].flat()}
-          >
-            {kubernetesObjects === undefined && error === undefined && (
-              <Progress />
-            )}
+    <RequireKubernetesPermissions>
+      <DetectedErrorsContext.Provider
+        value={[...detectedErrors.values()].flat()}
+      >
+        {kubernetesObjects === undefined && error === undefined && <Progress />}
 
-            {/* errors retrieved from the kubernetes clusters */}
-            {clustersWithErrors.length > 0 && (
-              <Grid container spacing={3} direction="column">
-                <Grid item>
-                  <ErrorPanel
-                    entityName={entity.metadata.name}
-                    clustersWithErrors={clustersWithErrors}
-                  />
-                </Grid>
-              </Grid>
-            )}
+        {/* errors retrieved from the kubernetes clusters */}
+        {clustersWithErrors.length > 0 && (
+          <Grid container spacing={3} direction="column">
+            <Grid item>
+              <ErrorPanel
+                entityName={entity.metadata.name}
+                clustersWithErrors={clustersWithErrors}
+              />
+            </Grid>
+          </Grid>
+        )}
 
-            {/* other errors */}
-            {error !== undefined && (
-              <Grid container spacing={3} direction="column">
-                <Grid item>
-                  <ErrorPanel
-                    entityName={entity.metadata.name}
-                    errorMessage={error}
-                  />
-                </Grid>
-              </Grid>
-            )}
+        {/* other errors */}
+        {error !== undefined && (
+          <Grid container spacing={3} direction="column">
+            <Grid item>
+              <ErrorPanel
+                entityName={entity.metadata.name}
+                errorMessage={error}
+              />
+            </Grid>
+          </Grid>
+        )}
 
-            {kubernetesObjects && (
-              <Grid container spacing={3} direction="column">
-                <Grid item>
-                  <ErrorReporting
-                    detectedErrors={detectedErrors}
-                    clusters={clusters}
-                  />
+        {kubernetesObjects && (
+          <Grid container spacing={3} direction="column">
+            <Grid item>
+              <ErrorReporting
+                detectedErrors={detectedErrors}
+                clusters={clusters}
+              />
+            </Grid>
+            <Grid item>
+              <Typography variant="h3">Your Clusters</Typography>
+            </Grid>
+            <Grid item container>
+              {kubernetesObjects?.items.length <= 0 && (
+                <Grid
+                  container
+                  justifyContent="space-around"
+                  direction="row"
+                  alignItems="center"
+                  spacing={2}
+                >
+                  <Grid item xs={8}>
+                    <EmptyState
+                      missing="data"
+                      title="No Kubernetes resources"
+                      description={`No resources on any known clusters for ${entity.metadata.name}`}
+                    />
+                  </Grid>
                 </Grid>
-                <Grid item>
-                  <Typography variant="h3">Your Clusters</Typography>
-                </Grid>
-                <Grid item container>
-                  {kubernetesObjects?.items.length <= 0 && (
-                    <Grid
-                      container
-                      justifyContent="space-around"
-                      direction="row"
-                      alignItems="center"
-                      spacing={2}
-                    >
-                      <Grid item xs={8}>
-                        <EmptyState
-                          missing="data"
-                          title="No Kubernetes resources"
-                          description={`No resources on any known clusters for ${entity.metadata.name}`}
-                        />
-                      </Grid>
+              )}
+              {kubernetesObjects?.items.length > 0 &&
+                kubernetesObjects?.items.map((item, i) => {
+                  const podsWithErrors = new Set<string>(
+                    detectedErrors
+                      .get(item.cluster.name)
+                      ?.filter(de => de.sourceRef.kind === 'Pod')
+                      .map(de => de.sourceRef.name),
+                  );
+
+                  return (
+                    <Grid item key={i} xs={12}>
+                      <Cluster
+                        clusterObjects={item}
+                        podsWithErrors={podsWithErrors}
+                      />
                     </Grid>
-                  )}
-                  {kubernetesObjects?.items.length > 0 &&
-                    kubernetesObjects?.items.map((item, i) => {
-                      const podsWithErrors = new Set<string>(
-                        detectedErrors
-                          .get(item.cluster.name)
-                          ?.filter(de => de.sourceRef.kind === 'Pod')
-                          .map(de => de.sourceRef.name),
-                      );
-
-                      return (
-                        <Grid item key={i} xs={12}>
-                          <Cluster
-                            clusterObjects={item}
-                            podsWithErrors={podsWithErrors}
-                          />
-                        </Grid>
-                      );
-                    })}
-                </Grid>
-              </Grid>
-            )}
-          </DetectedErrorsContext.Provider>
-        </RequireKubernetesPermissions>
-      </Content>
-    </Page>
+                  );
+                })}
+            </Grid>
+          </Grid>
+        )}
+      </DetectedErrorsContext.Provider>
+    </RequireKubernetesPermissions>
   );
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!
this PR is an fix over https://github.com/backstage/backstage/pull/29982, that was closed and not posible to re-open

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

When adding the k8s content to an entity page there is a double padding, One from entityPage content and a second one from the kubernetes page content

This PR removes the K8s padding
| before k8 padding | entityPage padding |
| --- | --- |
| ![Screenshot 2025-05-15 at 23 08 04](https://github.com/user-attachments/assets/5fc1cb43-9fbe-4d50-91e3-b8f92252a0a4) | ![Screenshot 2025-05-15 at 23 08 22](https://github.com/user-attachments/assets/688356cd-6a52-4808-a5a1-a53e335ccb03) |

|after just entityPage padding|
|---|
|![Screenshot 2025-05-16 at 10 37 24](https://github.com/user-attachments/assets/74d68ed2-daaf-475a-86fd-5a4541ad225b)|

## Update:
Remove the page and content  as this page lives inside the entity page.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
