### PR TITLE
Canon - Export Card and Skeleton components

### DIFF
--- a/.changeset/plain-cobras-doubt.md
+++ b/.changeset/plain-cobras-doubt.md
@@ -2,4 +2,4 @@
 '@backstage/canon': patch
 ---
 
-Export Skeleton component from Canon.
+Export Card and Skeleton components.

--- a/packages/canon/report.api.md
+++ b/packages/canon/report.api.md
@@ -219,6 +219,35 @@ export interface ButtonProps extends ButtonProps_2 {
     | Partial<Record<Breakpoint, 'primary' | 'secondary' | 'tertiary'>>;
 }
 
+// @public
+export const Card: ForwardRefExoticComponent<
+  CardProps & RefAttributes<HTMLDivElement>
+>;
+
+// @public
+export interface CardBodyProps extends React.HTMLAttributes<HTMLDivElement> {
+  // (undocumented)
+  children?: React.ReactNode;
+}
+
+// @public
+export interface CardFooterProps extends React.HTMLAttributes<HTMLDivElement> {
+  // (undocumented)
+  children?: React.ReactNode;
+}
+
+// @public
+export interface CardHeaderProps extends React.HTMLAttributes<HTMLDivElement> {
+  // (undocumented)
+  children?: React.ReactNode;
+}
+
+// @public
+export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
+  // (undocumented)
+  children?: React.ReactNode;
+}
+
 // @public (undocumented)
 export const Checkbox: ForwardRefExoticComponent<
   CheckboxProps & RefAttributes<HTMLButtonElement>

--- a/packages/canon/src/index.ts
+++ b/packages/canon/src/index.ts
@@ -34,6 +34,7 @@ export * from './components/Heading';
 // UI components
 export * from './components/Avatar';
 export * from './components/Button';
+export * from './components/Card';
 export * from './components/Collapsible';
 export * from './components/DataTable';
 export * from './components/FieldLabel';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The Card and Skeleton components (added in https://github.com/backstage/backstage/pull/30467 and https://github.com/backstage/backstage/pull/30466 respectively) were never exported from the Canon entry point, which this PR rectifies.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
