### PR TITLE
removes duplication on origins

### DIFF
--- a/.changeset/spicy-beds-draw.md
+++ b/.changeset/spicy-beds-draw.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-notifications-backend': patch
+'@backstage/plugin-notifications': patch
+---
+
+Fixes a bug duplicating origins in the Notifications Panel.

--- a/plugins/notifications-backend/src/service/router.ts
+++ b/plugins/notifications-backend/src/service/router.ts
@@ -147,9 +147,6 @@ export async function createRouter(
     topics: { origin: string; topic: string }[],
   ) => {
     const existingChannel = settings.channels.find(c => c.id === channelId);
-    if (existingChannel) {
-      return existingChannel;
-    }
     return {
       id: channelId,
       origins: origins.map(originId =>

--- a/plugins/notifications/src/components/UserNotificationSettingsCard/OriginRow.tsx
+++ b/plugins/notifications/src/components/UserNotificationSettingsCard/OriginRow.tsx
@@ -15,7 +15,6 @@
  */
 
 import {
-  ChannelSetting,
   isNotificationsEnabledFor,
   NotificationSettings,
   OriginSetting,
@@ -30,7 +29,6 @@ import { NoBorderTableCell } from './NoBorderTableCell';
 import { useNotificationFormat } from './UserNotificationSettingsCard';
 
 export const OriginRow = (props: {
-  channel: ChannelSetting;
   origin: OriginSetting;
   settings: NotificationSettings;
   handleChange: (
@@ -42,8 +40,7 @@ export const OriginRow = (props: {
   open: boolean;
   handleRowToggle: (originId: string) => void;
 }) => {
-  const { channel, origin, settings, handleChange, open, handleRowToggle } =
-    props;
+  const { origin, settings, handleChange, open, handleRowToggle } = props;
   const { formatOriginName } = useNotificationFormat();
   return (
     <TableRow>
@@ -67,7 +64,7 @@ export const OriginRow = (props: {
       {settings.channels.map(ch => (
         <NoBorderTableCell key={ch.id} align="center">
           <Tooltip
-            title={`Enable or disable ${channel.id.toLocaleLowerCase(
+            title={`Enable or disable ${ch.id.toLocaleLowerCase(
               'en-US',
             )} notifications from ${formatOriginName(origin.id)}`}
           >

--- a/plugins/notifications/src/components/UserNotificationSettingsCard/UserNotificationSettingsPanel.tsx
+++ b/plugins/notifications/src/components/UserNotificationSettingsCard/UserNotificationSettingsPanel.tsx
@@ -15,7 +15,10 @@
  */
 
 import { useState } from 'react';
-import { NotificationSettings } from '@backstage/plugin-notifications-common';
+import {
+  NotificationSettings,
+  OriginSetting,
+} from '@backstage/plugin-notifications-common';
 import Table from '@material-ui/core/Table';
 import MuiTableCell from '@material-ui/core/TableCell';
 import { withStyles } from '@material-ui/core/styles';
@@ -23,8 +26,8 @@ import TableHead from '@material-ui/core/TableHead';
 import Typography from '@material-ui/core/Typography';
 import TableBody from '@material-ui/core/TableBody';
 import TableRow from '@material-ui/core/TableRow';
-import { TopicRow } from './TopicRow';
 import { OriginRow } from './OriginRow';
+import { TopicRow } from './TopicRow';
 
 const TableCell = withStyles({
   root: {
@@ -108,6 +111,17 @@ export const UserNotificationSettingsPanel = (props: {
       </Typography>
     );
   }
+  const uniqueOriginsMap = settings.channels
+    .flatMap(channel => channel.origins)
+    .reduce((map, origin) => {
+      if (!map.has(origin.id)) {
+        map.set(origin.id, origin);
+      }
+      return map;
+    }, new Map<string, OriginSetting>())
+    .values();
+
+  const uniqueOrigins = Array.from(uniqueOriginsMap);
 
   return (
     <Table>
@@ -130,30 +144,27 @@ export const UserNotificationSettingsPanel = (props: {
         </TableRow>
       </TableHead>
       <TableBody>
-        {settings.channels.map(channel =>
-          channel.origins.flatMap(origin => [
-            <OriginRow
-              key={origin.id}
-              channel={channel}
-              origin={origin}
-              settings={settings}
-              open={expandedRows.has(origin.id)}
-              handleChange={handleChange}
-              handleRowToggle={handleRowToggle}
-            />,
-            ...(expandedRows.has(origin.id)
-              ? origin.topics?.map(topic => (
-                  <TopicRow
-                    key={`${origin.id}-${topic.id}`}
-                    topic={topic}
-                    origin={origin}
-                    settings={settings}
-                    handleChange={handleChange}
-                  />
-                )) || []
-              : []),
-          ]),
-        )}
+        {uniqueOrigins.flatMap(origin => [
+          <OriginRow
+            key={origin.id}
+            origin={origin}
+            settings={settings}
+            open={expandedRows.has(origin.id)}
+            handleChange={handleChange}
+            handleRowToggle={handleRowToggle}
+          />,
+          ...(expandedRows.has(origin.id)
+            ? origin.topics?.map(topic => (
+                <TopicRow
+                  key={`${origin.id}-${topic.id}`}
+                  topic={topic}
+                  origin={origin}
+                  settings={settings}
+                  handleChange={handleChange}
+                />
+              )) || []
+            : []),
+        ])}
       </TableBody>
     </Table>
   );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I've corrected a bug that shows duplicate Origins in the notifications panel. #30464

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
