### PR TITLE
feat(techdocs): Allow client caching for hashed CSS files

### DIFF
--- a/.changeset/swift-ravens-argue.md
+++ b/.changeset/swift-ravens-argue.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-node': minor
+---
+
+feat(techdocs): add client caching for hashed CSS files

--- a/plugins/techdocs-node/src/stages/publish/awsS3.ts
+++ b/plugins/techdocs-node/src/stages/publish/awsS3.ts
@@ -46,7 +46,7 @@ import {
   bulkStorageOperation,
   getCloudPathForLocalPath,
   getFileTreeRecursively,
-  getHeadersForFileExtension,
+  getHeadersForFilename,
   getStaleFiles,
   isValidContentPath,
   lowerCaseEntityTriplet,
@@ -468,8 +468,7 @@ export class AwsS3Publish implements PublisherBase {
       }
 
       // Files with different extensions (CSS, HTML) need to be served with different headers
-      const fileExtension = path.extname(filePath);
-      const responseHeaders = getHeadersForFileExtension(fileExtension);
+      const responseHeaders = getHeadersForFilename(filePath);
 
       try {
         const resp = await this.storageClient.send(

--- a/plugins/techdocs-node/src/stages/publish/azureBlobStorage.ts
+++ b/plugins/techdocs-node/src/stages/publish/azureBlobStorage.ts
@@ -25,15 +25,15 @@ import { assertError, ForwardedError } from '@backstage/errors';
 import express from 'express';
 import JSON5 from 'json5';
 import limiterFactory from 'p-limit';
-import { default as path, default as platformPath } from 'path';
+import { default as path } from 'path';
 import {
-  bulkStorageOperation,
-  getCloudPathForLocalPath,
+  getHeadersForFilename,
   getFileTreeRecursively,
-  getHeadersForFileExtension,
+  getCloudPathForLocalPath,
+  bulkStorageOperation,
   lowerCaseEntityTriplet,
-  getStaleFiles,
   lowerCaseEntityTripletInStoragePath,
+  getStaleFiles,
 } from './helpers';
 import {
   PublisherBase,
@@ -349,8 +349,7 @@ export class AzureBlobStoragePublish implements PublisherBase {
         : lowerCaseEntityTripletInStoragePath(decodedUri);
 
       // Files with different extensions (CSS, HTML) need to be served with different headers
-      const fileExtension = platformPath.extname(filePath);
-      const responseHeaders = getHeadersForFileExtension(fileExtension);
+      const responseHeaders = getHeadersForFilename(filePath);
 
       const blobClient = this.storageClient
         .getContainerClient(this.containerName)

--- a/plugins/techdocs-node/src/stages/publish/googleStorage.ts
+++ b/plugins/techdocs-node/src/stages/publish/googleStorage.ts
@@ -28,7 +28,7 @@ import path from 'path';
 import { Readable } from 'stream';
 import {
   getFileTreeRecursively,
-  getHeadersForFileExtension,
+  getHeadersForFilename,
   isValidContentPath,
   lowerCaseEntityTriplet,
   lowerCaseEntityTripletInStoragePath,
@@ -317,8 +317,7 @@ export class GoogleGCSPublish implements PublisherBase {
       }
 
       // Files with different extensions (CSS, HTML) need to be served with different headers
-      const fileExtension = path.extname(filePath);
-      const responseHeaders = getHeadersForFileExtension(fileExtension);
+      const responseHeaders = getHeadersForFilename(filePath);
 
       // Pipe file chunks directly from storage to client.
       this.storageClient

--- a/plugins/techdocs-node/src/stages/publish/local.ts
+++ b/plugins/techdocs-node/src/stages/publish/local.ts
@@ -40,7 +40,7 @@ import {
 } from './types';
 import {
   getFileTreeRecursively,
-  getHeadersForFileExtension,
+  getHeadersForFilename,
   lowerCaseEntityTripletInStoragePath,
 } from './helpers';
 import { ForwardedError } from '@backstage/errors';
@@ -232,8 +232,7 @@ export class LocalPublish implements PublisherBase {
       express.static(this.staticDocsDir, {
         // Handle content-type header the same as all other publishers.
         setHeaders: (res, filePath) => {
-          const fileExtension = path.extname(filePath);
-          const headers = getHeadersForFileExtension(fileExtension);
+          const headers = getHeadersForFilename(filePath);
           for (const [header, value] of Object.entries(headers)) {
             res.setHeader(header, value);
           }

--- a/plugins/techdocs-node/src/stages/publish/openStackSwift.ts
+++ b/plugins/techdocs-node/src/stages/publish/openStackSwift.ts
@@ -26,7 +26,7 @@ import { Stream, Readable } from 'stream';
 
 import {
   getFileTreeRecursively,
-  getHeadersForFileExtension,
+  getHeadersForFilename,
   lowerCaseEntityTripletInStoragePath,
 } from './helpers';
 import {
@@ -243,8 +243,7 @@ export class OpenStackSwiftPublish implements PublisherBase {
       const filePath = decodeURI(req.path.replace(/^\//, ''));
 
       // Files with different extensions (CSS, HTML) need to be served with different headers
-      const fileExtension = path.extname(filePath);
-      const responseHeaders = getHeadersForFileExtension(fileExtension);
+      const responseHeaders = getHeadersForFilename(filePath);
 
       const downloadResponse = await this.storageClient.download(
         this.containerName,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds cache control headers for CSS files with 8-character hash suffixes (e.g., `main.a1b2c3d4.min.css`).

Sets `Cache-Control: public, max-age=31536000, immutable` to allow browsers to cache these files indefinitely since their content never changes.

Very conservative approach - only allows caching for hashed CSS files, which should save ~23kb per page.

We could add support for other files, but I haven't found other use-cases (must say I haven't looked very far, let me know if you find something for mkdocs that will suffix images with a unique hash!).

Tested in backstage app...
<img width="1079" height="179" alt="image" src="https://github.com/user-attachments/assets/01c2cc51-ec42-41f5-8a78-f1451a4b4191" />

...and in production
<img width="1079" height="195" alt="Network tab showing request served from cache, with the proper Cache-Control header" src="https://github.com/user-attachments/assets/65f96225-9c32-4bd2-90c3-39d3a090eb9d" />



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
