### PR TITLE
Update broken link for OAuth2 Proxy documentation

### DIFF
--- a/docs/auth/oauth2-proxy/provider.md
+++ b/docs/auth/oauth2-proxy/provider.md
@@ -11,7 +11,7 @@ The Backstage `@backstage/plugin-auth-backend` package comes with an
 actual Backstage instance. This enables to reuse existing authentications within
 a cluster. In general the `oauth2-proxy` supports all OpenID Connect providers,
 for more details check this
-[list of supported providers](https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/oauth_provider).
+[list of supported providers](https://oauth2-proxy.github.io/oauth2-proxy/configuration/providers/).
 
 :::note Note
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I noticed that there was a broken link in the oauth2-provider proxy documentation. I was able to track down the updated url that the OAuth2 Proxy documentation is now using.

Previous link url:

<img width="1008" height="412" alt="image" src="https://github.com/user-attachments/assets/aab4c6bc-5a6b-44a8-ac0a-18ae6d762c61" />

After fix:

<img width="907" height="672" alt="image" src="https://github.com/user-attachments/assets/0d6d85b1-9eef-406b-b407-1f6a990b9f7f" />

#### :heavy_check_mark: Checklist

- [ ] ~A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))~
- [x] Added or updated documentation
- [ ] ~Tests for new functionality and regression tests for bug fixes~
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
