### PR TITLE
Link Google Analytics plugin to G4 version

### DIFF
--- a/microsite/data/plugins/analytics-module-ga.yaml
+++ b/microsite/data/plugins/analytics-module-ga.yaml
@@ -4,7 +4,7 @@ author: Spotify
 authorUrl: https://github.com/spotify
 category: Monitoring
 description: Track usage of your Backstage instance using Google Analytics.
-documentation: https://github.com/backstage/community-plugins/blob/main/workspaces/analytics/plugins/analytics-module-ga/README.md
+documentation: https://github.com/backstage/community-plugins/tree/main/workspaces/analytics/plugins/analytics-module-ga4#readme
 iconUrl: /img/ga-icon.png
-npmPackageName: '@backstage/plugin-analytics-module-ga'
-addedDate: '2021-10-07'
+npmPackageName: '@backstage/plugin-analytics-module-ga4'
+addedDate: '2024-04-19'

--- a/microsite/data/plugins/analytics-module-ga.yaml
+++ b/microsite/data/plugins/analytics-module-ga.yaml
@@ -3,8 +3,8 @@ title: 'Analytics Module: Google Analytics'
 author: Spotify
 authorUrl: https://github.com/spotify
 category: Monitoring
-description: Track usage of your Backstage instance using Google Analytics.
+description: Track usage of your Backstage instance using Google Analytics 4.
 documentation: https://github.com/backstage/community-plugins/tree/main/workspaces/analytics/plugins/analytics-module-ga4#readme
 iconUrl: /img/ga-icon.png
 npmPackageName: '@backstage/plugin-analytics-module-ga4'
-addedDate: '2024-04-19'
+addedDate: '2021-10-07'


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The plugin docs were linking to the original Google Analytics plugin that only supports Universal Analytics, which is now deprecated by Google. The G4 version is the compatible version with Google Analytics now and should be the default link.

Signed-off-by: Brie Hodson <briemarie@users.noreply.github.com>

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [NA] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [NA] Added or updated documentation
- [NA] Tests for new functionality and regression tests for bug fixes
- [NA] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
