### PR TITLE
Techdocs: support HumanDuration for cache config

### DIFF
--- a/.changeset/flat-colts-know.md
+++ b/.changeset/flat-colts-know.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-backend': minor
+---
+
+Techdocs: support HumanDuration for cache TTL and timeout configuration

--- a/plugins/techdocs-backend/config.d.ts
+++ b/plugins/techdocs-backend/config.d.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { HumanDuration } from '@backstage/types';
+
 export interface Config {
   /**
    * Configuration options for the techdocs-backend plugin
@@ -277,7 +279,7 @@ export interface Config {
      */
     cache?: {
       /**
-       * The cache time-to-live for TechDocs sites (in milliseconds). Set this
+       * The cache time-to-live for TechDocs sites, in milliseconds for a number or a human duration. Set this
        * to a non-zero value to cache TechDocs sites and assets as they are
        * read from storage.
        *
@@ -285,16 +287,16 @@ export interface Config {
        * and to pass a PluginCacheManager instance to TechDocs Backend's
        * createRouter method in your backend.
        */
-      ttl: number;
+      ttl: number | HumanDuration | string;
 
       /**
-       * The time (in milliseconds) that the TechDocs backend will wait for
+       * The time (in milliseconds for a number or a human duration) that the TechDocs backend will wait for
        * a cache service to respond before continuing on as though the cached
        * object was not found (e.g. when the cache sercice is unavailable).
        *
        * Defaults to 1000 milliseconds.
        */
-      readTimeout?: number;
+      readTimeout?: number | HumanDuration | string;
     };
 
     /**

--- a/plugins/techdocs-backend/package.json
+++ b/plugins/techdocs-backend/package.json
@@ -71,6 +71,7 @@
     "@backstage/plugin-search-backend-module-techdocs": "workspace:^",
     "@backstage/plugin-techdocs-common": "workspace:^",
     "@backstage/plugin-techdocs-node": "workspace:^",
+    "@backstage/types": "workspace:^",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
     "fs-extra": "^11.2.0",

--- a/plugins/techdocs-backend/src/service/router.ts
+++ b/plugins/techdocs-backend/src/service/router.ts
@@ -16,7 +16,7 @@
 
 import { CatalogApi, CatalogClient } from '@backstage/catalog-client';
 import { stringifyEntityRef } from '@backstage/catalog-model';
-import { Config } from '@backstage/config';
+import { Config, readDurationFromConfig } from '@backstage/config';
 import { NotFoundError } from '@backstage/errors';
 import {
   DocsBuildStrategy,
@@ -41,6 +41,7 @@ import {
   HttpAuthService,
   LoggerService,
 } from '@backstage/backend-plugin-api';
+import { durationToMilliseconds } from '@backstage/types';
 
 /**
  * Required dependencies for running TechDocs in the "out-of-the-box"
@@ -130,9 +131,18 @@ export async function createRouter(
 
   // Set up a cache client if configured.
   let cache: TechDocsCache | undefined;
-  const defaultTtl = config.getOptionalNumber('techdocs.cache.ttl');
-  if (defaultTtl) {
-    const cacheClient = options.cache.withOptions({ defaultTtl });
+  if (config.has('techdocs.cache.ttl')) {
+    let ttlMs: number;
+    if (typeof config.get('techdocs.cache.ttl') === 'number') {
+      ttlMs = config.getNumber('techdocs.cache.ttl');
+    } else {
+      ttlMs = durationToMilliseconds(
+        readDurationFromConfig(config, {
+          key: 'techdocs.cache.ttl',
+        }),
+      );
+    }
+    const cacheClient = options.cache.withOptions({ defaultTtl: ttlMs });
     cache = TechDocsCache.fromConfig(config, { cache: cacheClient, logger });
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8720,6 +8720,7 @@ __metadata:
     "@backstage/plugin-search-backend-module-techdocs": "workspace:^"
     "@backstage/plugin-techdocs-common": "workspace:^"
     "@backstage/plugin-techdocs-node": "workspace:^"
+    "@backstage/types": "workspace:^"
     "@types/express": "npm:^4.17.6"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Hey 👋 

I noticed that techdocs-backend was reading duration as ms only, and was not using the common `HumanDuration`.

Here's a MR to fix that, so we can configure techdocs cache TTL and timeout with strings and objects, in addition to the current numbers. Minor test fixture changes were needed around configuration mocking.

Let me know if you believe it could be moved to shared util.

Have a great day!

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
