### PR TITLE
Fix github-org extension documentation

### DIFF
--- a/docs/integrations/github/org.md
+++ b/docs/integrations/github/org.md
@@ -168,6 +168,7 @@ const backend = createBackend();
 
 backend.add(import('@backstage/plugin-catalog-backend'));
 
+backend.add(import('@backstage/plugin-catalog-backend-module-github-org'));
 backend.add(githubOrgModule);
 
 backend.start();


### PR DESCRIPTION
## Hey, I just made a Pull Request!

From what I can tell (very new to Backstage), the docs for extending the github-org catalog plugin with custom transformers aren't complete. Without the line I added in the PR, I get this error on startup:

```
Error: Service or extension point dependencies of module 'github-org-extensions' for plugin 'catalog' are missing for the following ref(s): extensionPoint{catalog.githubOrgEntityProvider}
```

Maybe this is obvious to experienced users?

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
