### PR TITLE
Update stackoverflow-teams.yaml

### DIFF
--- a/microsite/data/plugins/stackoverflow-teams.yaml
+++ b/microsite/data/plugins/stackoverflow-teams.yaml
@@ -1,10 +1,10 @@
 ---
 title: Stack Overflow for Teams
-author: EstoesMoises
-authorUrl: https://github.com/estoesmoises/
+author: Stack Overflow
+authorUrl: https://github.com/StackExchange/
 category: Discovery
 description: Provide seamless access to Stack Overflow Teams most relevant data, allowing you to display the top users, top tags, and top questions directly within Backstage. It also allows to securely create SO Teams questions from Backstage.
-documentation: https://github.com/StackExchange/backstage-stackoverflow/blob/main/README.md
+documentation: https://stackoverflowteams.help/en/articles/9692515-backstage-io-integration
 iconUrl: /img/stack-overflow-logo.svg
 npmPackageName: 'backstage-plugin-stack-overflow-teams'
 addedDate: '2025-06-10'


### PR DESCRIPTION
- Update author and authorurl for Stack Overflow instead of my username. Wanted to make this change as I work for Stack and the plugin lives in the [StackExchange repository ](https://github.com/StackExchange/backstage-stackoverflow).
- Updating documentation url with [Stack Overflow Help Center article](https://stackoverflowteams.help/en/articles/9692515-backstage-io-integration).

Thank you  !