### PR TITLE
canon.backstage.io -> ui.backstage.io

### DIFF
--- a/canon-docs/public/CNAME
+++ b/canon-docs/public/CNAME
@@ -1,1 +1,1 @@
-canon.backstage.io
+ui.backstage.io

--- a/packages/ui/static/CNAME
+++ b/packages/ui/static/CNAME
@@ -1,1 +1,1 @@
-canon.backstage.io
+ui.backstage.io


### PR DESCRIPTION
Already updated in the docs repo, but this makes sure we don't override that on the next build