### PR TITLE
`nfs`: Added `type` to `convertLegacyEntityCardExtension`

### DIFF
--- a/.changeset/hot-clowns-behave.md
+++ b/.changeset/hot-clowns-behave.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-react': patch
 ---
 
-Adding `type` as an override to the `convertLegacyCardExtension`
+Adding `type` as an override to the `convertLegacyEntityCardExtension`

--- a/.changeset/hot-clowns-behave.md
+++ b/.changeset/hot-clowns-behave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Adding `type` as an override to the `convertLegacyCardExtension`

--- a/plugins/catalog-react/report-alpha.api.md
+++ b/plugins/catalog-react/report-alpha.api.md
@@ -95,6 +95,7 @@ export function convertLegacyEntityCardExtension(
   overrides?: {
     name?: string;
     filter?: string | EntityPredicate | ((entity: Entity) => boolean);
+    type?: EntityCardType;
   },
 ): ExtensionDefinition;
 

--- a/plugins/catalog-react/src/alpha/converters/convertLegacyEntityCardExtension.test.tsx
+++ b/plugins/catalog-react/src/alpha/converters/convertLegacyEntityCardExtension.test.tsx
@@ -26,7 +26,7 @@ import {
 import { screen } from '@testing-library/react';
 import { convertLegacyEntityCardExtension } from './convertLegacyEntityCardExtension';
 import { convertLegacyRouteRef } from '@backstage/core-compat-api';
-import { EntityContentBlueprint } from '../blueprints';
+import { EntityCardBlueprint } from '../blueprints';
 
 const routeRef = createLegacyRouteRef({ id: 'test' });
 const legacyPlugin = createLegacyPlugin({
@@ -60,12 +60,14 @@ describe('convertLegacyEntityCardExtension', () => {
 
     await expect(screen.findByText('Hello')).resolves.toBeInTheDocument();
 
-    expect(tester.get(EntityContentBlueprint.dataRefs.filterExpression)).toBe(
+    expect(tester.get(EntityCardBlueprint.dataRefs.filterExpression)).toBe(
       undefined,
     );
-    expect(tester.get(EntityContentBlueprint.dataRefs.filterFunction)).toBe(
+    expect(tester.get(EntityCardBlueprint.dataRefs.filterFunction)).toBe(
       undefined,
     );
+
+    expect(tester.get(EntityCardBlueprint.dataRefs.type)).toBe(undefined);
   });
 
   it('should convert an entity card extension with overrides', async () => {
@@ -94,10 +96,10 @@ describe('convertLegacyEntityCardExtension', () => {
 
     await expect(screen.findByText('Hello')).resolves.toBeInTheDocument();
 
-    expect(tester.get(EntityContentBlueprint.dataRefs.filterExpression)).toBe(
+    expect(tester.get(EntityCardBlueprint.dataRefs.filterExpression)).toBe(
       'my-filter',
     );
-    expect(tester.get(EntityContentBlueprint.dataRefs.filterFunction)).toBe(
+    expect(tester.get(EntityCardBlueprint.dataRefs.filterFunction)).toBe(
       undefined,
     );
   });
@@ -122,5 +124,33 @@ describe('convertLegacyEntityCardExtension', () => {
     expect(getDiscoveredId('EntityExampleCard')).toBe('entity-card:example');
     expect(getDiscoveredId('EntityExAmpleCard')).toBe('entity-card:ex-ample');
     expect(getDiscoveredId('ExampleCard')).toBe('entity-card:example-card');
+  });
+
+  it('should support the type override', async () => {
+    const LegacyExtension = legacyPlugin.provide(
+      createRoutableExtension({
+        name: 'EntityExampleCard',
+        mountPoint: routeRef,
+        component: async () => () => <div>Hello</div>,
+      }),
+    );
+
+    const converted = convertLegacyEntityCardExtension(LegacyExtension, {
+      type: 'info',
+    });
+
+    const tester = createExtensionTester(converted);
+
+    expect(tester.query(converted).node.spec.id).toBe('entity-card:example');
+
+    await renderInTestApp(tester.reactElement(), {
+      mountedRoutes: {
+        '/': convertLegacyRouteRef(routeRef),
+      },
+    });
+
+    await expect(screen.findByText('Hello')).resolves.toBeInTheDocument();
+
+    expect(tester.get(EntityCardBlueprint.dataRefs.type)).toBe('info');
   });
 });

--- a/plugins/catalog-react/src/alpha/converters/convertLegacyEntityCardExtension.tsx
+++ b/plugins/catalog-react/src/alpha/converters/convertLegacyEntityCardExtension.tsx
@@ -22,6 +22,7 @@ import { EntityCardBlueprint } from '../blueprints/EntityCardBlueprint';
 import kebabCase from 'lodash/kebabCase';
 import { EntityPredicate } from '../predicates/types';
 import { Entity } from '@backstage/catalog-model';
+import { EntityCardType } from '../blueprints/extensionData';
 
 /** @alpha */
 export function convertLegacyEntityCardExtension(
@@ -29,6 +30,7 @@ export function convertLegacyEntityCardExtension(
   overrides?: {
     name?: string;
     filter?: string | EntityPredicate | ((entity: Entity) => boolean);
+    type?: EntityCardType;
   },
 ): ExtensionDefinition {
   const element = <LegacyExtension />;
@@ -63,6 +65,7 @@ export function convertLegacyEntityCardExtension(
     params: {
       filter: overrides?.filter,
       loader: async () => compatWrapper(element),
+      type: overrides?.type,
     },
   });
 }


### PR DESCRIPTION
- **feat: support `type` override in the `convertLegacyEntityCardExtension`**
- **chore: add changeset**

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
