### PR TITLE
Make host optional in type definition

### DIFF
--- a/plugins/catalog-backend-module-azure/config.d.ts
+++ b/plugins/catalog-backend-module-azure/config.d.ts
@@ -28,9 +28,9 @@ export interface Config {
       azureDevOps?: {
         [name: string]: {
           /**
-           * (Optional) The DevOps host; leave empty for `dev.azure.com`, otherwise set to your self-hosted instance host.
+           * (Optional) The DevOps host; defaults to `dev.azure.com` if left empty, otherwise set to your self-hosted instance host.
            */
-          host: string;
+          host?: string;
           /**
            * (Required) Your organization slug.
            */


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Make azureDevOps -> host key optional in the type definition

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
