### PR TITLE
feat(scaffolder): Add step info to scaffolder action context

### DIFF
--- a/.changeset/wild-apes-care.md
+++ b/.changeset/wild-apes-care.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-scaffolder-node-test-utils': patch
+'@backstage/plugin-scaffolder-backend': minor
+'@backstage/plugin-scaffolder-node': patch
+---
+
+Add step info to scaffolder action context to access the step id and name.

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.test.ts
@@ -361,6 +361,24 @@ describe('NunjucksWorkflowRunner', () => {
         expect.objectContaining({ backstageToken: token }),
       );
     });
+
+    it('should pass step info through', async () => {
+      const task = createMockTaskWithSpec({
+        steps: [
+          {
+            id: 'test',
+            name: 'name',
+            action: 'jest-validated-action',
+            input: { foo: 1 },
+          },
+        ],
+      });
+
+      await runner.execute(task);
+
+      expect(fakeActionHandler.mock.calls[0][0].step.id).toEqual('test');
+      expect(fakeActionHandler.mock.calls[0][0].step.name).toEqual('name');
+    });
   });
 
   describe('conditionals', () => {
@@ -1446,6 +1464,35 @@ describe('NunjucksWorkflowRunner', () => {
       expect(
         fakeActionHandler.mock.calls[0][0].templateInfo.entity.metadata.name,
       ).toEqual('test-template');
+    });
+
+    it('should have step info in action context during dry run', async () => {
+      const task = createMockTaskWithSpec(
+        {
+          templateInfo: {
+            entityRef: 'dryRun-Entity',
+            entity: { metadata: { name: 'test-template' } },
+          },
+          steps: [
+            {
+              id: 'test',
+              name: 'name',
+              action: 'jest-validated-action',
+              input: { foo: 1 },
+            },
+          ],
+        },
+        {
+          backstageToken: token,
+        },
+        true,
+      );
+
+      await runner.execute(task);
+
+      expect(fakeActionHandler.mock.calls[0][0].isDryRun).toEqual(true);
+      expect(fakeActionHandler.mock.calls[0][0].step.id).toEqual('test');
+      expect(fakeActionHandler.mock.calls[0][0].step.name).toEqual('name');
     });
   });
 

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
@@ -438,6 +438,10 @@ export class NunjucksWorkflowRunner implements WorkflowRunner {
           isDryRun: task.isDryRun,
           signal: task.cancelSignal,
           getInitiatorCredentials: () => task.getInitiatorCredentials(),
+          step: {
+            id: step.id,
+            name: step.name,
+          },
         });
       }
 

--- a/plugins/scaffolder-node-test-utils/src/actions/mockActionContext.ts
+++ b/plugins/scaffolder-node-test-utils/src/actions/mockActionContext.ts
@@ -54,6 +54,10 @@ export function createMockActionContext<
     task: {
       id: 'mock-task-id',
     },
+    step: {
+      id: 'mock-step-id',
+      name: 'mock step name',
+    },
   };
 
   const createDefaultWorkspace = () => ({

--- a/plugins/scaffolder-node/report.api.md
+++ b/plugins/scaffolder-node/report.api.md
@@ -53,6 +53,10 @@ export type ActionContext<
   };
   signal?: AbortSignal;
   each?: JsonObject;
+  step?: {
+    id?: string;
+    name?: string;
+  };
 };
 
 // @public (undocumented)

--- a/plugins/scaffolder-node/src/actions/types.ts
+++ b/plugins/scaffolder-node/src/actions/types.ts
@@ -93,6 +93,20 @@ export type ActionContext<
    * Optional value of each invocation
    */
   each?: JsonObject;
+
+  /**
+   * Step information
+   */
+  step?: {
+    /**
+     * The id of step which triggered the action
+     */
+    id?: string;
+    /**
+     * The name of the step which triggered the action
+     */
+    name?: string;
+  };
 };
 
 /** @public */


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Resolves #29724 
Adds step info to scaffolder action context so you can see the id and name of the step that triggered the action.
Example: `ctx.step.id` and `ctx.step.name`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
