### PR TITLE
`nfs`: support passthrough of `allowUnknownExtensionConfig` from `createApp`

### DIFF
--- a/.changeset/spotty-icons-shake.md
+++ b/.changeset/spotty-icons-shake.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-defaults': patch
+---
+
+Added support for passing through `allowUnknownExtensionConfig` as a flag

--- a/packages/frontend-defaults/report.api.md
+++ b/packages/frontend-defaults/report.api.md
@@ -44,6 +44,10 @@ export interface CreateAppOptions {
     | FrontendFeatureLoader
     | CreateAppFeatureLoader
   )[];
+  // (undocumented)
+  flags?: {
+    allowUnknownExtensionConfig?: boolean;
+  };
   loadingComponent?: ReactNode;
   // (undocumented)
   pluginInfoResolver?: FrontendPluginInfoResolver;

--- a/packages/frontend-defaults/src/createApp.test.tsx
+++ b/packages/frontend-defaults/src/createApp.test.tsx
@@ -282,6 +282,38 @@ describe('createApp', () => {
     ).resolves.toBeInTheDocument();
   });
 
+  it('should allow unknown extension config if the flag is set', async () => {
+    const app = createApp({
+      configLoader: async () => ({
+        config: mockApis.config({
+          data: {
+            app: {
+              extensions: [{ 'unknown:lols/wut': false }],
+            },
+          },
+        }),
+      }),
+      features: [
+        appPlugin,
+        createFrontendPlugin({
+          pluginId: 'test',
+          extensions: [
+            PageBlueprint.make({
+              params: {
+                defaultPath: '/',
+                loader: async () => <div>Derp</div>,
+              },
+            }),
+          ],
+        }),
+      ],
+      flags: { allowUnknownExtensionConfig: true },
+    });
+
+    await renderWithEffects(app.createRoot());
+
+    await expect(screen.findByText('Derp')).resolves.toBeInTheDocument();
+  });
   it('should make the app structure available through the AppTreeApi', async () => {
     let appTreeApi: AppTreeApi | undefined = undefined;
 

--- a/packages/frontend-defaults/src/createApp.tsx
+++ b/packages/frontend-defaults/src/createApp.tsx
@@ -80,6 +80,7 @@ export interface CreateAppOptions {
     | ExtensionFactoryMiddleware
     | ExtensionFactoryMiddleware[];
   pluginInfoResolver?: FrontendPluginInfoResolver;
+  flags?: { allowUnknownExtensionConfig?: boolean };
 }
 
 /**
@@ -115,6 +116,7 @@ export function createApp(options?: CreateAppOptions): {
       bindRoutes: options?.bindRoutes,
       extensionFactoryMiddleware: options?.extensionFactoryMiddleware,
       pluginInfoResolver: options?.pluginInfoResolver,
+      flags: options?.flags,
     });
 
     const rootEl = app.tree.root.instance!.getData(


### PR DESCRIPTION
- **feat: added flags to pass through to specialized app Signed-off-by: benjdlambert <ben@blam.sh>**
- **chore: added changeset Signed-off-by: benjdlambert <ben@blam.sh>**

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
