### PR TITLE
catalog: eager info column scroll

### DIFF
--- a/.changeset/orange-poems-report.md
+++ b/.changeset/orange-poems-report.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Adjusted the sticky scrolling of the new entity layout so that the info columns scrolls to the bottom more eagerly.

--- a/plugins/catalog/src/alpha/DefaultEntityContentLayout.tsx
+++ b/plugins/catalog/src/alpha/DefaultEntityContentLayout.tsx
@@ -79,7 +79,8 @@ const useStyles = makeStyles<
     infoArea: {
       gridArea: 'info',
       position: 'sticky',
-      top: theme.spacing(3),
+      bottom: theme.spacing(3),
+      alignSelf: 'end',
       marginLeft: theme.spacing(3),
     },
     contentArea: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adjusts the info column scrolling for the new entity page so that it scrolls to the bottom immediately on scroll rather than as one scrolls to the bottom of the page.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
