### PR TITLE
feat(sanitizer): add support for allowlisting additional URI protocols

### DIFF
--- a/.changeset/nice-buttons-return.md
+++ b/.changeset/nice-buttons-return.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': minor
+---
+
+Adds `additionalAllowedURIProtocols` to sanitizer config

--- a/docs/features/techdocs/how-to-guides.md
+++ b/docs/features/techdocs/how-to-guides.md
@@ -606,6 +606,25 @@ techdocs:
 
 This way, custom element like `<backstage-element attribute1="value"></backstage-element>` will be allowed in the result HTML.
 
+## How to allow additional URI protocols in TechDocs
+
+TechDocs uses the [DOMPurify](https://github.com/cure53/DOMPurify) library to
+sanitize HTML and prevent XSS attacks.
+
+It's possible to allow additional URI protocols based on a list of protocols. To do
+this, add the allowed protocols in the `techdocs.sanitizer.additionalAllowedURIProtocols`
+and `additionalAllowedURIProtocols` configuration of your `app-config.yaml`.
+
+For example:
+
+```yaml
+techdocs:
+  sanitizer:
+    additionalAllowedURIProtocols: ["vscode"],
+```
+
+This way, links like `<a href="vscode://settings/">VSCode Settings<a>` will be allowed in the result HTML
+
 ## How to render PlantUML diagram in TechDocs
 
 PlantUML allows you to create diagrams from plain text language. Each diagram description begins with the keyword - (@startXYZ and @endXYZ, depending on the kind of diagram). For UML Diagrams, Keywords @startuml & @enduml should be used. Further details for all types of diagrams can be found at [PlantUML Language Reference Guide](https://plantuml.com/guide).

--- a/plugins/techdocs/config.d.ts
+++ b/plugins/techdocs/config.d.ts
@@ -58,6 +58,16 @@ export interface Config {
        * @visibility frontend
        */
       allowedCustomElementAttributeNameRegExp?: string;
+      /**
+       * Allows listed protocols in attributes with URI values
+       * Example:
+       *  additionalAllowedURIProtocols: ['vscode']
+       *  this will allow all attributes with URI values to have `vscode` protocol like `vscode://some/path` in addition to the default protocols
+       *  matched by DOMPurify's IS_ALLOWED_URI RegExp:
+       *  @see: https://raw.githubusercontent.com/cure53/DOMPurify/master/src/regexp.ts
+       * @visibility frontend
+       */
+      additionalAllowedURIProtocols?: string;
     };
   };
 }


### PR DESCRIPTION
## Allow additional protocols to be added to DOMPurify config

Past discussions about configurability of DOMPurify within TechDocs indicate that a targeted, restrictive approach to allowing DOMPurify configuration is preferred over full user-land flexibility (hooray for secure by default!). As such, this PR introduces a constrained means by which to allow additional protocols to be permitted.

#### Motivation
Question asked in Discord:
https://discord.com/channels/687207715902193673/714754240933003266/1394274725466865695


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [N/A] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
