### PR TITLE
fix(cli): add missing GitHub App permissions for repository creation

### DIFF
--- a/packages/cli/src/modules/create-github-app/commands/create-github-app/GithubCreateAppServer.ts
+++ b/packages/cli/src/modules/create-github-app/commands/create-github-app/GithubCreateAppServer.ts
@@ -126,6 +126,12 @@ export class GithubCreateAppServer {
           checks: 'read',
           actions: 'write',
         }),
+        ...(this.permissions.includes('administration') && {
+          administration: 'write',
+        }),
+        ...(this.permissions.includes('workflows') && {
+          workflows: 'write',
+        }),
       },
       name: 'Backstage-<changeme>',
       url: 'https://backstage.io',

--- a/packages/cli/src/modules/create-github-app/commands/create-github-app/index.ts
+++ b/packages/cli/src/modules/create-github-app/commands/create-github-app/index.ts
@@ -43,8 +43,16 @@ export default async (org: string) => {
         checked: true,
       },
       {
-        name: 'Read and Write to content and actions (required by Software Templates to create new repositories)',
+        name: 'Read and Write to content and actions (provides content and actions write access)',
         value: 'write',
+      },
+      {
+        name: 'Administration (required for repository creation, deletion, settings, teams, and collaborators)',
+        value: 'administration',
+      },
+      {
+        name: 'Workflows (required if repositories contain GitHub Workflows)',
+        value: 'workflows',
       },
     ],
   });


### PR DESCRIPTION

## Hey, I just made a Pull Request!

#30530

### What I added

- Fixed the `create-github-app` command to include the missing GitHub App permissions required for repository creation and GitHub Workflows support. Previously, users who selected all three permission options would still get permission errors when using software templates with the `publish:github` action.

### Changes:
- Added **Administration permission** option for repository creation, deletion, settings, teams, and collaborators
- Added **Workflows permission** option for repositories containing GitHub Workflows  
- Updated permission descriptions for better clarity

- Now when running `npx @backstage/cli create-github-app <org>`, users will see 5 permission options instead of 3, allowing them to properly configure GitHub Apps for software template repository creation.