### PR TITLE
`catalog`: fix order of filters in nfs

### DIFF
--- a/.changeset/nice-actors-cheer.md
+++ b/.changeset/nice-actors-cheer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Adding a more sensible default order to the default filters

--- a/plugins/catalog/src/alpha/filters.tsx
+++ b/plugins/catalog/src/alpha/filters.tsx
@@ -133,13 +133,14 @@ const catalogListCatalogFilter = CatalogFilterBlueprint.makeWithOverrides({
   },
 });
 
+// this is the default order that the filters will be applied in
 export default [
-  catalogTagCatalogFilter,
   catalogKindCatalogFilter,
   catalogTypeCatalogFilter,
-  catalogModeCatalogFilter,
-  catalogNamespaceCatalogFilter,
-  catalogLifecycleCatalogFilter,
-  catalogProcessingStatusCatalogFilter,
   catalogListCatalogFilter,
+  catalogModeCatalogFilter,
+  catalogLifecycleCatalogFilter,
+  catalogTagCatalogFilter,
+  catalogProcessingStatusCatalogFilter,
+  catalogNamespaceCatalogFilter,
 ];


### PR DESCRIPTION
- **chore: ammend the order in which the filters are loaded**
- **chore: changeset**

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
