### PR TITLE
Add data attributes for BUI

### DIFF
--- a/.changeset/great-snakes-dress.md
+++ b/.changeset/great-snakes-dress.md
@@ -1,0 +1,5 @@
+---
+'@backstage/theme': patch
+---
+
+We are introducing two new data attributes on the `body` to support Backstage UI (BUI) new theming system.

--- a/packages/theme/src/unified/UnifiedThemeProvider.tsx
+++ b/packages/theme/src/unified/UnifiedThemeProvider.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ReactNode } from 'react';
+import { ReactNode, useEffect } from 'react';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import {
   ThemeProvider,
@@ -70,6 +70,15 @@ export function UnifiedThemeProvider(
 
   const v4Theme = theme.getTheme('v4') as Mui4Theme;
   const v5Theme = theme.getTheme('v5') as Mui5Theme;
+  const themeMode = v4Theme ? v4Theme.palette.type : v5Theme?.palette.mode;
+
+  useEffect(() => {
+    document.body.setAttribute('data-theme-mode', themeMode);
+
+    return () => {
+      document.body.removeAttribute('data-theme-mode');
+    };
+  }, [themeMode]);
 
   let cssBaseline: JSX.Element | undefined = undefined;
   if (!noCssBaseline) {

--- a/packages/theme/src/unified/UnifiedThemeProvider.tsx
+++ b/packages/theme/src/unified/UnifiedThemeProvider.tsx
@@ -71,14 +71,17 @@ export function UnifiedThemeProvider(
   const v4Theme = theme.getTheme('v4') as Mui4Theme;
   const v5Theme = theme.getTheme('v5') as Mui5Theme;
   const themeMode = v4Theme ? v4Theme.palette.type : v5Theme?.palette.mode;
+  const themeName = 'backstage';
 
   useEffect(() => {
     document.body.setAttribute('data-theme-mode', themeMode);
+    document.body.setAttribute('data-theme-name', themeName);
 
     return () => {
       document.body.removeAttribute('data-theme-mode');
+      document.body.removeAttribute('data-theme-name');
     };
-  }, [themeMode]);
+  }, [themeMode, themeName]);
 
   let cssBaseline: JSX.Element | undefined = undefined;
   if (!noCssBaseline) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Backstage UI is based on CSS only for its theming. To make it work we need to add custom data attributes on the body for `light` and `dark` mode. What's new compared to our existing theming capacity in MUI is that we are differentiating the mode (`light` or `dark`) with the theme name. Users will be able to set a custom theme in both and light mode with Backstage UI.

We will introduce two new data attributes on the `body`:
- `data-theme-mode` - It could be `light` or `dark`
- `data-theme-name` - The actual name of your custom theme. By default we are using `backstage`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
