### PR TITLE
Detect HTTP-429 responses from GitLab

### DIFF
--- a/.changeset/fluffy-friends-brake.md
+++ b/.changeset/fluffy-friends-brake.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+Detect whether the GitLab API is returning an HTTP-429 response, indicating that the request has been rate-limited. Throw a specific error in this case.

--- a/packages/integration/src/gitlab/core.ts
+++ b/packages/integration/src/gitlab/core.ts
@@ -154,6 +154,10 @@ export async function getProjectId(
         );
       }
 
+      if (response.status === 429) {
+        throw new Error('GitLab Error: 429 - Too Many Requests.');
+      }
+
       throw new Error(
         `GitLab Error '${data.error}', ${data.error_description}`,
       );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Previously, if the GitLab API responded with an HTTP-429 response (indicating that the request was rate-limited) this would not be apparent in the resultant error that was thrown. This was because the `data.error` and `data.error_description` fields were not populated in these types of responses.

Now, we look specifically for an HTTP-429 response code, and throw a descriptive error in this case.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
