### PR TITLE
Add Holiday Tracker Plugin To Marketplace

### DIFF
--- a/microsite/data/plugins/holiday-tracker.yaml
+++ b/microsite/data/plugins/holiday-tracker.yaml
@@ -1,0 +1,10 @@
+---
+title: Holiday Tracker
+author: Infosys Limited
+authorUrl: https://github.com/Infosys
+category: Utility
+description: The Holiday Tracker Plugin for Backstage provides real-time public holiday information for a specified country or region using the Calendarific API.
+documentation: https://github.com/Infosys/holiday-tracker-plugin/blob/main/plugins/holiday-tracker/README.md
+iconUrl: https://github.com/Infosys/holiday-tracker-plugin/blob/main/plugins/holiday-tracker/src/docs/holiday-tracker-plugin.logo.png?raw=true
+npmPackageName: '@infosys_ltd/holiday-tracker-plugin'
+addedDate: '2025-07-23'


### PR DESCRIPTION
**This PR introduces a new plugin: [Holiday Tracker Plugin for Backstage](https://www.npmjs.com/package/@infosys_ltd/holiday-tracker-plugin), designed to fetch and display public holiday information using the Calendarific API. The plugin is useful for displaying holiday calendars specific to a country and year, providing easy integration for organizations using Backstage.**

<img width="670" height="566" alt="Holiday tracker architecture" src="https://github.com/user-attachments/assets/ca1060fa-cb90-48bf-a841-abb604d3e7e6" />

<img width="1346" height="598" alt="image" src="https://github.com/user-attachments/assets/b774b665-ba05-4400-8a73-e747baa7ab96" />




🧩 Plugin Features
📆 Holiday Display: Show public holidays for any given country and year.

🔐 Secure Backend Proxy: Uses the Backstage proxy feature to securely fetch data from Calendarific without exposing the API key in the frontend.

🔧 Flexible Configuration: Supports both static and environment variable-based configurations for API key, country, and year.