### PR TITLE
bugfix: Fixed fs:readdir action example

### DIFF
--- a/.changeset/great-hounds-fix.md
+++ b/.changeset/great-hounds-fix.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+Fixed fs:readdir action example

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/filesystem/read.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/filesystem/read.ts
@@ -18,7 +18,7 @@ import { resolveSafeChildPath } from '@backstage/backend-plugin-api';
 import fs from 'fs/promises';
 import path from 'path';
 import { z as zod } from 'zod';
-import { examples } from './rename.examples';
+import { examples } from './read.examples';
 
 const contentSchema = (z: typeof zod) =>
   z.object({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixed fs:readdir action example. 

<details>
<summary>Before</summary>
<img width="1182" height="874" alt="CleanShot 2025-07-23 at 16 14 19@2x" src="https://github.com/user-attachments/assets/95ee9118-61cd-484c-b3a8-4cd40599fc8e" />
</details>

<details>
<summary>Now</summary>
<img width="2452" height="1576" alt="CleanShot 2025-07-23 at 16 15 19@2x" src="https://github.com/user-attachments/assets/df5a7bf4-cf5a-42f1-a973-9f25126cb63f" />
</details>

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
