### PR TITLE
Update backend plugin tutorial to refer to /todos endpoint instead of…

### DIFF
--- a/docs/plugins/backend-plugin.md
+++ b/docs/plugins/backend-plugin.md
@@ -48,11 +48,18 @@ This will think for a bit, and then say `Listening on :7007`. In a different
 terminal window, now run
 
 ```sh
-curl localhost:7007/api/carmen/health
+curl localhost:7007/api/carmen/todos
 ```
 
-This should return `{"status":"ok"}`. Success! Press `Ctrl + c` to stop it
-again.
+You should see the following response:
+```sh
+{
+"items": []
+} 
+```
+:::note Note: The route shown here matches the default in the current backend plugin template. If you want a `/health` endpoint for health checks, you can add it to your router yourself.
+
+:::
 
 ## Developing your Backend Plugin
 


### PR DESCRIPTION
… /health

This PR updates the backend plugin tutorial documentation to match the current plugin template. Previously, the tutorial referenced a /health endpoint, which does not exist in the generated backend plugin.

## Hey, I just made a Pull Request!

<!-- This PR updates the backend plugin tutorial documentation to match the current plugin template. Previously, the tutorial referenced a /health endpoint, which does not exist in the generated backend plugin. -->
Fixes: #30322
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
