### PR TITLE
Make the `description`property in the `publish:gitlab:merge-request` optional again

### DIFF
--- a/.changeset/fuzzy-ducks-speak.md
+++ b/.changeset/fuzzy-ducks-speak.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gitlab': patch
+---
+
+The `description` property in `publish:gitlab:merge-request` has been made optional again to comply with the GitLab API.

--- a/plugins/scaffolder-backend-module-gitlab/report.api.md
+++ b/plugins/scaffolder-backend-module-gitlab/report.api.md
@@ -218,8 +218,8 @@ export const createPublishGitlabMergeRequestAction: (options: {
   {
     repoUrl: string;
     title: string;
-    description: string;
     branchName: string;
+    description?: string | undefined;
     targetBranchName?: string | undefined;
     sourcePath?: string | undefined;
     targetPath?: string | undefined;

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabMergeRequest.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabMergeRequest.ts
@@ -157,7 +157,10 @@ Accepts the format \`gitlab.com?repo=project_name&owner=group_name\` where \
 \`project_name\` is the repository name and \`group_name\` is a group or username`),
         title: z => z.string().describe('The name for the merge request'),
         description: z =>
-          z.string().describe('The description of the merge request'),
+          z
+            .string()
+            .optional()
+            .describe('The description of the merge request'),
         branchName: z =>
           z.string().describe('The source branch name of the merge request'),
         targetBranchName: z =>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Just a tiny little pull request to make the `description` property in `publish:gitlab:merge-request` optional again.

When the action was refactored (from JSON schema to Zod), the description property was made required, which broke some of our templates - [more info](https://github.com/backstage/backstage/pull/29952#issuecomment-3103705437). 

However, according to the [GitLab API](https://docs.gitlab.com/api/merge_requests/#create-mr), this field is not required—hence this PR.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
