### PR TITLE
chore: remove deprecated loggerToWinstonLogger

### DIFF
--- a/.changeset/calm-geese-serve.md
+++ b/.changeset/calm-geese-serve.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Remove usage of the deprecated `loggerToWinstonLogger` from `@backstage/backend-common`.

--- a/plugins/kubernetes-backend/src/service/KubernetesProxy.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesProxy.ts
@@ -42,10 +42,7 @@ import {
   LoggerService,
   PermissionsService,
 } from '@backstage/backend-plugin-api';
-import {
-  createLegacyAuthAdapters,
-  loggerToWinstonLogger,
-} from '@backstage/backend-common';
+import { createLegacyAuthAdapters } from '@backstage/backend-common';
 
 export const APPLICATION_JSON: string = 'application/json';
 
@@ -153,8 +150,13 @@ export class KubernetesProxy {
     if (!middleware) {
       const logger = this.logger.child({ cluster: originalCluster.name });
       middleware = createProxyMiddleware({
-        // TODO: Add 'log' to LoggerService
-        logProvider: () => loggerToWinstonLogger(logger),
+        logProvider: () => ({
+          log: logger.info.bind(logger),
+          debug: logger.debug.bind(logger),
+          info: logger.info.bind(logger),
+          warn: logger.warn.bind(logger),
+          error: logger.error.bind(logger),
+        }),
         ws: true,
         secure: !originalCluster.skipTLSVerify,
         changeOrigin: true,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

I removed usage of the deprecated `loggerToWinstonLogger` from `@backstage/backend-common`. We follow a similar method as #28987.

Contributes to https://github.com/backstage/backstage/issues/26353 phase 2.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
