### PR TITLE
cli: allow js files to be processed by nodeTransform

### DIFF
--- a/.changeset/yellow-ducks-burn.md
+++ b/.changeset/yellow-ducks-burn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Allow js files to be processed by the nodeTransform loader

--- a/packages/cli/config/nodeTransformHooks.mjs
+++ b/packages/cli/config/nodeTransformHooks.mjs
@@ -127,10 +127,10 @@ async function withDetectedModuleType(resolved) {
     };
   }
 
-  // TODO(Rugvip): Afaik this should never happen and we can remove this check, but want it here for a little while to verify.
-  if (ext === '.js') {
-    throw new Error('Unexpected .js file without explicit format');
-  }
+  // Under normal circumstances .js files should reliably have a format and so
+  // we should only reach this point for .ts files. However, if additional
+  // custom loaders are being used the format may not be detected for .js files
+  // either. As such we don't restrict the file format at this point.
 
   // TODO(Rugvip): Does this need caching? kept it simple for now but worth exploring
   const packageJsonPath = await findPackageJSON(fileURLToPath(resolved.url));


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Allows the nodeTransform loader to be used for transpiling .ts files when other custom loaders (like the yarn pnp esm loader) are in use.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
