### PR TITLE
Fix: Show additional information about the cause in error messages from GitLab in the scaffolder-backend-module-GitLab.

### DIFF
--- a/.changeset/deep-apples-attack.md
+++ b/.changeset/deep-apples-attack.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-backend-module-gitlab': patch
 ---
 
-Show additional information about the cause in error messages from GitLab in scaffolder-backend-module-GitLab.
+Show additional information about the cause in error messages from GitLab

--- a/.changeset/deep-apples-attack.md
+++ b/.changeset/deep-apples-attack.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gitlab': patch
+---
+
+Show additional information about the cause in error messages from GitLab in scaffolder-backend-module-GitLab.

--- a/plugins/scaffolder-backend-module-gitlab/package.json
+++ b/plugins/scaffolder-backend-module-gitlab/package.json
@@ -50,6 +50,7 @@
     "@backstage/errors": "workspace:^",
     "@backstage/integration": "workspace:^",
     "@backstage/plugin-scaffolder-node": "workspace:^",
+    "@gitbeaker/requester-utils": "^41.2.0",
     "@gitbeaker/rest": "^41.2.0",
     "luxon": "^3.0.0",
     "winston": "^3.2.1",

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/helpers.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/helpers.ts
@@ -17,6 +17,7 @@ import { parseRepoUrl } from '@backstage/plugin-scaffolder-node';
 import { ErrorLike, InputError, isError } from '@backstage/errors';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import { Gitlab } from '@gitbeaker/rest';
+import { GitbeakerRequestError } from '@gitbeaker/requester-utils';
 
 export function createGitlabApi(options: {
   integrations: ScmIntegrationRegistry;
@@ -57,7 +58,13 @@ function isGitlabError(e: unknown): e is GitlabError {
   return isError(e) && 'description' in e && typeof e.description === 'string';
 }
 
+function isGitbeakerRequestError(e: unknown): e is GitbeakerRequestError {
+  return isError(e) && (e as any).name === 'GitbeakerRequestError';
+}
+
 export function getErrorMessage(e: unknown): string {
+  if (isGitbeakerRequestError(e) && e.cause)
+    return `${e} - ${e.cause.description}`;
   if (isGitlabError(e)) return `${e} - ${e.description}`;
   return String(e);
 }

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/helpers.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/helpers.ts
@@ -59,7 +59,7 @@ function isGitlabError(e: unknown): e is GitlabError {
 }
 
 function isGitbeakerRequestError(e: unknown): e is GitbeakerRequestError {
-  return isError(e) && (e as any).name === 'GitbeakerRequestError';
+  return isError(e) && e.name === 'GitbeakerRequestError';
 }
 
 export function getErrorMessage(e: unknown): string {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7240,6 +7240,7 @@ __metadata:
     "@backstage/integration": "workspace:^"
     "@backstage/plugin-scaffolder-node": "workspace:^"
     "@backstage/plugin-scaffolder-node-test-utils": "workspace:^"
+    "@gitbeaker/requester-utils": "npm:^41.2.0"
     "@gitbeaker/rest": "npm:^41.2.0"
     luxon: "npm:^3.0.0"
     winston: "npm:^3.2.1"
@@ -9788,7 +9789,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gitbeaker/requester-utils@npm:^41.3.0":
+"@gitbeaker/requester-utils@npm:^41.2.0, @gitbeaker/requester-utils@npm:^41.3.0":
   version: 41.3.0
   resolution: "@gitbeaker/requester-utils@npm:41.3.0"
   dependencies:


### PR DESCRIPTION
## Problem

In error messages from scaffolder-backend-module-GitLab that were reported from the GitLab API only very basic information like "Unauthorized" or "BadRequest" was contained but additional information about the error cause was lost.

## Solution

For errors of type GitbeakerRequestError the error's cause.description is added to the error message if available to provide more information to the user.

## Testing

- Errors of type GitbeakerRequestError result in the expected error message.
- All existing tests continue to pass