### PR TITLE
Bug 30641 - update search logo on .io website for theme-toggle-friend…

### DIFF
--- a/microsite/static/img/backstage-search-platform.svg
+++ b/microsite/static/img/backstage-search-platform.svg
@@ -3,8 +3,8 @@
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 380 380" style="enable-background:new 0 0 380 380;" xml:space="preserve">
 <style type="text/css">
-	.st0{fill:#121212;stroke:#7DF3E1;stroke-width:3;stroke-linejoin:round;stroke-miterlimit:10;}
-	.st1{fill:#121212;stroke:#7DF3E1;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
+	.st0{fill:none;stroke:#7DF3E1;stroke-width:3;stroke-linejoin:round;stroke-miterlimit:10;}
+	.st1{fill:none;stroke:#7DF3E1;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
 </style>
 <g>
 	<path class="st0" d="M148.71,175.36l111.65,103.46c7.55,6.99,5.63,19.4-3.67,23.79h0c-5.36,2.53-11.72,1.55-16.07-2.48


### PR DESCRIPTION
This is an attempt to fix https://github.com/backstage/backstage/issues/30641.

## Hey, I just made a Pull Request!

There is a pattern as the other backstage-* SVG files use a light theme with:
  - No dark fills (#121212)
  - Only stroke outlines in cyan (#7df3e1)
  - Transparent/no fill backgrounds

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

<img width="1327" height="849" alt="Screenshot 2025-07-28 at 22 35 49" src="https://github.com/user-attachments/assets/029d98d2-2c76-4bd5-b5a3-016c16ce1732" />
<img width="1367" height="772" alt="Screenshot 2025-07-28 at 22 35 54" src="https://github.com/user-attachments/assets/5f18b23e-2c24-4a55-b53e-bced3b1d89ac" />

