### PR TITLE
Export `FormField` type from Scaffolder

### DIFF
--- a/.changeset/mighty-cycles-stay.md
+++ b/.changeset/mighty-cycles-stay.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Export `FormField` type.

--- a/plugins/scaffolder/report-alpha.api.md
+++ b/plugins/scaffolder/report-alpha.api.md
@@ -281,6 +281,8 @@ export const formDecoratorsApi: ExtensionDefinition<{
 // @alpha (undocumented)
 export const formDecoratorsApiRef: ApiRef<ScaffolderFormDecoratorsApi>;
 
+export { FormField };
+
 export { formFieldsApiRef };
 
 // @alpha @deprecated
@@ -394,10 +396,10 @@ export const scaffolderTranslationRef: TranslationRef<
     readonly 'ongoingTask.title': 'Run of';
     readonly 'ongoingTask.contextMenu.cancel': 'Cancel';
     readonly 'ongoingTask.contextMenu.startOver': 'Start Over';
-    readonly 'ongoingTask.contextMenu.retry': 'Retry';
     readonly 'ongoingTask.contextMenu.hideLogs': 'Hide Logs';
     readonly 'ongoingTask.contextMenu.showLogs': 'Show Logs';
     readonly 'ongoingTask.contextMenu.hideButtonBar': 'Hide Button Bar';
+    readonly 'ongoingTask.contextMenu.retry': 'Retry';
     readonly 'ongoingTask.contextMenu.showButtonBar': 'Show Button Bar';
     readonly 'ongoingTask.subtitle': 'Task {{taskId}}';
     readonly 'ongoingTask.pageTitle.hasTemplateName': 'Run of {{templateName}}';
@@ -415,8 +417,6 @@ export const scaffolderTranslationRef: TranslationRef<
     readonly 'renderSchema.tableCell.description': 'Description';
     readonly 'templatingExtensions.content.values.title': 'Values';
     readonly 'templatingExtensions.content.values.notAvailable': 'There are no global template values defined.';
-    readonly 'templatingExtensions.content.emptyState.title': 'No information to display';
-    readonly 'templatingExtensions.content.emptyState.description': 'There are no templating extensions available or there was an issue communicating with the backend.';
     readonly 'templatingExtensions.content.filters.title': 'Filters';
     readonly 'templatingExtensions.content.filters.schema.input': 'Input';
     readonly 'templatingExtensions.content.filters.schema.output': 'Output';
@@ -424,6 +424,8 @@ export const scaffolderTranslationRef: TranslationRef<
     readonly 'templatingExtensions.content.filters.examples': 'Examples';
     readonly 'templatingExtensions.content.filters.notAvailable': 'There are no template filters defined.';
     readonly 'templatingExtensions.content.filters.metadataAbsent': 'Filter metadata unavailable';
+    readonly 'templatingExtensions.content.emptyState.title': 'No information to display';
+    readonly 'templatingExtensions.content.emptyState.description': 'There are no templating extensions available or there was an issue communicating with the backend.';
     readonly 'templatingExtensions.content.searchFieldPlaceholder': 'Search for an extension';
     readonly 'templatingExtensions.content.functions.title': 'Functions';
     readonly 'templatingExtensions.content.functions.schema.output': 'Output';
@@ -480,8 +482,8 @@ export const scaffolderTranslationRef: TranslationRef<
     readonly 'templateListPage.pageTitle': 'Create a new component';
     readonly 'templateListPage.templateGroups.defaultTitle': 'Templates';
     readonly 'templateListPage.templateGroups.otherTitle': 'Other Templates';
-    readonly 'templateListPage.contentHeader.supportButtonTitle': 'Create new software components using standard templates. Different templates create different kinds of components (services, websites, documentation, ...).';
     readonly 'templateListPage.contentHeader.registerExistingButtonTitle': 'Register Existing Component';
+    readonly 'templateListPage.contentHeader.supportButtonTitle': 'Create new software components using standard templates. Different templates create different kinds of components (services, websites, documentation, ...).';
     readonly 'templateListPage.additionalLinksForEntity.viewTechDocsTitle': 'View TechDocs';
     readonly 'templateWizardPage.title': 'Create a new component';
     readonly 'templateWizardPage.subtitle': 'Create new software components using standard templates in your organization';
@@ -494,8 +496,8 @@ export const scaffolderTranslationRef: TranslationRef<
     readonly 'templateEditorToolbar.addToCatalogDialogTitle': 'Publish changes';
     readonly 'templateEditorToolbar.addToCatalogDialogContent.stepsIntroduction': 'Follow the instructions below to create or update a template:';
     readonly 'templateEditorToolbar.addToCatalogDialogContent.stepsListItems': 'Save the template files in a local directory\nCreate a pull request to a new or existing git repository\nIf the template already exists, the changes will be reflected in the software catalog once the pull request gets merged\nBut if you are creating a new template, follow the documentation linked below to register the new template repository in software catalog';
-    readonly 'templateEditorToolbar.addToCatalogDialogActions.documentationUrl': 'https://backstage.io/docs/features/software-templates/adding-templates/';
     readonly 'templateEditorToolbar.addToCatalogDialogActions.documentationButton': 'Go to the documentation';
+    readonly 'templateEditorToolbar.addToCatalogDialogActions.documentationUrl': 'https://backstage.io/docs/features/software-templates/adding-templates/';
     readonly 'templateEditorToolbarFileMenu.button': 'File';
     readonly 'templateEditorToolbarFileMenu.options.openDirectory': 'Open template directory';
     readonly 'templateEditorToolbarFileMenu.options.createDirectory': 'Create template directory';

--- a/plugins/scaffolder/src/alpha/index.ts
+++ b/plugins/scaffolder/src/alpha/index.ts
@@ -30,4 +30,6 @@ export {
   type ScaffolderFormFieldsApi,
 } from '@backstage/plugin-scaffolder-react/alpha';
 
+export { type FormField } from '@internal/scaffolder';
+
 export { default } from './plugin';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Attempting to re-export the Scaffolder plugin (e.g. to use `.withOverrides`) results in a type error due to the fact that the plugin return type references the `FormField` type which itself is not exported, therefore the TypeScript compiler is unable to determine the shape of it in the new plugin. This PR exports the `FormField` type to resolve this, however let me know if that is undesirable and another solution is preferred instead

```typescript
import { default as alphaScaffolderPlugin } from "@backstage/plugin-scaffolder/alpha";

export const scaffolderPlugin = alphaScaffolderPlugin;
             ~~~~~~~~~~~~~~~~
                    ^
Exported variable 'scaffolderPlugin' has or is using name 'FormField' from external module "node_modules/@backstage/plugin-scaffolder/dist/alpha" but cannot be named.
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
