### PR TITLE
frontend-plugin-api: advanced blueprint param types

### DIFF
--- a/.changeset/every-schools-find.md
+++ b/.changeset/every-schools-find.md
@@ -1,0 +1,20 @@
+---
+'@backstage/plugin-catalog-unprocessed-entities': patch
+'@backstage/frontend-app-api': patch
+'@backstage/core-compat-api': patch
+'@backstage/plugin-scaffolder-react': patch
+'@backstage/plugin-catalog-import': patch
+'@backstage/plugin-notifications': patch
+'@backstage/plugin-kubernetes': patch
+'@backstage/plugin-scaffolder': patch
+'@backstage/plugin-api-docs': patch
+'@backstage/plugin-devtools': patch
+'@backstage/plugin-techdocs': patch
+'@backstage/plugin-catalog': patch
+'@backstage/plugin-signals': patch
+'@backstage/plugin-search': patch
+'@backstage/plugin-home': patch
+'@backstage/plugin-app': patch
+---
+
+Internal update to use the new variant of `ApiBlueprint`.

--- a/.changeset/odd-beans-sell.md
+++ b/.changeset/odd-beans-sell.md
@@ -1,0 +1,40 @@
+---
+'@backstage/frontend-plugin-api': minor
+---
+
+**BREAKING**: The `ApiBlueprint` has been updated to use the new advanced type parameters through the new `defineParams` blueprint option. This is an immediate breaking change that requires all existing usages of `ApiBlueprint` to switch to the new callback format. Existing extensions created with the old format are still compatible with the latest version of the plugin API however, meaning that this does not break existing plugins.
+
+To update existing usages of `ApiBlueprint`, you remove the outer level of the `params` object and replace `createApiFactory(...)` with `define => define(...)`.
+
+For example, the following old usage:
+
+```ts
+ApiBlueprint.make({
+  name: 'error',
+  params: {
+    factory: createApiFactory({
+      api: errorApiRef,
+      deps: { alertApi: alertApiRef },
+      factory: ({ alertApi }) => {
+        return ...;
+      },
+    })
+  },
+})
+```
+
+is migrated to the following:
+
+```ts
+ApiBlueprint.make({
+  name: 'error',
+  params: define =>
+    define({
+      api: errorApiRef,
+      deps: { alertApi: alertApiRef },
+      factory: ({ alertApi }) => {
+        return ...;
+      },
+    }),
+})
+```

--- a/.changeset/quiet-parks-cheer.md
+++ b/.changeset/quiet-parks-cheer.md
@@ -39,4 +39,4 @@ const example = ExampleBlueprint.make({
 });
 ```
 
-This `define => define(<params>)` is also known as the "callback syntax" and is is required if a blueprint is created with the new `defineParams` option. The callback syntax can also optionally be used for other blueprints too, which means that it is not a breaking change to remove the `defineParams` option, as long as the external parameter types remain compatible.
+This `define => define(<params>)` is also known as the "callback syntax" and is required if a blueprint is created with the new `defineParams` option. The callback syntax can also optionally be used for other blueprints too, which means that it is not a breaking change to remove the `defineParams` option, as long as the external parameter types remain compatible.

--- a/.changeset/quiet-parks-cheer.md
+++ b/.changeset/quiet-parks-cheer.md
@@ -1,0 +1,42 @@
+---
+'@backstage/frontend-plugin-api': minor
+---
+
+Added support for advanced parameter types in extension blueprints. The primary purpose of this is to allow extension authors to use type inference in the definition of the blueprint parameters. This often removes the need for extra imports and improves discoverability of blueprint parameters.
+
+This feature is introduced through the new `defineParams` option of `createExtensionBlueprint`, along with accompanying `createExtensionBlueprintParams` function to help implement the new format.
+
+The following is an example of how to create an extension blueprint that uses the new option:
+
+```ts
+const ExampleBlueprint = createExtensionBlueprint({
+  kind: 'example',
+  attachTo: { id: 'example', input: 'example' },
+  output: [exampleComponentDataRef, exampleFetcherDataRef],
+  defineParams<T>(params: {
+    component(props: ExampleProps<T>): JSX.Element | null;
+    fetcher(options: FetchOptions): Promise<FetchResult<T>>;
+  }) {
+    // The returned params must be wrapped with `createExtensionBlueprintParams`
+    return createExtensionBlueprintParams(params);
+  },
+  *factory(params) {
+    // These params are now inferred
+    yield exampleComponentDataRef(params.component);
+    yield exampleFetcherDataRef(params.fetcher);
+  },
+});
+```
+
+Usage of the above example looks as follows:
+
+```ts
+const example = ExampleBlueprint.make({
+  params: define => define({
+    component: ...,
+    fetcher: ...,
+  }),
+});
+```
+
+This `define => define(<params>)` is also known as the "callback syntax" and is is required if a blueprint is created with the new `defineParams` option. The callback syntax can also optionally be used for other blueprints too, which means that it is not a breaking change to remove the `defineParams` option, as long as the external parameter types remain compatible.

--- a/docs/frontend-system/architecture/23-extension-blueprints.md
+++ b/docs/frontend-system/architecture/23-extension-blueprints.md
@@ -60,6 +60,39 @@ When using `makeWithOverrides`, we no longer pass the blueprint parameters direc
 
 Apart from the addition of the blueprint parameters of the first argument to the original factory function, the `makeWithOverrides` method works the same way as [extension overrides](./25-extension-overrides.md). All the same options and rules apply, including the ability to define additional inputs, override outputs, and so on. We therefore defer to the [extension overrides](./25-extension-overrides.md) documentation for more information on how to use the `makeWithOverrides` method.
 
+### Creating an extension from a blueprint with advanced parameter types
+
+Some blueprints may be defined with something known as "advanced parameter types". This is a feature that enables type inference and transform of the blueprint parameters, and the way that you pass the parameters look a little bit different. Rather than passing the parameters directly, they are instead passed as a callback function of the form `define => define(<params>)`.
+
+An example of a blueprint that uses advanced parameter types is the `ApiBlueprint` blueprint. Using it to create a simple implementation for the `AlertApi` might look like this:
+
+```ts
+const alertApiBlueprint = ApiBlueprint.make({
+  params: define =>
+    define({
+      api: alertApiRef,
+      deps: {},
+      factory: () => new MyAlertApi(),
+    }),
+});
+```
+
+This also works with `makeWithOverrides`, where the define callback is passed as the first argument to the original factory:
+
+```ts
+const alertApiBlueprint = ApiBlueprint.makeWithOverrides({
+  factory(originalFactory, { config }) {
+    return originalFactory(define =>
+      define({
+        api: alertApiRef,
+        deps: {},
+        factory: () => new MyAlertApi(config),
+      }),
+    );
+  },
+});
+```
+
 ## Creating an extension blueprint
 
 To create a new extension blueprint, you use the `createExtensionBlueprint` function. At the surface it is very similar to `createExtension`, but with a few key differences. Firstly you must provide a `kind` option, which will be the kind of all extensions created with the blueprint. See the [naming patterns section](./50-naming-patterns.md) for more information about how to select a good extension kind. Secondly, the `factory` function has a new signature where the first parameter is the blueprint parameters, and the second is the factory context. And finally, rather than returning an extension, `createExtensionBlueprint` returns a blueprint object with the `make` method and friends, which is used as is described above.
@@ -98,6 +131,41 @@ export const MyWidgetBlueprint = createExtensionBlueprint({
 This is of course a quite bare-bones example blueprint, but still a very real example. Blueprints can be very simple, there's already a lot of value in encapsulating the extension kind, attachment point, and output in a blueprint.
 
 Most of the options provided to `createExtensionBlueprint` can be overridden when using `makeWithOverrides` to create an extension from the blueprint. These overrides work the same way as [extension overrides](./25-extension-overrides.md), and we defer to that documentation for more information on how overrides work.
+
+### Creating an extension blueprint with advanced parameter types
+
+In some cases you may want to use inferred type parameters in the definition of the blueprint parameters. For this you need to use something known as "advanced parameter types". This is a feature that enables type inference and transform of the blueprint parameters, and the way you define the parameter type is a bit different. Rather than defining the type of the parameters as part of the factory function, you instead provide a separate `defineParams` options. This is a function that takes the parameters as a single argument, and must then return the parameters wrapped with the `createExtensionBlueprintParams` function.
+
+The following is an example of how one might define a blueprint where the parameters make use of inferred types:
+
+```ts
+export interface MyWidgetBlueprintParams<T> {
+  defaultOptions: T;
+  elementFactory(options: T): JSX.Element;
+}
+
+export const MyWidgetBlueprint = createExtensionBlueprint({
+  kind: 'my-widget',
+  attachTo: { id: 'page:my-plugin', input: 'widgets' },
+  output: [coreExtensionData.reactElement],
+  defineParams<T>(params: MyWidgetBlueprintParams<T>) {
+    return createExtensionBlueprintParams(params);
+  },
+  // Note that we no longer define the parameters type here, they are inferred from the defineParams function
+  factory(params) {
+    return [
+      coreExtensionData.reactElement(
+        <MyWidgetRenderer
+          defaultOptions={params.defaultOptions}
+          elementFactory={params.elementFactory}
+        />,
+      ),
+    ];
+  },
+});
+```
+
+If you happen to ask yourself, "why can't I just define type parameters on the factory function instead?", this is a limitation in the TypeScript type system. We could technically support that in the blueprint definition, but there would be no way for that logic to be carried forward to the blueprint `.make` and `.makeWithOverrides` methods.
 
 ### Blueprint-specific extension data references
 

--- a/docs/frontend-system/building-apps/08-migrating.md
+++ b/docs/frontend-system/building-apps/08-migrating.md
@@ -199,13 +199,12 @@ import { ApiBlueprint } from '@backstage/frontend-plugin-api';
 
 const scmIntegrationsApi = ApiBlueprint.make({
   name: 'scm-integrations',
-  params: {
-    factory: createApiFactory({
+  params: define =>
+    define({
       api: scmIntegrationsApiRef,
       deps: { configApi: configApiRef },
       factory: ({ configApi }) => ScmIntegrationsApi.fromConfig(configApi),
     }),
-  },
 });
 ```
 

--- a/docs/frontend-system/building-plugins/01-index.md
+++ b/docs/frontend-system/building-plugins/01-index.md
@@ -154,19 +154,18 @@ export function ExamplePage() {
 ```
 
 ```tsx title="in src/plugin.ts - Registering a factory for our API"
-import { createApiFactory, ApiBlueprint } from '@backstage/frontend-plugin-api';
+import { ApiBlueprint } from '@backstage/frontend-plugin-api';
 import { exampleApiRef, DefaultExampleApi } from './api';
 
 // highlight-add-start
 const exampleApi = ApiBlueprint.make({
   name: 'example',
-  params: {
-    factory: createApiFactory({
+  params: define =>
+    define({
       api: exampleApiRef,
       deps: {},
       factory: () => new DefaultExampleApi(),
     }),
-  },
 });
 // highlight-add-end
 

--- a/docs/frontend-system/building-plugins/05-migrating.md
+++ b/docs/frontend-system/building-plugins/05-migrating.md
@@ -205,22 +205,17 @@ The major changes we'll make are
 The end result, after simplifying imports and cleaning up a bit, might look like this:
 
 ```tsx title="in @internal/plugin-example"
-import {
-  storageApiRef,
-  createApiFactory,
-  ApiBlueprint,
-} from '@backstage/frontend-plugin-api';
+import { storageApiRef, ApiBlueprint } from '@backstage/frontend-plugin-api';
 import { workApiRef } from '@internal/plugin-example-react';
 import { WorkImpl } from './WorkImpl';
 
 const exampleWorkApi = ApiBlueprint.make({
-  params: {
-    factory: createApiFactory({
+  params: define =>
+    define({
       api: workApiRef,
       deps: { storageApi: storageApiRef },
       factory: ({ storageApi }) => new WorkImpl({ storageApi }),
     }),
-  },
 });
 ```
 

--- a/docs/frontend-system/utility-apis/02-creating.md
+++ b/docs/frontend-system/utility-apis/02-creating.md
@@ -45,7 +45,6 @@ The plugin itself now wants to provide this API and its default implementation, 
 ```tsx title="in @internal/plugin-example"
 import {
   ApiBlueprint,
-  createApiFactory,
   createFrontendPlugin,
   storageApiRef,
   StorageApi,
@@ -63,15 +62,14 @@ class WorkImpl implements WorkApi {
 
 const workApi = ApiBlueprint.make({
   name: 'work',
-  params: {
-    factory: createApiFactory({
+  params: define =>
+    define({
       api: workApiRef,
       deps: { storageApi: storageApiRef },
       factory: ({ storageApi }) => {
         return new WorkImpl({ storageApi });
       },
     }),
-  },
 });
 
 /**

--- a/docs/frontend-system/utility-apis/03-consuming.md
+++ b/docs/frontend-system/utility-apis/03-consuming.md
@@ -46,14 +46,13 @@ Your utility APIs can depend on other utility APIs in their factories. You do th
 import {
   configApiRef,
   ApiBlueprint,
-  createApiFactory,
   discoveryApiRef,
 } from '@backstage/frontend-plugin-api';
 import { MyApiImpl } from './MyApiImpl';
 
 const myApi = ApiBlueprint.make({
-  params: {
-    factory: createApiFactory({
+  params: define =>
+    define({
       api: myApiRef,
       deps: {
         configApi: configApiRef,
@@ -63,7 +62,6 @@ const myApi = ApiBlueprint.make({
         return new MyApiImpl({ configApi, discoveryApi });
       },
     }),
-  },
 });
 ```
 

--- a/packages/core-compat-api/src/collectLegacyRoutes.tsx
+++ b/packages/core-compat-api/src/collectLegacyRoutes.tsx
@@ -310,7 +310,7 @@ export function collectLegacyRoutes(
           ...Array.from(plugin.getApis()).map(factory =>
             ApiBlueprint.make({
               name: factory.api.id,
-              params: { factory },
+              params: define => define(factory),
             }),
           ),
         ],

--- a/packages/core-compat-api/src/convertLegacyApp.test.tsx
+++ b/packages/core-compat-api/src/convertLegacyApp.test.tsx
@@ -232,31 +232,32 @@ describe('convertLegacyApp', () => {
     const catalogOverride = catalogPlugin.withOverrides({
       extensions: [
         catalogPlugin.getExtension('api:catalog').override({
-          params: {
-            factory: createApiFactory(
-              catalogApiRef,
-              catalogApiMock({
-                entities: [
-                  {
-                    apiVersion: 'backstage.io/v1alpha1',
-                    kind: 'test',
-                    metadata: {
-                      name: 'x',
+          params: define =>
+            define({
+              api: catalogApiRef,
+              deps: {},
+              factory: () =>
+                catalogApiMock({
+                  entities: [
+                    {
+                      apiVersion: 'backstage.io/v1alpha1',
+                      kind: 'test',
+                      metadata: {
+                        name: 'x',
+                      },
+                      spec: {},
                     },
-                    spec: {},
-                  },
-                  {
-                    apiVersion: 'backstage.io/v1alpha1',
-                    kind: 'other',
-                    metadata: {
-                      name: 'x',
+                    {
+                      apiVersion: 'backstage.io/v1alpha1',
+                      kind: 'other',
+                      metadata: {
+                        name: 'x',
+                      },
+                      spec: {},
                     },
-                    spec: {},
-                  },
-                ],
-              }),
-            ),
-          },
+                  ],
+                }),
+            }),
         }),
       ],
     });

--- a/packages/core-compat-api/src/convertLegacyAppOptions.tsx
+++ b/packages/core-compat-api/src/convertLegacyAppOptions.tsx
@@ -74,7 +74,10 @@ export function convertLegacyAppOptions(
     new Map(allApis.map(api => [api.api.id, api])).values(),
   );
   const extensions: ExtensionDefinition[] = deduplicatedApis.map(factory =>
-    ApiBlueprint.make({ name: factory.api.id, params: { factory } }),
+    ApiBlueprint.make({
+      name: factory.api.id,
+      params: define => define(factory),
+    }),
   );
 
   if (icons) {

--- a/packages/core-compat-api/src/convertLegacyPlugin.ts
+++ b/packages/core-compat-api/src/convertLegacyPlugin.ts
@@ -29,7 +29,10 @@ export function convertLegacyPlugin(
   options: { extensions: ExtensionDefinition[] },
 ): NewBackstagePlugin {
   const apiExtensions = Array.from(legacyPlugin.getApis()).map(factory =>
-    ApiBlueprint.make({ name: factory.api.id, params: { factory } }),
+    ApiBlueprint.make({
+      name: factory.api.id,
+      params: define => define(factory),
+    }),
   );
   return createFrontendPlugin({
     pluginId: legacyPlugin.getId(),

--- a/packages/frontend-app-api/src/wiring/createSpecializedApp.test.tsx
+++ b/packages/frontend-app-api/src/wiring/createSpecializedApp.test.tsx
@@ -31,11 +31,7 @@ import {
 import { screen, render } from '@testing-library/react';
 import { createSpecializedApp } from './createSpecializedApp';
 import { mockApis, TestApiRegistry } from '@backstage/test-utils';
-import {
-  configApiRef,
-  createApiFactory,
-  featureFlagsApiRef,
-} from '@backstage/core-plugin-api';
+import { configApiRef, featureFlagsApiRef } from '@backstage/core-plugin-api';
 import { MemoryRouter } from 'react-router-dom';
 import { ApiProvider, ConfigReader } from '@backstage/core-app-api';
 import { Fragment } from 'react';
@@ -148,16 +144,20 @@ describe('createSpecializedApp', () => {
               ],
             }),
             ApiBlueprint.make({
-              params: {
-                factory: createApiFactory(featureFlagsApiRef, {
-                  registerFlag(flag) {
-                    flags.push(flag);
-                  },
-                  getRegisteredFlags() {
-                    return flags;
-                  },
-                } as typeof featureFlagsApiRef.T),
-              },
+              params: define =>
+                define({
+                  api: featureFlagsApiRef,
+                  deps: {},
+                  factory: () =>
+                    ({
+                      registerFlag(flag) {
+                        flags.push(flag);
+                      },
+                      getRegisteredFlags() {
+                        return flags;
+                      },
+                    } as typeof featureFlagsApiRef.T),
+                }),
             }),
           ],
         }),
@@ -253,15 +253,14 @@ describe('createSpecializedApp', () => {
           pluginId: 'first',
           extensions: [
             ApiBlueprint.make({
-              params: {
-                factory: createApiFactory({
+              params: define =>
+                define({
                   api: analyticsApiRef,
                   deps: {},
                   factory: () => {
                     throw new Error('BROKEN');
                   },
                 }),
-              },
             }),
           ],
         }),
@@ -295,13 +294,12 @@ describe('createSpecializedApp', () => {
               },
             }),
             ApiBlueprint.make({
-              params: {
-                factory: createApiFactory({
+              params: define =>
+                define({
                   api: analyticsApiRef,
                   deps: {},
                   factory: mockAnalyticsApi,
                 }),
-              },
             }),
           ],
         }),

--- a/packages/frontend-plugin-api/src/blueprints/ApiBlueprint.test.ts
+++ b/packages/frontend-plugin-api/src/blueprints/ApiBlueprint.test.ts
@@ -16,21 +16,19 @@
 
 import { createExtensionInput } from '../wiring';
 import { ApiBlueprint } from './ApiBlueprint';
-import { createApiFactory, createApiRef } from '@backstage/core-plugin-api';
+import { createApiRef } from '@backstage/core-plugin-api';
 
 describe('ApiBlueprint', () => {
   it('should create an extension with sensible defaults', () => {
     const api = createApiRef<{ foo: string }>({ id: 'test' });
-    const factory = createApiFactory({
-      api,
-      deps: {},
-      factory: () => ({ foo: 'bar' }),
-    });
 
     const extension = ApiBlueprint.make({
-      params: {
-        factory,
-      },
+      params: define =>
+        define({
+          api,
+          deps: {},
+          factory: () => ({ foo: 'bar' }),
+        }),
       name: 'test',
     });
 
@@ -58,6 +56,97 @@ describe('ApiBlueprint', () => {
     `);
   });
 
+  it('should properly type the API factory', () => {
+    const fooApi = createApiRef<{ foo: string }>({ id: 'foo' });
+    const barApi = createApiRef<{ bar: string }>({ id: 'bar' });
+
+    expect('test').not.toBe('failing without assertions');
+
+    ApiBlueprint.make({
+      params: define =>
+        define({ api: fooApi, deps: {}, factory: () => ({ foo: 'foo' }) }),
+    });
+
+    ApiBlueprint.make({
+      params: define =>
+        define({
+          api: fooApi,
+          deps: {},
+          // @ts-expect-error missing property
+          factory: () => ({}),
+        }),
+    });
+
+    ApiBlueprint.make({
+      params: define =>
+        define({
+          api: fooApi,
+          deps: {},
+          // @ts-expect-error wrong property
+          factory: () => ({
+            bar: 'bar',
+          }),
+        }),
+    });
+
+    ApiBlueprint.make({
+      params: define =>
+        define({
+          api: fooApi,
+          deps: {},
+          factory: () => ({
+            // @ts-expect-error wrong type
+            foo: 1,
+          }),
+        }),
+    });
+
+    ApiBlueprint.make({
+      params: define =>
+        define({
+          api: fooApi,
+          deps: { bar: barApi },
+          factory: ({ bar }) => ({ foo: bar.bar }),
+        }),
+    });
+
+    ApiBlueprint.make({
+      params: define =>
+        define({
+          api: fooApi,
+          deps: { bar: barApi },
+          factory: ({ bar }) => ({
+            // @ts-expect-error not an available property
+            foo: bar.foo,
+          }),
+        }),
+    });
+
+    ApiBlueprint.make({
+      params: define =>
+        define({
+          api: fooApi,
+          deps: { bar: barApi },
+          factory: ({ bar }) => ({
+            // @ts-expect-error not an available property
+            foo: bar.foo,
+          }),
+        }),
+    });
+
+    ApiBlueprint.make({
+      params: define =>
+        define({
+          api: fooApi,
+          deps: {},
+          factory: ({ bar }) => ({
+            // @ts-expect-error unknown dep
+            foo: bar.bar,
+          }),
+        }),
+    });
+  });
+
   it('should create an extension with custom factory', () => {
     const api = createApiRef<{ foo: string }>({ id: 'test' });
     const factory = jest.fn(() => ({ foo: 'bar' }));
@@ -73,13 +162,7 @@ describe('ApiBlueprint', () => {
       },
       name: api.id,
       factory(originalFactory, { config: _config, inputs: _inputs }) {
-        return originalFactory({
-          factory: createApiFactory({
-            api,
-            deps: {},
-            factory,
-          }),
-        });
+        return originalFactory(define => define({ api, deps: {}, factory }));
       },
     });
 

--- a/packages/frontend-plugin-api/src/blueprints/ApiBlueprint.ts
+++ b/packages/frontend-plugin-api/src/blueprints/ApiBlueprint.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
+import { AnyApiFactory, ApiFactory } from '../apis/system';
 import { createExtensionBlueprint, createExtensionDataRef } from '../wiring';
-import { AnyApiFactory } from '@backstage/core-plugin-api';
+import { createExtensionBlueprintParams } from '../wiring/createExtensionBlueprint';
 
 const factoryDataRef = createExtensionDataRef<AnyApiFactory>().with({
   id: 'core.api.factory',
@@ -33,7 +34,14 @@ export const ApiBlueprint = createExtensionBlueprint({
   dataRefs: {
     factory: factoryDataRef,
   },
-  *factory(params: { factory: AnyApiFactory }) {
-    yield factoryDataRef(params.factory);
+  defineParams: <
+    TApi,
+    TImpl extends TApi,
+    TDeps extends { [name in string]: unknown },
+  >(
+    params: ApiFactory<TApi, TImpl, TDeps>,
+  ) => createExtensionBlueprintParams(params as AnyApiFactory),
+  *factory(params) {
+    yield factoryDataRef(params);
   },
 });

--- a/packages/frontend-plugin-api/src/wiring/createExtension.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.ts
@@ -30,10 +30,7 @@ import { z } from 'zod';
 import { createSchemaFromZod } from '../schema/createSchemaFromZod';
 import { OpaqueExtensionDefinition } from '@internal/frontend';
 import { ExtensionDataContainer } from './types';
-import {
-  BlueprintParamsDefiner,
-  BlueprintParamsFactory,
-} from './createExtensionBlueprint';
+import { ExtensionBlueprintParamsDefiner } from './createExtensionBlueprint';
 
 /**
  * This symbol is used to pass parameter overrides from the extension override to the blueprint factory
@@ -165,15 +162,22 @@ export type ExtensionDefinitionParameters = {
       { optional: boolean; singleton: boolean }
     >;
   };
-  params?: object | BlueprintParamsDefiner;
+  params?: object | ExtensionBlueprintParamsDefiner;
 };
 
-type AnyParamsInput<TParams extends object | BlueprintParamsDefiner> =
-  TParams extends BlueprintParamsDefiner<infer IParams>
-    ? IParams | BlueprintParamsFactory<TParams>
+/**
+ * Same as the one in `createExtensionBlueprint`, but with `ParamsFactory` inlined.
+ * It can't be exported because it breaks API reports.
+ * @ignore
+ */
+type AnyParamsInput<TParams extends object | ExtensionBlueprintParamsDefiner> =
+  TParams extends ExtensionBlueprintParamsDefiner<infer IParams>
+    ? IParams | ((define: TParams) => ReturnType<TParams>)
     :
         | TParams
-        | BlueprintParamsFactory<BlueprintParamsDefiner<TParams, TParams>>;
+        | ((
+            define: ExtensionBlueprintParamsDefiner<TParams, TParams>,
+          ) => ReturnType<ExtensionBlueprintParamsDefiner<TParams, TParams>>);
 
 /** @public */
 export type ExtensionDefinition<
@@ -194,7 +198,7 @@ export type ExtensionDefinition<
         { optional: boolean; singleton: boolean }
       >;
     },
-    TParamsReturn extends AnyParamsInput<NonNullable<T['params']>>,
+    TParamsInput extends AnyParamsInput<NonNullable<T['params']>>,
   >(
     args: Expand<
       {
@@ -224,9 +228,9 @@ export type ExtensionDefinition<
               } & ([T['params']] extends [never]
                 ? {}
                 : {
-                    params?: TFactoryParamsReturn extends BlueprintParamsDefiner
+                    params?: TFactoryParamsReturn extends ExtensionBlueprintParamsDefiner
                       ? TFactoryParamsReturn
-                      : T['params'] extends BlueprintParamsDefiner
+                      : T['params'] extends ExtensionBlueprintParamsDefiner
                       ? 'Error: This blueprint uses advanced parameter types and requires you to pass parameters as using the following callback syntax: `originalFactory(define => define(<params>))`'
                       : Partial<T['params']>;
                   })
@@ -246,9 +250,9 @@ export type ExtensionDefinition<
       } & ([T['params']] extends [never]
         ? {}
         : {
-            params?: TParamsReturn extends BlueprintParamsDefiner
-              ? TParamsReturn
-              : T['params'] extends BlueprintParamsDefiner
+            params?: TParamsInput extends ExtensionBlueprintParamsDefiner
+              ? TParamsInput
+              : T['params'] extends ExtensionBlueprintParamsDefiner
               ? 'Error: This blueprint uses advanced parameter types and requires you to pass parameters as using the following callback syntax: `originalFactory(define => define(<params>))`'
               : Partial<T['params']>;
           })

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.test.tsx
@@ -15,7 +15,10 @@
  */
 
 import { coreExtensionData } from './coreExtensionData';
-import { createExtensionBlueprint } from './createExtensionBlueprint';
+import {
+  createExtensionBlueprint,
+  createExtensionBlueprintParams,
+} from './createExtensionBlueprint';
 import {
   createExtensionTester,
   renderInTestApp,
@@ -876,6 +879,21 @@ describe('createExtensionBlueprint', () => {
       test2: 'orig-2',
     });
 
+    const extensionDef = blueprint.make({
+      // Using define is optional in this case
+      params: define =>
+        define({
+          test1: 'orig-1',
+          test2: 'orig-2',
+        }),
+    });
+
+    expect(getOutputs(extensionDef)).toEqual({
+      test1: 'orig-1',
+      test2: 'orig-2',
+    });
+
+    // Plain override
     expect(
       getOutputs(
         extension.override({
@@ -896,11 +914,65 @@ describe('createExtensionBlueprint', () => {
         extension.override({
           params: {
             test2: 'override-2',
+            // @ts-expect-error
+            test3: 'nonexistent',
           },
         }),
       ),
     ).toEqual({
       test1: 'orig-1',
+      test2: 'override-2',
+    });
+
+    // Partial override with original define
+    expect(
+      getOutputs(
+        extensionDef.override({
+          params: {
+            test2: 'override-2',
+            // @ts-expect-error
+            test3: 'nonexistent',
+          },
+        }),
+      ),
+    ).toEqual({
+      test1: 'orig-1',
+      test2: 'override-2',
+    });
+
+    // Override with define
+    expect(
+      getOutputs(
+        extension.override({
+          params: define =>
+            define({
+              test1: 'override-1',
+              test2: 'override-2',
+              // @ts-expect-error
+              test3: 'nonexistent',
+            }),
+        }),
+      ),
+    ).toEqual({
+      test1: 'override-1',
+      test2: 'override-2',
+    });
+
+    // Override with define with original define
+    expect(
+      getOutputs(
+        extensionDef.override({
+          params: define =>
+            define({
+              test1: 'override-1',
+              test2: 'override-2',
+              // @ts-expect-error
+              test3: 'nonexistent',
+            }),
+        }),
+      ),
+    ).toEqual({
+      test1: 'override-1',
       test2: 'override-2',
     });
 
@@ -930,6 +1002,8 @@ describe('createExtensionBlueprint', () => {
             return origFactory({
               params: {
                 test2: 'override-2',
+                // @ts-expect-error
+                test3: 'nonexistent',
               },
             });
           },
@@ -937,6 +1011,70 @@ describe('createExtensionBlueprint', () => {
       ),
     ).toEqual({
       test1: 'orig-1',
+      test2: 'override-2',
+    });
+
+    // Partial override via factory with original define
+    expect(
+      getOutputs(
+        extensionDef.override({
+          factory(origFactory) {
+            return origFactory({
+              params: {
+                test2: 'override-2',
+                // @ts-expect-error
+                test3: 'nonexistent',
+              },
+            });
+          },
+        }),
+      ),
+    ).toEqual({
+      test1: 'orig-1',
+      test2: 'override-2',
+    });
+
+    // Override via factory with define
+    expect(
+      getOutputs(
+        extension.override({
+          factory(origFactory) {
+            return origFactory({
+              params: define =>
+                define({
+                  test1: 'override-1',
+                  test2: 'override-2',
+                  // @ts-expect-error
+                  test3: 'nonexistent',
+                }),
+            });
+          },
+        }),
+      ),
+    ).toEqual({
+      test1: 'override-1',
+      test2: 'override-2',
+    });
+
+    // Override via factory with define with original define
+    expect(
+      getOutputs(
+        extensionDef.override({
+          factory(origFactory) {
+            return origFactory({
+              params: define =>
+                define({
+                  test1: 'override-1',
+                  test2: 'override-2',
+                  // @ts-expect-error
+                  test3: 'nonexistent',
+                }),
+            });
+          },
+        }),
+      ),
+    ).toEqual({
+      test1: 'override-1',
       test2: 'override-2',
     });
 
@@ -991,6 +1129,21 @@ describe('createExtensionBlueprint', () => {
       test2: 'orig-2',
     });
 
+    const extensionDef = blueprint.make({
+      // Using define is optional in this case
+      params: define =>
+        define({
+          test1: 'orig-1',
+          test2: 'orig-2',
+        }),
+    });
+
+    expect(getOutputs(extensionDef)).toEqual({
+      test1: 'orig-1',
+      test2: 'orig-2',
+    });
+
+    // Plain override
     expect(
       getOutputs(
         extension.override({
@@ -1011,6 +1164,8 @@ describe('createExtensionBlueprint', () => {
         extension.override({
           params: {
             test2: 'override-2',
+            // @ts-expect-error
+            test3: 'nonexistent',
           },
         }),
       ),
@@ -1019,6 +1174,59 @@ describe('createExtensionBlueprint', () => {
       test2: 'override-2',
     });
 
+    // Partial override with original define
+    expect(
+      getOutputs(
+        extensionDef.override({
+          params: {
+            test2: 'override-2',
+            // @ts-expect-error
+            test3: 'nonexistent',
+          },
+        }),
+      ),
+    ).toEqual({
+      test1: 'orig-1',
+      test2: 'override-2',
+    });
+
+    // Override with define
+    expect(
+      getOutputs(
+        extension.override({
+          params: define =>
+            define({
+              test1: 'override-1',
+              test2: 'override-2',
+              // @ts-expect-error
+              test3: 'nonexistent',
+            }),
+        }),
+      ),
+    ).toEqual({
+      test1: 'override-1',
+      test2: 'override-2',
+    });
+
+    // Override with define with original define
+    expect(
+      getOutputs(
+        extensionDef.override({
+          params: define =>
+            define({
+              test1: 'override-1',
+              test2: 'override-2',
+              // @ts-expect-error
+              test3: 'nonexistent',
+            }),
+        }),
+      ),
+    ).toEqual({
+      test1: 'override-1',
+      test2: 'override-2',
+    });
+
+    // Override via factory
     expect(
       getOutputs(
         extension.override({
@@ -1045,6 +1253,8 @@ describe('createExtensionBlueprint', () => {
             return origFactory({
               params: {
                 test2: 'override-2',
+                // @ts-expect-error
+                test3: 'nonexistent',
               },
             });
           },
@@ -1052,6 +1262,70 @@ describe('createExtensionBlueprint', () => {
       ),
     ).toEqual({
       test1: 'orig-1',
+      test2: 'override-2',
+    });
+
+    // Partial override via factory with original define
+    expect(
+      getOutputs(
+        extensionDef.override({
+          factory(origFactory) {
+            return origFactory({
+              params: {
+                test2: 'override-2',
+                // @ts-expect-error
+                test3: 'nonexistent',
+              },
+            });
+          },
+        }),
+      ),
+    ).toEqual({
+      test1: 'orig-1',
+      test2: 'override-2',
+    });
+
+    // Override via factory with define
+    expect(
+      getOutputs(
+        extension.override({
+          factory(origFactory) {
+            return origFactory({
+              params: define =>
+                define({
+                  test1: 'override-1',
+                  test2: 'override-2',
+                  // @ts-expect-error
+                  test3: 'nonexistent',
+                }),
+            });
+          },
+        }),
+      ),
+    ).toEqual({
+      test1: 'override-1',
+      test2: 'override-2',
+    });
+
+    // Override via factory with define with original define
+    expect(
+      getOutputs(
+        extensionDef.override({
+          factory(origFactory) {
+            return origFactory({
+              params: define =>
+                define({
+                  test1: 'override-1',
+                  test2: 'override-2',
+                  // @ts-expect-error
+                  test3: 'nonexistent',
+                }),
+            });
+          },
+        }),
+      ),
+    ).toEqual({
+      test1: 'override-1',
       test2: 'override-2',
     });
 
@@ -1068,5 +1342,184 @@ describe('createExtensionBlueprint', () => {
         }),
       ),
     ).toThrow('Refused to override params and factory at the same time');
+  });
+
+  describe('with advanced parameter types', () => {
+    const testDataRef = createExtensionDataRef<string>().with({ id: 'test' });
+
+    const TestExtensionBlueprint = createExtensionBlueprint({
+      kind: 'test-extension',
+      attachTo: { id: 'test', input: 'default' },
+      output: [testDataRef],
+      defineParams<const A extends string, const B extends A>(params: {
+        a: A;
+        b: B;
+      }) {
+        return createExtensionBlueprintParams(params);
+      },
+      factory(params) {
+        return [testDataRef(`${params.a} ${params.b}`)];
+      },
+    });
+
+    it('should allow creation of extension blueprints', () => {
+      TestExtensionBlueprint.make({
+        // @ts-expect-error not using define func
+        params: {
+          a: 'x',
+          b: 'y',
+        },
+      });
+
+      TestExtensionBlueprint.make({
+        params: define =>
+          define({
+            a: 'x',
+            // @ts-expect-error b doesn't match a
+            b: 'y',
+          }),
+      });
+
+      const extension = TestExtensionBlueprint.make({
+        params: define =>
+          define({
+            a: 'x',
+            b: 'x',
+          }),
+      });
+
+      expect(extension).toEqual({
+        $$type: '@backstage/ExtensionDefinition',
+        T: undefined,
+        attachTo: {
+          id: 'test',
+          input: 'default',
+        },
+        configSchema: undefined,
+        disabled: false,
+        inputs: {},
+        kind: 'test-extension',
+        name: undefined,
+        namespace: undefined,
+        output: [testDataRef],
+        factory: expect.any(Function),
+        toString: expect.any(Function),
+        override: expect.any(Function),
+        version: 'v2',
+      });
+
+      expect(createExtensionTester(extension).get(testDataRef)).toBe('x x');
+
+      extension.override({
+        // @ts-expect-error not using define func
+        params: {
+          a: 'z',
+          b: 'w',
+        },
+      });
+
+      extension.override({
+        params: define =>
+          define({
+            a: 'z',
+            // @ts-expect-error b doesn't match a
+            b: 'w',
+          }),
+      });
+
+      const override = extension.override({
+        params: define =>
+          define({
+            a: 'z',
+            b: 'z',
+          }),
+      });
+
+      expect(createExtensionTester(override).get(testDataRef)).toBe('z z');
+    });
+
+    it('should allow overriding of the default factory', () => {
+      TestExtensionBlueprint.makeWithOverrides({
+        factory(originalFactory) {
+          // @ts-expect-error not using define func
+          return originalFactory({
+            a: 'x',
+            b: 'y',
+          });
+        },
+      });
+
+      TestExtensionBlueprint.makeWithOverrides({
+        factory(originalFactory) {
+          return originalFactory(define =>
+            define({
+              a: 'x',
+              // @ts-expect-error b doesn't match a
+              b: 'y',
+            }),
+          );
+        },
+      });
+
+      const extension = TestExtensionBlueprint.makeWithOverrides({
+        factory(originalFactory) {
+          return originalFactory(define =>
+            define({
+              a: 'x',
+              b: 'x',
+            }),
+          );
+        },
+      });
+
+      expect(extension).toEqual({
+        $$type: '@backstage/ExtensionDefinition',
+        T: undefined,
+        attachTo: {
+          id: 'test',
+          input: 'default',
+        },
+        configSchema: undefined,
+        disabled: false,
+        inputs: {},
+        kind: 'test-extension',
+        name: undefined,
+        namespace: undefined,
+        output: [testDataRef],
+        factory: expect.any(Function),
+        toString: expect.any(Function),
+        override: expect.any(Function),
+        version: 'v2',
+      });
+
+      expect(createExtensionTester(extension).get(testDataRef)).toBe('x x');
+
+      extension.override({
+        // @ts-expect-error not using define func
+        params: {
+          a: 'z',
+          b: 'w',
+        },
+      });
+
+      extension.override({
+        params: define =>
+          define({
+            a: 'z',
+            // @ts-expect-error b doesn't match a
+            b: 'w',
+          }),
+      });
+
+      const override = extension.override({
+        params: define =>
+          define({
+            a: 'z',
+            b: 'z',
+          }),
+      });
+
+      expect(createExtensionTester(override).get(testDataRef)).toBe('z z');
+    });
   });
 });

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.test.tsx
@@ -1380,6 +1380,16 @@ describe('createExtensionBlueprint', () => {
           }),
       });
 
+      TestExtensionBlueprint.make({
+        params: define =>
+          define({
+            a: 'x',
+            b: 'x',
+            // @ts-expect-error extra param
+            c: 'y',
+          }),
+      });
+
       const extension = TestExtensionBlueprint.make({
         params: define =>
           define({
@@ -1424,6 +1434,16 @@ describe('createExtensionBlueprint', () => {
             a: 'z',
             // @ts-expect-error b doesn't match a
             b: 'w',
+          }),
+      });
+
+      extension.override({
+        params: define =>
+          define({
+            a: 'z',
+            b: 'z',
+            // @ts-expect-error extra param
+            c: 'w',
           }),
       });
 

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.test.tsx
@@ -1541,5 +1541,44 @@ describe('createExtensionBlueprint', () => {
 
       expect(createExtensionTester(override).get(testDataRef)).toBe('z z');
     });
+
+    it('should allow the params definer to transform the params', () => {
+      const TestTransformExtensionBlueprint = createExtensionBlueprint({
+        kind: 'test-extension',
+        attachTo: { id: 'test', input: 'default' },
+        output: [testDataRef],
+        defineParams(params: { a: number; b: number }) {
+          return createExtensionBlueprintParams({
+            x: params.a + 1,
+            y: params.b + 1,
+          });
+        },
+        factory(params) {
+          return [testDataRef(`${params.x} ${params.y}`)];
+        },
+      });
+
+      const extension = TestTransformExtensionBlueprint.make({
+        params: define =>
+          define({
+            a: 0,
+            b: 10,
+          }),
+      });
+
+      expect(createExtensionTester(extension).get(testDataRef)).toBe(`1 11`);
+
+      expect(
+        createExtensionTester(
+          extension.override({
+            params: define =>
+              define({
+                a: 20,
+                b: 30,
+              }),
+          }),
+        ).get(testDataRef),
+      ).toBe(`21 31`);
+    });
   });
 });

--- a/packages/frontend-plugin-api/src/wiring/index.ts
+++ b/packages/frontend-plugin-api/src/wiring/index.ts
@@ -66,6 +66,9 @@ export {
   type CreateExtensionBlueprintOptions,
   type ExtensionBlueprint,
   type ExtensionBlueprintParameters,
+  type ExtensionBlueprintParams,
+  type ExtensionBlueprintParamsDefiner,
   createExtensionBlueprint,
+  createExtensionBlueprintParams,
 } from './createExtensionBlueprint';
 export { type ResolveInputValueOverrides } from './resolveInputOverrides';

--- a/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.test.ts
@@ -113,6 +113,7 @@ describe('ResolveExtensionId', () => {
       kind: TKind;
       name: TName;
       output: any;
+      params: never;
     }>;
     const id1: 'k:ns' = {} as ResolveExtensionId<
       NamedExtension<'k', undefined>,

--- a/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.ts
+++ b/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.ts
@@ -116,6 +116,7 @@ export type ResolveExtensionId<
 > = TExtension extends ExtensionDefinition<{
   kind: infer IKind extends string | undefined;
   name: infer IName extends string | undefined;
+  params: any;
 }>
   ? [string] extends [IKind | IName]
     ? never

--- a/plugins/api-docs/report-alpha.api.md
+++ b/plugins/api-docs/report-alpha.api.md
@@ -7,12 +7,12 @@ import { AnyApiFactory } from '@backstage/frontend-plugin-api';
 import { AnyExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { AnyRouteRefParams } from '@backstage/frontend-plugin-api';
 import { ApiFactory } from '@backstage/frontend-plugin-api';
-import { BlueprintParams } from '@backstage/frontend-plugin-api/src/wiring/createExtensionBlueprint';
 import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { defaultEntityContentGroups } from '@backstage/plugin-catalog-react/alpha';
 import { Entity } from '@backstage/catalog-model';
 import { EntityCardType } from '@backstage/plugin-catalog-react/alpha';
 import { EntityPredicate } from '@backstage/plugin-catalog-react/alpha';
+import { ExtensionBlueprintParams } from '@backstage/frontend-plugin-api';
 import { ExtensionDefinition } from '@backstage/frontend-plugin-api';
 import { ExtensionInput } from '@backstage/frontend-plugin-api';
 import { ExternalRouteRef } from '@backstage/frontend-plugin-api';
@@ -81,7 +81,7 @@ const _default: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'entity-card:api-docs/consumed-apis': ExtensionDefinition<{
       kind: 'entity-card';

--- a/plugins/api-docs/report-alpha.api.md
+++ b/plugins/api-docs/report-alpha.api.md
@@ -6,6 +6,8 @@
 import { AnyApiFactory } from '@backstage/frontend-plugin-api';
 import { AnyExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { AnyRouteRefParams } from '@backstage/frontend-plugin-api';
+import { ApiFactory } from '@backstage/frontend-plugin-api';
+import { BlueprintParams } from '@backstage/frontend-plugin-api/src/wiring/createExtensionBlueprint';
 import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { defaultEntityContentGroups } from '@backstage/plugin-catalog-react/alpha';
 import { Entity } from '@backstage/catalog-model';
@@ -73,9 +75,13 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'entity-card:api-docs/consumed-apis': ExtensionDefinition<{
       kind: 'entity-card';

--- a/plugins/api-docs/src/alpha.tsx
+++ b/plugins/api-docs/src/alpha.tsx
@@ -20,7 +20,6 @@ import {
   ApiBlueprint,
   NavItemBlueprint,
   PageBlueprint,
-  createApiFactory,
   createFrontendPlugin,
 } from '@backstage/frontend-plugin-api';
 
@@ -55,8 +54,8 @@ const apiDocsNavItem = NavItemBlueprint.make({
 
 const apiDocsConfigApi = ApiBlueprint.make({
   name: 'config',
-  params: {
-    factory: createApiFactory({
+  params: define =>
+    define({
       api: apiDocsConfigRef,
       deps: {},
       factory: () => {
@@ -68,7 +67,6 @@ const apiDocsConfigApi = ApiBlueprint.make({
         };
       },
     }),
-  },
 });
 
 const apiDocsExplorerPage = PageBlueprint.makeWithOverrides({

--- a/plugins/app/report.api.md
+++ b/plugins/app/report.api.md
@@ -8,10 +8,10 @@ import { AnyExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { AnyRouteRefParams } from '@backstage/frontend-plugin-api';
 import { ApiFactory } from '@backstage/frontend-plugin-api';
 import { AppTheme } from '@backstage/frontend-plugin-api';
-import { BlueprintParams } from '@backstage/frontend-plugin-api/src/wiring/createExtensionBlueprint';
 import { ComponentRef } from '@backstage/frontend-plugin-api';
 import { ComponentType } from 'react';
 import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
+import { ExtensionBlueprintParams } from '@backstage/frontend-plugin-api';
 import { ExtensionDefinition } from '@backstage/frontend-plugin-api';
 import { ExtensionInput } from '@backstage/frontend-plugin-api';
 import { FrontendPlugin } from '@backstage/frontend-plugin-api';
@@ -230,7 +230,7 @@ const appPlugin: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'api:app/analytics': ExtensionDefinition<{
       kind: 'api';
@@ -249,7 +249,7 @@ const appPlugin: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'api:app/app-language': ExtensionDefinition<{
       kind: 'api';
@@ -268,7 +268,7 @@ const appPlugin: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'api:app/app-theme': ExtensionDefinition<{
       config: {};
@@ -295,7 +295,7 @@ const appPlugin: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'api:app/atlassian-auth': ExtensionDefinition<{
       kind: 'api';
@@ -314,7 +314,7 @@ const appPlugin: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'api:app/bitbucket-auth': ExtensionDefinition<{
       kind: 'api';
@@ -333,7 +333,7 @@ const appPlugin: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'api:app/bitbucket-server-auth': ExtensionDefinition<{
       kind: 'api';
@@ -352,7 +352,7 @@ const appPlugin: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'api:app/components': ExtensionDefinition<{
       config: {};
@@ -386,7 +386,7 @@ const appPlugin: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'api:app/dialog': ExtensionDefinition<{
       kind: 'api';
@@ -405,7 +405,7 @@ const appPlugin: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'api:app/discovery': ExtensionDefinition<{
       kind: 'api';
@@ -424,7 +424,7 @@ const appPlugin: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'api:app/error': ExtensionDefinition<{
       kind: 'api';
@@ -443,7 +443,7 @@ const appPlugin: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'api:app/feature-flags': ExtensionDefinition<{
       kind: 'api';
@@ -462,7 +462,7 @@ const appPlugin: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'api:app/fetch': ExtensionDefinition<{
       kind: 'api';
@@ -481,7 +481,7 @@ const appPlugin: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'api:app/github-auth': ExtensionDefinition<{
       kind: 'api';
@@ -500,7 +500,7 @@ const appPlugin: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'api:app/gitlab-auth': ExtensionDefinition<{
       kind: 'api';
@@ -519,7 +519,7 @@ const appPlugin: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'api:app/google-auth': ExtensionDefinition<{
       kind: 'api';
@@ -538,7 +538,7 @@ const appPlugin: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'api:app/icons': ExtensionDefinition<{
       config: {};
@@ -571,7 +571,7 @@ const appPlugin: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'api:app/microsoft-auth': ExtensionDefinition<{
       kind: 'api';
@@ -590,7 +590,7 @@ const appPlugin: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'api:app/oauth-request': ExtensionDefinition<{
       kind: 'api';
@@ -609,7 +609,7 @@ const appPlugin: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'api:app/okta-auth': ExtensionDefinition<{
       kind: 'api';
@@ -628,7 +628,7 @@ const appPlugin: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'api:app/onelogin-auth': ExtensionDefinition<{
       kind: 'api';
@@ -647,7 +647,7 @@ const appPlugin: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'api:app/permission': ExtensionDefinition<{
       kind: 'api';
@@ -666,7 +666,7 @@ const appPlugin: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'api:app/scm-auth': ExtensionDefinition<{
       kind: 'api';
@@ -685,7 +685,7 @@ const appPlugin: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'api:app/scm-integrations': ExtensionDefinition<{
       kind: 'api';
@@ -704,7 +704,7 @@ const appPlugin: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'api:app/storage': ExtensionDefinition<{
       kind: 'api';
@@ -723,7 +723,7 @@ const appPlugin: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'api:app/translations': ExtensionDefinition<{
       config: {};
@@ -761,7 +761,7 @@ const appPlugin: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'api:app/vmware-cloud-auth': ExtensionDefinition<{
       kind: 'api';
@@ -780,7 +780,7 @@ const appPlugin: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'app-root-element:app/alert-display': ExtensionDefinition<{
       config: {

--- a/plugins/app/report.api.md
+++ b/plugins/app/report.api.md
@@ -6,7 +6,9 @@
 import { AnyApiFactory } from '@backstage/frontend-plugin-api';
 import { AnyExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { AnyRouteRefParams } from '@backstage/frontend-plugin-api';
+import { ApiFactory } from '@backstage/frontend-plugin-api';
 import { AppTheme } from '@backstage/frontend-plugin-api';
+import { BlueprintParams } from '@backstage/frontend-plugin-api/src/wiring/createExtensionBlueprint';
 import { ComponentRef } from '@backstage/frontend-plugin-api';
 import { ComponentType } from 'react';
 import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
@@ -222,9 +224,13 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'api:app/analytics': ExtensionDefinition<{
       kind: 'api';
@@ -237,9 +243,13 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'api:app/app-language': ExtensionDefinition<{
       kind: 'api';
@@ -252,9 +262,13 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'api:app/app-theme': ExtensionDefinition<{
       config: {};
@@ -275,9 +289,13 @@ const appPlugin: FrontendPlugin<
       };
       kind: 'api';
       name: 'app-theme';
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'api:app/atlassian-auth': ExtensionDefinition<{
       kind: 'api';
@@ -290,9 +308,13 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'api:app/bitbucket-auth': ExtensionDefinition<{
       kind: 'api';
@@ -305,9 +327,13 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'api:app/bitbucket-server-auth': ExtensionDefinition<{
       kind: 'api';
@@ -320,9 +346,13 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'api:app/components': ExtensionDefinition<{
       config: {};
@@ -350,9 +380,13 @@ const appPlugin: FrontendPlugin<
       };
       kind: 'api';
       name: 'components';
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'api:app/dialog': ExtensionDefinition<{
       kind: 'api';
@@ -365,9 +399,13 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'api:app/discovery': ExtensionDefinition<{
       kind: 'api';
@@ -380,9 +418,13 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'api:app/error': ExtensionDefinition<{
       kind: 'api';
@@ -395,9 +437,13 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'api:app/feature-flags': ExtensionDefinition<{
       kind: 'api';
@@ -410,9 +456,13 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'api:app/fetch': ExtensionDefinition<{
       kind: 'api';
@@ -425,9 +475,13 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'api:app/github-auth': ExtensionDefinition<{
       kind: 'api';
@@ -440,9 +494,13 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'api:app/gitlab-auth': ExtensionDefinition<{
       kind: 'api';
@@ -455,9 +513,13 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'api:app/google-auth': ExtensionDefinition<{
       kind: 'api';
@@ -470,9 +532,13 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'api:app/icons': ExtensionDefinition<{
       config: {};
@@ -499,9 +565,13 @@ const appPlugin: FrontendPlugin<
       };
       kind: 'api';
       name: 'icons';
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'api:app/microsoft-auth': ExtensionDefinition<{
       kind: 'api';
@@ -514,9 +584,13 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'api:app/oauth-request': ExtensionDefinition<{
       kind: 'api';
@@ -529,9 +603,13 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'api:app/okta-auth': ExtensionDefinition<{
       kind: 'api';
@@ -544,9 +622,13 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'api:app/onelogin-auth': ExtensionDefinition<{
       kind: 'api';
@@ -559,9 +641,13 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'api:app/permission': ExtensionDefinition<{
       kind: 'api';
@@ -574,9 +660,13 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'api:app/scm-auth': ExtensionDefinition<{
       kind: 'api';
@@ -589,9 +679,13 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'api:app/scm-integrations': ExtensionDefinition<{
       kind: 'api';
@@ -604,9 +698,13 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'api:app/storage': ExtensionDefinition<{
       kind: 'api';
@@ -619,9 +717,13 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'api:app/translations': ExtensionDefinition<{
       config: {};
@@ -653,9 +755,13 @@ const appPlugin: FrontendPlugin<
       };
       kind: 'api';
       name: 'translations';
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'api:app/vmware-cloud-auth': ExtensionDefinition<{
       kind: 'api';
@@ -668,9 +774,13 @@ const appPlugin: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'app-root-element:app/alert-display': ExtensionDefinition<{
       config: {

--- a/plugins/app/src/defaultApis.ts
+++ b/plugins/app/src/defaultApis.ts
@@ -39,7 +39,6 @@ import {
 } from '../../../packages/core-app-api/src/apis/implementations';
 
 import {
-  createApiFactory,
   alertApiRef,
   analyticsApiRef,
   errorApiRef,
@@ -75,18 +74,17 @@ import { DefaultDialogApi } from './apis/DefaultDialogApi';
 export const apis = [
   ApiBlueprint.make({
     name: 'dialog',
-    params: {
-      factory: createApiFactory({
+    params: define =>
+      define({
         api: dialogApiRef,
         deps: {},
         factory: () => new DefaultDialogApi(),
       }),
-    },
   }),
   ApiBlueprint.make({
     name: 'discovery',
-    params: {
-      factory: createApiFactory({
+    params: define =>
+      define({
         api: discoveryApiRef,
         deps: { configApi: configApiRef },
         factory: ({ configApi }) =>
@@ -94,32 +92,29 @@ export const apis = [
             `${configApi.getString('backend.baseUrl')}/api/{{ pluginId }}`,
           ),
       }),
-    },
   }),
   ApiBlueprint.make({
     name: 'alert',
-    params: {
-      factory: createApiFactory({
+    params: define =>
+      define({
         api: alertApiRef,
         deps: {},
         factory: () => new AlertApiForwarder(),
       }),
-    },
   }),
   ApiBlueprint.make({
     name: 'analytics',
-    params: {
-      factory: createApiFactory({
+    params: define =>
+      define({
         api: analyticsApiRef,
         deps: {},
         factory: () => new NoOpAnalyticsApi(),
       }),
-    },
   }),
   ApiBlueprint.make({
     name: 'error',
-    params: {
-      factory: createApiFactory({
+    params: define =>
+      define({
         api: errorApiRef,
         deps: { alertApi: alertApiRef },
         factory: ({ alertApi }) => {
@@ -128,22 +123,20 @@ export const apis = [
           return errorApi;
         },
       }),
-    },
   }),
   ApiBlueprint.make({
     name: 'storage',
-    params: {
-      factory: createApiFactory({
+    params: define =>
+      define({
         api: storageApiRef,
         deps: { errorApi: errorApiRef },
         factory: ({ errorApi }) => WebStorage.create({ errorApi }),
       }),
-    },
   }),
   ApiBlueprint.make({
     name: 'fetch',
-    params: {
-      factory: createApiFactory({
+    params: define =>
+      define({
         api: fetchApiRef,
         deps: {
           configApi: configApiRef,
@@ -164,22 +157,20 @@ export const apis = [
           });
         },
       }),
-    },
   }),
   ApiBlueprint.make({
     name: 'oauth-request',
-    params: {
-      factory: createApiFactory({
+    params: define =>
+      define({
         api: oauthRequestApiRef,
         deps: {},
         factory: () => new OAuthRequestManager(),
       }),
-    },
   }),
   ApiBlueprint.make({
     name: 'google-auth',
-    params: {
-      factory: createApiFactory({
+    params: define =>
+      define({
         api: googleAuthApiRef,
         deps: {
           discoveryApi: discoveryApiRef,
@@ -194,12 +185,11 @@ export const apis = [
             environment: configApi.getOptionalString('auth.environment'),
           }),
       }),
-    },
   }),
   ApiBlueprint.make({
     name: 'microsoft-auth',
-    params: {
-      factory: createApiFactory({
+    params: define =>
+      define({
         api: microsoftAuthApiRef,
         deps: {
           discoveryApi: discoveryApiRef,
@@ -214,12 +204,11 @@ export const apis = [
             environment: configApi.getOptionalString('auth.environment'),
           }),
       }),
-    },
   }),
   ApiBlueprint.make({
     name: 'github-auth',
-    params: {
-      factory: createApiFactory({
+    params: define =>
+      define({
         api: githubAuthApiRef,
         deps: {
           discoveryApi: discoveryApiRef,
@@ -235,12 +224,11 @@ export const apis = [
             environment: configApi.getOptionalString('auth.environment'),
           }),
       }),
-    },
   }),
   ApiBlueprint.make({
     name: 'okta-auth',
-    params: {
-      factory: createApiFactory({
+    params: define =>
+      define({
         api: oktaAuthApiRef,
         deps: {
           discoveryApi: discoveryApiRef,
@@ -255,12 +243,11 @@ export const apis = [
             environment: configApi.getOptionalString('auth.environment'),
           }),
       }),
-    },
   }),
   ApiBlueprint.make({
     name: 'gitlab-auth',
-    params: {
-      factory: createApiFactory({
+    params: define =>
+      define({
         api: gitlabAuthApiRef,
         deps: {
           discoveryApi: discoveryApiRef,
@@ -275,12 +262,11 @@ export const apis = [
             environment: configApi.getOptionalString('auth.environment'),
           }),
       }),
-    },
   }),
   ApiBlueprint.make({
     name: 'onelogin-auth',
-    params: {
-      factory: createApiFactory({
+    params: define =>
+      define({
         api: oneloginAuthApiRef,
         deps: {
           discoveryApi: discoveryApiRef,
@@ -295,12 +281,11 @@ export const apis = [
             environment: configApi.getOptionalString('auth.environment'),
           }),
       }),
-    },
   }),
   ApiBlueprint.make({
     name: 'bitbucket-auth',
-    params: {
-      factory: createApiFactory({
+    params: define =>
+      define({
         api: bitbucketAuthApiRef,
         deps: {
           discoveryApi: discoveryApiRef,
@@ -316,12 +301,11 @@ export const apis = [
             environment: configApi.getOptionalString('auth.environment'),
           }),
       }),
-    },
   }),
   ApiBlueprint.make({
     name: 'bitbucket-server-auth',
-    params: {
-      factory: createApiFactory({
+    params: define =>
+      define({
         api: bitbucketServerAuthApiRef,
         deps: {
           discoveryApi: discoveryApiRef,
@@ -337,12 +321,11 @@ export const apis = [
             environment: configApi.getOptionalString('auth.environment'),
           }),
       }),
-    },
   }),
   ApiBlueprint.make({
     name: 'atlassian-auth',
-    params: {
-      factory: createApiFactory({
+    params: define =>
+      define({
         api: atlassianAuthApiRef,
         deps: {
           discoveryApi: discoveryApiRef,
@@ -358,12 +341,11 @@ export const apis = [
           });
         },
       }),
-    },
   }),
   ApiBlueprint.make({
     name: 'vmware-cloud-auth',
-    params: {
-      factory: createApiFactory({
+    params: define =>
+      define({
         api: vmwareCloudAuthApiRef,
         deps: {
           discoveryApi: discoveryApiRef,
@@ -379,12 +361,11 @@ export const apis = [
           });
         },
       }),
-    },
   }),
   ApiBlueprint.make({
     name: 'permission',
-    params: {
-      factory: createApiFactory({
+    params: define =>
+      define({
         api: permissionApiRef,
         deps: {
           discovery: discoveryApiRef,
@@ -394,22 +375,18 @@ export const apis = [
         factory: ({ config, discovery, identity }) =>
           IdentityPermissionApi.create({ config, discovery, identity }),
       }),
-    },
   }),
   ApiBlueprint.make({
     name: 'scm-auth',
-    params: {
-      factory: ScmAuth.createDefaultApiFactory(),
-    },
+    params: define => define(ScmAuth.createDefaultApiFactory()),
   }),
   ApiBlueprint.make({
     name: 'scm-integrations',
-    params: {
-      factory: createApiFactory({
+    params: define =>
+      define({
         api: scmIntegrationsApiRef,
         deps: { configApi: configApiRef },
         factory: ({ configApi }) => ScmIntegrationsApi.fromConfig(configApi),
       }),
-    },
   }),
 ] as const;

--- a/plugins/app/src/extensions/AppLanguageApi.ts
+++ b/plugins/app/src/extensions/AppLanguageApi.ts
@@ -17,14 +17,14 @@
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
 import { AppLanguageSelector } from '../../../../packages/core-app-api/src/apis/implementations/AppLanguageApi';
 import { appLanguageApiRef } from '@backstage/core-plugin-api/alpha';
-import { ApiBlueprint, createApiFactory } from '@backstage/frontend-plugin-api';
+import { ApiBlueprint } from '@backstage/frontend-plugin-api';
 
 export const AppLanguageApi = ApiBlueprint.make({
   name: 'app-language',
-  params: {
-    factory: createApiFactory(
-      appLanguageApiRef,
-      AppLanguageSelector.createWithStorage(),
-    ),
-  },
+  params: define =>
+    define({
+      api: appLanguageApiRef,
+      deps: {},
+      factory: () => AppLanguageSelector.createWithStorage(),
+    }),
 });

--- a/plugins/app/src/extensions/AppThemeApi.tsx
+++ b/plugins/app/src/extensions/AppThemeApi.tsx
@@ -24,7 +24,6 @@ import {
   createExtensionInput,
   ThemeBlueprint,
   ApiBlueprint,
-  createApiFactory,
   appThemeApiRef,
 } from '@backstage/frontend-plugin-api';
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
@@ -41,14 +40,16 @@ export const AppThemeApi = ApiBlueprint.makeWithOverrides({
     }),
   },
   factory: (originalFactory, { inputs }) => {
-    return originalFactory({
-      factory: createApiFactory(
-        appThemeApiRef,
-        AppThemeSelector.createWithStorage(
-          inputs.themes.map(i => i.get(ThemeBlueprint.dataRefs.theme)),
-        ),
-      ),
-    });
+    return originalFactory(define =>
+      define({
+        api: appThemeApiRef,
+        deps: {},
+        factory: () =>
+          AppThemeSelector.createWithStorage(
+            inputs.themes.map(i => i.get(ThemeBlueprint.dataRefs.theme)),
+          ),
+      }),
+    );
   },
 });
 

--- a/plugins/app/src/extensions/ComponentsApi.tsx
+++ b/plugins/app/src/extensions/ComponentsApi.tsx
@@ -18,7 +18,6 @@ import {
   createComponentExtension,
   createExtensionInput,
   ApiBlueprint,
-  createApiFactory,
   componentsApiRef,
 } from '@backstage/frontend-plugin-api';
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
@@ -36,15 +35,17 @@ export const ComponentsApi = ApiBlueprint.makeWithOverrides({
     ),
   },
   factory: (originalFactory, { inputs }) => {
-    return originalFactory({
-      factory: createApiFactory(
-        componentsApiRef,
-        DefaultComponentsApi.fromComponents(
-          inputs.components.map(i =>
-            i.get(createComponentExtension.componentDataRef),
+    return originalFactory(define =>
+      define({
+        api: componentsApiRef,
+        deps: {},
+        factory: () =>
+          DefaultComponentsApi.fromComponents(
+            inputs.components.map(i =>
+              i.get(createComponentExtension.componentDataRef),
+            ),
           ),
-        ),
-      ),
-    });
+      }),
+    );
   },
 });

--- a/plugins/app/src/extensions/FeatureFlagsApi.ts
+++ b/plugins/app/src/extensions/FeatureFlagsApi.ts
@@ -16,7 +16,6 @@
 
 import {
   ApiBlueprint,
-  createApiFactory,
   featureFlagsApiRef,
 } from '@backstage/frontend-plugin-api';
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
@@ -27,12 +26,11 @@ import { LocalStorageFeatureFlags } from '../../../../packages/core-app-api/src/
  */
 export const FeatureFlagsApi = ApiBlueprint.make({
   name: 'feature-flags',
-  params: {
-    // TODO: properly discovery feature flags, maybe rework the whole thing
-    factory: createApiFactory({
+  params: define =>
+    define({
+      // TODO: properly discovery feature flags, maybe rework the whole thing
       api: featureFlagsApiRef,
       deps: {},
       factory: () => new LocalStorageFeatureFlags(),
     }),
-  },
 });

--- a/plugins/app/src/extensions/IconsApi.ts
+++ b/plugins/app/src/extensions/IconsApi.ts
@@ -18,7 +18,6 @@ import {
   createExtensionInput,
   IconBundleBlueprint,
   ApiBlueprint,
-  createApiFactory,
   iconsApiRef,
 } from '@backstage/frontend-plugin-api';
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
@@ -37,15 +36,17 @@ export const IconsApi = ApiBlueprint.makeWithOverrides({
     }),
   },
   factory: (originalFactory, { inputs }) => {
-    return originalFactory({
-      factory: createApiFactory(
-        iconsApiRef,
-        new DefaultIconsApi(
-          inputs.icons
-            .map(i => i.get(IconBundleBlueprint.dataRefs.icons))
-            .reduce((acc, bundle) => ({ ...acc, ...bundle }), defaultIcons),
-        ),
-      ),
-    });
+    return originalFactory(define =>
+      define({
+        api: iconsApiRef,
+        deps: {},
+        factory: () =>
+          new DefaultIconsApi(
+            inputs.icons
+              .map(i => i.get(IconBundleBlueprint.dataRefs.icons))
+              .reduce((acc, bundle) => ({ ...acc, ...bundle }), defaultIcons),
+          ),
+      }),
+    );
   },
 });

--- a/plugins/app/src/extensions/TranslationsApi.tsx
+++ b/plugins/app/src/extensions/TranslationsApi.tsx
@@ -16,7 +16,6 @@
 import {
   ApiBlueprint,
   TranslationBlueprint,
-  createApiFactory,
   createExtensionInput,
 } from '@backstage/frontend-plugin-api';
 import {
@@ -39,8 +38,8 @@ export const TranslationsApi = ApiBlueprint.makeWithOverrides({
     ),
   },
   factory: (originalFactory, { inputs }) => {
-    return originalFactory({
-      factory: createApiFactory({
+    return originalFactory(define =>
+      define({
         api: translationApiRef,
         deps: { languageApi: appLanguageApiRef },
         factory: ({ languageApi }) =>
@@ -51,6 +50,6 @@ export const TranslationsApi = ApiBlueprint.makeWithOverrides({
             ),
           }),
       }),
-    });
+    );
   },
 });

--- a/plugins/catalog-import/report-alpha.api.md
+++ b/plugins/catalog-import/report-alpha.api.md
@@ -6,8 +6,8 @@
 import { AnyApiFactory } from '@backstage/core-plugin-api';
 import { AnyRouteRefParams } from '@backstage/frontend-plugin-api';
 import { ApiFactory } from '@backstage/core-plugin-api';
-import { BlueprintParams } from '@backstage/frontend-plugin-api/src/wiring/createExtensionBlueprint';
 import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
+import { ExtensionBlueprintParams } from '@backstage/frontend-plugin-api';
 import { ExtensionDefinition } from '@backstage/frontend-plugin-api';
 import { FrontendPlugin } from '@backstage/frontend-plugin-api';
 import { JSX as JSX_2 } from 'react';
@@ -111,7 +111,7 @@ const _default: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'page:catalog-import': ExtensionDefinition<{
       kind: 'page';

--- a/plugins/catalog-import/report-alpha.api.md
+++ b/plugins/catalog-import/report-alpha.api.md
@@ -5,6 +5,8 @@
 ```ts
 import { AnyApiFactory } from '@backstage/core-plugin-api';
 import { AnyRouteRefParams } from '@backstage/frontend-plugin-api';
+import { ApiFactory } from '@backstage/core-plugin-api';
+import { BlueprintParams } from '@backstage/frontend-plugin-api/src/wiring/createExtensionBlueprint';
 import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { ExtensionDefinition } from '@backstage/frontend-plugin-api';
 import { FrontendPlugin } from '@backstage/frontend-plugin-api';
@@ -103,9 +105,13 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'page:catalog-import': ExtensionDefinition<{
       kind: 'page';

--- a/plugins/catalog-import/src/alpha.tsx
+++ b/plugins/catalog-import/src/alpha.tsx
@@ -16,7 +16,6 @@
 
 import {
   configApiRef,
-  createApiFactory,
   discoveryApiRef,
   fetchApiRef,
 } from '@backstage/core-plugin-api';
@@ -53,8 +52,8 @@ const catalogImportPage = PageBlueprint.make({
 });
 
 const catalogImportApi = ApiBlueprint.make({
-  params: {
-    factory: createApiFactory({
+  params: define =>
+    define({
       api: catalogImportApiRef,
       deps: {
         discoveryApi: discoveryApiRef,
@@ -81,7 +80,6 @@ const catalogImportApi = ApiBlueprint.make({
           configApi,
         }),
     }),
-  },
 });
 
 /** @alpha */

--- a/plugins/catalog-unprocessed-entities/report-alpha.api.md
+++ b/plugins/catalog-unprocessed-entities/report-alpha.api.md
@@ -5,6 +5,8 @@
 ```ts
 import { AnyApiFactory } from '@backstage/frontend-plugin-api';
 import { AnyRouteRefParams } from '@backstage/frontend-plugin-api';
+import { ApiFactory } from '@backstage/frontend-plugin-api';
+import { BlueprintParams } from '@backstage/frontend-plugin-api/src/wiring/createExtensionBlueprint';
 import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { ExtensionDefinition } from '@backstage/frontend-plugin-api';
 import { FrontendPlugin } from '@backstage/frontend-plugin-api';
@@ -30,9 +32,13 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'nav-item:catalog-unprocessed-entities': ExtensionDefinition<{
       kind: 'nav-item';

--- a/plugins/catalog-unprocessed-entities/report-alpha.api.md
+++ b/plugins/catalog-unprocessed-entities/report-alpha.api.md
@@ -6,8 +6,8 @@
 import { AnyApiFactory } from '@backstage/frontend-plugin-api';
 import { AnyRouteRefParams } from '@backstage/frontend-plugin-api';
 import { ApiFactory } from '@backstage/frontend-plugin-api';
-import { BlueprintParams } from '@backstage/frontend-plugin-api/src/wiring/createExtensionBlueprint';
 import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
+import { ExtensionBlueprintParams } from '@backstage/frontend-plugin-api';
 import { ExtensionDefinition } from '@backstage/frontend-plugin-api';
 import { FrontendPlugin } from '@backstage/frontend-plugin-api';
 import { IconComponent } from '@backstage/core-plugin-api';
@@ -38,7 +38,7 @@ const _default: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'nav-item:catalog-unprocessed-entities': ExtensionDefinition<{
       kind: 'nav-item';

--- a/plugins/catalog-unprocessed-entities/src/alpha/plugin.tsx
+++ b/plugins/catalog-unprocessed-entities/src/alpha/plugin.tsx
@@ -15,7 +15,6 @@
  */
 
 import {
-  createApiFactory,
   createFrontendPlugin,
   discoveryApiRef,
   fetchApiRef,
@@ -37,8 +36,8 @@ import { rootRouteRef } from '../routes';
 
 /** @alpha */
 export const catalogUnprocessedEntitiesApi = ApiBlueprint.make({
-  params: {
-    factory: createApiFactory({
+  params: define =>
+    define({
       api: catalogUnprocessedEntitiesApiRef,
       deps: {
         discoveryApi: discoveryApiRef,
@@ -47,7 +46,6 @@ export const catalogUnprocessedEntitiesApi = ApiBlueprint.make({
       factory: ({ discoveryApi, fetchApi }) =>
         new CatalogUnprocessedEntitiesClient(discoveryApi, fetchApi),
     }),
-  },
 });
 
 /** @alpha */

--- a/plugins/catalog/report-alpha.api.md
+++ b/plugins/catalog/report-alpha.api.md
@@ -7,7 +7,6 @@ import { AnyApiFactory } from '@backstage/frontend-plugin-api';
 import { AnyExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { AnyRouteRefParams } from '@backstage/frontend-plugin-api';
 import { ApiFactory } from '@backstage/frontend-plugin-api';
-import { BlueprintParams } from '@backstage/frontend-plugin-api/src/wiring/createExtensionBlueprint';
 import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { defaultEntityContentGroups } from '@backstage/plugin-catalog-react/alpha';
 import { Entity } from '@backstage/catalog-model';
@@ -15,6 +14,7 @@ import { EntityCardType } from '@backstage/plugin-catalog-react/alpha';
 import { EntityContentLayoutProps } from '@backstage/plugin-catalog-react/alpha';
 import { EntityContextMenuItemParams } from '@backstage/plugin-catalog-react/alpha';
 import { EntityPredicate } from '@backstage/plugin-catalog-react/alpha';
+import { ExtensionBlueprintParams } from '@backstage/frontend-plugin-api';
 import { ExtensionDefinition } from '@backstage/frontend-plugin-api';
 import { ExtensionInput } from '@backstage/frontend-plugin-api';
 import { ExternalRouteRef } from '@backstage/frontend-plugin-api';
@@ -154,7 +154,7 @@ const _default: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'api:catalog/entity-presentation': ExtensionDefinition<{
       kind: 'api';
@@ -173,7 +173,7 @@ const _default: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'api:catalog/starred-entities': ExtensionDefinition<{
       kind: 'api';
@@ -192,7 +192,7 @@ const _default: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'catalog-filter:catalog/kind': ExtensionDefinition<{
       config: {

--- a/plugins/catalog/report-alpha.api.md
+++ b/plugins/catalog/report-alpha.api.md
@@ -6,6 +6,8 @@
 import { AnyApiFactory } from '@backstage/frontend-plugin-api';
 import { AnyExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { AnyRouteRefParams } from '@backstage/frontend-plugin-api';
+import { ApiFactory } from '@backstage/frontend-plugin-api';
+import { BlueprintParams } from '@backstage/frontend-plugin-api/src/wiring/createExtensionBlueprint';
 import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { defaultEntityContentGroups } from '@backstage/plugin-catalog-react/alpha';
 import { Entity } from '@backstage/catalog-model';
@@ -146,9 +148,13 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'api:catalog/entity-presentation': ExtensionDefinition<{
       kind: 'api';
@@ -161,9 +167,13 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'api:catalog/starred-entities': ExtensionDefinition<{
       kind: 'api';
@@ -176,9 +186,13 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'catalog-filter:catalog/kind': ExtensionDefinition<{
       config: {

--- a/plugins/catalog/src/alpha/apis.tsx
+++ b/plugins/catalog/src/alpha/apis.tsx
@@ -15,7 +15,6 @@
  */
 
 import {
-  createApiFactory,
   discoveryApiRef,
   fetchApiRef,
   storageApiRef,
@@ -33,8 +32,8 @@ import {
 } from '../apis';
 
 export const catalogApi = ApiBlueprint.make({
-  params: {
-    factory: createApiFactory({
+  params: define =>
+    define({
       api: catalogApiRef,
       deps: {
         discoveryApi: discoveryApiRef,
@@ -43,31 +42,28 @@ export const catalogApi = ApiBlueprint.make({
       factory: ({ discoveryApi, fetchApi }) =>
         new CatalogClient({ discoveryApi, fetchApi }),
     }),
-  },
 });
 
 export const catalogStarredEntitiesApi = ApiBlueprint.make({
   name: 'starred-entities',
-  params: {
-    factory: createApiFactory({
+  params: define =>
+    define({
       api: starredEntitiesApiRef,
       deps: { storageApi: storageApiRef },
       factory: ({ storageApi }) =>
         new DefaultStarredEntitiesApi({ storageApi }),
     }),
-  },
 });
 
 export const entityPresentationApi = ApiBlueprint.make({
   name: 'entity-presentation',
-  params: {
-    factory: createApiFactory({
+  params: define =>
+    define({
       api: entityPresentationApiRef,
       deps: { catalogApiImp: catalogApiRef },
       factory: ({ catalogApiImp }) =>
         DefaultEntityPresentationApi.create({ catalogApi: catalogApiImp }),
     }),
-  },
 });
 
 export default [catalogApi, catalogStarredEntitiesApi, entityPresentationApi];

--- a/plugins/devtools/report-alpha.api.md
+++ b/plugins/devtools/report-alpha.api.md
@@ -5,6 +5,8 @@
 ```ts
 import { AnyApiFactory } from '@backstage/frontend-plugin-api';
 import { AnyRouteRefParams } from '@backstage/frontend-plugin-api';
+import { ApiFactory } from '@backstage/frontend-plugin-api';
+import { BlueprintParams } from '@backstage/frontend-plugin-api/src/wiring/createExtensionBlueprint';
 import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { ExtensionDefinition } from '@backstage/frontend-plugin-api';
 import { FrontendPlugin } from '@backstage/frontend-plugin-api';
@@ -30,9 +32,13 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'nav-item:devtools': ExtensionDefinition<{
       kind: 'nav-item';

--- a/plugins/devtools/report-alpha.api.md
+++ b/plugins/devtools/report-alpha.api.md
@@ -6,8 +6,8 @@
 import { AnyApiFactory } from '@backstage/frontend-plugin-api';
 import { AnyRouteRefParams } from '@backstage/frontend-plugin-api';
 import { ApiFactory } from '@backstage/frontend-plugin-api';
-import { BlueprintParams } from '@backstage/frontend-plugin-api/src/wiring/createExtensionBlueprint';
 import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
+import { ExtensionBlueprintParams } from '@backstage/frontend-plugin-api';
 import { ExtensionDefinition } from '@backstage/frontend-plugin-api';
 import { FrontendPlugin } from '@backstage/frontend-plugin-api';
 import { IconComponent } from '@backstage/core-plugin-api';
@@ -38,7 +38,7 @@ const _default: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'nav-item:devtools': ExtensionDefinition<{
       kind: 'nav-item';

--- a/plugins/devtools/src/alpha/plugin.tsx
+++ b/plugins/devtools/src/alpha/plugin.tsx
@@ -15,7 +15,6 @@
  */
 
 import {
-  createApiFactory,
   createFrontendPlugin,
   discoveryApiRef,
   fetchApiRef,
@@ -34,8 +33,8 @@ import { rootRouteRef } from '../routes';
 
 /** @alpha */
 export const devToolsApi = ApiBlueprint.make({
-  params: {
-    factory: createApiFactory({
+  params: define =>
+    define({
       api: devToolsApiRef,
       deps: {
         discoveryApi: discoveryApiRef,
@@ -44,7 +43,6 @@ export const devToolsApi = ApiBlueprint.make({
       factory: ({ discoveryApi, fetchApi }) =>
         new DevToolsClient({ discoveryApi, fetchApi }),
     }),
-  },
 });
 
 /** @alpha */

--- a/plugins/home/report-alpha.api.md
+++ b/plugins/home/report-alpha.api.md
@@ -6,8 +6,8 @@
 import { AnyApiFactory } from '@backstage/frontend-plugin-api';
 import { AnyRouteRefParams } from '@backstage/frontend-plugin-api';
 import { ApiFactory } from '@backstage/frontend-plugin-api';
-import { BlueprintParams } from '@backstage/frontend-plugin-api/src/wiring/createExtensionBlueprint';
 import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
+import { ExtensionBlueprintParams } from '@backstage/frontend-plugin-api';
 import { ExtensionDefinition } from '@backstage/frontend-plugin-api';
 import { ExtensionInput } from '@backstage/frontend-plugin-api';
 import { FrontendPlugin } from '@backstage/frontend-plugin-api';
@@ -39,7 +39,7 @@ const _default: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'app-root-element:home/visit-listener': ExtensionDefinition<{
       kind: 'app-root-element';

--- a/plugins/home/report-alpha.api.md
+++ b/plugins/home/report-alpha.api.md
@@ -5,6 +5,8 @@
 ```ts
 import { AnyApiFactory } from '@backstage/frontend-plugin-api';
 import { AnyRouteRefParams } from '@backstage/frontend-plugin-api';
+import { ApiFactory } from '@backstage/frontend-plugin-api';
+import { BlueprintParams } from '@backstage/frontend-plugin-api/src/wiring/createExtensionBlueprint';
 import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { ExtensionDefinition } from '@backstage/frontend-plugin-api';
 import { ExtensionInput } from '@backstage/frontend-plugin-api';
@@ -31,9 +33,13 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'app-root-element:home/visit-listener': ExtensionDefinition<{
       kind: 'app-root-element';

--- a/plugins/home/src/alpha.tsx
+++ b/plugins/home/src/alpha.tsx
@@ -24,7 +24,6 @@ import {
   AppRootElementBlueprint,
   identityApiRef,
   storageApiRef,
-  createApiFactory,
   ApiBlueprint,
 } from '@backstage/frontend-plugin-api';
 import { compatWrapper } from '@backstage/core-compat-api';
@@ -79,8 +78,8 @@ const visitListenerAppRootElement = AppRootElementBlueprint.make({
 
 const visitsApi = ApiBlueprint.make({
   name: 'visits',
-  params: {
-    factory: createApiFactory({
+  params: define =>
+    define({
       api: visitsApiRef,
       deps: {
         storageApi: storageApiRef,
@@ -89,7 +88,6 @@ const visitsApi = ApiBlueprint.make({
       factory: ({ storageApi, identityApi }) =>
         VisitsStorageApi.create({ storageApi, identityApi }),
     }),
-  },
 });
 
 /**

--- a/plugins/kubernetes/report-alpha.api.md
+++ b/plugins/kubernetes/report-alpha.api.md
@@ -5,6 +5,8 @@
 ```ts
 import { AnyApiFactory } from '@backstage/frontend-plugin-api';
 import { AnyRouteRefParams } from '@backstage/frontend-plugin-api';
+import { ApiFactory } from '@backstage/frontend-plugin-api';
+import { BlueprintParams } from '@backstage/frontend-plugin-api/src/wiring/createExtensionBlueprint';
 import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { defaultEntityContentGroups } from '@backstage/plugin-catalog-react/alpha';
 import { Entity } from '@backstage/catalog-model';
@@ -33,9 +35,13 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'api:kubernetes/auth-providers': ExtensionDefinition<{
       kind: 'api';
@@ -48,9 +54,13 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'api:kubernetes/cluster-link-formatter': ExtensionDefinition<{
       kind: 'api';
@@ -63,9 +73,13 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'api:kubernetes/proxy': ExtensionDefinition<{
       kind: 'api';
@@ -78,9 +92,13 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'entity-content:kubernetes/kubernetes': ExtensionDefinition<{
       kind: 'entity-content';

--- a/plugins/kubernetes/report-alpha.api.md
+++ b/plugins/kubernetes/report-alpha.api.md
@@ -6,11 +6,11 @@
 import { AnyApiFactory } from '@backstage/frontend-plugin-api';
 import { AnyRouteRefParams } from '@backstage/frontend-plugin-api';
 import { ApiFactory } from '@backstage/frontend-plugin-api';
-import { BlueprintParams } from '@backstage/frontend-plugin-api/src/wiring/createExtensionBlueprint';
 import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { defaultEntityContentGroups } from '@backstage/plugin-catalog-react/alpha';
 import { Entity } from '@backstage/catalog-model';
 import { EntityPredicate } from '@backstage/plugin-catalog-react/alpha';
+import { ExtensionBlueprintParams } from '@backstage/frontend-plugin-api';
 import { ExtensionDefinition } from '@backstage/frontend-plugin-api';
 import { FrontendPlugin } from '@backstage/frontend-plugin-api';
 import { JSX as JSX_2 } from 'react';
@@ -41,7 +41,7 @@ const _default: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'api:kubernetes/auth-providers': ExtensionDefinition<{
       kind: 'api';
@@ -60,7 +60,7 @@ const _default: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'api:kubernetes/cluster-link-formatter': ExtensionDefinition<{
       kind: 'api';
@@ -79,7 +79,7 @@ const _default: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'api:kubernetes/proxy': ExtensionDefinition<{
       kind: 'api';
@@ -98,7 +98,7 @@ const _default: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'entity-content:kubernetes/kubernetes': ExtensionDefinition<{
       kind: 'entity-content';

--- a/plugins/kubernetes/src/alpha/apis.tsx
+++ b/plugins/kubernetes/src/alpha/apis.tsx
@@ -16,7 +16,6 @@
 
 import {
   ApiBlueprint,
-  createApiFactory,
   discoveryApiRef,
   fetchApiRef,
 } from '@backstage/frontend-plugin-api';
@@ -41,8 +40,8 @@ import {
 } from '@backstage/core-plugin-api';
 
 export const kubernetesApiExtension = ApiBlueprint.make({
-  params: {
-    factory: createApiFactory({
+  params: define =>
+    define({
       api: kubernetesApiRef,
       deps: {
         discoveryApi: discoveryApiRef,
@@ -56,13 +55,12 @@ export const kubernetesApiExtension = ApiBlueprint.make({
           kubernetesAuthProvidersApi,
         }),
     }),
-  },
 });
 
 export const kubernetesProxyApi = ApiBlueprint.make({
   name: 'proxy',
-  params: {
-    factory: createApiFactory({
+  params: define =>
+    define({
       api: kubernetesProxyApiRef,
       deps: {
         kubernetesApi: kubernetesApiRef,
@@ -72,13 +70,12 @@ export const kubernetesProxyApi = ApiBlueprint.make({
           kubernetesApi,
         }),
     }),
-  },
 });
 
 export const kubernetesAuthProvidersApi = ApiBlueprint.make({
   name: 'auth-providers',
-  params: {
-    factory: createApiFactory({
+  params: define =>
+    define({
       api: kubernetesAuthProvidersApiRef,
       deps: {
         gitlabAuthApi: gitlabAuthApiRef,
@@ -109,13 +106,12 @@ export const kubernetesAuthProvidersApi = ApiBlueprint.make({
         });
       },
     }),
-  },
 });
 
 export const kubernetesClusterLinkFormatterApi = ApiBlueprint.make({
   name: 'cluster-link-formatter',
-  params: {
-    factory: createApiFactory({
+  params: define =>
+    define({
       api: kubernetesClusterLinkFormatterApiRef,
       deps: { googleAuthApi: googleAuthApiRef },
       factory: deps => {
@@ -126,5 +122,4 @@ export const kubernetesClusterLinkFormatterApi = ApiBlueprint.make({
         });
       },
     }),
-  },
 });

--- a/plugins/notifications/report-alpha.api.md
+++ b/plugins/notifications/report-alpha.api.md
@@ -5,6 +5,8 @@
 ```ts
 import { AnyApiFactory } from '@backstage/frontend-plugin-api';
 import { AnyRouteRefParams } from '@backstage/frontend-plugin-api';
+import { ApiFactory } from '@backstage/frontend-plugin-api';
+import { BlueprintParams } from '@backstage/frontend-plugin-api/src/wiring/createExtensionBlueprint';
 import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { ExtensionDefinition } from '@backstage/frontend-plugin-api';
 import { FrontendPlugin } from '@backstage/frontend-plugin-api';
@@ -29,9 +31,13 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'page:notifications': ExtensionDefinition<{
       kind: 'page';

--- a/plugins/notifications/report-alpha.api.md
+++ b/plugins/notifications/report-alpha.api.md
@@ -6,8 +6,8 @@
 import { AnyApiFactory } from '@backstage/frontend-plugin-api';
 import { AnyRouteRefParams } from '@backstage/frontend-plugin-api';
 import { ApiFactory } from '@backstage/frontend-plugin-api';
-import { BlueprintParams } from '@backstage/frontend-plugin-api/src/wiring/createExtensionBlueprint';
 import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
+import { ExtensionBlueprintParams } from '@backstage/frontend-plugin-api';
 import { ExtensionDefinition } from '@backstage/frontend-plugin-api';
 import { FrontendPlugin } from '@backstage/frontend-plugin-api';
 import { JSX as JSX_2 } from 'react';
@@ -37,7 +37,7 @@ const _default: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'page:notifications': ExtensionDefinition<{
       kind: 'page';

--- a/plugins/notifications/src/alpha.tsx
+++ b/plugins/notifications/src/alpha.tsx
@@ -17,7 +17,6 @@
 import {
   ApiBlueprint,
   PageBlueprint,
-  createApiFactory,
   createFrontendPlugin,
   discoveryApiRef,
   fetchApiRef,
@@ -41,14 +40,13 @@ const page = PageBlueprint.make({
 });
 
 const api = ApiBlueprint.make({
-  params: {
-    factory: createApiFactory({
+  params: define =>
+    define({
       api: notificationsApiRef,
       deps: { discoveryApi: discoveryApiRef, fetchApi: fetchApiRef },
       factory: ({ discoveryApi, fetchApi }) =>
         new NotificationsClient({ discoveryApi, fetchApi }),
     }),
-  },
 });
 
 /** @alpha */

--- a/plugins/scaffolder-react/report-alpha.api.md
+++ b/plugins/scaffolder-react/report-alpha.api.md
@@ -8,12 +8,12 @@ import { AnyApiRef } from '@backstage/core-plugin-api';
 import { ApiFactory } from '@backstage/frontend-plugin-api';
 import { ApiHolder } from '@backstage/core-plugin-api';
 import { ApiRef } from '@backstage/frontend-plugin-api';
-import { BlueprintParams } from '@backstage/frontend-plugin-api/src/wiring/createExtensionBlueprint';
 import { ComponentType } from 'react';
 import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { CustomFieldValidator } from '@backstage/plugin-scaffolder-react';
 import { Dispatch } from 'react';
 import { ExtensionBlueprint } from '@backstage/frontend-plugin-api';
+import { ExtensionBlueprintParams } from '@backstage/frontend-plugin-api';
 import { ExtensionDefinition } from '@backstage/frontend-plugin-api';
 import { ExtensionInput } from '@backstage/frontend-plugin-api';
 import { FieldExtensionComponentProps } from '@backstage/plugin-scaffolder-react';
@@ -226,7 +226,7 @@ export const formFieldsApi: ExtensionDefinition<{
     TDeps extends { [name in string]: unknown },
   >(
     params: ApiFactory<TApi, TImpl, TDeps>,
-  ) => BlueprintParams<AnyApiFactory>;
+  ) => ExtensionBlueprintParams<AnyApiFactory>;
 }>;
 
 // @alpha @deprecated (undocumented)

--- a/plugins/scaffolder-react/report-alpha.api.md
+++ b/plugins/scaffolder-react/report-alpha.api.md
@@ -5,8 +5,10 @@
 ```ts
 import { AnyApiFactory } from '@backstage/frontend-plugin-api';
 import { AnyApiRef } from '@backstage/core-plugin-api';
+import { ApiFactory } from '@backstage/frontend-plugin-api';
 import { ApiHolder } from '@backstage/core-plugin-api';
 import { ApiRef } from '@backstage/frontend-plugin-api';
+import { BlueprintParams } from '@backstage/frontend-plugin-api/src/wiring/createExtensionBlueprint';
 import { ComponentType } from 'react';
 import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { CustomFieldValidator } from '@backstage/plugin-scaffolder-react';
@@ -218,9 +220,13 @@ export const formFieldsApi: ExtensionDefinition<{
   };
   kind: 'api';
   name: 'form-fields';
-  params: {
-    factory: AnyApiFactory;
-  };
+  params: <
+    TApi,
+    TImpl extends TApi,
+    TDeps extends { [name in string]: unknown },
+  >(
+    params: ApiFactory<TApi, TImpl, TDeps>,
+  ) => BlueprintParams<AnyApiFactory>;
 }>;
 
 // @alpha @deprecated (undocumented)

--- a/plugins/scaffolder-react/src/next/api/FormFieldsApi.ts
+++ b/plugins/scaffolder-react/src/next/api/FormFieldsApi.ts
@@ -16,7 +16,6 @@
 
 import {
   ApiBlueprint,
-  createApiFactory,
   createExtensionInput,
 } from '@backstage/frontend-plugin-api';
 import { formFieldsApiRef } from './ref';
@@ -53,12 +52,12 @@ export const formFieldsApi = ApiBlueprint.makeWithOverrides({
       e.get(FormFieldBlueprint.dataRefs.formFieldLoader),
     );
 
-    return originalFactory({
-      factory: createApiFactory({
+    return originalFactory(define =>
+      define({
         api: formFieldsApiRef,
         deps: {},
         factory: () => new DefaultScaffolderFormFieldsApi(formFieldLoaders),
       }),
-    });
+    );
   },
 });

--- a/plugins/scaffolder/report-alpha.api.md
+++ b/plugins/scaffolder/report-alpha.api.md
@@ -5,7 +5,9 @@
 ```ts
 import { AnyApiFactory } from '@backstage/frontend-plugin-api';
 import { AnyRouteRefParams } from '@backstage/frontend-plugin-api';
+import { ApiFactory } from '@backstage/frontend-plugin-api';
 import { ApiRef } from '@backstage/frontend-plugin-api';
+import { BlueprintParams } from '@backstage/frontend-plugin-api/src/wiring/createExtensionBlueprint';
 import { ComponentType } from 'react';
 import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { Entity } from '@backstage/catalog-model';
@@ -66,9 +68,13 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'api:scaffolder/form-decorators': ExtensionDefinition<{
       config: {};
@@ -93,9 +99,13 @@ const _default: FrontendPlugin<
       };
       kind: 'api';
       name: 'form-decorators';
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'api:scaffolder/form-fields': ExtensionDefinition<{
       config: {};
@@ -120,9 +130,13 @@ const _default: FrontendPlugin<
       };
       kind: 'api';
       name: 'form-fields';
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'entity-icon-link:scaffolder/launch-template': ExtensionDefinition<{
       kind: 'entity-icon-link';
@@ -273,9 +287,13 @@ export const formDecoratorsApi: ExtensionDefinition<{
   };
   kind: 'api';
   name: 'form-decorators';
-  params: {
-    factory: AnyApiFactory;
-  };
+  params: <
+    TApi,
+    TImpl extends TApi,
+    TDeps extends { [name in string]: unknown },
+  >(
+    params: ApiFactory<TApi, TImpl, TDeps>,
+  ) => BlueprintParams<AnyApiFactory>;
 }>;
 
 // @alpha (undocumented)

--- a/plugins/scaffolder/report-alpha.api.md
+++ b/plugins/scaffolder/report-alpha.api.md
@@ -7,11 +7,11 @@ import { AnyApiFactory } from '@backstage/frontend-plugin-api';
 import { AnyRouteRefParams } from '@backstage/frontend-plugin-api';
 import { ApiFactory } from '@backstage/frontend-plugin-api';
 import { ApiRef } from '@backstage/frontend-plugin-api';
-import { BlueprintParams } from '@backstage/frontend-plugin-api/src/wiring/createExtensionBlueprint';
 import { ComponentType } from 'react';
 import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { Entity } from '@backstage/catalog-model';
 import { EntityPredicate } from '@backstage/plugin-catalog-react/alpha';
+import { ExtensionBlueprintParams } from '@backstage/frontend-plugin-api';
 import { ExtensionDefinition } from '@backstage/frontend-plugin-api';
 import { ExtensionInput } from '@backstage/frontend-plugin-api';
 import { ExternalRouteRef } from '@backstage/frontend-plugin-api';
@@ -74,7 +74,7 @@ const _default: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'api:scaffolder/form-decorators': ExtensionDefinition<{
       config: {};
@@ -105,7 +105,7 @@ const _default: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'api:scaffolder/form-fields': ExtensionDefinition<{
       config: {};
@@ -136,7 +136,7 @@ const _default: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'entity-icon-link:scaffolder/launch-template': ExtensionDefinition<{
       kind: 'entity-icon-link';
@@ -293,7 +293,7 @@ export const formDecoratorsApi: ExtensionDefinition<{
     TDeps extends { [name in string]: unknown },
   >(
     params: ApiFactory<TApi, TImpl, TDeps>,
-  ) => BlueprintParams<AnyApiFactory>;
+  ) => ExtensionBlueprintParams<AnyApiFactory>;
 }>;
 
 // @alpha (undocumented)

--- a/plugins/scaffolder/src/alpha/api/FormDecoratorsApi.ts
+++ b/plugins/scaffolder/src/alpha/api/FormDecoratorsApi.ts
@@ -16,7 +16,6 @@
 
 import {
   ApiBlueprint,
-  createApiFactory,
   createExtensionInput,
 } from '@backstage/frontend-plugin-api';
 import { ScaffolderFormDecoratorsApi } from './types';
@@ -58,8 +57,8 @@ export const formDecoratorsApi = ApiBlueprint.makeWithOverrides({
       e.get(FormDecoratorBlueprint.dataRefs.formDecoratorLoader),
     );
 
-    return originalFactory({
-      factory: createApiFactory({
+    return originalFactory(define =>
+      define({
         api: formDecoratorsApiRef,
         deps: {},
         factory: () =>
@@ -67,6 +66,6 @@ export const formDecoratorsApi = ApiBlueprint.makeWithOverrides({
             decorators: formDecorators,
           }),
       }),
-    });
+    );
   },
 });

--- a/plugins/scaffolder/src/alpha/extensions.tsx
+++ b/plugins/scaffolder/src/alpha/extensions.tsx
@@ -22,7 +22,6 @@ import {
   NavItemBlueprint,
   PageBlueprint,
   ApiBlueprint,
-  createApiFactory,
   discoveryApiRef,
   fetchApiRef,
   identityApiRef,
@@ -74,8 +73,8 @@ export const repoUrlPickerFormField = FormFieldBlueprint.make({
 });
 
 export const scaffolderApi = ApiBlueprint.make({
-  params: {
-    factory: createApiFactory({
+  params: define =>
+    define({
       api: scaffolderApiRef,
       deps: {
         discoveryApi: discoveryApiRef,
@@ -91,5 +90,4 @@ export const scaffolderApi = ApiBlueprint.make({
           identityApi,
         }),
     }),
-  },
 });

--- a/plugins/search/report-alpha.api.md
+++ b/plugins/search/report-alpha.api.md
@@ -6,8 +6,8 @@
 import { AnyApiFactory } from '@backstage/core-plugin-api';
 import { AnyRouteRefParams } from '@backstage/frontend-plugin-api';
 import { ApiFactory } from '@backstage/core-plugin-api';
-import { BlueprintParams } from '@backstage/frontend-plugin-api/src/wiring/createExtensionBlueprint';
 import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
+import { ExtensionBlueprintParams } from '@backstage/frontend-plugin-api';
 import { ExtensionDefinition } from '@backstage/frontend-plugin-api';
 import { ExtensionInput } from '@backstage/frontend-plugin-api';
 import { FrontendPlugin } from '@backstage/frontend-plugin-api';
@@ -43,7 +43,7 @@ const _default: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'nav-item:search': ExtensionDefinition<{
       kind: 'nav-item';
@@ -157,7 +157,7 @@ export const searchApi: ExtensionDefinition<{
     TDeps extends { [name in string]: unknown },
   >(
     params: ApiFactory<TApi, TImpl, TDeps>,
-  ) => BlueprintParams<AnyApiFactory>;
+  ) => ExtensionBlueprintParams<AnyApiFactory>;
 }>;
 
 // @alpha (undocumented)

--- a/plugins/search/report-alpha.api.md
+++ b/plugins/search/report-alpha.api.md
@@ -5,6 +5,8 @@
 ```ts
 import { AnyApiFactory } from '@backstage/core-plugin-api';
 import { AnyRouteRefParams } from '@backstage/frontend-plugin-api';
+import { ApiFactory } from '@backstage/core-plugin-api';
+import { BlueprintParams } from '@backstage/frontend-plugin-api/src/wiring/createExtensionBlueprint';
 import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { ExtensionDefinition } from '@backstage/frontend-plugin-api';
 import { ExtensionInput } from '@backstage/frontend-plugin-api';
@@ -35,9 +37,13 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'nav-item:search': ExtensionDefinition<{
       kind: 'nav-item';
@@ -145,9 +151,13 @@ export const searchApi: ExtensionDefinition<{
   configInput: {};
   output: ConfigurableExtensionDataRef<AnyApiFactory, 'core.api.factory', {}>;
   inputs: {};
-  params: {
-    factory: AnyApiFactory;
-  };
+  params: <
+    TApi,
+    TImpl extends TApi,
+    TDeps extends { [name in string]: unknown },
+  >(
+    params: ApiFactory<TApi, TImpl, TDeps>,
+  ) => BlueprintParams<AnyApiFactory>;
 }>;
 
 // @alpha (undocumented)

--- a/plugins/search/src/alpha.tsx
+++ b/plugins/search/src/alpha.tsx
@@ -31,7 +31,6 @@ import {
   useApi,
   discoveryApiRef,
   fetchApiRef,
-  createApiFactory,
 } from '@backstage/core-plugin-api';
 
 import {
@@ -77,14 +76,13 @@ import {
 
 /** @alpha */
 export const searchApi = ApiBlueprint.make({
-  params: {
-    factory: createApiFactory({
+  params: define =>
+    define({
       api: searchApiRef,
       deps: { discoveryApi: discoveryApiRef, fetchApi: fetchApiRef },
       factory: ({ discoveryApi, fetchApi }) =>
         new SearchClient({ discoveryApi, fetchApi }),
     }),
-  },
 });
 
 const useSearchPageStyles = makeStyles((theme: Theme) => ({

--- a/plugins/signals/report-alpha.api.md
+++ b/plugins/signals/report-alpha.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 import { AnyApiFactory } from '@backstage/frontend-plugin-api';
+import { ApiFactory } from '@backstage/frontend-plugin-api';
+import { BlueprintParams } from '@backstage/frontend-plugin-api/src/wiring/createExtensionBlueprint';
 import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { ExtensionDefinition } from '@backstage/frontend-plugin-api';
 import { FrontendPlugin } from '@backstage/frontend-plugin-api';
@@ -25,9 +27,13 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'app-root-element:signals/signals-display': ExtensionDefinition<{
       kind: 'app-root-element';

--- a/plugins/signals/report-alpha.api.md
+++ b/plugins/signals/report-alpha.api.md
@@ -5,8 +5,8 @@
 ```ts
 import { AnyApiFactory } from '@backstage/frontend-plugin-api';
 import { ApiFactory } from '@backstage/frontend-plugin-api';
-import { BlueprintParams } from '@backstage/frontend-plugin-api/src/wiring/createExtensionBlueprint';
 import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
+import { ExtensionBlueprintParams } from '@backstage/frontend-plugin-api';
 import { ExtensionDefinition } from '@backstage/frontend-plugin-api';
 import { FrontendPlugin } from '@backstage/frontend-plugin-api';
 import { JSX as JSX_2 } from 'react';
@@ -33,7 +33,7 @@ const _default: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'app-root-element:signals/signals-display': ExtensionDefinition<{
       kind: 'app-root-element';

--- a/plugins/signals/src/alpha.tsx
+++ b/plugins/signals/src/alpha.tsx
@@ -17,7 +17,6 @@
 import {
   ApiBlueprint,
   AppRootElementBlueprint,
-  createApiFactory,
   createFrontendPlugin,
   discoveryApiRef,
   identityApiRef,
@@ -28,8 +27,8 @@ import { SignalsDisplay } from './plugin';
 import { compatWrapper } from '@backstage/core-compat-api';
 
 const api = ApiBlueprint.make({
-  params: {
-    factory: createApiFactory({
+  params: define =>
+    define({
       api: signalApiRef,
       deps: {
         identity: identityApiRef,
@@ -42,7 +41,6 @@ const api = ApiBlueprint.make({
         });
       },
     }),
-  },
 });
 
 const signalsDisplayAppRootElement = AppRootElementBlueprint.make({

--- a/plugins/techdocs/report-alpha.api.md
+++ b/plugins/techdocs/report-alpha.api.md
@@ -6,6 +6,8 @@
 import { AnyApiFactory } from '@backstage/frontend-plugin-api';
 import { AnyExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { AnyRouteRefParams } from '@backstage/frontend-plugin-api';
+import { ApiFactory } from '@backstage/frontend-plugin-api';
+import { BlueprintParams } from '@backstage/frontend-plugin-api/src/wiring/createExtensionBlueprint';
 import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { defaultEntityContentGroups } from '@backstage/plugin-catalog-react/alpha';
 import { Entity } from '@backstage/catalog-model';
@@ -46,9 +48,13 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'api:techdocs/storage': ExtensionDefinition<{
       kind: 'api';
@@ -61,9 +67,13 @@ const _default: FrontendPlugin<
         {}
       >;
       inputs: {};
-      params: {
-        factory: AnyApiFactory;
-      };
+      params: <
+        TApi,
+        TImpl extends TApi,
+        TDeps extends { [name in string]: unknown },
+      >(
+        params: ApiFactory<TApi, TImpl, TDeps>,
+      ) => BlueprintParams<AnyApiFactory>;
     }>;
     'empty-state:techdocs/entity-content': ExtensionDefinition<{
       config: {};

--- a/plugins/techdocs/report-alpha.api.md
+++ b/plugins/techdocs/report-alpha.api.md
@@ -7,11 +7,11 @@ import { AnyApiFactory } from '@backstage/frontend-plugin-api';
 import { AnyExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { AnyRouteRefParams } from '@backstage/frontend-plugin-api';
 import { ApiFactory } from '@backstage/frontend-plugin-api';
-import { BlueprintParams } from '@backstage/frontend-plugin-api/src/wiring/createExtensionBlueprint';
 import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { defaultEntityContentGroups } from '@backstage/plugin-catalog-react/alpha';
 import { Entity } from '@backstage/catalog-model';
 import { EntityPredicate } from '@backstage/plugin-catalog-react/alpha';
+import { ExtensionBlueprintParams } from '@backstage/frontend-plugin-api';
 import { ExtensionDefinition } from '@backstage/frontend-plugin-api';
 import { ExtensionInput } from '@backstage/frontend-plugin-api';
 import { FrontendPlugin } from '@backstage/frontend-plugin-api';
@@ -54,7 +54,7 @@ const _default: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'api:techdocs/storage': ExtensionDefinition<{
       kind: 'api';
@@ -73,7 +73,7 @@ const _default: FrontendPlugin<
         TDeps extends { [name in string]: unknown },
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
-      ) => BlueprintParams<AnyApiFactory>;
+      ) => ExtensionBlueprintParams<AnyApiFactory>;
     }>;
     'empty-state:techdocs/entity-content': ExtensionDefinition<{
       config: {};

--- a/plugins/techdocs/src/alpha/index.tsx
+++ b/plugins/techdocs/src/alpha/index.tsx
@@ -26,7 +26,6 @@ import {
 } from '@backstage/frontend-plugin-api';
 import {
   configApiRef,
-  createApiFactory,
   discoveryApiRef,
   fetchApiRef,
 } from '@backstage/core-plugin-api';
@@ -68,8 +67,8 @@ const techdocsEntityIconLink = EntityIconLinkBlueprint.make({
 /** @alpha */
 const techDocsStorageApi = ApiBlueprint.make({
   name: 'storage',
-  params: {
-    factory: createApiFactory({
+  params: define =>
+    define({
       api: techdocsStorageApiRef,
       deps: {
         configApi: configApiRef,
@@ -83,13 +82,12 @@ const techDocsStorageApi = ApiBlueprint.make({
           fetchApi,
         }),
     }),
-  },
 });
 
 /** @alpha */
 const techDocsClientApi = ApiBlueprint.make({
-  params: {
-    factory: createApiFactory({
+  params: define =>
+    define({
       api: techdocsApiRef,
       deps: {
         configApi: configApiRef,
@@ -103,7 +101,6 @@ const techDocsClientApi = ApiBlueprint.make({
           fetchApi,
         }),
     }),
-  },
 });
 
 /** @alpha */


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This introduces a new way to define params for blueprints in the new frontend system. It's done with a new option to `createExtensionBlueprint` that is shaped in such a way that it is possible to use inferred type parameters as part of the declaration. As usual the design priority favors the use of the resulting blueprint, aiming to keep that as simple and intuitive as possible.

With this in place, we can clean up a lot of the APIs that were relying on helper functions for the creation of blueprint params. Most notable is the `ApiBlueprint`, which you currently use like this:

```ts
ApiBlueprint.make({
  name: 'error',
  params: {
    factory: createApiFactory({
      api: errorApiRef,
      deps: { alertApi: alertApiRef },
      factory: ({ alertApi }) => ...,
    })
  },
})
```

A big problem here is that as you're using the bluprint, using autocomplete to find what parameters are availble, you can easily get led in the wrong direction at this point:

```ts
ApiBlueprint.make({
  name: 'error',
  params: {
    factory: 
         // ^ autocomplete tells you to add an object with `api`, `deps`, and `factory`, but that's wrong
})
```

The new version looks like this:

```ts
ApiBlueprint.make({
  name: 'error',
  params: define => define({
    api: errorApiRef,
    deps: { alertApi: alertApiRef },
    factory: ({ alertApi }) => ...,
  }),
})
```

There's no need for a separate import of `createApiFactory` anymore, and if you be more clearly guided towards the correct use. If you try to define params as an object, you'll get this error:

```ts
ApiBlueprint.make({
  name: 'error',
  params: { }
// ^ Type '{ api: ... }' is not assignable to type '"Error: This blueprint uses advanced parameter types and requires you to pass parameters as using the following callback syntax: `<blueprint>.make({ params: define => define(<params>) })`"'.
})
```

We are rolling this out as an immediate breaking change for the `ApiBlueprint` and perhaps a few other ones. It does not affect the functionality and ability to install old plugins in an app though, it's only upon upgrading to the 1.42 release that this takes affect and the blueprint usage needs to be updated. This does also not affect any other blueprints that do not use these advanced param types, which the exception that it is possible to use the callback form to define params, because that helps with backwards compatibility if one wants to switch a blueprint back to simpler types.

Forking on a doc update for this too, but figured it's best to get up a bit earlier and maybe for the release today.

Oh, and this is how the `ApiBlueprint` is now defined:

```ts
export const ApiBlueprint = createExtensionBlueprint({
  kind: 'api',
  attachTo: { id: 'root', input: 'apis' },
  output: [factoryDataRef],
  dataRefs: { factory: factoryDataRef, },
  defineParams: <TApi, TImpl extends TApi, TDeps extends { [name in string]: unknown }>(
    params: ApiFactory<TApi, TImpl, TDeps>,
  ) => createExtensionBlueprintParams(params as AnyApiFactory),
  *factory(params) {
    yield factoryDataRef(params);
  },
});
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
