### PR TITLE
BUI - Small fix to make the library React 17 compatible

### DIFF
--- a/.changeset/polite-trains-notice.md
+++ b/.changeset/polite-trains-notice.md
@@ -2,4 +2,4 @@
 '@backstage/ui': patch
 ---
 
-Updated Combobox to not use the useId() hook to support React 17.
+Updated Menu component in Backstage UI to use useId() from React Aria instead of React to support React 17.

--- a/.changeset/polite-trains-notice.md
+++ b/.changeset/polite-trains-notice.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Updated Combobox to not use the useId() hook to support React 17.

--- a/packages/ui/src/components/Menu/Combobox.tsx
+++ b/packages/ui/src/components/Menu/Combobox.tsx
@@ -19,7 +19,6 @@ import {
   useState,
   useMemo,
   useCallback,
-  useId,
   ChangeEvent,
   KeyboardEvent,
   useRef,
@@ -28,6 +27,13 @@ import {
 import clsx from 'clsx';
 import { MenuComboboxOption, MenuComboboxProps } from './types';
 import { Icon } from '../..';
+
+// React 17 compatible unique ID generator
+let comboboxIdCounter = 0;
+function generateComboboxId(): string {
+  comboboxIdCounter += 1;
+  return `combobox-${comboboxIdCounter.toString(36)}`;
+}
 
 const getListboxItemId = (listboxId: string, optionValue: string): string =>
   `${listboxId}-option-${optionValue}`;
@@ -96,7 +102,7 @@ export const Combobox = forwardRef<HTMLDivElement, MenuComboboxProps>(
       ...rest
     } = props;
 
-    const triggerId = useId();
+    const triggerId = generateComboboxId();
     const listboxId = `${triggerId}-listbox`;
 
     // State management

--- a/packages/ui/src/components/Menu/Combobox.tsx
+++ b/packages/ui/src/components/Menu/Combobox.tsx
@@ -27,13 +27,7 @@ import {
 import clsx from 'clsx';
 import { MenuComboboxOption, MenuComboboxProps } from './types';
 import { Icon } from '../..';
-
-// React 17 compatible unique ID generator
-let comboboxIdCounter = 0;
-function generateComboboxId(): string {
-  comboboxIdCounter += 1;
-  return `combobox-${comboboxIdCounter.toString(36)}`;
-}
+import { useId } from 'react-aria';
 
 const getListboxItemId = (listboxId: string, optionValue: string): string =>
   `${listboxId}-option-${optionValue}`;
@@ -102,7 +96,7 @@ export const Combobox = forwardRef<HTMLDivElement, MenuComboboxProps>(
       ...rest
     } = props;
 
-    const triggerId = generateComboboxId();
+    const triggerId = useId();
     const listboxId = `${triggerId}-listbox`;
 
     // State management


### PR DESCRIPTION
## Hey, I just made a Pull Request!

`useId()` is only available on React 18. By removing it we make the package ready for React 17.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
