### PR TITLE
 backend-defaults: use configured namespace and keyPrefixSeparator in cache manager

### DIFF
--- a/.changeset/big-cameras-turn.md
+++ b/.changeset/big-cameras-turn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Fixed cache namespace and key prefix separator configuration to properly use configured values instead of hardcoded plugin ID. The cache manager now correctly combines the configured namespace with plugin IDs using the configured separator for Redis and Valkey. Memcache and memory store continue to use plugin ID as namespace.

--- a/docs/backend-system/core-services/cache.md
+++ b/docs/backend-system/core-services/cache.md
@@ -7,6 +7,39 @@ description: Documentation for the Cache service
 
 This service lets your plugin interact with a cache. It is bound to your plugin too, so that you will only set and get values in your plugin's private namespace.
 
+## Configuration
+
+The cache service can be configured using the `backend.cache` section in your `app-config.yaml`:
+
+```yaml
+backend:
+  cache:
+    store: redis # or 'valkey', 'memcache', 'memory'
+    connection: redis://localhost:6379
+
+    # Store-specific configuration (Redis/Valkey only)
+    redis:
+      client:
+        # Optional: Global namespace prefix for all cache keys
+        namespace: 'my-app'
+        # Optional: Separator used between namespace and plugin ID (default: ':')
+        keyPrefixSeparator: ':'
+        # Other Redis-specific options...
+        clearBatchSize: 1000
+        useUnlink: false
+```
+
+### Namespace Configuration
+
+For Redis and Valkey stores, you can configure a global namespace that will be prefixed to all cache keys:
+
+- **Without namespace**: Cache keys use only the plugin ID (e.g., `catalog:some-key`)
+- **With namespace**: Cache keys use the format `namespace:pluginId:key` (e.g., `my-app:catalog:some-key`)
+
+The `keyPrefixSeparator` controls what character is used between the namespace and plugin ID (defaults to `:`).
+
+**Note**: Memory and Memcache stores do not support namespace configuration and will always use the plugin ID directly.
+
 ## Using the service
 
 The following example shows how to get a cache client in your `example` backend plugin and setting and getting values from the cache.

--- a/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
@@ -213,6 +213,25 @@ export class CacheManager {
     return redisOptions;
   }
 
+  /**
+   * Construct the full namespace based on the options and pluginId.
+   *
+   * @param pluginId - The plugin ID to namespace
+   * @param storeOptions - Optional cache store configuration options
+   * @returns The constructed namespace string combining the configured namespace with pluginId
+   */
+  private static constructNamespace(
+    pluginId: string,
+    storeOptions: CacheStoreOptions | undefined,
+  ): string {
+    if (storeOptions?.client?.namespace) {
+      const separator = storeOptions.client.keyPrefixSeparator ?? ':';
+      return `${storeOptions.client.namespace}${separator}${pluginId}`;
+    }
+
+    return pluginId;
+  }
+
   /** @internal */
   constructor(
     store: string,
@@ -286,7 +305,7 @@ export class CacheManager {
         });
       }
       return new Keyv({
-        namespace: pluginId,
+        namespace: CacheManager.constructNamespace(pluginId, this.storeOptions),
         ttl: defaultTtl,
         store: stores[pluginId],
         emitErrors: false,
@@ -326,7 +345,7 @@ export class CacheManager {
         });
       }
       return new Keyv({
-        namespace: pluginId,
+        namespace: CacheManager.constructNamespace(pluginId, this.storeOptions),
         ttl: defaultTtl,
         store: stores[pluginId],
         emitErrors: false,

--- a/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
@@ -222,14 +222,15 @@ export class CacheManager {
    */
   private static constructNamespace(
     pluginId: string,
-    storeOptions: CacheStoreOptions | undefined,
+    storeOptions: RedisCacheStoreOptions | undefined,
   ): string {
-    if (storeOptions?.client?.namespace) {
-      const separator = storeOptions.client.keyPrefixSeparator ?? ':';
-      return `${storeOptions.client.namespace}${separator}${pluginId}`;
-    }
+    const prefix = storeOptions?.client?.namespace
+      ? `${storeOptions.client.namespace}${
+          storeOptions.client.keyPrefixSeparator ?? ':'
+        }`
+      : '';
 
-    return pluginId;
+    return `${prefix}${pluginId}`;
   }
 
   /** @internal */


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Noticed that the `backend.cache.redis.client.namespace` option was not being utilized when creating a new Keyv client.

Fixed cache namespace and key prefix separator configuration to properly use configured values instead of hardcoded plugin ID. The cache manager now correctly combines the configured namespace with plugin IDs using the configured separator for Redis and Valkey. Memcache and memory store continue to use plugin ID as namespace.

In `CacheManager.ts` there is this `stores[pluginId] = new KeyvRedis(this.connection, redisOptions);` and `redisOptions` here contains the namespace option from `app-config.yaml` However based on my testing and https://github.com/jaredwray/keyv/issues/1254 if the namespace is set on both then the Keyv namespace will override the store adapter namespace.

Setting `backend.cache.redis.client.namespace` to `namespaceeee` yield following results:
 
Before
<img width="473" height="91" alt="image" src="https://github.com/user-attachments/assets/0b678342-7c0b-4df2-b5e8-f6dcf02ed0b1" />

After
<img width="589" height="118" alt="image" src="https://github.com/user-attachments/assets/377e7756-c953-47df-a5a2-7212ad393148" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Fixes #31078 