### PR TITLE
chore(events): remove luxon dependency

### DIFF
--- a/.changeset/sad-candies-open.md
+++ b/.changeset/sad-candies-open.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-events-backend-module-kafka': patch
+---
+
+Remove luxon dependency and minor internal improvements

--- a/plugins/events-backend-module-kafka/package.json
+++ b/plugins/events-backend-module-kafka/package.json
@@ -39,8 +39,7 @@
     "@backstage/config": "workspace:^",
     "@backstage/plugin-events-node": "workspace:^",
     "@backstage/types": "workspace:^",
-    "kafkajs": "^2.2.4",
-    "luxon": "^3.0.0"
+    "kafkajs": "^2.2.4"
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "workspace:^",

--- a/plugins/events-backend-module-kafka/src/publisher/KafkaConsumerClient.ts
+++ b/plugins/events-backend-module-kafka/src/publisher/KafkaConsumerClient.ts
@@ -25,8 +25,6 @@ import { loggerServiceAdapter } from './LoggerServiceAdapter';
  * KafkaConsumerClient
  *
  * This class creates the Kafka client that will be used to create the KafkaConsumingEventPublisher
- *
- * @public
  */
 export class KafkaConsumerClient {
   private readonly kafka: Kafka;

--- a/plugins/events-backend-module-kafka/src/publisher/KafkaConsumingEventPublisher.ts
+++ b/plugins/events-backend-module-kafka/src/publisher/KafkaConsumingEventPublisher.ts
@@ -21,11 +21,8 @@ import { KafkaConsumerConfig } from './config';
 type EventMetadata = EventParams['metadata'];
 
 /**
- *
  * This class subscribes to Kafka topics and publishes events received to the registered subscriber.
  * The message payload will be used as the event payload and passed to the subscribers.
- *
- * @public
  */
 export class KafkaConsumingEventPublisher {
   private readonly kafkaConsumer: Consumer;

--- a/plugins/events-backend-module-kafka/src/publisher/LoggerServiceAdapter.ts
+++ b/plugins/events-backend-module-kafka/src/publisher/LoggerServiceAdapter.ts
@@ -16,22 +16,20 @@
 import { LoggerService } from '@backstage/backend-plugin-api';
 import { LogEntry, logLevel } from 'kafkajs';
 
-export const loggerServiceAdapter =
-  (loggerService: LoggerService) => (_level: logLevel) => {
+export const loggerServiceAdapter = (loggerService: LoggerService) => {
+  const logMethods: Record<logLevel, (message: string, meta?: object) => void> =
+    {
+      [logLevel.ERROR]: loggerService.error,
+      [logLevel.WARN]: loggerService.warn,
+      [logLevel.INFO]: loggerService.info,
+      [logLevel.DEBUG]: loggerService.debug,
+      [logLevel.NOTHING]: () => {},
+    };
+
+  return (_level: logLevel) => {
     return (entry: LogEntry) => {
       const { namespace, level, log } = entry;
       const { message, ...extra } = log;
-
-      const logMethods: Record<
-        logLevel,
-        (message: string, meta?: object) => void
-      > = {
-        [logLevel.ERROR]: loggerService.error,
-        [logLevel.WARN]: loggerService.warn,
-        [logLevel.INFO]: loggerService.info,
-        [logLevel.DEBUG]: loggerService.debug,
-        [logLevel.NOTHING]: () => {},
-      };
 
       // Use loggerService method that matches the level
       logMethods[level].call(
@@ -43,3 +41,4 @@ export const loggerServiceAdapter =
       );
     };
   };
+};

--- a/plugins/events-backend-module-kafka/src/publisher/config.ts
+++ b/plugins/events-backend-module-kafka/src/publisher/config.ts
@@ -17,18 +17,12 @@ import { Config, readDurationFromConfig } from '@backstage/config';
 import { durationToMilliseconds } from '@backstage/types';
 import { ConsumerConfig, ConsumerSubscribeTopics, KafkaConfig } from 'kafkajs';
 
-/**
- * @public
- */
 export interface KafkaConsumerConfig {
   backstageTopic: string;
   consumerConfig: ConsumerConfig;
   consumerSubscribeTopics: ConsumerSubscribeTopics;
 }
 
-/**
- * @public
- */
 export interface KafkaEventSourceConfig {
   kafkaConfig: KafkaConfig;
   kafkaConsumerConfigs: KafkaConsumerConfig[];

--- a/plugins/events-backend-module-kafka/src/publisher/config.ts
+++ b/plugins/events-backend-module-kafka/src/publisher/config.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 import { Config, readDurationFromConfig } from '@backstage/config';
+import { durationToMilliseconds } from '@backstage/types';
 import { ConsumerConfig, ConsumerSubscribeTopics, KafkaConfig } from 'kafkajs';
-import { Duration } from 'luxon';
 
 /**
  * @public
@@ -54,7 +54,7 @@ const readOptionalHumanDurationInMs = (
 
   if (!humanDuration) return undefined;
 
-  return Duration.fromObject(humanDuration).as('milliseconds');
+  return durationToMilliseconds(humanDuration);
 };
 
 export const readConfig = (

--- a/yarn.lock
+++ b/yarn.lock
@@ -6246,7 +6246,6 @@ __metadata:
     "@backstage/plugin-events-node": "workspace:^"
     "@backstage/types": "workspace:^"
     kafkajs: "npm:^2.2.4"
-    luxon: "npm:^3.0.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!
     
This PR addresses the leftover comments from https://github.com/backstage/backstage/pull/29315 by removing the luxon dependency and using `durationToMilliseconds` from the `@backstage/types` package. I have also removed incorrect public comments and updated the `loggerServiceAdapter` to avoid reconstructing the `logMethods` on every call.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
