### PR TITLE
frontend-plugin-api: add aliasFor option to createRouteRef

### DIFF
--- a/.changeset/clever-plants-warn.md
+++ b/.changeset/clever-plants-warn.md
@@ -1,0 +1,24 @@
+---
+'@backstage/frontend-plugin-api': patch
+'@backstage/frontend-app-api': patch
+---
+
+Add support for a new `aliasFor` option for `createRouteRef`. This allows for the creation of a new route ref that acts as an alias for an existing route ref that is installed in the app. This is particularly useful when creating modules that override existing plugin pages, without referring to the existing plugin. For example:
+
+```tsx
+export default createFrontendModule({
+  pluginId: 'catalog',
+  extensions: [
+    PageBlueprint.make({
+      params: {
+        defaultPath: '/catalog',
+        routeRef: createRouteRef({ aliasFor: 'catalog.catalogIndex' }),
+        loader: () =>
+          import('./CustomCatalogIndexPage').then(m => (
+            <m.CustomCatalogIndexPage />
+          )),
+      },
+    }),
+  ],
+});
+```

--- a/docs/frontend-system/architecture/36-routes.md
+++ b/docs/frontend-system/architecture/36-routes.md
@@ -419,3 +419,42 @@ export default createFrontendPlugin({
   extensions: [catalogIndexPage],
 });
 ```
+
+## Route Aliases - Overriding Routed Extensions in Modules
+
+It is possible to [override extensions of a plugin using a module](./25-extension-overrides.md#creating-a-frontend-module). In some cases the extension you're overriding may require a route reference. You could import import the plugin instance and access the it via the `routes` property, but this creates a direct dependency on the plugin and risks leading to package duplication issues that would also break the route reference.
+
+Instead of accessing the route reference directly, you can create a new route reference that acts as an alias for the original one from the plugin. For example, you can override the catalog index page with a custom one like this:
+
+```tsx
+const indexRouteRef = createRouteRef({ aliasFor: 'catalog.catalogIndex' });
+
+export default createFrontendModule({
+  pluginId: 'catalog',
+  extensions: [
+    PageBlueprint.make({
+      params: {
+        defaultPath: '/catalog',
+        routeRef: indexRouteRef,
+        loader: () =>
+          import('./CustomCatalogIndexPage').then(m => (
+            <m.CustomCatalogIndexPage />
+          )),
+      },
+    }),
+  ],
+});
+```
+
+Aliases are limited to the plugin that they are defined in. These aliases can also be imported and used as usual with for example `useRouteRef`, but they must always be registered in the app via an extension for this to work. For example, the following will not work:
+
+```tsx
+function MyInvalidComponent() {
+  // This is NOT valid
+  const link = useRouteRef(
+    createRouteRef({ aliasFor: 'catalog.catalogIndex' }),
+  );
+
+  // ...
+}
+```

--- a/packages/frontend-app-api/src/routing/RouteAliasResolver.ts
+++ b/packages/frontend-app-api/src/routing/RouteAliasResolver.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RouteRef } from '@backstage/frontend-plugin-api';
+import { RouteRefsById } from './collectRouteIds';
+// eslint-disable-next-line @backstage/no-relative-monorepo-imports
+import { toInternalRouteRef } from '../../../frontend-plugin-api/src/routing/RouteRef';
+
+/**
+ * @internal
+ */
+export type RouteAliasResolver = {
+  (routeRef: RouteRef, pluginId?: string): RouteRef;
+  (routeRef?: RouteRef, pluginId?: string): RouteRef | undefined;
+};
+
+/**
+ * Creates a route alias resolver that resolves aliases based on the route IDs
+ * @internal
+ */
+export function createRouteAliasResolver(
+  routeRefsById: RouteRefsById,
+): RouteAliasResolver {
+  const resolver = (routeRef: RouteRef | undefined, pluginId?: string) => {
+    if (!routeRef) {
+      return undefined;
+    }
+
+    let currentRef = routeRef;
+    for (let i = 0; i < 100; i++) {
+      const alias = toInternalRouteRef(currentRef).alias;
+      if (alias) {
+        if (pluginId) {
+          const [aliasPluginId] = alias.split('.');
+          if (aliasPluginId !== pluginId) {
+            throw new Error(
+              `Refused to resolve alias '${alias}' for ${currentRef} as it points to a different plugin, the expected plugin is '${pluginId}' but the alias points to '${aliasPluginId}'`,
+            );
+          }
+        }
+        const aliasRef = routeRefsById.routes.get(alias);
+        if (!aliasRef) {
+          throw new Error(
+            `Unable to resolve RouteRef alias '${alias}' for ${currentRef}`,
+          );
+        }
+        if (aliasRef.$$type === '@backstage/SubRouteRef') {
+          throw new Error(
+            `RouteRef alias '${alias}' for ${currentRef} points to a SubRouteRef, which is not supported`,
+          );
+        }
+        currentRef = aliasRef;
+      } else {
+        return currentRef;
+      }
+    }
+    throw new Error(`Alias loop detected for ${routeRef}`);
+  };
+
+  return resolver as RouteAliasResolver;
+}
+
+/**
+ * Creates a route alias resolver that resolves aliases based on a map of route refs to their aliases
+ * @internal
+ */
+export function createExactRouteAliasResolver(
+  routeAliases: Map<RouteRef, RouteRef | undefined>,
+): RouteAliasResolver {
+  const resolver = (routeRef?: RouteRef) => {
+    if (routeRef && routeAliases.has(routeRef)) {
+      return routeAliases.get(routeRef);
+    }
+    return routeRef;
+  };
+  return resolver as RouteAliasResolver;
+}

--- a/packages/frontend-app-api/src/routing/RouteResolver.ts
+++ b/packages/frontend-app-api/src/routing/RouteResolver.ts
@@ -35,6 +35,7 @@ import {
 } from '../../../frontend-plugin-api/src/routing/SubRouteRef';
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
 import { isExternalRouteRef } from '../../../frontend-plugin-api/src/routing/ExternalRouteRef';
+import { RouteAliasResolver } from './RouteAliasResolver';
 
 // Joins a list of paths together, avoiding trailing and duplicate slashes
 export function joinPaths(...paths: string[]): string {
@@ -189,6 +190,7 @@ export class RouteResolver implements RouteResolutionApi {
       RouteRef | SubRouteRef
     >,
     private readonly appBasePath: string, // base path without a trailing slash
+    private readonly routeAliasResolver: RouteAliasResolver,
   ) {}
 
   resolve<TParams extends AnyRouteRefParams>(
@@ -200,7 +202,9 @@ export class RouteResolver implements RouteResolutionApi {
   ): RouteFunc<TParams> | undefined {
     // First figure out what our target absolute ref is, as well as our target path.
     const [targetRef, targetPath] = resolveTargetRef(
-      anyRouteRef,
+      anyRouteRef?.$$type === '@backstage/RouteRef'
+        ? this.routeAliasResolver(anyRouteRef)
+        : anyRouteRef,
       this.routePaths,
       this.routeBindings,
     );

--- a/packages/frontend-app-api/src/routing/extractRouteInfoFromAppNode.test.ts
+++ b/packages/frontend-app-api/src/routing/extractRouteInfoFromAppNode.test.ts
@@ -46,6 +46,11 @@ const ref4 = createRouteRef();
 const ref5 = createRouteRef();
 const refOrder: RouteRef<AnyRouteRefParams>[] = [ref1, ref2, ref3, ref4, ref5];
 
+const emptyRouteRefsById = {
+  routes: new Map(),
+  externalRoutes: new Map(),
+};
+
 function createTestExtension(options: {
   name: string;
   parent?: string;
@@ -99,7 +104,7 @@ function routeInfoFromExtensions(extensions: ExtensionDefinition[]) {
 
   instantiateAppNodeTree(tree.root, TestApiRegistry.from());
 
-  return extractRouteInfoFromAppNode(tree.root);
+  return extractRouteInfoFromAppNode(tree.root, emptyRouteRefsById);
 }
 
 function sortedEntries<T>(map: Map<RouteRef, T>): [RouteRef, T][] {

--- a/packages/frontend-app-api/src/wiring/createSpecializedApp.tsx
+++ b/packages/frontend-app-api/src/wiring/createSpecializedApp.tsx
@@ -237,12 +237,10 @@ export function createSpecializedApp(options?: {
   const factories = createApiFactories({ tree });
   const appBasePath = getBasePath(config);
   const appTreeApi = new AppTreeApiProxy(tree, appBasePath);
+
+  const routeRefsById = collectRouteIds(features);
   const routeResolutionApi = new RouteResolutionApiProxy(
-    resolveRouteBindings(
-      options?.bindRoutes,
-      config,
-      collectRouteIds(features),
-    ),
+    resolveRouteBindings(options?.bindRoutes, config, routeRefsById),
     appBasePath,
   );
 
@@ -288,7 +286,7 @@ export function createSpecializedApp(options?: {
     mergeExtensionFactoryMiddleware(options?.extensionFactoryMiddleware),
   );
 
-  const routeInfo = extractRouteInfoFromAppNode(tree.root);
+  const routeInfo = extractRouteInfoFromAppNode(tree.root, routeRefsById);
 
   routeResolutionApi.initialize(routeInfo);
   appTreeApi.initialize(routeInfo);

--- a/packages/frontend-app-api/src/wiring/createSpecializedApp.tsx
+++ b/packages/frontend-app-api/src/wiring/createSpecializedApp.tsx
@@ -81,6 +81,7 @@ import {
   createPluginInfoAttacher,
   FrontendPluginInfoResolver,
 } from './createPluginInfoAttacher';
+import { createRouteAliasResolver } from '../routing/RouteAliasResolver';
 
 function deduplicateFeatures(
   allFeatures: FrontendFeature[],
@@ -187,6 +188,7 @@ class RouteResolutionApiProxy implements RouteResolutionApi {
       routeInfo.routeObjects,
       this.routeBindings,
       this.appBasePath,
+      routeInfo.routeAliasResolver,
     );
     this.#routeObjects = routeInfo.routeObjects;
 
@@ -286,7 +288,10 @@ export function createSpecializedApp(options?: {
     mergeExtensionFactoryMiddleware(options?.extensionFactoryMiddleware),
   );
 
-  const routeInfo = extractRouteInfoFromAppNode(tree.root, routeRefsById);
+  const routeInfo = extractRouteInfoFromAppNode(
+    tree.root,
+    createRouteAliasResolver(routeRefsById),
+  );
 
   routeResolutionApi.initialize(routeInfo);
   appTreeApi.initialize(routeInfo);

--- a/packages/frontend-app-api/src/wiring/types.ts
+++ b/packages/frontend-app-api/src/wiring/types.ts
@@ -16,6 +16,7 @@
 import { RouteRef } from '@backstage/frontend-plugin-api';
 import { FrontendFeature as PluginApiFrontendFeature } from '@backstage/frontend-plugin-api';
 import { BackstageRouteObject } from '../routing/types';
+import { RouteAliasResolver } from '../routing/RouteAliasResolver';
 
 /** @public
  * @deprecated Use {@link @backstage/frontend-plugin-api#FrontendFeature} instead.
@@ -27,4 +28,5 @@ export type RouteInfo = {
   routePaths: Map<RouteRef, string>;
   routeParents: Map<RouteRef, RouteRef | undefined>;
   routeObjects: BackstageRouteObject[];
+  routeAliasResolver: RouteAliasResolver;
 };

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -823,7 +823,10 @@ export function createRouteRef<
     | undefined = undefined,
   TParamKeys extends string = string,
 >(config?: {
-  readonly params: string extends TParamKeys ? (keyof TParams)[] : TParamKeys[];
+  readonly params?: string extends TParamKeys
+    ? (keyof TParams)[]
+    : TParamKeys[];
+  aliasFor?: string;
 }): RouteRef<
   keyof TParams extends never
     ? undefined

--- a/packages/frontend-plugin-api/src/routing/RouteRef.ts
+++ b/packages/frontend-plugin-api/src/routing/RouteRef.ts
@@ -41,6 +41,8 @@ export interface InternalRouteRef<
   getParams(): string[];
   getDescription(): string;
 
+  alias: string | undefined;
+
   setId(id: string): void;
 }
 
@@ -68,16 +70,26 @@ export class RouteRefImpl implements InternalRouteRef {
   declare readonly T: never;
 
   #id?: string;
-  #params: string[];
-  #creationSite: string;
+  readonly #params: string[];
+  readonly #creationSite: string;
+  readonly #alias?: string;
 
-  constructor(readonly params: string[] = [], creationSite: string) {
+  constructor(
+    readonly params: string[] = [],
+    creationSite: string,
+    alias?: string,
+  ) {
     this.#params = params;
     this.#creationSite = creationSite;
+    this.#alias = alias;
   }
 
   getParams(): string[] {
     return this.#params;
+  }
+
+  get alias(): string | undefined {
+    return this.#alias;
   }
 
   getDescription(): string {
@@ -121,7 +133,11 @@ export function createRouteRef<
   TParamKeys extends string = string,
 >(config?: {
   /** A list of parameter names that the path that this route ref is bound to must contain */
-  readonly params: string extends TParamKeys ? (keyof TParams)[] : TParamKeys[];
+  readonly params?: string extends TParamKeys
+    ? (keyof TParams)[]
+    : TParamKeys[];
+
+  aliasFor?: string;
 }): RouteRef<
   keyof TParams extends never
     ? undefined
@@ -132,5 +148,6 @@ export function createRouteRef<
   return new RouteRefImpl(
     config?.params as string[] | undefined,
     describeParentCallSite(),
+    config?.aliasFor,
   ) as RouteRef<any>;
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes a gap in the new frontend system APIs that made it unnecessarily tricky to override existing plugin pages using a module. Our intention is for this to be possible to do using a plain `PageBlueprint` call or similar, but right now you're somewhat forced to import the existing plugin and reference the route ref. What's even worse is that you might also end up with some dependency duplication where that import leads to a duplicate plugin instance, and you end up with a completely broken page due to the duplicate route ref instance. @jabrks 👀

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
