### PR TITLE
Support waiting for GitHub Actions workflow completion and fetching o…

### DIFF
--- a/plugins/scaffolder-backend-module-github/src/actions/githubActionsDispatch.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubActionsDispatch.ts
@@ -26,9 +26,11 @@ import {
 import { Octokit } from 'octokit';
 import { getOctokitOptions } from '../util';
 import { examples } from './githubActionsDispatch.examples';
+import AdmZip from 'adm-zip'; // For ZIP extraction
 
 /**
- * Creates a new action that dispatches a GitHub Action workflow for a given branch or tag.
+ * Creates a new action that dispatches a GitHub Action workflow for a given branch or tag,
+ * optionally waits for completion, and fetches output artifact.
  * @public
  */
 export function createGithubActionsDispatchAction(options: {
@@ -40,7 +42,7 @@ export function createGithubActionsDispatchAction(options: {
   return createTemplateAction({
     id: 'github:actions:dispatch',
     description:
-      'Dispatches a GitHub Action workflow for a given branch or tag',
+      'Dispatches a GitHub Action workflow for a given branch or tag, optionally waits for completion and fetches output artifact',
     examples,
     schema: {
       input: {
@@ -72,6 +74,19 @@ export function createGithubActionsDispatchAction(options: {
                 'The `GITHUB_TOKEN` to use for authorization to GitHub',
             })
             .optional(),
+
+        // New inputs:
+        waitForCompletion: z =>
+          z.boolean({
+            description:
+              'If true, the action will wait for the workflow run to complete before continuing',
+          }).optional().default(false),
+
+        outputArtifactName: z =>
+          z.string({
+            description:
+              'If provided, fetch this JSON artifact from the completed workflow run and expose as outputs',
+          }).optional(),
       },
     },
     async handler(ctx) {
@@ -81,6 +96,8 @@ export function createGithubActionsDispatchAction(options: {
         branchOrTagName,
         workflowInputs,
         token: providedToken,
+        waitForCompletion = false,
+        outputArtifactName,
       } = ctx.input;
 
       ctx.logger.info(
@@ -109,6 +126,7 @@ export function createGithubActionsDispatchAction(options: {
       await ctx.checkpoint({
         key: `create.workflow.dispatch.${owner}.${repo}.${workflowId}`,
         fn: async () => {
+          // Dispatch the workflow
           await client.rest.actions.createWorkflowDispatch({
             owner,
             repo,
@@ -118,6 +136,133 @@ export function createGithubActionsDispatchAction(options: {
           });
 
           ctx.logger.info(`Workflow ${workflowId} dispatched successfully`);
+
+          if (waitForCompletion) {
+            // Poll to find the workflow run that was created by the dispatch
+            ctx.logger.info('Waiting for workflow run to be created...');
+            let workflowRun;
+            const maxRunPollAttempts = 12;
+            for (let i = 0; i < maxRunPollAttempts; i++) {
+              const { data } = await client.rest.actions.listWorkflowRuns({
+                owner,
+                repo,
+                workflow_id: workflowId,
+                event: 'workflow_dispatch',
+                branch: branchOrTagName,
+                per_page: 5,
+              });
+              // Pick the most recent run matching the branch/tag
+              workflowRun = data.workflow_runs
+                .filter(run => run.head_branch === branchOrTagName)
+                .sort(
+                  (a, b) =>
+                    +new Date(b.created_at) - +new Date(a.created_at),
+                )[0];
+              if (workflowRun) break;
+              ctx.logger.info(
+                'Workflow run not found yet, retrying in 5 seconds...',
+              );
+              await new Promise(res => setTimeout(res, 5000));
+            }
+
+            if (!workflowRun) {
+              throw new Error('Unable to find workflow run for dispatch');
+            }
+
+            const runId = workflowRun.id;
+            ctx.logger.info(`Found workflow run: ${runId}`);
+
+            // Poll for workflow completion
+            const maxPollAttempts = 60;
+            const pollIntervalMs = 5000;
+            let completed = false;
+            let runData = workflowRun;
+
+            ctx.logger.info('Polling workflow run for completion...');
+            for (let attempt = 0; attempt < maxPollAttempts; attempt++) {
+              const { data: run } = await client.rest.actions.getWorkflowRun({
+                owner,
+                repo,
+                run_id: runId,
+              });
+
+              if (run.status === 'completed') {
+                completed = true;
+                runData = run;
+                break;
+              }
+
+              ctx.logger.info(
+                `Attempt ${attempt + 1}: Workflow status: ${run.status}, waiting ${pollIntervalMs /
+                  1000}s...`,
+              );
+              await new Promise(res => setTimeout(res, pollIntervalMs));
+            }
+
+            if (!completed) {
+              throw new Error('Timed out waiting for workflow completion');
+            }
+
+            ctx.logger.info(
+              `Workflow run completed with conclusion: ${runData.conclusion}`,
+            );
+            ctx.output('conclusion', runData.conclusion);
+
+            // If requested, fetch and parse output artifact JSON
+            if (outputArtifactName) {
+              ctx.logger.info(
+                `Fetching output artifact '${outputArtifactName}' for run ${runId}`,
+              );
+              const { data: artifactsData } =
+                await client.rest.actions.listWorkflowRunArtifacts({
+                  owner,
+                  repo,
+                  run_id: runId,
+                });
+
+              const artifact = artifactsData.artifacts.find(
+                a => a.name === outputArtifactName,
+              );
+
+              if (artifact) {
+                const { data: zipData } =
+                  await client.rest.actions.downloadArtifact({
+                    owner,
+                    repo,
+                    artifact_id: artifact.id,
+                    archive_format: 'zip',
+                  });
+
+                try {
+                  const zip = new AdmZip(Buffer.from(zipData));
+                  const zipEntries = zip.getEntries();
+                  let outputJson: any = undefined;
+                  for (const zipEntry of zipEntries) {
+                    if (zipEntry.entryName.endsWith('.json')) {
+                      const content = zipEntry.getData().toString('utf8');
+                      outputJson = JSON.parse(content);
+                      break;
+                    }
+                  }
+
+                  if (outputJson) {
+                    ctx.logger.info('Output artifact JSON parsed successfully');
+                    ctx.output('outputs', outputJson);
+                  } else {
+                    ctx.logger.warn(
+                      'No JSON file found inside output artifact ZIP',
+                    );
+                  }
+                } catch (error) {
+                  ctx.logger.warn(
+                    `Failed to extract or parse output artifact: ${error}`,
+                  );
+                }
+              } else {
+                ctx.logger.warn(`Artifact '${outputArtifactName}' not found`);
+              }
+            }
+          } // end if waitForCompletion
         },
       });
     },


### PR DESCRIPTION
…utput artifacts in github:actions:dispatch

This PR enhances the github:actions:dispatch action by adding support to wait for a GitHub Actions workflow run to complete and to fetch outputs from a specified workflow artifact. It improves feedback and integration in Backstage scaffolder pipelines by exposing the workflow’s conclusion and artifact data as step outputs.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
