### PR TITLE
perf(gitlab): eliminate project ID resolution API calls to prevent ra…

### DIFF
--- a/.changeset/cool-ads-nail.md
+++ b/.changeset/cool-ads-nail.md
@@ -1,0 +1,8 @@
+---
+'@backstage/backend-defaults': patch
+'@backstage/integration': patch
+---
+
+Updates calls to Gitlab APIs to use a namespaced path in place of a project ID. This removes the need to call
+a separate Gitlab API to determine the project ID for a project, resulting in significantly fewer API calls
+to Gitlab, and faster catalog ingestion when syncing with Gitlab.

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/GitlabUrlReader.test.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/GitlabUrlReader.test.ts
@@ -78,9 +78,6 @@ describe('GitlabUrlReader', () => {
   describe('read', () => {
     beforeEach(() => {
       worker.use(
-        rest.get('*/api/v4/projects/:name', (_, res, ctx) =>
-          res(ctx.status(200), ctx.json({ id: 12345 })),
-        ),
         rest.get('*', (req, res, ctx) =>
           res(
             ctx.status(200),
@@ -107,14 +104,14 @@ describe('GitlabUrlReader', () => {
         url: 'https://gitlab.com/groupA/teams/teamA/subgroupA/repoA/-/blob/branch/my/path/to/file.yaml',
         config: createConfig(),
         response: expect.objectContaining({
-          url: 'https://gitlab.com/api/v4/projects/12345/repository/files/my%2Fpath%2Fto%2Ffile.yaml/raw?ref=branch',
+          url: 'https://gitlab.com/api/v4/projects/groupA%2Fteams%2FteamA%2FsubgroupA%2FrepoA/repository/files/my%2Fpath%2Fto%2Ffile.yaml/raw?ref=branch',
         }),
       },
       {
         url: 'https://gitlab.example.com/groupA/teams/teamA/subgroupA/repoA/-/blob/branch/my/path/to/file.yaml',
         config: createConfig('0123456789'),
         response: expect.objectContaining({
-          url: 'https://gitlab.example.com/api/v4/projects/12345/repository/files/my%2Fpath%2Fto%2Ffile.yaml/raw?ref=branch',
+          url: 'https://gitlab.example.com/api/v4/projects/groupA%2Fteams%2FteamA%2FsubgroupA%2FrepoA/repository/files/my%2Fpath%2Fto%2Ffile.yaml/raw?ref=branch',
           headers: expect.objectContaining({
             authorization: 'Bearer 0123456789',
           }),
@@ -124,7 +121,7 @@ describe('GitlabUrlReader', () => {
         url: 'https://gitlab.com/groupA/teams/teamA/repoA/-/blob/branch/my/path/to/file.yaml', // Repo not in subgroup
         config: createConfig(),
         response: expect.objectContaining({
-          url: 'https://gitlab.com/api/v4/projects/12345/repository/files/my%2Fpath%2Fto%2Ffile.yaml/raw?ref=branch',
+          url: 'https://gitlab.com/api/v4/projects/groupA%2Fteams%2FteamA%2FrepoA/repository/files/my%2Fpath%2Fto%2Ffile.yaml/raw?ref=branch',
         }),
       },
 
@@ -133,7 +130,7 @@ describe('GitlabUrlReader', () => {
         url: 'https://gitlab.example.com/a/b/blob/master/c.yaml',
         config: createConfig(),
         response: expect.objectContaining({
-          url: 'https://gitlab.example.com/api/v4/projects/12345/repository/files/c.yaml/raw?ref=master',
+          url: 'https://gitlab.example.com/api/v4/projects/a%2Fb/repository/files/c.yaml/raw?ref=master',
         }),
       },
     ])('should handle happy path %#', async ({ url, config, response }) => {
@@ -177,9 +174,6 @@ describe('GitlabUrlReader', () => {
 
     it('should throw NotModified on HTTP 304 from etag', async () => {
       worker.use(
-        rest.get('*/api/v4/projects/:name', (_, res, ctx) =>
-          res(ctx.status(200), ctx.json({ id: 12345 })),
-        ),
         rest.get('*', (req, res, ctx) => {
           expect(req.headers.get('If-None-Match')).toBe('999');
           return res(ctx.status(304));
@@ -198,9 +192,6 @@ describe('GitlabUrlReader', () => {
 
     it('should throw NotModified on HTTP 304 from lastModifiedAt', async () => {
       worker.use(
-        rest.get('*/api/v4/projects/:name', (_, res, ctx) =>
-          res(ctx.status(200), ctx.json({ id: 12345 })),
-        ),
         rest.get('*', (req, res, ctx) => {
           expect(req.headers.get('If-Modified-Since')).toBe(
             new Date('2019 12 31 23:59:59 GMT').toUTCString(),
@@ -221,9 +212,6 @@ describe('GitlabUrlReader', () => {
 
     it('should return etag and last-modified in response', async () => {
       worker.use(
-        rest.get('*/api/v4/projects/:name', (_, res, ctx) =>
-          res(ctx.status(200), ctx.json({ id: 12345 })),
-        ),
         rest.get('*', (_req, res, ctx) => {
           return res(
             ctx.status(200),
@@ -248,15 +236,6 @@ describe('GitlabUrlReader', () => {
 
     it('should return the file when using a user token', async () => {
       worker.use(
-        rest.get('*/api/v4/projects/user%2Fproject', (req, res, ctx) => {
-          if (req.headers.get('authorization') !== 'Bearer gl-user-token') {
-            return res(
-              ctx.status(401),
-              ctx.json({ message: '401 Unauthorized' }),
-            );
-          }
-          return res(ctx.status(200), ctx.json({ id: 12345 }));
-        }),
         rest.get('*', (_req, res, ctx) => {
           return res(ctx.status(200), ctx.body('foo'));
         }),
@@ -566,18 +545,6 @@ describe('GitlabUrlReader', () => {
     });
 
     it('should return the file when using a user token', async () => {
-      worker.use(
-        rest.get('*/api/v4/projects/user%2Fproject', (req, res, ctx) => {
-          if (req.headers.get('authorization') !== 'Bearer gl-user-token') {
-            return res(
-              ctx.status(401),
-              ctx.json({ message: '401 Unauthorized' }),
-            );
-          }
-          return res(ctx.status(200), ctx.json({ id: 12345 }));
-        }),
-      );
-
       const response = await gitlabProcessor.readTree(
         'https://gitlab.com/user/project/tree/main',
         { token: 'gl-user-token' },
@@ -727,30 +694,13 @@ describe('GitlabUrlReader', () => {
   });
 
   describe('getGitlabFetchUrl', () => {
-    beforeEach(() => {
-      worker.use(
-        rest.get(
-          '*/api/v4/projects/group%2Fsubgroup%2Fproject',
-          (_, res, ctx) => res(ctx.status(200), ctx.json({ id: 12345 })),
-        ),
-        rest.get('*/api/v4/projects/user%2Fproject', (req, res, ctx) => {
-          if (req.headers.get('authorization') !== 'Bearer gl-user-token') {
-            return res(
-              ctx.status(401),
-              ctx.json({ message: '401 Unauthorized' }),
-            );
-          }
-          return res(ctx.status(200), ctx.json({ id: 12345 }));
-        }),
-      );
-    });
     it('should fall back to getGitLabFileFetchUrl for blob urls', async () => {
       await expect(
         (gitlabProcessor as any).getGitlabFetchUrl(
           'https://gitlab.com/group/subgroup/project/-/blob/branch/my/path/to/file.yaml',
         ),
       ).resolves.toEqual(
-        'https://gitlab.com/api/v4/projects/12345/repository/files/my%2Fpath%2Fto%2Ffile.yaml/raw?ref=branch',
+        'https://gitlab.com/api/v4/projects/group%2Fsubgroup%2Fproject/repository/files/my%2Fpath%2Fto%2Ffile.yaml/raw?ref=branch',
       );
     });
     it('should work for job artifact urls', async () => {
@@ -759,7 +709,7 @@ describe('GitlabUrlReader', () => {
           'https://gitlab.com/group/subgroup/project/-/jobs/artifacts/branch/raw/my/path/to/file.yaml?job=myJob',
         ),
       ).resolves.toEqual(
-        'https://gitlab.com/api/v4/projects/12345/jobs/artifacts/branch/raw/my/path/to/file.yaml?job=myJob',
+        'https://gitlab.com/api/v4/projects/group%2Fsubgroup%2Fproject/jobs/artifacts/branch/raw/my/path/to/file.yaml?job=myJob',
       );
     });
     it('should fail on unfamiliar or non-Gitlab urls', async () => {
@@ -768,7 +718,7 @@ describe('GitlabUrlReader', () => {
           'https://gitlab.com/some/random/endpoint',
         ),
       ).rejects.toThrow(
-        'Failed converting /some/random/endpoint to a project id. Url path must include /blob/.',
+        'Failed extracting project path from /some/random/endpoint. Url path must include /blob/.',
       );
     });
     it('should resolve the project path using a user token', async () => {
@@ -778,39 +728,18 @@ describe('GitlabUrlReader', () => {
           'gl-user-token',
         ),
       ).resolves.toEqual(
-        'https://gitlab.com/api/v4/projects/12345/repository/files/my%2Fpath%2Fto%2Ffile.yaml/raw?ref=branch',
+        'https://gitlab.com/api/v4/projects/user%2Fproject/repository/files/my%2Fpath%2Fto%2Ffile.yaml/raw?ref=branch',
       );
     });
   });
 
   describe('getGitlabArtifactFetchUrl', () => {
-    beforeEach(() => {
-      worker.use(
-        rest.get(
-          '*/api/v4/projects/group%2Fsubgroup%2Fproject',
-          (_, res, ctx) => res(ctx.status(200), ctx.json({ id: 12345 })),
-        ),
-        rest.get(
-          '*/api/v4/projects/groupA%2Fsubgroup%2Fproject',
-          (_, res, ctx) => res(ctx.status(404)),
-        ),
-        rest.get('*/api/v4/projects/user%2Fproject', (req, res, ctx) => {
-          if (req.headers.get('authorization') !== 'Bearer gl-user-token') {
-            return res(
-              ctx.status(401),
-              ctx.json({ message: '401 Unauthorized' }),
-            );
-          }
-          return res(ctx.status(200), ctx.json({ id: 12345 }));
-        }),
-      );
-    });
-    it('should reject urls that are not for the job artifacts API', async () => {
-      await expect(
+    it('should reject urls that are not for the job artifacts API', () => {
+      expect(() =>
         (gitlabProcessor as any).getGitlabArtifactFetchUrl(
           new URL('https://gitlab.com/some/url'),
         ),
-      ).rejects.toThrow('Unable to process url as an GitLab artifact');
+      ).toThrow('Unable to process url as an GitLab artifact');
     });
     it('should work for job artifact urls', async () => {
       await expect(
@@ -821,18 +750,22 @@ describe('GitlabUrlReader', () => {
         ),
       ).resolves.toEqual(
         new URL(
-          'https://gitlab.com/api/v4/projects/12345/jobs/artifacts/branch/raw/my/path/to/file.yaml?job=myJob',
+          'https://gitlab.com/api/v4/projects/group%2Fsubgroup%2Fproject/jobs/artifacts/branch/raw/my/path/to/file.yaml?job=myJob',
         ),
       );
     });
-    it('errors in mapping the project ID should be captured', async () => {
+    it('should work for job artifact urls with any project path', async () => {
       await expect(
         (gitlabProcessor as any).getGitlabArtifactFetchUrl(
           new URL(
             'https://gitlab.com/groupA/subgroup/project/-/jobs/artifacts/branch/raw/my/path/to/file.yaml?job=myJob',
           ),
         ),
-      ).rejects.toThrow(/^Unable to translate GitLab artifact URL:/);
+      ).resolves.toEqual(
+        new URL(
+          'https://gitlab.com/api/v4/projects/groupA%2Fsubgroup%2Fproject/jobs/artifacts/branch/raw/my/path/to/file.yaml?job=myJob',
+        ),
+      );
     });
     it('should resolve the project path using a user token', async () => {
       await expect(
@@ -844,51 +777,9 @@ describe('GitlabUrlReader', () => {
         ),
       ).resolves.toEqual(
         new URL(
-          'https://gitlab.com/api/v4/projects/12345/jobs/artifacts/branch/raw/my/path/to/file.yaml?job=myJob',
+          'https://gitlab.com/api/v4/projects/user%2Fproject/jobs/artifacts/branch/raw/my/path/to/file.yaml?job=myJob',
         ),
       );
-    });
-  });
-
-  describe('resolveProjectToId', () => {
-    beforeEach(() => {
-      worker.use(
-        rest.get('*/api/v4/projects/group%2Fproject', (req, res, ctx) => {
-          if (req.headers.get('authorization') !== 'Bearer gl-dummy-token') {
-            return res(
-              ctx.status(401),
-              ctx.json({ message: '401 Unauthorized' }),
-            );
-          }
-          return res(ctx.status(200), ctx.json({ id: 12345 }));
-        }),
-        rest.get('*/api/v4/projects/user%2Fproject', (req, res, ctx) => {
-          if (req.headers.get('authorization') !== 'Bearer gl-user-token') {
-            return res(
-              ctx.status(401),
-              ctx.json({ message: '401 Unauthorized' }),
-            );
-          }
-          return res(ctx.status(200), ctx.json({ id: 12345 }));
-        }),
-      );
-    });
-
-    it('should resolve the project path to a valid project id', async () => {
-      await expect(
-        (gitlabProcessor as any).resolveProjectToId(
-          new URL('https://gitlab.com/group/project'),
-        ),
-      ).resolves.toEqual(12345);
-    });
-
-    it('should resolve the project path to a valid project id using a user token', async () => {
-      await expect(
-        (gitlabProcessor as any).resolveProjectToId(
-          new URL('https://gitlab.com/user/project'),
-          'gl-user-token',
-        ),
-      ).resolves.toEqual(12345);
     });
   });
 });

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/GitlabUrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/GitlabUrlReader.ts
@@ -335,74 +335,48 @@ export class GitlabUrlReader implements UrlReaderService {
     // If the target is for a job artifact then go down that path
     const targetUrl = new URL(target);
     if (targetUrl.pathname.includes('/-/jobs/artifacts/')) {
-      return this.getGitlabArtifactFetchUrl(targetUrl, token).then(value =>
+      return this.getGitlabArtifactFetchUrl(targetUrl).then(value =>
         value.toString(),
       );
     }
-    // Default to the old behavior of assuming the url is for a file
+    // Default to the optimized behavior - no API call needed for file URLs
     return getGitLabFileFetchUrl(target, this.integration.config, token);
   }
 
   // convert urls of the form:
   //    https://example.com/<namespace>/<project>/-/jobs/artifacts/<ref>/raw/<path_to_file>?job=<job_name>
   // to urls of the form:
-  //    https://example.com/api/v4/projects/:id/jobs/artifacts/:ref_name/raw/*artifact_path?job=<job_name>
-  private async getGitlabArtifactFetchUrl(
-    target: URL,
-    token?: string,
-  ): Promise<URL> {
+  //    https://example.com/api/v4/projects/namespace%2Fproject/jobs/artifacts/:ref_name/raw/*artifact_path?job=<job_name>
+  private getGitlabArtifactFetchUrl(target: URL): Promise<URL> {
     if (!target.pathname.includes('/-/jobs/artifacts/')) {
       throw new Error('Unable to process url as an GitLab artifact');
     }
     try {
       const [namespaceAndProject, ref] =
         target.pathname.split('/-/jobs/artifacts/');
-      const projectPath = new URL(target);
-      projectPath.pathname = namespaceAndProject;
-      const projectId = await this.resolveProjectToId(projectPath, token);
+
+      // Extract project path directly instead of making API call
       const relativePath = getGitLabIntegrationRelativePath(
         this.integration.config,
       );
+
+      let projectPath = namespaceAndProject;
+      // Check relative path exist and remove it if so
+      if (relativePath) {
+        projectPath = projectPath.replace(relativePath, '');
+      }
+      // Trim an initial / if it exists
+      projectPath = projectPath.replace(/^\//, '');
+
       const newUrl = new URL(target);
-      newUrl.pathname = `${relativePath}/api/v4/projects/${projectId}/jobs/artifacts/${ref}`;
-      return newUrl;
+      newUrl.pathname = `${relativePath}/api/v4/projects/${encodeURIComponent(
+        projectPath,
+      )}/jobs/artifacts/${ref}`;
+      return Promise.resolve(newUrl);
     } catch (e) {
       throw new Error(
         `Unable to translate GitLab artifact URL: ${target}, ${e}`,
       );
     }
-  }
-
-  private async resolveProjectToId(
-    pathToProject: URL,
-    token?: string,
-  ): Promise<number> {
-    let project = pathToProject.pathname;
-    // Check relative path exist and remove it if so
-    const relativePath = getGitLabIntegrationRelativePath(
-      this.integration.config,
-    );
-    if (relativePath) {
-      project = project.replace(relativePath, '');
-    }
-    // Trim an initial / if it exists
-    project = project.replace(/^\//, '');
-    const result = await fetch(
-      `${
-        pathToProject.origin
-      }${relativePath}/api/v4/projects/${encodeURIComponent(project)}`,
-      getGitLabRequestOptions(this.integration.config, token),
-    );
-    const data = await result.json();
-    if (!result.ok) {
-      if (result.status === 401) {
-        throw new Error(
-          'GitLab Error: 401 - Unauthorized. The access token used is either expired, or does not have permission to read the project',
-        );
-      }
-
-      throw new Error(`Gitlab error: ${data.error}, ${data.error_description}`);
-    }
-    return Number(data.id);
   }
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

perf(gitlab): eliminate project ID resolution API calls to prevent rate limiting

Replace project ID lookup API calls with direct project path usage in GitLab 
URL reader. This optimization leverages GitLab API v4's native support for 
URL-encoded project paths in endpoints, eliminating the need for preliminary 
/api/v4/projects/{path} calls that were causing rate limiting issues.

Changes:
- Update getGitLabFileFetchUrl to use project paths directly (now synchronous)
- Add extractProjectPath utility for consistent path extraction from URLs
- Modify buildProjectUrl to accept both project paths and IDs
- Optimize getGitlabArtifactFetchUrl to use project paths for artifact endpoints
- Remove resolveProjectToId function (no longer needed)
- Update all unit tests to expect project path-based URLs

This eliminates ~1 API call per file operation while maintaining full 
compatibility with both GitLab.com and self-hosted instances.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
