### PR TITLE
frontend-plugin-api: AppRootElementBlueprint now only accepts an element

### DIFF
--- a/.changeset/honest-seas-repeat.md
+++ b/.changeset/honest-seas-repeat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-app': minor
+---
+
+**BREAKING**: The `app-root-element` extension now only accepts `JSX.Element` in its `element` param, meaning overrides need to be updated.

--- a/.changeset/small-trams-do.md
+++ b/.changeset/small-trams-do.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': minor
+---
+
+**BREAKING**: The `element` param for `AppRootElementBlueprint` no longer accepts a component. If you are currently passing a component such as `element: () => <MyComponent />` or `element: MyComponent`, simply switch to `element: <MyComponent />`.

--- a/.changeset/thick-breads-add.md
+++ b/.changeset/thick-breads-add.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-signals': patch
+'@backstage/plugin-home': patch
+---
+
+**BREAKING ALPHA**: The `app-root-element` extension now only accepts `JSX.Element` in its `element` param, meaning overrides need to be updated.

--- a/.github/vale/config/vocabularies/Backstage/accept.txt
+++ b/.github/vale/config/vocabularies/Backstage/accept.txt
@@ -324,6 +324,8 @@ pagerduty
 pageview
 Pandey
 parallelization
+param
+params
 parseable
 Patrik
 pattison

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -254,7 +254,7 @@ export const AppRootElementBlueprint: ExtensionBlueprint<{
   kind: 'app-root-element';
   name: undefined;
   params: {
-    element: JSX.Element | (() => JSX.Element);
+    element: JSX.Element;
   };
   output: ConfigurableExtensionDataRef<JSX_3.Element, 'core.reactElement', {}>;
   inputs: {};

--- a/packages/frontend-plugin-api/src/blueprints/AppRootElementBlueprint.ts
+++ b/packages/frontend-plugin-api/src/blueprints/AppRootElementBlueprint.ts
@@ -26,9 +26,7 @@ export const AppRootElementBlueprint = createExtensionBlueprint({
   kind: 'app-root-element',
   attachTo: { id: 'app/root', input: 'elements' },
   output: [coreExtensionData.reactElement],
-  *factory(params: { element: JSX.Element | (() => JSX.Element) }) {
-    yield coreExtensionData.reactElement(
-      typeof params.element === 'function' ? params.element() : params.element,
-    );
+  *factory(params: { element: JSX.Element }) {
+    yield coreExtensionData.reactElement(params.element);
   },
 });

--- a/plugins/app/report.api.md
+++ b/plugins/app/report.api.md
@@ -816,7 +816,7 @@ const appPlugin: FrontendPlugin<
       kind: 'app-root-element';
       name: 'alert-display';
       params: {
-        element: JSX.Element | (() => JSX.Element);
+        element: JSX.Element;
       };
     }>;
     'app-root-element:app/dialog-display': ExtensionDefinition<{
@@ -839,7 +839,7 @@ const appPlugin: FrontendPlugin<
       kind: 'app-root-element';
       name: 'dialog-display';
       params: {
-        element: JSX.Element | (() => JSX.Element);
+        element: JSX.Element;
       };
     }>;
     'app-root-element:app/oauth-request-dialog': ExtensionDefinition<{
@@ -854,7 +854,7 @@ const appPlugin: FrontendPlugin<
       >;
       inputs: {};
       params: {
-        element: JSX.Element | (() => JSX.Element);
+        element: JSX.Element;
       };
     }>;
     'sign-in-page:app': ExtensionDefinition<{

--- a/plugins/app/src/extensions/elements.tsx
+++ b/plugins/app/src/extensions/elements.tsx
@@ -41,7 +41,7 @@ export const alertDisplayAppRootElement =
     },
     factory: (originalFactory, { config }) => {
       return originalFactory({
-        element: () => <AlertDisplay {...config} />,
+        element: <AlertDisplay {...config} />,
       });
     },
   });

--- a/plugins/home/report-alpha.api.md
+++ b/plugins/home/report-alpha.api.md
@@ -53,7 +53,7 @@ const _default: FrontendPlugin<
       >;
       inputs: {};
       params: {
-        element: JSX.Element | (() => JSX.Element);
+        element: JSX.Element;
       };
     }>;
     'page:home': ExtensionDefinition<{

--- a/plugins/signals/report-alpha.api.md
+++ b/plugins/signals/report-alpha.api.md
@@ -47,7 +47,7 @@ const _default: FrontendPlugin<
       >;
       inputs: {};
       params: {
-        element: JSX.Element | (() => JSX.Element);
+        element: JSX.Element;
       };
     }>;
   }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

If it says element it should be one right? 😅 

This is part of broader work to align naming and patterns for passing elements and components to blueprints.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
