### PR TITLE
Fixed bug in the customProperties type

### DIFF
--- a/.changeset/rotten-rats-dream.md
+++ b/.changeset/rotten-rats-dream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-github': patch
+---
+
+Fixed bug in the `customProperties` type which was preventing it being used to set a list of values against a key (e.g. for multi-select fields)

--- a/plugins/scaffolder-backend-module-github/report.api.md
+++ b/plugins/scaffolder-backend-module-github/report.api.md
@@ -267,7 +267,7 @@ export function createGithubRepoCreateAction(options: {
       | undefined;
     requiredCommitSigning?: boolean | undefined;
     requiredLinearHistory?: boolean | undefined;
-    customProperties?: Record<string, string> | undefined;
+    customProperties?: Record<string, string | string[]> | undefined;
     subscribe?: boolean | undefined;
   },
   {
@@ -426,7 +426,7 @@ export function createPublishGithubAction(options: {
       | undefined;
     requiredCommitSigning?: boolean | undefined;
     requiredLinearHistory?: boolean | undefined;
-    customProperties?: Record<string, string> | undefined;
+    customProperties?: Record<string, string | string[]> | undefined;
     subscribe?: boolean | undefined;
   },
   {

--- a/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
@@ -330,7 +330,7 @@ describe('publish:github', () => {
         ...mockContext.input,
         customProperties: {
           foo: 'bar',
-          foo2: 'bar2',
+          foo2: ['bar2', 'bar3'],
         },
       },
     });
@@ -505,7 +505,7 @@ describe('publish:github', () => {
         ...mockContext.input,
         customProperties: {
           foo: 'bar',
-          foo2: 'bar2',
+          foo2: ['bar2', 'bar3'],
         },
       },
     });

--- a/plugins/scaffolder-backend-module-github/src/actions/githubRepoCreate.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubRepoCreate.test.ts
@@ -279,7 +279,7 @@ describe('github:repo:create', () => {
         ...mockContext.input,
         customProperties: {
           foo: 'bar',
-          foo2: 'bar2',
+          foo2: ['bar2', 'bar3'],
         },
       },
     });
@@ -455,7 +455,7 @@ describe('github:repo:create', () => {
         ...mockContext.input,
         customProperties: {
           foo: 'bar',
-          foo2: 'bar2',
+          foo2: ['bar2', 'bar3'],
         },
       },
     });

--- a/plugins/scaffolder-backend-module-github/src/actions/helpers.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/helpers.ts
@@ -75,7 +75,7 @@ export async function createGithubRepoWithCollaboratorsAndTopics(
         includeClaimKeys?: string[];
       }
     | undefined,
-  customProperties: { [key: string]: string } | undefined,
+  customProperties: { [key: string]: string | string[] } | undefined,
   subscribe: boolean | undefined,
   logger: LoggerService,
 ) {

--- a/plugins/scaffolder-backend-module-github/src/actions/inputProperties.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/inputProperties.ts
@@ -385,9 +385,9 @@ const oidcCustomization = (z: typeof zod) =>
 
 const customProperties = (z: typeof zod) =>
   z
-    .record(z.string(), {
+    .record(z.union([z.string(), z.array(z.string())]), {
       description:
-        'Custom properties to be added to the repository (note, this only works for organization repositories)',
+        'Custom properties to be added to the repository (note, this only works for organization repositories). All values must be strings',
     })
     .optional();
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixed an issue with the `customProperties` type in `plugin-scaffolder-backend-module-github` which prevented setting a list of values for multi-select fields

See: https://github.com/backstage/backstage/issues/30705

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
