### PR TITLE
frontend-plugin-api: remove name option from createExtensionBlueprint

### DIFF
--- a/.changeset/floppy-groups-hug.md
+++ b/.changeset/floppy-groups-hug.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': minor
+---
+
+**BREAKING**: Removed the ability to define a default extension `name` in blueprints. This option had no practical purpose as blueprints already use the `kind` to identity the source of the extension.

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -178,7 +178,6 @@ export type AnyRoutes = {
 // @public
 export const ApiBlueprint: ExtensionBlueprint<{
   kind: 'api';
-  name: undefined;
   params: <
     TApi,
     TImpl extends TApi,
@@ -252,7 +251,6 @@ export interface AppNodeSpec {
 // @public
 export const AppRootElementBlueprint: ExtensionBlueprint<{
   kind: 'app-root-element';
-  name: undefined;
   params: {
     element: JSX.Element | (() => JSX.Element);
   };
@@ -266,7 +264,6 @@ export const AppRootElementBlueprint: ExtensionBlueprint<{
 // @public
 export const AppRootWrapperBlueprint: ExtensionBlueprint<{
   kind: 'app-root-wrapper';
-  name: undefined;
   params: {
     Component: ComponentType<PropsWithChildren<{}>>;
   };
@@ -539,14 +536,12 @@ export function createExtensionBlueprint<
   },
   UFactoryOutput extends ExtensionDataValue<any, any>,
   TKind extends string,
-  TName extends string | undefined = undefined,
   TDataRefs extends {
     [name in string]: AnyExtensionDataRef;
   } = never,
 >(
   options: CreateExtensionBlueprintOptions<
     TKind,
-    TName,
     TParams,
     UOutput,
     TInputs,
@@ -556,7 +551,6 @@ export function createExtensionBlueprint<
   >,
 ): ExtensionBlueprint<{
   kind: TKind;
-  name: TName;
   params: TParams;
   output: UOutput;
   inputs: string extends keyof TInputs ? {} : TInputs;
@@ -578,7 +572,6 @@ export function createExtensionBlueprint<
 // @public (undocumented)
 export type CreateExtensionBlueprintOptions<
   TKind extends string,
-  TName extends string | undefined,
   TParams extends object | ExtensionBlueprintParamsDefiner,
   UOutput extends AnyExtensionDataRef,
   TInputs extends {
@@ -603,7 +596,6 @@ export type CreateExtensionBlueprintOptions<
   disabled?: boolean;
   inputs?: TInputs;
   output: Array<UOutput>;
-  name?: TName;
   config?: {
     schema: TConfigSchema;
   };
@@ -926,10 +918,10 @@ export interface ExtensionBlueprint<
   dataRefs: T['dataRefs'];
   // (undocumented)
   make<
-    TNewName extends string | undefined,
+    TName extends string | undefined,
     TParamsInput extends AnyParamsInput_2<NonNullable<T['params']>>,
   >(args: {
-    name?: TNewName;
+    name?: TName;
     attachTo?: ExtensionAttachToSpec;
     disabled?: boolean;
     params: TParamsInput extends ExtensionBlueprintParamsDefiner
@@ -939,7 +931,7 @@ export interface ExtensionBlueprint<
       : TParamsInput;
   }): ExtensionDefinition<{
     kind: T['kind'];
-    name: string | undefined extends TNewName ? T['name'] : TNewName;
+    name: string | undefined extends TName ? undefined : TName;
     config: T['config'];
     configInput: T['configInput'];
     output: T['output'];
@@ -947,7 +939,7 @@ export interface ExtensionBlueprint<
     params: T['params'];
   }>;
   makeWithOverrides<
-    TNewName extends string | undefined,
+    TName extends string | undefined,
     TExtensionConfigSchema extends {
       [key in string]: (zImpl: typeof z) => z.ZodType;
     },
@@ -963,7 +955,7 @@ export interface ExtensionBlueprint<
       >;
     },
   >(args: {
-    name?: TNewName;
+    name?: TName;
     attachTo?: ExtensionAttachToSpec;
     disabled?: boolean;
     inputs?: TExtraInputs & {
@@ -1030,7 +1022,7 @@ export interface ExtensionBlueprint<
     output: AnyExtensionDataRef extends UNewOutput ? T['output'] : UNewOutput;
     inputs: T['inputs'] & TExtraInputs;
     kind: T['kind'];
-    name: string | undefined extends TNewName ? T['name'] : TNewName;
+    name: string | undefined extends TName ? undefined : TName;
     params: T['params'];
   }>;
 }
@@ -1038,7 +1030,6 @@ export interface ExtensionBlueprint<
 // @public (undocumented)
 export type ExtensionBlueprintParameters = {
   kind: string;
-  name?: string;
   params?: object | ExtensionBlueprintParamsDefiner;
   configInput?: {
     [K in string]: any;
@@ -1422,7 +1413,6 @@ export { googleAuthApiRef };
 // @public (undocumented)
 export const IconBundleBlueprint: ExtensionBlueprint<{
   kind: 'icon-bundle';
-  name: undefined;
   params: {
     icons: { [key in string]: IconComponent };
   };
@@ -1472,7 +1462,6 @@ export { microsoftAuthApiRef };
 // @public
 export const NavContentBlueprint: ExtensionBlueprint_2<{
   kind: 'nav-content';
-  name: undefined;
   params: {
     component: NavContentComponent;
   };
@@ -1512,7 +1501,6 @@ export interface NavContentComponentProps {
 // @public
 export const NavItemBlueprint: ExtensionBlueprint<{
   kind: 'nav-item';
-  name: undefined;
   params: {
     title: string;
     icon: IconComponent_3;
@@ -1564,7 +1552,6 @@ export { OpenIdConnectApi };
 // @public
 export const PageBlueprint: ExtensionBlueprint<{
   kind: 'page';
-  name: undefined;
   params: {
     defaultPath: string;
     loader: () => Promise<JSX.Element>;
@@ -1722,7 +1709,6 @@ export type RouteFunc<TParams extends AnyRouteRefParams> = (
 // @public (undocumented)
 export const RouterBlueprint: ExtensionBlueprint<{
   kind: 'app-router-component';
-  name: undefined;
   params: {
     Component: ComponentType<PropsWithChildren<{}>>;
   };
@@ -1784,7 +1770,6 @@ export { SessionState };
 // @public
 export const SignInPageBlueprint: ExtensionBlueprint<{
   kind: 'sign-in-page';
-  name: undefined;
   params: {
     loader: () => Promise<ComponentType<SignInPageProps>>;
   };
@@ -1826,7 +1811,6 @@ export interface SubRouteRef<
 // @public
 export const ThemeBlueprint: ExtensionBlueprint<{
   kind: 'theme';
-  name: undefined;
   params: {
     theme: AppTheme;
   };
@@ -1842,7 +1826,6 @@ export const ThemeBlueprint: ExtensionBlueprint<{
 // @public
 export const TranslationBlueprint: ExtensionBlueprint<{
   kind: 'translation';
-  name: undefined;
   params: {
     resource: TranslationResource | TranslationMessages;
   };

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
@@ -103,7 +103,6 @@ export function createExtensionBlueprintParams<T extends object = object>(
  */
 export type CreateExtensionBlueprintOptions<
   TKind extends string,
-  TName extends string | undefined,
   TParams extends object | ExtensionBlueprintParamsDefiner,
   UOutput extends AnyExtensionDataRef,
   TInputs extends {
@@ -121,7 +120,6 @@ export type CreateExtensionBlueprintOptions<
   disabled?: boolean;
   inputs?: TInputs;
   output: Array<UOutput>;
-  name?: TName;
   config?: {
     schema: TConfigSchema;
   };
@@ -186,7 +184,6 @@ export type CreateExtensionBlueprintOptions<
 /** @public */
 export type ExtensionBlueprintParameters = {
   kind: string;
-  name?: string;
   params?: object | ExtensionBlueprintParamsDefiner;
   configInput?: { [K in string]: any };
   config?: { [K in string]: any };
@@ -228,10 +225,10 @@ export interface ExtensionBlueprint<
   dataRefs: T['dataRefs'];
 
   make<
-    TNewName extends string | undefined,
+    TName extends string | undefined,
     TParamsInput extends AnyParamsInput<NonNullable<T['params']>>,
   >(args: {
-    name?: TNewName;
+    name?: TName;
     attachTo?: ExtensionAttachToSpec;
     disabled?: boolean;
     params: TParamsInput extends ExtensionBlueprintParamsDefiner
@@ -241,7 +238,7 @@ export interface ExtensionBlueprint<
       : TParamsInput;
   }): ExtensionDefinition<{
     kind: T['kind'];
-    name: string | undefined extends TNewName ? T['name'] : TNewName;
+    name: string | undefined extends TName ? undefined : TName;
     config: T['config'];
     configInput: T['configInput'];
     output: T['output'];
@@ -256,7 +253,7 @@ export interface ExtensionBlueprint<
    * optionally call the original factory with the same params.
    */
   makeWithOverrides<
-    TNewName extends string | undefined,
+    TName extends string | undefined,
     TExtensionConfigSchema extends {
       [key in string]: (zImpl: typeof z) => z.ZodType;
     },
@@ -269,7 +266,7 @@ export interface ExtensionBlueprint<
       >;
     },
   >(args: {
-    name?: TNewName;
+    name?: TName;
     attachTo?: ExtensionAttachToSpec;
     disabled?: boolean;
     inputs?: TExtraInputs & {
@@ -336,7 +333,7 @@ export interface ExtensionBlueprint<
     output: AnyExtensionDataRef extends UNewOutput ? T['output'] : UNewOutput;
     inputs: T['inputs'] & TExtraInputs;
     kind: T['kind'];
-    name: string | undefined extends TNewName ? T['name'] : TNewName;
+    name: string | undefined extends TName ? undefined : TName;
     params: T['params'];
   }>;
 }
@@ -429,12 +426,10 @@ export function createExtensionBlueprint<
   TConfigSchema extends { [key in string]: (zImpl: typeof z) => z.ZodType },
   UFactoryOutput extends ExtensionDataValue<any, any>,
   TKind extends string,
-  TName extends string | undefined = undefined,
   TDataRefs extends { [name in string]: AnyExtensionDataRef } = never,
 >(
   options: CreateExtensionBlueprintOptions<
     TKind,
-    TName,
     TParams,
     UOutput,
     TInputs,
@@ -444,7 +439,6 @@ export function createExtensionBlueprint<
   >,
 ): ExtensionBlueprint<{
   kind: TKind;
-  name: TName;
   params: TParams;
   output: UOutput;
   inputs: string extends keyof TInputs ? {} : TInputs;
@@ -469,7 +463,7 @@ export function createExtensionBlueprint<
     make(args) {
       return createExtension({
         kind: options.kind,
-        name: args.name ?? options.name,
+        name: args.name,
         attachTo: args.attachTo ?? options.attachTo,
         disabled: args.disabled ?? options.disabled,
         inputs: options.inputs,
@@ -485,7 +479,7 @@ export function createExtensionBlueprint<
     makeWithOverrides(args) {
       return createExtension({
         kind: options.kind,
-        name: args.name ?? options.name,
+        name: args.name,
         attachTo: args.attachTo ?? options.attachTo,
         disabled: args.disabled ?? options.disabled,
         inputs: { ...args.inputs, ...options.inputs },
@@ -532,7 +526,6 @@ export function createExtensionBlueprint<
     },
   } as ExtensionBlueprint<{
     kind: TKind;
-    name: TName;
     params: TParams;
     output: UOutput;
     inputs: string extends keyof TInputs ? {} : TInputs;

--- a/plugins/catalog-react/report-alpha.api.md
+++ b/plugins/catalog-react/report-alpha.api.md
@@ -20,7 +20,6 @@ import { TranslationRef } from '@backstage/core-plugin-api/alpha';
 // @alpha
 export const CatalogFilterBlueprint: ExtensionBlueprint<{
   kind: 'catalog-filter';
-  name: undefined;
   params: {
     loader: () => Promise<JSX.Element>;
   };
@@ -123,7 +122,6 @@ export const defaultEntityContentGroups: {
 // @alpha
 export const EntityCardBlueprint: ExtensionBlueprint<{
   kind: 'entity-card';
-  name: undefined;
   params: {
     loader: () => Promise<JSX.Element>;
     filter?: string | EntityPredicate | ((entity: Entity) => boolean);
@@ -186,7 +184,6 @@ export type EntityCardType = 'summary' | 'info' | 'content';
 // @alpha
 export const EntityContentBlueprint: ExtensionBlueprint<{
   kind: 'entity-content';
-  name: undefined;
   params: {
     loader: () => Promise<JSX.Element>;
     defaultPath: string;
@@ -267,7 +264,6 @@ export const EntityContentBlueprint: ExtensionBlueprint<{
 // @alpha (undocumented)
 export const EntityContentLayoutBlueprint: ExtensionBlueprint<{
   kind: 'entity-content-layout';
-  name: undefined;
   params: {
     filter?: string | EntityPredicate | ((entity: Entity) => boolean);
     loader: () => Promise<(props: EntityContentLayoutProps) => JSX_2.Element>;
@@ -332,7 +328,6 @@ export interface EntityContentLayoutProps {
 // @alpha (undocumented)
 export const EntityContextMenuItemBlueprint: ExtensionBlueprint<{
   kind: 'entity-context-menu-item';
-  name: undefined;
   params: EntityContextMenuItemParams;
   output:
     | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
@@ -369,7 +364,6 @@ export type EntityContextMenuItemParams = {
 // @alpha (undocumented)
 export const EntityHeaderBlueprint: ExtensionBlueprint<{
   kind: 'entity-header';
-  name: undefined;
   params: {
     loader: () => Promise<JSX.Element>;
     filter?: EntityPredicate | ((entity: Entity) => boolean);
@@ -420,7 +414,6 @@ export const EntityHeaderBlueprint: ExtensionBlueprint<{
 // @alpha (undocumented)
 export const EntityIconLinkBlueprint: ExtensionBlueprint<{
   kind: 'entity-icon-link';
-  name: undefined;
   params: {
     useProps: () => Omit<IconLinkVerticalProps, 'color'>;
     filter?: EntityPredicate | ((entity: Entity) => boolean);

--- a/plugins/scaffolder-react/report-alpha.api.md
+++ b/plugins/scaffolder-react/report-alpha.api.md
@@ -135,7 +135,6 @@ export const Form: (
 // @alpha
 export const FormDecoratorBlueprint: ExtensionBlueprint<{
   kind: 'scaffolder-form-decorator';
-  name: undefined;
   params: {
     decorator: ScaffolderFormDecorator;
   };
@@ -165,7 +164,6 @@ export interface FormField {
 // @alpha
 export const FormFieldBlueprint: ExtensionBlueprint<{
   kind: 'scaffolder-form-field';
-  name: undefined;
   params: {
     field: () => Promise<FormField>;
   };

--- a/plugins/search-react/report-alpha.api.md
+++ b/plugins/search-react/report-alpha.api.md
@@ -19,7 +19,6 @@ export type BaseSearchResultListItemProps<T = {}> = T & {
 // @alpha (undocumented)
 export const SearchFilterBlueprint: ExtensionBlueprint<{
   kind: 'search-filter';
-  name: undefined;
   params: SearchFilterBlueprintParams;
   output: ConfigurableExtensionDataRef<
     {
@@ -61,7 +60,6 @@ export type SearchFilterExtensionComponentProps = {
 // @alpha (undocumented)
 export const SearchFilterResultTypeBlueprint: ExtensionBlueprint<{
   kind: 'search-filter-result-type';
-  name: undefined;
   params: SearchFilterResultTypeBlueprintParams;
   output: ConfigurableExtensionDataRef<
     {
@@ -128,7 +126,6 @@ export type SearchResultItemExtensionPredicate = (
 // @alpha
 export const SearchResultListItemBlueprint: ExtensionBlueprint<{
   kind: 'search-result-list-item';
-  name: undefined;
   params: SearchResultListItemBlueprintParams;
   output: ConfigurableExtensionDataRef<
     {

--- a/plugins/techdocs-react/report-alpha.api.md
+++ b/plugins/techdocs-react/report-alpha.api.md
@@ -10,7 +10,6 @@ import { ExtensionBlueprint } from '@backstage/frontend-plugin-api';
 // @alpha
 export const AddonBlueprint: ExtensionBlueprint<{
   kind: 'addon';
-  name: undefined;
   params: TechDocsAddonOptions;
   output: ConfigurableExtensionDataRef<
     TechDocsAddonOptions,


### PR DESCRIPTION
🧹, really no reason for this option to exist, blueprints should always use `kind` instead.