### PR TITLE
Add  "refresh entity" button to EntityContextMenu (old + new FE)

### DIFF
--- a/.changeset/light-taxis-jog.md
+++ b/.changeset/light-taxis-jog.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+EntityContextMenu now has a "refresh entity" button

--- a/plugins/catalog/report-alpha.api.md
+++ b/plugins/catalog/report-alpha.api.md
@@ -80,6 +80,9 @@ export const catalogTranslationRef: TranslationRef<
     readonly 'entityContextMenu.inspectMenuTitle': 'Inspect entity';
     readonly 'entityContextMenu.copyURLMenuTitle': 'Copy entity URL';
     readonly 'entityContextMenu.unregisterMenuTitle': 'Unregister entity';
+    readonly 'entityContextMenu.refreshMenuTitle': 'Refresh Entity';
+    readonly 'entityContextMenu.refreshedMessage': 'Entity refreshed successfully';
+    readonly 'entityContextMenu.refreshError': 'Failed to refresh entity';
     readonly 'entityLabelsCard.title': 'Labels';
     readonly 'entityLabelsCard.emptyDescription': 'No labels defined for this entity. You can add labels to your entity YAML as shown in the highlighted example below:';
     readonly 'entityLabelsCard.readMoreButtonTitle': 'Read more';
@@ -925,6 +928,27 @@ const _default: FrontendPlugin<
     'entity-context-menu-item:catalog/inspect-entity': ExtensionDefinition<{
       kind: 'entity-context-menu-item';
       name: 'inspect-entity';
+      config: {
+        filter: EntityPredicate | undefined;
+      };
+      configInput: {
+        filter?: EntityPredicate | undefined;
+      };
+      output:
+        | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
+        | ConfigurableExtensionDataRef<
+            (entity: Entity) => boolean,
+            'catalog.entity-filter-function',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+      params: EntityContextMenuItemParams;
+    }>;
+    'entity-context-menu-item:catalog/refresh-entity': ExtensionDefinition<{
+      kind: 'entity-context-menu-item';
+      name: 'refresh-entity';
       config: {
         filter: EntityPredicate | undefined;
       };

--- a/plugins/catalog/src/alpha/translation.ts
+++ b/plugins/catalog/src/alpha/translation.ts
@@ -97,6 +97,9 @@ export const catalogTranslationRef = createTranslationRef({
       inspectMenuTitle: 'Inspect entity',
       copyURLMenuTitle: 'Copy entity URL',
       unregisterMenuTitle: 'Unregister entity',
+      refreshMenuTitle: 'Refresh Entity',
+      refreshedMessage: 'Entity refreshed successfully',
+      refreshError: 'Failed to refresh entity',
     },
     entityLabelsCard: {
       title: 'Labels',

--- a/plugins/catalog/src/components/EntityContextMenu/EntityContextMenu.test.tsx
+++ b/plugins/catalog/src/components/EntityContextMenu/EntityContextMenu.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { EntityProvider } from '@backstage/plugin-catalog-react';
+import { EntityProvider, catalogApiRef } from '@backstage/plugin-catalog-react';
 import { permissionApiRef } from '@backstage/plugin-permission-react';
 import {
   mockApis,
@@ -25,10 +25,28 @@ import SearchIcon from '@material-ui/icons/Search';
 import { fireEvent, screen } from '@testing-library/react';
 import { ReactNode } from 'react';
 import { EntityContextMenu } from './EntityContextMenu';
+import { alertApiRef } from '@backstage/core-plugin-api';
 
 function render(children: ReactNode) {
   return renderInTestApp(
-    <TestApiProvider apis={[[permissionApiRef, mockApis.permission()]]}>
+    <TestApiProvider
+      apis={[
+        [permissionApiRef, mockApis.permission()],
+        [
+          catalogApiRef,
+          {
+            refreshEntity: jest.fn(),
+          },
+        ],
+        [
+          alertApiRef,
+          {
+            post: jest.fn(),
+            alert$: jest.fn(),
+          },
+        ],
+      ]}
+    >
       <EntityProvider
         entity={{ apiVersion: 'a', kind: 'b', metadata: { name: 'c' } }}
         children={children}


### PR DESCRIPTION
## Hey, I just made a Pull Request!
<img width="1118" height="501" alt="Screenshot 2025-08-01 at 10 56 23" src="https://github.com/user-attachments/assets/480df42b-70f5-48b5-9ddb-04d0f046a91a" />

Adding a refresh button so every entity can be refreshed. Currently the problem is that at the "about" box we have this option, but most of the entity pages are heavily edited, thus missing this button. I've decided to allow all entities to be refreshed.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ :heavy_check_mark:] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ :heavy_check_mark:] Added or updated documentation
- [ :heavy_check_mark:] Tests for new functionality and regression tests for bug fixes
- [ :heavy_check_mark:] Screenshots attached (for UI changes)
- [ :heavy_check_mark:] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
