### PR TITLE
frontend-plugin-api: switch naming recommendation from define to defineParams

### DIFF
--- a/.changeset/odd-beans-sell.md
+++ b/.changeset/odd-beans-sell.md
@@ -4,7 +4,7 @@
 
 **BREAKING**: The `ApiBlueprint` has been updated to use the new advanced type parameters through the new `defineParams` blueprint option. This is an immediate breaking change that requires all existing usages of `ApiBlueprint` to switch to the new callback format. Existing extensions created with the old format are still compatible with the latest version of the plugin API however, meaning that this does not break existing plugins.
 
-To update existing usages of `ApiBlueprint`, you remove the outer level of the `params` object and replace `createApiFactory(...)` with `define => define(...)`.
+To update existing usages of `ApiBlueprint`, you remove the outer level of the `params` object and replace `createApiFactory(...)` with `defineParams => defineParams(...)`.
 
 For example, the following old usage:
 
@@ -28,8 +28,8 @@ is migrated to the following:
 ```ts
 ApiBlueprint.make({
   name: 'error',
-  params: define =>
-    define({
+  params: defineParams =>
+    defineParams({
       api: errorApiRef,
       deps: { alertApi: alertApiRef },
       factory: ({ alertApi }) => {

--- a/.changeset/quiet-parks-cheer.md
+++ b/.changeset/quiet-parks-cheer.md
@@ -32,11 +32,11 @@ Usage of the above example looks as follows:
 
 ```ts
 const example = ExampleBlueprint.make({
-  params: define => define({
+  params: defineParams => defineParams({
     component: ...,
     fetcher: ...,
   }),
 });
 ```
 
-This `define => define(<params>)` is also known as the "callback syntax" and is required if a blueprint is created with the new `defineParams` option. The callback syntax can also optionally be used for other blueprints too, which means that it is not a breaking change to remove the `defineParams` option, as long as the external parameter types remain compatible.
+This `defineParams => defineParams(<params>)` is also known as the "callback syntax" and is required if a blueprint is created with the new `defineParams` option. The callback syntax can also optionally be used for other blueprints too, which means that it is not a breaking change to remove the `defineParams` option, as long as the external parameter types remain compatible.

--- a/.changeset/rich-seals-itch.md
+++ b/.changeset/rich-seals-itch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': patch
+---
+
+Updated the recommended naming of the blueprint param callback from `define` to `defineParams`, making the syntax `defineParams => defineParams(...)`.

--- a/docs/frontend-system/architecture/23-extension-blueprints.md
+++ b/docs/frontend-system/architecture/23-extension-blueprints.md
@@ -62,14 +62,14 @@ Apart from the addition of the blueprint parameters of the first argument to the
 
 ### Creating an extension from a blueprint with advanced parameter types
 
-Some blueprints may be defined with something known as "advanced parameter types". This is a feature that enables type inference and transform of the blueprint parameters, and the way that you pass the parameters look a little bit different. Rather than passing the parameters directly, they are instead passed as a callback function of the form `define => define(<params>)`.
+Some blueprints may be defined with something known as "advanced parameter types". This is a feature that enables type inference and transform of the blueprint parameters, and the way that you pass the parameters look a little bit different. Rather than passing the parameters directly, they are instead passed as a callback function of the form `defineParams => defineParams(<params>)`.
 
 An example of a blueprint that uses advanced parameter types is the `ApiBlueprint` blueprint. Using it to create a simple implementation for the `AlertApi` might look like this:
 
 ```ts
 const alertApiBlueprint = ApiBlueprint.make({
-  params: define =>
-    define({
+  params: defineParams =>
+    defineParams({
       api: alertApiRef,
       deps: {},
       factory: () => new MyAlertApi(),
@@ -82,8 +82,8 @@ This also works with `makeWithOverrides`, where the define callback is passed as
 ```ts
 const alertApiBlueprint = ApiBlueprint.makeWithOverrides({
   factory(originalFactory, { config }) {
-    return originalFactory(define =>
-      define({
+    return originalFactory(defineParams =>
+      defineParams({
         api: alertApiRef,
         deps: {},
         factory: () => new MyAlertApi(config),

--- a/docs/frontend-system/building-apps/08-migrating.md
+++ b/docs/frontend-system/building-apps/08-migrating.md
@@ -199,8 +199,8 @@ import { ApiBlueprint } from '@backstage/frontend-plugin-api';
 
 const scmIntegrationsApi = ApiBlueprint.make({
   name: 'scm-integrations',
-  params: define =>
-    define({
+  params: defineParams =>
+    defineParams({
       api: scmIntegrationsApiRef,
       deps: { configApi: configApiRef },
       factory: ({ configApi }) => ScmIntegrationsApi.fromConfig(configApi),

--- a/docs/frontend-system/building-plugins/01-index.md
+++ b/docs/frontend-system/building-plugins/01-index.md
@@ -160,8 +160,8 @@ import { exampleApiRef, DefaultExampleApi } from './api';
 // highlight-add-start
 const exampleApi = ApiBlueprint.make({
   name: 'example',
-  params: define =>
-    define({
+  params: defineParams =>
+    defineParams({
       api: exampleApiRef,
       deps: {},
       factory: () => new DefaultExampleApi(),

--- a/docs/frontend-system/building-plugins/05-migrating.md
+++ b/docs/frontend-system/building-plugins/05-migrating.md
@@ -210,8 +210,8 @@ import { workApiRef } from '@internal/plugin-example-react';
 import { WorkImpl } from './WorkImpl';
 
 const exampleWorkApi = ApiBlueprint.make({
-  params: define =>
-    define({
+  params: defineParams =>
+    defineParams({
       api: workApiRef,
       deps: { storageApi: storageApiRef },
       factory: ({ storageApi }) => new WorkImpl({ storageApi }),

--- a/docs/frontend-system/utility-apis/02-creating.md
+++ b/docs/frontend-system/utility-apis/02-creating.md
@@ -62,8 +62,8 @@ class WorkImpl implements WorkApi {
 
 const workApi = ApiBlueprint.make({
   name: 'work',
-  params: define =>
-    define({
+  params: defineParams =>
+    defineParams({
       api: workApiRef,
       deps: { storageApi: storageApiRef },
       factory: ({ storageApi }) => {

--- a/docs/frontend-system/utility-apis/03-consuming.md
+++ b/docs/frontend-system/utility-apis/03-consuming.md
@@ -51,8 +51,8 @@ import {
 import { MyApiImpl } from './MyApiImpl';
 
 const myApi = ApiBlueprint.make({
-  params: define =>
-    define({
+  params: defineParams =>
+    defineParams({
       api: myApiRef,
       deps: {
         configApi: configApiRef,

--- a/packages/core-compat-api/src/collectLegacyRoutes.tsx
+++ b/packages/core-compat-api/src/collectLegacyRoutes.tsx
@@ -310,7 +310,7 @@ export function collectLegacyRoutes(
           ...Array.from(plugin.getApis()).map(factory =>
             ApiBlueprint.make({
               name: factory.api.id,
-              params: define => define(factory),
+              params: defineParams => defineParams(factory),
             }),
           ),
         ],

--- a/packages/core-compat-api/src/convertLegacyApp.test.tsx
+++ b/packages/core-compat-api/src/convertLegacyApp.test.tsx
@@ -232,8 +232,8 @@ describe('convertLegacyApp', () => {
     const catalogOverride = catalogPlugin.withOverrides({
       extensions: [
         catalogPlugin.getExtension('api:catalog').override({
-          params: define =>
-            define({
+          params: defineParams =>
+            defineParams({
               api: catalogApiRef,
               deps: {},
               factory: () =>

--- a/packages/core-compat-api/src/convertLegacyAppOptions.tsx
+++ b/packages/core-compat-api/src/convertLegacyAppOptions.tsx
@@ -76,7 +76,7 @@ export function convertLegacyAppOptions(
   const extensions: ExtensionDefinition[] = deduplicatedApis.map(factory =>
     ApiBlueprint.make({
       name: factory.api.id,
-      params: define => define(factory),
+      params: defineParams => defineParams(factory),
     }),
   );
 

--- a/packages/core-compat-api/src/convertLegacyPlugin.ts
+++ b/packages/core-compat-api/src/convertLegacyPlugin.ts
@@ -31,7 +31,7 @@ export function convertLegacyPlugin(
   const apiExtensions = Array.from(legacyPlugin.getApis()).map(factory =>
     ApiBlueprint.make({
       name: factory.api.id,
-      params: define => define(factory),
+      params: defineParams => defineParams(factory),
     }),
   );
   return createFrontendPlugin({

--- a/packages/frontend-app-api/src/wiring/createSpecializedApp.test.tsx
+++ b/packages/frontend-app-api/src/wiring/createSpecializedApp.test.tsx
@@ -144,8 +144,8 @@ describe('createSpecializedApp', () => {
               ],
             }),
             ApiBlueprint.make({
-              params: define =>
-                define({
+              params: defineParams =>
+                defineParams({
                   api: featureFlagsApiRef,
                   deps: {},
                   factory: () =>
@@ -253,8 +253,8 @@ describe('createSpecializedApp', () => {
           pluginId: 'first',
           extensions: [
             ApiBlueprint.make({
-              params: define =>
-                define({
+              params: defineParams =>
+                defineParams({
                   api: analyticsApiRef,
                   deps: {},
                   factory: () => {
@@ -294,8 +294,8 @@ describe('createSpecializedApp', () => {
               },
             }),
             ApiBlueprint.make({
-              params: define =>
-                define({
+              params: defineParams =>
+                defineParams({
                   api: analyticsApiRef,
                   deps: {},
                   factory: mockAnalyticsApi,

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -915,7 +915,7 @@ export interface ExtensionBlueprint<
     params: TParamsInput extends ExtensionBlueprintParamsDefiner
       ? TParamsInput
       : T['params'] extends ExtensionBlueprintParamsDefiner
-      ? 'Error: This blueprint uses advanced parameter types and requires you to pass parameters as using the following callback syntax: `<blueprint>.make({ params: define => define(<params>) })`'
+      ? 'Error: This blueprint uses advanced parameter types and requires you to pass parameters as using the following callback syntax: `<blueprint>.make({ params: defineParams => defineParams(<params>) })`'
       : T['params'];
   }): ExtensionDefinition<{
     kind: T['kind'];
@@ -964,7 +964,7 @@ export interface ExtensionBlueprint<
         params: TParamsInput extends ExtensionBlueprintParamsDefiner
           ? TParamsInput
           : T['params'] extends ExtensionBlueprintParamsDefiner
-          ? 'Error: This blueprint uses advanced parameter types and requires you to pass parameters as using the following callback syntax: `originalFactory(define => define(<params>))`'
+          ? 'Error: This blueprint uses advanced parameter types and requires you to pass parameters as using the following callback syntax: `originalFactory(defineParams => defineParams(<params>))`'
           : T['params'],
         context?: {
           config?: T['config'];
@@ -1182,7 +1182,7 @@ export type ExtensionDefinition<
                     params?: TFactoryParamsReturn extends ExtensionBlueprintParamsDefiner
                       ? TFactoryParamsReturn
                       : T['params'] extends ExtensionBlueprintParamsDefiner
-                      ? 'Error: This blueprint uses advanced parameter types and requires you to pass parameters as using the following callback syntax: `originalFactory(define => define(<params>))`'
+                      ? 'Error: This blueprint uses advanced parameter types and requires you to pass parameters as using the following callback syntax: `originalFactory(defineParams => defineParams(<params>))`'
                       : Partial<T['params']>;
                   })
             >,
@@ -1204,7 +1204,7 @@ export type ExtensionDefinition<
             params?: TParamsInput extends ExtensionBlueprintParamsDefiner
               ? TParamsInput
               : T['params'] extends ExtensionBlueprintParamsDefiner
-              ? 'Error: This blueprint uses advanced parameter types and requires you to pass parameters as using the following callback syntax: `originalFactory(define => define(<params>))`'
+              ? 'Error: This blueprint uses advanced parameter types and requires you to pass parameters as using the following callback syntax: `originalFactory(defineParams => defineParams(<params>))`'
               : Partial<T['params']>;
           })
     > &

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -505,7 +505,7 @@ export function createExtension<
 
 // @public
 export function createExtensionBlueprint<
-  TParams extends object | ExtensionBlueprintParamsDefiner,
+  TParams extends object | ExtensionBlueprintDefineParams,
   UOutput extends ExtensionDataRef,
   TInputs extends {
     [inputName in string]: ExtensionInput<
@@ -557,7 +557,7 @@ export function createExtensionBlueprint<
 // @public (undocumented)
 export type CreateExtensionBlueprintOptions<
   TKind extends string,
-  TParams extends object | ExtensionBlueprintParamsDefiner,
+  TParams extends object | ExtensionBlueprintDefineParams,
   UOutput extends ExtensionDataRef,
   TInputs extends {
     [inputName in string]: ExtensionInput<
@@ -584,11 +584,11 @@ export type CreateExtensionBlueprintOptions<
   config?: {
     schema: TConfigSchema;
   };
-  defineParams?: TParams extends ExtensionBlueprintParamsDefiner
+  defineParams?: TParams extends ExtensionBlueprintDefineParams
     ? TParams
     : 'The defineParams option must be a function if provided, see the docs for details';
   factory(
-    params: TParams extends ExtensionBlueprintParamsDefiner
+    params: TParams extends ExtensionBlueprintDefineParams
       ? ReturnType<TParams>['T']
       : TParams,
     context: {
@@ -912,9 +912,9 @@ export interface ExtensionBlueprint<
     name?: TName;
     attachTo?: ExtensionAttachToSpec;
     disabled?: boolean;
-    params: TParamsInput extends ExtensionBlueprintParamsDefiner
+    params: TParamsInput extends ExtensionBlueprintDefineParams
       ? TParamsInput
-      : T['params'] extends ExtensionBlueprintParamsDefiner
+      : T['params'] extends ExtensionBlueprintDefineParams
       ? 'Error: This blueprint uses advanced parameter types and requires you to pass parameters as using the following callback syntax: `<blueprint>.make({ params: defineParams => defineParams(<params>) })`'
       : T['params'];
   }): ExtensionDefinition<{
@@ -961,9 +961,9 @@ export interface ExtensionBlueprint<
       originalFactory: <
         TParamsInput extends AnyParamsInput_2<NonNullable<T['params']>>,
       >(
-        params: TParamsInput extends ExtensionBlueprintParamsDefiner
+        params: TParamsInput extends ExtensionBlueprintDefineParams
           ? TParamsInput
-          : T['params'] extends ExtensionBlueprintParamsDefiner
+          : T['params'] extends ExtensionBlueprintDefineParams
           ? 'Error: This blueprint uses advanced parameter types and requires you to pass parameters as using the following callback syntax: `originalFactory(defineParams => defineParams(<params>))`'
           : T['params'],
         context?: {
@@ -1015,10 +1015,16 @@ export interface ExtensionBlueprint<
   }>;
 }
 
+// @public
+export type ExtensionBlueprintDefineParams<
+  TParams extends object = object,
+  TInput = any,
+> = (params: TInput) => ExtensionBlueprintParams<TParams>;
+
 // @public (undocumented)
 export type ExtensionBlueprintParameters = {
   kind: string;
-  params?: object | ExtensionBlueprintParamsDefiner;
+  params?: object | ExtensionBlueprintDefineParams;
   configInput?: {
     [K in string]: any;
   };
@@ -1045,12 +1051,6 @@ export type ExtensionBlueprintParams<T extends object = object> = {
   $$type: '@backstage/BlueprintParams';
   T: T;
 };
-
-// @public
-export type ExtensionBlueprintParamsDefiner<
-  TParams extends object = object,
-  TInput = any,
-> = (params: TInput) => ExtensionBlueprintParams<TParams>;
 
 // @public (undocumented)
 export function ExtensionBoundary(props: ExtensionBoundaryProps): JSX_2.Element;
@@ -1179,9 +1179,9 @@ export type ExtensionDefinition<
               } & ([T['params']] extends [never]
                 ? {}
                 : {
-                    params?: TFactoryParamsReturn extends ExtensionBlueprintParamsDefiner
+                    params?: TFactoryParamsReturn extends ExtensionBlueprintDefineParams
                       ? TFactoryParamsReturn
-                      : T['params'] extends ExtensionBlueprintParamsDefiner
+                      : T['params'] extends ExtensionBlueprintDefineParams
                       ? 'Error: This blueprint uses advanced parameter types and requires you to pass parameters as using the following callback syntax: `originalFactory(defineParams => defineParams(<params>))`'
                       : Partial<T['params']>;
                   })
@@ -1201,9 +1201,9 @@ export type ExtensionDefinition<
       } & ([T['params']] extends [never]
         ? {}
         : {
-            params?: TParamsInput extends ExtensionBlueprintParamsDefiner
+            params?: TParamsInput extends ExtensionBlueprintDefineParams
               ? TParamsInput
-              : T['params'] extends ExtensionBlueprintParamsDefiner
+              : T['params'] extends ExtensionBlueprintDefineParams
               ? 'Error: This blueprint uses advanced parameter types and requires you to pass parameters as using the following callback syntax: `originalFactory(defineParams => defineParams(<params>))`'
               : Partial<T['params']>;
           })
@@ -1255,7 +1255,7 @@ export type ExtensionDefinitionParameters = {
       }
     >;
   };
-  params?: object | ExtensionBlueprintParamsDefiner;
+  params?: object | ExtensionBlueprintDefineParams;
 };
 
 // @public (undocumented)

--- a/packages/frontend-plugin-api/src/blueprints/ApiBlueprint.test.ts
+++ b/packages/frontend-plugin-api/src/blueprints/ApiBlueprint.test.ts
@@ -23,8 +23,8 @@ describe('ApiBlueprint', () => {
     const api = createApiRef<{ foo: string }>({ id: 'test' });
 
     const extension = ApiBlueprint.make({
-      params: define =>
-        define({
+      params: defineParams =>
+        defineParams({
           api,
           deps: {},
           factory: () => ({ foo: 'bar' }),
@@ -63,13 +63,17 @@ describe('ApiBlueprint', () => {
     expect('test').not.toBe('failing without assertions');
 
     ApiBlueprint.make({
-      params: define =>
-        define({ api: fooApi, deps: {}, factory: () => ({ foo: 'foo' }) }),
+      params: defineParams =>
+        defineParams({
+          api: fooApi,
+          deps: {},
+          factory: () => ({ foo: 'foo' }),
+        }),
     });
 
     ApiBlueprint.make({
-      params: define =>
-        define({
+      params: defineParams =>
+        defineParams({
           api: fooApi,
           deps: {},
           // @ts-expect-error missing property
@@ -78,8 +82,8 @@ describe('ApiBlueprint', () => {
     });
 
     ApiBlueprint.make({
-      params: define =>
-        define({
+      params: defineParams =>
+        defineParams({
           api: fooApi,
           deps: {},
           // @ts-expect-error wrong property
@@ -90,8 +94,8 @@ describe('ApiBlueprint', () => {
     });
 
     ApiBlueprint.make({
-      params: define =>
-        define({
+      params: defineParams =>
+        defineParams({
           api: fooApi,
           deps: {},
           factory: () => ({
@@ -102,8 +106,8 @@ describe('ApiBlueprint', () => {
     });
 
     ApiBlueprint.make({
-      params: define =>
-        define({
+      params: defineParams =>
+        defineParams({
           api: fooApi,
           deps: { bar: barApi },
           factory: ({ bar }) => ({ foo: bar.bar }),
@@ -111,8 +115,8 @@ describe('ApiBlueprint', () => {
     });
 
     ApiBlueprint.make({
-      params: define =>
-        define({
+      params: defineParams =>
+        defineParams({
           api: fooApi,
           deps: { bar: barApi },
           factory: ({ bar }) => ({
@@ -123,8 +127,8 @@ describe('ApiBlueprint', () => {
     });
 
     ApiBlueprint.make({
-      params: define =>
-        define({
+      params: defineParams =>
+        defineParams({
           api: fooApi,
           deps: { bar: barApi },
           factory: ({ bar }) => ({
@@ -135,8 +139,8 @@ describe('ApiBlueprint', () => {
     });
 
     ApiBlueprint.make({
-      params: define =>
-        define({
+      params: defineParams =>
+        defineParams({
           api: fooApi,
           deps: {},
           factory: ({ bar }) => ({
@@ -162,7 +166,9 @@ describe('ApiBlueprint', () => {
       },
       name: api.id,
       factory(originalFactory, { config: _config, inputs: _inputs }) {
-        return originalFactory(define => define({ api, deps: {}, factory }));
+        return originalFactory(defineParams =>
+          defineParams({ api, deps: {}, factory }),
+        );
       },
     });
 

--- a/packages/frontend-plugin-api/src/wiring/createExtension.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.ts
@@ -228,7 +228,7 @@ export type ExtensionDefinition<
                     params?: TFactoryParamsReturn extends ExtensionBlueprintParamsDefiner
                       ? TFactoryParamsReturn
                       : T['params'] extends ExtensionBlueprintParamsDefiner
-                      ? 'Error: This blueprint uses advanced parameter types and requires you to pass parameters as using the following callback syntax: `originalFactory(define => define(<params>))`'
+                      ? 'Error: This blueprint uses advanced parameter types and requires you to pass parameters as using the following callback syntax: `originalFactory(defineParams => defineParams(<params>))`'
                       : Partial<T['params']>;
                   })
             >,
@@ -250,7 +250,7 @@ export type ExtensionDefinition<
             params?: TParamsInput extends ExtensionBlueprintParamsDefiner
               ? TParamsInput
               : T['params'] extends ExtensionBlueprintParamsDefiner
-              ? 'Error: This blueprint uses advanced parameter types and requires you to pass parameters as using the following callback syntax: `originalFactory(define => define(<params>))`'
+              ? 'Error: This blueprint uses advanced parameter types and requires you to pass parameters as using the following callback syntax: `originalFactory(defineParams => defineParams(<params>))`'
               : Partial<T['params']>;
           })
     > &

--- a/packages/frontend-plugin-api/src/wiring/createExtension.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.ts
@@ -27,7 +27,7 @@ import { z } from 'zod';
 import { createSchemaFromZod } from '../schema/createSchemaFromZod';
 import { OpaqueExtensionDefinition } from '@internal/frontend';
 import { ExtensionDataContainer } from './types';
-import { ExtensionBlueprintParamsDefiner } from './createExtensionBlueprint';
+import { ExtensionBlueprintDefineParams } from './createExtensionBlueprint';
 
 /**
  * This symbol is used to pass parameter overrides from the extension override to the blueprint factory
@@ -159,7 +159,7 @@ export type ExtensionDefinitionParameters = {
       { optional: boolean; singleton: boolean }
     >;
   };
-  params?: object | ExtensionBlueprintParamsDefiner;
+  params?: object | ExtensionBlueprintDefineParams;
 };
 
 /**
@@ -167,14 +167,14 @@ export type ExtensionDefinitionParameters = {
  * It can't be exported because it breaks API reports.
  * @ignore
  */
-type AnyParamsInput<TParams extends object | ExtensionBlueprintParamsDefiner> =
-  TParams extends ExtensionBlueprintParamsDefiner<infer IParams>
+type AnyParamsInput<TParams extends object | ExtensionBlueprintDefineParams> =
+  TParams extends ExtensionBlueprintDefineParams<infer IParams>
     ? IParams | ((define: TParams) => ReturnType<TParams>)
     :
         | TParams
         | ((
-            define: ExtensionBlueprintParamsDefiner<TParams, TParams>,
-          ) => ReturnType<ExtensionBlueprintParamsDefiner<TParams, TParams>>);
+            define: ExtensionBlueprintDefineParams<TParams, TParams>,
+          ) => ReturnType<ExtensionBlueprintDefineParams<TParams, TParams>>);
 
 /** @public */
 export type ExtensionDefinition<
@@ -225,9 +225,9 @@ export type ExtensionDefinition<
               } & ([T['params']] extends [never]
                 ? {}
                 : {
-                    params?: TFactoryParamsReturn extends ExtensionBlueprintParamsDefiner
+                    params?: TFactoryParamsReturn extends ExtensionBlueprintDefineParams
                       ? TFactoryParamsReturn
-                      : T['params'] extends ExtensionBlueprintParamsDefiner
+                      : T['params'] extends ExtensionBlueprintDefineParams
                       ? 'Error: This blueprint uses advanced parameter types and requires you to pass parameters as using the following callback syntax: `originalFactory(defineParams => defineParams(<params>))`'
                       : Partial<T['params']>;
                   })
@@ -247,9 +247,9 @@ export type ExtensionDefinition<
       } & ([T['params']] extends [never]
         ? {}
         : {
-            params?: TParamsInput extends ExtensionBlueprintParamsDefiner
+            params?: TParamsInput extends ExtensionBlueprintDefineParams
               ? TParamsInput
-              : T['params'] extends ExtensionBlueprintParamsDefiner
+              : T['params'] extends ExtensionBlueprintDefineParams
               ? 'Error: This blueprint uses advanced parameter types and requires you to pass parameters as using the following callback syntax: `originalFactory(defineParams => defineParams(<params>))`'
               : Partial<T['params']>;
           })

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.test.tsx
@@ -881,9 +881,9 @@ describe('createExtensionBlueprint', () => {
     });
 
     const extensionDef = blueprint.make({
-      // Using define is optional in this case
-      params: define =>
-        define({
+      // Using defineParams is optional in this case
+      params: defineParams =>
+        defineParams({
           test1: 'orig-1',
           test2: 'orig-2',
         }),
@@ -925,7 +925,7 @@ describe('createExtensionBlueprint', () => {
       test2: 'override-2',
     });
 
-    // Partial override with original define
+    // Partial override with original defineParams
     expect(
       getOutputs(
         extensionDef.override({
@@ -941,12 +941,12 @@ describe('createExtensionBlueprint', () => {
       test2: 'override-2',
     });
 
-    // Override with define
+    // Override with defineParams
     expect(
       getOutputs(
         extension.override({
-          params: define =>
-            define({
+          params: defineParams =>
+            defineParams({
               test1: 'override-1',
               test2: 'override-2',
               // @ts-expect-error
@@ -959,12 +959,12 @@ describe('createExtensionBlueprint', () => {
       test2: 'override-2',
     });
 
-    // Override with define with original define
+    // Override with defineParams with original defineParams
     expect(
       getOutputs(
         extensionDef.override({
-          params: define =>
-            define({
+          params: defineParams =>
+            defineParams({
               test1: 'override-1',
               test2: 'override-2',
               // @ts-expect-error
@@ -1015,7 +1015,7 @@ describe('createExtensionBlueprint', () => {
       test2: 'override-2',
     });
 
-    // Partial override via factory with original define
+    // Partial override via factory with original defineParams
     expect(
       getOutputs(
         extensionDef.override({
@@ -1035,14 +1035,14 @@ describe('createExtensionBlueprint', () => {
       test2: 'override-2',
     });
 
-    // Override via factory with define
+    // Override via factory with defineParams
     expect(
       getOutputs(
         extension.override({
           factory(origFactory) {
             return origFactory({
-              params: define =>
-                define({
+              params: defineParams =>
+                defineParams({
                   test1: 'override-1',
                   test2: 'override-2',
                   // @ts-expect-error
@@ -1057,14 +1057,14 @@ describe('createExtensionBlueprint', () => {
       test2: 'override-2',
     });
 
-    // Override via factory with define with original define
+    // Override via factory with defineParams with original defineParams
     expect(
       getOutputs(
         extensionDef.override({
           factory(origFactory) {
             return origFactory({
-              params: define =>
-                define({
+              params: defineParams =>
+                defineParams({
                   test1: 'override-1',
                   test2: 'override-2',
                   // @ts-expect-error
@@ -1131,9 +1131,9 @@ describe('createExtensionBlueprint', () => {
     });
 
     const extensionDef = blueprint.make({
-      // Using define is optional in this case
-      params: define =>
-        define({
+      // Using defineParams is optional in this case
+      params: defineParams =>
+        defineParams({
           test1: 'orig-1',
           test2: 'orig-2',
         }),
@@ -1175,7 +1175,7 @@ describe('createExtensionBlueprint', () => {
       test2: 'override-2',
     });
 
-    // Partial override with original define
+    // Partial override with original defineParams
     expect(
       getOutputs(
         extensionDef.override({
@@ -1191,12 +1191,12 @@ describe('createExtensionBlueprint', () => {
       test2: 'override-2',
     });
 
-    // Override with define
+    // Override with defineParams
     expect(
       getOutputs(
         extension.override({
-          params: define =>
-            define({
+          params: defineParams =>
+            defineParams({
               test1: 'override-1',
               test2: 'override-2',
               // @ts-expect-error
@@ -1209,12 +1209,12 @@ describe('createExtensionBlueprint', () => {
       test2: 'override-2',
     });
 
-    // Override with define with original define
+    // Override with defineParams with original defineParams
     expect(
       getOutputs(
         extensionDef.override({
-          params: define =>
-            define({
+          params: defineParams =>
+            defineParams({
               test1: 'override-1',
               test2: 'override-2',
               // @ts-expect-error
@@ -1266,7 +1266,7 @@ describe('createExtensionBlueprint', () => {
       test2: 'override-2',
     });
 
-    // Partial override via factory with original define
+    // Partial override via factory with original defineParams
     expect(
       getOutputs(
         extensionDef.override({
@@ -1286,14 +1286,14 @@ describe('createExtensionBlueprint', () => {
       test2: 'override-2',
     });
 
-    // Override via factory with define
+    // Override via factory with defineParams
     expect(
       getOutputs(
         extension.override({
           factory(origFactory) {
             return origFactory({
-              params: define =>
-                define({
+              params: defineParams =>
+                defineParams({
                   test1: 'override-1',
                   test2: 'override-2',
                   // @ts-expect-error
@@ -1308,14 +1308,14 @@ describe('createExtensionBlueprint', () => {
       test2: 'override-2',
     });
 
-    // Override via factory with define with original define
+    // Override via factory with defineParams with original defineParams
     expect(
       getOutputs(
         extensionDef.override({
           factory(origFactory) {
             return origFactory({
-              params: define =>
-                define({
+              params: defineParams =>
+                defineParams({
                   test1: 'override-1',
                   test2: 'override-2',
                   // @ts-expect-error
@@ -1373,8 +1373,8 @@ describe('createExtensionBlueprint', () => {
       });
 
       TestExtensionBlueprint.make({
-        params: define =>
-          define({
+        params: defineParams =>
+          defineParams({
             a: 'x',
             // @ts-expect-error b doesn't match a
             b: 'y',
@@ -1382,8 +1382,8 @@ describe('createExtensionBlueprint', () => {
       });
 
       TestExtensionBlueprint.make({
-        params: define =>
-          define({
+        params: defineParams =>
+          defineParams({
             a: 'x',
             b: 'x',
             // @ts-expect-error extra param
@@ -1392,8 +1392,8 @@ describe('createExtensionBlueprint', () => {
       });
 
       const extension = TestExtensionBlueprint.make({
-        params: define =>
-          define({
+        params: defineParams =>
+          defineParams({
             a: 'x',
             b: 'x',
           }),
@@ -1430,8 +1430,8 @@ describe('createExtensionBlueprint', () => {
       });
 
       extension.override({
-        params: define =>
-          define({
+        params: defineParams =>
+          defineParams({
             a: 'z',
             // @ts-expect-error b doesn't match a
             b: 'w',
@@ -1439,8 +1439,8 @@ describe('createExtensionBlueprint', () => {
       });
 
       extension.override({
-        params: define =>
-          define({
+        params: defineParams =>
+          defineParams({
             a: 'z',
             b: 'z',
             // @ts-expect-error extra param
@@ -1449,8 +1449,8 @@ describe('createExtensionBlueprint', () => {
       });
 
       const override = extension.override({
-        params: define =>
-          define({
+        params: defineParams =>
+          defineParams({
             a: 'z',
             b: 'z',
           }),
@@ -1472,8 +1472,8 @@ describe('createExtensionBlueprint', () => {
 
       TestExtensionBlueprint.makeWithOverrides({
         factory(originalFactory) {
-          return originalFactory(define =>
-            define({
+          return originalFactory(defineParams =>
+            defineParams({
               a: 'x',
               // @ts-expect-error b doesn't match a
               b: 'y',
@@ -1484,8 +1484,8 @@ describe('createExtensionBlueprint', () => {
 
       const extension = TestExtensionBlueprint.makeWithOverrides({
         factory(originalFactory) {
-          return originalFactory(define =>
-            define({
+          return originalFactory(defineParams =>
+            defineParams({
               a: 'x',
               b: 'x',
             }),
@@ -1524,8 +1524,8 @@ describe('createExtensionBlueprint', () => {
       });
 
       extension.override({
-        params: define =>
-          define({
+        params: defineParams =>
+          defineParams({
             a: 'z',
             // @ts-expect-error b doesn't match a
             b: 'w',
@@ -1533,8 +1533,8 @@ describe('createExtensionBlueprint', () => {
       });
 
       const override = extension.override({
-        params: define =>
-          define({
+        params: defineParams =>
+          defineParams({
             a: 'z',
             b: 'z',
           }),
@@ -1560,8 +1560,8 @@ describe('createExtensionBlueprint', () => {
       });
 
       const extension = TestTransformExtensionBlueprint.make({
-        params: define =>
-          define({
+        params: defineParams =>
+          defineParams({
             a: 0,
             b: 10,
           }),
@@ -1572,8 +1572,8 @@ describe('createExtensionBlueprint', () => {
       expect(
         createExtensionTester(
           extension.override({
-            params: define =>
-              define({
+            params: defineParams =>
+              defineParams({
                 a: 20,
                 b: 30,
               }),
@@ -1597,18 +1597,18 @@ describe('createExtensionBlueprint', () => {
       });
 
       const extension = TestTransformExtensionBlueprint.make({
-        params: define => define({ x: 1 }),
+        params: defineParams => defineParams({ x: 1 }),
       });
 
       expect(createExtensionTester(extension).get(testDataRef)).toBe(`x: 1`);
 
       TestTransformExtensionBlueprint.make({
-        params: define => define({ x: 2 }),
+        params: defineParams => defineParams({ x: 2 }),
       });
 
       TestTransformExtensionBlueprint.make({
         // @ts-expect-error doesn't match any overload
-        params: define => define({ x: 3 }),
+        params: defineParams => defineParams({ x: 3 }),
       });
     });
   });

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
@@ -151,7 +151,7 @@ export type CreateExtensionBlueprintOptions<
    * Usage of the above example blueprint:
    * ```ts
    * const example = ExampleBlueprint.make({
-   *   params: define => define({
+   *   params: defineParams => defineParams({
    *     component: ...,
    *     fetcher: ...,
    *   }),
@@ -196,7 +196,7 @@ export type ExtensionBlueprintParameters = {
 
 /** @ignore */
 type ParamsFactory<TDefiner extends ExtensionBlueprintParamsDefiner> = (
-  define: TDefiner,
+  defineParams: TDefiner,
 ) => ReturnType<TDefiner>;
 
 /**
@@ -231,7 +231,7 @@ export interface ExtensionBlueprint<
     params: TParamsInput extends ExtensionBlueprintParamsDefiner
       ? TParamsInput
       : T['params'] extends ExtensionBlueprintParamsDefiner
-      ? 'Error: This blueprint uses advanced parameter types and requires you to pass parameters as using the following callback syntax: `<blueprint>.make({ params: define => define(<params>) })`'
+      ? 'Error: This blueprint uses advanced parameter types and requires you to pass parameters as using the following callback syntax: `<blueprint>.make({ params: defineParams => defineParams(<params>) })`'
       : T['params'];
   }): ExtensionDefinition<{
     kind: T['kind'];
@@ -284,7 +284,7 @@ export interface ExtensionBlueprint<
         params: TParamsInput extends ExtensionBlueprintParamsDefiner
           ? TParamsInput
           : T['params'] extends ExtensionBlueprintParamsDefiner
-          ? 'Error: This blueprint uses advanced parameter types and requires you to pass parameters as using the following callback syntax: `originalFactory(define => define(<params>))`'
+          ? 'Error: This blueprint uses advanced parameter types and requires you to pass parameters as using the following callback syntax: `originalFactory(defineParams => defineParams(<params>))`'
           : T['params'],
         context?: {
           config?: T['config'];

--- a/packages/frontend-plugin-api/src/wiring/index.ts
+++ b/packages/frontend-plugin-api/src/wiring/index.ts
@@ -67,7 +67,7 @@ export {
   type ExtensionBlueprint,
   type ExtensionBlueprintParameters,
   type ExtensionBlueprintParams,
-  type ExtensionBlueprintParamsDefiner,
+  type ExtensionBlueprintDefineParams,
   createExtensionBlueprint,
   createExtensionBlueprintParams,
 } from './createExtensionBlueprint';

--- a/plugins/api-docs/src/alpha.tsx
+++ b/plugins/api-docs/src/alpha.tsx
@@ -54,8 +54,8 @@ const apiDocsNavItem = NavItemBlueprint.make({
 
 const apiDocsConfigApi = ApiBlueprint.make({
   name: 'config',
-  params: define =>
-    define({
+  params: defineParams =>
+    defineParams({
       api: apiDocsConfigRef,
       deps: {},
       factory: () => {

--- a/plugins/app/src/defaultApis.ts
+++ b/plugins/app/src/defaultApis.ts
@@ -74,8 +74,8 @@ import { DefaultDialogApi } from './apis/DefaultDialogApi';
 export const apis = [
   ApiBlueprint.make({
     name: 'dialog',
-    params: define =>
-      define({
+    params: defineParams =>
+      defineParams({
         api: dialogApiRef,
         deps: {},
         factory: () => new DefaultDialogApi(),
@@ -83,8 +83,8 @@ export const apis = [
   }),
   ApiBlueprint.make({
     name: 'discovery',
-    params: define =>
-      define({
+    params: defineParams =>
+      defineParams({
         api: discoveryApiRef,
         deps: { configApi: configApiRef },
         factory: ({ configApi }) =>
@@ -95,8 +95,8 @@ export const apis = [
   }),
   ApiBlueprint.make({
     name: 'alert',
-    params: define =>
-      define({
+    params: defineParams =>
+      defineParams({
         api: alertApiRef,
         deps: {},
         factory: () => new AlertApiForwarder(),
@@ -104,8 +104,8 @@ export const apis = [
   }),
   ApiBlueprint.make({
     name: 'analytics',
-    params: define =>
-      define({
+    params: defineParams =>
+      defineParams({
         api: analyticsApiRef,
         deps: {},
         factory: () => new NoOpAnalyticsApi(),
@@ -113,8 +113,8 @@ export const apis = [
   }),
   ApiBlueprint.make({
     name: 'error',
-    params: define =>
-      define({
+    params: defineParams =>
+      defineParams({
         api: errorApiRef,
         deps: { alertApi: alertApiRef },
         factory: ({ alertApi }) => {
@@ -126,8 +126,8 @@ export const apis = [
   }),
   ApiBlueprint.make({
     name: 'storage',
-    params: define =>
-      define({
+    params: defineParams =>
+      defineParams({
         api: storageApiRef,
         deps: { errorApi: errorApiRef },
         factory: ({ errorApi }) => WebStorage.create({ errorApi }),
@@ -135,8 +135,8 @@ export const apis = [
   }),
   ApiBlueprint.make({
     name: 'fetch',
-    params: define =>
-      define({
+    params: defineParams =>
+      defineParams({
         api: fetchApiRef,
         deps: {
           configApi: configApiRef,
@@ -160,8 +160,8 @@ export const apis = [
   }),
   ApiBlueprint.make({
     name: 'oauth-request',
-    params: define =>
-      define({
+    params: defineParams =>
+      defineParams({
         api: oauthRequestApiRef,
         deps: {},
         factory: () => new OAuthRequestManager(),
@@ -169,8 +169,8 @@ export const apis = [
   }),
   ApiBlueprint.make({
     name: 'google-auth',
-    params: define =>
-      define({
+    params: defineParams =>
+      defineParams({
         api: googleAuthApiRef,
         deps: {
           discoveryApi: discoveryApiRef,
@@ -188,8 +188,8 @@ export const apis = [
   }),
   ApiBlueprint.make({
     name: 'microsoft-auth',
-    params: define =>
-      define({
+    params: defineParams =>
+      defineParams({
         api: microsoftAuthApiRef,
         deps: {
           discoveryApi: discoveryApiRef,
@@ -207,8 +207,8 @@ export const apis = [
   }),
   ApiBlueprint.make({
     name: 'github-auth',
-    params: define =>
-      define({
+    params: defineParams =>
+      defineParams({
         api: githubAuthApiRef,
         deps: {
           discoveryApi: discoveryApiRef,
@@ -227,8 +227,8 @@ export const apis = [
   }),
   ApiBlueprint.make({
     name: 'okta-auth',
-    params: define =>
-      define({
+    params: defineParams =>
+      defineParams({
         api: oktaAuthApiRef,
         deps: {
           discoveryApi: discoveryApiRef,
@@ -246,8 +246,8 @@ export const apis = [
   }),
   ApiBlueprint.make({
     name: 'gitlab-auth',
-    params: define =>
-      define({
+    params: defineParams =>
+      defineParams({
         api: gitlabAuthApiRef,
         deps: {
           discoveryApi: discoveryApiRef,
@@ -265,8 +265,8 @@ export const apis = [
   }),
   ApiBlueprint.make({
     name: 'onelogin-auth',
-    params: define =>
-      define({
+    params: defineParams =>
+      defineParams({
         api: oneloginAuthApiRef,
         deps: {
           discoveryApi: discoveryApiRef,
@@ -284,8 +284,8 @@ export const apis = [
   }),
   ApiBlueprint.make({
     name: 'bitbucket-auth',
-    params: define =>
-      define({
+    params: defineParams =>
+      defineParams({
         api: bitbucketAuthApiRef,
         deps: {
           discoveryApi: discoveryApiRef,
@@ -304,8 +304,8 @@ export const apis = [
   }),
   ApiBlueprint.make({
     name: 'bitbucket-server-auth',
-    params: define =>
-      define({
+    params: defineParams =>
+      defineParams({
         api: bitbucketServerAuthApiRef,
         deps: {
           discoveryApi: discoveryApiRef,
@@ -324,8 +324,8 @@ export const apis = [
   }),
   ApiBlueprint.make({
     name: 'atlassian-auth',
-    params: define =>
-      define({
+    params: defineParams =>
+      defineParams({
         api: atlassianAuthApiRef,
         deps: {
           discoveryApi: discoveryApiRef,
@@ -344,8 +344,8 @@ export const apis = [
   }),
   ApiBlueprint.make({
     name: 'vmware-cloud-auth',
-    params: define =>
-      define({
+    params: defineParams =>
+      defineParams({
         api: vmwareCloudAuthApiRef,
         deps: {
           discoveryApi: discoveryApiRef,
@@ -364,8 +364,8 @@ export const apis = [
   }),
   ApiBlueprint.make({
     name: 'permission',
-    params: define =>
-      define({
+    params: defineParams =>
+      defineParams({
         api: permissionApiRef,
         deps: {
           discovery: discoveryApiRef,
@@ -378,12 +378,12 @@ export const apis = [
   }),
   ApiBlueprint.make({
     name: 'scm-auth',
-    params: define => define(ScmAuth.createDefaultApiFactory()),
+    params: defineParams => defineParams(ScmAuth.createDefaultApiFactory()),
   }),
   ApiBlueprint.make({
     name: 'scm-integrations',
-    params: define =>
-      define({
+    params: defineParams =>
+      defineParams({
         api: scmIntegrationsApiRef,
         deps: { configApi: configApiRef },
         factory: ({ configApi }) => ScmIntegrationsApi.fromConfig(configApi),

--- a/plugins/app/src/extensions/AppLanguageApi.ts
+++ b/plugins/app/src/extensions/AppLanguageApi.ts
@@ -21,8 +21,8 @@ import { ApiBlueprint } from '@backstage/frontend-plugin-api';
 
 export const AppLanguageApi = ApiBlueprint.make({
   name: 'app-language',
-  params: define =>
-    define({
+  params: defineParams =>
+    defineParams({
       api: appLanguageApiRef,
       deps: {},
       factory: () => AppLanguageSelector.createWithStorage(),

--- a/plugins/app/src/extensions/AppThemeApi.tsx
+++ b/plugins/app/src/extensions/AppThemeApi.tsx
@@ -40,8 +40,8 @@ export const AppThemeApi = ApiBlueprint.makeWithOverrides({
     }),
   },
   factory: (originalFactory, { inputs }) => {
-    return originalFactory(define =>
-      define({
+    return originalFactory(defineParams =>
+      defineParams({
         api: appThemeApiRef,
         deps: {},
         factory: () =>

--- a/plugins/app/src/extensions/ComponentsApi.tsx
+++ b/plugins/app/src/extensions/ComponentsApi.tsx
@@ -35,8 +35,8 @@ export const ComponentsApi = ApiBlueprint.makeWithOverrides({
     ),
   },
   factory: (originalFactory, { inputs }) => {
-    return originalFactory(define =>
-      define({
+    return originalFactory(defineParams =>
+      defineParams({
         api: componentsApiRef,
         deps: {},
         factory: () =>

--- a/plugins/app/src/extensions/FeatureFlagsApi.ts
+++ b/plugins/app/src/extensions/FeatureFlagsApi.ts
@@ -26,8 +26,8 @@ import { LocalStorageFeatureFlags } from '../../../../packages/core-app-api/src/
  */
 export const FeatureFlagsApi = ApiBlueprint.make({
   name: 'feature-flags',
-  params: define =>
-    define({
+  params: defineParams =>
+    defineParams({
       // TODO: properly discovery feature flags, maybe rework the whole thing
       api: featureFlagsApiRef,
       deps: {},

--- a/plugins/app/src/extensions/IconsApi.ts
+++ b/plugins/app/src/extensions/IconsApi.ts
@@ -36,8 +36,8 @@ export const IconsApi = ApiBlueprint.makeWithOverrides({
     }),
   },
   factory: (originalFactory, { inputs }) => {
-    return originalFactory(define =>
-      define({
+    return originalFactory(defineParams =>
+      defineParams({
         api: iconsApiRef,
         deps: {},
         factory: () =>

--- a/plugins/app/src/extensions/TranslationsApi.tsx
+++ b/plugins/app/src/extensions/TranslationsApi.tsx
@@ -38,8 +38,8 @@ export const TranslationsApi = ApiBlueprint.makeWithOverrides({
     ),
   },
   factory: (originalFactory, { inputs }) => {
-    return originalFactory(define =>
-      define({
+    return originalFactory(defineParams =>
+      defineParams({
         api: translationApiRef,
         deps: { languageApi: appLanguageApiRef },
         factory: ({ languageApi }) =>

--- a/plugins/catalog-import/src/alpha.tsx
+++ b/plugins/catalog-import/src/alpha.tsx
@@ -52,8 +52,8 @@ const catalogImportPage = PageBlueprint.make({
 });
 
 const catalogImportApi = ApiBlueprint.make({
-  params: define =>
-    define({
+  params: defineParams =>
+    defineParams({
       api: catalogImportApiRef,
       deps: {
         discoveryApi: discoveryApiRef,

--- a/plugins/catalog-unprocessed-entities/src/alpha/plugin.tsx
+++ b/plugins/catalog-unprocessed-entities/src/alpha/plugin.tsx
@@ -36,8 +36,8 @@ import { rootRouteRef } from '../routes';
 
 /** @alpha */
 export const catalogUnprocessedEntitiesApi = ApiBlueprint.make({
-  params: define =>
-    define({
+  params: defineParams =>
+    defineParams({
       api: catalogUnprocessedEntitiesApiRef,
       deps: {
         discoveryApi: discoveryApiRef,

--- a/plugins/catalog/src/alpha/apis.tsx
+++ b/plugins/catalog/src/alpha/apis.tsx
@@ -32,8 +32,8 @@ import {
 } from '../apis';
 
 export const catalogApi = ApiBlueprint.make({
-  params: define =>
-    define({
+  params: defineParams =>
+    defineParams({
       api: catalogApiRef,
       deps: {
         discoveryApi: discoveryApiRef,
@@ -46,8 +46,8 @@ export const catalogApi = ApiBlueprint.make({
 
 export const catalogStarredEntitiesApi = ApiBlueprint.make({
   name: 'starred-entities',
-  params: define =>
-    define({
+  params: defineParams =>
+    defineParams({
       api: starredEntitiesApiRef,
       deps: { storageApi: storageApiRef },
       factory: ({ storageApi }) =>
@@ -57,8 +57,8 @@ export const catalogStarredEntitiesApi = ApiBlueprint.make({
 
 export const entityPresentationApi = ApiBlueprint.make({
   name: 'entity-presentation',
-  params: define =>
-    define({
+  params: defineParams =>
+    defineParams({
       api: entityPresentationApiRef,
       deps: { catalogApiImp: catalogApiRef },
       factory: ({ catalogApiImp }) =>

--- a/plugins/devtools/src/alpha/plugin.tsx
+++ b/plugins/devtools/src/alpha/plugin.tsx
@@ -33,8 +33,8 @@ import { rootRouteRef } from '../routes';
 
 /** @alpha */
 export const devToolsApi = ApiBlueprint.make({
-  params: define =>
-    define({
+  params: defineParams =>
+    defineParams({
       api: devToolsApiRef,
       deps: {
         discoveryApi: discoveryApiRef,

--- a/plugins/home/src/alpha.tsx
+++ b/plugins/home/src/alpha.tsx
@@ -78,8 +78,8 @@ const visitListenerAppRootElement = AppRootElementBlueprint.make({
 
 const visitsApi = ApiBlueprint.make({
   name: 'visits',
-  params: define =>
-    define({
+  params: defineParams =>
+    defineParams({
       api: visitsApiRef,
       deps: {
         storageApi: storageApiRef,

--- a/plugins/kubernetes/src/alpha/apis.tsx
+++ b/plugins/kubernetes/src/alpha/apis.tsx
@@ -40,8 +40,8 @@ import {
 } from '@backstage/core-plugin-api';
 
 export const kubernetesApiExtension = ApiBlueprint.make({
-  params: define =>
-    define({
+  params: defineParams =>
+    defineParams({
       api: kubernetesApiRef,
       deps: {
         discoveryApi: discoveryApiRef,
@@ -59,8 +59,8 @@ export const kubernetesApiExtension = ApiBlueprint.make({
 
 export const kubernetesProxyApi = ApiBlueprint.make({
   name: 'proxy',
-  params: define =>
-    define({
+  params: defineParams =>
+    defineParams({
       api: kubernetesProxyApiRef,
       deps: {
         kubernetesApi: kubernetesApiRef,
@@ -74,8 +74,8 @@ export const kubernetesProxyApi = ApiBlueprint.make({
 
 export const kubernetesAuthProvidersApi = ApiBlueprint.make({
   name: 'auth-providers',
-  params: define =>
-    define({
+  params: defineParams =>
+    defineParams({
       api: kubernetesAuthProvidersApiRef,
       deps: {
         gitlabAuthApi: gitlabAuthApiRef,
@@ -110,8 +110,8 @@ export const kubernetesAuthProvidersApi = ApiBlueprint.make({
 
 export const kubernetesClusterLinkFormatterApi = ApiBlueprint.make({
   name: 'cluster-link-formatter',
-  params: define =>
-    define({
+  params: defineParams =>
+    defineParams({
       api: kubernetesClusterLinkFormatterApiRef,
       deps: { googleAuthApi: googleAuthApiRef },
       factory: deps => {

--- a/plugins/notifications/src/alpha.tsx
+++ b/plugins/notifications/src/alpha.tsx
@@ -40,8 +40,8 @@ const page = PageBlueprint.make({
 });
 
 const api = ApiBlueprint.make({
-  params: define =>
-    define({
+  params: defineParams =>
+    defineParams({
       api: notificationsApiRef,
       deps: { discoveryApi: discoveryApiRef, fetchApi: fetchApiRef },
       factory: ({ discoveryApi, fetchApi }) =>

--- a/plugins/scaffolder-react/src/next/api/FormFieldsApi.ts
+++ b/plugins/scaffolder-react/src/next/api/FormFieldsApi.ts
@@ -52,8 +52,8 @@ export const formFieldsApi = ApiBlueprint.makeWithOverrides({
       e.get(FormFieldBlueprint.dataRefs.formFieldLoader),
     );
 
-    return originalFactory(define =>
-      define({
+    return originalFactory(defineParams =>
+      defineParams({
         api: formFieldsApiRef,
         deps: {},
         factory: () => new DefaultScaffolderFormFieldsApi(formFieldLoaders),

--- a/plugins/scaffolder/src/alpha/api/FormDecoratorsApi.ts
+++ b/plugins/scaffolder/src/alpha/api/FormDecoratorsApi.ts
@@ -57,8 +57,8 @@ export const formDecoratorsApi = ApiBlueprint.makeWithOverrides({
       e.get(FormDecoratorBlueprint.dataRefs.formDecoratorLoader),
     );
 
-    return originalFactory(define =>
-      define({
+    return originalFactory(defineParams =>
+      defineParams({
         api: formDecoratorsApiRef,
         deps: {},
         factory: () =>

--- a/plugins/scaffolder/src/alpha/extensions.tsx
+++ b/plugins/scaffolder/src/alpha/extensions.tsx
@@ -73,8 +73,8 @@ export const repoUrlPickerFormField = FormFieldBlueprint.make({
 });
 
 export const scaffolderApi = ApiBlueprint.make({
-  params: define =>
-    define({
+  params: defineParams =>
+    defineParams({
       api: scaffolderApiRef,
       deps: {
         discoveryApi: discoveryApiRef,

--- a/plugins/search/src/alpha.tsx
+++ b/plugins/search/src/alpha.tsx
@@ -76,8 +76,8 @@ import {
 
 /** @alpha */
 export const searchApi = ApiBlueprint.make({
-  params: define =>
-    define({
+  params: defineParams =>
+    defineParams({
       api: searchApiRef,
       deps: { discoveryApi: discoveryApiRef, fetchApi: fetchApiRef },
       factory: ({ discoveryApi, fetchApi }) =>

--- a/plugins/signals/src/alpha.tsx
+++ b/plugins/signals/src/alpha.tsx
@@ -27,8 +27,8 @@ import { SignalsDisplay } from './plugin';
 import { compatWrapper } from '@backstage/core-compat-api';
 
 const api = ApiBlueprint.make({
-  params: define =>
-    define({
+  params: defineParams =>
+    defineParams({
       api: signalApiRef,
       deps: {
         identity: identityApiRef,

--- a/plugins/techdocs/src/alpha/index.tsx
+++ b/plugins/techdocs/src/alpha/index.tsx
@@ -67,8 +67,8 @@ const techdocsEntityIconLink = EntityIconLinkBlueprint.make({
 /** @alpha */
 const techDocsStorageApi = ApiBlueprint.make({
   name: 'storage',
-  params: define =>
-    define({
+  params: defineParams =>
+    defineParams({
       api: techdocsStorageApiRef,
       deps: {
         configApi: configApiRef,
@@ -86,8 +86,8 @@ const techDocsStorageApi = ApiBlueprint.make({
 
 /** @alpha */
 const techDocsClientApi = ApiBlueprint.make({
-  params: define =>
-    define({
+  params: defineParams =>
+    defineParams({
       api: techdocsApiRef,
       deps: {
         configApi: configApiRef,


### PR DESCRIPTION
Had a bit of discussion about this one. In the end we're thinking it's most clear to line up the naming of `defineParams` across the blueprint definition and invocation. They're the same function after all. This also likely makes it a bit easier to read and understand code that uses this. In the end this is only a recommendation of course, since it's just the name of a caller define function parameter.