### PR TITLE
Retry 429 Responses in fetchApi

### DIFF
--- a/.changeset/eleven-adults-train.md
+++ b/.changeset/eleven-adults-train.md
@@ -1,0 +1,17 @@
+---
+'@backstage/backend-defaults': patch
+'@backstage/integration': patch
+---
+
+Add retry mechanism for GitLab requests on HTTP 429 responses
+
+Added a retry mechanism to handle HTTP 429 (rate limiting) responses from GitLab API requests. This enhancement improves the robustness of GitLab integrations by automatically retrying failed requests due to rate limiting.
+
+**Changes include:**
+
+- New `fetchWithRetry` utility function in backend-defaults
+- Enhanced GitLab URL reader with retry functionality
+- Updated GitLab core integration to use retry mechanisms
+- Added helper functions for retry logic in integration package
+
+This change addresses intermittent failures when GitLab APIs return rate limiting responses, making the GitLab integration more reliable in high-traffic scenarios.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

feat: implement fetchWithRetry utility for improved Gitlab requests 

This PR adds retry logic for HTTP 429 (Too Many Requests) responses specifically when interacting with the GitLab API via the fetchApi. 

Changes:

* Introduced retry mechanism for 429 responses in GitLab integrations.
* Respects the Retry-After header when present, using its value to determine the delay before retrying.
* Falls back to exponential backoff if the Retry-After header is missing.
* Retries are limited to 3 to prevent excessive delays or loops.

This change increases the robustness of GitLab integrations by reducing the likelihood of failures due to temporary rate limiting, leading to a more stable and resilient user experience.

https://github.com/backstage/backstage/issues/30601

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))


