### PR TITLE
frontend-plugin-api: removed routable prop from ExtensionBoundary

### DIFF
--- a/.changeset/fancy-ducks-help.md
+++ b/.changeset/fancy-ducks-help.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': minor
+---
+
+**BREAKING**: Removed the `routable` property from `ExtensionBoundary`. This property was never needed in practice and is instead inferred from whether or not the extension outputs a route reference. It can be safely removed.

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -1096,7 +1096,6 @@ export interface ExtensionBoundaryProps {
   children: ReactNode;
   // (undocumented)
   node: AppNode;
-  routable?: boolean;
 }
 
 // @public (undocumented)

--- a/packages/frontend-plugin-api/src/blueprints/SignInPageBlueprint.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/SignInPageBlueprint.tsx
@@ -48,7 +48,7 @@ export const SignInPageBlueprint = createExtensionBlueprint({
     );
 
     yield componentDataRef(props => (
-      <ExtensionBoundary node={node} routable>
+      <ExtensionBoundary node={node}>
         <ExtensionComponent {...props} />
       </ExtensionBoundary>
     ));


### PR DESCRIPTION
🧹, with the previous refactor of the `ExtensionBoundary`, the `routable` prop is no longer needed.