### PR TITLE
feat(config): allow specifying env specific config files

### DIFF
--- a/.changeset/better-eagles-tickle.md
+++ b/.changeset/better-eagles-tickle.md
@@ -2,4 +2,4 @@
 '@backstage/config-loader': patch
 ---
 
-Allow using `BACKSTAGE_ENVIRONMENT` for loading environment specific config files
+Allow using `BACKSTAGE_ENV` for loading environment specific config files

--- a/.changeset/better-eagles-tickle.md
+++ b/.changeset/better-eagles-tickle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/config-loader': patch
+---
+
+Allow using `BACKSTAGE_ENVIRONMENT` for loading environment specific config files

--- a/docs/conf/index.md
+++ b/docs/conf/index.md
@@ -17,15 +17,15 @@ allowing for customization.
 
 Configuration is stored in YAML files where the defaults are `app-config.yaml`
 and `app-config.local.yaml` for local overrides. Additionally, it is possible
-to define environment based configuration files with `BACKSTAGE_ENVIRONMENT`
-environment variable, which will load `app-config.<BACKSTAGE_ENVIRONMENT>.yaml`.
+to define environment based configuration files with `BACKSTAGE_ENV`
+environment variable, which will load `app-config.<BACKSTAGE_ENV>.yaml`.
 
 Loading order of these files is as follows:
 
 1. `app-config.yaml`
-2. `app-config.<BACKSTAGE_ENVIRONMENT>.yaml`
+2. `app-config.<BACKSTAGE_ENV>.yaml`
 3. `app-config.local.yaml`
-4. `app-config.<BACKSTAGE_ENVIRONMENT>.local.yaml`
+4. `app-config.<BACKSTAGE_ENV>.local.yaml`
 
 Other sets of files can by loaded by passing `--config <path>` flags.
 Read more about the configuration loading order in the

--- a/docs/conf/index.md
+++ b/docs/conf/index.md
@@ -25,6 +25,7 @@ Loading order of these files is as follows:
 1. `app-config.yaml`
 2. `app-config.<BACKSTAGE_ENVIRONMENT>.yaml`
 3. `app-config.local.yaml`
+4. `app-config.<BACKSTAGE_ENVIRONMENT>.local.yaml`
 
 Other sets of files can by loaded by passing `--config <path>` flags.
 Read more about the configuration loading order in the

--- a/docs/conf/index.md
+++ b/docs/conf/index.md
@@ -16,10 +16,23 @@ allowing for customization.
 ## Supplying Configuration
 
 Configuration is stored in YAML files where the defaults are `app-config.yaml`
-and `app-config.local.yaml` for local overrides. Other sets of files can by
-loaded by passing `--config <path>` flags. The configuration files themselves
-contain plain YAML, but with support for loading in data and secrets from
-various sources using for example `$env` and `$file` keys.
+and `app-config.local.yaml` for local overrides. Additionally, it is possible
+to define environment based configuration files with `BACKSTAGE_ENVIRONMENT`
+environment variable, which will load `app-config.<BACKSTAGE_ENVIRONMENT>.yaml`.
+
+Loading order of these files is as follows:
+
+1. `app-config.yaml`
+2. `app-config.<BACKSTAGE_ENVIRONMENT>.yaml`
+3. `app-config.local.yaml`
+
+Other sets of files can by loaded by passing `--config <path>` flags.
+Read more about the configuration loading order in the
+[Configuration Files](./writing.md#configuration-files) section.
+
+The configuration files themselves contain plain YAML, but with support for
+loading in data and secrets from various sources using for example
+`$env` and `$file` keys.
 
 It is also possible to supply configuration through environment variables, for
 example `APP_CONFIG_app_baseUrl=https://staging.example.com`. However these

--- a/packages/config-loader/src/sources/ConfigSources.test.ts
+++ b/packages/config-loader/src/sources/ConfigSources.test.ts
@@ -99,6 +99,7 @@ describe('ConfigSources', () => {
       { name: 'FileConfigSource', path: `${root}app-config.yaml` },
       { name: 'FileConfigSource', path: `${root}app-config.test.yaml` },
       { name: 'FileConfigSource', path: `${root}app-config.local.yaml` },
+      { name: 'FileConfigSource', path: `${root}app-config.test.local.yaml` },
     ]);
 
     fsSpy.mockRestore();

--- a/packages/config-loader/src/sources/ConfigSources.test.ts
+++ b/packages/config-loader/src/sources/ConfigSources.test.ts
@@ -90,7 +90,7 @@ describe('ConfigSources', () => {
       { name: 'FileConfigSource', path: `${root}app-config.local.yaml` },
     ]);
 
-    process.env = Object.assign(process.env, { BACKSTAGE_ENVIRONMENT: 'test' });
+    process.env = Object.assign(process.env, { BACKSTAGE_ENV: 'test' });
     expect(
       mergeSources(
         ConfigSources.defaultForTargets({ rootDir: '/', targets: [] }),

--- a/packages/config-loader/src/sources/ConfigSources.test.ts
+++ b/packages/config-loader/src/sources/ConfigSources.test.ts
@@ -89,6 +89,18 @@ describe('ConfigSources', () => {
       { name: 'FileConfigSource', path: `${root}app-config.yaml` },
       { name: 'FileConfigSource', path: `${root}app-config.local.yaml` },
     ]);
+
+    process.env = Object.assign(process.env, { BACKSTAGE_ENVIRONMENT: 'test' });
+    expect(
+      mergeSources(
+        ConfigSources.defaultForTargets({ rootDir: '/', targets: [] }),
+      ),
+    ).toEqual([
+      { name: 'FileConfigSource', path: `${root}app-config.yaml` },
+      { name: 'FileConfigSource', path: `${root}app-config.test.yaml` },
+      { name: 'FileConfigSource', path: `${root}app-config.local.yaml` },
+    ]);
+
     fsSpy.mockRestore();
 
     expect(

--- a/packages/config-loader/src/sources/ConfigSources.ts
+++ b/packages/config-loader/src/sources/ConfigSources.ts
@@ -184,11 +184,11 @@ export class ConfigSources {
       const localPath = resolvePath(rootDir, 'app-config.local.yaml');
       const envPath = resolvePath(
         rootDir,
-        `app-config.${process.env.BACKSTAGE_ENVIRONMENT}.yaml`,
+        `app-config.${process.env.BACKSTAGE_ENV}.yaml`,
       );
       const envLocalPath = resolvePath(
         rootDir,
-        `app-config.${process.env.BACKSTAGE_ENVIRONMENT}.local.yaml`,
+        `app-config.${process.env.BACKSTAGE_ENV}.local.yaml`,
       );
       const alwaysIncludeDefaultConfigSource =
         !options.allowMissingDefaultConfig;
@@ -203,7 +203,7 @@ export class ConfigSources {
         );
       }
 
-      if (process.env.BACKSTAGE_ENVIRONMENT && fs.pathExistsSync(envPath)) {
+      if (process.env.BACKSTAGE_ENV && fs.pathExistsSync(envPath)) {
         argSources.push(
           FileConfigSource.create({
             watch: options.watch,
@@ -223,10 +223,7 @@ export class ConfigSources {
         );
       }
 
-      if (
-        process.env.BACKSTAGE_ENVIRONMENT &&
-        fs.pathExistsSync(envLocalPath)
-      ) {
+      if (process.env.BACKSTAGE_ENV && fs.pathExistsSync(envLocalPath)) {
         argSources.push(
           FileConfigSource.create({
             watch: options.watch,

--- a/packages/config-loader/src/sources/ConfigSources.ts
+++ b/packages/config-loader/src/sources/ConfigSources.ts
@@ -186,6 +186,10 @@ export class ConfigSources {
         rootDir,
         `app-config.${process.env.BACKSTAGE_ENVIRONMENT}.yaml`,
       );
+      const envLocalPath = resolvePath(
+        rootDir,
+        `app-config.${process.env.BACKSTAGE_ENVIRONMENT}.local.yaml`,
+      );
       const alwaysIncludeDefaultConfigSource =
         !options.allowMissingDefaultConfig;
 
@@ -214,6 +218,19 @@ export class ConfigSources {
           FileConfigSource.create({
             watch: options.watch,
             path: localPath,
+            substitutionFunc: options.substitutionFunc,
+          }),
+        );
+      }
+
+      if (
+        process.env.BACKSTAGE_ENVIRONMENT &&
+        fs.pathExistsSync(envLocalPath)
+      ) {
+        argSources.push(
+          FileConfigSource.create({
+            watch: options.watch,
+            path: envLocalPath,
             substitutionFunc: options.substitutionFunc,
           }),
         );

--- a/packages/config-loader/src/sources/ConfigSources.ts
+++ b/packages/config-loader/src/sources/ConfigSources.ts
@@ -182,6 +182,10 @@ export class ConfigSources {
     if (argSources.length === 0) {
       const defaultPath = resolvePath(rootDir, 'app-config.yaml');
       const localPath = resolvePath(rootDir, 'app-config.local.yaml');
+      const envPath = resolvePath(
+        rootDir,
+        `app-config.${process.env.BACKSTAGE_ENVIRONMENT}.yaml`,
+      );
       const alwaysIncludeDefaultConfigSource =
         !options.allowMissingDefaultConfig;
 
@@ -190,6 +194,16 @@ export class ConfigSources {
           FileConfigSource.create({
             watch: options.watch,
             path: defaultPath,
+            substitutionFunc: options.substitutionFunc,
+          }),
+        );
+      }
+
+      if (process.env.BACKSTAGE_ENVIRONMENT && fs.pathExistsSync(envPath)) {
+        argSources.push(
+          FileConfigSource.create({
+            watch: options.watch,
+            path: envPath,
             substitutionFunc: options.substitutionFunc,
           }),
         );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

this change allows to specify loading of environment specific config files based on `BACKSTAGE_ENVIRONMENT` environment variable.

relates to #30716

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
