### PR TITLE
frontend-plugin-api: inline RouteResolutionApiResolveOptions

### DIFF
--- a/.changeset/funny-brooms-trade.md
+++ b/.changeset/funny-brooms-trade.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': minor
+---
+
+**BREAKING**: The separate `RouteResolutionApiResolveOptions` type has been removed.

--- a/packages/core-compat-api/src/compatWrapper/ForwardsCompatProvider.tsx
+++ b/packages/core-compat-api/src/compatWrapper/ForwardsCompatProvider.tsx
@@ -33,7 +33,6 @@ import {
   RouteFunc,
   RouteRef,
   RouteResolutionApi,
-  RouteResolutionApiResolveOptions,
   SubRouteRef,
   componentsApiRef,
   coreComponentRefs,
@@ -112,7 +111,7 @@ class CompatRouteResolutionApi implements RouteResolutionApi {
       | RouteRef<TParams>
       | SubRouteRef<TParams>
       | ExternalRouteRef<TParams>,
-    options?: RouteResolutionApiResolveOptions | undefined,
+    options?: { sourcePath?: string },
   ): RouteFunc<TParams> | undefined {
     const legacyRef = convertLegacyRouteRef(anyRouteRef as RouteRef<TParams>);
     return this.#routeResolver.resolve(legacyRef, options?.sourcePath ?? '/');

--- a/packages/frontend-app-api/src/routing/RouteResolver.ts
+++ b/packages/frontend-app-api/src/routing/RouteResolver.ts
@@ -21,7 +21,6 @@ import {
   SubRouteRef,
   AnyRouteRefParams,
   RouteFunc,
-  RouteResolutionApiResolveOptions,
   RouteResolutionApi,
 } from '@backstage/frontend-plugin-api';
 import mapValues from 'lodash/mapValues';
@@ -196,7 +195,7 @@ export class RouteResolver implements RouteResolutionApi {
       | RouteRef<TParams>
       | SubRouteRef<TParams>
       | ExternalRouteRef<TParams>,
-    options?: RouteResolutionApiResolveOptions,
+    options?: { sourcePath?: string },
   ): RouteFunc<TParams> | undefined {
     // First figure out what our target absolute ref is, as well as our target path.
     const [targetRef, targetPath] = resolveTargetRef(

--- a/packages/frontend-app-api/src/wiring/createSpecializedApp.tsx
+++ b/packages/frontend-app-api/src/wiring/createSpecializedApp.tsx
@@ -25,7 +25,6 @@ import {
   SubRouteRef,
   AnyRouteRefParams,
   RouteFunc,
-  RouteResolutionApiResolveOptions,
   RouteResolutionApi,
   createApiFactory,
   routeResolutionApiRef,
@@ -169,7 +168,7 @@ class RouteResolutionApiProxy implements RouteResolutionApi {
       | RouteRef<TParams>
       | SubRouteRef<TParams>
       | ExternalRouteRef<TParams>,
-    options?: RouteResolutionApiResolveOptions,
+    options?: { sourcePath?: string },
   ): RouteFunc<TParams> | undefined {
     if (!this.#delegate) {
       throw new Error(

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -1765,17 +1765,14 @@ export interface RouteResolutionApi {
       | RouteRef<TParams>
       | SubRouteRef<TParams>
       | ExternalRouteRef<TParams>,
-    options?: RouteResolutionApiResolveOptions,
+    options?: {
+      sourcePath?: string;
+    },
   ): RouteFunc<TParams> | undefined;
 }
 
 // @public
 export const routeResolutionApiRef: ApiRef<RouteResolutionApi>;
-
-// @public (undocumented)
-export type RouteResolutionApiResolveOptions = {
-  sourcePath?: string;
-};
 
 export { SessionApi };
 

--- a/packages/frontend-plugin-api/src/apis/definitions/RouteResolutionApi.ts
+++ b/packages/frontend-plugin-api/src/apis/definitions/RouteResolutionApi.ts
@@ -44,24 +44,19 @@ export type RouteFunc<TParams extends AnyRouteRefParams> = (
 /**
  * @public
  */
-export type RouteResolutionApiResolveOptions = {
-  /**
-   * An absolute path to use as a starting point when resolving the route.
-   * If no path is provided the route will be resolved from the root of the app.
-   */
-  sourcePath?: string;
-};
-
-/**
- * @public
- */
 export interface RouteResolutionApi {
   resolve<TParams extends AnyRouteRefParams>(
     anyRouteRef:
       | RouteRef<TParams>
       | SubRouteRef<TParams>
       | ExternalRouteRef<TParams>,
-    options?: RouteResolutionApiResolveOptions,
+    options?: {
+      /**
+       * An absolute path to use as a starting point when resolving the route.
+       * If no path is provided the route will be resolved from the root of the app.
+       */
+      sourcePath?: string;
+    },
   ): RouteFunc<TParams> | undefined;
 }
 


### PR DESCRIPTION
🧹, just a bit of cleanup. This isn't used outside the framework itself.