### PR TITLE
create-app - Adjusted package order

### DIFF
--- a/.changeset/legal-donkeys-camp.md
+++ b/.changeset/legal-donkeys-camp.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Updated order of packages in the `app-next` `package.json` so that there isn't a changed file other than the `yarn.lock` when creating an instance

--- a/packages/create-app/templates/next-app/packages/app/package.json.hbs
+++ b/packages/create-app/templates/next-app/packages/app/package.json.hbs
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@backstage/core-compat-api": "^{{ version '@backstage/core-compat-api'}}",
+    "@backstage/core-components": "^{{ version '@backstage/core-components'}}",
     "@backstage/frontend-defaults": "^{{ version '@backstage/frontend-defaults'}}",
     "@backstage/frontend-plugin-api": "^{{ version '@backstage/frontend-plugin-api'}}",
     "@backstage/plugin-catalog": "^{{ version '@backstage/plugin-catalog'}}",
@@ -22,7 +23,6 @@
     "@backstage/plugin-scaffolder": "^{{ version '@backstage/plugin-scaffolder'}}",
     "@backstage/plugin-search": "^{{ version '@backstage/plugin-search'}}",
     "@backstage/plugin-user-settings": "^{{ version '@backstage/plugin-user-settings'}}",
-    "@backstage/core-components": "^{{ version '@backstage/core-components'}}",
     "@backstage/ui": "^{{ version '@backstage/ui'}}",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

While trying out the new `--next` flag I noticed that there's two uncommitted changes, one of them was due to the order of packages, this PR fixes this.

Screenshot for reference:

<img width="1375" height="774" alt="image" src="https://github.com/user-attachments/assets/3b1b7bdd-d7e9-4056-9991-e0d7818d0b41" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
