### PR TITLE
docs - Added additional properties note to `1.40.0` release notes

### DIFF
--- a/docs/releases/v1.40.0.md
+++ b/docs/releases/v1.40.0.md
@@ -56,6 +56,16 @@ createTemplateAction({
 
 ```
 
+:::note
+
+As the new `zod` format is more strict if there are any additional properties in your Software Template YAML where you define your action it will trigger an `InputError`. Here is an exact example for reference:
+
+> "InputError: Invalid input passed to action publish:github, instance is not allowed to have the additional property "allowedHosts"
+
+To fix these you will simply need to remove the extra property details in your Software Template YAML where you define your action.
+
+:::
+
 The `scaffolder-backend` plugin has been converted to being New Backend System only, which means a lot of the public API has been cleaned up.
 
 The `createRouter` and `createBuiltinActions` have been removed as they were only used in the legacy backend system.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added additional properties note to `1.40.0` release notes as this came up on Discord - https://discord.com/channels/687207715902193673/1397165472818008064 - and it wasn't communicated that this would be something that happens. The is a bit on the late side but for those who might not have upgraded yet this could help.

<img width="1097" height="437" alt="Screenshot 2025-08-02 at 1 01 24 PM" src="https://github.com/user-attachments/assets/3bf6289d-999c-4b93-82c5-9763610d3797" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
