### PR TITLE
[NFS](frontend-plugin-api): remove deprecated `AppNodeSpec.source`

### DIFF
--- a/.changeset/chatty-schools-post.md
+++ b/.changeset/chatty-schools-post.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': minor
+---
+
+**BREAKING**: Remove deprecated `source` property from the `AppNodeSpec` type, use `AppNodeSpec.plugin` instead.

--- a/packages/app-next/src/examples/pagesPlugin.tsx
+++ b/packages/app-next/src/examples/pagesPlugin.tsx
@@ -44,7 +44,7 @@ function PluginInfo() {
   const [info, setInfo] = useState<FrontendPluginInfo | undefined>(undefined);
 
   useEffect(() => {
-    node?.spec.source?.info().then(setInfo);
+    node?.spec.plugin?.info().then(setInfo);
   }, [node]);
 
   return (

--- a/packages/frontend-app-api/src/tree/instantiateAppNodeTree.test.ts
+++ b/packages/frontend-app-api/src/tree/instantiateAppNodeTree.test.ts
@@ -56,7 +56,6 @@ function makeSpec<TConfig, TConfigInput>(
     attachTo: extension.attachTo,
     disabled: extension.disabled,
     extension: extension as Extension<unknown, unknown>,
-    source: undefined,
     plugin: undefined,
     ...spec,
   };

--- a/packages/frontend-app-api/src/wiring/createSpecializedApp.test.tsx
+++ b/packages/frontend-app-api/src/wiring/createSpecializedApp.test.tsx
@@ -691,7 +691,7 @@ describe('createSpecializedApp', () => {
 
       await expect(plugin.info()).rejects.toThrow(errorMsg);
 
-      const installedPlugin = app.tree.nodes.get('test')?.spec.source;
+      const installedPlugin = app.tree.nodes.get('test')?.spec.plugin;
       expect(installedPlugin).toBeDefined();
       const info = await installedPlugin?.info();
       expect(info).toEqual({});
@@ -707,7 +707,7 @@ describe('createSpecializedApp', () => {
       });
 
       const app = createSpecializedApp({ features: [plugin] });
-      const info = await app.tree.nodes.get('test')?.spec.source?.info();
+      const info = await app.tree.nodes.get('test')?.spec.plugin?.info();
       expect(info).toMatchObject({
         packageName: '@backstage/frontend-app-api',
       });
@@ -730,7 +730,7 @@ describe('createSpecializedApp', () => {
       });
 
       const app = createSpecializedApp({ features: [overriddenPlugin] });
-      const info = await app.tree.nodes.get('test')?.spec.source?.info();
+      const info = await app.tree.nodes.get('test')?.spec.plugin?.info();
       expect(info).toMatchObject({
         packageName: 'test-override',
       });
@@ -754,7 +754,7 @@ describe('createSpecializedApp', () => {
       });
 
       const app = createSpecializedApp({ features: [plugin] });
-      const info = await app.tree.nodes.get('test')?.spec.source?.info();
+      const info = await app.tree.nodes.get('test')?.spec.plugin?.info();
       expect(info).toEqual({
         packageName: '@backstage/frontend-app-api',
         version: expect.any(String),
@@ -782,7 +782,7 @@ describe('createSpecializedApp', () => {
           return { info: { packageName: `decorated:${info.packageName}` } };
         },
       });
-      const info = await app.tree.nodes.get('test')?.spec.source?.info();
+      const info = await app.tree.nodes.get('test')?.spec.plugin?.info();
       expect(info).toEqual({
         packageName: 'decorated:@backstage/frontend-app-api',
       });

--- a/packages/frontend-defaults/src/createApp.test.tsx
+++ b/packages/frontend-defaults/src/createApp.test.tsx
@@ -131,7 +131,7 @@ describe('createApp', () => {
       );
 
       useEffect(() => {
-        appNode?.spec.source?.info().then(setInfo);
+        appNode?.spec.plugin?.info().then(setInfo);
       }, [appNode]);
 
       return <div>Package name: {info?.packageName}</div>;

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -245,8 +245,6 @@ export interface AppNodeSpec {
   readonly id: string;
   // (undocumented)
   readonly plugin?: FrontendPlugin;
-  // @deprecated (undocumented)
-  readonly source?: FrontendPlugin;
 }
 
 // @public

--- a/packages/frontend-plugin-api/src/apis/definitions/AppTreeApi.ts
+++ b/packages/frontend-plugin-api/src/apis/definitions/AppTreeApi.ts
@@ -38,10 +38,6 @@ export interface AppNodeSpec {
   readonly disabled: boolean;
   readonly config?: unknown;
   readonly plugin?: FrontendPlugin;
-  /**
-   * @deprecated Use {@link AppNodeSpec.plugin} instead.
-   */
-  readonly source?: FrontendPlugin;
 }
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Remove deprecated `source` property from the `AppNodeSpec` type, use `AppNodeSpec.plugin` instead.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
