### PR TITLE
fix: Add VisitListContextProvider with colorVariants prop to allow cu…

### DIFF
--- a/.changeset/tame-crabs-strive.md
+++ b/.changeset/tame-crabs-strive.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-home': patch
+---
+
+Add VisitListContextProvider with colorVariants prop to allow custom chip colors in Recent & Top Visited

--- a/plugins/home/README.md
+++ b/plugins/home/README.md
@@ -356,6 +356,43 @@ home:
 
 In order to validate the config you can use `backstage/cli config:check`
 
+### Custom Chip Colors
+
+If you want to provide your own chip colors for the recent and top visited lists, you can wrap the components in `VisitListContextProvider` with custom `colorVariants`. The colors provided will be used instead of the hard coded [colorVariants](https://github.com/backstage/backstage/blob/2da352043425bcab4c4422e4d2820c26c0a83382/packages/theme/src/base/pageTheme.ts#L46) provided via `@backstage/theme`.
+
+```tsx
+import {
+  CustomHomepageGrid,
+  HomePageTopVisited,
+  HomePageRecentlyVisited,
+  VisitListContextProvider,
+} from '@backstage/plugin-home';
+
+const customColorVariants = {
+  purple: ['#b39ddb'],
+  blue: ['#90caf9'],
+  softGreen: ['#a5d6a7'],
+  yellow: ['#fff59d'],
+  orange: ['#ffb74d'],
+  tan: ['#ffe0b2'],
+  red: ['#ef9a9a'],
+  gray: ['#bdbdbd'],
+  brown: ['#bcaaa4'],
+  pink: ['#f48fb1'],
+};
+
+export default function HomePage() {
+  return (
+    <VisitListContextProvider colorVariants={customColorVariants}>
+      <CustomHomepageGrid title="Your Dashboard">
+        <HomePageRecentlyVisited />
+        <HomePageTopVisited />
+      </CustomHomepageGrid>
+    </VisitListContextProvider>
+  );
+}
+```
+
 ## Contributing
 
 ### Homepage Components

--- a/plugins/home/report.api.md
+++ b/plugins/home/report.api.md
@@ -246,6 +246,9 @@ export type ToolkitContentProps = {
 };
 
 // @public
+export const useColorVariants: () => Record<string, string[]>;
+
+// @public
 export type Visit = {
   id: string;
   name: string;
@@ -265,6 +268,18 @@ export type VisitedByTypeProps = {
   numVisitsTotal?: number;
   loading?: boolean;
   kind: VisitedByTypeKind;
+};
+
+// @public
+export const VisitListContextProvider: ({
+  children,
+  colorVariants,
+}: VisitListContextProviderProps) => JSX_2.Element;
+
+// @public
+export type VisitListContextProviderProps = {
+  children: ReactNode;
+  colorVariants?: Record<string, string[]>;
 };
 
 // @public

--- a/plugins/home/src/components/VisitList/Context.tsx
+++ b/plugins/home/src/components/VisitList/Context.tsx
@@ -18,15 +18,27 @@ import { colorVariants as defaultColorVariants } from '@backstage/theme';
 
 const VisitListContext = createContext(defaultColorVariants);
 
+/**
+ * Hook to access color variants from the VisitList context
+ * @public
+ */
 export const useColorVariants = () => {
   return useContext(VisitListContext);
 };
 
-type VisitListContextProviderProps = {
+/**
+ * Props for VisitListContextProvider
+ * @public
+ */
+export type VisitListContextProviderProps = {
   children: ReactNode;
   colorVariants?: Record<string, string[]>;
 };
 
+/**
+ * Context provider for VisitList color variants (used for chip colors)
+ * @public
+ */
 export const VisitListContextProvider = ({
   children,
   colorVariants = defaultColorVariants,

--- a/plugins/home/src/components/VisitList/Context.tsx
+++ b/plugins/home/src/components/VisitList/Context.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ReactNode, createContext, useContext } from 'react';
+import { colorVariants as defaultColorVariants } from '@backstage/theme';
+
+const VisitListContext = createContext(defaultColorVariants);
+
+export const useColorVariants = () => {
+  return useContext(VisitListContext);
+};
+
+type VisitListContextProviderProps = {
+  children: ReactNode;
+  colorVariants?: Record<string, string[]>;
+};
+
+export const VisitListContextProvider = ({
+  children,
+  colorVariants = defaultColorVariants,
+}: VisitListContextProviderProps) => {
+  return (
+    <VisitListContext.Provider value={colorVariants}>
+      {children}
+    </VisitListContext.Provider>
+  );
+};

--- a/plugins/home/src/components/VisitList/ItemCategory.tsx
+++ b/plugins/home/src/components/VisitList/ItemCategory.tsx
@@ -16,7 +16,7 @@
 
 import Chip from '@material-ui/core/Chip';
 import { makeStyles } from '@material-ui/core/styles';
-import { colorVariants } from '@backstage/theme';
+import { useColorVariants } from './Context';
 import { Visit } from '../../api/VisitsApi';
 import { CompoundEntityRef, parseEntityRef } from '@backstage/catalog-model';
 
@@ -34,13 +34,19 @@ const maybeEntity = (visit: Visit): CompoundEntityRef | undefined => {
     return undefined;
   }
 };
-const getColorByIndex = (index: number) => {
+const getColorByIndex = (
+  index: number,
+  colorVariants: Record<string, string[]>,
+): string => {
   const variants = Object.keys(colorVariants);
   const variantIndex = index % variants.length;
   return colorVariants[variants[variantIndex]][0];
 };
-const getChipColor = (entity: CompoundEntityRef | undefined): string => {
-  const defaultColor = getColorByIndex(0);
+const getChipColor = (
+  entity: CompoundEntityRef | undefined,
+  colorVariants: Record<string, string[]>,
+): string => {
+  const defaultColor = getColorByIndex(0, colorVariants);
   if (!entity) return defaultColor;
 
   // IDEA: Use or replicate useAllKinds hook thus supporting all software catalog
@@ -61,10 +67,13 @@ const getChipColor = (entity: CompoundEntityRef | undefined): string => {
   const foundIndex = entityKinds.indexOf(
     entity.kind.toLocaleLowerCase('en-US'),
   );
-  return foundIndex === -1 ? defaultColor : getColorByIndex(foundIndex + 1);
+  return foundIndex === -1
+    ? defaultColor
+    : getColorByIndex(foundIndex + 1, colorVariants);
 };
 
 export const ItemCategory = ({ visit }: { visit: Visit }) => {
+  const colorVariants = useColorVariants();
   const classes = useStyles();
   const entity = maybeEntity(visit);
 
@@ -73,7 +82,7 @@ export const ItemCategory = ({ visit }: { visit: Visit }) => {
       size="small"
       className={classes.chip}
       label={(entity?.kind ?? 'Other').toLocaleLowerCase('en-US')}
-      style={{ background: getChipColor(entity) }}
+      style={{ background: getChipColor(entity, colorVariants) }}
     />
   );
 };

--- a/plugins/home/src/components/VisitList/index.ts
+++ b/plugins/home/src/components/VisitList/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { VisitList } from './VisitList';
+export { VisitListContextProvider, useColorVariants } from './Context';

--- a/plugins/home/src/components/VisitList/index.ts
+++ b/plugins/home/src/components/VisitList/index.ts
@@ -14,4 +14,8 @@
  * limitations under the License.
  */
 
-export { VisitListContextProvider, useColorVariants } from './Context';
+export {
+  VisitListContextProvider,
+  useColorVariants,
+  type VisitListContextProviderProps,
+} from './Context';

--- a/plugins/home/src/components/index.ts
+++ b/plugins/home/src/components/index.ts
@@ -17,3 +17,4 @@
 export { HomepageCompositionRoot } from './HomepageCompositionRoot';
 export * from './CustomHomepage';
 export * from './VisitListener';
+export * from './VisitList';

--- a/plugins/home/src/homePageComponents/VisitedByType/VisitedByType.tsx
+++ b/plugins/home/src/homePageComponents/VisitedByType/VisitedByType.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { VisitList } from '../../components/VisitList';
+import { VisitList } from '../../components/VisitList/VisitList';
 import { useContext } from './Context';
 
 export const VisitedByType = () => {


### PR DESCRIPTION
…stom chip colors in Recent & Top Visited

## Hey, I just made a Pull Request!

Added `VisitListContextProvider` to `@backstage/plugin-home` with `colorVariants` property. Users can wrap recently visited & top visited home page components in the provider to allow for custom chip colors instead of the hard coded [colorVariants](https://github.com/backstage/backstage/blob/2da352043425bcab4c4422e4d2820c26c0a83382/packages/theme/src/base/pageTheme.ts#L46) inside `@backstage/theme`. 

I tried to keep the changes minimal since I assume the main focus is on the new frontend plugin & design systems. 

I considered adding a new configuration property `home.visitsChipColors` but wanted to allow the user flexibility if they wanted to use different colors for different themes. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
