### PR TITLE
techdocs: Disallow javascript URLs

### DIFF
--- a/.changeset/great-adults-stare.md
+++ b/.changeset/great-adults-stare.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': minor
+---
+
+Ensure that techdocs rewritten URLs do not contain potentially dangerous javascript: URLs.

--- a/plugins/techdocs/src/reader/transformers/rewriteDocLinks.test.ts
+++ b/plugins/techdocs/src/reader/transformers/rewriteDocLinks.test.ts
@@ -71,6 +71,33 @@ describe('rewriteDocLinks', () => {
     expect(getSample(shadowDom, 'a', 'href')).toEqual([]);
     expect(shadowDom.innerHTML).toContain(expectedText);
   });
+
+  it('should rewrite javascript hrefs as text', async () => {
+    const samples: Array<[string, string]> = [
+      // eslint-disable-next-line no-script-url
+      ['javascript:alert(1)', 'JS 1'],
+      ['  javascript:alert(2)', 'JS 2 (leading space)'],
+      ['\n\tjavascript:alert(3)', 'JS 3 (whitespace)'],
+      // eslint-disable-next-line no-script-url
+      ['JaVaScRiPt:alert(4)', 'JS 4 (mixed case)'],
+      ['javascript&#x3A;alert(5)', 'JS 5 (entity-encoded colon)'],
+    ];
+
+    const html = samples
+      .map(([href, text]) => `<a href="${href}">${text}</a>`)
+      .join('\n');
+
+    const shadowDom = await createTestShadowDom(html, {
+      preTransformers: [rewriteDocLinks()],
+      postTransformers: [],
+    });
+
+    // There should be no <a> tags, but the link text should remain.
+    expect(getSample(shadowDom, 'a', 'href')).toEqual([]);
+    for (const [, text] of samples) {
+      expect(shadowDom.innerHTML).toContain(text);
+    }
+  });
 });
 
 describe('normalizeUrl', () => {

--- a/plugins/techdocs/src/reader/transformers/rewriteDocLinks.ts
+++ b/plugins/techdocs/src/reader/transformers/rewriteDocLinks.ts
@@ -16,6 +16,11 @@
 
 import type { Transformer } from './transformer';
 
+// See https://github.com/facebook/react/blob/f0cf832e1d0c8544c36aa8b310960885a11a847c/packages/react-dom-bindings/src/shared/sanitizeURL.js
+const scriptProtocolPattern =
+  // eslint-disable-next-line no-control-regex
+  /^[\u0000-\u001F ]*j[\r\n\t]*a[\r\n\t]*v[\r\n\t]*a[\r\n\t]*s[\r\n\t]*c[\r\n\t]*r[\r\n\t]*i[\r\n\t]*p[\r\n\t]*t[\r\n\t]*\:/i;
+
 export const rewriteDocLinks = (): Transformer => {
   return dom => {
     const updateDom = <T extends Element>(
@@ -33,6 +38,12 @@ export const rewriteDocLinks = (): Transformer => {
             }
 
             try {
+              if (scriptProtocolPattern.test(elemAttribute)) {
+                throw new TypeError(
+                  `Invalid location ref '${elemAttribute}', target is a javascript: URL`,
+                );
+              }
+
               const normalizedWindowLocation = normalizeUrl(
                 window.location.href,
               );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

`techdocs` now checks whether a dangerous URL, using the `javascript` schema, is going to be written used for the `href` attribute of an `a` tag. In the event this does happen, the link will just be a text. This change brings `techdocs` in line with how `techdocs-node` works.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
