### PR TITLE
frontend-plugin-api: remove AnyRoutes and AnyExternalRoutes

### DIFF
--- a/.changeset/itchy-doodles-boil.md
+++ b/.changeset/itchy-doodles-boil.md
@@ -1,0 +1,12 @@
+---
+'@backstage/frontend-plugin-api': minor
+---
+
+**BREAKING**: The `AnyRoutes` and `AnyExternalRoutes` types have been removed and their usage has been inlined instead.
+
+Existing usage can be replaced according to their previous definitions:
+
+```ts
+type AnyRoutes = { [name in string]: RouteRef | SubRouteRef };
+type AnyExternalRoutes = { [name in string]: ExternalRouteRef };
+```

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -154,22 +154,12 @@ export { AnyApiRef };
 // @public @deprecated (undocumented)
 export type AnyExtensionDataRef = ExtensionDataRef;
 
-// @public (undocumented)
-export type AnyExternalRoutes = {
-  [name in string]: ExternalRouteRef;
-};
-
 // @public
 export type AnyRouteRefParams =
   | {
       [param in string]: string;
     }
   | undefined;
-
-// @public (undocumented)
-export type AnyRoutes = {
-  [name in string]: RouteRef | SubRouteRef;
-};
 
 // @public
 export const ApiBlueprint: ExtensionBlueprint<{
@@ -761,8 +751,12 @@ export interface CreateFrontendModuleOptions<
 // @public (undocumented)
 export function createFrontendPlugin<
   TId extends string,
-  TRoutes extends AnyRoutes = {},
-  TExternalRoutes extends AnyExternalRoutes = {},
+  TRoutes extends {
+    [name in string]: RouteRef | SubRouteRef;
+  } = {},
+  TExternalRoutes extends {
+    [name in string]: ExternalRouteRef;
+  } = {},
   TExtensions extends readonly ExtensionDefinition[] = [],
 >(
   options: PluginOptions<TId, TRoutes, TExternalRoutes, TExtensions>,
@@ -775,8 +769,12 @@ export function createFrontendPlugin<
 // @public @deprecated (undocumented)
 export function createFrontendPlugin<
   TId extends string,
-  TRoutes extends AnyRoutes = {},
-  TExternalRoutes extends AnyExternalRoutes = {},
+  TRoutes extends {
+    [name in string]: RouteRef | SubRouteRef;
+  } = {},
+  TExternalRoutes extends {
+    [name in string]: ExternalRouteRef;
+  } = {},
   TExtensions extends readonly ExtensionDefinition[] = [],
 >(
   options: Omit<
@@ -1345,8 +1343,16 @@ export interface FrontendModule {
 
 // @public (undocumented)
 export interface FrontendPlugin<
-  TRoutes extends AnyRoutes = AnyRoutes,
-  TExternalRoutes extends AnyExternalRoutes = AnyExternalRoutes,
+  TRoutes extends {
+    [name in string]: RouteRef | SubRouteRef;
+  } = {
+    [name in string]: RouteRef | SubRouteRef;
+  },
+  TExternalRoutes extends {
+    [name in string]: ExternalRouteRef;
+  } = {
+    [name in string]: ExternalRouteRef;
+  },
   TExtensionMap extends {
     [id in string]: ExtensionDefinition;
   } = {
@@ -1572,8 +1578,12 @@ export { PendingOAuthRequest };
 // @public (undocumented)
 export interface PluginOptions<
   TId extends string,
-  TRoutes extends AnyRoutes,
-  TExternalRoutes extends AnyExternalRoutes,
+  TRoutes extends {
+    [name in string]: RouteRef | SubRouteRef;
+  },
+  TExternalRoutes extends {
+    [name in string]: ExternalRouteRef;
+  },
   TExtensions extends readonly ExtensionDefinition[],
 > {
   // (undocumented)

--- a/packages/frontend-plugin-api/src/wiring/createFrontendPlugin.ts
+++ b/packages/frontend-plugin-api/src/wiring/createFrontendPlugin.ts
@@ -23,9 +23,10 @@ import {
   Extension,
   resolveExtensionDefinition,
 } from './resolveExtensionDefinition';
-import { AnyExternalRoutes, AnyRoutes, FeatureFlagConfig } from './types';
+import { FeatureFlagConfig } from './types';
 import { MakeSortedExtensionsMap } from './MakeSortedExtensionsMap';
 import { JsonObject } from '@backstage/types';
+import { RouteRef, SubRouteRef, ExternalRouteRef } from '../routing';
 
 /**
  * Information about the plugin.
@@ -89,8 +90,12 @@ export type FrontendPluginInfoOptions = {
 
 /** @public */
 export interface FrontendPlugin<
-  TRoutes extends AnyRoutes = AnyRoutes,
-  TExternalRoutes extends AnyExternalRoutes = AnyExternalRoutes,
+  TRoutes extends { [name in string]: RouteRef | SubRouteRef } = {
+    [name in string]: RouteRef | SubRouteRef;
+  },
+  TExternalRoutes extends { [name in string]: ExternalRouteRef } = {
+    [name in string]: ExternalRouteRef;
+  },
   TExtensionMap extends { [id in string]: ExtensionDefinition } = {
     [id in string]: ExtensionDefinition;
   },
@@ -118,8 +123,8 @@ export interface FrontendPlugin<
 /** @public */
 export interface PluginOptions<
   TId extends string,
-  TRoutes extends AnyRoutes,
-  TExternalRoutes extends AnyExternalRoutes,
+  TRoutes extends { [name in string]: RouteRef | SubRouteRef },
+  TExternalRoutes extends { [name in string]: ExternalRouteRef },
   TExtensions extends readonly ExtensionDefinition[],
 > {
   pluginId: TId;
@@ -133,8 +138,8 @@ export interface PluginOptions<
 /** @public */
 export function createFrontendPlugin<
   TId extends string,
-  TRoutes extends AnyRoutes = {},
-  TExternalRoutes extends AnyExternalRoutes = {},
+  TRoutes extends { [name in string]: RouteRef | SubRouteRef } = {},
+  TExternalRoutes extends { [name in string]: ExternalRouteRef } = {},
   TExtensions extends readonly ExtensionDefinition[] = [],
 >(
   options: PluginOptions<TId, TRoutes, TExternalRoutes, TExtensions>,
@@ -149,8 +154,8 @@ export function createFrontendPlugin<
  */
 export function createFrontendPlugin<
   TId extends string,
-  TRoutes extends AnyRoutes = {},
-  TExternalRoutes extends AnyExternalRoutes = {},
+  TRoutes extends { [name in string]: RouteRef | SubRouteRef } = {},
+  TExternalRoutes extends { [name in string]: ExternalRouteRef } = {},
   TExtensions extends readonly ExtensionDefinition[] = [],
 >(
   options: Omit<
@@ -164,8 +169,8 @@ export function createFrontendPlugin<
 >;
 export function createFrontendPlugin<
   TId extends string,
-  TRoutes extends AnyRoutes = {},
-  TExternalRoutes extends AnyExternalRoutes = {},
+  TRoutes extends { [name in string]: RouteRef | SubRouteRef } = {},
+  TExternalRoutes extends { [name in string]: ExternalRouteRef } = {},
   TExtensions extends readonly ExtensionDefinition[] = [],
 >(
   options:

--- a/packages/frontend-plugin-api/src/wiring/index.ts
+++ b/packages/frontend-plugin-api/src/wiring/index.ts
@@ -55,8 +55,6 @@ export {
 } from './createFrontendFeatureLoader';
 export { type Extension } from './resolveExtensionDefinition';
 export {
-  type AnyRoutes,
-  type AnyExternalRoutes,
   type ExtensionDataContainer,
   type FeatureFlagConfig,
   type ExtensionFactoryMiddleware,

--- a/packages/frontend-plugin-api/src/wiring/types.ts
+++ b/packages/frontend-plugin-api/src/wiring/types.ts
@@ -15,7 +15,6 @@
  */
 
 import { JsonObject } from '@backstage/types';
-import { ExternalRouteRef, RouteRef, SubRouteRef } from '../routing';
 import { ExtensionDefinition } from './createExtension';
 import { ExtensionDataRef, ExtensionDataValue } from './createExtensionDataRef';
 import { ApiHolder, AppNode } from '../apis';
@@ -31,12 +30,6 @@ export type FeatureFlagConfig = {
   /** Feature flag name */
   name: string;
 };
-
-/** @public */
-export type AnyRoutes = { [name in string]: RouteRef | SubRouteRef };
-
-/** @public */
-export type AnyExternalRoutes = { [name in string]: ExternalRouteRef };
 
 /** @public */
 export type ExtensionMap<


### PR DESCRIPTION
🧹, these were quite redundant, only used in a few specific places in the system itself.