### PR TITLE
populate missing profile fields from catalog entity

### DIFF
--- a/.changeset/nine-times-fold.md
+++ b/.changeset/nine-times-fold.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-user-settings': patch
+---
+
+For any undefined field in the user's profile (picture, displayName, email), populate it from the user's catalog entity

--- a/plugins/user-settings/src/components/useUserProfileInfo.ts
+++ b/plugins/user-settings/src/components/useUserProfileInfo.ts
@@ -37,15 +37,24 @@ export const useUserProfile = () => {
     const catalogProfile = (await catalogApi.getEntityByRef(
       backStageIdentity.userEntityRef,
     )) as unknown as UserEntity;
-    if (
-      identityProfile.picture === undefined &&
-      catalogProfile?.spec?.profile?.picture
-    ) {
-      identityProfile = {
-        ...identityProfile,
-        picture: catalogProfile.spec.profile.picture,
-      };
-    }
+    // Merge catalog profile fields into identity profile if missing
+    const fieldsToMerge: (keyof ProfileInfo)[] = [
+      'picture',
+      'displayName',
+      'email',
+    ];
+    identityProfile = fieldsToMerge.reduce((profile, field) => {
+      if (
+        profile[field] === undefined &&
+        catalogProfile?.spec?.profile?.[field]
+      ) {
+        return {
+          ...profile,
+          [field]: catalogProfile.spec.profile[field],
+        };
+      }
+      return profile;
+    }, identityProfile);
     return {
       profile: identityProfile,
       identity: backStageIdentity,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Auto-populate undefined user profile fields (picture, displayName, email) from the user's catalog entity when they are not available in the identity profile. This provides a fallback mechanism to ensure user profiles are more complete by leveraging catalog data.

This is particularly useful when logging in using the Guest auth provider, and a particular catalog user entity. This ensures that the user's profile will be populated with all appropriate fields from that catalog user entity, which improves the usability of the Guest provider for local testing.

Previously, only the user's picture was populated into the identity profile. This PR extends that behavior to also include the email and displayName properties.

Before:
<img width="817" height="589" alt="image" src="https://github.com/user-attachments/assets/46b2677d-a3c6-4f07-8d3e-f8400ceb624b" />

<img width="228" height="128" alt="image" src="https://github.com/user-attachments/assets/f09e5e3a-86bf-4ffb-bf77-8d0e845416b0" />

After:
<img width="112" height="71" alt="image" src="https://github.com/user-attachments/assets/b41002d1-df74-4fbe-b79c-d0a541a1d9f4" />

<img width="817" height="589" alt="image" src="https://github.com/user-attachments/assets/a24834ab-0080-4fbe-a6c6-32417c294dbd" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
