### PR TITLE
docs: Corrected DCO instructions to use uppercase -S for signed commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -292,7 +292,7 @@ As with other CNCF projects, Backstage has adopted a [Developers Certificate of 
 
 To certify the code you submit to the repository, you'll need to add a `Signed-off-by` line to your commits.
 
-`$ git commit -s -m 'Awesome commit message'`
+`$ git commit -S -m 'Awesome commit message'`
 
 Which will look something like the following in the repo;
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The documentation previously used -s for the git commit command when referring to signed commits. Updated it to -S to correctly indicate GPG-signed commits as required by the DCO.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
