### PR TITLE
Adjusted the dialog API types to have more sensible defaults

### DIFF
--- a/.changeset/short-parks-love.md
+++ b/.changeset/short-parks-love.md
@@ -1,0 +1,6 @@
+---
+'@backstage/frontend-plugin-api': patch
+'@backstage/plugin-app': patch
+---
+
+Adjusted the dialog API types to have more sensible defaults

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -880,14 +880,14 @@ export { createTranslationResource };
 
 // @public
 export interface DialogApi {
-  show<TResult = {}>(
+  show<TResult = void>(
     elementOrComponent:
       | JSX.Element
       | ((props: {
           dialog: DialogApiDialog<TResult | undefined>;
         }) => JSX.Element),
   ): DialogApiDialog<TResult | undefined>;
-  showModal<TResult = {}>(
+  showModal<TResult = void>(
     elementOrComponent:
       | JSX.Element
       | ((props: { dialog: DialogApiDialog<TResult> }) => JSX.Element),
@@ -895,7 +895,7 @@ export interface DialogApi {
 }
 
 // @public
-export interface DialogApiDialog<TResult = unknown> {
+export interface DialogApiDialog<TResult = void> {
   close(
     ...args: undefined extends TResult ? [result?: TResult] : [result: TResult]
   ): void;

--- a/packages/frontend-plugin-api/src/apis/definitions/DialogApi.ts
+++ b/packages/frontend-plugin-api/src/apis/definitions/DialogApi.ts
@@ -25,7 +25,7 @@ import { createApiRef } from '@backstage/core-plugin-api';
  *
  * @public
  */
-export interface DialogApiDialog<TResult = unknown> {
+export interface DialogApiDialog<TResult = void> {
   /**
    * Closes the dialog with that provided result.
    *
@@ -109,7 +109,7 @@ export interface DialogApi {
    * @param elementOrComponent - The element or component to render in the dialog. If a component is provided, it will be provided with a `dialog` prop that contains the dialog handle.
    * @public
    */
-  show<TResult = {}>(
+  show<TResult = void>(
     elementOrComponent:
       | JSX.Element
       | ((props: {
@@ -161,7 +161,7 @@ export interface DialogApi {
    * @param elementOrComponent - The element or component to render in the dialog. If a component is provided, it will be provided with a `dialog` prop that contains the dialog handle.
    * @public
    */
-  showModal<TResult = {}>(
+  showModal<TResult = void>(
     elementOrComponent:
       | JSX.Element
       | ((props: { dialog: DialogApiDialog<TResult> }) => JSX.Element),

--- a/plugins/app/README.md
+++ b/plugins/app/README.md
@@ -1,9 +1,3 @@
 # app
 
-Welcome to the app plugin!
-
-_This plugin was created through the Backstage CLI_
-
-## Getting started
-
-Your plugin has been added to the example app in this repository, meaning you'll be able to access it by running `yarn start` in the root directory, and then navigating to [/app](http://localhost:3000/app).
+This plugin is part of the new frontend system, and represents the foundation of the frontend application itself, which then other features attach themselves into.

--- a/plugins/app/src/apis/DefaultDialogApi.ts
+++ b/plugins/app/src/apis/DefaultDialogApi.ts
@@ -19,7 +19,7 @@ import { DialogApi, DialogApiDialog } from '@backstage/frontend-plugin-api';
 export type OnShowDialog = (options: {
   component: (props: { dialog: DialogApiDialog<any> }) => React.JSX.Element;
   modal: boolean;
-}) => DialogApiDialog;
+}) => DialogApiDialog<unknown>;
 
 /**
  * Default implementation for the {@link DialogApi}.
@@ -28,7 +28,7 @@ export type OnShowDialog = (options: {
 export class DefaultDialogApi implements DialogApi {
   #onShow?: OnShowDialog;
 
-  show<TResult = {}>(
+  show<TResult = void>(
     elementOrComponent:
       | JSX.Element
       | ((props: {
@@ -47,7 +47,7 @@ export class DefaultDialogApi implements DialogApi {
     }) as DialogApiDialog<TResult | undefined>;
   }
 
-  showModal<TResult = {}>(
+  showModal<TResult = void>(
     elementOrComponent:
       | JSX.Element
       | ((props: { dialog: DialogApiDialog<TResult> }) => JSX.Element),

--- a/plugins/app/src/extensions/DialogDisplay.tsx
+++ b/plugins/app/src/extensions/DialogDisplay.tsx
@@ -31,7 +31,7 @@ function getDialogId() {
   return dialogId.toString(36);
 }
 
-type DialogState = DialogApiDialog & {
+type DialogState = DialogApiDialog<unknown> & {
   id: string;
   modal: boolean;
 };


### PR DESCRIPTION
I guessed the void type (that is compatible with undefined) might be the right choice here. We already have usages of `close()` without args and I think this turns out looking OK.