### PR TITLE
nfs: only allow swappable extensions to be installed in the app plugin

### DIFF
--- a/.changeset/cold-lemons-design.md
+++ b/.changeset/cold-lemons-design.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-app': patch
+---
+
+Force installation of `SwappableComponent` extensions using the `app` plugin

--- a/plugins/app/src/extensions/SwappableComponentsApi.ts
+++ b/plugins/app/src/extensions/SwappableComponentsApi.ts
@@ -40,9 +40,14 @@ export const SwappableComponentsApi = ApiBlueprint.makeWithOverrides({
         deps: {},
         factory: () =>
           DefaultSwappableComponentsApi.fromComponents(
-            inputs.components.map(i =>
-              i.get(SwappableComponentBlueprint.dataRefs.component),
-            ),
+            inputs.components.map(i => {
+              if (i.node.spec.plugin?.id !== 'app') {
+                throw new Error(
+                  `SwappableComponents can only be installed as an extension in the app plugin. You can either use appPlugin.override(), or provide a module for the app-plugin with the extension there instead. id={${i.node.spec.id}}`,
+                );
+              }
+              return i.get(SwappableComponentBlueprint.dataRefs.component);
+            }),
           ),
       }),
     );


### PR DESCRIPTION
We don't want random plugins providing these extensions, they should be only provided from the app plugin using an override or a module.

Will add additional docs to this and maybe a link to those docs too.