### PR TITLE
fix(catalog-backend-module-github): Fix entity provider event processing branch matching

### DIFF
--- a/.changeset/thick-hotels-enter.md
+++ b/.changeset/thick-hotels-enter.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+Fix GitHub catalog entity provider branch matching on event processing.

--- a/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.test.ts
@@ -961,6 +961,33 @@ describe('GithubEntityProvider', () => {
 
         expect(entityProviderConnection.refresh).toHaveBeenCalledTimes(1);
       });
+
+      it('should fail with incorrect branch matching', async () => {
+        const config = createSingleProviderConfig({
+          providerConfig: {
+            catalogPath: '**/catalog-info.yaml',
+          },
+        });
+        const provider = createProviders(config)[0];
+
+        const entityProviderConnection: EntityProviderConnection = {
+          applyMutation: jest.fn(),
+          refresh: jest.fn(),
+        };
+        await provider.connect(entityProviderConnection);
+
+        const event = createPushEvent({
+          catalogFile: {
+            action: 'added',
+            path: 'folder1/folder2/folder3/catalog-info.yaml',
+          },
+          ref: 'refs/heads/my-main-branch',
+        });
+
+        await provider.onEvent(event);
+
+        expect(entityProviderConnection.applyMutation).toHaveBeenCalledTimes(0);
+      });
     });
 
     describe('on repository event', () => {

--- a/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.ts
@@ -343,7 +343,7 @@ export class GithubEntityProvider implements EntityProvider, EventSubscriber {
     const branch =
       this.config.filters.branch || event.repository.default_branch;
 
-    if (!event.ref.includes(branch)) {
+    if (event.ref !== `refs/heads/${branch}`) {
       this.logger.debug(`skipping push event from ref ${event.ref}`);
       return;
     }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Assume branch filter or default branch = `main`
Current behavior will match branches `main`, `my-main-branch`, `main/my-branch`, etc. and process the push events.

This PR fixes the matching condition so it will only process the branch that is intended.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
