### PR TITLE
cli: add support for built-in type stripping in Node.js

### DIFF
--- a/.changeset/three-snakes-deny.md
+++ b/.changeset/three-snakes-deny.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+The Node.js transform in `@backstage/cli/config/nodeTransformHooks.mjs` now supports the built-in type stripping in Node.js, which is enabled by default from v22.18.0.

--- a/packages/cli/config/nodeTransformHooks.mjs
+++ b/packages/cli/config/nodeTransformHooks.mjs
@@ -255,6 +255,18 @@ export async function load(url, context, nextLoad) {
     return nextLoad(url, { ...context, format });
   }
 
+  // If the Node.js version we're running supports TypeScript, i.e. type
+  // stripping, we hand over to the default loader. This is done for all cases
+  // except if we're loading a .ts file that's been resolved to CommonJS format.
+  // This is because these files aren't actually CommonJS in the Backstage build
+  // system, and need to be transformed to CommonJS.
+  if (
+    format === 'module-typescript' ||
+    (format === 'module-commonjs' && ext !== '.ts')
+  ) {
+    return nextLoad(url, { ...context, format });
+  }
+
   const transformed = await transformFile(fileURLToPath(url), {
     sourceMaps: 'inline',
     module: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Since Node.js v22.18 the built-in type stripping is enabled by default. This broke our transform a lil bit because of the new `commonjs-typescript` and `module-typescript` formats. Especially the latter caused accidental transform of ESM to CJS, which breaks things.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
