### PR TITLE
style(api-docs): improve styling for dark mode

### DIFF
--- a/.changeset/lazy-webs-brake.md
+++ b/.changeset/lazy-webs-brake.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-api-docs': patch
+---
+
+Improved styling for dark mode

--- a/plugins/api-docs/src/components/AsyncApiDefinitionWidget/AsyncApiDefinition.tsx
+++ b/plugins/api-docs/src/components/AsyncApiDefinitionWidget/AsyncApiDefinition.tsx
@@ -125,8 +125,11 @@ const useStyles = makeStyles(theme => ({
     },
     '& .prose': {
       color: theme.palette.text.secondary,
-      '& h3': {
+      '& h3, code': {
         color: theme.palette.text.primary,
+      },
+      '& a': {
+        color: theme.palette.link,
       },
     },
     '& .bg-gray-100, .bg-gray-200': {


### PR DESCRIPTION
This PR improves styling for dark mode by explicitly adding styling for `code` and `a` tags.

Before: 
<img width="648" height="276" alt="Scherm­afbeelding 2025-08-11 om 16 34 37" src="https://github.com/user-attachments/assets/8144c6a8-9129-4d16-a0be-a1dcaf3c7394" />

After:
<img width="643" height="272" alt="Scherm­afbeelding 2025-08-11 om 16 34 56" src="https://github.com/user-attachments/assets/df4c6fce-2375-4ac1-b36c-e35569e8738b" />

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
