### PR TITLE
[Catalog provider gcp] Support google service account creds json

### DIFF
--- a/.changeset/fluffy-bananas-shake.md
+++ b/.changeset/fluffy-bananas-shake.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-gcp': patch
+---
+
+Added support for optional `authProvider` and `owner` configuration parameters for GkeEntityProvider

--- a/.changeset/fluffy-bananas-shake.md
+++ b/.changeset/fluffy-bananas-shake.md
@@ -3,4 +3,4 @@
 ---
 
 Added support for Google Service account credentials config used in GkeEntityProvider.
-Added support for additional metadata `authProvider` and `owner` to be set for the gke cluster entities.
+Added support for additional metadata `authProvider` and `owner` to be set for the GKE cluster entities.

--- a/.changeset/fluffy-bananas-shake.md
+++ b/.changeset/fluffy-bananas-shake.md
@@ -2,4 +2,5 @@
 '@backstage/plugin-catalog-backend-module-gcp': patch
 ---
 
-Added support for optional `authProvider` and `owner` configuration parameters for GkeEntityProvider
+Added support for Google Service account credentials config used in GkeEntityProvider.
+Added support for additional metadata `authProvider` and `owner` to be set for the gke cluster entities.

--- a/plugins/catalog-backend-module-gcp/README.md
+++ b/plugins/catalog-backend-module-gcp/README.md
@@ -2,6 +2,15 @@
 
 This is an extension module to the plugin-catalog-backend plugin, containing catalog processors and providers to ingest GCP resources as `Resource` kind entities.
 
+## Authentication
+
+The GKE Entity Provider supports two authentication methods:
+
+1. **Service Account Credentials** (recommended for production): Provide Google Service Account credentials directly in the configuration
+2. **Application Default Credentials**: If no credentials are provided, the provider falls back to:
+   - `GOOGLE_APPLICATION_CREDENTIALS` environment variable pointing to a service account key file
+   - Google Cloud SDK default credentials (when running on Google Cloud Platform)
+
 ## installation
 
 Register the plugin in `catalog.ts``
@@ -38,4 +47,19 @@ catalog:
           frequency: { minutes: 30 }
           # supports ISO duration, "human duration" as used in code
           timeout: { minutes: 3 }
+        # Optional: Google Service Account credentials for authentication
+        # If not provided, falls back to Application Default Credentials or GOOGLE_APPLICATION_CREDENTIALS
+        googleServiceAccountCredentials: |
+          {
+            "type": "service_account",
+            "project_id": "your-project-id",
+            "private_key_id": "key-id",
+            "private_key": "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n",
+            "client_email": "your-service-account@your-project.iam.gserviceaccount.com",
+            "client_id": "client-id",
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+            "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/..."
+          }
 ```

--- a/plugins/catalog-backend-module-gcp/README.md
+++ b/plugins/catalog-backend-module-gcp/README.md
@@ -62,4 +62,11 @@ catalog:
             "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
             "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/..."
           }
+        # Optional: Authentication provider for Kubernetes clusters
+        # Defaults to 'google' if not specified
+        # Common values: 'google', 'googleServiceAccount'
+        authProvider: googleServiceAccount
+        # Optional: Owner of the discovered GKE clusters
+        # Defaults to 'unknown' if not specified
+        owner: platform-team
 ```

--- a/plugins/catalog-backend-module-gcp/config.d.ts
+++ b/plugins/catalog-backend-module-gcp/config.d.ts
@@ -44,6 +44,16 @@ export interface Config {
            * @visibility secret
            */
           googleServiceAccountCredentials?: string;
+          /**
+           * (Optional) Authentication provider to use for Kubernetes clusters
+           * Defaults to 'google' for backward compatibility
+           */
+          authProvider?: string;
+          /**
+           * (Optional) Owner of the discovered clusters
+           * Defaults to 'unknown' if not specified
+           */
+          owner?: string;
         };
       };
     };

--- a/plugins/catalog-backend-module-gcp/config.d.ts
+++ b/plugins/catalog-backend-module-gcp/config.d.ts
@@ -38,6 +38,12 @@ export interface Config {
            * (Optional) TaskScheduleDefinition for the refresh.
            */
           schedule: SchedulerServiceTaskScheduleDefinitionConfig;
+          /**
+           * (Optional) Google Service Account credentials for authentication
+           * JSON string containing the service account key
+           * @visibility secret
+           */
+          googleServiceAccountCredentials?: string;
         };
       };
     };

--- a/plugins/catalog-backend-module-gcp/src/providers/GkeEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gcp/src/providers/GkeEntityProvider.test.ts
@@ -306,7 +306,7 @@ describe('GkeEntityProvider', () => {
 
       expect(MockedClusterManagerClient).toHaveBeenCalledWith({
         credentials: mockCredentials,
-        scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+        scopes: ['https://www.googleapis.com/auth/container.readonly'],
       });
     });
 

--- a/plugins/catalog-backend-module-gcp/src/providers/GkeEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gcp/src/providers/GkeEntityProvider.test.ts
@@ -306,7 +306,6 @@ describe('GkeEntityProvider', () => {
 
       expect(MockedClusterManagerClient).toHaveBeenCalledWith({
         credentials: mockCredentials,
-        scopes: ['https://www.googleapis.com/auth/container.readonly'],
       });
     });
 

--- a/plugins/catalog-backend-module-gcp/src/providers/GkeEntityProvider.ts
+++ b/plugins/catalog-backend-module-gcp/src/providers/GkeEntityProvider.ts
@@ -90,7 +90,6 @@ export class GkeEntityProvider implements EntityProvider {
         const credentialsObject = JSON.parse(credentials);
         clusterManagerClient = new container.v1.ClusterManagerClient({
           credentials: credentialsObject,
-          scopes: ['https://www.googleapis.com/auth/container.readonly'],
         });
       } catch (error) {
         throw new Error(

--- a/plugins/catalog-backend-module-gcp/src/providers/GkeEntityProvider.ts
+++ b/plugins/catalog-backend-module-gcp/src/providers/GkeEntityProvider.ts
@@ -47,6 +47,8 @@ export class GkeEntityProvider implements EntityProvider {
   private readonly logger: LoggerService;
   private readonly scheduleFn: () => Promise<void>;
   private readonly gkeParents: string[];
+  private readonly gkeAuthProvider: string | undefined;
+  private readonly gkeOwner: string | undefined;
   private readonly clusterManagerClient: container.v1.ClusterManagerClient;
   private connection?: EntityProviderConnection;
 
@@ -54,11 +56,15 @@ export class GkeEntityProvider implements EntityProvider {
     logger: LoggerService,
     taskRunner: SchedulerServiceTaskRunner,
     gkeParents: string[],
+    gkeAuthProvider: string | undefined,
+    gkeOwner: string | undefined,
     clusterManagerClient: container.v1.ClusterManagerClient,
   ) {
     this.logger = logger;
     this.scheduleFn = this.createScheduleFn(taskRunner);
     this.gkeParents = gkeParents;
+    this.gkeAuthProvider = gkeAuthProvider;
+    this.gkeOwner = gkeOwner;
     this.clusterManagerClient = clusterManagerClient;
   }
 
@@ -125,6 +131,8 @@ export class GkeEntityProvider implements EntityProvider {
       logger,
       scheduler.createScheduledTaskRunner(schedule),
       gkeProviderConfig.getStringArray('parents'),
+      gkeProviderConfig.getOptionalString('authProvider'),
+      gkeProviderConfig.getOptionalString('owner'),
       clusterManagerClient,
     );
   }
@@ -179,7 +187,8 @@ export class GkeEntityProvider implements EntityProvider {
             [ANNOTATION_KUBERNETES_API_SERVER]: `https://${cluster.endpoint}`,
             [ANNOTATION_KUBERNETES_API_SERVER_CA]:
               cluster.masterAuth?.clusterCaCertificate || '',
-            [ANNOTATION_KUBERNETES_AUTH_PROVIDER]: 'google',
+            [ANNOTATION_KUBERNETES_AUTH_PROVIDER]:
+              this.gkeAuthProvider || 'google',
             [ANNOTATION_KUBERNETES_DASHBOARD_APP]: 'gke',
             [ANNOTATION_LOCATION]: location,
             [ANNOTATION_ORIGIN_LOCATION]: location,
@@ -194,7 +203,7 @@ export class GkeEntityProvider implements EntityProvider {
         },
         spec: {
           type: 'kubernetes-cluster',
-          owner: 'unknown',
+          owner: this.gkeOwner || 'unknown',
         },
       },
     };

--- a/plugins/catalog-backend-module-gcp/src/providers/GkeEntityProvider.ts
+++ b/plugins/catalog-backend-module-gcp/src/providers/GkeEntityProvider.ts
@@ -90,7 +90,7 @@ export class GkeEntityProvider implements EntityProvider {
         const credentialsObject = JSON.parse(credentials);
         clusterManagerClient = new container.v1.ClusterManagerClient({
           credentials: credentialsObject,
-          scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+          scopes: ['https://www.googleapis.com/auth/container.readonly'],
         });
       } catch (error) {
         throw new Error(

--- a/plugins/catalog-backend-module-gcp/src/providers/__snapshots__/GkeEntityProvider.test.ts.snap
+++ b/plugins/catalog-backend-module-gcp/src/providers/__snapshots__/GkeEntityProvider.test.ts.snap
@@ -67,3 +67,47 @@ exports[`GkeEntityProvider should return clusters as Resources 1`] = `
   ],
 }
 `;
+
+exports[`GkeEntityProvider should use configured values for authProvider and owner 1`] = `
+[MockFunction] {
+  "calls": [
+    [
+      {
+        "entities": [
+          {
+            "entity": {
+              "apiVersion": "backstage.io/v1alpha1",
+              "kind": "Resource",
+              "metadata": {
+                "annotations": {
+                  "backstage.io/managed-by-location": "gcp-gke:some-location",
+                  "backstage.io/managed-by-origin-location": "gcp-gke:some-location",
+                  "kubernetes.io/api-server": "https://127.0.0.1",
+                  "kubernetes.io/api-server-certificate-authority": "abcdefg",
+                  "kubernetes.io/auth-provider": "googleServiceAccount",
+                  "kubernetes.io/dashboard-app": "gke",
+                  "kubernetes.io/dashboard-parameters": "{"projectId":"parent1","region":"some-location","clusterName":"some-cluster"}",
+                },
+                "name": "some-cluster",
+                "namespace": "default",
+              },
+              "spec": {
+                "owner": "sre",
+                "type": "kubernetes-cluster",
+              },
+            },
+            "locationKey": "gcp-gke:some-location",
+          },
+        ],
+        "type": "full",
+      },
+    ],
+  ],
+  "results": [
+    {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Service Account Credentials Support
- adds googleServiceAccountCredentials option in config
- use service account creds when available or fallback to Application Default Credentials or GOOGLE_APPLICATION_CREDENTIALS

Configurable Resource Metadata

1. adds authProvider option in config

- defaults to `google` for backward compatibility
- automatically applied to discovered cluster annotations

2. adds owner option in config

- sets the spec/owner to for the gke clusters discovered 
- defaults to 'unknown' if not specified

closes https://github.com/backstage/backstage/issues/27737 and based on https://github.com/backstage/backstage/pull/27933

cc @pfrybar 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
