### PR TITLE
Fix conditional scaffolder task permission checks on the frontend

### DIFF
--- a/.changeset/thirty-jobs-look.md
+++ b/.changeset/thirty-jobs-look.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+add `getResources` method to `permissionIntegrationRouter` for frontend task permission checks

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -363,6 +363,13 @@ export async function createRouter(
         resourceType: RESOURCE_TYPE_SCAFFOLDER_TASK,
         permissions: scaffolderTaskPermissions,
         rules: taskRules,
+        getResources: async resourceRefs => {
+          return Promise.all(
+            resourceRefs.map(async taskId => {
+              return await taskBroker.get(taskId);
+            }),
+          );
+        },
       },
     ],
     permissions: scaffolderPermissions,


### PR DESCRIPTION

## Hey, I just made a Pull Request!

Added the `getResources` method to `permissionIntegrationRouter` to enable conditional scaffolder task permission checks on the frontend.

Conditional permission checks, for example:
```
usePermission({
    permission: taskReadPermission,
    resourceRef: taskId,
  });
```
Lead to the following error: 
```
"name":"NotImplementedError","message":"This plugin does not expose any permission rule or can't evaluate the conditions request for scaffolder-task"
```

After this change, the above mentioned error no longer occurs and users with appropriate permissions can retry or cancel tasks.

Fixes https://github.com/backstage/backstage/issues/30849

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
