### PR TITLE
feat(catalog): allow using negation in entity filter query

### DIFF
--- a/.changeset/eleven-queens-accept.md
+++ b/.changeset/eleven-queens-accept.md
@@ -1,0 +1,24 @@
+---
+'@backstage/catalog-client': patch
+'@backstage/plugin-catalog-backend': patch
+---
+
+Allow using negated filter in filter query.
+
+This allows users to filter entities that do not match a specific column in the search table by
+adding a `!` suffix to the column name in the filter query.
+
+For example, you can use the following filter to find all entities that do not have a specific name:
+
+```ts
+const response = await catalogClient.getEntities(
+  {
+    filter: {
+      'metadata.name!': 'excluded-name',
+    },
+  },
+  { token },
+);
+```
+
+This also works in the scaffolder entity pickers and other components that use the filter query.

--- a/packages/catalog-client/src/CatalogClient.test.ts
+++ b/packages/catalog-client/src/CatalogClient.test.ts
@@ -92,6 +92,7 @@ describe('CatalogClient', () => {
             'a=1,b=2,b=3,ö==',
             'a=2',
             'c',
+            'a!=4,b!=5,b!=6',
           ]);
           return res(ctx.json([]));
         }),
@@ -111,6 +112,10 @@ describe('CatalogClient', () => {
             {
               c: CATALOG_FILTER_EXISTS,
             },
+            {
+              'a!': '4',
+              'b!': ['5', '6'],
+            },
           ],
         },
         { token },
@@ -125,7 +130,9 @@ describe('CatalogClient', () => {
       server.use(
         rest.get(`${mockBaseUrl}/entities`, (req, res, ctx) => {
           const queryParams = new URLSearchParams(req.url.search);
-          expect(queryParams.getAll('filter')).toEqual(['a=1,b=2,b=3,ö==,c']);
+          expect(queryParams.getAll('filter')).toEqual([
+            'a=1,b=2,b=3,ö==,c,d!=4',
+          ]);
           return res(ctx.json([]));
         }),
       );
@@ -137,6 +144,7 @@ describe('CatalogClient', () => {
             b: ['2', '3'],
             ö: '=',
             c: CATALOG_FILTER_EXISTS,
+            'd!': '4',
           },
         },
         { token },

--- a/packages/catalog-client/src/types/api.ts
+++ b/packages/catalog-client/src/types/api.ts
@@ -73,6 +73,23 @@ export const CATALOG_FILTER_EXISTS = Symbol.for(
  * (metadata.name = 'a' AND metadata.namespace = 'b' )
  * ```
  *
+ * To make the filter a negation, simply add `!` in the end of the key, for example:
+ *
+ * ```
+ * [
+ *   { 'kind!': ['API', 'Component'] },
+ *   { 'metadata.name!': 'a' }
+ * ]
+ * ```
+ *
+ * This effectively means
+ *
+ * ```
+ * (kind != 'API' AND kind != 'Component')
+ * OR
+ * (metadata.name != 'a')
+ * ```
+ *
  * @public
  */
 export type EntityFilterQuery =

--- a/plugins/catalog-backend/src/service/request/applyEntityFilterToQuery.test.ts
+++ b/plugins/catalog-backend/src/service/request/applyEntityFilterToQuery.test.ts
@@ -148,6 +148,14 @@ describe.each(databases.eachSupportedId())(
         ).resolves.toEqual(['1', '2', '3']);
 
         await expect(
+          query({ key: 'spec.foo!', values: ['c'] }),
+        ).resolves.toEqual(['1', '2', '3']);
+
+        await expect(
+          query({ key: 'spec.foo!', values: ['b', 'c'] }),
+        ).resolves.toEqual(['1', '2']);
+
+        await expect(
           query({
             anyOf: [
               { key: 'spec.foo', values: ['a'] },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

this feature adds support to make negated queries using the catalog client by suffixing the filter key with `!`. this also works for entity pickers and other components using the catalog client to fetch entities.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
