### PR TITLE
Fix feature discovery crash with packages using exports fields

### DIFF
--- a/.changeset/lovely-cobras-doubt.md
+++ b/.changeset/lovely-cobras-doubt.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Fixed bug in PackageDiscoveryService where packages with "exports" field caused ERR_PACKAGE_PATH_NOT_EXPORTED error during backend startup.

--- a/packages/backend-defaults/src/PackageDiscoveryService.ts
+++ b/packages/backend-defaults/src/PackageDiscoveryService.ts
@@ -23,6 +23,7 @@ import {
   RootLoggerService,
 } from '@backstage/backend-plugin-api';
 import { BackstagePackageJson } from '@backstage/cli-node';
+import { isError } from '@backstage/errors';
 
 const DETECTED_PACKAGE_ROLES = [
   'node-library',
@@ -133,10 +134,7 @@ export class PackageDiscoveryService {
         depPkg = require(packageJsonPath) as BackstagePackageJson;
       } catch (error) {
         // Handle packages with "exports" field that don't export ./package.json
-        if (
-          error instanceof Error &&
-          (error as any).code === 'ERR_PACKAGE_PATH_NOT_EXPORTED'
-        ) {
+        if (isError(error) && error.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
           continue; // Skip packages that don't export package.json - they can't be Backstage packages
         }
         throw error;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When using packages that employ modern Node.js "exports" fields without exporting ./package.json (such as OpenTelemetry packages), the feature discovery service crashes with ERR_PACKAGE_PATH_NOT_EXPORTED errors. This happens because these packages restrict which files can be accessed via require(), and many don't expose their package.json files.

Wraps the package.json resolution with error handling to gracefully skip packages that don't export their package.json. Since these packages can't be Backstage plugins anyway (we need access to the backstage.role field).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
