### PR TITLE
fix: add missing space in alert display component

### DIFF
--- a/.changeset/breezy-fans-exist.md
+++ b/.changeset/breezy-fans-exist.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Added missing space for alert display component

--- a/packages/core-components/src/components/AlertDisplay/AlertDisplay.tsx
+++ b/packages/core-components/src/components/AlertDisplay/AlertDisplay.tsx
@@ -124,6 +124,7 @@ export function AlertDisplay(props: AlertDisplayProps) {
           {String(firstMessage.message)}
           {messages.length > 1 && (
             <em>
+              {' '}
               {t('alertDisplay.message', {
                 count: messages.length - 1,
               })}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Previosly the message was "Message(x newer messages)" and fixed is "Message (x newer messages)"

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
