### PR TITLE
Fix scaffolder duplicate logs in `fetch:template`

### DIFF
--- a/.changeset/twelve-ants-knock.md
+++ b/.changeset/twelve-ants-knock.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Stop logging of `SPLAT` twice in logs

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/logger.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/logger.ts
@@ -61,23 +61,22 @@ export class BackstageLoggerTransport extends Transport {
 
     const message = info[MESSAGE];
     const level = info[LEVEL];
-    const splat = info[SPLAT];
 
     switch (level) {
       case 'error':
-        this.backstageLogger.error(String(message), ...splat);
+        this.backstageLogger.error(String(message));
         break;
       case 'warn':
-        this.backstageLogger.warn(String(message), ...splat);
+        this.backstageLogger.warn(String(message));
         break;
       case 'info':
-        this.backstageLogger.info(String(message), ...splat);
+        this.backstageLogger.info(String(message));
         break;
       case 'debug':
-        this.backstageLogger.debug(String(message), ...splat);
+        this.backstageLogger.debug(String(message));
         break;
       default:
-        this.backstageLogger.info(String(message), ...splat);
+        this.backstageLogger.info(String(message));
     }
 
     this.taskContext.emitLog(message, { stepId: this.stepId });


### PR DESCRIPTION
Fix for #30876