### PR TITLE
fix(catalog): sort msgraph provider arrays

### DIFF
--- a/.changeset/clean-ducks-walk.md
+++ b/.changeset/clean-ducks-walk.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-msgraph': patch
+---
+
+Fixed some users being restitched due to changing order in the groups the user is member of

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/org.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/org.ts
@@ -35,6 +35,12 @@ export function buildOrgHierarchy(groups: GroupEntity[]) {
         parent.spec.children.push(selfName);
       }
     }
+
+    if (group.spec.children) {
+      group.spec.children = group.spec.children.sort((a, b) =>
+        a.localeCompare(b),
+      );
+    }
   }
 
   //
@@ -82,6 +88,8 @@ export function buildMemberOf(groups: GroupEntity[], users: UserEntity[]) {
       }
     }
 
-    user.spec.memberOf = [...transitiveMemberOf];
+    user.spec.memberOf = [...transitiveMemberOf].sort((a, b) =>
+      a.localeCompare(b),
+    );
   });
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

this fixes unnecessary restitching when the order of users' groups coming from msgraph are not always in the same order. same applies for the group children array.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
