### PR TITLE
fix(catalog): sort default spec fields for stable hash

### DIFF
--- a/.changeset/huge-spoons-remain.md
+++ b/.changeset/huge-spoons-remain.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Sort built-in relation fields for more stable entity hash in the processing engine

--- a/plugins/catalog-backend/report.api.md
+++ b/plugins/catalog-backend/report.api.md
@@ -61,6 +61,8 @@ export class BuiltinKindsEntityProcessor implements CatalogProcessor {
     emit: CatalogProcessorEmit,
   ): Promise<Entity>;
   // (undocumented)
+  preProcessEntity(entity: Entity): Promise<Entity>;
+  // (undocumented)
   validateEntityKind(entity: Entity): Promise<boolean>;
 }
 

--- a/plugins/catalog-backend/src/processors/BuiltinKindsEntityProcessor.test.ts
+++ b/plugins/catalog-backend/src/processors/BuiltinKindsEntityProcessor.test.ts
@@ -26,6 +26,49 @@ import {
 import { BuiltinKindsEntityProcessor } from './BuiltinKindsEntityProcessor';
 
 describe('BuiltinKindsEntityProcessor', () => {
+  describe('preProcessEntity', () => {
+    const processor = new BuiltinKindsEntityProcessor();
+    afterEach(() => jest.resetAllMocks());
+
+    it('should order relation fields correctly', async () => {
+      const entity: ComponentEntity = {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: { name: 'n' },
+        spec: {
+          type: 'service',
+          owner: 'o',
+          subcomponentOf: 's',
+          lifecycle: 'l',
+          providesApis: ['b', 'a'],
+          consumesApis: ['c', 'x'],
+          dependsOn: ['resource:r', 'component:d'],
+          dependencyOf: ['resource:f', 'component:g'],
+          system: 's',
+        },
+      };
+
+      const ret = await processor.preProcessEntity(entity);
+
+      expect(ret).toEqual({
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: { name: 'n' },
+        spec: {
+          type: 'service',
+          owner: 'o',
+          subcomponentOf: 's',
+          lifecycle: 'l',
+          providesApis: ['a', 'b'],
+          consumesApis: ['c', 'x'],
+          dependsOn: ['component:d', 'resource:r'],
+          dependencyOf: ['component:g', 'resource:f'],
+          system: 's',
+        },
+      });
+    });
+  });
+
   describe('postProcessEntity', () => {
     const processor = new BuiltinKindsEntityProcessor();
     const location = { type: 'a', target: 'b' };

--- a/plugins/catalog-backend/src/processors/BuiltinKindsEntityProcessor.ts
+++ b/plugins/catalog-backend/src/processors/BuiltinKindsEntityProcessor.ts
@@ -54,6 +54,7 @@ import {
   CatalogProcessorEmit,
   processingResult,
 } from '@backstage/plugin-catalog-node';
+import { get, set } from 'lodash';
 
 /** @public */
 export class BuiltinKindsEntityProcessor implements CatalogProcessor {
@@ -81,6 +82,30 @@ export class BuiltinKindsEntityProcessor implements CatalogProcessor {
     }
 
     return false;
+  }
+
+  async preProcessEntity(entity: Entity): Promise<Entity> {
+    function sortField(field: string) {
+      const value = get(entity, field);
+      if (
+        value &&
+        Array.isArray(value) &&
+        value.every(v => typeof v === 'string')
+      ) {
+        set(entity, field, value.sort());
+      }
+    }
+
+    // Sort the fields of the entity to ensure consistent hash
+    sortField('spec.providesApis');
+    sortField('spec.consumesApis');
+    sortField('spec.dependsOn');
+    sortField('spec.dependencyOf');
+    sortField('spec.memberOf');
+    sortField('spec.children');
+    sortField('spec.members');
+
+    return entity;
   }
 
   async postProcessEntity(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

sort fields of known spec relation fields so that the default processing engine hash calculation is more stable leading to less re-stitching of entities

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
