### PR TITLE
fix: remove domain attribute to set OAuth cookies as host-only

### DIFF
--- a/.changeset/wet-kiwis-strive.md
+++ b/.changeset/wet-kiwis-strive.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-node': patch
+---
+
+Changes OAuth cookies from domain-scoped to host-only by avoid setting the domain attribute in the default cookie configurer.

--- a/.github/vale/config/vocabularies/Backstage/accept.txt
+++ b/.github/vale/config/vocabularies/Backstage/accept.txt
@@ -77,6 +77,7 @@ Config
 configmaps
 configs
 configurability
+configurer
 conformant
 const
 cookiecutter

--- a/plugins/auth-backend-module-atlassian-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-atlassian-provider/src/module.test.ts
@@ -52,7 +52,7 @@ describe('authModuleAtlassianProvider', () => {
     expect(res.status).toEqual(302);
 
     const nonceCookie = agent.jar.getCookie('atlassian-nonce', {
-      domain: 'localhost',
+      domain: '127.0.0.1',
       path: '/api/auth/atlassian/handler',
       script: false,
       secure: false,
@@ -111,7 +111,7 @@ describe('authModuleAtlassianProvider', () => {
     expect(res.status).toEqual(302);
 
     const nonceCookie = agent.jar.getCookie('atlassian-nonce', {
-      domain: 'localhost',
+      domain: '127.0.0.1',
       path: '/api/auth/atlassian/handler',
       script: false,
       secure: false,

--- a/plugins/auth-backend-module-auth0-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-auth0-provider/src/module.test.ts
@@ -59,7 +59,7 @@ describe('authModuleAuth0Provider', () => {
     expect(res.status).toEqual(302);
 
     const nonceCookie = agent.jar.getCookie('auth0-nonce', {
-      domain: 'localhost',
+      domain: '127.0.0.1',
       path: '/api/auth/auth0/handler',
       script: false,
       secure: false,

--- a/plugins/auth-backend-module-bitbucket-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-bitbucket-provider/src/module.test.ts
@@ -52,7 +52,7 @@ describe('authModuleBitbucketProvider', () => {
     expect(res.status).toEqual(302);
 
     const nonceCookie = agent.jar.getCookie('bitbucket-nonce', {
-      domain: 'localhost',
+      domain: '127.0.0.1',
       path: '/api/auth/bitbucket/handler',
       script: false,
       secure: false,

--- a/plugins/auth-backend-module-bitbucket-server-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-bitbucket-server-provider/src/module.test.ts
@@ -56,7 +56,7 @@ describe('authModuleBitbucketServerProvider', () => {
     expect(res.status).toEqual(302);
 
     const nonceCookie = agent.jar.getCookie('bitbucketServer-nonce', {
-      domain: 'localhost',
+      domain: '127.0.0.1',
       path: '/api/auth/bitbucketServer/handler',
       script: false,
       secure: false,

--- a/plugins/auth-backend-module-github-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-github-provider/src/module.test.ts
@@ -52,7 +52,7 @@ describe('authModuleGithubProvider', () => {
     expect(res.status).toEqual(302);
 
     const nonceCookie = agent.jar.getCookie('github-nonce', {
-      domain: 'localhost',
+      domain: '127.0.0.1',
       path: '/api/auth/github/handler',
       script: false,
       secure: false,

--- a/plugins/auth-backend-module-gitlab-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-gitlab-provider/src/module.test.ts
@@ -52,7 +52,7 @@ describe('authModuleGitlabProvider', () => {
     expect(res.status).toEqual(302);
 
     const nonceCookie = agent.jar.getCookie('gitlab-nonce', {
-      domain: 'localhost',
+      domain: '127.0.0.1',
       path: '/api/auth/gitlab/handler',
       script: false,
       secure: false,

--- a/plugins/auth-backend-module-google-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-google-provider/src/module.test.ts
@@ -52,7 +52,7 @@ describe('authModuleGoogleProvider', () => {
     expect(res.status).toBe(302);
 
     const nonceCookie = agent.jar.getCookie('google-nonce', {
-      domain: 'localhost',
+      domain: '127.0.0.1',
       path: '/api/auth/google/handler',
       script: false,
       secure: false,

--- a/plugins/auth-backend-module-microsoft-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-microsoft-provider/src/module.test.ts
@@ -55,7 +55,7 @@ describe('authModuleMicrosoftProvider', () => {
     expect(res.status).toEqual(302);
 
     const nonceCookie = agent.jar.getCookie('microsoft-nonce', {
-      domain: 'localhost',
+      domain: '127.0.0.1',
       path: '/api/auth/microsoft/handler',
       script: false,
       secure: false,
@@ -114,7 +114,7 @@ describe('authModuleMicrosoftProvider', () => {
     expect(res.status).toEqual(302);
 
     const nonceCookie = agent.jar.getCookie('microsoft-nonce', {
-      domain: 'localhost',
+      domain: '127.0.0.1',
       path: '/api/auth/microsoft/handler',
       script: false,
       secure: false,
@@ -175,7 +175,7 @@ describe('authModuleMicrosoftProvider', () => {
     expect(res.status).toEqual(302);
 
     const nonceCookie = agent.jar.getCookie('microsoft-nonce', {
-      domain: 'localhost',
+      domain: '127.0.0.1',
       path: '/api/auth/microsoft/handler',
       script: false,
       secure: false,

--- a/plugins/auth-backend-module-oauth2-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-oauth2-provider/src/module.test.ts
@@ -54,7 +54,7 @@ describe('authModuleOauth2Provider', () => {
     expect(res.status).toEqual(302);
 
     const nonceCookie = agent.jar.getCookie('oauth2-nonce', {
-      domain: 'localhost',
+      domain: '127.0.0.1',
       path: '/api/auth/oauth2/handler',
       script: false,
       secure: false,

--- a/plugins/auth-backend-module-oidc-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-oidc-provider/src/module.test.ts
@@ -185,7 +185,7 @@ describe('authModuleOidcProvider', () => {
     expect(startResponse.status).toEqual(302);
 
     const nonceCookie = agent.jar.getCookie('oidc-nonce', {
-      domain: 'localhost',
+      domain: '127.0.0.1',
       path: '/api/auth/oidc/handler',
       script: false,
       secure: false,

--- a/plugins/auth-backend-module-okta-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-okta-provider/src/module.test.ts
@@ -53,7 +53,7 @@ describe('authModuleOktaProvider', () => {
     expect(res.status).toEqual(302);
 
     const nonceCookie = agent.jar.getCookie('okta-nonce', {
-      domain: 'localhost',
+      domain: '127.0.0.1',
       path: '/api/auth/okta/handler',
       script: false,
       secure: false,

--- a/plugins/auth-backend-module-onelogin-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-onelogin-provider/src/module.test.ts
@@ -53,7 +53,7 @@ describe('authModuleOneLoginProvider', () => {
     expect(res.status).toEqual(302);
 
     const nonceCookie = agent.jar.getCookie('onelogin-nonce', {
-      domain: 'localhost',
+      domain: '127.0.0.1',
       path: '/api/auth/onelogin/handler',
       script: false,
       secure: false,

--- a/plugins/auth-backend-module-vmware-cloud-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-vmware-cloud-provider/src/module.test.ts
@@ -58,7 +58,7 @@ describe('authModuleVmwareCloudProvider', () => {
     expect(res.status).toEqual(302);
 
     const nonceCookie = agent.jar.getCookie('vmwareCloudServices-nonce', {
-      domain: 'localhost',
+      domain: '127.0.0.1',
       path: '/api/auth/vmwareCloudServices/handler',
       script: false,
       secure: false,

--- a/plugins/auth-node/report.api.md
+++ b/plugins/auth-node/report.api.md
@@ -178,7 +178,7 @@ export type CookieConfigurer = (ctx: {
   callbackUrl: string;
   appOrigin: string;
 }) => {
-  domain: string;
+  domain?: string;
   path: string;
   secure: boolean;
   sameSite?: 'none' | 'lax' | 'strict';

--- a/plugins/auth-node/src/oauth/OAuthCookieManager.ts
+++ b/plugins/auth-node/src/oauth/OAuthCookieManager.ts
@@ -47,7 +47,7 @@ const defaultCookieConfigurer: CookieConfigurer = ({
     ? pathname.slice(0, -'/handler/frame'.length)
     : `${pathname}/${providerId}`;
 
-  return { domain, path, secure, sameSite };
+  return { path, secure, sameSite };
 };
 
 /** @internal */
@@ -182,6 +182,15 @@ export class OAuthCookieManager {
         }
         output = output.cookie(key, '', this.getRemoveCookieOptions());
       }
+    }
+
+    // If using the default cookieConfigurer, delete old cookie with domain set to the callbackUrl's domain (legacy behavior)
+    if (this.cookieConfigurer === defaultCookieConfigurer) {
+      const { hostname: domain } = new URL(this.options.callbackUrl);
+      output = output.cookie(name, '', {
+        ...this.getRemoveCookieOptions(),
+        domain: `.${domain}`,
+      });
     }
 
     return output.cookie(name, val, options);

--- a/plugins/auth-node/src/types.ts
+++ b/plugins/auth-node/src/types.ts
@@ -411,7 +411,7 @@ export type CookieConfigurer = (ctx: {
   /** The origin URL of the app */
   appOrigin: string;
 }) => {
-  domain: string;
+  domain?: string;
   path: string;
   secure: boolean;
   sameSite?: 'none' | 'lax' | 'strict';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR unsets the domain attribute in the default cookie configurer to make OAuth cookies host-only to prevent duplicate-cookie sign-in issues.

Related to https://github.com/backstage/backstage/issues/28126
- PR is a continuation of https://github.com/backstage/backstage/pull/29343

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
