### PR TITLE
microsite: add datacontract plugin

### DIFF
--- a/microsite/data/plugins/datacontract.yaml
+++ b/microsite/data/plugins/datacontract.yaml
@@ -1,0 +1,10 @@
+---
+title: Data Contract
+author: Jan Remunda
+authorUrl: https://www.remunda.cz/#backstage
+category: Discovery
+description: Ingest and visualize Data Contracts to your catalog via API Entities.
+documentation: https://www.npmjs.com/package/@remunda/backstage-plugin-datacontract
+iconUrl: https://www.remunda.cz/logos/datacontract.png
+npmPackageName: '@remunda/backstage-plugin-datacontract'
+addedDate: '2025-08-19'


### PR DESCRIPTION
Hey Backstage devs :)

I've created a plugin that allows to ingest Data Contract YAML files via API Entities (type=datacontract)

see docs for details https://www.npmjs.com/package/@remunda/backstage-plugin-datacontract

Thank you!

#### :heavy_check_mark: Checklist

- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
