### PR TITLE
[NFS] (create-app): redirect from home to catalog

### DIFF
--- a/.changeset/brave-bugs-know.md
+++ b/.changeset/brave-bugs-know.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': minor
+---
+
+Creates a plugin that redirects from the Home page to the Catalog index page to avoid seeing a not found page error when starting the app.

--- a/packages/create-app/templates/next-app/packages/app/src/App.tsx
+++ b/packages/create-app/templates/next-app/packages/app/src/App.tsx
@@ -1,7 +1,8 @@
 import { createApp } from '@backstage/frontend-defaults';
 import catalogPlugin from '@backstage/plugin-catalog/alpha';
+import { homePlugin } from './plugins/home';
 import { navModule } from './modules/nav';
 
 export default createApp({
-  features: [catalogPlugin, navModule],
+  features: [homePlugin,catalogPlugin, navModule],
 });

--- a/packages/create-app/templates/next-app/packages/app/src/plugins/home/HomePage.tsx
+++ b/packages/create-app/templates/next-app/packages/app/src/plugins/home/HomePage.tsx
@@ -1,0 +1,9 @@
+import { PageBlueprint } from '@backstage/frontend-plugin-api';
+import { Navigate } from 'react-router';
+
+export const HomePage = PageBlueprint.make({
+  params: {
+    path: '/',
+    loader: async () => <Navigate to="catalog" />
+  }
+});

--- a/packages/create-app/templates/next-app/packages/app/src/plugins/home/index.tsx
+++ b/packages/create-app/templates/next-app/packages/app/src/plugins/home/index.tsx
@@ -1,0 +1,8 @@
+
+import { createFrontendPlugin } from '@backstage/frontend-plugin-api';
+import { HomePage } from './HomePage';
+
+export const homePlugin = createFrontendPlugin({
+  pluginId: 'home',
+  extensions: [HomePage],
+});


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Creates a plugin that redirects from the Home page to the Catalog index page to avoid seeing a not found page error when starting the app.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
