### PR TITLE
`catalog-react`: Add support for backwards comat of `default*` props for Blueprints

### DIFF
--- a/.changeset/yellow-dragons-float.md
+++ b/.changeset/yellow-dragons-float.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Support `default*` for older packages as this package is in range for breaking `/alpha` changes

--- a/plugins/catalog-react/src/alpha/blueprints/EntityContentBlueprint.ts
+++ b/plugins/catalog-react/src/alpha/blueprints/EntityContentBlueprint.ts
@@ -86,9 +86,12 @@ export const EntityContentBlueprint = createExtensionBlueprint({
     },
     { node, config },
   ) {
-    const path = config.path ?? params.path;
-    const title = config.title ?? params.title;
-    const group = config.group ?? params.group;
+    // TODO(blam): Remove support for all the `default*` props in the future, this breaks backwards compatibility without it
+    // As this is marked as BREAKING ALPHA, it doesn't affect the public API so it falls in range and gets picked
+    // up by packages that depend on `catalog-react`.
+    const path = config.path ?? params.path ?? params.defaultPath;
+    const title = config.title ?? params.title ?? params.defaultTitle;
+    const group = config.group ?? params.group ?? params.defaultGroup;
 
     yield coreExtensionData.reactElement(
       ExtensionBoundary.lazy(node, params.loader),
@@ -104,7 +107,7 @@ export const EntityContentBlueprint = createExtensionBlueprint({
 
     yield* resolveEntityFilterData(params.filter, config, node);
 
-    if (group) {
+    if (group && typeof group === 'string') {
       yield entityContentGroupDataRef(group);
     }
   },

--- a/plugins/catalog-react/src/alpha/converters/convertLegacyEntityContentExtension.tsx
+++ b/plugins/catalog-react/src/alpha/converters/convertLegacyEntityContentExtension.tsx
@@ -82,13 +82,19 @@ export function convertLegacyEntityContentExtension(
     }
   }
   name = name && kebabCase(name);
-
+  // TODO(blam): Remove support for all the `default*` props in the future, this breaks backwards compatibility without it
+  // As this is marked as BREAKING ALPHA, it doesn't affect the public API so it falls in range and gets picked
+  // up by packages that depend on `catalog-react`.
   return EntityContentBlueprint.make({
     name: overrides?.name ?? name,
     params: {
       filter: overrides?.filter,
-      path: overrides?.path ?? `/${kebabCase(infix)}`,
-      title: overrides?.title ?? startCase(infix),
+      path: (overrides?.path ??
+        overrides?.defaultPath ??
+        `/${kebabCase(infix)}`) as string,
+      title: (overrides?.title ??
+        overrides?.defaultTitle ??
+        startCase(infix)) as string,
       routeRef: mountPoint && convertLegacyRouteRef(mountPoint),
       loader: async () => compatWrapper(element),
     },


### PR DESCRIPTION
Because the previous deprecation and change wasn't marked as breaking because it was only breaking alpha change, this means that this package currently meets the range of some of the new frontend system modules and ends up breaking at runtime because no `routePath` is emitted.

This fixes the backwards compatibility, and it will be removed eventually.

The changes in `convertLegacyContentExtension` shouldn't be needed as we don't expect that function to be used outside of an local backstage plugin, and should not be used in packages that are published publically.