### PR TITLE
feat(search): truncate document text to fit PostgreSQL tsvector size limit

### DIFF
--- a/.changeset/brown-falcons-own.md
+++ b/.changeset/brown-falcons-own.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend-module-pg': patch
+---
+
+Truncate long docs to fit PG index size limit

--- a/plugins/search-backend-module-pg/report.api.md
+++ b/plugins/search-backend-module-pg/report.api.md
@@ -24,7 +24,11 @@ export type ConcretePgSearchQuery = {
 export class DatabaseDocumentStore implements DatabaseStore {
   constructor(db: Knex);
   // (undocumented)
-  completeInsert(tx: Knex.Transaction, type: string): Promise<void>;
+  completeInsert(
+    tx: Knex.Transaction,
+    type: string,
+    truncate?: boolean,
+  ): Promise<void>;
   // (undocumented)
   static create(database: DatabaseService): Promise<DatabaseDocumentStore>;
   // (undocumented)
@@ -51,7 +55,11 @@ export class DatabaseDocumentStore implements DatabaseStore {
 // @public (undocumented)
 export interface DatabaseStore {
   // (undocumented)
-  completeInsert(tx: Knex.Transaction, type: string): Promise<void>;
+  completeInsert(
+    tx: Knex.Transaction,
+    type: string,
+    truncate?: boolean,
+  ): Promise<void>;
   // (undocumented)
   getTransaction(): Promise<Knex.Transaction>;
   // (undocumented)

--- a/plugins/search-backend-module-pg/src/database/DatabaseDocumentStore.test.ts
+++ b/plugins/search-backend-module-pg/src/database/DatabaseDocumentStore.test.ts
@@ -22,6 +22,7 @@ import {
 import { IndexableDocument } from '@backstage/plugin-search-common';
 import { PgSearchHighlightOptions } from '../PgSearchEngine';
 import { DatabaseDocumentStore } from './DatabaseDocumentStore';
+import { v4 as uuidv4 } from 'uuid';
 
 const highlightOptions: PgSearchHighlightOptions = {
   preTag: '<tag>',
@@ -119,6 +120,32 @@ describe('DatabaseDocumentStore', () => {
         expect(
           await knex.count('*').where('type', 'my-type').from('documents'),
         ).toEqual([{ count: '2' }]);
+      },
+    );
+
+    it.each(databases.eachSupportedId())(
+      'should insert truncated documents, %p',
+      async databaseId => {
+        const { store, knex } = await createStore(databaseId);
+
+        await store.transaction(async tx => {
+          await store.prepareInsert(tx);
+
+          await store.insertDocuments(tx, 'my-type', [
+            {
+              title: 'TITLE 1',
+              text: Array.from({ length: 100000 })
+                .map(() => uuidv4()) // text tokens should be unique to overflow the tsvector indexing and trigger truncation
+                .join(' '),
+              location: 'LOCATION-1',
+            },
+          ]);
+          await store.completeInsert(tx, 'my-type', true);
+        });
+
+        expect(
+          await knex.count('*').where('type', 'my-type').from('documents'),
+        ).toEqual([{ count: '1' }]);
       },
     );
 

--- a/plugins/search-backend-module-pg/src/database/types.ts
+++ b/plugins/search-backend-module-pg/src/database/types.ts
@@ -38,7 +38,11 @@ export interface DatabaseStore {
     type: string,
     documents: IndexableDocument[],
   ): Promise<void>;
-  completeInsert(tx: Knex.Transaction, type: string): Promise<void>;
+  completeInsert(
+    tx: Knex.Transaction,
+    type: string,
+    truncate?: boolean,
+  ): Promise<void>;
   query(
     tx: Knex.Transaction,
     pgQuery: PgSearchQuery,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This pull request adds support for handling and truncating overly long documents to prevent errors when indexing into PostgreSQL's `tsvector` column in the search backend. The main changes include retrying inserts with truncated text if a "string is too long for tsvector" error occurs, updating the relevant database methods and tests, and ensuring the system can now index documents that previously would have failed.

**Error handling and truncation logic:**

* Updated `PgSearchEngineIndexer` to detect tsvector length errors during document insert and automatically retry with truncated document text, ensuring large documents don't block the indexing process.
* Modified `DatabaseDocumentStore.completeInsert` to accept a `truncate` flag, and when set, truncates the `text` field of documents to 50,000 characters before inserting. [[1]](diffhunk://#diff-fbfa5a965a1bd17d13d8f960ffb813d8a6e75c6de69b67a0f42a34af84aa4568L105-R121) [[2]](diffhunk://#diff-3dc4523f3f0f4f27627135e0ffa4ae65d819515333cff22004cc56f86fddf82eL41-R45)

**Testing improvements:**

* Added and updated tests in `PgSearchEngineIndexer.test.ts` to verify that the indexer retries with truncation on tsvector errors and to check the correct arguments are passed to `completeInsert`. [[1]](diffhunk://#diff-0483d4fd30282f5dc451c9179b99e973e5c03fcb2b80fd095973e82025d7024fL68-R111) [[2]](diffhunk://#diff-0483d4fd30282f5dc451c9179b99e973e5c03fcb2b80fd095973e82025d7024fL85-R124)
* Added a test in `DatabaseDocumentStore.test.ts` to confirm that truncated documents are correctly inserted and counted in the database.

Resolves https://github.com/backstage/backstage/issues/30981

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
