### PR TITLE
fix(scaffolder-react): set minimum height for scaffolder task log stream 

### DIFF
--- a/.changeset/tangy-squids-film.md
+++ b/.changeset/tangy-squids-film.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+Fix scaffolder task log stream not having a minimum height

--- a/plugins/scaffolder-react/src/next/components/TaskLogStream/TaskLogStream.tsx
+++ b/plugins/scaffolder-react/src/next/components/TaskLogStream/TaskLogStream.tsx
@@ -21,6 +21,7 @@ const useStyles = makeStyles({
     width: '100%',
     height: '100%',
     position: 'relative',
+    minHeight: 240,
   },
 });
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The scaffolder task log stream does not have a minimum height so in conditions where the log stream is towards the bottom of the page or past the viewable height of the page, the log stream is not viewable since it's height is set to 0 so it just displays weirdly as an empty thing. This PR adds a minimum height to the log stream so it displays as expected.

Before:

https://github.com/user-attachments/assets/5702e536-1de5-42b2-9683-8d6ee06cceca

After:

https://github.com/user-attachments/assets/a658c4c7-d5e4-496d-b279-f15133d05599


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
