### PR TITLE
`k8s`: fix issue with `objectsToFetch` defaulting

### DIFF
--- a/.changeset/ripe-plants-pump.md
+++ b/.changeset/ripe-plants-pump.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Fix issue with default objects not being loaded properly

--- a/plugins/kubernetes-backend/src/service/KubernetesInitializer.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesInitializer.ts
@@ -177,7 +177,7 @@ export class KubernetesInitializer {
 
     return {
       customResources,
-      objectTypesToFetch: objectTypesToFetch ?? [],
+      objectTypesToFetch: objectTypesToFetch ?? DEFAULT_OBJECTS,
     };
   }
 


### PR DESCRIPTION
Previously when this was marked as `undefined` it would get defaulted in to `DEFAULT_OBJECTS`.

I incorrectly marked the defaults as an empty array, so it never got defaulted correctly, but we need to default them to something pretty early.

This marks them as the `DEFAULT_OBJECTS` a little ealier.