### PR TITLE
`nfs`: fix `compatWrapper` behavior in NFS to not render `ForwardsCompatWrappers`

### DIFF
--- a/.changeset/sixty-places-push.md
+++ b/.changeset/sixty-places-push.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-compat-api': patch
+---
+
+Fix for `compatWrapper` creating many wrapping `Providers` when they should not

--- a/packages/core-compat-api/src/compatWrapper/compatWrapper.tsx
+++ b/packages/core-compat-api/src/compatWrapper/compatWrapper.tsx
@@ -18,15 +18,21 @@ import { useVersionedContext } from '@backstage/version-bridge';
 import { ReactNode } from 'react';
 import { BackwardsCompatProvider } from './BackwardsCompatProvider';
 import { ForwardsCompatProvider } from './ForwardsCompatProvider';
+import { appTreeApiRef, useApiHolder } from '@backstage/frontend-plugin-api';
 
 function BidirectionalCompatProvider(props: { children: ReactNode }) {
-  const isInNewApp = !useVersionedContext<{ 1: unknown }>('app-context');
+  const isInOldApp = useVersionedContext<{ 1: unknown }>('app-context');
+  const isInNewApp = Boolean(useApiHolder().get(appTreeApiRef));
 
-  if (isInNewApp) {
+  if (isInNewApp && !isInOldApp) {
     return <BackwardsCompatProvider {...props} />;
   }
 
-  return <ForwardsCompatProvider {...props} />;
+  if (isInOldApp && !isInNewApp) {
+    return <ForwardsCompatProvider {...props} />;
+  }
+
+  return props.children;
 }
 
 /**


### PR DESCRIPTION
This causes some of the hanging when migrating your apps. There's a recursion that happens with the polyfill we have for `componentRefs` and `SwappableComponent` which should not be happening.

This should hopefully fix the crashing of the tabs when working through the migration guide.