### PR TITLE
Patch release of #30959, #30958

### DIFF
--- a/.changeset/easy-wings-turn.md
+++ b/.changeset/easy-wings-turn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Fixing issue with extra slash in the routing

--- a/.changeset/easy-wings-turn.md
+++ b/.changeset/easy-wings-turn.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-org': patch
----
-
-Fixing issue with extra slash in the routing

--- a/docs/frontend-system/architecture/33-utility-apis.md
+++ b/docs/frontend-system/architecture/33-utility-apis.md
@@ -5,10 +5,6 @@ sidebar_label: Utility APIs
 description: Utility APIs
 ---
 
-:::note Note
-The new frontend system is in alpha and is only supported by a small number of plugins.
-:::
-
 ## Overview
 
 Utility APIs are pieces of standalone functionality, interfaces that can be requested by plugins to use. They are defined by a TypeScript interface as well as a reference (an "API ref") used to access its implementation. They can be provided both by plugins and the core framework, and are themselves [extensions](../architecture/20-extensions.md) that can have inputs, be replaced, and be declaratively configured in your app-config.

--- a/docs/frontend-system/building-plugins/02-testing.md
+++ b/docs/frontend-system/building-plugins/02-testing.md
@@ -7,12 +7,6 @@ description: Testing plugins in the frontend system
 
 # Testing Frontend Plugins
 
-:::note Note
-
-The new frontend system is in alpha, and some plugins do not yet fully implement it.
-
-:::
-
 Utilities for testing frontend features and components are available in `@backstage/frontend-test-utils`.
 
 ## Testing React components

--- a/docs/frontend-system/index.md
+++ b/docs/frontend-system/index.md
@@ -7,6 +7,6 @@ description: The Frontend System
 
 ## Status
 
-The new frontend system is in alpha, and only a few plugins support the system so far. We do not yet recommend migrating any apps to the new system. If you add support for the new system to your plugin, please do so under a `/alpha` sub-path export.
+We recommend migrating your frontend plugins to the new frontend system. If you do please do so under an `/alpha` sub-path export.
 
 You can find an example app setup in the [`app-next` package](https://github.com/backstage/backstage/tree/master/packages/app-next).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.42.2",
+  "version": "1.42.3",
   "backstage": {
     "cli": {
       "new": {

--- a/plugins/org/CHANGELOG.md
+++ b/plugins/org/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/plugin-org
 
+## 0.6.43
+
+### Patch Changes
+
+- df3b5ef: Fixing issue with extra slash in the routing
+
 ## 0.6.42
 
 ### Patch Changes

--- a/plugins/org/package.json
+++ b/plugins/org/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-org",
-  "version": "0.6.42",
+  "version": "0.6.43",
   "description": "A Backstage plugin that helps you create entity pages for your organization",
   "backstage": {
     "role": "frontend-plugin",

--- a/plugins/org/src/components/Cards/OwnershipCard/ComponentsGrid.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/ComponentsGrid.tsx
@@ -135,6 +135,7 @@ export const ComponentsGrid = ({
   entityLimit?: number;
 }) => {
   const catalogLink = useRouteRef(catalogIndexRouteRef);
+
   if (!relationsType && !relationAggregation) {
     throw new Error(
       'The relationAggregation property must be set as an EntityRelationAggregation type.',
@@ -161,7 +162,7 @@ export const ComponentsGrid = ({
             counter={c.counter}
             kind={c.kind}
             type={c.type}
-            url={catalogLink && `${catalogLink()}/?${c.queryParams}`}
+            url={catalogLink && `${catalogLink()}?${c.queryParams}`}
           />
         </Grid>
       ))}


### PR DESCRIPTION
This release fixes an issue where the `org` plugin would crash when navigating to the `catalog` plugin if the plugin is mounted at the root of the app