### PR TITLE
Add identifier to detected plugins module

### DIFF
--- a/.changeset/fancy-tools-stand.md
+++ b/.changeset/fancy-tools-stand.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Suffix the generated `__backstage-autodetected-plugins__` module from each package with the directory name.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When running the `backstage repo build` command in a monorepo with multiple Backstage applications, each of those application builds will output a module importing all of the features detected at build time. The problem with this is that all of those modules are currently written to the same place (`node_modules/__backstage-autodetected-plugins__.js`) and so, with multiple builds running in parallel, it's possible for one build to load the module emitted from another. This will cause problems for applications using frontend feature detection, as the loaded module will not necessarily contain the correct features for that particular application. To address this, I've added the name of the directory that a particular package sits in as a suffix to the module so that there's no longer an overlap.

Disclaimer: it's still possible to run into a clash with this change if you have multiple workspaces in a monorepo with the same directory name in different parent directories. I'm open to suggestions if there is a better identifier that can be used for each module that addresses this additional case. One thought I had was using a hash of the module contents instead, but I opted for this solution as a simpler starting point for now.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
