### PR TITLE
cli: fix package detection conflict

### DIFF
--- a/.changeset/lucky-glasses-slide.md
+++ b/.changeset/lucky-glasses-slide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Fixed an issue that could cause conflicts of detected modules in workspaces with multiple apps.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This switches the detected modules file to be written to the packages' own `node_modules`, instead of the root one. I actually though we had this fix in quite a while ago, but seems we didn't. 😅

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
