### PR TITLE
fix(scaffolder-backend): sets router max upload size to 10MB

### DIFF
--- a/.changeset/silent-results-stick.md
+++ b/.changeset/silent-results-stick.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Fixed a regression that prevented uploads greater than 100KB. Uploads up to 10MB are supported again.

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -186,9 +186,12 @@ const readDuration = (
 export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {
-  const router = await createOpenApiRouter();
-  // Be generous in upload size to support a wide range of templates in dry-run mode.
-  router.use(express.json({ limit: '10MB' }));
+  const router = await createOpenApiRouter({
+    middleware: [
+      // Be generous in upload size to support a wide range of templates in dry-run mode.
+      express.json({ limit: '10MB' }),
+    ],
+  });
 
   const {
     logger: parentLogger,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The switch to the [OpenApi generated router](https://github.com/backstage/backstage/blob/master/packages/backend-openapi-utils/src/stub.ts#L68-L76) applies some [default middleware](https://github.com/backstage/backstage/blob/master/packages/backend-openapi-utils/src/stub.ts#L47-L49)e, which register the `json` middleware with the default 100kb payload limit.

This change registers the `json` middleware with the `10MB` limit as it was previously.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
