### PR TITLE
Add detail in error messages when yarn plugin can't detect backstage version

### DIFF
--- a/packages/yarn-plugin/package.json
+++ b/packages/yarn-plugin/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@backstage/cli-common": "workspace:^",
+    "@backstage/errors": "workspace:^",
     "@backstage/release-manifests": "workspace:^",
     "@yarnpkg/core": "^4.4.1",
     "@yarnpkg/fslib": "^3.1.2",

--- a/packages/yarn-plugin/src/util/getCurrentBackstageVersion.test.ts
+++ b/packages/yarn-plugin/src/util/getCurrentBackstageVersion.test.ts
@@ -73,17 +73,15 @@ describe('getCurrentBackstageVersion', () => {
   });
 
   it.each`
-    description              | content
-    ${'is missing'}          | ${{}}
-    ${'is invalid'}          | ${{ 'backstage.json': '}{' }}
-    ${'has missing version'} | ${{ 'backstage.json': '{"a":"b"}' }}
-    ${'has invalid version'} | ${{ 'backstage.json': '{"version":"foobar"}' }}
-  `('throws if backstage.json $description', ({ content }) => {
+    description              | content                                         | message
+    ${'is missing'}          | ${{}}                                           | ${/valid version string not found.*no such file/i}
+    ${'is invalid'}          | ${{ 'backstage.json': '}{' }}                   | ${/valid version string not found.*not valid json/i}
+    ${'has missing version'} | ${{ 'backstage.json': '{"a":"b"}' }}            | ${/valid version string not found.*version field is missing/i}
+    ${'has invalid version'} | ${{ 'backstage.json': '{"version":"foobar"}' }} | ${/valid version string not found.*exists but is not valid semver/i}
+  `('throws if backstage.json $description', ({ content, message }) => {
     mockDir.addContent(content);
 
-    expect(() => getCurrentBackstageVersion()).toThrow(
-      /valid version string not found/i,
-    );
+    expect(() => getCurrentBackstageVersion()).toThrow(message);
   });
 
   it('caches repeated calls', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -49826,6 +49826,7 @@ __metadata:
     "@backstage/backend-test-utils": "workspace:^"
     "@backstage/cli": "workspace:^"
     "@backstage/cli-common": "workspace:^"
+    "@backstage/errors": "workspace:^"
     "@backstage/release-manifests": "workspace:^"
     "@yarnpkg/builder": "npm:^4.2.1"
     "@yarnpkg/core": "npm:^4.4.1"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I was confused for ~15 minutes today when updating to using the yarn plugin. It was failing in docker but not locally, and I didn't know why. It turned out to be because I forgot to copy the backstage.json into the docker image. This was confusing, because the error seemed to indicate I was failing the semver checks. This change propagates error detail down the line, so people will see the actual cause. (i.e. missing file, no version field, semver wrong)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
