### PR TITLE
fix(home): Correct clearAll logic to properly handle deletable flag in CustomHomepageGrid

### DIFF
--- a/.changeset/fuzzy-trams-kick.md
+++ b/.changeset/fuzzy-trams-kick.md
@@ -1,0 +1,6 @@
+---
+'example-app': patch
+'@backstage/plugin-home': patch
+---
+
+fix(home): correct clearAll logic to properly handle deletable flag

--- a/.changeset/fuzzy-trams-kick.md
+++ b/.changeset/fuzzy-trams-kick.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-home': patch
 ---
 
-fix(home): correct clearAll logic to properly handle deletable flag
+fix(home): correct `clearAll` logic to properly handle `deletable` flag

--- a/.changeset/fuzzy-trams-kick.md
+++ b/.changeset/fuzzy-trams-kick.md
@@ -1,5 +1,4 @@
 ---
-'example-app': patch
 '@backstage/plugin-home': patch
 ---
 

--- a/packages/app/src/components/home/CustomizableHomePage.tsx
+++ b/packages/app/src/components/home/CustomizableHomePage.tsx
@@ -37,6 +37,7 @@ const defaultConfig = [
     y: 0,
     width: 24,
     height: 2,
+    deletable: false,
   },
   {
     component: 'HomePageRecentlyVisited',

--- a/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.tsx
+++ b/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.tsx
@@ -275,7 +275,7 @@ export const CustomHomepageGrid = (props: CustomHomepageGridProps) => {
   };
 
   const clearLayout = () => {
-    setWidgets(widgets.filter(w => !w.deletable));
+    setWidgets(widgets.filter(w => w.deletable === false));
   };
 
   const changeEditMode = (mode: boolean) => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!
The `Clear All` button in the CustomHomepageGrid component stopped working properly after PR #30788. By default, if the `deletable` flag is not set, widgets should be considered as deletable unless explicitly set to `false`.

## Solution
Changed the filter logic from `w => !w.deletable` to `w => w.deletable === false`. This ensures that:

- Widgets with `deletable: false` are preserved (not deleted)
- Widgets with `deletable: true` are removed (deleted)  
- Widgets with `deletable: undefined` (when not set) are removed (Default)

## Behavior
The clear all button now works as expected:
- **Default behavior**: All widgets are deletable unless explicitly marked as non-deletable
- **Opt-out approach**: Only widgets with `deletable: false` are preserved during clear operations
- **Backward compatibility**: Existing configurations continue to work as intended

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
