### PR TITLE
fix: modified available providers in setting page to wrap description

### DIFF
--- a/.changeset/dry-lamps-kneel.md
+++ b/.changeset/dry-lamps-kneel.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-user-settings': patch
+---
+
+Fixed available providers in settings page to wrap description in screen sizes approx. 1000 px and smaller

--- a/plugins/user-settings/src/components/AuthProviders/ProviderSettingsItem.tsx
+++ b/plugins/user-settings/src/components/AuthProviders/ProviderSettingsItem.tsx
@@ -87,15 +87,19 @@ export const ProviderSettingsItem = (props: {
   }, [api]);
 
   return (
-    <ListItem>
+    <ListItem divider>
       <ListItemIcon>
         <Icon />
       </ListItemIcon>
       <ListItemText
-        primary={title}
+        primary={
+          <Typography variant="subtitle1" color="textPrimary" gutterBottom>
+            {title}
+          </Typography>
+        }
         secondary={
           <Tooltip placement="top" arrow title={description}>
-            <Grid container spacing={6}>
+            <Grid container spacing={3}>
               <Grid item>
                 <ProviderSettingsAvatar size={48} picture={profile.picture} />
               </Grid>
@@ -116,7 +120,11 @@ export const ProviderSettingsItem = (props: {
                         {profile.email}
                       </Typography>
                     )}
-                    <Typography variant="body2" color="textSecondary">
+                    <Typography
+                      variant="body2"
+                      color="textSecondary"
+                      gutterBottom
+                    >
                       {description}
                     </Typography>
                   </Grid>
@@ -125,7 +133,9 @@ export const ProviderSettingsItem = (props: {
             </Grid>
           </Tooltip>
         }
-        secondaryTypographyProps={{ noWrap: true, style: { width: '80%' } }}
+        secondaryTypographyProps={{
+          style: { width: '80%', whiteSpace: 'normal' },
+        }}
       />
       <ListItemSecondaryAction>
         <Tooltip


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
The available authentication providers in the setting page was a bit messy and hard read.  

**Before the change** description was cut when screen size was narrowed. The items were also not so well distinguished from each other.

<img width="429" height="658" alt="Näyttökuva 2025-08-25 090520" src="https://github.com/user-attachments/assets/98a50b48-6b85-4f09-8d20-5b454d694060" />
<img width="513" height="628" alt="Näyttökuva 2025-08-26 103552" src="https://github.com/user-attachments/assets/6333134c-4461-4e64-867a-f48c86ccecb9" />

**After the change** description in wrapped when screen is narrowed. Also the items are divided and the gap inside of an item is smaller. 

<img width="428" height="576" alt="Näyttökuva 2025-08-25 141745" src="https://github.com/user-attachments/assets/ca506aab-b976-4f13-b96e-9a6e81fc4b7e" />
<img width="450" height="728" alt="Näyttökuva 2025-08-25 141814" src="https://github.com/user-attachments/assets/aca17f88-11e2-410e-a909-59a398b0870f" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
