### PR TITLE
Add /alpha to example docs for ActionsRegistryService

### DIFF
--- a/docs/backend-system/core-services/actions-registry.md
+++ b/docs/backend-system/core-services/actions-registry.md
@@ -45,7 +45,7 @@ When an action is executed, it receives a context object (`ActionsRegistryAction
 Here's an example of how to register an action with the Actions Registry Service:
 
 ```typescript
-import { ActionsRegistryService } from '@backstage/backend-plugin-api';
+import { ActionsRegistryService } from '@backstage/backend-plugin-api/alpha';
 
 export function registerMyActions(actionsRegistry: ActionsRegistryService) {
   // Register a simple read-only action


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Noticed the example was missing the `/alpha` suffix when testing out the new service.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
