### PR TITLE
fix: deduplicate discovered backend features

### DIFF
--- a/.changeset/afraid-streets-pay.md
+++ b/.changeset/afraid-streets-pay.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Deduplicate discovered features discovered with discoveryFeatureLoader

--- a/packages/backend-defaults/src/PackageDiscoveryService.ts
+++ b/packages/backend-defaults/src/PackageDiscoveryService.ts
@@ -175,6 +175,6 @@ export class PackageDiscoveryService {
       }
     }
 
-    return { features };
+    return { features: Array.from(new Set(features)) };
   }
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This pull request makes a small improvement to the `PackageDiscoveryService` by ensuring that the returned `features` array contains only unique values. This allows using `discoveryFeatureLoader` with backend plugins that still export `alpha` modules. Without deduplication such plugins result in errors similar to the following:

```
2025-08-28T08:59:07.759Z backstage info Detected: @backstage/plugin-events-backend 
2025-08-28T08:59:07.768Z backstage info Detected: @backstage/plugin-events-backend 
2025-08-28T08:59:07.773Z rootHttpRouter info Listening on :7007 
Backend failed to start up Error: ExtensionPoint with ID 'events' is already registered
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
