### PR TITLE
Only run provider orphan cleanup if the engine is started

### DIFF
--- a/.changeset/whole-dingos-lay.md
+++ b/.changeset/whole-dingos-lay.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Only run provider orphan cleanup if the engine is started in the first place

--- a/plugins/catalog-backend/src/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.ts
@@ -622,18 +622,21 @@ export class CatalogBuilder {
       enableRelationsCompatibility,
     });
 
-    if (config.getOptionalString('catalog.orphanProviderStrategy') !== 'keep') {
-      await evictEntitiesFromOrphanedProviders({
-        db: providerDatabase,
-        providers: entityProviders,
-        logger,
-      });
-    }
     await connectEntityProviders(providerDatabase, entityProviders);
 
     return {
       processingEngine: {
         async start() {
+          if (
+            config.getOptionalString('catalog.orphanProviderStrategy') !==
+            'keep'
+          ) {
+            await evictEntitiesFromOrphanedProviders({
+              db: providerDatabase,
+              providers: entityProviders,
+              logger,
+            });
+          }
           await processingEngine.start();
           await stitcher.start();
         },


### PR DESCRIPTION
If you set `processingInterval: false`, you don't expect ANY aspect of the processing and provider loops to run. Especially if you have a read-write split; it doesn't make sense to have your read nodes try to perform deletions on their probably readonly restricted replica.

I would argue that connecting the providers should be moved in here too. But that could be thought of as a breaking change - what if people actually do metrics tracking or perform some other related tasks in these providers (such as reacting to webhooks)? So I chose to postpone that for now.