### PR TITLE
Improve MCP backend error handling

### DIFF
--- a/.changeset/curvy-sites-rhyme.md
+++ b/.changeset/curvy-sites-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+The 'get-catalog-entity' action now throws a ConflictError instead of generic Error if multiple entities are found, so MCP call doesn't fail with 500.

--- a/.changeset/icy-camels-throw.md
+++ b/.changeset/icy-camels-throw.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-mcp-actions-backend': patch
+---
+
+The MCP backend will now convert known Backstage errors into textual responses with `isError: true`.
+The error message can be useful for an LLM to understand and maybe give back to the user.
+Previously all errors where thrown out to `@modelcontextprotocol/sdk` which causes a generic 500.

--- a/plugins/catalog-backend/src/actions/createGetCatalogEntityAction.ts
+++ b/plugins/catalog-backend/src/actions/createGetCatalogEntityAction.ts
@@ -15,7 +15,7 @@
  */
 import { ActionsRegistryService } from '@backstage/backend-plugin-api/alpha';
 import { stringifyEntityRef } from '@backstage/catalog-model';
-import { InputError } from '@backstage/errors';
+import { ConflictError, InputError } from '@backstage/errors';
 import { CatalogService } from '@backstage/plugin-catalog-node';
 
 export const createGetCatalogEntityAction = ({
@@ -76,7 +76,7 @@ Each entity is identified by a unique entity reference, which is a string of the
       }
 
       if (items.length > 1) {
-        throw new Error(
+        throw new ConflictError(
           `Multiple entities found with name "${
             input.name
           }", please provide more specific filters. Entities found: ${items

--- a/plugins/mcp-actions-backend/src/services/McpService.test.ts
+++ b/plugins/mcp-actions-backend/src/services/McpService.test.ts
@@ -178,14 +178,21 @@ describe('McpService', () => {
       server.connect(serverTransport),
     ]);
 
-    await expect(
-      client.request(
+    const result = await client.request(
+      {
+        method: 'tools/call',
+        params: { name: 'mock-action', arguments: { input: 'test' } },
+      },
+      CallToolResultSchema,
+    );
+    await expect(result).toEqual({
+      content: [
         {
-          method: 'tools/call',
-          params: { name: 'mock-action', arguments: { input: 'test' } },
+          text: expect.stringMatching('Action "mock-action" not found'),
+          type: 'text',
         },
-        CallToolResultSchema,
-      ),
-    ).rejects.toThrow('Action "mock-action" not found');
+      ],
+      isError: true,
+    });
   });
 });

--- a/plugins/mcp-actions-backend/src/services/handleErrors.ts
+++ b/plugins/mcp-actions-backend/src/services/handleErrors.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ErrorLike,
+  ForwardedError,
+  isError,
+  serializeError,
+} from '@backstage/errors';
+
+import { Server as McpServer } from '@modelcontextprotocol/sdk/server/index.js';
+
+const knownErrors = new Set([
+  'InputError',
+  'AuthenticationError',
+  'NotAllowedError',
+  'NotFoundError',
+  'ConflictError',
+  'NotModifiedError',
+  'NotImplementedError',
+  'ResponseError',
+]);
+
+// Extracts the cause error, if the provided error is `ResponseError` or
+// `ForwardedError` with a cause.
+function extractCause(err: ErrorLike): ErrorLike {
+  if (
+    (err.name === 'ResponseError' || err instanceof ForwardedError) &&
+    isError(err.cause)
+  ) {
+    return err.cause;
+  }
+  return err;
+}
+
+/**
+ * Takes a value expected to be an object, and returns a description of the
+ * error to return to the MCP client, if the error is a known Backstage error.
+ *
+ * Re-throws the original error otherwise
+ */
+function describeError(err: unknown): string {
+  if (err instanceof Error) {
+    const serialized = serializeError(err);
+
+    const { name, message } = extractCause(serialized);
+
+    if (knownErrors.has(name)) {
+      return `${name}: ${message}`;
+    }
+  }
+
+  throw err;
+}
+
+type RequestResultType = ReturnType<
+  Parameters<McpServer['setRequestHandler']>[1]
+>;
+/**
+ * Wraps a request function with an error handler that turns known Backstage
+ * errors into user-friendly messages, instead of failing the request
+ * generically with a 500.
+ */
+export async function handleErrors(
+  fn: () => RequestResultType | Promise<RequestResultType>,
+): Promise<RequestResultType> {
+  try {
+    return await fn();
+  } catch (err) {
+    // This will rethrow if the error is not a known Backstage error
+    const description = describeError(err);
+    return {
+      content: [{ type: 'text', text: description }],
+      isError: true,
+    };
+  }
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When using the MCP backend, an action that throws an error will turn into a "500 Internal Server Error".

For known Backstage errors e.g. `NotFoundError`, the error will now be converted into a textual response with the `isError` flag set to true. May of the errors that can be thrown aren't "internal server errors", but conflicts, not found, input error, etc - rather something like 400's.

This logic mimics the default backend [error handler](https://github.com/backstage/backstage/blob/923491eece9bd571aceb9d44f119db2fdd98c782/packages/backend-common/src/middleware/errorHandler.ts#L115)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
