### PR TITLE
ui: add bui-align-baseline class implied by Flex component

### DIFF
--- a/.changeset/busy-chairs-itch.md
+++ b/.changeset/busy-chairs-itch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Add missing class for flex: baseline

--- a/packages/ui/css/styles.css
+++ b/packages/ui/css/styles.css
@@ -8797,6 +8797,10 @@
   align-items: end;
 }
 
+.bui-align-baseline {
+  align-items: baseline;
+}
+
 .bui-align-stretch {
   align-items: stretch;
 }

--- a/packages/ui/src/css/utilities/flex.css
+++ b/packages/ui/src/css/utilities/flex.css
@@ -10,6 +10,10 @@
   align-items: end;
 }
 
+.bui-align-baseline {
+  align-items: baseline;
+}
+
 .bui-align-stretch {
   align-items: stretch;
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Noticed this class was missing, so setting `align="baseline"` on a `Flex` component currently does nothing.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
