### PR TITLE
Patch release of #31018

### DIFF
--- a/.changeset/sweet-lemons-wonder.md
+++ b/.changeset/sweet-lemons-wonder.md
@@ -1,5 +1,0 @@
----
-'@techdocs/cli': patch
----
-
-Fixed an issue causing the `@techdocs/cli serve` to not pick up the latest changes of TechDocs.

--- a/.changeset/sweet-lemons-wonder.md
+++ b/.changeset/sweet-lemons-wonder.md
@@ -1,0 +1,5 @@
+---
+'@techdocs/cli': patch
+---
+
+Fixed an issue causing the `@techdocs/cli serve` to not pick up the latest changes of TechDocs.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.42.4",
+  "version": "1.42.5",
   "backstage": {
     "cli": {
       "new": {

--- a/packages/techdocs-cli/CHANGELOG.md
+++ b/packages/techdocs-cli/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- 15da5af: Fixed an issue causing the `@techdocs/cli serve` to not pick up the latest changes of TechDocs.
+- 15da5af: Fixed an issue where `@techdocs/cli serve` command did not pick up the latest changes to TechDocs.
 
 ## 1.9.6
 

--- a/packages/techdocs-cli/CHANGELOG.md
+++ b/packages/techdocs-cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @techdocs/cli
 
+## 1.9.7
+
+### Patch Changes
+
+- 15da5af: Fixed an issue causing the `@techdocs/cli serve` to not pick up the latest changes of TechDocs.
+
 ## 1.9.6
 
 ### Patch Changes

--- a/packages/techdocs-cli/package.json
+++ b/packages/techdocs-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@techdocs/cli",
-  "version": "1.9.6",
+  "version": "1.9.7",
   "description": "Utility CLI for managing TechDocs sites in Backstage.",
   "backstage": {
     "role": "cli"


### PR DESCRIPTION
This release fixes an issue where the `@techdocs/cli serve` command didn't pick up the latest changes of TechDocs.