### PR TITLE
Make the submenuConfig public

### DIFF
--- a/.changeset/five-hounds-listen.md
+++ b/.changeset/five-hounds-listen.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Make the `submenuConfig` public.

--- a/packages/core-components/report.api.md
+++ b/packages/core-components/report.api.md
@@ -917,8 +917,6 @@ export type SelectItem = {
 // @public
 export const Sidebar: (props: SidebarProps) => JSX_2.Element;
 
-// Warning: (ae-missing-release-tag) "SIDEBAR_INTRO_LOCAL_STORAGE" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
 export const SIDEBAR_INTRO_LOCAL_STORAGE =
   '@backstage/core/sidebar-intro-dismissed';
@@ -926,8 +924,6 @@ export const SIDEBAR_INTRO_LOCAL_STORAGE =
 // @public (undocumented)
 export type SidebarClassKey = 'drawer' | 'drawerOpen';
 
-// Warning: (ae-missing-release-tag) "sidebarConfig" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
 export const sidebarConfig: {
   drawerWidthClosed: number;
@@ -1281,6 +1277,13 @@ export interface StructuredMetadataTableProps {
     nestedValuesAsYaml?: boolean;
   };
 }
+
+// @public (undocumented)
+export const submenuConfig: {
+  drawerWidthClosed: number;
+  drawerWidthOpen: number;
+  defaultOpenDelayMs: number;
+};
 
 // @public (undocumented)
 export type SubmenuOptions = {

--- a/packages/core-components/src/layout/Sidebar/config.ts
+++ b/packages/core-components/src/layout/Sidebar/config.ts
@@ -49,6 +49,7 @@ export type SidebarConfig = {
   mobileSidebarHeight: number;
 };
 
+/** @public */
 export const sidebarConfig = {
   drawerWidthClosed,
   drawerWidthOpen: 224,
@@ -85,6 +86,7 @@ export type SubmenuConfig = {
   defaultOpenDelayMs: number;
 };
 
+/** @public */
 export const submenuConfig = {
   drawerWidthClosed: 0,
   drawerWidthOpen: 202,
@@ -98,6 +100,7 @@ export const makeSidebarSubmenuConfig = (
   ...customSubmenuConfig,
 });
 
+/** @public */
 export const SIDEBAR_INTRO_LOCAL_STORAGE =
   '@backstage/core/sidebar-intro-dismissed';
 

--- a/packages/core-components/src/layout/Sidebar/index.ts
+++ b/packages/core-components/src/layout/Sidebar/index.ts
@@ -48,7 +48,11 @@ export type {
   SidebarSpacerClassKey,
   SidebarDividerClassKey,
 } from './Items';
-export { SIDEBAR_INTRO_LOCAL_STORAGE, sidebarConfig } from './config';
+export {
+  SIDEBAR_INTRO_LOCAL_STORAGE,
+  sidebarConfig,
+  submenuConfig,
+} from './config';
 export type { SidebarOptions, SubmenuOptions } from './config';
 export {
   LegacySidebarContext as SidebarContext,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

The submenu config should be public to reach its attributes (mainly the drawer width).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
