### PR TITLE
add internal reference to the plugin kubernetes-backend to use a constant for SERVICEACCOUNT_CA_PATH, because kubernetes-common plugin has @internal 

### DIFF
--- a/plugins/kubernetes-common/src/certificate-authority-constants.ts
+++ b/plugins/kubernetes-common/src/certificate-authority-constants.ts
@@ -17,7 +17,7 @@
 /**
  * A constant that specifies the location of the certificate for the service account.
  *
- * @internal
+ * @public
  */
 export const SERVICEACCOUNT_CA_PATH =
   '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

trying to debug this:
https://github.com/backstage/backstage/issues/31014
i build the plugin kubernetes-backend and had errors.
because kubernetes-common plugin has @internal for SERVICEACCOUNT_CA_PATH, kubernetes-backend gives error when building it.
I added internal reference to the plugin kubernetes-backend to use a constant for SERVICEACCOUNT_CA_PATH

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
