### PR TITLE
frontend-plugin-api: improve type errors for createFrontend{Plugin,Module}

### DIFF
--- a/.changeset/fine-hands-think.md
+++ b/.changeset/fine-hands-think.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': patch
+---
+
+Improved the types of `createFrontendPlugin` and `createFrontendModule` so that errors due to incompatible options are indicated more clearly.

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -691,7 +691,7 @@ export interface CreateFrontendFeatureLoaderOptions {
 // @public
 export function createFrontendModule<
   TId extends string,
-  TExtensions extends readonly ExtensionDefinition[] = [],
+  TExtensions extends readonly ExtensionDefinition[],
 >(options: CreateFrontendModuleOptions<TId, TExtensions>): FrontendModule;
 
 // @public (undocumented)
@@ -710,13 +710,13 @@ export interface CreateFrontendModuleOptions<
 // @public
 export function createFrontendPlugin<
   TId extends string,
+  TExtensions extends readonly ExtensionDefinition[],
   TRoutes extends {
     [name in string]: RouteRef | SubRouteRef;
   } = {},
   TExternalRoutes extends {
     [name in string]: ExternalRouteRef;
   } = {},
-  TExtensions extends readonly ExtensionDefinition[] = [],
 >(
   options: PluginOptions<TId, TRoutes, TExternalRoutes, TExtensions>,
 ): OverridableFrontendPlugin<

--- a/packages/frontend-plugin-api/src/wiring/createFrontendModule.ts
+++ b/packages/frontend-plugin-api/src/wiring/createFrontendModule.ts
@@ -86,7 +86,7 @@ export interface InternalFrontendModule extends FrontendModule {
  */
 export function createFrontendModule<
   TId extends string,
-  TExtensions extends readonly ExtensionDefinition[] = [],
+  TExtensions extends readonly ExtensionDefinition[],
 >(options: CreateFrontendModuleOptions<TId, TExtensions>): FrontendModule {
   const { pluginId } = options;
 

--- a/packages/frontend-plugin-api/src/wiring/createFrontendPlugin.ts
+++ b/packages/frontend-plugin-api/src/wiring/createFrontendPlugin.ts
@@ -182,9 +182,9 @@ export interface PluginOptions<
  */
 export function createFrontendPlugin<
   TId extends string,
+  TExtensions extends readonly ExtensionDefinition[],
   TRoutes extends { [name in string]: RouteRef | SubRouteRef } = {},
   TExternalRoutes extends { [name in string]: ExternalRouteRef } = {},
-  TExtensions extends readonly ExtensionDefinition[] = [],
 >(
   options: PluginOptions<TId, TRoutes, TExternalRoutes, TExtensions>,
 ): OverridableFrontendPlugin<


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Before this fix you'd get a quite confusing error when omitting `pluginId` and passing a different prop:

<img width="779" height="437" alt="image" src="https://github.com/user-attachments/assets/8cee626b-910e-440d-95fc-0267d0cd475c" />

This ofc mostly has an impact because of the recent removal of the deprecated `id` option, which is now `pluginId` instead.

With the fix in place, the error is more clear:

<img width="722" height="242" alt="image" src="https://github.com/user-attachments/assets/3788d139-e91c-4a3b-840b-a01a6dbc482f" />

An empty or missing `extensions` options still behaves correctly after this change:

<img width="519" height="349" alt="image" src="https://github.com/user-attachments/assets/c1a436e2-ca5d-4a1a-aa44-0a32a43860bd" />

<img width="476" height="321" alt="image" src="https://github.com/user-attachments/assets/6ac245bb-4c9a-427c-8390-56764a0253ed" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
