### PR TITLE
ui: include `aria-` props on `Select` component

### DIFF
--- a/.changeset/fix-select-aria-props.md
+++ b/.changeset/fix-select-aria-props.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Fix Select component to properly attach aria-label and aria-labelledby props to the rendered element for improved accessibility.

--- a/packages/ui/src/components/Select/Select.stories.tsx
+++ b/packages/ui/src/components/Select/Select.stories.tsx
@@ -328,3 +328,34 @@ export const WithLongNamesAndPadding: Story = {
     ),
   ],
 };
+
+export const WithAccessibilityProps: Story = {
+  args: {
+    ...Default.args,
+  },
+  render: args => (
+    <Flex direction="column" gap="4">
+      <div>
+        <h3 style={{ marginBottom: 8 }}>With aria-label</h3>
+        <Select
+          {...args}
+          aria-label="Choose font family"
+          placeholder="Select a font family"
+          name="font-aria"
+        />
+      </div>
+      <div>
+        <h3 style={{ marginBottom: 8 }}>With aria-labelledby</h3>
+        <div id="font-label" style={{ marginBottom: 8, fontWeight: 600 }}>
+          Font Family Selection
+        </div>
+        <Select
+          {...args}
+          aria-labelledby="font-label"
+          placeholder="Select a font family"
+          name="font-labelledby"
+        />
+      </div>
+    </Flex>
+  ),
+};

--- a/packages/ui/src/components/Select/Select.tsx
+++ b/packages/ui/src/components/Select/Select.tsx
@@ -70,6 +70,8 @@ export const Select = forwardRef<HTMLDivElement, SelectProps>((props, ref) => {
       className={clsx(classNames.root, className)}
       {...dataAttributes}
       ref={ref}
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
       {...rest}
     >
       <FieldLabel


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The Select component was accepting aria-label and aria-labelledby props
but not forwarding them to the underlying AriaSelect element, making
them ineffective for accessibility. This fix ensures these props are
properly attached to the rendered element.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
