### PR TITLE
Fixed duplicate route warning for TechDocs Addons documentation in Do…

### DIFF
--- a/docs/features/techdocs/addons--new.md
+++ b/docs/features/techdocs/addons--new.md
@@ -5,7 +5,7 @@ description: How to find, use, or create TechDocs Addons.
 ---
 
 :::info
-This documentation is written for [the new frontend system](../../frontend-system/index.md) which is still in alpha and is only supported by a small number of plugins.
+This documentation is written for [the new frontend system](../../frontend-system/index.md) which is still in alpha and is only supported by a small number of plugins. If you are on the [old frontend system](./getting-started.md#adding-techdocs-frontend-plugin) you may want to read [its own article](./addons.md) instead.
 :::
 
 ## Concepts

--- a/docs/features/techdocs/addons--new.md
+++ b/docs/features/techdocs/addons--new.md
@@ -1,5 +1,5 @@
 ---
-id: addons
+id: addons--new
 title: TechDocs Addons
 description: How to find, use, or create TechDocs Addons.
 ---

--- a/docs/features/techdocs/addons.md
+++ b/docs/features/techdocs/addons.md
@@ -1,5 +1,5 @@
 ---
-id: addons--old
+id: addons
 title: TechDocs Addons
 description: How to find, use, or create TechDocs Addons.
 ---

--- a/docs/features/techdocs/addons.md
+++ b/docs/features/techdocs/addons.md
@@ -1,5 +1,5 @@
 ---
-id: addons
+id: addons--old
 title: TechDocs Addons
 description: How to find, use, or create TechDocs Addons.
 ---


### PR DESCRIPTION

<img width="1149" height="120" alt="image" src="https://github.com/user-attachments/assets/ef4b8029-35ab-4e7c-a4f5-c9795817482e" />


This PR resolves a Docusaurus routing warning caused by two markdown files _(addons.md and addons--new.md)_ using the same `id: addons` in their frontmatter. This resulted in both files attempting to generate the same route (/docs/addons), leading to non-deterministic routing behavior as shown in the waring.

Changes

- Updated the id in addon.md to addons--old
- Added route in addons--new.md to navigate to addons.md