### PR TITLE
Handle MODULE_NOT_FOUND errors for optional dependencies

### DIFF
--- a/.changeset/ripe-masks-build.md
+++ b/.changeset/ripe-masks-build.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Enhanced error handling in PackageDiscoveryService to skip optional dependencies that trigger MODULE_NOT_FOUND errors during package discovery.

--- a/packages/backend-defaults/src/PackageDiscoveryService.ts
+++ b/packages/backend-defaults/src/PackageDiscoveryService.ts
@@ -137,6 +137,10 @@ export class PackageDiscoveryService {
         if (isError(error) && error.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
           continue; // Skip packages that don't export package.json - they can't be Backstage packages
         }
+        // Handle packages that cannot be found (e.g., optional dependencies)
+        if (isError(error) && error.code === 'MODULE_NOT_FOUND') {
+          continue; // Skip packages that are not available
+        }
         throw error;
       }
       if (


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Enhanced error handling in PackageDiscoveryService to skip optional dependencies that trigger MODULE_NOT_FOUND errors during package discovery.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
