### PR TITLE
Fix getDefault for kubernetesFetcherExtensionPoint

### DIFF
--- a/.changeset/heavy-lies-listen.md
+++ b/.changeset/heavy-lies-listen.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Fix a bug where `getDefault` in the `kubernetesFetcherExtensionPoint` had the wrong `this` value

--- a/plugins/kubernetes-backend/src/service/KubernetesInitializer.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesInitializer.ts
@@ -183,8 +183,9 @@ export class KubernetesInitializer {
 
   async init() {
     const fetcher =
-      (await this.opts.fetcher?.({ getDefault: this.defaultFetcher })) ??
-      (await this.defaultFetcher());
+      (await this.opts.fetcher?.({
+        getDefault: () => this.defaultFetcher(),
+      })) ?? (await this.defaultFetcher());
 
     const authStrategyMap =
       this.opts.authStrategyMap ?? (await this.defaultAuthStrategy());


### PR DESCRIPTION
Fixes #31000

Good old `this` rearing its ugly head again.