### PR TITLE
fix(kubernetes): fixes calculation of pod cpu utilization

### DIFF
--- a/.changeset/twelve-guests-sit.md
+++ b/.changeset/twelve-guests-sit.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-react': patch
+---
+
+Fixes calculation of CPU utilization in the PodTable

--- a/plugins/kubernetes-react/src/components/Pods/PodsTable.test.tsx
+++ b/plugins/kubernetes-react/src/components/Pods/PodsTable.test.tsx
@@ -74,7 +74,7 @@ describe('PodsTable', () => {
           limitTotal: '134217728',
         },
         cpu: {
-          currentUsage: 0.4966115,
+          currentUsage: 0.0496,
           requestTotal: 0.05,
           limitTotal: 0.05,
         },

--- a/plugins/kubernetes-react/src/utils/pod.test.tsx
+++ b/plugins/kubernetes-react/src/utils/pod.test.tsx
@@ -42,7 +42,7 @@ describe('pod', () => {
       const result = podStatusToCpuUtil({
         cpu: {
           // ~50m
-          currentUsage: 0.4966115,
+          currentUsage: 0.0496,
           // 50m
           requestTotal: 0.05,
           // 100m

--- a/plugins/kubernetes-react/src/utils/pod.tsx
+++ b/plugins/kubernetes-react/src/utils/pod.tsx
@@ -139,22 +139,14 @@ export const currentToDeclaredResourceToPerc = (
 export const podStatusToCpuUtil = (podStatus: ClientPodStatus): ReactNode => {
   const cpuUtil = podStatus.cpu;
 
-  let currentUsage: number | string = cpuUtil.currentUsage;
-
-  // current usage number for CPU is a different unit than request/limit total
-  // this might be a bug in the k8s library
-  if (typeof cpuUtil.currentUsage === 'number') {
-    currentUsage = cpuUtil.currentUsage / 10;
-  }
-
   return (
     <SubvalueCell
       value={`requests: ${currentToDeclaredResourceToPerc(
-        currentUsage,
+        cpuUtil.currentUsage,
         cpuUtil.requestTotal,
       )} of ${formatMillicores(cpuUtil.requestTotal)}`}
       subvalue={`limits: ${currentToDeclaredResourceToPerc(
-        currentUsage,
+        cpuUtil.currentUsage,
         cpuUtil.limitTotal,
       )} of ${formatMillicores(cpuUtil.limitTotal)}`}
     />


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The PodTable and PodDrawer components are currently showing different values for CPU Utilization %. The PodDrawer seems to show the correct calculation, while the PodTable shows 1/10th of that value.

PodDrawer:
<img width="522" height="207" alt="image" src="https://github.com/user-attachments/assets/c33a45ac-c1d5-4f16-ae3f-f55ccc904030" />

PodTable:
<img width="182" height="134" alt="image" src="https://github.com/user-attachments/assets/cf71fab9-d7e0-4065-9dd5-bdaca36e5551" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
