### PR TITLE
The frontend package, when executed within a Continuous Integration (CI) environment, will not have its file watcher functionality enabled.

### DIFF
--- a/.changeset/sixty-hornets-cheat.md
+++ b/.changeset/sixty-hornets-cheat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+The frontend package, when executed within a Continuous Integration (CI) environment, will not have its file watcher functionality enabled.

--- a/packages/cli/src/modules/build/lib/bundler/config.ts
+++ b/packages/cli/src/modules/build/lib/bundler/config.ts
@@ -365,7 +365,7 @@ export async function createConfig(
   return {
     mode,
     profile: false,
-    ...(isDev
+    ...(isDev && !process.env.CI
       ? {
           watchOptions: {
             ignored: /node_modules\/(?!__backstage-autodetected-plugins__)/,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I had the use-case where I have to run frontend package on the CI and it is not possible right now due too many files are watched. Logically I think there is no need to watch them even if it is a dev mode, that would make sense to do it only on developer laptop.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
