### PR TITLE
Disable Ajv's allErrors option

### DIFF
--- a/.changeset/heavy-breads-kneel.md
+++ b/.changeset/heavy-breads-kneel.md
@@ -1,0 +1,7 @@
+---
+'@backstage/backend-openapi-utils': minor
+'@backstage/catalog-model': minor
+'@backstage/config-loader': minor
+---
+
+Disable Ajv's allErrors option in production.

--- a/packages/backend-openapi-utils/src/schema/validation.ts
+++ b/packages/backend-openapi-utils/src/schema/validation.ts
@@ -24,7 +24,7 @@ import { RequestBodyParser } from './request-body-validation';
 import { mockttpToFetchRequest, mockttpToFetchResponse } from './utils';
 import { ResponseBodyParser } from './response-body-validation';
 
-const ajv = new Ajv({ allErrors: true });
+const ajv = new Ajv({ allErrors: process.env.NODE_ENV !== 'production' });
 
 class RequestBodyValidator implements Validator {
   schema: OpenAPIObject;

--- a/packages/catalog-model/src/validation/ajv.ts
+++ b/packages/catalog-model/src/validation/ajv.ts
@@ -70,7 +70,7 @@ export function compileAjvSchema(
   const extraSchemas = getExtraSchemas(schema);
   const ajv = new Ajv({
     allowUnionTypes: true,
-    allErrors: true,
+    allErrors: process.env.NODE_ENV !== 'production',
     validateSchema: true,
   });
   if (extraSchemas.length) {

--- a/packages/config-loader/src/schema/compile.ts
+++ b/packages/config-loader/src/schema/compile.ts
@@ -52,7 +52,7 @@ export function compileConfigSchemas(
   const deprecationByDataPath = new Map<string, string>();
 
   const ajv = new Ajv({
-    allErrors: true,
+    allErrors: process.env.NODE_ENV !== 'production',
     allowUnionTypes: true,
     coerceTypes: true,
     schemas: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The problem is that Ajv is configured with allErrors: true, which forces the validator to keep checking every possible error instead of stopping at the first one. This makes validation much slower and more resource-intensive, allowing malicious inputs to trigger excessive CPU and memory usage, potentially causing denial of service. See https://hackerone.com/reports/903521 for more information.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
