### PR TITLE
fix(scaffolder): add missing templatingExtensions option to RouterProps contextMenu

### DIFF
--- a/.changeset/ready-pots-arrive.md
+++ b/.changeset/ready-pots-arrive.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Add missing `templatingExtensions` option to RouterProps.contextMenu to allow global control across scaffolder pages

--- a/plugins/scaffolder/src/components/ActionsPage/ActionsPage.tsx
+++ b/plugins/scaffolder/src/components/ActionsPage/ActionsPage.tsx
@@ -240,6 +240,7 @@ export type ActionsPageProps = {
     editor?: boolean;
     tasks?: boolean;
     create?: boolean;
+    templatingExtensions?: boolean;
   };
 };
 
@@ -265,7 +266,10 @@ export const ActionsPage = (props: ActionsPageProps) => {
       props?.contextMenu?.create !== false
         ? () => navigate(createLink())
         : undefined,
-    onTemplatingExtensionsClicked: () => navigate(templatingExtensionsLink()),
+    onTemplatingExtensionsClicked:
+      props?.contextMenu?.templatingExtensions !== false
+        ? () => navigate(templatingExtensionsLink())
+        : undefined,
   };
 
   return (

--- a/plugins/scaffolder/src/components/ListTasksPage/ListTasksPage.tsx
+++ b/plugins/scaffolder/src/components/ListTasksPage/ListTasksPage.tsx
@@ -55,6 +55,7 @@ export interface MyTaskPageProps {
     editor?: boolean;
     actions?: boolean;
     create?: boolean;
+    templatingExtensions?: boolean;
   };
 }
 
@@ -193,7 +194,10 @@ export const ListTasksPage = (props: MyTaskPageProps) => {
       props?.contextMenu?.create !== false
         ? () => navigate(createLink())
         : undefined,
-    onTemplatingExtensionsClicked: () => navigate(templatingExtensionsLink()),
+    onTemplatingExtensionsClicked:
+      props?.contextMenu?.templatingExtensions !== false
+        ? () => navigate(templatingExtensionsLink())
+        : undefined,
   };
   return (
     <Page themeId="home">

--- a/plugins/scaffolder/src/components/Router/Router.tsx
+++ b/plugins/scaffolder/src/components/Router/Router.tsx
@@ -103,6 +103,8 @@ export type RouterProps = {
     tasks?: boolean;
     /** Whether to show a link to the create page (on /create subroutes) */
     create?: boolean;
+    /** Whether to show a link to the templating extensions page */
+    templatingExtensions?: boolean;
   };
 };
 
@@ -244,7 +246,7 @@ export const InternalRouter = (
       />
       <Route
         path={templatingExtensionsRouteRef.path}
-        element={<TemplatingExtensionsPage />}
+        element={<TemplatingExtensionsPage contextMenu={props.contextMenu} />}
       />
       <Route path="*" element={<NotFoundErrorPage />} />
     </Routes>

--- a/plugins/scaffolder/src/components/TemplatingExtensionsPage/TemplatingExtensionsPage.tsx
+++ b/plugins/scaffolder/src/components/TemplatingExtensionsPage/TemplatingExtensionsPage.tsx
@@ -296,7 +296,18 @@ export const TemplatingExtensionsPageContent = ({
   );
 };
 
-export const TemplatingExtensionsPage = () => {
+export type TemplatingExtensionsPageProps = {
+  contextMenu?: {
+    editor?: boolean;
+    actions?: boolean;
+    tasks?: boolean;
+    create?: boolean;
+  };
+};
+
+export const TemplatingExtensionsPage = (
+  props: TemplatingExtensionsPageProps,
+) => {
   const navigate = useNavigate();
   const editorLink = useRouteRef(editRouteRef);
   const tasksLink = useRouteRef(scaffolderListTaskRouteRef);
@@ -304,10 +315,23 @@ export const TemplatingExtensionsPage = () => {
   const actionsLink = useRouteRef(actionsRouteRef);
 
   const scaffolderPageContextMenuProps: ScaffolderPageContextMenuProps = {
-    onEditorClicked: () => navigate(editorLink()),
-    onActionsClicked: () => navigate(actionsLink()),
-    onTasksClicked: () => navigate(tasksLink()),
-    onCreateClicked: () => navigate(createLink()),
+    onEditorClicked:
+      props?.contextMenu?.editor !== false
+        ? () => navigate(editorLink())
+        : undefined,
+    onActionsClicked:
+      props?.contextMenu?.actions !== false
+        ? () => navigate(actionsLink())
+        : undefined,
+    onTasksClicked:
+      props?.contextMenu?.tasks !== false
+        ? () => navigate(tasksLink())
+        : undefined,
+    onCreateClicked:
+      props?.contextMenu?.create !== false
+        ? () => navigate(createLink())
+        : undefined,
+    onTemplatingExtensionsClicked: undefined,
   };
 
   const { t } = useTranslationRef(scaffolderTranslationRef);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
This PR adds the missing `templatingExtensions` option to `RouterProps.contextMenu` in the Scaffolder plugin and ensures consistent propagation of the `contextMenu` to the `TemplatingExtensionsPage`.

Closes #30587 

#### What’s Changed
- Added `templatingExtensions?: boolean` to `RouterProps.contextMenu`.

```
contextMenu?: {
  editor?: boolean;
  actions?: boolean;
  tasks?: boolean;
  create?: boolean;
  templatingExtensions?: boolean; // ✅ newly added
};
```
- Updated `TemplatingExtensionsPage` to accept `contextMenu` props, consistent with other scaffolder pages (`ListTasksPage`, `ActionsPage` etc).
- Added a `.changeset` entry (patch bump for `@backstage/plugin-scaffolder`). 

#### Motivation
Previously:
- `templatingExtensions` could only be toggled via `TemplateListPageProps`, preventing global enable/disable across scaffolder pages.
- `TemplatingExtensionsPage` ignored `contextMenu` and always rendered its items, making it inconsistent with other scaffolder pages.

This PR fixes both gaps and makes context menu handling consistent across all scaffolder pages.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
