### PR TITLE
Tool-tip text correction for the Theme selection in settings page

### DIFF
--- a/.changeset/red-shrimps-fall.md
+++ b/.changeset/red-shrimps-fall.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-user-settings': patch
+---
+
+Tool-tip text correction for the Theme selection in settings page

--- a/plugins/user-settings/report-alpha.api.md
+++ b/plugins/user-settings/report-alpha.api.md
@@ -123,7 +123,7 @@ export const userSettingsTranslationRef: TranslationRef<
     readonly 'languageToggle.select': 'Select language {{language}}';
     readonly 'languageToggle.title': 'Language';
     readonly 'languageToggle.description': 'Change the language';
-    readonly 'themeToggle.select': 'Select theme {{theme}}';
+    readonly 'themeToggle.select': 'Select {{theme}}';
     readonly 'themeToggle.title': 'Theme';
     readonly 'themeToggle.description': 'Change the theme mode';
     readonly 'themeToggle.names.auto': 'Auto';

--- a/plugins/user-settings/src/translation.ts
+++ b/plugins/user-settings/src/translation.ts
@@ -28,7 +28,7 @@ export const userSettingsTranslationRef = createTranslationRef({
     themeToggle: {
       title: 'Theme',
       description: 'Change the theme mode',
-      select: 'Select theme {{theme}}',
+      select: 'Select {{theme}}',
       selectAuto: 'Select Auto Theme',
       names: {
         light: 'Light',


### PR DESCRIPTION
Before it was showing an extra "theme" string:
<img width="775" height="296" alt="image" src="https://github.com/user-attachments/assets/19c32785-c444-4390-92ae-6a49a54ea0a5" />

After the change:
<img width="718" height="427" alt="image" src="https://github.com/user-attachments/assets/f84e8e05-0b3a-4721-bd99-688a7e689ab9" />
