### PR TITLE
fix(module-federation): disallow imported fallback modules in mf

### DIFF
--- a/.changeset/angry-heads-design.md
+++ b/.changeset/angry-heads-design.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Disallow import fallback of critical shared dependencies in module federation.

--- a/packages/cli/src/modules/build/lib/bundler/config.ts
+++ b/packages/cli/src/modules/build/lib/bundler/config.ts
@@ -264,24 +264,30 @@ export async function createConfig(
             singleton: true,
             requiredVersion: '*',
             eager: !isRemote,
+            import: false,
           },
           'react-dom': {
             singleton: true,
             requiredVersion: '*',
             eager: !isRemote,
+            import: false,
           },
           // React Router
           'react-router': {
             singleton: true,
             requiredVersion: '*',
             eager: !isRemote,
+            import: false,
           },
           'react-router-dom': {
             singleton: true,
             requiredVersion: '*',
             eager: !isRemote,
+            import: false,
           },
           // MUI v4
+          // not setting import: false for MUI packages as this
+          // will break once Backstage moves to BUI
           '@material-ui/core/styles': {
             singleton: true,
             requiredVersion: '*',
@@ -293,6 +299,8 @@ export async function createConfig(
             eager: !isRemote,
           },
           // MUI v5
+          // not setting import: false for MUI packages as this
+          // will break once Backstage moves to BUI
           '@mui/material/styles/': {
             singleton: true,
             requiredVersion: '*',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### Changes
- Ensure that a plugin in a module federation container cannot pollute the host app with a direct dependency on shared dependencies. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
