### PR TITLE
catalog-react: removed entity card type deprecation warning

### DIFF
--- a/.changeset/tough-cars-cry.md
+++ b/.changeset/tough-cars-cry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Removed the deprecation warning when not passing an explicit type to `EntityCardBlueprint`. Omitting the type is now intended, allowing the layout to pick the default type instead, typically `content`.

--- a/plugins/catalog-react/src/alpha/blueprints/EntityCardBlueprint.ts
+++ b/plugins/catalog-react/src/alpha/blueprints/EntityCardBlueprint.ts
@@ -75,11 +75,6 @@ export const EntityCardBlueprint = createExtensionBlueprint({
     const finalType = config.type ?? type;
     if (finalType) {
       yield entityCardTypeDataRef(finalType);
-    } else {
-      // eslint-disable-next-line no-console
-      console.warn(
-        `DEPRECATION WARNING: Not providing type for entity cards is deprecated. Missing from '${node.spec.id}'`,
-      );
     }
   },
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Thinking that forcing an explicit entity card type is a but unnecessary and that this warning is just creating a bunch of noice currently. It's even potentially useful to allow the entity layout to pick the fallback type.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
