### PR TITLE
Fixes issue with organization name case sensitivity when using allowedInstallationOwners

### DIFF
--- a/.changeset/thin-phones-press.md
+++ b/.changeset/thin-phones-press.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+Fixes issue with Github credentials provider which fails to match organization name if using allowedInstallationOwners

--- a/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.ts
+++ b/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.ts
@@ -102,7 +102,9 @@ class GithubAppManager {
   private readonly allowedInstallationOwners: string[] | undefined; // undefined allows all installations
 
   constructor(config: GithubAppConfig, baseUrl?: string) {
-    this.allowedInstallationOwners = config.allowedInstallationOwners;
+    this.allowedInstallationOwners = config.allowedInstallationOwners?.map(
+      owner => owner.toLocaleLowerCase('en-US'),
+    );
     this.baseUrl = baseUrl;
     this.baseAuthConfig = {
       appId: config.appId,
@@ -121,7 +123,11 @@ class GithubAppManager {
     repo?: string,
   ): Promise<{ accessToken: string | undefined }> {
     if (this.allowedInstallationOwners) {
-      if (!this.allowedInstallationOwners?.includes(owner)) {
+      if (
+        !this.allowedInstallationOwners?.includes(
+          owner.toLocaleLowerCase('en-US'),
+        )
+      ) {
         return { accessToken: undefined }; // An empty token allows anonymous access to public repos
       }
     }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When using the Github Organization provider, it uses the URLs directly from Github's API response. In certain cases, these URLs can have caps in the organization id. 

When this occurs, in combination with the use of `allowedInstallationOwners` in a Github App, there is a check that looks for matches in the list of installation owners which is done with case sensitive matching. If the `allowedInstallationOwners` value(s) don't match the precise case in the user-supplied URL, the function will not return credentials.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
