### PR TITLE
bui: add new NumberField component

### DIFF
--- a/.changeset/fifty-islands-unite.md
+++ b/.changeset/fifty-islands-unite.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Add NumberField component

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@base-ui-components/react": "1.0.0-alpha.7",
+    "@react-types/shared": "^3.30.0",
     "@remixicon/react": "^4.6.0",
     "@storybook/test": "^8.6.12",
     "@tanstack/react-table": "^8.21.3",

--- a/packages/ui/src/components/NumberField/NumberField.stories.tsx
+++ b/packages/ui/src/components/NumberField/NumberField.stories.tsx
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { NumberField } from './NumberField';
+import { Form, I18nProvider } from 'react-aria-components';
+import { Icon } from '../Icon';
+import { Flex } from '../Flex';
+import { FieldLabel } from '../FieldLabel';
+
+const meta = {
+  title: 'Backstage UI/NumberField',
+  component: NumberField,
+  argTypes: {
+    isRequired: {
+      control: 'boolean',
+    },
+    icon: {
+      control: 'object',
+    },
+  },
+} satisfies Meta<typeof NumberField>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    name: 'amount',
+    placeholder: 'Enter a value',
+    style: {
+      maxWidth: '300px',
+    },
+  },
+};
+
+export const Sizes: Story = {
+  args: {
+    ...Default.args,
+  },
+  render: args => (
+    <Flex direction="row" gap="4" style={{ width: '100%', maxWidth: '600px' }}>
+      <NumberField {...args} size="small" icon={<Icon name="sparkling" />} />
+      <NumberField {...args} size="medium" icon={<Icon name="sparkling" />} />
+    </Flex>
+  ),
+};
+
+export const DefaultValue: Story = {
+  args: {
+    ...Default.args,
+    defaultValue: 100,
+  },
+};
+
+export const WithLabel: Story = {
+  args: {
+    ...Default.args,
+    label: 'Label',
+  },
+};
+
+export const WithDescription: Story = {
+  args: {
+    ...WithLabel.args,
+    description: 'Description',
+  },
+};
+
+export const WithCustomLocale: Story = {
+  args: {
+    ...Default.args,
+    label: 'Number rendered with locale "de-DE"',
+    value: 1234.56,
+  },
+  render: args => (
+    <I18nProvider locale="de-DE">
+      <NumberField {...args} />
+    </I18nProvider>
+  ),
+};
+
+export const Required: Story = {
+  args: {
+    ...WithLabel.args,
+    isRequired: true,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    ...Default.args,
+    isDisabled: true,
+  },
+};
+
+export const WithIcon: Story = {
+  args: {
+    ...Default.args,
+  },
+  render: args => (
+    <NumberField
+      {...args}
+      placeholder="Enter a number"
+      size="small"
+      icon={<Icon name="eye" />}
+    />
+  ),
+};
+
+export const DisabledWithIcon: Story = {
+  args: {
+    ...WithIcon.args,
+    isDisabled: true,
+  },
+  render: WithIcon.render,
+};
+
+export const ShowError: Story = {
+  args: {
+    ...WithLabel.args,
+  },
+  render: args => (
+    <Form validationErrors={{ amount: 'Invalid value' }}>
+      <NumberField {...args} />
+    </Form>
+  ),
+};
+
+export const Restrictions: Story = {
+  args: {
+    ...WithLabel.args,
+    placeholder: 'Enter an integer value between 0 and 100',
+    minValue: 0,
+    maxValue: 100,
+    step: 1,
+  },
+};
+
+export const Validation: Story = {
+  args: {
+    ...WithLabel.args,
+    placeholder: `You'd better not enter 42`,
+    validate: value =>
+      value === 42 ? `I can't believe you've done this` : null,
+  },
+};
+
+export const CustomField: Story = {
+  render: () => (
+    <>
+      <FieldLabel
+        htmlFor="custom-field"
+        id="custom-field-label"
+        label="Custom Field"
+      />
+      <NumberField
+        id="custom-field"
+        aria-labelledby="custom-field-label"
+        name="custom-field"
+        defaultValue={50}
+      />
+    </>
+  ),
+};

--- a/packages/ui/src/components/NumberField/NumberField.tsx
+++ b/packages/ui/src/components/NumberField/NumberField.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { forwardRef, useEffect } from 'react';
+import { Input, NumberField as AriaNumberField } from 'react-aria-components';
+import clsx from 'clsx';
+import { FieldLabel } from '../FieldLabel';
+import { FieldError } from '../FieldError';
+
+import type { NumberFieldProps } from './types';
+import { useStyles } from '../../hooks/useStyles';
+
+/** @public */
+export const NumberField = forwardRef<HTMLDivElement, NumberFieldProps>(
+  (props, ref) => {
+    const {
+      className,
+      icon,
+      size = 'small',
+      label,
+      secondaryLabel,
+      description,
+      isRequired,
+      'aria-label': ariaLabel,
+      'aria-labelledby': ariaLabelledBy,
+      placeholder,
+      value,
+      defaultValue,
+      onChange,
+      ...rest
+    } = props;
+
+    useEffect(() => {
+      if (!label && !ariaLabel && !ariaLabelledBy) {
+        console.warn(
+          'NumberField requires either a visible label, aria-label, or aria-labelledby for accessibility',
+        );
+      }
+    }, [label, ariaLabel, ariaLabelledBy]);
+
+    // Reuse styles from TextField. The UI here is identical, the only
+    // difference is the validation logic and value type.
+    const { classNames, dataAttributes } = useStyles('TextField', {
+      size,
+    });
+
+    // If a secondary label is provided, use it. Otherwise, use 'Required' if the field is required.
+    const secondaryLabelText =
+      secondaryLabel || (isRequired ? 'Required' : null);
+
+    return (
+      <AriaNumberField
+        className={clsx(classNames.root, className)}
+        {...dataAttributes}
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+        value={value === null ? NaN : value}
+        defaultValue={defaultValue === null ? NaN : defaultValue}
+        onChange={newValue => onChange?.(isNaN(newValue) ? null : newValue)}
+        {...rest}
+        ref={ref}
+      >
+        <FieldLabel
+          label={label}
+          secondaryLabel={secondaryLabelText}
+          description={description}
+        />
+        <div
+          className={classNames.inputWrapper}
+          data-size={dataAttributes['data-size']}
+        >
+          {icon && (
+            <div
+              className={classNames.inputIcon}
+              data-size={dataAttributes['data-size']}
+              aria-hidden="true"
+            >
+              {icon}
+            </div>
+          )}
+          <Input
+            className={classNames.input}
+            {...(icon && { 'data-icon': true })}
+            placeholder={placeholder}
+          />
+        </div>
+        <FieldError />
+      </AriaNumberField>
+    );
+  },
+);
+
+NumberField.displayName = 'NumberField';

--- a/packages/ui/src/components/NumberField/index.ts
+++ b/packages/ui/src/components/NumberField/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './NumberField';
+export * from './types';

--- a/packages/ui/src/components/NumberField/types.ts
+++ b/packages/ui/src/components/NumberField/types.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { NumberFieldProps as AriaNumberFieldProps } from 'react-aria-components';
+import type { ValueBase } from '@react-types/shared';
+import { ReactNode } from 'react';
+import type { Breakpoint } from '../../types';
+import type { FieldLabelProps } from '../FieldLabel/types';
+
+/** @public */
+export interface NumberFieldProps
+  extends Omit<AriaNumberFieldProps, keyof ValueBase<number>>,
+    Omit<FieldLabelProps, 'htmlFor' | 'id'>,
+    ValueBase<number | null> {
+  /**
+   * The current value (controlled).
+   */
+  value?: number | null;
+
+  /**
+   * An icon to render before the input
+   */
+  icon?: ReactNode;
+
+  /**
+   * The size of the text field
+   * @defaultValue 'medium'
+   */
+  size?: 'small' | 'medium' | Partial<Record<Breakpoint, 'small' | 'medium'>>;
+
+  /**
+   * Text to display in the input when it has no value
+   */
+  placeholder?: string;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7546,6 +7546,7 @@ __metadata:
   dependencies:
     "@backstage/cli": "workspace:^"
     "@base-ui-components/react": "npm:1.0.0-alpha.7"
+    "@react-types/shared": "npm:^3.30.0"
     "@remixicon/react": "npm:^4.6.0"
     "@storybook/react": "npm:^8.6.12"
     "@storybook/test": "npm:^8.6.12"


### PR DESCRIPTION

## Hey, I just made a Pull Request!

Mirrors the TextField BUI component but uses the [NumberField](https://react-spectrum.adobe.com/react-aria/NumberField.html) from react-aria-components instead of the TextField.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
