### PR TITLE
fix(cli): identify custom patterns that extend the default pattern

### DIFF
--- a/.changeset/fast-corners-roll.md
+++ b/.changeset/fast-corners-roll.md
@@ -1,0 +1,11 @@
+---
+'@backstage/cli': patch
+---
+
+Modify the `backstage.json` also for custom patterns if it extends the default pattern.
+
+Examples:
+
+- `@backstage/*` (default pattern)
+- `@{backstage,backstage-community}/*`
+- `@{extra1,backstage,extra2}/*`

--- a/packages/cli/src/modules/migrate/commands/versions/bump.test.ts
+++ b/packages/cli/src/modules/migrate/commands/versions/bump.test.ts
@@ -772,6 +772,7 @@ describe('bump', () => {
           res(
             ctx.status(200),
             ctx.json({
+              releaseVersion: '1.0.0',
               packages: [],
             }),
           ),
@@ -797,7 +798,7 @@ describe('bump', () => {
       'bumping @backstage-extra/custom in b to ^1.1.0',
       'bumping @backstage-extra/custom-two in b to ^2.0.0',
       'bumping @backstage/theme in b to ^2.0.0',
-      'Skipping backstage.json update as custom pattern is used',
+      'Your project is now at version 1.0.0, which has been written to backstage.json',
       'Running yarn install to install new versions',
       'Checking for moved packages to the @backstage-community namespace...',
       '⚠️  The following packages may have breaking changes:',

--- a/packages/cli/src/modules/migrate/commands/versions/bump.ts
+++ b/packages/cli/src/modules/migrate/commands/versions/bump.ts
@@ -18,6 +18,7 @@ maybeBootstrapProxy();
 
 import fs from 'fs-extra';
 import chalk from 'chalk';
+import { minimatch } from 'minimatch';
 import semver from 'semver';
 import { OptionValues } from 'commander';
 import yaml from 'yaml';
@@ -77,6 +78,14 @@ type PkgVersionInfo = {
   name: string;
   location: string;
 };
+
+function extendsDefaultPattern(pattern: string): boolean {
+  if (!pattern.endsWith('/*')) {
+    return false;
+  }
+
+  return minimatch('@backstage/', pattern.slice(0, -1));
+}
 
 export default async (opts: OptionValues) => {
   const lockfilePath = paths.resolveTargetRoot('yarn.lock');
@@ -245,8 +254,8 @@ export default async (opts: OptionValues) => {
 
     console.log();
 
-    // Do not update backstage.json when upgrade patterns are used.
-    if (pattern === DEFAULT_PATTERN_GLOB) {
+    // Do not update backstage.json when default pattern is not covered
+    if (extendsDefaultPattern(pattern)) {
       await bumpBackstageJsonVersion(
         releaseManifest.releaseVersion,
         hasYarnPlugin,


### PR DESCRIPTION
If a custom pattern is used, `backstage.json` will not be updated. However, if the custom pattern extends the default pattern, `backstage.json` will be updated, too.

Example:

- `@backstage/*` (default)
- `@{backstage,backstage-community}/*`
- `@{extra1,backstage,extra2}/*`

Fixes: #28839

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
