### PR TITLE
feat(yarn-plugin): custom manifest location

### DIFF
--- a/.changeset/heavy-chicken-find.md
+++ b/.changeset/heavy-chicken-find.md
@@ -6,7 +6,7 @@ Allow using custom manifest location in the yarn plugin and version bump.
 
 The Backstage yarn plugin and version bump allows two new environment variables to configure custom manifest location:
 
-- `BACKSTAGE_MANIFEST_BASE_URL`: The base URL for fetching the Backstage version
+- `BACKSTAGE_VERSIONS_BASE_URL`: The base URL for fetching the Backstage version
   manifest. Defaults to `https://versions.backstage.io/v1/releases/VERSION/manifest.json`.
   Useful for running the plugin in environment without direct access to the internet,
   for example by using a mirror of the versions API or a proxy.

--- a/packages/cli/src/modules/migrate/commands/versions/bump.test.ts
+++ b/packages/cli/src/modules/migrate/commands/versions/bump.test.ts
@@ -1061,18 +1061,19 @@ describe('environment variables', () => {
 
   beforeEach(() => {
     delete process.env.BACKSTAGE_MANIFEST_FILE;
-    delete process.env.BACKSTAGE_MANIFEST_BASE_URL;
+    process.env.BACKSTAGE_VERSIONS_BASE_URL = 'https://custom.example.com';
   });
 
   afterEach(() => {
     jest.resetAllMocks();
-    delete process.env.BACKSTAGE_MANIFEST_FILE;
-    delete process.env.BACKSTAGE_MANIFEST_BASE_URL;
   });
 
-  it('should use custom base URL when BACKSTAGE_MANIFEST_BASE_URL is set', async () => {
-    process.env.BACKSTAGE_MANIFEST_BASE_URL = 'https://custom.example.com';
+  afterAll(() => {
+    delete process.env.BACKSTAGE_MANIFEST_FILE;
+    delete process.env.BACKSTAGE_VERSIONS_BASE_URL;
+  });
 
+  it('should use custom base URL when BACKSTAGE_VERSIONS_BASE_URL is set', async () => {
     mockDir.setContent({
       'yarn.lock': lockfileMock,
       'package.json': JSON.stringify({
@@ -1230,9 +1231,7 @@ describe('environment variables', () => {
     });
   });
 
-  it('should use custom base URL for yarn plugin when BACKSTAGE_MANIFEST_BASE_URL is set with yarn plugin', async () => {
-    process.env.BACKSTAGE_MANIFEST_BASE_URL = 'https://custom.example.com';
-
+  it('should use custom base URL for yarn plugin when BACKSTAGE_VERSIONS_BASE_URL is set with yarn plugin', async () => {
     mockDir.setContent({
       '.yarnrc.yml': yarnRcMock,
       'yarn.lock': lockfileMock,
@@ -1331,8 +1330,6 @@ describe('environment variables', () => {
   });
 
   it('should handle network errors when using custom base URL', async () => {
-    process.env.BACKSTAGE_MANIFEST_BASE_URL = 'https://custom.example.com';
-
     mockDir.setContent({
       'yarn.lock': lockfileMock,
       'package.json': JSON.stringify({

--- a/packages/cli/src/modules/migrate/commands/versions/bump.ts
+++ b/packages/cli/src/modules/migrate/commands/versions/bump.ts
@@ -114,11 +114,11 @@ export default async (opts: OptionValues) => {
     if (opts.release === 'next') {
       const next = await getManifestByReleaseLine({
         releaseLine: 'next',
-        versionsBaseUrl: env.BACKSTAGE_MANIFEST_BASE_URL,
+        versionsBaseUrl: env.BACKSTAGE_VERSIONS_BASE_URL,
       });
       const main = await getManifestByReleaseLine({
         releaseLine: 'main',
-        versionsBaseUrl: env.BACKSTAGE_MANIFEST_BASE_URL,
+        versionsBaseUrl: env.BACKSTAGE_VERSIONS_BASE_URL,
       });
       // Prefer manifest with the latest release version
       releaseManifest = semver.gt(next.releaseVersion, main.releaseVersion)
@@ -127,7 +127,7 @@ export default async (opts: OptionValues) => {
     } else {
       releaseManifest = await getManifestByReleaseLine({
         releaseLine: opts.release,
-        versionsBaseUrl: env.BACKSTAGE_MANIFEST_BASE_URL,
+        versionsBaseUrl: env.BACKSTAGE_VERSIONS_BASE_URL,
       });
     }
     findTargetVersion = createVersionFinder({
@@ -143,8 +143,8 @@ export default async (opts: OptionValues) => {
     );
     console.log();
 
-    const yarnPluginUrl = env.BACKSTAGE_MANIFEST_BASE_URL
-      ? `${env.BACKSTAGE_MANIFEST_BASE_URL}/v1/releases/${releaseManifest.releaseVersion}/yarn-plugin`
+    const yarnPluginUrl = env.BACKSTAGE_VERSIONS_BASE_URL
+      ? `${env.BACKSTAGE_VERSIONS_BASE_URL}/v1/releases/${releaseManifest.releaseVersion}/yarn-plugin`
       : `https://versions.backstage.io/v1/releases/${releaseManifest.releaseVersion}/yarn-plugin`;
 
     await run('yarn', ['plugin', 'import', yarnPluginUrl]);

--- a/packages/yarn-plugin/README.md
+++ b/packages/yarn-plugin/README.md
@@ -29,7 +29,7 @@ backstage.json.
 
 The plugin functionality can be configured with environment variables:
 
-- `BACKSTAGE_MANIFEST_BASE_URL` - The base URL for fetching the Backstage version
+- `BACKSTAGE_VERSIONS_BASE_URL` - The base URL for fetching the Backstage version
   manifest. Defaults to `https://versions.backstage.io/v1/releases/VERSION/manifest.json`.
   Useful for running the plugin in environment without direct access to the internet,
   for example by using a mirror of the versions API or a proxy.

--- a/packages/yarn-plugin/src/util/getPackageVersion.test.ts
+++ b/packages/yarn-plugin/src/util/getPackageVersion.test.ts
@@ -43,8 +43,6 @@ describe('getPackageVersion', () => {
   const mockConfiguration = {} as Configuration;
 
   beforeEach(() => {
-    jest.clearAllMocks();
-
     mockGetCurrentBackstageVersion.mockReturnValue('1.23.4');
     mockStructUtils.stringifyIdent.mockImplementation(
       (descriptor: any) =>
@@ -57,6 +55,10 @@ describe('getPackageVersion', () => {
       protocol: range.includes('backstage:') ? 'backstage:' : 'npm:',
       selector: range.includes('^') ? '^' : range.split(':')[1] || '',
     }));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   describe('successful package resolution', () => {
@@ -96,8 +98,8 @@ describe('getPackageVersion', () => {
     });
 
     it('uses custom versionsBaseUrl from environment when provided', async () => {
-      const originalEnv = process.env.BACKSTAGE_MANIFEST_BASE_URL;
-      process.env.BACKSTAGE_MANIFEST_BASE_URL = 'https://custom.example.com';
+      const originalEnv = process.env.BACKSTAGE_VERSIONS_BASE_URL;
+      process.env.BACKSTAGE_VERSIONS_BASE_URL = 'https://custom.example.com';
 
       const descriptor = {
         scope: '@backstage',
@@ -113,7 +115,7 @@ describe('getPackageVersion', () => {
         fetch: expect.any(Function),
       });
 
-      process.env.BACKSTAGE_MANIFEST_BASE_URL = originalEnv;
+      process.env.BACKSTAGE_VERSIONS_BASE_URL = originalEnv;
     });
 
     it('uses yarn httpUtils for fetching with proper response format', async () => {

--- a/packages/yarn-plugin/src/util/getPackageVersion.ts
+++ b/packages/yarn-plugin/src/util/getPackageVersion.ts
@@ -52,7 +52,7 @@ export const getPackageVersion = async (
     ? await xfs.readJsonSync(manifestFile as PortablePath)
     : await getManifestByVersion({
         version: backstageVersion,
-        versionsBaseUrl: env.BACKSTAGE_MANIFEST_BASE_URL,
+        versionsBaseUrl: env.BACKSTAGE_VERSIONS_BASE_URL,
         // We override the fetch function used inside getManifestByVersion with a
         // custom implementation that calls yarn's built-in `httpUtils` method
         // instead. This has a couple of benefits:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

added two environment variables that can be used to control the location of backstage manifest file used by the yarn plugin. this helps using the plugin in restricted environments without direct or access at all to the internet.

closes #31101

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
