### PR TITLE
fix: correct import path for catalogPermissionRules.ts

### DIFF
--- a/docs/permissions/custom-rules.md
+++ b/docs/permissions/custom-rules.md
@@ -184,7 +184,7 @@ To install custom rules in a plugin, we need to use the [`PermissionsRegistrySer
      import('@backstage/plugin-catalog-backend-module-scaffolder-entity-model'),
    );
    /* highlight-add-next-line */
-   backend.add(import('./modules/catalogPermissionRules.ts'));
+   backend.add(import('./modules/catalogPermissionRules'));
    ```
 
 5. Now when you run you Backstage instance - `yarn start` - the rule will be added to the catalog plugin.


### PR DESCRIPTION
Update incorrect file path reference in catalogPermissionRules.ts import statement.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
