### PR TITLE
fix(scaffolder): prevent MultiEntityPicker from removing existing options from form data

### DIFF
--- a/.changeset/two-coins-stop.md
+++ b/.changeset/two-coins-stop.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Prevent the MultiEntityPicker from removing options present in form state when new options are selected

--- a/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.test.tsx
@@ -262,6 +262,71 @@ describe('<MultiEntityPicker />', () => {
     });
   });
 
+  describe('with existing form data', () => {
+    beforeEach(() => {
+      uiSchema = { 'ui:options': {} };
+      props = {
+        onChange,
+        schema,
+        required,
+        uiSchema,
+        rawErrors,
+        formData: ['group:default/team-a'],
+      } as unknown as FieldProps;
+    });
+
+    it('preserves existing data on blur', async () => {
+      const { getByRole } = await renderInTestApp(
+        <Wrapper>
+          <MultiEntityPicker {...props} />
+        </Wrapper>,
+      );
+
+      const input = getByRole('textbox');
+
+      fireEvent.change(input, { target: { value: 'squ' } });
+      fireEvent.blur(input);
+
+      expect(onChange).toHaveBeenCalledWith(['group:default/team-a', 'squ']);
+    });
+
+    it('preserves existing data on value create', async () => {
+      const { getByRole } = await renderInTestApp(
+        <Wrapper>
+          <MultiEntityPicker {...props} />
+        </Wrapper>,
+      );
+
+      const input = getByRole('textbox');
+
+      fireEvent.change(input, { target: { value: 'squ' } });
+      fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+
+      expect(onChange).toHaveBeenCalledWith(['group:default/team-a', 'squ']);
+    });
+
+    it('preserves existing data on selecting an existing option', async () => {
+      catalogApi.getEntities.mockResolvedValue({ items: entities });
+
+      const { getByRole } = await renderInTestApp(
+        <Wrapper>
+          <MultiEntityPicker {...props} />
+        </Wrapper>,
+      );
+
+      const input = getByRole('textbox');
+
+      fireEvent.mouseDown(input);
+      const optionA = screen.getByText('squad-b');
+      await userEvent.click(optionA as HTMLElement);
+
+      expect(onChange).toHaveBeenCalledWith([
+        'group:default/team-a',
+        'group:default/squad-b',
+      ]);
+    });
+  });
+
   describe('uses full entity ref', () => {
     beforeEach(() => {
       uiSchema = {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `MultiEntityPicker` has a bug in it where restarting a Template execution and then adding existing entities to the field causes the form data to become out of sync and wipes the original contents.

Here is a demo of this in action:

https://github.com/user-attachments/assets/70623fe3-bdcc-4834-b033-d4fbf36aa525

This PR fixes that to always respect existing form data when changes are made (unless, of course, a value is removed) and to not accidentally wipe existing contents

Here is a demo of the fix:

https://github.com/user-attachments/assets/d9f8bbee-a433-4257-bce9-1e8a3e4df86e


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation: N/A
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
