### PR TITLE
fix(cli): replace `backstage:^` with explicit version for moved packages

### DIFF
--- a/.changeset/famous-spiders-work.md
+++ b/.changeset/famous-spiders-work.md
@@ -1,0 +1,11 @@
+---
+'@backstage/cli': patch
+---
+
+Replace `backstage:^` with an explicit version for moved packages.
+
+Example:
+
+```
+@backstage/some-package@backstage:^ -> @backstage-community/some-package@^1.0.1
+```


### PR DESCRIPTION
Example:

```
@backstage/some-package@backstage:^ -> @backstage-community/some-package@^1.0.1
```

Fixes: #31114

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
