### PR TITLE
ui: fix matchMedia fallback

### DIFF
--- a/.changeset/shy-chicken-smash.md
+++ b/.changeset/shy-chicken-smash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Removed the need to mock `window.matchMedia` in tests, falling back to default breakpoint values instead.

--- a/.github/vale/config/vocabularies/Backstage/accept.txt
+++ b/.github/vale/config/vocabularies/Backstage/accept.txt
@@ -38,6 +38,7 @@ Bitrise
 Blackbox
 bool
 boolean
+breakpoint
 Brex
 broadcasted
 bugfixes

--- a/packages/ui/src/hooks/useMediaQuery.ts
+++ b/packages/ui/src/hooks/useMediaQuery.ts
@@ -22,7 +22,8 @@ type UseMediaQueryOptions = {
   initializeWithValue?: boolean;
 };
 
-const IS_SERVER = typeof window === 'undefined';
+const IS_SERVER =
+  typeof window === 'undefined' || typeof window.matchMedia === 'undefined';
 
 export function useMediaQuery(
   query: string,
@@ -51,6 +52,9 @@ export function useMediaQuery(
   }
 
   useIsomorphicLayoutEffect(() => {
+    if (IS_SERVER) {
+      return;
+    }
     const matchMedia = window.matchMedia(query);
 
     // Triggered at the first client-side load and if query changes


### PR DESCRIPTION
## Hey, I just made a Pull Request!

🧹, this removes the need to mock `matchMedia` in all tests that use BUI.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
