### PR TITLE
fix(confluence-to-markdown): Prefer pageID for Confluence fetch with fallback to title+space

### DIFF
--- a/.changeset/tender-days-marry.md
+++ b/.changeset/tender-days-marry.md
@@ -1,0 +1,14 @@
+---
+'@backstage/plugin-scaffolder-backend-module-confluence-to-markdown': minor
+---
+
+Prefer page ID for Confluence fetch with fallback to title+space in `confluence:transform:markdown`.
+
+- When the input URL contains `spaces/{space}/pages/{id}/{title}`, the action now fetches the page by ID first
+  using `/rest/api/content/{id}?expand=body.export_view`.
+- If fetching by ID fails, or when the URL does not contain an ID, the action falls back to the existing
+  exact title + space lookup using `/rest/api/content?title=...&spaceKey=...&expand=body.export_view`.
+- Attachments, Markdown conversion, and mkdocs navigation update behavior are unchanged.
+
+This improves reliability for pages where the URL slug does not exactly match the Confluence title
+(for example, titles with emoji or special characters), while preserving compatibility with existing inputs.

--- a/plugins/scaffolder-backend-module-confluence-to-markdown/src/actions/confluence/helpers.ts
+++ b/plugins/scaffolder-backend-module-confluence-to-markdown/src/actions/confluence/helpers.ts
@@ -187,6 +187,7 @@ export const createConfluenceVariables = (url: string) => {
   let spacekey: string | undefined = undefined;
   let title: string | undefined = undefined;
   let titleWithSpaces: string | undefined = '';
+  let pageId: string | undefined = undefined;
   const params = new URL(url);
   const pathParts = params.pathname.split('/').filter(Boolean);
 
@@ -199,6 +200,10 @@ export const createConfluenceVariables = (url: string) => {
     // /spaces/<SPACEKEY>/pages/<PAGEID>/<TITLE>
     const idx = pathParts.indexOf('spaces');
     spacekey = pathParts[idx + 1];
+    const maybePages = pathParts[idx + 2];
+    if (maybePages === 'pages') {
+      pageId = pathParts[idx + 3];
+    }
     title = pathParts[pathParts.length - 1];
   } else {
     throw new Error(
@@ -207,5 +212,5 @@ export const createConfluenceVariables = (url: string) => {
   }
 
   titleWithSpaces = title?.replace(/\+/g, ' ');
-  return { spacekey, title, titleWithSpaces };
+  return { spacekey, title, titleWithSpaces, pageId };
 };


### PR DESCRIPTION
This pull request improves the reliability of fetching Confluence pages in the `confluence:transform:markdown` scaffolder action by preferring to fetch pages by their unique page ID when available, with a fallback to the previous title+space lookup. This change ensures that pages with special characters or emojis in the title can be reliably fetched, while maintaining compatibility with existing URLs and workflows. The update includes enhancements to the URL parsing logic, the main action handler, and new tests to verify the new behaviors.

**Confluence Page Fetch Improvements:**

* Updated the `createConfluenceVariables` helper to extract the page ID from Confluence URLs of the form `/spaces/{space}/pages/{id}/{title}`, returning it along with the space key and title. [[1]](diffhunk://#diff-b0d66a25dc64a19367ba5a2ad5a2a159039f1cdbe6fdf7b26cbd8221c4721156R190) [[2]](diffhunk://#diff-b0d66a25dc64a19367ba5a2ad5a2a159039f1cdbe6fdf7b26cbd8221c4721156R203-R206) [[3]](diffhunk://#diff-b0d66a25dc64a19367ba5a2ad5a2a159039f1cdbe6fdf7b26cbd8221c4721156L210-R215)
* Modified the main action handler in `confluenceToMarkdown.ts` to:
  * Attempt to fetch the Confluence page by ID if available.
  * Fall back to fetching by title and space if the ID fetch fails or is not present.
  * Use the correct content and attachment IDs depending on the fetch method. [[1]](diffhunk://#diff-d92d996859d61264ef8b114a73fbf46dff8bf84d26aa157b71d8f17010e237e8L108-R155) [[2]](diffhunk://#diff-d92d996859d61264ef8b114a73fbf46dff8bf84d26aa157b71d8f17010e237e8L168-R200)

**Testing Enhancements:**

* Added tests to verify that the action correctly uses the page ID when present and falls back to title+space lookup when fetching by ID fails.

**Documentation:**

* Added a changeset describing the new behavior, its benefits, and its backward compatibility

** #Fixes #21736 ”

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
