### PR TITLE
dedupe dependabot PRs

### DIFF
--- a/.github/workflows/automate_dependabot_dedupe.yml
+++ b/.github/workflows/automate_dependabot_dedupe.yml
@@ -1,0 +1,68 @@
+name: Dedupe Dependabot PRs
+
+on:
+  push:
+    branches: ['dependabot/**']
+
+permissions:
+  contents: write
+  pull-requests: write
+  repository-projects: write
+
+jobs:
+  dedupe:
+    name: Dedupe Dependabot PRs
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20.x]
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: use node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: https://registry.npmjs.org/ # Needed for auth
+
+      - name: yarn install
+        uses: backstage/actions/yarn-install@b3c1841fd69e1658ac631afafd0fb140a2309024 # v0.6.17
+        with:
+          cache-prefix: ${{ runner.os }}-v${{ matrix.node-version }}
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Configure Git
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Detect working directory
+        id: computed
+        run: |
+          echo "WORKING_DIRECTORY=$(git log -1 --pretty=%B | sed -n 's/.* in \/\(.*\)$/\1/p')" >> $GITHUB_OUTPUT
+
+      - name: Dedupe dependencies
+        run: yarn dedupe
+        working-directory: ${{ steps.computed.outputs.WORKING_DIRECTORY }}
+        env:
+          HUSKY: 0
+
+      - name: Commit changes
+        run: |
+          git add .
+          git commit -m '[dependabot skip] Dedupe dependencies' || true
+        working-directory: ${{ steps.computed.outputs.WORKING_DIRECTORY }}
+
+      - name: Push changes
+        run: git push
+        working-directory: ${{ steps.computed.outputs.WORKING_DIRECTORY }}


### PR DESCRIPTION
This is frustrating that it's not happening automatically. It's stopping security fixes [like this one](https://github.com/backstage/backstage/pull/31099) from getting auto merged.

Taken and adapted from [here](https://github.com/wojtekmaj/react-date-picker/blob/v10.0.3/.github/workflows/dependabot-dedupe.yml), see discussion issue [here](https://github.com/dependabot/dependabot-core/issues/5830).