### PR TITLE
Fixed DependencyGraph size issue

### DIFF
--- a/.changeset/public-sites-admire.md
+++ b/.changeset/public-sites-admire.md
@@ -3,4 +3,4 @@
 '@backstage/plugin-catalog-graph': patch
 ---
 
-Fixed DependencyGraph svg size not adapting to the container size
+Fixed DependencyGraph `svg` size not adapting to the container size

--- a/.changeset/public-sites-admire.md
+++ b/.changeset/public-sites-admire.md
@@ -1,0 +1,6 @@
+---
+'@backstage/core-components': patch
+'@backstage/plugin-catalog-graph': patch
+---
+
+Fixed DependencyGraph svg size not adapting to the container size

--- a/packages/core-components/src/components/DependencyGraph/DependencyGraph.tsx
+++ b/packages/core-components/src/components/DependencyGraph/DependencyGraph.tsx
@@ -23,6 +23,7 @@ import {
   useState,
 } from 'react';
 import useMeasure from 'react-use/esm/useMeasure';
+import classNames from 'classnames';
 import { once } from 'lodash';
 import * as d3Zoom from 'd3-zoom';
 import * as d3Selection from 'd3-selection';
@@ -465,14 +466,14 @@ export function DependencyGraph<NodeData, EdgeData>(
   return (
     <div
       ref={containerRef}
-      className={combineClasses(
+      className={classNames(
         styles.root,
         fit === 'contain' && styles.fixedHeight,
       )}
     >
       <FullScreen
         handle={fullScreenHandle}
-        className={combineClasses(
+        className={classNames(
           fullScreenHandle.active ? styles.fullscreen : styles.root,
           fit === 'contain' && styles.fixedHeight,
         )}
@@ -562,8 +563,4 @@ export function DependencyGraph<NodeData, EdgeData>(
       </FullScreen>
     </div>
   );
-}
-
-function combineClasses(...classes: (string | false | undefined)[]) {
-  return classes.filter(c => !!c).join(' ');
 }

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/EntityRelationsGraph.tsx
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/EntityRelationsGraph.tsx
@@ -158,6 +158,7 @@ export const EntityRelationsGraph = (props: EntityRelationsGraphProps) => {
           renderLabel={renderLabel || DefaultRenderLabel}
           direction={direction}
           className={classes.graph}
+          fit="contain"
           paddingX={theme.spacing(4)}
           paddingY={theme.spacing(4)}
           labelPosition={DependencyGraphTypes.LabelPosition.RIGHT}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Since #31005 reported in #31165, the catalog graph didn't size the graph correctly.

When debugging this, I also saw in the developer tools that the inner `<svg>` element got updated repeatedly in an indefinite loop, caused by `setEdge` being a function that's not memoized, and the inner `<Edge>` has a hook dependency on it, causing the graph to re-render. The side effect of this was that the sizing measurements were recalculated, so when resizing the window, the graph was resized too, out of pure "luck".

This PR:

 * Fixes the indefinite re-rendering by instead using `useMeasure` to trigger the component to re-render, and implicitly resize, no more hogging browser cpu for no reason.
 * Fixes the "Fullscreen" button to not consume height from the inner svg (pushing it down). It's now properly floating.
 * Fixes inner svg size when `fit` is "contained", and using that prop from the `EntityRelationsGraph`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
