### PR TITLE
cli: fix module federation config to only omit imports for remote

### DIFF
--- a/.changeset/hungry-crews-fetch.md
+++ b/.changeset/hungry-crews-fetch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Fixed module federation config by only setting `import: false` on shared libraries for remote.

--- a/packages/cli/src/modules/build/lib/bundler/config.ts
+++ b/packages/cli/src/modules/build/lib/bundler/config.ts
@@ -264,26 +264,26 @@ export async function createConfig(
             singleton: true,
             requiredVersion: '*',
             eager: !isRemote,
-            import: false,
+            ...(isRemote && { import: false }),
           },
           'react-dom': {
             singleton: true,
             requiredVersion: '*',
             eager: !isRemote,
-            import: false,
+            ...(isRemote && { import: false }),
           },
           // React Router
           'react-router': {
             singleton: true,
             requiredVersion: '*',
             eager: !isRemote,
-            import: false,
+            ...(isRemote && { import: false }),
           },
           'react-router-dom': {
             singleton: true,
             requiredVersion: '*',
             eager: !isRemote,
-            import: false,
+            ...(isRemote && { import: false }),
           },
           // MUI v4
           // not setting import: false for MUI packages as this


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Oops, only tested this one properly on the remote setup, it should ofc not be set for the host 😅 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
