### PR TITLE
Allow Chromatic to be run manually

### DIFF
--- a/.github/workflows/verify_chromatic.yml
+++ b/.github/workflows/verify_chromatic.yml
@@ -1,6 +1,7 @@
 name: Chromatic
 on:
   # NOTE: If you change these you must update verify_storybook-noop.yml as well
+  workflow_dispatch:
   pull_request:
     paths:
       - '.github/workflows/verify_chromatic.yml'


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is small update to allow Chromatic to be run manually from Github website.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
