### PR TITLE
fix: Counting distinct results for entity facets in search table

### DIFF
--- a/.changeset/cold-coats-show.md
+++ b/.changeset/cold-coats-show.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Fix for duplicate search results in entity-facets API call

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
@@ -2359,6 +2359,52 @@ describe('DefaultEntitiesCatalog', () => {
         });
       },
     );
+
+    it.each(databases.eachSupportedId())(
+      'works when the entity is duplicated in search results, %p',
+      async databaseId => {
+        await createDatabase(databaseId);
+
+        await addEntityToSearch({
+          apiVersion: 'a',
+          kind: 'k',
+          metadata: {
+            name: 'one',
+            uid: 'uid-a',
+          },
+          spec: {},
+        });
+
+        // Manually insert a duplicate search entry, this shouldn't happen but does in reality
+        await knex<DbSearchRow>('search').insert([
+          {
+            entity_id: 'uid-a',
+            key: 'metadata.name',
+            value: 'one',
+            original_value: 'one',
+          },
+        ]);
+
+        const catalog = new DefaultEntitiesCatalog({
+          database: knex,
+          logger: mockServices.logger.mock(),
+          stitcher,
+        });
+
+        await expect(
+          catalog.facets({
+            facets: ['metadata.name'],
+            credentials: mockCredentials.none(),
+          }),
+        ).resolves.toEqual({
+          facets: {
+            'metadata.name': expect.arrayContaining([
+              { value: 'one', count: 1 },
+            ]),
+          },
+        });
+      },
+    );
   });
 });
 

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -683,7 +683,7 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
       .select({
         facet: 'search.key',
         value: 'search.original_value',
-        count: this.database.raw('count(*)'),
+        count: this.database.raw('count(DISTINCT search.entity_id)'),
       })
       .groupBy(['search.key', 'search.original_value']);
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!
As detailed in issue [26997](https://github.com/backstage/backstage/issues/26997) occasionally there are duplicate entries for an entity in the search table. This PR does not fix this issue, but like other PR's have done this stops duplicated results being returned this time in the `entity-facets` API call.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
