### PR TITLE
Feat: Mcp-actions - output type support

### DIFF
--- a/.changeset/funny-areas-follow.md
+++ b/.changeset/funny-areas-follow.md
@@ -1,0 +1,95 @@
+---
+'@backstage/plugin-mcp-actions-backend': minor
+---
+
+## Summary
+
+Adds support for MCP action outputs of type `image`. When an action returns `{ type: 'image', data: <base64> }`, the service now emits an image content block instead of coercing the entire output into a fenced JSON text blob. This avoids unnecessary LLM parsing overhead and enables compatible clients to render images directly.
+
+Previously every tool/action result was wrapped as a text payload:
+
+````json
+{
+  "content": [
+    {
+      "type": "text",
+      "text": "```json\n{...}\n```"
+    }
+  ]
+}
+````
+
+This caused:
+
+- Image generation tools to be treated as text, slowing responses.
+- Failures or degraded behavior when large base64 data was reinterpreted downstream.
+
+Now image outputs pass through structurally:
+
+```json
+{
+  "content": [
+    {
+      "type": "image",
+      "data": "<base64>",
+      "mimeType": "image/png"
+    }
+  ]
+}
+```
+
+## Usage
+
+### Register the action
+
+```ts
+actionsRegistry.register(createGenerateImageAction());
+```
+
+### Inside the action
+
+```ts
+return {
+  output: {
+    type: 'image',
+    data: base64Data,
+  },
+};
+```
+
+### Client receives
+
+```json
+{
+  "content": [
+    {
+      "type": "image",
+      "data": "<base64>",
+      "mimeType": "image/png"
+    }
+  ]
+}
+```
+
+## Implementation Notes
+
+- Added type guards:
+  - `isJsonObject(value: JsonValue): value is JsonObject`
+  - `isImageOutput(obj: JsonObject): obj is { type: 'image'; data: JsonValue }`
+- Conditional branch in `McpService.callTool`:
+  - If image → `{ type: 'image', data, mimeType: 'image/png' }`
+  - Else → legacy fenced JSON text output preserved (no breaking change)
+- MIME type currently fixed to `image/png` (can be generalized later).
+
+## Diff (Excerpt)
+
+````diff
++ // Type guard to check if a JsonValue is a JsonObject
++ function isJsonObject(value: JsonValue): value is JsonObject { ... }
++ function isImageOutput(obj: JsonObject): obj is JsonObject & { type: 'image'; data: JsonValue } { ... }
+...
+-  type: 'text'
+-  text: ```json ... ```
++  type: isImageType ? 'image' : 'text'
++  (image → data + mimeType, else → fenced JSON)
+````


### PR DESCRIPTION
## Feat: Mcp-actions - output type support

At the moment the return type is always text. As a result of this when an image is returned the MCP client tends to parse this data with the LLM and tends to slow down to a crawl.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
