### PR TITLE
Fix translation key for owner column title

### DIFF
--- a/.changeset/eager-toes-start.md
+++ b/.changeset/eager-toes-start.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Correct translation key from "type" to "owner" for owner column in entity table to ensure the right translation is loaded.

--- a/plugins/catalog-react/src/components/EntityTable/columns.test.tsx
+++ b/plugins/catalog-react/src/components/EntityTable/columns.test.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen } from '@testing-library/react';
+import { columnFactories } from './columns';
+import { mockApis, MockErrorApi, TestApiProvider } from '@backstage/test-utils';
+import { errorApiRef } from '@backstage/core-plugin-api';
+import { translationApiRef } from '@backstage/core-plugin-api/alpha';
+
+describe('columns', () => {
+  it('should render owner title', async () => {
+    const { title } = columnFactories.createOwnerColumn();
+
+    render(
+      <TestApiProvider
+        apis={[
+          [errorApiRef, new MockErrorApi()],
+          [translationApiRef, mockApis.translation()],
+        ]}
+      >
+        {title}
+      </TestApiProvider>,
+    );
+
+    expect(await screen.findByText('Owner')).toBeInTheDocument();
+  });
+});

--- a/plugins/catalog-react/src/components/EntityTable/columns.tsx
+++ b/plugins/catalog-react/src/components/EntityTable/columns.tsx
@@ -108,7 +108,7 @@ export const columnFactories = Object.freeze({
   },
   createOwnerColumn<T extends Entity>(): TableColumn<T> {
     return this.createEntityRelationColumn({
-      title: <EntityTableColumnTitle translationKey="type" />,
+      title: <EntityTableColumnTitle translationKey="owner" />,
       relation: RELATION_OWNED_BY,
       defaultKind: 'group',
     });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The entity table currently has two columns labelled "Type" as a regression was introduced in https://github.com/backstage/backstage/pull/30076 which used the same translation key for the owner column as well as the type column. This PR corrects the key so that both columns now have the correct labels.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
