### PR TITLE
Fix light mode colour token in ItemCardHeader

### DIFF
--- a/.changeset/fast-queens-guess.md
+++ b/.changeset/fast-queens-guess.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Swap base token for semantic token in ItemCardHeader to ensure readability in light mode.

--- a/packages/core-components/src/layout/ItemCard/ItemCardHeader.tsx
+++ b/packages/core-components/src/layout/ItemCard/ItemCardHeader.tsx
@@ -30,7 +30,7 @@ export type ItemCardHeaderClassKey = 'root';
 const styles = (theme: Theme) =>
   createStyles({
     root: {
-      color: theme.palette.common.white,
+      color: theme.palette.text.primary,
       padding: theme.spacing(2, 2, 3),
       backgroundImage: theme.getPageTheme({ themeId: 'card' }).backgroundImage,
       backgroundPosition: 0,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The text colour in the ItemCardHeader component is always white, which makes the content unreadable that when you're rendering on a white background in light mode. This switches to a semantic token instead that will dynamically adjust to whichever theme is currently set.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
