### PR TITLE
Workaround for Gitea failing to return freshly scaffolded files

### DIFF
--- a/.changeset/new-lizards-report.md
+++ b/.changeset/new-lizards-report.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Workaround for Gitea taking some time until scaffolded files can be fetched.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

It happens that after scaffolding to Gitea the registration fails with "unknown encoding" because the `catalog-config.yaml` can not yet be read. Gitea returns a success response but with an empty array instead of the object with the file contents. This PR introduces a retry mechanism to give Gitea some more time to return the file.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
