### PR TITLE
remove host from azure blog storage integration type

### DIFF
--- a/.changeset/five-olives-bet.md
+++ b/.changeset/five-olives-bet.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+remove host from azure blob storage integration type

--- a/packages/integration/config.d.ts
+++ b/packages/integration/config.d.ts
@@ -105,11 +105,9 @@ export interface Config {
       endpointSuffix?: string;
 
       /**
-       * The host of the target that this matches on, e.g., "blob.core.windows.net".
+       * Optional endpoint URL for custom domain. Uses default if not provided.
        * @visibility frontend
        */
-      host: string;
-
       endpoint?: string;
       /**
        * Optional credential to use for Azure Active Directory authentication.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Follow-up PR. This PR remove the `host` from the integration type. 

`host` is either derived from the endpoint or uses a default one. It is never read by the [config reader](https://github.com/backstage/backstage/blob/master/packages/integration/src/azureBlobStorage/config.ts). 


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
