### PR TITLE
fix: remove default selection of tab

### DIFF
--- a/.changeset/clever-papers-watch.md
+++ b/.changeset/clever-papers-watch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+remove default selection of tab

--- a/packages/ui/src/components/Header/Header.stories.tsx
+++ b/packages/ui/src/components/Header/Header.stories.tsx
@@ -57,14 +57,17 @@ const tabs: HeaderTab[] = [
   {
     id: 'overview',
     label: 'Overview',
+    href: '/overview',
   },
   {
     id: 'checks',
     label: 'Checks',
+    href: '/checks',
   },
   {
     id: 'tracks',
     label: 'Tracks',
+    href: '/tracks',
   },
   {
     id: 'campaigns',
@@ -82,14 +85,17 @@ const tabs2: HeaderTab[] = [
   {
     id: 'Banana',
     label: 'Banana',
+    href: '/banana',
   },
   {
     id: 'Apple',
     label: 'Apple',
+    href: '/apple',
   },
   {
     id: 'Orange',
     label: 'Orange',
+    href: '/orange',
   },
 ];
 

--- a/packages/ui/src/components/Tabs/Tabs.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.tsx
@@ -117,7 +117,7 @@ export const Tabs = (props: TabsProps) => {
         }
       }
     }
-    return undefined;
+    return null;
   })();
 
   if (!children) return null;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix tab selection to return null when no URL matches (prevents auto-selecting first tab)

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
