### PR TITLE
fix(bui): Enable tooltips on disabled buttons

### DIFF
--- a/.changeset/moody-singers-deny.md
+++ b/.changeset/moody-singers-deny.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Enable tooltips on disabled buttons with automatic wrapper

--- a/packages/ui/src/components/Button/Button.stories.tsx
+++ b/packages/ui/src/components/Button/Button.stories.tsx
@@ -19,6 +19,7 @@ import { Button } from './Button';
 import { Flex } from '../Flex';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
+import { Tooltip, TooltipTrigger } from '../Tooltip';
 
 const meta = {
   title: 'Backstage UI/Button',
@@ -214,5 +215,14 @@ export const Playground: Story = {
         </Flex>
       ))}
     </Flex>
+  ),
+};
+
+export const DisabledWithTooltips: Story = {
+  render: () => (
+    <TooltipTrigger>
+      <Button isDisabled>Save</Button>
+      <Tooltip>Why this is disabled</Tooltip>
+    </TooltipTrigger>
   ),
 };

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -16,7 +16,7 @@
 
 import clsx from 'clsx';
 import { forwardRef, Ref } from 'react';
-import { Button as RAButton } from 'react-aria-components';
+import { Button as RAButton, Focusable } from 'react-aria-components';
 import type { ButtonProps } from './types';
 import { useStyles } from '../../hooks/useStyles';
 
@@ -30,6 +30,7 @@ export const Button = forwardRef(
       iconEnd,
       children,
       className,
+      isDisabled,
       ...rest
     } = props;
 
@@ -38,17 +39,28 @@ export const Button = forwardRef(
       variant,
     });
 
-    return (
+    const btn = (
       <RAButton
         className={clsx(classNames.root, className)}
         ref={ref}
         {...dataAttributes}
         {...rest}
+        isDisabled={!!isDisabled}
       >
         {iconStart}
         {children}
         {iconEnd}
       </RAButton>
+    );
+
+    return isDisabled ? (
+      <Focusable>
+        <span role="button" tabIndex={0} style={{ display: 'inline-flex' }}>
+          {btn}
+        </span>
+      </Focusable>
+    ) : (
+      btn
     );
   },
 );


### PR DESCRIPTION
## Hey, I just made a Pull Request!


Enable tooltips for isDisabled buttons by wrapping the button in a focusable container. The wrapper receives hover/focus events, allowing TooltipTrigger to open the tooltip while the inner button remains truly disabled.

<img width="183" height="110" alt="Skärmavbild 2025-09-23 kl  12 11 15" src="https://github.com/user-attachments/assets/724ca401-8d25-4a93-bb6d-9099a7cd2bb9" />


- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
