### PR TITLE
fix(catalog): config for priority and enabled

### DIFF
--- a/.changeset/fast-heads-brake.md
+++ b/.changeset/fast-heads-brake.md
@@ -1,0 +1,25 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Moved catalog processor and provider disabling and priorities under own config objects.
+
+This is due to issue with some existing providers, such as GitHub, using array syntax for the provider configuration.
+
+The new config format is not backwards compatible, so users will need to update their config files. The new format
+is as follows:
+
+```yaml
+catalog:
+  providerOptions:
+    providerA:
+      disabled: false
+    providerB:
+      disabled: true
+  processorOptions:
+    processorA:
+      disabled: false
+      priority: 10
+    processorB:
+      disabled: true
+```

--- a/docs/features/software-catalog/configuration.md
+++ b/docs/features/software-catalog/configuration.md
@@ -90,6 +90,35 @@ also write a _custom processor_ to convert between the existing system and
 Backstage's descriptor format. This is documented in
 [External Integrations](external-integrations.md).
 
+### Processor configuration
+
+You can configure processors under the `catalog.processorOptions` key. You can define
+options for each processor by its name. With the processor options you can disable
+a processor or set its priority.
+
+```yaml
+catalog:
+  processorOptions:
+    processorName:
+      disabled: false # Defaults to false
+      priority: 100
+```
+
+The priority is a number defining the order in which processors are executed. The lower the number,
+the higher the priority. The default priority is `20`.
+
+## Provider configuration
+
+It's possible to also disable entity providers using the config. You can configure providers
+under the `catalog.providerOptions` key. The key is the provider name.
+
+```yaml
+catalog:
+  providerOptions:
+    providerName:
+      disabled: true
+```
+
 ## Catalog Rules
 
 By default, the catalog will only allow the ingestion of entities with the kind

--- a/plugins/catalog-backend/config.d.ts
+++ b/plugins/catalog-backend/config.d.ts
@@ -223,38 +223,36 @@ export interface Config {
     processingInterval?: HumanDuration | false;
 
     /**
-     * Catalog provide specific configuration.
-     * Additional configuration for providers are specified in the catalog
-     * modules.
+     * Provider-specific additional configuration options.
      */
-    providers?: {
+    providerOptions?: {
       /**
-       * Name is the provider ID, e.g. "bitbucketServer"
+       * Key is the provider name, value is an object with additional configuration
        */
       [name: string]: {
         /**
-         * Whether the provider is enabled or not. Defaults to true.
+         * Determines whether this provider is disabled or not. If not specified,
+         * defaults to false.
          */
-        enabled?: boolean;
+        disabled?: boolean;
       };
     };
+
     /**
-     * Configuration for entity processors. Additional configuration for
-     * processors are specified in the catalog modules.
+     * Processor-specific additional configuration options.
      */
-    processors?: {
+    processorOptions?: {
       /**
-       * Name is the processor ID, e.g. "catalog-processor"
+       * Key is the processor name, value is an object with additional configuration
        */
       [name: string]: {
         /**
-         * Whether the processor is enabled or not. Defaults to true.
+         * Determines whether this processor is disabled or not. If not specified,
+         * defaults to false.
          */
-        enabled?: boolean;
+        disabled?: boolean;
         /**
-         * The priority of the processor, which is used to determine the order in which
-         * processors are run. The default priority is 20, and lower value means
-         * that the processor runs earlier.
+         * The default priority is 20, and lower value means that the processor runs earlier.
          */
         priority?: number;
       };

--- a/plugins/catalog-backend/src/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.ts
@@ -736,13 +736,13 @@ export class CatalogBuilder {
         try {
           return (
             config.getOptionalNumber(
-              `catalog.processors.${processor.getProcessorName()}.priority`,
+              `catalog.processorOptions.${processor.getProcessorName()}.priority`,
             ) ??
             processor.getPriority?.() ??
             20
           );
         } catch (_) {
-          // In case the processor config is not an object, just return default priority
+          // In case the processor config throws, just return default priority
           return 20;
         }
       };
@@ -757,22 +757,12 @@ export class CatalogBuilder {
 
   private filterProcessors(processors: CatalogProcessor[]) {
     const { config } = this.env;
-    const processorsConfig = config.getOptionalConfig('catalog.processors');
-    if (!processorsConfig) {
-      return processors;
-    }
-
-    return processors.filter(p => {
-      try {
-        const processorConfig = processorsConfig.getOptionalConfig(
-          p.getProcessorName(),
-        );
-        return processorConfig?.getOptionalBoolean('enabled') ?? true;
-      } catch (_) {
-        // In case the processor config is not an object, just include the processor
-        return true;
-      }
-    });
+    return processors.filter(
+      p =>
+        config.getOptionalBoolean(
+          `catalog.processorOptions.${p.getProcessorName()}.disabled`,
+        ) !== true,
+    );
   }
 
   // TODO(Rugvip): These old processors are removed, for a while we'll be throwing
@@ -887,22 +877,12 @@ export class CatalogBuilder {
 
   private filterProviders(providers: EntityProvider[]) {
     const { config } = this.env;
-    const providersConfig = config.getOptionalConfig('catalog.providers');
-    if (!providersConfig) {
-      return providers;
-    }
-
-    return providers.filter(p => {
-      try {
-        const providerConfig = providersConfig.getOptionalConfig(
-          p.getProviderName(),
-        );
-        return providerConfig?.getOptionalBoolean('enabled') ?? true;
-      } catch (_) {
-        // In case the provider config is not an object, just include the provider
-        return true;
-      }
-    });
+    return providers.filter(
+      p =>
+        config.getOptionalBoolean(
+          `catalog.providerOptions.${p.getProviderName()}.disabled`,
+        ) !== true,
+    );
   }
 
   private static getDefaultProcessingInterval(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Moved catalog processor and provider disabling and priorities under own config objects.

This is due to issue with some existing providers, such as GitHub, using array syntax for the provider configuration.

The new config format is not backwards compatible, so users will need to update their config files. The new format
is as follows:

```yaml
catalog:
  providerOptions:
    providerA:
      disabled: false
    providerB:
      disabled: true
  processorOptions:
    processorA:
      disabled: false
      priority: 10
    processorB:
      disabled: true
```


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
