### PR TITLE
fix(bui): Add missing Cell component props to table documentation

### DIFF
--- a/docs-ui/src/content/components/table.props.ts
+++ b/docs-ui/src/content/components/table.props.ts
@@ -212,6 +212,11 @@ export const cellPropDefs: Record<string, PropDef> = {
     description:
       "A string representation of the cell's contents, used for features like typeahead.",
   },
+  leadingIcon: {
+    type: 'enum',
+    values: ['ReactNode'],
+    description: 'Optional icon to display before the cell content.',
+  },
   ...classNamePropDefs,
   ...stylePropDefs,
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Update BUI documentation for the `Table` component to include `leadingIcon ` as a prop for table cells.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
