### PR TITLE
Implement AbortController request cancellation for search.

### DIFF
--- a/.changeset/ripe-yaks-brake.md
+++ b/.changeset/ripe-yaks-brake.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-search-react': patch
+'@backstage/plugin-search': patch
+---
+
+Implement AbortController request cancellation in SearchBar to prevent overlapping search requests. This change ensures that when users type quickly, previous search requests are properly canceled before new ones start.

--- a/.changeset/ripe-yaks-brake.md
+++ b/.changeset/ripe-yaks-brake.md
@@ -3,4 +3,4 @@
 '@backstage/plugin-search': patch
 ---
 
-Implement AbortController request cancellation in SearchBar to prevent overlapping search requests. This change ensures that when users type quickly, previous search requests are properly canceled before new ones start.
+Implemented AbortController request cancellation for overlapping search requests. This change ensures that when users type quickly, previous search requests are properly canceled before new ones start.

--- a/plugins/search-react/report.api.md
+++ b/plugins/search-react/report.api.md
@@ -93,13 +93,23 @@ export class MockSearchApi implements SearchApi {
   // (undocumented)
   mockedResults?: SearchResultSet | undefined;
   // (undocumented)
-  query(): Promise<SearchResultSet>;
+  query(
+    _query: SearchQuery,
+    _options?: {
+      signal?: AbortSignal;
+    },
+  ): Promise<SearchResultSet>;
 }
 
 // @public (undocumented)
 export interface SearchApi {
   // (undocumented)
-  query(query: SearchQuery): Promise<SearchResultSet>;
+  query(
+    query: SearchQuery,
+    options?: {
+      signal?: AbortSignal;
+    },
+  ): Promise<SearchResultSet>;
 }
 
 // @public (undocumented)

--- a/plugins/search-react/src/api.ts
+++ b/plugins/search-react/src/api.ts
@@ -28,7 +28,10 @@ export const searchApiRef = createApiRef<SearchApi>({
  * @public
  */
 export interface SearchApi {
-  query(query: SearchQuery): Promise<SearchResultSet>;
+  query(
+    query: SearchQuery,
+    options?: { signal?: AbortSignal },
+  ): Promise<SearchResultSet>;
 }
 
 /**
@@ -39,7 +42,10 @@ export interface SearchApi {
 export class MockSearchApi implements SearchApi {
   constructor(public mockedResults?: SearchResultSet) {}
 
-  query(): Promise<SearchResultSet> {
+  query(
+    _query: SearchQuery,
+    _options?: { signal?: AbortSignal },
+  ): Promise<SearchResultSet> {
     return Promise.resolve(this.mockedResults || { results: [] });
   }
 }

--- a/plugins/search-react/src/components/SearchAutocomplete/SearchAutocomplete.test.tsx
+++ b/plugins/search-react/src/components/SearchAutocomplete/SearchAutocomplete.test.tsx
@@ -95,12 +95,17 @@ describe('SearchAutocomplete', () => {
     );
 
     await waitFor(() => {
-      expect(query).toHaveBeenCalledWith({
-        filters: {},
-        pageCursor: undefined,
-        term: options[0],
-        types: [],
-      });
+      expect(query).toHaveBeenCalledWith(
+        {
+          filters: {},
+          pageCursor: undefined,
+          term: options[0],
+          types: [],
+        },
+        {
+          signal: expect.any(AbortSignal),
+        },
+      );
     });
   });
 
@@ -117,23 +122,33 @@ describe('SearchAutocomplete', () => {
     );
 
     await waitFor(() => {
-      expect(query).toHaveBeenCalledWith({
-        filters: {},
-        pageCursor: undefined,
-        term: options[0],
-        types: [],
-      });
+      expect(query).toHaveBeenCalledWith(
+        {
+          filters: {},
+          pageCursor: undefined,
+          term: options[0],
+          types: [],
+        },
+        {
+          signal: expect.any(AbortSignal),
+        },
+      );
     });
 
     await userEvent.click(screen.getByLabelText('Clear'));
 
     await waitFor(() => {
-      expect(query).toHaveBeenCalledWith({
-        filters: {},
-        pageCursor: undefined,
-        term: '',
-        types: [],
-      });
+      expect(query).toHaveBeenCalledWith(
+        {
+          filters: {},
+          pageCursor: undefined,
+          term: '',
+          types: [],
+        },
+        {
+          signal: expect.any(AbortSignal),
+        },
+      );
     });
   });
 
@@ -154,12 +169,17 @@ describe('SearchAutocomplete', () => {
     await userEvent.click(screen.getByText(options[0]));
 
     await waitFor(() => {
-      expect(query).toHaveBeenCalledWith({
-        filters: {},
-        pageCursor: undefined,
-        term: options[0],
-        types: [],
-      });
+      expect(query).toHaveBeenCalledWith(
+        {
+          filters: {},
+          pageCursor: undefined,
+          term: options[0],
+          types: [],
+        },
+        {
+          signal: expect.any(AbortSignal),
+        },
+      );
     });
   });
 

--- a/plugins/search-react/src/components/SearchBar/SearchBar.test.tsx
+++ b/plugins/search-react/src/components/SearchBar/SearchBar.test.tsx
@@ -171,6 +171,9 @@ describe('SearchBar', () => {
 
     expect(searchApiMock.query).toHaveBeenLastCalledWith(
       expect.objectContaining({ term: value }),
+      {
+        signal: expect.any(AbortSignal),
+      },
     );
 
     jest.runAllTimers();
@@ -203,6 +206,9 @@ describe('SearchBar', () => {
 
     expect(searchApiMock.query).toHaveBeenLastCalledWith(
       expect.objectContaining({ term: '' }),
+      {
+        signal: expect.any(AbortSignal),
+      },
     );
   });
 
@@ -254,6 +260,9 @@ describe('SearchBar', () => {
     await waitFor(() =>
       expect(searchApiMock.query).not.toHaveBeenLastCalledWith(
         expect.objectContaining({ term: value }),
+        expect.objectContaining({
+          signal: expect.any(AbortSignal),
+        }),
       ),
     );
 
@@ -265,6 +274,9 @@ describe('SearchBar', () => {
 
     expect(searchApiMock.query).toHaveBeenLastCalledWith(
       expect.objectContaining({ term: value }),
+      {
+        signal: expect.any(AbortSignal),
+      },
     );
 
     jest.runAllTimers();

--- a/plugins/search-react/src/components/SearchFilter/SearchFilter.test.tsx
+++ b/plugins/search-react/src/components/SearchFilter/SearchFilter.test.tsx
@@ -178,6 +178,7 @@ describe('SearchFilter', () => {
       await waitFor(() => {
         expect(searchApiMock.query).toHaveBeenLastCalledWith(
           expect.objectContaining({ filters: { field: [values[0]] } }),
+          { signal: expect.any(Object) },
         );
       });
 
@@ -186,6 +187,7 @@ describe('SearchFilter', () => {
       await waitFor(() => {
         expect(searchApiMock.query).toHaveBeenLastCalledWith(
           expect.objectContaining({ filters: {} }),
+          { signal: expect.any(Object) },
         );
       });
     });
@@ -217,6 +219,7 @@ describe('SearchFilter', () => {
           expect.objectContaining({
             filters: { ...filters, field: [values[0]] },
           }),
+          { signal: expect.any(Object) },
         );
       });
 
@@ -225,6 +228,7 @@ describe('SearchFilter', () => {
       await waitFor(() => {
         expect(searchApiMock.query).toHaveBeenLastCalledWith(
           expect.objectContaining({ filters }),
+          { signal: expect.any(Object) },
         );
       });
     });
@@ -421,6 +425,7 @@ describe('SearchFilter', () => {
           expect.objectContaining({
             filters: { [name]: values[0] },
           }),
+          { signal: expect.any(AbortSignal) },
         );
       });
 
@@ -437,6 +442,7 @@ describe('SearchFilter', () => {
           expect.objectContaining({
             filters: {},
           }),
+          { signal: expect.any(AbortSignal) },
         );
       });
     });
@@ -479,6 +485,7 @@ describe('SearchFilter', () => {
           expect.objectContaining({
             filters: { ...filters, [name]: values[0] },
           }),
+          { signal: expect.any(AbortSignal) },
         );
       });
 
@@ -493,6 +500,7 @@ describe('SearchFilter', () => {
       await waitFor(() => {
         expect(searchApiMock.query).toHaveBeenLastCalledWith(
           expect.objectContaining({ filters }),
+          { signal: expect.any(AbortSignal) },
         );
       });
     });

--- a/plugins/search-react/src/components/SearchPagination/SearchPagination.test.tsx
+++ b/plugins/search-react/src/components/SearchPagination/SearchPagination.test.tsx
@@ -197,6 +197,9 @@ describe('SearchPagination', () => {
       expect.objectContaining({
         pageLimit: 10,
       }),
+      {
+        signal: expect.any(AbortSignal),
+      },
     );
   });
 
@@ -229,6 +232,9 @@ describe('SearchPagination', () => {
       expect.objectContaining({
         pageCursor: 'Mg==', // page: 2
       }),
+      {
+        signal: expect.any(AbortSignal),
+      },
     );
 
     await userEvent.click(screen.getByLabelText('Previous page'));
@@ -239,6 +245,9 @@ describe('SearchPagination', () => {
       expect.objectContaining({
         pageCursor: 'MQ==', // page: 1
       }),
+      {
+        signal: expect.any(AbortSignal),
+      },
     );
   });
 
@@ -271,6 +280,9 @@ describe('SearchPagination', () => {
         pageCursor: undefined,
         pageLimit: 10,
       }),
+      {
+        signal: expect.any(AbortSignal),
+      },
     );
   });
 });

--- a/plugins/search-react/src/context/SearchContext.test.tsx
+++ b/plugins/search-react/src/context/SearchContext.test.tsx
@@ -264,11 +264,14 @@ describe('SearchContext', () => {
         result.current.setTerm(term);
       });
 
-      expect(searchApiMock.query).toHaveBeenLastCalledWith({
-        term,
-        types: ['*'],
-        filters: {},
-      });
+      expect(searchApiMock.query).toHaveBeenLastCalledWith(
+        {
+          term,
+          types: ['*'],
+          filters: {},
+        },
+        { signal: expect.any(AbortSignal) },
+      );
     });
 
     it('When types is set', async () => {
@@ -286,11 +289,14 @@ describe('SearchContext', () => {
         result.current.setTypes(types);
       });
 
-      expect(searchApiMock.query).toHaveBeenLastCalledWith({
-        types,
-        term: '',
-        filters: {},
-      });
+      expect(searchApiMock.query).toHaveBeenLastCalledWith(
+        {
+          types,
+          term: '',
+          filters: {},
+        },
+        { signal: expect.any(AbortSignal) },
+      );
     });
 
     it('When filters are set', async () => {
@@ -308,11 +314,14 @@ describe('SearchContext', () => {
         result.current.setFilters(filters);
       });
 
-      expect(searchApiMock.query).toHaveBeenLastCalledWith({
-        filters,
-        term: '',
-        types: ['*'],
-      });
+      expect(searchApiMock.query).toHaveBeenLastCalledWith(
+        {
+          filters,
+          term: '',
+          types: ['*'],
+        },
+        { signal: expect.any(AbortSignal) },
+      );
     });
 
     it('When page limit is set', async () => {
@@ -330,12 +339,15 @@ describe('SearchContext', () => {
         result.current.setPageLimit(pageLimit);
       });
 
-      expect(searchApiMock.query).toHaveBeenLastCalledWith({
-        pageLimit,
-        term: '',
-        types: ['*'],
-        filters: {},
-      });
+      expect(searchApiMock.query).toHaveBeenLastCalledWith(
+        {
+          pageLimit,
+          term: '',
+          types: ['*'],
+          filters: {},
+        },
+        { signal: expect.any(AbortSignal) },
+      );
     });
 
     it('When page cursor is set', async () => {
@@ -353,12 +365,15 @@ describe('SearchContext', () => {
         result.current.setPageCursor(pageCursor);
       });
 
-      expect(searchApiMock.query).toHaveBeenLastCalledWith({
-        pageCursor,
-        term: '',
-        types: ['*'],
-        filters: {},
-      });
+      expect(searchApiMock.query).toHaveBeenLastCalledWith(
+        {
+          pageCursor,
+          term: '',
+          types: ['*'],
+          filters: {},
+        },
+        { signal: expect.any(AbortSignal) },
+      );
     });
 
     it('provides function for fetch the next page', async () => {
@@ -382,12 +397,15 @@ describe('SearchContext', () => {
         result.current.fetchNextPage!();
       });
 
-      expect(searchApiMock.query).toHaveBeenLastCalledWith({
-        term: '',
-        types: ['*'],
-        filters: {},
-        pageCursor: 'NEXT',
-      });
+      expect(searchApiMock.query).toHaveBeenLastCalledWith(
+        {
+          term: '',
+          types: ['*'],
+          filters: {},
+          pageCursor: 'NEXT',
+        },
+        { signal: expect.any(AbortSignal) },
+      );
     });
 
     it('provides function for fetch the previous page', async () => {
@@ -410,12 +428,15 @@ describe('SearchContext', () => {
         result.current.fetchPreviousPage!();
       });
 
-      expect(searchApiMock.query).toHaveBeenLastCalledWith({
-        term: '',
-        types: ['*'],
-        filters: {},
-        pageCursor: 'PREVIOUS',
-      });
+      expect(searchApiMock.query).toHaveBeenLastCalledWith(
+        {
+          term: '',
+          types: ['*'],
+          filters: {},
+          pageCursor: 'PREVIOUS',
+        },
+        { signal: expect.any(AbortSignal) },
+      );
     });
   });
 
@@ -456,11 +477,14 @@ describe('SearchContext', () => {
       });
 
       await waitFor(() => {
-        expect(searchApiMock.query).toHaveBeenCalledWith({
-          term: '',
-          types: ['*'],
-          filters: {},
-        });
+        expect(searchApiMock.query).toHaveBeenCalledWith(
+          {
+            term: '',
+            types: ['*'],
+            filters: {},
+          },
+          { signal: expect.any(AbortSignal) },
+        );
         expect(analyticsApiMock.captureEvent).not.toHaveBeenCalled();
       });
 
@@ -470,11 +494,14 @@ describe('SearchContext', () => {
       });
 
       await waitFor(() => {
-        expect(searchApiMock.query).toHaveBeenCalledWith({
-          term: 'eva',
-          types: ['*'],
-          filters: {},
-        });
+        expect(searchApiMock.query).toHaveBeenCalledWith(
+          {
+            term: 'eva',
+            types: ['*'],
+            filters: {},
+          },
+          { signal: expect.any(AbortSignal) },
+        );
         expect(analyticsApiMock.captureEvent).toHaveBeenCalledWith({
           action: 'search',
           subject: 'eva',
@@ -493,11 +520,14 @@ describe('SearchContext', () => {
       });
 
       await waitFor(() => {
-        expect(searchApiMock.query).toHaveBeenCalledWith({
-          term: 'eva.m',
-          types: ['*'],
-          filters: {},
-        });
+        expect(searchApiMock.query).toHaveBeenCalledWith(
+          {
+            term: 'eva.m',
+            types: ['*'],
+            filters: {},
+          },
+          { signal: expect.any(AbortSignal) },
+        );
         expect(analyticsApiMock.captureEvent).toHaveBeenCalledWith({
           action: 'search',
           subject: 'eva.m',
@@ -531,11 +561,14 @@ describe('SearchContext', () => {
       });
 
       await waitFor(() => {
-        expect(searchApiMock.query).toHaveBeenLastCalledWith({
-          term: 'term',
-          types: ['*'],
-          filters: {},
-        });
+        expect(searchApiMock.query).toHaveBeenLastCalledWith(
+          {
+            term: 'term',
+            types: ['*'],
+            filters: {},
+          },
+          { signal: expect.any(AbortSignal) },
+        );
         expect(analyticsApiMock.captureEvent).toHaveBeenCalledWith({
           action: 'search',
           subject: 'term',

--- a/plugins/search/src/apis.test.ts
+++ b/plugins/search/src/apis.test.ts
@@ -52,10 +52,19 @@ describe('apis', () => {
     identityApi.getCredentials.mockResolvedValue({});
     await client.query(query);
     expect(getBaseUrl).toHaveBeenLastCalledWith('search');
-    expect(mockFetch).toHaveBeenLastCalledWith(
-      `${baseUrl}/query?term=`,
-      undefined,
-    );
+    expect(mockFetch).toHaveBeenLastCalledWith(`${baseUrl}/query?term=`, {
+      signal: undefined,
+    });
+  });
+
+  it('Fetch is called with abort signal when provided', async () => {
+    identityApi.getCredentials.mockResolvedValue({});
+    const abortController = new AbortController();
+    await client.query(query, { signal: abortController.signal });
+    expect(getBaseUrl).toHaveBeenLastCalledWith('search');
+    expect(mockFetch).toHaveBeenLastCalledWith(`${baseUrl}/query?term=`, {
+      signal: abortController.signal,
+    });
   });
 
   it('Resolves JSON from fetch response', async () => {

--- a/plugins/search/src/apis.ts
+++ b/plugins/search/src/apis.ts
@@ -30,12 +30,17 @@ export class SearchClient implements SearchApi {
     this.fetchApi = options.fetchApi;
   }
 
-  async query(query: SearchQuery): Promise<SearchResultSet> {
+  async query(
+    query: SearchQuery,
+    options?: { signal?: AbortSignal },
+  ): Promise<SearchResultSet> {
     const queryString = qs.stringify(query);
     const url = `${await this.discoveryApi.getBaseUrl(
       'search',
     )}/query?${queryString}`;
-    const response = await this.fetchApi.fetch(url);
+    const response = await this.fetchApi.fetch(url, {
+      signal: options?.signal,
+    });
 
     if (!response.ok) {
       throw await ResponseError.fromResponse(response);

--- a/plugins/search/src/components/HomePageComponent/HomePageSearchBar.test.tsx
+++ b/plugins/search/src/components/HomePageComponent/HomePageSearchBar.test.tsx
@@ -48,6 +48,9 @@ describe('<HomePageSearchBar/>', () => {
 
     expect(searchApiMock.query).toHaveBeenCalledWith(
       expect.objectContaining({ term: '' }),
+      {
+        signal: expect.any(AbortSignal),
+      },
     );
 
     await userEvent.type(screen.getByLabelText('Search'), 'term{enter}');

--- a/plugins/search/src/components/SearchModal/SearchModal.test.tsx
+++ b/plugins/search/src/components/SearchModal/SearchModal.test.tsx
@@ -88,7 +88,9 @@ describe('SearchModal', () => {
     );
 
     expect(screen.getByRole('dialog')).toBeInTheDocument();
-    expect(searchApiMock.query).toHaveBeenCalledWith(initialState);
+    expect(searchApiMock.query).toHaveBeenCalledWith(initialState, {
+      signal: expect.any(AbortSignal),
+    });
   });
 
   it('Should create a local search context if a parent is not defined', async () => {
@@ -104,12 +106,15 @@ describe('SearchModal', () => {
     );
 
     expect(screen.getByRole('dialog')).toBeInTheDocument();
-    expect(searchApiMock.query).toHaveBeenCalledWith({
-      term: '',
-      filters: {},
-      types: [],
-      pageCursor: undefined,
-    });
+    expect(searchApiMock.query).toHaveBeenCalledWith(
+      {
+        term: '',
+        filters: {},
+        types: [],
+        pageCursor: undefined,
+      },
+      { signal: expect.any(AbortSignal) },
+    );
   });
 
   it('Should render a custom Modal correctly', async () => {
@@ -200,6 +205,7 @@ describe('SearchModal', () => {
 
     expect(searchApiMock.query).toHaveBeenCalledWith(
       expect.objectContaining({ term: 'term' }),
+      { signal: expect.any(AbortSignal) },
     );
 
     const input = screen.getByLabelText<HTMLInputElement>('Search');
@@ -232,6 +238,7 @@ describe('SearchModal', () => {
 
     expect(searchApiMock.query).toHaveBeenCalledWith(
       expect.objectContaining({ term: 'term' }),
+      { signal: expect.any(AbortSignal) },
     );
 
     const fullResultsBtn = screen.getByRole('button', {

--- a/plugins/search/src/components/SearchType/SearchType.Accordion.test.tsx
+++ b/plugins/search/src/components/SearchType/SearchType.Accordion.test.tsx
@@ -157,18 +157,28 @@ describe('SearchType.Accordion', () => {
       </Wrapper>,
     );
 
-    expect(searchApiMock.query).toHaveBeenCalledWith({
-      term: 'abc',
-      types: [],
-      filters: { foo: 'bar' },
-      pageLimit: 0,
-    });
-    expect(searchApiMock.query).toHaveBeenCalledWith({
-      term: 'abc',
-      types: [expectedType.value],
-      filters: {},
-      pageLimit: 0,
-    });
+    expect(searchApiMock.query).toHaveBeenCalledWith(
+      {
+        term: 'abc',
+        types: [],
+        filters: { foo: 'bar' },
+        pageLimit: 0,
+      },
+      {
+        signal: expect.any(AbortSignal),
+      },
+    );
+    expect(searchApiMock.query).toHaveBeenCalledWith(
+      {
+        term: 'abc',
+        types: [expectedType.value],
+        filters: {},
+        pageLimit: 0,
+      },
+      {
+        signal: expect.any(AbortSignal),
+      },
+    );
     await waitFor(() => {
       const countLabels = getAllByText('1234 results');
       expect(countLabels.length).toEqual(2);

--- a/plugins/search/src/components/SearchType/SearchType.test.tsx
+++ b/plugins/search/src/components/SearchType/SearchType.test.tsx
@@ -192,6 +192,9 @@ describe('SearchType', () => {
           expect.objectContaining({
             types: [values[0]],
           }),
+          {
+            signal: expect.any(AbortSignal),
+          },
         );
       });
 
@@ -240,6 +243,9 @@ describe('SearchType', () => {
           expect.objectContaining({
             types: [...typeValues, values[0]],
           }),
+          {
+            signal: expect.any(AbortSignal),
+          },
         );
       });
 
@@ -253,7 +259,12 @@ describe('SearchType', () => {
 
       await waitFor(() => {
         expect(searchApiMock.query).toHaveBeenLastCalledWith(
-          expect.objectContaining([]),
+          expect.objectContaining({
+            types: typeValues,
+          }),
+          {
+            signal: expect.any(AbortSignal),
+          },
         );
       });
     });

--- a/plugins/techdocs/src/search/components/TechDocsSearch.test.tsx
+++ b/plugins/techdocs/src/search/components/TechDocsSearch.test.tsx
@@ -84,16 +84,21 @@ it('should trigger query when autocomplete input changed', async () => {
   );
 
   await singleResult;
-  expect(querySpy).toHaveBeenCalledWith({
-    filters: {
-      kind: 'Testable',
-      name: 'test',
-      namespace: 'testspace',
+  expect(querySpy).toHaveBeenCalledWith(
+    {
+      filters: {
+        kind: 'Testable',
+        name: 'test',
+        namespace: 'testspace',
+      },
+      pageCursor: '',
+      term: '',
+      types: ['techdocs'],
     },
-    pageCursor: '',
-    term: '',
-    types: ['techdocs'],
-  });
+    {
+      signal: expect.any(AbortSignal),
+    },
+  );
 
   const autocomplete = screen.getByTestId('techdocs-search-bar');
   const input = within(autocomplete).getByRole('textbox');
@@ -105,16 +110,21 @@ it('should trigger query when autocomplete input changed', async () => {
 
   await singleResult;
   await waitFor(() =>
-    expect(querySpy).toHaveBeenCalledWith({
-      filters: {
-        kind: 'Testable',
-        name: 'test',
-        namespace: 'testspace',
+    expect(querySpy).toHaveBeenCalledWith(
+      {
+        filters: {
+          kind: 'Testable',
+          name: 'test',
+          namespace: 'testspace',
+        },
+        pageCursor: '',
+        term: 'asdf',
+        types: ['techdocs'],
       },
-      pageCursor: '',
-      term: 'asdf',
-      types: ['techdocs'],
-    }),
+      {
+        signal: expect.any(AbortSignal),
+      },
+    ),
   );
 });
 
@@ -144,16 +154,21 @@ it('should update filter values when a new entityName is provided', async () => 
   await renderInTestApp(<WrappedSearchBar />);
 
   await singleResult;
-  expect(querySpy).toHaveBeenCalledWith({
-    filters: {
-      kind: 'Testable',
-      name: 'test',
-      namespace: 'testspace',
+  expect(querySpy).toHaveBeenCalledWith(
+    {
+      filters: {
+        kind: 'Testable',
+        name: 'test',
+        namespace: 'testspace',
+      },
+      pageCursor: '',
+      term: '',
+      types: ['techdocs'],
     },
-    pageCursor: '',
-    term: '',
-    types: ['techdocs'],
-  });
+    {
+      signal: expect.any(AbortSignal),
+    },
+  );
 
   const button = screen.getByText('Update Entity');
   act(() => {
@@ -162,15 +177,20 @@ it('should update filter values when a new entityName is provided', async () => 
 
   await singleResult;
   await waitFor(() =>
-    expect(querySpy).toHaveBeenCalledWith({
-      filters: {
-        kind: 'TestableDiff',
-        name: 'test-diff',
-        namespace: 'testspace-diff',
+    expect(querySpy).toHaveBeenCalledWith(
+      {
+        filters: {
+          kind: 'TestableDiff',
+          name: 'test-diff',
+          namespace: 'testspace-diff',
+        },
+        pageCursor: '',
+        term: '',
+        types: ['techdocs'],
       },
-      pageCursor: '',
-      term: '',
-      types: ['techdocs'],
-    }),
+      {
+        signal: expect.any(AbortSignal),
+      },
+    ),
   );
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Implement AbortController request cancellation to prevent overlapping search requests.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
