### PR TITLE
Docs: Add PromiseRouter import to http-router.md

### DIFF
--- a/docs/backend-system/core-services/http-router.md
+++ b/docs/backend-system/core-services/http-router.md
@@ -135,6 +135,7 @@ import {
   createRateLimitMiddleware,
 } from '@backstage/backend-defaults/httpRouter';
 import PromiseRouter from 'express-promise-router';
+import { Handler } from 'express';
 import { createServiceFactory } from '@backstage/backend-plugin-api';
 
 const backend = createBackend();

--- a/docs/backend-system/core-services/http-router.md
+++ b/docs/backend-system/core-services/http-router.md
@@ -134,6 +134,7 @@ import {
   createAuthIntegrationRouter,
   createRateLimitMiddleware,
 } from '@backstage/backend-defaults/httpRouter';
+import PromiseRouter from 'express-promise-router';
 import { createServiceFactory } from '@backstage/backend-plugin-api';
 
 const backend = createBackend();

--- a/docs/backend-system/core-services/http-router.md
+++ b/docs/backend-system/core-services/http-router.md
@@ -136,7 +136,11 @@ import {
 } from '@backstage/backend-defaults/httpRouter';
 import PromiseRouter from 'express-promise-router';
 import { Handler } from 'express';
-import { createServiceFactory } from '@backstage/backend-plugin-api';
+import { 
+  createServiceFactory, 
+  coreServices, 
+  HttpRouterServiceAuthPolicy 
+} from '@backstage/backend-plugin-api';
 
 const backend = createBackend();
 


### PR DESCRIPTION
## Hey, I just made a a small Pull Request to improve documentation!

### Docs Affected
- [Docs > Framework > Backend System > Core Services > Http Router > Http Router Service # Configuring the service](https://backstage.io/docs/backend-system/core-services/http-router#configuring-the-service)
   - Added missing `import PromiseRouter from 'express-promise-router`
   - Added missing `import { Handler } from 'express';`
   - Added missing `import { ...,  coreServices,  HttpRouterServiceAuthPolicy  } from '@backstage/backend-plugin-api';`
   
So developers don't need to guess from where should import and dig on the code to find out to reproduce the code example