### PR TITLE
feat(catalog): add optional branch to bitbucket-server

### DIFF
--- a/.changeset/sour-spiders-dress.md
+++ b/.changeset/sour-spiders-dress.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-bitbucket-server': minor
+---
+
+feat(catalog): add optional branch to bitbucket-server

--- a/docs/integrations/bitbucketServer/discovery.md
+++ b/docs/integrations/bitbucketServer/discovery.md
@@ -65,6 +65,7 @@ catalog:
         filters: # optional
           projectKey: '^apis-.*$' # optional; RegExp
           repoSlug: '^service-.*$' # optional; RegExp
+          branch: 'master' # optional; string
           skipArchivedRepos: true # optional; boolean
         validateLocationsExist: false # optional; boolean
         schedule: # same options as in SchedulerServiceTaskScheduleDefinition
@@ -85,6 +86,8 @@ catalog:
     Regular expression used to filter results based on the project key.
   - **`repoSlug`** _(optional)_:
     Regular expression used to filter results based on the repo slug.
+  - **`branch`** _(optional)_:
+    String used to filter results based on the branch name.
   - **`skipArchivedRepos`** _(optional)_:
     Boolean flag to filter out archived repositories.
 - **`validateLocationsExist`** _(optional)_:

--- a/plugins/catalog-backend-module-bitbucket-server/config.d.ts
+++ b/plugins/catalog-backend-module-bitbucket-server/config.d.ts
@@ -47,6 +47,11 @@ export interface Config {
                */
               projectKey?: string;
               /**
+               * (Optional) String used to filter results based on the branch name.
+               * @visibility frontend
+               */
+              branch?: string;
+              /**
                * (Optional) Skip archived repositories
                */
               skipArchivedRepos?: boolean;
@@ -83,6 +88,11 @@ export interface Config {
                  * @visibility frontend
                  */
                 projectKey?: string;
+                /**
+                 * (Optional) String used to filter results based on the branch name.
+                 * @visibility frontend
+                 */
+                branch?: string;
                 /**
                  * (Optional) Skip archived repositories
                  */

--- a/plugins/catalog-backend-module-bitbucket-server/report.api.md
+++ b/plugins/catalog-backend-module-bitbucket-server/report.api.md
@@ -33,6 +33,7 @@ export class BitbucketServerClient {
   getFile(options: {
     projectKey: string;
     repo: string;
+    branch: string;
     path: string;
   }): Promise<Response>;
   // (undocumented)

--- a/plugins/catalog-backend-module-bitbucket-server/src/lib/BitbucketServerClient.test.ts
+++ b/plugins/catalog-backend-module-bitbucket-server/src/lib/BitbucketServerClient.test.ts
@@ -177,6 +177,7 @@ describe('BitbucketServerClient', () => {
       projectKey: 'test-project',
       repo: 'test-repo',
       path: 'catalog-info.yaml',
+      branch: 'master',
     });
     expect(await response.text()).toEqual(catalogInfoFile);
   });

--- a/plugins/catalog-backend-module-bitbucket-server/src/lib/BitbucketServerClient.ts
+++ b/plugins/catalog-backend-module-bitbucket-server/src/lib/BitbucketServerClient.ts
@@ -68,13 +68,17 @@ export class BitbucketServerClient {
   async getFile(options: {
     projectKey: string;
     repo: string;
+    branch: string;
     path: string;
   }): Promise<Response> {
     const normalizedPath = options.path.startsWith('/')
       ? options.path.substring(1)
       : options.path;
+    const params = convertToParamsString({
+      at: options.branch,
+    });
     return fetch(
-      `${this.config.apiBaseUrl}/projects/${options.projectKey}/repos/${options.repo}/raw/${normalizedPath}`,
+      `${this.config.apiBaseUrl}/projects/${options.projectKey}/repos/${options.repo}/raw/${normalizedPath}${params}`,
       getBitbucketServerRequestOptions(this.config),
     );
   }
@@ -202,4 +206,12 @@ export async function* paginated(
       yield item;
     }
   } while (!res.isLastPage);
+}
+
+export function convertToParamsString(options: Record<string, string>): string {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(options)) {
+    if (value) params.append(key, value);
+  }
+  return params.size === 0 ? '' : `?${params}`;
 }

--- a/plugins/catalog-backend-module-bitbucket-server/src/lib/index.ts
+++ b/plugins/catalog-backend-module-bitbucket-server/src/lib/index.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-export { BitbucketServerClient, paginated } from './BitbucketServerClient';
+export {
+  BitbucketServerClient,
+  paginated,
+  convertToParamsString,
+} from './BitbucketServerClient';
 export type {
   BitbucketServerPagedResponse,
   BitbucketServerListOptions,

--- a/plugins/catalog-backend-module-bitbucket-server/src/providers/BitbucketServerEntityProviderConfig.test.ts
+++ b/plugins/catalog-backend-module-bitbucket-server/src/providers/BitbucketServerEntityProviderConfig.test.ts
@@ -135,6 +135,7 @@ describe('readProviderConfigs', () => {
               filters: {
                 projectKey: 'project1',
                 repoSlug: '.*',
+                branch: 'test',
                 skipArchivedRepos: true,
               },
             },
@@ -152,6 +153,7 @@ describe('readProviderConfigs', () => {
       filters: {
         projectKey: /project1/,
         repoSlug: /.*/,
+        branch: 'test',
         skipArchivedRepos: true,
       },
       schedule: undefined,

--- a/plugins/catalog-backend-module-bitbucket-server/src/providers/BitbucketServerEntityProviderConfig.ts
+++ b/plugins/catalog-backend-module-bitbucket-server/src/providers/BitbucketServerEntityProviderConfig.ts
@@ -30,6 +30,7 @@ export type BitbucketServerEntityProviderConfig = {
   filters?: {
     projectKey?: RegExp;
     repoSlug?: RegExp;
+    branch?: string;
     skipArchivedRepos?: boolean;
   };
   validateLocationsExist: boolean;
@@ -64,6 +65,7 @@ function readProviderConfig(
     config.getOptionalString('catalogPath') ?? DEFAULT_CATALOG_PATH;
   const projectKeyPattern = config.getOptionalString('filters.projectKey');
   const repoSlugPattern = config.getOptionalString('filters.repoSlug');
+  const branchPattern = config.getOptionalString('filters.branch');
   const skipArchivedReposFlag = config.getOptionalBoolean(
     'filters.skipArchivedRepos',
   );
@@ -82,6 +84,7 @@ function readProviderConfig(
     filters: {
       projectKey: projectKeyPattern ? new RegExp(projectKeyPattern) : undefined,
       repoSlug: repoSlugPattern ? new RegExp(repoSlugPattern) : undefined,
+      branch: branchPattern,
       skipArchivedRepos: skipArchivedReposFlag,
     },
     validateLocationsExist: validateLocationsExistFlag,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added optional branch to bitbucket-server. User is able to define a branch for the catalog. If branch is not specified, fetch default branch. (https://github.com/backstage/backstage/issues/31194)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
