### PR TITLE
[NFS] Providing the default `searchFilters` and `resultTypes` as extensions of the search plugin

### DIFF
--- a/.changeset/sweet-ads-teach.md
+++ b/.changeset/sweet-ads-teach.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-search-react': minor
+'@backstage/plugin-search': minor
+---
+
+Providing the default `searchFilters` and `resultTypes` as extensions of the search plugin

--- a/plugins/search-react/report-alpha.api.md
+++ b/plugins/search-react/report-alpha.api.md
@@ -24,17 +24,23 @@ export const SearchFilterBlueprint: ExtensionBlueprint<{
   output: ExtensionDataRef<
     {
       component: SearchFilterExtensionComponent;
+      typeFilter?: (types: string[]) => boolean;
     },
     'search.filters.filter',
     {}
   >;
   inputs: {};
-  config: {};
-  configInput: {};
+  config: {
+    types: string[] | undefined;
+  };
+  configInput: {
+    types?: string[] | undefined;
+  };
   dataRefs: {
     searchFilters: ConfigurableExtensionDataRef<
       {
         component: SearchFilterExtensionComponent;
+        typeFilter?: (types: string[]) => boolean;
       },
       'search.filters.filter',
       {}
@@ -46,6 +52,7 @@ export const SearchFilterBlueprint: ExtensionBlueprint<{
 export interface SearchFilterBlueprintParams {
   // (undocumented)
   component: SearchFilterExtensionComponent;
+  typeFilter?: (types: string[]) => boolean;
 }
 
 // @alpha (undocumented)

--- a/plugins/search-react/src/alpha/blueprints/SearchFilterBlueprint.tsx
+++ b/plugins/search-react/src/alpha/blueprints/SearchFilterBlueprint.tsx
@@ -19,6 +19,12 @@ import { searchFilterDataRef, SearchFilterExtensionComponent } from './types';
 
 /** @alpha */
 export interface SearchFilterBlueprintParams {
+  /**
+   * The filter will only be shown if this predicate returns true.
+   *
+   * @param types - the currently selected result types
+   */
+  typeFilter?: (types: string[]) => boolean;
   component: SearchFilterExtensionComponent;
 }
 
@@ -35,9 +41,25 @@ export const SearchFilterBlueprint = createExtensionBlueprint({
   dataRefs: {
     searchFilters: searchFilterDataRef,
   },
-  *factory(params: SearchFilterBlueprintParams) {
+  config: {
+    schema: {
+      types: z =>
+        z
+          .array(z.string(), {
+            description:
+              'A list of result types where this search filter should be shown for',
+          })
+          .optional(),
+    },
+  },
+  *factory(params: SearchFilterBlueprintParams, { config }) {
+    const configTypes = config.types;
+    const typeFilter = configTypes?.length
+      ? (types: string[]) => configTypes.some(t => types.includes(t))
+      : params.typeFilter;
     yield searchFilterDataRef({
       component: params.component,
+      typeFilter: typeFilter,
     });
   },
 });

--- a/plugins/search-react/src/alpha/blueprints/types.ts
+++ b/plugins/search-react/src/alpha/blueprints/types.ts
@@ -62,4 +62,10 @@ export type SearchFilterExtensionComponent = (
 /** @alpha */
 export const searchFilterDataRef = createExtensionDataRef<{
   component: SearchFilterExtensionComponent;
+  /**
+   * The filter will only be shown if this predicate returns true.
+   *
+   * @param types - the currently selected result types
+   */
+  typeFilter?: (types: string[]) => boolean;
 }>().with({ id: 'search.filters.filter' });

--- a/plugins/search/report-alpha.api.md
+++ b/plugins/search/report-alpha.api.md
@@ -15,7 +15,9 @@ import { IconComponent } from '@backstage/core-plugin-api';
 import { JSX as JSX_2 } from 'react';
 import { OverridableFrontendPlugin } from '@backstage/frontend-plugin-api';
 import { RouteRef } from '@backstage/frontend-plugin-api';
+import { SearchFilterBlueprintParams } from '@backstage/plugin-search-react/alpha';
 import { SearchFilterExtensionComponent } from '@backstage/plugin-search-react/alpha';
+import { SearchFilterResultTypeBlueprintParams } from '@backstage/plugin-search-react/alpha';
 import { SearchResultItemExtensionComponent } from '@backstage/plugin-search-react/alpha';
 import { SearchResultItemExtensionPredicate } from '@backstage/plugin-search-react/alpha';
 import { TranslationRef } from '@backstage/core-plugin-api/alpha';
@@ -118,6 +120,7 @@ const _default: OverridableFrontendPlugin<
           ConfigurableExtensionDataRef<
             {
               component: SearchFilterExtensionComponent;
+              typeFilter?: (types: string[]) => boolean;
             },
             'search.filters.filter',
             {}
@@ -136,6 +139,100 @@ const _default: OverridableFrontendPlugin<
         loader: () => Promise<JSX.Element>;
         routeRef?: RouteRef;
       };
+    }>;
+    'search-filter:search/entity-kind-filter': ExtensionDefinition<{
+      kind: 'search-filter';
+      name: 'entity-kind-filter';
+      config: {
+        types: string[] | undefined;
+      };
+      configInput: {
+        types?: string[] | undefined;
+      };
+      output: ExtensionDataRef<
+        {
+          component: SearchFilterExtensionComponent;
+          typeFilter?: (types: string[]) => boolean;
+        },
+        'search.filters.filter',
+        {}
+      >;
+      inputs: {};
+      params: SearchFilterBlueprintParams;
+    }>;
+    'search-filter:search/lifecycle-filter': ExtensionDefinition<{
+      kind: 'search-filter';
+      name: 'lifecycle-filter';
+      config: {
+        types: string[] | undefined;
+      };
+      configInput: {
+        types?: string[] | undefined;
+      };
+      output: ExtensionDataRef<
+        {
+          component: SearchFilterExtensionComponent;
+          typeFilter?: (types: string[]) => boolean;
+        },
+        'search.filters.filter',
+        {}
+      >;
+      inputs: {};
+      params: SearchFilterBlueprintParams;
+    }>;
+    'search-filter:search/techdocs-relevant-entities-filter': ExtensionDefinition<{
+      kind: 'search-filter';
+      name: 'techdocs-relevant-entities-filter';
+      config: {
+        types: string[] | undefined;
+      };
+      configInput: {
+        types?: string[] | undefined;
+      };
+      output: ExtensionDataRef<
+        {
+          component: SearchFilterExtensionComponent;
+          typeFilter?: (types: string[]) => boolean;
+        },
+        'search.filters.filter',
+        {}
+      >;
+      inputs: {};
+      params: SearchFilterBlueprintParams;
+    }>;
+    'search-filter-result-type:search/software-catalog': ExtensionDefinition<{
+      kind: 'search-filter-result-type';
+      name: 'software-catalog';
+      config: {};
+      configInput: {};
+      output: ExtensionDataRef<
+        {
+          value: string;
+          name: string;
+          icon: JSX.Element;
+        },
+        'search.filters.result-types.type',
+        {}
+      >;
+      inputs: {};
+      params: SearchFilterResultTypeBlueprintParams;
+    }>;
+    'search-filter-result-type:search/techdocs': ExtensionDefinition<{
+      kind: 'search-filter-result-type';
+      name: 'techdocs';
+      config: {};
+      configInput: {};
+      output: ExtensionDataRef<
+        {
+          value: string;
+          name: string;
+          icon: JSX.Element;
+        },
+        'search.filters.result-types.type',
+        {}
+      >;
+      inputs: {};
+      params: SearchFilterResultTypeBlueprintParams;
     }>;
   }
 >;
@@ -237,6 +334,7 @@ export const searchPage: ExtensionDefinition<{
       ConfigurableExtensionDataRef<
         {
           component: SearchFilterExtensionComponent;
+          typeFilter?: (types: string[]) => boolean;
         },
         'search.filters.filter',
         {}


### PR DESCRIPTION
This commit refactors the Backstage search plugin architecture to make search filters and result types extensible through a plugin system.
 Instead of hardcoding filters like entity kind, lifecycle, and TechDocs filters directly in the search page component, they are now defined as separate extensions that are registered with the plugin.

1. The `SearchFilterBlueprint` is enhanced with a new `typeFilter` function that determines when a filter should be visible based on the selected result types, plus a configuration schema that allows specifying which result types a filter applies to.
2. The search page now dynamically renders only the relevant filters based on the current search context.
3. Default result types (Software Catalog and Documentation) and common filters (entity kind, lifecycle, and TechDocs entity filters) are provided as built-in extensions but can now be customized or replaced.

This change makes the search functionality more modular and allows other plugins to extend search capabilities without modifying the core search plugin code.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
