### PR TITLE
fix(bui): remove default selection for tabs that have href defined

### DIFF
--- a/.changeset/thin-hoops-bathe.md
+++ b/.changeset/thin-hoops-bathe.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Remove auto selection of tabs for tabs that all have href defined

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "@yarnpkg/plugin-npm@npm:^3.1.0": "patch:@yarnpkg/plugin-npm@npm%3A3.1.0#~/.yarn/patches/@yarnpkg-plugin-npm-npm-3.1.0-6533d0f5a1.patch",
+    "GendocuPublicApis": "npm:gendocu-public-apis@^1.0.0",
     "ast-types@0.14.2": "patch:ast-types@npm%3A0.14.2#./.yarn/patches/ast-types-npm-0.14.2-43c4ac4b0d.patch",
     "ast-types@^0.14.1": "patch:ast-types@npm%3A0.14.2#./.yarn/patches/ast-types-npm-0.14.2-43c4ac4b0d.patch",
     "ast-types@npm:0.14.2": "patch:ast-types@npm%3A0.16.1#./.yarn/patches/ast-types-npm-0.16.1-43c4ac4b0d.patch",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "@yarnpkg/plugin-npm@npm:^3.1.0": "patch:@yarnpkg/plugin-npm@npm%3A3.1.0#~/.yarn/patches/@yarnpkg-plugin-npm-npm-3.1.0-6533d0f5a1.patch",
-    "GendocuPublicApis": "npm:gendocu-public-apis@^1.0.0",
     "ast-types@0.14.2": "patch:ast-types@npm%3A0.14.2#./.yarn/patches/ast-types-npm-0.14.2-43c4ac4b0d.patch",
     "ast-types@^0.14.1": "patch:ast-types@npm%3A0.14.2#./.yarn/patches/ast-types-npm-0.14.2-43c4ac4b0d.patch",
     "ast-types@npm:0.14.2": "patch:ast-types@npm%3A0.16.1#./.yarn/patches/ast-types-npm-0.16.1-43c4ac4b0d.patch",

--- a/packages/ui/src/components/HeaderPage/HeaderPage.stories.tsx
+++ b/packages/ui/src/components/HeaderPage/HeaderPage.stories.tsx
@@ -163,7 +163,11 @@ export const WithCustomActions: Story = {
         <>
           <Button>Custom action</Button>
           <MenuTrigger>
-            <ButtonIcon variant="tertiary" icon={<RiMore2Line />} />
+            <ButtonIcon
+              variant="tertiary"
+              icon={<RiMore2Line />}
+              aria-label="More options"
+            />
             <Menu placement="bottom end">
               {menuItems.map(option => (
                 <MenuItem

--- a/packages/ui/src/components/HeaderPage/HeaderPage.stories.tsx
+++ b/packages/ui/src/components/HeaderPage/HeaderPage.stories.tsx
@@ -44,27 +44,22 @@ const tabs: HeaderTab[] = [
   {
     id: 'overview',
     label: 'Overview',
-    href: '/overview',
   },
   {
     id: 'checks',
     label: 'Checks',
-    href: '/checks',
   },
   {
     id: 'tracks',
     label: 'Tracks',
-    href: '/tracks',
   },
   {
     id: 'campaigns',
     label: 'Campaigns',
-    href: '/campaigns',
   },
   {
     id: 'integrations',
     label: 'Integrations',
-    href: '/integrations',
   },
 ];
 
@@ -94,19 +89,10 @@ const withRouter = (Story: StoryFn) => (
   </MemoryRouter>
 );
 
-// White background decorator for stories
-const withWhiteBackground = (Story: StoryFn) => (
-  <div
-    style={{ backgroundColor: 'white', padding: '20px', borderRadius: '4px' }}
-  >
-    <Story />
-  </div>
-);
-
 // Extract layout decorator as a reusable constant
 const layoutDecorator = [
   (Story: StoryFn) => (
-    <div style={{ backgroundColor: 'white' }}>
+    <>
       <div
         style={{
           width: '250px',
@@ -135,7 +121,7 @@ const layoutDecorator = [
           </Text>
         </Container>
       </div>
-    </div>
+    </>
   ),
 ];
 
@@ -143,7 +129,6 @@ export const Default: Story = {
   args: {
     title: 'Page Title',
   },
-  decorators: [withWhiteBackground],
 };
 
 export const WithTabs: Story = {
@@ -151,11 +136,11 @@ export const WithTabs: Story = {
     ...Default.args,
     tabs,
   },
-  decorators: [withRouter, withWhiteBackground],
+  decorators: [withRouter],
 };
 
 export const WithCustomActions: Story = {
-  decorators: [withRouter, withWhiteBackground],
+  decorators: [withRouter],
   render: () => (
     <HeaderPage
       {...Default.args}
@@ -187,7 +172,7 @@ export const WithCustomActions: Story = {
 };
 
 export const WithBreadcrumbs: Story = {
-  decorators: [withRouter, withWhiteBackground],
+  decorators: [withRouter],
   args: {
     ...Default.args,
     breadcrumbs: [{ label: 'Home', href: '/' }],
@@ -195,7 +180,7 @@ export const WithBreadcrumbs: Story = {
 };
 
 export const WithLongBreadcrumbs: Story = {
-  decorators: [withRouter, withWhiteBackground],
+  decorators: [withRouter],
   args: {
     ...Default.args,
     breadcrumbs: [
@@ -206,7 +191,7 @@ export const WithLongBreadcrumbs: Story = {
 };
 
 export const WithEverything: Story = {
-  decorators: [withRouter, withWhiteBackground],
+  decorators: [withRouter],
   render: () => (
     <HeaderPage
       {...Default.args}
@@ -226,7 +211,6 @@ export const WithLayout: Story = {
 };
 
 export const WithTabsMatchingStrategies: Story = {
-  decorators: [withWhiteBackground],
   args: {
     title: 'Route Matching Demo',
     tabs: [
@@ -287,7 +271,6 @@ export const WithTabsMatchingStrategies: Story = {
 };
 
 export const WithTabsExactMatching: Story = {
-  decorators: [withWhiteBackground],
   args: {
     title: 'Exact Matching Demo',
     tabs: [
@@ -327,7 +310,6 @@ export const WithTabsExactMatching: Story = {
 };
 
 export const WithTabsPrefixMatchingDeep: Story = {
-  decorators: [withWhiteBackground],
   args: {
     title: 'Deep Nesting Demo',
     tabs: [

--- a/packages/ui/src/components/HeaderPage/HeaderPage.stories.tsx
+++ b/packages/ui/src/components/HeaderPage/HeaderPage.stories.tsx
@@ -44,22 +44,27 @@ const tabs: HeaderTab[] = [
   {
     id: 'overview',
     label: 'Overview',
+    href: '/overview',
   },
   {
     id: 'checks',
     label: 'Checks',
+    href: '/checks',
   },
   {
     id: 'tracks',
     label: 'Tracks',
+    href: '/tracks',
   },
   {
     id: 'campaigns',
     label: 'Campaigns',
+    href: '/campaigns',
   },
   {
     id: 'integrations',
     label: 'Integrations',
+    href: '/integrations',
   },
 ];
 
@@ -89,10 +94,19 @@ const withRouter = (Story: StoryFn) => (
   </MemoryRouter>
 );
 
+// White background decorator for stories
+const withWhiteBackground = (Story: StoryFn) => (
+  <div
+    style={{ backgroundColor: 'white', padding: '20px', borderRadius: '4px' }}
+  >
+    <Story />
+  </div>
+);
+
 // Extract layout decorator as a reusable constant
 const layoutDecorator = [
   (Story: StoryFn) => (
-    <>
+    <div style={{ backgroundColor: 'white' }}>
       <div
         style={{
           width: '250px',
@@ -121,7 +135,7 @@ const layoutDecorator = [
           </Text>
         </Container>
       </div>
-    </>
+    </div>
   ),
 ];
 
@@ -129,6 +143,7 @@ export const Default: Story = {
   args: {
     title: 'Page Title',
   },
+  decorators: [withWhiteBackground],
 };
 
 export const WithTabs: Story = {
@@ -136,11 +151,11 @@ export const WithTabs: Story = {
     ...Default.args,
     tabs,
   },
-  decorators: [withRouter],
+  decorators: [withRouter, withWhiteBackground],
 };
 
 export const WithCustomActions: Story = {
-  decorators: [withRouter],
+  decorators: [withRouter, withWhiteBackground],
   render: () => (
     <HeaderPage
       {...Default.args}
@@ -168,7 +183,7 @@ export const WithCustomActions: Story = {
 };
 
 export const WithBreadcrumbs: Story = {
-  decorators: [withRouter],
+  decorators: [withRouter, withWhiteBackground],
   args: {
     ...Default.args,
     breadcrumbs: [{ label: 'Home', href: '/' }],
@@ -176,7 +191,7 @@ export const WithBreadcrumbs: Story = {
 };
 
 export const WithLongBreadcrumbs: Story = {
-  decorators: [withRouter],
+  decorators: [withRouter, withWhiteBackground],
   args: {
     ...Default.args,
     breadcrumbs: [
@@ -187,7 +202,7 @@ export const WithLongBreadcrumbs: Story = {
 };
 
 export const WithEverything: Story = {
-  decorators: [withRouter],
+  decorators: [withRouter, withWhiteBackground],
   render: () => (
     <HeaderPage
       {...Default.args}
@@ -207,6 +222,7 @@ export const WithLayout: Story = {
 };
 
 export const WithTabsMatchingStrategies: Story = {
+  decorators: [withWhiteBackground],
   args: {
     title: 'Route Matching Demo',
     tabs: [
@@ -267,6 +283,7 @@ export const WithTabsMatchingStrategies: Story = {
 };
 
 export const WithTabsExactMatching: Story = {
+  decorators: [withWhiteBackground],
   args: {
     title: 'Exact Matching Demo',
     tabs: [
@@ -306,6 +323,7 @@ export const WithTabsExactMatching: Story = {
 };
 
 export const WithTabsPrefixMatchingDeep: Story = {
+  decorators: [withWhiteBackground],
   args: {
     title: 'Deep Nesting Demo',
     tabs: [

--- a/packages/ui/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.stories.tsx
@@ -34,32 +34,17 @@ const withRouter = (Story: StoryFn) => (
   </MemoryRouter>
 );
 
-// White background decorator for stories
-const withWhiteBackground = (Story: StoryFn) => (
-  <div
-    style={{ backgroundColor: 'white', padding: '20px', borderRadius: '4px' }}
-  >
-    <Story />
-  </div>
-);
-
 export const Default: Story = {
   args: {
     children: '',
   },
-  decorators: [withRouter, withWhiteBackground],
+  decorators: [withRouter],
   render: () => (
     <Tabs>
       <TabList>
-        <Tab id="tab1" href="/tab1">
-          Tab 1
-        </Tab>
-        <Tab id="tab2" href="/tab2">
-          Tab 2
-        </Tab>
-        <Tab id="tab3" href="/tab3">
-          Tab 3 With long title
-        </Tab>
+        <Tab id="tab1">Tab 1</Tab>
+        <Tab id="tab2">Tab 2</Tab>
+        <Tab id="tab3">Tab 3 With long title</Tab>
       </TabList>
     </Tabs>
   ),
@@ -69,7 +54,7 @@ export const WithTabPanels: Story = {
   args: {
     children: '',
   },
-  decorators: [withRouter, withWhiteBackground],
+  decorators: [withRouter],
   render: () => (
     <Tabs>
       <TabList>
@@ -94,7 +79,6 @@ export const WithMockedURLTab2: Story = {
   args: {
     children: '',
   },
-  decorators: [withWhiteBackground],
   render: () => (
     <MemoryRouter initialEntries={['/tab2']}>
       <Tabs>
@@ -127,7 +111,6 @@ export const WithMockedURLTab3: Story = {
   args: {
     children: '',
   },
-  decorators: [withWhiteBackground],
   render: () => (
     <MemoryRouter initialEntries={['/tab3']}>
       <Tabs>
@@ -160,7 +143,6 @@ export const WithMockedURLNoMatch: Story = {
   args: {
     children: '',
   },
-  decorators: [withWhiteBackground],
   render: () => (
     <MemoryRouter initialEntries={['/some-other-page']}>
       <Tabs>
@@ -199,7 +181,6 @@ export const ExactMatchingDefault: Story = {
   args: {
     children: '',
   },
-  decorators: [withWhiteBackground],
   render: () => (
     <MemoryRouter initialEntries={['/mentorship/events']}>
       <Tabs>
@@ -236,7 +217,6 @@ export const PrefixMatchingForNestedRoutes: Story = {
   args: {
     children: '',
   },
-  decorators: [withWhiteBackground],
   render: () => (
     <MemoryRouter initialEntries={['/mentorship/events']}>
       <Tabs>
@@ -277,7 +257,6 @@ export const PrefixMatchingDeepNesting: Story = {
   args: {
     children: '',
   },
-  decorators: [withWhiteBackground],
   render: () => (
     <MemoryRouter initialEntries={['/catalog/users/john/details']}>
       <Tabs>
@@ -313,7 +292,6 @@ export const MixedMatchingStrategies: Story = {
   args: {
     children: '',
   },
-  decorators: [withWhiteBackground],
   render: () => (
     <MemoryRouter initialEntries={['/dashboard/analytics/reports']}>
       <Tabs>
@@ -365,7 +343,6 @@ export const PrefixMatchingEdgeCases: Story = {
   args: {
     children: '',
   },
-  decorators: [withWhiteBackground],
   render: () => (
     <MemoryRouter initialEntries={['/foobar']}>
       <Tabs>
@@ -408,7 +385,6 @@ export const PrefixMatchingWithSlash: Story = {
   args: {
     children: '',
   },
-  decorators: [withWhiteBackground],
   render: () => (
     <MemoryRouter initialEntries={['/foo/bar']}>
       <Tabs>
@@ -450,7 +426,6 @@ export const RootPathMatching: Story = {
   args: {
     children: '',
   },
-  decorators: [withWhiteBackground],
   render: () => (
     <MemoryRouter initialEntries={['/']}>
       <Tabs>
@@ -485,7 +460,6 @@ export const AutoSelectionOfTabs: Story = {
   args: {
     children: '',
   },
-  decorators: [withWhiteBackground],
   render: () => (
     <MemoryRouter initialEntries={['/random-page']}>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '24px' }}>

--- a/packages/ui/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.stories.tsx
@@ -455,3 +455,60 @@ export const RootPathMatching: Story = {
     </MemoryRouter>
   ),
 };
+
+export const AutoSelectionOfTabs: Story = {
+  args: {
+    children: '',
+  },
+  render: () => (
+    <MemoryRouter initialEntries={['/random-page']}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '24px' }}>
+        <Text style={{ fontSize: '16px', color: '#666' }}>
+          Current URL: <strong>/random-page</strong>
+        </Text>
+
+        {/* Without hrefs */}
+        <Text>
+          {' '}
+          <strong>Case 1: Without hrefs</strong>
+        </Text>
+        <Tabs>
+          <TabList>
+            <Tab id="settings">Settings</Tab>
+            <Tab id="preferences">Preferences</Tab>
+            <Tab id="advanced">Advanced</Tab>
+          </TabList>
+          <TabPanel id="settings">
+            <Text>Settings content - React Aria manages this selection</Text>
+          </TabPanel>
+          <TabPanel id="preferences">
+            <Text>Preferences content - works normally</Text>
+          </TabPanel>
+          <TabPanel id="advanced">
+            <Text>Advanced content - local state only</Text>
+          </TabPanel>
+        </Tabs>
+
+        {/* With hrefs */}
+        <Text>
+          {' '}
+          <strong>Case 2: With hrefs</strong> By default no selection is shown
+          because the URL doesn't match any tab's href.{' '}
+        </Text>
+        <Tabs>
+          <TabList>
+            <Tab id="catalog" href="/catalog">
+              Catalog
+            </Tab>
+            <Tab id="create" href="/create">
+              Create
+            </Tab>
+            <Tab id="docs" href="/docs">
+              Docs
+            </Tab>
+          </TabList>
+        </Tabs>
+      </div>
+    </MemoryRouter>
+  ),
+};

--- a/packages/ui/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.stories.tsx
@@ -34,17 +34,32 @@ const withRouter = (Story: StoryFn) => (
   </MemoryRouter>
 );
 
+// White background decorator for stories
+const withWhiteBackground = (Story: StoryFn) => (
+  <div
+    style={{ backgroundColor: 'white', padding: '20px', borderRadius: '4px' }}
+  >
+    <Story />
+  </div>
+);
+
 export const Default: Story = {
   args: {
     children: '',
   },
-  decorators: [withRouter],
+  decorators: [withRouter, withWhiteBackground],
   render: () => (
     <Tabs>
       <TabList>
-        <Tab id="tab1">Tab 1</Tab>
-        <Tab id="tab2">Tab 2</Tab>
-        <Tab id="tab3">Tab 3 With long title</Tab>
+        <Tab id="tab1" href="/tab1">
+          Tab 1
+        </Tab>
+        <Tab id="tab2" href="/tab2">
+          Tab 2
+        </Tab>
+        <Tab id="tab3" href="/tab3">
+          Tab 3 With long title
+        </Tab>
       </TabList>
     </Tabs>
   ),
@@ -54,7 +69,7 @@ export const WithTabPanels: Story = {
   args: {
     children: '',
   },
-  decorators: [withRouter],
+  decorators: [withRouter, withWhiteBackground],
   render: () => (
     <Tabs>
       <TabList>
@@ -79,6 +94,7 @@ export const WithMockedURLTab2: Story = {
   args: {
     children: '',
   },
+  decorators: [withWhiteBackground],
   render: () => (
     <MemoryRouter initialEntries={['/tab2']}>
       <Tabs>
@@ -111,6 +127,7 @@ export const WithMockedURLTab3: Story = {
   args: {
     children: '',
   },
+  decorators: [withWhiteBackground],
   render: () => (
     <MemoryRouter initialEntries={['/tab3']}>
       <Tabs>
@@ -143,6 +160,7 @@ export const WithMockedURLNoMatch: Story = {
   args: {
     children: '',
   },
+  decorators: [withWhiteBackground],
   render: () => (
     <MemoryRouter initialEntries={['/some-other-page']}>
       <Tabs>
@@ -181,6 +199,7 @@ export const ExactMatchingDefault: Story = {
   args: {
     children: '',
   },
+  decorators: [withWhiteBackground],
   render: () => (
     <MemoryRouter initialEntries={['/mentorship/events']}>
       <Tabs>
@@ -217,6 +236,7 @@ export const PrefixMatchingForNestedRoutes: Story = {
   args: {
     children: '',
   },
+  decorators: [withWhiteBackground],
   render: () => (
     <MemoryRouter initialEntries={['/mentorship/events']}>
       <Tabs>
@@ -257,6 +277,7 @@ export const PrefixMatchingDeepNesting: Story = {
   args: {
     children: '',
   },
+  decorators: [withWhiteBackground],
   render: () => (
     <MemoryRouter initialEntries={['/catalog/users/john/details']}>
       <Tabs>
@@ -292,6 +313,7 @@ export const MixedMatchingStrategies: Story = {
   args: {
     children: '',
   },
+  decorators: [withWhiteBackground],
   render: () => (
     <MemoryRouter initialEntries={['/dashboard/analytics/reports']}>
       <Tabs>
@@ -343,6 +365,7 @@ export const PrefixMatchingEdgeCases: Story = {
   args: {
     children: '',
   },
+  decorators: [withWhiteBackground],
   render: () => (
     <MemoryRouter initialEntries={['/foobar']}>
       <Tabs>
@@ -385,6 +408,7 @@ export const PrefixMatchingWithSlash: Story = {
   args: {
     children: '',
   },
+  decorators: [withWhiteBackground],
   render: () => (
     <MemoryRouter initialEntries={['/foo/bar']}>
       <Tabs>
@@ -426,6 +450,7 @@ export const RootPathMatching: Story = {
   args: {
     children: '',
   },
+  decorators: [withWhiteBackground],
   render: () => (
     <MemoryRouter initialEntries={['/']}>
       <Tabs>
@@ -460,6 +485,7 @@ export const AutoSelectionOfTabs: Story = {
   args: {
     children: '',
   },
+  decorators: [withWhiteBackground],
   render: () => (
     <MemoryRouter initialEntries={['/random-page']}>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '24px' }}>

--- a/packages/ui/src/components/Tabs/Tabs.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.tsx
@@ -115,9 +115,22 @@ export const Tabs = (props: TabsProps) => {
             }
           }
         }
+
+        //No route matches - check if all tabs have hrefs (pure navigation)
+        const allTabsHaveHref = tabListChildren.every(
+          child => isValidElement(child) && child.props.href,
+        );
+
+        if (allTabsHaveHref) {
+          // Pure navigation tabs, no route match
+          return null;
+        } else {
+          // Mixed tabs or pure local state
+          return undefined;
+        }
       }
     }
-    return null;
+    return undefined;
   })();
 
   if (!children) return null;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

**Current behavior:**
If tab selection logic returns `undefined`, the first tab is auto-selected. This causes mismatches when the current page isn’t part of the tab set (the first tab gets highlighted even though its content doesn’t match).

**Proposed fix:**
If all tabs have href, return null → prevents auto-select, avoids mismatched tab states.
Otherwise, keep the current fallback (auto-select first tab).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
