### PR TITLE
Removed the private flag so that we can publish the BUI Themer

### DIFF
--- a/plugins/bui-themer/package.json
+++ b/plugins/bui-themer/package.json
@@ -13,7 +13,6 @@
     "main": "dist/index.esm.js",
     "types": "dist/index.d.ts"
   },
-  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/backstage/backstage",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Removed the private flag so that we can publish the BUI Themer

No changeset as there is one from this - https://github.com/backstage/backstage/pull/31140 - already.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
