### PR TITLE
Support custom start URL search parameters in OIDC provider

### DIFF
--- a/docs/auth/oidc.md
+++ b/docs/auth/oidc.md
@@ -264,6 +264,12 @@ check the App Registration you created:
 - `prompt`: Recommended to use `auto` so the browser will request login to the IDP if the
   user has no active session.
 - `sessionDuration` (optional): Lifespan of the user session.
+- `startUrlSearchParams`: This is a dictionary of search (query) parameters for the OIDC
+  authorization start URL. Don't define it unless you want to change the identity
+  provider's behavior. (For example, you could set the `organization` parameter to guide
+  users towards a particular sign-in option that your organization prefers.) **Note:** the
+  start URL is controlled by the browser, so this feature is only for improving the
+  Backstage user experience.
 
 Note that for the time being, any change in this yaml file requires a restart of the app,
 also you need to have the `session.secret` part to use OIDC (some other providers might

--- a/plugins/auth-backend-module-oidc-provider/config.d.ts
+++ b/plugins/auth-backend-module-oidc-provider/config.d.ts
@@ -33,6 +33,7 @@ export interface Config {
           additionalScopes?: string | string[];
           prompt?: string;
           timeout?: HumanDuration | string;
+          startUrlSearchParams?: [string: string];
           signIn?: {
             resolvers: Array<
               | {

--- a/plugins/auth-backend-module-oidc-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-oidc-provider/src/module.test.ts
@@ -232,4 +232,96 @@ describe('authModuleOidcProvider', () => {
       encodeURIComponent(`"accessToken":"accessToken"`),
     );
   });
+
+  it('should include custom search params in the start URL when configured', async () => {
+    const backend = await startTestBackend({
+      features: [
+        authModuleOidcProvider,
+        import('@backstage/plugin-auth-backend'),
+        mockServices.rootConfig.factory({
+          data: {
+            app: { baseUrl: 'http://localhost' },
+            auth: {
+              session: { secret: 'test' },
+              providers: {
+                oidc: {
+                  development: {
+                    metadataUrl:
+                      'https://oidc.test/.well-known/openid-configuration',
+                    clientId: 'clientId',
+                    clientSecret: 'clientSecret',
+                    startUrlSearchParams: {
+                      foo: '1',
+                      bar: '2',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        }),
+      ],
+    });
+
+    const agent = request.agent(backend.server);
+    const startResponse = await agent.get(
+      `/api/auth/oidc/start?env=development`,
+    );
+
+    expect(startResponse.status).toEqual(302);
+    const startUrl = new URL(startResponse.get('location'));
+    expect(startUrl.searchParams.get('foo')).toBe('1');
+    expect(startUrl.searchParams.get('bar')).toBe('2');
+
+    backend.server.close();
+  });
+
+  it('should not override the core start URL search params', async () => {
+    const backend = await startTestBackend({
+      features: [
+        authModuleOidcProvider,
+        import('@backstage/plugin-auth-backend'),
+        mockServices.rootConfig.factory({
+          data: {
+            app: { baseUrl: 'http://localhost' },
+            auth: {
+              session: { secret: 'test' },
+              providers: {
+                oidc: {
+                  development: {
+                    metadataUrl:
+                      'https://oidc.test/.well-known/openid-configuration',
+                    clientId: 'clientId',
+                    clientSecret: 'clientSecret',
+                    startUrlSearchParams: {
+                      foo: '1',
+                      prompt: 'customPrompt',
+                      scope: 'customScope',
+                      state: 'customState',
+                      nonce: 'customNonce',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        }),
+      ],
+    });
+
+    const agent = request.agent(backend.server);
+    const startResponse = await agent.get(
+      `/api/auth/oidc/start?env=development`,
+    );
+
+    expect(startResponse.status).toEqual(302);
+    const startUrl = new URL(startResponse.get('location'));
+    expect(startUrl.searchParams.get('foo')).toBe('1');
+    expect(startUrl.searchParams.get('scope')).not.toBe('customScope');
+    expect(startUrl.searchParams.get('state')).not.toBe('customState');
+    expect(startUrl.searchParams.get('nonce')).not.toBe('customNonce');
+    expect(startUrl.searchParams.get('prompt')).not.toBe('customPrompt');
+
+    backend.server.close();
+  });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Allow the Backstage admin to define custom OIDC start URL search (query) parameters for the OIDC authentication provider.

This is done by defining the `startUrlSearchParameters` property in the Backstage YAML config.

Implements #30754

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
