### PR TITLE
fix: trim mspraph query params

### DIFF
--- a/.changeset/some-signs-sort.md
+++ b/.changeset/some-signs-sort.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-msgraph': patch
+---
+
+Trim `mspraph` query params because the folded-styled definition in the `app-config.yaml` adds a line-break to the end of the string.

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/client.test.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/client.test.ts
@@ -358,6 +358,28 @@ describe('MicrosoftGraphClient', () => {
 
     expect(organization).toEqual({ displayName: 'Example' });
   });
+
+  it.each(['search', 'filter', 'expand'])(
+    'should trim the %s param',
+    async paramName => {
+      worker.use(
+        rest.get('https://example.com/users', (req, res, ctx) =>
+          res(ctx.status(200), ctx.json({ queryString: req.url.search })),
+        ),
+      );
+
+      const response = await client.requestApi('users', {
+        [paramName]: `
+          text to trim
+        `,
+      });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({
+        queryString: `?%24${paramName}=text%20to%20trim`,
+      });
+    },
+  );
 });
 
 async function collectAsyncIterable<T>(

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/client.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/client.ts
@@ -186,10 +186,10 @@ export class MicrosoftGraphClient {
   ): Promise<Response> {
     const queryString = qs.stringify(
       {
-        $search: query?.search,
-        $filter: query?.filter,
+        $search: query?.search?.trim(),
+        $filter: query?.filter?.trim(),
         $select: query?.select?.join(','),
-        $expand: query?.expand,
+        $expand: query?.expand?.trim(),
         $count: query?.count,
         $top: query?.top,
       },


### PR DESCRIPTION
…he app-config.yaml adds a line-break at the end of the string

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

The folded style definition in the `app-config.yaml` automatically adds a line-break to the end of the string.
In the Backstage version 1.43.0 the `encode` was set to `true` in the `qs.stringify()` in the _msgraph_.

That is why we have to `trim()` the query params to cut the unnecessary line breaks.
Without trimming the discovery does not work.

More context:

The folded style definition is forced in the [documentation](https://backstage.io/docs/integrations/azure/org/#installation):

```
        filter: >
            securityEnabled eq false
            and mailEnabled eq true
            and groupTypes/any(c:c+eq+'Unified')
``` 

But from v1.43.0 only the double-quoted style definition works:

```
        filter: "securityEnabled eq false \
            and mailEnabled eq true \
            and groupTypes/any(c:c+eq+'Unified')"
``` 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
