### PR TITLE
fix(frontend): forward disabled prop to EntityPicker

### DIFF
--- a/.changeset/disabled-prop-forward.md
+++ b/.changeset/disabled-prop-forward.md
@@ -1,0 +1,3 @@
+@backstage/plugin-scaffolder
+patch
+Forward ui:disabled in OwnedEntityPicker to allow disabling it

--- a/.changeset/disabled-prop-forward.md
+++ b/.changeset/disabled-prop-forward.md
@@ -1,3 +1,5 @@
-@backstage/plugin-scaffolder
-patch
-Forward ui:disabled in OwnedEntityPicker to allow disabling it
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Forward `ui:disabled` in `OwnedEntityPicker` to allow disabling it

--- a/plugins/scaffolder/src/components/fields/OwnedEntityPicker/OwnedEntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/OwnedEntityPicker/OwnedEntityPicker.tsx
@@ -115,6 +115,7 @@ function buildEntityPickerUISchema(
       ...extraOptions,
       catalogFilter,
     },
+    'ui:disabled':uiSchema['ui:disabled'],
   };
 }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Resolves https://github.com/backstage/backstage/issues/31311

Forward the ui:disabled prop in OwnedEntityPicker to the underlying EntityPicker component to allow disabling it in templates

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
