### PR TITLE
fix(homepage): prevent duplicate widget additions and add empty state

### DIFF
--- a/.changeset/wise-bees-worry.md
+++ b/.changeset/wise-bees-worry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-home': patch
+---
+
+Prevent duplicate widget additions and add empty state for Add Widget dialog

--- a/.changeset/wise-bees-worry.md
+++ b/.changeset/wise-bees-worry.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-home': patch
 ---
 
-Prevent duplicate widget additions and add empty state for Add Widget dialog
+Optionally prevent duplicate widget additions via config and added empty state for Add Widget dialog

--- a/.changeset/wise-bees-worry.md
+++ b/.changeset/wise-bees-worry.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-home': patch
 ---
 
-Optionally prevent duplicate widget additions via config and added empty state for Add Widget dialog
+Optionally prevent duplicate widget additions via prop and added empty state for Add Widget dialog

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -92,7 +92,7 @@ const customHomePageModule = createFrontendModule({
                   <HeaderWorldClock clockConfigs={clockConfigs} />
                 </Header>
                 <Content>
-                  <CustomHomepageGrid>
+                  <CustomHomepageGrid preventDuplicateWidgets>
                     {widgets.map((widget, index) => (
                       <Fragment key={widget.name ?? index}>
                         {widget.component}

--- a/plugins/home/README.md
+++ b/plugins/home/README.md
@@ -132,6 +132,19 @@ const myWidget = HomePageWidgetBlueprint.make({
 
 > **Example**: See [dev/index.tsx](dev/index.tsx) for a comprehensive example of creating multiple homepage widgets and layouts.
 
+### Preventing Duplicate Widgets
+
+The `CustomHomepageGrid` supports preventing duplicate widgets from being added to the homepage via the `preventDuplicateWidgets` prop (default: `false`):
+
+```tsx
+<CustomHomepageGrid preventDuplicateWidgets={true}>
+  <HomePageSearchBar />
+  <HomePageRandomJoke />
+  <HomePageStarredEntities />
+</CustomHomepageGrid>
+```
+
+
 ## Contributing
 
 ### Homepage Components
@@ -484,9 +497,50 @@ home:
       - field:
         operator:
         value:
+  customHomepage:
+    preventDuplicateWidgets: true
 ```
 
 `filterBy` configs that are not defined in the above format will be ignored.
+
+### Custom Homepage Configuration
+
+The custom homepage grid supports additional configuration options:
+
+```yaml
+home:
+  customHomepage:
+    # Whether to prevent duplicate widgets from being added to the homepage
+    # This can be overridden by the preventDuplicateWidgets prop on CustomHomepageGrid
+    # Default: false
+    preventDuplicateWidgets: true
+```
+
+#### Configuration Precedence
+
+The `preventDuplicateWidgets` setting follows this precedence order (highest to lowest):
+
+1. **Prop override**: `preventDuplicateWidgets` prop on `CustomHomepageGrid` component
+2. **App configuration**: `home.customHomepage.preventDuplicateWidgets` in `app-config.yaml`
+3. **Default**: `false`
+
+#### Usage Examples
+
+**App-level configuration (app-config.yaml):**
+
+```yaml
+home:
+  customHomepage:
+    preventDuplicateWidgets: true
+```
+
+**Component-level override:**
+
+```tsx
+<CustomHomepageGrid preventDuplicateWidgets={false}>
+  {/* Widgets */}
+</CustomHomepageGrid>
+```
 
 In order to validate the config you can use `backstage/cli config:check`
 

--- a/plugins/home/README.md
+++ b/plugins/home/README.md
@@ -497,50 +497,9 @@ home:
       - field:
         operator:
         value:
-  customHomepage:
-    preventDuplicateWidgets: true
 ```
 
 `filterBy` configs that are not defined in the above format will be ignored.
-
-### Custom Homepage Configuration
-
-The custom homepage grid supports additional configuration options:
-
-```yaml
-home:
-  customHomepage:
-    # Whether to prevent duplicate widgets from being added to the homepage
-    # This can be overridden by the preventDuplicateWidgets prop on CustomHomepageGrid
-    # Default: false
-    preventDuplicateWidgets: true
-```
-
-#### Configuration Precedence
-
-The `preventDuplicateWidgets` setting follows this precedence order (highest to lowest):
-
-1. **Prop override**: `preventDuplicateWidgets` prop on `CustomHomepageGrid` component
-2. **App configuration**: `home.customHomepage.preventDuplicateWidgets` in `app-config.yaml`
-3. **Default**: `false`
-
-#### Usage Examples
-
-**App-level configuration (app-config.yaml):**
-
-```yaml
-home:
-  customHomepage:
-    preventDuplicateWidgets: true
-```
-
-**Component-level override:**
-
-```tsx
-<CustomHomepageGrid preventDuplicateWidgets={false}>
-  {/* Widgets */}
-</CustomHomepageGrid>
-```
 
 In order to validate the config you can use `backstage/cli config:check`
 

--- a/plugins/home/README.md
+++ b/plugins/home/README.md
@@ -144,7 +144,6 @@ The `CustomHomepageGrid` supports preventing duplicate widgets from being added 
 </CustomHomepageGrid>
 ```
 
-
 ## Contributing
 
 ### Homepage Components

--- a/plugins/home/config.d.ts
+++ b/plugins/home/config.d.ts
@@ -70,7 +70,7 @@ export interface Config {
      */
     customHomepage?: {
       /**
-       * Whether to prevent duplicate widgets from being added to the homepage
+       * Whether to prevent duplicate widgets from being added to the homepage; default `false`
        * @visibility frontend
        */
       preventDuplicateWidgets?: boolean;

--- a/plugins/home/config.d.ts
+++ b/plugins/home/config.d.ts
@@ -64,5 +64,16 @@ export interface Config {
         value: string | number;
       }>;
     };
+    /**
+     * Custom homepage grid configuration
+     * @visibility frontend
+     */
+    customHomepage?: {
+      /**
+       * Whether to prevent duplicate widgets from being added to the homepage
+       * @visibility frontend
+       */
+      preventDuplicateWidgets?: boolean;
+    };
   };
 }

--- a/plugins/home/config.d.ts
+++ b/plugins/home/config.d.ts
@@ -64,16 +64,5 @@ export interface Config {
         value: string | number;
       }>;
     };
-    /**
-     * Custom homepage grid configuration
-     * @visibility frontend
-     */
-    customHomepage?: {
-      /**
-       * Whether to prevent duplicate widgets from being added to the homepage; default `false`
-       * @visibility frontend
-       */
-      preventDuplicateWidgets?: boolean;
-    };
   };
 }

--- a/plugins/home/report-alpha.api.md
+++ b/plugins/home/report-alpha.api.md
@@ -190,8 +190,8 @@ export const homeTranslationRef: TranslationRef<
   {
     readonly 'starredEntities.noStarredEntitiesMessage': 'Click the star beside an entity name to add it to this list!';
     readonly 'addWidgetDialog.title': 'Add new widget to dashboard';
-    readonly 'customHomepageButtons.cancel': 'Cancel';
     readonly 'addWidgetDialog.noAvailableWidgets': 'All available widgets have been added to the dashboard.';
+    readonly 'customHomepageButtons.cancel': 'Cancel';
     readonly 'customHomepageButtons.clearAll': 'Clear all';
     readonly 'customHomepageButtons.edit': 'Edit';
     readonly 'customHomepageButtons.restoreDefaults': 'Restore defaults';

--- a/plugins/home/report-alpha.api.md
+++ b/plugins/home/report-alpha.api.md
@@ -191,6 +191,7 @@ export const homeTranslationRef: TranslationRef<
     readonly 'starredEntities.noStarredEntitiesMessage': 'Click the star beside an entity name to add it to this list!';
     readonly 'addWidgetDialog.title': 'Add new widget to dashboard';
     readonly 'customHomepageButtons.cancel': 'Cancel';
+    readonly 'addWidgetDialog.noAvailableWidgets': 'All available widgets have been added to the dashboard.';
     readonly 'customHomepageButtons.clearAll': 'Clear all';
     readonly 'customHomepageButtons.edit': 'Edit';
     readonly 'customHomepageButtons.restoreDefaults': 'Restore defaults';

--- a/plugins/home/report.api.md
+++ b/plugins/home/report.api.md
@@ -102,6 +102,7 @@ export type CustomHomepageGridProps = {
   compactType?: 'vertical' | 'horizontal' | null;
   allowOverlap?: boolean;
   preventCollision?: boolean;
+  preventDuplicateWidgets?: boolean;
 };
 
 // @public

--- a/plugins/home/report.api.md
+++ b/plugins/home/report.api.md
@@ -184,6 +184,7 @@ export const homeTranslationRef: TranslationRef<
   {
     readonly 'starredEntities.noStarredEntitiesMessage': 'Click the star beside an entity name to add it to this list!';
     readonly 'addWidgetDialog.title': 'Add new widget to dashboard';
+    readonly 'addWidgetDialog.noAvailableWidgets': 'All available widgets have been added to the dashboard.';
     readonly 'customHomepageButtons.cancel': 'Cancel';
     readonly 'customHomepageButtons.clearAll': 'Clear all';
     readonly 'customHomepageButtons.edit': 'Edit';

--- a/plugins/home/src/components/CustomHomepage/AddWidgetDialog.tsx
+++ b/plugins/home/src/components/CustomHomepage/AddWidgetDialog.tsx
@@ -25,6 +25,7 @@ import ListItemText from '@material-ui/core/ListItemText';
 import Typography from '@material-ui/core/Typography';
 import { useTranslationRef } from '@backstage/frontend-plugin-api';
 import { homeTranslationRef } from '../../translation';
+import Box from '@material-ui/core/Box';
 
 interface AddWidgetDialogProps {
   widgets: Widget[];
@@ -42,39 +43,47 @@ export const AddWidgetDialog = (props: AddWidgetDialogProps) => {
     <>
       <DialogTitle>{t('addWidgetDialog.title')}</DialogTitle>
       <DialogContent>
-        <List dense>
-          {widgets.map(widget => {
-            return (
-              <ListItem
-                key={widget.name}
-                button
-                onClick={() => handleAdd(widget)}
-              >
-                <ListItemAvatar>
-                  <AddIcon />
-                </ListItemAvatar>
-                <ListItemText
-                  secondary={
-                    widget.description && (
-                      <Typography
-                        component="span"
-                        variant="caption"
-                        color="textPrimary"
-                      >
-                        {widget.description}
+        {widgets.length === 0 ? (
+          <Box pb={3} textAlign="center">
+            <Typography variant="body1" color="textSecondary">
+              {t('addWidgetDialog.noAvailableWidgets')}
+            </Typography>
+          </Box>
+        ) : (
+          <List dense>
+            {widgets.map(widget => {
+              return (
+                <ListItem
+                  key={widget.name}
+                  button
+                  onClick={() => handleAdd(widget)}
+                >
+                  <ListItemAvatar>
+                    <AddIcon />
+                  </ListItemAvatar>
+                  <ListItemText
+                    secondary={
+                      widget.description && (
+                        <Typography
+                          component="span"
+                          variant="caption"
+                          color="textPrimary"
+                        >
+                          {widget.description}
+                        </Typography>
+                      )
+                    }
+                    primary={
+                      <Typography variant="body1" color="textPrimary">
+                        {getTitle(widget)}
                       </Typography>
-                    )
-                  }
-                  primary={
-                    <Typography variant="body1" color="textPrimary">
-                      {getTitle(widget)}
-                    </Typography>
-                  }
-                />
-              </ListItem>
-            );
-          })}
-        </List>
+                    }
+                  />
+                </ListItem>
+              );
+            })}
+          </List>
+        )}
       </DialogContent>
     </>
   );

--- a/plugins/home/src/components/CustomHomepage/AddWidgetDialog.tsx
+++ b/plugins/home/src/components/CustomHomepage/AddWidgetDialog.tsx
@@ -15,6 +15,7 @@
  */
 
 import { Widget } from './types';
+import Box from '@material-ui/core/Box';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import DialogContent from '@material-ui/core/DialogContent';
@@ -25,7 +26,6 @@ import ListItemText from '@material-ui/core/ListItemText';
 import Typography from '@material-ui/core/Typography';
 import { useTranslationRef } from '@backstage/frontend-plugin-api';
 import { homeTranslationRef } from '../../translation';
-import Box from '@material-ui/core/Box';
 
 interface AddWidgetDialogProps {
   widgets: Widget[];

--- a/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.test.tsx
+++ b/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.test.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import { CustomHomepageGrid } from './CustomHomepageGrid';
 import {
   renderInTestApp,
@@ -77,6 +77,11 @@ const defaultConfig: ComponentProps<typeof CustomHomepageGrid>['config'] = [
     width: 20,
     height: 10,
   },
+];
+
+const twoWidgetConfig: ComponentProps<typeof CustomHomepageGrid>['config'] = [
+  { component: 'A', x: 0, y: 0, width: 10, height: 10 },
+  { component: 'B', x: 10, y: 0, width: 10, height: 10 },
 ];
 
 describe('CustomHomepageGrid', () => {
@@ -165,5 +170,100 @@ describe('CustomHomepageGrid', () => {
     ).toEqual(
       expect.objectContaining({ presence: 'absent', value: undefined }),
     );
+  });
+
+  it('should list all widgets and allows adding duplicates when preventDuplicateWidgets is false', async () => {
+    const mockStorage = mockApis.storage();
+
+    await renderInTestApp(
+      <TestApiProvider apis={[[storageApiRef, mockStorage]]}>
+        <CustomHomepageGrid
+          config={defaultConfig}
+          preventDuplicateWidgets={false}
+        >
+          <ComponentA />
+          <ComponentB />
+          <ComponentC />
+        </CustomHomepageGrid>
+      </TestApiProvider>,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Add widget' }));
+
+    const dialog = screen.getByRole('dialog');
+    expect(
+      within(dialog).getByRole('heading', {
+        name: 'Add new widget to dashboard',
+      }),
+    ).toBeInTheDocument();
+    expect(within(dialog).getByText('A')).toBeInTheDocument();
+    expect(within(dialog).getByText('B')).toBeInTheDocument();
+    expect(within(dialog).getByText('C')).toBeInTheDocument();
+
+    await userEvent.click(within(dialog).getByText('A'));
+    expect(screen.getAllByText('A')).toHaveLength(2);
+  });
+
+  it('should only list available widgets not already on the grid when preventDuplicateWidgets is true', async () => {
+    const mockStorage = mockApis.storage();
+
+    await renderInTestApp(
+      <TestApiProvider apis={[[storageApiRef, mockStorage]]}>
+        <CustomHomepageGrid config={twoWidgetConfig} preventDuplicateWidgets>
+          <ComponentA />
+          <ComponentB />
+          <ComponentC />
+        </CustomHomepageGrid>
+      </TestApiProvider>,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Add widget' }));
+
+    const dialog = screen.getByRole('dialog');
+    expect(
+      within(dialog).getByRole('heading', {
+        name: 'Add new widget to dashboard',
+      }),
+    ).toBeInTheDocument();
+    expect(within(dialog).getByText('C')).toBeInTheDocument();
+    expect(within(dialog).queryByText('A')).not.toBeInTheDocument();
+    expect(within(dialog).queryByText('B')).not.toBeInTheDocument();
+
+    await userEvent.click(within(dialog).getByText('C'));
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Add widget' }),
+    );
+
+    expect(
+      await screen.findByText(
+        'All available widgets have been added to the dashboard.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('should show empty state when preventDuplicateWidgets is true and all widgets are on grid', async () => {
+    const mockStorage = mockApis.storage();
+
+    await renderInTestApp(
+      <TestApiProvider apis={[[storageApiRef, mockStorage]]}>
+        <CustomHomepageGrid config={defaultConfig} preventDuplicateWidgets>
+          <ComponentA />
+          <ComponentB />
+          <ComponentC />
+        </CustomHomepageGrid>
+      </TestApiProvider>,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Add widget' }));
+
+    expect(
+      screen.getByText(
+        'All available widgets have been added to the dashboard.',
+      ),
+    ).toBeInTheDocument();
   });
 });

--- a/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.tsx
+++ b/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.tsx
@@ -174,9 +174,9 @@ const convertConfigToDefaultWidgets = (
         isResizable: false,
       },
       settings: {},
-      movable: conf.movable ?? true,
-      deletable: conf.deletable ?? true,
-      resizable: conf.resizable ?? true,
+      movable: conf.movable,
+      deletable: conf.deletable,
+      resizable: conf.resizable,
     };
   });
   return compact(ret);
@@ -232,7 +232,6 @@ export const CustomHomepageGrid = (props: CustomHomepageGridProps) => {
     useHomeStorage(defaultLayout);
   const [widgets, setWidgets] = useState(storedWidgets);
 
-
   // Get preventDuplicateWidgets from config with prop override
   const configPreventDuplicates = configApi.getOptionalBoolean(
     'home.customHomepage.preventDuplicateWidgets',
@@ -270,7 +269,6 @@ export const CustomHomepageGrid = (props: CustomHomepageGridProps) => {
   };
 
   const handleAdd = (widget: Widget) => {
-    const defaultConfig = defaultLayout.find(w => w.id.includes(widget.name));
     const widgetId = `${widget.name}__${widgets.length + 1}${Math.random()
       .toString(36)
       .slice(2)}`;
@@ -293,9 +291,9 @@ export const CustomHomepageGrid = (props: CustomHomepageGridProps) => {
           isDraggable: editMode,
         },
         settings: {},
-        movable: widget.movable ?? defaultConfig?.movable ?? true,
-        deletable: widget.deletable ?? defaultConfig?.deletable ?? true,
-        resizable: widget.resizable ?? defaultConfig?.resizable ?? true,
+        movable: widget.movable,
+        deletable: widget.deletable,
+        resizable: widget.resizable,
       },
     ]);
     setAddWidgetDialogOpen(false);

--- a/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.tsx
+++ b/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.tsx
@@ -173,9 +173,9 @@ const convertConfigToDefaultWidgets = (
         isResizable: false,
       },
       settings: {},
-      movable: conf.movable,
-      deletable: conf.deletable,
-      resizable: conf.resizable,
+      movable: conf.movable ?? true,
+      deletable: conf.deletable ?? true,
+      resizable: conf.resizable ?? true,
     };
   });
   return compact(ret);
@@ -247,7 +247,16 @@ export const CustomHomepageGrid = (props: CustomHomepageGridProps) => {
   };
   const { t } = useTranslationRef(homeTranslationRef);
 
+  // Get available widgets that are not already in use
+  const getAvailableWidgets = () => {
+    const usedWidgetNames = new Set(
+      widgets.map(w => getWidgetNameFromKey(w.id)),
+    );
+    return availableWidgets.filter(widget => !usedWidgetNames.has(widget.name));
+  };
+
   const handleAdd = (widget: Widget) => {
+    const defaultConfig = defaultLayout.find(w => w.id.includes(widget.name));
     const widgetId = `${widget.name}__${widgets.length + 1}${Math.random()
       .toString(36)
       .slice(2)}`;
@@ -270,9 +279,9 @@ export const CustomHomepageGrid = (props: CustomHomepageGridProps) => {
           isDraggable: editMode,
         },
         settings: {},
-        movable: widget.movable,
-        deletable: widget.deletable,
-        resizable: widget.resizable,
+        movable: widget.movable ?? defaultConfig?.movable ?? true,
+        deletable: widget.deletable ?? defaultConfig?.deletable ?? true,
+        resizable: widget.resizable ?? defaultConfig?.resizable ?? true,
       },
     ]);
     setAddWidgetDialogOpen(false);
@@ -375,7 +384,12 @@ export const CustomHomepageGrid = (props: CustomHomepageGridProps) => {
         open={addWidgetDialogOpen}
         onClose={() => setAddWidgetDialogOpen(false)}
       >
-        <AddWidgetDialog widgets={availableWidgets} handleAdd={handleAdd} />
+        {addWidgetDialogOpen && (
+          <AddWidgetDialog
+            widgets={getAvailableWidgets()}
+            handleAdd={handleAdd}
+          />
+        )}
       </Dialog>
       {!editMode && widgets.length === 0 && (
         <Typography variant="h5" align="center">

--- a/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.tsx
+++ b/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.tsx
@@ -387,6 +387,7 @@ export const CustomHomepageGrid = (props: CustomHomepageGridProps) => {
         open={addWidgetDialogOpen}
         onClose={() => setAddWidgetDialogOpen(false)}
       >
+        {/* Only mount when open so the list does not update (e.g. remove the added widget) before the modal closes */}
         {addWidgetDialogOpen && (
           <AddWidgetDialog
             widgets={getAvailableWidgets()}

--- a/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.tsx
+++ b/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.tsx
@@ -28,7 +28,6 @@ import {
   storageApiRef,
   useApi,
   useElementFilter,
-  configApiRef,
 } from '@backstage/core-plugin-api';
 import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';
@@ -217,7 +216,6 @@ const availableWidgetsFilter = (elements: ElementCollection) => {
 export const CustomHomepageGrid = (props: CustomHomepageGridProps) => {
   const styles = useStyles();
   const theme = useTheme();
-  const configApi = useApi(configApiRef);
   const availableWidgets = useElementFilter(
     props.children,
     availableWidgetsFilter,
@@ -232,14 +230,7 @@ export const CustomHomepageGrid = (props: CustomHomepageGridProps) => {
     useHomeStorage(defaultLayout);
   const [widgets, setWidgets] = useState(storedWidgets);
 
-  // Get preventDuplicateWidgets from config with prop override
-  const configPreventDuplicates = configApi.getOptionalBoolean(
-    'home.customHomepage.preventDuplicateWidgets',
-  );
-
-  // Precedence: prop > config > default (false)
-  const preventDuplicateWidgets =
-    props.preventDuplicateWidgets ?? configPreventDuplicates ?? false;
+  const preventDuplicateWidgets = props.preventDuplicateWidgets ?? false;
 
   const [addWidgetDialogOpen, setAddWidgetDialogOpen] = useState(false);
   const editModeOn = widgets.find(w => w.layout.isResizable) !== undefined;

--- a/plugins/home/src/components/CustomHomepage/types.ts
+++ b/plugins/home/src/components/CustomHomepage/types.ts
@@ -102,6 +102,11 @@ export type CustomHomepageGridProps = {
    * @defaultValue true
    */
   preventCollision?: boolean;
+  /**
+   * Controls if widgets can be added to the grid if they already exist. If true, already existing widgets will not be added.
+   * @defaultValue false
+   */
+  preventDuplicateWidgets?: boolean;
 };
 
 export const LayoutConfigurationSchema = z.object({

--- a/plugins/home/src/components/CustomHomepage/types.ts
+++ b/plugins/home/src/components/CustomHomepage/types.ts
@@ -103,7 +103,7 @@ export type CustomHomepageGridProps = {
    */
   preventCollision?: boolean;
   /**
-   * Controls if widgets can be added to the grid if they already exist. If true, already existing widgets will not be added.
+   * Controls if widgets can be added to the grid if they already exist. If true, widgets already present on the grid are excluded from the Add Widget dialog (preventing duplicates)
    * @defaultValue false
    */
   preventDuplicateWidgets?: boolean;

--- a/plugins/home/src/translation.ts
+++ b/plugins/home/src/translation.ts
@@ -26,6 +26,8 @@ export const homeTranslationRef = createTranslationRef({
   messages: {
     addWidgetDialog: {
       title: 'Add new widget to dashboard',
+      noAvailableWidgets:
+        'All available widgets have been added to the dashboard.',
     },
     customHomepageButtons: {
       edit: 'Edit',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

### Fixes

https://github.com/backstage/backstage/issues/31292

### Problem
- Users could add the same widget multiple times through the Add Widget dialog

### Solution
- Add Widget dialog now filters out already-used widgets to prevent duplicates via prop.
- Added empty state with proper styling and messaging (translation supported) for Add Widget dialog

**prop**

```tsx
<CustomHomepageGrid preventDuplicateWidgets={true}>
  <HomePageSearchBar />
  <HomePageRandomJoke />
  <HomePageStarredEntities />
</CustomHomepageGrid>
```



## Screenshots/Video


https://github.com/user-attachments/assets/2599a58a-8eb2-42f0-8eed-bf6ecad2bc1b


**Empty state for All widgets used scenario:**

<img width="1724" height="729" alt="Screenshot 2025-10-01 at 11 26 37 PM" src="https://github.com/user-attachments/assets/9562d91b-404b-4a3a-be88-08dc4b31c570" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
