### PR TITLE
backend-app-api: earlier handling or unhandled errors

### DIFF
--- a/.changeset/cuddly-mugs-act.md
+++ b/.changeset/cuddly-mugs-act.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+Moved up registration of unhandled rejections and errors listeners to be done as early as possible, avoiding flakiness in backend startups and instead always logging these failures rather than sometimes crashing the process.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The fact that we registered these after the backend had started was quite arbitrary. If you have some variance in the init speed of plugins (which there will be) it just risks causing flaky behavior where the backend sometimes crashes and sometimes not. The intention of this was to more easily catch these errors, but I think it's better to prioritize stability for this case.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
