### PR TITLE
chore(search): add missing highlight prop

### DIFF
--- a/.changeset/sixty-cameras-talk.md
+++ b/.changeset/sixty-cameras-talk.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-react': patch
+---
+
+Added missing hihglight prop for `BaseSearchResultListItemProps`

--- a/plugins/search-react/report-alpha.api.md
+++ b/plugins/search-react/report-alpha.api.md
@@ -7,6 +7,7 @@ import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { ExtensionBlueprint } from '@backstage/frontend-plugin-api';
 import { ExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { ListItemProps } from '@material-ui/core/ListItem';
+import { ResultHighlight } from '@backstage/plugin-search-common';
 import { SearchDocument } from '@backstage/plugin-search-common';
 import { SearchResult } from '@backstage/plugin-search-common';
 import { TranslationRef } from '@backstage/core-plugin-api/alpha';
@@ -15,6 +16,7 @@ import { TranslationRef } from '@backstage/core-plugin-api/alpha';
 export type BaseSearchResultListItemProps<T = {}> = T & {
   rank?: number;
   result?: SearchDocument;
+  highlight?: ResultHighlight;
 } & Omit<ListItemProps, 'button'>;
 
 // @alpha (undocumented)

--- a/plugins/search-react/src/alpha/blueprints/types.ts
+++ b/plugins/search-react/src/alpha/blueprints/types.ts
@@ -15,13 +15,18 @@
  */
 
 import { ListItemProps } from '@material-ui/core/ListItem';
-import { SearchDocument, SearchResult } from '@backstage/plugin-search-common';
+import {
+  ResultHighlight,
+  SearchDocument,
+  SearchResult,
+} from '@backstage/plugin-search-common';
 import { createExtensionDataRef } from '@backstage/frontend-plugin-api';
 
 /** @alpha */
 export type BaseSearchResultListItemProps<T = {}> = T & {
   rank?: number;
   result?: SearchDocument;
+  highlight?: ResultHighlight;
 } & Omit<ListItemProps, 'button'>;
 
 /** @alpha */


### PR DESCRIPTION
## Hey, I just made a Pull Request!

it's passed to the list item fine but the type doesn't know about this by default so added the highlight parameter to
`BaseSearchResultListItemProps`

closes #31305

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
