### PR TITLE
Fix BUI Header hrefs

### DIFF
--- a/.changeset/few-weeks-create.md
+++ b/.changeset/few-weeks-create.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Making href mandatory in tabs that are part of a Header component

--- a/packages/ui/report.api.md
+++ b/packages/ui/report.api.md
@@ -1038,7 +1038,7 @@ export interface HeaderProps {
 // @public
 export interface HeaderTab {
   // (undocumented)
-  href?: string;
+  href: string;
   // (undocumented)
   id: string;
   // (undocumented)

--- a/packages/ui/src/components/Header/types.ts
+++ b/packages/ui/src/components/Header/types.ts
@@ -39,7 +39,7 @@ export interface HeaderProps {
 export interface HeaderTab {
   id: string;
   label: string;
-  href?: string;
+  href: string;
   /**
    * Strategy for matching the current route to determine if this tab should be active.
    * - 'exact': Tab href must exactly match the current pathname (default)

--- a/packages/ui/src/components/HeaderPage/HeaderPage.stories.tsx
+++ b/packages/ui/src/components/HeaderPage/HeaderPage.stories.tsx
@@ -44,22 +44,27 @@ const tabs: HeaderTab[] = [
   {
     id: 'overview',
     label: 'Overview',
+    href: '/overview',
   },
   {
     id: 'checks',
     label: 'Checks',
+    href: '/checks',
   },
   {
     id: 'tracks',
     label: 'Tracks',
+    href: '/tracks',
   },
   {
     id: 'campaigns',
     label: 'Campaigns',
+    href: '/campaigns',
   },
   {
     id: 'integrations',
     label: 'Integrations',
+    href: '/integrations',
   },
 ];
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

For header components using tabs it should be mandatory to define a href for each tab since it is used for navigation

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
