### PR TITLE
Remove app-root-element:signals/signals-display

### DIFF
--- a/.changeset/forty-crabs-travel.md
+++ b/.changeset/forty-crabs-travel.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-signals': patch
+---
+
+Remove `app-root-element:signals/signals-display` which was not doing anything useful

--- a/plugins/signals/report-alpha.api.md
+++ b/plugins/signals/report-alpha.api.md
@@ -8,7 +8,6 @@ import { ApiFactory } from '@backstage/frontend-plugin-api';
 import { ExtensionBlueprintParams } from '@backstage/frontend-plugin-api';
 import { ExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { ExtensionDefinition } from '@backstage/frontend-plugin-api';
-import { JSX as JSX_2 } from 'react';
 import { OverridableFrontendPlugin } from '@backstage/frontend-plugin-api';
 
 // @alpha (undocumented)
@@ -30,17 +29,6 @@ const _default: OverridableFrontendPlugin<
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
       ) => ExtensionBlueprintParams<AnyApiFactory>;
-    }>;
-    'app-root-element:signals/signals-display': ExtensionDefinition<{
-      kind: 'app-root-element';
-      name: 'signals-display';
-      config: {};
-      configInput: {};
-      output: ExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>;
-      inputs: {};
-      params: {
-        element: JSX.Element;
-      };
     }>;
   }
 >;

--- a/plugins/signals/src/alpha.tsx
+++ b/plugins/signals/src/alpha.tsx
@@ -16,15 +16,12 @@
 
 import {
   ApiBlueprint,
-  AppRootElementBlueprint,
   createFrontendPlugin,
   discoveryApiRef,
   identityApiRef,
 } from '@backstage/frontend-plugin-api';
 import { signalApiRef } from '@backstage/plugin-signals-react';
 import { SignalClient } from './api/SignalClient';
-import { SignalsDisplay } from './plugin';
-import { compatWrapper } from '@backstage/core-compat-api';
 
 const api = ApiBlueprint.make({
   params: defineParams =>
@@ -43,16 +40,9 @@ const api = ApiBlueprint.make({
     }),
 });
 
-const signalsDisplayAppRootElement = AppRootElementBlueprint.make({
-  name: 'signals-display',
-  params: {
-    element: compatWrapper(<SignalsDisplay />),
-  },
-});
-
 /** @alpha */
 export default createFrontendPlugin({
   pluginId: 'signals',
   info: { packageJson: () => import('../package.json') },
-  extensions: [api, signalsDisplayAppRootElement],
+  extensions: [api],
 });


### PR DESCRIPTION
The original root element just returned `null` and was there just to get the signals plugin discovered. In NFS that is no longer an issue.