### PR TITLE
Exclude suspend users gh enterprise

### DIFF
--- a/.changeset/fuzzy-phones-own.md
+++ b/.changeset/fuzzy-phones-own.md
@@ -1,0 +1,9 @@
+---
+'@backstage/plugin-catalog-backend-module-github-org': minor
+'@backstage/plugin-catalog-backend-module-github': minor
+---
+
+Introduce new configuration option to exclude suspended users from GitHub Enterprise instances.
+
+When it’s set to true, suspended users won’t be emitted by the default transform.
+Note that this option should be used only against GitHub Enterprise instances, the property does not exist in the github.com GraphQL schema, setting it will cause a schema validation error and the syncing of users will fail.

--- a/docs/integrations/github/org.md
+++ b/docs/integrations/github/org.md
@@ -86,6 +86,7 @@ catalog:
           initialDelay: { seconds: 30 }
           frequency: { hours: 1 }
           timeout: { minutes: 50 }
+        excludeSuspendedUsers: true
 ```
 
 Directly under the `githubOrg` is a list of configurations, each entry is a structure with the following elements:
@@ -94,6 +95,7 @@ Directly under the `githubOrg` is a list of configurations, each entry is a stru
 - `githubUrl`: The target that this provider should consume
 - `orgs` (optional): The list of the GitHub orgs to consume. If you only list a single org the generated group entities will use the `default` namespace, otherwise they will use the org name as the namespace. By default the provider will consume all accessible orgs on the given GitHub instance (support for GitHub App integration only).
 - `schedule`: The refresh schedule to use, matches the structure of [`SchedulerServiceTaskScheduleDefinitionConfig`](https://backstage.io/docs/reference/backend-plugin-api.schedulerservicetaskscheduledefinitionconfig/)
+- `excludeSuspendedUsers` (optional): Whether to exclude suspended users when querying organization users. Only for GitHub Enterprise instances. Will error if used against GitHub.com API.
 
 ### Events Support
 

--- a/plugins/catalog-backend-module-github-org/src/module.ts
+++ b/plugins/catalog-backend-module-github-org/src/module.ts
@@ -120,6 +120,7 @@ export const catalogModuleGithubOrgEntityProvider = createBackendModule({
               teamTransformer,
               alwaysUseDefaultNamespace:
                 definitions.length === 1 && definition.orgs?.length === 1,
+              excludeSuspendedUsers: definition.excludeSuspendedUsers,
             }),
           );
         }
@@ -132,6 +133,7 @@ function readDefinitionsFromConfig(rootConfig: Config): Array<{
   id: string;
   githubUrl: string;
   orgs?: string[];
+  excludeSuspendedUsers?: boolean;
   schedule: SchedulerServiceTaskScheduleDefinition;
 }> {
   const baseKey = 'catalog.providers.githubOrg';
@@ -148,6 +150,8 @@ function readDefinitionsFromConfig(rootConfig: Config): Array<{
     id: c.getString('id'),
     githubUrl: c.getString('githubUrl'),
     orgs: c.getOptionalStringArray('orgs'),
+    excludeSuspendedUsers:
+      c.getOptionalBoolean('excludeSuspendedUsers') ?? false,
     schedule: readSchedulerServiceTaskScheduleDefinitionFromConfig(
       c.getConfig('schedule'),
     ),

--- a/plugins/catalog-backend-module-github/config.d.ts
+++ b/plugins/catalog-backend-module-github/config.d.ts
@@ -241,6 +241,13 @@ export interface Config {
             orgs?: string[];
 
             /**
+             * (Optional) Only for GitHub Enterprise. Whether to exclude suspended users when querying organization users.
+             * If true, the defaultTransformer will not return suspended users.
+             * Default: `false`.
+             */
+            excludeSuspendedUsers?: boolean;
+
+            /**
              * The refresh schedule to use.
              */
             schedule: SchedulerServiceTaskScheduleDefinitionConfig;
@@ -268,6 +275,13 @@ export interface Config {
              * orgs on the given GitHub instance (support for GitHub App integration only).
              */
             orgs?: string[];
+
+            /**
+             * (Optional) Only for GitHub Enterprise. Whether to exclude suspended users when querying organization users.
+             * If true, the defaultTransformer will not return suspended users.
+             * Default: `false`.
+             */
+            excludeSuspendedUsers?: boolean;
 
             /**
              * The refresh schedule to use.

--- a/plugins/catalog-backend-module-github/report.api.md
+++ b/plugins/catalog-backend-module-github/report.api.md
@@ -150,6 +150,7 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
     userTransformer?: UserTransformer;
     teamTransformer?: TeamTransformer;
     alwaysUseDefaultNamespace?: boolean;
+    excludeSuspendedUsers?: boolean;
   });
   connect(connection: EntityProviderConnection): Promise<void>;
   // (undocumented)
@@ -165,6 +166,7 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
 export interface GithubMultiOrgEntityProviderOptions {
   alwaysUseDefaultNamespace?: boolean;
   events?: EventsService;
+  excludeSuspendedUsers?: boolean;
   githubCredentialsProvider?: GithubCredentialsProvider;
   githubUrl: string;
   id: string;
@@ -225,6 +227,7 @@ export class GithubOrgEntityProvider implements EntityProvider {
     githubCredentialsProvider?: GithubCredentialsProvider;
     userTransformer?: UserTransformer;
     teamTransformer?: TeamTransformer;
+    excludeSuspendedUsers?: boolean;
   });
   connect(connection: EntityProviderConnection): Promise<void>;
   // (undocumented)
@@ -242,6 +245,7 @@ export type GitHubOrgEntityProviderOptions = GithubOrgEntityProviderOptions;
 // @public
 export interface GithubOrgEntityProviderOptions {
   events?: EventsService;
+  excludeSuspendedUsers?: boolean;
   githubCredentialsProvider?: GithubCredentialsProvider;
   id: string;
   logger: LoggerService;
@@ -296,6 +300,7 @@ export type GithubUser = {
   email?: string;
   name?: string;
   organizationVerifiedDomainEmails?: string[];
+  suspendedAt?: string;
 };
 
 // @public

--- a/plugins/catalog-backend-module-github/src/lib/defaultTransformers.ts
+++ b/plugins/catalog-backend-module-github/src/lib/defaultTransformers.ts
@@ -62,6 +62,9 @@ export const defaultUserTransformer = async (
   item: GithubUser,
   _ctx: TransformerContext,
 ): Promise<UserEntity | undefined> => {
+  if (item.suspendedAt) {
+    return undefined;
+  }
   const entity: UserEntity = {
     apiVersion: 'backstage.io/v1alpha1',
     kind: 'User',

--- a/plugins/catalog-backend-module-github/src/lib/github.test.ts
+++ b/plugins/catalog-backend-module-github/src/lib/github.test.ts
@@ -166,6 +166,54 @@ describe('github', () => {
         getOrganizationUsers(graphql, 'a', 'token'),
       ).resolves.toEqual(output);
     });
+
+    it('reads members excluding suspended users', async () => {
+      const input: QueryResponse = {
+        organization: {
+          membersWithRole: {
+            pageInfo: { hasNextPage: false },
+            nodes: [
+              {
+                login: 'a',
+                name: 'b',
+                bio: 'c',
+                email: 'd',
+                avatarUrl: 'e',
+                suspendedAt: '2025-01-01',
+              },
+              {
+                login: 'a',
+                name: 'b',
+                bio: 'c',
+                email: 'd',
+                avatarUrl: 'e',
+                suspendedAt: undefined,
+              },
+            ],
+          },
+        },
+      };
+
+      const output = {
+        users: [
+          expect.objectContaining({
+            metadata: expect.objectContaining({ name: 'a', description: 'c' }),
+            spec: {
+              profile: { displayName: 'b', email: 'd', picture: 'e' },
+              memberOf: [],
+            },
+          }),
+        ],
+      };
+
+      server.use(
+        graphqlMsw.query('users', () => HttpResponse.json({ data: input })),
+      );
+
+      await expect(
+        getOrganizationUsers(graphql, 'a', 'token', true),
+      ).resolves.toEqual(output);
+    });
   });
 
   describe('getOrganizationUsers using custom UserTransformer', () => {
@@ -226,7 +274,13 @@ describe('github', () => {
       );
 
       await expect(
-        getOrganizationUsers(graphql, 'a', 'token', customUserTransformer),
+        getOrganizationUsers(
+          graphql,
+          'a',
+          'token',
+          false,
+          customUserTransformer,
+        ),
       ).resolves.toEqual(output);
     });
 
@@ -273,11 +327,68 @@ describe('github', () => {
         graphql,
         'a',
         'token',
+        false,
         customUserTransformer,
       );
 
       expect(users.users).toHaveLength(1);
       expect(users).toEqual(output);
+    });
+
+    it('reads members including suspended users', async () => {
+      const input: QueryResponse = {
+        organization: {
+          membersWithRole: {
+            pageInfo: { hasNextPage: false },
+            nodes: [
+              {
+                login: 'a',
+                name: 'b',
+                bio: 'c',
+                email: 'd',
+                avatarUrl: 'e',
+              },
+              {
+                login: 'ab',
+                name: 'bb',
+                bio: 'cc',
+                email: 'dd',
+                avatarUrl: 'ee',
+                suspendedAt: '2025-01-01',
+              },
+            ],
+          },
+        },
+      };
+
+      const output = {
+        users: [
+          expect.objectContaining({
+            metadata: expect.objectContaining({
+              name: 'a-custom',
+            }),
+          }),
+          expect.objectContaining({
+            metadata: expect.objectContaining({
+              name: 'ab-custom',
+            }),
+          }),
+        ],
+      };
+
+      server.use(
+        graphqlMsw.query('users', () => HttpResponse.json({ data: input })),
+      );
+
+      await expect(
+        getOrganizationUsers(
+          graphql,
+          'a',
+          'token',
+          true,
+          customUserTransformer,
+        ),
+      ).resolves.toEqual(output);
     });
   });
 

--- a/plugins/catalog-backend-module-github/src/lib/github.ts
+++ b/plugins/catalog-backend-module-github/src/lib/github.ts
@@ -75,6 +75,7 @@ export type GithubUser = {
   email?: string;
   name?: string;
   organizationVerifiedDomainEmails?: string[];
+  suspendedAt?: string;
 };
 
 /**
@@ -141,8 +142,10 @@ export async function getOrganizationUsers(
   client: typeof graphql,
   org: string,
   tokenType: GithubCredentialType,
+  excludeSuspendedUsers: boolean = false,
   userTransformer: UserTransformer = defaultUserTransformer,
 ): Promise<{ users: Entity[] }> {
+  const suspendedAtField = excludeSuspendedUsers ? 'suspendedAt,' : '';
   const query = `
     query users($org: String!, $email: Boolean!, $cursor: String) {
       organization(login: $org) {
@@ -154,6 +157,7 @@ export async function getOrganizationUsers(
             email @include(if: $email),
             login,
             name,
+            ${suspendedAtField}
             organizationVerifiedDomainEmails(login: $org)
           }
         }

--- a/plugins/catalog-backend-module-github/src/processors/GithubMultiOrgReaderProcessor.ts
+++ b/plugins/catalog-backend-module-github/src/processors/GithubMultiOrgReaderProcessor.ts
@@ -148,6 +148,7 @@ export class GithubMultiOrgReaderProcessor implements CatalogProcessor {
           client,
           orgConfig.name,
           tokenType,
+          false,
           async (githubUser, ctx): Promise<Entity | undefined> => {
             const result = this.options.userTransformer
               ? await this.options.userTransformer(githubUser, ctx)

--- a/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
@@ -166,6 +166,14 @@ export interface GithubMultiOrgEntityProviderOptions {
    * By default, groups will be namespaced according to their GitHub org.
    */
   teamTransformer?: TeamTransformer;
+
+  /**
+   * Optionally exclude suspended users when querying organization users.
+   * @defaultValue false
+   * @remarks
+   * Only for GitHub Enterprise instances. Will error if used against GitHub.com API.
+   */
+  excludeSuspendedUsers?: boolean;
 }
 
 type CreateDeltaOperation = (entities: Entity[]) => {
@@ -212,6 +220,7 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
       teamTransformer: options.teamTransformer,
       events: options.events,
       alwaysUseDefaultNamespace: options.alwaysUseDefaultNamespace,
+      excludeSuspendedUsers: options.excludeSuspendedUsers,
     });
 
     provider.schedule(options.schedule);
@@ -231,6 +240,7 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
       userTransformer?: UserTransformer;
       teamTransformer?: TeamTransformer;
       alwaysUseDefaultNamespace?: boolean;
+      excludeSuspendedUsers?: boolean;
     },
   ) {}
 
@@ -285,6 +295,7 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
         client,
         org,
         tokenType,
+        this.options.excludeSuspendedUsers,
         this.options.userTransformer,
       );
 
@@ -433,6 +444,7 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
       client,
       org,
       tokenType,
+      this.options.excludeSuspendedUsers,
       this.options.userTransformer,
     );
 
@@ -660,6 +672,7 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
       client,
       org,
       tokenType,
+      this.options.excludeSuspendedUsers,
       this.options.userTransformer,
     );
 

--- a/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.ts
@@ -130,6 +130,14 @@ export interface GithubOrgEntityProviderOptions {
    * Optionally include a team transformer for transforming from GitHub teams to Group Entities
    */
   teamTransformer?: TeamTransformer;
+
+  /**
+   * Optionally exclude suspended users when querying organization users.
+   * @defaultValue false
+   * @remarks
+   * Only for GitHub Enterprise instances. Will error if used against GitHub.com API.
+   */
+  excludeSuspendedUsers?: boolean;
 }
 
 /**
@@ -167,6 +175,7 @@ export class GithubOrgEntityProvider implements EntityProvider {
       userTransformer: options.userTransformer,
       teamTransformer: options.teamTransformer,
       events: options.events,
+      excludeSuspendedUsers: options.excludeSuspendedUsers,
     });
 
     provider.schedule(options.schedule);
@@ -184,6 +193,7 @@ export class GithubOrgEntityProvider implements EntityProvider {
       githubCredentialsProvider?: GithubCredentialsProvider;
       userTransformer?: UserTransformer;
       teamTransformer?: TeamTransformer;
+      excludeSuspendedUsers?: boolean;
     },
   ) {
     this.credentialsProvider =
@@ -235,6 +245,7 @@ export class GithubOrgEntityProvider implements EntityProvider {
       client,
       org,
       tokenType,
+      this.options.excludeSuspendedUsers,
       this.options.userTransformer,
     );
     const { teams } = await getOrganizationTeams(
@@ -363,6 +374,7 @@ export class GithubOrgEntityProvider implements EntityProvider {
       client,
       org,
       tokenType,
+      this.options.excludeSuspendedUsers,
       this.options.userTransformer,
     );
 
@@ -454,6 +466,7 @@ export class GithubOrgEntityProvider implements EntityProvider {
       client,
       org,
       tokenType,
+      this.options.excludeSuspendedUsers,
       this.options.userTransformer,
     );
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Introduce new option in the GitHub catalog plugin to exclude suspended users.

This PR Introduces an optional setting to exclude suspended users from GitHub Enterprise instances. When it’s set to true, suspended users won’t be emitted by the default transform. If a custom transformer is used, it should check if the property `suspendedAt` from the `GithubUser` is defined, in order to exclude such users. 
The same logic was not introduced in the `GithubMultiOrgReaderProcessor.ts`, since the usage there is marked as deprecated.

This configuration option should be only used against GitHub Enterprise instances. The property does not exist in the github.com GraphQL schema. Adding it will cause a schema validation error, and the syncing of users will fail.

Closes #31336

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
