### PR TITLE
fix: BitbuckerUrlReader ignoring provided token #31348

### DIFF
--- a/.changeset/warm-moments-repeat.md
+++ b/.changeset/warm-moments-repeat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Fix #31348 issue where BitbucketUrlReader ignored provided token and instead always used integration credentials

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/BitbucketUrlReader.test.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/BitbucketUrlReader.test.ts
@@ -130,6 +130,27 @@ describe('BitbucketUrlReader', () => {
       expect(buffer.toString()).toBe('foo');
     });
 
+    it('should be able to readUrl using provided token', async () => {
+      worker.use(
+        rest.get(
+          'https://api.bitbucket.org/2.0/repositories/backstage-verification/test-template/src/master/template.yaml',
+          (req, res, ctx) => {
+            expect(req.headers.get('authorization')).toBe(
+              'Bearer manual-token',
+            );
+            return res(ctx.status(200), ctx.body('foo'));
+          },
+        ),
+      );
+
+      const result = await bitbucketProcessor.readUrl(
+        'https://bitbucket.org/backstage-verification/test-template/src/master/template.yaml',
+        { token: 'manual-token' },
+      );
+      const buffer = await result.buffer();
+      expect(buffer.toString()).toBe('foo');
+    });
+
     it('should be able to readUrl via stream without ETag', async () => {
       worker.use(
         rest.get(

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/BitbucketUrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/BitbucketUrlReader.ts
@@ -93,13 +93,27 @@ export class BitbucketUrlReader implements UrlReaderService {
     return response.buffer();
   }
 
+  private getCredentials = async (options?: {
+    token?: string;
+  }): Promise<{ headers: Record<string, string> }> => {
+    if (options?.token) {
+      return {
+        headers: {
+          Authorization: `Bearer ${options.token}`,
+        },
+      };
+    }
+
+    return await getBitbucketRequestOptions(this.integration.config);
+  };
+
   async readUrl(
     url: string,
     options?: UrlReaderServiceReadUrlOptions,
   ): Promise<UrlReaderServiceReadUrlResponse> {
     const { etag, lastModifiedAfter, signal } = options ?? {};
     const bitbucketUrl = getBitbucketFileFetchUrl(url, this.integration.config);
-    const requestOptions = getBitbucketRequestOptions(this.integration.config);
+    const requestOptions = await this.getCredentials(options);
 
     let response: Response;
     try {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixed a bug where BitbucketUrlReader ignored provided token.
I copied the implementation from GitHubUrlReader.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
