### PR TITLE
Create sds_workspace.yaml

### DIFF
--- a/microsite/data/plugins/sds_workspace.yaml
+++ b/microsite/data/plugins/sds_workspace.yaml
@@ -1,0 +1,10 @@
+---
+title: Citrix Secure Developer Spaces (SDS)
+author: Citrix
+authorUrl: https://github.com/strong-network
+category: Development
+description: Connect Backstage with Citrix Secure Developer Spaces (SDS) to view and create developer workspaces.
+documentation: https://www.npmjs.com/package/@citrixcloud/backstage-sds-workspaces
+iconUrl: /img/citrix_sds.png
+npmPackageName: '@citrixcloud/backstage-sds-workspaces'
+addedDate: '2025-10-07'


### PR DESCRIPTION
This PR adds the Citrix Secure Developer Spaces (SDS) plugin to the Backstage plugin directory. Name: @citrixcloud/backstage-sds-workspaces
Author: Citrix
Category: Development
Description: Connect Backstage with Citrix Secure Developer Spaces (SDS) to view and create developer workspaces. Documentation: https://www.npmjs.com/package/@citrixcloud/backstage-sds-workspaces NPM Package: https://www.npmjs.com/package/@citrixcloud/backstage-sds-workspaces Icon: /img/citrix_sds.png
The package is published on npm and publicly available. The repository includes installation and usage documentation.
