### PR TITLE
workflows/e2e-techdocs: add explicit node setup

### DIFF
--- a/.github/workflows/verify_e2e-techdocs.yml
+++ b/.github/workflows/verify_e2e-techdocs.yml
@@ -41,6 +41,10 @@ jobs:
         with:
           python-version: '3.9'
 
+      - name: use node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: ${{ matrix.node-version }}
       - name: yarn install
         uses: backstage/actions/yarn-install@b3c1841fd69e1658ac631afafd0fb140a2309024 # v0.6.17
         with:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes the SQLite build issues that keep popping up in CI. It's been broken since #31291 because without an explicit node setup we'll always use the default Node v20, and sometimes the install output of that ends up being saved to the v22 cache.
