### PR TITLE
feat(catalog): add query entities action to registry

### DIFF
--- a/.changeset/warm-banks-hope.md
+++ b/.changeset/warm-banks-hope.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+New action added to actions registry to query catalog entities

--- a/plugins/catalog-backend/src/actions/createQueryCatalogEntitiesAction.test.ts
+++ b/plugins/catalog-backend/src/actions/createQueryCatalogEntitiesAction.test.ts
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { createQueryCatalogEntitiesAction } from './createQueryCatalogEntitiesAction';
+import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
+import { actionsRegistryServiceMock } from '@backstage/backend-test-utils/alpha';
+
+describe('createQueryCatalogEntitiesAction', () => {
+  it('should return empty results when no entities match the filter', async () => {
+    const mockActionsRegistry = actionsRegistryServiceMock();
+    const mockCatalog = catalogServiceMock({
+      entities: [],
+    });
+
+    createQueryCatalogEntitiesAction({
+      catalog: mockCatalog,
+      actionsRegistry: mockActionsRegistry,
+    });
+
+    const result = await mockActionsRegistry.invoke({
+      id: 'test:query-catalog-entities',
+      input: { filter: { kind: 'NonExistentKind' } },
+    });
+
+    expect(result.output).toEqual({
+      items: [],
+      totalItems: 0,
+      hasMoreEntities: false,
+      nextPageCursor: undefined,
+    });
+  });
+
+  it('should return all entities when no filter is provided', async () => {
+    const testEntities = [
+      {
+        kind: 'Component',
+        apiVersion: 'backstage.io/v1alpha1',
+        metadata: {
+          name: 'test-component',
+          namespace: 'default',
+        },
+        spec: {
+          type: 'service',
+        },
+      },
+      {
+        kind: 'API',
+        apiVersion: 'backstage.io/v1alpha1',
+        metadata: {
+          name: 'test-api',
+          namespace: 'default',
+        },
+      },
+    ];
+
+    const mockActionsRegistry = actionsRegistryServiceMock();
+    const mockCatalog = catalogServiceMock({
+      entities: testEntities,
+    });
+
+    createQueryCatalogEntitiesAction({
+      catalog: mockCatalog,
+      actionsRegistry: mockActionsRegistry,
+    });
+
+    const result = await mockActionsRegistry.invoke({
+      id: 'test:query-catalog-entities',
+      input: {},
+    });
+
+    expect(result.output).toEqual({
+      items: testEntities,
+      totalItems: 2,
+      hasMoreEntities: false,
+      nextPageCursor: undefined,
+    });
+  });
+
+  it('should filter entities by kind', async () => {
+    const testEntities = [
+      {
+        kind: 'Component',
+        apiVersion: 'backstage.io/v1alpha1',
+        metadata: {
+          name: 'test-component',
+          namespace: 'default',
+        },
+        spec: {
+          type: 'service',
+        },
+      },
+      {
+        kind: 'API',
+        apiVersion: 'backstage.io/v1alpha1',
+        metadata: {
+          name: 'test-api',
+          namespace: 'default',
+        },
+      },
+    ];
+
+    const mockActionsRegistry = actionsRegistryServiceMock();
+    const mockCatalog = catalogServiceMock({
+      entities: testEntities,
+    });
+
+    createQueryCatalogEntitiesAction({
+      catalog: mockCatalog,
+      actionsRegistry: mockActionsRegistry,
+    });
+
+    const result = await mockActionsRegistry.invoke({
+      id: 'test:query-catalog-entities',
+      input: { filter: { kind: 'Component' } },
+    });
+
+    expect(result.output).toEqual({
+      items: [testEntities[0]],
+      totalItems: 1,
+      hasMoreEntities: false,
+      nextPageCursor: undefined,
+    });
+  });
+
+  it('should filter entities by metadata name', async () => {
+    const testEntities = [
+      {
+        kind: 'Component',
+        apiVersion: 'backstage.io/v1alpha1',
+        metadata: {
+          name: 'test-component',
+          namespace: 'default',
+        },
+        spec: {
+          type: 'service',
+        },
+      },
+      {
+        kind: 'Component',
+        apiVersion: 'backstage.io/v1alpha1',
+        metadata: {
+          name: 'another-component',
+          namespace: 'default',
+        },
+        spec: {
+          type: 'library',
+        },
+      },
+    ];
+
+    const mockActionsRegistry = actionsRegistryServiceMock();
+    const mockCatalog = catalogServiceMock({
+      entities: testEntities,
+    });
+
+    createQueryCatalogEntitiesAction({
+      catalog: mockCatalog,
+      actionsRegistry: mockActionsRegistry,
+    });
+
+    const result = await mockActionsRegistry.invoke({
+      id: 'test:query-catalog-entities',
+      input: { filter: { 'metadata.name': 'test-component' } },
+    });
+
+    expect(result.output).toEqual({
+      items: [testEntities[0]],
+      totalItems: 1,
+      hasMoreEntities: false,
+      nextPageCursor: undefined,
+    });
+  });
+
+  it('should handle multiple filter criteria', async () => {
+    const testEntities = [
+      {
+        kind: 'Component',
+        apiVersion: 'backstage.io/v1alpha1',
+        metadata: {
+          name: 'test-component',
+          namespace: 'default',
+        },
+        spec: {
+          type: 'service',
+        },
+      },
+      {
+        kind: 'Component',
+        apiVersion: 'backstage.io/v1alpha1',
+        metadata: {
+          name: 'test-component',
+          namespace: 'production',
+        },
+        spec: {
+          type: 'library',
+        },
+      },
+      {
+        kind: 'API',
+        apiVersion: 'backstage.io/v1alpha1',
+        metadata: {
+          name: 'test-api',
+          namespace: 'default',
+        },
+      },
+    ];
+
+    const mockActionsRegistry = actionsRegistryServiceMock();
+    const mockCatalog = catalogServiceMock({
+      entities: testEntities,
+    });
+
+    createQueryCatalogEntitiesAction({
+      catalog: mockCatalog,
+      actionsRegistry: mockActionsRegistry,
+    });
+
+    const result = await mockActionsRegistry.invoke({
+      id: 'test:query-catalog-entities',
+      input: {
+        filter: {
+          kind: 'Component',
+          'metadata.namespace': 'default',
+        },
+      },
+    });
+
+    expect(result.output).toEqual({
+      items: [testEntities[0]],
+      totalItems: 1,
+      hasMoreEntities: false,
+      nextPageCursor: undefined,
+    });
+  });
+
+  it('should pass through pagination and ordering options', async () => {
+    const testEntities = [
+      {
+        kind: 'Component',
+        apiVersion: 'backstage.io/v1alpha1',
+        metadata: {
+          name: 'component-a',
+          namespace: 'default',
+        },
+      },
+      {
+        kind: 'Component',
+        apiVersion: 'backstage.io/v1alpha1',
+        metadata: {
+          name: 'component-b',
+          namespace: 'default',
+        },
+      },
+    ];
+
+    const mockActionsRegistry = actionsRegistryServiceMock();
+    const mockCatalog = catalogServiceMock({
+      entities: testEntities,
+    });
+
+    // Spy on the queryEntities method to verify it's called with correct parameters
+    const queryEntitiesSpy = jest.spyOn(mockCatalog, 'queryEntities');
+
+    createQueryCatalogEntitiesAction({
+      catalog: mockCatalog,
+      actionsRegistry: mockActionsRegistry,
+    });
+
+    const result = await mockActionsRegistry.invoke({
+      id: 'test:query-catalog-entities',
+      input: {
+        filter: { kind: 'Component' },
+        limit: 10,
+        offset: 0,
+        orderFields: { field: 'metadata.name', order: 'asc' },
+        fields: ['metadata.name', 'kind'],
+      },
+    });
+
+    expect(result.output).toEqual({
+      items: testEntities,
+      totalItems: 2,
+      hasMoreEntities: false,
+      nextPageCursor: undefined,
+    });
+    expect(queryEntitiesSpy).toHaveBeenCalledWith(
+      {
+        filter: { kind: 'Component' },
+        limit: 10,
+        offset: 0,
+        orderFields: { field: 'metadata.name', order: 'asc' },
+        fields: ['metadata.name', 'kind'],
+      },
+      expect.any(Object),
+    );
+  });
+});

--- a/plugins/catalog-backend/src/actions/createQueryCatalogEntitiesAction.ts
+++ b/plugins/catalog-backend/src/actions/createQueryCatalogEntitiesAction.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ActionsRegistryService } from '@backstage/backend-plugin-api/alpha';
+import { CatalogService } from '@backstage/plugin-catalog-node';
+import { QueryEntitiesRequest } from '@backstage/catalog-client';
+
+export const createQueryCatalogEntitiesAction = ({
+  catalog,
+  actionsRegistry,
+}: {
+  catalog: CatalogService;
+  actionsRegistry: ActionsRegistryService;
+}) => {
+  actionsRegistry.register({
+    name: 'query-catalog-entities',
+    title: 'Query Catalog Entities',
+    attributes: {
+      destructive: false,
+      readOnly: true,
+      idempotent: true,
+    },
+    description: `
+This allows you to query multiple entities from the software catalog using filters.
+You can filter by entity properties like kind, namespace, metadata fields, and more.
+Using limit is recommended to avoid fetching too many entities at once. You can use the cursor returned in the response to fetch next set of entities.
+The action returns a list of entities matching the specified criteria.
+Fields are using dot notation, e.g. "kind", "metadata.name", "spec.type" in the filter, fields, orderFields and fullTextFilter.fields parameters.
+    `,
+    schema: {
+      input: z =>
+        z.object({
+          filter: z
+            .record(z.string())
+            .optional()
+            .describe(
+              'Filter criteria for querying entities. Keys are field paths and values are the expected values.',
+            ),
+          fields: z
+            .array(z.string())
+            .optional()
+            .describe(
+              'Specific fields to include in the response. If not provided, all fields are returned.',
+            ),
+          limit: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe('Maximum number of entities to return.'),
+          offset: z
+            .number()
+            .int()
+            .min(0)
+            .optional()
+            .describe('Number of entities to skip before returning results.'),
+          orderFields: z
+            .object({
+              field: z.string().describe('Field to order by'),
+              order: z
+                .enum(['asc', 'desc'])
+                .optional()
+                .default('asc')
+                .describe('Sort order'),
+            })
+            .optional()
+            .describe('Ordering criteria for the results.'),
+          fullTextFilter: z
+            .object({
+              term: z.string().describe('Full text search term'),
+              fields: z
+                .array(z.string())
+                .optional()
+                .describe('Fields to search within'),
+            })
+            .optional()
+            .describe('Full text search criteria'),
+          cursor: z
+            .string()
+            .optional()
+            .describe(
+              'Cursor for pagination. This can be used only after first request with response containing a cursor',
+            ),
+        }),
+      output: z =>
+        z.object({
+          items: z
+            .array(z.object({}).passthrough())
+            .describe('List of entities'),
+          totalItems: z.number().describe('Total number of entities'),
+          hasMoreEntities: z
+            .boolean()
+            .describe('Whether more entities are available'),
+          nextPageCursor: z
+            .string()
+            .optional()
+            .describe('Next page cursor used to fetch next page of entities'),
+        }),
+    },
+    action: async ({ input, credentials }) => {
+      let queryRequest: QueryEntitiesRequest;
+      if (input.cursor) {
+        queryRequest = {
+          cursor: input.cursor,
+          fields: input.fields,
+          limit: input.limit,
+        };
+      } else {
+        queryRequest = {
+          filter: input.filter,
+          fields: input.fields,
+          limit: input.limit,
+          offset: input.offset,
+          orderFields: input.orderFields,
+        };
+      }
+
+      const response = await catalog.queryEntities(queryRequest, {
+        credentials,
+      });
+
+      return {
+        output: {
+          items: response.items,
+          totalItems: response.totalItems,
+          hasMoreEntities: response.totalItems > response.items.length,
+          nextPageCursor: response.pageInfo.nextCursor,
+        },
+      };
+    },
+  });
+};

--- a/plugins/catalog-backend/src/actions/index.ts
+++ b/plugins/catalog-backend/src/actions/index.ts
@@ -17,6 +17,7 @@ import { ActionsRegistryService } from '@backstage/backend-plugin-api/alpha';
 import { CatalogService } from '@backstage/plugin-catalog-node';
 import { createGetCatalogEntityAction } from './createGetCatalogEntityAction.ts';
 import { createValidateEntityAction } from './createValidateEntityAction.ts';
+import { createQueryCatalogEntitiesAction } from './createQueryCatalogEntitiesAction';
 
 export const createCatalogActions = (options: {
   actionsRegistry: ActionsRegistryService;
@@ -24,4 +25,5 @@ export const createCatalogActions = (options: {
 }) => {
   createGetCatalogEntityAction(options);
   createValidateEntityAction(options);
+  createQueryCatalogEntitiesAction(options);
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

adds new query-catalog-entities action to the actions registry

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
