### PR TITLE
codeowners: move vale config ownership to docs maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,7 @@ yarn.lock                                         @backstage/maintainers @backst
 /.changeset                                       @backstage/operations-maintainers
 /.changeset/*.md
 /.github                                          @backstage/operations-maintainers
+/.github/vale                                     @backstage/documentation-maintainers
 /beps/0001-notifications-system                   @backstage/maintainers @backstage/notifications-maintainers
 /docs                                             @backstage/maintainers @backstage/documentation-maintainers
 /docs/assets/search                               @backstage/search-maintainers


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Noticed in #30925 that we're blocking on operations-maintainers review for Vale changes which seems unintuitive. Most if not all of the vale changes are related to docs updates so I think it makes sense to carve this out for docs maintainers.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
