### PR TITLE
BUI - Fix scroll jumping when opening Menu

### DIFF
--- a/.changeset/evil-webs-create.md
+++ b/.changeset/evil-webs-create.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Fix scroll jumping when opening menu in Backstage UI.

--- a/packages/ui/src/components/Menu/Menu.stories.tsx
+++ b/packages/ui/src/components/Menu/Menu.stories.tsx
@@ -412,3 +412,38 @@ export const VirtualizedMaxHeight: Story = {
     );
   },
 };
+
+export const WithScroll: Story = {
+  args: {
+    children: null,
+  },
+  decorators: [
+    Story => (
+      <div style={{ height: '2000px', overflow: 'auto' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  render: () => (
+    <MenuTrigger>
+      <Button aria-label="Menu">Menu</Button>
+      <Menu>
+        <MenuItem>Edit</MenuItem>
+        <MenuItem>Duplicate</MenuItem>
+        <MenuItem>Rename</MenuItem>
+        <MenuSeparator />
+        <MenuItem iconStart={<RiShareBoxLine />}>Share</MenuItem>
+        <MenuItem iconStart={<RiChat1Line />}>Feedback</MenuItem>
+        <MenuSeparator />
+        <SubmenuTrigger>
+          <MenuItem iconStart={<RiSettingsLine />}>Settings</MenuItem>
+          <Menu placement="right top">
+            <MenuItem>Edit</MenuItem>
+            <MenuItem>Duplicate</MenuItem>
+            <MenuItem>Rename</MenuItem>
+          </Menu>
+        </SubmenuTrigger>
+      </Menu>
+    </MenuTrigger>
+  ),
+};


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This update remove the default modal behaviour on popovers in `Menu` to make sure this is not removing the scroll on body as this was making the experience quite jumpy. React Aria doesn't seem to handle this use case so this recreate the closing behaviour when clicking outside the popover.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
