### PR TITLE
add support for Kafka offset management

### DIFF
--- a/.changeset/thin-flies-travel.md
+++ b/.changeset/thin-flies-travel.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-events-backend-module-kafka': minor
+---
+
+Add support for Kafka offset configuration (`fromBeginning`) and `autoCommit`

--- a/plugins/events-backend-module-kafka/README.md
+++ b/plugins/events-backend-module-kafka/README.md
@@ -33,6 +33,10 @@ events:
                 topics: # (Required) The Kafka topics to subscribe to.
                   - topic1
                 groupId: your-group-id # (Required) The GroupId to be used by the topic consumers.
+                # Optional offset management settings (these can be omitted to use defaults):
+                # fromBeginning: false # Start from earliest offset when no committed offset exists. Default: not set (latest)
+                # autoCommit: true # Enable auto-commit. Default: true (for backward compatibility)
+                # pauseOnError: false # Pause consumer on error. Default: false (for backward compatibility)
 ```
 
 ### KafkaPublishingEventConsumer Configuration
@@ -56,6 +60,77 @@ events:
 ```
 
 For a complete list of all available fields that can be configured, refer to the [config.d.ts file](./config.d.ts).
+
+### Offset Management
+
+The plugin supports configurable offset management to control message delivery semantics:
+
+#### Auto Commit (Default - Backward Compatible)
+
+By default (`autoCommit: true` or not specified), Kafka automatically commits offsets at regular intervals. This is the original behavior and ensures backward compatibility.
+
+#### Manual Commit (Opt-in for Reliability)
+
+When you explicitly set `autoCommit: false`, the plugin will:
+
+1. Start consuming from the last committed offset for the consumer group
+2. Process each message by publishing it to the Backstage events system
+3. Only commit the offset after successful processing
+4. If processing fails, pause the consumer and do not commit the offset
+
+**Example configuration for manual commit:**
+
+```yaml
+kafka:
+  topics:
+    - topic1
+  groupId: my-group
+  autoCommit: false # Enable manual commit
+```
+
+#### Error Handling
+
+The `pauseOnError` option controls how the consumer behaves when message processing fails:
+
+**Skip Failed Messages (Default - Backward Compatible)**
+
+By default (`pauseOnError: false` or not specified), the consumer will skip failed messages and continue processing:
+
+- The consumer logs the error but continues processing subsequent messages
+- If `autoCommit: false`, the offset is still committed to skip the failed message
+- If `autoCommit: true`, Kafka's auto-commit handles the offset
+- Recommended when occasional message failures are acceptable and should not block processing
+
+**Pause on Error (Opt-in)**
+
+When you explicitly set `pauseOnError: true`, the consumer will pause when an error occurs during message processing:
+
+- The consumer pauses and stops processing new messages
+- The failed message offset is not committed
+- The error is re-thrown and logged
+- Recommended when you want to investigate and fix issues before continuing
+
+**Example configuration to pause on error:**
+
+```yaml
+kafka:
+  topics:
+    - topic1
+  groupId: my-group
+  autoCommit: false
+  pauseOnError: true # Pause consumer when a message fails
+```
+
+**Note:** When using the default behavior (`pauseOnError: false`) with `autoCommit: false`, failed messages will have their offsets committed, meaning they will be skipped and not reprocessed. Use this configuration carefully based on your application's requirements.
+
+#### Starting Position
+
+The `fromBeginning` option controls where the consumer starts when no committed offset exists:
+
+- `fromBeginning: true` - Start from the earliest available message
+- `fromBeginning: false` (default) - Start from the latest message (only new messages)
+
+Once the consumer group has committed an offset, it will always resume from that position, regardless of the `fromBeginning` setting.
 
 ### Optional SSL Configuration
 

--- a/plugins/events-backend-module-kafka/config.d.ts
+++ b/plugins/events-backend-module-kafka/config.d.ts
@@ -200,6 +200,29 @@ export interface Config {
                    * Default: 5000
                    */
                   maxWaitTime?: HumanDuration | string;
+
+                  /**
+                   * (Optional) If true, the consumer group will start from the earliest offset when no committed offset is found.
+                   * If false or not specified, it will start from the latest offset.
+                   * Default: undefined (start from latest)
+                   */
+                  fromBeginning?: boolean;
+
+                  /**
+                   * (Optional) Enable auto-commit of offsets.
+                   * When true (default), offsets are automatically committed at regular intervals (at-most-once delivery).
+                   * When false, offsets are only committed after successful message processing (at-least-once delivery).
+                   * Default: true (auto-commit enabled for backward compatibility)
+                   */
+                  autoCommit?: boolean;
+
+                  /**
+                   * (Optional) When true, the consumer will pause on error and stop processing messages.
+                   * When false (default), the consumer will skip failed messages and continue processing.
+                   * Note: When pauseOnError is false and autoCommit is also false, failed messages will still have their offsets committed.
+                   * Default: false (skip errors for backward compatibility)
+                   */
+                  pauseOnError?: boolean;
                 };
               }>;
             }
@@ -374,6 +397,29 @@ export interface Config {
                      * Default: 5000
                      */
                     maxWaitTime?: HumanDuration | string;
+
+                    /**
+                     * (Optional) If true, the consumer group will start from the earliest offset when no committed offset is found.
+                     * If false or not specified, it will start from the latest offset.
+                     * Default: undefined (start from latest)
+                     */
+                    fromBeginning?: boolean;
+
+                    /**
+                     * (Optional) Enable auto-commit of offsets.
+                     * When true (default), offsets are automatically committed at regular intervals (at-most-once delivery).
+                     * When false, offsets are only committed after successful message processing (at-least-once delivery).
+                     * Default: true (auto-commit enabled for backward compatibility)
+                     */
+                    autoCommit?: boolean;
+
+                    /**
+                     * (Optional) When true, the consumer will pause on error and stop processing messages.
+                     * When false (default), the consumer will skip failed messages and continue processing.
+                     * Note: When pauseOnError is false and autoCommit is also false, failed messages will still have their offsets committed.
+                     * Default: false (skip errors for backward compatibility)
+                     */
+                    pauseOnError?: boolean;
                   };
                 }>;
               };

--- a/plugins/events-backend-module-kafka/src/KafkaConsumingEventPublisher/config.test.ts
+++ b/plugins/events-backend-module-kafka/src/KafkaConsumingEventPublisher/config.test.ts
@@ -86,6 +86,8 @@ describe('readConsumerConfig', () => {
         consumerSubscribeTopics: {
           topics: ['topic-A'],
         },
+        autoCommit: true,
+        pauseOnError: false,
       },
       {
         backstageTopic: 'fake2',
@@ -95,6 +97,8 @@ describe('readConsumerConfig', () => {
         consumerSubscribeTopics: {
           topics: ['topic-B'],
         },
+        autoCommit: true,
+        pauseOnError: false,
       },
     ]);
   });
@@ -209,6 +213,8 @@ describe('readConsumerConfig', () => {
         consumerSubscribeTopics: {
           topics: ['topic-A'],
         },
+        autoCommit: true,
+        pauseOnError: false,
       },
       {
         backstageTopic: 'fake2',
@@ -218,6 +224,8 @@ describe('readConsumerConfig', () => {
         consumerSubscribeTopics: {
           topics: ['topic-B'],
         },
+        autoCommit: true,
+        pauseOnError: false,
       },
     ]);
   });
@@ -334,6 +342,8 @@ describe('readConsumerConfig', () => {
         consumerSubscribeTopics: {
           topics: ['topic-A'],
         },
+        autoCommit: true,
+        pauseOnError: false,
       },
       {
         backstageTopic: 'fake2',
@@ -343,6 +353,8 @@ describe('readConsumerConfig', () => {
         consumerSubscribeTopics: {
           topics: ['topic-B'],
         },
+        autoCommit: true,
+        pauseOnError: false,
       },
     ]);
 
@@ -350,5 +362,55 @@ describe('readConsumerConfig', () => {
     expect(mockLogger.warn).toHaveBeenCalledWith(
       'Legacy single config format detected at events.modules.kafka.kafkaConsumingEventPublisher.',
     );
+  });
+
+  it('offset management fields (autoCommit, pauseOnError, fromBeginning)', () => {
+    const config = new ConfigReader({
+      events: {
+        modules: {
+          kafka: {
+            kafkaConsumingEventPublisher: {
+              dev: {
+                clientId: 'backstage-events',
+                brokers: ['kafka1:9092'],
+                topics: [
+                  {
+                    topic: 'fake1',
+                    kafka: {
+                      topics: ['topic-A'],
+                      groupId: 'my-group',
+                      autoCommit: false,
+                      pauseOnError: true,
+                      fromBeginning: true,
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const publisherConfigs = readConsumerConfig(config, mockLogger);
+
+    expect(publisherConfigs).toBeDefined();
+    expect(publisherConfigs).toHaveLength(1);
+
+    const devConfig = publisherConfigs[0];
+    expect(devConfig.kafkaConsumerConfigs).toEqual([
+      {
+        backstageTopic: 'fake1',
+        consumerConfig: {
+          groupId: 'my-group',
+        },
+        consumerSubscribeTopics: {
+          topics: ['topic-A'],
+          fromBeginning: true,
+        },
+        autoCommit: false,
+        pauseOnError: true,
+      },
+    ]);
   });
 });

--- a/plugins/events-backend-module-kafka/src/KafkaConsumingEventPublisher/config.ts
+++ b/plugins/events-backend-module-kafka/src/KafkaConsumingEventPublisher/config.ts
@@ -25,6 +25,8 @@ export interface KafkaConsumerConfig {
   backstageTopic: string;
   consumerConfig: ConsumerConfig;
   consumerSubscribeTopics: ConsumerSubscribeTopics;
+  autoCommit: boolean;
+  pauseOnError: boolean;
 }
 
 export interface KafkaConsumingEventPublisherConfig {
@@ -78,7 +80,16 @@ const processSinglePublisher = (
           },
           consumerSubscribeTopics: {
             topics: topicConfig.getStringArray('kafka.topics'),
+            fromBeginning: topicConfig.getOptionalBoolean(
+              'kafka.fromBeginning',
+            ),
           },
+          // Default autoCommit to true to match KafkaJS default and ensure consistency
+          // between KafkaJS's auto-commit behavior and our manual commit logic
+          autoCommit:
+            topicConfig.getOptionalBoolean('kafka.autoCommit') ?? true,
+          pauseOnError:
+            topicConfig.getOptionalBoolean('kafka.pauseOnError') ?? false,
         };
       }),
   };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds configurable Kafka offset management to the  events-backend-module-kafka plugin, enabling users to control message  delivery semantics:

  - Adds `autoCommit` configuration option (default: true for backward
  compatibility) to enable manual offset commit for at-least-once
  delivery semantics
  - Adds `fromBeginning` configuration option to control consumer starting
  position when no committed offset exists
 - Adds `pauseOnError` configuration option to control whether the consumer should pause on error.
  - Implements manual offset commit logic that only commits after
  successful event processing, with error handling that pauses
  consumption on failure

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
