### PR TITLE
cli: fix low frequency test flakiness

### DIFF
--- a/packages/cli/src/lib/version.test.ts
+++ b/packages/cli/src/lib/version.test.ts
@@ -152,7 +152,7 @@ describe('createPackageVersionProvider', () => {
     it('should not use backstage protocol when preferBackstageProtocol is false', async () => {
       mockDir.setContent({
         'yarn.lock': `${HEADER}
-"@backstage/core-plugin-api@^1.0.0":
+"@backstage/core-plugin-api@*":
   version "1.0.0"
 `,
       });
@@ -163,15 +163,13 @@ describe('createPackageVersionProvider', () => {
         preferBackstageProtocol: false,
       });
 
-      expect(provider('@backstage/core-plugin-api')).toBe(
-        `^${corePluginApiPkg.version}`,
-      );
+      expect(provider('@backstage/core-plugin-api')).toBe('*');
     });
 
     it('should not use backstage protocol when options are not provided', async () => {
       mockDir.setContent({
         'yarn.lock': `${HEADER}
-"@backstage/core-plugin-api@^1.0.0":
+"@backstage/core-plugin-api@*":
   version "1.0.0"
 `,
       });
@@ -180,9 +178,7 @@ describe('createPackageVersionProvider', () => {
       const lockfile = await Lockfile.load(lockfilePath);
       const provider = createPackageVersionProvider(lockfile);
 
-      expect(provider('@backstage/core-plugin-api')).toBe(
-        `^${corePluginApiPkg.version}`,
-      );
+      expect(provider('@backstage/core-plugin-api')).toBe('*');
     });
   });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Switches the test to no longer be dependent on whether we're in prerelease or not. Also fixes the assertion 😁. This was the intended behavior, i.e. use the entry from the lockfile.