### PR TITLE
Change npm package name for Stack Overflow Teams

### DIFF
--- a/microsite/data/plugins/stackoverflow-teams.yaml
+++ b/microsite/data/plugins/stackoverflow-teams.yaml
@@ -6,5 +6,5 @@ category: Discovery
 description: Provide seamless access to Stack Overflow Teams most relevant data, allowing you to display the top users, top tags, and top questions directly within Backstage. It also allows to securely create SO Teams questions from Backstage.
 documentation: https://stackoverflowteams.help/en/articles/9692515-backstage-io-integration
 iconUrl: /img/stack-overflow-logo.svg
-npmPackageName: 'backstage-plugin-stack-overflow-teams'
+npmPackageName: '@stackoverflow/backstage-plugin-stack-overflow-teams'
 addedDate: '2025-06-10'


### PR DESCRIPTION
Updated npm package name for Stack Overflow Teams plugin.

It now lives on https://www.npmjs.com/package/@stackoverflow/backstage-plugin-stack-overflow-teams 
