### PR TITLE
repo-tools: update knip to detect dependencies in new dev pattern

### DIFF
--- a/.changeset/breezy-times-ring.md
+++ b/.changeset/breezy-times-ring.md
@@ -1,0 +1,5 @@
+---
+'@backstage/repo-tools': patch
+---
+
+Updated knip-reports to detect dependencies in dev/alpha pattern

--- a/packages/repo-tools/src/commands/knip-reports/knip-extractor.ts
+++ b/packages/repo-tools/src/commands/knip-reports/knip-extractor.ts
@@ -58,7 +58,7 @@ async function generateKnipConfig({ knipConfigPath }: KnipConfigOptions) {
     workspaces: {
       '.': {},
       '{packages,plugins}/*': {
-        entry: ['dev/index.{ts,tsx}', 'src/index.{ts,tsx}'],
+        entry: ['dev/**/*.{ts,tsx}', 'src/index.{ts,tsx}'],
         ignore: [
           '.eslintrc.js',
           'config.d.ts',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

With some of the plugins migrating to the NFS and following the new suggested testing structure laid out in #31255, the knip reports are currently detecting erroneous unused dependencies (like in [bookmarks](https://github.com/backstage/community-plugins/pull/5767/files#diff-2fc754080fe21683d4df1debe4861f7e2fe1f7b86e8cf74ec65bbaa0572bb9f7)). This adds the new dev/alpha pattern (both dev/alpha/index.{ts,tsx}, which is currently being used by a few plugins, and dev/alpha.{ts,tsx} which is [being encouraged](https://github.com/backstage/backstage/pull/31255#issuecomment-3327160838)?) to avoid this.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
