### PR TITLE
[Docs] Update publishing mainline release steps

### DIFF
--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -53,8 +53,6 @@ Additional steps for the main line release
   - Mention any security fixes
 - Create Release Notes PR
   - Add the release note file as [`/docs/releases/vx.y.0.md`](./releases)
-  - Add an entry to [`/microsite/sidebars.ts`](https://github.com/backstage/backstage/blob/master/microsite/sidebars.ts) for the release note
-  - Update the navigation bar item in [`/microsite/docusaurus.config.ts`](https://github.com/backstage/backstage/blob/master/microsite/docusaurus.config.ts) to point to the new release note
   - Finally copy the content, without the metadata header, into the description of the [`Version Packages` Pull Request](https://github.com/backstage/backstage/pulls?q=is%3Aopen+is%3Apr+in%3Atitle+%22Version+Packages)
 
 Once the release has been published edit the newly created release in the [GitHub repository](https://github.com/backstage/backstage/releases) and replace the text content with the release notes.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Remove steps that were previously manually executed to publish a mainline release, these steps are now automated:

- Update microsite sidebar to add the new release notes entry
- Update docusaurus config to point to the new release notes entry

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
