### PR TITLE
fix(techdocs-cli): Missing styles, illegible pages

### DIFF
--- a/packages/techdocs-cli-embedded-app/package.json
+++ b/packages/techdocs-cli-embedded-app/package.json
@@ -45,6 +45,7 @@
     "@backstage/plugin-techdocs-react": "workspace:^",
     "@backstage/test-utils": "workspace:^",
     "@backstage/theme": "workspace:^",
+    "@backstage/ui": "workspace:^",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "history": "^5.0.0",

--- a/packages/techdocs-cli-embedded-app/src/index.tsx
+++ b/packages/techdocs-cli-embedded-app/src/index.tsx
@@ -16,6 +16,7 @@
 
 import '@backstage/cli/asset-types';
 import ReactDOM from 'react-dom/client';
+import '@backstage/ui/css/styles.css';
 import App from './App';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(<App />);

--- a/yarn.lock
+++ b/yarn.lock
@@ -46507,6 +46507,7 @@ __metadata:
     "@backstage/plugin-techdocs-react": "workspace:^"
     "@backstage/test-utils": "workspace:^"
     "@backstage/theme": "workspace:^"
+    "@backstage/ui": "workspace:^"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@testing-library/dom": "npm:^10.0.0"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Techdocs CLI 1.10.0 has missing styles due to MUI->BUI baselines.

Before:
<img width="2531" height="791" alt="Screenshot 2025-10-17 at 10 29 24" src="https://github.com/user-attachments/assets/184572c8-1a5e-45ce-9175-e428b4f95299" />

After:
<img width="2531" height="791" alt="Screenshot 2025-10-17 at 10 29 44" src="https://github.com/user-attachments/assets/a52b7110-4ddf-4b0f-a300-e1bbd839d4e1" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
