### PR TITLE
fix: auto-logout not working when closing tabs and reopening

### DIFF
--- a/.changeset/pretty-parts-admire.md
+++ b/.changeset/pretty-parts-admire.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/core-components': minor
+'@backstage/core-components': patch
 ---
 
 Fix autologout not working correctly when closing all tabs

--- a/.changeset/pretty-parts-admire.md
+++ b/.changeset/pretty-parts-admire.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': minor
+---
+
+Fix autologout not working correctly when closing all tabs

--- a/packages/core-components/src/components/AutoLogout/AutoLogout.tsx
+++ b/packages/core-components/src/components/AutoLogout/AutoLogout.tsx
@@ -146,7 +146,13 @@ const ConditionalAutoLogout = ({
     onPrompt: promptBeforeIdle ? onPrompt : undefined,
     promptBeforeIdle: promptBeforeIdle ? promptBeforeIdleMillis : undefined,
     syncTimers: 1000,
+    leaderElection: true,
   });
+
+  // Check if the current tab is the only active tab. In practice, this gets checked once per second
+  if (timer.isLeader()) {
+    lastSeenOnlineStore.save(new Date());
+  }
 
   return (
     <>

--- a/packages/core-components/src/components/AutoLogout/AutoLogout.tsx
+++ b/packages/core-components/src/components/AutoLogout/AutoLogout.tsx
@@ -114,6 +114,7 @@ const ConditionalAutoLogout = ({
     // Events will be rebound as long as `stopOnMount` is not set.
     setPromptOpen(false);
     setRemainingTimeCountdown(0);
+    lastSeenOnlineStore.delete();
     identityApi.signOut();
   };
 

--- a/packages/core-components/src/components/AutoLogout/AutoLogout.tsx
+++ b/packages/core-components/src/components/AutoLogout/AutoLogout.tsx
@@ -21,7 +21,7 @@ import {
   identityApiRef,
   useApi,
 } from '@backstage/core-plugin-api';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   EventsType,
   IIdleTimer,

--- a/packages/core-components/src/components/AutoLogout/AutoLogout.tsx
+++ b/packages/core-components/src/components/AutoLogout/AutoLogout.tsx
@@ -231,7 +231,6 @@ const parseConfig = (
 export const AutoLogout = (props: AutoLogoutProps): JSX.Element | null => {
   const identityApi = useApi(identityApiRef);
   const configApi = useApi(configApiRef);
-  const isLoggedRef = useRef<boolean | null>(null);
   const [isLogged, setIsLogged] = useState<boolean | null>(null);
   const lastSeenOnlineStore: TimestampStore = useMemo(
     () => new DefaultTimestampStore(LAST_SEEN_ONLINE_STORAGE_KEY),
@@ -239,18 +238,7 @@ export const AutoLogout = (props: AutoLogoutProps): JSX.Element | null => {
   );
 
   useEffect(() => {
-    isLoggedRef.current = isLogged;
-  }, [isLogged]);
-
-  useEffect(() => {
     let cancelled = false;
-
-    const timeoutId = setTimeout(() => {
-      if (cancelled) return;
-      if (isLoggedRef.current === null || isLoggedRef.current === false) {
-        lastSeenOnlineStore.delete();
-      }
-    }, 3000);
 
     async function checkLogin(identity: IdentityApi) {
       try {
@@ -272,7 +260,6 @@ export const AutoLogout = (props: AutoLogoutProps): JSX.Element | null => {
 
     return () => {
       cancelled = true;
-      clearTimeout(timeoutId);
     };
   }, [lastSeenOnlineStore, identityApi]);
 

--- a/packages/core-components/src/components/AutoLogout/AutoLogout.tsx
+++ b/packages/core-components/src/components/AutoLogout/AutoLogout.tsx
@@ -21,7 +21,7 @@ import {
   identityApiRef,
   useApi,
 } from '@backstage/core-plugin-api';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   EventsType,
   IIdleTimer,
@@ -231,6 +231,7 @@ const parseConfig = (
 export const AutoLogout = (props: AutoLogoutProps): JSX.Element | null => {
   const identityApi = useApi(identityApiRef);
   const configApi = useApi(configApiRef);
+  const isLoggedRef = useRef<boolean | null>(null);
   const [isLogged, setIsLogged] = useState<boolean | null>(null);
   const lastSeenOnlineStore: TimestampStore = useMemo(
     () => new DefaultTimestampStore(LAST_SEEN_ONLINE_STORAGE_KEY),
@@ -238,15 +239,23 @@ export const AutoLogout = (props: AutoLogoutProps): JSX.Element | null => {
   );
 
   useEffect(() => {
-    async function isLoggedIn(identity: IdentityApi) {
+    isLoggedRef.current = isLogged;
+  }, [isLogged]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const timeoutId = setTimeout(() => {
+      if (cancelled) return;
+      if (isLoggedRef.current === null || isLoggedRef.current === false) {
+        lastSeenOnlineStore.delete();
+      }
+    }, 3000);
+
+    async function checkLogin(identity: IdentityApi) {
       try {
-        // Add timeout if identity.getCredentials() hangs/takes too long to return
-        setTimeout(() => {
-          if (isLogged === null || isLogged === false) {
-            lastSeenOnlineStore.delete();
-          }
-        }, 3000);
         const creds = await identity.getCredentials();
+        if (cancelled) return;
         if (creds?.token) {
           setIsLogged(true);
         } else {
@@ -254,12 +263,18 @@ export const AutoLogout = (props: AutoLogoutProps): JSX.Element | null => {
           lastSeenOnlineStore.delete();
         }
       } catch (err) {
+        if (cancelled) return;
         setIsLogged(false);
         lastSeenOnlineStore.delete();
       }
     }
-    isLoggedIn(identityApi);
-  }, [isLogged, lastSeenOnlineStore, identityApi]);
+    checkLogin(identityApi);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timeoutId);
+    };
+  }, [lastSeenOnlineStore, identityApi]);
 
   const {
     enabled,

--- a/packages/core-components/src/components/AutoLogout/disconnectedUsers.test.ts
+++ b/packages/core-components/src/components/AutoLogout/disconnectedUsers.test.ts
@@ -35,10 +35,27 @@ const mockTimestampStore = {
 };
 
 describe('useLogoutDisconnectedUserEffect', () => {
-  it('should not do anything if effect is not enabled', () => {
+  it('should not do anything if isLoggedIn has not yet resolved', () => {
+    const props: UseLogoutDisconnectedUserEffectProps = {
+      enableEffect: true,
+      autologoutIsEnabled: true,
+      isLoggedIn: null,
+      idleTimeoutSeconds: 300,
+      lastSeenOnlineStore: mockTimestampStore,
+      identityApi: mockIdentityApi,
+    };
+
+    renderHook(() => useLogoutDisconnectedUserEffect(props));
+
+    expect(mockTimestampStore.get).not.toHaveBeenCalled();
+    expect(mockIdentityApi.signOut).not.toHaveBeenCalled();
+  });
+
+  it('should not do anything if effect is not enabled and isLoggedIn is false', () => {
     const props: UseLogoutDisconnectedUserEffectProps = {
       enableEffect: false,
       autologoutIsEnabled: true,
+      isLoggedIn: false,
       idleTimeoutSeconds: 300,
       lastSeenOnlineStore: mockTimestampStore,
       identityApi: mockIdentityApi,
@@ -54,6 +71,7 @@ describe('useLogoutDisconnectedUserEffect', () => {
     const props: UseLogoutDisconnectedUserEffectProps = {
       enableEffect: true,
       autologoutIsEnabled: false,
+      isLoggedIn: true,
       idleTimeoutSeconds: 300,
       lastSeenOnlineStore: mockTimestampStore,
       identityApi: mockIdentityApi,
@@ -70,6 +88,7 @@ describe('useLogoutDisconnectedUserEffect', () => {
     const props: UseLogoutDisconnectedUserEffectProps = {
       enableEffect: true,
       autologoutIsEnabled: true,
+      isLoggedIn: true,
       idleTimeoutSeconds: 1,
       lastSeenOnlineStore: {
         ...mockTimestampStore,
@@ -93,6 +112,7 @@ describe('useLogoutDisconnectedUserEffect', () => {
     const props: UseLogoutDisconnectedUserEffectProps = {
       enableEffect: true,
       autologoutIsEnabled: true,
+      isLoggedIn: true,
       idleTimeoutSeconds: 300,
       lastSeenOnlineStore: mockTimestampStore,
       identityApi: mockIdentityApi,

--- a/packages/core-components/src/components/AutoLogout/disconnectedUsers.test.ts
+++ b/packages/core-components/src/components/AutoLogout/disconnectedUsers.test.ts
@@ -84,6 +84,27 @@ describe('useLogoutDisconnectedUserEffect', () => {
     expect(mockTimestampStore.delete).toHaveBeenCalled();
   });
 
+  it('should delete the store and sign out when idle timeout has passed', () => {
+    const staleStore = {
+      ...mockTimestampStore,
+      get: jest.fn().mockReturnValue(new Date(Date.now() - 2000)),
+    };
+    const props: UseLogoutDisconnectedUserEffectProps = {
+      enableEffect: true,
+      autologoutIsEnabled: true,
+      isLoggedIn: true,
+      idleTimeoutSeconds: 1,
+      lastSeenOnlineStore: staleStore,
+      identityApi: mockIdentityApi,
+    };
+
+    renderHook(() => useLogoutDisconnectedUserEffect(props));
+
+    expect(staleStore.delete).toHaveBeenCalled();
+    expect(mockIdentityApi.signOut).toHaveBeenCalled();
+    expect(staleStore.save).not.toHaveBeenCalled();
+  });
+
   it('should call signOut if idle timeout passed', () => {
     jest.useFakeTimers();
 

--- a/packages/core-components/src/components/AutoLogout/disconnectedUsers.test.ts
+++ b/packages/core-components/src/components/AutoLogout/disconnectedUsers.test.ts
@@ -48,6 +48,8 @@ describe('useLogoutDisconnectedUserEffect', () => {
     renderHook(() => useLogoutDisconnectedUserEffect(props));
 
     expect(mockTimestampStore.get).not.toHaveBeenCalled();
+    expect(mockTimestampStore.delete).not.toHaveBeenCalled();
+    expect(mockTimestampStore.save).not.toHaveBeenCalled();
     expect(mockIdentityApi.signOut).not.toHaveBeenCalled();
   });
 

--- a/packages/core-components/src/components/AutoLogout/disconnectedUsers.ts
+++ b/packages/core-components/src/components/AutoLogout/disconnectedUsers.ts
@@ -51,16 +51,11 @@ export const useLogoutDisconnectedUserEffect = ({
         );
         if (nowSeconds - lastSeenOnlineSeconds > idleTimeoutSeconds) {
           identityApi.signOut();
+          // Delete lastSeen time to prevent getting locked out after logout
+          lastSeenOnlineStore.delete();
+          return;
         }
       }
-      /**
-       * save for the first time when app is loaded, so that
-       * if user logs in and does nothing we still have a
-       * lastSeenOnline value in store
-       */
-      lastSeenOnlineStore.save(new Date());
-    } else {
-      lastSeenOnlineStore.delete();
     }
   }, [
     autologoutIsEnabled,

--- a/packages/core-components/src/components/AutoLogout/disconnectedUsers.ts
+++ b/packages/core-components/src/components/AutoLogout/disconnectedUsers.ts
@@ -24,6 +24,7 @@ export const LAST_SEEN_ONLINE_STORAGE_KEY =
 export type UseLogoutDisconnectedUserEffectProps = {
   enableEffect: boolean;
   autologoutIsEnabled: boolean;
+  isLoggedIn: boolean | null;
   idleTimeoutSeconds: number;
   lastSeenOnlineStore: TimestampStore;
   identityApi: IdentityApi;
@@ -32,6 +33,7 @@ export type UseLogoutDisconnectedUserEffectProps = {
 export const useLogoutDisconnectedUserEffect = ({
   enableEffect,
   autologoutIsEnabled,
+  isLoggedIn,
   idleTimeoutSeconds,
   lastSeenOnlineStore,
   identityApi,
@@ -41,7 +43,12 @@ export const useLogoutDisconnectedUserEffect = ({
      * Considers disconnected users as inactive users.
      * If all Backstage tabs are closed and idleTimeoutMinutes are passed then logout the user anyway.
      */
-    if (autologoutIsEnabled && enableEffect) {
+    // Prevent lastSeen getting deleted before logged state is checked
+    if (isLoggedIn === null) {
+      return;
+    }
+
+    if (autologoutIsEnabled && isLoggedIn && enableEffect) {
       const lastSeenOnline = lastSeenOnlineStore.get();
       if (lastSeenOnline) {
         const now = new Date();
@@ -51,15 +58,16 @@ export const useLogoutDisconnectedUserEffect = ({
         );
         if (nowSeconds - lastSeenOnlineSeconds > idleTimeoutSeconds) {
           identityApi.signOut();
-          // Delete lastSeen time to prevent getting locked out after logout
-          lastSeenOnlineStore.delete();
-          return;
         }
       }
+      lastSeenOnlineStore.save(new Date());
+    } else {
+      lastSeenOnlineStore.delete();
     }
   }, [
     autologoutIsEnabled,
     enableEffect,
+    isLoggedIn,
     identityApi,
     idleTimeoutSeconds,
     lastSeenOnlineStore,

--- a/packages/core-components/src/components/AutoLogout/disconnectedUsers.ts
+++ b/packages/core-components/src/components/AutoLogout/disconnectedUsers.ts
@@ -46,26 +46,27 @@ export const useLogoutDisconnectedUserEffect = ({
     const shouldCheckDisconnectedUser = autologoutIsEnabled && enableEffect;
 
     // Prevent lastSeen getting deleted before logged state is checked
-    if (shouldCheckDisconnectedUser && isLoggedIn === null) {
+    if (isLoggedIn === null) {
       return;
     }
 
-    if (shouldCheckDisconnectedUser && isLoggedIn) {
-      const lastSeenOnline = lastSeenOnlineStore.get();
-      if (lastSeenOnline) {
-        const now = new Date();
-        const nowSeconds = Math.ceil(now.getTime() / 1000);
-        const lastSeenOnlineSeconds = Math.ceil(
-          lastSeenOnline.getTime() / 1000,
-        );
-        if (nowSeconds - lastSeenOnlineSeconds > idleTimeoutSeconds) {
-          identityApi.signOut();
-        }
-      }
-      lastSeenOnlineStore.save(new Date());
-    } else {
+    if (!shouldCheckDisconnectedUser || !isLoggedIn) {
       lastSeenOnlineStore.delete();
+      return;
     }
+
+    const lastSeenOnline = lastSeenOnlineStore.get();
+    if (lastSeenOnline) {
+      const now = new Date();
+      const nowSeconds = Math.ceil(now.getTime() / 1000);
+      const lastSeenOnlineSeconds = Math.ceil(lastSeenOnline.getTime() / 1000);
+      if (nowSeconds - lastSeenOnlineSeconds > idleTimeoutSeconds) {
+        lastSeenOnlineStore.delete();
+        identityApi.signOut();
+        return;
+      }
+    }
+    lastSeenOnlineStore.save(new Date());
   }, [
     autologoutIsEnabled,
     enableEffect,

--- a/packages/core-components/src/components/AutoLogout/disconnectedUsers.ts
+++ b/packages/core-components/src/components/AutoLogout/disconnectedUsers.ts
@@ -43,12 +43,14 @@ export const useLogoutDisconnectedUserEffect = ({
      * Considers disconnected users as inactive users.
      * If all Backstage tabs are closed and idleTimeoutMinutes are passed then logout the user anyway.
      */
+    const shouldCheckDisconnectedUser = autologoutIsEnabled && enableEffect;
+
     // Prevent lastSeen getting deleted before logged state is checked
-    if (isLoggedIn === null) {
+    if (shouldCheckDisconnectedUser && isLoggedIn === null) {
       return;
     }
 
-    if (autologoutIsEnabled && isLoggedIn && enableEffect) {
+    if (shouldCheckDisconnectedUser && isLoggedIn) {
       const lastSeenOnline = lastSeenOnlineStore.get();
       if (lastSeenOnline) {
         const now = new Date();


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #31264 (bug with autologout not working when closing all tabs and opening a new one).

Note that this bug *might* be caused by a problem with the `identityApi.getCredentials()` promise which never seems to resolve or reject. I've only tried testing with Google OIDC but perhaps this is an issue with other providers as well. Either case, I don't think the flow was handled correctly before assuming proper resolution of `getCredentials`.  

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
