### PR TITLE
fix(catalog-backend-module-github): add configurable page sizes for GitHub GraphQL queries

### DIFF
--- a/.changeset/configurable-github-page-sizes.md
+++ b/.changeset/configurable-github-page-sizes.md
@@ -1,0 +1,18 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+Added configurable page sizes for GitHub API queries to help avoid RESOURCE_LIMITS_EXCEEDED errors when syncing large organizations. Default page sizes have been reduced by 50% to work within GitHub's September 2025 API resource limits. Page sizes can now be configured via app-config.yaml:
+
+```yaml
+catalog:
+  providers:
+    github:
+      production:
+        organization: myorg
+        pageSizes:
+          teams: 25 # default: 25
+          members: 50 # default: 50
+          repositories: 25 # default: 25
+          repositoryTopics: 50 # default: 50
+```

--- a/plugins/catalog-backend-module-github/config.d.ts
+++ b/plugins/catalog-backend-module-github/config.d.ts
@@ -131,6 +131,31 @@ export interface Config {
              * (Optional) TaskScheduleDefinition for the refresh.
              */
             schedule?: SchedulerServiceTaskScheduleDefinitionConfig;
+            /**
+             * (Optional) GraphQL API page sizes for querying GitHub.
+             */
+            pageSizes?: {
+              /**
+               * (Optional) Page size for fetching organization teams.
+               * Default: 25
+               */
+              teams?: number;
+              /**
+               * (Optional) Page size for fetching team members.
+               * Default: 50
+               */
+              members?: number;
+              /**
+               * (Optional) Page size for fetching organization repositories.
+               * Default: 25
+               */
+              repositories?: number;
+              /**
+               * (Optional) Page size for fetching repository topics.
+               * Default: 50
+               */
+              repositoryTopics?: number;
+            };
           }
         | {
             [name: string]: {
@@ -209,6 +234,31 @@ export interface Config {
                * (Optional) TaskScheduleDefinition for the refresh.
                */
               schedule?: SchedulerServiceTaskScheduleDefinitionConfig;
+              /**
+               * (Optional) GraphQL API page sizes for querying GitHub.
+               */
+              pageSizes?: {
+                /**
+                 * (Optional) Page size for fetching organization teams.
+                 * Default: 25
+                 */
+                teams?: number;
+                /**
+                 * (Optional) Page size for fetching team members.
+                 * Default: 50
+                 */
+                members?: number;
+                /**
+                 * (Optional) Page size for fetching organization repositories.
+                 * Default: 25
+                 */
+                repositories?: number;
+                /**
+                 * (Optional) Page size for fetching repository topics.
+                 * Default: 50
+                 */
+                repositoryTopics?: number;
+              };
             };
           };
 
@@ -244,6 +294,32 @@ export interface Config {
              * The refresh schedule to use.
              */
             schedule: SchedulerServiceTaskScheduleDefinitionConfig;
+
+            /**
+             * (Optional) GraphQL API page sizes for querying GitHub.
+             */
+            pageSizes?: {
+              /**
+               * (Optional) Page size for fetching organization teams.
+               * Default: 25
+               */
+              teams?: number;
+              /**
+               * (Optional) Page size for fetching team members.
+               * Default: 50
+               */
+              members?: number;
+              /**
+               * (Optional) Page size for fetching organization repositories.
+               * Default: 25
+               */
+              repositories?: number;
+              /**
+               * (Optional) Page size for fetching repository topics.
+               * Default: 50
+               */
+              repositoryTopics?: number;
+            };
           }
         | Array<{
             /**
@@ -273,6 +349,32 @@ export interface Config {
              * The refresh schedule to use.
              */
             schedule: SchedulerServiceTaskScheduleDefinitionConfig;
+
+            /**
+             * (Optional) GraphQL API page sizes for querying GitHub.
+             */
+            pageSizes?: {
+              /**
+               * (Optional) Page size for fetching organization teams.
+               * Default: 25
+               */
+              teams?: number;
+              /**
+               * (Optional) Page size for fetching team members.
+               * Default: 50
+               */
+              members?: number;
+              /**
+               * (Optional) Page size for fetching organization repositories.
+               * Default: 25
+               */
+              repositories?: number;
+              /**
+               * (Optional) Page size for fetching repository topics.
+               * Default: 50
+               */
+              repositoryTopics?: number;
+            };
           }>;
     };
   };

--- a/plugins/catalog-backend-module-github/report.api.md
+++ b/plugins/catalog-backend-module-github/report.api.md
@@ -37,6 +37,14 @@ export const defaultUserTransformer: (
 ) => Promise<UserEntity | undefined>;
 
 // @public
+export type GithubApiPageSizes = {
+  teams?: number;
+  members?: number;
+  repositories?: number;
+  repositoryTopics?: number;
+};
+
+// @public
 const githubCatalogModule: BackendFeature;
 export default githubCatalogModule;
 
@@ -150,6 +158,7 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
     userTransformer?: UserTransformer;
     teamTransformer?: TeamTransformer;
     alwaysUseDefaultNamespace?: boolean;
+    pageSizes?: GithubApiPageSizes;
   });
   connect(connection: EntityProviderConnection): Promise<void>;
   // (undocumented)
@@ -170,6 +179,7 @@ export interface GithubMultiOrgEntityProviderOptions {
   id: string;
   logger: LoggerService;
   orgs?: string[];
+  pageSizes?: GithubApiPageSizes;
   schedule?: 'manual' | SchedulerServiceTaskRunner;
   teamTransformer?: TeamTransformer;
   userTransformer?: UserTransformer;
@@ -225,6 +235,7 @@ export class GithubOrgEntityProvider implements EntityProvider {
     githubCredentialsProvider?: GithubCredentialsProvider;
     userTransformer?: UserTransformer;
     teamTransformer?: TeamTransformer;
+    pageSizes?: GithubApiPageSizes;
   });
   connect(connection: EntityProviderConnection): Promise<void>;
   // (undocumented)
@@ -246,6 +257,7 @@ export interface GithubOrgEntityProviderOptions {
   id: string;
   logger: LoggerService;
   orgUrl: string;
+  pageSizes?: GithubApiPageSizes;
   schedule?: 'manual' | SchedulerServiceTaskRunner;
   teamTransformer?: TeamTransformer;
   userTransformer?: UserTransformer;

--- a/plugins/catalog-backend-module-github/src/index.ts
+++ b/plugins/catalog-backend-module-github/src/index.ts
@@ -32,6 +32,7 @@ export type { GithubMultiOrgEntityProviderOptions } from './providers/GithubMult
 export { GithubOrgEntityProvider } from './providers/GithubOrgEntityProvider';
 export type { GithubOrgEntityProviderOptions } from './providers/GithubOrgEntityProvider';
 export {
+  type GithubApiPageSizes,
   type GithubMultiOrgConfig,
   type GithubTeam,
   type GithubUser,

--- a/plugins/catalog-backend-module-github/src/lib/github.test.ts
+++ b/plugins/catalog-backend-module-github/src/lib/github.test.ts
@@ -863,4 +863,104 @@ describe('github', () => {
       });
     });
   });
+
+  describe('pageSizes parameter', () => {
+    it('getOrganizationUsers uses custom page size', async () => {
+      server.use(
+        graphqlMsw.query('users', ({ variables }) => {
+          expect(variables.pageSize).toBe(10);
+          return HttpResponse.json({
+            data: {
+              organization: {
+                membersWithRole: {
+                  pageInfo: { hasNextPage: false },
+                  nodes: [],
+                },
+              },
+            },
+          });
+        }),
+      );
+
+      await getOrganizationUsers(graphql, 'test-org', 'token', undefined, {
+        members: 10,
+      });
+    });
+
+    it('getOrganizationTeams uses custom page sizes', async () => {
+      server.use(
+        graphqlMsw.query('teams', ({ variables }) => {
+          expect(variables.teamsPageSize).toBe(15);
+          expect(variables.membersPageSize).toBe(25);
+          return HttpResponse.json({
+            data: {
+              organization: {
+                teams: {
+                  pageInfo: { hasNextPage: false },
+                  nodes: [],
+                },
+              },
+            },
+          });
+        }),
+      );
+
+      await getOrganizationTeams(graphql, 'test-org', undefined, {
+        teams: 15,
+        members: 25,
+      });
+    });
+
+    it('getOrganizationRepositories uses custom page sizes', async () => {
+      server.use(
+        graphqlMsw.query('repositories', ({ variables }) => {
+          expect(variables.reposPageSize).toBe(10);
+          expect(variables.topicsPageSize).toBe(20);
+          return HttpResponse.json({
+            data: {
+              repositoryOwner: {
+                repositories: {
+                  pageInfo: { hasNextPage: false },
+                  nodes: [],
+                },
+              },
+            },
+          });
+        }),
+      );
+
+      await getOrganizationRepositories(
+        graphql,
+        'test-org',
+        '/catalog-info.yaml',
+        { repositories: 10, repositoryTopics: 20 },
+      );
+    });
+
+    it('uses default page sizes when pageSizes is undefined', async () => {
+      server.use(
+        graphqlMsw.query('users', ({ variables }) => {
+          expect(variables.pageSize).toBe(50);
+          return HttpResponse.json({
+            data: {
+              organization: {
+                membersWithRole: {
+                  pageInfo: { hasNextPage: false },
+                  nodes: [],
+                },
+              },
+            },
+          });
+        }),
+      );
+
+      await getOrganizationUsers(
+        graphql,
+        'test-org',
+        'token',
+        undefined,
+        undefined,
+      );
+    });
+  });
 });

--- a/plugins/catalog-backend-module-github/src/lib/index.ts
+++ b/plugins/catalog-backend-module-github/src/lib/index.ts
@@ -22,6 +22,7 @@ export {
   getOrganizationUsers,
   type GithubUser,
   type GithubTeam,
+  type GithubApiPageSizes,
 } from './github';
 export {
   type UserTransformer,

--- a/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.ts
@@ -263,7 +263,12 @@ export class GithubEntityProvider implements EntityProvider, EventSubscriber {
       const client = await this.createGraphqlClient(organization);
 
       const { repositories: repositoriesFromGithub } =
-        await getOrganizationRepositories(client, organization, catalogPath);
+        await getOrganizationRepositories(
+          client,
+          organization,
+          catalogPath,
+          this.config.pageSizes,
+        );
       repositories = repositories.concat(
         repositoriesFromGithub.map(r =>
           this.createRepoFromGithubResponse(r, organization),

--- a/plugins/catalog-backend-module-github/src/providers/GithubEntityProviderConfig.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubEntityProviderConfig.test.ts
@@ -425,4 +425,95 @@ describe('readProviderConfigs', () => {
 
     expect(() => readProviderConfigs(config)).toThrow();
   });
+
+  describe('pageSizes', () => {
+    it('reads page sizes from config', () => {
+      const config = new ConfigReader({
+        catalog: {
+          providers: {
+            github: {
+              providerId: {
+                organization: 'my-org',
+                pageSizes: {
+                  teams: 10,
+                  members: 20,
+                  repositories: 15,
+                  repositoryTopics: 30,
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const actual = readProviderConfigs(config)[0];
+      expect(actual.pageSizes).toEqual({
+        teams: 10,
+        members: 20,
+        repositories: 15,
+        repositoryTopics: 30,
+      });
+    });
+
+    it('allows partial page size configuration', () => {
+      const config = new ConfigReader({
+        catalog: {
+          providers: {
+            github: {
+              providerId: {
+                organization: 'my-org',
+                pageSizes: {
+                  teams: 15,
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const actual = readProviderConfigs(config)[0];
+      expect(actual.pageSizes).toEqual({
+        teams: 15,
+      });
+    });
+
+    it('returns undefined when page sizes are not specified', () => {
+      const config = new ConfigReader({
+        catalog: {
+          providers: {
+            github: {
+              providerId: {
+                organization: 'my-org',
+              },
+            },
+          },
+        },
+      });
+
+      const actual = readProviderConfigs(config)[0];
+      expect(actual.pageSizes).toBeUndefined();
+    });
+
+    it('reads page sizes for simple provider config', () => {
+      const config = new ConfigReader({
+        catalog: {
+          providers: {
+            github: {
+              organization: 'test-org',
+              pageSizes: {
+                teams: 5,
+                members: 10,
+              },
+            },
+          },
+        },
+      });
+
+      const actual = readProviderConfigs(config)[0];
+      expect(actual.pageSizes).toEqual({
+        teams: 5,
+        members: 10,
+      });
+    });
+  });
 });

--- a/plugins/catalog-backend-module-github/src/providers/GithubEntityProviderConfig.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubEntityProviderConfig.ts
@@ -19,6 +19,7 @@ import {
   readSchedulerServiceTaskScheduleDefinitionFromConfig,
 } from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
+import { GithubApiPageSizes } from '../lib/github';
 
 const DEFAULT_CATALOG_PATH = '/catalog-info.yaml';
 const DEFAULT_PROVIDER_ID = 'default';
@@ -48,6 +49,7 @@ export type GithubEntityProviderConfig = {
   };
   validateLocationsExist: boolean;
   schedule?: SchedulerServiceTaskScheduleDefinition;
+  pageSizes?: GithubApiPageSizes;
 };
 
 export type GithubTopicFilters = {
@@ -128,6 +130,17 @@ function readProviderConfig(
       )
     : DEFAULT_GITHUB_ENTITY_PROVIDER_CONFIG_SCHEDULE;
 
+  const pageSizes: GithubApiPageSizes | undefined = config.has('pageSizes')
+    ? {
+        teams: config.getOptionalNumber('pageSizes.teams'),
+        members: config.getOptionalNumber('pageSizes.members'),
+        repositories: config.getOptionalNumber('pageSizes.repositories'),
+        repositoryTopics: config.getOptionalNumber(
+          'pageSizes.repositoryTopics',
+        ),
+      }
+    : undefined;
+
   return {
     id,
     catalogPath,
@@ -149,6 +162,7 @@ function readProviderConfig(
     },
     schedule,
     validateLocationsExist,
+    pageSizes,
   };
 }
 

--- a/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
@@ -62,6 +62,7 @@ import {
   getOrganizationTeams,
   assignGroupsToUser,
   getOrganizationUsers,
+  GithubApiPageSizes,
   GithubTeam,
   TeamTransformer,
   TransformerContext,
@@ -166,6 +167,11 @@ export interface GithubMultiOrgEntityProviderOptions {
    * By default, groups will be namespaced according to their GitHub org.
    */
   teamTransformer?: TeamTransformer;
+
+  /**
+   * Optionally configure page sizes for GitHub GraphQL API queries.
+   */
+  pageSizes?: GithubApiPageSizes;
 }
 
 type CreateDeltaOperation = (entities: Entity[]) => {
@@ -212,6 +218,7 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
       teamTransformer: options.teamTransformer,
       events: options.events,
       alwaysUseDefaultNamespace: options.alwaysUseDefaultNamespace,
+      pageSizes: options.pageSizes,
     });
 
     provider.schedule(options.schedule);
@@ -231,6 +238,7 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
       userTransformer?: UserTransformer;
       teamTransformer?: TeamTransformer;
       alwaysUseDefaultNamespace?: boolean;
+      pageSizes?: GithubApiPageSizes;
     },
   ) {}
 
@@ -286,12 +294,14 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
         org,
         tokenType,
         this.options.userTransformer,
+        this.options.pageSizes,
       );
 
       const { teams } = await getOrganizationTeams(
         client,
         org,
         this.defaultMultiOrgTeamTransformer.bind(this),
+        this.options.pageSizes,
       );
 
       // Grab current users from `allUsersMap` if they already exist in our
@@ -434,12 +444,14 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
       org,
       tokenType,
       this.options.userTransformer,
+      this.options.pageSizes,
     );
 
     const { teams } = await getOrganizationTeams(
       client,
       org,
       this.defaultMultiOrgTeamTransformer.bind(this),
+      this.options.pageSizes,
     );
 
     if (users.length) {
@@ -464,6 +476,7 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
               u.metadata.name,
           ),
           this.defaultMultiOrgTeamTransformer.bind(this),
+          this.options.pageSizes,
         );
 
         if (areGroupEntities(userTeams) && areUserEntities(users)) {
@@ -563,6 +576,7 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
           userOrg,
           login,
           this.defaultMultiOrgTeamTransformer.bind(this),
+          this.options.pageSizes,
         );
 
         if (isUserEntity(user) && areGroupEntities(teams)) {
@@ -661,6 +675,7 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
       org,
       tokenType,
       this.options.userTransformer,
+      this.options.pageSizes,
     );
 
     const usersFromChangedGroup = isGroupEntity(team)
@@ -693,6 +708,7 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
               u.metadata.name,
           ),
           this.defaultMultiOrgTeamTransformer.bind(this),
+          this.options.pageSizes,
         );
 
         if (areGroupEntities(teams) && areUserEntities(usersToRebuild)) {
@@ -806,6 +822,7 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
           userOrg,
           login,
           this.defaultMultiOrgTeamTransformer.bind(this),
+          this.options.pageSizes,
         );
 
         if (areGroupEntities(teams)) {

--- a/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.ts
@@ -58,6 +58,7 @@ import {
   getOrganizationTeams,
   getOrganizationTeamsFromUsers,
   getOrganizationUsers,
+  GithubApiPageSizes,
   GithubTeam,
 } from '../lib/github';
 import { areGroupEntities, areUserEntities } from '../lib/guards';
@@ -130,6 +131,11 @@ export interface GithubOrgEntityProviderOptions {
    * Optionally include a team transformer for transforming from GitHub teams to Group Entities
    */
   teamTransformer?: TeamTransformer;
+
+  /**
+   * Optionally configure page sizes for GitHub GraphQL API queries.
+   */
+  pageSizes?: GithubApiPageSizes;
 }
 
 /**
@@ -167,6 +173,7 @@ export class GithubOrgEntityProvider implements EntityProvider {
       userTransformer: options.userTransformer,
       teamTransformer: options.teamTransformer,
       events: options.events,
+      pageSizes: options.pageSizes,
     });
 
     provider.schedule(options.schedule);
@@ -184,6 +191,7 @@ export class GithubOrgEntityProvider implements EntityProvider {
       githubCredentialsProvider?: GithubCredentialsProvider;
       userTransformer?: UserTransformer;
       teamTransformer?: TeamTransformer;
+      pageSizes?: GithubApiPageSizes;
     },
   ) {
     this.credentialsProvider =
@@ -236,11 +244,13 @@ export class GithubOrgEntityProvider implements EntityProvider {
       org,
       tokenType,
       this.options.userTransformer,
+      this.options.pageSizes,
     );
     const { teams } = await getOrganizationTeams(
       client,
       org,
       this.options.teamTransformer,
+      this.options.pageSizes,
     );
 
     if (areGroupEntities(teams)) {
@@ -364,6 +374,7 @@ export class GithubOrgEntityProvider implements EntityProvider {
       org,
       tokenType,
       this.options.userTransformer,
+      this.options.pageSizes,
     );
 
     if (!isGroupEntity(team)) {
@@ -380,6 +391,7 @@ export class GithubOrgEntityProvider implements EntityProvider {
       org,
       usersToRebuild.map(u => u.metadata.name),
       this.options.teamTransformer,
+      this.options.pageSizes,
     );
 
     if (areGroupEntities(teams)) {
@@ -455,6 +467,7 @@ export class GithubOrgEntityProvider implements EntityProvider {
       org,
       tokenType,
       this.options.userTransformer,
+      this.options.pageSizes,
     );
 
     const usersToRebuild = users.filter(u => u.metadata.name === userLogin);
@@ -464,6 +477,7 @@ export class GithubOrgEntityProvider implements EntityProvider {
       org,
       [userLogin],
       this.options.teamTransformer,
+      this.options.pageSizes,
     );
 
     // we include group because the removed event need to update the old group too


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### Summary
Adds configurable page sizes for GitHub GraphQL API queries to prevent `RESOURCE_LIMITS_EXCEEDED` errors when syncing large GitHub organizations (100+ teams). Default page sizes have been reduced by 50% to comply with GitHub's September 2025 API resource consumption limits and it also add supports for configuring them.

In the past the default page sizes were statically set to the below:
```
Teams: 50
Members: 100
Repositories: 50
Repository Topics: 100
```

This change reduces these by default to the below:
```
Teams: 25
Members: 50
Repositories: 25
Repository Topics: 50
```

It also adds a new `pageSizes` configuration option so that these can be adjusted like below:
```
catalog:
  providers:
    github:
      production:
        organization: 'my-org'
        catalogPath: '/catalog-info.yaml'
        schedule:
          frequency: { hours: 1 }
          timeout: { minutes: 50 }
        pageSizes:
          teams: 25
          members: 50
          repositories: 25
          repositoryTopics: 50
```

The change covers all 3 of: `GithubEntityProvider`, `GithubOrgEntityProvider`, and `GithubMultiOrgEntityProvider` and includes some tests for each.

There is a performance implication of these changes since more API calls are required but it allows for staying within GitHub rate limits and users can configure it as needed for their own organization(s)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [?] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [N/A] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
