### PR TITLE
feat(mcp-actions): support _meta field for actions

### DIFF
--- a/.changeset/stupid-jobs-take.md
+++ b/.changeset/stupid-jobs-take.md
@@ -1,0 +1,7 @@
+---
+'@backstage/backend-plugin-api': patch
+'@backstage/backend-test-utils': patch
+'@backstage/plugin-mcp-actions-backend': patch
+---
+
+Added support for MCP action metadata field

--- a/packages/backend-plugin-api/report-alpha.api.md
+++ b/packages/backend-plugin-api/report-alpha.api.md
@@ -27,6 +27,7 @@ export type ActionsRegistryActionOptions<
   name: string;
   title: string;
   description: string;
+  metadata?: Record<string, unknown>;
   schema: {
     input: (zod: typeof z) => TInputSchema;
     output: (zod: typeof z) => TOutputSchema;
@@ -85,6 +86,7 @@ export type ActionsServiceAction = {
   name: string;
   title: string;
   description: string;
+  metadata?: Record<string, unknown>;
   schema: {
     input: JSONSchema7;
     output: JSONSchema7;

--- a/packages/backend-plugin-api/src/alpha/ActionsRegistryService.ts
+++ b/packages/backend-plugin-api/src/alpha/ActionsRegistryService.ts
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { z, AnyZodObject } from 'zod';
+import { AnyZodObject, z } from 'zod';
 import {
-  LoggerService,
   BackstageCredentials,
+  LoggerService,
 } from '@backstage/backend-plugin-api';
 
 /**
@@ -38,6 +38,7 @@ export type ActionsRegistryActionOptions<
   name: string;
   title: string;
   description: string;
+  metadata?: Record<string, unknown>;
   schema: {
     input: (zod: typeof z) => TInputSchema;
     output: (zod: typeof z) => TOutputSchema;

--- a/packages/backend-plugin-api/src/alpha/ActionsService.ts
+++ b/packages/backend-plugin-api/src/alpha/ActionsService.ts
@@ -25,6 +25,7 @@ export type ActionsServiceAction = {
   name: string;
   title: string;
   description: string;
+  metadata?: Record<string, unknown>;
   schema: {
     input: JSONSchema7;
     output: JSONSchema7;

--- a/packages/backend-test-utils/src/alpha/services/MockActionsRegistry.ts
+++ b/packages/backend-test-utils/src/alpha/services/MockActionsRegistry.ts
@@ -19,7 +19,7 @@ import {
 } from '@backstage/backend-plugin-api';
 import { ForwardedError, InputError, NotFoundError } from '@backstage/errors';
 import { JsonObject, JsonValue } from '@backstage/types';
-import { z, AnyZodObject } from 'zod';
+import { AnyZodObject, z } from 'zod';
 import zodToJsonSchema from 'zod-to-json-schema';
 import { mockCredentials } from '../../services';
 import {
@@ -81,6 +81,7 @@ export class MockActionsRegistry
         name: action.name,
         title: action.title,
         description: action.description,
+        metadata: action.metadata,
         attributes: {
           destructive: action.attributes?.destructive ?? true,
           idempotent: action.attributes?.idempotent ?? false,

--- a/plugins/mcp-actions-backend/package.json
+++ b/plugins/mcp-actions-backend/package.json
@@ -40,7 +40,7 @@
     "@backstage/errors": "workspace:^",
     "@backstage/plugin-catalog-node": "workspace:^",
     "@backstage/types": "workspace:^",
-    "@modelcontextprotocol/sdk": "^1.12.3",
+    "@modelcontextprotocol/sdk": "^1.20.1",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
     "zod": "^3.22.4"

--- a/plugins/mcp-actions-backend/src/services/McpService.test.ts
+++ b/plugins/mcp-actions-backend/src/services/McpService.test.ts
@@ -31,6 +31,7 @@ describe('McpService', () => {
       name: 'mock-action',
       title: 'Test',
       description: 'Test',
+      metadata: { someMeta: 'data' },
       schema: {
         input: z => z.object({ input: z.string() }),
         output: z => z.object({ output: z.string() }),
@@ -76,6 +77,7 @@ describe('McpService', () => {
           title: 'Test',
         },
         description: 'Test',
+        _meta: { someMeta: 'data' },
         inputSchema: {
           $schema: 'http://json-schema.org/draft-07/schema#',
           additionalProperties: false,

--- a/plugins/mcp-actions-backend/src/services/McpService.ts
+++ b/plugins/mcp-actions-backend/src/services/McpService.ts
@@ -16,8 +16,8 @@
 import { BackstageCredentials } from '@backstage/backend-plugin-api';
 import { Server as McpServer } from '@modelcontextprotocol/sdk/server/index.js';
 import {
-  ListToolsRequestSchema,
   CallToolRequestSchema,
+  ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { JsonObject } from '@backstage/types';
 import { ActionsService } from '@backstage/backend-plugin-api/alpha';
@@ -55,6 +55,7 @@ export class McpService {
           // outputSchema: action.schema.output,
           name: action.name,
           description: action.description,
+          _meta: action.metadata,
           annotations: {
             title: action.title,
             destructiveHint: action.attributes.destructive,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5663,7 +5663,7 @@ __metadata:
     "@backstage/errors": "workspace:^"
     "@backstage/plugin-catalog-node": "workspace:^"
     "@backstage/types": "workspace:^"
-    "@modelcontextprotocol/sdk": "npm:^1.12.3"
+    "@modelcontextprotocol/sdk": "npm:^1.20.1"
     "@types/express": "npm:^4.17.6"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
@@ -10718,22 +10718,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@modelcontextprotocol/sdk@npm:^1.12.3":
-  version: 1.13.1
-  resolution: "@modelcontextprotocol/sdk@npm:1.13.1"
+"@modelcontextprotocol/sdk@npm:^1.20.1":
+  version: 1.20.1
+  resolution: "@modelcontextprotocol/sdk@npm:1.20.1"
   dependencies:
     ajv: "npm:^6.12.6"
     content-type: "npm:^1.0.5"
     cors: "npm:^2.8.5"
     cross-spawn: "npm:^7.0.5"
     eventsource: "npm:^3.0.2"
+    eventsource-parser: "npm:^3.0.0"
     express: "npm:^5.0.1"
     express-rate-limit: "npm:^7.5.0"
     pkce-challenge: "npm:^5.0.0"
     raw-body: "npm:^3.0.0"
     zod: "npm:^3.23.8"
     zod-to-json-schema: "npm:^3.24.1"
-  checksum: 10/b516d72e1cd14c67c8a2e5cb95fcc1c03c50be989850e3e963a7ed11000acb604e65efeaad47ea93c847130536ee51859a8d34e6dbe99d408e1a24224592e57f
+  checksum: 10/7f9f3a35c70e1c955cc87d0fe399b1ac7646b0cfcda09a8170c9d08c484a847867fee5558dc6aa4b7749170b8df9c2db9b71f9549084ea862a09c2ae6ecfa289
   languageName: node
   linkType: hard
 
@@ -29477,10 +29478,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eventsource-parser@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "eventsource-parser@npm:3.0.1"
-  checksum: 10/2730c54c3cb47d55d2967f2ece843f9fc95d8a11c2fef6fece8d17d9080193cbe3cd9ac7b04a325977f63cbf8c1664fdd0512dec1aec601666a5c5bd8564b61f
+"eventsource-parser@npm:^3.0.0, eventsource-parser@npm:^3.0.1":
+  version: 3.0.6
+  resolution: "eventsource-parser@npm:3.0.6"
+  checksum: 10/febf7058b9c2168ecbb33e92711a1646e06bd1568f60b6eb6a01a8bf9f8fcd29cc8320d57247059cacf657a296280159f21306d2e3ff33309a9552b2ef889387
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

actions can now use `metadata` field to add additional metadata for mcp server use. this field is optional so it's not breaking change. see https://modelcontextprotocol.io/specification/2025-06-18/basic/index#meta for details about the metadata.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
