### PR TITLE
Set browser title in BUI Header component.

### DIFF
--- a/.changeset/slimy-horses-visit.md
+++ b/.changeset/slimy-horses-visit.md
@@ -1,0 +1,9 @@
+---
+'@backstage/ui': patch
+---
+
+The Header and HeaderPage components now automatically set the browser title.
+
+The Header component sets a title template that allows other components (like HeaderPage) to automatically include the header title as part of the browser title. The default browser title is `{title} | {appTitle}`, where `title` comes from the Header component props and `appTitle` is retrieved from your Backstage `app.title` configuration (defaults to "Backstage" if not set).
+
+When using HeaderPage alongside a Header, the browser title becomes `{headerPageTitle} | {headerTitle} | {appTitle}`. Using Helmet to set the title directly has a similar effect when Header is used, the browser title would become `{helmetTitle} | {headerTitle} | {appTitle}`.

--- a/docs-ui/src/content/components/header-page.mdx
+++ b/docs-ui/src/content/components/header-page.mdx
@@ -32,6 +32,10 @@ import { ChangelogComponent } from '@/components/ChangelogComponent';
 
 <CodeBlock code={usage} />
 
+## Browser Title
+
+The HeaderPage component automatically sets the browser title based on its `title` prop. When used alongside a Header component (recommended), the browser title becomes `{headerPageTitle} | {headerTitle} | {app.title}`. If used without the Header component, the browser title will simply be set to the `title` prop.
+
 ## API reference
 
 <PropsTable data={propDefs} />

--- a/docs-ui/src/content/components/header.mdx
+++ b/docs-ui/src/content/components/header.mdx
@@ -31,6 +31,12 @@ import { ChangelogComponent } from '@/components/ChangelogComponent';
 
 <CodeBlock code={usage} />
 
+## Browser Title
+
+The Header component automatically sets the browser title using a title template. When used alone, the browser title is `{title} | {app.title}`, where `app.title` is retrieved from your Backstage configuration and defaults to "Backstage".
+
+When using HeaderPage alongside a Header, the browser title becomes `{headerPageTitle} | {headerTitle} | {app.title}`. Using helmet directly to set the title has a similar effect, where the browser title becomes `{helmetTitle} | {headerTitle} | {app.title}`.
+
 ## API reference
 
 <PropsTable data={propDefs} />

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -38,11 +38,13 @@
     "test": "backstage-cli package test"
   },
   "dependencies": {
+    "@backstage/core-plugin-api": "workspace:^",
     "@base-ui-components/react": "1.0.0-alpha.7",
     "@remixicon/react": "^4.6.0",
     "@tanstack/react-table": "^8.21.3",
     "clsx": "^2.1.1",
-    "react-aria-components": "^1.13.0"
+    "react-aria-components": "^1.13.0",
+    "react-helmet": "6.1.0"
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",

--- a/packages/ui/src/components/Header/Header.tsx
+++ b/packages/ui/src/components/Header/Header.tsx
@@ -21,6 +21,8 @@ import { useStyles } from '../../hooks/useStyles';
 import { type NavigateOptions } from 'react-router-dom';
 import styles from './Header.module.css';
 import clsx from 'clsx';
+import { Helmet } from 'react-helmet';
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
 
 declare module 'react-aria-components' {
   interface RouterConfig {
@@ -35,13 +37,28 @@ declare module 'react-aria-components' {
  */
 export const Header = (props: HeaderProps) => {
   const { classNames, cleanedProps } = useStyles('Header', props);
-  const { tabs, icon, title, titleLink, customActions, onTabSelectionChange } =
-    cleanedProps;
+  const {
+    tabs,
+    icon,
+    title = 'Your plugin',
+    titleLink,
+    customActions,
+    onTabSelectionChange,
+  } = cleanedProps;
+
+  const configApi = useApi(configApiRef);
+  const appTitle = configApi.getOptionalString('app.title') || 'Backstage';
+  const pluginTitle = `${title} | ${appTitle}`;
+  const pluginPageTitleTemplate = `%s | ${pluginTitle}`;
 
   const hasTabs = tabs && tabs.length > 0;
 
   return (
     <>
+      <Helmet
+        titleTemplate={pluginPageTitleTemplate}
+        defaultTitle={pluginTitle}
+      />
       <HeaderToolbar
         icon={icon}
         title={title}

--- a/packages/ui/src/components/Header/HeaderToolbar.tsx
+++ b/packages/ui/src/components/Header/HeaderToolbar.tsx
@@ -46,7 +46,7 @@ export const HeaderToolbar = (props: HeaderToolbarProps) => {
       >
         {icon || <RiShapesLine />}
       </div>
-      <Text variant="body-medium">{title || 'Your plugin'}</Text>
+      <Text variant="body-medium">{title}</Text>
     </>
   );
 

--- a/packages/ui/src/components/HeaderPage/HeaderPage.tsx
+++ b/packages/ui/src/components/HeaderPage/HeaderPage.tsx
@@ -24,6 +24,7 @@ import { Link } from '../Link';
 import { Fragment } from 'react/jsx-runtime';
 import styles from './HeaderPage.module.css';
 import clsx from 'clsx';
+import { Helmet } from 'react-helmet';
 
 /**
  * A component that renders a header page.
@@ -36,6 +37,7 @@ export const HeaderPage = (props: HeaderPageProps) => {
 
   return (
     <Container className={clsx(classNames.root, styles[classNames.root])}>
+      <Helmet title={title} />
       <div className={clsx(classNames.content, styles[classNames.content])}>
         <div
           className={clsx(

--- a/yarn.lock
+++ b/yarn.lock
@@ -7516,6 +7516,7 @@ __metadata:
   resolution: "@backstage/ui@workspace:packages/ui"
   dependencies:
     "@backstage/cli": "workspace:^"
+    "@backstage/core-plugin-api": "workspace:^"
     "@base-ui-components/react": "npm:1.0.0-alpha.7"
     "@remixicon/react": "npm:^4.6.0"
     "@tanstack/react-table": "npm:^8.21.3"
@@ -7531,6 +7532,7 @@ __metadata:
     react: "npm:^18.0.2"
     react-aria-components: "npm:^1.13.0"
     react-dom: "npm:^18.0.2"
+    react-helmet: "npm:6.1.0"
     react-router-dom: "npm:^6.3.0"
     storybook: "npm:^9.1.7"
   peerDependencies:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The BUI Header component now automatically sets the browser tab title.

Changes made:
- Header component now uses `react-helmet` to set browser title
- `title` prop and config `app.title` is used as the title
- Added `react-helmet` and `@backstage/core-plugin-api` dependencies to `@backstage/ui package`
- Moved definition of the default title "Your plugin" to prevent undefined values in browser title
- Updated documentation in docs-ui to explain the browser title behavior

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
