### PR TITLE
feat: Expand `EntityFilter.getCatalogFilters` to return `EntityFilterQuery`

### DIFF
--- a/.changeset/bitter-suns-build.md
+++ b/.changeset/bitter-suns-build.md
@@ -1,0 +1,46 @@
+---
+'@backstage/plugin-catalog-react': major
+'@backstage/catalog-client': minor
+---
+
+**BREAKING** Expand `EntityFilter.getCatalogFilters` to return `EntityFilterQuery`
+
+```diff
+import { Entity } from '@backstage/catalog-model';
++ import { EntityFilterQuery } from '@backstage/catalog-client';
+
+/** @public */
+export type EntityFilter = {
+-  getCatalogFilters?: () => Record<
+-    string,
+-    string | symbol | (string | symbol)[]
+-  >;
++  getCatalogFilters?: () => EntityFilterQuery;
+};
+```
+
+This change allows `EntityFilter`s to utilize more complete functionality of the `CatalogApi`, specifically the
+`queryEntities` and `getEntities` methods which support an `EntityFilterQuery` as the `filter` parameter in the request.
+
+Allowing `EntityFilter`s to return a complete `EntityFilterQuery` allows them to produce more complex filter logic.
+
+The primary example is allowing an `EntityFilter` to produce an array of filter records that would produce an 'OR'
+query, filtering on A OR B criteria.
+
+To complete this change, some of the helpers and utilities used by Entity filtering functionality
+(ex: `useEntityListProvider`) needed to be updated to account for the possibility of an array of filter records.
+
+### Updating Consumers
+
+If consumers have implemented functionality that calls the `getCatalogFilters` method on `EntityFilter`s, this code will
+need to be updated to account for the possibility of the method returning an array of records in addition to a single
+record.
+
+```typescript
+const recordOrRecords = entityFilter.getCatalogFilters?.();
+if (Array.isArray(recordOrRecords)) {
+  // Handle the more complex array of records case.
+} else {
+  // Handle single record as before.
+}
+```

--- a/packages/catalog-client/report.api.md
+++ b/packages/catalog-client/report.api.md
@@ -199,9 +199,16 @@ export const ENTITY_STATUS_CATALOG_PROCESSING_TYPE =
 export type EntityFieldsQuery = string[];
 
 // @public
-export type EntityFilterQuery =
-  | Record<string, string | symbol | (string | symbol)[]>[]
-  | Record<string, string | symbol | (string | symbol)[]>;
+export type EntityFilterQuery = EntityFilterSets | EntityFilterSet;
+
+// @public
+export type EntityFilterSet = Record<
+  string,
+  string | symbol | (string | symbol)[]
+>;
+
+// @public
+export type EntityFilterSets = EntityFilterSet[];
 
 // @public
 export type EntityOrderQuery =
@@ -291,6 +298,12 @@ type Location_2 = {
 export { Location_2 as Location };
 
 // @public
+export function omitEntityFilterQueryKey(
+  key: string,
+  query: EntityFilterQuery,
+): EntityFilterQuery;
+
+// @public
 export type QueryEntitiesCursorRequest = {
   fields?: string[];
   limit?: number;
@@ -324,6 +337,13 @@ export type QueryEntitiesResponse = {
     prevCursor?: string;
   };
 };
+
+// @public
+export function setEntityFilterQueryKey(
+  key: string,
+  value: string | symbol | (string | symbol)[],
+  query: EntityFilterQuery,
+): EntityFilterQuery;
 
 // @public
 export type StreamEntitiesRequest = Omit<

--- a/packages/catalog-client/src/index.ts
+++ b/packages/catalog-client/src/index.ts
@@ -22,3 +22,4 @@
 
 export { CatalogClient } from './CatalogClient';
 export * from './types';
+export { omitEntityFilterQueryKey, setEntityFilterQueryKey } from './utils';

--- a/packages/catalog-client/src/types/api.ts
+++ b/packages/catalog-client/src/types/api.ts
@@ -34,6 +34,23 @@ export const CATALOG_FILTER_EXISTS = Symbol.for(
 );
 
 /**
+ * A single key-value based filter expression for entities.
+ *
+ * @public
+ */
+export type EntityFilterSet = Record<
+  string,
+  string | symbol | (string | symbol)[]
+>;
+
+/**
+ * A collection of key-value based filter expressions for entities.
+ *
+ * @public
+ */
+export type EntityFilterSets = EntityFilterSet[];
+
+/**
  * A key-value based filter expression for entities.
  *
  * @remarks
@@ -75,9 +92,7 @@ export const CATALOG_FILTER_EXISTS = Symbol.for(
  *
  * @public
  */
-export type EntityFilterQuery =
-  | Record<string, string | symbol | (string | symbol)[]>[]
-  | Record<string, string | symbol | (string | symbol)[]>;
+export type EntityFilterQuery = EntityFilterSets | EntityFilterSet;
 
 /**
  * A set of dot-separated paths into an entity's keys, showing what parts of an

--- a/packages/catalog-client/src/types/index.ts
+++ b/packages/catalog-client/src/types/index.ts
@@ -22,6 +22,8 @@ export type {
   CatalogRequestOptions,
   EntityFieldsQuery,
   EntityFilterQuery,
+  EntityFilterSet,
+  EntityFilterSets,
   EntityOrderQuery,
   GetEntitiesByRefsRequest,
   GetEntitiesByRefsResponse,

--- a/packages/catalog-client/src/utils.test.ts
+++ b/packages/catalog-client/src/utils.test.ts
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import { splitRefsIntoChunks } from './utils';
+import {
+  omitEntityFilterQueryKey,
+  setEntityFilterQueryKey,
+  splitRefsIntoChunks,
+} from './utils';
+import { EntityFilterQuery } from './types';
 
 describe('splitRefsIntoChunks', () => {
   it('splits by count limit', () => {
@@ -120,5 +125,69 @@ describe('splitRefsIntoChunks', () => {
         maxCountPerChunk: 2, // the stricter limit now
       }),
     ).toEqual([['aaa', 'bbb'], ['ccc']]);
+  });
+});
+
+describe('omitEntityFilterQueryKey', () => {
+  it('removes a key from a simple query object', () => {
+    const query: EntityFilterQuery = {
+      kind: 'Component',
+      namespace: 'default',
+    };
+    const result = omitEntityFilterQueryKey('namespace', query);
+    expect(result).toEqual({ kind: 'Component' });
+  });
+
+  it('removes a key from each EntityFilterSet', () => {
+    const query: EntityFilterQuery = [
+      { kind: 'Component', namespace: 'default' },
+      { type: 'service', namespace: 'default' },
+    ];
+    const result = omitEntityFilterQueryKey('namespace', query);
+    expect(result).toEqual([{ kind: 'Component' }, { type: 'service' }]);
+  });
+
+  it('returns the same object if the key does not exist', () => {
+    const query: EntityFilterQuery = { kind: 'Component' };
+    const result = omitEntityFilterQueryKey('namespace', query);
+    expect(result).toEqual({ kind: 'Component' });
+  });
+});
+
+describe('setEntityFilterQueryKey', () => {
+  it('sets a key in an EntityFilterSet', () => {
+    const query: EntityFilterQuery = { kind: 'Component' };
+    const result = setEntityFilterQueryKey('namespace', 'default', query);
+    expect(result).toEqual({ kind: 'Component', namespace: 'default' });
+  });
+
+  it('overwrites an existing key in an EntityFilterSet', () => {
+    const query: EntityFilterQuery = { kind: 'Component', namespace: 'old' };
+    const result = setEntityFilterQueryKey('namespace', 'new', query);
+    expect(result).toEqual({ kind: 'Component', namespace: 'new' });
+  });
+
+  it('sets a key in each EntityFilterSet', () => {
+    const query: EntityFilterQuery = [
+      { kind: 'Component' },
+      { type: 'service' },
+    ];
+    const result = setEntityFilterQueryKey('namespace', 'default', query);
+    expect(result).toEqual([
+      { kind: 'Component', namespace: 'default' },
+      { type: 'service', namespace: 'default' },
+    ]);
+  });
+
+  it('overwrites a key in each EntityFilterSet', () => {
+    const query: EntityFilterQuery = [
+      { kind: 'Component', namespace: 'old' },
+      { type: 'service', namespace: 'old' },
+    ];
+    const result = setEntityFilterQueryKey('namespace', 'default', query);
+    expect(result).toEqual([
+      { kind: 'Component', namespace: 'default' },
+      { type: 'service', namespace: 'default' },
+    ]);
   });
 });

--- a/packages/catalog-client/src/utils.ts
+++ b/packages/catalog-client/src/utils.ts
@@ -15,6 +15,8 @@
  */
 
 import {
+  EntityFilterQuery,
+  EntityFilterSets,
   QueryEntitiesCursorRequest,
   QueryEntitiesInitialRequest,
 } from './types/api';
@@ -87,4 +89,40 @@ export function splitRefsIntoChunks(
   chunks.push(refs.slice(currentChunkStart, refs.length));
 
   return chunks;
+}
+
+/**
+ * Utility to remove a key from an EntityFilterQuery
+ *
+ * @public
+ */
+export function omitEntityFilterQueryKey(
+  key: string,
+  query: EntityFilterQuery,
+): EntityFilterQuery {
+  if (!Array.isArray(query)) {
+    const { [key]: _, ...rest } = query;
+    return rest;
+  }
+
+  return query.map(q => omitEntityFilterQueryKey(key, q)) as EntityFilterSets;
+}
+
+/**
+ * Utility to add a key to an EntityFilterQuery
+ *
+ * @public
+ */
+export function setEntityFilterQueryKey(
+  key: string,
+  value: string | symbol | (string | symbol)[],
+  query: EntityFilterQuery,
+): EntityFilterQuery {
+  if (!Array.isArray(query)) {
+    return { ...query, [key]: value };
+  }
+
+  return query.map(q =>
+    setEntityFilterQueryKey(key, value, q),
+  ) as EntityFilterSets;
 }

--- a/plugins/catalog-react/report.api.md
+++ b/plugins/catalog-react/report.api.md
@@ -12,6 +12,7 @@ import { ComponentProps } from 'react';
 import { CompoundEntityRef } from '@backstage/catalog-model';
 import { Context } from 'react';
 import { Entity } from '@backstage/catalog-model';
+import { EntityFilterQuery } from '@backstage/catalog-client';
 import { EntityOrderQuery } from '@backstage/catalog-client';
 import IconButton from '@material-ui/core/IconButton';
 import { IconComponent } from '@backstage/core-plugin-api';
@@ -268,10 +269,7 @@ export class EntityErrorFilter implements EntityFilter {
 
 // @public (undocumented)
 export type EntityFilter = {
-  getCatalogFilters?: () => Record<
-    string,
-    string | symbol | (string | symbol)[]
-  >;
+  getCatalogFilters?: () => EntityFilterQuery;
   filterEntity?: (entity: Entity) => boolean;
   toQueryValue?: () => string | string[];
 };

--- a/plugins/catalog-react/src/components/UserListPicker/useOwnedEntitiesCount.ts
+++ b/plugins/catalog-react/src/components/UserListPicker/useOwnedEntitiesCount.ts
@@ -24,6 +24,10 @@ import { useEntityList } from '../../hooks';
 import { CatalogFilters, reduceCatalogFilters } from '../../utils/filters';
 import useAsyncFn from 'react-use/esm/useAsyncFn';
 import useDeepCompareEffect from 'react-use/esm/useDeepCompareEffect';
+import {
+  omitEntityFilterQueryKey,
+  setEntityFilterQueryKey,
+} from '@backstage/catalog-client';
 
 export function useOwnedEntitiesCount() {
   const identityApi = useApi(identityApiRef);
@@ -60,14 +64,18 @@ export function useOwnedEntitiesCount() {
           return 0;
         }
 
-        const { ['metadata.name']: metadata, ...filter } = req.filter.filter;
+        const filter = omitEntityFilterQueryKey(
+          'metadata.name',
+          req.filter.filter,
+        );
 
         const { totalItems } = await catalogApi.queryEntities({
           ...req.filter,
-          filter: {
-            ...filter,
-            'relations.ownedBy': ownedClaims,
-          },
+          filter: setEntityFilterQueryKey(
+            'relations.ownedBy',
+            ownedClaims,
+            filter,
+          ),
           limit: 0,
         });
         return totalItems;

--- a/plugins/catalog-react/src/types.ts
+++ b/plugins/catalog-react/src/types.ts
@@ -15,6 +15,7 @@
  */
 
 import { Entity } from '@backstage/catalog-model';
+import { EntityFilterQuery } from '@backstage/catalog-client';
 
 /** @public */
 export type EntityFilter = {
@@ -24,10 +25,7 @@ export type EntityFilter = {
    *   `{ field: 'kind', values: ['component'] }`
    *   `{ field: 'metadata.name', values: ['component-1', 'component-2'] }`
    */
-  getCatalogFilters?: () => Record<
-    string,
-    string | symbol | (string | symbol)[]
-  >;
+  getCatalogFilters?: () => EntityFilterQuery;
 
   /**
    * Filter entities on the frontend after a catalog-backend request. This function will be called

--- a/plugins/catalog-react/src/utils/filters.test.ts
+++ b/plugins/catalog-react/src/utils/filters.test.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { reduceCatalogFilters } from './filters';
+import { EntityTextFilter, EntityOrderFilter } from '../filters';
+import { EntityFilter } from '../types';
+
+describe('reduceCatalogFilters', () => {
+  it('should merge catalog filters from multiple filters', () => {
+    const filter1: EntityFilter = {
+      getCatalogFilters: () => ({ kind: 'Component' }),
+    };
+    const filter2: EntityFilter = {
+      getCatalogFilters: () => ({ namespace: 'default' }),
+    };
+
+    const result = reduceCatalogFilters([filter1, filter2]);
+    expect(result.filter).toEqual({ kind: 'Component', namespace: 'default' });
+  });
+
+  it('should overwrite catalog filters from overlapping filters', () => {
+    const filter1: EntityFilter = {
+      getCatalogFilters: () => ({ kind: 'Component' }),
+    };
+    const filter2: EntityFilter = {
+      getCatalogFilters: () => ({ kind: 'User' }),
+    };
+
+    const result = reduceCatalogFilters([filter1, filter2]);
+    expect(result.filter).toEqual({ kind: 'User' });
+  });
+
+  it('should matrix catalog filters from filters that return array', () => {
+    const filter1: EntityFilter = {
+      getCatalogFilters: () => ({ kind: 'Component' }),
+    };
+    const filter2: EntityFilter = {
+      getCatalogFilters: (): Record<string, string>[] => [
+        { namespace: 'default' },
+        { lifecycle: 'production' },
+      ],
+    };
+
+    const result = reduceCatalogFilters([filter1, filter2]);
+    expect(result.filter).toEqual([
+      { kind: 'Component', namespace: 'default' },
+      { kind: 'Component', lifecycle: 'production' },
+    ]);
+  });
+
+  it('should matrix catalog filters from multiple filters that return array', () => {
+    const filter1: EntityFilter = {
+      getCatalogFilters: () => ({ kind: 'Component' }),
+    };
+    const filter2: EntityFilter = {
+      getCatalogFilters: (): Record<string, string>[] => [
+        { namespace: 'default' },
+        { lifecycle: 'production' },
+      ],
+    };
+    const filter3: EntityFilter = {
+      getCatalogFilters: (): Record<string, string>[] => [
+        { type: 'service' },
+        { orphan: 'true' },
+      ],
+    };
+
+    const result = reduceCatalogFilters([filter1, filter2, filter3]);
+    expect(result.filter).toEqual(
+      expect.arrayContaining([
+        { kind: 'Component', namespace: 'default', type: 'service' },
+        { kind: 'Component', lifecycle: 'production', type: 'service' },
+        { kind: 'Component', namespace: 'default', orphan: 'true' },
+        { kind: 'Component', lifecycle: 'production', orphan: 'true' },
+      ]),
+    );
+  });
+
+  it('should extract fullTextFilter from EntityTextFilter', () => {
+    const textFilter = new EntityTextFilter('searchTerm');
+    const result = reduceCatalogFilters([textFilter]);
+    expect(result.fullTextFilter).toMatchObject({ term: 'searchTerm' });
+  });
+
+  it('should extract orderFields from EntityOrderFilter', () => {
+    const orderFilter = new EntityOrderFilter([['metadata.name', 'desc']]);
+    const result = reduceCatalogFilters([orderFilter]);
+    expect(result.orderFields).toEqual([
+      { field: 'metadata.name', order: 'desc' },
+    ]);
+  });
+
+  it('should use default orderFields if no EntityOrderFilter is present', () => {
+    const result = reduceCatalogFilters([]);
+    expect(result.orderFields).toEqual([
+      { field: 'metadata.name', order: 'asc' },
+    ]);
+  });
+});


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This change allows `EntityFilter`s to utilize more complete functionality of the `CatalogApi`, specifically the `queryEntities` and `getEntities` methods which support an `EntityFilterQuery` as the `filter` parameter in the request.

Allowing `EntityFilter`s to return a complete `EntityFilterQuery` allows them to produce more complex filter logic.

The primary example is allowing an `EntityFilter` to produce an array of filter records that would produce an 'OR' query, filtering on A OR B criteria.

To complete this change, some of the helpers and utilities used by Entity filtering functionality (ex: `useEntityListProvider`) needed to be updated to account for the possibility of an array of filter records.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
