### PR TITLE
fix(techdocs): Improve sidebar scrolling area (sticky/scrollbars)

### DIFF
--- a/.changeset/slimy-dots-sing.md
+++ b/.changeset/slimy-dots-sing.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Improve sidebars (nav/TOC) layout and scrolling

--- a/plugins/techdocs/src/reader/transformers/styles/rules/layout.ts
+++ b/plugins/techdocs/src/reader/transformers/styles/rules/layout.ts
@@ -81,15 +81,12 @@ export default ({ theme, sidebar }: RuleOptions) => `
   bottom: 75px;
   position: fixed;
   width: 16rem;
-  overflow-y: auto;
-  overflow-x: hidden;
-  scrollbar-color: rgb(193, 193, 193) #eee;
-  scrollbar-width: thin;
 }
 .md-sidebar .md-sidebar__scrollwrap {
   width: calc(16rem);
-  overflow-y: hidden;
+  height: 100%
 }
+
 @supports selector(::-webkit-scrollbar) {
   [dir=ltr] .md-sidebar__inner {
       padding-right: calc(100% - 15.1rem);
@@ -97,28 +94,6 @@ export default ({ theme, sidebar }: RuleOptions) => `
 }
 .md-sidebar--secondary {
   right: ${theme.spacing(3)}px;
-}
-.md-sidebar::-webkit-scrollbar {
-  width: 5px;
-}
-.md-sidebar::-webkit-scrollbar-button {
-  width: 5px;
-  height: 5px;
-}
-.md-sidebar::-webkit-scrollbar-track {
-  background: #eee;
-  border: 1 px solid rgb(250, 250, 250);
-  box-shadow: 0px 0px 3px #dfdfdf inset;
-  border-radius: 3px;
-}
-.md-sidebar::-webkit-scrollbar-thumb {
-  width: 5px;
-  background: rgb(193, 193, 193);
-  border: transparent;
-  border-radius: 3px;
-}
-.md-sidebar::-webkit-scrollbar-thumb:hover {
-  background: rgb(125, 125, 125);
 }
 
 .md-content {
@@ -155,6 +130,8 @@ export default ({ theme, sidebar }: RuleOptions) => `
 @media screen and (min-width: 76.25em) {
   .md-sidebar {
     height: auto;
+    /* Less padding before the Previous / Next buttons */
+    padding-bottom: 0 !important;
   }
 }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This MR fixes the Techdocs sidebars rendering.

- Scrollbar is properly themed on Firefox/Chrome
  - Safari scrollbar rendering would be improved by #31469
- "Sticky" sidebar title is working properly
- Sidebar content was below the shadow of the title (without scroll)
- Tweaked the next/previous page padding, to help with short windows / long navs
  - Having the prev/next buttons in the sidebar is a Techdocs customization, so no comparison to upstream.

This restores the sidebars scrolling to work like Mkdocs Material.

Before:
<img width="2553" height="1348" alt="Screenshot 2025-10-21 at 10 10 12" src="https://github.com/user-attachments/assets/aa91c0ad-5946-4130-946f-13dbe37d1620" />

After: Notice the slimmer scrollbars (upstream theme) for Chrome/Firefox, the proper spacing between the sidebar title and content
<img width="2553" height="1348" alt="Screenshot 2025-10-21 at 10 09 31" src="https://github.com/user-attachments/assets/8b974865-6fc9-41b0-b085-190e54d0b305" />

Tested with Firefox/Safari/Chrome. 

Also tested with changed from #30499.

### Context

Upstream Mkdocs has a sidebar `scrollwrap` component for sticky nav.
Techdocs customizations was not using it, but instead putting the scroll area directly in the sidebar.

### Risks

This previous tweak may have been needed for somer older Mkdocs versions. I haven' found the any specific reasons yet.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
