### PR TITLE
Fix grammar in GitHub webhook setup instructions

### DIFF
--- a/docs/integrations/github/discovery.md
+++ b/docs/integrations/github/discovery.md
@@ -58,7 +58,7 @@ To receive the `repository.transferred` event, the new owner account must have t
 
 :::
 
-When creating the webhook in GitHub the "Payload URL" will looks something along these lines: `https://<your-intance-name>/api/events/http/github` and the "Content Type" should be `application/json`.
+When creating the webhook in GitHub the "Payload URL" will looks something along these lines: `https://<your-instance-name>/api/events/http/github` and the "Content Type" should be `application/json`.
 
 The GitHub Webhooks UI will send a trial event to validate it can connect when you save your new Webhook. It is possible to retry this trial event if it fails and you want to send it again. Additionally there is a Recent Deliveries tab you can use to validate that the events are being fired should you need to do any later troubleshooting.
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Corrected grammatical errors in webhook instructions.
Fixing page: https://backstage.io/docs/integrations/github/discovery/#prerequisites

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
