### PR TITLE
add custom expectation message field for Catalog validator override

### DIFF
--- a/.changeset/giant-hands-smell.md
+++ b/.changeset/giant-hands-smell.md
@@ -1,0 +1,35 @@
+---
+'@backstage/plugin-catalog-backend': patch
+'@backstage/catalog-model': patch
+'@backstage/plugin-catalog-node': patch
+---
+
+Adds an optional expectations field to setFieldValidators(). It provides custom expectation messages that will be shown upon failure for the associated field type.
+
+```diff
+catalogModel.setFieldValidators(
+    {
+    // This is only one of many methods that you can pass into
+    // setFieldValidators; your editor of choice should help you
+    // find the others. The length checks and regexp inside are
+    // just examples and can be adjusted as needed, but take care
+    // to test your changes thoroughly to ensure that you get
+    // them right.
+    isValidEntityName(value) {
+        return (
+            typeof value === 'string' &&
+            value.length >= 1 &&
+            value.length <= 63 &&
+            /^[A-Za-z0-9]+$/.test(value)
+        );
+    },
+    },
++    {
++   // Optional: provide custom expectation messages that will be
++   // shown when validation fails. This helps users understand
++   // what format is expected for your custom validators.
++    isValidEntityName:
++   'a string of 1-63 characters containing only letters and numbers.',
++    },
+);
+```

--- a/docs/features/software-catalog/extending-the-model.md
+++ b/docs/features/software-catalog/extending-the-model.md
@@ -143,7 +143,8 @@ of the base envelope and metadata make sense - in short, things that aren't
 entity-kind-specific. Some or all of these validators can be replaced when
 building the backend using the catalog's dedicated `catalogModelExtensionPoint`
 (or directly on the `CatalogBuilder` if you are still using the old backend
-system).
+system). You can also optionally provide custom expectation messages that will
+be shown in validation error messages when using custom validators.
 
 The risk and impact of this type of extension varies, based on what it is that
 you want to do. For example, extending the valid character set for kinds,
@@ -177,22 +178,31 @@ const myCatalogCustomizations = createBackendModule({
         catalogModel: catalogModelExtensionPoint,
       },
       async init({ catalogModel }) {
-        catalogModel.setFieldValidators({
-          // This is only one of many methods that you can pass into
-          // setFieldValidators; your editor of choice should help you
-          // find the others. The length checks and regexp inside are
-          // just examples and can be adjusted as needed, but take care
-          // to test your changes thoroughly to ensure that you get
-          // them right.
-          isValidEntityName(value) {
-            return (
-              typeof value === 'string' &&
-              value.length >= 1 &&
-              value.length <= 63 &&
-              /^[A-Za-z0-9@+_.-]+$/.test(value)
-            );
+        catalogModel.setFieldValidators(
+          {
+            // This is only one of many methods that you can pass into
+            // setFieldValidators; your editor of choice should help you
+            // find the others. The length checks and regexp inside are
+            // just examples and can be adjusted as needed, but take care
+            // to test your changes thoroughly to ensure that you get
+            // them right.
+            isValidEntityName(value) {
+              return (
+                typeof value === 'string' &&
+                value.length >= 1 &&
+                value.length <= 63 &&
+                /^[A-Za-z0-9@+_.-]+$/.test(value)
+              );
+            },
           },
-        });
+          {
+            // Optional: provide custom expectation messages that will be
+            // shown when validation fails. This helps users understand
+            // what format is expected for your custom validators.
+            isValidEntityName:
+              'a string of 1-63 characters containing letters, numbers, and the characters @+_.-',
+          },
+        );
       },
     });
   },

--- a/packages/catalog-model/report.api.md
+++ b/packages/catalog-model/report.api.md
@@ -208,7 +208,7 @@ export function entitySchemaValidator<T extends Entity = Entity>(
 
 // @public
 export class FieldFormatEntityPolicy implements EntityPolicy {
-  constructor(validators?: Validators);
+  constructor(validators?: Validators, expectations?: ValidatorExpectations);
   // (undocumented)
   enforce(entity: Entity): Promise<Entity>;
 }
@@ -486,6 +486,11 @@ export { UserEntityV1alpha1 };
 
 // @public
 export const userEntityV1alpha1Validator: KindValidator;
+
+// @public
+export type ValidatorExpectations = {
+  [K in keyof Validators]?: string;
+};
 
 // @public
 export type Validators = {

--- a/packages/catalog-model/src/entity/policies/FieldFormatEntityPolicy.ts
+++ b/packages/catalog-model/src/entity/policies/FieldFormatEntityPolicy.ts
@@ -19,6 +19,7 @@ import {
   CommonValidatorFunctions,
   KubernetesValidatorFunctions,
   makeValidator,
+  ValidatorExpectations,
   Validators,
 } from '../../validation';
 import { Entity } from '../Entity';
@@ -35,17 +36,23 @@ import { Entity } from '../Entity';
  */
 export class FieldFormatEntityPolicy implements EntityPolicy {
   private readonly validators: Validators;
+  private readonly expectations?: ValidatorExpectations;
 
-  constructor(validators: Validators = makeValidator()) {
+  constructor(
+    validators: Validators = makeValidator(),
+    expectations?: ValidatorExpectations,
+  ) {
     this.validators = validators;
+    this.expectations = expectations;
   }
 
   async enforce(entity: Entity): Promise<Entity> {
-    function require(
+    const require = (
       field: string,
       value: any,
       validator: (value: any) => boolean,
-    ) {
+      validatorKey?: keyof Validators,
+    ) => {
       if (value === undefined || value === null) {
         throw new Error(`${field} must have a value`);
       }
@@ -59,47 +66,54 @@ export class FieldFormatEntityPolicy implements EntityPolicy {
 
       if (!isValid) {
         let expectation;
-        switch (
-          validator.name as
-            | keyof typeof KubernetesValidatorFunctions
-            | keyof typeof CommonValidatorFunctions
-        ) {
-          case 'isValidLabelValue':
-          case 'isValidObjectName':
-            expectation =
-              'a string that is sequences of [a-zA-Z0-9] separated by any of [-_.], at most 63 characters in total';
-            break;
-          case 'isValidLabelKey':
-          case 'isValidApiVersion':
-          case 'isValidAnnotationKey':
-            expectation = 'a valid prefix and/or suffix';
-            break;
-          case 'isValidNamespace':
-          case 'isValidDnsLabel':
-            expectation =
-              'a string that is sequences of [a-z0-9] separated by [-], at most 63 characters in total';
-            break;
-          case 'isValidTag':
-            expectation =
-              'a string that is sequences of [a-z0-9+#] separated by [-], at most 63 characters in total';
-            break;
-          case 'isValidAnnotationValue':
-            expectation = 'a string';
-            break;
-          case 'isValidKind':
-            expectation =
-              'a string that is a sequence of [a-zA-Z][a-z0-9A-Z], at most 63 characters in total';
-            break;
-          case 'isValidUrl':
-            expectation = 'a string that is a valid url';
-            break;
-          case 'isValidString':
-          case 'isNonEmptyString':
-            expectation = 'a non empty string';
-            break;
-          default:
-            expectation = undefined;
-            break;
+
+        // First check for custom expectation value
+        if (validatorKey && this.expectations?.[validatorKey]) {
+          expectation = this.expectations[validatorKey];
+        } else {
+          // Fall back to hardcoded expectations based on function name
+          switch (
+            validator.name as
+              | keyof typeof KubernetesValidatorFunctions
+              | keyof typeof CommonValidatorFunctions
+          ) {
+            case 'isValidLabelValue':
+            case 'isValidObjectName':
+              expectation =
+                'a string that is sequences of [a-zA-Z0-9] separated by any of [-_.], at most 63 characters in total';
+              break;
+            case 'isValidLabelKey':
+            case 'isValidApiVersion':
+            case 'isValidAnnotationKey':
+              expectation = 'a valid prefix and/or suffix';
+              break;
+            case 'isValidNamespace':
+            case 'isValidDnsLabel':
+              expectation =
+                'a string that is sequences of [a-z0-9] separated by [-], at most 63 characters in total';
+              break;
+            case 'isValidTag':
+              expectation =
+                'a string that is sequences of [a-z0-9+#] separated by [-], at most 63 characters in total';
+              break;
+            case 'isValidAnnotationValue':
+              expectation = 'a string';
+              break;
+            case 'isValidKind':
+              expectation =
+                'a string that is a sequence of [a-zA-Z][a-z0-9A-Z], at most 63 characters in total';
+              break;
+            case 'isValidUrl':
+              expectation = 'a string that is a valid url';
+              break;
+            case 'isValidString':
+            case 'isNonEmptyString':
+              expectation = 'a non empty string';
+              break;
+            default:
+              expectation = undefined;
+              break;
+          }
         }
 
         // ensure that if there are other/future validators, the error message defaults to a general "is not valid, visit link"
@@ -111,41 +125,50 @@ export class FieldFormatEntityPolicy implements EntityPolicy {
           `"${field}" is not valid;${message} To learn more about catalog file format, visit: https://github.com/backstage/backstage/blob/master/docs/architecture-decisions/adr002-default-catalog-file-format.md`,
         );
       }
-    }
+    };
 
-    function optional(
+    const optional = (
       field: string,
       value: any,
       validator: (value: any) => boolean,
-    ) {
-      return value === undefined || require(field, value, validator);
-    }
+      validatorKey?: keyof Validators,
+    ) => {
+      return (
+        value === undefined || require(field, value, validator, validatorKey)
+      );
+    };
 
-    require('apiVersion', entity.apiVersion, this.validators.isValidApiVersion);
-    require('kind', entity.kind, this.validators.isValidKind);
+    require('apiVersion', entity.apiVersion, this.validators
+      .isValidApiVersion, 'isValidApiVersion');
+    require('kind', entity.kind, this.validators.isValidKind, 'isValidKind');
 
     require('metadata.name', entity.metadata.name, this.validators
-      .isValidEntityName);
+      .isValidEntityName, 'isValidEntityName');
     optional(
       'metadata.namespace',
       entity.metadata.namespace,
       this.validators.isValidNamespace,
+      'isValidNamespace',
     );
 
     for (const [k, v] of Object.entries(entity.metadata.labels ?? [])) {
-      require(`labels.${k}`, k, this.validators.isValidLabelKey);
-      require(`labels.${k}`, v, this.validators.isValidLabelValue);
+      require(`labels.${k}`, k, this.validators
+        .isValidLabelKey, 'isValidLabelKey');
+      require(`labels.${k}`, v, this.validators
+        .isValidLabelValue, 'isValidLabelValue');
     }
 
     for (const [k, v] of Object.entries(entity.metadata.annotations ?? [])) {
-      require(`annotations.${k}`, k, this.validators.isValidAnnotationKey);
-      require(`annotations.${k}`, v, this.validators.isValidAnnotationValue);
+      require(`annotations.${k}`, k, this.validators
+        .isValidAnnotationKey, 'isValidAnnotationKey');
+      require(`annotations.${k}`, v, this.validators
+        .isValidAnnotationValue, 'isValidAnnotationValue');
     }
 
     const tags = entity.metadata.tags ?? [];
 
     for (let i = 0; i < tags.length; ++i) {
-      require(`tags.${i}`, tags[i], this.validators.isValidTag);
+      require(`tags.${i}`, tags[i], this.validators.isValidTag, 'isValidTag');
     }
 
     const links = entity.metadata.links ?? [];

--- a/packages/catalog-model/src/validation/index.ts
+++ b/packages/catalog-model/src/validation/index.ts
@@ -20,4 +20,4 @@ export { entityKindSchemaValidator } from './entityKindSchemaValidator';
 export { entitySchemaValidator } from './entitySchemaValidator';
 export { KubernetesValidatorFunctions } from './KubernetesValidatorFunctions';
 export { makeValidator } from './makeValidator';
-export type { Validators } from './types';
+export type { ValidatorExpectations, Validators } from './types';

--- a/packages/catalog-model/src/validation/types.ts
+++ b/packages/catalog-model/src/validation/types.ts
@@ -30,3 +30,12 @@ export type Validators = {
   isValidAnnotationValue(value: unknown): boolean;
   isValidTag(value: unknown): boolean;
 };
+
+/**
+ * Type for providing custom expectation messages for validators.
+ *
+ * @public
+ */
+export type ValidatorExpectations = {
+  [K in keyof Validators]?: string;
+};

--- a/plugins/catalog-backend/src/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.ts
@@ -23,6 +23,7 @@ import {
   makeValidator,
   NoForeignRootFieldsEntityPolicy,
   SchemaValidEntityPolicy,
+  ValidatorExpectations,
   Validators,
 } from '@backstage/catalog-model';
 import { ScmIntegrations } from '@backstage/integration';
@@ -156,6 +157,7 @@ export class CatalogBuilder {
   private entityPoliciesReplace: boolean;
   private placeholderResolvers: Record<string, PlaceholderResolver>;
   private fieldFormatValidators: Partial<Validators>;
+  private fieldFormatValidatorExpectations: Partial<ValidatorExpectations>;
   private entityProviders: EntityProvider[];
   private processors: CatalogProcessor[];
   private locationAnalyzers: ScmLocationAnalyzer[];
@@ -184,6 +186,7 @@ export class CatalogBuilder {
     this.entityPoliciesReplace = false;
     this.placeholderResolvers = {};
     this.fieldFormatValidators = {};
+    this.fieldFormatValidatorExpectations = {};
     this.entityProviders = [];
     this.processors = [];
     this.locationAnalyzers = [];
@@ -267,9 +270,16 @@ export class CatalogBuilder {
    * {@link CatalogBuilder#replaceEntityPolicies}.
    *
    * @param validators - The (subset of) validators to set
+   * @param expectations - Optional expectation messages for custom validators
    */
-  setFieldFormatValidators(validators: Partial<Validators>): CatalogBuilder {
+  setFieldFormatValidators(
+    validators: Partial<Validators>,
+    expectations?: Partial<ValidatorExpectations>,
+  ): CatalogBuilder {
     lodash.merge(this.fieldFormatValidators, validators);
+    if (expectations) {
+      lodash.merge(this.fieldFormatValidatorExpectations, expectations);
+    }
     return this;
   }
 
@@ -628,6 +638,7 @@ export class CatalogBuilder {
           new NoForeignRootFieldsEntityPolicy(),
           new FieldFormatEntityPolicy(
             makeValidator(this.fieldFormatValidators),
+            this.fieldFormatValidatorExpectations,
           ),
           ...this.entityPolicies,
         ];

--- a/plugins/catalog-backend/src/service/CatalogPlugin.ts
+++ b/plugins/catalog-backend/src/service/CatalogPlugin.ts
@@ -17,7 +17,11 @@ import {
   coreServices,
   createBackendPlugin,
 } from '@backstage/backend-plugin-api';
-import { Entity, Validators } from '@backstage/catalog-model';
+import {
+  Entity,
+  ValidatorExpectations,
+  Validators,
+} from '@backstage/catalog-model';
 import { ForwardedError } from '@backstage/errors';
 import {
   CatalogProcessor,
@@ -147,13 +151,24 @@ class CatalogPermissionExtensionPointImpl
 
 class CatalogModelExtensionPointImpl implements CatalogModelExtensionPoint {
   #fieldValidators: Partial<Validators> = {};
+  #fieldValidatorExpectations: Partial<ValidatorExpectations> = {};
 
-  setFieldValidators(validators: Partial<Validators>): void {
+  setFieldValidators(
+    validators: Partial<Validators>,
+    expectations?: Partial<ValidatorExpectations>,
+  ): void {
     merge(this.#fieldValidators, validators);
+    if (expectations) {
+      merge(this.#fieldValidatorExpectations, expectations);
+    }
   }
 
   get fieldValidators() {
     return this.#fieldValidators;
+  }
+
+  get fieldValidatorExpectations() {
+    return this.#fieldValidatorExpectations;
   }
 
   #entityDataParser?: CatalogProcessorParser;
@@ -301,7 +316,10 @@ export const catalogPlugin = createBackendPlugin({
         }
         builder.addPermissions(...permissionExtensions.permissions);
         builder.addPermissionRules(...permissionExtensions.permissionRules);
-        builder.setFieldFormatValidators(modelExtensions.fieldValidators);
+        builder.setFieldFormatValidators(
+          modelExtensions.fieldValidators,
+          modelExtensions.fieldValidatorExpectations,
+        );
 
         if (locationTypeExtensions.allowedLocationTypes) {
           builder.setAllowedLocationTypes(

--- a/plugins/catalog-node/report-alpha.api.md
+++ b/plugins/catalog-node/report-alpha.api.md
@@ -18,6 +18,7 @@ import { PermissionRuleParams } from '@backstage/plugin-permission-common';
 import { PlaceholderResolver } from '@backstage/plugin-catalog-node';
 import { ScmLocationAnalyzer } from '@backstage/plugin-catalog-node';
 import { ServiceRef } from '@backstage/backend-plugin-api';
+import { ValidatorExpectations } from '@backstage/catalog-model';
 import { Validators } from '@backstage/catalog-model';
 
 // @alpha (undocumented)
@@ -54,7 +55,10 @@ export const catalogLocationsExtensionPoint: ExtensionPoint<CatalogLocationsExte
 // @alpha (undocumented)
 export interface CatalogModelExtensionPoint {
   setEntityDataParser(parser: CatalogProcessorParser): void;
-  setFieldValidators(validators: Partial<Validators>): void;
+  setFieldValidators(
+    validators: Partial<Validators>,
+    expectations?: Partial<ValidatorExpectations>,
+  ): void;
 }
 
 // @alpha (undocumented)

--- a/plugins/catalog-node/src/extensions.ts
+++ b/plugins/catalog-node/src/extensions.ts
@@ -15,7 +15,11 @@
  */
 
 import { createExtensionPoint } from '@backstage/backend-plugin-api';
-import { Entity, Validators } from '@backstage/catalog-model';
+import {
+  Entity,
+  ValidatorExpectations,
+  Validators,
+} from '@backstage/catalog-model';
 import {
   CatalogProcessor,
   CatalogProcessorParser,
@@ -105,8 +109,12 @@ export interface CatalogModelExtensionPoint {
    * not sufficient.
    *
    * @param validators - The (subset of) validators to set
+   * @param expectations - Optional expectation messages for custom validators
    */
-  setFieldValidators(validators: Partial<Validators>): void;
+  setFieldValidators(
+    validators: Partial<Validators>,
+    expectations?: Partial<ValidatorExpectations>,
+  ): void;
 
   /**
    * Sets the entity data parser which is used to read raw data from locations


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Noticed some user confusion when utilizing the extension setFieldValidators() - if the regex is overridden and validation fails, the resulting logs are less verbose / helpful in determining what went wrong. This PR provides an additional optional field to the extension - allowing the module overriding the validation function to also provide an expectation string associated with the new function, which will get injected into any failure logs. Made as a patch change given new fields are entirely optional / backwards compatible. Open to any feedback!

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
