### PR TITLE
feat(catalog): allow processors to emit status items

### DIFF
--- a/.changeset/sixty-shirts-sink.md
+++ b/.changeset/sixty-shirts-sink.md
@@ -1,0 +1,20 @@
+---
+'@backstage/plugin-catalog-backend': patch
+'@backstage/catalog-model': patch
+'@backstage/plugin-catalog-node': patch
+'@backstage/plugin-catalog': patch
+---
+
+Allow entity processors to add status items to an entity.
+
+This change enables entity processors to contribute status items to entities during processing.
+Status items can provide valuable insights into the state of an entity, such as validation results or processing outcomes.
+
+To add status items, entity processors can now use the `status` method available in the `processingResult`, like so:
+
+```ts
+emit(processingResult.status('This is a status message', 'info'));
+```
+
+The `AlphaEntity` export has now been deprecated and the `status` field has been added to the main `Entity` type in
+`@backstage/catalog-model`.

--- a/docs/features/software-catalog/extending-the-model.md
+++ b/docs/features/software-catalog/extending-the-model.md
@@ -580,9 +580,22 @@ export class FoobarEntitiesProcessor implements CatalogProcessor {
       // Typically you will want to emit any relations associated with the
       // entity here.
       emit(processingResult.relation({ ... }))
+
+      // Or you might want to emit status items based on the entity's data
+      if(entity.spec.someField === 'someCondition') {
+        // Emit a warning status item
+        emit(processingResult.status('Foobar entity is in a warning state', 'warning'));
+      } else if(entity.spec.someField === 'errorCondition') {
+        // Emit an error status item
+        emit(processingResult.status('Foobar entity is in an error state', 'error'));
+      } else {
+        // Or emit informational status items
+        emit(processingResult.status('This is a status message', 'info'));
+      }
     }
 
-    return entity;
+    // Return the (possibly mutated) entity
+    return {...entity, spec: { ...entity.spec, newField: 'someValue' }};
   }
 }
 ```

--- a/packages/catalog-model/report-alpha.api.md
+++ b/packages/catalog-model/report-alpha.api.md
@@ -6,17 +6,17 @@
 import { Entity } from '@backstage/catalog-model';
 import { SerializedError } from '@backstage/errors';
 
-// @alpha
+// @alpha @deprecated
 export interface AlphaEntity extends Entity {
   status?: EntityStatus;
 }
 
-// @alpha
+// @public
 export type EntityStatus = {
   items?: EntityStatusItem[];
 };
 
-// @alpha
+// @public
 export type EntityStatusItem = {
   type: string;
   level: EntityStatusLevel;
@@ -24,7 +24,7 @@ export type EntityStatusItem = {
   error?: SerializedError;
 };
 
-// @alpha
+// @public
 export type EntityStatusLevel = 'info' | 'warning' | 'error';
 
 // (No @packageDocumentation comment for this package)

--- a/packages/catalog-model/report.api.md
+++ b/packages/catalog-model/report.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 import { JsonObject } from '@backstage/types';
+import { SerializedError } from '@backstage/errors';
 
 // @public
 export const ANNOTATION_EDIT_URL = 'backstage.io/edit-url';
@@ -140,6 +141,7 @@ export type Entity = {
   metadata: EntityMeta;
   spec?: JsonObject;
   relations?: EntityRelation[];
+  status?: EntityStatus;
 };
 
 // @public
@@ -205,6 +207,22 @@ export type EntityRelation = {
 export function entitySchemaValidator<T extends Entity = Entity>(
   schema?: unknown,
 ): (data: unknown) => T;
+
+// @public
+export type EntityStatus = {
+  items?: EntityStatusItem[];
+};
+
+// @public
+export type EntityStatusItem = {
+  type: string;
+  level: EntityStatusLevel;
+  message: string;
+  error?: SerializedError;
+};
+
+// @public
+export type EntityStatusLevel = 'info' | 'warning' | 'error';
 
 // @public
 export class FieldFormatEntityPolicy implements EntityPolicy {

--- a/packages/catalog-model/src/entity/AlphaEntity.ts
+++ b/packages/catalog-model/src/entity/AlphaEntity.ts
@@ -27,6 +27,7 @@ import { EntityStatus } from './EntityStatus';
  * Available via the `@backstage/catalog-model/alpha` import.
  *
  * @alpha
+ * @deprecated use `Entity` from `@backstage/catalog-model` instead. The `status` field is now stable.
  */
 export interface AlphaEntity extends Entity {
   /**

--- a/packages/catalog-model/src/entity/Entity.ts
+++ b/packages/catalog-model/src/entity/Entity.ts
@@ -15,6 +15,7 @@
  */
 
 import { JsonObject } from '@backstage/types';
+import { EntityStatus } from './EntityStatus';
 
 /**
  * The parts of the format that's common to all versions/kinds of entity.
@@ -51,6 +52,14 @@ export type Entity = {
    * The relations that this entity has with other entities.
    */
   relations?: EntityRelation[];
+
+  /**
+   * The current status of the entity, as claimed by various sources.
+   *
+   * The keys are implementation defined and the values can be any JSON object
+   * with semantics that match that implementation.
+   */
+  status?: EntityStatus;
 };
 
 /**

--- a/packages/catalog-model/src/entity/EntityStatus.ts
+++ b/packages/catalog-model/src/entity/EntityStatus.ts
@@ -19,7 +19,7 @@ import { SerializedError } from '@backstage/errors';
 /**
  * The current status of the entity, as claimed by various sources.
  *
- * @alpha
+ * @public
  */
 export type EntityStatus = {
   /**
@@ -30,7 +30,7 @@ export type EntityStatus = {
 
 /**
  * A specific status item on a well known format.
- * @alpha
+ * @public
  */
 export type EntityStatusItem = {
   /**
@@ -56,7 +56,7 @@ export type EntityStatusItem = {
 
 /**
  * Each entity status item has a level, describing its severity.
- * @alpha
+ * @public
  */
 export type EntityStatusLevel =
   | 'info' // Only informative data

--- a/packages/catalog-model/src/index.ts
+++ b/packages/catalog-model/src/index.ts
@@ -26,3 +26,8 @@ export * from './kinds';
 export * from './location';
 export type { CompoundEntityRef } from './types';
 export * from './validation';
+export type {
+  EntityStatus,
+  EntityStatusItem,
+  EntityStatusLevel,
+} from './entity/EntityStatus';

--- a/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.test.ts
+++ b/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.test.ts
@@ -71,6 +71,7 @@ class FooBarProcessor implements CatalogProcessor {
           target: { kind: 'foobar', name: 'my-target', namespace: 'default' },
         }),
       );
+      emit(processingResult.status('This is a status message', 'info'));
     }
     return entity;
   }
@@ -121,7 +122,18 @@ describe('DefaultCatalogProcessingOrchestrator', () => {
         }),
       ).resolves.toEqual({
         ok: true,
-        completedEntity: entity,
+        completedEntity: {
+          ...entity,
+          status: {
+            items: [
+              {
+                level: 'info',
+                message: 'This is a status message',
+                type: 'backstage.io/catalog-processing',
+              },
+            ],
+          },
+        },
         refreshKeys: [],
         deferredEntities: [
           {

--- a/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.ts
+++ b/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.ts
@@ -176,8 +176,16 @@ export class DefaultCatalogProcessingOrchestrator
         }
       }
 
+      entity.status =
+        collectorResults.statusItems.length > 0
+          ? { items: collectorResults.statusItems }
+          : undefined;
+
       return {
-        ...collectorResults,
+        relations: collectorResults.relations,
+        refreshKeys: collectorResults.refreshKeys,
+        deferredEntities: collectorResults.deferredEntities,
+        errors: collectorResults.errors,
         completedEntity: entity,
         state: { cache: cache.collect() },
         ok: collectorResults.errors.length === 0,

--- a/plugins/catalog-backend/src/processing/ProcessorOutputCollector.ts
+++ b/plugins/catalog-backend/src/processing/ProcessorOutputCollector.ts
@@ -18,6 +18,7 @@ import {
   ANNOTATION_LOCATION,
   ANNOTATION_ORIGIN_LOCATION,
   Entity,
+  EntityStatusItem,
   stringifyEntityRef,
   stringifyLocationRef,
 } from '@backstage/catalog-model';
@@ -45,6 +46,7 @@ export class ProcessorOutputCollector {
   private readonly relations = new Array<EntityRelationSpec>();
   private readonly deferredEntities = new Array<DeferredEntity>();
   private readonly refreshKeys = new Array<RefreshKeyData>();
+  private readonly statusItems = new Array<EntityStatusItem>();
   private done = false;
 
   constructor(
@@ -72,6 +74,7 @@ export class ProcessorOutputCollector {
       relations: this.relations,
       refreshKeys: this.refreshKeys,
       deferredEntities: this.deferredEntities,
+      statusItems: this.statusItems,
     };
   }
 
@@ -153,6 +156,8 @@ export class ProcessorOutputCollector {
       this.errors.push(i.error);
     } else if (i.type === 'refresh') {
       this.refreshKeys.push({ key: i.key });
+    } else if (i.type === 'status') {
+      this.statusItems.push(i.status);
     }
   }
 }

--- a/plugins/catalog-node/report.api.md
+++ b/plugins/catalog-node/report.api.md
@@ -11,6 +11,8 @@ import { AnalyzeLocationResponse } from '@backstage/plugin-catalog-common';
 import { BackstageCredentials } from '@backstage/backend-plugin-api';
 import { CompoundEntityRef } from '@backstage/catalog-model';
 import { Entity } from '@backstage/catalog-model';
+import { EntityStatusItem } from '@backstage/catalog-model';
+import { EntityStatusLevel } from '@backstage/catalog-model';
 import { GetEntitiesByRefsRequest } from '@backstage/catalog-client';
 import { GetEntitiesByRefsResponse } from '@backstage/catalog-client';
 import { GetEntitiesRequest } from '@backstage/catalog-client';
@@ -117,7 +119,14 @@ export type CatalogProcessorResult =
   | CatalogProcessorEntityResult
   | CatalogProcessorRelationResult
   | CatalogProcessorErrorResult
-  | CatalogProcessorRefreshKeysResult;
+  | CatalogProcessorRefreshKeysResult
+  | CatalogProcessorStatusResult;
+
+// @public (undocumented)
+export type CatalogProcessorStatusResult = {
+  type: 'status';
+  status: EntityStatusItem;
+};
 
 // @public
 export interface CatalogService {
@@ -363,6 +372,12 @@ export const processingResult: Readonly<{
   ) => CatalogProcessorResult;
   readonly relation: (spec: EntityRelationSpec) => CatalogProcessorResult;
   readonly refresh: (key: string) => CatalogProcessorResult;
+  readonly status: (
+    message: string,
+    level: EntityStatusLevel,
+    type?: string,
+    error?: Error,
+  ) => CatalogProcessorResult;
 }>;
 
 // @public (undocumented)

--- a/plugins/catalog-node/src/api/index.ts
+++ b/plugins/catalog-node/src/api/index.ts
@@ -32,6 +32,7 @@ export type {
   CatalogProcessorErrorResult,
   CatalogProcessorResult,
   CatalogProcessorRefreshKeysResult,
+  CatalogProcessorStatusResult,
 } from './processor';
 export type {
   EntityProvider,

--- a/plugins/catalog-node/src/api/processingResult.ts
+++ b/plugins/catalog-node/src/api/processingResult.ts
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-import { InputError, NotFoundError } from '@backstage/errors';
-import { Entity } from '@backstage/catalog-model';
+import { InputError, NotFoundError, serializeError } from '@backstage/errors';
+import { Entity, EntityStatusLevel } from '@backstage/catalog-model';
 import { CatalogProcessorResult } from './processor';
 import { EntityRelationSpec } from './common';
 import { LocationSpec } from '@backstage/plugin-catalog-common';
+import { ENTITY_STATUS_CATALOG_PROCESSING_TYPE } from '@backstage/catalog-client';
 
 /**
  * Factory functions for the standard processing result types.
@@ -42,6 +43,8 @@ export const processingResult = Object.freeze({
 
   /**
    * Associates an InputError with the processing state of the current entity.
+   *
+   * TODO: Should this be deprecated in favor of `status`?
    */
   inputError(
     atLocation: LocationSpec,
@@ -56,6 +59,8 @@ export const processingResult = Object.freeze({
 
   /**
    * Associates a general Error with the processing state of the current entity.
+   *
+   * TODO: Should this be deprecated in favor of `status`?
    */
   generalError(
     atLocation: LocationSpec,
@@ -112,5 +117,25 @@ export const processingResult = Object.freeze({
    */
   refresh(key: string): CatalogProcessorResult {
     return { type: 'refresh', key };
+  },
+
+  /**
+   * Associates a status item with the processing state of the current entity.
+   */
+  status(
+    message: string,
+    level: EntityStatusLevel,
+    type?: string,
+    error?: Error,
+  ): CatalogProcessorResult {
+    return {
+      type: 'status',
+      status: {
+        type: type ?? ENTITY_STATUS_CATALOG_PROCESSING_TYPE,
+        message,
+        level,
+        error: error ? serializeError(error) : undefined,
+      },
+    };
   },
 } as const);

--- a/plugins/catalog-node/src/api/processor.ts
+++ b/plugins/catalog-node/src/api/processor.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Entity } from '@backstage/catalog-model';
+import { Entity, EntityStatusItem } from '@backstage/catalog-model';
 import { JsonValue } from '@backstage/types';
 import { EntityRelationSpec } from './common';
 import { LocationSpec } from '@backstage/plugin-catalog-common';
@@ -186,9 +186,16 @@ export type CatalogProcessorRefreshKeysResult = {
 };
 
 /** @public */
+export type CatalogProcessorStatusResult = {
+  type: 'status';
+  status: EntityStatusItem;
+};
+
+/** @public */
 export type CatalogProcessorResult =
   | CatalogProcessorLocationResult
   | CatalogProcessorEntityResult
   | CatalogProcessorRelationResult
   | CatalogProcessorErrorResult
-  | CatalogProcessorRefreshKeysResult;
+  | CatalogProcessorRefreshKeysResult
+  | CatalogProcessorStatusResult;

--- a/plugins/catalog/src/components/EntityProcessingErrorsPanel/EntityProcessingErrorsPanel.tsx
+++ b/plugins/catalog/src/components/EntityProcessingErrorsPanel/EntityProcessingErrorsPanel.tsx
@@ -14,8 +14,11 @@
  * limitations under the License.
  */
 
-import { AlphaEntity, EntityStatusItem } from '@backstage/catalog-model/alpha';
-import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
+import {
+  Entity,
+  EntityStatusItem,
+  stringifyEntityRef,
+} from '@backstage/catalog-model';
 import {
   catalogApiRef,
   EntityRefLink,
@@ -27,7 +30,7 @@ import {
   CatalogApi,
   ENTITY_STATUS_CATALOG_PROCESSING_TYPE,
 } from '@backstage/catalog-client';
-import { useApi, ApiHolder } from '@backstage/core-plugin-api';
+import { ApiHolder, useApi } from '@backstage/core-plugin-api';
 import useAsync from 'react-use/esm/useAsync';
 import { SerializedError } from '@backstage/errors';
 import { catalogTranslationRef } from '../../alpha/translation';
@@ -52,7 +55,7 @@ async function getOwnAndAncestorsErrors(
   const ancestors = await catalogApi.getEntityAncestors({ entityRef });
   const items = ancestors.items
     .map(item => {
-      const statuses = (item.entity as AlphaEntity).status?.items ?? [];
+      const statuses = (item.entity as Entity).status?.items ?? [];
       const errors = statuses
         .filter(errorFilter)
         .map(e => e.error)


### PR DESCRIPTION
## Hey, I just made a Pull Request!

this change allows catalog processors to emit status items to be shown in the NFS catalog page.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
