### PR TITLE
Fix package name plugin infix with yarn new

### DIFF
--- a/.changeset/funny-stars-open.md
+++ b/.changeset/funny-stars-open.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Fix inconsistent behavior in the `new` command for the `@internal` scope: it now consistently defaults to the `backstage-plugin-` infix whether the `--scope` option is not set or it's set to `internal`.

--- a/packages/cli/src/modules/new/lib/preparation/loadPortableTemplateConfig.test.ts
+++ b/packages/cli/src/modules/new/lib/preparation/loadPortableTemplateConfig.test.ts
@@ -196,7 +196,7 @@ describe('loadPortableTemplateConfig', () => {
       private: true,
       version: '0.1.0',
       packageNamePrefix: '@internal/',
-      packageNamePluginInfix: 'plugin-',
+      packageNamePluginInfix: 'backstage-plugin-',
     });
   });
 
@@ -316,7 +316,7 @@ describe('loadPortableTemplateConfig', () => {
       version: '0.1.0',
       private: true,
       packageNamePrefix: '@internal/',
-      packageNamePluginInfix: 'plugin-',
+      packageNamePluginInfix: 'backstage-plugin-',
     });
 
     await expect(
@@ -333,7 +333,7 @@ describe('loadPortableTemplateConfig', () => {
       version: '0.1.0',
       private: true,
       packageNamePrefix: '@internal/',
-      packageNamePluginInfix: 'plugin-',
+      packageNamePluginInfix: 'backstage-plugin-',
     });
   });
 });

--- a/packages/cli/src/modules/new/lib/preparation/loadPortableTemplateConfig.ts
+++ b/packages/cli/src/modules/new/lib/preparation/loadPortableTemplateConfig.ts
@@ -70,6 +70,21 @@ type LoadConfigOptions = {
   overrides?: Partial<PortableTemplateConfig>;
 };
 
+function computePackageNamePluginInfix(
+  packageNamePrefix: string,
+  namePluginInfix?: string,
+) {
+  const packageNamePluginInfix =
+    namePluginInfix ??
+    (packageNamePrefix.includes('backstage')
+      ? defaults.packageNamePluginInfix
+      : 'backstage-plugin-');
+
+  return {
+    packageNamePluginInfix,
+  };
+}
+
 export async function loadPortableTemplateConfig(
   options: LoadConfigOptions = {},
 ): Promise<PortableTemplateConfig> {
@@ -116,6 +131,16 @@ export async function loadPortableTemplateConfig(
     templateNameConflicts.set(pointer.name, rawPointer);
   }
 
+  const packageNamePrefix =
+    overrides.packageNamePrefix ??
+    config?.globals?.namePrefix ??
+    defaults.packageNamePrefix;
+
+  const { packageNamePluginInfix } = computePackageNamePluginInfix(
+    packageNamePrefix,
+    overrides.packageNamePluginInfix ?? config?.globals?.namePluginInfix,
+  );
+
   return {
     isUsingDefaultTemplates: !config?.templates,
     templatePointers: templatePointerEntries.map(({ pointer }) => pointer),
@@ -126,14 +151,8 @@ export async function loadPortableTemplateConfig(
       overrides.publishRegistry ??
       config?.globals?.publishRegistry ??
       defaults.publishRegistry,
-    packageNamePrefix:
-      overrides.packageNamePrefix ??
-      config?.globals?.namePrefix ??
-      defaults.packageNamePrefix,
-    packageNamePluginInfix:
-      overrides.packageNamePluginInfix ??
-      config?.globals?.namePluginInfix ??
-      defaults.packageNamePluginInfix,
+    packageNamePrefix,
+    packageNamePluginInfix,
   };
 }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes #31510

Fix a behavior inconsistency in the `new` command for `@internal `scopes. Previously, it defaulted to the `plugin-` infix when `--scope` was not set, but used `backstage-plugin-` when `--scope` is set to `internal`. These defaults are now aligned for consistent behavior.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
