### PR TITLE
frontend-plugin-api: add support for relative attachments

### DIFF
--- a/.changeset/plugin-relative-extensions.md
+++ b/.changeset/plugin-relative-extensions.md
@@ -1,0 +1,17 @@
+---
+'@backstage/frontend-plugin-api': patch
+---
+
+Added support for plugin-relative `attachTo` declarations for extension definitions. This allows for the creation of extension and extension blueprints that attach to other extensions of a particular `kind` in the same plugin, rather than needing to provide the exact extension ID. This is particularly useful when wanting to provide extension blueprints with a built-in hierarchy where the extensions created from one blueprint attach to extensions created from the other blueprint, for example:
+
+```ts
+// kind: 'tabbed-page'
+const parentPage = TabbedPageBlueprint.make({
+  params: {....}
+})
+// attachTo: { kind: 'tabbed-page', input: 'tabs' }
+const child1 = TabContentBlueprint.make({
+  name: 'tab1',
+  params: {....}
+})
+```

--- a/docs/frontend-system/architecture/20-extensions.md
+++ b/docs/frontend-system/architecture/20-extensions.md
@@ -352,3 +352,41 @@ const extension = createExtension({
   },
 });
 ```
+
+## Relative attachment points
+
+When creating an extension or an [extension blueprint](./23-extension-blueprints.md) you can specify an attachment point that is relative to the current plugin. This is particularly useful for groups of blueprints that are part of a common hierarchy, with extensions from one blueprint attaching to extensions from the other blueprint. For example, the following pair of extension definitions could be installed multiple times in different plugins, each creating their own hierarchy:
+
+```tsx
+// Parent extension with a fixed attachment point
+const parentExtension = createExtension({
+  kind: 'section',
+  attachTo: [{ id: 'app/some-fixed-extension', input: 'children' }],
+  inputs: {
+    content: createExtensionInput([coreExtensionData.reactElement], {
+      singleton: true,
+    }),
+  },
+  output: [coreExtensionData.reactElement],
+  factory({ inputs }) {
+    return [
+      coreExtensionData.reactElement(
+        <section>
+          <h1>Section Title</h1>
+          {inputs.content.get(coreExtensionData.reactElement)}
+        </section>,
+      ),
+    ];
+  },
+});
+
+// Child extension with a relative attachment point
+const childExtension = createExtension({
+  kind: 'section-content',
+  attachTo: [{ relative: { kind: 'section' }, input: 'content' }],
+  output: [coreExtensionData.reactElement],
+  factory() {
+    return [coreExtensionData.reactElement(<p>Section Content</p>)];
+  },
+});
+```

--- a/packages/frontend-internal/src/wiring/InternalExtensionDefinition.ts
+++ b/packages/frontend-internal/src/wiring/InternalExtensionDefinition.ts
@@ -17,7 +17,7 @@
 import {
   ApiHolder,
   AppNode,
-  ExtensionAttachToSpec,
+  ExtensionDefinitionAttachTo,
   ExtensionDataValue,
   ExtensionDataRef,
   ExtensionDefinition,
@@ -36,7 +36,7 @@ export const OpaqueExtensionDefinition = OpaqueType.create<{
         readonly kind?: string;
         readonly namespace?: string;
         readonly name?: string;
-        readonly attachTo: ExtensionAttachToSpec;
+        readonly attachTo: ExtensionDefinitionAttachTo;
         readonly disabled: boolean;
         readonly configSchema?: PortableSchema<any, any>;
         readonly inputs: {
@@ -67,7 +67,7 @@ export const OpaqueExtensionDefinition = OpaqueType.create<{
         readonly kind?: string;
         readonly namespace?: string;
         readonly name?: string;
-        readonly attachTo: ExtensionAttachToSpec;
+        readonly attachTo: ExtensionDefinitionAttachTo;
         readonly disabled: boolean;
         readonly configSchema?: PortableSchema<any, any>;
         readonly inputs: { [inputName in string]: ExtensionInput };

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -259,7 +259,7 @@ export interface AppNodeInstance {
 // @public
 export interface AppNodeSpec {
   // (undocumented)
-  readonly attachTo: ExtensionAttachToSpec;
+  readonly attachTo: ExtensionAttachTo;
   // (undocumented)
   readonly config?: unknown;
   // (undocumented)
@@ -510,7 +510,7 @@ export type CreateExtensionBlueprintOptions<
   },
 > = {
   kind: TKind;
-  attachTo: ExtensionAttachToSpec;
+  attachTo: ExtensionDefinitionAttachTo;
   disabled?: boolean;
   inputs?: TInputs;
   output: Array<UOutput>;
@@ -592,7 +592,7 @@ export type CreateExtensionOptions<
 > = {
   kind?: TKind;
   name?: TName;
-  attachTo: ExtensionAttachToSpec;
+  attachTo: ExtensionDefinitionAttachTo;
   disabled?: boolean;
   inputs?: TInputs;
   output: Array<UOutput>;
@@ -839,7 +839,7 @@ export interface Extension<TConfig, TConfigInput = TConfig> {
 }
 
 // @public (undocumented)
-export type ExtensionAttachToSpec =
+export type ExtensionAttachTo =
   | {
       id: string;
       input: string;
@@ -848,6 +848,9 @@ export type ExtensionAttachToSpec =
       id: string;
       input: string;
     }>;
+
+// @public @deprecated (undocumented)
+export type ExtensionAttachToSpec = ExtensionAttachTo;
 
 // @public (undocumented)
 export interface ExtensionBlueprint<
@@ -861,7 +864,7 @@ export interface ExtensionBlueprint<
     TParamsInput extends AnyParamsInput<NonNullable<T['params']>>,
   >(args: {
     name?: TName;
-    attachTo?: ExtensionAttachToSpec;
+    attachTo?: ExtensionDefinitionAttachTo;
     disabled?: boolean;
     params: TParamsInput extends ExtensionBlueprintDefineParams
       ? TParamsInput
@@ -889,7 +892,7 @@ export interface ExtensionBlueprint<
     },
   >(args: {
     name?: TName;
-    attachTo?: ExtensionAttachToSpec;
+    attachTo?: ExtensionDefinitionAttachTo;
     disabled?: boolean;
     inputs?: TExtraInputs & {
       [KName in keyof T['inputs']]?: `Error: Input '${KName &
@@ -1086,7 +1089,7 @@ export type ExtensionDefinition<
   >(
     args: Expand<
       {
-        attachTo?: ExtensionAttachToSpec;
+        attachTo?: ExtensionDefinitionAttachTo;
         disabled?: boolean;
         inputs?: TExtraInputs & {
           [KName in keyof T['inputs']]?: `Error: Input '${KName &
@@ -1167,6 +1170,37 @@ export type ExtensionDefinition<
       >;
   }>;
 };
+
+// @public
+export type ExtensionDefinitionAttachTo =
+  | {
+      id: string;
+      input: string;
+      relative?: never;
+    }
+  | {
+      relative: {
+        kind?: string;
+        name?: string;
+      };
+      input: string;
+      id?: never;
+    }
+  | Array<
+      | {
+          id: string;
+          input: string;
+          relative?: never;
+        }
+      | {
+          relative: {
+            kind?: string;
+            name?: string;
+          };
+          input: string;
+          id?: never;
+        }
+    >;
 
 // @public (undocumented)
 export type ExtensionDefinitionParameters = {

--- a/packages/frontend-plugin-api/src/apis/definitions/AppTreeApi.ts
+++ b/packages/frontend-plugin-api/src/apis/definitions/AppTreeApi.ts
@@ -19,7 +19,7 @@ import {
   FrontendPlugin,
   Extension,
   ExtensionDataRef,
-  ExtensionAttachToSpec,
+  ExtensionAttachTo,
 } from '../../wiring';
 
 /**
@@ -33,7 +33,7 @@ import {
  */
 export interface AppNodeSpec {
   readonly id: string;
-  readonly attachTo: ExtensionAttachToSpec;
+  readonly attachTo: ExtensionAttachTo;
   readonly extension: Extension<unknown, unknown>;
   readonly disabled: boolean;
   readonly config?: unknown;

--- a/packages/frontend-plugin-api/src/wiring/createExtension.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.test.ts
@@ -216,6 +216,22 @@ describe('createExtension', () => {
     );
   });
 
+  it('should create an extension with a relative attachment point', () => {
+    const extension = createExtension({
+      attachTo: [
+        { relative: {}, input: 'tabs' },
+        { relative: { kind: 'page' }, input: 'tabs' },
+        { relative: { name: 'index' }, input: 'tabs' },
+        { relative: { kind: 'page', name: 'index' }, input: 'tabs' },
+      ],
+      output: [stringDataRef],
+      factory: () => [stringDataRef('bar')],
+    });
+    expect(String(extension)).toBe(
+      'ExtensionDefinition{attachTo=<plugin>@tabs+page:<plugin>@tabs+<plugin>/index@tabs+page:<plugin>/index@tabs}',
+    );
+  });
+
   it('should create an extension with input', () => {
     const extension = createExtension({
       attachTo: { id: 'root', input: 'default' },

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
@@ -18,7 +18,7 @@ import { ApiHolder, AppNode } from '../apis';
 import { Expand } from '@backstage/types';
 import { OpaqueType } from '@internal/opaque';
 import {
-  ExtensionAttachToSpec,
+  ExtensionDefinitionAttachTo,
   ExtensionDefinition,
   ResolvedExtensionInputs,
   VerifyExtensionFactoryOutput,
@@ -109,7 +109,7 @@ export type CreateExtensionBlueprintOptions<
   TDataRefs extends { [name in string]: ExtensionDataRef },
 > = {
   kind: TKind;
-  attachTo: ExtensionAttachToSpec;
+  attachTo: ExtensionDefinitionAttachTo;
   disabled?: boolean;
   inputs?: TInputs;
   output: Array<UOutput>;
@@ -214,7 +214,7 @@ export interface ExtensionBlueprint<
     TParamsInput extends AnyParamsInput<NonNullable<T['params']>>,
   >(args: {
     name?: TName;
-    attachTo?: ExtensionAttachToSpec;
+    attachTo?: ExtensionDefinitionAttachTo;
     disabled?: boolean;
     params: TParamsInput extends ExtensionBlueprintDefineParams
       ? TParamsInput
@@ -247,7 +247,7 @@ export interface ExtensionBlueprint<
     TExtraInputs extends { [inputName in string]: ExtensionInput },
   >(args: {
     name?: TName;
-    attachTo?: ExtensionAttachToSpec;
+    attachTo?: ExtensionDefinitionAttachTo;
     disabled?: boolean;
     inputs?: TExtraInputs & {
       [KName in keyof T['inputs']]?: `Error: Input '${KName &

--- a/packages/frontend-plugin-api/src/wiring/index.ts
+++ b/packages/frontend-plugin-api/src/wiring/index.ts
@@ -19,7 +19,7 @@ export {
   createExtension,
   type ExtensionDefinition,
   type ExtensionDefinitionParameters,
-  type ExtensionAttachToSpec,
+  type ExtensionDefinitionAttachTo,
   type CreateExtensionOptions,
   type ResolvedExtensionInput,
   type ResolvedExtensionInputs,
@@ -54,7 +54,11 @@ export {
   type FrontendFeatureLoader,
   type CreateFrontendFeatureLoaderOptions,
 } from './createFrontendFeatureLoader';
-export { type Extension } from './resolveExtensionDefinition';
+export {
+  type Extension,
+  type ExtensionAttachTo,
+  type ExtensionAttachToSpec,
+} from './resolveExtensionDefinition';
 export {
   type ExtensionDataContainer,
   type FeatureFlagConfig,

--- a/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.test.ts
@@ -60,6 +60,23 @@ describe('resolveExtensionDefinition', () => {
       'Extension must declare an explicit namespace or name as it could not be resolved from context, kind=undefined namespace=undefined name=undefined',
     );
   });
+
+  it('should resolve relative attachment points', () => {
+    const resolved = resolveExtensionDefinition(
+      {
+        ...baseDef,
+        attachTo: [
+          { relative: { kind: 'page' }, input: 'tabs' },
+          { relative: { kind: 'page', name: 'index' }, input: 'tabs' },
+        ],
+      } as ExtensionDefinition,
+      { namespace: 'test' },
+    );
+    expect(resolved.attachTo).toEqual([
+      { id: 'page:test', input: 'tabs' },
+      { id: 'page:test/index', input: 'tabs' },
+    ]);
+  });
 });
 
 describe('old resolveExtensionDefinition', () => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds support for relative attachment points in the new frontend system. It's a bit of a gap we detected where it's not currently possible to provide a hierarchy of blueprints that attach to each other in a nice way. This makes it possible to essentially have one blueprint attach to another without needing to explicitly declare the attachment point explicitly when using the child blueprint. The `kind` is currently required in order to constraint the design a bit, as this is primarily intended to be used with blueprints.

The current design only allows this to be done easily once per plugin, which I think might be enough. If we see that relative attachment points are used a lot with the need to create multiple hierarchies from the same blueprints within a single plugin, then I think we could consider adding the ability to be able to define partial relative attachment points when using a blueprint, i.e. `attachTo: { relative: { name: 'other-parent' } }`.

The entire implementation lives in the plugin API, with the resolution happening at the same time as we resolve the full extension IDs in the plugin.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
