### PR TITLE
ui: enable tree shaking of components

### DIFF
--- a/.changeset/smart-donuts-teach.md
+++ b/.changeset/smart-donuts-teach.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Enable tree-shaking of imports other than `*.css`.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -19,7 +19,9 @@
     "directory": "packages/ui"
   },
   "license": "Apache-2.0",
-  "sideEffects": true,
+  "sideEffects": [
+    "*.css"
+  ],
   "main": "src/index.ts",
   "types": "src/index.ts",
   "files": [


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This enables tree shaking for all imports other than `*.css` ones: https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
