### PR TITLE
BUI - Fix broken external links in the Header

### DIFF
--- a/.changeset/all-camels-agree.md
+++ b/.changeset/all-camels-agree.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Fix broken external links in Backstage UI Header component.

--- a/packages/ui/src/components/Header/HeaderToolbar.tsx
+++ b/packages/ui/src/components/Header/HeaderToolbar.tsx
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 
-import { Link, RouterProvider } from 'react-aria-components';
+import { Link } from 'react-aria-components';
 import { useStyles } from '../../hooks/useStyles';
 import { useRef } from 'react';
 import { RiShapesLine } from '@remixicon/react';
 import type { HeaderToolbarProps } from './types';
 import { Text } from '../Text';
-import { useNavigate, useHref } from 'react-router-dom';
 import styles from './Header.module.css';
 import clsx from 'clsx';
 
@@ -33,7 +32,6 @@ export const HeaderToolbar = (props: HeaderToolbarProps) => {
   const { classNames, cleanedProps } = useStyles('Header', props);
   const { className, icon, title, titleLink, customActions, hasTabs } =
     cleanedProps;
-  let navigate = useNavigate();
 
   // Refs for collision detection
   const toolbarWrapperRef = useRef<HTMLDivElement>(null);
@@ -52,63 +50,61 @@ export const HeaderToolbar = (props: HeaderToolbarProps) => {
   );
 
   return (
-    <RouterProvider navigate={navigate} useHref={useHref}>
+    <div
+      className={clsx(
+        classNames.toolbar,
+        styles[classNames.toolbar],
+        className,
+      )}
+      data-has-tabs={hasTabs}
+    >
       <div
         className={clsx(
-          classNames.toolbar,
-          styles[classNames.toolbar],
-          className,
+          classNames.toolbarWrapper,
+          styles[classNames.toolbarWrapper],
         )}
-        data-has-tabs={hasTabs}
+        ref={toolbarWrapperRef}
       >
         <div
           className={clsx(
-            classNames.toolbarWrapper,
-            styles[classNames.toolbarWrapper],
+            classNames.toolbarContent,
+            styles[classNames.toolbarContent],
           )}
-          ref={toolbarWrapperRef}
+          ref={toolbarContentRef}
         >
-          <div
-            className={clsx(
-              classNames.toolbarContent,
-              styles[classNames.toolbarContent],
+          <Text as="h1" variant="body-medium">
+            {titleLink ? (
+              <Link
+                className={clsx(
+                  classNames.toolbarName,
+                  styles[classNames.toolbarName],
+                )}
+                href={titleLink}
+              >
+                {titleContent}
+              </Link>
+            ) : (
+              <div
+                className={clsx(
+                  classNames.toolbarName,
+                  styles[classNames.toolbarName],
+                )}
+              >
+                {titleContent}
+              </div>
             )}
-            ref={toolbarContentRef}
-          >
-            <Text as="h1" variant="body-medium">
-              {titleLink ? (
-                <Link
-                  className={clsx(
-                    classNames.toolbarName,
-                    styles[classNames.toolbarName],
-                  )}
-                  href={titleLink}
-                >
-                  {titleContent}
-                </Link>
-              ) : (
-                <div
-                  className={clsx(
-                    classNames.toolbarName,
-                    styles[classNames.toolbarName],
-                  )}
-                >
-                  {titleContent}
-                </div>
-              )}
-            </Text>
-          </div>
-          <div
-            className={clsx(
-              classNames.toolbarControls,
-              styles[classNames.toolbarControls],
-            )}
-            ref={toolbarControlsRef}
-          >
-            {customActions}
-          </div>
+          </Text>
+        </div>
+        <div
+          className={clsx(
+            classNames.toolbarControls,
+            styles[classNames.toolbarControls],
+          )}
+          ref={toolbarControlsRef}
+        >
+          {customActions}
         </div>
       </div>
-    </RouterProvider>
+    </div>
   );
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This removes `RouterProvider` in `HeaderToolbar` as it was conflicting with nested `RouterProvider` inside `ButtonLink`. The code change looks quite complex but all that was done is remove the `RouterProvider` wrapper in `HeaderToolbar`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
