### PR TITLE
fix(notifications): show default settings before first notification

### DIFF
--- a/.changeset/fast-tools-mate.md
+++ b/.changeset/fast-tools-mate.md
@@ -1,0 +1,10 @@
+---
+'@backstage/plugin-notifications-backend': patch
+---
+
+Show default settings for notifications even before receiving first notification.
+
+Previously, it was not possible for the users to see or modify their notification settings until they had received at
+least one notification from specific origin or topic.
+This update ensures that default settings are displayed from the outset,
+allowing users to customize their preferences immediately.

--- a/plugins/notifications-backend/src/service/router.test.ts
+++ b/plugins/notifications-backend/src/service/router.test.ts
@@ -68,6 +68,16 @@ describe.each(databases.eachSupportedId())('createRouter (%s)', databaseId => {
                   id: 'external:test-service2',
                   enabled: false,
                 },
+                {
+                  id: 'external:test-service3',
+                  enabled: true,
+                  topics: [
+                    {
+                      id: 'test-topic3',
+                      enabled: false,
+                    },
+                  ],
+                },
               ],
             },
           ],
@@ -829,6 +839,16 @@ describe.each(databases.eachSupportedId())('createRouter (%s)', databaseId => {
                 id: 'external:test-service2',
                 topics: [{ enabled: false, id: 'test-topic2' }],
               },
+              {
+                enabled: true,
+                id: 'external:test-service3',
+                topics: [
+                  {
+                    enabled: false,
+                    id: 'test-topic3',
+                  },
+                ],
+              },
             ]),
           },
         ],
@@ -863,6 +883,16 @@ describe.each(databases.eachSupportedId())('createRouter (%s)', databaseId => {
                 id: 'external:test-service2',
                 topics: [{ enabled: false, id: 'test-topic2' }],
               },
+              {
+                enabled: true,
+                id: 'external:test-service3',
+                topics: [
+                  {
+                    enabled: false,
+                    id: 'test-topic3',
+                  },
+                ],
+              },
             ]),
           },
         ],
@@ -886,6 +916,16 @@ describe.each(databases.eachSupportedId())('createRouter (%s)', databaseId => {
                 enabled: false,
                 id: 'external:test-service2',
                 topics: [{ enabled: false, id: 'test-topic2' }],
+              },
+              {
+                enabled: true,
+                id: 'external:test-service3',
+                topics: [
+                  {
+                    enabled: false,
+                    id: 'test-topic3',
+                  },
+                ],
               },
             ]),
           },

--- a/plugins/notifications-backend/src/service/router.ts
+++ b/plugins/notifications-backend/src/service/router.ts
@@ -207,6 +207,27 @@ export async function createRouter(
     const settings = await store.getNotificationSettings({ user });
     const channels = getNotificationChannels();
 
+    // Merge existing channels/origins/topics with configured settings
+    for (const channel of defaultNotificationSettings?.channels ?? []) {
+      if (!channels.includes(channel.id)) {
+        channels.push(channel.id);
+      }
+
+      for (const origin of channel.origins) {
+        if (!origins.includes(origin.id)) {
+          origins.push(origin.id);
+        }
+
+        for (const topic of origin.topics ?? []) {
+          if (
+            !topics.some(t => t.origin === origin.id && t.topic === topic.id)
+          ) {
+            topics.push({ origin: origin.id, topic: topic.id });
+          }
+        }
+      }
+    }
+
     return {
       channels: channels.map(channelId =>
         getChannelSettings(channelId, settings, origins, topics),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

this fixes default notification configuration not showing in the notification settings before user has received first notification from the specific origin/topic

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
