### PR TITLE
fix: do not spread truncate property on the text component

### DIFF
--- a/packages/ui/src/components/Text/Text.tsx
+++ b/packages/ui/src/components/Text/Text.tsx
@@ -34,7 +34,7 @@ function TextComponent<T extends ElementType = 'span'>(
     ...props,
   });
 
-  const { className, ...restProps } = cleanedProps;
+  const { className, truncate, ...restProps } = cleanedProps;
 
   return (
     <Component


### PR DESCRIPTION
## Hey, I just made a Pull Request!

change to not add truncate property to the rendered text component

prevents the error / warning in the console below

<img width="1053" height="222" alt="Screenshot 2025-11-03 at 12 25 12" src="https://github.com/user-attachments/assets/67dd9b4f-5c56-4b3a-83cb-69a28c324d55" />



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
