### PR TITLE
fix(ui): prevent radio button ellipse distortion in RadioGroup

### DIFF
--- a/.changeset/ripe-crabs-care.md
+++ b/.changeset/ripe-crabs-care.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed RadioGroup radio button ellipse distortion by preventing flex shrink and grow.

--- a/packages/ui/src/components/RadioGroup/RadioGroup.module.css
+++ b/packages/ui/src/components/RadioGroup/RadioGroup.module.css
@@ -54,6 +54,8 @@
       background: var(--bui-gray-1);
       border-radius: var(--bui-radius-full);
       transition: all 200ms;
+      flex-shrink: 0;
+      flex-grow: 0;
     }
 
     &[data-pressed]:before {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixed radio button circles becoming elliptical by preventing flex shrink and grow on the button's ::before pseudo-element.

**Before**
<img width="611" height="137" alt="image" src="https://github.com/user-attachments/assets/6ae65451-81fd-4e93-acfc-20745c5ceaf3" />

**After**
<img width="609" height="143" alt="image" src="https://github.com/user-attachments/assets/11e9a54f-ea3b-431b-85e8-6361cbf2b845" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
