### PR TITLE
fix gitlab search with multiple globs

### DIFF
--- a/.changeset/eleven-carpets-win.md
+++ b/.changeset/eleven-carpets-win.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Fix a bug in the Gitlab URL reader where `search` did not handle multiple globs

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/GitlabUrlReader.test.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/GitlabUrlReader.test.ts
@@ -670,6 +670,17 @@ describe('GitlabUrlReader', () => {
       );
     });
 
+    it('works when there are multiple globs', async () => {
+      const result = await gitlabProcessor.search(
+        'https://gitlab.com/backstage/mock/tree/main/**/docs/**/index.*',
+      );
+      expect(result.etag).toBe('sha123abc');
+      expect(result.files.length).toBe(1);
+      expect(result.files[0].url).toBe(
+        'https://gitlab.com/backstage/mock/tree/main/docs/index.md',
+      );
+    });
+
     it('works for the naive case', async () => {
       const result = await gitlabProcessor.search(
         'https://gitlab.com/backstage/mock/tree/main/**/index.*',

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/GitlabUrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/GitlabUrlReader.ts
@@ -319,14 +319,10 @@ export class GitlabUrlReader implements UrlReaderService {
    */
   private getStaticPart(globPattern: string) {
     const segments = globPattern.split('/');
-    let i = segments.length;
-    while (
-      i > 0 &&
-      new Minimatch(segments.slice(0, i).join('/')).match(globPattern)
-    ) {
-      i--;
-    }
-    return segments.slice(0, i).join('/');
+    const globIndex = segments.findIndex(segment => segment.match(/[*?]/));
+    return globIndex === -1
+      ? globPattern
+      : segments.slice(0, globIndex).join('/');
   }
 
   toString() {


### PR DESCRIPTION
Before this change, if you searched for `**/a/**/b`, the path sent to the gitlab API would be `**%2fa` which it of course could not handle.