### PR TITLE
fix(ui): display single initial for x-small and small Avatar sizes

### DIFF
--- a/.changeset/long-humans-sink.md
+++ b/.changeset/long-humans-sink.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Avatar components in x-small and small sizes now display only one initial instead of two, improving readability at smaller dimensions.

--- a/packages/ui/src/components/Avatar/Avatar.stories.tsx
+++ b/packages/ui/src/components/Avatar/Avatar.stories.tsx
@@ -45,12 +45,21 @@ export const Sizes: Story = {
     ...Default.args,
   },
   render: args => (
-    <Flex>
-      <Avatar {...args} size="x-small" />
-      <Avatar {...args} size="small" />
-      <Avatar {...args} size="medium" />
-      <Avatar {...args} size="large" />
-      <Avatar {...args} size="x-large" />
+    <Flex direction="column" gap="6">
+      <Flex>
+        <Avatar {...args} size="x-small" />
+        <Avatar {...args} size="small" />
+        <Avatar {...args} size="medium" />
+        <Avatar {...args} size="large" />
+        <Avatar {...args} size="x-large" />
+      </Flex>
+      <Flex>
+        <Avatar {...args} size="x-small" src="" />
+        <Avatar {...args} size="small" src="" />
+        <Avatar {...args} size="medium" src="" />
+        <Avatar {...args} size="large" src="" />
+        <Avatar {...args} size="x-large" src="" />
+      </Flex>
     </Flex>
   ),
 };

--- a/packages/ui/src/components/Avatar/Avatar.tsx
+++ b/packages/ui/src/components/Avatar/Avatar.tsx
@@ -47,12 +47,16 @@ export const Avatar = forwardRef<HTMLDivElement, AvatarProps>((props, ref) => {
     };
   }, [src]);
 
+  const initialsCount = ['x-small', 'small'].includes(cleanedProps.size)
+    ? 1
+    : 2;
+
   const initials = name
     .split(' ')
     .map(word => word[0])
     .join('')
     .toLocaleUpperCase('en-US')
-    .slice(0, 2);
+    .slice(0, initialsCount);
 
   return (
     <div


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Avatar components in x-small and small sizes now display only one initial instead of two, improving readability at smaller dimensions.

Updated the Storybook story to demonstrate both image-based and initial-based avatars across all size variants.

**Before**
<img width="286" height="175" alt="image" src="https://github.com/user-attachments/assets/307bd07d-9cfa-47e7-af1a-a2f14e009f6f" />

**After**
<img width="305" height="158" alt="image" src="https://github.com/user-attachments/assets/c03c572f-ff2b-4001-a3bf-1ede3f3899ec" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
