### PR TITLE
typo: change permissionPolicyExtension to permissionsPolicyExtension

### DIFF
--- a/docs/permissions/custom-rules.md
+++ b/docs/permissions/custom-rules.md
@@ -159,7 +159,7 @@ To install custom rules in a plugin, we need to use the [`PermissionsRegistrySer
    ```typescript title="packages/backend/src/modules/catalogPermissionRules.ts"
    import { createBackendModule } from '@backstage/backend-plugin-api';
    import { catalogPermissionExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
-   import { isInSystemRule } from './permissionPolicyExtension';
+   import { isInSystemRule } from './permissionsPolicyExtension';
 
    export default createBackendModule({
      pluginId: 'catalog',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This pull request corrects a small typo in the import path for the `isInSystemRule` function in the documentation. The import now correctly references `permissionsPolicyExtension` instead of `permissionPolicyExtension`. 

* Fixed import path for `isInSystemRule` in the code example in `custom-rules.md` to reference `permissionsPolicyExtension`

<img width="1702" height="1279" alt="Screenshot 2025-11-05 at 11 53 55" src="https://github.com/user-attachments/assets/5b04a49b-b5b3-4837-8915-0e1064ab15f1" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
