### PR TITLE
fix(ui): improve dialog backdrop appearance in dark mode

### DIFF
--- a/.changeset/honest-lamps-occur.md
+++ b/.changeset/honest-lamps-occur.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed dialog backdrop appearance in dark mode.

--- a/packages/ui/src/components/Dialog/Dialog.module.css
+++ b/packages/ui/src/components/Dialog/Dialog.module.css
@@ -23,7 +23,7 @@
     left: 0;
     width: 100%;
     height: 100%;
-    background: rgba(232, 232, 232, 0.8);
+    background: color-mix(in srgb, var(--bui-gray-2) 80%, transparent);
     display: flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

What it says in the title, replaces the hardcoded color for the backdrop background with one that is dynamically based on the `--bui-gray-2` variable at 80% transparency. This fixes the issue where the dialog backdrop in dark mode was too bright.

### Before

**Dark mode**
<img width="593" height="456" alt="image" src="https://github.com/user-attachments/assets/e8e4b9a8-9573-4777-8142-eb4195b0d24d" />

**Light mode**
<img width="594" height="442" alt="image" src="https://github.com/user-attachments/assets/94f953b3-a552-41c2-aff2-395904216af4" />

### After

**Dark mode**
<img width="595" height="450" alt="image" src="https://github.com/user-attachments/assets/857de770-f840-4cd5-aa8e-e102dd463936" />

**Light mode**
<img width="593" height="445" alt="image" src="https://github.com/user-attachments/assets/f3cadb42-528d-4d61-98df-14a4685d539b" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
