### PR TITLE
fix(ui): enable Table Row href to open in new tabs

### DIFF
--- a/.changeset/warm-carrots-lead.md
+++ b/.changeset/warm-carrots-lead.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed Table Row component to properly support opening links in new tabs via right-click or Cmd+Click when using the href prop.

--- a/packages/ui/src/components/Table/components/Row.tsx
+++ b/packages/ui/src/components/Table/components/Row.tsx
@@ -57,6 +57,7 @@ export function Row<T extends object>(props: RowProps<T>) {
     return (
       <ReactAriaRow
         id={id}
+        href={href}
         className={clsx(classNames.row, styles[classNames.row])}
         {...rest}
       >
@@ -69,6 +70,7 @@ export function Row<T extends object>(props: RowProps<T>) {
     <RouterProvider navigate={navigate} useHref={useHref}>
       <ReactAriaRow
         id={id}
+        href={href}
         className={clsx(classNames.row, styles[classNames.row])}
         data-react-aria-pressable="true"
         {...rest}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The Table Row component's href prop was being destructured but not passed to the underlying ReactAriaRow component, preventing rows from rendering as <a> elements. This blocked native browser link behaviors like right-click "Open in new tab" and Cmd+Click.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
