### PR TITLE
fix(techdocs): use correct type for additionalAllowedUriProtocols

### DIFF
--- a/.changeset/gentle-results-lie.md
+++ b/.changeset/gentle-results-lie.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Fixed schema type for additionalAllowedURIProtocols

--- a/plugins/techdocs/config.d.ts
+++ b/plugins/techdocs/config.d.ts
@@ -67,7 +67,7 @@ export interface Config {
        *  @see: https://raw.githubusercontent.com/cure53/DOMPurify/master/src/regexp.ts
        * @visibility frontend
        */
-      additionalAllowedURIProtocols?: string;
+      additionalAllowedURIProtocols?: string[];
     };
   };
 }


### PR DESCRIPTION
The code for allowined additional uri protocols in techdocs clearly expects a `string[]` but the schema specifies `string`, this change brings the schema in line with the code

[Consuming code](https://github.com/backstage/backstage/blob/01476f00dea50b8870443eafbf22f0edd3041f63/plugins/techdocs/src/reader/transformers/html/transformer.ts#L69)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
