### PR TITLE
fix(catalog-graph): fix height scaling in catalog graph entity card

### DIFF
--- a/.changeset/purple-deer-bet.md
+++ b/.changeset/purple-deer-bet.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-graph': patch
+---
+
+Ensure the catalog graph entity card respects the height prop so the visualization scales down properly on wide screens.

--- a/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.tsx
@@ -38,22 +38,27 @@ import {
 import { useTranslationRef } from '@backstage/frontend-plugin-api';
 import { catalogGraphTranslationRef } from '../../translation';
 import { Direction, EntityNode } from '../../lib/types';
+import classNames from 'classnames';
 
 /** @public */
 export type CatalogGraphCardClassKey = 'card' | 'graph';
 
-const useStyles = makeStyles<Theme, { height: number | undefined }>(
+const useStyles = makeStyles<Theme, { height?: number }>(
   {
     card: ({ height }) => ({
       display: 'flex',
       flexDirection: 'column',
-      maxHeight: height,
-      minHeight: height,
+      ...(height && {
+        height,
+        maxHeight: height,
+        minHeight: height,
+      }),
     }),
-    graph: {
-      flex: 1,
+    graph: ({ height }) => ({
+      flex: height ? '0 0 auto' : 1,
       minHeight: 0,
-    },
+      ...(height && { height }),
+    }),
   },
   { name: 'PluginCatalogGraphCatalogGraphCard' },
 );
@@ -142,7 +147,7 @@ export const CatalogGraphCard = (
         {...props}
         rootEntityNames={rootEntityNames || entityName}
         onNodeClick={onNodeClick || defaultOnNodeClick}
-        className={className || classes.graph}
+        className={classNames(classes.graph, className)}
         maxDepth={maxDepth}
         unidirectional={unidirectional}
         mergeRelations={mergeRelations}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When using the catalog graph entity card `height` prop the graph doesn't scale with the height and appears cropped. This PR fixes the entity card component so the graph scales as expected when provided with an optional height.

Before:
<img width="3430" height="1251" alt="Screenshot 2025-11-07 at 5 11 21 PM" src="https://github.com/user-attachments/assets/8c96bef2-90de-472f-81ba-3331e1215b29" />

After:
<img width="3430" height="1251" alt="Screenshot 2025-11-07 at 5 11 51 PM" src="https://github.com/user-attachments/assets/7ff180d5-4548-4240-8ee8-1e29ac0fc293" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
