### PR TITLE
[TechDocs] - Add support for custom TechDocs transformers

### DIFF
--- a/packages/app-next/src/App.tsx
+++ b/packages/app-next/src/App.tsx
@@ -21,18 +21,12 @@ import userSettingsPlugin from '@backstage/plugin-user-settings/alpha';
 import homePlugin, {
   titleExtensionDataRef,
 } from '@backstage/plugin-home/alpha';
-
 import {
   coreExtensionData,
   createExtension,
   createFrontendModule,
 } from '@backstage/frontend-plugin-api';
-import {
-  techdocsPlugin,
-  TechDocsIndexPage,
-  TechDocsReaderPage,
-  EntityTechdocsContent,
-} from '@backstage/plugin-techdocs';
+import techdocsPlugin from '@backstage/plugin-techdocs/alpha';
 import appVisualizerPlugin from '@backstage/plugin-app-visualizer';
 import { homePage } from './HomePage';
 import { convertLegacyAppRoot } from '@backstage/core-compat-api';
@@ -40,11 +34,9 @@ import { FlatRoutes } from '@backstage/core-app-api';
 import { Route } from 'react-router';
 import { CatalogImportPage } from '@backstage/plugin-catalog-import';
 import kubernetesPlugin from '@backstage/plugin-kubernetes/alpha';
-import { convertLegacyPlugin } from '@backstage/core-compat-api';
-import { convertLegacyPageExtension } from '@backstage/core-compat-api';
-import { convertLegacyEntityContentExtension } from '@backstage/plugin-catalog-react/alpha';
 import { pluginInfoResolver } from './pluginInfoResolver';
 import { appModuleNav } from './modules/appModuleNav';
+import { techDocsTransformersModule } from './modules/customTechdocsTransformer';
 
 /*
 
@@ -79,20 +71,33 @@ TODO:
  * TechDocs does support the new frontend system so this conversion is not
  * strictly necessary, but it's left here to provide a demo of the utilities for
  * converting legacy plugins.
- */
-const convertedTechdocsPlugin = convertLegacyPlugin(techdocsPlugin, {
-  extensions: [
-    // TODO: We likely also need a way to convert an entire <Route> tree similar to collectLegacyRoutes
-    convertLegacyPageExtension(TechDocsIndexPage, {
-      name: 'index',
-      path: '/docs',
-    }),
-    convertLegacyPageExtension(TechDocsReaderPage, {
-      path: '/docs/:namespace/:kind/:name/*',
-    }),
-    convertLegacyEntityContentExtension(EntityTechdocsContent),
-  ],
-});
+ * 
+ *
+  import {
+    techDocsPlugin,
+    TechDocsIndexPage,
+    TechDocsReaderPage,
+    EntityTechdocsContent,
+  } from '@backstage/plugin-techdocs';
+
+  import { convertLegacyPlugin } from '@backstage/core-compat-api';
+  import { convertLegacyPageExtension } from '@backstage/core-compat-api';
+  import { convertLegacyEntityContentExtension } from '@backstage/plugin-catalog-react/alpha';
+
+  const convertedTechdocsPlugin = convertLegacyPlugin(techdocsPlugin, {
+    extensions: [
+      // TODO: We likely also need a way to convert an entire <Route> tree similar to collectLegacyRoutes
+      convertLegacyPageExtension(TechDocsIndexPage, {
+        name: 'index',
+        path: '/docs',
+      }),
+      convertLegacyPageExtension(TechDocsReaderPage, {
+        path: '/docs/:namespace/:kind/:name/*',
+      }),
+      convertLegacyEntityContentExtension(EntityTechdocsContent),
+    ],
+  });
+*/
 
 const customHomePageModule = createFrontendModule({
   pluginId: 'home',
@@ -125,7 +130,8 @@ const collectedLegacyPlugins = convertLegacyAppRoot(
 const app = createApp({
   features: [
     pagesPlugin,
-    convertedTechdocsPlugin,
+    techdocsPlugin,
+    techDocsTransformersModule,
     userSettingsPlugin,
     homePlugin,
     appVisualizerPlugin,

--- a/packages/app-next/src/examples/addBannerTransformerExtension.ts
+++ b/packages/app-next/src/examples/addBannerTransformerExtension.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TransformerBlueprint } from '@backstage/plugin-techdocs-react/alpha';
+
+export const bannerTransformer = TransformerBlueprint.make({
+  name: 'test-banner',
+  params: {
+    phase: 'pre',
+    priority: 45,
+    transformer: async dom => {
+      const banner = document.createElement('div');
+      banner.style.backgroundColor = '#4caf50';
+      banner.style.color = 'white';
+      banner.style.padding = '1rem';
+      banner.style.fontSize = '1.5rem';
+      banner.style.fontWeight = 'bold';
+      banner.style.textAlign = 'center';
+      banner.style.margin = '0 0 1rem 0';
+      banner.innerHTML = '🎉 CUSTOM TRANSFORMER IS WORKING! 🎉';
+
+      // Find the content area and prepend the banner
+      const content = dom.querySelector('.md-content__inner');
+      if (content) {
+        content.insertBefore(banner, content.firstChild);
+      } else {
+        // Fallback: try to insert at the start of the dom element itself
+        if (dom.firstChild) {
+          dom.insertBefore(banner, dom.firstChild);
+        }
+      }
+      return dom;
+    },
+  },
+});

--- a/packages/app-next/src/modules/customTechdocsTransformer.ts
+++ b/packages/app-next/src/modules/customTechdocsTransformer.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { createFrontendModule } from '@backstage/frontend-plugin-api';
+import { bannerTransformer } from '../examples/addBannerTransformerExtension';
+
+/**
+ * Test module for custom TechDocs transformers
+ */
+export const techDocsTransformersModule = createFrontendModule({
+  pluginId: 'techdocs',
+  extensions: [
+    // Test transformer 1: Add a big banner at the top
+    bannerTransformer,
+  ],
+});

--- a/plugins/techdocs-react/src/api.ts
+++ b/plugins/techdocs-react/src/api.ts
@@ -16,7 +16,11 @@
 
 import { CompoundEntityRef } from '@backstage/catalog-model';
 import { createApiRef } from '@backstage/core-plugin-api';
-import { TechDocsEntityMetadata, TechDocsMetadata } from './types';
+import {
+  TechDocsEntityMetadata,
+  TechDocsMetadata,
+  TechDocsTransformerOptions,
+} from './types';
 
 /**
  * API to talk to techdocs-backend.
@@ -77,3 +81,53 @@ export interface TechDocsStorageApi {
 export const techdocsStorageApiRef = createApiRef<TechDocsStorageApi>({
   id: 'plugin.techdocs.storageservice',
 });
+
+/**
+ * API for providing custom TechDocs transformers.
+ * Implement this API to provide custom DOM transformers that will be applied
+ * to the TechDocs content during rendering.
+ *
+ * @alpha
+ */
+export interface TechDocsTransformersApi {
+  /**
+   * Get the list of custom transformers to apply to TechDocs content.
+   *
+   * @param defaults - The default built-in transformers. You can filter, modify,
+   *                   or replace these transformers as needed.
+   *
+   * @returns An array of transformer options. These will be sorted by priority
+   *          before being applied.
+   *
+   * @example
+   * ```typescript
+   * // Add custom transformers to defaults
+   * getTransformers: (defaults) => [...defaults, myCustomTransformer]
+   *
+   * // Remove a specific default transformer
+   * getTransformers: (defaults) => defaults.filter(t => t.name !== 'removeMkdocsHeader')
+   *
+   * // Modify a default transformer's priority
+   * getTransformers: (defaults) => defaults.map(t =>
+   *   t.name === 'sanitizer' ? { ...t, priority: 5 } : t
+   * )
+   *
+   * // Replace defaults entirely
+   * getTransformers: () => [myCustomTransformer1, myCustomTransformer2]
+   * ```
+   */
+  getTransformers(
+    defaults: TechDocsTransformerOptions[],
+  ): TechDocsTransformerOptions[];
+}
+
+/**
+ * Utility API reference for the {@link TechDocsTransformersApi}.
+ *
+ * @alpha
+ */
+export const techdocsTransformersApiRef = createApiRef<TechDocsTransformersApi>(
+  {
+    id: 'plugin.techdocs.transformers',
+  },
+);

--- a/plugins/techdocs-react/src/context.tsx
+++ b/plugins/techdocs-react/src/context.tsx
@@ -39,9 +39,14 @@ import {
   AnalyticsContext,
   configApiRef,
   useApi,
+  useApiHolder,
 } from '@backstage/core-plugin-api';
 
-import { techdocsApiRef } from './api';
+import {
+  techdocsApiRef,
+  techdocsTransformersApiRef,
+  TechDocsTransformersApi,
+} from './api';
 import { TechDocsEntityMetadata, TechDocsMetadata } from './types';
 
 import { toLowercaseEntityRefMaybe } from './helpers';
@@ -72,6 +77,11 @@ export type TechDocsReaderPageValue = {
    * @deprecated property can be passed down directly to the `TechDocsReaderPageContent` instead.
    */
   onReady?: () => void;
+  /**
+   * Transformers API that can customize default and add custom transformers.
+   * @alpha
+   */
+  transformersApi?: TechDocsTransformersApi;
 };
 
 const defaultTechDocsReaderPageValue: TechDocsReaderPageValue = {
@@ -83,6 +93,7 @@ const defaultTechDocsReaderPageValue: TechDocsReaderPageValue = {
   metadata: { loading: true },
   entityMetadata: { loading: true },
   entityRef: { kind: '', name: '', namespace: '' },
+  transformersApi: undefined,
 };
 
 const TechDocsReaderPageContext = createVersionedContext<{
@@ -118,6 +129,8 @@ export const TechDocsReaderPageProvider = memo(
 
     const techdocsApi = useApi(techdocsApiRef);
     const config = useApi(configApiRef);
+    const apiHolder = useApiHolder();
+    const transformersApi = apiHolder.get(techdocsTransformersApiRef);
 
     const entityMetadata = useAsync(async () => {
       return techdocsApi.getEntityMetadata(entityRef);
@@ -157,6 +170,7 @@ export const TechDocsReaderPageProvider = memo(
       setTitle,
       subtitle,
       setSubtitle,
+      transformersApi: transformersApi || undefined,
     };
     const versionedValue = createVersionedValueMap({ 1: value });
 

--- a/plugins/techdocs-react/src/index.ts
+++ b/plugins/techdocs-react/src/index.ts
@@ -27,8 +27,17 @@ export {
   TECHDOCS_ADDONS_WRAPPER_KEY,
   TECHDOCS_ADDONS_KEY,
 } from './addons';
-export { techdocsApiRef, techdocsStorageApiRef } from './api';
-export type { SyncResult, TechDocsApi, TechDocsStorageApi } from './api';
+export {
+  techdocsApiRef,
+  techdocsStorageApiRef,
+  techdocsTransformersApiRef,
+} from './api';
+export type {
+  SyncResult,
+  TechDocsApi,
+  TechDocsStorageApi,
+  TechDocsTransformersApi,
+} from './api';
 export { TechDocsReaderPageProvider, useTechDocsReaderPage } from './context';
 export type {
   TechDocsReaderPageProviderProps,

--- a/plugins/techdocs-react/src/types.ts
+++ b/plugins/techdocs-react/src/types.ts
@@ -115,3 +115,30 @@ export type TechDocsAddonOptions<TAddonProps = {}> = {
   location: keyof typeof TechDocsAddonLocations;
   component: ComponentType<TAddonProps>;
 };
+
+/**
+ * A transformer function that takes a DOM element and returns a transformed DOM element.
+ * @alpha
+ */
+export type Transformer = (dom: Element) => Element | Promise<Element>;
+
+/**
+ * The phase in which a transformer should run.
+ * - pre: Runs before the DOM is attached to the document (faster, no event listeners)
+ * - post: Runs after the DOM is attached (can attach event listeners)
+ * @alpha
+ */
+export type TransformerPhase = 'pre' | 'post';
+
+/**
+ * Options for creating a TechDocs transformer.
+ * @alpha
+ */
+export type TechDocsTransformerOptions = {
+  // If a name is not provided, one will be generated
+  // based on the extension name.
+  name?: string;
+  transformer: Transformer;
+  phase: TransformerPhase;
+  priority?: number;
+};

--- a/plugins/techdocs/src/reader/README.md
+++ b/plugins/techdocs/src/reader/README.md
@@ -2,9 +2,102 @@
 
 The TechDocs reader is a component that fetches a remote page, runs transformers on it and renders it into a shadow dom.
 
-Currently there's no easy way to customize which transformers to run or add new ones. If that is needed you would have to fork the TechDocs plugin and make your changes in that fork.
+## Custom Transformers
 
-Transformers are functions that optionally takes in parameters from the Reader.tsx component and returns a function which gets passed the DOM of the fetched page. A very simple transformer can look like this.
+You can now easily add custom transformers to TechDocs using the new frontend system's extension API. Transformers are functions that modify the DOM of documentation pages.
+
+### Creating a Custom Transformer
+
+Use the `TransformerBlueprint` from `@backstage/plugin-techdocs-react/alpha` to create custom transformers:
+
+```typescript
+import { createFrontendPlugin } from '@backstage/frontend-plugin-api';
+import { TransformerBlueprint } from '@backstage/plugin-techdocs-react/alpha';
+
+export default createFrontendPlugin({
+  id: 'my-techdocs-customizations',
+  extensions: [
+    TransformerBlueprint.make({
+      name: 'highlight-notes',
+      params: {
+        phase: 'pre', // 'pre' or 'post'
+        priority: 45, // Lower numbers run first (default: 50)
+        transformer: async dom => {
+          // Find all elements with class "note" and highlight them
+          const notes = dom.querySelectorAll('.note');
+          notes.forEach(note => {
+            note.style.backgroundColor = '#fff3cd';
+            note.style.padding = '1rem';
+            note.style.borderLeft = '4px solid #ffc107';
+          });
+          return dom;
+        },
+      },
+    }),
+  ],
+});
+```
+
+### Transformer Phases
+
+Transformers run in two phases:
+
+- **`pre`**: Runs before the DOM is attached to the browser (faster, no event listeners)
+- **`post`**: Runs after the DOM is attached (can attach event listeners and interact with real DOM)
+
+### Transformer Priority
+
+Transformers are executed in order of priority (lowest to highest). Default transformers use priorities 10-80:
+
+- **Pre-render** (10-80): sanitizer, addBaseUrl, rewriteDocLinks, addSidebarToggle, removeMkdocsHeader, simplifyMkdocsFooter, addGitFeedbackLink, styles
+- **Post-render** (10-60): handleMetaRedirects, scrollIntoNavigation, copyToClipboard, addLinkClickListener, onCssReady, addNavLinkKeyboardToggle
+
+Set custom priorities to control execution order relative to built-in transformers.
+
+### Example: Custom Syntax Highlighting
+
+```typescript
+TransformerBlueprint.make({
+  name: 'custom-syntax-highlight',
+  params: {
+    phase: 'post',
+    priority: 35, // Run after copyToClipboard (30)
+    transformer: async dom => {
+      const codeBlocks = dom.querySelectorAll('pre code');
+      codeBlocks.forEach(block => {
+        // Apply custom syntax highlighting
+        hljs.highlightElement(block);
+      });
+      return dom;
+    },
+  },
+});
+```
+
+### Example: Add Custom Link Icons
+
+```typescript
+TransformerBlueprint.make({
+  name: 'external-link-icons',
+  params: {
+    phase: 'pre',
+    priority: 35, // Run after rewriteDocLinks (30)
+    transformer: async dom => {
+      const externalLinks = dom.querySelectorAll('a[target="_blank"]');
+      externalLinks.forEach(link => {
+        const icon = document.createElement('span');
+        icon.innerHTML = ' 🔗';
+        link.appendChild(icon);
+      });
+      return dom;
+    },
+  },
+});
+```
+
+## Writing Transformers (Legacy Info)
+
+Transformers are functions that optionally take in parameters and return a function which gets passed the DOM of the fetched page. A very simple transformer can look like this:
 
 ```typescript
 export const updateH1Text = (): Transformer => {
@@ -16,5 +109,3 @@ export const updateH1Text = (): Transformer => {
   };
 };
 ```
-
-The transformers are then registered in the Reader.tsx file. They are registered in two places, one place that runs before it's attached to the actual browser DOM (`preTransformer`s) and once after (`postTransformer`s). Doing modifications is faster before it's attached, but doesn't allow us to do some things, such as attaching event listeners.

--- a/plugins/techdocs/src/reader/transformers/defaults.ts
+++ b/plugins/techdocs/src/reader/transformers/defaults.ts
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Theme } from '@material-ui/core/styles';
+import type { AnalyticsTracker, ConfigApi } from '@backstage/core-plugin-api';
+import type { TechDocsStorageApi } from '@backstage/plugin-techdocs-react';
+import type { CompoundEntityRef } from '@backstage/catalog-model';
+import type { ScmIntegrationRegistry } from '@backstage/integration';
+import type {
+  TechDocsTransformerOptions,
+  Transformer,
+} from '@backstage/plugin-techdocs-react/alpha';
+
+import {
+  addBaseUrl,
+  addGitFeedbackLink,
+  addLinkClickListener,
+  addSidebarToggle,
+  onCssReady,
+  removeMkdocsHeader,
+  rewriteDocLinks,
+  simplifyMkdocsFooter,
+  scrollIntoNavigation,
+  copyToClipboard,
+  handleMetaRedirects,
+  addNavLinkKeyboardToggle,
+} from './index';
+
+/**
+ * Dependencies required for default transformers
+ * @alpha
+ */
+export interface DefaultTransformerDependencies {
+  // Pre-render dependencies
+  sanitizerTransformer: Transformer;
+  stylesTransformer: Transformer;
+  techdocsStorageApi: TechDocsStorageApi;
+  scmIntegrationsApi: ScmIntegrationRegistry;
+  entityRef: CompoundEntityRef;
+  contentPath: string;
+
+  // Post-render dependencies
+  theme: Theme;
+  navigate: (url: string) => void;
+  analytics: AnalyticsTracker;
+  configApi: ConfigApi;
+}
+
+/**
+ * Returns the default TechDocs transformers with proper priorities.
+ * These match the built-in transformers that were previously hardcoded.
+ * @alpha
+ */
+export const getDefaultTransformers = (
+  deps: DefaultTransformerDependencies,
+): TechDocsTransformerOptions[] => {
+  const baseUrl =
+    deps.configApi.getOptionalString('app.baseUrl') || window.location.origin;
+
+  return [
+    // Pre-render transformers (run before DOM attachment)
+    {
+      name: 'sanitizer',
+      transformer: deps.sanitizerTransformer,
+      phase: 'pre',
+      priority: 10,
+    },
+    {
+      name: 'addBaseUrl',
+      transformer: addBaseUrl({
+        techdocsStorageApi: deps.techdocsStorageApi,
+        entityId: deps.entityRef,
+        path: deps.contentPath,
+      }),
+      phase: 'pre',
+      priority: 20,
+    },
+    {
+      name: 'rewriteDocLinks',
+      transformer: rewriteDocLinks(),
+      phase: 'pre',
+      priority: 30,
+    },
+    {
+      name: 'addSidebarToggle',
+      transformer: addSidebarToggle(),
+      phase: 'pre',
+      priority: 40,
+    },
+    {
+      name: 'removeMkdocsHeader',
+      transformer: removeMkdocsHeader(),
+      phase: 'pre',
+      priority: 50,
+    },
+    {
+      name: 'simplifyMkdocsFooter',
+      transformer: simplifyMkdocsFooter(),
+      phase: 'pre',
+      priority: 60,
+    },
+    {
+      name: 'addGitFeedbackLink',
+      transformer: addGitFeedbackLink(deps.scmIntegrationsApi),
+      phase: 'pre',
+      priority: 70,
+    },
+    {
+      name: 'styles',
+      transformer: deps.stylesTransformer,
+      phase: 'pre',
+      priority: 80,
+    },
+
+    // Post-render transformers (run after DOM attachment)
+    {
+      name: 'handleMetaRedirects',
+      transformer: handleMetaRedirects(deps.navigate, deps.entityRef.name),
+      phase: 'post',
+      priority: 10,
+    },
+    {
+      name: 'scrollIntoNavigation',
+      transformer: scrollIntoNavigation(),
+      phase: 'post',
+      priority: 20,
+    },
+    {
+      name: 'copyToClipboard',
+      transformer: copyToClipboard(deps.theme),
+      phase: 'post',
+      priority: 30,
+    },
+    {
+      name: 'addLinkClickListener',
+      transformer: addLinkClickListener({
+        baseUrl,
+        onClick: (event: MouseEvent, url: string) => {
+          // detect if CTRL or META keys are pressed so that links can be opened in a new tab with `window.open`
+          const modifierActive = event.ctrlKey || event.metaKey;
+          const parsedUrl = new URL(url);
+
+          // capture link clicks within documentation
+          const linkText =
+            (event.target as HTMLAnchorElement | undefined)?.innerText || url;
+          const to = url.replace(window.location.origin, '');
+          deps.analytics.captureEvent('click', linkText, {
+            attributes: { to },
+          });
+
+          // hash exists when anchor is clicked on secondary sidebar
+          if (parsedUrl.hash) {
+            if (modifierActive) {
+              window.open(url, '_blank');
+            } else {
+              // If it's in a different page, we navigate to it
+              if (window.location.pathname !== parsedUrl.pathname) {
+                deps.navigate(url);
+              } else {
+                // If it's in the same page we avoid using navigate that causes
+                // the page to rerender.
+                window.history.pushState(null, document.title, parsedUrl.hash);
+              }
+              // Note: The actual scrolling logic needs the transformedElement,
+              // which will be handled in the transformer itself
+            }
+          } else {
+            if (modifierActive) {
+              window.open(url, '_blank');
+            } else {
+              deps.navigate(url);
+            }
+          }
+        },
+      }),
+      phase: 'post',
+      priority: 40,
+    },
+    {
+      name: 'onCssReady-disableDrawerToggle',
+      transformer: onCssReady({
+        onLoading: () => {},
+        onLoaded: (transformedElement: Element) => {
+          transformedElement
+            .querySelector('.md-nav__title')
+            ?.removeAttribute('for');
+        },
+      }),
+      phase: 'post',
+      priority: 50,
+    },
+    {
+      name: 'onCssReady-hideSidebars',
+      transformer: onCssReady({
+        onLoading: (transformedElement: Element) => {
+          const sidebars = Array.from(
+            transformedElement.querySelectorAll<HTMLElement>('.md-sidebar'),
+          );
+          sidebars.forEach(element => {
+            element.style.setProperty('opacity', '0');
+          });
+        },
+        onLoaded: () => {},
+      }),
+      phase: 'post',
+      priority: 51,
+    },
+    {
+      name: 'addNavLinkKeyboardToggle',
+      transformer: addNavLinkKeyboardToggle(),
+      phase: 'post',
+      priority: 60,
+    },
+  ];
+};

--- a/plugins/techdocs/src/reader/transformers/index.ts
+++ b/plugins/techdocs/src/reader/transformers/index.ts
@@ -29,3 +29,4 @@ export * from './scrollIntoNavigation';
 export * from './transformer';
 export * from './handleMetaRedirects';
 export * from './addNavLinkKeyboardToggle';
+export * from './defaults';

--- a/plugins/techdocs/src/reader/transformers/onCssReady.ts
+++ b/plugins/techdocs/src/reader/transformers/onCssReady.ts
@@ -18,8 +18,8 @@ import { SHADOW_DOM_STYLE_LOAD_EVENT } from '@backstage/plugin-techdocs-react';
 import type { Transformer } from './transformer';
 
 type OnCssReadyOptions = {
-  onLoading: () => void;
-  onLoaded: () => void;
+  onLoading: (transformedElement: Element) => void;
+  onLoaded: (transformedElement: Element) => void;
 };
 
 export const onCssReady = ({
@@ -27,11 +27,11 @@ export const onCssReady = ({
   onLoaded,
 }: OnCssReadyOptions): Transformer => {
   return dom => {
-    onLoading();
+    onLoading(dom);
     dom.addEventListener(
       SHADOW_DOM_STYLE_LOAD_EVENT,
       function handleShadowDomStyleLoad() {
-        onLoaded();
+        onLoaded(dom);
         dom.removeEventListener(
           SHADOW_DOM_STYLE_LOAD_EVENT,
           handleShadowDomStyleLoad,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Introduces a new extension API for registering custom TechDocs DOM transformers via TransformerBlueprint. Refactors transformer handling to use a prioritized, phase-based system and exposes the TechDocsTransformersApi for customization. Updates documentation and internal logic to support easy addition and ordering of custom and default transformers.

Example Transformer Code:
```typescript
import { TransformerBlueprint } from '@backstage/plugin-techdocs-react/alpha';

export const bannerTransformer = TransformerBlueprint.make({
  name: 'test-banner',
  params: {
    phase: 'pre',
    priority: 45,
    transformer: async dom => {
      const banner = document.createElement('div');

      // We ♥️ Inline Styles
      banner.style.backgroundColor = '#4caf50';
      banner.style.color = 'white';
      banner.style.padding = '1rem';
      banner.style.fontSize = '1.5rem';
      banner.style.fontWeight = 'bold';
      banner.style.textAlign = 'center';
      banner.style.margin = '0 0 1rem 0';
      banner.innerHTML = '🎉 CUSTOM TRANSFORMER IS WORKING! 🎉';

      // Find the content area and prepend the banner
      const content = dom.querySelector('.md-content__inner');
      if (content) {
        content.insertBefore(banner, content.firstChild);
      } else {
        // Fallback: try to insert at the start of the dom element itself
        if (dom.firstChild) {
          dom.insertBefore(banner, dom.firstChild);
        }
      }
      return dom;
    },
  },
});
```

See here
<img width="1707" height="907" alt="Screenshot 2025-11-09 at 8 59 06 PM" src="https://github.com/user-attachments/assets/b4043987-da8d-4d60-8a68-189f68e0bf13" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
