### PR TITLE
Added EventCatalog to Backstage Plugins

### DIFF
--- a/microsite/data/plugins/eventcatalog.yaml
+++ b/microsite/data/plugins/eventcatalog.yaml
@@ -1,0 +1,10 @@
+---
+title: EventCatalog Backstage Plugin  
+author: EventCatalog  
+authorUrl: https://www.eventcatalog.dev  
+category: Discovery  
+description: Embed your Event-Driven Architecture source-of-truth from EventCatalog directly into Backstage.  
+documentation: https://www.eventcatalog.dev/docs/development/plugins/backstage/intro  
+iconUrl: https://www.eventcatalog.dev/img/logo.png
+npmPackageName: '@eventcatalog/backstage-plugin-eventcatalog'  
+addedDate: '2025-11-10'


### PR DESCRIPTION
I added [EventCatalog](https://www.eventcatalog.dev/integrations/backstage) backstage plugin to the plugin list.

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
