### PR TITLE
Tweak some of the mock services to have more precise types

### DIFF
--- a/.changeset/open-cloths-listen.md
+++ b/.changeset/open-cloths-listen.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-test-utils': patch
+---
+
+Tweak some of the mock services to have more precise types

--- a/packages/backend-test-utils/report.api.md
+++ b/packages/backend-test-utils/report.api.md
@@ -230,11 +230,7 @@ export namespace mockServices {
   export function events(): EventsService;
   // (undocumented)
   export namespace events {
-    const factory: () => ServiceFactory<
-      EventsService,
-      'plugin',
-      'singleton' | 'multiton'
-    >;
+    const factory: () => ServiceFactory<EventsService, 'plugin', 'singleton'>;
     const mock: (
       partialImpl?: Partial<EventsService> | undefined,
     ) => ServiceMock<EventsService>;
@@ -320,7 +316,7 @@ export namespace mockServices {
     const // (undocumented)
       factory: (
         options?: Options | undefined,
-      ) => ServiceFactory<RootConfigService, 'root', 'singleton' | 'multiton'>;
+      ) => ServiceFactory<RootConfigService, 'root', 'singleton'>;
     const // (undocumented)
       mock: (
         partialImpl?: Partial<RootConfigService> | undefined,
@@ -356,7 +352,7 @@ export namespace mockServices {
       factory: () => ServiceFactory<
         RootInstanceMetadataService,
         'root',
-        'singleton' | 'multiton'
+        'singleton'
       >;
   }
   // (undocumented)
@@ -369,7 +365,7 @@ export namespace mockServices {
       ) => ServiceMock<RootLifecycleService>;
   }
   // (undocumented)
-  export function rootLogger(options?: rootLogger.Options): LoggerService;
+  export function rootLogger(options?: rootLogger.Options): RootLoggerService;
   // (undocumented)
   export namespace rootLogger {
     // (undocumented)
@@ -379,7 +375,7 @@ export namespace mockServices {
     const // (undocumented)
       factory: (
         options?: Options | undefined,
-      ) => ServiceFactory<LoggerService, 'root', 'singleton' | 'multiton'>;
+      ) => ServiceFactory<RootLoggerService, 'root', 'singleton'>;
     const // (undocumented)
       mock: (
         partialImpl?: Partial<RootLoggerService> | undefined,

--- a/packages/backend-test-utils/src/services/mockServices.ts
+++ b/packages/backend-test-utils/src/services/mockServices.ts
@@ -35,7 +35,6 @@ import {
   DiscoveryService,
   HttpAuthService,
   RootInstanceMetadataService,
-  LoggerService,
   PermissionsService,
   RootConfigService,
   SchedulerService,
@@ -44,6 +43,7 @@ import {
   UserInfoService,
   coreServices,
   createServiceFactory,
+  RootLoggerService,
 } from '@backstage/backend-plugin-api';
 import { ConfigReader } from '@backstage/config';
 import { EventsService, eventsServiceRef } from '@backstage/plugin-events-node';
@@ -77,14 +77,15 @@ function createLoggerMock() {
 function simpleFactoryWithOptions<
   TService,
   TScope extends 'root' | 'plugin',
+  TInstances extends 'singleton' | 'multiton',
   TOptions extends [options?: object] = [],
 >(
-  ref: ServiceRef<TService, TScope>,
+  ref: ServiceRef<TService, TScope, TInstances>,
   factory: (...options: TOptions) => TService,
-): (...options: TOptions) => ServiceFactory<TService, TScope> {
+): (...options: TOptions) => ServiceFactory<TService, TScope, TInstances> {
   const factoryWithOptions = (...options: TOptions) =>
     createServiceFactory({
-      service: ref as ServiceRef<TService, any>,
+      service: ref as ServiceRef<TService, any, any>,
       deps: {},
       async factory() {
         return factory(...options);
@@ -93,8 +94,8 @@ function simpleFactoryWithOptions<
   return Object.assign(
     factoryWithOptions,
     factoryWithOptions(...([undefined] as unknown as TOptions)),
-  ) as ServiceFactory<TService, TScope> &
-    ((...options: TOptions) => ServiceFactory<TService, TScope>);
+  ) as ServiceFactory<TService, TScope, TInstances> &
+    ((...options: TOptions) => ServiceFactory<TService, TScope, TInstances>);
 }
 
 /**
@@ -178,7 +179,7 @@ export namespace mockServices {
     }));
   }
 
-  export function rootLogger(options?: rootLogger.Options): LoggerService {
+  export function rootLogger(options?: rootLogger.Options): RootLoggerService {
     return MockRootLoggerService.create(options);
   }
   export namespace rootLogger {


### PR DESCRIPTION
I noticed that the `simpleFactoryWithOptions` was producing types like `'singleton' | 'multiton'` always, instead of the actual strict type from the ref.

No functional change, just types.