### PR TITLE
fix(widgetoverlay): light mode wrong background color

### DIFF
--- a/.changeset/yummy-clowns-fetch.md
+++ b/.changeset/yummy-clowns-fetch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-home': patch
+---
+
+Updated WidgetOverlay color to use `alpha(theme.palette.background.paper, 0.93)` for better theme alignment instead of hardcoded RGBA

--- a/plugins/home/src/components/CustomHomepage/WidgetSettingsOverlay.tsx
+++ b/plugins/home/src/components/CustomHomepage/WidgetSettingsOverlay.tsx
@@ -21,7 +21,12 @@ import DialogContent from '@material-ui/core/DialogContent';
 import Grid from '@material-ui/core/Grid';
 import IconButton from '@material-ui/core/IconButton';
 import Tooltip from '@material-ui/core/Tooltip';
-import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+import {
+  alpha,
+  createStyles,
+  makeStyles,
+  Theme,
+} from '@material-ui/core/styles';
 import DeleteIcon from '@material-ui/icons/Delete';
 import SettingsIcon from '@material-ui/icons/Settings';
 import { useState } from 'react';
@@ -44,7 +49,7 @@ const useStyles = makeStyles((theme: Theme) =>
     },
     settingsOverlay: {
       position: 'absolute',
-      backgroundColor: 'rgba(40, 40, 40, 0.93)',
+      backgroundColor: alpha(theme.palette.background.paper, 0.93),
       width: '100%',
       height: '100%',
       top: 0,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
This PR replaces hard coded color for widget overlay background with theme-based color theme.palette.background.paper so that it uses the correct color in light mode

before:
<img width="1429" height="377" alt="light-theme-overlay-color-before" src="https://github.com/user-attachments/assets/fb98b1c9-b2bd-44c4-a8df-14525586b4db" />

after:
<img width="1441" height="378" alt="light-theme-overlay-color-after" src="https://github.com/user-attachments/assets/43073f0d-0784-4f60-9096-c7c1db96e899" />

Changeset:
@backstage/plugin-home

fixes #31627
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset
- [ ] Added or updated documentation: not applicable
- [ ] Tests for new functionality and regression tests for bug fixes: not applicable
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
