### PR TITLE
fix(core-components): Add i18n support for LogViewer search control

### DIFF
--- a/.changeset/slick-onions-wash.md
+++ b/.changeset/slick-onions-wash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Add i18n support for LogViewer search control

--- a/packages/core-components/report-alpha.api.md
+++ b/packages/core-components/report-alpha.api.md
@@ -63,6 +63,7 @@ export const coreComponentsTranslationRef: TranslationRef<
     readonly 'autoLogout.stillTherePrompt.buttonText': "Yes! Don't log me out";
     readonly 'dependencyGraph.fullscreenTooltip': 'Toggle fullscreen';
     readonly 'proxiedSignInPage.title': 'You do not appear to be signed in. Please try reloading the browser page.';
+    readonly 'logViewer.searchField.placeholder': 'Search';
   }
 >;
 

--- a/packages/core-components/src/components/LogViewer/LogViewerControls.tsx
+++ b/packages/core-components/src/components/LogViewer/LogViewerControls.tsx
@@ -15,17 +15,20 @@
  */
 
 import { KeyboardEvent } from 'react';
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import IconButton from '@material-ui/core/IconButton';
 import TextField from '@material-ui/core/TextField';
 import Typography from '@material-ui/core/Typography';
 import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 import FilterListIcon from '@material-ui/icons/FilterList';
+import { coreComponentsTranslationRef } from '../../translation';
 import { LogViewerSearch } from './useLogViewerSearch';
 
 export interface LogViewerControlsProps extends LogViewerSearch {}
 
 export function LogViewerControls(props: LogViewerControlsProps) {
+  const { t } = useTranslationRef(coreComponentsTranslationRef);
   const { resultCount, resultIndexStep, toggleShouldFilter } = props;
   const resultIndex = props.resultIndex ?? 0;
 
@@ -57,7 +60,7 @@ export function LogViewerControls(props: LogViewerControlsProps) {
       <TextField
         size="small"
         variant="standard"
-        placeholder="Search"
+        placeholder={t('logViewer.searchField.placeholder')}
         value={props.searchInput}
         onKeyPress={handleKeyPress}
         onChange={e => props.setSearchInput(e.target.value)}

--- a/packages/core-components/src/translation.ts
+++ b/packages/core-components/src/translation.ts
@@ -127,5 +127,10 @@ export const coreComponentsTranslationRef = createTranslationRef({
       title:
         'You do not appear to be signed in. Please try reloading the browser page.',
     },
+    logViewer: {
+      searchField: {
+        placeholder: 'Search',
+      },
+    },
   },
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Super small change to make the LogViewer "search" placeholder (used in techdocs plugins) "translatable":

Before:

<img width="1787" height="381" alt="image" src="https://github.com/user-attachments/assets/f0b357b5-3bbe-4036-9639-b20f2ff0da11" />

With this PR and the right translation:

<img width="1787" height="381" alt="image" src="https://github.com/user-attachments/assets/dfedec71-b7d6-4fc9-9603-d736d4309f73" />

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
