### PR TITLE
feat(techdocs): Add i18n support to techdocs table and log view

### DIFF
--- a/.changeset/huge-wolves-punch.md
+++ b/.changeset/huge-wolves-punch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Add i18n support to techdocs table and log view

--- a/plugins/techdocs/report-alpha.api.md
+++ b/plugins/techdocs/report-alpha.api.md
@@ -23,6 +23,7 @@ import { SearchResultItemExtensionComponent } from '@backstage/plugin-search-rea
 import { SearchResultItemExtensionPredicate } from '@backstage/plugin-search-react/alpha';
 import { SearchResultListItemBlueprintParams } from '@backstage/plugin-search-react/alpha';
 import { TechDocsAddonOptions } from '@backstage/plugin-techdocs-react';
+import { TranslationRef } from '@backstage/core-plugin-api/alpha';
 
 // @alpha (undocumented)
 const _default: OverridableFrontendPlugin<
@@ -384,6 +385,28 @@ export const techDocsSearchResultListItemExtension: ExtensionDefinition<{
   name: undefined;
   params: SearchResultListItemBlueprintParams;
 }>;
+
+// @alpha (undocumented)
+export const techdocsTranslationRef: TranslationRef<
+  'techdocs',
+  {
+    readonly 'aboutCard.viewTechdocs': 'View TechDocs';
+    readonly 'docsTable.columns.type': 'Type';
+    readonly 'docsTable.columns.document': 'Document';
+    readonly 'docsTable.columns.kind': 'Kind';
+    readonly 'docsTable.columns.owner': 'Owner';
+    readonly 'docsTable.emptyState.title': 'No documents to show';
+    readonly 'docsTable.emptyState.description': 'Create your own document. Check out our Getting Started Information';
+    readonly 'docsTable.emptyState.readMoreButton': 'Read more';
+    readonly 'docsTable.allTitle': 'All';
+    readonly 'techDocsBuildLogs.title': 'Build Details';
+    readonly 'techDocsBuildLogs.showBuildLogsButton': 'Show Build Logs';
+    readonly 'techDocsBuildLogs.closeDrawerTooltip': 'Close the drawer';
+    readonly 'techDocsBuildLogs.waitingForLogsMessage': 'Waiting for logs...';
+    readonly 'techDocsPageWrapper.title': 'Documentation';
+    readonly 'techDocsPageWrapper.subtitle': 'Documentation available in {{ organizationName }}';
+  }
+>;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/techdocs/src/alpha/index.tsx
+++ b/plugins/techdocs/src/alpha/index.tsx
@@ -47,6 +47,8 @@ import {
   rootRouteRef,
 } from '../routes';
 import { TechDocsReaderLayout } from '../reader';
+
+export { techdocsTranslationRef } from '../translation';
 import { attachTechDocsAddonComponentData } from '@backstage/plugin-techdocs-react/alpha';
 import {
   TechDocsAddons,

--- a/plugins/techdocs/src/home/components/Tables/DocsTable.tsx
+++ b/plugins/techdocs/src/home/components/Tables/DocsTable.tsx
@@ -18,7 +18,7 @@ import useCopyToClipboard from 'react-use/esm/useCopyToClipboard';
 
 import { configApiRef, useApi, useRouteRef } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
-import { rootDocsRouteRef } from '../../../routes';
+import { useTranslationRef } from '@backstage/frontend-plugin-api';
 import {
   EmptyState,
   LinkButton,
@@ -27,6 +27,8 @@ import {
   TableOptions,
   TableProps,
 } from '@backstage/core-components';
+import { rootDocsRouteRef } from '../../../routes';
+import { techdocsTranslationRef } from '../../../translation';
 import { actionFactories } from './actions';
 import { columnFactories, defaultColumns } from './columns';
 import { DocsTableRow } from './types';
@@ -56,6 +58,7 @@ export const DocsTable = (props: DocsTableProps) => {
   const [, copyToClipboard] = useCopyToClipboard();
   const getRouteToReaderPageFor = useRouteRef(rootDocsRouteRef);
   const config = useApi(configApiRef);
+  const { t } = useTranslationRef(techdocsTranslationRef);
   if (!entities) return null;
 
   const documents = entitiesToDocsMapper(
@@ -89,21 +92,21 @@ export const DocsTable = (props: DocsTableProps) => {
           title={
             title
               ? `${title} (${documents.length})`
-              : `All (${documents.length})`
+              : `${t('docsTable.allTitle')} (${documents.length})`
           }
         />
       ) : (
         <EmptyState
           missing="data"
-          title="No documents to show"
-          description="Create your own document. Check out our Getting Started Information"
+          title={t('docsTable.emptyState.title')}
+          description={t('docsTable.emptyState.description')}
           action={
             <LinkButton
               color="primary"
               to="https://backstage.io/docs/features/techdocs/getting-started"
               variant="contained"
             >
-              DOCS
+              {t('docsTable.emptyState.readMoreButton')}
             </LinkButton>
           }
         />

--- a/plugins/techdocs/src/home/components/Tables/TableColumnTitle.test.tsx
+++ b/plugins/techdocs/src/home/components/Tables/TableColumnTitle.test.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { screen } from '@testing-library/react';
+import { TableColumnTitle } from './TableColumnTitle';
+import { renderInTestApp } from '@backstage/test-utils';
+
+describe('<TableColumnTitle />', () => {
+  it('renders the translated title for the given key', async () => {
+    await renderInTestApp(<TableColumnTitle translationKey="document" />);
+    expect(screen.getByText('Document')).toBeInTheDocument();
+  });
+});

--- a/plugins/techdocs/src/home/components/Tables/TableColumnTitle.tsx
+++ b/plugins/techdocs/src/home/components/Tables/TableColumnTitle.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useTranslationRef } from '@backstage/frontend-plugin-api';
+import { techdocsTranslationRef } from '../../../translation';
+
+/**
+ * @alpha
+ */
+export type TableColumnTitleProps = {
+  translationKey: 'document' | 'owner' | 'kind' | 'type';
+};
+
+/**
+ * @alpha
+ */
+export const TableColumnTitle = ({ translationKey }: TableColumnTitleProps) => {
+  const { t } = useTranslationRef(techdocsTranslationRef);
+  return t(`docsTable.columns.${translationKey}`);
+};

--- a/plugins/techdocs/src/home/components/Tables/columns.tsx
+++ b/plugins/techdocs/src/home/components/Tables/columns.tsx
@@ -18,6 +18,7 @@ import { Link, SubvalueCell, TableColumn } from '@backstage/core-components';
 import { EntityRefLinks } from '@backstage/plugin-catalog-react';
 import { Entity } from '@backstage/catalog-model';
 import { DocsTableRow } from './types';
+import { TableColumnTitle } from './TableColumnTitle';
 
 function customTitle(entity: Entity): string {
   return entity.metadata.title || entity.metadata.name;
@@ -39,7 +40,7 @@ export const columnFactories = {
   },
   createNameColumn(): TableColumn<DocsTableRow> {
     return {
-      title: 'Document',
+      title: <TableColumnTitle translationKey="document" />,
       field: 'entity.metadata.name',
       highlight: true,
       searchable: true,
@@ -61,7 +62,7 @@ export const columnFactories = {
   },
   createOwnerColumn(): TableColumn<DocsTableRow> {
     return {
-      title: 'Owner',
+      title: <TableColumnTitle translationKey="owner" />,
       field: 'resolved.ownedByRelationsTitle',
       render: ({ resolved }) => (
         <EntityRefLinks
@@ -73,13 +74,13 @@ export const columnFactories = {
   },
   createKindColumn(): TableColumn<DocsTableRow> {
     return {
-      title: 'Kind',
+      title: <TableColumnTitle translationKey="kind" />,
       field: 'entity.kind',
     };
   },
   createTypeColumn(): TableColumn<DocsTableRow> {
     return {
-      title: 'Type',
+      title: <TableColumnTitle translationKey="type" />,
       field: 'entity.spec.type',
     };
   },

--- a/plugins/techdocs/src/home/components/TechDocsPageWrapper.tsx
+++ b/plugins/techdocs/src/home/components/TechDocsPageWrapper.tsx
@@ -18,6 +18,8 @@ import { ReactNode, FC } from 'react';
 
 import { PageWithHeader } from '@backstage/core-components';
 import { useApi, configApiRef } from '@backstage/core-plugin-api';
+import { useTranslationRef } from '@backstage/frontend-plugin-api';
+import { techdocsTranslationRef } from '../../translation';
 
 /**
  * Props for {@link TechDocsPageWrapper}
@@ -37,9 +39,11 @@ export type TechDocsPageWrapperProps = {
 export const TechDocsPageWrapper = (props: TechDocsPageWrapperProps) => {
   const { children, CustomPageWrapper } = props;
   const configApi = useApi(configApiRef);
-  const generatedSubtitle = `Documentation available in ${
-    configApi.getOptionalString('organization.name') ?? 'Backstage'
-  }`;
+  const { t } = useTranslationRef(techdocsTranslationRef);
+  const generatedSubtitle = t('techDocsPageWrapper.subtitle', {
+    organizationName:
+      configApi.getOptionalString('organization.name') ?? 'Backstage',
+  });
 
   return (
     <>
@@ -47,7 +51,7 @@ export const TechDocsPageWrapper = (props: TechDocsPageWrapperProps) => {
         <CustomPageWrapper>{children}</CustomPageWrapper>
       ) : (
         <PageWithHeader
-          title="Documentation"
+          title={t('techDocsPageWrapper.title')}
           subtitle={generatedSubtitle}
           themeId="documentation"
         >

--- a/plugins/techdocs/src/reader/components/TechDocsBuildLogs.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsBuildLogs.tsx
@@ -15,6 +15,7 @@
  */
 
 import { LogViewer } from '@backstage/core-components';
+import { useTranslationRef } from '@backstage/frontend-plugin-api';
 import Button from '@material-ui/core/Button';
 import Drawer from '@material-ui/core/Drawer';
 import Grid from '@material-ui/core/Grid';
@@ -23,6 +24,7 @@ import Typography from '@material-ui/core/Typography';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import Close from '@material-ui/icons/Close';
 import { useState } from 'react';
+import { techdocsTranslationRef } from '../../translation';
 
 const useDrawerStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -54,8 +56,12 @@ export const TechDocsBuildLogsDrawerContent = ({
   onClose: () => void;
 }) => {
   const classes = useDrawerStyles();
+  const { t } = useTranslationRef(techdocsTranslationRef);
+
   const logText =
-    buildLog.length === 0 ? 'Waiting for logs...' : buildLog.join('\n');
+    buildLog.length === 0
+      ? t('techDocsBuildLogs.waitingForLogsMessage')
+      : buildLog.join('\n');
   return (
     <Grid
       container
@@ -72,10 +78,10 @@ export const TechDocsBuildLogsDrawerContent = ({
         spacing={0}
         wrap="nowrap"
       >
-        <Typography variant="h5">Build Details</Typography>
+        <Typography variant="h5">{t('techDocsBuildLogs.title')}</Typography>
         <IconButton
           key="dismiss"
-          title="Close the drawer"
+          title={t('techDocsBuildLogs.closeDrawerTooltip')}
           onClick={onClose}
           color="inherit"
         >
@@ -90,13 +96,14 @@ export const TechDocsBuildLogsDrawerContent = ({
 };
 
 export const TechDocsBuildLogs = ({ buildLog }: { buildLog: string[] }) => {
+  const { t } = useTranslationRef(techdocsTranslationRef);
   const classes = useDrawerStyles();
   const [open, setOpen] = useState(false);
 
   return (
     <>
       <Button color="inherit" onClick={() => setOpen(true)}>
-        Show Build Logs
+        {t('techDocsBuildLogs.showBuildLogsButton')}
       </Button>
       <Drawer
         classes={{ paper: classes.paper }}

--- a/plugins/techdocs/src/translation.ts
+++ b/plugins/techdocs/src/translation.ts
@@ -23,5 +23,31 @@ export const techdocsTranslationRef = createTranslationRef({
     aboutCard: {
       viewTechdocs: 'View TechDocs',
     },
+    docsTable: {
+      // title: 'Documentation',
+      allTitle: 'All',
+      columns: {
+        document: 'Document',
+        owner: 'Owner',
+        kind: 'Kind',
+        type: 'Type',
+      },
+      emptyState: {
+        title: 'No documents to show',
+        description:
+          'Create your own document. Check out our Getting Started Information',
+        readMoreButton: 'Read more',
+      },
+    },
+    techDocsBuildLogs: {
+      title: 'Build Details',
+      showBuildLogsButton: 'Show Build Logs',
+      closeDrawerTooltip: 'Close the drawer',
+      waitingForLogsMessage: 'Waiting for logs...',
+    },
+    techDocsPageWrapper: {
+      title: 'Documentation',
+      subtitle: 'Documentation available in {{ organizationName }}',
+    },
   },
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Use existing translationRef and extend it for the table and log view components. Exported the translationRef also in the `/alpha` export.

| Before | With this PR and some translations |
| --- | --- |
| <img width="1787" height="659" alt="Screenshot From 2025-11-12 12-37-13" src="https://github.com/user-attachments/assets/2c0430d4-d70c-4b96-876d-a115e52f6a19" /> | <img width="1787" height="659" alt="Screenshot From 2025-11-12 12-36-49" src="https://github.com/user-attachments/assets/0ccab353-d22e-4693-85f4-9974a92ab60f" /> |
| <img width="1787" height="659" alt="Screenshot From 2025-11-12 12-36-59" src="https://github.com/user-attachments/assets/97b8fb03-d5d0-477a-8868-52cfc3fc4e39" /> | <img width="1787" height="659" alt="Screenshot From 2025-11-12 12-37-24" src="https://github.com/user-attachments/assets/9919966d-1f8e-4e67-b572-11f7a445f430" /> |

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
