### PR TITLE
Add `version` to mock user credentials

### DIFF
--- a/packages/backend-test-utils/src/services/mockCredentials.ts
+++ b/packages/backend-test-utils/src/services/mockCredentials.ts
@@ -122,6 +122,7 @@ export namespace mockCredentials {
     validateUserEntityRef(userEntityRef);
     const result = {
       $$type: '@backstage/BackstageCredentials',
+      version: 'v1',
       principal: {
         type: 'user',
         userEntityRef,


### PR DESCRIPTION
Absense of `version` causes `UserInfoService.getUserInfo(credentials)` to throw error when using mock user.

Example code from documentation: https://backstage.io/docs/backend-system/core-services/user-info

```ts
router.get('/some-request', async (req, res) => {
  const credentials = await httpAuth.credentials(req, { allow: ['user'] });
  const info = await userInfo.getUserInfo(credentials); // Error: Invalid credential version undefined
});
```

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
