### PR TITLE
fix(catalog): fix react warnings for unstable keys using NFS

### DIFF
--- a/.changeset/early-berries-bet.md
+++ b/.changeset/early-berries-bet.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Fix React warnings for elements not having stable keys.

--- a/plugins/catalog/src/alpha/DefaultEntityContentLayout.tsx
+++ b/plugins/catalog/src/alpha/DefaultEntityContentLayout.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { Fragment } from 'react';
 import Grid from '@material-ui/core/Grid';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 import { EntityContentLayoutProps } from '@backstage/plugin-catalog-react/alpha';
@@ -168,22 +169,35 @@ export function DefaultEntityContentLayout(props: EntityContentLayoutProps) {
       <div className={classes.root}>
         {infoCards.length > 0 ? (
           <div className={classes.infoArea}>
-            {infoCards.map(card => card.element)}
+            {infoCards.map((card, index) => (
+              <Fragment key={card.element.key ?? index}>
+                {card.element}
+              </Fragment>
+            ))}
           </div>
         ) : null}
         <div className={classes.mainContent}>
           {summaryCards.length > 0 ? (
             <div className={classes.summaryArea}>
               <HorizontalScrollGrid scrollStep={400} scrollSpeed={100}>
-                {summaryCards.map(card => (
-                  <div className={classes.summaryCard}>{card.element}</div>
+                {summaryCards.map((card, index) => (
+                  <div
+                    key={card.element.key ?? index}
+                    className={classes.summaryCard}
+                  >
+                    {card.element}
+                  </div>
                 ))}
               </HorizontalScrollGrid>
             </div>
           ) : null}
           {contentCards.length > 0 ? (
             <div className={classes.contentArea}>
-              {contentCards.map(card => card.element)}
+              {contentCards.map((card, index) => (
+                <Fragment key={card.element.key ?? index}>
+                  {card.element}
+                </Fragment>
+              ))}
             </div>
           ) : null}
         </div>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Using catalog with new frontend system you receive many warnings in console on the entity page:
`Warning: Each child in a list should have a unique "key" prop.`

This PR fixes these warnings by adding a stable unique key to each child in lists on the default entity layout.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
