### PR TITLE
fix(catalog): fix responsiveness for catalog entity content in nfs

### DIFF
--- a/.changeset/lucky-parrots-yell.md
+++ b/.changeset/lucky-parrots-yell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Fixed responsiveness issues with catalog entity content layout using the new frontend system.

--- a/plugins/catalog/src/alpha/DefaultEntityContentLayout.tsx
+++ b/plugins/catalog/src/alpha/DefaultEntityContentLayout.tsx
@@ -52,7 +52,7 @@ const useStyles = makeStyles<
   infoArea: {
     display: 'flex',
     flexFlow: 'column nowrap',
-    alignItems: 'flex-start',
+    alignItems: 'stretch',
     gap: theme.spacing(3),
     minWidth: 0,
     '& > *': {
@@ -62,10 +62,11 @@ const useStyles = makeStyles<
   },
   summaryArea: {
     minWidth: 0,
-    margin: theme.spacing(1.5), // To counteract MUI negative grid margin
+    margin: theme.spacing(1), // To counteract MUI negative grid margin
   },
   summaryCard: {
     flex: '0 0 auto',
+    width: '100%',
     '& + &': {
       marginLeft: theme.spacing(3),
     },
@@ -96,7 +97,7 @@ const useStyles = makeStyles<
     },
     summaryArea: {
       gridArea: 'summary',
-      marginBottom: theme.spacing(3),
+      margin: theme.spacing(1), // To counteract MUI negative grid margin
     },
     infoArea: {
       gridArea: 'info',
@@ -116,6 +117,9 @@ const useStyles = makeStyles<
       '&::-webkit-scrollbar': {
         display: 'none',
       },
+    },
+    summaryCard: {
+      width: 'auto',
     },
   },
 }));


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes: #31547 

This PR fixes responsiveness issues with catalog entity content layout using new frontend system.

- On small screen sizes when cards collapse into a single column, "info" and "summary" cards will stretch to fit the column.
- Fix some slightly incorrect margins for the "summary" cards

Before:

<img width="951" height="789" alt="Screenshot 2025-11-13 at 10 42 49 PM" src="https://github.com/user-attachments/assets/42c3cb9a-019c-495b-a00d-1f9be114e430" />

<img width="951" height="789" alt="Screenshot 2025-11-13 at 10 43 34 PM" src="https://github.com/user-attachments/assets/5f27d1a8-37a9-44ef-bd93-a7104718764e" />

After:

<img width="951" height="789" alt="Screenshot 2025-11-13 at 10 43 53 PM" src="https://github.com/user-attachments/assets/b4ea6915-ce98-4f1c-ad93-fd1777ef7d6f" />

<img width="951" height="789" alt="Screenshot 2025-11-13 at 10 44 12 PM" src="https://github.com/user-attachments/assets/1ed886c2-8bf5-46c7-acbb-1ebfdcaee0a5" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
