### PR TITLE
fix(catalog): fix refresh service ancestry to follow the tree

### DIFF
--- a/.changeset/tiny-suns-trade.md
+++ b/.changeset/tiny-suns-trade.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Fixed default refresh service to go through the whole ancestry of the entity.

--- a/plugins/catalog-backend/src/service/DefaultRefreshService.ts
+++ b/plugins/catalog-backend/src/service/DefaultRefreshService.ts
@@ -29,20 +29,17 @@ export class DefaultRefreshService implements RefreshService {
       const { entityRefs } = await this.database.listAncestors(tx, {
         entityRef: options.entityRef,
       });
-      const locationAncestor = entityRefs.find(ref =>
+
+      const locationAncestors = entityRefs.filter(ref =>
         ref.startsWith('location:'),
       );
 
       // TODO: Refreshes are currently scheduled(as soon as possible) for execution and will therefore happen in the future.
       // There's room for improvements here where the refresh could potentially hang or return an ID so that the user can check progress.
-      if (locationAncestor) {
-        await this.database.refresh(tx, {
-          entityRef: locationAncestor,
-        });
+      for (const locationAncestor of locationAncestors) {
+        await this.database.refresh(tx, { entityRef: locationAncestor });
       }
-      await this.database.refresh(tx, {
-        entityRef: options.entityRef,
-      });
+      await this.database.refresh(tx, { entityRef: options.entityRef });
     });
   }
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

if location is referenced by another location, that will not get updated properly

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
