### PR TITLE
fix(ui): render html in gfm mode in MarkdownContent component

### DIFF
--- a/.changeset/few-teams-punch.md
+++ b/.changeset/few-teams-punch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+The MarkdownContent component now handles HTML content the same way as GitHub when rendering GitHub-flavored Markdown

--- a/packages/core-components/package.json
+++ b/packages/core-components/package.json
@@ -77,6 +77,7 @@
     "linkify-react": "4.3.2",
     "linkifyjs": "4.3.2",
     "lodash": "^4.17.21",
+    "parse5": "^6.0.0",
     "pluralize": "^8.0.0",
     "qs": "^6.9.4",
     "rc-progress": "3.5.1",
@@ -90,6 +91,8 @@
     "react-use": "^17.3.2",
     "react-virtualized-auto-sizer": "^1.0.11",
     "react-window": "^1.8.6",
+    "rehype-raw": "^6.0.0",
+    "rehype-sanitize": "^5.0.0",
     "remark-gfm": "^3.0.1",
     "zen-observable": "^0.10.0",
     "zod": "^3.22.4"

--- a/packages/core-components/src/components/MarkdownContent/MarkdownContent.stories.tsx
+++ b/packages/core-components/src/components/MarkdownContent/MarkdownContent.stories.tsx
@@ -45,6 +45,29 @@ const markdownGithubFlavored =
   '* [ ] to do\n' +
   '* [x] done';
 
+const markdownGithubFlavoredWithHTML =
+  '# GFM with HTML\n' +
+  '\n' +
+  'This is a paragraph with <strong>bold text</strong> and <em>italic text</em>.\n' +
+  '\n' +
+  '<br />\n' +
+  '\n' +
+  'Here is a list:\n' +
+  '\n' +
+  '<ul>\n' +
+  '  <li>First item</li>\n' +
+  '  <li>Second item with <a href="https://example.com">a link</a></li>\n' +
+  '  <li>Third item</li>\n' +
+  '</ul>\n' +
+  '\n' +
+  'And a code block:\n' +
+  '\n' +
+  '<pre><code class="language-js">\n' +
+  'function greet() {\n' +
+  '  console.log("Hello, world!");\n' +
+  '}\n' +
+  '</code></pre>\n';
+
 const markdown =
   '# Choreas Iovis\n' +
   '\n' +
@@ -116,4 +139,8 @@ export const MarkdownContentCommonMark = () => (
 
 export const MarkdownContentGithubFlavoredCommonMark = () => (
   <MarkdownContent content={markdownGithubFlavored} dialect="gfm" />
+);
+
+export const MarkdownContentGithubFlavoredWithHTML = () => (
+  <MarkdownContent content={markdownGithubFlavoredWithHTML} dialect="gfm" />
 );

--- a/packages/core-components/src/components/MarkdownContent/MarkdownContent.test.tsx
+++ b/packages/core-components/src/components/MarkdownContent/MarkdownContent.test.tsx
@@ -163,4 +163,52 @@ describe('<MarkdownContent />', () => {
       'the-fitnessgram-pacer-test-is-a-multistage-aerobic-capacity-test',
     );
   });
+
+  it('render MarkdownContent component with br tags for new lines in GFM dialect', async () => {
+    await renderInTestApp(
+      <MarkdownContent
+        content="<p>Line 1</p><br /><p>Line 2</p><br><p>Line 3</p><br />"
+        dialect="gfm"
+      />,
+    );
+
+    const line1 = screen.getByText(/Line 1/);
+    const line2 = screen.getByText(/Line 2/);
+    const line3 = screen.getByText(/Line 3/);
+
+    expect(line1.nextSibling?.nodeName).toBe('BR');
+    expect(line2.previousSibling?.nodeName).toBe('BR');
+    expect(line2.nextSibling?.nodeName).toBe('BR');
+    expect(line3.previousSibling?.nodeName).toBe('BR');
+  });
+
+  it('render MarkdownContent component without allowing inline styles in GFM dialect', async () => {
+    await renderInTestApp(
+      <MarkdownContent
+        content='<div style="color: blue; border: 1px solid black; padding: 10px;">This is a custom HTML block with inline styles.</div>'
+        dialect="gfm"
+      />,
+    );
+
+    const divElement = screen.getByText(
+      'This is a custom HTML block with inline styles.',
+    );
+    expect(divElement).toBeInTheDocument();
+    expect(divElement).not.toHaveStyle('color: blue');
+    expect(divElement).not.toHaveStyle('border: 1px solid black');
+    expect(divElement).not.toHaveStyle('padding: 10px');
+  });
+
+  it('render MarkdownContent component without disallowed elements in GFM dialect', async () => {
+    const { container } = await renderInTestApp(
+      <MarkdownContent
+        content='<script>alert("XSS Attack!");</script><style>body { background-color: red; }</style><p>Safe Content</p>'
+        dialect="gfm"
+      />,
+    );
+
+    expect(screen.getByText('Safe Content')).toBeInTheDocument();
+    expect(container.querySelector('script')).toBeNull();
+    expect(container.querySelector('style')).toBeNull();
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3645,6 +3645,7 @@ __metadata:
     linkifyjs: "npm:4.3.2"
     lodash: "npm:^4.17.21"
     msw: "npm:^1.0.0"
+    parse5: "npm:^6.0.0"
     pluralize: "npm:^8.0.0"
     qs: "npm:^6.9.4"
     rc-progress: "npm:3.5.1"
@@ -3661,6 +3662,8 @@ __metadata:
     react-use: "npm:^17.3.2"
     react-virtualized-auto-sizer: "npm:^1.0.11"
     react-window: "npm:^1.8.6"
+    rehype-raw: "npm:^6.0.0"
+    rehype-sanitize: "npm:^5.0.0"
     remark-gfm: "npm:^3.0.1"
     zen-observable: "npm:^0.10.0"
     zod: "npm:^3.22.4"
@@ -21464,6 +21467,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/parse5@npm:^6.0.0":
+  version: 6.0.3
+  resolution: "@types/parse5@npm:6.0.3"
+  checksum: 10/834d40c9b1a8a99a9574b0b3f6629cf48adcff2eda01a35d701f1de5dcf46ce24223684647890aba9f985d6c801b233f878168683de0ae425940403c383fba8f
+  languageName: node
+  linkType: hard
+
 "@types/passport-auth0@npm:^1.0.5":
   version: 1.0.9
   resolution: "@types/passport-auth0@npm:1.0.9"
@@ -33057,10 +33067,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hast-util-from-parse5@npm:^7.0.0":
+  version: 7.1.2
+  resolution: "hast-util-from-parse5@npm:7.1.2"
+  dependencies:
+    "@types/hast": "npm:^2.0.0"
+    "@types/unist": "npm:^2.0.0"
+    hastscript: "npm:^7.0.0"
+    property-information: "npm:^6.0.0"
+    vfile: "npm:^5.0.0"
+    vfile-location: "npm:^4.0.0"
+    web-namespaces: "npm:^2.0.0"
+  checksum: 10/7a90a16430a1482ed1be5c2f8b182e8b12aee8834781245b101700b5a04cea8b569cf40ef08214e1eb333249432e861b17e6fe46d0447b5281827c8798e86f1a
+  languageName: node
+  linkType: hard
+
 "hast-util-parse-selector@npm:^2.0.0":
   version: 2.2.4
   resolution: "hast-util-parse-selector@npm:2.2.4"
   checksum: 10/06e8b534626517929856877df116d95b46d384cc159595270c1e5b3af7404f20843065a1c675d60944445f7356c5c876ed10d5e2d66654b62fe06ecc8b423d45
+  languageName: node
+  linkType: hard
+
+"hast-util-parse-selector@npm:^3.0.0":
+  version: 3.1.1
+  resolution: "hast-util-parse-selector@npm:3.1.1"
+  dependencies:
+    "@types/hast": "npm:^2.0.0"
+  checksum: 10/511d373465f60dd65e924f88bf0954085f4fb6e3a2b062a4b5ac43b93cbfd36a8dce6234b5d1e3e63499d936375687e83fc5da55628b22bd6b581b5ee167d1c4
   languageName: node
   linkType: hard
 
@@ -33070,6 +33104,48 @@ __metadata:
   dependencies:
     "@types/hast": "npm:^3.0.0"
   checksum: 10/76087670d3b0b50b23a6cb70bca53a6176d6608307ccdbb3ed18b650b82e7c3513bfc40348f1389dc0c5ae872b9a768851f4335f44654abd7deafd6974c52402
+  languageName: node
+  linkType: hard
+
+"hast-util-raw@npm:^7.2.0":
+  version: 7.2.3
+  resolution: "hast-util-raw@npm:7.2.3"
+  dependencies:
+    "@types/hast": "npm:^2.0.0"
+    "@types/parse5": "npm:^6.0.0"
+    hast-util-from-parse5: "npm:^7.0.0"
+    hast-util-to-parse5: "npm:^7.0.0"
+    html-void-elements: "npm:^2.0.0"
+    parse5: "npm:^6.0.0"
+    unist-util-position: "npm:^4.0.0"
+    unist-util-visit: "npm:^4.0.0"
+    vfile: "npm:^5.0.0"
+    web-namespaces: "npm:^2.0.0"
+    zwitch: "npm:^2.0.0"
+  checksum: 10/fe39d4b9e68de7131ec61e9abe887cc0579dc7491f738735150c6021565fc998e37c9d096e97fc35c769e986e04b721d4724835ee82fcc22076d778acf6c4832
+  languageName: node
+  linkType: hard
+
+"hast-util-sanitize@npm:^4.0.0":
+  version: 4.1.0
+  resolution: "hast-util-sanitize@npm:4.1.0"
+  dependencies:
+    "@types/hast": "npm:^2.0.0"
+  checksum: 10/8258ba32be9e57e871f894d3c6b3187dd98e0682bf1382cd1306c20045cd5dc209589919817dc079803d9a259b420d9cd88771535088c9fe0eea122028c348eb
+  languageName: node
+  linkType: hard
+
+"hast-util-to-parse5@npm:^7.0.0":
+  version: 7.1.0
+  resolution: "hast-util-to-parse5@npm:7.1.0"
+  dependencies:
+    "@types/hast": "npm:^2.0.0"
+    comma-separated-tokens: "npm:^2.0.0"
+    property-information: "npm:^6.0.0"
+    space-separated-tokens: "npm:^2.0.0"
+    web-namespaces: "npm:^2.0.0"
+    zwitch: "npm:^2.0.0"
+  checksum: 10/695539881431f9713ca4a0be7d06bf3e57ae4d9f930eccba371534c50cff11855d345f8ec30099d04482637ad82e3c70d480269bfa4c109f37993536e8ea690d
   languageName: node
   linkType: hard
 
@@ -33090,6 +33166,19 @@ __metadata:
     property-information: "npm:^5.0.0"
     space-separated-tokens: "npm:^1.0.0"
   checksum: 10/78f91b71e50506f7499c8275d67645f9f4f130e6f12b038853261d1fa7393432da4113baf3508c41b79d933f255089d6d593beea9d4cda89dfd34d0a498cf378
+  languageName: node
+  linkType: hard
+
+"hastscript@npm:^7.0.0":
+  version: 7.2.0
+  resolution: "hastscript@npm:7.2.0"
+  dependencies:
+    "@types/hast": "npm:^2.0.0"
+    comma-separated-tokens: "npm:^2.0.0"
+    hast-util-parse-selector: "npm:^3.0.0"
+    property-information: "npm:^6.0.0"
+    space-separated-tokens: "npm:^2.0.0"
+  checksum: 10/98740e0b69b4765a23d0174fb93eb1c1bdcae6a9f1c9e1b07de6aca2d578427a42e1d45ee98eda26463ac58ff73a8ce45af19c4eb8b5f6f768a9c8543964d28f
   languageName: node
   linkType: hard
 
@@ -33297,6 +33386,13 @@ __metadata:
   bin:
     html-minifier-terser: cli.js
   checksum: 10/a244fa944e002b57c66cc829a3f2dfdb9514b1833c2d838ada624964bf8c0afaf61d36c371758c7e44dedae95cea740a84d8d1067b916ed204f35175184d0e27
+  languageName: node
+  linkType: hard
+
+"html-void-elements@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "html-void-elements@npm:2.0.1"
+  checksum: 10/06d41f13b9d5d6e0f39861c4bec9a9196fa4906d56cd5cf6cf54ad2e52a85bf960cca2bf9600026bde16c8331db171bedba5e5a35e2e43630c8f1d497b2fb658
   languageName: node
   linkType: hard
 
@@ -41217,6 +41313,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parse5@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "parse5@npm:6.0.1"
+  checksum: 10/dfb110581f62bd1425725a7c784ae022a24669bd0efc24b58c71fc731c4d868193e2ebd85b74cde2dbb965e4dcf07059b1e651adbec1b3b5267531bd132fdb75
+  languageName: node
+  linkType: hard
+
 "parse5@npm:^7.0.0, parse5@npm:^7.1.2":
   version: 7.3.0
   resolution: "parse5@npm:7.3.0"
@@ -44468,6 +44571,28 @@ __metadata:
   dependencies:
     rc: "npm:^1.2.8"
   checksum: 10/bcea86c84a0dbb66467b53187fadebfea79017cddfb4a45cf27530d7275e49082fe9f44301976eb0164c438e395684bcf3dae4819b36ff9d1640d8cc60c73df9
+  languageName: node
+  linkType: hard
+
+"rehype-raw@npm:^6.0.0":
+  version: 6.1.1
+  resolution: "rehype-raw@npm:6.1.1"
+  dependencies:
+    "@types/hast": "npm:^2.0.0"
+    hast-util-raw: "npm:^7.2.0"
+    unified: "npm:^10.0.0"
+  checksum: 10/3599d22c45264bea52c93eec2136f50f119282c0bd4e9604aeb2421fe20db84f9c4536caebf64f29158d8c2403b6fd3b3da634211393fdda9cdd500149d00ae4
+  languageName: node
+  linkType: hard
+
+"rehype-sanitize@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "rehype-sanitize@npm:5.0.1"
+  dependencies:
+    "@types/hast": "npm:^2.0.0"
+    hast-util-sanitize: "npm:^4.0.0"
+    unified: "npm:^10.0.0"
+  checksum: 10/b9d9efc0b3c894fe5da84558147148c355c933794c3411dc7c02278b28ea251d241020cd26836e5cc5c979e0e058b45ca51a0eb87824ffdb7241efecd65b6d29
   languageName: node
   linkType: hard
 
@@ -49700,6 +49825,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vfile-location@npm:^4.0.0":
+  version: 4.1.0
+  resolution: "vfile-location@npm:4.1.0"
+  dependencies:
+    "@types/unist": "npm:^2.0.0"
+    vfile: "npm:^5.0.0"
+  checksum: 10/c894e8e5224170d1f85288f4a1d1ebcee0780823ea2b49d881648ab360ebf01b37ecb09b1c4439a75f9a51f31a9f9742cd045e987763e367c352a1ef7c50d446
+  languageName: node
+  linkType: hard
+
 "vfile-message@npm:^3.0.0":
   version: 3.0.2
   resolution: "vfile-message@npm:3.0.2"
@@ -49921,6 +50056,13 @@ __metadata:
     "@zxing/text-encoding":
       optional: true
   checksum: 10/243518cfa8388ac05eeb4041bd330d38c599476ff9a93239b386d1ba2af130089a2fcefb0cf65b385f989105ff460ae69dca7e42236f4d98dc776b04e558cdb5
+  languageName: node
+  linkType: hard
+
+"web-namespaces@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "web-namespaces@npm:2.0.1"
+  checksum: 10/b6d9f02f1a43d0ef0848a812d89c83801d5bbad57d8bb61f02eb6d7eb794c3736f6cc2e1191664bb26136594c8218ac609f4069722c6f56d9fc2d808fa9271c6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Fix HTML rendering in the `MarkdownContent` component when rendering github-flavored markdown

Fixes #30989

**This was created as a contribfest contribution from Kubecon 2025**

Previously, the `MarkdownContent` component did not parse HTML present within the provided markdown content even when GitHub-flavored markdown was specified. This is dissimilar to the rendering behavior of GitHub when rendering the same markdown. 

I have updated the component to render HTML when present in the content and have configured the component to invoke the `rehype-sanitize` plugin to keep unsafe/unwanted elements and attributes from being parsed and rendered.

### Example Content
```md
# GFM with HTML

This is a paragraph with <strong>bold text</strong> and <em>italic text</em>.

<br>

Here is a list:

<ul>
  <li>First item</li>
  <li>Second item with <a href="https://example.com">a link</a></li>
  <li>Third item</li>
</ul>

And a code block:

<pre><code class="language-js">
function greet() {
  console.log("Hello, world!");
}
</code></pre>
```

### Before
<img width="851" height="292" alt="image" src="https://github.com/user-attachments/assets/2c21a22f-dc4a-4308-8987-d657af4fa3de" />

### After
<img width="851" height="364" alt="image" src="https://github.com/user-attachments/assets/bdbd2257-bcf8-4cda-8308-ef5d0a426096" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
