### PR TITLE
Do not perform a query when search term is empty or blank

### DIFF
--- a/.changeset/some-groups-send.md
+++ b/.changeset/some-groups-send.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search': minor
+---
+
+Do not perform a query when search term is empty or blank

--- a/plugins/search/src/apis.ts
+++ b/plugins/search/src/apis.ts
@@ -34,6 +34,10 @@ export class SearchClient implements SearchApi {
     query: SearchQuery,
     options?: { signal?: AbortSignal },
   ): Promise<SearchResultSet> {
+    if (!query.term || !query.term.trim()) {
+      const empty: SearchResultSet = { results: [] };
+      return empty;
+    }
     const queryString = qs.stringify(query);
     const url = `${await this.discoveryApi.getBaseUrl(
       'search',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Avoid empty queries on the search plugin

close #31695

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))