### PR TITLE
gateway-backend: add loop detection

### DIFF
--- a/.changeset/modern-actors-warn.md
+++ b/.changeset/modern-actors-warn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-gateway-backend': minor
+---
+
+Added hop count tracking to prevent proxy loops. The gateway now tracks the number of proxy hops using the `backstage-gateway-hops` header and rejects requests that exceed 3 hops with a 508 Loop Detected error.

--- a/plugins/gateway-backend/src/plugin.test.ts
+++ b/plugins/gateway-backend/src/plugin.test.ts
@@ -161,6 +161,21 @@ describe('gateway', () => {
     expect(data).toEqual({ bar: true });
   });
 
+  it('should detect looped requests', async () => {
+    const response = await fetch(
+      'http://localhost:7777/api/nonexistent-plugin/foo',
+    );
+    expect(response.status).toBe(508);
+
+    const data = await response.json();
+    expect(data).toEqual({
+      error: {
+        name: 'LoopDetectedError',
+        message: 'Maximum proxy hop count exceeded (3)',
+      },
+    });
+  });
+
   it('should close the response for sse connections', async () => {
     const eventSource = new EventSource(
       'http://localhost:7777/api/external-plugin/endpoint-sse',

--- a/plugins/gateway-backend/src/router.ts
+++ b/plugins/gateway-backend/src/router.ts
@@ -23,9 +23,13 @@ import { createProxyMiddleware } from 'http-proxy-middleware';
 import { context } from '@opentelemetry/api';
 import { getRPCMetadata } from '@opentelemetry/core';
 
+const MAX_HOPS = 3;
+const HOPS_HEADER = 'backstage-gateway-hops';
+
 export async function createRouter({
   discovery,
   instanceMeta,
+  logger,
 }: {
   discovery: DiscoveryService;
   instanceMeta: RootInstanceMetadataService;
@@ -41,6 +45,12 @@ export async function createRouter({
       return discovery.getBaseUrl(pluginId);
     },
     on: {
+      proxyReq(proxyReq, req: Request<{ pluginId: string }>) {
+        const currentHops =
+          parseInt(req.headers[HOPS_HEADER] as string, 10) || 0;
+
+        proxyReq.setHeader(HOPS_HEADER, currentHops + 1);
+      },
       proxyRes(proxyRes, _req, res) {
         // https://github.com/chimurai/http-proxy-middleware/discussions/765
         proxyRes.on('close', () => {
@@ -59,6 +69,20 @@ export async function createRouter({
   ) {
     if (localPluginIds.has(req.params.pluginId)) {
       next();
+      return;
+    }
+
+    const currentHops = parseInt(req.headers[HOPS_HEADER] as string, 10) || 0;
+    if (currentHops >= MAX_HOPS) {
+      logger.warn(
+        `Proxy loop detected for plugin '${req.params.pluginId}': request exceeded maximum hop count (${currentHops})`,
+      );
+      res.status(508).json({
+        error: {
+          name: 'LoopDetectedError',
+          message: `Maximum proxy hop count exceeded (${currentHops})`,
+        },
+      });
       return;
     }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes part of #31775. Opted for a hops detection because we can't reliably use `getBaseUrl` to check whether we're proxying to ourselves. Kept the count a bit over 1 because one could concievably chain multiple gateway plugins, but kept the count low because let's keep things sensible 😅 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
