### PR TITLE
fix(ui): prioritize providedRowCount in useTable hook

### DIFF
--- a/.changeset/spicy-teeth-study.md
+++ b/.changeset/spicy-teeth-study.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed `useTable` hook to prioritize `providedRowCount` over data length for accurate row count in server-side pagination scenarios.

--- a/packages/ui/src/components/Table/hooks/useTable.ts
+++ b/packages/ui/src/components/Table/hooks/useTable.ts
@@ -50,8 +50,8 @@ export function useTable<T = any>(
   const isControlled =
     controlledOffset !== undefined || controlledPageSize !== undefined;
 
-  // Calculate row count from data or use provided value
-  const rowCount = data?.length ?? providedRowCount ?? 0;
+  // Use providedRowCount if passed, otherwise fallback to data length
+  const rowCount = providedRowCount ?? data?.length ?? 0;
 
   // Internal state for uncontrolled mode
   const [internalOffset, setInternalOffset] = useState(defaultOffset);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Changed the row count calculation in the useTable hook to prioritize the providedRowCount prop over data.length. This ensures accurate row count values in server-side pagination scenarios where the total number of rows differs from the current page's data length.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
