### PR TITLE
frontend-plugin-api: fix input incompatibility crash

### DIFF
--- a/.changeset/flat-pillows-rush.md
+++ b/.changeset/flat-pillows-rush.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': patch
+---
+
+Fixed a versioning conflict that could result in a `.withContext` is not a function error.

--- a/packages/frontend-internal/src/wiring/InternalExtensionInput.ts
+++ b/packages/frontend-internal/src/wiring/InternalExtensionInput.ts
@@ -28,7 +28,7 @@ export const OpaqueExtensionInput = OpaqueType.create<{
   versions: {
     readonly version: undefined;
     readonly context?: ExtensionInputContext;
-    withContext(context: ExtensionInputContext): ExtensionInput;
+    withContext?(context: ExtensionInputContext): ExtensionInput;
   };
 }>({
   type: '@backstage/ExtensionInput',

--- a/packages/frontend-plugin-api/src/wiring/createExtension.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.test.ts
@@ -1318,4 +1318,26 @@ describe('createExtension', () => {
       );
     });
   });
+
+  it('should old inputs without context support', () => {
+    const legacyInput = createExtensionInput([numberDataRef]);
+
+    // old API without context
+    delete (legacyInput as any).context;
+    delete (legacyInput as any).withContext;
+
+    const extension = createExtension({
+      attachTo: { id: 'root', input: 'default' },
+      output: [stringDataRef],
+      inputs: {
+        foo: legacyInput,
+      },
+      factory({ inputs }) {
+        unused(inputs.foo);
+        return [stringDataRef('output')];
+      },
+    });
+
+    expect(extension.inputs.foo).toBe(legacyInput);
+  });
 });

--- a/packages/frontend-plugin-api/src/wiring/createExtension.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.ts
@@ -368,11 +368,11 @@ function bindInputs(
   return Object.fromEntries(
     Object.entries(inputs).map(([inputName, input]) => [
       inputName,
-      OpaqueExtensionInput.toInternal(input).withContext({
+      OpaqueExtensionInput.toInternal(input).withContext?.({
         kind,
         name,
         input: inputName,
-      }),
+      }) ?? input,
     ]),
   );
 }

--- a/packages/frontend-plugin-api/src/wiring/createExtensionInput.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionInput.test.ts
@@ -60,7 +60,7 @@ describe('createExtensionInput', () => {
     const input = createExtensionInput([stringDataRef, numberDataRef]);
     const context = { input: 'test1', kind: 'test2', name: 'test3' };
     const inputWithContext =
-      OpaqueExtensionInput.toInternal(input).withContext(context);
+      OpaqueExtensionInput.toInternal(input).withContext?.(context);
     expect(inputWithContext).toEqual({
       $$type: '@backstage/ExtensionInput',
       extensionData: [stringDataRef, numberDataRef],

--- a/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.test.ts
@@ -80,7 +80,7 @@ describe('resolveExtensionDefinition', () => {
       resolveExtensionDefinition(
         OpaqueExtensionDefinition.toInternal({
           ...baseDef,
-          attachTo: baseInpuf.withContext({
+          attachTo: baseInpuf.withContext?.({
             kind: 'parent',
             name: 'example',
             input: 'children',
@@ -97,7 +97,7 @@ describe('resolveExtensionDefinition', () => {
       resolveExtensionDefinition(
         OpaqueExtensionDefinition.toInternal({
           ...baseDef,
-          attachTo: baseInpuf.withContext({
+          attachTo: baseInpuf.withContext?.({
             name: 'example',
             input: 'children',
           }),
@@ -113,7 +113,7 @@ describe('resolveExtensionDefinition', () => {
       resolveExtensionDefinition(
         OpaqueExtensionDefinition.toInternal({
           ...baseDef,
-          attachTo: baseInpuf.withContext({
+          attachTo: baseInpuf.withContext?.({
             kind: 'parent',
             input: 'children',
           }),
@@ -129,7 +129,7 @@ describe('resolveExtensionDefinition', () => {
       resolveExtensionDefinition(
         OpaqueExtensionDefinition.toInternal({
           ...baseDef,
-          attachTo: baseInpuf.withContext({
+          attachTo: baseInpuf.withContext?.({
             input: 'children',
           }),
         }),
@@ -145,15 +145,15 @@ describe('resolveExtensionDefinition', () => {
         OpaqueExtensionDefinition.toInternal({
           ...baseDef,
           attachTo: [
-            baseInpuf.withContext({
+            baseInpuf.withContext?.({
               kind: 'k1',
               input: 'children',
             }),
-            baseInpuf.withContext({
+            baseInpuf.withContext?.({
               kind: 'k2',
               input: 'children',
             }),
-            baseInpuf.withContext({
+            baseInpuf.withContext?.({
               kind: 'k3',
               input: 'children',
             }),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes a crash when mixing `@backstage/frontend-plugin-api` versions. I thought it wouldn't be possible to get a mix of producter/consumer version for extension/extension inputs. Turns out that's possible when you use a blueprint from a non-core library 🤦

More context in https://discord.com/channels/687207715902193673/687207715902193679/1440697696213274778

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
