### PR TITLE
feat(techdocs): add app-config option to disable external font download

### DIFF
--- a/.changeset/funny-animals-prove.md
+++ b/.changeset/funny-animals-prove.md
@@ -1,0 +1,5 @@
+---
+'@techdocs/cli': minor
+---
+
+Add support for disabling external font downloads via techdocs-cli `techdocs-cli generate --disableExternalFonts`, useful for air-gapped Backstage instances.

--- a/.changeset/kind-files-press.md
+++ b/.changeset/kind-files-press.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-techdocs-backend': minor
+'@backstage/plugin-techdocs-node': minor
+---
+
+Add support for disabling external font downloads via app-config option `techdocs.generator.mkdocs.disableExternalFonts`, useful for air-gapped Backstage instances.

--- a/.github/vale/config/vocabularies/Backstage/accept.txt
+++ b/.github/vale/config/vocabularies/Backstage/accept.txt
@@ -587,3 +587,4 @@ zod
 Zolotusky
 zoomable
 zsh
+patcher

--- a/.github/vale/config/vocabularies/Backstage/accept.txt
+++ b/.github/vale/config/vocabularies/Backstage/accept.txt
@@ -343,6 +343,7 @@ params
 parseable
 passthrough
 passwordless
+patcher
 Patrik
 pattison
 Peloton
@@ -587,4 +588,3 @@ zod
 Zolotusky
 zoomable
 zsh
-patcher

--- a/docs/features/techdocs/cli.md
+++ b/docs/features/techdocs/cli.md
@@ -149,6 +149,8 @@ Options:
                                   Defaults to false, which means that the techdocs-core plugin is always added to the mkdocs file.
   --legacyCopyReadmeMdToIndexMd   Attempt to ensure an index.md exists falling back to using <docs-dir>/README.md or README.md
                                   in case a default <docs-dir>/index.md is not provided. (default: false)
+  --disableExternalFonts          Disable external font downloads for all TechDocs sites. Useful for air-gapped environments
+                                  where Google fonts cannot be accessed. (default: false)
   --runAsDefaultUser              Bypass setting the container user as the same user and group id as host for Linux and MacOS (default: false)
   -v, --verbose                   Enable verbose output. (default: false)
   -h, --help                      display help for command

--- a/docs/features/techdocs/configuration.md
+++ b/docs/features/techdocs/configuration.md
@@ -97,6 +97,33 @@ techdocs:
       legacyCopyReadmeMdToIndexMd: false
 ```
 
+#### Disable external fonts
+
+`techdocs.generator.mkdocs.disableExternalFonts`
+
+(Optional) Use this when the generator cannot reach the internet (for example air-gapped or restricted networks). MkDocs Material otherwise tries to download the Roboto font from Google during generation.
+
+When `true`, TechDocs patches each `mkdocs.yml` during generation: if no `theme` section exists it adds `name: material` and `font: false`; if a `theme` exists but `font` is omitted, it sets `font: false`; if `font` is already set in the file, your value is left unchanged.
+
+**Example:**
+
+```yaml
+techdocs:
+  generator:
+    mkdocs:
+      disableExternalFonts: true
+```
+
+Alternatively, configure `mkdocs.yml` manually:
+
+```yaml
+theme:
+  name: material
+  font: false
+```
+
+**Note:** When using `theme.font` in `mkdocs.yml`, `theme.name: material` is required. If `font` is already set in the file, app-config patching does not override it; it only adds `font: false` when `font` was not configured.
+
 #### Default Plugins
 
 `techdocs.generator.mkdocs.defaultPlugins`

--- a/docs/features/techdocs/how-to-guides.md
+++ b/docs/features/techdocs/how-to-guides.md
@@ -551,7 +551,31 @@ Done! You now have support for TechDocs in your own software template!
 
 ### Prevent download of Google fonts
 
-If your Backstage instance does not have internet access, the generation will fail. TechDocs tries to download the Roboto font from Google. You can disable it by adding the following lines to mkdocs.yaml:
+If your Backstage instance does not have internet access, the generation will fail. TechDocs tries to download the Roboto font from Google. You can disable it by configuring your `app-config.yaml` or by manually updating your `mkdocs.yml` file.
+
+#### Using app-config
+
+Add the following configuration to your `app-config.yaml` to automatically
+disable external font downloads for all TechDocs sites:
+
+```yaml
+techdocs:
+  generator:
+    mkdocs:
+      disableExternalFonts: true
+```
+
+This configuration will automatically patch the `mkdocs.yml` file during the
+generation process. If no `theme` section exists, it will create one with `name:
+material` and `font: false`. If a `theme` section exists but `font` is not
+configured, it will add `font: false` to the existing theme. If `font` is
+already explicitly configured in your `mkdocs.yml`, the patcher will respect
+your file-level configuration and not override it.
+
+#### Manual configuration in mkdocs.yml
+
+Alternatively, you can manually add the following configuration to your `mkdocs.yaml`
+file:
 
 ```yaml
 theme:
@@ -561,7 +585,11 @@ theme:
 
 :::note Note
 
-The addition `name: material` is necessary. Otherwise it will not work
+The addition `name: material` is necessary. Otherwise it will not work.
+
+If you explicitly set `font: true` or `font: false` in your `mkdocs.yml`, the
+app-config patcher will respect that setting and not override it. The patcher
+only adds `font: false` when the `font` property is not already configured.
 
 :::
 

--- a/docs/features/techdocs/how-to-guides.md
+++ b/docs/features/techdocs/how-to-guides.md
@@ -574,7 +574,7 @@ your file-level configuration and not override it.
 
 #### Manual configuration in mkdocs.yml
 
-Alternatively, you can manually add the following configuration to your `mkdocs.yaml`
+Alternatively, you can manually add the following configuration to your `mkdocs.yml`
 file:
 
 ```yaml
@@ -592,6 +592,18 @@ app-config patcher will respect that setting and not override it. The patcher
 only adds `font: false` when the `font` property is not already configured.
 
 :::
+
+#### Using techdocs-cli in CI/CD
+
+When generating TechDocs sites in CI/CD workflows using `techdocs-cli`, you can
+use the `--disableExternalFonts` flag:
+
+```bash
+techdocs-cli generate --disableExternalFonts
+```
+
+This will automatically patch the `mkdocs.yml` file during the generation
+process, just like the `app-config.yaml` option does for local generation.
 
 ## How to enable iframes in TechDocs
 

--- a/docs/features/techdocs/how-to-guides.md
+++ b/docs/features/techdocs/how-to-guides.md
@@ -549,14 +549,15 @@ on how you have configured your `template.yaml`.
 
 Done! You now have support for TechDocs in your own software template!
 
-### Prevent download of Google fonts
+### Disable external fonts
 
-If your Backstage instance does not have internet access, the generation will fail. TechDocs tries to download the Roboto font from Google. You can disable it by configuring your `app-config.yaml` or by manually updating your `mkdocs.yml` file.
+`techdocs.generator.mkdocs.disableExternalFonts`
 
-#### Using app-config
+(Optional) Use this when the generator cannot reach the internet (for example air-gapped or restricted networks). MkDocs Material otherwise tries to download the Roboto font from Google during generation.
 
-Add the following configuration to your `app-config.yaml` to automatically
-disable external font downloads for all TechDocs sites:
+When `true`, TechDocs patches each `mkdocs.yml` during generation: if no `theme` section exists it adds `name: material` and `font: false`; if a `theme` exists but `font` is omitted, it sets `font: false`; if `font` is already set in the file, your value is left unchanged.
+
+**Example:**
 
 ```yaml
 techdocs:
@@ -565,17 +566,7 @@ techdocs:
       disableExternalFonts: true
 ```
 
-This configuration will automatically patch the `mkdocs.yml` file during the
-generation process. If no `theme` section exists, it will create one with `name:
-material` and `font: false`. If a `theme` section exists but `font` is not
-configured, it will add `font: false` to the existing theme. If `font` is
-already explicitly configured in your `mkdocs.yml`, the patcher will respect
-your file-level configuration and not override it.
-
-#### Manual configuration in mkdocs.yml
-
-Alternatively, you can manually add the following configuration to your `mkdocs.yml`
-file:
+Alternatively, configure `mkdocs.yml` manually:
 
 ```yaml
 theme:
@@ -583,15 +574,7 @@ theme:
   font: false
 ```
 
-:::note Note
-
-The addition `name: material` is necessary. Otherwise it will not work.
-
-If you explicitly set `font: true` or `font: false` in your `mkdocs.yml`, the
-app-config patcher will respect that setting and not override it. The patcher
-only adds `font: false` when the `font` property is not already configured.
-
-:::
+**Note:** When using `theme.font` in `mkdocs.yml`, `theme.name: material` is required. If `font` is already set in the file, app-config patching does not override it; it only adds `font: false` when `font` was not configured.
 
 #### Using techdocs-cli in CI/CD
 

--- a/packages/techdocs-cli/cli-report.md
+++ b/packages/techdocs-cli/cli-report.md
@@ -27,6 +27,7 @@ Usage: techdocs-cli generate|build [options]
 
 Options:
   --defaultPlugin [defaultPlugins...]
+  --disableExternalFonts
   --docker-image <DOCKER_IMAGE>
   --etag <ETAG>
   --legacyCopyReadmeMdToIndexMd

--- a/packages/techdocs-cli/src/commands/generate/generate.ts
+++ b/packages/techdocs-cli/src/commands/generate/generate.ts
@@ -42,6 +42,7 @@ export default async function generate(opts: OptionValues) {
   const dockerImage = opts.dockerImage;
   const pullImage = opts.pull;
   const legacyCopyReadmeMdToIndexMd = opts.legacyCopyReadmeMdToIndexMd;
+  const disableExternalFonts = opts.disableExternalFonts;
   const defaultPlugins = opts.defaultPlugin;
 
   logger.info(`Using source dir ${sourceDir}`);
@@ -64,6 +65,7 @@ export default async function generate(opts: OptionValues) {
         mkdocs: {
           legacyCopyReadmeMdToIndexMd,
           omitTechdocsCorePlugin,
+          disableExternalFonts,
           defaultPlugins,
         },
       },

--- a/packages/techdocs-cli/src/commands/index.ts
+++ b/packages/techdocs-cli/src/commands/index.ts
@@ -71,6 +71,11 @@ export function registerCommands(program: Command) {
       false,
     )
     .option(
+      '--disableExternalFonts',
+      'Disable external font downloads by default by setting theme.font: false in mkdocs.yml when not already configured. Useful for air-gapped environments where Google fonts cannot be accessed.',
+      false,
+    )
+    .option(
       '--defaultPlugin [defaultPlugins...]',
       'Plugins which should be added automatically to the mkdocs.yaml file',
       [],

--- a/plugins/techdocs-backend/config.d.ts
+++ b/plugins/techdocs-backend/config.d.ts
@@ -76,6 +76,14 @@ export interface Config {
          * @see https://www.mkdocs.org/user-guide/configuration/#hooks
          */
         dangerouslyAllowAdditionalKeys?: string[];
+        
+        /**
+         * Disable external fonts for all TechDocs sites.
+         * If not set, the default value is false.
+         * If set to true, the external font will be disabled for all TechDocs sites.
+         * If set to false, the external font will be enabled for all TechDocs sites.
+         */
+        disableExternalFonts?: boolean;
       };
     };
 

--- a/plugins/techdocs-backend/config.d.ts
+++ b/plugins/techdocs-backend/config.d.ts
@@ -76,7 +76,7 @@ export interface Config {
          * @see https://www.mkdocs.org/user-guide/configuration/#hooks
          */
         dangerouslyAllowAdditionalKeys?: string[];
-        
+
         /**
          * Disable external fonts for all TechDocs sites.
          * If not set, the default value is false.

--- a/plugins/techdocs-node/src/stages/generate/helpers.test.ts
+++ b/plugins/techdocs-node/src/stages/generate/helpers.test.ts
@@ -37,7 +37,7 @@ import {
   patchMkdocsYmlPreBuild,
   patchMkdocsYmlWithPlugins,
   sanitizeMkdocsYml,
-  patchMkdocsYmlWithFontDisabled
+  patchMkdocsYmlWithFontDisabled,
 } from './mkdocsPatchers';
 import yaml from 'js-yaml';
 

--- a/plugins/techdocs-node/src/stages/generate/helpers.test.ts
+++ b/plugins/techdocs-node/src/stages/generate/helpers.test.ts
@@ -492,7 +492,13 @@ theme:
   name: material
   font: false
 `,
+        'mkdocs_with_theme_non_material.yml': `site_name: Test Site
+docs_dir: docs
+theme:
+  name: test-theme
+`,
       });
+      mockLogger.debug.mockClear();
     });
 
     it('should create theme section with font disabled when no theme exists', async () => {
@@ -561,6 +567,18 @@ theme:
       expect(parsedYml.theme).toBeDefined();
       expect(parsedYml.theme?.name).toBe('material');
       expect(parsedYml.theme?.font).toBe(false);
+    });
+
+    it('should not patch when theme name is not material', async () => {
+      const fixturePath = mockDir.resolve('mkdocs_with_theme_non_material.yml');
+      const before = await fs.readFile(fixturePath, 'utf8');
+
+      await patchMkdocsYmlWithFontDisabled(fixturePath, mockLogger);
+
+      await expect(fs.readFile(fixturePath, 'utf8')).resolves.toEqual(before);
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        'mkdocs.yml theme is not "material"; skipping font disabling patch',
+      );
     });
   });
 

--- a/plugins/techdocs-node/src/stages/generate/mkdocsPatchers.ts
+++ b/plugins/techdocs-node/src/stages/generate/mkdocsPatchers.ts
@@ -210,14 +210,25 @@ export const patchMkdocsYmlWithFontDisabled = async (
       return true;
     }
 
-    // Theme section exists, check if font is not configured, add font: false
+    // Theme section exists. Only modify it when the configured theme is Material
     if (
       mkdocsYml.theme &&
       typeof mkdocsYml.theme === 'object' &&
+      (mkdocsYml.theme as any).name === MATERIAL_THEME &&
       !('font' in mkdocsYml.theme)
     ) {
       mkdocsYml.theme.font = false;
       return true;
+    }
+
+    if (
+      mkdocsYml.theme &&
+      typeof mkdocsYml.theme === 'object' &&
+      (mkdocsYml.theme as any).name !== MATERIAL_THEME
+    ) {
+      logger.debug(
+        'mkdocs.yml theme is not "material"; skipping font disabling patch',
+      );
     }
 
     return false;
@@ -288,4 +299,3 @@ export const sanitizeMkdocsYml = async (
     return true;
   });
 };
-

--- a/plugins/techdocs-node/src/stages/generate/mkdocsPatchers.ts
+++ b/plugins/techdocs-node/src/stages/generate/mkdocsPatchers.ts
@@ -25,11 +25,17 @@ import { assertError } from '@backstage/errors';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import { LoggerService } from '@backstage/backend-plugin-api';
 
+const MATERIAL_THEME = 'material';
+
 type MkDocsObject = {
   plugins?: string[];
   docs_dir: string;
   repo_url?: string;
   edit_uri?: string;
+  theme?: {
+    name?: string;
+    font?: boolean;
+  };
 };
 
 const patchMkdocsFile = async (
@@ -186,6 +192,39 @@ export const patchMkdocsYmlWithPlugins = async (
 };
 
 /**
+ * Disable external font download for the material theme.
+ * @param mkdocsYmlPath - Absolute path to mkdocs.yml or equivalent of a docs site
+ * @param logger
+ */
+export const patchMkdocsYmlWithFontDisabled = async (
+  mkdocsYmlPath: string,
+  logger: LoggerService,
+) => {
+  await patchMkdocsFile(mkdocsYmlPath, logger, mkdocsYml => {
+    if (!('theme' in mkdocsYml)) {
+      // No theme section exists, create it with font disabled
+      mkdocsYml.theme = {
+        name: MATERIAL_THEME,
+        font: false,
+      };
+      return true;
+    }
+
+    // Theme section exists, check if font is not configured, add font: false
+    if (
+      mkdocsYml.theme &&
+      typeof mkdocsYml.theme === 'object' &&
+      !('font' in mkdocsYml.theme)
+    ) {
+      mkdocsYml.theme.font = false;
+      return true;
+    }
+
+    return false;
+  });
+};
+
+/**
  * Sanitize mkdocs.yml by keeping only allowed configuration keys.
  *
  * TechDocs only supports a subset of MkDocs configuration options.
@@ -249,3 +288,4 @@ export const sanitizeMkdocsYml = async (
     return true;
   });
 };
+

--- a/plugins/techdocs-node/src/stages/generate/mkdocsPatchers.ts
+++ b/plugins/techdocs-node/src/stages/generate/mkdocsPatchers.ts
@@ -27,15 +27,21 @@ import { LoggerService } from '@backstage/backend-plugin-api';
 
 const MATERIAL_THEME = 'material';
 
+type MkDocsThemeObject = {
+  name?: string;
+  font?: boolean;
+};
+
+function isThemeObject(theme: unknown): theme is MkDocsThemeObject {
+  return typeof theme === 'object' && theme !== null && !Array.isArray(theme);
+}
+
 type MkDocsObject = {
   plugins?: string[];
   docs_dir: string;
   repo_url?: string;
   edit_uri?: string;
-  theme?: {
-    name?: string;
-    font?: boolean;
-  };
+  theme?: MkDocsThemeObject;
 };
 
 const patchMkdocsFile = async (
@@ -210,25 +216,18 @@ export const patchMkdocsYmlWithFontDisabled = async (
       return true;
     }
 
-    // Theme section exists. Only modify it when the configured theme is Material
-    if (
-      mkdocsYml.theme &&
-      typeof mkdocsYml.theme === 'object' &&
-      (mkdocsYml.theme as any).name === MATERIAL_THEME &&
-      !('font' in mkdocsYml.theme)
-    ) {
-      mkdocsYml.theme.font = false;
-      return true;
-    }
-
-    if (
-      mkdocsYml.theme &&
-      typeof mkdocsYml.theme === 'object' &&
-      (mkdocsYml.theme as any).name !== MATERIAL_THEME
-    ) {
-      logger.debug(
-        'mkdocs.yml theme is not "material"; skipping font disabling patch',
-      );
+    const theme = mkdocsYml.theme;
+    if (isThemeObject(theme)) {
+      // Theme section exists. Only modify it when the configured theme is Material
+      if (theme.name === MATERIAL_THEME && !('font' in theme)) {
+        theme.font = false;
+        return true;
+      }
+      if (theme.name !== MATERIAL_THEME) {
+        logger.debug(
+          'mkdocs.yml theme is not "material"; skipping font disabling patch',
+        );
+      }
     }
 
     return false;

--- a/plugins/techdocs-node/src/stages/generate/techdocs.ts
+++ b/plugins/techdocs-node/src/stages/generate/techdocs.ts
@@ -269,7 +269,7 @@ export function readGeneratorConfig(
       'techdocs.generator.mkdocs.dangerouslyAllowAdditionalKeys',
     ),
     disableExternalFonts: config.getOptionalBoolean(
-      'techdocs.generator.mkdocs.disableExternalFonts'
+      'techdocs.generator.mkdocs.disableExternalFonts',
     ),
   };
 }

--- a/plugins/techdocs-node/src/stages/generate/techdocs.ts
+++ b/plugins/techdocs-node/src/stages/generate/techdocs.ts
@@ -32,6 +32,7 @@ import {
 
 import {
   patchMkdocsYmlPreBuild,
+  patchMkdocsYmlWithFontDisabled,
   patchMkdocsYmlWithPlugins,
   sanitizeMkdocsYml,
 } from './mkdocsPatchers';
@@ -150,6 +151,9 @@ export class TechdocsGenerator implements GeneratorBase {
     }
 
     await patchMkdocsYmlWithPlugins(mkdocsYmlPath, childLogger, defaultPlugins);
+    if (this.options.disableExternalFonts) {
+      await patchMkdocsYmlWithFontDisabled(mkdocsYmlPath, childLogger);
+    }
 
     // Directories to bind on container
     const mountDirs = {
@@ -263,6 +267,9 @@ export function readGeneratorConfig(
     ),
     dangerouslyAllowAdditionalKeys: config.getOptionalStringArray(
       'techdocs.generator.mkdocs.dangerouslyAllowAdditionalKeys',
+    ),
+    disableExternalFonts: config.getOptionalBoolean(
+      'techdocs.generator.mkdocs.disableExternalFonts'
     ),
   };
 }

--- a/plugins/techdocs-node/src/stages/generate/types.ts
+++ b/plugins/techdocs-node/src/stages/generate/types.ts
@@ -46,6 +46,7 @@ export type GeneratorConfig = {
   legacyCopyReadmeMdToIndexMd?: boolean;
   defaultPlugins?: string[];
   dangerouslyAllowAdditionalKeys?: string[];
+  disableExternalFonts?: boolean;
 };
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Fixes: https://github.com/backstage/backstage/issues/31827

Adds support for automatically disabling external font downloads (Google Roboto) in TechDocs sites through app-config. This feature is particularly useful for Backstage instances that don't have internet access, where font downloads would cause TechDocs generation to fail.


- **App-config option**: `techdocs.generator.mkdocs.disableExternalFonts: true`
  - When enabled, automatically patches `mkdocs.yml` files to disable external font downloads
  - Works for both remote (`url:`) and local (`dir:`) TechDocs sources

## Configuration via `app-config` file:

```yaml
techdocs:
  generator:
    mkdocs:
      disableExternalFonts: true
```

The above config automatically patches all the techdocs site's `mkdocs.yml` files with below theme configuration:
**mkdocs.yml**
```yaml
theme:
  name: material
  font: false 
```

## Behavior
- **Automatic patching**: Only adds `font: false` when the property is not already configured
- **File-level precedence**: If `font: true` or `font: false` is explicitly set in `mkdocs.yml`, the patcher respects that setting
- **Backward compatible**: Existing TechDocs sites continue to work without changes

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
