### PR TITLE
fix(ui): correct Column sorting indicator direction

### DIFF
--- a/.changeset/twenty-ducks-relate.md
+++ b/.changeset/twenty-ducks-relate.md
@@ -1,0 +1,7 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed Table column sorting indicator to show up arrow when no sort is active, correctly indicating that clicking will sort ascending.
+
+Affected components: Column

--- a/packages/ui/src/components/Table/components/Column.tsx
+++ b/packages/ui/src/components/Table/components/Column.tsx
@@ -48,10 +48,10 @@ export const Column = (props: ColumnProps) => {
                 styles[classNames.headSortButton],
               )}
             >
-              {sortDirection === 'ascending' ? (
-                <RiArrowUpLine size={16} />
-              ) : (
+              {sortDirection === 'descending' ? (
                 <RiArrowDownLine size={16} />
+              ) : (
+                <RiArrowUpLine size={16} />
               )}
             </span>
           )}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixed the Table Column sorting indicator to show an up arrow when no sorting is active, correctly indicating that clicking will sort ascending. Previously, the down arrow was shown by default, which was misleading.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

#### Changeset illustration

<img width="256" height="384" alt="image" src="https://github.com/user-attachments/assets/2c77427a-bb4e-481f-91d8-7dc12aff01b1" />

