### PR TITLE
fix(auth): remove leading dot in auth cookie cleanup

### DIFF
--- a/.changeset/clean-toys-reply.md
+++ b/.changeset/clean-toys-reply.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-node': patch
+---
+
+remove leading dot in auth cookie cleanup call

--- a/plugins/auth-node/src/oauth/OAuthCookieManager.ts
+++ b/plugins/auth-node/src/oauth/OAuthCookieManager.ts
@@ -189,7 +189,7 @@ export class OAuthCookieManager {
       const { hostname: domain } = new URL(this.options.callbackUrl);
       output = output.cookie(name, '', {
         ...this.getRemoveCookieOptions(),
-        domain: `.${domain}`,
+        domain: domain,
       });
     }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### Background

This PR was triggered by an investigation when looking into [this bug](https://github.com/backstage/backstage/issues/31295) as a result of [this change](https://github.com/backstage/backstage/pull/30922).

See [comment](https://github.com/backstage/backstage/issues/31295#issuecomment-3481448925): 
> The leading dot notation is now obsolete per [RFC 6265](https://www.rfc-editor.org/rfc/rfc6265) (which is what all modern browsers follow) and in the [RFC](https://www.rfc-editor.org/rfc/rfc6265#section-4.1.2.3) it says the leading dot is ignored and does not determine whether or not a cookie is host-only or not. The dot is only shown in browser tools to distinguish domain-scoped cookies from host-only.

I have updated the old cookie removal code to remove the outdated leading dot which may have been triggering some bugs. 

### Verification
I've tested this change to make sure the behaviour is as expected:

This is the call that:
1. Expires the old cookie with explicitly set domain `"domain=sub.backstage.local"`
2. Sets a new cookie without the domain field (i.e. host-only)
<img width="1174" height="230" alt="image-mh" src="https://github.com/user-attachments/assets/9a46d802-2892-4cc0-8c95-f9553207f531" />

The old cookies with the dot prefix is removed by this call: 
<img width="507" height="194" alt="image" src="https://github.com/user-attachments/assets/75e5b5da-5516-47b5-bb3a-a653d4fbe08e" />


The final state of cookies
<img width="413" height="48" alt="image" src="https://github.com/user-attachments/assets/409c1fdc-4c62-4b7a-babb-4f90ea7e5c0d" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
