### PR TITLE
fix: Add ordering to OwnerPicker

### DIFF
--- a/.changeset/fine-clocks-add.md
+++ b/.changeset/fine-clocks-add.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-scaffolder': patch
+'@backstage/plugin-home': patch
+---
+
+Build api reports

--- a/.changeset/huge-berries-cry.md
+++ b/.changeset/huge-berries-cry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Added default ordering to the `EntityPicker` (and therefore `OwnerPicker`) so that catalog results are returned in a stable alphabetical order even when `catalog.enableRelationsCompatibility` is disabled.

--- a/plugins/home/report.api.md
+++ b/plugins/home/report.api.md
@@ -126,7 +126,16 @@ export type GetLabelFunction = (visit: Visit) => string;
 // @public
 export const HeaderWorldClock: (props: {
   clockConfigs: ClockConfig[];
-  customTimeFormat?: Intl.DateTimeFormatOptions;
+  customTimeFormat?: /**
+   * A component to display a company logo for the user.
+   *
+   * @public
+   */
+  /**
+   * A component to display a company logo for the user.
+   *
+   * @public
+   */ Intl.DateTimeFormatOptions;
 }) => JSX_2.Element | null;
 
 // @public

--- a/plugins/scaffolder/CHANGELOG.md
+++ b/plugins/scaffolder/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/plugin-scaffolder
 
+## 1.34.4
+
+### Patch Changes
+
+- Added default ordering to the `EntityPicker` (and therefore `OwnerPicker`) so that catalog results are returned in a stable alphabetical order even when `catalog.enableRelationsCompatibility` is disabled. We can override this ordering by supplying `ui:options.orderFields` in your template schema.
+
 ## 1.34.3
 
 ### Patch Changes

--- a/plugins/scaffolder/report.api.md
+++ b/plugins/scaffolder/report.api.md
@@ -76,6 +76,12 @@ export const EntityPickerFieldExtension: FieldExtensionComponent_2<
   {
     defaultKind?: string | undefined;
     defaultNamespace?: string | false | undefined;
+    orderFields?:
+      | {
+          field: string;
+          order?: 'desc' | 'asc' | undefined;
+        }[]
+      | undefined;
     catalogFilter?:
       | Record<
           string,
@@ -105,6 +111,12 @@ export const EntityPickerFieldSchema: FieldSchema_2<
   {
     defaultKind?: string | undefined;
     defaultNamespace?: string | false | undefined;
+    orderFields?:
+      | {
+          field: string;
+          order?: 'desc' | 'asc' | undefined;
+        }[]
+      | undefined;
     catalogFilter?:
       | Record<
           string,
@@ -251,6 +263,12 @@ export const OwnedEntityPickerFieldExtension: FieldExtensionComponent_2<
   {
     defaultKind?: string | undefined;
     defaultNamespace?: string | false | undefined;
+    orderFields?:
+      | {
+          field: string;
+          order?: 'desc' | 'asc' | undefined;
+        }[]
+      | undefined;
     catalogFilter?:
       | Record<
           string,
@@ -280,6 +298,12 @@ export const OwnedEntityPickerFieldSchema: FieldSchema_2<
   {
     defaultKind?: string | undefined;
     defaultNamespace?: string | false | undefined;
+    orderFields?:
+      | {
+          field: string;
+          order?: 'desc' | 'asc' | undefined;
+        }[]
+      | undefined;
     catalogFilter?:
       | Record<
           string,

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.test.tsx
@@ -37,6 +37,12 @@ const makeEntity = (kind: string, namespace: string, name: string): Entity => ({
   metadata: { namespace, name },
 });
 
+const defaultOrder = [
+  { field: 'kind', order: 'asc' as const },
+  { field: 'metadata.namespace', order: 'asc' as const },
+  { field: 'metadata.name', order: 'asc' as const },
+];
+
 describe('<EntityPicker />', () => {
   const entities: Entity[] = [
     makeEntity('Group', 'default', 'team-a'),
@@ -73,6 +79,36 @@ describe('<EntityPicker />', () => {
     );
   });
 
+  describe('with orderFields override', () => {
+    it('uses custom ordering when provided', async () => {
+      uiSchema = {
+        'ui:options': {
+          orderFields: [{ field: 'metadata.title', order: 'desc' }],
+        },
+      };
+      props = {
+        onChange,
+        schema,
+        required,
+        uiSchema,
+        rawErrors,
+        formData,
+      } as unknown as FieldProps;
+
+      await renderInTestApp(
+        <Wrapper>
+          <EntityPicker {...props} />
+        </Wrapper>,
+      );
+
+      expect(catalogApi.getEntities).toHaveBeenCalledWith(
+        expect.objectContaining({
+          order: [{ field: 'metadata.title', order: 'desc' }],
+        }),
+      );
+    });
+  });
+
   afterEach(() => jest.resetAllMocks());
 
   describe('without allowedKinds and catalogFilter', () => {
@@ -106,6 +142,7 @@ describe('<EntityPicker />', () => {
           'spec.type',
         ],
         filter: undefined,
+        order: defaultOrder,
       });
     });
 
@@ -152,6 +189,7 @@ describe('<EntityPicker />', () => {
           filter: {
             kind: ['User'],
           },
+          order: defaultOrder,
         }),
       );
     });
@@ -204,6 +242,7 @@ describe('<EntityPicker />', () => {
               'metadata.name': 'test-entity',
             },
           ],
+          order: defaultOrder,
         }),
       );
     });
@@ -231,6 +270,7 @@ describe('<EntityPicker />', () => {
             kind: ['Group'],
             'metadata.name': 'test-entity',
           },
+          order: defaultOrder,
         }),
       );
     });
@@ -261,6 +301,7 @@ describe('<EntityPicker />', () => {
               'metadata.annotation.some/anotation': CATALOG_FILTER_EXISTS,
             },
           ],
+          order: defaultOrder,
         }),
       );
     });
@@ -373,6 +414,7 @@ describe('<EntityPicker />', () => {
               'metadata.name': 'test-group',
             },
           ],
+          order: defaultOrder,
         }),
       );
     });

--- a/plugins/scaffolder/src/components/fields/EntityPicker/schema.ts
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/schema.ts
@@ -61,6 +61,17 @@ export const EntityPickerFieldSchema = makeFieldSchema({
       )
         .optional()
         .describe('List of key-value filter expression for entities'),
+      orderFields: z
+        .array(
+          z.object({
+            field: z.string(),
+            order: z.enum(['asc', 'desc']).optional(),
+          }),
+        )
+        .optional()
+        .describe(
+          'Ordering directives passed to the catalog when loading options',
+        ),
     }),
 });
 

--- a/plugins/scaffolder/src/components/fields/OwnerPicker/OwnerPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/OwnerPicker/OwnerPicker.test.tsx
@@ -34,6 +34,11 @@ const makeEntity = (kind: string, namespace: string, name: string): Entity => ({
   metadata: { namespace, name },
 });
 
+const ownerDefaultOrder = [
+  { field: 'spec.profile.displayName', order: 'asc' as const },
+  { field: 'metadata.name', order: 'asc' as const },
+];
+
 describe('<OwnerPicker />', () => {
   const entities: Entity[] = [
     makeEntity('Group', 'default', 'team-a'),
@@ -49,6 +54,7 @@ describe('<OwnerPicker />', () => {
       allowArbitraryValues?: boolean;
       defaultNamespace?: string | false;
       catalogFilter?: EntityFilterQuery;
+      orderFields?: { field: string; order?: 'asc' | 'desc' }[];
     };
   };
   const rawErrors: string[] = [];
@@ -113,6 +119,7 @@ describe('<OwnerPicker />', () => {
             'spec.profile.displayName',
             'spec.type',
           ],
+          order: ownerDefaultOrder,
         }),
       );
     });
@@ -219,6 +226,7 @@ describe('<OwnerPicker />', () => {
             'spec.profile.displayName',
             'spec.type',
           ],
+          order: ownerDefaultOrder,
         }),
       );
     });
@@ -263,6 +271,7 @@ describe('<OwnerPicker />', () => {
               'spec.type': 'team',
             },
           ],
+          order: ownerDefaultOrder,
         }),
       );
     });
@@ -310,6 +319,7 @@ describe('<OwnerPicker />', () => {
               'spec.type': ['team', 'business-unit'],
             },
           ],
+          order: ownerDefaultOrder,
         }),
       );
     });

--- a/plugins/scaffolder/src/components/fields/OwnerPicker/OwnerPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/OwnerPicker/OwnerPicker.tsx
@@ -43,6 +43,10 @@ export const OwnerPicker = (props: OwnerPickerProps) => {
   const catalogFilter = uiSchema['ui:options']?.catalogFilter || {
     kind: allowedKinds || ['Group', 'User'],
   };
+  const orderFields = uiSchema['ui:options']?.orderFields || [
+    { field: 'spec.profile.displayName', order: 'asc' },
+    { field: 'metadata.name', order: 'asc' },
+  ];
 
   const ownerUiSchema = {
     ...uiSchema,
@@ -51,6 +55,7 @@ export const OwnerPicker = (props: OwnerPickerProps) => {
       defaultKind: 'Group',
       allowArbitraryValues:
         uiSchema['ui:options']?.allowArbitraryValues ?? true,
+      orderFields,
       ...(defaultNamespace !== undefined ? { defaultNamespace } : {}),
     },
   };

--- a/plugins/scaffolder/src/components/fields/OwnerPicker/OwnerPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/OwnerPicker/OwnerPicker.tsx
@@ -47,12 +47,15 @@ export const OwnerPicker = (props: OwnerPickerProps) => {
   const catalogFilter = uiSchema['ui:options']?.catalogFilter || {
     kind: allowedKinds || ['Group', 'User'],
   };
-  const orderFields: EntityPickerUiOptions['orderFields'] = uiSchema[
-    'ui:options'
-  ]?.orderFields || [
+
+  const defaultOrderFields: EntityPickerUiOptions['orderFields'] = [
     { field: 'spec.profile.displayName', order: 'asc' },
     { field: 'metadata.name', order: 'asc' },
   ];
+  const orderFields = Array.isArray(uiSchema['ui:options']?.orderFields)
+    ? (uiSchema['ui:options']
+        ?.orderFields as EntityPickerUiOptions['orderFields'])
+    : defaultOrderFields;
 
   const ownerUiSchema: EntityPickerProps['uiSchema'] = {
     ...uiSchema,

--- a/plugins/scaffolder/src/components/fields/OwnerPicker/OwnerPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/OwnerPicker/OwnerPicker.tsx
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 import { EntityPicker } from '../EntityPicker/EntityPicker';
+import type {
+  EntityPickerProps,
+  EntityPickerUiOptions,
+} from '../EntityPicker/schema';
 import { OwnerPickerProps } from './schema';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { scaffolderTranslationRef } from '../../../translation';
@@ -43,12 +47,14 @@ export const OwnerPicker = (props: OwnerPickerProps) => {
   const catalogFilter = uiSchema['ui:options']?.catalogFilter || {
     kind: allowedKinds || ['Group', 'User'],
   };
-  const orderFields = uiSchema['ui:options']?.orderFields || [
+  const orderFields: EntityPickerUiOptions['orderFields'] = uiSchema[
+    'ui:options'
+  ]?.orderFields || [
     { field: 'spec.profile.displayName', order: 'asc' },
     { field: 'metadata.name', order: 'asc' },
   ];
 
-  const ownerUiSchema = {
+  const ownerUiSchema: EntityPickerProps['uiSchema'] = {
     ...uiSchema,
     'ui:options': {
       catalogFilter,

--- a/plugins/search-react/report-alpha.api.md
+++ b/plugins/search-react/report-alpha.api.md
@@ -134,7 +134,10 @@ export const SearchResultListItemBlueprint: ExtensionBlueprint<{
     {
       predicate?: SearchResultItemExtensionPredicate;
       component: SearchResultItemExtensionComponent;
-      icon?: JSX_2.Element;
+      icon?: JSX_2.Element
+      /**
+       * The icon of the result item.
+       */;
     },
     'search.search-result-list-item.item',
     {}
@@ -151,7 +154,10 @@ export const SearchResultListItemBlueprint: ExtensionBlueprint<{
       {
         predicate?: SearchResultItemExtensionPredicate;
         component: SearchResultItemExtensionComponent;
-        icon?: JSX_2.Element;
+        icon?: JSX_2.Element
+        /**
+         * The icon of the result item.
+         */;
       },
       'search.search-result-list-item.item',
       {}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added default ordering to the `EntityPicker` (and therefore `OwnerPicker`) so that catalog results are returned in a stable alphabetical order even when `catalog.enableRelationsCompatibility` is disabled. We can override this ordering by supplying `ui:options.orderFields` in your template schema

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Fixes #31304