### PR TITLE
fix(ui): apply className only to root element in ButtonIcon

### DIFF
--- a/.changeset/common-coins-stare.md
+++ b/.changeset/common-coins-stare.md
@@ -1,0 +1,7 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed `ButtonIcon` incorrectly applying `className` to inner elements instead of only the root element.
+
+Affected components: ButtonIcon

--- a/.patches/pr-31900.txt
+++ b/.patches/pr-31900.txt
@@ -1,0 +1,1 @@
+Fix incorrectly applying className to three elements internally in ButtonIcon.

--- a/packages/ui/src/components/ButtonIcon/ButtonIcon.tsx
+++ b/packages/ui/src/components/ButtonIcon/ButtonIcon.tsx
@@ -64,7 +64,6 @@ export const ButtonIcon = forwardRef(
                 classNamesButtonIcon.content,
                 stylesButton[classNames.content],
                 stylesButtonIcon[classNamesButtonIcon.content],
-                className,
               )}
             >
               {icon}
@@ -79,7 +78,6 @@ export const ButtonIcon = forwardRef(
                   classNamesButtonIcon.spinner,
                   stylesButton[classNames.spinner],
                   stylesButtonIcon[classNamesButtonIcon.spinner],
-                  className,
                 )}
               >
                 <RiLoader4Line aria-hidden="true" />


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Remove duplicate className application from inner elements (content and spinner). The className prop should only be applied to the root button element, matching the behavior of the Button component.
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
