### PR TITLE
patches: remove published patches

### DIFF
--- a/.patches/pr-31817.txt
+++ b/.patches/pr-31817.txt
@@ -1,1 +1,0 @@
-Fixed an issue where the `useTable` hook from `@backstage/ui` did not use the provided `rowCount`

--- a/.patches/pr-31843.txt
+++ b/.patches/pr-31843.txt
@@ -1,1 +1,0 @@
-Fix table row with `href` still being rendered with routing context in `@backstage/ui`

--- a/.patches/pr-31900.txt
+++ b/.patches/pr-31900.txt
@@ -1,1 +1,0 @@
-Fix incorrectly applying className to three elements internally in ButtonIcon.

--- a/.patches/pr-31904.txt
+++ b/.patches/pr-31904.txt
@@ -1,1 +1,0 @@
-Fix unselected Checkboxes subtly appearing selected.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The [cleanup workflow](https://github.com/backstage/backstage/blob/master/.github/workflows/cleanup_patch-files.yml) wasn't merged at the base of the `patch/v1.45.0` branch so it's not triggering on pushes to that branch. Manual cleanup for now 😅 