### PR TITLE
Properly create workspace in OS tmpdir for generate-patch command

### DIFF
--- a/.changeset/neat-pens-clean.md
+++ b/.changeset/neat-pens-clean.md
@@ -1,0 +1,5 @@
+---
+'@backstage/repo-tools': patch
+---
+
+Properly create workspace in OS temporary directory for `generate-patch` command

--- a/packages/repo-tools/src/commands/generate-patch/generate-patch.ts
+++ b/packages/repo-tools/src/commands/generate-patch/generate-patch.ts
@@ -98,7 +98,9 @@ export default async (
     throw new Error(`Could not find package ${packageArg} in source repo`);
   }
 
-  const tmpDir = await fs.mkdtemp(os.tmpdir());
+  const tmpDir = await fs.mkdtemp(
+    joinPath(os.tmpdir(), 'backstage-repo-tools-generate-patch-'),
+  );
   const ctx: PatchContext = {
     sourceRepo,
     targetRepo,


### PR DESCRIPTION
The parameter is truly used as a pure prefix - the end result typically ended up being `/tmpXXXXXX` before this change.

Fixes https://github.com/backstage/backstage/issues/31858