### PR TITLE
feat(core-components): adding adding internationalization (i18n) for `app.title`

### DIFF
--- a/.changeset/salty-lamps-move.md
+++ b/.changeset/salty-lamps-move.md
@@ -1,6 +1,13 @@
 ---
 '@backstage/core-components': patch
 '@backstage/core-app-api': patch
+'@backstage/plugin-auth': patch
+'@backstage/plugin-catalog-import': patch
+'@backstage/plugin-catalog-react': patch
+'@backstage/plugin-home': patch
+'@backstage/plugin-search-react': patch
+'@backstage/plugin-techdocs-module-addons-contrib': patch
+'@backstage/plugin-techdocs': patch
 ---
 
 Add internationalization support for app title with the `useAppTitle()` hook.
@@ -8,4 +15,4 @@ All components that display the app title now support translations via the fixed
 
 **Translation priority:** translation override → config value → default ('Backstage').
 
-**Updated components:**- Header, SignInPage, OAuthRequestDialog, SearchBar, ImportInfoCard, ConsentPage, TechDocsReaderPageHeader, CompanyLogo, UnregisterEntityDialog, and more.
+**Updated components:** Header, SignInPage, OAuthRequestDialog, SearchBar, ImportInfoCard, ConsentPage, TechDocsReaderPageHeader, CompanyLogo, UnregisterEntityDialog, and more.

--- a/.changeset/salty-lamps-move.md
+++ b/.changeset/salty-lamps-move.md
@@ -14,5 +14,3 @@ Add internationalization support for app title with the `useAppTitle()` hook.
 All components that display the app title now support translations via the fixed translation key `app.title`.
 
 **Translation priority:** translation override → config value → default ('Backstage').
-
-**Updated components:** Header, SignInPage, OAuthRequestDialog, SearchBar, ImportInfoCard, ConsentPage, TechDocsReaderPageHeader, CompanyLogo, UnregisterEntityDialog, and more.

--- a/.changeset/salty-lamps-move.md
+++ b/.changeset/salty-lamps-move.md
@@ -1,0 +1,11 @@
+---
+'@backstage/core-components': patch
+'@backstage/core-app-api': patch
+---
+
+Add internationalization support for app title with the `useAppTitle()` hook.
+All components that display the app title now support translations via the fixed translation key `app.title`.
+
+**Translation priority:** translation override → config value → default ('Backstage').
+
+**Updated components:**- Header, SignInPage, OAuthRequestDialog, SearchBar, ImportInfoCard, ConsentPage, TechDocsReaderPageHeader, CompanyLogo, UnregisterEntityDialog, and more.

--- a/packages/core-app-api/config.d.ts
+++ b/packages/core-app-api/config.d.ts
@@ -27,6 +27,14 @@ export interface Config {
 
     /**
      * The title of the app, as shown in the Backstage web interface.
+     *
+     * Translation priority:
+     * 1. Translated value for 'app.title' (if translation override exists)
+     * 2. This config value (used when no translation override is provided)
+     * 3. Default value 'Backstage' (if neither translation nor config is set)
+     *
+     * Translations can be provided via the i18n system using the fixed key 'app.title'.
+     *
      * @visibility frontend
      */
     title?: string;

--- a/packages/core-components/report-alpha.api.md
+++ b/packages/core-components/report-alpha.api.md
@@ -21,6 +21,7 @@ export const coreComponentsTranslationRef: TranslationRef<
     readonly 'table.pagination.lastTooltip': 'Last Page';
     readonly 'table.pagination.nextTooltip': 'Next Page';
     readonly 'table.pagination.previousTooltip': 'Previous Page';
+    readonly 'app.title': 'Backstage';
     readonly 'signIn.title': 'Sign In';
     readonly 'signIn.loginFailed': 'Login failed';
     readonly 'signIn.customProvider.title': 'Custom User';

--- a/packages/core-components/report.api.md
+++ b/packages/core-components/report.api.md
@@ -1551,6 +1551,9 @@ export function TrendLine(
 export function UnstarredIcon(props: IconComponentProps): JSX_2.Element;
 
 // @public
+export function useAppTitle(): string;
+
+// @public
 export function useContent(): {
   focusContent: () => void;
   contentRef: MutableRefObject<HTMLElement | null> | undefined;

--- a/packages/core-components/src/components/OAuthRequestDialog/LoginRequestListItem.tsx
+++ b/packages/core-components/src/components/OAuthRequestDialog/LoginRequestListItem.tsx
@@ -22,14 +22,11 @@ import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
 import { useState } from 'react';
 import { isError } from '@backstage/errors';
-import {
-  configApiRef,
-  PendingOAuthRequest,
-  useApi,
-} from '@backstage/core-plugin-api';
+import { PendingOAuthRequest } from '@backstage/core-plugin-api';
 import { coreComponentsTranslationRef } from '../../translation';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import Box from '@material-ui/core/Box';
+import { useAppTitle } from '../../hooks';
 
 export type LoginRequestListItemClassKey = 'root';
 
@@ -55,7 +52,7 @@ const LoginRequestListItem = ({ request, busy, setBusy }: RowProps) => {
   const classes = useItemStyles();
   const [error, setError] = useState<string>();
   const { t } = useTranslationRef(coreComponentsTranslationRef);
-  const configApi = useApi(configApiRef);
+  const appTitle = useAppTitle();
 
   const handleContinue = async () => {
     setBusy(true);
@@ -72,7 +69,7 @@ const LoginRequestListItem = ({ request, busy, setBusy }: RowProps) => {
   const message =
     request.provider.message ??
     t('oauthRequestDialog.message', {
-      appTitle: configApi.getString('app.title'),
+      appTitle,
       provider: request.provider.title,
     });
 

--- a/packages/core-components/src/hooks/index.ts
+++ b/packages/core-components/src/hooks/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+export { useAppTitle } from './useAppTitle';
 export { useQueryParamState } from './useQueryParamState';
 export { useSupportConfig } from './useSupportConfig';
 export type {

--- a/packages/core-components/src/hooks/useAppTitle.test.tsx
+++ b/packages/core-components/src/hooks/useAppTitle.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/core-components/src/hooks/useAppTitle.test.tsx
+++ b/packages/core-components/src/hooks/useAppTitle.test.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ReactNode } from 'react';
+import { TestApiProvider } from '@backstage/test-utils';
+import { renderHook, waitFor } from '@testing-library/react';
+import { ConfigReader } from '@backstage/core-app-api';
+import { configApiRef } from '@backstage/core-plugin-api';
+import {
+  translationApiRef,
+  TranslationApi,
+} from '@backstage/core-plugin-api/alpha';
+// eslint-disable-next-line @backstage/no-relative-monorepo-imports
+import { I18nextTranslationApi } from '../../../core-app-api/src/apis/implementations/TranslationApi';
+// eslint-disable-next-line @backstage/no-relative-monorepo-imports
+import { AppLanguageSelector } from '../../../core-app-api/src/apis/implementations/AppLanguageApi';
+import { createTranslationResource } from '@backstage/core-plugin-api/alpha';
+import { useAppTitle } from './useAppTitle';
+import { coreComponentsTranslationRef } from '../translation';
+
+function makeWrapper(translationApi: TranslationApi, config: object = {}) {
+  return ({ children }: { children: ReactNode }) => (
+    <TestApiProvider
+      apis={[
+        [translationApiRef, translationApi],
+        [configApiRef, new ConfigReader(config as any)],
+      ]}
+      children={children}
+    />
+  );
+}
+
+describe('useAppTitle', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return translation override when it takes precedence', async () => {
+    const languageApi = AppLanguageSelector.create();
+    const translationApi = I18nextTranslationApi.create({
+      languageApi,
+      resources: [
+        createTranslationResource({
+          ref: coreComponentsTranslationRef,
+          translations: {
+            en: () =>
+              Promise.resolve({
+                default: {
+                  'app.title': 'My Translated App',
+                } as any,
+              }),
+          },
+        }),
+      ],
+    });
+
+    const { result } = renderHook(() => useAppTitle(), {
+      wrapper: makeWrapper(translationApi, { app: { title: 'Config Title' } }),
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBe('My Translated App');
+    });
+  });
+
+  it('should fall back to config value when no translation override', async () => {
+    const languageApi = AppLanguageSelector.create();
+    // No translation resource override - uses default 'Backstage'
+    const translationApi = I18nextTranslationApi.create({ languageApi });
+
+    const { result } = renderHook(() => useAppTitle(), {
+      wrapper: makeWrapper(translationApi, { app: { title: 'My Config App' } }),
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBe('My Config App');
+    });
+  });
+
+  it('should fall back to default "Backstage" when neither translation nor config is set', async () => {
+    const languageApi = AppLanguageSelector.create();
+    // No translation resource override - uses default 'Backstage'
+    const translationApi = I18nextTranslationApi.create({ languageApi });
+
+    const { result } = renderHook(() => useAppTitle(), {
+      wrapper: makeWrapper(translationApi, {}),
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBe('Backstage');
+    });
+  });
+});

--- a/packages/core-components/src/hooks/useAppTitle.test.tsx
+++ b/packages/core-components/src/hooks/useAppTitle.test.tsx
@@ -18,7 +18,7 @@ import { ReactNode } from 'react';
 import { TestApiProvider } from '@backstage/test-utils';
 import { renderHook, waitFor } from '@testing-library/react';
 import { ConfigReader } from '@backstage/core-app-api';
-import { configApiRef } from '@backstage/core-plugin-api';
+import { configApiRef, errorApiRef } from '@backstage/core-plugin-api';
 import {
   translationApiRef,
   TranslationApi,
@@ -37,6 +37,7 @@ function makeWrapper(translationApi: TranslationApi, config: object = {}) {
       apis={[
         [translationApiRef, translationApi],
         [configApiRef, new ConfigReader(config as any)],
+        [errorApiRef, { post: jest.fn(), error$: jest.fn() }],
       ]}
       children={children}
     />

--- a/packages/core-components/src/hooks/useAppTitle.ts
+++ b/packages/core-components/src/hooks/useAppTitle.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/core-components/src/hooks/useAppTitle.ts
+++ b/packages/core-components/src/hooks/useAppTitle.ts
@@ -29,6 +29,13 @@ import { coreComponentsTranslationRef } from '../translation';
  * 2. Fallback to app.title from config
  * 3. Default translation ('Backstage')
  *
+ * @remarks
+ * Note: If you explicitly translate 'app.title' to "Backstage" (the same as the
+ * default value), the hook cannot distinguish between a deliberate translation
+ * and the default, so it will fall back to the config value. If you want to use
+ * "Backstage" as your translated title while having a different `app.title` in
+ * config, set the config value to "Backstage" as well.
+ *
  * @public
  * @example
  * ```tsx

--- a/packages/core-components/src/hooks/useAppTitle.ts
+++ b/packages/core-components/src/hooks/useAppTitle.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useApi, configApiRef } from '@backstage/core-plugin-api';
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import { coreComponentsTranslationRef } from '../translation';
+
+/**
+ * Hook that returns the app title with translation support.
+ *
+ * This hook automatically uses translated values for the app title based on the
+ * current language. It uses the fixed translation key 'app.title'.
+ *
+ * Translation priority:
+ * 1. Translated value for 'app.title' in the current language
+ * 2. Fallback to app.title from config
+ * 3. Default translation ('Backstage')
+ *
+ * @public
+ * @example
+ * ```tsx
+ * const MyComponent = () => {
+ *   const appTitle = useAppTitle();
+ *   return <h1>{appTitle}</h1>;
+ * };
+ * ```
+ */
+export function useAppTitle(): string {
+  const configApi = useApi(configApiRef);
+  const { t } = useTranslationRef(coreComponentsTranslationRef);
+
+  // Default value defined in coreComponentsTranslationRef
+  const defaultTitle = 'Backstage';
+
+  // Try to get translation for the current language
+  const translatedTitle = t('app.title', {});
+
+  // Get the fallback title from config
+  const configTitle = configApi.getOptionalString('app.title');
+
+  // Priority: translation override → config value → default
+  // If translation is different from default, it means an override exists
+  if (translatedTitle !== defaultTitle) {
+    return translatedTitle;
+  }
+
+  // Otherwise, use config value or fall back to default
+  return configTitle || defaultTitle;
+}

--- a/packages/core-components/src/hooks/useAppTitle.ts
+++ b/packages/core-components/src/hooks/useAppTitle.ts
@@ -53,7 +53,7 @@ export function useAppTitle(): string {
   const defaultTitle = 'Backstage';
 
   // Try to get translation for the current language
-  const translatedTitle = t('app.title', {});
+  const translatedTitle = t('app.title');
 
   // Get the fallback title from config
   const configTitle = configApi.getOptionalString('app.title');

--- a/packages/core-components/src/layout/Header/Header.tsx
+++ b/packages/core-components/src/layout/Header/Header.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { configApiRef, useApi } from '@backstage/core-plugin-api';
 import Box from '@material-ui/core/Box';
 import Grid from '@material-ui/core/Grid';
 import { makeStyles } from '@material-ui/core/styles';
@@ -25,6 +24,7 @@ import { Helmet } from 'react-helmet';
 import { Link } from '../../components/Link';
 import { Breadcrumbs } from '../Breadcrumbs';
 import { useContent } from '../Sidebar';
+import { useAppTitle } from '../../hooks';
 
 /** @public */
 export type HeaderClassKey =
@@ -218,8 +218,7 @@ export function Header(props: PropsWithChildren<Props>) {
     typeLink,
   } = props;
   const classes = useStyles();
-  const configApi = useApi(configApiRef);
-  const appTitle = configApi.getOptionalString('app.title') || 'Backstage';
+  const appTitle = useAppTitle();
   const documentTitle = pageTitleOverride || title;
   const pageTitle = title || pageTitleOverride;
   const titleTemplate = `${documentTitle} | %s | ${appTitle}`;

--- a/packages/core-components/src/layout/SignInPage/SignInPage.tsx
+++ b/packages/core-components/src/layout/SignInPage/SignInPage.tsx
@@ -16,7 +16,6 @@
 
 import {
   BackstageIdentityResponse,
-  configApiRef,
   SignInPageProps,
   useAnalytics,
   useApi,
@@ -39,6 +38,7 @@ import { IdentityProviders, SignInProviderConfig } from './types';
 import { coreComponentsTranslationRef } from '../../translation';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { useSearchParams } from 'react-router-dom';
+import { useAppTitle } from '../../hooks';
 
 type CommonSignInPageProps = SignInPageProps & {
   /**
@@ -69,8 +69,8 @@ export const MultiSignInPage = ({
   titleComponent,
   align = 'left',
 }: MultiSignInPageProps) => {
-  const configApi = useApi(configApiRef);
   const classes = useStyles();
+  const appTitle = useAppTitle();
 
   const signInProviders = getSignInProviders(providers);
   const [loading, providerElements] = useSignInProviders(
@@ -84,7 +84,7 @@ export const MultiSignInPage = ({
 
   return (
     <Page themeId="home">
-      <Header title={configApi.getString('app.title')} />
+      <Header title={appTitle} />
       <Content>
         {(title || titleComponent) && (
           <ContentHeader
@@ -115,7 +115,7 @@ export const SingleSignInPage = ({
 }: SingleSignInPageProps) => {
   const classes = useStyles();
   const authApi = useApi(provider.apiRef);
-  const configApi = useApi(configApiRef);
+  const appTitle = useAppTitle();
   const { t } = useTranslationRef(coreComponentsTranslationRef);
   const analytics = useAnalytics();
 
@@ -186,7 +186,7 @@ export const SingleSignInPage = ({
 
   return showLoginPage ? (
     <Page themeId="home">
-      <Header title={configApi.getString('app.title')} />
+      <Header title={appTitle} />
       <Content>
         <Grid
           container

--- a/packages/core-components/src/translation.ts
+++ b/packages/core-components/src/translation.ts
@@ -20,6 +20,9 @@ import { createTranslationRef } from '@backstage/core-plugin-api/alpha';
 export const coreComponentsTranslationRef = createTranslationRef({
   id: 'core-components',
   messages: {
+    app: {
+      title: 'Backstage',
+    },
     signIn: {
       title: 'Sign In',
       loginFailed: 'Login failed',

--- a/plugins/auth/src/components/ConsentPage/ConsentPage.tsx
+++ b/plugins/auth/src/components/ConsentPage/ConsentPage.tsx
@@ -37,9 +37,9 @@ import {
   Page,
   Progress,
   ResponseErrorPanel,
+  useAppTitle,
 } from '@backstage/core-components';
 import { useConsentSession } from './useConsentSession';
-import { configApiRef, useApi } from '@backstage/frontend-plugin-api';
 
 const useStyles = makeStyles(theme => ({
   authCard: {
@@ -101,8 +101,7 @@ export const ConsentPage = () => {
   const classes = useStyles();
   const { sessionId } = useParams<{ sessionId: string }>();
   const { state, handleAction } = useConsentSession({ sessionId });
-  const configApi = useApi(configApiRef);
-  const appTitle = configApi.getOptionalString('app.title') ?? 'Backstage';
+  const appTitle = useAppTitle();
 
   if (!sessionId) {
     return (

--- a/plugins/catalog-import/src/components/DefaultImportPage/DefaultImportPage.tsx
+++ b/plugins/catalog-import/src/components/DefaultImportPage/DefaultImportPage.tsx
@@ -20,8 +20,8 @@ import {
   Header,
   Page,
   SupportButton,
+  useAppTitle,
 } from '@backstage/core-components';
-import { configApiRef, useApi } from '@backstage/core-plugin-api';
 import { useTranslationRef } from '@backstage/frontend-plugin-api';
 import Grid from '@material-ui/core/Grid';
 import { useTheme } from '@material-ui/core/styles';
@@ -39,9 +39,8 @@ import { ImportStepper } from '../ImportStepper';
 export const DefaultImportPage = () => {
   const { t } = useTranslationRef(catalogImportTranslationRef);
   const theme = useTheme();
-  const configApi = useApi(configApiRef);
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
-  const appTitle = configApi.getOptionalString('app.title') || 'Backstage';
+  const appTitle = useAppTitle();
 
   const contentItems = [
     <Grid key={0} item xs={12} md={4} lg={6} xl={8}>

--- a/plugins/catalog-import/src/components/ImportInfoCard/ImportInfoCard.tsx
+++ b/plugins/catalog-import/src/components/ImportInfoCard/ImportInfoCard.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { InfoCard } from '@backstage/core-components';
+import { InfoCard, useAppTitle } from '@backstage/core-components';
 import { configApiRef, useApi } from '@backstage/core-plugin-api';
 import { useTranslationRef } from '@backstage/frontend-plugin-api';
 import Chip from '@material-ui/core/Chip';
@@ -47,7 +47,7 @@ export const ImportInfoCard = (props: ImportInfoCardProps) => {
 
   const { t } = useTranslationRef(catalogImportTranslationRef);
   const configApi = useApi(configApiRef);
-  const appTitle = configApi.getOptionalString('app.title') || 'Backstage';
+  const appTitle = useAppTitle();
   const catalogImportApi = useApi(catalogImportApiRef);
 
   const hasGithubIntegration = configApi.has('integrations.github');

--- a/plugins/catalog-import/src/components/StepReviewLocation/StepReviewLocation.tsx
+++ b/plugins/catalog-import/src/components/StepReviewLocation/StepReviewLocation.tsx
@@ -15,8 +15,8 @@
  */
 
 import { stringifyEntityRef } from '@backstage/catalog-model';
-import { Link } from '@backstage/core-components';
-import { configApiRef, useAnalytics, useApi } from '@backstage/core-plugin-api';
+import { Link, useAppTitle } from '@backstage/core-components';
+import { useAnalytics, useApi } from '@backstage/core-plugin-api';
 import { assertError } from '@backstage/errors';
 import { useTranslationRef } from '@backstage/frontend-plugin-api';
 import { catalogApiRef } from '@backstage/plugin-catalog-react';
@@ -44,10 +44,8 @@ export const StepReviewLocation = ({
 }: Props) => {
   const { t } = useTranslationRef(catalogImportTranslationRef);
   const catalogApi = useApi(catalogApiRef);
-  const configApi = useApi(configApiRef);
   const analytics = useAnalytics();
-
-  const appTitle = configApi.getOptionalString('app.title') || 'Backstage';
+  const appTitle = useAppTitle();
 
   const [submitted, setSubmitted] = useState(false);
   const [error, setError] = useState<string>();

--- a/plugins/catalog-react/src/components/UnregisterEntityDialog/UnregisterEntityDialog.tsx
+++ b/plugins/catalog-react/src/components/UnregisterEntityDialog/UnregisterEntityDialog.tsx
@@ -23,8 +23,12 @@ import {
   useUnregisterEntityDialogState,
 } from './useUnregisterEntityDialogState';
 
-import { alertApiRef, configApiRef, useApi } from '@backstage/core-plugin-api';
-import { Progress, ResponseErrorPanel } from '@backstage/core-components';
+import { alertApiRef, useApi } from '@backstage/core-plugin-api';
+import {
+  Progress,
+  ResponseErrorPanel,
+  useAppTitle,
+} from '@backstage/core-components';
 import { assertError } from '@backstage/errors';
 import { catalogReactTranslationRef } from '../../translation';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
@@ -330,8 +334,7 @@ function DialogContents({
 }) {
   const classes = useStyles();
   const { t } = useTranslationRef(catalogReactTranslationRef);
-  const configApi = useApi(configApiRef);
-  const appTitle = configApi.getOptionalString('app.title') ?? 'Backstage';
+  const appTitle = useAppTitle();
 
   const handlers = useUnregisterDialogHandlers(entity, onConfirm, onClose);
   const { body, actionButton } = useDialogContent(handlers, appTitle);

--- a/plugins/home/src/homePageComponents/CompanyLogo/CompanyLogo.tsx
+++ b/plugins/home/src/homePageComponents/CompanyLogo/CompanyLogo.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import Typography from '@material-ui/core/Typography';
-import { configApiRef, useApi } from '@backstage/core-plugin-api';
+import { useAppTitle } from '@backstage/core-components';
 import { ReactNode } from 'react';
 
 type CompanyLogoProps = {
@@ -29,15 +29,11 @@ type CompanyLogoProps = {
  */
 export const CompanyLogo = (props: CompanyLogoProps) => {
   const { logo, className } = props;
-  const configApi = useApi(configApiRef);
+  const appTitle = useAppTitle();
 
   return (
     <div className={className}>
-      {logo ? (
-        <>{logo}</>
-      ) : (
-        <Typography variant="h1">{configApi.getString('app.title')}</Typography>
-      )}
+      {logo ? <>{logo}</> : <Typography variant="h1">{appTitle}</Typography>}
     </div>
   );
 };

--- a/plugins/search-react/src/components/SearchBar/SearchBar.tsx
+++ b/plugins/search-react/src/components/SearchBar/SearchBar.tsx
@@ -14,12 +14,8 @@
  * limitations under the License.
  */
 
-import {
-  AnalyticsContext,
-  configApiRef,
-  useApi,
-  useApp,
-} from '@backstage/core-plugin-api';
+import { AnalyticsContext, useApp } from '@backstage/core-plugin-api';
+import { useAppTitle } from '@backstage/core-components';
 import IconButton from '@material-ui/core/IconButton';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import TextField from '@material-ui/core/TextField';
@@ -80,10 +76,10 @@ export const SearchBarBase = forwardRef((props: SearchBarBaseProps, ref) => {
     ...rest
   } = props;
 
-  const configApi = useApi(configApiRef);
   const [value, setValue] = useState<string>('');
   const forwardedValueRef = useRef<string>('');
   const { t } = useTranslationRef(searchReactTranslationRef);
+  const appTitle = useAppTitle();
 
   useEffect(() => {
     setValue(prevValue => {
@@ -139,7 +135,7 @@ export const SearchBarBase = forwardRef((props: SearchBarBaseProps, ref) => {
   const inputPlaceholder =
     placeholder ??
     t('searchBar.placeholder', {
-      org: configApi.getOptionalString('app.title') || 'Backstage',
+      org: appTitle,
     });
   const SearchIcon = useApp().getSystemIcon('search') || DefaultSearchIcon;
 

--- a/plugins/techdocs-module-addons-contrib/src/ReportIssue/hooks.ts
+++ b/plugins/techdocs-module-addons-contrib/src/ReportIssue/hooks.ts
@@ -16,7 +16,8 @@
 
 import parseGitUrl from 'git-url-parse';
 
-import { configApiRef, useApi } from '@backstage/core-plugin-api';
+import { useApi } from '@backstage/core-plugin-api';
+import { useAppTitle } from '@backstage/core-components';
 import {
   replaceGithubUrlType,
   replaceGitLabUrlType,
@@ -77,8 +78,7 @@ export const useGitTemplate = (debounceTime?: number) => {
   const [editLink] = useShadowRootElements([PAGE_EDIT_LINK_SELECTOR]);
   const url = (editLink as HTMLAnchorElement)?.href ?? '';
   const scmIntegrationsApi = useApi(scmIntegrationsApiRef);
-  const configApi = useApi(configApiRef);
-  const appTitle = configApi.getOptionalString('app.title') || 'Backstage';
+  const appTitle = useAppTitle();
   if (!selection || !url) return initialTemplate;
 
   const type = scmIntegrationsApi.byUrl(url)?.type;

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageHeader/TechDocsReaderPageHeader.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageHeader/TechDocsReaderPageHeader.tsx
@@ -39,8 +39,8 @@ import {
   CompoundEntityRef,
   stringifyEntityRef,
 } from '@backstage/catalog-model';
-import { Header, HeaderLabel } from '@backstage/core-components';
-import { useRouteRef, configApiRef, useApi } from '@backstage/core-plugin-api';
+import { Header, HeaderLabel, useAppTitle } from '@backstage/core-components';
+import { useRouteRef, useApi } from '@backstage/core-plugin-api';
 
 import capitalize from 'lodash/capitalize';
 
@@ -72,7 +72,7 @@ export const TechDocsReaderPageHeader = (
 ) => {
   const { children } = props;
   const addons = useTechDocsAddons();
-  const configApi = useApi(configApiRef);
+  const appTitle = useAppTitle();
 
   const entityPresentationApi = useApi(entityPresentationApiRef);
   const { '*': path = '' } = useParams();
@@ -98,8 +98,6 @@ export const TechDocsReaderPageHeader = (
       return site_description;
     });
   }, [metadata, setTitle, setSubtitle]);
-
-  const appTitle = configApi.getOptional('app.title') || 'Backstage';
 
   const { locationMetadata, spec } = entityMetadata || {};
   const lifecycle = spec?.lifecycle;


### PR DESCRIPTION
## Description 
This PR adds internationalization (i18n) support for the app title across the entire Backstage application. All components that display or use `app.title` now support translations, allowing users to see the app title in their preferred language.

 ### Translation priority:
 1. Translated value for 'app.title' in the current language
 2. Fallback to app.title from config
 3. Default translation ('Backstage')

## UI after changes ( with [example translation](https://github.com/its-mitesh-kumar/backstage/pull/2) )


https://github.com/user-attachments/assets/63c2baef-e02e-4567-886c-a8ce5be27e32


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
