### PR TITLE
Update missing target branch error message

### DIFF
--- a/.changeset/tall-ideas-lead.md
+++ b/.changeset/tall-ideas-lead.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-bitbucket-server': patch
+---
+
+Improve error message when provided target branch is missing

--- a/plugins/scaffolder-backend-module-bitbucket-server/src/actions/bitbucketServerPullRequest.test.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-server/src/actions/bitbucketServerPullRequest.test.ts
@@ -399,4 +399,33 @@ describe('publish:bitbucketServer:pull-request', () => {
       'https://hosted.bitbucket.com/projects/project/repos/repo/pull-requests/1',
     );
   });
+
+  it('should throw an error when the target branch is not found', async () => {
+    server.use(
+      rest.get(
+        'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos/repo/branches',
+        (_, res, ctx) => {
+          return res(
+            ctx.status(200),
+            ctx.set('Content-Type', 'application/json'),
+            ctx.json(responseOfBranches),
+          );
+        },
+      ),
+    );
+
+    await expect(
+      action.handler({
+        ...mockContext,
+        input: {
+          ...mockContext.input,
+          repoUrl: 'hosted.bitbucket.com?project=project&repo=repo',
+          targetBranch: 'non-existent-branch',
+          sourceBranch: 'develop',
+        },
+      }),
+    ).rejects.toThrow(
+      /Target branch 'non-existent-branch' not found in repository project\/repo/,
+    );
+  });
 });

--- a/plugins/scaffolder-backend-module-bitbucket-server/src/actions/bitbucketServerPullRequest.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-server/src/actions/bitbucketServerPullRequest.ts
@@ -380,6 +380,12 @@ export function createPublishBitbucketServerPullRequestAction(options: {
         apiBaseUrl,
       });
 
+      if (!toRef) {
+        throw new InputError(
+          `Target branch '${finalTargetBranch}' not found in repository ${project}/${repo}. Please ensure the branch exists before creating a pull request.`,
+        );
+      }
+
       let fromRef = await findBranches({
         project,
         repo,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When providing a target branch that does not exist, the pull requests action currently provides an unintuitive error message:
```
2025-12-02T17:13:07.000Z TypeError: Cannot read properties of undefined (reading 'latestCommit')
    at Object.handler (/app/node_modules/@backstage/plugin-scaffolder-backend-module-bitbucket-server/dist/actions/bitbucketServerPullRequest.cjs.js:261:98)
```

Instead, the user should be notified of the specific problem, such as:
```
Target branch 'main' not found in repository project/repo. Please ensure the branch exists before creating a pull request.
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
