### PR TITLE
added patch for postgres18 test databases

### DIFF
--- a/.patches/pr-31974.txt
+++ b/.patches/pr-31974.txt
@@ -1,0 +1,1 @@
+Fixed an issue where TestDatabases would fail to run for PostgreSQL 18 tests


### PR DESCRIPTION
Patch for https://github.com/backstage/backstage/pull/31974 since it is being disruptive for users.