### PR TITLE
Use a versioned context for `useEntityList`

### DIFF
--- a/.changeset/green-lizards-boil.md
+++ b/.changeset/green-lizards-boil.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Use a versioned context for `useEntityList`, to better work with mixed `@backstage/plugin-catalog-react` versions.

--- a/plugins/catalog-react/report.api.md
+++ b/plugins/catalog-react/report.api.md
@@ -322,7 +322,7 @@ export const EntityLifecyclePicker: (props: {
   initialFilter?: string[];
 }) => JSX_2.Element;
 
-// @public
+// @public @deprecated
 export const EntityListContext: Context<
   EntityListContextProps<any> | undefined
 >;

--- a/plugins/catalog-react/src/deprecated.tsx
+++ b/plugins/catalog-react/src/deprecated.tsx
@@ -15,10 +15,12 @@
  */
 
 import { PropsWithChildren, useCallback, useMemo, useState } from 'react';
+import { createVersionedValueMap } from '@backstage/version-bridge';
 import {
   DefaultEntityFilters,
-  EntityListContext,
   EntityListContextProps,
+  NewEntityListContext,
+  OldEntityListContext,
 } from './hooks/useEntityListProvider';
 
 /**
@@ -81,8 +83,18 @@ export function MockEntityListContextProvider<
   );
 
   return (
-    <EntityListContext.Provider value={resolvedValue}>
+    <NewEntityListContext.Provider
+      value={createVersionedValueMap({ 1: resolvedValue })}
+    >
       {children}
-    </EntityListContext.Provider>
+    </NewEntityListContext.Provider>
   );
 }
+
+/**
+ * Creates new context for entity listing and filtering.
+ *
+ * @public
+ * @deprecated Please use `EntityListProvider` and `EntityListProvider` instead.
+ */
+export const EntityListContext = OldEntityListContext;

--- a/plugins/catalog-react/src/hooks/index.ts
+++ b/plugins/catalog-react/src/hooks/index.ts
@@ -24,11 +24,7 @@ export type {
   EntityProviderProps,
   AsyncEntityProviderProps,
 } from './useEntity';
-export {
-  EntityListContext,
-  EntityListProvider,
-  useEntityList,
-} from './useEntityListProvider';
+export { EntityListProvider, useEntityList } from './useEntityListProvider';
 export type {
   DefaultEntityFilters,
   EntityListContextProps,

--- a/plugins/catalog-react/src/hooks/useEntityListProvider.test.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.test.tsx
@@ -42,7 +42,13 @@ import {
 } from '../filters';
 import { createDeferred } from '@backstage/types';
 import { EntityListPagination } from '../types';
-import { EntityListProvider, useEntityList } from './useEntityListProvider';
+import {
+  EntityListContextProps,
+  EntityListProvider,
+  NewEntityListContext,
+  useEntityList,
+} from './useEntityListProvider';
+import { createVersionedValueMap } from '@backstage/version-bridge';
 
 const entities: Entity[] = [
   {
@@ -1046,5 +1052,61 @@ describe(`<EntityListProvider pagination={{ mode: 'offset' }} />`, () => {
         filter: { kind: 'group' },
       }),
     );
+  });
+});
+
+describe('versioned context', () => {
+  it('should work explicitly with new versioned contexts', () => {
+    const value: EntityListContextProps<any> = {
+      filters: {},
+      entities: [],
+      backendEntities: [],
+      updateFilters: jest.fn(),
+      queryParameters: {},
+      loading: true,
+      limit: 277,
+      setLimit: jest.fn(),
+      setOffset: jest.fn(),
+      paginationMode: 'none',
+    };
+
+    const { result } = renderHook(() => useEntityList(), {
+      wrapper: ({ children }) => {
+        const InitialFiltersWrapper = (f: PropsWithChildren<{}>) => {
+          const { updateFilters } = useEntityList();
+          useMountEffect(() => {
+            updateFilters({
+              kind: new EntityKindFilter('component', 'Component'),
+            });
+          });
+          return <>{f.children}</>;
+        };
+
+        return (
+          <MemoryRouter initialEntries={['/catalog']}>
+            <TestApiProvider
+              apis={[
+                [configApiRef, mockApis.config()],
+                [catalogApiRef, mockCatalogApi],
+                [identityApiRef, mockIdentityApi],
+                [storageApiRef, mockApis.storage()],
+                [starredEntitiesApiRef, new MockStarredEntitiesApi()],
+                [alertApiRef, { post: jest.fn() }],
+                [translationApiRef, mockApis.translation()],
+                [errorApiRef, { error$: jest.fn(), post: jest.fn() }],
+              ]}
+            >
+              <NewEntityListContext.Provider
+                value={createVersionedValueMap({ 1: value })}
+              >
+                <InitialFiltersWrapper>{children}</InitialFiltersWrapper>
+              </NewEntityListContext.Provider>
+            </TestApiProvider>
+          </MemoryRouter>
+        );
+      },
+    });
+
+    expect(result.current.limit).toBe(277);
   });
 });

--- a/plugins/catalog-react/src/testUtils/MockEntityListContextProvider.tsx
+++ b/plugins/catalog-react/src/testUtils/MockEntityListContextProvider.tsx
@@ -17,9 +17,10 @@
 import { PropsWithChildren, useCallback, useMemo, useState } from 'react';
 import {
   DefaultEntityFilters,
-  EntityListContext,
   EntityListContextProps,
 } from '@backstage/plugin-catalog-react';
+import { createVersionedValueMap } from '@backstage/version-bridge';
+import { NewEntityListContext } from '../hooks/useEntityListProvider';
 
 /**
  * Simplifies testing of code that uses the entity list hooks.
@@ -82,8 +83,10 @@ export function MockEntityListContextProvider<
   );
 
   return (
-    <EntityListContext.Provider value={resolvedValue}>
+    <NewEntityListContext.Provider
+      value={createVersionedValueMap({ 1: resolvedValue })}
+    >
       {children}
-    </EntityListContext.Provider>
+    </NewEntityListContext.Provider>
   );
 }


### PR DESCRIPTION
This does the same thing as `useEntity`, to ensure that a consistent context will be presented even if there's a mixture of `@backstage/plugin-catalog-react` versions - which in particular can happen when using nightlies or -next versions.