### PR TITLE
fix(auth): update cookie deletion logic for chunked cookies

### DIFF
--- a/.changeset/sour-bats-press.md
+++ b/.changeset/sour-bats-press.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-node': patch
+---
+
+fix flawed cookie removal logic with chunked tokens

--- a/plugins/auth-node/src/oauth/OAuthCookieManager.ts
+++ b/plugins/auth-node/src/oauth/OAuthCookieManager.ts
@@ -152,6 +152,36 @@ export class OAuthCookieManager {
     };
     const req = res.req;
     let output = res;
+
+    const chunkedFormatExists = OAuthCookieManager.chunkedCookieExists(
+      req,
+      name,
+    );
+
+    // If using the default cookieConfigurer, delete old cookie with domain
+    // explicitly set to the callbackUrl's domain (legacy behavior)
+    if (this.cookieConfigurer === defaultCookieConfigurer) {
+      const { hostname: domain } = new URL(this.options.callbackUrl);
+      output = output.cookie(name, '', {
+        ...this.getRemoveCookieOptions(),
+        domain: domain,
+      });
+
+      if (chunkedFormatExists) {
+        for (let chunkNumber = 0; ; chunkNumber++) {
+          const key = OAuthCookieManager.getCookieChunkName(name, chunkNumber);
+          const exists = !!req.cookies[key];
+          if (!exists) {
+            break;
+          }
+          output = output.cookie(key, '', {
+            ...this.getRemoveCookieOptions(),
+            domain: domain,
+          });
+        }
+      }
+    }
+
     if (val.length > MAX_COOKIE_SIZE_CHARACTERS) {
       const nonChunkedFormatExists = !!req.cookies[name];
       if (nonChunkedFormatExists) {
@@ -169,10 +199,6 @@ export class OAuthCookieManager {
       return output;
     }
 
-    const chunkedFormatExists = OAuthCookieManager.chunkedCookieExists(
-      req,
-      name,
-    );
     if (chunkedFormatExists) {
       for (let chunkNumber = 0; ; chunkNumber++) {
         const key = OAuthCookieManager.getCookieChunkName(name, chunkNumber);
@@ -182,15 +208,6 @@ export class OAuthCookieManager {
         }
         output = output.cookie(key, '', this.getRemoveCookieOptions());
       }
-    }
-
-    // If using the default cookieConfigurer, delete old cookie with domain set to the callbackUrl's domain (legacy behavior)
-    if (this.cookieConfigurer === defaultCookieConfigurer) {
-      const { hostname: domain } = new URL(this.options.callbackUrl);
-      output = output.cookie(name, '', {
-        ...this.getRemoveCookieOptions(),
-        domain: domain,
-      });
     }
 
     return output.cookie(name, val, options);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Addresses #31927 

When migrating away from the old cookie format (where the domain attribute was explicitly set), the cleanup now correctly checks for and deletes any chunked cookies (`<name>-0`, `<name>-1`, ...) if they exist, in addition to the main one.
  - Moved deletion logic earlier in the `setCookie()` flow
  - Added unit tests to cover migration cases

_Aside:_ I also found another potential issue: when the new cookie has fewer chunks than the old, the excess chunks are not cleaned up. I’m not sure how common this use case is, but I can propose this fix in another PR if necessary.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
