### PR TITLE
feat: add generated index pages for all sidebar items

### DIFF
--- a/microsite/sidebars.ts
+++ b/microsite/sidebars.ts
@@ -676,6 +676,7 @@ export default {
               'Guides for migrating between different versions and systems.',
           },
           [
+            'tutorials/jest30-migration',
             'tutorials/react-router-stable-migration',
             'tutorials/react18-migration',
             'tutorials/package-role-migration',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Running with the work from https://github.com/backstage/backstage/pull/31863/files. The goal is to use these generated pages in the new docs entry point table instead of listing all sidebar items.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
