### PR TITLE
frontend-plugin-api: new error boundary API option + boundary for app root elements

### DIFF
--- a/.changeset/alert-api-replay.md
+++ b/.changeset/alert-api-replay.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-app-api': patch
+---
+
+Added replay functionality to `AlertApiForwarder` to buffer and replay recent alerts to new subscribers, preventing missed alerts that were posted before subscription.

--- a/.changeset/error-boundary-api.md
+++ b/.changeset/error-boundary-api.md
@@ -1,0 +1,7 @@
+---
+'@backstage/frontend-plugin-api': patch
+---
+
+Added a new `errorPresentation` prop to `ExtensionBoundary` to control how errors are presented to the user. The default is `'error-display'`, which is the current behavior of showing the error in the `ErrorDisplay` component. The new option is `'error-api'`, posts errors to the `ErrorApi` and does not allow retries.
+
+The `AppRootElementBlueprint` now wraps its element in an `ErrorBoundary` using the new `'error-api'` presentation mode.

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -1146,6 +1146,8 @@ export interface ExtensionBoundaryProps {
   // (undocumented)
   children: ReactNode;
   // (undocumented)
+  errorPresentation?: 'error-api' | 'error-display';
+  // (undocumented)
   node: AppNode;
 }
 

--- a/packages/frontend-plugin-api/src/blueprints/AppRootElementBlueprint.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/AppRootElementBlueprint.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { ExtensionBoundary } from '@backstage/frontend-plugin-api';
 import { coreExtensionData, createExtensionBlueprint } from '../wiring';
 
 /**
@@ -26,7 +27,11 @@ export const AppRootElementBlueprint = createExtensionBlueprint({
   kind: 'app-root-element',
   attachTo: { id: 'app/root', input: 'elements' },
   output: [coreExtensionData.reactElement],
-  *factory(params: { element: JSX.Element }) {
-    yield coreExtensionData.reactElement(params.element);
+  *factory(params: { element: JSX.Element }, { node }) {
+    yield coreExtensionData.reactElement(
+      <ExtensionBoundary node={node} errorPresentation="error-api">
+        {params.element}
+      </ExtensionBoundary>,
+    );
   },
 });

--- a/packages/frontend-plugin-api/src/components/ErrorApiBoundary.tsx
+++ b/packages/frontend-plugin-api/src/components/ErrorApiBoundary.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, ErrorInfo, ReactNode } from 'react';
+import { AppNode, ErrorApi } from '../apis';
+import { ForwardedError } from '@backstage/errors';
+
+/** @internal */
+export class ErrorApiBoundary extends Component<
+  {
+    children: ReactNode;
+    node: AppNode;
+    errorApi?: ErrorApi;
+  },
+  { error?: Error }
+> {
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  state = { error: undefined };
+
+  componentDidCatch(error: Error, _errorInfo: ErrorInfo) {
+    const { node, errorApi } = this.props;
+    errorApi?.post(
+      new ForwardedError(`Error in extension '${node.spec.id}'`, error),
+    );
+  }
+
+  render() {
+    if (this.state.error) {
+      return null;
+    }
+
+    return this.props.children;
+  }
+}

--- a/packages/frontend-plugin-api/src/components/ErrorDisplayBoundary.tsx
+++ b/packages/frontend-plugin-api/src/components/ErrorDisplayBoundary.tsx
@@ -14,25 +14,23 @@
  * limitations under the License.
  */
 
-import { Component, PropsWithChildren } from 'react';
+import { Component, ReactNode } from 'react';
 import { FrontendPlugin } from '../wiring';
 import { ErrorDisplay } from './DefaultSwappableComponents';
 
-type ErrorBoundaryProps = PropsWithChildren<{
-  plugin?: FrontendPlugin;
-}>;
-type ErrorBoundaryState = { error?: Error };
-
 /** @internal */
-export class ErrorBoundary extends Component<
-  ErrorBoundaryProps,
-  ErrorBoundaryState
+export class ErrorDisplayBoundary extends Component<
+  {
+    children: ReactNode;
+    plugin: FrontendPlugin;
+  },
+  { error?: Error }
 > {
   static getDerivedStateFromError(error: Error) {
     return { error };
   }
 
-  state: ErrorBoundaryState = { error: undefined };
+  state = { error: undefined };
 
   handleErrorReset = () => {
     this.setState({ error: undefined });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The app root elements weren't wrapped in extension boundaries because the error display didn't make sense for them. This adds a new option to the `ExtensionBoundary` that switches the error rendering from using `ErrorDisplay` to instead posting to the `ErrorApi`.  It then uses that new option to wrap elements passed to `AppRootElementBlueprint` in an `ExtensionBoundary`, making sure they can't crash the entire app.

Bit of an edge-case was a new race condition where the `AlertApi` forwarding to the `AlertDisplay` didn't work for alerts that were posted before the `AlertDisplay` got the chance to render. This fixes that by adding replay functionality to the `AlertApi` for new subscribers.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
