### PR TITLE
fix(catalog): filter icon links before calling useProps

### DIFF
--- a/.changeset/ready-results-march.md
+++ b/.changeset/ready-results-march.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Fixed `catalogAboutEntityCard` to filter icon links before calling useProps(), preventing side effects from hooks in filtered-out links

--- a/plugins/catalog/src/alpha/entityCards.tsx
+++ b/plugins/catalog/src/alpha/entityCards.tsx
@@ -41,12 +41,14 @@ export const catalogAboutEntityCard = EntityCardBlueprint.makeWithOverrides({
       // The "useProps" functions may be calling other hooks, so we need to
       // call them in a component function to avoid breaking the rules of hooks.
       const links = inputs.iconLinks.reduce((rest, iconLink) => {
-        const props = iconLink.get(EntityIconLinkBlueprint.dataRefs.useProps)();
         const filter = buildFilterFn(
           iconLink.get(EntityIconLinkBlueprint.dataRefs.filterFunction),
           iconLink.get(EntityIconLinkBlueprint.dataRefs.filterExpression),
         );
         if (filter(entity)) {
+          const props = iconLink.get(
+            EntityIconLinkBlueprint.dataRefs.useProps,
+          )();
           return [...rest, props];
         }
         return rest;


### PR DESCRIPTION
The `catalogAboutEntityCard` was calling useProps() for all icon links before checking filters, causing hooks with side effects to execute for all entity types. This fix reverses the order to check the filter first, then only call useProps() if the filter passes.

This prevents unnecessary side effects like API calls, auth flows, or state updates from running for icon links that won't be displayed.

Closes #32081 

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
