### PR TITLE
fix(techdocs): correct colors calculation

### DIFF
--- a/.changeset/rude-moose-dig.md
+++ b/.changeset/rude-moose-dig.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Corrected color of some elements such as Grid cards and Tables.

--- a/plugins/techdocs/src/reader/transformers/styles/rules/typeset.ts
+++ b/plugins/techdocs/src/reader/transformers/styles/rules/typeset.ts
@@ -110,7 +110,7 @@ ${headings.reduce<string>((style, heading) => {
 
 .md-typeset table:not([class]) {
   font-size: var(--md-typeset-font-size);
-  border: 1px solid var(--md-default-fg-color);
+  border: 1px solid var(--md-typeset-table-color);
   border-bottom: none;
   border-collapse: collapse;
   border-radius: ${theme.shape.borderRadius}px;
@@ -119,7 +119,7 @@ ${headings.reduce<string>((style, heading) => {
   font-weight: bold;
 }
 .md-typeset table:not([class]) td, .md-typeset table:not([class]) th {
-  border-bottom: 1px solid var(--md-default-fg-color);
+  border-bottom: 1px solid var(--md-typeset-table-color);
 }
 
 .md-typeset pre > code::-webkit-scrollbar-thumb {

--- a/plugins/techdocs/src/reader/transformers/styles/rules/variables.ts
+++ b/plugins/techdocs/src/reader/transformers/styles/rules/variables.ts
@@ -28,11 +28,8 @@ export default ({ theme }: RuleOptions) => `
   /* FONT */
   --md-default-fg-color: ${theme.palette.text.primary};
   --md-default-fg-color--light: ${theme.palette.text.secondary};
-  --md-default-fg-color--lighter: ${lighten(theme.palette.text.secondary, 0.7)};
-  --md-default-fg-color--lightest: ${lighten(
-    theme.palette.text.secondary,
-    0.3,
-  )};
+  --md-default-fg-color--lighter: ${alpha(theme.palette.text.secondary, 0.3)};
+  --md-default-fg-color--lightest: ${alpha(theme.palette.text.secondary, 0.15)};
 
   /* BACKGROUND */
   --md-default-bg-color:${theme.palette.background.default};
@@ -146,7 +143,7 @@ export default ({ theme }: RuleOptions) => `
   --md-typeset-font-size: 1rem;
   --md-typeset-color: var(--md-default-fg-color);
   --md-typeset-a-color: ${theme.palette.link};
-  --md-typeset-table-color: ${theme.palette.text.primary};
+  --md-typeset-table-color: ${alpha(theme.palette.text.primary, 0.15)};
   --md-typeset-table-color--light: ${alpha(theme.palette.text.primary, 0.05)};
   --md-typeset-del-color: ${
     theme.palette.type === 'dark'


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Based on [what's done in Material for MkDocs](https://github.com/squidfunk/mkdocs-material/blob/673d8ca986c37ddeabe25c7e7b7299ec644910ed/src/templates/assets/stylesheets/main/_colors.scss#L76), this changes the way `lightest` and `light` variants are calculated.

This is mostly done in an attempt to fix Grid and Tables border colors.

---

### Grids

**Before / After (Light Theme)**
<img width="1132" height="256" alt="image" src="https://github.com/user-attachments/assets/ffb5fdc3-b3c5-4572-8709-1d3d66267971" />

<img width="1138" height="269" alt="image" src="https://github.com/user-attachments/assets/49400478-6e7c-4df2-80b3-5a10ffe29dac" />


**Before / After (Dark Theme)**

<img width="1132" height="256" alt="image" src="https://github.com/user-attachments/assets/50cb36e4-6f92-4114-a03f-154646af1c40" />

<img width="1138" height="269" alt="image" src="https://github.com/user-attachments/assets/135a101d-f68c-4ecc-897e-133d5e3c615b" />



**Material for MkDocs reference:**
<img width="788" height="304" alt="image" src="https://github.com/user-attachments/assets/6dfe86e6-7feb-4cc8-b72c-52cf0d3f6f5c" />

---

### Tables

**Before / After (Light)**

<img width="971" height="350" alt="image" src="https://github.com/user-attachments/assets/72c2dab1-2d1e-48e5-9288-eb3b3b3e900d" />

<img width="971" height="350" alt="image" src="https://github.com/user-attachments/assets/59033005-2a34-47b1-b2f9-0474047a000f" />


**Before / After (Dark)**

<img width="971" height="350" alt="image" src="https://github.com/user-attachments/assets/ca7c3df0-81a9-40d1-9d8c-3b8f110463aa" />

<img width="940" height="341" alt="image" src="https://github.com/user-attachments/assets/39e8678f-fdf1-4640-9576-5702cabf7c40" />

**Material for MkDocs Reference:**

<img width="776" height="323" alt="image" src="https://github.com/user-attachments/assets/67100ade-f6df-44c1-94d7-0dbd13c752f1" />


---

I'm trying to create a patch internally so I created this PR but this feels a bit "wobbly", I wonder if there's a way to reduce the render gap between Material for MkDocs and TechDocs as a whole, instead of doing small band-aid patches like this 😅 (eg, some other colors seem to have the same calculation issue but I'm not sure what it would change, the font size of tables is bigger, etc)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] ~Added or updated documentation~
- [ ] ~Tests for new functionality and regression tests for bug fixes~
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
