### PR TITLE
cli: move back to ES2022 in tsconfig

### DIFF
--- a/.changeset/stupid-cases-fold.md
+++ b/.changeset/stupid-cases-fold.md
@@ -2,4 +2,6 @@
 '@backstage/cli': patch
 ---
 
-Switched ECMAScript version to ES2023.
+Switched compilation target to ES2022 in order to match the new set of supported Node.js versions, which are 22 and 24.
+
+The TypeScript compilation target has been set to ES2022, because setting it to a higher target will break projects on older TypeScript versions. If you use a newer TypeScript version in your own project, you can bump `compilerOptions.target` to ES2023 or ES2024 in your own `tsconfig.json` file.

--- a/packages/cli/config/tsconfig.json
+++ b/packages/cli/config/tsconfig.json
@@ -33,7 +33,7 @@
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
     "stripInternal": true,
-    "target": "ES2023",
+    "target": "ES2022",
     "types": ["node", "jest", "webpack-env"],
     "useDefineForClassFields": true
   }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Discussed with @awanlin today as we ran into some trouble bumping the demo site to the latest release. Keeping the default target at ES2022 makes sure we're staying compatible with a wider range of TypeScript versions. Related to #31454

The tricky bit is that if we specify ES2023 or ES2024 as the target in the common config, users on older versions of TypeScript won't be able to use the common `tsconfig.json` at all, because typescript refuses to load it. This happens even if the user overrides the target in their own `tsconfig.json`, because TypeScript validates each file in isolation. Because of that it's a bit safer to stay at a lower target to not force users to update too early, while still allowing a later target to be set.

None of this should affect runtime, since we have separate explicit configurations for that.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
