### PR TITLE
Add support for persisted feature flags

### DIFF
--- a/.changeset/chubby-gifts-fry.md
+++ b/.changeset/chubby-gifts-fry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/test-utils': patch
+---
+
+Add `BroadcastChannel` to `globalThis` to allow for frontend logic to use it

--- a/.changeset/five-years-talk.md
+++ b/.changeset/five-years-talk.md
@@ -1,0 +1,10 @@
+---
+'@backstage/app-defaults': patch
+'@backstage/frontend-plugin-api': patch
+'@backstage/frontend-app-api': patch
+'@backstage/core-plugin-api': patch
+'@backstage/core-app-api': patch
+'@backstage/plugin-user-settings': patch
+---
+
+Added support for making individual feature flags persisted (stored using the StorageApi)

--- a/docs/plugins/feature-flags.md
+++ b/docs/plugins/feature-flags.md
@@ -19,10 +19,17 @@ import { createPlugin } from '@backstage/core-plugin-api';
 
 export const examplePlugin = createPlugin({
   // ...
-  featureFlags: [{ name: 'show-example-feature' }],
+  featureFlags: [
+    {
+      name: 'show-example-feature',
+      persisted: true, // Optional
+    },
+  ],
   // ...
 });
 ```
+
+If `persisted` is left out (or false), the feature flag will be stored in the browser for the user. If true, it will be stored in the StorageApi, which may use the backend for storage if implemented using the UserStorage plugin. It will then be persisted for any browser the user is using.
 
 ### In the application
 
@@ -73,11 +80,19 @@ import { FeatureFlagged } from '@backstage/core-app-api';
 
 ## Evaluating Feature Flag State
 
-It is also possible to query a feature flag using the [FeatureFlags Api](https://backstage.io/api/stable/interfaces/_backstage_core-plugin-api.index.FeatureFlagsApi.html).
+It is also possible to query a feature flag using either the hook `useFeatureFlag` or the [FeatureFlags Api](https://backstage.io/api/stable/interfaces/_backstage_core-plugin-api.index.FeatureFlagsApi.html).
 
 ```ts
-import { useApi, featureFlagsApiRef } from '@backstage/core-plugin-api';
+import { useFeatureFlag } from '@backstage/frontend-plugin-api';
+
+const isOn = useFeatureFlag('show-example-feature');
+```
+
+or
+
+```ts
+import { useApi, featureFlagsApiRef } from '@backstage/frontend-plugin-api';
 
 const featureFlagsApi = useApi(featureFlagsApiRef);
-const isOn = featureFlagsApi.isActive('show-example-feature');
+const isOn = await featureFlagsApi.getFlag('show-example-feature');
 ```

--- a/packages/app-defaults/src/defaults/apis.ts
+++ b/packages/app-defaults/src/defaults/apis.ts
@@ -15,10 +15,7 @@
  */
 
 import {
-  AlertApiForwarder,
   NoOpAnalyticsApi,
-  ErrorApiForwarder,
-  ErrorAlerter,
   GoogleAuth,
   GithubAuth,
   OktaAuth,
@@ -27,9 +24,7 @@ import {
   BitbucketAuth,
   BitbucketServerAuth,
   OAuthRequestManager,
-  WebStorage,
   OneLoginAuth,
-  UnhandledErrorForwarder,
   AtlassianAuth,
   createFetchApi,
   FetchMiddlewares,
@@ -40,9 +35,7 @@ import {
 
 import {
   createApiFactory,
-  alertApiRef,
   analyticsApiRef,
-  errorApiRef,
   discoveryApiRef,
   fetchApiRef,
   identityApiRef,
@@ -52,7 +45,6 @@ import {
   oktaAuthApiRef,
   gitlabAuthApiRef,
   microsoftAuthApiRef,
-  storageApiRef,
   configApiRef,
   oneloginAuthApiRef,
   bitbucketAuthApiRef,
@@ -73,28 +65,9 @@ export const apis = [
     factory: ({ configApi }) => FrontendHostDiscovery.fromConfig(configApi),
   }),
   createApiFactory({
-    api: alertApiRef,
-    deps: {},
-    factory: () => new AlertApiForwarder(),
-  }),
-  createApiFactory({
     api: analyticsApiRef,
     deps: {},
     factory: () => new NoOpAnalyticsApi(),
-  }),
-  createApiFactory({
-    api: errorApiRef,
-    deps: { alertApi: alertApiRef },
-    factory: ({ alertApi }) => {
-      const errorApi = new ErrorAlerter(alertApi, new ErrorApiForwarder());
-      UnhandledErrorForwarder.forward(errorApi, { hidden: false });
-      return errorApi;
-    },
-  }),
-  createApiFactory({
-    api: storageApiRef,
-    deps: { errorApi: errorApiRef },
-    factory: ({ errorApi }) => WebStorage.create({ errorApi }),
   }),
   createApiFactory({
     api: fetchApiRef,

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -66,6 +66,7 @@
     "@backstage/plugin-search-backend-node": "workspace:^",
     "@backstage/plugin-signals-backend": "workspace:^",
     "@backstage/plugin-techdocs-backend": "workspace:^",
+    "@backstage/plugin-user-settings-backend": "workspace:^",
     "@opentelemetry/auto-instrumentations-node": "^0.67.0",
     "@opentelemetry/exporter-prometheus": "^0.211.0",
     "@opentelemetry/sdk-node": "^0.211.0",

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -74,4 +74,5 @@ backend.add(rootSystemMetadataServiceFactory);
 
 backend.add(import('@backstage/plugin-events-backend-module-google-pubsub'));
 backend.add(import('@backstage/plugin-mcp-actions-backend'));
+backend.add(import('@backstage/plugin-user-settings-backend'));
 backend.start();

--- a/packages/core-app-api/report.api.md
+++ b/packages/core-app-api/report.api.md
@@ -224,7 +224,8 @@ export type AppOptions = {
       >;
     }
   >;
-  featureFlags?: (FeatureFlag & Omit<FeatureFlag, 'pluginId'>)[];
+  featureFlags?: (Omit<FeatureFlag, 'pluginId' | 'persisted'> &
+    Partial<Pick<FeatureFlag, 'pluginId' | 'persisted'>>)[];
   components: AppComponents;
   themes: (Partial<AppTheme> & Omit<AppTheme, 'theme'>)[];
   configLoader?: AppConfigLoader;
@@ -493,14 +494,21 @@ export class GoogleAuth {
 
 // @public
 export class LocalStorageFeatureFlags implements FeatureFlagsApi {
+  constructor();
+  // (undocumented)
+  getFlag(name: string): Promise<boolean>;
   // (undocumented)
   getRegisteredFlags(): FeatureFlag[];
   // (undocumented)
   isActive(name: string): boolean;
   // (undocumented)
+  observe$(name: string): Observable<boolean>;
+  // (undocumented)
   registerFlag(flag: FeatureFlag): void;
   // (undocumented)
   save(options: FeatureFlagsSaveOptions): void;
+  // (undocumented)
+  setFlag(name: string, active: boolean): Promise<void>;
 }
 
 // @public
@@ -532,6 +540,27 @@ export class MicrosoftAuth {
 export class MultipleAnalyticsApi implements AnalyticsApi {
   captureEvent(event: AnalyticsEvent): void;
   static fromApis(actualApis: AnalyticsApi[]): MultipleAnalyticsApi;
+}
+
+// @public
+export class MultiStorageFeatureFlags implements FeatureFlagsApi {
+  constructor({ storageApi }: { storageApi: StorageApi });
+  // (undocumented)
+  getFlag(name: string): Promise<boolean>;
+  // (undocumented)
+  getRegisteredFlags(): FeatureFlag[];
+  // (undocumented)
+  initialize(): void;
+  // (undocumented)
+  isActive(name: string): boolean;
+  // (undocumented)
+  observe$(name: string): Observable<boolean>;
+  // (undocumented)
+  registerFlag(flag: FeatureFlag): void;
+  // (undocumented)
+  save(options: FeatureFlagsSaveOptions): void;
+  // (undocumented)
+  setFlag(name: string, active: boolean): Promise<void>;
 }
 
 // @public

--- a/packages/core-app-api/src/apis/implementations/FeatureFlagsApi/BroadcastSignal.ts
+++ b/packages/core-app-api/src/apis/implementations/FeatureFlagsApi/BroadcastSignal.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import ZenObservable from 'zen-observable';
+
+import { FeatureFlagState } from '@backstage/core-plugin-api';
+import type { Observable } from '@backstage/types';
+
+type MessageData = {
+  name: string;
+  state: FeatureFlagState;
+  persisted: boolean;
+};
+
+function isValidMessage(ev: MessageEvent): ev is MessageEvent<MessageData> {
+  return (
+    ev.data &&
+    typeof ev.data.name === 'string' &&
+    typeof ev.data.state === 'number' &&
+    typeof ev.data.persisted === 'boolean'
+  );
+}
+
+export class BroadcastSignal {
+  #listenBroadcast: BroadcastChannel;
+  #postBroadcast: BroadcastChannel;
+
+  constructor(
+    onUpdate: (
+      name: string,
+      state: FeatureFlagState,
+      persisted: boolean,
+    ) => void,
+  ) {
+    this.#postBroadcast = new BroadcastChannel('feature-flags');
+
+    this.#listenBroadcast = new BroadcastChannel('feature-flags');
+    this.#listenBroadcast.addEventListener('message', ev => {
+      if (isValidMessage(ev)) {
+        onUpdate(ev.data.name, ev.data.state, ev.data.persisted);
+      }
+    });
+  }
+
+  signal(name: string, state: FeatureFlagState, persisted: boolean) {
+    this.#postBroadcast.postMessage({ name, state, persisted });
+  }
+
+  observe$(name: string): Observable<boolean> {
+    return new ZenObservable(subscriber => {
+      const handleMessage = (ev: MessageEvent) => {
+        if (isValidMessage(ev) && ev.data.name === name) {
+          subscriber.next(ev.data.state === FeatureFlagState.Active);
+        }
+      };
+      this.#listenBroadcast.addEventListener('message', handleMessage);
+      return () => {
+        this.#listenBroadcast.removeEventListener('message', handleMessage);
+      };
+    });
+  }
+}

--- a/packages/core-app-api/src/apis/implementations/FeatureFlagsApi/MultiStorageFeatureFlags.tsx
+++ b/packages/core-app-api/src/apis/implementations/FeatureFlagsApi/MultiStorageFeatureFlags.tsx
@@ -1,0 +1,321 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import ZenObservable from 'zen-observable';
+
+import {
+  FeatureFlagState,
+  FeatureFlagsApi,
+  FeatureFlag,
+  FeatureFlagsSaveOptions,
+  StorageApi,
+} from '@backstage/core-plugin-api';
+import type { Observable } from '@backstage/types';
+
+import { validateFlagName } from './validateFlagName';
+import { BroadcastSignal } from './BroadcastSignal';
+
+function toState(active: boolean): FeatureFlagState {
+  return active ? FeatureFlagState.Active : FeatureFlagState.None;
+}
+function fromState(state: FeatureFlagState | undefined): boolean | undefined {
+  if (typeof state === 'undefined') {
+    return undefined;
+  }
+  return state === FeatureFlagState.Active;
+}
+
+/**
+ * A feature flags implementation that stores the flags in the browser's local
+ * storage as well as using the StorageApi for persistent flags.
+ *
+ * @public
+ */
+export class MultiStorageFeatureFlags implements FeatureFlagsApi {
+  #isInitialized = false;
+  #storageApi: StorageApi;
+  #signal: BroadcastSignal;
+
+  private registeredLocalFlags = new Map<string, FeatureFlag>();
+  private registeredPersistedFlags = new Map<string, FeatureFlag>();
+  private localFlags = new Map<string, FeatureFlagState>();
+  private persistedFlags = new Map<string, FeatureFlagState>();
+
+  constructor({ storageApi }: { storageApi: StorageApi }) {
+    this.#storageApi = storageApi.forBucket('feature-flags');
+    this.#signal = new BroadcastSignal((name, state, persisted) => {
+      if (persisted) {
+        this.persistedFlags.set(name, state);
+      } else {
+        this.localFlags.set(name, state);
+      }
+    });
+  }
+
+  #writeLocalFlags(): void {
+    const enabled = Array.from(this.localFlags.entries()).filter(
+      ([, s]) => s === FeatureFlagState.Active,
+    );
+
+    window.localStorage.setItem(
+      'featureFlags',
+      JSON.stringify(Object.fromEntries(enabled)),
+    );
+  }
+
+  initialize(): void {
+    if (this.#isInitialized) {
+      return;
+    }
+    this.#isInitialized = true;
+    this.loadLocal();
+    this.loadPersisted();
+  }
+
+  registerFlag(flag: FeatureFlag) {
+    validateFlagName(flag.name);
+    if (flag.persisted) {
+      this.registeredPersistedFlags.set(flag.name, flag);
+    } else {
+      this.registeredLocalFlags.set(flag.name, flag);
+    }
+  }
+
+  getRegisteredFlags(): FeatureFlag[] {
+    return ([] as FeatureFlag[]).concat(
+      Array.from(this.registeredLocalFlags.values()),
+      Array.from(this.registeredPersistedFlags.values()),
+    );
+  }
+
+  async getFlag(name: string): Promise<boolean> {
+    if (this.registeredPersistedFlags.has(name)) {
+      return new Promise<boolean>((resolve, reject) => {
+        const subscription = this.#observePersisted$(name).subscribe(
+          value => {
+            resolve(value);
+            subscription.unsubscribe();
+          },
+          err => {
+            reject(err);
+            subscription.unsubscribe();
+          },
+        );
+      });
+    }
+
+    this.initialize();
+    return fromState(this.localFlags.get(name)) ?? false;
+  }
+
+  async #setPersistedFlag(
+    name: string,
+    state: FeatureFlagState,
+  ): Promise<void> {
+    this.persistedFlags.set(name, state);
+    await this.#storageApi.set<FeatureFlagState>(name, state);
+  }
+
+  #setLocalFlag(name: string, state: FeatureFlagState): void {
+    this.localFlags.set(name, state);
+
+    this.#writeLocalFlags();
+  }
+
+  async setFlag(name: string, active: boolean): Promise<void> {
+    this.initialize();
+
+    const state = toState(active);
+    const persisted = this.registeredPersistedFlags.has(name);
+
+    if (persisted) {
+      await this.#setPersistedFlag(name, state);
+    } else {
+      this.#setLocalFlag(name, state);
+    }
+
+    this.#signal.signal(name, state, persisted);
+  }
+
+  #observePersisted$(name: string): Observable<boolean> {
+    this.initialize();
+
+    return new ZenObservable(subscriber => {
+      return this.#storageApi.observe$<FeatureFlagState>(name).subscribe({
+        next(snapshot) {
+          subscriber.next(snapshot.value === FeatureFlagState.Active);
+        },
+        error(error) {
+          subscriber.error(error);
+        },
+        complete() {
+          subscriber.complete();
+        },
+      });
+    });
+  }
+
+  observe$(name: string): Observable<boolean> {
+    this.initialize();
+
+    const isLocal = this.registeredLocalFlags.has(name);
+    const isPersisted = this.registeredPersistedFlags.has(name);
+
+    return new ZenObservable(subscriber => {
+      if (isLocal) {
+        const enabled = fromState(this.localFlags?.get(name));
+        // Signal the current cached value
+        subscriber.next(enabled ?? false);
+        // Subscribe to changes
+        return this.#signal.observe$(name).subscribe(subscriber);
+      } else if (isPersisted) {
+        const enabled = fromState(this.persistedFlags?.get(name));
+        // Signal the current cached value
+        if (typeof enabled !== 'undefined') {
+          subscriber.next(enabled);
+        }
+        // Subscribe to changes
+        return this.#observePersisted$(name).subscribe(subscriber);
+      }
+
+      subscriber.next(false);
+      subscriber.complete();
+      return undefined;
+    });
+  }
+
+  // Deprecated
+  isActive(name: string): boolean {
+    this.initialize();
+
+    if (this.registeredPersistedFlags.has(name)) {
+      return this.persistedFlags?.get(name) === FeatureFlagState.Active;
+    }
+    return this.localFlags?.get(name) === FeatureFlagState.Active;
+  }
+
+  // Deprecated
+  save(options: FeatureFlagsSaveOptions): void {
+    this.initialize();
+
+    let removedKeys: string[] = [];
+    if (!options.merge) {
+      removedKeys = Array.from(this.localFlags.keys());
+      this.localFlags.clear();
+    }
+
+    const saveStates = Object.entries(options.states).map(([name, state]) => ({
+      name,
+      persisted: this.registeredPersistedFlags.has(name),
+      state,
+    }));
+
+    const localSaves = saveStates.filter(s => !s.persisted);
+    const persistedSaves = saveStates.filter(s => s.persisted);
+
+    for (const name of removedKeys) {
+      if (!(name in options.states)) {
+        this.#signal.signal(name, FeatureFlagState.None, false);
+      }
+    }
+
+    for (const { name, state } of localSaves) {
+      this.localFlags.set(name, state);
+      this.#signal.signal(name, state, false);
+    }
+    this.#writeLocalFlags();
+
+    Promise.all(
+      persistedSaves.map(async ({ name, state }) => {
+        this.persistedFlags.set(name, state);
+        await this.#storageApi.set<FeatureFlagState>(name, state);
+        this.#signal.signal(name, state, true);
+      }),
+    )
+      // eslint-disable-next-line no-console
+      .catch(error => console.error('Failed to save feature flags', error));
+  }
+
+  private loadLocal(): void {
+    this.localFlags = (() => {
+      try {
+        const jsonStr = window.localStorage.getItem('featureFlags');
+        if (!jsonStr) {
+          return new Map();
+        }
+        const json = JSON.parse(jsonStr) as unknown;
+        if (typeof json !== 'object' || json === null || Array.isArray(json)) {
+          return new Map();
+        }
+
+        const entries = Object.entries(json).filter(([name, value]) => {
+          validateFlagName(name);
+          return value === FeatureFlagState.Active;
+        });
+
+        return new Map(entries);
+      } catch {
+        return new Map();
+      }
+    })();
+  }
+
+  // This observes all known persisted feature flags (and loads all them into
+  // memory), so that:
+  //  * They are synchronously available to plugins using the old synchronous
+  //    isActive() function.
+  //    Caveat; as the loading is async, any calls to isActive() made before
+  //    this has completed will return false negatives.
+  //    NOTE; New code should use observe$() or getFlag() which are async-safe
+  //    and won't return stale data.
+  //  * They are instantly available when observing via observe$()
+  //  * The initial values are taken from local feature flags (if they were
+  //    converted from a local feature flag to a persisted one)
+  private loadPersisted(): void {
+    for (const name of this.registeredPersistedFlags.keys()) {
+      this.#storageApi.observe$<FeatureFlagState>(name).subscribe(snapshot => {
+        let isHandled = false;
+        if (snapshot.presence === 'present') {
+          this.persistedFlags.set(name, snapshot.value);
+          isHandled = true;
+        } else if (snapshot.presence === 'absent' && !isHandled) {
+          isHandled = true;
+          let initialValue = false;
+          // This might have been converted from a local feature flag (i.e. if
+          // it's in the local feature flag state, but not registered anymore).
+          const localState = this.localFlags.get(name);
+          if (
+            !this.registeredLocalFlags.has(name) &&
+            typeof localState !== 'undefined'
+          ) {
+            initialValue = fromState(localState) ?? false;
+            // The flag is no longer registered as local, so remove it
+            this.#setLocalFlag(name, FeatureFlagState.None);
+            // If multiple tabs are open, there might be a race between clearing
+            // the local flag and saving the persisted one. If the stale local
+            // flag is active, save it after a while, to let all open tabs
+            // settle and potential overwriting of false values to happen first.
+            setTimeout(() => {
+              this.setFlag(name, initialValue);
+            }, 5000);
+          }
+          this.setFlag(name, initialValue);
+          isHandled = true;
+        }
+      });
+    }
+  }
+}

--- a/packages/core-app-api/src/apis/implementations/FeatureFlagsApi/index.ts
+++ b/packages/core-app-api/src/apis/implementations/FeatureFlagsApi/index.ts
@@ -15,3 +15,4 @@
  */
 
 export { LocalStorageFeatureFlags } from './LocalStorageFeatureFlags';
+export { MultiStorageFeatureFlags } from './MultiStorageFeatureFlags';

--- a/packages/core-app-api/src/apis/implementations/FeatureFlagsApi/validateFlagName.ts
+++ b/packages/core-app-api/src/apis/implementations/FeatureFlagsApi/validateFlagName.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function validateFlagName(name: string): void {
+  if (name.length < 3) {
+    throw new Error(
+      `The '${name}' feature flag must have a minimum length of three characters.`,
+    );
+  }
+
+  if (name.length > 150) {
+    throw new Error(
+      `The '${name}' feature flag must not exceed 150 characters.`,
+    );
+  }
+
+  if (!name.match(/^[a-z]+[a-z0-9-]+$/)) {
+    throw new Error(
+      `The '${name}' feature flag must start with a lowercase letter and only contain lowercase letters, numbers and hyphens. ` +
+        'Examples: feature-flag-one, alpha, release-2020',
+    );
+  }
+}

--- a/packages/core-app-api/src/apis/implementations/StorageApi/WebStorage.ts
+++ b/packages/core-app-api/src/apis/implementations/StorageApi/WebStorage.ts
@@ -108,6 +108,10 @@ export class WebStorage implements StorageApi {
       WebStorage.addStorageEventListener();
       WebStorage.hasSubscribed = true;
     }
+
+    // Ensure the subscriber gets an initial value
+    setTimeout(() => this.notifyChanges(key), 0);
+
     return this.observable.filter(({ key: messageKey }) => messageKey === key);
   }
 

--- a/packages/core-app-api/src/app/AppManager.test.tsx
+++ b/packages/core-app-api/src/app/AppManager.test.tsx
@@ -399,6 +399,7 @@ describe('Integration Test', () => {
 
     expect(storageFlags.registerFlag).toHaveBeenCalledWith({
       name: 'name',
+      persisted: false,
       pluginId: 'test',
     });
   });
@@ -476,10 +477,12 @@ describe('Integration Test', () => {
 
     expect(storageFlags.registerFlag).toHaveBeenCalledWith({
       name: 'foo',
+      persisted: false,
       pluginId: 'test',
     });
     expect(storageFlags.registerFlag).toHaveBeenCalledWith({
       name: 'old-feature-flag',
+      persisted: false,
       pluginId: 'old-test',
     });
   });

--- a/packages/core-app-api/src/app/AppManager.tsx
+++ b/packages/core-app-api/src/app/AppManager.tsx
@@ -24,10 +24,15 @@ import {
 } from 'react';
 import useAsync from 'react-use/esm/useAsync';
 import {
+  AlertApiForwarder,
   ApiProvider,
   AppThemeSelector,
   ConfigReader,
-  LocalStorageFeatureFlags,
+  ErrorAlerter,
+  ErrorApiForwarder,
+  MultiStorageFeatureFlags,
+  UnhandledErrorForwarder,
+  WebStorage,
 } from '../apis';
 import {
   AnyApiFactory,
@@ -45,6 +50,8 @@ import {
   fetchApiRef,
   discoveryApiRef,
   errorApiRef,
+  storageApiRef,
+  alertApiRef,
 } from '@backstage/core-plugin-api';
 import {
   AppLanguageApi,
@@ -183,7 +190,12 @@ export class AppManager implements BackstageApp {
     this.apis = options.apis ?? [];
     this.icons = options.icons;
     this.plugins = new Set((options.plugins as CompatiblePlugin[]) ?? []);
-    this.featureFlags = options.featureFlags ?? [];
+    this.featureFlags =
+      options.featureFlags?.map(flag => ({
+        ...flag,
+        persisted: flag.persisted ?? false,
+        pluginId: flag.pluginId ?? '',
+      })) ?? [];
     this.components = options.components;
     this.themes = options.themes as AppTheme[];
     this.configLoader = options.configLoader ?? defaultConfigLoader;
@@ -339,6 +351,7 @@ DEPRECATION WARNING: React Router Beta is deprecated and support for it will be 
               for (const flag of plugin.getFeatureFlags()) {
                 featureFlagsApi.registerFlag({
                   name: flag.name,
+                  persisted: flag.persisted ?? false,
                   pluginId: plugin.getId(),
                 });
               }
@@ -347,6 +360,7 @@ DEPRECATION WARNING: React Router Beta is deprecated and support for it will be 
                 if (output.type === 'feature-flag') {
                   featureFlagsApi.registerFlag({
                     name: output.name,
+                    persisted: false,
                     pluginId: plugin.getId(),
                   });
                 }
@@ -357,13 +371,19 @@ DEPRECATION WARNING: React Router Beta is deprecated and support for it will be 
           // Go through the featureFlags returned from the traversal and
           // register those now the configApi has been loaded
           const registeredFlags = featureFlagsApi.getRegisteredFlags();
-          const flagNames = new Set(registeredFlags.map(f => f.name));
+          const flagNames = new Map(registeredFlags.map(f => [f.name, f]));
           for (const name of featureFlags) {
             // Prevents adding duplicate feature flags
             if (!flagNames.has(name)) {
-              featureFlagsApi.registerFlag({ name, pluginId: '' });
+              featureFlagsApi.registerFlag({
+                name,
+                pluginId: '',
+                persisted: flagNames.get(name)?.persisted ?? false,
+              });
             }
           }
+
+          featureFlagsApi.initialize?.();
         }
       }
 
@@ -477,12 +497,40 @@ DEPRECATION WARNING: React Router Beta is deprecated and support for it will be 
         }),
     });
 
+    // The feature flags API requires StorageApi hence ErrorApi and AlertApi,
+    // so we'll create them here instead of defaultApis.
+    this.apiFactoryRegistry.register('default', {
+      api: alertApiRef,
+      deps: {},
+      factory: () => new AlertApiForwarder(),
+    });
+    this.apiFactoryRegistry.register('default', {
+      api: errorApiRef,
+      deps: {
+        alertApi: alertApiRef,
+      },
+      factory: ({ alertApi }) => {
+        const errorApi = new ErrorAlerter(alertApi, new ErrorApiForwarder());
+        UnhandledErrorForwarder.forward(errorApi, { hidden: false });
+        return errorApi;
+      },
+    });
+    this.apiFactoryRegistry.register('default', {
+      api: storageApiRef,
+      deps: {
+        errorApi: errorApiRef,
+      },
+      factory: ({ errorApi }) => WebStorage.create({ errorApi }),
+    });
+
     // It's possible to replace the feature flag API, but since we must have at least
     // one implementation we add it here directly instead of through the defaultApis.
     this.apiFactoryRegistry.register('default', {
       api: featureFlagsApiRef,
-      deps: {},
-      factory: () => new LocalStorageFeatureFlags(),
+      deps: {
+        storageApi: storageApiRef,
+      },
+      factory: ({ storageApi }) => new MultiStorageFeatureFlags({ storageApi }),
     });
     for (const factory of this.defaultApis) {
       this.apiFactoryRegistry.register('default', factory);

--- a/packages/core-app-api/src/app/types.ts
+++ b/packages/core-app-api/src/app/types.ts
@@ -220,7 +220,8 @@ export type AppOptions = {
   /**
    * Application level feature flags.
    */
-  featureFlags?: (FeatureFlag & Omit<FeatureFlag, 'pluginId'>)[];
+  featureFlags?: (Omit<FeatureFlag, 'pluginId' | 'persisted'> &
+    Partial<Pick<FeatureFlag, 'pluginId' | 'persisted'>>)[];
 
   /**
    * Supply components to the app to override the default ones.

--- a/packages/core-app-api/src/routing/FeatureFlagged.test.tsx
+++ b/packages/core-app-api/src/routing/FeatureFlagged.test.tsx
@@ -19,7 +19,16 @@ import { FeatureFlagged } from './FeatureFlagged';
 import { render, screen } from '@testing-library/react';
 import { LocalStorageFeatureFlags } from '../apis';
 import { TestApiProvider } from '@backstage/test-utils';
-import { featureFlagsApiRef } from '@backstage/core-plugin-api';
+import { featureFlagsApiRef, useFeatureFlag } from '@backstage/core-plugin-api';
+
+jest.mock('@backstage/core-plugin-api', () => ({
+  ...jest.requireActual('@backstage/core-plugin-api'),
+  useFeatureFlag: jest.fn(),
+}));
+
+const mockedUseFeatureFlag = useFeatureFlag as jest.MockedFunction<
+  typeof useFeatureFlag
+>;
 
 const mockFeatureFlagsApi = new LocalStorageFeatureFlags();
 const Wrapper = ({ children }: { children?: ReactNode }) => (
@@ -31,9 +40,7 @@ const Wrapper = ({ children }: { children?: ReactNode }) => (
 describe('FeatureFlagged', () => {
   describe('with', () => {
     it('should render contents when the feature flag is enabled', async () => {
-      jest
-        .spyOn(mockFeatureFlagsApi, 'isActive')
-        .mockImplementation(() => true);
+      mockedUseFeatureFlag.mockImplementation(() => true);
 
       render(
         <Wrapper>
@@ -48,9 +55,7 @@ describe('FeatureFlagged', () => {
       expect(screen.getByText('BACKSTAGE!')).toBeInTheDocument();
     });
     it('should not render contents when the feature flag is disabled', async () => {
-      jest
-        .spyOn(mockFeatureFlagsApi, 'isActive')
-        .mockImplementation(() => false);
+      mockedUseFeatureFlag.mockImplementation(() => false);
 
       render(
         <Wrapper>
@@ -67,9 +72,7 @@ describe('FeatureFlagged', () => {
   });
   describe('without', () => {
     it('should not render contents when the feature flag is enabled', async () => {
-      jest
-        .spyOn(mockFeatureFlagsApi, 'isActive')
-        .mockImplementation(() => true);
+      mockedUseFeatureFlag.mockImplementation(() => true);
 
       render(
         <Wrapper>
@@ -84,9 +87,7 @@ describe('FeatureFlagged', () => {
       expect(screen.queryByText('BACKSTAGE!')).not.toBeInTheDocument();
     });
     it('should render contents when the feature flag is disabled', async () => {
-      jest
-        .spyOn(mockFeatureFlagsApi, 'isActive')
-        .mockImplementation(() => false);
+      mockedUseFeatureFlag.mockImplementation(() => false);
 
       render(
         <Wrapper>

--- a/packages/core-app-api/src/routing/FeatureFlagged.tsx
+++ b/packages/core-app-api/src/routing/FeatureFlagged.tsx
@@ -15,9 +15,8 @@
  */
 
 import {
-  featureFlagsApiRef,
-  useApi,
   attachComponentData,
+  useFeatureFlag,
 } from '@backstage/core-plugin-api';
 import { ReactNode } from 'react';
 
@@ -39,11 +38,17 @@ export type FeatureFlaggedProps = { children: ReactNode } & (
  */
 export const FeatureFlagged = (props: FeatureFlaggedProps) => {
   const { children } = props;
-  const featureFlagApi = useApi(featureFlagsApiRef);
-  const isEnabled =
-    'with' in props
-      ? featureFlagApi.isActive(props.with)
-      : !featureFlagApi.isActive(props.without);
+
+  const flagName = 'with' in props ? props.with : props.without;
+
+  const enabled = useFeatureFlag(flagName, { strictPresence: true });
+
+  if (typeof enabled === 'undefined') {
+    // Flag is not yet settled
+    return <>{null}</>;
+  }
+
+  const isEnabled = 'with' in props ? enabled : !enabled;
   return <>{isEnabled ? children : null}</>;
 };
 

--- a/packages/core-app-api/src/setupTests.ts
+++ b/packages/core-app-api/src/setupTests.ts
@@ -15,3 +15,5 @@
  */
 
 import '@testing-library/jest-dom';
+
+globalThis.BroadcastChannel = require('worker_threads').BroadcastChannel;

--- a/packages/core-plugin-api/report.api.md
+++ b/packages/core-plugin-api/report.api.md
@@ -76,6 +76,7 @@ import { StorageValueSnapshot } from '@backstage/frontend-plugin-api';
 import { TypesToApiRefs } from '@backstage/frontend-plugin-api';
 import { useApi } from '@backstage/frontend-plugin-api';
 import { useApiHolder } from '@backstage/frontend-plugin-api';
+import { useFeatureFlag } from '@backstage/frontend-plugin-api';
 import { vmwareCloudAuthApiRef } from '@backstage/frontend-plugin-api';
 import { withApis } from '@backstage/frontend-plugin-api';
 
@@ -500,6 +501,7 @@ export type PluginConfig<
 // @public
 export type PluginFeatureFlagConfig = {
   name: string;
+  persisted?: boolean;
 };
 
 export { ProfileInfo };
@@ -562,6 +564,8 @@ export function useElementFilter<T>(
   filterFn: (arg: ElementCollection) => T,
   dependencies?: any[],
 ): T;
+
+export { useFeatureFlag };
 
 // @public
 export function useRouteRef<Optional extends boolean, Params extends AnyParams>(

--- a/packages/core-plugin-api/src/hooks/index.ts
+++ b/packages/core-plugin-api/src/hooks/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2025 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,4 @@
  * limitations under the License.
  */
 
-export * from './apis';
-export { default as mockBreakpoint } from './mockBreakpoint';
-export {
-  wrapInTestApp,
-  renderInTestApp,
-  textContentMatcher,
-  createTestAppWrapper,
-} from './appWrappers';
-export type { TestAppOptions } from './appWrappers';
-export * from './msw';
-export * from './logCollector';
-export * from './testingLibrary';
-export { TestApiProvider, TestApiRegistry } from './TestApiProvider';
-export type { TestApiProviderProps } from './TestApiProvider';
-
-import './support';
+export { useFeatureFlag } from '@backstage/frontend-plugin-api';

--- a/packages/core-plugin-api/src/index.ts
+++ b/packages/core-plugin-api/src/index.ts
@@ -24,6 +24,7 @@ export * from './analytics';
 export * from './apis';
 export * from './app';
 export * from './extensions';
+export * from './hooks';
 export * from './icons';
 export * from './plugin';
 export * from './routing';

--- a/packages/core-plugin-api/src/plugin/types.ts
+++ b/packages/core-plugin-api/src/plugin/types.ts
@@ -73,6 +73,8 @@ export type BackstagePlugin<
 export type PluginFeatureFlagConfig = {
   /** Feature flag name */
   name: string;
+  /** Persisted feature flag */
+  persisted?: boolean;
 };
 
 /**

--- a/packages/frontend-app-api/src/wiring/createSpecializedApp.tsx
+++ b/packages/frontend-app-api/src/wiring/createSpecializedApp.tsx
@@ -357,7 +357,9 @@ export function createSpecializedApp(options?: CreateSpecializedAppOptions): {
         OpaqueFrontendPlugin.toInternal(feature).featureFlags.forEach(flag =>
           featureFlagApi.registerFlag({
             name: flag.name,
+            description: flag.description,
             pluginId: feature.id,
+            persisted: flag.persisted ?? false,
           }),
         );
       }
@@ -365,11 +367,14 @@ export function createSpecializedApp(options?: CreateSpecializedAppOptions): {
         toInternalFrontendModule(feature).featureFlags.forEach(flag =>
           featureFlagApi.registerFlag({
             name: flag.name,
+            description: flag.description,
             pluginId: feature.pluginId,
+            persisted: flag.persisted ?? false,
           }),
         );
       }
     }
+    featureFlagApi.initialize?.();
   }
 
   // Now instantiate the entire tree, which will skip anything that's already been instantiated

--- a/packages/frontend-plugin-api/package.json
+++ b/packages/frontend-plugin-api/package.json
@@ -47,6 +47,7 @@
     "@backstage/errors": "workspace:^",
     "@backstage/types": "workspace:^",
     "@backstage/version-bridge": "workspace:^",
+    "react-use": "^17.2.4",
     "zod": "^3.25.76",
     "zod-to-json-schema": "^3.25.1"
   },

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -1283,6 +1283,7 @@ export interface ExternalRouteRef<
 // @public
 export type FeatureFlag = {
   name: string;
+  persisted: boolean;
   pluginId: string;
   description?: string;
 };
@@ -1290,14 +1291,22 @@ export type FeatureFlag = {
 // @public
 export type FeatureFlagConfig = {
   name: string;
+  description?: string;
+  persisted?: boolean;
 };
 
 // @public
 export interface FeatureFlagsApi {
+  getFlag(name: string): Promise<boolean>;
   getRegisteredFlags(): FeatureFlag[];
+  initialize?(): void;
+  // @deprecated
   isActive(name: string): boolean;
+  observe$(name: string): Observable<boolean>;
   registerFlag(flag: FeatureFlag): void;
+  // @deprecated
   save(options: FeatureFlagsSaveOptions): void;
+  setFlag(name: string, active: boolean): Promise<void>;
 }
 
 // @public
@@ -2283,6 +2292,14 @@ export function useApiHolder(): ApiHolder;
 
 // @public
 export function useAppNode(): AppNode | undefined;
+
+// @public
+export function useFeatureFlag<StrictPresence extends boolean = false>(
+  name: string,
+  options?: {
+    strictPresence: StrictPresence;
+  },
+): StrictPresence extends true ? boolean | undefined : boolean;
 
 // @public
 export function useRouteRef<TParams extends AnyRouteRefParams>(

--- a/packages/frontend-plugin-api/src/apis/definitions/FeatureFlagsApi.ts
+++ b/packages/frontend-plugin-api/src/apis/definitions/FeatureFlagsApi.ts
@@ -16,6 +16,8 @@
 /* We want to maintain the same information as an enum, so we disable the redeclaration warning */
 /* eslint-disable @typescript-eslint/no-redeclare */
 
+import type { Observable } from '@backstage/types';
+
 import { ApiRef, createApiRef } from '../system';
 
 /**
@@ -24,8 +26,16 @@ import { ApiRef, createApiRef } from '../system';
  * @public
  */
 export type FeatureFlag = {
+  /** Unique name of the feature flag */
   name: string;
+  /**
+   * Whether the feature flag is persisted in the StorageApi or locally in the
+   * browser
+   */
+  persisted: boolean;
+  /** ID of the plugin that registered the feature flag */
   pluginId: string;
+  /** Description of the feature flag */
   description?: string;
 };
 
@@ -95,6 +105,12 @@ export type FeatureFlagsSaveOptions = {
  */
 export interface FeatureFlagsApi {
   /**
+   * Initializes the feature flags API. This is called once on app startup, and
+   * is not expected to be called by plugins.
+   */
+  initialize?(): void;
+
+  /**
    * Registers a new feature flag. Once a feature flag has been registered it
    * can be toggled by users, and read back to enable or disable features.
    */
@@ -106,12 +122,31 @@ export interface FeatureFlagsApi {
   getRegisteredFlags(): FeatureFlag[];
 
   /**
+   * Get the value of a feature flag with the given name.
+   */
+  getFlag(name: string): Promise<boolean>;
+
+  /**
+   * Save the user's choice of a feature flag.
+   */
+  setFlag(name: string, active: boolean): Promise<void>;
+
+  /**
+   * Observe the value of a feature flag with the given name.
+   */
+  observe$(name: string): Observable<boolean>;
+
+  /**
    * Whether the feature flag with the given name is currently activated for the user.
+   *
+   * @deprecated Use `useFeatureFlag` or {@link FeatureFlagsApi.getFlag | getFlag} instead.
    */
   isActive(name: string): boolean;
 
   /**
    * Save the user's choice of feature flag states.
+   *
+   * @deprecated Use {@link FeatureFlagsApi.setFlag | setFlag} instead.
    */
   save(options: FeatureFlagsSaveOptions): void;
 }

--- a/packages/frontend-plugin-api/src/hooks/index.ts
+++ b/packages/frontend-plugin-api/src/hooks/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2025 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,4 @@
  * limitations under the License.
  */
 
-export * from './apis';
-export { default as mockBreakpoint } from './mockBreakpoint';
-export {
-  wrapInTestApp,
-  renderInTestApp,
-  textContentMatcher,
-  createTestAppWrapper,
-} from './appWrappers';
-export type { TestAppOptions } from './appWrappers';
-export * from './msw';
-export * from './logCollector';
-export * from './testingLibrary';
-export { TestApiProvider, TestApiRegistry } from './TestApiProvider';
-export type { TestApiProviderProps } from './TestApiProvider';
-
-import './support';
+export { useFeatureFlag } from './useFeatureFlag';

--- a/packages/frontend-plugin-api/src/hooks/useFeatureFlag.ts
+++ b/packages/frontend-plugin-api/src/hooks/useFeatureFlag.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useMemo } from 'react';
+import useObservable from 'react-use/esm/useObservable';
+
+import { featureFlagsApiRef, useApi } from '../apis';
+
+/**
+ * Returns the state of a feature flag.
+ *
+ * If the strictPresence option is provided, it indicates whether the feature
+ * flag must be known to be valid. If true, `undefined` will be returned until
+ * the value is resolved.
+ *
+ * @public
+ */
+export function useFeatureFlag<StrictPresence extends boolean = false>(
+  name: string,
+  options: { strictPresence: StrictPresence } = {
+    strictPresence: false as StrictPresence,
+  },
+): StrictPresence extends true ? boolean | undefined : boolean {
+  const { strictPresence } = options;
+
+  const featureFlagsApi = useApi(featureFlagsApiRef);
+
+  const observable = useMemo(
+    () => featureFlagsApi.observe$(name),
+    [featureFlagsApi, name],
+  );
+
+  const value = useObservable(observable);
+
+  if (typeof value === 'undefined' && strictPresence) {
+    return undefined as boolean | undefined as boolean;
+  }
+  return value ?? false;
+}

--- a/packages/frontend-plugin-api/src/index.ts
+++ b/packages/frontend-plugin-api/src/index.ts
@@ -24,6 +24,7 @@ export * from './analytics';
 export * from './apis';
 export * from './blueprints';
 export * from './components';
+export * from './hooks';
 export * from './icons';
 export * from './routing';
 export * from './schema';

--- a/packages/frontend-plugin-api/src/wiring/types.ts
+++ b/packages/frontend-plugin-api/src/wiring/types.ts
@@ -29,6 +29,13 @@ import { FrontendPlugin } from './createFrontendPlugin';
 export type FeatureFlagConfig = {
   /** Feature flag name */
   name: string;
+  /** Feature flag description */
+  description?: string;
+  /**
+   * Whether the feature flag is persisted in the StorageApi or locally in the
+   * browser. Defaults to `false` (local).
+   */
+  persisted?: boolean;
 };
 
 /** @public */

--- a/packages/test-utils/src/setupTests.ts
+++ b/packages/test-utils/src/setupTests.ts
@@ -15,3 +15,5 @@
  */
 
 import '@testing-library/jest-dom';
+
+import './testUtils/support';

--- a/packages/test-utils/src/testUtils/support.ts
+++ b/packages/test-utils/src/testUtils/support.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2025 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,4 @@
  * limitations under the License.
  */
 
-export * from './apis';
-export { default as mockBreakpoint } from './mockBreakpoint';
-export {
-  wrapInTestApp,
-  renderInTestApp,
-  textContentMatcher,
-  createTestAppWrapper,
-} from './appWrappers';
-export type { TestAppOptions } from './appWrappers';
-export * from './msw';
-export * from './logCollector';
-export * from './testingLibrary';
-export { TestApiProvider, TestApiRegistry } from './TestApiProvider';
-export type { TestApiProviderProps } from './TestApiProvider';
-
-import './support';
+globalThis.BroadcastChannel = require('worker_threads').BroadcastChannel;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2291,7 +2291,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.10.4, @babel/code-frame@npm:^7.16.0, @babel/code-frame@npm:^7.16.7, @babel/code-frame@npm:^7.27.1, @babel/code-frame@npm:^7.8.3":
+"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.10.4, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.16.0, @babel/code-frame@npm:^7.16.7, @babel/code-frame@npm:^7.27.1, @babel/code-frame@npm:^7.8.3":
   version: 7.27.1
   resolution: "@babel/code-frame@npm:7.27.1"
   dependencies:
@@ -2437,6 +2437,13 @@ __metadata:
   version: 7.27.1
   resolution: "@babel/helper-plugin-utils@npm:7.27.1"
   checksum: 10/96136c2428888e620e2ec493c25888f9ceb4a21099dcf3dd4508ea64b58cdedbd5a9fb6c7b352546de84d6c24edafe482318646932a22c449ebd16d16c22d864
+  languageName: node
+  linkType: hard
+
+"@babel/helper-plugin-utils@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/helper-plugin-utils@npm:7.25.9"
+  checksum: 10/e347d87728b1ab10b6976d46403941c8f9008c045ea6d99997a7ffca7b852dc34b6171380f7b17edf94410e0857ff26f3a53d8618f11d73744db86e8ca9b8c64
   languageName: node
   linkType: hard
 
@@ -2615,7 +2622,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-jsx@npm:^7.24.7, @babel/plugin-syntax-jsx@npm:^7.27.1":
+"@babel/plugin-syntax-jsx@npm:^7.24.7":
+  version: 7.24.7
+  resolution: "@babel/plugin-syntax-jsx@npm:7.24.7"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.24.7"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10/a93516ae5b34868ab892a95315027d4e5e38e8bd1cfca6158f2974b0901cbb32bbe64ea10ad5b25f919ddc40c6d8113c4823372909c9c9922170c12b0b1acecb
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-jsx@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/plugin-syntax-jsx@npm:7.27.1"
   dependencies:
@@ -2714,7 +2732,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-typescript@npm:^7.24.7, @babel/plugin-syntax-typescript@npm:^7.27.1":
+"@babel/plugin-syntax-typescript@npm:^7.24.7":
+  version: 7.25.9
+  resolution: "@babel/plugin-syntax-typescript@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10/0e9821e8ba7d660c36c919654e4144a70546942ae184e85b8102f2322451eae102cbfadbcadd52ce077a2b44b400ee52394c616feab7b5b9f791b910e933fd33
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-typescript@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/plugin-syntax-typescript@npm:7.27.1"
   dependencies:
@@ -2899,7 +2928,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.24.7, @babel/types@npm:^7.24.8, @babel/types@npm:^7.27.1, @babel/types@npm:^7.27.3, @babel/types@npm:^7.28.2, @babel/types@npm:^7.28.4, @babel/types@npm:^7.28.5":
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.24.7, @babel/types@npm:^7.24.8, @babel/types@npm:^7.27.1, @babel/types@npm:^7.28.2, @babel/types@npm:^7.28.4":
+  version: 7.28.4
+  resolution: "@babel/types@npm:7.28.4"
+  dependencies:
+    "@babel/helper-string-parser": "npm:^7.27.1"
+    "@babel/helper-validator-identifier": "npm:^7.27.1"
+  checksum: 10/db50bf257aafa5d845ad16dae0587f57d596e4be4cbb233ea539976a4c461f9fbcc0bf3d37adae3f8ce5dcb4001462aa608f3558161258b585f6ce6ce21a2e45
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.27.3, @babel/types@npm:^7.28.5":
   version: 7.28.5
   resolution: "@babel/types@npm:7.28.5"
   dependencies:
@@ -3958,6 +3997,7 @@ __metadata:
     react: "npm:^18.0.2"
     react-dom: "npm:^18.0.2"
     react-router-dom: "npm:^6.30.2"
+    react-use: "npm:^17.2.4"
     zod: "npm:^3.25.76"
     zod-to-json-schema: "npm:^3.25.1"
   peerDependencies:
@@ -7854,7 +7894,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@backstage/plugin-user-settings-backend@workspace:plugins/user-settings-backend":
+"@backstage/plugin-user-settings-backend@workspace:^, @backstage/plugin-user-settings-backend@workspace:plugins/user-settings-backend":
   version: 0.0.0-use.local
   resolution: "@backstage/plugin-user-settings-backend@workspace:plugins/user-settings-backend"
   dependencies:
@@ -8927,10 +8967,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/aix-ppc64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/aix-ppc64@npm:0.27.1"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
 "@esbuild/aix-ppc64@npm:0.27.3":
   version: 0.27.3
   resolution: "@esbuild/aix-ppc64@npm:0.27.3"
   conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/android-arm64@npm:0.27.1"
+  conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -8941,10 +8995,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/android-arm@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/android-arm@npm:0.27.1"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-arm@npm:0.27.3":
   version: 0.27.3
   resolution: "@esbuild/android-arm@npm:0.27.3"
   conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/android-x64@npm:0.27.1"
+  conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
 
@@ -8955,10 +9023,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/darwin-arm64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/darwin-arm64@npm:0.27.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/darwin-arm64@npm:0.27.3":
   version: 0.27.3
   resolution: "@esbuild/darwin-arm64@npm:0.27.3"
   conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/darwin-x64@npm:0.27.1"
+  conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
@@ -8969,10 +9051,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/freebsd-arm64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/freebsd-arm64@npm:0.27.1"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/freebsd-arm64@npm:0.27.3":
   version: 0.27.3
   resolution: "@esbuild/freebsd-arm64@npm:0.27.3"
   conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/freebsd-x64@npm:0.27.1"
+  conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
@@ -8983,10 +9079,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-arm64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/linux-arm64@npm:0.27.1"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-arm64@npm:0.27.3":
   version: 0.27.3
   resolution: "@esbuild/linux-arm64@npm:0.27.3"
   conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/linux-arm@npm:0.27.1"
+  conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
@@ -8997,10 +9107,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-ia32@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/linux-ia32@npm:0.27.1"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-ia32@npm:0.27.3":
   version: 0.27.3
   resolution: "@esbuild/linux-ia32@npm:0.27.3"
   conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/linux-loong64@npm:0.27.1"
+  conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
 
@@ -9011,10 +9135,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-mips64el@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/linux-mips64el@npm:0.27.1"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-mips64el@npm:0.27.3":
   version: 0.27.3
   resolution: "@esbuild/linux-mips64el@npm:0.27.3"
   conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/linux-ppc64@npm:0.27.1"
+  conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
 
@@ -9025,10 +9163,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-riscv64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/linux-riscv64@npm:0.27.1"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-riscv64@npm:0.27.3":
   version: 0.27.3
   resolution: "@esbuild/linux-riscv64@npm:0.27.3"
   conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/linux-s390x@npm:0.27.1"
+  conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
 
@@ -9039,10 +9191,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-x64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/linux-x64@npm:0.27.1"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-x64@npm:0.27.3":
   version: 0.27.3
   resolution: "@esbuild/linux-x64@npm:0.27.3"
   conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-arm64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/netbsd-arm64@npm:0.27.1"
+  conditions: os=netbsd & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -9053,10 +9219,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/netbsd-x64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/netbsd-x64@npm:0.27.1"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/netbsd-x64@npm:0.27.3":
   version: 0.27.3
   resolution: "@esbuild/netbsd-x64@npm:0.27.3"
   conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-arm64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/openbsd-arm64@npm:0.27.1"
+  conditions: os=openbsd & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -9067,10 +9247,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/openbsd-x64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/openbsd-x64@npm:0.27.1"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/openbsd-x64@npm:0.27.3":
   version: 0.27.3
   resolution: "@esbuild/openbsd-x64@npm:0.27.3"
   conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openharmony-arm64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/openharmony-arm64@npm:0.27.1"
+  conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -9081,10 +9275,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/sunos-x64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/sunos-x64@npm:0.27.1"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/sunos-x64@npm:0.27.3":
   version: 0.27.3
   resolution: "@esbuild/sunos-x64@npm:0.27.3"
   conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/win32-arm64@npm:0.27.1"
+  conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -9095,10 +9303,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/win32-ia32@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/win32-ia32@npm:0.27.1"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-ia32@npm:0.27.3":
   version: 0.27.3
   resolution: "@esbuild/win32-ia32@npm:0.27.3"
   conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/win32-x64@npm:0.27.1"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -10388,6 +10610,15 @@ __metadata:
   dependencies:
     "@jest/get-type": "npm:30.1.0"
   checksum: 10/f2442f1bceb3411240d0f16fd0074377211b4373d3b8b2dc28929e861b6527a6deb403a362c25afa511d933cda4dfbdc98d4a08eeb51ee4968f7cb0299562349
+  languageName: node
+  linkType: hard
+
+"@jest/expect-utils@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/expect-utils@npm:29.7.0"
+  dependencies:
+    jest-get-type: "npm:^29.6.3"
+  checksum: 10/ef8d379778ef574a17bde2801a6f4469f8022a46a5f9e385191dc73bb1fc318996beaed4513fbd7055c2847227a1bed2469977821866534593a6e52a281499ee
   languageName: node
   linkType: hard
 
@@ -18196,12 +18427,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sinonjs/fake-timers@npm:^13.0.0, @sinonjs/fake-timers@npm:^13.0.1":
+"@sinonjs/fake-timers@npm:^13.0.0":
   version: 13.0.5
   resolution: "@sinonjs/fake-timers@npm:13.0.5"
   dependencies:
     "@sinonjs/commons": "npm:^3.0.1"
   checksum: 10/11ee417968fc4dce1896ab332ac13f353866075a9d2a88ed1f6258f17cc4f7d93e66031b51fcddb8c203aa4d53fd980b0ae18aba06269f4682164878a992ec3f
+  languageName: node
+  linkType: hard
+
+"@sinonjs/fake-timers@npm:^13.0.1":
+  version: 13.0.2
+  resolution: "@sinonjs/fake-timers@npm:13.0.2"
+  dependencies:
+    "@sinonjs/commons": "npm:^3.0.1"
+  checksum: 10/77cca5c548e2529931908c48ac375f162ee901bc52110197b4c470b2535c6c571f9ecd4fa12157f4d2ae174c5391f03940fb563a681a691fb44204a0ef3ded35
   languageName: node
   linkType: hard
 
@@ -21618,7 +21858,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/express@npm:*, @types/express@npm:^4.16.1, @types/express@npm:^4.17.21, @types/express@npm:^4.17.25, @types/express@npm:^4.17.6":
+"@types/express@npm:*, @types/express@npm:^4.16.1, @types/express@npm:^4.17.21, @types/express@npm:^4.17.6":
+  version: 4.17.23
+  resolution: "@types/express@npm:4.17.23"
+  dependencies:
+    "@types/body-parser": "npm:*"
+    "@types/express-serve-static-core": "npm:^4.17.33"
+    "@types/qs": "npm:*"
+    "@types/serve-static": "npm:*"
+  checksum: 10/cf4d540bbd90801cdc79a46107b8873404698a7fd0c3e8dd42989d52d3bd7f5b8768672e54c20835e41e27349c319bb47a404ad14c0f8db0e9d055ba1cb8a05b
+  languageName: node
+  linkType: hard
+
+"@types/express@npm:^4.17.25":
   version: 4.17.25
   resolution: "@types/express@npm:4.17.25"
   dependencies:
@@ -22642,6 +22894,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/serve-static@npm:*":
+  version: 1.15.7
+  resolution: "@types/serve-static@npm:1.15.7"
+  dependencies:
+    "@types/http-errors": "npm:*"
+    "@types/node": "npm:*"
+    "@types/send": "npm:*"
+  checksum: 10/c5a7171d5647f9fbd096ed1a26105759f3153ccf683824d99fee4c7eb9cde2953509621c56a070dd9fb1159e799e86d300cbe4e42245ebc5b0c1767e8ca94a67
+  languageName: node
+  linkType: hard
+
 "@types/serve-static@npm:^1, @types/serve-static@npm:^1.15.5":
   version: 1.15.10
   resolution: "@types/serve-static@npm:1.15.10"
@@ -22717,6 +22980,13 @@ __metadata:
     "@types/node": "npm:*"
     "@types/ssh2-streams": "npm:*"
   checksum: 10/fc2584af091da49da9d6628dd8a5e851b217bb9b1b732b0361903894f2730ab3fdf8634f954be34c5a513f7eb0b2772d059d64062bcf6b4a0eb73bfc83c4b858
+  languageName: node
+  linkType: hard
+
+"@types/stack-utils@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@types/stack-utils@npm:2.0.0"
+  checksum: 10/b3fbae25b073116977ecb5c67d22f14567b51a7792403b0bf46e5de8f29bde3bd4ec1626afb22065495ca7f1c699c8bd66720050c94b8f8f9bcefbee79d161fd
   languageName: node
   linkType: hard
 
@@ -29371,9 +29641,9 @@ __metadata:
   linkType: hard
 
 "detect-libc@npm:^2.0.0":
-  version: 2.1.2
-  resolution: "detect-libc@npm:2.1.2"
-  checksum: 10/b736c8d97d5d46164c0d1bed53eb4e6a3b1d8530d460211e2d52f1c552875e706c58a5376854e4e54f8b828c9cada58c855288c968522eb93ac7696d65970766
+  version: 2.0.3
+  resolution: "detect-libc@npm:2.0.3"
+  checksum: 10/b4ea018d623e077bd395f168a9e81db77370dde36a5b01d067f2ad7989924a81d31cb547ff764acb2aa25d50bb7fdde0b0a93bec02212b0cb430621623246d39
   languageName: node
   linkType: hard
 
@@ -30466,7 +30736,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0, esbuild@npm:^0.27.0, esbuild@npm:^0.27.1":
+"esbuild@npm:^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0, esbuild@npm:^0.27.1":
   version: 0.27.3
   resolution: "esbuild@npm:0.27.3"
   dependencies:
@@ -30552,6 +30822,95 @@ __metadata:
   bin:
     esbuild: bin/esbuild
   checksum: 10/aa74b8d8a3ed8e2eea4d8421737b322f4d21215244e8fa2156c6402d49b5bda01343c220196f1e3f830a7ce92b54ef653c6c723a8cc2e912bb4d17b7398b51ae
+  languageName: node
+  linkType: hard
+
+"esbuild@npm:^0.27.0":
+  version: 0.27.1
+  resolution: "esbuild@npm:0.27.1"
+  dependencies:
+    "@esbuild/aix-ppc64": "npm:0.27.1"
+    "@esbuild/android-arm": "npm:0.27.1"
+    "@esbuild/android-arm64": "npm:0.27.1"
+    "@esbuild/android-x64": "npm:0.27.1"
+    "@esbuild/darwin-arm64": "npm:0.27.1"
+    "@esbuild/darwin-x64": "npm:0.27.1"
+    "@esbuild/freebsd-arm64": "npm:0.27.1"
+    "@esbuild/freebsd-x64": "npm:0.27.1"
+    "@esbuild/linux-arm": "npm:0.27.1"
+    "@esbuild/linux-arm64": "npm:0.27.1"
+    "@esbuild/linux-ia32": "npm:0.27.1"
+    "@esbuild/linux-loong64": "npm:0.27.1"
+    "@esbuild/linux-mips64el": "npm:0.27.1"
+    "@esbuild/linux-ppc64": "npm:0.27.1"
+    "@esbuild/linux-riscv64": "npm:0.27.1"
+    "@esbuild/linux-s390x": "npm:0.27.1"
+    "@esbuild/linux-x64": "npm:0.27.1"
+    "@esbuild/netbsd-arm64": "npm:0.27.1"
+    "@esbuild/netbsd-x64": "npm:0.27.1"
+    "@esbuild/openbsd-arm64": "npm:0.27.1"
+    "@esbuild/openbsd-x64": "npm:0.27.1"
+    "@esbuild/openharmony-arm64": "npm:0.27.1"
+    "@esbuild/sunos-x64": "npm:0.27.1"
+    "@esbuild/win32-arm64": "npm:0.27.1"
+    "@esbuild/win32-ia32": "npm:0.27.1"
+    "@esbuild/win32-x64": "npm:0.27.1"
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-arm64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-arm64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/openharmony-arm64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 10/534148f01e85ca93ec3a4ae8bef133680f5659e639915cd3a453d6ec9ead94c9a2e9bfd61380301471447e182beb62841cb72e0fa18251cdce3454a2511d7cf4
   languageName: node
   linkType: hard
 
@@ -31371,6 +31730,7 @@ __metadata:
     "@backstage/plugin-search-backend-node": "workspace:^"
     "@backstage/plugin-signals-backend": "workspace:^"
     "@backstage/plugin-techdocs-backend": "workspace:^"
+    "@backstage/plugin-user-settings-backend": "workspace:^"
     "@opentelemetry/auto-instrumentations-node": "npm:^0.67.0"
     "@opentelemetry/exporter-prometheus": "npm:^0.211.0"
     "@opentelemetry/sdk-node": "npm:^0.211.0"
@@ -31464,7 +31824,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expect@npm:30.2.0, expect@npm:>28.1.3, expect@npm:^30.0.0":
+"expect@npm:30.2.0, expect@npm:^30.0.0":
   version: 30.2.0
   resolution: "expect@npm:30.2.0"
   dependencies:
@@ -31475,6 +31835,19 @@ __metadata:
     jest-mock: "npm:30.2.0"
     jest-util: "npm:30.2.0"
   checksum: 10/cf98ab45ab2e9f2fb9943a3ae0097f72d63a94be179a19fd2818d8fdc3b7681d31cc8ef540606eb8dd967d9c44d73fef263a614e9de260c22943ffb122ad66fd
+  languageName: node
+  linkType: hard
+
+"expect@npm:>28.1.3":
+  version: 29.7.0
+  resolution: "expect@npm:29.7.0"
+  dependencies:
+    "@jest/expect-utils": "npm:^29.7.0"
+    jest-get-type: "npm:^29.6.3"
+    jest-matcher-utils: "npm:^29.7.0"
+    jest-message-util: "npm:^29.7.0"
+    jest-util: "npm:^29.7.0"
+  checksum: 10/63f97bc51f56a491950fb525f9ad94f1916e8a014947f8d8445d3847a665b5471b768522d659f5e865db20b6c2033d2ac10f35fcbd881a4d26407a4f6f18451a
   languageName: node
   linkType: hard
 
@@ -32263,7 +32636,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.15.11":
+"follow-redirects@npm:^1.0.0":
+  version: 1.15.6
+  resolution: "follow-redirects@npm:1.15.6"
+  peerDependenciesMeta:
+    debug:
+      optional: true
+  checksum: 10/70c7612c4cab18e546e36b991bbf8009a1a41cf85354afe04b113d1117569abf760269409cb3eb842d9f7b03d62826687086b081c566ea7b1e6613cf29030bf7
+  languageName: node
+  linkType: hard
+
+"follow-redirects@npm:^1.15.11":
   version: 1.15.11
   resolution: "follow-redirects@npm:1.15.11"
   peerDependenciesMeta:
@@ -35057,7 +35440,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-core-module@npm:^2.13.0, is-core-module@npm:^2.16.1":
+"is-core-module@npm:^2.13.0, is-core-module@npm:^2.16.0, is-core-module@npm:^2.16.1":
   version: 2.16.1
   resolution: "is-core-module@npm:2.16.1"
   dependencies:
@@ -36068,7 +36451,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-diff@npm:^29.2.0":
+"jest-diff@npm:^29.2.0, jest-diff@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-diff@npm:29.7.0"
   dependencies:
@@ -36168,6 +36551,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-matcher-utils@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-matcher-utils@npm:29.7.0"
+  dependencies:
+    chalk: "npm:^4.0.0"
+    jest-diff: "npm:^29.7.0"
+    jest-get-type: "npm:^29.6.3"
+    pretty-format: "npm:^29.7.0"
+  checksum: 10/981904a494299cf1e3baed352f8a3bd8b50a8c13a662c509b6a53c31461f94ea3bfeffa9d5efcfeb248e384e318c87de7e3baa6af0f79674e987482aa189af40
+  languageName: node
+  linkType: hard
+
 "jest-message-util@npm:30.2.0":
   version: 30.2.0
   resolution: "jest-message-util@npm:30.2.0"
@@ -36182,6 +36577,23 @@ __metadata:
     slash: "npm:^3.0.0"
     stack-utils: "npm:^2.0.6"
   checksum: 10/e29ec76e8c8e4da5f5b25198be247535626ccf3a940e93fdd51fc6a6bcf70feaa2921baae3806182a090431d90b08c939eb13fb64249b171d2e9ae3a452a8fd2
+  languageName: node
+  linkType: hard
+
+"jest-message-util@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-message-util@npm:29.7.0"
+  dependencies:
+    "@babel/code-frame": "npm:^7.12.13"
+    "@jest/types": "npm:^29.6.3"
+    "@types/stack-utils": "npm:^2.0.0"
+    chalk: "npm:^4.0.0"
+    graceful-fs: "npm:^4.2.9"
+    micromatch: "npm:^4.0.4"
+    pretty-format: "npm:^29.7.0"
+    slash: "npm:^3.0.0"
+    stack-utils: "npm:^2.0.3"
+  checksum: 10/31d53c6ed22095d86bab9d14c0fa70c4a92c749ea6ceece82cf30c22c9c0e26407acdfbdb0231435dc85a98d6d65ca0d9cbcd25cd1abb377fe945e843fb770b9
   languageName: node
   linkType: hard
 
@@ -39241,7 +39653,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"micromatch@npm:^4.0.2, micromatch@npm:^4.0.5, micromatch@npm:^4.0.7, micromatch@npm:^4.0.8":
+"micromatch@npm:^4.0.2, micromatch@npm:^4.0.4, micromatch@npm:^4.0.5, micromatch@npm:^4.0.7, micromatch@npm:^4.0.8":
   version: 4.0.8
   resolution: "micromatch@npm:4.0.8"
   dependencies:
@@ -39404,14 +39816,14 @@ __metadata:
   linkType: hard
 
 "mini-css-extract-plugin@npm:^2.4.2":
-  version: 2.10.0
-  resolution: "mini-css-extract-plugin@npm:2.10.0"
+  version: 2.9.4
+  resolution: "mini-css-extract-plugin@npm:2.9.4"
   dependencies:
     schema-utils: "npm:^4.0.0"
     tapable: "npm:^2.2.1"
   peerDependencies:
     webpack: ^5.0.0
-  checksum: 10/bae5350ab82171c6c9a22a4397df14aa69280f5ff0e1ff4d2429ea841bc096927b1e27ba7b75a9c3dd77bd44bab449d6197bd748381f1326cbc8befcb10d1a9e
+  checksum: 10/24a0418dc49baed58a10a8b81e4d2fe474e89ccdc9370a7c69bd0aeeb5a70d2b4ee12f33b98c95a68423c79c1de7cc2a25aaa2105600b712e7d594cb0d56c9d4
   languageName: node
   linkType: hard
 
@@ -42270,10 +42682,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pg-connection-string@npm:^2.11.0, pg-connection-string@npm:^2.3.0, pg-connection-string@npm:^2.5.0":
+"pg-connection-string@npm:^2.11.0":
   version: 2.11.0
   resolution: "pg-connection-string@npm:2.11.0"
   checksum: 10/0333bb1b7ddeac6fa5262920f82a983222c600d21ef14fdc5254b0d3cbb1763030d20c1e8e3c20fa767a6eda8f4b4773550954c06f3e072e5288b6fa9e9cae13
+  languageName: node
+  linkType: hard
+
+"pg-connection-string@npm:^2.3.0, pg-connection-string@npm:^2.5.0":
+  version: 2.9.1
+  resolution: "pg-connection-string@npm:2.9.1"
+  checksum: 10/40e9e9cd752121e72bff18d83e6c7ecda9056426815a84294de018569a319293c924704c8b7f0604fdc588835c7927647dea4f3c87a014e715bcbb17d794e9f0
   languageName: node
   linkType: hard
 
@@ -43702,7 +44121,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:^6.10.1, qs@npm:^6.10.3, qs@npm:^6.11.2, qs@npm:^6.12.2, qs@npm:^6.12.3, qs@npm:^6.14.0, qs@npm:^6.14.1, qs@npm:^6.7.0, qs@npm:^6.9.4":
+"qs@npm:^6.10.1, qs@npm:^6.10.3, qs@npm:^6.11.2, qs@npm:^6.12.2, qs@npm:^6.12.3, qs@npm:^6.14.0, qs@npm:^6.7.0, qs@npm:^6.9.4":
+  version: 6.14.0
+  resolution: "qs@npm:6.14.0"
+  dependencies:
+    side-channel: "npm:^1.1.0"
+  checksum: 10/a60e49bbd51c935a8a4759e7505677b122e23bf392d6535b8fc31c1e447acba2c901235ecb192764013cd2781723dc1f61978b5fdd93cc31d7043d31cdc01974
+  languageName: node
+  linkType: hard
+
+"qs@npm:^6.14.1":
   version: 6.15.0
   resolution: "qs@npm:6.15.0"
   dependencies:
@@ -45480,7 +45908,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.1.6, resolve@npm:^1.1.7, resolve@npm:^1.17.0, resolve@npm:^1.19.0, resolve@npm:^1.20.0, resolve@npm:^1.22.1, resolve@npm:^1.22.10, resolve@npm:^1.22.4, resolve@npm:^1.22.8, resolve@npm:~1.22.1, resolve@npm:~1.22.2":
+"resolve@npm:^1.1.6, resolve@npm:^1.17.0, resolve@npm:^1.19.0, resolve@npm:^1.20.0, resolve@npm:^1.22.1, resolve@npm:^1.22.10, resolve@npm:^1.22.4, resolve@npm:^1.22.8, resolve@npm:~1.22.1, resolve@npm:~1.22.2":
+  version: 1.22.10
+  resolution: "resolve@npm:1.22.10"
+  dependencies:
+    is-core-module: "npm:^2.16.0"
+    path-parse: "npm:^1.0.7"
+    supports-preserve-symlinks-flag: "npm:^1.0.0"
+  bin:
+    resolve: bin/resolve
+  checksum: 10/0a398b44da5c05e6e421d70108822c327675febb880eebe905587628de401854c61d5df02866ff34fc4cb1173a51c9f0e84a94702738df3611a62e2acdc68181
+  languageName: node
+  linkType: hard
+
+"resolve@npm:^1.1.7":
   version: 1.22.11
   resolution: "resolve@npm:1.22.11"
   dependencies:
@@ -45519,7 +45960,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@npm%3A^1.1.6#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.1.7#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.17.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.19.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.10#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.8#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A~1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A~1.22.2#optional!builtin<compat/resolve>":
+"resolve@patch:resolve@npm%3A^1.1.6#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.17.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.19.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.10#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.8#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A~1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A~1.22.2#optional!builtin<compat/resolve>":
+  version: 1.22.10
+  resolution: "resolve@patch:resolve@npm%3A1.22.10#optional!builtin<compat/resolve>::version=1.22.10&hash=c3c19d"
+  dependencies:
+    is-core-module: "npm:^2.16.0"
+    path-parse: "npm:^1.0.7"
+    supports-preserve-symlinks-flag: "npm:^1.0.0"
+  bin:
+    resolve: bin/resolve
+  checksum: 10/d4d878bfe3702d215ea23e75e0e9caf99468e3db76f5ca100d27ebdc527366fee3877e54bce7d47cc72ca8952fc2782a070d238bfa79a550eeb0082384c3b81a
+  languageName: node
+  linkType: hard
+
+"resolve@patch:resolve@npm%3A^1.1.7#optional!builtin<compat/resolve>":
   version: 1.22.11
   resolution: "resolve@patch:resolve@npm%3A1.22.11#optional!builtin<compat/resolve>::version=1.22.11&hash=c3c19d"
   dependencies:
@@ -47359,7 +47813,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stack-utils@npm:^2.0.2, stack-utils@npm:^2.0.6":
+"stack-utils@npm:^2.0.2, stack-utils@npm:^2.0.3, stack-utils@npm:^2.0.6":
   version: 2.0.6
   resolution: "stack-utils@npm:2.0.6"
   dependencies:
@@ -51251,9 +51705,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:*, ws@npm:^8.12.0, ws@npm:^8.13.0, ws@npm:^8.17.1, ws@npm:^8.18.0, ws@npm:^8.18.2, ws@npm:^8.18.3, ws@npm:^8.8.0":
-  version: 8.19.0
-  resolution: "ws@npm:8.19.0"
+"ws@npm:*, ws@npm:^8.12.0, ws@npm:^8.13.0, ws@npm:^8.17.1, ws@npm:^8.18.0, ws@npm:^8.18.2, ws@npm:^8.8.0":
+  version: 8.18.3
+  resolution: "ws@npm:8.18.3"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -51262,7 +51716,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10/26e4901e93abaf73af9f26a93707c95b4845e91a7a347ec8c569e6e9be7f9df066f6c2b817b2d685544e208207898a750b78461e6e8d810c11a370771450c31b
+  checksum: 10/725964438d752f0ab0de582cd48d6eeada58d1511c3f613485b5598a83680bedac6187c765b0fe082e2d8cc4341fc57707c813ae780feee82d0c5efe6a4c61b6
   languageName: node
   linkType: hard
 
@@ -51293,6 +51747,21 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: 10/9c796b84ba80ffc2c2adcdfc9c8e9a219ba99caa435c9a8d45f9ac593bba325563b3f83edc5eb067cc6d21b9a6bf2c930adf76dd40af5f58a5ca6859e81858f0
+  languageName: node
+  linkType: hard
+
+"ws@npm:^8.18.3":
+  version: 8.19.0
+  resolution: "ws@npm:8.19.0"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10/26e4901e93abaf73af9f26a93707c95b4845e91a7a347ec8c569e6e9be7f9df066f6c2b817b2d685544e208207898a750b78461e6e8d810c11a370771450c31b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

_This is a follow-up and re-implentation of https://github.com/backstage/community-plugins/pull/6362. Initial rationale can be found there._

This PR adds support for feature flags to be _persisted_, i.e. stored using the StorageApi. An implementer can choose certain (or all) feature flags to be persisted in the backend, such as functionality, features, etc. Some feature flags may make more sense to store per-browser, leaving this choice to the implementer.

The API surface has been changed (with backwards compatibility) to be async by nature. An initial call to query all StorageApi-based feature flags on start-up is made, to allow for the old (synchronous) `isActive(flag)` to still work. The new API also deprecates the `save()` method, which will ultimately hide the `FeatureFlagState` type (a storage type of `0` or `1`, which is a technical detail that shouldn't be needed to be exposed).

A hook `useFeatureFlag(flag)` is introduced to simplify usage in components. It listenes to observable changes.

Both the _local_ (in-browser) feature flags and StorageApi based feature flags now emit browser-level events (using [BroadcastChannel](https://developer.mozilla.org/en-US/docs/Web/API/Broadcast_Channel_API)) when updated, so flipping a flag will live-update any `useFeatureFlag` hooks in the same tab and other browser tabs. If the SignalApi is enabled for the StorageApi, it will naturally also affect other browser sessions too.

Given the comment from @Rugvip in https://github.com/backstage/community-plugins/pull/6362, this PR could act as an initial support for persistency using the StorageApi, while future work to incorporate external sources could be added later, once the async behavior in this PR is in place.

This PR would greatly benefit from #31106, but not require it.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
