### PR TITLE
frontend-plugin-api: remove unnecessary dependencies

### DIFF
--- a/.changeset/swift-wolves-judge.md
+++ b/.changeset/swift-wolves-judge.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': patch
+---
+
+Removed unnecessary dependencies on `@backstage/core-components`, `@backstage/config`, `@material-ui/core`, and `lodash`.

--- a/packages/frontend-internal/package.json
+++ b/packages/frontend-internal/package.json
@@ -25,8 +25,7 @@
   "dependencies": {
     "@backstage/frontend-plugin-api": "workspace:^",
     "@backstage/types": "workspace:^",
-    "@backstage/version-bridge": "workspace:^",
-    "zod": "^3.22.4"
+    "@backstage/version-bridge": "workspace:^"
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",

--- a/packages/frontend-plugin-api/package.json
+++ b/packages/frontend-plugin-api/package.json
@@ -40,18 +40,15 @@
     "test": "backstage-cli package test"
   },
   "dependencies": {
-    "@backstage/config": "workspace:^",
-    "@backstage/core-components": "workspace:^",
     "@backstage/errors": "workspace:^",
     "@backstage/types": "workspace:^",
     "@backstage/version-bridge": "workspace:^",
-    "@material-ui/core": "^4.12.4",
-    "lodash": "^4.17.21",
     "zod": "^3.22.4",
     "zod-to-json-schema": "^3.21.4"
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",
+    "@backstage/config": "workspace:^",
     "@backstage/frontend-app-api": "workspace:^",
     "@backstage/frontend-test-utils": "workspace:^",
     "@backstage/test-utils": "workspace:^",

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -6,7 +6,7 @@
 import { AnyRouteRefParams as AnyRouteRefParams_2 } from '@backstage/frontend-plugin-api';
 import { ApiRef as ApiRef_2 } from '@backstage/frontend-plugin-api';
 import { ComponentType } from 'react';
-import { Config } from '@backstage/config';
+import type { Config } from '@backstage/config';
 import { ConfigurableExtensionDataRef as ConfigurableExtensionDataRef_2 } from '@backstage/frontend-plugin-api';
 import { Expand } from '@backstage/types';
 import { ExpandRecursive } from '@backstage/types';
@@ -23,7 +23,7 @@ import { PropsWithChildren } from 'react';
 import { ReactNode } from 'react';
 import { RouteRef as RouteRef_2 } from '@backstage/frontend-plugin-api';
 import { SwappableComponentRef as SwappableComponentRef_2 } from '@backstage/frontend-plugin-api';
-import { z } from 'zod';
+import type { z } from 'zod';
 
 // @public
 export type AlertApi = {

--- a/packages/frontend-plugin-api/src/apis/definitions/ConfigApi.ts
+++ b/packages/frontend-plugin-api/src/apis/definitions/ConfigApi.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { ApiRef, createApiRef } from '../system';
-import { Config } from '@backstage/config';
+import type { Config } from '@backstage/config';
 
 /**
  * The Config API is used to provide a mechanism to access the

--- a/packages/frontend-plugin-api/src/schema/createSchemaFromZod.ts
+++ b/packages/frontend-plugin-api/src/schema/createSchemaFromZod.ts
@@ -15,7 +15,7 @@
  */
 
 import { JsonObject } from '@backstage/types';
-import { z, ZodSchema, ZodTypeDef } from 'zod';
+import { z, type ZodSchema, type ZodTypeDef } from 'zod';
 import zodToJsonSchema from 'zod-to-json-schema';
 import { PortableSchema } from './types';
 

--- a/packages/frontend-plugin-api/src/wiring/createExtension.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.ts
@@ -26,7 +26,7 @@ import {
 } from '@internal/frontend';
 import { ExtensionDataRef, ExtensionDataValue } from './createExtensionDataRef';
 import { ExtensionInput } from './createExtensionInput';
-import { z } from 'zod';
+import type { z } from 'zod';
 import { createSchemaFromZod } from '../schema/createSchemaFromZod';
 import { OpaqueExtensionDefinition } from '@internal/frontend';
 import { ExtensionDataContainer } from './types';

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
@@ -26,7 +26,7 @@ import {
   ctxParamsSymbol,
   VerifyExtensionAttachTo,
 } from './createExtension';
-import { z } from 'zod';
+import type { z } from 'zod';
 import { ExtensionInput } from './createExtensionInput';
 import { ExtensionDataRef, ExtensionDataValue } from './createExtensionDataRef';
 import { createExtensionDataContainer } from '@internal/frontend';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3819,19 +3819,16 @@ __metadata:
   dependencies:
     "@backstage/cli": "workspace:^"
     "@backstage/config": "workspace:^"
-    "@backstage/core-components": "workspace:^"
     "@backstage/errors": "workspace:^"
     "@backstage/frontend-app-api": "workspace:^"
     "@backstage/frontend-test-utils": "workspace:^"
     "@backstage/test-utils": "workspace:^"
     "@backstage/types": "workspace:^"
     "@backstage/version-bridge": "workspace:^"
-    "@material-ui/core": "npm:^4.12.4"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^16.0.0"
     "@types/react": "npm:^18.0.0"
     history: "npm:^5.3.0"
-    lodash: "npm:^4.17.21"
     react: "npm:^18.0.2"
     react-dom: "npm:^18.0.2"
     react-router-dom: "npm:^6.3.0"
@@ -9873,7 +9870,6 @@ __metadata:
     "@backstage/version-bridge": "workspace:^"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^16.0.0"
-    zod: "npm:^3.22.4"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Was wondering why the total bundle size of frontend-plugin-api was so large, turns out a ton of extra deps had snuck in. Also think I wanna try to get rid of the direct `zod` dependency if possible, but will investigate that separately.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
