### PR TITLE
fix(scaffolder-backend): pass missing config to NunjucksWorkflowRunner

### DIFF
--- a/.changeset/bumpy-papers-clean.md
+++ b/.changeset/bumpy-papers-clean.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Fixed a bug where config was not passed to NunjucksWorkflowRunner, causing defaultEnvironment to be undefined

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/TaskWorker.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/TaskWorker.ts
@@ -134,6 +134,7 @@ export class TaskWorker {
       additionalTemplateFilters,
       additionalTemplateGlobals,
       permissions,
+      config,
     });
 
     return new TaskWorker({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This fixes a bug where defaultEnvironment config was ignored because config wasn't passed to NunjucksWorkflowRunner.

It seems unit tests missed this because they use a Mock Config, while the runtime code (TaskWorker.ts) was actually failing to pass it.

Note: This change resolves the issue in my environment. However, since defaultEnvironment is a core feature and there haven’t been many related issues reported, I think it’s worth double-checking whether this aligns with the intended behavior. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
