### PR TITLE
TechDocs: mark some aws config as visibility backend

### DIFF
--- a/.changeset/cold-dogs-study.md
+++ b/.changeset/cold-dogs-study.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-backend': patch
+---
+
+Some AWS `publisher` config options such as `region`, `endpoint`, `accountId` are now marked as `@visibility backend` instead of `secret`.

--- a/plugins/techdocs-backend/config.d.ts
+++ b/plugins/techdocs-backend/config.d.ts
@@ -100,7 +100,6 @@ export interface Config {
              * If account ID is not set and no credentials are set, environment variables or aws config file will be used to authenticate.
              * @see https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/loading-node-credentials-environment.html
              * @see https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/loading-node-credentials-shared.html
-             * @visibility secret
              */
             accountId?: string;
             /**
@@ -141,14 +140,12 @@ export interface Config {
              * (Optional) AWS Region.
              * If not set, AWS_REGION environment variable or aws config file will be used.
              * @see https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-region.html
-             * @visibility secret
              */
             region?: string;
             /**
              * (Optional) AWS Endpoint.
              * The endpoint URI to send requests to. The default endpoint is built from the configured region.
              * @see https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#constructor-property
-             * @visibility secret
              */
             endpoint?: string;
             /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Some TechDocs aws publisher config options were incorrectly marked as visibility secret

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
