### PR TITLE
chore: update how GithubOrgEntityProvider handle membership

### DIFF
--- a/.changeset/ten-vans-agree.md
+++ b/.changeset/ten-vans-agree.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+Improved efficiency of `GithubOrgEntityProvider` membership event handling and edit team. The provider now fetches only the specific user's teams instead of all organization users when processing membership events, and uses `addEntitiesOperation` instead of `replaceEntitiesOperation` to avoid unnecessary entity deletions.

--- a/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.test.ts
@@ -840,6 +840,9 @@ describe('GithubOrgEntityProvider', () => {
             name: {
               from: 'mygroup with spaces',
             },
+            description: {
+              from: 'old description',
+            },
           },
           team: {
             node_id: 'xpto',
@@ -956,21 +959,21 @@ describe('GithubOrgEntityProvider', () => {
                     'url:https://github.com/orgs/backstage/teams/mygroup-with-spaces',
                   'backstage.io/managed-by-origin-location':
                     'url:https://github.com/orgs/backstage/teams/mygroup-with-spaces',
+                  'github.com/team-slug': 'backstage/mygroup-with-spaces',
                 },
                 name: 'mygroup-with-spaces',
-                description: 'description-from-the-new-team',
+                description: 'old description',
               },
               apiVersion: 'backstage.io/v1alpha1',
               kind: 'Group',
               spec: {
                 type: 'team',
                 profile: {
-                  displayName: 'Team',
-                  picture: 'http://example.com/team.jpeg',
+                  displayName: 'mygroup with spaces',
                 },
                 children: [],
-                parent: 'parent',
-                members: ['a', 'githubuser'],
+                parent: 'father-team',
+                members: [],
               },
             },
           },
@@ -1012,6 +1015,7 @@ describe('GithubOrgEntityProvider', () => {
       const mockClient = jest.fn();
 
       mockClient
+        // getOrganizationTeam
         .mockResolvedValueOnce({
           organization: {
             team: {
@@ -1032,31 +1036,7 @@ describe('GithubOrgEntityProvider', () => {
             },
           },
         })
-        .mockResolvedValueOnce({
-          organization: {
-            membersWithRole: {
-              pageInfo: { hasNextPage: false },
-              nodes: [
-                {
-                  login: 'a',
-                  id: 'f',
-                  name: 'b',
-                  bio: 'c',
-                  email: 'd',
-                  avatarUrl: 'e',
-                },
-                {
-                  login: 'githubuser',
-                  id: 'githubuserId',
-                  name: 'githubuser',
-                  bio: 'githubuser',
-                  email: 'd',
-                  avatarUrl: 'e',
-                },
-              ],
-            },
-          },
-        })
+        // getOrganizationTeamsForUser
         .mockResolvedValueOnce({
           organization: {
             teams: {
@@ -1070,12 +1050,6 @@ describe('GithubOrgEntityProvider', () => {
                   avatarUrl: 'http://example.com/team.jpeg',
                   parentTeam: {
                     slug: 'parent',
-                    combinedSlug: '',
-                    members: { pageInfo: { hasNextPage: false }, nodes: [] },
-                  },
-                  members: {
-                    pageInfo: { hasNextPage: false },
-                    nodes: [{ login: 'a' }, { login: 'githubuser' }],
                   },
                 },
               ],
@@ -1101,6 +1075,10 @@ describe('GithubOrgEntityProvider', () => {
           },
           member: {
             login: 'githubuser',
+            avatar_url: 'e',
+            email: 'd',
+            name: 'githubuser',
+            node_id: 'githubuserId',
           },
           organization: {
             login: 'test-org',
@@ -1120,33 +1098,6 @@ describe('GithubOrgEntityProvider', () => {
               metadata: {
                 annotations: {
                   'backstage.io/managed-by-location':
-                    'url:https://github.com/githubuser',
-                  'backstage.io/managed-by-origin-location':
-                    'url:https://github.com/githubuser',
-                  'github.com/user-login': 'githubuser',
-                  'github.com/user-id': 'githubuserId',
-                },
-                name: 'githubuser',
-                description: 'githubuser',
-              },
-              apiVersion: 'backstage.io/v1alpha1',
-              kind: 'User',
-              spec: {
-                profile: {
-                  displayName: 'githubuser',
-                  email: 'd',
-                  picture: 'e',
-                },
-                memberOf: ['team'],
-              },
-            },
-          },
-          {
-            locationKey: 'github-org-provider:my-id',
-            entity: {
-              metadata: {
-                annotations: {
-                  'backstage.io/managed-by-location':
                     'url:https://github.com/orgs/backstage/teams/team',
                   'backstage.io/managed-by-origin-location':
                     'url:https://github.com/orgs/backstage/teams/team',
@@ -1169,8 +1120,6 @@ describe('GithubOrgEntityProvider', () => {
               },
             },
           },
-        ],
-        removed: [
           {
             locationKey: 'github-org-provider:my-id',
             entity: {
@@ -1184,7 +1133,6 @@ describe('GithubOrgEntityProvider', () => {
                   'github.com/user-id': 'githubuserId',
                 },
                 name: 'githubuser',
-                description: 'githubuser',
               },
               apiVersion: 'backstage.io/v1alpha1',
               kind: 'User',
@@ -1198,35 +1146,8 @@ describe('GithubOrgEntityProvider', () => {
               },
             },
           },
-          {
-            locationKey: 'github-org-provider:my-id',
-            entity: {
-              metadata: {
-                annotations: {
-                  'backstage.io/managed-by-location':
-                    'url:https://github.com/orgs/backstage/teams/team',
-                  'backstage.io/managed-by-origin-location':
-                    'url:https://github.com/orgs/backstage/teams/team',
-                  'github.com/team-slug': 'blah/team',
-                },
-                name: 'team',
-                description: 'The one and only team',
-              },
-              apiVersion: 'backstage.io/v1alpha1',
-              kind: 'Group',
-              spec: {
-                type: 'team',
-                profile: {
-                  displayName: 'Team',
-                  picture: 'http://example.com/team.jpeg',
-                },
-                children: [],
-                parent: 'parent',
-                members: ['a', 'githubuser'],
-              },
-            },
-          },
         ],
+        removed: [],
         type: 'delta',
       });
     });
@@ -1264,6 +1185,7 @@ describe('GithubOrgEntityProvider', () => {
       const mockClient = jest.fn();
 
       mockClient
+        // getOrganizationTeam
         .mockResolvedValueOnce({
           organization: {
             team: {
@@ -1284,23 +1206,7 @@ describe('GithubOrgEntityProvider', () => {
             },
           },
         })
-        .mockResolvedValueOnce({
-          organization: {
-            membersWithRole: {
-              pageInfo: { hasNextPage: false },
-              nodes: [
-                {
-                  login: 'githubuser',
-                  id: 'githubuserId',
-                  name: 'githubuser',
-                  bio: 'githubuser',
-                  email: 'd',
-                  avatarUrl: 'e',
-                },
-              ],
-            },
-          },
-        })
+        // getOrganizationTeamsForUser - returns empty teams since user was removed
         .mockResolvedValueOnce({
           organization: {
             teams: {
@@ -1328,6 +1234,10 @@ describe('GithubOrgEntityProvider', () => {
           },
           member: {
             login: 'githubuser',
+            avatar_url: 'e',
+            email: 'd',
+            name: 'githubuser',
+            node_id: 'githubuserId',
           },
           organization: {
             login: 'test-org',
@@ -1347,33 +1257,6 @@ describe('GithubOrgEntityProvider', () => {
               metadata: {
                 annotations: {
                   'backstage.io/managed-by-location':
-                    'url:https://github.com/githubuser',
-                  'backstage.io/managed-by-origin-location':
-                    'url:https://github.com/githubuser',
-                  'github.com/user-login': 'githubuser',
-                  'github.com/user-id': 'githubuserId',
-                },
-                name: 'githubuser',
-                description: 'githubuser',
-              },
-              apiVersion: 'backstage.io/v1alpha1',
-              kind: 'User',
-              spec: {
-                profile: {
-                  displayName: 'githubuser',
-                  email: 'd',
-                  picture: 'e',
-                },
-                memberOf: [],
-              },
-            },
-          },
-          {
-            locationKey: 'github-org-provider:my-id',
-            entity: {
-              metadata: {
-                annotations: {
-                  'backstage.io/managed-by-location':
                     'url:https://github.com/orgs/backstage/teams/team',
                   'backstage.io/managed-by-origin-location':
                     'url:https://github.com/orgs/backstage/teams/team',
@@ -1396,8 +1279,6 @@ describe('GithubOrgEntityProvider', () => {
               },
             },
           },
-        ],
-        removed: [
           {
             locationKey: 'github-org-provider:my-id',
             entity: {
@@ -1411,7 +1292,6 @@ describe('GithubOrgEntityProvider', () => {
                   'github.com/user-id': 'githubuserId',
                 },
                 name: 'githubuser',
-                description: 'githubuser',
               },
               apiVersion: 'backstage.io/v1alpha1',
               kind: 'User',
@@ -1425,35 +1305,8 @@ describe('GithubOrgEntityProvider', () => {
               },
             },
           },
-          {
-            locationKey: 'github-org-provider:my-id',
-            entity: {
-              metadata: {
-                annotations: {
-                  'backstage.io/managed-by-location':
-                    'url:https://github.com/orgs/backstage/teams/team',
-                  'backstage.io/managed-by-origin-location':
-                    'url:https://github.com/orgs/backstage/teams/team',
-                  'github.com/team-slug': 'blah/team',
-                },
-                name: 'team',
-                description: 'The one and only team',
-              },
-              apiVersion: 'backstage.io/v1alpha1',
-              kind: 'Group',
-              spec: {
-                type: 'team',
-                profile: {
-                  displayName: 'Team',
-                  picture: 'http://example.com/team.jpeg',
-                },
-                children: [],
-                parent: 'parent',
-                members: ['a'],
-              },
-            },
-          },
         ],
+        removed: [],
         type: 'delta',
       });
     });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I updated the GithubOrgEntityProvider to be more like the GithubMultiOrgEntityProvider


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
