### PR TITLE
Fix large icon rendering in catalog graph nodes

### DIFF
--- a/.changeset/fair-ads-decide.md
+++ b/.changeset/fair-ads-decide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-graph': patch
+---
+
+Fix large icon rendering in catalog graph nodes

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/EntityIcon.tsx
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/EntityIcon.tsx
@@ -20,6 +20,8 @@ import { IconComponent } from '@backstage/core-plugin-api';
 
 export function EntityIcon({
   icon,
+  width,
+  height,
   ...props
 }: {
   icon: IconComponent | undefined;
@@ -30,5 +32,12 @@ export function EntityIcon({
   className?: string;
 }) {
   const Icon = (icon as OverridableComponent<SvgIconTypeMap>) ?? SvgIcon;
-  return <Icon {...props} />;
+  return (
+    <Icon
+      style={{ width, height, fontSize: height }}
+      width={width}
+      height={height}
+      {...props}
+    />
+  );
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR fixes a visual regression in the Catalog Graph plugin where entity icons inside the "Relations" card were rendering too large. The issue was that the `EntityIcon` component was not correctly applying the calculated `width` and `height` constraints to the underlying Material UI icon styles.

This change explicitly passes the dimensions to the icon's `style` prop, ensuring they fit correctly within the graph nodes.

**Fixes #32196**

### Screenshots

**After:**
<img width="1000" height="586" alt="Screenshot 2025-12-23 at 11 46 59 PM" src="https://github.com/user-attachments/assets/c682441f-3763-4da4-8976-383dc2f57935" />

#### :heavy_check_mark: Checklist



- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))