### PR TITLE
fix: use correct PR ID to post comments

### DIFF
--- a/.github/workflows/api-breaking-changes-comment.yml
+++ b/.github/workflows/api-breaking-changes-comment.yml
@@ -122,6 +122,6 @@ jobs:
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
+          issue-number: ${{ needs.setup.outputs.pr-number }}
           body-path: comment.md
           edit-mode: replace


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I've noticed a bunch of failing workflow runs for this recently while working on API schema updates, example - https://github.com/backstage/backstage/actions/runs/20604206270/job/59176331994. Looks like the PR ID we use to post the comment is wrong.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
