### PR TITLE
fix(docsite): incorrect generated index URLs

### DIFF
--- a/microsite/sidebars.ts
+++ b/microsite/sidebars.ts
@@ -27,17 +27,17 @@ function sidebarElementWithIndex(
   },
   children: Array<string | object>,
 ) {
-  const { label, description, differentiator } = element;
+  const { label, description, differentiator = '' } = element;
   return {
     type: 'category',
-    label: label,
+    label,
     description,
     link: {
       type: 'generated-index',
       title: label,
       slug: `/${differentiator}${label
         .toLowerCase()
-        .replace(/[^a-z0-9 _-]/gi, '-')}/generated-index`,
+        .replace(/[^a-z0-9]/g, '-')}/generated-index`,
     },
     items: children,
   };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The regex + differentiator were incorrect causing URLs like https://backstage.io/docs/next/undefinedgetting%20started/generated-index. This PR fixes both of those issues and generates URLs like http://localhost:3000/docs/using-backstage/generated-index locally.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
