### PR TITLE
fix(frontend-system-doc): use PascalCase for SidebarContent in migration guide

### DIFF
--- a/docs/frontend-system/building-apps/08-migrating.md
+++ b/docs/frontend-system/building-apps/08-migrating.md
@@ -694,20 +694,20 @@ In order to migrate your existing sidebar, you will want to create an override f
 
 ```tsx title="in packages/app/src/modules/nav/index.ts"
 import { createFrontendModule } from '@backstage/frontend-plugin-api';
-import { sidebarContent } from './Sidebar';
+import { SidebarContent } from './Sidebar';
 
 export const navModule = createFrontendModule({
   pluginId: 'app',
-  extensions: [sidebarContent],
+  extensions: [SidebarContent],
 });
 ```
 
-Then in the actual implementation for the `sidebarContent` extension, you can provide something like the following, where you implement the entire `Sidebar` component.
+Then in the actual implementation for the `SidebarContent` extension, you can provide something like the following, where you implement the entire `Sidebar` component.
 
 ```tsx title="in packages/app/src/modules/nav/Sidebar.tsx"
 import { NavContentBlueprint } from '@backstage/frontend-plugin-api';
 
-export const sidebarContent = NavContentBlueprint.make({
+export const SidebarContent = NavContentBlueprint.make({
   params: {
     component: ({ items }) => (
       <Sidebar>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

**What changed:**
Updated all instances of `sidebarContent` to `SidebarContent` (PascalCase) in the frontend migration guide to align with the naming convention used in projects created with `create-app`.

This ensures consistency across the documentation and matches the actual implementation pattern used in newly created apps.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
