### PR TITLE
feat: add table options and title for components cards of api

### DIFF
--- a/.changeset/rude-geckos-lead.md
+++ b/.changeset/rude-geckos-lead.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-api-docs': patch
+---
+
+Add `tableOptions` and `title` to Components cards of APIs

--- a/plugins/api-docs/report.api.md
+++ b/plugins/api-docs/report.api.md
@@ -104,7 +104,9 @@ export const ConsumedApisCard: (props: {
 // @public (undocumented)
 export const ConsumingComponentsCard: (props: {
   variant?: InfoCardVariants;
+  title?: string;
   columns?: TableColumn<ComponentEntity>[];
+  tableOptions?: TableOptions;
 }) => JSX_2.Element;
 
 // @public
@@ -138,7 +140,9 @@ export const EntityConsumedApisCard: (props: {
 // @public (undocumented)
 export const EntityConsumingComponentsCard: (props: {
   variant?: InfoCardVariants;
+  title?: string;
   columns?: TableColumn<ComponentEntity>[];
+  tableOptions?: TableOptions;
 }) => JSX_2.Element;
 
 // @public (undocumented)
@@ -160,7 +164,9 @@ export const EntityProvidedApisCard: (props: {
 // @public (undocumented)
 export const EntityProvidingComponentsCard: (props: {
   variant?: InfoCardVariants;
+  title?: string;
   columns?: TableColumn<ComponentEntity>[];
+  tableOptions?: TableOptions;
 }) => JSX_2.Element;
 
 // @public (undocumented)
@@ -215,7 +221,9 @@ export const ProvidedApisCard: (props: {
 // @public (undocumented)
 export const ProvidingComponentsCard: (props: {
   variant?: InfoCardVariants;
+  title?: string;
   columns?: TableColumn<ComponentEntity>[];
+  tableOptions?: TableOptions;
 }) => JSX_2.Element;
 
 // @public (undocumented)

--- a/plugins/api-docs/src/components/ComponentsCards/ConsumingComponentsCard.tsx
+++ b/plugins/api-docs/src/components/ComponentsCards/ConsumingComponentsCard.tsx
@@ -31,6 +31,7 @@ import {
   Link,
   Progress,
   TableColumn,
+  TableOptions,
   WarningPanel,
 } from '@backstage/core-components';
 import { useTranslationRef } from '@backstage/frontend-plugin-api';
@@ -41,19 +42,25 @@ import { apiDocsTranslationRef } from '../../translation';
  */
 export const ConsumingComponentsCard = (props: {
   variant?: InfoCardVariants;
+  title?: string;
   columns?: TableColumn<ComponentEntity>[];
+  tableOptions?: TableOptions;
 }) => {
-  const { variant = 'gridItem', columns = EntityTable.componentEntityColumns } =
-    props;
+  const { t } = useTranslationRef(apiDocsTranslationRef);
+  const {
+    variant = 'gridItem',
+    title = t('consumingComponentsCard.title'),
+    columns = EntityTable.componentEntityColumns,
+    tableOptions = {},
+  } = props;
   const { entity } = useEntity();
   const { entities, loading, error } = useRelatedEntities(entity, {
     type: RELATION_API_CONSUMED_BY,
   });
-  const { t } = useTranslationRef(apiDocsTranslationRef);
 
   if (loading) {
     return (
-      <InfoCard variant={variant} title={t('consumingComponentsCard.title')}>
+      <InfoCard variant={variant} title={title}>
         <Progress />
       </InfoCard>
     );
@@ -61,7 +68,7 @@ export const ConsumingComponentsCard = (props: {
 
   if (error || !entities) {
     return (
-      <InfoCard variant={variant} title={t('consumingComponentsCard.title')}>
+      <InfoCard variant={variant} title={title}>
         <WarningPanel
           severity="error"
           title={t('consumingComponentsCard.error.title')}
@@ -73,7 +80,7 @@ export const ConsumingComponentsCard = (props: {
 
   return (
     <EntityTable
-      title={t('consumingComponentsCard.title')}
+      title={title}
       variant={variant}
       emptyContent={
         <div style={{ textAlign: 'center' }}>
@@ -88,6 +95,7 @@ export const ConsumingComponentsCard = (props: {
         </div>
       }
       columns={columns}
+      tableOptions={tableOptions}
       entities={entities as ComponentEntity[]}
     />
   );

--- a/plugins/api-docs/src/components/ComponentsCards/ProvidingComponentsCard.tsx
+++ b/plugins/api-docs/src/components/ComponentsCards/ProvidingComponentsCard.tsx
@@ -31,6 +31,7 @@ import {
   Link,
   Progress,
   TableColumn,
+  TableOptions,
   WarningPanel,
 } from '@backstage/core-components';
 import { useTranslationRef } from '@backstage/frontend-plugin-api';
@@ -39,19 +40,25 @@ import { apiDocsTranslationRef } from '../../translation';
 /** @public */
 export const ProvidingComponentsCard = (props: {
   variant?: InfoCardVariants;
+  title?: string;
   columns?: TableColumn<ComponentEntity>[];
+  tableOptions?: TableOptions;
 }) => {
-  const { variant = 'gridItem', columns = EntityTable.componentEntityColumns } =
-    props;
+  const { t } = useTranslationRef(apiDocsTranslationRef);
+  const {
+    variant = 'gridItem',
+    title = t('providingComponentsCard.title'),
+    columns = EntityTable.componentEntityColumns,
+    tableOptions = {},
+  } = props;
   const { entity } = useEntity();
   const { entities, loading, error } = useRelatedEntities(entity, {
     type: RELATION_API_PROVIDED_BY,
   });
-  const { t } = useTranslationRef(apiDocsTranslationRef);
 
   if (loading) {
     return (
-      <InfoCard variant={variant} title={t('providingComponentsCard.title')}>
+      <InfoCard variant={variant} title={title}>
         <Progress />
       </InfoCard>
     );
@@ -59,7 +66,7 @@ export const ProvidingComponentsCard = (props: {
 
   if (error || !entities) {
     return (
-      <InfoCard variant={variant} title={t('providingComponentsCard.title')}>
+      <InfoCard variant={variant} title={title}>
         <WarningPanel
           severity="error"
           title={t('providingComponentsCard.error.title')}
@@ -71,7 +78,7 @@ export const ProvidingComponentsCard = (props: {
 
   return (
     <EntityTable
-      title={t('providingComponentsCard.title')}
+      title={title}
       variant={variant}
       emptyContent={
         <div style={{ textAlign: 'center' }}>
@@ -86,6 +93,7 @@ export const ProvidingComponentsCard = (props: {
         </div>
       }
       columns={columns}
+      tableOptions={tableOptions}
       entities={entities as ComponentEntity[]}
     />
   );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds `tableOptions` and `title` to Components cards of APIs, to align them with these other entity tables. I would like to add pagination to these cards, as you are able to do with the others. Noticed a similar PR was made a while back to bring the other tables in this plugin "up to speed" (https://github.com/backstage/backstage/pull/25545), although the Components cards were not included there.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
