### PR TITLE
docs: add info about specific version bump with --release

### DIFF
--- a/docs/getting-started/keeping-backstage-updated.md
+++ b/docs/getting-started/keeping-backstage-updated.md
@@ -45,6 +45,10 @@ yarn backstage-cli versions:bump --release next
 
 You can also use the `--release` option to target a specific version. This is useful if you need to pin your app to a specific release or if you need to downgrade to a previous version (e.g. moving from `1.45.0` back to `1.43.0`).
 
+:::warning
+Note that downgrading across significant version gaps (e.g. 2-3 releases) may result in package mismatches or errors due to the way Backstage manages dependencies. This method is best suited for small adjustments.
+:::
+
 ```bash
 yarn backstage-cli versions:bump --release 1.43.0
 ```


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Clarifies in the documentation that the `--release` flag can be used to downgrade or pin specific versions, as suggested in issue #32008.

Fixes #32008

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
