### PR TITLE
Added code for 3rd type of button

### DIFF
--- a/docs-ui/src/content/button.props.ts
+++ b/docs-ui/src/content/button.props.ts
@@ -4,7 +4,7 @@ import type { PropDef } from '@/utils/propDefs';
 export const buttonPropDefs: Record<string, PropDef> = {
   variant: {
     type: 'enum',
-    values: ['primary', 'secondary'],
+    values: ['primary', 'secondary', 'tertiary'],
     default: 'primary',
     responsive: true,
   },
@@ -40,6 +40,9 @@ export const buttonVariantsSnippet = `<Flex align="center">
   <Button iconStart="cloud" variant="secondary">
     Button
   </Button>
+  <Button iconStart="cloud" variant="tertiary">
+    Button
+  </Button>
 </Flex>`;
 
 export const buttonSizesSnippet = `<Flex align="center">
@@ -59,6 +62,9 @@ export const buttonDisabledSnippet = `<Flex gap="4">
   </Button>
   <Button variant="secondary" isDisabled>
     Secondary
+  </Button>
+  <Button variant="tertiary" isDisabled>
+    Tertiary
   </Button>
 </Flex>`;
 


### PR DESCRIPTION
Currently the [ui.backstage.io](https://ui.backstage.io/components/button) shows 3 buttons but provide code for only two type
<img width="526" height="332" alt="current" src="https://github.com/user-attachments/assets/5bfc3c94-c085-445e-a4c8-4e97a8e15825" />

I updated the code to show all the 3 types of button
<img width="535" height="417" alt="updated" src="https://github.com/user-attachments/assets/de227cb0-892f-4a4e-b310-d099727ae088" />
#### :heavy_check_mark: Checklist


<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
