### PR TITLE
fix(techdocs): Code block Copy To Clipboard button layout with latest mkdocs-material

### DIFF
--- a/.changeset/some-spiders-serve.md
+++ b/.changeset/some-spiders-serve.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Code block "Copy to clipboard" button was not positioned correctly for docs built with `mkdocs-material>=9.7`

--- a/plugins/techdocs/src/reader/transformers/copyToClipboard.tsx
+++ b/plugins/techdocs/src/reader/transformers/copyToClipboard.tsx
@@ -67,7 +67,12 @@ const CopyToClipboardButton = ({ text }: CopyToClipboardButtonProps) => {
       leaveDelay={1000}
     >
       <IconButton
-        style={{ position: 'absolute' }}
+        style={{
+          position: 'absolute',
+          // top & right was removed from upstream .md-clipboard in mkdocs-material 9.7.0
+          top: '0.5rem',
+          right: '0.5rem',
+        }}
         className="md-clipboard md-icon"
         onClick={handleClick}
         aria-label="Copy to clipboard"
@@ -81,6 +86,8 @@ const CopyToClipboardButton = ({ text }: CopyToClipboardButtonProps) => {
 /**
  * Recreates copy-to-clipboard functionality attached to <code> snippets that
  * is native to mkdocs-material theme.
+ *
+ * Unlike native mkdocs-material theme, this is always enabled and does not respect the mkdocs's config `theme.features` `content.code.copy` setting.
  */
 export const copyToClipboard = (theme: Theme): Transformer => {
   return dom => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix #32259 

Tested both with docs built with `mkdocs-material` 9.6 & 9.7, with no visual changes. As `mkdocs-material` went to maintenance mode, we can expect no further upstream styling changes.

Before
<img width="869" height="224" alt="image" src="https://github.com/user-attachments/assets/137e44c4-b101-4b91-94ad-5235d549500c" />


After
<img width="869" height="224" alt="image" src="https://github.com/user-attachments/assets/e2923c2b-209d-425f-ab8f-5ce681b3f7b4" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
