### PR TITLE
BUI - Fixes RouterProvider on Link

### DIFF
--- a/.changeset/new-windows-reply.md
+++ b/.changeset/new-windows-reply.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed `Link` component causing hard page refreshes for internal routes. The component now properly uses React Router's navigation instead of full page reloads.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `RouterProvider` was wrapping the rendered `<a>` element, but the useLink hook was being called before the `RouterProvider` wrapper. This meant the hook couldn't access the router context and couldn't use React Router for navigation, causing hard page refreshes.

### The Solution
I've split the component into two parts:

1. `LinkInternal` - Contains the link rendering logic and the useLink hook
2. `Link` (outer wrapper) - Checks if the link is external/internal and wraps LinkInternal with `RouterProvider` for internal links

Now the RouterProvider wraps the component that uses the hooks, so useLink can properly access the router context and use React Router's navigate function instead of triggering a full page refresh.

The internal links should now use React Router navigation properly! 🎉

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
