### PR TITLE
converted the note syntax for consistency with other documentation files

### DIFF
--- a/docs/dls/contributing-to-storybook.md
+++ b/docs/dls/contributing-to-storybook.md
@@ -56,10 +56,9 @@ core
 ```
 
 :::note Note
- 
+
 Make sure your component story file has the following format
 componentName.stories.tsx
-
 :::
 
 ## Running locally


### PR DESCRIPTION
Note formatting is changed in contribution-to-storybook.md for consistency with other documentation files
<img width="1084" height="193" alt="image" src="https://github.com/user-attachments/assets/c457176c-1356-44a1-b797-4ecf85c4ed50" />

#### :heavy_check_mark: Checklist
<!--- Please include the following in your Pull Request when applicable: -->
- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))