### PR TITLE
Add an option to customize the Playwright browser channel

### DIFF
--- a/.changeset/custom-playwright-channel.md
+++ b/.changeset/custom-playwright-channel.md
@@ -1,0 +1,15 @@
+---
+'@backstage/e2e-test-utils': patch
+---
+
+Added optional `channel` option to `generateProjects()` to allow customizing the Playwright browser channel for testing against different browsers variants. When not provided, the function defaults to 'chrome' to maintain backward compatibility.
+
+Example usage:
+
+```ts
+import { generateProjects } from '@backstage/e2e-test-utils';
+
+export default defineConfig({
+  projects: generateProjects({ channel: 'msedge' }),
+});
+```

--- a/packages/e2e-test-utils/report-playwright.api.md
+++ b/packages/e2e-test-utils/report-playwright.api.md
@@ -9,7 +9,9 @@ import { PlaywrightTestConfig } from '@playwright/test';
 export function failOnBrowserErrors(): void;
 
 // @public
-export function generateProjects(): PlaywrightTestConfig['projects'];
+export function generateProjects(options?: {
+  channel?: string;
+}): PlaywrightTestConfig['projects'];
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/packages/e2e-test-utils/src/playwright/generateProjects.ts
+++ b/packages/e2e-test-utils/src/playwright/generateProjects.ts
@@ -24,8 +24,14 @@ import type { BackstagePackage } from '@backstage/cli-node';
  * Generates a list of playwright projects by scanning the monorepo for packages with an `e2e-tests/` folder.
  *
  * @public
+ *
+ * @param options - Optional configuration for the generated Playwright projects.
+ *   When provided, `options.channel` controls the browser channel used for tests.
+ *   Valid values are listed in the [Playwright documentation](https://playwright.dev/docs/api/class-testoptions#test-options-channel).
  */
-export function generateProjects(): PlaywrightTestConfig['projects'] {
+export function generateProjects(options?: {
+  channel?: string;
+}): PlaywrightTestConfig['projects'] {
   // TODO(Rugvip): Switch this over to use @backstage/cli-node once released, and support SINCE=origin/main
   const { root, packages } = getPackagesSync(process.cwd());
   const e2eTestPackages = [...(root ? [root] : []), ...packages].filter(pkg => {
@@ -36,7 +42,7 @@ export function generateProjects(): PlaywrightTestConfig['projects'] {
     name: pkg.packageJson.name,
     testDir: resolvePath(pkg.dir, 'e2e-tests'),
     use: {
-      channel: 'chrome',
+      channel: options?.channel ?? 'chrome',
     },
   }));
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Add an option to customize the Playwright browser channel. This is useful for running the tests in headlessly in CI on chromium.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
