### PR TITLE
Feat/kafka event headers

### DIFF
--- a/.changeset/support-kafka-headers-forwarding.md
+++ b/.changeset/support-kafka-headers-forwarding.md
@@ -1,0 +1,12 @@
+---
+'@backstage/plugin-events-backend-module-kafka': minor
+---
+
+Add optional forwarding of Backstage event metadata as Kafka message headers in `KafkaPublishingEventConsumer`.
+
+- New `headers` config under `events.modules.kafka.kafkaPublishingEventConsumer.<instance>.topics[]`:
+  - `forward`: Enable forwarding metadata as headers (default: false)
+  - `whitelist`: Only include these header keys (case-insensitive)
+  - `blacklist`: Exclude these header keys (case-insensitive, default: ["authorization"]). Ignored when `whitelist` is provided.
+
+By default, headers are not forwarded. When enabled, the `Authorization` header is excluded unless a whitelist is specified. This provides safer observability metadata like trace IDs without leaking sensitive tokens.

--- a/plugins/events-backend-module-kafka/config.d.ts
+++ b/plugins/events-backend-module-kafka/config.d.ts
@@ -609,6 +609,19 @@ export interface Config {
                    */
                   retries?: number;
                 };
+                /**
+                 * (Optional) Forward Backstage event metadata as Kafka headers.
+                 * Defaults to not forwarding unless enabled. When forwarding is enabled,
+                 * the Authorization header is excluded by default unless a whitelist is provided.
+                 */
+                headers?: {
+                  /** Enable forwarding metadata as headers */
+                  forward?: boolean;
+                  /** Only include these header keys (case-insensitive). If set, blacklist is ignored. */
+                  whitelist?: string[];
+                  /** Exclude these header keys (case-insensitive). Default: ['authorization'] */
+                  blacklist?: string[];
+                };
               };
             }>;
           };

--- a/plugins/events-backend-module-kafka/src/KafkaPublishingEventConsumer/config.ts
+++ b/plugins/events-backend-module-kafka/src/KafkaPublishingEventConsumer/config.ts
@@ -25,6 +25,14 @@ export interface KafkaPublisherConfig {
   backstageTopic: string;
   kafkaTopic: string;
   producerConfig: ProducerConfig;
+  headers?: {
+    /** Enable forwarding Backstage event metadata as Kafka headers */
+    forward?: boolean;
+    /** Only forward these header keys (case-insensitive). If set, blacklist is ignored */
+    whitelist?: string[];
+    /** Do not forward these header keys (case-insensitive). Default: ['authorization'] */
+    blacklist?: string[];
+  };
 }
 
 export interface KafkaPublishingEventConsumerConfig {
@@ -74,6 +82,21 @@ export const readPublisherConfig = (
                   topicConfig.getOptionalConfig('kafka.retry'),
                 ),
               },
+              headers: (() => {
+                const headersCfg = topicConfig.getOptionalConfig('headers');
+                if (!headersCfg) return undefined;
+                const forward =
+                  headersCfg.getOptionalBoolean('forward') ?? false;
+                const whitelist =
+                  headersCfg.getOptionalStringArray('whitelist');
+                const blacklist =
+                  headersCfg.getOptionalStringArray('blacklist');
+                return {
+                  forward,
+                  whitelist,
+                  blacklist,
+                };
+              })(),
             };
           }),
       };

--- a/plugins/events-backend-module-kafka/src/utils/kafkaTransformers.ts
+++ b/plugins/events-backend-module-kafka/src/utils/kafkaTransformers.ts
@@ -27,9 +27,12 @@ export const convertHeadersToMetadata = (
 
   Object.entries(headers).forEach(([key, value]) => {
     // If value is an array use toString() on all values converting any Buffer types to valid strings
-    if (Array.isArray(value)) metadata[key] = value.map(v => v.toString());
-    // Always return the values using toString() to catch all Buffer types that should be converted to strings
-    else metadata[key] = value?.toString();
+    if (Array.isArray(value)) {
+      metadata[key] = value.map(v => v.toString());
+    } else {
+      // Always return the values using toString() to catch all Buffer types that should be converted to strings
+      metadata[key] = value?.toString();
+    }
   });
 
   return metadata;
@@ -46,4 +49,41 @@ export const payloadToBuffer = (payload: unknown): Buffer => {
 
   // Convert to JSON string then encode
   return Buffer.from(JSON.stringify(payload), 'utf8');
+};
+
+export const convertMetadataToHeaders = (
+  metadata: EventMetadata | undefined,
+  options?: {
+    whitelist?: string[];
+    blacklist?: string[];
+  },
+): IHeaders | undefined => {
+  if (!metadata) return undefined;
+
+  const wl = options?.whitelist?.map(k => k.toLowerCase());
+  const bl = options?.blacklist?.map(k => k.toLowerCase()) ?? ['authorization'];
+
+  const result: IHeaders = {};
+
+  for (const [key, value] of Object.entries(metadata)) {
+    const k = key.toLowerCase();
+    if (wl && wl.length > 0) {
+      if (!wl.includes(k)) continue;
+    } else {
+      if (bl.includes(k)) continue;
+    }
+
+    if (Array.isArray(value)) {
+      const filtered = value
+        .filter(v => v !== undefined)
+        .map(v => v!.toString());
+      result[key] = filtered.length > 0 ? filtered : undefined;
+    } else if (value === undefined) {
+      result[key] = undefined;
+    } else {
+      result[key] = value.toString();
+    }
+  }
+
+  return result;
 };

--- a/plugins/events-backend-module-kafka/src/utils/kafkaTransformers.ts
+++ b/plugins/events-backend-module-kafka/src/utils/kafkaTransformers.ts
@@ -85,5 +85,5 @@ export const convertMetadataToHeaders = (
     }
   }
 
-  return result;
+  return Object.keys(result).length > 0 ? result : undefined;
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### events-backend-module-kafka: Support publishing headers with safe defaults

Summary

- Adds optional forwarding of Backstage event [metadata](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) as Kafka message [headers](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) in the Kafka publishing module, enabling propagation of trace IDs, event type, and other metadata without altering payloads. Default behavior remains unchanged (no headers forwarded).

Motivation

- Addresses events system need to carry metadata via Kafka headers for observability and downstream processing, while avoiding leakage of sensitive values. Implements the proposal in issue #32251.

Changes

- Publisher header forwarding:
[KafkaPublishingEventConsumer.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html): Forward headers when enabled; apply whitelist or default blacklist ([authorization](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)).
- Config support:
[config.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html): Parse [headers.forward](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), [headers.whitelist](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), and [headers.blacklist](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
[config.d.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html): Document new [headers](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) options under [topics[]](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
- Utilities:
[kafkaTransformers.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html): Add [convertMetadataToHeaders()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and improve header conversions.
- Tests:
[KafkaPublishingEventConsumer.test.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html): Verify forwarding behavior, default blacklist, and whitelist.
[kafkaTransformers.test.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html): Cover conversion utilities, including array handling.
- Changeset:
[support-kafka-headers-forwarding.md](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html): Minor bump for [@backstage/plugin-events-backend-module-kafka](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).

Behavior
- Forwarding off by default.
- When on:
Default blacklist excludes [authorization](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (case-insensitive).
If a whitelist is present, only those keys are forwarded (blacklist ignored).
Arrays forwarded as string arrays; undefined entries dropped.
- Consuming path continues to map Kafka headers back to event [metadata](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (unchanged).

Test Plan
- Module tests pass (8 suites, 60 tests):
Header forwarding and filtering verified.
Utility conversions verified (strings, buffers, arrays, undefined).
- Type check: yarn tsc passes.
- Lint/format: yarn lint --fix and yarn prettier --write run on the module.

Release Notes
- [@backstage/plugin-events-backend-module-kafka](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html):
Added optional forwarding of event metadata as Kafka headers with config-controlled whitelist/blacklist and a safe default blacklist ([authorization](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)).
Default behavior unchanged (no headers forwarded).

Linked Issue

Fixes #32251

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
