### PR TITLE
fix: header in EntityLayout should always be shown

### DIFF
--- a/.changeset/early-boxes-work.md
+++ b/.changeset/early-boxes-work.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Header in EntityLayout should always be shown.
+Monitoring the loading status caused flickering when the refresh() method of the Async Entity was invoked.

--- a/plugins/catalog/src/alpha/components/EntityLayout/EntityLayout.tsx
+++ b/plugins/catalog/src/alpha/components/EntityLayout/EntityLayout.tsx
@@ -102,20 +102,12 @@ export const EntityLayout = (props: EntityLayoutProps) => {
     UNSTABLE_contextMenuOptions,
     contextMenuItems,
     children,
+    header,
     NotFoundComponent,
     parentEntityRelations,
   } = props;
   const { kind } = useRouteRefParams(entityRouteRef);
   const { entity, loading, error } = useAsyncEntity();
-
-  const header = props.header ?? (
-    <EntityHeader
-      parentEntityRelations={parentEntityRelations}
-      UNSTABLE_contextMenuOptions={UNSTABLE_contextMenuOptions}
-      UNSTABLE_extraContextMenuItems={UNSTABLE_extraContextMenuItems}
-      contextMenuItems={contextMenuItems}
-    />
-  );
 
   const routes = useElementFilter(
     children,
@@ -150,7 +142,14 @@ export const EntityLayout = (props: EntityLayoutProps) => {
 
   return (
     <Page themeId={entity?.spec?.type?.toString() ?? 'home'}>
-      {!loading && header}
+      {header ?? (
+        <EntityHeader
+          parentEntityRelations={parentEntityRelations}
+          UNSTABLE_contextMenuOptions={UNSTABLE_contextMenuOptions}
+          UNSTABLE_extraContextMenuItems={UNSTABLE_extraContextMenuItems}
+          contextMenuItems={contextMenuItems}
+        />
+      )}
 
       {loading && <Progress />}
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I have to revert the changes in the EntityLayout that were [added here](https://github.com/backstage/backstage/pull/30589/files#diff-feb3ee8ee724ae8be49d04e151c702b84ed2d929cf4e05f0e63a8592267b418e).

Monitoring the `loading` causes flickering when I invoke the `refresh()` method of the Async Entity.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
