### PR TITLE
Eslint-plugin: Support Flat Config, Eslint v9/v10

### DIFF
--- a/.changeset/cold-maps-begin.md
+++ b/.changeset/cold-maps-begin.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Require `eslint` ^8.57.1

--- a/.changeset/happy-kings-begin.md
+++ b/.changeset/happy-kings-begin.md
@@ -1,0 +1,8 @@
+---
+'@backstage/eslint-plugin': patch
+---
+
+Add experimental support for ESLint flat-config format to `@backstage/eslint-plugin` and declare support for ESLint v9/v10. Minimum ESLint version is now 8.57.1.
+
+This is only a prerequisite to an ESLint version or config format migration.
+This does **NOT** mean that the `@backstage/cli` is compatible with ESLint flat-config format nor ESLint v9/v10.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -88,7 +88,7 @@
     "css-loader": "^6.5.1",
     "ctrlc-windows": "^2.1.0",
     "esbuild": "^0.27.0",
-    "eslint": "^8.6.0",
+    "eslint": "^8.57.1",
     "eslint-config-prettier": "^9.0.0",
     "eslint-formatter-friendly": "^7.0.0",
     "eslint-plugin-deprecation": "^3.0.0",

--- a/packages/eslint-plugin/index.js
+++ b/packages/eslint-plugin/index.js
@@ -13,18 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+const pkg = require('./package.json');
 
-module.exports = {
+/** @type {import('eslint').ESLint.Plugin['rules']} */
+const recommendedRules = {
+  '@backstage/no-forbidden-package-imports': 'error',
+  '@backstage/no-relative-monorepo-imports': 'error',
+  '@backstage/no-undeclared-imports': 'error',
+  '@backstage/no-mixed-plugin-imports': 'warn',
+  '@backstage/no-ui-css-imports-in-non-frontend': 'error',
+};
+
+/** @type {import('eslint').ESLint.Plugin} */
+const plugin = {
+  meta: {
+    name: pkg.name,
+    version: pkg.version,
+  },
   configs: {
     recommended: {
       plugins: ['@backstage'],
-      rules: {
-        '@backstage/no-forbidden-package-imports': 'error',
-        '@backstage/no-relative-monorepo-imports': 'error',
-        '@backstage/no-undeclared-imports': 'error',
-        '@backstage/no-mixed-plugin-imports': 'warn',
-        '@backstage/no-ui-css-imports-in-non-frontend': 'error',
-      },
+      rules: recommendedRules,
     },
   },
   rules: {
@@ -36,3 +45,25 @@ module.exports = {
     'no-ui-css-imports-in-non-frontend': require('./rules/no-ui-css-imports-in-non-frontend'),
   },
 };
+
+// Assign configs here so we can reference `plugin` for flat config
+// cf https://eslint.org/docs/v8.x/extend/plugin-migration-flat-config#migrating-configs-for-flat-config
+Object.assign(plugin.configs, {
+  // Flat config format (ESLint v8.24+ / v9+)
+  // If flat config is enabled, this will be automatically used when `recommended` is loaded
+  // cf https://eslint.org/docs/latest/extend/plugins#backwards-compatibility-for-legacy-configs
+  'flat/recommended': {
+    plugins: {
+      '@backstage': plugin,
+    },
+    rules: recommendedRules,
+  },
+
+  // Legacy config format (ESLint v8 and earlier)
+  recommended: {
+    plugins: ['@backstage'],
+    rules: recommendedRules,
+  },
+});
+
+module.exports = plugin;

--- a/packages/eslint-plugin/index.js
+++ b/packages/eslint-plugin/index.js
@@ -42,10 +42,10 @@ const plugin = {
 };
 
 // Assign configs here so we can reference `plugin` for flat config
-// cf https://eslint.org/docs/v8.x/extend/plugin-migration-flat-config#migrating-configs-for-flat-config
+// cf https://eslint.org/docs/latest/extend/plugin-migration-flat-config#migrating-configs-for-flat-config
 Object.assign(plugin.configs, {
   // Flat config format (ESLint v8.24+ / v9+)
-  // If flat config is enabled, this will be automatically used when `recommended` is loaded
+  // When using defineConfig(), this is used as fallback when `recommended` is not in flat config format
   // cf https://eslint.org/docs/latest/extend/plugins#backwards-compatibility-for-legacy-configs
   'flat/recommended': {
     plugins: {

--- a/packages/eslint-plugin/index.js
+++ b/packages/eslint-plugin/index.js
@@ -13,9 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// @ts-check
+
 const pkg = require('./package.json');
 
-/** @type {import('eslint').ESLint.Plugin['rules']} */
+/** @type {import('eslint').Linter.RulesRecord} */
 const recommendedRules = {
   '@backstage/no-forbidden-package-imports': 'error',
   '@backstage/no-relative-monorepo-imports': 'error',
@@ -30,7 +33,14 @@ const plugin = {
     name: pkg.name,
     version: pkg.version,
   },
-  configs: {}, // Defined below
+  configs: {
+    // Legacy config format (ESLint v8 and earlier)
+    recommended: {
+      plugins: ['@backstage'],
+      rules: recommendedRules,
+    },
+    // Flat config defined below
+  },
   rules: {
     'no-forbidden-package-imports': require('./rules/no-forbidden-package-imports'),
     'no-relative-monorepo-imports': require('./rules/no-relative-monorepo-imports'),
@@ -43,22 +53,21 @@ const plugin = {
 
 // Assign configs here so we can reference `plugin` for flat config
 // cf https://eslint.org/docs/latest/extend/plugin-migration-flat-config#migrating-configs-for-flat-config
-Object.assign(plugin.configs, {
-  // Flat config format (ESLint v8.24+ / v9+)
-  // When using defineConfig(), this is used as fallback when `recommended` is not in flat config format
-  // cf https://eslint.org/docs/latest/extend/plugins#backwards-compatibility-for-legacy-configs
-  'flat/recommended': {
-    plugins: {
-      '@backstage': plugin,
+Object.assign(
+  /** @type {NonNullable<import('eslint').ESLint.Plugin['configs']>} */ (
+    plugin.configs
+  ),
+  {
+    // Flat config format (ESLint v8.24+ / v9+)
+    // When using defineConfig(), this is used as fallback when `recommended` is not in flat config format
+    // cf https://eslint.org/docs/latest/extend/plugins#backwards-compatibility-for-legacy-configs
+    'flat/recommended': {
+      plugins: {
+        '@backstage': plugin,
+      },
+      rules: recommendedRules,
     },
-    rules: recommendedRules,
   },
-
-  // Legacy config format (ESLint v8 and earlier)
-  recommended: {
-    plugins: ['@backstage'],
-    rules: recommendedRules,
-  },
-});
+);
 
 module.exports = plugin;

--- a/packages/eslint-plugin/index.js
+++ b/packages/eslint-plugin/index.js
@@ -30,12 +30,7 @@ const plugin = {
     name: pkg.name,
     version: pkg.version,
   },
-  configs: {
-    recommended: {
-      plugins: ['@backstage'],
-      rules: recommendedRules,
-    },
-  },
+  configs: {}, // Defined below
   rules: {
     'no-forbidden-package-imports': require('./rules/no-forbidden-package-imports'),
     'no-relative-monorepo-imports': require('./rules/no-relative-monorepo-imports'),

--- a/packages/eslint-plugin/lib/visitImports.js
+++ b/packages/eslint-plugin/lib/visitImports.js
@@ -121,7 +121,7 @@ function getImportInfo(node) {
  * @param {ImportVisitor} visitor
  */
 module.exports = function visitImports(context, visitor) {
-  const packages = getPackages(context.getCwd());
+  const packages = getPackages(context.cwd);
   if (!packages) {
     return;
   }

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -24,6 +24,9 @@
   "devDependencies": {
     "@backstage/cli": "workspace:^",
     "@types/estree": "^1.0.5",
-    "eslint": "^8.33.0"
+    "eslint": "^8.57.1"
+  },
+  "peerDependencies": {
+    "eslint": "^8.57.1 || ^9.0.0 || ^10.0.0"
   }
 }

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -25,8 +25,5 @@
     "@backstage/cli": "workspace:^",
     "@types/estree": "^1.0.5",
     "eslint": "^8.57.1"
-  },
-  "peerDependencies": {
-    "eslint": "^8.57.1 || ^9.0.0 || ^10.0.0"
   }
 }

--- a/packages/eslint-plugin/rules/no-mixed-plugin-imports.js
+++ b/packages/eslint-plugin/rules/no-mixed-plugin-imports.js
@@ -108,10 +108,7 @@ module.exports = {
       return {};
     }
 
-    const filePath = context.physicalFilename
-      ? context.physicalFilename
-      : context.filename;
-
+    const filePath = context.physicalFilename;
     /** @type {ExtendedPackage | undefined} */
     const pkg = packages.byPath(filePath);
     if (!pkg) {

--- a/packages/eslint-plugin/rules/no-relative-monorepo-imports.js
+++ b/packages/eslint-plugin/rules/no-relative-monorepo-imports.js
@@ -36,13 +36,11 @@ module.exports = {
     },
   },
   create(context) {
-    const packages = getPackageMap(context.getCwd());
+    const packages = getPackageMap(context.cwd);
     if (!packages) {
       return {};
     }
-    const filePath = context.getPhysicalFilename
-      ? context.getPhysicalFilename()
-      : context.getFilename();
+    const filePath = context.physicalFilename;
 
     const localPkg = packages.byPath(filePath);
     if (!localPkg) {

--- a/packages/eslint-plugin/rules/no-ui-css-imports-in-non-frontend.js
+++ b/packages/eslint-plugin/rules/no-ui-css-imports-in-non-frontend.js
@@ -34,12 +34,12 @@ module.exports = {
     },
   },
   create(context) {
-    const packages = getPackages(context.getCwd());
+    const packages = getPackages(context.cwd);
     if (!packages) {
       return {};
     }
 
-    const currentPackage = packages.byPath(context.filename);
+    const currentPackage = packages.byPath(context.physicalFilename);
     if (!currentPackage) {
       return {};
     }

--- a/packages/eslint-plugin/rules/no-undeclared-imports.js
+++ b/packages/eslint-plugin/rules/no-undeclared-imports.js
@@ -293,13 +293,11 @@ module.exports = {
     },
   },
   create(context) {
-    const packages = getPackageMap(context.getCwd());
+    const packages = getPackageMap(context.cwd);
     if (!packages) {
       return {};
     }
-    const filePath = context.getPhysicalFilename
-      ? context.getPhysicalFilename()
-      : context.getFilename();
+    const filePath = context.physicalFilename;
 
     const localPkg = packages.byPath(filePath);
     if (!localPkg) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3373,8 +3373,6 @@ __metadata:
     "@types/estree": "npm:^1.0.5"
     eslint: "npm:^8.57.1"
     minimatch: "npm:^10.2.1"
-  peerDependencies:
-    eslint: ^8.57.1 || ^9.0.0 || ^10.0.0
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2902,7 +2902,7 @@ __metadata:
     del: "npm:^8.0.0"
     esbuild: "npm:^0.27.0"
     esbuild-loader: "npm:^4.0.0"
-    eslint: "npm:^8.6.0"
+    eslint: "npm:^8.57.1"
     eslint-config-prettier: "npm:^9.0.0"
     eslint-formatter-friendly: "npm:^7.0.0"
     eslint-plugin-deprecation: "npm:^3.0.0"
@@ -3371,8 +3371,10 @@ __metadata:
     "@backstage/cli": "workspace:^"
     "@manypkg/get-packages": "npm:^1.1.3"
     "@types/estree": "npm:^1.0.5"
-    eslint: "npm:^8.33.0"
+    eslint: "npm:^8.57.1"
     minimatch: "npm:^10.2.1"
+  peerDependencies:
+    eslint: ^8.57.1 || ^9.0.0 || ^10.0.0
   languageName: unknown
   linkType: soft
 
@@ -30421,7 +30423,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^8.33.0, eslint@npm:^8.6.0":
+"eslint@npm:^8.57.1, eslint@npm:^8.6.0":
   version: 8.57.1
   resolution: "eslint@npm:8.57.1"
   dependencies:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Partial fix for #25542.

As upstream is moving towards [ESLInt 10](https://eslint.org/docs/next/use/migrate-to-10.0.0), we are still stuck with ESLint 8 and legacy-config format.

This PR is a first step towards supporting ESLint v9 and/or ESlint flat-configs, by bumping the required ESLint version to the ultimate v8 release, ~~adding some forward compatibility to `@backstage/cli`~~ and declaring flat-config support for `@backstage/eslint-plugin`.

- Require `eslint@8.57.1.` for `@backstage/cli` & `@backstage/eslint-plugin`
  - This is the ultimate v8 release with all the bugfixes & some forward-compatibility helpers
- Migrate some [deprecated](https://github.com/eslint/eslint/issues/16999) functions in `@backstage/eslint-plugin`
  - `context.getCwd()` -> `context.cwd`
  - `context.getPhysicalFilename()` -> `context.physicalFilename`
- ~~Experimental v9 support for `@backstage/cli`~~
  - => Removed, will be in a subsequent PR  
  - By using the `loadESLint` available in v8.57 and v9, the Backstage CLI can work with both versions (still using the old config format)
  - This was purposefully not reflect in the range of dependencies. v9 loads flat-config by default, so all direct calls to ESLint (e.g. IDE, `lint-staged`, probably some CIs) would need to be updated with `ESLINT_USE_FLAT_CONFIG=false`.
  - This is an annoying breaking changes for users, especially as we will need to support the flat-config soon, which will be another annoying but necessary breaking change.
  - To try ESLint v9 (experimental), you should set a Yarn resolution and update all your eslint direct calls e.g.
     ```diff
           "lint-staged": {
              "*.{js,jsx,ts,tsx,mjs,cjs}": [
                 - "eslint --fix",
                 + "cross-env ESLINT_USE_FLAT_CONFIG=false eslint --fix",
                "prettier --write"
              ],
     },
     ```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
