### PR TITLE
codeowners - Adjusted so that Vale/Microsite PRs aren't blocked by Docs Maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,7 +10,7 @@ yarn.lock                                         @backstage/maintainers @backst
 /.changeset                                       @backstage/operations-maintainers
 /.changeset/*.md
 /.github                                          @backstage/operations-maintainers
-/.github/vale                                     @backstage/documentation-maintainers
+/.github/vale                                     @backstage/maintainers @backstage/documentation-maintainers
 /.patches                                         @backstage/operations-maintainers
 /beps/0001-notifications-system                   @backstage/maintainers @backstage/notifications-maintainers
 /docs                                             @backstage/maintainers @backstage/documentation-maintainers
@@ -25,7 +25,7 @@ yarn.lock                                         @backstage/maintainers @backst
 /docs/plugins/integrating-search-into-plugins.md  @backstage/search-maintainers
 /docs/releases                                    @backstage/operations-maintainers
 /docs/tooling                                     @backstage/tooling-maintainers
-/microsite                                        @backstage/documentation-maintainers
+/microsite                                        @backstage/maintainers @backstage/documentation-maintainers
 /microsite/data/plugins                           @backstage/maintainers
 /microsite/static                                 @backstage/maintainers @backstage/documentation-maintainers
 /packages                                         @backstage/framework-maintainers


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adjusted `CODEOWNERS` file so that Vale/Microsite PRs aren't blocked by Docs Maintainers

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
