### PR TITLE
fix(repo-tools): Invalid --help for backstage-repo-tools package scema generate --help

### DIFF
--- a/.changeset/slow-bobcats-lose.md
+++ b/.changeset/slow-bobcats-lose.md
@@ -1,0 +1,5 @@
+---
+'@backstage/repo-tools': patch
+---
+
+Fixed help text for `backstage-repo-tools package schema openapi generate` command.

--- a/packages/repo-tools/cli-report.md
+++ b/packages/repo-tools/cli-report.md
@@ -160,7 +160,11 @@ Options:
 Usage: backstage-repo-tools package schema openapi generate [options]
 
 Options:
+  --client-additional-properties [properties]
   --client-package [package]
+  --server
+  --server-additional-properties [properties]
+  --watch
   -h, --help
 ```
 

--- a/packages/repo-tools/src/commands/index.ts
+++ b/packages/repo-tools/src/commands/index.ts
@@ -44,24 +44,26 @@ function registerPackageCommand(program: Command) {
 
   openApiCommand
     .command('generate')
+    .description(
+      'Command to generate a client and/or a server stub from an OpenAPI spec.',
+    )
     .option(
       '--client-package [package]',
       'Top-level path to where the client should be generated, ie packages/catalog-client.',
     )
-    .option('--server')
-    .description(
-      'Command to generate a client and/or a server stub from an OpenAPI spec.',
-    )
-    .option('--client-additional-properties [properties]')
-    .description(
+    .option('--server', 'Generate server stub')
+    .option(
+      '--client-additional-properties [properties]',
       'Additional properties that can be passed to @openapitools/openapi-generator-cli',
     )
-    .option('--server-additional-properties [properties]')
-    .description(
+    .option(
+      '--server-additional-properties [properties]',
       'Additional properties that can be passed to @openapitools/openapi-generator-cli',
     )
-    .option('--watch')
-    .description('Watch the OpenAPI spec for changes and regenerate on save.')
+    .option(
+      '--watch',
+      'Watch the OpenAPI spec for changes and regenerate on save.',
+    )
     .action(lazy(() => import('./package/schema/openapi/generate'), 'command'));
 
   openApiCommand


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix #32304 

Before:
```
❯ yarn backstage-repo-tools package schema openapi generate --help
Usage: backstage-repo-tools package schema openapi generate [options]

Watch the OpenAPI spec for changes and regenerate on save.

Options:
  --client-package [package]                   Top-level path to where the client should be generated, ie packages/catalog-client.
  --server
  --client-additional-properties [properties]
  --server-additional-properties [properties]
  --watch
  -h, --help                                   display help for command
```

After
```
❯ yarn backstage-repo-tools package schema openapi generate --help
Usage: backstage-repo-tools package schema openapi generate [options]

Command to generate a client and/or a server stub from an OpenAPI spec.

Options:
  --client-package [package]                   Top-level path to where the client should be generated, ie packages/catalog-client.
  --server                                     Generate server stub
  --client-additional-properties [properties]  Additional properties that can be passed to @openapitools/openapi-generator-cli
  --server-additional-properties [properties]  Additional properties that can be passed to @openapitools/openapi-generator-cli
  --watch                                      Watch the OpenAPI spec for changes and regenerate on save.
  -h, --help                                   display help for command
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
