### PR TITLE
Upgrade `zod-validation-error` to version 4

### DIFF
--- a/.changeset/sour-mails-smoke.md
+++ b/.changeset/sour-mails-smoke.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-auth-node': patch
+'@backstage/cli': patch
+---
+
+Upgrade `zod-validation-error` to version 4

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -143,7 +143,7 @@
     "yml-loader": "^2.1.0",
     "yn": "^4.0.0",
     "zod": "^3.22.4",
-    "zod-validation-error": "^3.4.0"
+    "zod-validation-error": "^4.0.2"
   },
   "devDependencies": {
     "@backstage/backend-plugin-api": "workspace:^",

--- a/packages/cli/src/modules/new/lib/preparation/loadPortableTemplate.ts
+++ b/packages/cli/src/modules/new/lib/preparation/loadPortableTemplate.ts
@@ -28,7 +28,7 @@ import {
 } from '../types';
 import { PortableTemplate } from '../types';
 import { ForwardedError } from '@backstage/errors';
-import { fromZodError } from 'zod-validation-error';
+import { fromZodError } from 'zod-validation-error/v3';
 
 const templateDefinitionSchema = z
   .object({

--- a/packages/cli/src/modules/new/lib/preparation/loadPortableTemplateConfig.ts
+++ b/packages/cli/src/modules/new/lib/preparation/loadPortableTemplateConfig.ts
@@ -25,7 +25,7 @@ import {
 } from '../types';
 import { parse as parseYaml } from 'yaml';
 import { z } from 'zod';
-import { fromZodError } from 'zod-validation-error';
+import { fromZodError } from 'zod-validation-error/v3';
 import { ForwardedError } from '@backstage/errors';
 
 const defaults = {

--- a/plugins/auth-node/package.json
+++ b/plugins/auth-node/package.json
@@ -52,7 +52,7 @@
     "passport": "^0.7.0",
     "zod": "^3.22.4",
     "zod-to-json-schema": "^3.25.1",
-    "zod-validation-error": "^3.4.0"
+    "zod-validation-error": "^4.0.2"
   },
   "devDependencies": {
     "@backstage/backend-defaults": "workspace:^",

--- a/plugins/auth-node/src/sign-in/createSignInResolverFactory.ts
+++ b/plugins/auth-node/src/sign-in/createSignInResolverFactory.ts
@@ -18,7 +18,7 @@ import { ZodSchema, ZodTypeDef } from 'zod';
 import { SignInResolver } from '../types';
 import zodToJsonSchema from 'zod-to-json-schema';
 import { JsonObject } from '@backstage/types';
-import { fromError } from 'zod-validation-error';
+import { fromError } from 'zod-validation-error/v3';
 import { InputError } from '@backstage/errors';
 
 /** @public */

--- a/yarn.lock
+++ b/yarn.lock
@@ -3415,7 +3415,7 @@ __metadata:
     yml-loader: "npm:^2.1.0"
     yn: "npm:^4.0.0"
     zod: "npm:^3.22.4"
-    zod-validation-error: "npm:^3.4.0"
+    zod-validation-error: "npm:^4.0.2"
   peerDependencies:
     "@jest/environment-jsdom-abstract": ^30.0.0
     "@module-federation/enhanced": ^0.9.0
@@ -4697,7 +4697,7 @@ __metadata:
     uuid: "npm:^11.0.0"
     zod: "npm:^3.22.4"
     zod-to-json-schema: "npm:^3.25.1"
-    zod-validation-error: "npm:^3.4.0"
+    zod-validation-error: "npm:^4.0.2"
   languageName: unknown
   linkType: soft
 
@@ -51127,12 +51127,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod-validation-error@npm:^3.4.0":
-  version: 3.5.4
-  resolution: "zod-validation-error@npm:3.5.4"
+"zod-validation-error@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "zod-validation-error@npm:4.0.2"
   peerDependencies:
-    zod: ^3.24.4
-  checksum: 10/eb85392e6fd7af255fb233713b1f038134e66cbaff20d1a52d46bd4210fe7b776d48d7dd2170095fbd2b375f6c41d629109bd5eac245c576083c9cf6e131a20b
+    zod: ^3.25.0 || ^4.0.0
+  checksum: 10/5e35ca8ebb4602dcb526e122d7e9fca695c4a479bd97535f3400a732d49160f24f7213a9ed64986fc9dc3a2e8a6c4e1241ec0c4d8a4e3e69ea91a0328ded2192
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Upgrades `zod-validation-error` to version 4, and updates all imports to remain compatible with version 3 of Zod. See #30607 for more details.