### PR TITLE
fix(changelog): fix radio-group component name

### DIFF
--- a/docs-ui/src/utils/changelogs/v0.9.0.ts
+++ b/docs-ui/src/utils/changelogs/v0.9.0.ts
@@ -288,7 +288,7 @@ export const changelog_0_9_0: ChangelogProps[] = [
     commitSha: '3c0ea67',
   },
   {
-    components: ['radiogroup'],
+    components: ['radio-group'],
     version: '0.9.0',
     prs: ['31576'],
     description: `Fixed RadioGroup radio button ellipse distortion by preventing flex shrink and grow.`,


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Quick fix to the Backstage UI docs changelog, a change in v9.0.0 had an incorrect component name which caused it to not appear on the docs page.
Before:
<img width="1320" height="463" alt="image" src="https://github.com/user-attachments/assets/112af9ff-e315-4388-bbd8-8ad6649f4145" />
After:
<img width="1320" height="463" alt="image" src="https://github.com/user-attachments/assets/0fd8e3d4-2149-4e39-add4-6dc0e25fca80" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
