### PR TITLE
docs: Backstage is an ~~application~~ framework

### DIFF
--- a/docs/faq/technical.md
+++ b/docs/faq/technical.md
@@ -7,7 +7,7 @@ description: General technical questions about Backstage.
 ### What technology does Backstage use?
 
 Backstage is a large scale [TypeScript](https://www.typescriptlang.org/)
-application whose frontend parts use [React](https://react.dev/) and
+framework whose frontend parts use [React](https://react.dev/) and
 [Material UI](https://material-ui.com/), while the backend parts use
 [Node.js](https://nodejs.org/) and the [Express](https://expressjs.com/)
 framework.


### PR DESCRIPTION
The very [first question in the Technical FAQ](https://backstage.io/docs/faq/technical/#what-technology-does-backstage-use) says that "Backstage is a large scale TypeScript **application**".

Claiming that "Backstage is an application" is a misleading information that brings a lot of confusion.

I see both tech and non-tech people sometimes thinking that "deploying a Backstage" is a thing. Clearly lacking the understanding that "building a portal with Backstage" is the realistic view.

This PR simply replaces ~~application~~ with **framework**.