### PR TITLE
fix(ui): add missing aria-label to SearchField components

### DIFF
--- a/.changeset/bumpy-carrots-stare.md
+++ b/.changeset/bumpy-carrots-stare.md
@@ -1,0 +1,7 @@
+---
+'@backstage/ui': patch
+---
+
+Added missing `aria-label` attributes to `SearchField` components in `Select`, `MenuAutocomplete`, and `MenuAutocompleteListbox` to fix accessibility warnings.
+
+Affected components: Select, MenuAutocomplete, MenuAutocompleteListbox

--- a/packages/ui/src/components/Menu/Menu.tsx
+++ b/packages/ui/src/components/Menu/Menu.tsx
@@ -255,13 +255,13 @@ export const MenuAutocomplete = (props: MenuAutocompleteProps<object>) => {
               classNames.searchField,
               styles[classNames.searchField],
             )}
+            aria-label={props.placeholder || 'Search'}
           >
             <RAInput
               className={clsx(
                 classNames.searchFieldInput,
                 styles[classNames.searchFieldInput],
               )}
-              aria-label="Search"
               placeholder={props.placeholder || 'Search...'}
             />
             <RAButton
@@ -334,13 +334,13 @@ export const MenuAutocompleteListbox = (
             classNames.searchField,
             styles[classNames.searchField],
           )}
+          aria-label={props.placeholder || 'Search'}
         >
           <RAInput
             className={clsx(
               classNames.searchFieldInput,
               styles[classNames.searchFieldInput],
             )}
-            aria-label="Search"
             placeholder={props.placeholder || 'Search...'}
           />
           <RAButton

--- a/packages/ui/src/components/Select/SelectContent.tsx
+++ b/packages/ui/src/components/Select/SelectContent.tsx
@@ -55,6 +55,7 @@ export function SelectContent({
           classNames.searchWrapper,
           styles[classNames.searchWrapper],
         )}
+        aria-label={searchPlaceholder}
       >
         <Input
           placeholder={searchPlaceholder}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add `aria-label` attributes to `SearchField` components to fix
accessibility warnings from React Aria.

- **Select**: add aria-label to SearchField using searchPlaceholder
- **MenuAutocomplete**: add aria-label to RASearchField, remove
  redundant aria-label from RAInput
- **MenuAutocompleteListbox**: same as MenuAutocomplete

Per React Aria docs, aria-label should be on SearchField, not
the child Input.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.