### PR TITLE
frontend-app-api: restrict the ability for plugins to override APIs

### DIFF
--- a/.changeset/busy-hairs-attend.md
+++ b/.changeset/busy-hairs-attend.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': patch
+---
+
+Updated documentation for `createApiRef` to clarify the role of the ID in specifying the owning plugin of an API.

--- a/.changeset/quiet-coins-protect.md
+++ b/.changeset/quiet-coins-protect.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-app-api': minor
+---
+
+BREAKING: The ability for plugins to override APIs has been restricted to only allow overrides of APIs within the same plugin. For example, a plugin can no longer override any of the core APIs provided by the `app` plugin, this must be done with an `app` module instead.

--- a/docs/frontend-system/building-plugins/01-index.md
+++ b/docs/frontend-system/building-plugins/01-index.md
@@ -124,7 +124,7 @@ export interface ExampleApi {
 }
 
 export const exampleApiRef = createApiRef<ExampleApi>({
-  id: 'plugin.example',
+  id: 'plugin.example.api',
 });
 
 export class DefaultExampleApi implements ExampleApi {

--- a/docs/frontend-system/utility-apis/02-creating.md
+++ b/docs/frontend-system/utility-apis/02-creating.md
@@ -36,6 +36,9 @@ export const workApiRef = createApiRef<WorkApi>({
 
 Both of these are properly exported publicly from the package, so that consumers can reach them.
 
+The frontend system infers the owning plugin for an API from the `ApiRef` id, so
+use the pattern `plugin.<plugin-id>.*` to make ownership explicit. This ensures that other plugins can't mistakenly override your API.
+
 ## Providing an extension through your plugin
 
 The plugin itself now wants to provide this API and its default implementation, in the form of an API extension. Doing so means that when users install the Example plugin, an instance of the Work utility API will also be automatically available in their apps - both to the Example plugin itself, and to others. We do this in the main plugin package, not the `-react` package.

--- a/docs/frontend-system/utility-apis/04-configuring.md
+++ b/docs/frontend-system/utility-apis/04-configuring.md
@@ -36,6 +36,8 @@ Well written input-enabled extension often have extension creator functions that
 
 Like with other extension types, you replace Utility APIs with your own custom implementation using [extension overrides](../architecture/25-extension-overrides.md).
 
+Note that it is only possible to override a Utility API using a module for the plugin that originally provided the API. Attempting to override an API using a different plugin or module for a different plugin will result in a conflict error.
+
 ```tsx title="in your app"
 /* highlight-add-start */
 import { createFrontendModule } from '@backstage/frontend-plugin-api';

--- a/packages/frontend-app-api/report.api.md
+++ b/packages/frontend-app-api/report.api.md
@@ -109,6 +109,14 @@ export type AppErrorTypes = {
       node: AppNode;
     };
   };
+  API_FACTORY_CONFLICT: {
+    context: {
+      node: AppNode;
+      apiRefId: string;
+      pluginId: string;
+      existingPluginId: string;
+    };
+  };
   ROUTE_DUPLICATE: {
     context: {
       routeId: string;

--- a/packages/frontend-app-api/src/wiring/createErrorCollector.ts
+++ b/packages/frontend-app-api/src/wiring/createErrorCollector.ts
@@ -66,6 +66,14 @@ export type AppErrorTypes = {
   API_EXTENSION_INVALID: {
     context: { node: AppNode };
   };
+  API_FACTORY_CONFLICT: {
+    context: {
+      node: AppNode;
+      apiRefId: string;
+      pluginId: string;
+      existingPluginId: string;
+    };
+  };
   // routing
   ROUTE_DUPLICATE: {
     context: { routeId: string };

--- a/packages/frontend-app-api/src/wiring/createSpecializedApp.test.tsx
+++ b/packages/frontend-app-api/src/wiring/createSpecializedApp.test.tsx
@@ -20,7 +20,9 @@ import {
   coreExtensionData,
   createExtension,
   createFrontendPlugin,
+  createFrontendModule,
   ApiBlueprint,
+  createApiRef,
   createRouteRef,
   createExternalRouteRef,
   createExtensionInput,
@@ -36,21 +38,22 @@ import { MemoryRouter } from 'react-router-dom';
 import { ApiProvider, ConfigReader } from '@backstage/core-app-api';
 import { Fragment } from 'react';
 
+function makeAppPlugin(label: string = 'Test') {
+  return createFrontendPlugin({
+    pluginId: 'app',
+    extensions: [
+      createExtension({
+        attachTo: { id: 'root', input: 'app' },
+        output: [coreExtensionData.reactElement],
+        factory: () => [coreExtensionData.reactElement(<div>{label}</div>)],
+      }),
+    ],
+  });
+}
 describe('createSpecializedApp', () => {
   it('should render the root app', () => {
     const app = createSpecializedApp({
-      features: [
-        createFrontendPlugin({
-          pluginId: 'test',
-          extensions: [
-            createExtension({
-              attachTo: { id: 'root', input: 'app' },
-              output: [coreExtensionData.reactElement],
-              factory: () => [coreExtensionData.reactElement(<div>Test</div>)],
-            }),
-          ],
-        }),
-      ],
+      features: [makeAppPlugin()],
     });
 
     render(app.tree.root.instance!.getData(coreExtensionData.reactElement));
@@ -60,32 +63,7 @@ describe('createSpecializedApp', () => {
 
   it('should deduplicate features keeping the last received one', () => {
     const app = createSpecializedApp({
-      features: [
-        createFrontendPlugin({
-          pluginId: 'test',
-          extensions: [
-            createExtension({
-              attachTo: { id: 'root', input: 'app' },
-              output: [coreExtensionData.reactElement],
-              factory: () => [
-                coreExtensionData.reactElement(<div>Test 1</div>),
-              ],
-            }),
-          ],
-        }),
-        createFrontendPlugin({
-          pluginId: 'test',
-          extensions: [
-            createExtension({
-              attachTo: { id: 'root', input: 'app' },
-              output: [coreExtensionData.reactElement],
-              factory: () => [
-                coreExtensionData.reactElement(<div>Test 2</div>),
-              ],
-            }),
-          ],
-        }),
-      ],
+      features: [makeAppPlugin('Test 1'), makeAppPlugin('Test 2')],
     });
 
     render(app.tree.root.instance!.getData(coreExtensionData.reactElement));
@@ -249,8 +227,9 @@ describe('createSpecializedApp', () => {
 
     const app = createSpecializedApp({
       features: [
-        createFrontendPlugin({
-          pluginId: 'first',
+        makeAppPlugin(),
+        createFrontendModule({
+          pluginId: 'app',
           extensions: [
             ApiBlueprint.make({
               params: defineParams =>
@@ -264,9 +243,8 @@ describe('createSpecializedApp', () => {
             }),
           ],
         }),
-        createFrontendPlugin({
-          pluginId: 'test',
-          featureFlags: [{ name: 'a' }, { name: 'b' }],
+        createFrontendModule({
+          pluginId: 'app',
           extensions: [
             createExtension({
               attachTo: { id: 'root', input: 'app' },
@@ -309,6 +287,107 @@ describe('createSpecializedApp', () => {
     render(app.tree.root.instance!.getData(coreExtensionData.reactElement));
 
     expect(mockAnalyticsApi).toHaveBeenCalled();
+  });
+
+  it('should select the API factory from the owning plugin on conflict', () => {
+    const testApiRef = createApiRef<{ value: string }>({ id: 'test.api' });
+
+    const app = createSpecializedApp({
+      features: [
+        makeAppPlugin(),
+        createFrontendPlugin({
+          pluginId: 'other-before',
+          extensions: [
+            ApiBlueprint.make({
+              params: defineParams =>
+                defineParams({
+                  api: testApiRef,
+                  deps: {},
+                  factory: () => ({ value: 'other' }),
+                }),
+            }),
+          ],
+        }),
+        createFrontendPlugin({
+          pluginId: 'test',
+          extensions: [
+            ApiBlueprint.make({
+              params: defineParams =>
+                defineParams({
+                  api: testApiRef,
+                  deps: {},
+                  factory: () => ({ value: 'owner' }),
+                }),
+            }),
+          ],
+        }),
+        createFrontendPlugin({
+          pluginId: 'other-after',
+          extensions: [
+            ApiBlueprint.make({
+              params: defineParams =>
+                defineParams({
+                  api: testApiRef,
+                  deps: {},
+                  factory: () => ({ value: 'other' }),
+                }),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    expect(app.errors).toEqual([
+      expect.objectContaining({
+        code: 'API_FACTORY_CONFLICT',
+        message: expect.stringContaining("API 'test.api'"),
+      }),
+      expect.objectContaining({
+        code: 'API_FACTORY_CONFLICT',
+        message: expect.stringContaining("API 'test.api'"),
+      }),
+    ]);
+
+    expect(app.apis.get(testApiRef)).toEqual({ value: 'owner' });
+  });
+
+  it('should allow API overrides within the same plugin', () => {
+    const testApiRef = createApiRef<{ value: string }>({ id: 'test.api' });
+
+    const app = createSpecializedApp({
+      features: [
+        makeAppPlugin(),
+        createFrontendPlugin({
+          pluginId: 'test',
+          extensions: [
+            ApiBlueprint.make({
+              params: defineParams =>
+                defineParams({
+                  api: testApiRef,
+                  deps: {},
+                  factory: () => ({ value: 'plugin' }),
+                }),
+            }),
+          ],
+        }),
+        createFrontendModule({
+          pluginId: 'test',
+          extensions: [
+            ApiBlueprint.make({
+              params: defineParams =>
+                defineParams({
+                  api: testApiRef,
+                  deps: {},
+                  factory: () => ({ value: 'module' }),
+                }),
+            }),
+          ],
+        }),
+      ],
+    });
+
+    expect(app.errors).toBeUndefined();
+    expect(app.apis.get(testApiRef)).toEqual({ value: 'module' });
   });
 
   it('should use provided apis', async () => {

--- a/packages/frontend-plugin-api/src/apis/system/ApiRef.ts
+++ b/packages/frontend-plugin-api/src/apis/system/ApiRef.ts
@@ -53,7 +53,15 @@ class ApiRefImpl<T> implements ApiRef<T> {
 }
 
 /**
- * Creates a reference to an API.
+ * Creates a reference to an API. The provided `id` is a stable identifier for
+ * the API implementation.
+ *
+ * @remarks
+ *
+ * The frontend system infers the owning plugin for an API from the `id`. The
+ * recommended pattern is `plugin.<plugin-id>.*` (for example,
+ * `plugin.catalog.entity-presentation`). This ensures that other plugins can't
+ * mistakenly override your API implementation.
  *
  * @param config - The descriptor of the API to reference.
  * @returns An API reference.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This restricts the ability to override API factories to plugin modules. If an API is provided by a plugin, no other plugin can provide the same API again, but modules for that plugin can still override the API. This has the biggest impact for core APIs and is the way it worked in the old frontend system. For example, plugins in the new frontend system could override things like the `AlertApi`, which is not what we intended. This was an oversight in carrying over the Utility API system from the old frontend system to the new.

I think we ship this as an immediate breaking change because very few plugins should be doing this and I think it's best to be a bit aggressive in the removal of this ability, as it was never intended in the first place.

The main tricky bit in this change is how we assign APIs to specific plugins. This has become a bigger problem because of the introduction of the `app` plugin as the way we ship default core functionality. In the old system all the core APIs were provided by the framework, but now they're just provided by another plugin that follows the same rules as the rest. I settled on parsing the API reference ID as that requires the fewest changes to existing code, but open to other suggestions.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
