### PR TITLE
Fix ItemCardHeader colour token again

### DIFF
--- a/.changeset/good-chicken-check.md
+++ b/.changeset/good-chicken-check.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Update colour token again in ItemCardHeader to respect theme definition.

--- a/packages/core-components/src/layout/ItemCard/ItemCardHeader.tsx
+++ b/packages/core-components/src/layout/ItemCard/ItemCardHeader.tsx
@@ -30,7 +30,7 @@ export type ItemCardHeaderClassKey = 'root';
 const styles = (theme: Theme) =>
   createStyles({
     root: {
-      color: theme.palette.text.primary,
+      color: theme.getPageTheme({ themeId: 'card' }).fontColor,
       padding: theme.spacing(2, 2, 3),
       backgroundImage: theme.getPageTheme({ themeId: 'card' }).backgroundImage,
       backgroundPosition: 0,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Follow up to https://github.com/backstage/backstage/pull/31203, specifically addressing https://github.com/backstage/backstage/pull/31203#issuecomment-3611831218.

The previous change didn't take into account the card background images when setting the text colour, causing the text to change colour between light & dark mode when it was supposed to stay the same. This implements the desired behaviour from the last PR more favourably by using the theme to determine the text colour as well as the background.

| Before    | After |
| -------- | ------- |
| <img alt="Before" src="https://github.com/user-attachments/assets/0d1a4b2d-354d-4c67-9132-e6a61ffe7f64" />  | <img  alt="After" src="https://github.com/user-attachments/assets/d933a557-e3d0-455a-8fb4-f5e666198f34" />    |

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
