### PR TITLE
Fixes Menu trigger

### DIFF
--- a/.changeset/fine-lines-warn.md
+++ b/.changeset/fine-lines-warn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed Menu component trigger button not toggling correctly. Removed custom click-outside handler that was interfering with React Aria's built-in state management, allowing the menu to properly open and close when clicking the trigger button.

--- a/packages/ui/src/components/Menu/Menu.tsx
+++ b/packages/ui/src/components/Menu/Menu.tsx
@@ -33,7 +33,6 @@ import {
   RouterProvider,
   Virtualizer,
   ListLayout,
-  OverlayTriggerStateContext,
 } from 'react-aria-components';
 import { useStyles } from '../../hooks/useStyles';
 import { MenuDefinition } from './definition';
@@ -56,7 +55,6 @@ import {
 } from '@remixicon/react';
 import { useNavigate, useHref } from 'react-router-dom';
 import { isExternalLink } from '../../utils/isExternalLink';
-import { useRef, useEffect, useContext } from 'react';
 import styles from './Menu.module.css';
 import clsx from 'clsx';
 
@@ -98,33 +96,6 @@ export const Menu = (props: MenuProps<object>) => {
 
   const navigate = useNavigate();
   let newMaxWidth = maxWidth || (virtualized ? '260px' : 'undefined');
-  const popoverRef = useRef<HTMLDivElement>(null);
-  const state = useContext(OverlayTriggerStateContext);
-
-  // Custom click-outside handler for non-modal popovers
-  useEffect(() => {
-    if (!state?.isOpen) return;
-
-    const handleClickOutside = (event: MouseEvent) => {
-      const target = event.target as Node;
-
-      // Check if click is outside the popover
-      if (popoverRef.current && !popoverRef.current.contains(target)) {
-        // Check if click is on a trigger button or submenu
-        const isOnTrigger = (target as Element).closest('[data-trigger]');
-        const isOnSubmenu = (target as Element).closest('[role="menu"]');
-
-        if (!isOnTrigger && !isOnSubmenu) {
-          state.close();
-        }
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [state]);
 
   const menuContent = (
     <RAMenu
@@ -137,15 +108,12 @@ export const Menu = (props: MenuProps<object>) => {
 
   return (
     <RAPopover
-      ref={popoverRef}
       className={clsx(
         classNames.popover,
         styles[classNames.popover],
         className,
       )}
       placement={placement}
-      isNonModal={true}
-      isKeyboardDismissDisabled={false}
     >
       <RouterProvider navigate={navigate} useHref={useHref}>
         {virtualized ? (


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Bypassing the default popover setup created unexpected behaviours and potentially had an impact on screen readers. To avoid that, this reverts back to the default React Aria behaviour where `isNonModal` is undefined.

We previously tried to set the menu as non-modal to avoid layout shifts. React Aria recommends to keep setting it up as modal as this will guarantee full accessibility.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
