### PR TITLE
Fix silent orphan cleanup failure caused by unhandled Promise rejection

### DIFF
--- a/plugins/catalog-backend/src/processing/DefaultCatalogProcessingEngine.ts
+++ b/plugins/catalog-backend/src/processing/DefaultCatalogProcessingEngine.ts
@@ -118,7 +118,7 @@ export class DefaultCatalogProcessingEngine {
     }
 
     const stopPipeline = this.startPipeline();
-    const stopCleanup = this.startOrphanCleanup();
+    const stopCleanup = await this.startOrphanCleanup();
 
     this.stopFunc = () => {
       stopPipeline();
@@ -347,7 +347,7 @@ export class DefaultCatalogProcessingEngine {
     });
   }
 
-  private startOrphanCleanup(): () => void {
+  private async startOrphanCleanup(): Promise<() => void> {
     const orphanStrategy =
       this.config.getOptionalString('catalog.orphanStrategy') ?? 'delete';
     if (orphanStrategy !== 'delete') {
@@ -371,7 +371,7 @@ export class DefaultCatalogProcessingEngine {
     };
 
     const abortController = new AbortController();
-    this.scheduler.scheduleTask({
+    await this.scheduler.scheduleTask({
       id: 'catalog_orphan_cleanup',
       frequency: { milliseconds: this.orphanCleanupIntervalMs },
       timeout: { milliseconds: this.orphanCleanupIntervalMs * 0.8 },


### PR DESCRIPTION
### Summary
This PR fixes a lifecycle bug in the catalog processing engine where orphan cleanup could silently fail during backend startup.

The orphan cleanup task was being scheduled asynchronously without awaiting the result. If task scheduling failed (e.g. due to database unavailability), the Promise rejection was unhandled, backend startup still reported success, and orphan cleanup was permanently disabled with no indication.

This change makes orphan cleanup scheduling part of the startup contract so failures are surfaced immediately and startup fails fast.

---

### Problem
`startOrphanCleanup()` was synchronous but invoked the async `scheduler.scheduleTask()` without awaiting it.

If `scheduleTask()` failed due to:
- database connection failure
- task persistence failure
- invalid task ID validation

the error became an unhandled Promise rejection that:
- was not propagated to `engine.start()`
- did not fail backend startup
- left orphan cleanup permanently disabled
- produced no clear error or signal to operators

This resulted in orphaned catalog entities accumulating indefinitely.

---

### Impact
- Orphaned entities are never cleaned up
- `final_entities` table grows without bound
- Catalog queries return stale / phantom entities
- Search indexes become polluted
- Data integrity degrades over time with no alerting

This affects all production Backstage instances using  
`catalog.orphanStrategy: delete`.

---

### Fix
- Converted `startOrphanCleanup()` to an async method
- Awaited `scheduler.scheduleTask()` during initialization
- Updated `start()` to await orphan cleanup startup

This ensures that:
- Startup fails fast if orphan cleanup cannot be scheduled
- Errors are properly propagated and visible
- Unhandled Promise rejections are eliminated
- Orphan cleanup cannot silently fail

---

### Code Changes
- `startOrphanCleanup()` is now `async`
- `scheduler.scheduleTask()` is awaited
- `engine.start()` awaits orphan cleanup initialization

---

### Steps to Reproduce (Before Fix)
1. Deploy Backstage with PostgreSQL
2. Configure an entity provider (e.g. GitHub)
3. Make the database temporarily unavailable during backend startup
4. Backend reports successful startup
5. `catalog_orphan_cleanup` task is never created
6. Remove entities from the source
7. Wait for multiple refresh cycles
8. Orphaned entities still appear in the catalog

---

### Behavior After Fix
- Backend startup fails immediately if orphan cleanup cannot be scheduled
- Clear error is surfaced to the caller
- Orphan cleanup is guaranteed to be active when startup succeeds
- Catalog data integrity is preserved over time

---

### Why This Matters
Orphan cleanup is a correctness-critical subsystem when `orphanStrategy: delete` is enabled.  
Failing fast is preferable to silently corrupting catalog data and accumulating stale entities in production.

---

### Checklist
- [x] Fix eliminates unhandled Promise rejection
- [x] Startup lifecycle correctly propagates failures
- [x] No behavior change when scheduler succeeds
- [x] Prevents silent catalog corruption

