### PR TITLE
 Fix: Stop execution after OAuth token refresh rejection

### DIFF
--- a/plugins/auth-node/src/passport/PassportHelpers.ts
+++ b/plugins/auth-node/src/passport/PassportHelpers.ts
@@ -199,6 +199,7 @@ export class PassportHelpers {
         ) => {
           if (err) {
             reject(new ForwardedError(`Failed to refresh access token`, err));
+            return;
           }
           if (!accessToken) {
             reject(
@@ -206,6 +207,7 @@ export class PassportHelpers {
                 `Failed to refresh access token, no access token received`,
               ),
             );
+            return;
           }
 
           resolve({


### PR DESCRIPTION
### Summary
This PR fixes a control-flow bug in the OAuth token refresh logic where execution continued after calling `reject()`, allowing the code path to reach `resolve()` with potentially invalid data.

While JavaScript Promises only settle once, continuing execution after a rejection is incorrect and can lead to misleading logs, unclear error attribution, and unsafe assumptions in a security-critical authentication flow.

This change ensures execution halts immediately after an error during token refresh.

---

### 📍 Affected Code
- **File:** `plugins/auth-node/src/passport/PassportHelpers.ts`
- **Function:** `executeRefreshTokenStrategy`

---

### ❌ Problem
In the OAuth refresh callback, `reject()` was called without returning:

```ts
if (err) {
  reject(new ForwardedError(`Failed to refresh access token`, err));
}

if (!accessToken) {
  reject(new Error(`Failed to refresh access token, no access token received`));
}

resolve({ accessToken, refreshToken: newRefreshToken, params });
