### PR TITLE
Doc fix: Updated CircleCI plugin reference link in the "Phase 2 Service Catalog" documentation

### DIFF
--- a/microsite/blog/2020-05-22-phase-2-service-catalog.mdx
+++ b/microsite/blog/2020-05-22-phase-2-service-catalog.mdx
@@ -39,7 +39,7 @@ On top of that, we have found that the service catalog is a great way to organis
 
 ![img](assets/20-05-20/tabs.png)
 
-More concretely, having this structure in place will allow plugins such as [CircleCI](https://github.com/backstage/backstage/tree/master/plugins/circleci) to show only the builds for the specific service you are viewing, or a [Spinnaker](https://github.com/backstage/backstage/issues/631) plugin to show running deployments, or an Open API plugin to [show documentation](https://github.com/backstage/backstage/issues/627) for endpoints exposed by the service, or the [Lighthouse](https://github.com/backstage/community-plugins/tree/main/workspaces/lighthouse/plugins/lighthouse) plugin to show audit reports for your website. You get the point.
+More concretely, having this structure in place will allow plugins such as [CircleCI](https://github.com/CircleCI-Public/backstage-plugin/tree/main/plugins/circleci) to show only the builds for the specific service you are viewing, or a [Spinnaker](https://github.com/backstage/backstage/issues/631) plugin to show running deployments, or an Open API plugin to [show documentation](https://github.com/backstage/backstage/issues/627) for endpoints exposed by the service, or the [Lighthouse](https://github.com/backstage/community-plugins/tree/main/workspaces/lighthouse/plugins/lighthouse) plugin to show audit reports for your website. You get the point.
 
 ## Timeline
 


### PR DESCRIPTION
Updated the CircleCI plugin reference link in the "Phase 2 Service Catalog" documentation inside 2020-05-22-phase-2-service-catalog.mdx file to ensure it points to the correct CircleCI plugin location.
<img width="1438" height="903" alt="image" src="https://github.com/user-attachments/assets/999055b3-4f68-4824-a025-7d799870f631" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
