### PR TITLE
doc: fix README link in getting-involved.md documentation

### DIFF
--- a/docs/contribute/getting-involved.md
+++ b/docs/contribute/getting-involved.md
@@ -40,7 +40,7 @@ Docs are published to [backstage.io/docs](https://backstage.io/docs). If you
 contribute to the documentation, you might want to preview your changes before
 submitting them. You'll find the website sources under [/microsite](https://github.com/backstage/backstage/tree/master/microsite)
 with instructions for building and locally serving the website in the
-[README](/microsite#readme).
+[README](https://github.com/backstage/backstage/blob/master/microsite/README.md).
 
 For additional information and helpful guidelines on how to contribute to the documentation, check out these [Documentation Guidelines](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#documentation-guidelines)!
 


### PR DESCRIPTION

<img width="1605" height="937" alt="image" src="https://github.com/user-attachments/assets/fc860c07-0bfe-4318-9003-a07d26fc2cb2" />

Updated an outdated README reference link in the Getting Involved documentation to ensure contributors are directed to the correct resource.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
