### PR TITLE
fix(ui): add missing cell styles to table selection column

### DIFF
--- a/.changeset/stupid-words-fail.md
+++ b/.changeset/stupid-words-fail.md
@@ -1,0 +1,7 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed missing border styles on table selection cells in multi-select mode.
+
+Affected components: Table

--- a/packages/ui/src/components/Table/components/Row.tsx
+++ b/packages/ui/src/components/Table/components/Row.tsx
@@ -47,6 +47,7 @@ export function Row<T extends object>(props: RowProps<T>) {
         <ReactAriaCell
           className={clsx(
             classNames.cellSelection,
+            styles[classNames.cell],
             styles[classNames.cellSelection],
           )}
         >


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The selection cell in multi-select tables was missing the base cell styles, causing border styling to be incomplete. This adds the `cell` class alongside the `cellSelection` class to ensure proper styling.

Before this fix, this is what it looked like:
<img width="400" height="206" alt="image" src="https://github.com/user-attachments/assets/66cbda88-ed55-4c3e-b7e2-4d7eedebccf6" />


#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.