### PR TITLE
ui: add indeterminate state to Checkbox component

### DIFF
--- a/.changeset/brown-grapes-fry.md
+++ b/.changeset/brown-grapes-fry.md
@@ -1,0 +1,7 @@
+---
+'@backstage/ui': patch
+---
+
+Added indeterminate state support to the Checkbox component for handling partial selection scenarios like table header checkboxes.
+
+Affected components: Checkbox

--- a/packages/ui/report.api.md
+++ b/packages/ui/report.api.md
@@ -460,6 +460,7 @@ export const CheckboxDefinition: {
   };
   readonly dataAttributes: {
     readonly selected: readonly [true, false];
+    readonly indeterminate: readonly [true, false];
   };
 };
 

--- a/packages/ui/src/components/Checkbox/Checkbox.module.css
+++ b/packages/ui/src/components/Checkbox/Checkbox.module.css
@@ -62,7 +62,14 @@
       color: var(--bui-fg-solid);
     }
 
-    .bui-Checkbox[data-hovered]:not([data-selected]) & {
+    .bui-Checkbox[data-indeterminate] & {
+      background-color: var(--bui-bg-surface-1);
+      box-shadow: inset 0 0 0 1px var(--bui-border);
+      color: var(--bui-fg-primary);
+    }
+
+    .bui-Checkbox[data-hovered]:not([data-selected]):not([data-indeterminate])
+      & {
       box-shadow: inset 0 0 0 1px var(--bui-border-hover);
     }
 

--- a/packages/ui/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/ui/src/components/Checkbox/Checkbox.stories.tsx
@@ -28,15 +28,26 @@ export const Default = meta.story({
   },
 });
 
+export const Indeterminate = meta.story({
+  args: {
+    children: 'Select all',
+    isIndeterminate: true,
+  },
+});
+
 export const AllVariants = meta.story({
   ...Default.input,
   render: () => (
     <Flex direction="column" gap="2">
       <Checkbox>Unchecked</Checkbox>
       <Checkbox isSelected>Checked</Checkbox>
+      <Checkbox isIndeterminate>Indeterminate</Checkbox>
       <Checkbox isDisabled>Disabled</Checkbox>
       <Checkbox isSelected isDisabled>
         Checked & Disabled
+      </Checkbox>
+      <Checkbox isIndeterminate isDisabled>
+        Indeterminate & Disabled
       </Checkbox>
     </Flex>
   ),

--- a/packages/ui/src/components/Checkbox/Checkbox.tsx
+++ b/packages/ui/src/components/Checkbox/Checkbox.tsx
@@ -21,7 +21,7 @@ import { useStyles } from '../../hooks/useStyles';
 import { CheckboxDefinition } from './definition';
 import clsx from 'clsx';
 import styles from './Checkbox.module.css';
-import { RiCheckLine } from '@remixicon/react';
+import { RiCheckLine, RiSubtractLine } from '@remixicon/react';
 
 /** @public */
 export const Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(
@@ -35,12 +35,23 @@ export const Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(
         className={clsx(classNames.root, styles[classNames.root], className)}
         {...rest}
       >
-        <div
-          className={clsx(classNames.indicator, styles[classNames.indicator])}
-        >
-          <RiCheckLine size={12} />
-        </div>
-        {children}
+        {({ isIndeterminate }) => (
+          <>
+            <div
+              className={clsx(
+                classNames.indicator,
+                styles[classNames.indicator],
+              )}
+            >
+              {isIndeterminate ? (
+                <RiSubtractLine size={12} />
+              ) : (
+                <RiCheckLine size={12} />
+              )}
+            </div>
+            {children}
+          </>
+        )}
       </RACheckbox>
     );
   },

--- a/packages/ui/src/components/Checkbox/definition.ts
+++ b/packages/ui/src/components/Checkbox/definition.ts
@@ -27,5 +27,6 @@ export const CheckboxDefinition = {
   },
   dataAttributes: {
     selected: [true, false] as const,
+    indeterminate: [true, false] as const,
   },
 } as const satisfies ComponentDefinition;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added support for the indeterminate state in the Checkbox component,
displaying a horizontal dash icon instead of a checkmark. This is
useful for "select all" scenarios in tables where only some rows
are selected.

The indeterminate state maintains the unchecked visual style
(white background with border) while showing the dash icon.

<img width="760" height="196" alt="image" src="https://github.com/user-attachments/assets/f8f93a28-e2d2-48c6-97fd-9ea40e669231" />


#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.

### Changeset illustration

<img width="256" height="384" alt="image" src="https://github.com/user-attachments/assets/cf6e33d2-2343-4d72-aa70-9bc4bb4bfda5" />
