### PR TITLE
fix(cli): use content-based hashing for CSS module class names

### DIFF
--- a/.changeset/orange-hoops-matter.md
+++ b/.changeset/orange-hoops-matter.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Fixed CSS module class name collisions when running multiple versions of packages simultaneously by using content-based hashing for class name generation.

--- a/packages/cli/src/modules/build/lib/builder/config.ts
+++ b/packages/cli/src/modules/build/lib/builder/config.ts
@@ -16,7 +16,9 @@
 
 import chalk from 'chalk';
 import fs from 'fs-extra';
+import { createHash } from 'crypto';
 import {
+  basename,
   extname,
   relative as relativePath,
   resolve as resolvePath,
@@ -239,7 +241,18 @@ export async function makeRollupConfigs(
           include: /node_modules/,
           exclude: [/\/[^/]+\.(?:stories|test)\.[^/]+$/],
         }),
-        postcss(),
+        postcss({
+          modules: {
+            generateScopedName(name: string, filename: string, css: string) {
+              const hash = createHash('md5')
+                .update(css)
+                .digest('hex')
+                .slice(0, 10);
+              const file = basename(filename, '.module.css');
+              return `${file}_${name}__${hash}`;
+            },
+          },
+        }),
         forwardFileImports({
           exclude: /\.icon\.svg$/,
           include: [


### PR DESCRIPTION
## Hey, I just made a Pull Request!

CSS module class names were colliding when multiple versions of the same
package were loaded simultaneously. The hash was based on file path and
class name only, not the actual CSS content.

This replaces the default path-based hash with a content-based hash derived
from the CSS content. This ensures:

- Different CSS content produces different class names
- Identical content produces identical class names (stable across builds)
- No dependency on package version or file path for uniqueness

Uses 10 characters of hex-encoded MD5 hash for safe, readable class name suffixes.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.