### PR TITLE
fix(ui): resolve circular dependency in TablePagination

### DIFF
--- a/packages/ui/src/components/TablePagination/TablePagination.tsx
+++ b/packages/ui/src/components/TablePagination/TablePagination.tsx
@@ -15,7 +15,9 @@
  */
 
 import clsx from 'clsx';
-import { Text, ButtonIcon, Select } from '../..';
+import { Text } from '../Text';
+import { ButtonIcon } from '../ButtonIcon';
+import { Select } from '../Select';
 import type { TablePaginationProps, PageSizeOption } from './types';
 import { useStyles } from '../../hooks/useStyles';
 import { TablePaginationDefinition } from './definition';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes Rollup circular dependency warning during build by replacing
barrel file import with direct component imports in TablePagination.

The cycle was: `index.ts → Table → TablePagination → index.ts`

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.