### PR TITLE
backend-test-utils: move reusable test failure case

### DIFF
--- a/packages/backend-test-utils/src/filesystem/MockDirectory.test.ts
+++ b/packages/backend-test-utils/src/filesystem/MockDirectory.test.ts
@@ -271,14 +271,16 @@ describe('createMockDirectory', () => {
   });
 
   it('should reject non-child paths', () => {
-    const path = mockDir.resolve('/root/a.txt');
-    expect(() => mockDir.setContent({ '/root/a.txt': 'a' })).toThrow(
+    const pathOutside = createMockDirectory().path;
+
+    const path = mockDir.resolve(pathOutside);
+    expect(() => mockDir.setContent({ [pathOutside]: 'a' })).toThrow(
       `Provided path must resolve to a child path of the mock directory, got '${path}'`,
     );
-    expect(() => mockDir.addContent({ '/root/a.txt': 'a' })).toThrow(
+    expect(() => mockDir.addContent({ [pathOutside]: 'a' })).toThrow(
       `Provided path must resolve to a child path of the mock directory, got '${path}'`,
     );
-    expect(() => mockDir.content({ path: '/root/a.txt' })).toThrow(
+    expect(() => mockDir.content({ path: pathOutside })).toThrow(
       `Provided path must resolve to a child path of the mock directory, got '${path}'`,
     );
   });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
