### PR TITLE
Revert "fix(create-app): pin memfs to 4.51.1 to fix e2e test failures"

### DIFF
--- a/packages/create-app/seed-yarn.lock
+++ b/packages/create-app/seed-yarn.lock
@@ -22,9 +22,3 @@
   version "1.11.31"
   resolved "https://registry.yarnpkg.com/@swc/core/-/core-1.11.31.tgz#e5de9ed005551ce9a16aa69e79935fc33065475c"
   integrity sha512-mAby9aUnKRjMEA7v8cVZS9Ah4duoRBnX7X6r5qrhTxErx+68MoY1TPrVwj/66/SWN3Bl+jijqAqoB8Qx0QE34A==
-
-// memfs@4.56.2 has broken dependencies: @jsonjoy.com/fs-snapshot requires @jsonjoy.com/util@^17.x but imports paths only in 1.x
-memfs@^4.51.1:
-  version "4.51.1"
-  resolved "https://registry.yarnpkg.com/memfs/-/memfs-4.51.1.tgz#25945de4a90d1573945105e187daa9385e1bca73"
-  integrity sha512-Eyt3XrufitN2ZL9c/uIRMyDwXanLI88h/L3MoWqNY747ha3dMR9dWqp8cRT5ntjZ0U1TNuq4U91ZXK0sMBjYOQ==


### PR DESCRIPTION
Reverts backstage/backstage#32380

Claims [to be fixed upstream](https://github.com/streamich/memfs/issues/1233) now.