### PR TITLE
Add link checker to verify_docs-quality workflow

### DIFF
--- a/.github/workflows/verify_docs-quality.yml
+++ b/.github/workflows/verify_docs-quality.yml
@@ -35,17 +35,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Link Checker
-        uses: lycheeverse/lychee-action@9f5e5c22c21c9b2981517972ed85e8b4785905a6 # v2.3.0
+        uses: lycheeverse/lychee-action@v2
         with:
-          args: >-
-            --verbose
-            --no-progress
-            --exclude "npmjs\.com"
-            --exclude "figma\.com"
-            --exclude "localhost"
-            --exclude "passportjs\.org"
-            --retry 5
-            --timeout 20
-            './**/*.md'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Check all markdown files in the repo
+          args: --root-dir "$(pwd)" --verbose --no-progress './**/*.md'
+          fail: true
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a broken link checker step to the existing `verify_docs-quality` workflow.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
