### PR TITLE
frontend-test-utils: fix Router deprecation warning

### DIFF
--- a/.changeset/seven-states-sleep.md
+++ b/.changeset/seven-states-sleep.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-test-utils': patch
+---
+
+Fixed Router deprecation warning and switched to using new `RouterBlueprint` from `@backstage/plugin-app-api`.

--- a/.patches/pr-32409.txt
+++ b/.patches/pr-32409.txt
@@ -1,0 +1,1 @@
+Fixes a deprecation warning for Router extension in tests

--- a/packages/frontend-test-utils/package.json
+++ b/packages/frontend-test-utils/package.json
@@ -35,6 +35,7 @@
     "@backstage/frontend-app-api": "workspace:^",
     "@backstage/frontend-plugin-api": "workspace:^",
     "@backstage/plugin-app": "workspace:^",
+    "@backstage/plugin-app-react": "workspace:^",
     "@backstage/test-utils": "workspace:^",
     "@backstage/types": "workspace:^",
     "@backstage/version-bridge": "workspace:^",

--- a/packages/frontend-test-utils/src/app/renderInTestApp.tsx
+++ b/packages/frontend-test-utils/src/app/renderInTestApp.tsx
@@ -27,11 +27,12 @@ import {
   RouteRef,
   useRouteRef,
   IconComponent,
-  RouterBlueprint,
   NavItemBlueprint,
   createFrontendPlugin,
   FrontendFeature,
+  createFrontendModule,
 } from '@backstage/frontend-plugin-api';
+import { RouterBlueprint } from '@backstage/plugin-app-react';
 import appPlugin from '@backstage/plugin-app';
 
 const DEFAULT_MOCK_CONFIG = {
@@ -154,15 +155,6 @@ export function renderInTestApp(
         return [coreExtensionData.reactElement(element)];
       },
     }),
-    RouterBlueprint.make({
-      params: {
-        component: ({ children }) => (
-          <MemoryRouter initialEntries={options?.initialRouteEntries}>
-            {children}
-          </MemoryRouter>
-        ),
-      },
-    }),
   ];
 
   if (options?.mountedRoutes) {
@@ -189,6 +181,20 @@ export function renderInTestApp(
   }
 
   const features: FrontendFeature[] = [
+    createFrontendModule({
+      pluginId: 'app',
+      extensions: [
+        RouterBlueprint.make({
+          params: {
+            component: ({ children }) => (
+              <MemoryRouter initialEntries={options?.initialRouteEntries}>
+                {children}
+              </MemoryRouter>
+            ),
+          },
+        }),
+      ],
+    }),
     createFrontendPlugin({
       pluginId: 'test',
       extensions,

--- a/packages/frontend-test-utils/src/app/renderTestApp.tsx
+++ b/packages/frontend-test-utils/src/app/renderTestApp.tsx
@@ -17,16 +17,17 @@
 import { createSpecializedApp } from '@backstage/frontend-app-api';
 import {
   coreExtensionData,
+  createFrontendModule,
   createFrontendPlugin,
   ExtensionDefinition,
   FrontendFeature,
-  RouterBlueprint,
 } from '@backstage/frontend-plugin-api';
 import { render } from '@testing-library/react';
 import appPlugin from '@backstage/plugin-app';
 import { JsonObject } from '@backstage/types';
 import { ConfigReader } from '@backstage/config';
 import { MemoryRouter } from 'react-router-dom';
+import { RouterBlueprint } from '@backstage/plugin-app-react';
 
 const DEFAULT_MOCK_CONFIG = {
   app: { baseUrl: 'http://localhost:3000' },
@@ -74,20 +75,23 @@ const appPluginOverride = appPlugin.withOverrides({
  * @public
  */
 export function renderTestApp(options: RenderTestAppOptions) {
-  const extensions = [
-    RouterBlueprint.make({
-      params: {
-        component: ({ children }) => (
-          <MemoryRouter initialEntries={options.initialRouteEntries}>
-            {children}
-          </MemoryRouter>
-        ),
-      },
-    }),
-    ...(options.extensions ?? []),
-  ];
+  const extensions = [...(options.extensions ?? [])];
 
   const features: FrontendFeature[] = [
+    createFrontendModule({
+      pluginId: 'app',
+      extensions: [
+        RouterBlueprint.make({
+          params: {
+            component: ({ children }) => (
+              <MemoryRouter initialEntries={options.initialRouteEntries}>
+                {children}
+              </MemoryRouter>
+            ),
+          },
+        }),
+      ],
+    }),
     createFrontendPlugin({
       pluginId: 'test',
       extensions,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3952,6 +3952,7 @@ __metadata:
     "@backstage/frontend-app-api": "workspace:^"
     "@backstage/frontend-plugin-api": "workspace:^"
     "@backstage/plugin-app": "workspace:^"
+    "@backstage/plugin-app-react": "workspace:^"
     "@backstage/test-utils": "workspace:^"
     "@backstage/types": "workspace:^"
     "@backstage/version-bridge": "workspace:^"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Reported by @drodil, fixes an issue where you'd get the following deprecation warning when using `renderTestApp` or `renderInTestApp`:

> DEPRECATION WARNING: Router should only be installed as an extension in the app plugin. You can either use appPlugin.override(), or a module for the app plugin. The following extension will be ignored in the future: app-router-component:test

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
