### PR TITLE
workflows/sync_patch-release: stop running on PR branches

### DIFF
--- a/.github/workflows/sync_patch-release.yml
+++ b/.github/workflows/sync_patch-release.yml
@@ -5,11 +5,6 @@ on:
       - master
     paths:
       - '.patches/**'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - '.patches/**'
 
 concurrency:
   group: sync-patch-release


### PR DESCRIPTION
Think I enabled this during development and forgot to remove before merging 😅 