### PR TITLE
docs/releases/v1.47.0: add security fix notice

### DIFF
--- a/docs/releases/v1.47.0.md
+++ b/docs/releases/v1.47.0.md
@@ -106,6 +106,10 @@ Contributed by [@angeliski](https://github.com/angeliski) in [#32184](https://gi
 
 Previously the `Link` component would cause hard page refreshes for internal routes. With this update, the component now properly uses React Router’s navigation instead of full page reloads.
 
+## Security Fixes
+
+This release contains security fixes for Software Templates and reading external content.
+
 ## Upgrade path
 
 We recommend that you keep your Backstage project up to date with this latest release. For more guidance on how to upgrade, check out the documentation for [keeping Backstage updated](https://backstage.io/docs/getting-started/keeping-backstage-updated).


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The 1.47 release included a couple of security fixes that have now also been backported with CVEs.