### PR TITLE
chore(ui): Fix vale error in changeset

### DIFF
--- a/.changeset/twelve-dolls-tap.md
+++ b/.changeset/twelve-dolls-tap.md
@@ -2,4 +2,4 @@
 '@backstage/ui': patch
 ---
 
-Fixed React 17 compatibility by using `useId` from `react-aria` instead of React's built-in hook which is only available in React 18+.
+Fixed React 17 compatibility by using `useId` from `react-aria` instead of the built-in React hook which is only available in React 18+.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixed a Vale linting error in the changeset for `@backstage/ui` by 
rephrasing "React's built-in hook" to "the built-in React hook".

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.