### PR TITLE
feat(gitlab): Allow setting optional description on group creation

### DIFF
--- a/.changeset/better-eggs-slide.md
+++ b/.changeset/better-eggs-slide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gitlab': patch
+---
+
+Allow setting optional description on group creation

--- a/plugins/scaffolder-backend-module-gitlab/report.api.md
+++ b/plugins/scaffolder-backend-module-gitlab/report.api.md
@@ -22,6 +22,7 @@ export const createGitlabGroupEnsureExistsAction: (options: {
         }
     )[];
     token?: string | undefined;
+    description?: string | undefined;
   },
   {
     groupId?: number | undefined;

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabGroupEnsureExists.examples.test.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabGroupEnsureExists.examples.test.ts
@@ -75,7 +75,7 @@ describe('gitlab:group:ensureExists', () => {
     expect(mockGitlabClient.Groups.create).toHaveBeenCalledWith(
       'group1',
       'group1',
-      {},
+      { description: 'This is a top-level group' },
     );
 
     expect(mockContext.output).toHaveBeenCalledWith('groupId', 3);

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabGroupEnsureExists.examples.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabGroupEnsureExists.examples.ts
@@ -18,7 +18,7 @@ import yaml from 'yaml';
 
 export const examples: TemplateExample[] = [
   {
-    description: 'Creating a group at the top level',
+    description: 'Creating a group at the top level, with a description',
     example: yaml.stringify({
       steps: [
         {
@@ -28,6 +28,7 @@ export const examples: TemplateExample[] = [
           input: {
             repoUrl: 'gitlab.com',
             path: ['group1'],
+            description: 'This is a top-level group',
           },
         },
       ],

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabGroupEnsureExists.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabGroupEnsureExists.ts
@@ -16,7 +16,7 @@
 
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
-import { GroupSchema } from '@gitbeaker/rest';
+import { GroupSchema, CreateGroupOptions } from '@gitbeaker/rest';
 import { getClient, parseRepoUrl } from '../util';
 import { examples } from './gitlabGroupEnsureExists.examples';
 
@@ -45,6 +45,12 @@ export const createGitlabGroupEnsureExistsAction = (options: {
           z
             .string({
               description: 'The token to use for authorization to GitLab',
+            })
+            .optional(),
+        description: z =>
+          z
+            .string({
+              description: 'The group’s description',
             })
             .optional(),
         path: z =>
@@ -77,8 +83,7 @@ export const createGitlabGroupEnsureExistsAction = (options: {
         ctx.output('groupId', 42);
         return;
       }
-
-      const { token, repoUrl, path } = ctx.input;
+      const { token, repoUrl, path, description } = ctx.input;
 
       const { host } = parseRepoUrl(repoUrl, integrations);
 
@@ -86,7 +91,10 @@ export const createGitlabGroupEnsureExistsAction = (options: {
 
       let currentPath: string | null = null;
       let parentId: number | null = null;
-      for (const { name, slug } of pathIterator(path)) {
+      const pathParts = [...pathIterator(path)];
+      const lastIndex = pathParts.length - 1;
+      for (let i = 0; i < pathParts.length; i++) {
+        const { name, slug } = pathParts[i];
         const fullPath: string = currentPath ? `${currentPath}/${slug}` : slug;
         const result = (await api.Groups.search(
           fullPath,
@@ -101,17 +109,11 @@ export const createGitlabGroupEnsureExistsAction = (options: {
             key: `ensure.${name}.${slug}.${parentId}`,
             // eslint-disable-next-line no-loop-func
             fn: async () => {
-              return (
-                await api.Groups.create(
-                  name,
-                  slug,
-                  parentId
-                    ? {
-                        parentId: parentId,
-                      }
-                    : {},
-                )
-              )?.id;
+              const groupOptions: CreateGroupOptions = {
+                ...(parentId ? { parentId } : {}),
+                ...(description && i === lastIndex ? { description } : {}),
+              };
+              return (await api.Groups.create(name, slug, groupOptions))?.id;
             },
           });
         } else {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Allow setting optional description on gitlab group creation

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
