### PR TITLE
fix(devtools): improve permission feedback in ScheduledTasksContent

### DIFF
--- a/.changeset/small-jars-lick.md
+++ b/.changeset/small-jars-lick.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-devtools': patch
+---
+
+Fixes an issue where a user lacking permission to schedule tasks can now easily see the issue through a custom icon + tooltip.

--- a/plugins/devtools/src/components/Content/ScheduledTasksContent/ScheduledTasksContent.tsx
+++ b/plugins/devtools/src/components/Content/ScheduledTasksContent/ScheduledTasksContent.tsx
@@ -35,6 +35,7 @@ import { alertApiRef, configApiRef, useApi } from '@backstage/core-plugin-api';
 import RefreshIcon from '@material-ui/icons/Refresh';
 import NightsStay from '@material-ui/icons/NightsStay';
 import ErrorIcon from '@material-ui/icons/Error';
+import BlockIcon from '@material-ui/icons/Block';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import { ScheduledTaskDetailPanel } from './ScheduledTaskDetailedPanel';
 import { RequirePermission } from '@backstage/plugin-permission-react';
@@ -87,6 +88,12 @@ const StatusDisplay = ({
       {text}
     </Typography>
   </Box>
+);
+
+const CreateNotAllowed = () => (
+  <Tooltip title="You are not allowed to perform this action">
+    <BlockIcon color="disabled" />
+  </Tooltip>
 );
 
 /** @public */
@@ -198,7 +205,10 @@ export const ScheduledTasksContent = () => {
     {
       title: 'Actions',
       render: (rowData: TaskApiTasksResponse) => (
-        <RequirePermission permission={devToolsTaskSchedulerCreatePermission}>
+        <RequirePermission
+          permission={devToolsTaskSchedulerCreatePermission}
+          errorPage={<CreateNotAllowed />}
+        >
           <Tooltip title="Run Task">
             <IconButton
               aria-label="Trigger"
@@ -225,6 +235,7 @@ export const ScheduledTasksContent = () => {
       ),
       sorting: false,
       width: '10%',
+      align: 'center',
     },
   ];
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Closses:
- #32429 

Updated the `ScheduledTasksContent` component to provide better visual feedback when a user lacks permission to trigger a scheduled task. This change introduces a `CreateNotAllowed` component that displays a disabled block icon with a descriptive tooltip, which is now used as the `errorPage` prop in the `RequirePermission` wrapper.

Additional changes:
- Centered the Actions column in the tasks table for better UI alignment.
- Added a changeset for the patch release.

<img width="1829" height="787" alt="image" src="https://github.com/user-attachments/assets/fbff2991-7445-4e71-b544-1dd179335074" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
