### PR TITLE
MenuItem fix in the UI

### DIFF
--- a/packages/ui/src/components/Menu/Menu.module.css
+++ b/packages/ui/src/components/Menu/Menu.module.css
@@ -107,6 +107,7 @@
     color: var(--bui-fg-primary);
     font-size: var(--bui-font-size-3);
     gap: var(--bui-space-6);
+    min-width: 0;
   }
 
   .bui-MenuItemListBox {
@@ -144,10 +145,17 @@
     display: flex;
     align-items: center;
     gap: var(--bui-space-2);
+    /* Allow content to shrink and handle overflow */
+    min-width: 0;
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 
     & > svg {
       width: 1rem;
       height: 1rem;
+      flex-shrink: 0;
     }
   }
 
@@ -155,6 +163,7 @@
     display: none;
     width: 1rem;
     height: 1rem;
+    flex-shrink: 0;
 
     & > svg {
       width: 1rem;

--- a/packages/ui/src/components/Menu/Menu.stories.tsx
+++ b/packages/ui/src/components/Menu/Menu.stories.tsx
@@ -444,3 +444,21 @@ export const WithScroll = meta.story({
     </MenuTrigger>
   ),
 });
+
+export const LongContent = meta.story({
+  args: {
+    children: null,
+  },
+  render: () => (
+    <MenuTrigger>
+      <Button aria-label="Support">Support</Button>
+      <Menu>
+        <MenuItem>#data-application-portal-support</MenuItem>
+        <MenuItem>This is another very long menu item that should handle overflow gracefully</MenuItem>
+        <MenuItem iconStart={<RiChat1Line />}>
+          #super-long-channel-name-with-many-words
+        </MenuItem>
+      </Menu>
+    </MenuTrigger>
+  ),
+});


### PR DESCRIPTION
#https://github.com/backstage/backstage/issues/32314

**Changes**

Added overflow handling to .bui-MenuItemContent in Menu.module.css
Long text now truncates with ellipsis instead of causing layout errors
Added LongContent story to demonstrate the fix

**Technical Details**

Set min-width: 0 on wrapper and content to enable flex shrinking
Added overflow: hidden, text-overflow: ellipsis, and white-space: nowrap to content
Icons and arrows get flex-shrink: 0 to maintain proper sizing
