### PR TITLE
fix: prevent backend server from hanging during e2e test

### DIFF
--- a/.changeset/gold-chairs-cross.md
+++ b/.changeset/gold-chairs-cross.md
@@ -1,5 +1,0 @@
----
-'e2e-test': patch
----
-
-The end to end backend will now exit on unhandled Node errors.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Noticed in #30438 - the E2Es didn't easily surface an issue with the backend starting up. The current behavior of the backend staying alive but not actually having started is confusing especially for E2Es where we expect an exit code to indicate step failure.

Using the env var from https://github.com/backstage/backstage/blob/master/packages/backend-app-api/src/wiring/BackendInitializer.ts#L265-L282.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
