### PR TITLE
fix(signals): race condition on multiple subscriptions

### DIFF
--- a/.changeset/spicy-phones-enter.md
+++ b/.changeset/spicy-phones-enter.md
@@ -1,0 +1,10 @@
+---
+'@backstage/plugin-signals': patch
+---
+
+Improved signals client handling of multiple subscriptions at the same time.
+
+When multiple subscriptions are requested at the same time, signals client
+starts multiple connections where the last one will actually send the subscription
+messages to the backend. This fixes it by wrapping the connect method inside
+a stored promise that is used for subscription calls.

--- a/plugins/signals/src/api/SignalsClient.test.ts
+++ b/plugins/signals/src/api/SignalsClient.test.ts
@@ -145,4 +145,202 @@ describe('SignalClient', () => {
       ]),
     );
   });
+
+  it('should handle multiple simultaneous subscriptions without creating multiple connections', async () => {
+    const messageMock1 = jest.fn();
+    const messageMock2 = jest.fn();
+    const messageMock3 = jest.fn();
+
+    let connectionCount = 0;
+    const OriginalWebSocket = global.WebSocket;
+
+    const WrappedWebSocket = function WebSocket(
+      url: string | URL,
+      protocols?: string | string[],
+    ) {
+      connectionCount++;
+      return new OriginalWebSocket(url, protocols);
+    } as any;
+
+    WrappedWebSocket.CONNECTING = OriginalWebSocket.CONNECTING;
+    WrappedWebSocket.OPEN = OriginalWebSocket.OPEN;
+    WrappedWebSocket.CLOSING = OriginalWebSocket.CLOSING;
+    WrappedWebSocket.CLOSED = OriginalWebSocket.CLOSED;
+    WrappedWebSocket.prototype = OriginalWebSocket.prototype;
+
+    global.WebSocket = WrappedWebSocket;
+
+    try {
+      const client = SignalClient.create({ discoveryApi, identity });
+
+      const sub1 = client.subscribe('channel1', messageMock1);
+      const sub2 = client.subscribe('channel2', messageMock2);
+      const sub3 = client.subscribe('channel3', messageMock3);
+
+      await server.connected;
+
+      expect(connectionCount).toBe(1);
+
+      await waitForExpect(() =>
+        expect(server.messages).toEqual([
+          { action: 'subscribe', channel: 'channel1' },
+          { action: 'subscribe', channel: 'channel2' },
+          { action: 'subscribe', channel: 'channel3' },
+        ]),
+      );
+
+      server.send({ channel: 'channel1', message: { test: '1' } });
+      server.send({ channel: 'channel2', message: { test: '2' } });
+      server.send({ channel: 'channel3', message: { test: '3' } });
+
+      await waitForExpect(() => {
+        expect(messageMock1).toHaveBeenCalledWith({ test: '1' });
+        expect(messageMock2).toHaveBeenCalledWith({ test: '2' });
+        expect(messageMock3).toHaveBeenCalledWith({ test: '3' });
+      });
+
+      expect(connectionCount).toBe(1);
+      sub1.unsubscribe();
+      sub2.unsubscribe();
+      sub3.unsubscribe();
+    } finally {
+      global.WebSocket = OriginalWebSocket;
+    }
+  });
+
+  it('should handle multiple simultaneous subscriptions to the same channel', async () => {
+    const messageMock1 = jest.fn();
+    const messageMock2 = jest.fn();
+    const messageMock3 = jest.fn();
+    const client = SignalClient.create({ discoveryApi, identity });
+
+    const sub1 = client.subscribe('channel', messageMock1);
+    const sub2 = client.subscribe('channel', messageMock2);
+    const sub3 = client.subscribe('channel', messageMock3);
+
+    await server.connected;
+
+    await waitForExpect(() =>
+      expect(server.messages).toEqual([
+        { action: 'subscribe', channel: 'channel' },
+      ]),
+    );
+
+    server.send({ channel: 'channel', message: { test: 'data' } });
+
+    await waitForExpect(() => {
+      expect(messageMock1).toHaveBeenCalledWith({ test: 'data' });
+      expect(messageMock2).toHaveBeenCalledWith({ test: 'data' });
+      expect(messageMock3).toHaveBeenCalledWith({ test: 'data' });
+    });
+
+    sub1.unsubscribe();
+    sub2.unsubscribe();
+
+    await waitForExpect(() => {
+      expect(server.messages).toHaveLength(1);
+    });
+
+    sub3.unsubscribe();
+
+    await waitForExpect(() =>
+      expect(server.messages).toEqual([
+        { action: 'subscribe', channel: 'channel' },
+        { action: 'unsubscribe', channel: 'channel' },
+      ]),
+    );
+  });
+
+  it('should resubscribe after reconnect even if initial connection failed', async () => {
+    const discoveryApi2 = {
+      getBaseUrl: jest
+        .fn()
+        .mockResolvedValue('http://localhost:1234/api/signals-test'),
+    };
+
+    const messageMock = jest.fn();
+    const client = SignalClient.create({
+      discoveryApi: discoveryApi2 as any,
+      identity,
+      reconnectTimeout: 50,
+      connectTimeout: 100,
+    });
+
+    const server2 = new WS('ws://localhost:1234/api/signals-test', {
+      jsonProtocol: true,
+    });
+
+    client.subscribe('channel', messageMock);
+    await server2.connected;
+    server2.close();
+
+    const server3 = new WS('ws://localhost:1234/api/signals-test', {
+      jsonProtocol: true,
+    });
+
+    await server3.connected;
+
+    await waitForExpect(() =>
+      expect(server3.messages).toEqual([
+        { action: 'subscribe', channel: 'channel' },
+      ]),
+    );
+
+    server3.send({ channel: 'channel', message: { reconnected: true } });
+    await waitForExpect(() => {
+      expect(messageMock).toHaveBeenCalledWith({ reconnected: true });
+    });
+
+    server3.close();
+  });
+
+  it('should resubscribe when server closes connection normally while subscriptions exist', async () => {
+    const messageMock = jest.fn();
+    const client = SignalClient.create({
+      discoveryApi,
+      identity,
+      reconnectTimeout: 50,
+      connectTimeout: 100,
+    });
+
+    client.subscribe('channel', messageMock);
+    await server.connected;
+
+    await waitForExpect(() =>
+      expect(server.messages).toEqual([
+        { action: 'subscribe', channel: 'channel' },
+      ]),
+    );
+
+    server.close();
+
+    const server2 = new WS('ws://localhost:1234/api/signals', {
+      jsonProtocol: true,
+    });
+
+    const messageMock2 = jest.fn();
+    client.subscribe('channel2', messageMock2);
+
+    await server2.connected;
+
+    await waitForExpect(() => {
+      expect(server2.messages).toEqual(
+        expect.arrayContaining([
+          { action: 'subscribe', channel: 'channel' },
+          { action: 'subscribe', channel: 'channel2' },
+        ]),
+      );
+      expect(server2.messages).toHaveLength(2);
+    });
+
+    server2.send({ channel: 'channel', message: { after: 'reconnect' } });
+    server2.send({ channel: 'channel2', message: { second: 'channel' } });
+
+    await waitForExpect(() => {
+      expect(messageMock).toHaveBeenCalledWith({ after: 'reconnect' });
+      expect(messageMock2).toHaveBeenCalledWith({ second: 'channel' });
+    });
+
+    server2.close();
+  });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

wrapped the connect functionality to internal promise to prevent multiple connect requests being made when there are a lot of subscriptions happening at the same time.

Before:

<img width="712" height="386" alt="image" src="https://github.com/user-attachments/assets/5caebe33-9643-4b53-995a-2269cbca3674" />

After (just one request):

<img width="792" height="18" alt="image" src="https://github.com/user-attachments/assets/c836a7b6-9731-4644-979e-9082bc04a558" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
