### PR TITLE
frontend-app-api: better isolation and attribution of instantiation failures

### DIFF
--- a/.changeset/good-eggs-tell.md
+++ b/.changeset/good-eggs-tell.md
@@ -6,3 +6,4 @@ Updated error reporting and app tree resolution logic to attribute errors to the
 
 - If an attachment fails to provide the required input data, the error is now attributed to the attachment rather than the parent extension.
 - Singleton extension inputs will now only forward attachment errors if the input is required.
+- Array extension inputs will now filter out failed attachments instead of failing the entire app tree resolution.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes for error handling of these bits that didn't line up with how extension failures work in general, such as throwing in the factory. Trying to attach an extension to an input without providing the required data would cause an error in the extension being attached to, rather than the attachment.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
