### PR TITLE
docs(ui): document limitation of nested Accordion usage

### DIFF
--- a/packages/ui/src/components/Accordion/AccordionPannel.stories.tsx
+++ b/packages/ui/src/components/Accordion/AccordionPannel.stories.tsx
@@ -1,0 +1,30 @@
+import preview from "../../../../../.storybook/preview";
+import { Content } from "../../../../core-components/src/layout";
+import { Accordion, AccordionPanel, AccordionTrigger } from "./Accordion";
+
+const meta = preview.meta({
+  title: "Backstage UI/Accordion",
+  component: Accordion,
+});
+
+export const NestedAccordion = meta.story({
+  render: () => (
+    <Accordion>
+      <AccordionTrigger title="Outer Panel" />
+      <AccordionPanel>
+        <Accordion>
+          <AccordionTrigger title="Inner Panel" />
+          <AccordionPanel>
+            <Content />
+          </AccordionPanel>
+        </Accordion>
+      </AccordionPanel>
+    </Accordion>
+  ),
+});
+
+// NOTE:
+// Nested Accordions are not fully supported.
+// Due to React Aria disclosure behavior, inner Accordions may
+// appear expanded when mounted. The Accordion component does
+// not currently expose an `onChange` callback for controlled usage.


### PR DESCRIPTION
#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages  
  _Not required — documentation / Storybook only_

- [x] Added or updated documentation

- [ ] Tests for new functionality and regression tests for bug fixes  
  _Not applicable — no runtime behavior change_

- [ ] Screenshots attached (for UI changes)  
  _Not applicable — Storybook documentation only_

- [x] All your commits have a `Signed-off-by` line in the message
