### PR TITLE
fix(search): prevent memory leak in LunrSearchEngine docStore

### DIFF
--- a/.changeset/hungry-pens-clap.md
+++ b/.changeset/hungry-pens-clap.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend-node': patch
+---
+
+Fixed memory leak in `LunrSearchEngine` where the document store grew unbounded across reindexing cycles. The fix replaces the single global `docStore` with per-type document stores that are fully replaced during each indexing cycle, preventing deleted documents from accumulating in memory.

--- a/.github/vale/config/vocabularies/Backstage/accept.txt
+++ b/.github/vale/config/vocabularies/Backstage/accept.txt
@@ -577,6 +577,7 @@ zod
 Zolotusky
 zoomable
 zsh
+reindexing
 resizable
 enums
 LLMs

--- a/plugins/search-backend-node/report.api.md
+++ b/plugins/search-backend-node/report.api.md
@@ -75,8 +75,12 @@ export type LunrQueryTranslator = (query: SearchQuery) => ConcreteLunrQuery;
 // @public
 export class LunrSearchEngine implements SearchEngine {
   constructor(options: { logger: LoggerService });
+  // @deprecated (undocumented)
+  protected get docStore(): Record<string, IndexableDocument>;
+  // Warning: (ae-setter-with-docs) The doc comment for the property "docStore" must appear on the getter, not the setter.
+  protected set docStore(value: Record<string, IndexableDocument>);
   // (undocumented)
-  protected docStore: Record<string, IndexableDocument>;
+  protected docStores: Record<string, Record<string, IndexableDocument>>;
   // (undocumented)
   getIndexer(type: string): Promise<LunrSearchEngineIndexer>;
   // (undocumented)

--- a/plugins/search-backend-node/report.api.md
+++ b/plugins/search-backend-node/report.api.md
@@ -77,8 +77,6 @@ export class LunrSearchEngine implements SearchEngine {
   constructor(options: { logger: LoggerService });
   // @deprecated (undocumented)
   protected get docStore(): Record<string, IndexableDocument>;
-  // Warning: (ae-setter-with-docs) The doc comment for the property "docStore" must appear on the getter, not the setter.
-  protected set docStore(value: Record<string, IndexableDocument>);
   // (undocumented)
   protected docStores: Record<string, Record<string, IndexableDocument>>;
   // (undocumented)

--- a/plugins/search-backend-node/src/engines/LunrSearchEngine.test.ts
+++ b/plugins/search-backend-node/src/engines/LunrSearchEngine.test.ts
@@ -39,10 +39,13 @@ class LunrSearchEngineForTests extends LunrSearchEngine {
     };
   }
   getDocStore() {
-    return this.docStore;
+    return Object.values(this.docStores).reduce(
+      (acc, store) => ({ ...acc, ...store }),
+      {},
+    );
   }
   setDocStore(docStore: Record<string, IndexableDocument>) {
-    this.docStore = docStore;
+    this.docStores.__legacy__ = docStore;
   }
   getLunrIndices() {
     return this.lunrIndices;

--- a/plugins/search-backend-node/src/engines/LunrSearchEngine.ts
+++ b/plugins/search-backend-node/src/engines/LunrSearchEngine.ts
@@ -66,11 +66,6 @@ export class LunrSearchEngine implements SearchEngine {
     );
   }
 
-  /** @deprecated Use docStores instead */
-  protected set docStore(value: Record<string, IndexableDocument>) {
-    this.docStores.__legacy__ = value;
-  }
-
   constructor(options: { logger: LoggerService }) {
     this.logger = options.logger;
     const uuidTag = uuid();
@@ -261,7 +256,7 @@ export class LunrSearchEngine implements SearchEngine {
     const realResultSet: IndexableResultSet = {
       results: results.slice(offset, offset + pageSize).map((d, index) => ({
         type: d.type,
-        document: this.docStore[d.result.ref],
+        document: this.docStores[d.type]?.[d.result.ref],
         rank: page * pageSize + index + 1,
         highlight: {
           preTag: this.highlightPreTag,
@@ -269,7 +264,7 @@ export class LunrSearchEngine implements SearchEngine {
           fields: parseHighlightFields({
             preTag: this.highlightPreTag,
             postTag: this.highlightPostTag,
-            doc: this.docStore[d.result.ref],
+            doc: this.docStores[d.type]?.[d.result.ref],
             positionMetadata: d.result.matchData.metadata as any,
           }),
         },

--- a/plugins/search-backend-node/src/engines/LunrSearchEngine.ts
+++ b/plugins/search-backend-node/src/engines/LunrSearchEngine.ts
@@ -61,7 +61,7 @@ export class LunrSearchEngine implements SearchEngine {
   /** @deprecated Use docStores instead */
   protected get docStore(): Record<string, IndexableDocument> {
     return Object.values(this.docStores).reduce(
-      (acc, store) => ({ ...acc, ...store }),
+      (acc, store) => Object.assign(acc, store),
       {},
     );
   }


### PR DESCRIPTION
## Summary

This PR fixes a memory leak in `LunrSearchEngine` where indexed documents were retained in memory across periodic reindexing cycles, even after being deleted from their source.

While Lunr indices were correctly replaced on each run, the backing document store (`docStore`) was merged additively, causing unbounded growth in long-running Backstage deployments with scheduled indexing.

---

## Fix

The document store has been made **type-aware**, ensuring that documents for a given search type are **fully replaced** on each reindex rather than merged globally.

### Key changes

* Replaced the single global document store with per-type stores:

```ts
protected docStores: Record<string, Record<string, IndexableDocument>> = {};
```

* Updated indexing behavior to replace documents per type:

```ts
this.docStores[type] = newDocuments;
```

* Preserved backward compatibility via a deprecated accessor:

```ts
/** @deprecated Use docStores instead */
protected get docStore() {
  return Object.values(this.docStores).reduce((a, s) => ({ ...a, ...s }), {});
}
```

This ensures deleted documents are automatically removed from memory on subsequent reindexing runs, while keeping search behavior unchanged.

---

#### :heavy_check_mark: Checklist

* [x] All your commits have a `Signed-off-by` line in the message. ([more info])

