### PR TITLE
frontend-app-api: switch new API conflict error to be a warning

### DIFF
--- a/.changeset/api-override-deprecation-warning-defaults.md
+++ b/.changeset/api-override-deprecation-warning-defaults.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-defaults': patch
+---
+
+The `API_FACTORY_CONFLICT` error is now treated as a warning and will not prevent the app from starting.

--- a/.changeset/api-override-deprecation-warning.md
+++ b/.changeset/api-override-deprecation-warning.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-app-api': patch
+---
+
+Updated the behavior of the new API override logic to log a deprecation warning instead of rejecting the override and blocking app startup, as was originally intended.

--- a/.patches/pr-32522.txt
+++ b/.patches/pr-32522.txt
@@ -1,0 +1,1 @@
+Rolls back the immediate breaking change of API factory conflicts in the new frontend system, making it a deprecation warning instead.

--- a/packages/frontend-app-api/src/wiring/createSpecializedApp.test.tsx
+++ b/packages/frontend-app-api/src/wiring/createSpecializedApp.test.tsx
@@ -289,7 +289,7 @@ describe('createSpecializedApp', () => {
     expect(mockAnalyticsApi).toHaveBeenCalled();
   });
 
-  it('should select the API factory from the owning plugin on conflict', () => {
+  it('should warn when API overrides would be blocked by new logic', () => {
     const testApiRef = createApiRef<{ value: string }>({ id: 'test.api' });
 
     const app = createSpecializedApp({
@@ -303,7 +303,7 @@ describe('createSpecializedApp', () => {
                 defineParams({
                   api: testApiRef,
                   deps: {},
-                  factory: () => ({ value: 'other' }),
+                  factory: () => ({ value: 'other-before' }),
                 }),
             }),
           ],
@@ -329,7 +329,7 @@ describe('createSpecializedApp', () => {
                 defineParams({
                   api: testApiRef,
                   deps: {},
-                  factory: () => ({ value: 'other' }),
+                  factory: () => ({ value: 'other-after' }),
                 }),
             }),
           ],
@@ -348,7 +348,8 @@ describe('createSpecializedApp', () => {
       }),
     ]);
 
-    expect(app.apis.get(testApiRef)).toEqual({ value: 'owner' });
+    // Old behavior: last factory wins
+    expect(app.apis.get(testApiRef)).toEqual({ value: 'other-after' });
   });
 
   it('should allow API overrides within the same plugin', () => {

--- a/packages/frontend-app-api/src/wiring/createSpecializedApp.tsx
+++ b/packages/frontend-app-api/src/wiring/createSpecializedApp.tsx
@@ -428,13 +428,14 @@ function createApiFactories(options: {
             existingPluginId: acceptedPluginId,
           },
         });
-        if (shouldReplace) {
-          factoriesById.set(apiRefId, {
-            pluginId,
-            factory: apiFactory,
-          });
+        if (!shouldReplace) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `DEPRECATION WARNING: Plugin '${rejectedPluginId}' is overriding API '${apiRefId}' ` +
+              `from plugin '${acceptedPluginId}'. This will be blocked in a future release. ` +
+              `Please use a module for plugin '${acceptedPluginId}' instead.`,
+          );
         }
-        continue;
       }
 
       factoriesById.set(apiRefId, { pluginId, factory: apiFactory });

--- a/packages/frontend-defaults/src/maybeCreateErrorPage.tsx
+++ b/packages/frontend-defaults/src/maybeCreateErrorPage.tsx
@@ -23,6 +23,7 @@ const DEFAULT_WARNING_CODES: Array<keyof AppErrorTypes> = [
   'INVALID_EXTENSION_CONFIG_KEY',
   'EXTENSION_INPUT_DATA_IGNORED',
   'EXTENSION_OUTPUT_IGNORED',
+  'API_FACTORY_CONFLICT',
 ];
 
 function AppErrorItem(props: { error: AppError }): JSX.Element {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Went a bit too far with this in the 1.47 release. It promised a deprecation period but instead we immediately broke conflicting API factories. This rolls it back to be a warning when the override would have happened, as well as an app-level warning whenever a conflict is detected.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
