### PR TITLE
fix(scaffolder-gitlab): Use Groups.show instead of search to check path existence

### DIFF
--- a/.changeset/easy-deer-eat.md
+++ b/.changeset/easy-deer-eat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gitlab': patch
+---
+
+Changed `gitlab:group:ensureExists` action to use `Groups.show` API instead of `Groups.search` for checking if a group path exists. This is more efficient as it directly retrieves the group by path rather than searching and filtering results.

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabGroupEnsureExists.examples.test.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabGroupEnsureExists.examples.test.ts
@@ -23,7 +23,7 @@ import { mockServices } from '@backstage/backend-test-utils';
 
 const mockGitlabClient = {
   Groups: {
-    search: jest.fn(),
+    show: jest.fn(),
     create: jest.fn(),
   },
 };
@@ -44,7 +44,9 @@ describe('gitlab:group:ensureExists', () => {
   });
 
   it(`Should ${examples[0].description}`, async () => {
-    mockGitlabClient.Groups.search.mockResolvedValue([]);
+    mockGitlabClient.Groups.show.mockRejectedValue({
+      cause: { response: { status: 404 } },
+    });
     mockGitlabClient.Groups.create.mockResolvedValue({
       id: 3,
       full_path: 'group1',
@@ -82,12 +84,9 @@ describe('gitlab:group:ensureExists', () => {
   });
 
   it(`Should ${examples[1].description}`, async () => {
-    mockGitlabClient.Groups.search.mockResolvedValue([
-      {
-        id: 1,
-        full_path: 'group1',
-      },
-    ]);
+    mockGitlabClient.Groups.show
+      .mockResolvedValueOnce({ id: 1, full_path: 'group1' })
+      .mockRejectedValueOnce({ cause: { response: { status: 404 } } });
     mockGitlabClient.Groups.create.mockResolvedValue({
       id: 3,
       full_path: 'group1/group2',
@@ -127,16 +126,10 @@ describe('gitlab:group:ensureExists', () => {
   });
 
   it(`Should ${examples[2].description}`, async () => {
-    mockGitlabClient.Groups.search.mockResolvedValue([
-      {
-        id: 1,
-        full_path: 'group1',
-      },
-      {
-        id: 2,
-        full_path: 'group1/group2',
-      },
-    ]);
+    mockGitlabClient.Groups.show
+      .mockResolvedValueOnce({ id: 1, full_path: 'group1' })
+      .mockResolvedValueOnce({ id: 2, full_path: 'group1/group2' })
+      .mockRejectedValueOnce({ cause: { response: { status: 404 } } });
     mockGitlabClient.Groups.create.mockResolvedValue({
       id: 3,
       full_path: 'group1/group2/group3',
@@ -199,23 +192,17 @@ describe('gitlab:group:ensureExists', () => {
       input: yaml.parse(examples[3].example).steps[0].input,
     });
 
-    expect(mockGitlabClient.Groups.search).not.toHaveBeenCalled();
+    expect(mockGitlabClient.Groups.show).not.toHaveBeenCalled();
     expect(mockGitlabClient.Groups.create).not.toHaveBeenCalled();
 
     expect(mockContext.output).toHaveBeenCalledWith('groupId', 42);
   });
 
   it(`Should ${examples[4].description}`, async () => {
-    mockGitlabClient.Groups.search.mockResolvedValue([
-      {
-        id: 1,
-        full_path: 'group1',
-      },
-      {
-        id: 2,
-        full_path: 'group1/group2',
-      },
-    ]);
+    mockGitlabClient.Groups.show
+      .mockResolvedValueOnce({ id: 1, full_path: 'group1' })
+      .mockResolvedValueOnce({ id: 2, full_path: 'group1/group2' })
+      .mockRejectedValueOnce({ cause: { response: { status: 404 } } });
     mockGitlabClient.Groups.create.mockResolvedValue({
       id: 3,
       full_path: 'group1/group2/group3',
@@ -255,20 +242,11 @@ describe('gitlab:group:ensureExists', () => {
   });
 
   it(`Should ${examples[5].description}`, async () => {
-    mockGitlabClient.Groups.search.mockResolvedValue([
-      {
-        id: 1,
-        full_path: 'group1',
-      },
-      {
-        id: 2,
-        full_path: 'group1/group2',
-      },
-      {
-        id: 3,
-        full_path: 'group1/group2/group3',
-      },
-    ]);
+    mockGitlabClient.Groups.show
+      .mockResolvedValueOnce({ id: 1, full_path: 'group1' })
+      .mockResolvedValueOnce({ id: 2, full_path: 'group1/group2' })
+      .mockResolvedValueOnce({ id: 3, full_path: 'group1/group2/group3' })
+      .mockRejectedValueOnce({ cause: { response: { status: 404 } } });
     mockGitlabClient.Groups.create.mockResolvedValue({
       id: 4,
       full_path: 'group1/group2/group3/group4',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The search API returns multiple results requiring filtering, while show directly returns the group by path or throws a 404 if not found. This is more efficient and accurate for checking if a specific path exists.

Speeds up group creation from 22s to 3s for us.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
