### PR TITLE
fix(ui): forward HTML attributes on Box component

### DIFF
--- a/.changeset/cute-parts-smash.md
+++ b/.changeset/cute-parts-smash.md
@@ -1,0 +1,7 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed Box component to forward HTML attributes to the underlying div element.
+
+**Affected components:** Box

--- a/packages/ui/report.api.md
+++ b/packages/ui/report.api.md
@@ -282,7 +282,11 @@ export type BoxOwnProps = {
 };
 
 // @public (undocumented)
-export interface BoxProps extends SpaceProps, BoxOwnProps, BoxUtilityProps {}
+export interface BoxProps
+  extends SpaceProps,
+    BoxOwnProps,
+    BoxUtilityProps,
+    React.HTMLAttributes<HTMLDivElement> {}
 
 // @public (undocumented)
 export type BoxUtilityProps = {

--- a/packages/ui/src/components/Box/Box.tsx
+++ b/packages/ui/src/components/Box/Box.tsx
@@ -21,7 +21,7 @@ import { BoxDefinition } from './definition';
 
 /** @public */
 export const Box = forwardRef<HTMLDivElement, BoxProps>((props, ref) => {
-  const { ownProps, dataAttributes, utilityStyle } = useDefinition(
+  const { ownProps, restProps, dataAttributes, utilityStyle } = useDefinition(
     BoxDefinition,
     props,
   );
@@ -34,6 +34,7 @@ export const Box = forwardRef<HTMLDivElement, BoxProps>((props, ref) => {
       className: classes.root,
       style: { ...ownProps.style, ...utilityStyle },
       ...dataAttributes,
+      ...restProps,
     },
     surfaceChildren,
   );

--- a/packages/ui/src/components/Box/types.ts
+++ b/packages/ui/src/components/Box/types.ts
@@ -41,4 +41,8 @@ export type BoxUtilityProps = {
 };
 
 /** @public */
-export interface BoxProps extends SpaceProps, BoxOwnProps, BoxUtilityProps {}
+export interface BoxProps
+  extends SpaceProps,
+    BoxOwnProps,
+    BoxUtilityProps,
+    React.HTMLAttributes<HTMLDivElement> {}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixed a regression where HTML attributes like `onClick`, `aria-*`, `data-*`, etc.
were not being forwarded to the underlying div element in the Box component.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.