### PR TITLE
fix: hard navigation to reference docsite

### DIFF
--- a/microsite/docusaurus.config.ts
+++ b/microsite/docusaurus.config.ts
@@ -395,11 +395,13 @@ const config: Config = {
           items: [
             {
               label: `Stable (${releases[0]})`,
-              to: '/api/stable',
+              href: 'https://backstage.io/api/stable',
+              target: '_self',
             },
             {
               label: 'Next',
-              to: '/api/next',
+              href: 'https://backstage.io/api/next',
+              target: '_self',
             },
           ],
         },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Noticed that Docusaurus is trying to perform soft navigations when clicking the existing buttons which unfortunately doesn't work since the `/api/stable` docs are hosted from a different index.html file.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
