### PR TITLE
fix(ui): improve disabled Switch styling

### DIFF
--- a/.changeset/twenty-clubs-itch.md
+++ b/.changeset/twenty-clubs-itch.md
@@ -1,0 +1,7 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed Switch component disabled state styling to show `not-allowed` cursor and disabled text color.
+
+**Affected components:** Switch

--- a/packages/ui/src/components/Switch/Switch.module.css
+++ b/packages/ui/src/components/Switch/Switch.module.css
@@ -27,6 +27,11 @@
     color: var(--bui-fg-primary);
     cursor: pointer;
 
+    &[data-disabled] {
+      cursor: not-allowed;
+      color: var(--bui-fg-disabled);
+    }
+
     &[data-pressed] .bui-SwitchIndicator {
       &:before {
         background: var(--bui-fg-solid);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds proper visual feedback for disabled Switch component by applying
`not-allowed` cursor and disabled text color using design tokens.

<img width="140" height="59" alt="image" src="https://github.com/user-attachments/assets/2d3f1f48-36bf-4fb4-80b3-2ee23451e52d" />

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.