### PR TITLE
fix(ui): prevent literal "undefined" class name in useDefinition

### DIFF
--- a/.changeset/gold-lions-stick.md
+++ b/.changeset/gold-lions-stick.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed `useDefinition` hook adding literal "undefined" class name when no className prop was passed.

--- a/packages/ui/src/hooks/useDefinition/useDefinition.tsx
+++ b/packages/ui/src/hooks/useDefinition/useDefinition.tsx
@@ -103,10 +103,8 @@ export function useDefinition<
     classes[name] = clsx(
       cssKey as string,
       definition.styles[cssKey as keyof typeof definition.styles],
-      {
-        [utilityClasses]: utilityTarget === name,
-        [ownPropsResolved.className]: classNameTarget === name,
-      },
+      utilityTarget === name && utilityClasses,
+      classNameTarget === name && ownPropsResolved.className,
     );
   }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixed a bug in the `useDefinition` hook where a literal "undefined" 
class name was added to components when no `className` prop was passed.

The issue occurred because `clsx` treats object keys as class names, 
and `{ [undefined]: true }` creates an "undefined" string key. Fixed 
by using conditional expressions that `clsx` ignores when falsy.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.