### PR TITLE
fix: add redis socket keepalive options

### DIFF
--- a/.changeset/redis-keepalive-options.md
+++ b/.changeset/redis-keepalive-options.md
@@ -2,6 +2,7 @@
 '@backstage/backend-defaults': patch
 ---
 
-Expose Redis socket keepalive and ping/timeout options in the backend cache
-configuration to address https://github.com/backstage/backstage/issues/31813
-and https://github.com/backstage/backstage/issues/31742.
+Expose Redis socket keepalive, ping/timeout, and reconnect strategy options in
+the backend cache configuration to address
+https://github.com/backstage/backstage/issues/31813 and
+https://github.com/backstage/backstage/issues/31742.

--- a/.changeset/redis-keepalive-options.md
+++ b/.changeset/redis-keepalive-options.md
@@ -2,5 +2,6 @@
 '@backstage/backend-defaults': patch
 ---
 
-Expose Redis socket keepalive options in the backend cache configuration to
-address https://github.com/backstage/backstage/issues/31813.
+Expose Redis socket keepalive and ping/timeout options in the backend cache
+configuration to address https://github.com/backstage/backstage/issues/31813
+and https://github.com/backstage/backstage/issues/31742.

--- a/.changeset/redis-keepalive-options.md
+++ b/.changeset/redis-keepalive-options.md
@@ -1,0 +1,6 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Expose Redis socket keepalive options in the backend cache configuration to
+address https://github.com/backstage/backstage/issues/31813.

--- a/packages/backend-defaults/config.d.ts
+++ b/packages/backend-defaults/config.d.ts
@@ -766,16 +766,15 @@ export interface Config {
               socket?: {
                 /**
                  * Enables TCP keepalive. When `true`, uses the Redis client default
-                 * delay (5000ms in node-redis). When a number, it is interpreted as
-                 * the initial delay in milliseconds. If unset, Backstage does not
-                 * override the Redis client defaults.
-                 *
-                 * Do not set a numeric value together with `keepAliveInitialDelay`;
-                 * prefer `keepAlive: true` with `keepAliveInitialDelay`. If only
+                 * delay (5000ms in node-redis). If unset, Backstage does not
+                 * override the Redis client defaults. If only
                  * `keepAliveInitialDelay` is set, keepalive is enabled with that
                  * delay.
+                 *
+                 * See https://github.com/redis/node-redis/blob/master/docs/client-configuration.md
+                 * and https://nodejs.org/api/net.html#socketsetkeepaliveenable-initialdelay
                  */
-                keepAlive?: boolean | number;
+                keepAlive?: boolean;
                 /**
                  * Initial delay in milliseconds for TCP keepalive probes.
                  */

--- a/packages/backend-defaults/config.d.ts
+++ b/packages/backend-defaults/config.d.ts
@@ -780,62 +780,62 @@ export interface Config {
                  */
                 keepAliveInitialDelay?: number;
                 /**
-                 * Send `PING` command at interval (in milliseconds). Useful for
-                 * environments with idle connection timeouts.
-                 */
-                pingInterval?: number;
-                /**
                  * The maximum duration (in milliseconds) that the socket can remain
                  * idle before being automatically closed.
                  */
                 socketTimeout?: number;
+              };
+              /**
+               * Send `PING` command at interval (in milliseconds). Useful for
+               * environments with idle connection timeouts.
+               */
+              pingInterval?: number;
+              /**
+               * Optional reconnect strategy configuration. When set, Backstage
+               * creates a reconnect strategy function and passes it to the Redis
+               * client. The strategy is used when node-redis detects a socket
+               * close or error (e.g. the connection was dropped by a load
+               * balancer or NAT).
+               *
+               * Note: half-open connections are not always detected by TCP. If
+               * the socket stays idle and the network silently drops it, the
+               * reconnect strategy will not run until the client observes an
+               * error. Use periodic traffic (pinger) or infrastructure/OS
+               * keepalive settings to avoid long idle periods.
+               *
+               * The strategy implements exponential backoff with jitter:
+               * delay = min(2^retries * baseDelayMs, maxDelayMs) ± jitterMs.
+               *
+               * See
+               * https://keyv.org/docs/storage-adapters/redis/#gracefully-handling-errors-and-timeouts.
+               */
+              reconnectStrategy?: {
                 /**
-                 * Optional reconnect strategy configuration. When set, Backstage
-                 * creates a reconnect strategy function and passes it to the Redis
-                 * client. The strategy is used when node-redis detects a socket
-                 * close or error (e.g. the connection was dropped by a load
-                 * balancer or NAT).
-                 *
-                 * Note: half-open connections are not always detected by TCP. If
-                 * the socket stays idle and the network silently drops it, the
-                 * reconnect strategy will not run until the client observes an
-                 * error. Use periodic traffic (pinger) or infrastructure/OS
-                 * keepalive settings to avoid long idle periods.
-                 *
-                 * The strategy implements exponential backoff with jitter:
-                 * delay = min(2^retries * baseDelayMs, maxDelayMs) ± jitterMs.
-                 *
-                 * See
-                 * https://keyv.org/docs/storage-adapters/redis/#gracefully-handling-errors-and-timeouts.
+                 * Base delay in milliseconds for exponential backoff. Defaults to
+                 * 100ms when reconnectStrategy is configured.
                  */
-                reconnectStrategy?: {
-                  /**
-                   * Base delay in milliseconds for exponential backoff. Defaults to
-                   * 100ms when reconnectStrategy is configured.
-                   */
-                  baseDelayMs?: number;
-                  /**
-                   * Max delay in milliseconds for exponential backoff. Defaults to
-                   * 2000ms when reconnectStrategy is configured.
-                   */
-                  maxDelayMs?: number;
-                  /**
-                   * Random jitter in milliseconds added to each delay (± jitter).
-                   * Defaults to 50ms when reconnectStrategy is configured.
-                   */
-                  jitterMs?: number;
-                  /**
-                   * Maximum number of retries before giving up. When unset, retries
-                   * are unbounded.
-                   */
-                  maxRetries?: number;
-                  /**
-                   * When true, stop reconnecting on socket timeout errors. This is
-                   * useful when you want timeouts to be treated as fatal and rely
-                   * on higher-level retry logic.
-                   */
-                  stopOnSocketTimeout?: boolean;
-                };
+                baseDelayMs?: number;
+                /**
+                 * Max delay in milliseconds for exponential backoff. Defaults to
+                 * 2000ms when reconnectStrategy is configured.
+                 */
+                maxDelayMs?: number;
+                /**
+                 * Random jitter in milliseconds added to each delay (± jitter).
+                 * Defaults to 50ms when reconnectStrategy is configured.
+                 */
+                jitterMs?: number;
+                /**
+                 * Maximum number of retries before giving up. When unset, retries
+                 * are unbounded.
+                 */
+                maxRetries?: number;
+                /**
+                 * When true, stop reconnecting on socket timeout errors. This is
+                 * useful when you want timeouts to be treated as fatal and rely
+                 * on higher-level retry logic.
+                 */
+                stopOnSocketTimeout?: boolean;
               };
             };
             /**

--- a/packages/backend-defaults/config.d.ts
+++ b/packages/backend-defaults/config.d.ts
@@ -758,6 +758,28 @@ export interface Config {
                * Defaults to `false`.
                */
               noNamespaceAffectsAll?: boolean;
+              /**
+               * Socket settings passed to the Redis client. See
+               * https://github.com/redis/node-redis/blob/master/docs/client-configuration.md.
+               */
+              socket?: {
+                /**
+                 * Enables TCP keepalive. When `true`, uses the Redis client default
+                 * delay (5000ms in node-redis). When a number, it is interpreted as
+                 * the initial delay in milliseconds. If unset, Backstage does not
+                 * override the Redis client defaults.
+                 *
+                 * Do not set a numeric value together with `keepAliveInitialDelay`;
+                 * prefer `keepAlive: true` with `keepAliveInitialDelay`. If only
+                 * `keepAliveInitialDelay` is set, keepalive is enabled with that
+                 * delay.
+                 */
+                keepAlive?: boolean | number;
+                /**
+                 * Initial delay in milliseconds for TCP keepalive probes.
+                 */
+                keepAliveInitialDelay?: number;
+              };
             };
             /**
              * An optional Redis cluster configuration.

--- a/packages/backend-defaults/config.d.ts
+++ b/packages/backend-defaults/config.d.ts
@@ -789,6 +789,38 @@ export interface Config {
                  * idle before being automatically closed.
                  */
                 socketTimeout?: number;
+                /**
+                 * Optional reconnect strategy configuration. When set, Backstage
+                 * creates a reconnect strategy function and passes it to the Redis
+                 * client. See
+                 * https://keyv.org/docs/storage-adapters/redis/#gracefully-handling-errors-and-timeouts.
+                 */
+                reconnectStrategy?: {
+                  /**
+                   * Base delay in milliseconds for exponential backoff. Defaults to
+                   * 100ms when reconnectStrategy is configured.
+                   */
+                  baseDelayMs?: number;
+                  /**
+                   * Max delay in milliseconds for exponential backoff. Defaults to
+                   * 2000ms when reconnectStrategy is configured.
+                   */
+                  maxDelayMs?: number;
+                  /**
+                   * Random jitter in milliseconds added to each delay (± jitter).
+                   * Defaults to 50ms when reconnectStrategy is configured.
+                   */
+                  jitterMs?: number;
+                  /**
+                   * Maximum number of retries before giving up. When unset, retries
+                   * are unbounded.
+                   */
+                  maxRetries?: number;
+                  /**
+                   * When true, stop reconnecting on socket timeout errors.
+                   */
+                  stopOnSocketTimeout?: boolean;
+                };
               };
             };
             /**

--- a/packages/backend-defaults/config.d.ts
+++ b/packages/backend-defaults/config.d.ts
@@ -776,20 +776,23 @@ export interface Config {
                  */
                 keepAlive?: boolean;
                 /**
-                 * Initial delay in milliseconds for TCP keepalive probes.
+                 * Initial delay before TCP keepalive probes. Supports a number in
+                 * milliseconds or a human duration string like '10s'.
                  */
-                keepAliveInitialDelay?: number;
+                keepAliveInitialDelay?: number | HumanDuration | string;
                 /**
-                 * The maximum duration (in milliseconds) that the socket can remain
-                 * idle before being automatically closed.
+                 * The maximum duration the socket can remain idle before being
+                 * automatically closed. Supports a number in milliseconds or a
+                 * human duration string like '10s'.
                  */
-                socketTimeout?: number;
+                socketTimeout?: number | HumanDuration | string;
               };
               /**
-               * Send `PING` command at interval (in milliseconds). Useful for
-               * environments with idle connection timeouts.
+               * Send `PING` command at interval. Supports a number in milliseconds
+               * or a human duration string like '10s'. Useful for environments
+               * with idle connection timeouts.
                */
-              pingInterval?: number;
+              pingInterval?: number | HumanDuration | string;
               /**
                * Optional reconnect strategy configuration. When set, Backstage
                * creates a reconnect strategy function and passes it to the Redis

--- a/packages/backend-defaults/config.d.ts
+++ b/packages/backend-defaults/config.d.ts
@@ -760,7 +760,8 @@ export interface Config {
               noNamespaceAffectsAll?: boolean;
               /**
                * Socket settings passed to the Redis client. See
-               * https://github.com/redis/node-redis/blob/master/docs/client-configuration.md.
+               * https://github.com/redis/node-redis/blob/master/docs/client-configuration.md
+               * and https://keyv.org/docs/storage-adapters/redis/#keyv-redis-options.
                */
               socket?: {
                 /**
@@ -779,6 +780,16 @@ export interface Config {
                  * Initial delay in milliseconds for TCP keepalive probes.
                  */
                 keepAliveInitialDelay?: number;
+                /**
+                 * Send `PING` command at interval (in milliseconds). Useful for
+                 * environments with idle connection timeouts.
+                 */
+                pingInterval?: number;
+                /**
+                 * The maximum duration (in milliseconds) that the socket can remain
+                 * idle before being automatically closed.
+                 */
+                socketTimeout?: number;
               };
             };
             /**

--- a/packages/backend-defaults/src/entrypoints/cache/CacheManager.test.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/CacheManager.test.ts
@@ -417,38 +417,29 @@ describe('CacheManager store options', () => {
     );
   });
 
-  it('warns and ignores numeric keepAlive values', () => {
-    const logger = mockServices.logger.mock();
-    const manager = CacheManager.fromConfig(
-      mockServices.rootConfig({
-        data: {
-          backend: {
-            cache: {
-              store: 'redis',
-              connection: 'redis://localhost:6379',
-              redis: {
-                client: {
-                  socket: {
-                    keepAlive: 7000,
+  it('throws on numeric keepAlive values', () => {
+    expect(() =>
+      CacheManager.fromConfig(
+        mockServices.rootConfig({
+          data: {
+            backend: {
+              cache: {
+                store: 'redis',
+                connection: 'redis://localhost:6379',
+                redis: {
+                  client: {
+                    socket: {
+                      keepAlive: 7000,
+                    },
                   },
                 },
               },
             },
           },
-        },
-      }),
-      { logger },
-    );
-
-    manager.forPlugin('p1');
-
-    const childLogger = (logger.child as jest.Mock).mock.results[0]?.value;
-    expect(childLogger?.warn).toHaveBeenCalledWith(
-      "Invalid 'client.socket.keepAlive' value. Expected boolean, got number. Ignoring keepAlive.",
-    );
-    expect(KeyvRedis).toHaveBeenCalledWith(
-      'redis://localhost:6379',
-      expect.objectContaining({ keyPrefixSeparator: ':' }),
+        }),
+      ),
+    ).toThrow(
+      "Unable to convert config value for key 'backend.cache.redis.client.socket.keepAlive' in 'mock-config' to a boolean",
     );
   });
 

--- a/packages/backend-defaults/src/entrypoints/cache/CacheManager.test.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/CacheManager.test.ts
@@ -210,133 +210,112 @@ describe('CacheManager integration', () => {
   });
 });
 
+type CacheManagerOptions = Parameters<typeof CacheManager.fromConfig>[1];
+
+const redisConnection = 'redis://localhost:6379';
+
+const createCacheManager = (
+  cacheConfig: object,
+  options?: CacheManagerOptions,
+) =>
+  CacheManager.fromConfig(
+    mockServices.rootConfig({
+      data: { backend: { cache: cacheConfig } },
+    }),
+    options,
+  );
+
+const createRedisManager = (
+  redis?: object,
+  options?: CacheManagerOptions,
+  cacheOverrides: object = {},
+) =>
+  createCacheManager(
+    {
+      store: 'redis',
+      connection: redisConnection,
+      ...(redis ? { redis } : {}),
+      ...cacheOverrides,
+    },
+    options,
+  );
+
+const createValkeyManager = (valkey?: object, options?: CacheManagerOptions) =>
+  createCacheManager(
+    {
+      store: 'valkey',
+      connection: redisConnection,
+      ...(valkey ? { valkey } : {}),
+    },
+    options,
+  );
+
 describe('CacheManager store options', () => {
   afterEach(jest.clearAllMocks);
 
   it('uses default options when no store-specific config exists', () => {
-    const manager = CacheManager.fromConfig(
-      mockServices.rootConfig({
-        data: {
-          backend: {
-            cache: {
-              store: 'redis',
-              connection: 'redis://localhost:6379',
-            },
-          },
-        },
-      }),
-    );
+    const manager = createRedisManager();
 
     manager.forPlugin('p1');
 
-    expect(KeyvRedis).toHaveBeenCalledWith('redis://localhost:6379', {
+    expect(KeyvRedis).toHaveBeenCalledWith(redisConnection, {
       keyPrefixSeparator: ':',
     });
   });
 
   it('defaults to non-clustered mode when cluster config is missing root nodes', () => {
-    const manager = CacheManager.fromConfig(
-      mockServices.rootConfig({
-        data: {
-          backend: {
-            cache: {
-              store: 'redis',
-              connection: 'redis://localhost:6379',
-              redis: {
-                cluster: {},
-              },
-            },
-          },
-        },
-      }),
-    );
+    const manager = createRedisManager({ cluster: {} });
     manager.forPlugin('p1');
 
-    expect(KeyvRedis).toHaveBeenCalledWith('redis://localhost:6379', {
+    expect(KeyvRedis).toHaveBeenCalledWith(redisConnection, {
       keyPrefixSeparator: ':',
     });
   });
 
   it('uses cluster config when present', () => {
-    const manager = CacheManager.fromConfig(
-      mockServices.rootConfig({
-        data: {
-          backend: {
-            cache: {
-              store: 'redis',
-              connection: 'redis://localhost:6379',
-              redis: {
-                cluster: {
-                  rootNodes: [{ url: 'redis://localhost:6379' }],
-                },
-              },
-            },
-          },
-        },
-      }),
-    );
+    const manager = createRedisManager({
+      cluster: {
+        rootNodes: [{ url: redisConnection }],
+      },
+    });
     manager.forPlugin('p1');
 
     expect(createCluster).toHaveBeenCalledWith({
-      rootNodes: [{ url: 'redis://localhost:6379' }],
+      rootNodes: [{ url: redisConnection }],
       defaults: undefined,
     });
   });
 
   it('respects client config for non-clustered mode', () => {
-    const manager = CacheManager.fromConfig(
-      mockServices.rootConfig({
-        data: {
-          backend: {
-            cache: {
-              store: 'redis',
-              connection: 'redis://localhost:6379',
-              redis: {
-                client: {
-                  keyPrefixSeparator: '!',
-                },
-              },
-            },
-          },
-        },
-      }),
-    );
+    const manager = createRedisManager({
+      client: {
+        keyPrefixSeparator: '!',
+      },
+    });
     manager.forPlugin('p1');
 
-    expect(KeyvRedis).toHaveBeenCalledWith('redis://localhost:6379', {
+    expect(KeyvRedis).toHaveBeenCalledWith(redisConnection, {
       keyPrefixSeparator: '!',
     });
   });
 
   it('accepts client config for clustered mode', () => {
     (createCluster as jest.Mock).mockReturnValue({
-      url: 'redis://localhost:6379',
+      url: redisConnection,
     });
-    const manager = CacheManager.fromConfig(
-      mockServices.rootConfig({
-        data: {
-          backend: {
-            cache: {
-              store: 'redis',
-              connection: 'redis://localhost:6379',
-              redis: {
-                client: {
-                  keyPrefixSeparator: '!',
-                },
-                cluster: {
-                  rootNodes: [{ url: 'redis://localhost:6379' }],
-                },
-              },
-            },
-          },
-        },
-      }),
-    );
+    const manager = createRedisManager({
+      client: {
+        keyPrefixSeparator: '!',
+      },
+      cluster: {
+        rootNodes: [{ url: redisConnection }],
+      },
+    });
     manager.forPlugin('p1');
 
     expect(KeyvRedis).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: 'redis://localhost:6379',
+        url: redisConnection,
       }),
       {
         keyPrefixSeparator: '!',
@@ -346,24 +325,14 @@ describe('CacheManager store options', () => {
 
   it('passes socket keepalive options to the redis client', () => {
     const logger = mockServices.logger.mock();
-    const manager = CacheManager.fromConfig(
-      mockServices.rootConfig({
-        data: {
-          backend: {
-            cache: {
-              store: 'redis',
-              connection: 'redis://localhost:6379',
-              redis: {
-                client: {
-                  socket: {
-                    keepAliveInitialDelay: 1234,
-                  },
-                },
-              },
-            },
+    const manager = createRedisManager(
+      {
+        client: {
+          socket: {
+            keepAliveInitialDelay: 1234,
           },
         },
-      }),
+      },
       { logger },
     );
 
@@ -375,7 +344,7 @@ describe('CacheManager store options', () => {
     );
     expect(KeyvRedis).toHaveBeenCalledWith(
       {
-        url: 'redis://localhost:6379',
+        url: redisConnection,
         socket: expect.objectContaining({
           keepAlive: true,
           keepAliveInitialDelay: 1234,
@@ -386,31 +355,19 @@ describe('CacheManager store options', () => {
   });
 
   it('passes boolean keepAlive to the redis client', () => {
-    const manager = CacheManager.fromConfig(
-      mockServices.rootConfig({
-        data: {
-          backend: {
-            cache: {
-              store: 'redis',
-              connection: 'redis://localhost:6379',
-              redis: {
-                client: {
-                  socket: {
-                    keepAlive: true,
-                  },
-                },
-              },
-            },
-          },
+    const manager = createRedisManager({
+      client: {
+        socket: {
+          keepAlive: true,
         },
-      }),
-    );
+      },
+    });
 
     manager.forPlugin('p1');
 
     expect(KeyvRedis).toHaveBeenCalledWith(
       {
-        url: 'redis://localhost:6379',
+        url: redisConnection,
         socket: expect.objectContaining({ keepAlive: true }),
       },
       expect.objectContaining({ keyPrefixSeparator: ':' }),
@@ -419,57 +376,33 @@ describe('CacheManager store options', () => {
 
   it('throws on numeric keepAlive values', () => {
     expect(() =>
-      CacheManager.fromConfig(
-        mockServices.rootConfig({
-          data: {
-            backend: {
-              cache: {
-                store: 'redis',
-                connection: 'redis://localhost:6379',
-                redis: {
-                  client: {
-                    socket: {
-                      keepAlive: 7000,
-                    },
-                  },
-                },
-              },
-            },
+      createRedisManager({
+        client: {
+          socket: {
+            keepAlive: 7000,
           },
-        }),
-      ),
+        },
+      }),
     ).toThrow(
       "Unable to convert config value for key 'backend.cache.redis.client.socket.keepAlive' in 'mock-config' to a boolean",
     );
   });
 
   it('ignores keepAliveInitialDelay when keepAlive is false', () => {
-    const manager = CacheManager.fromConfig(
-      mockServices.rootConfig({
-        data: {
-          backend: {
-            cache: {
-              store: 'redis',
-              connection: 'redis://localhost:6379',
-              redis: {
-                client: {
-                  socket: {
-                    keepAlive: false,
-                    keepAliveInitialDelay: 5000,
-                  },
-                },
-              },
-            },
-          },
+    const manager = createRedisManager({
+      client: {
+        socket: {
+          keepAlive: false,
+          keepAliveInitialDelay: 5000,
         },
-      }),
-    );
+      },
+    });
 
     manager.forPlugin('p1');
 
     expect(KeyvRedis).toHaveBeenCalledWith(
       {
-        url: 'redis://localhost:6379',
+        url: redisConnection,
         socket: expect.objectContaining({ keepAlive: false }),
       },
       expect.objectContaining({ keyPrefixSeparator: ':' }),
@@ -477,32 +410,20 @@ describe('CacheManager store options', () => {
   });
 
   it('passes ping interval and socket timeout to the redis client', () => {
-    const manager = CacheManager.fromConfig(
-      mockServices.rootConfig({
-        data: {
-          backend: {
-            cache: {
-              store: 'redis',
-              connection: 'redis://localhost:6379',
-              redis: {
-                client: {
-                  pingInterval: 15000,
-                  socket: {
-                    socketTimeout: 20000,
-                  },
-                },
-              },
-            },
-          },
+    const manager = createRedisManager({
+      client: {
+        pingInterval: 15000,
+        socket: {
+          socketTimeout: 20000,
         },
-      }),
-    );
+      },
+    });
 
     manager.forPlugin('p1');
 
     expect(KeyvRedis).toHaveBeenCalledWith(
       {
-        url: 'redis://localhost:6379',
+        url: redisConnection,
         pingInterval: 15000,
         socket: expect.objectContaining({
           socketTimeout: 20000,
@@ -516,39 +437,27 @@ describe('CacheManager store options', () => {
   });
 
   it('passes reconnect strategy options to the redis client', () => {
-    const manager = CacheManager.fromConfig(
-      mockServices.rootConfig({
-        data: {
-          backend: {
-            cache: {
-              store: 'redis',
-              connection: 'redis://localhost:6379',
-              redis: {
-                client: {
-                  pingInterval: 15000,
-                  socket: {
-                    socketTimeout: 20000,
-                    reconnectStrategy: {
-                      baseDelayMs: 100,
-                      maxDelayMs: 2000,
-                      jitterMs: 0,
-                      maxRetries: 20,
-                      stopOnSocketTimeout: true,
-                    },
-                  },
-                },
-              },
-            },
+    const manager = createRedisManager({
+      client: {
+        pingInterval: 15000,
+        socket: {
+          socketTimeout: 20000,
+          reconnectStrategy: {
+            baseDelayMs: 100,
+            maxDelayMs: 2000,
+            jitterMs: 0,
+            maxRetries: 20,
+            stopOnSocketTimeout: true,
           },
         },
-      }),
-    );
+      },
+    });
 
     manager.forPlugin('p1');
 
     expect(KeyvRedis).toHaveBeenCalledWith(
       {
-        url: 'redis://localhost:6379',
+        url: redisConnection,
         pingInterval: 15000,
         socket: expect.objectContaining({
           socketTimeout: 20000,
@@ -570,18 +479,7 @@ describe('CacheManager store options', () => {
   });
 
   it('recreates redis store after socket timeout error', () => {
-    const manager = CacheManager.fromConfig(
-      mockServices.rootConfig({
-        data: {
-          backend: {
-            cache: {
-              store: 'redis',
-              connection: 'redis://localhost:6379',
-            },
-          },
-        },
-      }),
-    );
+    const manager = createRedisManager();
 
     manager.forPlugin('p1');
 
@@ -599,27 +497,15 @@ describe('CacheManager store options', () => {
 
   it('reconnects on socket timeout when stopOnSocketTimeout is false', () => {
     const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.5);
-    const manager = CacheManager.fromConfig(
-      mockServices.rootConfig({
-        data: {
-          backend: {
-            cache: {
-              store: 'redis',
-              connection: 'redis://localhost:6379',
-              redis: {
-                client: {
-                  socket: {
-                    reconnectStrategy: {
-                      stopOnSocketTimeout: false,
-                    },
-                  },
-                },
-              },
-            },
+    const manager = createRedisManager({
+      client: {
+        socket: {
+          reconnectStrategy: {
+            stopOnSocketTimeout: false,
           },
         },
-      }),
-    );
+      },
+    });
 
     manager.forPlugin('p1');
 
@@ -633,66 +519,42 @@ describe('CacheManager store options', () => {
   });
 
   it('merges socket options into redis cluster defaults', () => {
-    const manager = CacheManager.fromConfig(
-      mockServices.rootConfig({
-        data: {
-          backend: {
-            cache: {
-              store: 'redis',
-              connection: 'redis://localhost:6379',
-              redis: {
-                client: {
-                  socket: {
-                    keepAliveInitialDelay: 4242,
-                  },
-                },
-                cluster: {
-                  rootNodes: [{ url: 'redis://localhost:6379' }],
-                },
-              },
-            },
-          },
+    const manager = createRedisManager({
+      client: {
+        socket: {
+          keepAliveInitialDelay: 4242,
         },
-      }),
-    );
+      },
+      cluster: {
+        rootNodes: [{ url: redisConnection }],
+      },
+    });
 
     manager.forPlugin('p1');
 
     expect(createCluster).toHaveBeenCalledWith({
-      rootNodes: [{ url: 'redis://localhost:6379' }],
+      rootNodes: [{ url: redisConnection }],
       defaults: { socket: { keepAlive: true, keepAliveInitialDelay: 4242 } },
     });
   });
 
   it('merges ping interval and socket timeout into redis cluster defaults', () => {
-    const manager = CacheManager.fromConfig(
-      mockServices.rootConfig({
-        data: {
-          backend: {
-            cache: {
-              store: 'redis',
-              connection: 'redis://localhost:6379',
-              redis: {
-                client: {
-                  pingInterval: 10000,
-                  socket: {
-                    socketTimeout: 12000,
-                  },
-                },
-                cluster: {
-                  rootNodes: [{ url: 'redis://localhost:6379' }],
-                },
-              },
-            },
-          },
+    const manager = createRedisManager({
+      client: {
+        pingInterval: 10000,
+        socket: {
+          socketTimeout: 12000,
         },
-      }),
-    );
+      },
+      cluster: {
+        rootNodes: [{ url: redisConnection }],
+      },
+    });
 
     manager.forPlugin('p1');
 
     expect(createCluster).toHaveBeenCalledWith({
-      rootNodes: [{ url: 'redis://localhost:6379' }],
+      rootNodes: [{ url: redisConnection }],
       defaults: {
         pingInterval: 10000,
         socket: {
@@ -703,37 +565,25 @@ describe('CacheManager store options', () => {
   });
 
   it('merges reconnect strategy into redis cluster defaults', () => {
-    const manager = CacheManager.fromConfig(
-      mockServices.rootConfig({
-        data: {
-          backend: {
-            cache: {
-              store: 'redis',
-              connection: 'redis://localhost:6379',
-              redis: {
-                client: {
-                  pingInterval: 10000,
-                  socket: {
-                    socketTimeout: 12000,
-                    reconnectStrategy: {
-                      baseDelayMs: 100,
-                    },
-                  },
-                },
-                cluster: {
-                  rootNodes: [{ url: 'redis://localhost:6379' }],
-                },
-              },
-            },
+    const manager = createRedisManager({
+      client: {
+        pingInterval: 10000,
+        socket: {
+          socketTimeout: 12000,
+          reconnectStrategy: {
+            baseDelayMs: 100,
           },
         },
-      }),
-    );
+      },
+      cluster: {
+        rootNodes: [{ url: redisConnection }],
+      },
+    });
 
     manager.forPlugin('p1');
 
     expect(createCluster).toHaveBeenCalledWith({
-      rootNodes: [{ url: 'redis://localhost:6379' }],
+      rootNodes: [{ url: redisConnection }],
       defaults: {
         pingInterval: 10000,
         socket: {
@@ -757,57 +607,29 @@ describe('CacheManager store options', () => {
     ];
 
     testCases.forEach(({ store, client }) => {
-      const manager = CacheManager.fromConfig(
-        mockServices.rootConfig({
-          data: {
-            backend: {
-              cache: {
-                store,
-                connection: 'redis://localhost:6379',
-                [store]: {
-                  client,
-                },
-              },
-            },
-          },
-        }),
-      );
+      const manager =
+        store === 'redis'
+          ? createRedisManager({ client })
+          : createValkeyManager({ client });
 
       manager.forPlugin('testPlugin');
 
       if (store === 'redis') {
         // eslint-disable-next-line jest/no-conditional-expect
-        expect(KeyvRedis).toHaveBeenCalledWith(
-          'redis://localhost:6379',
-          client,
-        );
+        expect(KeyvRedis).toHaveBeenCalledWith(redisConnection, client);
       } else if (store === 'valkey') {
         // eslint-disable-next-line jest/no-conditional-expect
-        expect(KeyvValkey).toHaveBeenCalledWith(
-          'redis://localhost:6379',
-          client,
-        );
+        expect(KeyvValkey).toHaveBeenCalledWith(redisConnection, client);
       }
     });
   });
 
   it('falls back to pluginId when no namespace is configured', () => {
-    const manager = CacheManager.fromConfig(
-      mockServices.rootConfig({
-        data: {
-          backend: {
-            cache: {
-              store: 'redis',
-              connection: 'redis://localhost:6379',
-            },
-          },
-        },
-      }),
-    );
+    const manager = createRedisManager();
 
     manager.forPlugin('testPlugin');
 
-    expect(KeyvRedis).toHaveBeenCalledWith('redis://localhost:6379', {
+    expect(KeyvRedis).toHaveBeenCalledWith(redisConnection, {
       keyPrefixSeparator: ':',
     });
   });

--- a/packages/backend-defaults/src/entrypoints/cache/CacheManager.test.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/CacheManager.test.ts
@@ -510,6 +510,9 @@ describe('CacheManager store options', () => {
 
     const connection = (KeyvRedis as jest.Mock).mock.calls[0][0];
     expect(connection.socket.reconnectStrategy).toBeUndefined();
+    expect(KeyvRedis).toHaveBeenCalledWith('redis://localhost:6379', {
+      keyPrefixSeparator: '!',
+    });
   });
 
   it('passes reconnect strategy options to the redis client', () => {
@@ -600,7 +603,6 @@ describe('CacheManager store options', () => {
 
   it('merges ping interval and socket timeout into redis cluster defaults', () => {
       defaults: { socket: { keepAliveInitialDelay: 4242 } },
-    });
   });
 
   it('merges reconnect strategy into redis cluster defaults', () => {

--- a/packages/backend-defaults/src/entrypoints/cache/CacheManager.test.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/CacheManager.test.ts
@@ -495,8 +495,8 @@ describe('CacheManager store options', () => {
               connection: 'redis://localhost:6379',
               redis: {
                 client: {
+                  pingInterval: 15000,
                   socket: {
-                    pingInterval: 15000,
                     socketTimeout: 20000,
                   },
                 },
@@ -512,8 +512,8 @@ describe('CacheManager store options', () => {
     expect(KeyvRedis).toHaveBeenCalledWith(
       {
         url: 'redis://localhost:6379',
+        pingInterval: 15000,
         socket: expect.objectContaining({
-          pingInterval: 15000,
           socketTimeout: 20000,
         }),
       },
@@ -534,8 +534,8 @@ describe('CacheManager store options', () => {
               connection: 'redis://localhost:6379',
               redis: {
                 client: {
+                  pingInterval: 15000,
                   socket: {
-                    pingInterval: 15000,
                     socketTimeout: 20000,
                     reconnectStrategy: {
                       baseDelayMs: 100,
@@ -558,8 +558,8 @@ describe('CacheManager store options', () => {
     expect(KeyvRedis).toHaveBeenCalledWith(
       {
         url: 'redis://localhost:6379',
+        pingInterval: 15000,
         socket: expect.objectContaining({
-          pingInterval: 15000,
           socketTimeout: 20000,
           reconnectStrategy: expect.any(Function),
         }),
@@ -607,6 +607,7 @@ describe('CacheManager store options', () => {
   });
 
   it('reconnects on socket timeout when stopOnSocketTimeout is false', () => {
+    const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.5);
     const manager = CacheManager.fromConfig(
       mockServices.rootConfig({
         data: {
@@ -637,6 +638,7 @@ describe('CacheManager store options', () => {
     socketTimeoutError.name = 'SocketTimeoutError';
 
     expect(strategy(1, socketTimeoutError)).toBe(200);
+    randomSpy.mockRestore();
   });
 
   it('merges socket options into redis cluster defaults', () => {
@@ -681,8 +683,8 @@ describe('CacheManager store options', () => {
               connection: 'redis://localhost:6379',
               redis: {
                 client: {
+                  pingInterval: 10000,
                   socket: {
-                    pingInterval: 10000,
                     socketTimeout: 12000,
                   },
                 },
@@ -701,8 +703,8 @@ describe('CacheManager store options', () => {
     expect(createCluster).toHaveBeenCalledWith({
       rootNodes: [{ url: 'redis://localhost:6379' }],
       defaults: {
+        pingInterval: 10000,
         socket: {
-          pingInterval: 10000,
           socketTimeout: 12000,
         },
       },
@@ -719,8 +721,8 @@ describe('CacheManager store options', () => {
               connection: 'redis://localhost:6379',
               redis: {
                 client: {
+                  pingInterval: 10000,
                   socket: {
-                    pingInterval: 10000,
                     socketTimeout: 12000,
                     reconnectStrategy: {
                       baseDelayMs: 100,
@@ -742,8 +744,8 @@ describe('CacheManager store options', () => {
     expect(createCluster).toHaveBeenCalledWith({
       rootNodes: [{ url: 'redis://localhost:6379' }],
       defaults: {
+        pingInterval: 10000,
         socket: {
-          pingInterval: 10000,
           socketTimeout: 12000,
           reconnectStrategy: expect.any(Function),
         },

--- a/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
@@ -187,19 +187,16 @@ export class CacheManager {
     const socketConfig = clientConfig?.getOptionalConfig('socket');
     const keepAliveConfig = socketConfig?.getOptional('keepAlive');
     const keepAlive =
-      typeof keepAliveConfig === 'boolean' ||
-      typeof keepAliveConfig === 'number'
-        ? keepAliveConfig
-        : undefined;
+      typeof keepAliveConfig === 'boolean' ? keepAliveConfig : undefined;
     const keepAliveInitialDelay = socketConfig?.getOptionalNumber(
       'keepAliveInitialDelay',
     );
     const pingInterval = socketConfig?.getOptionalNumber('pingInterval');
     const socketTimeout = socketConfig?.getOptionalNumber('socketTimeout');
 
-    if (typeof keepAlive === 'number' && keepAliveInitialDelay !== undefined) {
+    if (typeof keepAliveConfig === 'number') {
       logger?.warn(
-        "Both 'client.socket.keepAlive' (number) and 'client.socket.keepAliveInitialDelay' are set. Prefer 'keepAlive: true' with 'keepAliveInitialDelay'. Using 'keepAliveInitialDelay' and treating keepAlive as enabled.",
+        "Invalid 'client.socket.keepAlive' value. Expected boolean, got number. Ignoring keepAlive.",
       );
     }
 
@@ -209,17 +206,11 @@ export class CacheManager {
       );
     }
 
-    let keepAliveForSocket: number | true | false | undefined;
+    let keepAliveForSocket: boolean | undefined;
     let keepAliveInitialDelayForSocket: number | undefined;
 
     if (keepAlive === false) {
       keepAliveForSocket = false;
-    } else if (typeof keepAlive === 'number') {
-      if (keepAliveInitialDelay !== undefined) {
-        keepAliveInitialDelayForSocket = keepAliveInitialDelay;
-      } else {
-        keepAliveForSocket = keepAlive;
-      }
     } else {
       if (keepAliveInitialDelay !== undefined) {
         if (keepAlive !== true) {

--- a/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
@@ -160,7 +160,7 @@ export class CacheManager {
       );
     }
 
-    logger?.info('[REDIS PATCH] Store', { store });
+    logger?.debug('backend.cache: selected store', { store });
 
     switch (store) {
       case 'redis':
@@ -206,7 +206,6 @@ export class CacheManager {
 
     const clientConfig = redisConfig.getOptionalConfig('client');
     const socketConfig = clientConfig?.getOptionalConfig('socket');
-    const keepAliveConfig = socketConfig?.getOptional('keepAlive');
     const keepAlive = redisConfig.getOptionalBoolean('client.socket.keepAlive');
     const keepAliveInitialDelay = CacheManager.readOptionalDuration(
       redisConfig,
@@ -220,13 +219,6 @@ export class CacheManager {
       redisConfig,
       'client.socket.socketTimeout',
     );
-
-    logger?.info('[REDIS PATCH] Read socket config', {
-      keepAliveConfig,
-      keepAliveInitialDelay,
-      pingInterval,
-      socketTimeout,
-    });
 
     if (keepAlive === false && keepAliveInitialDelay !== undefined) {
       logger?.warn(
@@ -253,7 +245,7 @@ export class CacheManager {
       }
     }
 
-    logger?.info('[REDIS PATCH] Derived socket options', {
+    logger?.debug('backend.cache: derived socket options', {
       keepAliveForSocket,
       keepAliveInitialDelayForSocket,
     });
@@ -273,14 +265,6 @@ export class CacheManager {
       jitterMs !== undefined ||
       maxRetries !== undefined ||
       stopOnSocketTimeout !== undefined;
-
-    logger?.info('[REDIS PATCH] Read reconnect config', {
-      baseDelayMs,
-      maxDelayMs,
-      jitterMs,
-      maxRetries,
-      stopOnSocketTimeout,
-    });
 
     const reconnectStrategy = hasReconnectConfig
       ? (retries: number, cause: Error) => {
@@ -376,10 +360,20 @@ export class CacheManager {
       }
     }
 
-    logger?.info('[REDIS PATCH] Passing Redis options to Redis client', {
+    logger?.debug('backend.cache: redis client options', {
       hasClientOptions: Boolean(redisOptions.client),
       hasSocketOptions: Boolean(redisOptions.socket),
-      hasPingInterval: pingInterval !== undefined,
+      pingInterval,
+      socketTimeout,
+      keepAliveForSocket,
+      keepAliveInitialDelayForSocket,
+      reconnect: {
+        baseDelayMs,
+        maxDelayMs,
+        jitterMs,
+        maxRetries,
+        stopOnSocketTimeout,
+      },
       hasClusterOptions: Boolean(redisOptions.cluster),
     });
 

--- a/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
@@ -207,18 +207,15 @@ export class CacheManager {
     const clientConfig = redisConfig.getOptionalConfig('client');
     const socketConfig = clientConfig?.getOptionalConfig('socket');
     const keepAlive = redisConfig.getOptionalBoolean('client.socket.keepAlive');
-    const keepAliveInitialDelay = CacheManager.readOptionalDuration(
-      redisConfig,
-      'client.socket.keepAliveInitialDelay',
-    );
-    const pingInterval = CacheManager.readOptionalDuration(
-      redisConfig,
-      'client.pingInterval',
-    );
-    const socketTimeout = CacheManager.readOptionalDuration(
-      redisConfig,
-      'client.socket.socketTimeout',
-    );
+    const keepAliveInitialDelay = socketConfig
+      ? CacheManager.readOptionalDuration(socketConfig, 'keepAliveInitialDelay')
+      : undefined;
+    const pingInterval = clientConfig
+      ? CacheManager.readOptionalDuration(clientConfig, 'pingInterval')
+      : undefined;
+    const socketTimeout = socketConfig
+      ? CacheManager.readOptionalDuration(socketConfig, 'socketTimeout')
+      : undefined;
 
     let keepAliveForSocket: boolean | undefined;
     let keepAliveInitialDelayForSocket: number | undefined;

--- a/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
@@ -234,6 +234,8 @@ export class CacheManager {
 
     const reconnectStrategy = hasReconnectConfig
       ? (retries: number, cause: Error) => {
+          // Exponential backoff with jitter; return false to stop reconnecting.
+          // This only runs when node-redis observes a socket close/error.
           if (
             stopOnSocketTimeout &&
             (cause as { name?: string }).name === 'SocketTimeoutError'

--- a/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
@@ -209,7 +209,7 @@ export class CacheManager {
       );
     }
 
-    let keepAliveForSocket: number | false | undefined;
+    let keepAliveForSocket: number | true | false | undefined;
     let keepAliveInitialDelayForSocket: number | undefined;
 
     if (keepAlive === false) {
@@ -221,7 +221,17 @@ export class CacheManager {
         keepAliveForSocket = keepAlive;
       }
     } else {
-      keepAliveInitialDelayForSocket = keepAliveInitialDelay;
+      if (keepAliveInitialDelay !== undefined) {
+        if (keepAlive !== true) {
+          logger?.warn(
+            'Socket keepalive initial delay is set without keepalive enabled. Enabling keepalive.',
+          );
+        }
+        keepAliveForSocket = true;
+        keepAliveInitialDelayForSocket = keepAliveInitialDelay;
+      } else if (keepAlive === true) {
+        keepAliveForSocket = true;
+      }
     }
 
     const socketOptions =

--- a/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
@@ -239,6 +239,7 @@ export class CacheManager {
               : {}),
             ...(pingInterval !== undefined ? { pingInterval } : {}),
             ...(socketTimeout !== undefined ? { socketTimeout } : {}),
+            ...(reconnectStrategy !== undefined ? { reconnectStrategy } : {}),
           }
         : undefined;
 

--- a/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
@@ -220,12 +220,6 @@ export class CacheManager {
       'client.socket.socketTimeout',
     );
 
-    if (keepAlive === false && keepAliveInitialDelay !== undefined) {
-      logger?.warn(
-        "Both 'client.socket.keepAlive' (false) and 'client.socket.keepAliveInitialDelay' are set. Ignoring 'keepAliveInitialDelay' because keepalive is disabled.",
-      );
-    }
-
     let keepAliveForSocket: boolean | undefined;
     let keepAliveInitialDelayForSocket: number | undefined;
 

--- a/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
@@ -194,6 +194,8 @@ export class CacheManager {
     const keepAliveInitialDelay = socketConfig?.getOptionalNumber(
       'keepAliveInitialDelay',
     );
+    const pingInterval = socketConfig?.getOptionalNumber('pingInterval');
+    const socketTimeout = socketConfig?.getOptionalNumber('socketTimeout');
 
     if (typeof keepAlive === 'number' && keepAliveInitialDelay !== undefined) {
       logger?.warn(
@@ -224,7 +226,9 @@ export class CacheManager {
 
     const socketOptions =
       keepAliveForSocket !== undefined ||
-      keepAliveInitialDelayForSocket !== undefined
+      keepAliveInitialDelayForSocket !== undefined ||
+      pingInterval !== undefined ||
+      socketTimeout !== undefined
         ? {
             ...(keepAliveForSocket !== undefined
               ? { keepAlive: keepAliveForSocket }
@@ -232,6 +236,8 @@ export class CacheManager {
             ...(keepAliveInitialDelayForSocket !== undefined
               ? { keepAliveInitialDelay: keepAliveInitialDelayForSocket }
               : {}),
+            ...(pingInterval !== undefined ? { pingInterval } : {}),
+            ...(socketTimeout !== undefined ? { socketTimeout } : {}),
           }
         : undefined;
 

--- a/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
@@ -285,22 +285,27 @@ export class CacheManager {
         }
       : undefined;
 
-    const socketOptions =
+    let socketOptions: Record<string, unknown> | undefined;
+    if (
       keepAliveForSocket !== undefined ||
       keepAliveInitialDelayForSocket !== undefined ||
       socketTimeout !== undefined ||
       reconnectStrategy !== undefined
-        ? {
-            ...(keepAliveForSocket !== undefined
-              ? { keepAlive: keepAliveForSocket }
-              : {}),
-            ...(keepAliveInitialDelayForSocket !== undefined
-              ? { keepAliveInitialDelay: keepAliveInitialDelayForSocket }
-              : {}),
-            ...(socketTimeout !== undefined ? { socketTimeout } : {}),
-            ...(reconnectStrategy !== undefined ? { reconnectStrategy } : {}),
-          }
-        : undefined;
+    ) {
+      socketOptions = {};
+      if (keepAliveForSocket !== undefined) {
+        socketOptions.keepAlive = keepAliveForSocket;
+      }
+      if (keepAliveInitialDelayForSocket !== undefined) {
+        socketOptions.keepAliveInitialDelay = keepAliveInitialDelayForSocket;
+      }
+      if (socketTimeout !== undefined) {
+        socketOptions.socketTimeout = socketTimeout;
+      }
+      if (reconnectStrategy !== undefined) {
+        socketOptions.reconnectStrategy = reconnectStrategy;
+      }
+    }
 
     if (socketOptions) {
       // node-redis docs indicate keepAlive is boolean even if types differ.

--- a/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
@@ -142,6 +142,8 @@ export class CacheManager {
       );
     }
 
+    logger?.info('[REDIS PATCH] Store', { store });
+
     switch (store) {
       case 'redis':
         return CacheManager.parseRedisOptions(storeConfigPath, config, logger);
@@ -194,6 +196,13 @@ export class CacheManager {
     const pingInterval = socketConfig?.getOptionalNumber('pingInterval');
     const socketTimeout = socketConfig?.getOptionalNumber('socketTimeout');
 
+    logger?.info('[REDIS PATCH] Read socket config', {
+      keepAliveConfig,
+      keepAliveInitialDelay,
+      pingInterval,
+      socketTimeout,
+    });
+
     if (typeof keepAliveConfig === 'number') {
       logger?.warn(
         "Invalid 'client.socket.keepAlive' value. Expected boolean, got number. Ignoring keepAlive.",
@@ -225,6 +234,11 @@ export class CacheManager {
       }
     }
 
+    logger?.info('[REDIS PATCH] Derived socket options', {
+      keepAliveForSocket,
+      keepAliveInitialDelayForSocket,
+    });
+
     const reconnectConfig =
       socketConfig?.getOptionalConfig('reconnectStrategy');
     const baseDelayMs = reconnectConfig?.getOptionalNumber('baseDelayMs');
@@ -240,6 +254,14 @@ export class CacheManager {
       jitterMs !== undefined ||
       maxRetries !== undefined ||
       stopOnSocketTimeout !== undefined;
+
+    logger?.info('[REDIS PATCH] Read reconnect config', {
+      baseDelayMs,
+      maxDelayMs,
+      jitterMs,
+      maxRetries,
+      stopOnSocketTimeout,
+    });
 
     const reconnectStrategy = hasReconnectConfig
       ? (retries: number, cause: Error) => {
@@ -326,6 +348,12 @@ export class CacheManager {
         };
       }
     }
+
+    logger?.info('[REDIS PATCH] Passing Redis options to Redis client', {
+      client: redisOptions.client,
+      socket: redisOptions.socket,
+      cluster: redisOptions.cluster,
+    });
 
     return redisOptions;
   }

--- a/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
@@ -538,21 +538,37 @@ export class CacheManager {
           // Disconnects the client to force a new connection on the next request after errors.
           const store = stores[pluginId];
           if (store) {
-            try {
-              (store as { disconnect?: () => void }).disconnect?.();
-              (store as { quit?: () => void }).quit?.();
-            } catch (closeError) {
-              this.logger?.warn(
-                'Failed to close redis cache client after error',
-                closeError,
-              );
-            }
-            // Clear the store from the cache manager to force a new connection on the next request.
-            // Drops the client connection object, but does not lose the underlying cached data.
-            this.logger?.info(
-              `Clearing redis cache client for plugin ${pluginId} after error`,
-            );
-            delete stores[pluginId];
+            void (async () => {
+              try {
+                const closePromises: Array<Promise<unknown>> = [];
+                const disconnect = (store as { disconnect?: () => unknown })
+                  .disconnect;
+                const quit = (store as { quit?: () => unknown }).quit;
+
+                if (disconnect) {
+                  closePromises.push(Promise.resolve(disconnect()));
+                }
+                if (quit) {
+                  closePromises.push(Promise.resolve(quit()));
+                }
+
+                if (closePromises.length > 0) {
+                  await Promise.allSettled(closePromises);
+                }
+              } catch (closeError) {
+                this.logger?.warn(
+                  'Failed to close redis cache client after error',
+                  closeError,
+                );
+              } finally {
+                // Clear the store from the cache manager to force a new connection on the next request.
+                // Drops the client connection object, but does not lose the underlying cached data.
+                this.logger?.info(
+                  `Clearing redis cache client for plugin ${pluginId} after error`,
+                );
+                delete stores[pluginId];
+              }
+            })();
           }
         });
       }

--- a/packages/backend-defaults/src/entrypoints/cache/types.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/types.ts
@@ -16,7 +16,11 @@
 
 import { LoggerService } from '@backstage/backend-plugin-api';
 import { HumanDuration, durationToMilliseconds } from '@backstage/types';
-import { RedisClusterOptions, KeyvRedisOptions } from '@keyv/redis';
+import {
+  RedisClusterOptions,
+  KeyvRedisOptions,
+  RedisClientOptions,
+} from '@keyv/redis';
 import { KeyvValkeyOptions } from '@keyv/valkey';
 
 /**
@@ -28,6 +32,7 @@ export type RedisCacheStoreOptions = {
   type: 'redis';
   client?: KeyvRedisOptions;
   cluster?: RedisClusterOptions;
+  socket?: RedisClientOptions['socket'];
 };
 
 /**

--- a/packages/backend-defaults/src/entrypoints/cache/types.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/types.ts
@@ -33,6 +33,7 @@ export type RedisCacheStoreOptions = {
   client?: KeyvRedisOptions;
   cluster?: RedisClusterOptions;
   socket?: RedisClientOptions['socket'];
+  pingInterval?: number;
 };
 
 type RedisClusterOptions = Omit<KeyvRedisClusterOptions, 'defaults'> & {

--- a/packages/backend-defaults/src/entrypoints/cache/types.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/types.ts
@@ -17,7 +17,7 @@
 import { LoggerService } from '@backstage/backend-plugin-api';
 import { HumanDuration, durationToMilliseconds } from '@backstage/types';
 import {
-  RedisClusterOptions,
+  RedisClusterOptions as KeyvRedisClusterOptions,
   KeyvRedisOptions,
   RedisClientOptions,
 } from '@keyv/redis';
@@ -32,7 +32,23 @@ export type RedisCacheStoreOptions = {
   type: 'redis';
   client?: KeyvRedisOptions;
   cluster?: RedisClusterOptions;
-  socket?: RedisClientOptions['socket'];
+  socket?: RedisSocketOptions;
+};
+
+type RedisSocketOptions = Omit<
+  NonNullable<RedisClientOptions['socket']>,
+  'keepAlive'
+> & {
+  keepAlive?: boolean;
+};
+
+type RedisClusterOptions = Omit<KeyvRedisClusterOptions, 'defaults'> & {
+  defaults?: Omit<
+    NonNullable<KeyvRedisClusterOptions['defaults']>,
+    'socket'
+  > & {
+    socket?: RedisSocketOptions;
+  };
 };
 
 /**

--- a/packages/backend-defaults/src/entrypoints/cache/types.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/types.ts
@@ -49,6 +49,7 @@ type RedisClusterOptions = Omit<KeyvRedisClusterOptions, 'defaults'> & {
   > & {
     socket?: RedisSocketOptions;
   };
+  socket?: RedisClientOptions['socket'];
 };
 
 /**

--- a/packages/backend-defaults/src/entrypoints/cache/types.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/types.ts
@@ -32,14 +32,7 @@ export type RedisCacheStoreOptions = {
   type: 'redis';
   client?: KeyvRedisOptions;
   cluster?: RedisClusterOptions;
-  socket?: RedisSocketOptions;
-};
-
-type RedisSocketOptions = Omit<
-  NonNullable<RedisClientOptions['socket']>,
-  'keepAlive'
-> & {
-  keepAlive?: boolean;
+  socket?: RedisClientOptions['socket'];
 };
 
 type RedisClusterOptions = Omit<KeyvRedisClusterOptions, 'defaults'> & {
@@ -47,9 +40,8 @@ type RedisClusterOptions = Omit<KeyvRedisClusterOptions, 'defaults'> & {
     NonNullable<KeyvRedisClusterOptions['defaults']>,
     'socket'
   > & {
-    socket?: RedisSocketOptions;
+    socket?: RedisClientOptions['socket'];
   };
-  socket?: RedisClientOptions['socket'];
 };
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds Redis socket keepalive and reconnect configuration to the backend cache (`backend.cache.redis.client.socket`) and documents the new options. Also adds unit coverage for keepalive/reconnect config parsing and cluster defaults.

This is intended to address https://github.com/backstage/backstage/issues/31813 (and likely https://github.com/backstage/backstage/issues/31742) by exposing node‑redis socket controls (`keepAlive`, `keepAliveInitialDelay`, `pingInterval`, `socketTimeout`) and optional reconnect strategy configuration, mirroring the node‑redis client configuration options  

(See https://github.com/redis/node-redis/blob/master/docs/client-configuration.md)

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. (/.changeset/redis-keepalive-options.md)
- [x] Added or updated documentation (config schema `packages/backend-defaults/config.d.ts`)
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes) — __N/A - config example given instead__
- [x] All your commits have a `Signed-off-by` line in the message.

#### Tests run

- `yarn test --no-watch packages/backend-defaults/src/entrypoints/cache/CacheManager.test.ts`

#### Example Config Options Usage 

```yaml
backend:
  cache:
    store: redis
    connection: redis://localhost:6379/1
    defaultTtl: 3600000
    redis:
      client:
        namespace: my-backstage
        # Socket options passed through to node-redis:
        socket:
          keepAlive: true
          keepAliveInitialDelay: 10000
          socketTimeout: 20000
          reconnectStrategy:
            baseDelayMs: 100
            maxDelayMs: 2000
            jitterMs: 50
            maxRetries: 20
            stopOnSocketTimeout: true
        pingInterval: 15000
```

## Why This Is Needed

- Backstage cache uses Keyv → node‑redis, but didn’t expose socket controls or reconnect tuning for long‑lived connections.
- In real infra (LB/NAT/managed Redis), idle TCP connections are routinely dropped; without keepalive/ping/timeout or reconnect strategy controls, sockets can go stale and recovery becomes unreliable.
- node‑redis documents these socket options and defaults, but Backstage wasn’t mapping them cleanly.

## What This Changes

- Exposes supported node‑redis socket options (keepalive, delay, ping interval, socket timeout).
- Adds optional reconnect strategy configuration (backoff/jitter, max retries, stop‑on‑timeout).
  - In validating this change in our own internal instance, we found that it was necessary to override the default `keyv` reconnect.  Specifically, this forces stale connections to close to trigger a reconnect (instead of dangling in an unusable state)
- Ensures keepalive is explicitly enabled when a delay is set.
- Aligns config typing with node‑redis: `keepAlive` is boolean; timeouts/intervals accept numbers or human durations.

## Result

- Prevents silent stale sockets.
- Allows node‑redis to detect dead connections and reconnect reliably.
- Lets operators tune Redis connections to match infrastructure timeouts and error handling preferences.

## References
- https://github.com/redis/node-redis/blob/master/docs/client-configuration.md
- https://nodejs.org/api/net.html#socketsetkeepaliveenable-initialdelay
