### PR TITLE
fix(auth): oidc token expiration

### DIFF
--- a/.changeset/kind-candles-listen.md
+++ b/.changeset/kind-candles-listen.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Fixed OIDC token being able to expire before backstage token.
+
+This can cause issue with OIDC removing public keys from the `KeyStore`
+needed by the backstage token issuer.

--- a/plugins/auth-backend/src/service/readTokenExpiration.ts
+++ b/plugins/auth-backend/src/service/readTokenExpiration.ts
@@ -29,8 +29,11 @@ export function readBackstageTokenExpiration(config: RootConfigService) {
 }
 
 export function readDcrTokenExpiration(config: RootConfigService) {
+  const backstageExpiration = readBackstageTokenExpiration(config);
   return readTokenExpiration(config, {
     configKey: 'auth.experimentalDynamicClientRegistration.tokenExpiration',
+    minExpiration: backstageExpiration,
+    defaultExpiration: backstageExpiration,
   });
 }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

this will fix issue with custom `auth.backstageTokenExpiration` being longer than OIDC token expiration causing issues with auth providers not being able to verify user tokens.

closes #32115

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
