### PR TITLE
Revert API conflict warning change

### DIFF
--- a/.changeset/api-override-deprecation-warning-defaults.md
+++ b/.changeset/api-override-deprecation-warning-defaults.md
@@ -1,5 +1,0 @@
----
-'@backstage/frontend-defaults': patch
----
-
-The `API_FACTORY_CONFLICT` error is now treated as a warning and will not prevent the app from starting.

--- a/.changeset/api-override-deprecation-warning.md
+++ b/.changeset/api-override-deprecation-warning.md
@@ -1,5 +1,0 @@
----
-'@backstage/frontend-app-api': patch
----
-
-Updated the behavior of the new API override logic to log a deprecation warning instead of rejecting the override and blocking app startup, as was originally intended.

--- a/.patches/pr-32522.txt
+++ b/.patches/pr-32522.txt
@@ -1,1 +1,0 @@
-Rolls back the immediate breaking change of API factory conflicts in the new frontend system, making it a deprecation warning instead.

--- a/packages/frontend-app-api/src/wiring/createSpecializedApp.test.tsx
+++ b/packages/frontend-app-api/src/wiring/createSpecializedApp.test.tsx
@@ -289,7 +289,7 @@ describe('createSpecializedApp', () => {
     expect(mockAnalyticsApi).toHaveBeenCalled();
   });
 
-  it('should warn when API overrides would be blocked by new logic', () => {
+  it('should select the API factory from the owning plugin on conflict', () => {
     const testApiRef = createApiRef<{ value: string }>({ id: 'test.api' });
 
     const app = createSpecializedApp({
@@ -303,7 +303,7 @@ describe('createSpecializedApp', () => {
                 defineParams({
                   api: testApiRef,
                   deps: {},
-                  factory: () => ({ value: 'other-before' }),
+                  factory: () => ({ value: 'other' }),
                 }),
             }),
           ],
@@ -329,7 +329,7 @@ describe('createSpecializedApp', () => {
                 defineParams({
                   api: testApiRef,
                   deps: {},
-                  factory: () => ({ value: 'other-after' }),
+                  factory: () => ({ value: 'other' }),
                 }),
             }),
           ],
@@ -348,8 +348,7 @@ describe('createSpecializedApp', () => {
       }),
     ]);
 
-    // Old behavior: last factory wins
-    expect(app.apis.get(testApiRef)).toEqual({ value: 'other-after' });
+    expect(app.apis.get(testApiRef)).toEqual({ value: 'owner' });
   });
 
   it('should allow API overrides within the same plugin', () => {

--- a/packages/frontend-app-api/src/wiring/createSpecializedApp.tsx
+++ b/packages/frontend-app-api/src/wiring/createSpecializedApp.tsx
@@ -428,14 +428,13 @@ function createApiFactories(options: {
             existingPluginId: acceptedPluginId,
           },
         });
-        if (!shouldReplace) {
-          // eslint-disable-next-line no-console
-          console.warn(
-            `DEPRECATION WARNING: Plugin '${rejectedPluginId}' is overriding API '${apiRefId}' ` +
-              `from plugin '${acceptedPluginId}'. This will be blocked in a future release. ` +
-              `Please use a module for plugin '${acceptedPluginId}' instead.`,
-          );
+        if (shouldReplace) {
+          factoriesById.set(apiRefId, {
+            pluginId,
+            factory: apiFactory,
+          });
         }
+        continue;
       }
 
       factoriesById.set(apiRefId, { pluginId, factory: apiFactory });

--- a/packages/frontend-defaults/src/maybeCreateErrorPage.tsx
+++ b/packages/frontend-defaults/src/maybeCreateErrorPage.tsx
@@ -24,7 +24,6 @@ const DEFAULT_WARNING_CODES: Array<keyof AppErrorTypes> = [
   'EXTENSION_INPUT_DATA_IGNORED',
   'EXTENSION_INPUT_INTERNAL_IGNORED',
   'EXTENSION_OUTPUT_IGNORED',
-  'API_FACTORY_CONFLICT',
 ];
 
 function AppErrorItem(props: { error: AppError }): JSX.Element {


### PR DESCRIPTION
Reverts #32522, the change that made API factory conflicts warnings instead of errors.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.