### PR TITLE
Add changesets for API conflict error behavior

### DIFF
--- a/.changeset/api-override-conflict-error-defaults.md
+++ b/.changeset/api-override-conflict-error-defaults.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-defaults': minor
+---
+
+**BREAKING**: The `API_FACTORY_CONFLICT` warning is now treated as an error and will prevent the app from starting.

--- a/.changeset/api-override-conflict-error.md
+++ b/.changeset/api-override-conflict-error.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-app-api': minor
+---
+
+**BREAKING**: Updated the behavior of the new API override logic to reject the override and block app startup instead of just logging a deprecation warning.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Forgot that we need to introduce changesets for the actual change going out in the next release following the revert of https://github.com/backstage/backstage/pull/32564

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))