### PR TITLE
Add configurable text filter fields to catalog table

### DIFF
--- a/.changeset/dark-buttons-knock.md
+++ b/.changeset/dark-buttons-knock.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-catalog-react': minor
+'@backstage/plugin-catalog': minor
+---
+
+Added support for configurable text filter fields in the catalog.
+
+The `textFilterFields` prop accepts either a static array of fields for all kinds or a record mapping kind names to their specific filter fields.

--- a/docs/features/software-catalog/catalog-customization.md
+++ b/docs/features/software-catalog/catalog-customization.md
@@ -60,6 +60,23 @@ The tables used within Backstage are built on top of [`@material-table/core`](ht
 
 There are many options that can be set using `tableOptions`, the full list of settings can be found in the [`@material-table/core` `Options` interface](https://github.com/material-table-core/core/blob/v3.1.0/types/index.d.ts#L323) (this link goes to `v3.1.0` of `@material-table/core` as that is the version currently used by Backstage).
 
+## Text Filter Fields
+
+By default, the catalog text filter matches against `metadata.name`, `metadata.title`, and `spec.profile.displayName`. When [pagination](#pagination) is enabled, you can customize which fields are filtered using the `textFilterFields` prop:
+
+```tsx title="packages/app/src/App.tsx"
+// Same fields for all kinds
+<CatalogIndexPage textFilterFields={['metadata.name', 'spec.type']} />
+
+// Different fields per kind
+<CatalogIndexPage
+  textFilterFields={{
+    component: ['metadata.name', 'metadata.title', 'spec.type'],
+    user: ['metadata.name', 'spec.profile.displayName', 'spec.profile.email'],
+  }}
+/>
+```
+
 ## Customize Columns
 
 The columns you see in the `CatalogIndexPage` were selected to be a good starting point for most, but there may be cases where you would like to add or remove columns from existing or custom Kinds.

--- a/plugins/catalog-react/report.api.md
+++ b/plugins/catalog-react/report.api.md
@@ -352,6 +352,7 @@ export type EntityListContextProps<
   setLimit: (limit: number) => void;
   setOffset?: (offset: number) => void;
   paginationMode: PaginationMode;
+  textFilterFields?: TextFilterFieldsConfig;
 };
 
 // @public (undocumented)
@@ -375,6 +376,7 @@ export const EntityListProvider: <EntityFilters extends DefaultEntityFilters>(
 // @public (undocumented)
 export type EntityListProviderProps = PropsWithChildren<{
   pagination?: EntityListPagination;
+  textFilterFields?: TextFilterFieldsConfig;
 }>;
 
 // @public (undocumented)
@@ -635,7 +637,11 @@ export type EntityTagPickerProps = {
 
 // @public
 export class EntityTextFilter implements EntityFilter {
-  constructor(value: string);
+  constructor(value: string, fields?: string[]);
+  // (undocumented)
+  static readonly DEFAULT_FIELDS: string[];
+  // (undocumented)
+  readonly fields?: string[];
   // (undocumented)
   filterEntity(entity: Entity): boolean;
   // (undocumented)
@@ -776,6 +782,9 @@ export interface StarredEntitiesApi {
 
 // @public
 export const starredEntitiesApiRef: ApiRef_2<StarredEntitiesApi>;
+
+// @public
+export type TextFilterFieldsConfig = string[] | Record<string, string[]>;
 
 // @public (undocumented)
 export const UnregisterEntityDialog: (

--- a/plugins/catalog-react/src/components/EntitySearchBar/EntitySearchBar.test.tsx
+++ b/plugins/catalog-react/src/components/EntitySearchBar/EntitySearchBar.test.tsx
@@ -16,7 +16,7 @@
 
 import { fireEvent, waitFor, screen } from '@testing-library/react';
 import { EntitySearchBar } from './EntitySearchBar';
-import { EntityTextFilter } from '../../filters';
+import { EntityKindFilter, EntityTextFilter } from '../../filters';
 import { MockEntityListContextProvider } from '@backstage/plugin-catalog-react/testUtils';
 import { renderInTestApp } from '@backstage/test-utils';
 
@@ -50,6 +50,99 @@ describe('EntitySearchBar', () => {
     await waitFor(() => expect(updateFilters.mock.calls.length).toBe(2));
     expect(updateFilters).toHaveBeenCalledWith({
       text: undefined,
+    });
+  });
+
+  it('should use static array of search fields for all kinds', async () => {
+    const updateFilters = jest.fn();
+    const staticFields = ['metadata.name', 'spec.type'];
+
+    await renderInTestApp(
+      <MockEntityListContextProvider
+        value={{
+          updateFilters,
+          queryParameters: {},
+          textFilterFields: staticFields,
+          paginationMode: 'cursor',
+          filters: {
+            kind: new EntityKindFilter('component', 'Component'),
+          },
+        }}
+      >
+        <EntitySearchBar />
+      </MockEntityListContextProvider>,
+    );
+
+    const searchInput = screen.getByRole('textbox');
+    fireEvent.change(searchInput, { target: { value: 'test' } });
+
+    await waitFor(() => expect(updateFilters).toHaveBeenCalled());
+    expect(updateFilters).toHaveBeenCalledWith({
+      text: new EntityTextFilter('test', staticFields),
+    });
+  });
+
+  it('should use per-kind search fields based on current kind', async () => {
+    const updateFilters = jest.fn();
+    const perKindFields = {
+      component: ['metadata.name', 'spec.type'],
+      user: ['metadata.name', 'spec.profile.displayName'],
+    };
+
+    await renderInTestApp(
+      <MockEntityListContextProvider
+        value={{
+          updateFilters,
+          queryParameters: {},
+          textFilterFields: perKindFields,
+          paginationMode: 'cursor',
+          filters: {
+            kind: new EntityKindFilter('user', 'User'),
+          },
+        }}
+      >
+        <EntitySearchBar />
+      </MockEntityListContextProvider>,
+    );
+
+    const searchInput = screen.getByRole('textbox');
+    fireEvent.change(searchInput, { target: { value: 'john' } });
+
+    await waitFor(() => expect(updateFilters).toHaveBeenCalled());
+    expect(updateFilters).toHaveBeenCalledWith({
+      text: new EntityTextFilter('john', perKindFields.user),
+    });
+  });
+
+  it('should fallback to undefined when kind not found in per-kind config', async () => {
+    const updateFilters = jest.fn();
+    const perKindFields = {
+      component: ['metadata.name', 'spec.type'],
+    };
+
+    await renderInTestApp(
+      <MockEntityListContextProvider
+        value={{
+          updateFilters,
+          queryParameters: {},
+          textFilterFields: perKindFields,
+          paginationMode: 'cursor',
+          filters: {
+            kind: new EntityKindFilter('api', 'API'),
+          },
+        }}
+      >
+        <EntitySearchBar />
+      </MockEntityListContextProvider>,
+    );
+
+    const searchInput = screen.getByRole('textbox');
+    fireEvent.change(searchInput, { target: { value: 'test' } });
+
+    await waitFor(() => expect(updateFilters).toHaveBeenCalled());
+    // Should use undefined (defaults) since 'api' is not in the config
+    expect(updateFilters).toHaveBeenCalledWith({
+      text: new EntityTextFilter('test', undefined),
     });
   });
 });

--- a/plugins/catalog-react/src/filters.test.ts
+++ b/plugins/catalog-react/src/filters.test.ts
@@ -129,6 +129,48 @@ describe('EntityTextFilter', () => {
     expect(filter.filterEntity(users[0])).toBeTruthy();
     expect(filter.filterEntity(users[1])).toBeFalsy();
   });
+
+  it('should skip client-side filtering when custom fields are provided', () => {
+    // When custom fields are provided, filterEntity should return true
+    // (trust backend filtering) regardless of the entity content
+    const filter = new EntityTextFilter('nonexistent', ['metadata.name']);
+    expect(filter.filterEntity(entities[0])).toBeTruthy();
+    expect(filter.filterEntity(entities[1])).toBeTruthy();
+  });
+
+  describe('getFullTextFilters', () => {
+    it('should return term with default fields when no fields provided', () => {
+      const filter = new EntityTextFilter('search term');
+      expect(filter.getFullTextFilters()).toEqual({
+        term: 'search term',
+        fields: EntityTextFilter.DEFAULT_FIELDS,
+      });
+    });
+
+    it('should return term with custom fields when fields provided', () => {
+      const customFields = [
+        'metadata.name',
+        'spec.type',
+        'metadata.description',
+      ];
+      const filter = new EntityTextFilter('search term', customFields);
+      expect(filter.getFullTextFilters()).toEqual({
+        term: 'search term',
+        fields: customFields,
+      });
+    });
+
+    it('should store fields on the filter instance', () => {
+      const customFields = ['metadata.name', 'spec.owner'];
+      const filter = new EntityTextFilter('query', customFields);
+      expect(filter.fields).toEqual(customFields);
+    });
+
+    it('should have undefined fields when not provided', () => {
+      const filter = new EntityTextFilter('query');
+      expect(filter.fields).toBeUndefined();
+    });
+  });
 });
 
 describe('EntityOrphanFilter', () => {

--- a/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
@@ -52,7 +52,11 @@ import {
   EntityUserFilter,
   UserListFilter,
 } from '../filters';
-import { EntityFilter, EntityListPagination } from '../types';
+import {
+  EntityFilter,
+  EntityListPagination,
+  TextFilterFieldsConfig,
+} from '../types';
 import {
   reduceBackendCatalogFilters,
   reduceCatalogFilters,
@@ -125,6 +129,8 @@ export type EntityListContextProps<
   setLimit: (limit: number) => void;
   setOffset?: (offset: number) => void;
   paginationMode: PaginationMode;
+
+  textFilterFields?: TextFilterFieldsConfig;
 };
 
 // This context has support for multiple concurrent versions of this package.
@@ -157,6 +163,7 @@ type OutputState<EntityFilters extends DefaultEntityFilters> = {
  */
 export type EntityListProviderProps = PropsWithChildren<{
   pagination?: EntityListPagination;
+  textFilterFields?: TextFilterFieldsConfig;
 }>;
 
 /**
@@ -483,6 +490,7 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
       setLimit,
       setOffset,
       paginationMode,
+      textFilterFields: props.textFilterFields,
     }),
     [
       outputState,
@@ -496,6 +504,7 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
       paginationMode,
       setLimit,
       setOffset,
+      props.textFilterFields,
     ],
   );
 

--- a/plugins/catalog-react/src/testUtils/MockEntityListContextProvider.tsx
+++ b/plugins/catalog-react/src/testUtils/MockEntityListContextProvider.tsx
@@ -78,6 +78,7 @@ export function MockEntityListContextProvider<
       setLimit: value?.setLimit ?? (() => {}),
       setOffset: value?.setOffset,
       paginationMode: value?.paginationMode ?? 'none',
+      textFilterFields: value?.textFilterFields,
     }),
     [value, defaultValues, filters, updateFilters],
   );

--- a/plugins/catalog-react/src/types.ts
+++ b/plugins/catalog-react/src/types.ts
@@ -52,3 +52,11 @@ export type EntityListPagination =
   | boolean
   | { mode?: 'cursor'; limit?: number }
   | { mode: 'offset'; limit?: number; offset?: number };
+
+/**
+ * Configuration for text filter fields.
+ * Can be either a static array of fields for all kinds,
+ * or a record mapping kind names to their specific fields.
+ * @public
+ */
+export type TextFilterFieldsConfig = string[] | Record<string, string[]>;

--- a/plugins/catalog-react/src/utils/filters.ts
+++ b/plugins/catalog-react/src/utils/filters.ts
@@ -33,6 +33,7 @@ export interface CatalogFilters {
   filter: Record<string, string | symbol | (string | symbol)[]>;
   fullTextFilter?: {
     term: string;
+    fields?: string[];
   };
   orderFields?: EntityOrderQuery;
 }

--- a/plugins/catalog/report-alpha.api.md
+++ b/plugins/catalog/report-alpha.api.md
@@ -998,6 +998,7 @@ const _default: OverridableFrontendPlugin<
               offset?: number | undefined;
               limit?: number | undefined;
             };
+        textFilterFields: string[] | Record<string, string[]>;
         path: string | undefined;
         title: string | undefined;
       };
@@ -1010,6 +1011,7 @@ const _default: OverridableFrontendPlugin<
               limit?: number | undefined;
             }
           | undefined;
+        textFilterFields?: string[] | Record<string, string[]> | undefined;
         title?: string | undefined;
         path?: string | undefined;
       };

--- a/plugins/catalog/report.api.md
+++ b/plugins/catalog/report.api.md
@@ -38,6 +38,7 @@ import { TableColumn } from '@backstage/core-components';
 import { TableOptions } from '@backstage/core-components';
 import { TableProps } from '@backstage/core-components';
 import { TabProps } from '@material-ui/core/Tab';
+import { TextFilterFieldsConfig } from '@backstage/plugin-catalog-react';
 import { UserListFilterKind } from '@backstage/plugin-catalog-react';
 
 // @public
@@ -246,6 +247,8 @@ export interface DefaultCatalogPageProps {
   pagination?: EntityListPagination;
   // (undocumented)
   tableOptions?: TableProps<CatalogTableRow>['options'];
+  // (undocumented)
+  textFilterFields?: TextFilterFieldsConfig;
 }
 
 // @public

--- a/plugins/catalog/src/alpha/pages.tsx
+++ b/plugins/catalog/src/alpha/pages.tsx
@@ -53,6 +53,17 @@ export const catalogPage = PageBlueprint.makeWithOverrides({
             }),
           ])
           .default(true),
+      textFilterFields: z =>
+        z
+          .union([
+            z.array(z.string()),
+            z.record(z.string(), z.array(z.string())),
+          ])
+          .default([
+            'metadata.name',
+            'metadata.title',
+            'spec.profile.displayName',
+          ]),
     },
   },
   factory(originalFactory, { inputs, config }) {
@@ -70,6 +81,7 @@ export const catalogPage = PageBlueprint.makeWithOverrides({
           <BaseCatalogPage
             filters={<>{filters}</>}
             pagination={config.pagination}
+            textFilterFields={config.textFilterFields}
           />
         );
       },

--- a/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.tsx
@@ -30,6 +30,7 @@ import {
   EntityListPagination,
   EntityListProvider,
   EntityOwnerPickerProps,
+  TextFilterFieldsConfig,
   UserListFilterKind,
 } from '@backstage/plugin-catalog-react';
 import { ReactNode } from 'react';
@@ -46,11 +47,17 @@ export type BaseCatalogPageProps = {
   filters: ReactNode;
   content?: ReactNode;
   pagination?: EntityListPagination;
+  textFilterFields?: TextFilterFieldsConfig;
 };
 
 /** @internal */
 export function BaseCatalogPage(props: BaseCatalogPageProps) {
-  const { filters, content = <CatalogTable />, pagination } = props;
+  const {
+    filters,
+    content = <CatalogTable />,
+    pagination,
+    textFilterFields,
+  } = props;
   const orgName =
     useApi(configApiRef).getOptionalString('organization.name') ?? 'Backstage';
   const createComponentLink = useRouteRef(createComponentRouteRef);
@@ -71,7 +78,10 @@ export function BaseCatalogPage(props: BaseCatalogPageProps) {
           )}
           <SupportButton>{t('indexPage.supportButtonContent')}</SupportButton>
         </ContentHeader>
-        <EntityListProvider pagination={pagination}>
+        <EntityListProvider
+          pagination={pagination}
+          textFilterFields={textFilterFields}
+        >
           <CatalogFilterLayout>
             <CatalogFilterLayout.Filters>{filters}</CatalogFilterLayout.Filters>
             <CatalogFilterLayout.Content>{content}</CatalogFilterLayout.Content>
@@ -98,6 +108,7 @@ export interface DefaultCatalogPageProps {
   filters?: ReactNode;
   initiallySelectedNamespaces?: string[];
   pagination?: EntityListPagination;
+  textFilterFields?: TextFilterFieldsConfig;
 }
 
 export function DefaultCatalogPage(props: DefaultCatalogPageProps) {
@@ -112,6 +123,7 @@ export function DefaultCatalogPage(props: DefaultCatalogPageProps) {
     ownerPickerMode,
     filters,
     initiallySelectedNamespaces,
+    textFilterFields,
   } = props;
 
   return (
@@ -135,6 +147,7 @@ export function DefaultCatalogPage(props: DefaultCatalogPageProps) {
         />
       }
       pagination={pagination}
+      textFilterFields={textFilterFields}
     />
   );
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
When you filter entities in the catalog table, it only filters based on 3 hardcoded fields: `metadata.name`, `metadata.title`, `spec.profile.displayName`. I have added the ability to configure these filter fields and allow users to define which specific fields of the entities should be used and for which kind. It looks something like this:

For the new frontend system, it can be configured like:

```
app:
  title: Backstage Example App
  baseUrl: http://localhost:3000
  packages: all # ✨

  extensions:
    - page:catalog:
        config:
          pagination:
            mode: offset
            limit: 20
          textFilterFields:
            component:
              - metadata.name
              - metadata.title
              - spec.type
              - spec.lifecycle
              - metadata.annotations.foo
            system:
              - metadata.name
              - metadata.title
              - metadata.annotations.bar
```
For legacy:
```
<Route  path="/catalog"  element={    
  <CatalogIndexPage
      pagination={{ mode: 'offset', limit: 20 }}
      textFilterFields={{
        component: [
          'metadata.name',
          'metadata.title',
          'metadata.annotations.foo',
        ],
        system: [
          'metadata.name',
          'metadata.title',
          'metadata.annotations.bar',
        ],
      }}
    />
  }
/>
```

When pagination is not enabled, the current behavior is unchanged, it still only filters across the default fields as that is a frontend only filter.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
