### PR TITLE
feat(notifications): add support for included topics

### DIFF
--- a/.changeset/seven-poets-shout.md
+++ b/.changeset/seven-poets-shout.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-notifications-backend-module-email': patch
+'@backstage/plugin-notifications-backend': patch
+'@backstage/plugin-notifications-common': patch
+---
+
+Allow configuring included topics for email notifications.

--- a/plugins/notifications-backend-module-email/config.d.ts
+++ b/plugins/notifications-backend-module-email/config.d.ts
@@ -161,9 +161,14 @@ export interface Config {
            */
           maxSeverity?: NotificationSeverity;
           /**
-           * A notification who's topic is in this array will not be emailed
+           * A notification with topic is in this array will not be emailed
            */
           excludedTopics?: string[];
+          /**
+           * A notification with topic in this array will be emailed. If not defined, only
+           * excludedTopics takes effect.
+           */
+          includedTopics?: string[];
         };
         /**
          * White list of addresses to send email to

--- a/plugins/notifications-backend/src/service/router.ts
+++ b/plugins/notifications-backend/src/service/router.ts
@@ -365,6 +365,15 @@ export async function createRouter(
             continue;
           }
         }
+
+        if (filters.includedTopics) {
+          if (
+            !payload.topic ||
+            !filters.includedTopics.includes(payload.topic)
+          ) {
+            continue;
+          }
+        }
       }
       result.push(processor);
     }
@@ -418,14 +427,16 @@ export async function createRouter(
   ) => {
     const filtered = await filterProcessors(notification);
     for (const processor of filtered) {
-      if (processor.postProcess) {
-        try {
-          await processor.postProcess(notification, opts);
-        } catch (e) {
-          logger.error(
-            `Error while post processing notification with ${processor.getName()}: ${e}`,
-          );
-        }
+      if (!processor.postProcess) {
+        continue;
+      }
+
+      try {
+        await processor.postProcess(notification, opts);
+      } catch (e) {
+        logger.error(
+          `Error while post processing notification with ${processor.getName()}: ${e}`,
+        );
       }
     }
   };

--- a/plugins/notifications-common/report.api.md
+++ b/plugins/notifications-common/report.api.md
@@ -64,6 +64,7 @@ export type NotificationProcessorFilters = {
   minSeverity?: NotificationSeverity;
   maxSeverity?: NotificationSeverity;
   excludedTopics?: string[];
+  includedTopics?: string[];
 };
 
 // @public (undocumented)

--- a/plugins/notifications-common/src/filters.ts
+++ b/plugins/notifications-common/src/filters.ts
@@ -43,5 +43,8 @@ export const getProcessorFiltersFromConfig = (config: Config) => {
   filter.excludedTopics = config.getOptionalStringArray(
     'filter.excludedTopics',
   );
+  filter.includedTopics = config.getOptionalStringArray(
+    'filter.includedTopics',
+  );
   return filter;
 };

--- a/plugins/notifications-common/src/types.ts
+++ b/plugins/notifications-common/src/types.ts
@@ -130,6 +130,7 @@ export type NotificationProcessorFilters = {
   minSeverity?: NotificationSeverity;
   maxSeverity?: NotificationSeverity;
   excludedTopics?: string[];
+  includedTopics?: string[];
 };
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

this can be used to configure processors to only process notifications that contain specific topics. if notification does not have a topic and included topics are configured, the notification will not get processed by the specific processor. this is mainly for the email processor but can be used by other processors as well.

closes #32497

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
