### PR TITLE
docs - Added ui:options Examples to the Sidebar

### DIFF
--- a/microsite/sidebars.ts
+++ b/microsite/sidebars.ts
@@ -279,6 +279,7 @@ export default {
             'features/software-templates/adding-templates',
             'features/software-templates/writing-templates',
             'features/software-templates/input-examples',
+            'features/software-templates/ui-options-examples',
             'features/software-templates/builtin-actions',
             'features/software-templates/writing-custom-actions',
             'features/software-templates/writing-tests-for-actions',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added ui:options Examples to the Sidebar, this page was added back in 2023, we do link to it but I feel this gives it more visibility!

<img width="1918" height="1048" alt="Screenshot 2026-01-29 at 7 20 10 AM" src="https://github.com/user-attachments/assets/f67484a5-2ec5-4adb-a2be-0e69db490cfe" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
