### PR TITLE
feat(catalog): add table column customization via app-config

### DIFF
--- a/.changeset/catalog-table-columns-config.md
+++ b/.changeset/catalog-table-columns-config.md
@@ -22,11 +22,11 @@ app:
               - namespace
               - tags
             custom:
-              - title: "Security Tier"
+              - title: 'Security Tier'
                 field: "metadata.annotations['security/tier']"
                 width: 120
-                defaultValue: "Not Set"
-              - title: "Cost Center"
+                defaultValue: 'Not Set'
+              - title: 'Cost Center'
                 field: "metadata.labels['cost-center']"
                 kind:
                   - Component
@@ -36,6 +36,7 @@ app:
 Available built-in column IDs: `name`, `owner`, `type`, `lifecycle`, `description`, `tags`, `namespace`, `system`, `targets`.
 
 Custom columns support:
+
 - Dot notation for field paths (e.g., `spec.type`)
 - Bracket notation for annotations/labels (e.g., `metadata.annotations['key']`)
 - Optional width, sortable, defaultValue, and kind filtering

--- a/.changeset/catalog-table-columns-config.md
+++ b/.changeset/catalog-table-columns-config.md
@@ -1,0 +1,41 @@
+---
+'@backstage/plugin-catalog': minor
+---
+
+Added support for customizing catalog table columns via `app-config.yaml` in the New Frontend System.
+
+This feature allows platform engineers to configure which columns are displayed in the catalog table without code changes. The configuration supports:
+
+- **Include mode**: Show only specific columns by listing them
+- **Exclude mode**: Hide specific columns from the defaults
+- **Custom columns**: Add columns from entity metadata (annotations, labels, spec fields)
+
+Example configuration:
+
+```yaml
+app:
+  extensions:
+    - page:catalog:
+        config:
+          columns:
+            exclude:
+              - namespace
+              - tags
+            custom:
+              - title: "Security Tier"
+                field: "metadata.annotations['security/tier']"
+                width: 120
+                defaultValue: "Not Set"
+              - title: "Cost Center"
+                field: "metadata.labels['cost-center']"
+                kind:
+                  - Component
+                  - Resource
+```
+
+Available built-in column IDs: `name`, `owner`, `type`, `lifecycle`, `description`, `tags`, `namespace`, `system`, `targets`.
+
+Custom columns support:
+- Dot notation for field paths (e.g., `spec.type`)
+- Bracket notation for annotations/labels (e.g., `metadata.annotations['key']`)
+- Optional width, sortable, defaultValue, and kind filtering

--- a/.changeset/catalog-table-columns-config.md
+++ b/.changeset/catalog-table-columns-config.md
@@ -39,4 +39,4 @@ Custom columns support:
 
 - Dot notation for field paths (e.g., `spec.type`)
 - Bracket notation for annotations/labels (e.g., `metadata.annotations['key']`)
-- Optional width, sortable, defaultValue, and kind filtering
+- Optional `width`, `sortable`, `defaultValue`, and `kind` filtering

--- a/plugins/catalog/config.d.ts
+++ b/plugins/catalog/config.d.ts
@@ -23,5 +23,67 @@ export interface Config {
       | {
           limit?: number;
         };
+
+    /**
+     * Configuration for the catalog table columns.
+     * Allows customizing which columns are displayed and adding custom columns.
+     * @deepVisibility frontend
+     */
+    table?: {
+      /**
+       * Column configuration options.
+       */
+      columns?: {
+        /**
+         * When specified, only these columns are shown (whitelist mode).
+         * Available column IDs: name, owner, type, lifecycle, description, tags, namespace, system, targets
+         */
+        include?: string[];
+
+        /**
+         * Columns to remove from the defaults (blacklist mode).
+         * Available column IDs: name, owner, type, lifecycle, description, tags, namespace, system, targets
+         */
+        exclude?: string[];
+
+        /**
+         * Custom columns to add from entity metadata.
+         */
+        custom?: Array<{
+          /**
+           * Column header text (required).
+           */
+          title: string;
+
+          /**
+           * Entity field path using dot notation.
+           * Supports bracket notation for annotations/labels.
+           * Examples: "metadata.name", "metadata.annotations['backstage.io/techdocs-ref']"
+           */
+          field: string;
+
+          /**
+           * Column width in pixels (optional).
+           */
+          width?: number;
+
+          /**
+           * Enable sorting for this column (default: true).
+           */
+          sortable?: boolean;
+
+          /**
+           * Value to display when field is empty (optional).
+           */
+          defaultValue?: string;
+
+          /**
+           * Limit column to specific entity kinds (optional).
+           * When specified, the column only appears for these kinds.
+           */
+          kind?: string | string[];
+        }>;
+      };
+    };
   };
 }

--- a/plugins/catalog/package.json
+++ b/plugins/catalog/package.json
@@ -64,6 +64,7 @@
     "@backstage/core-components": "workspace:^",
     "@backstage/core-plugin-api": "workspace:^",
     "@backstage/errors": "workspace:^",
+    "@backstage/filter-predicates": "workspace:^",
     "@backstage/frontend-plugin-api": "workspace:^",
     "@backstage/integration-react": "workspace:^",
     "@backstage/plugin-catalog-common": "workspace:^",

--- a/plugins/catalog/package.json
+++ b/plugins/catalog/package.json
@@ -64,7 +64,6 @@
     "@backstage/core-components": "workspace:^",
     "@backstage/core-plugin-api": "workspace:^",
     "@backstage/errors": "workspace:^",
-    "@backstage/filter-predicates": "workspace:^",
     "@backstage/frontend-plugin-api": "workspace:^",
     "@backstage/integration-react": "workspace:^",
     "@backstage/plugin-catalog-common": "workspace:^",

--- a/plugins/catalog/report-alpha.api.md
+++ b/plugins/catalog/report-alpha.api.md
@@ -1000,10 +1000,42 @@ const _default: OverridableFrontendPlugin<
               offset?: number | undefined;
               limit?: number | undefined;
             };
+        columns:
+          | {
+              custom?:
+                | {
+                    title: string;
+                    field: string;
+                    width?: number | undefined;
+                    defaultValue?: string | undefined;
+                    kind?: string | string[] | undefined;
+                    sortable?: boolean | undefined;
+                  }[]
+                | undefined;
+              include?: string[] | undefined;
+              exclude?: string[] | undefined;
+            }
+          | undefined;
         path: string | undefined;
         title: string | undefined;
       };
       configInput: {
+        columns?:
+          | {
+              custom?:
+                | {
+                    title: string;
+                    field: string;
+                    width?: number | undefined;
+                    defaultValue?: string | undefined;
+                    kind?: string | string[] | undefined;
+                    sortable?: boolean | undefined;
+                  }[]
+                | undefined;
+              include?: string[] | undefined;
+              exclude?: string[] | undefined;
+            }
+          | undefined;
         pagination?:
           | boolean
           | {

--- a/plugins/catalog/report.api.md
+++ b/plugins/catalog/report.api.md
@@ -66,6 +66,12 @@ export interface AboutFieldProps {
   value?: string;
 }
 
+// @public
+export function applyColumnConfig(
+  columns: TableColumn<CatalogTableRow>[],
+  config: ColumnConfig | undefined,
+): TableColumn<CatalogTableRow>[];
+
 // @public (undocumented)
 export type BackstageOverrides = Overrides & {
   [Name in keyof PluginCatalogComponentsNameToClassKey]?: Partial<
@@ -75,6 +81,19 @@ export type BackstageOverrides = Overrides & {
 
 // @public (undocumented)
 export type Breakpoint = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+
+// @public
+export const BUILTIN_COLUMN_IDS: readonly [
+  'name',
+  'owner',
+  'type',
+  'lifecycle',
+  'description',
+  'tags',
+  'namespace',
+  'system',
+  'targets',
+];
 
 // @public (undocumented)
 export const CatalogEntityPage: () => JSX.Element;
@@ -189,6 +208,7 @@ export interface CatalogTableProps {
   actions?: TableProps<CatalogTableRow>['actions'];
   // (undocumented)
   columns?: TableColumn<CatalogTableRow>[] | CatalogTableColumnsFunc;
+  columnsConfig?: ColumnConfig;
   // (undocumented)
   emptyContent?: ReactNode;
   // (undocumented)
@@ -316,6 +336,32 @@ export const catalogTranslationRef: TranslationRef<
 
 // @public (undocumented)
 export type ColumnBreakpoints = Record<Breakpoint, number>;
+
+// @public
+export interface ColumnConfig {
+  // (undocumented)
+  custom?: CustomColumnConfig[];
+  // (undocumented)
+  exclude?: string[];
+  // (undocumented)
+  include?: string[];
+}
+
+// @public
+export interface CustomColumnConfig {
+  // (undocumented)
+  defaultValue?: string;
+  // (undocumented)
+  field: string;
+  // (undocumented)
+  kind?: string | string[];
+  // (undocumented)
+  sortable?: boolean;
+  // (undocumented)
+  title: string;
+  // (undocumented)
+  width?: number;
+}
 
 // @public
 export interface DefaultCatalogPageProps {
@@ -799,6 +845,9 @@ export type RelatedEntitiesCardProps<T extends Entity> = {
   asRenderableEntities: (entities: Entity[]) => T[];
   tableOptions?: TableOptions;
 };
+
+// @public
+export function resolveFieldPath(entity: Entity, fieldPath: string): unknown;
 
 // @public (undocumented)
 export type SystemDiagramCardClassKey =

--- a/plugins/catalog/report.api.md
+++ b/plugins/catalog/report.api.md
@@ -370,6 +370,8 @@ export interface DefaultCatalogPageProps {
   // (undocumented)
   columns?: TableColumn<CatalogTableRow>[] | CatalogTableColumnsFunc;
   // (undocumented)
+  columnsConfig?: ColumnConfig;
+  // (undocumented)
   emptyContent?: ReactNode;
   // (undocumented)
   filters?: ReactNode;

--- a/plugins/catalog/src/alpha/pages.tsx
+++ b/plugins/catalog/src/alpha/pages.tsx
@@ -36,6 +36,25 @@ import { rootRouteRef } from '../routes';
 import { useEntityFromUrl } from '../components/CatalogEntityPage/useEntityFromUrl';
 import { buildFilterFn } from './filter/FilterWrapper';
 
+const customColumnSchema = (z: typeof import('zod').z) =>
+  z.object({
+    title: z.string(),
+    field: z.string(),
+    width: z.number().optional(),
+    sortable: z.boolean().optional(),
+    defaultValue: z.string().optional(),
+    kind: z.union([z.string(), z.array(z.string())]).optional(),
+  });
+
+const columnsConfigSchema = (z: typeof import('zod').z) =>
+  z
+    .object({
+      include: z.array(z.string()).optional(),
+      exclude: z.array(z.string()).optional(),
+      custom: z.array(customColumnSchema(z)).optional(),
+    })
+    .optional();
+
 export const catalogPage = PageBlueprint.makeWithOverrides({
   inputs: {
     filters: createExtensionInput([coreExtensionData.reactElement]),
@@ -53,6 +72,7 @@ export const catalogPage = PageBlueprint.makeWithOverrides({
             }),
           ])
           .default(true),
+      columns: columnsConfigSchema,
     },
   },
   factory(originalFactory, { inputs, config }) {
@@ -72,6 +92,7 @@ export const catalogPage = PageBlueprint.makeWithOverrides({
           <NfsDefaultCatalogPage
             filters={<>{filters}</>}
             pagination={config.pagination}
+            columnsConfig={config.columns}
           />
         );
       },

--- a/plugins/catalog/src/alpha/pages.tsx
+++ b/plugins/catalog/src/alpha/pages.tsx
@@ -36,25 +36,6 @@ import { rootRouteRef } from '../routes';
 import { useEntityFromUrl } from '../components/CatalogEntityPage/useEntityFromUrl';
 import { buildFilterFn } from './filter/FilterWrapper';
 
-const customColumnSchema = (z: typeof import('zod').z) =>
-  z.object({
-    title: z.string(),
-    field: z.string(),
-    width: z.number().optional(),
-    sortable: z.boolean().optional(),
-    defaultValue: z.string().optional(),
-    kind: z.union([z.string(), z.array(z.string())]).optional(),
-  });
-
-const columnsConfigSchema = (z: typeof import('zod').z) =>
-  z
-    .object({
-      include: z.array(z.string()).optional(),
-      exclude: z.array(z.string()).optional(),
-      custom: z.array(customColumnSchema(z)).optional(),
-    })
-    .optional();
-
 export const catalogPage = PageBlueprint.makeWithOverrides({
   inputs: {
     filters: createExtensionInput([coreExtensionData.reactElement]),
@@ -72,7 +53,25 @@ export const catalogPage = PageBlueprint.makeWithOverrides({
             }),
           ])
           .default(true),
-      columns: columnsConfigSchema,
+      columns: z =>
+        z
+          .object({
+            include: z.array(z.string()).optional(),
+            exclude: z.array(z.string()).optional(),
+            custom: z
+              .array(
+                z.object({
+                  title: z.string(),
+                  field: z.string(),
+                  width: z.number().optional(),
+                  sortable: z.boolean().optional(),
+                  defaultValue: z.string().optional(),
+                  kind: z.union([z.string(), z.array(z.string())]).optional(),
+                }),
+              )
+              .optional(),
+          })
+          .optional(),
     },
   },
   factory(originalFactory, { inputs, config }) {

--- a/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.tsx
@@ -53,13 +53,17 @@ export type BaseCatalogPageProps = {
 
 function CatalogPageContent(props: BaseCatalogPageProps) {
   const { filters, content, pagination, columnsConfig } = props;
-  const tableContent = content ?? <CatalogTable columnsConfig={columnsConfig} />;
+  const tableContent = content ?? (
+    <CatalogTable columnsConfig={columnsConfig} />
+  );
 
   return (
     <EntityListProvider pagination={pagination}>
       <CatalogFilterLayout>
         <CatalogFilterLayout.Filters>{filters}</CatalogFilterLayout.Filters>
-        <CatalogFilterLayout.Content>{tableContent}</CatalogFilterLayout.Content>
+        <CatalogFilterLayout.Content>
+          {tableContent}
+        </CatalogFilterLayout.Content>
       </CatalogFilterLayout>
     </EntityListProvider>
   );
@@ -67,6 +71,36 @@ function CatalogPageContent(props: BaseCatalogPageProps) {
 
 /** @internal */
 export function BaseCatalogPage(props: BaseCatalogPageProps) {
+  const orgName =
+    useApi(configApiRef).getOptionalString('organization.name') ?? 'Backstage';
+  const createComponentLink = useRouteRef(createComponentRouteRef);
+  const { t } = useTranslationRef(catalogTranslationRef);
+  const { allowed } = usePermission({
+    permission: catalogEntityCreatePermission,
+  });
+  const headerActions = (
+    <>
+      {allowed && (
+        <CreateButton
+          title={t('indexPage.createButtonTitle')}
+          to={createComponentLink && createComponentLink()}
+        />
+      )}
+      <SupportButton>{t('indexPage.supportButtonContent')}</SupportButton>
+    </>
+  );
+
+  return (
+    <PageWithHeader title={t('indexPage.title', { orgName })} themeId="home">
+      <Content>
+        <ContentHeader title="">{headerActions}</ContentHeader>
+        <CatalogPageContent {...props} />
+      </Content>
+    </PageWithHeader>
+  );
+}
+
+function NfsBaseCatalogPage(props: BaseCatalogPageProps) {
   const orgName =
     useApi(configApiRef).getOptionalString('organization.name') ?? 'Backstage';
   const createComponentLink = useRouteRef(createComponentRouteRef);
@@ -92,7 +126,6 @@ export function BaseCatalogPage(props: BaseCatalogPageProps) {
         }
       />
       <Content>
-<<<<<<< HEAD
         <CatalogPageContent {...props} />
       </Content>
     </>

--- a/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.tsx
@@ -41,22 +41,25 @@ import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { CatalogTableColumnsFunc } from '../CatalogTable/types';
 import { catalogEntityCreatePermission } from '@backstage/plugin-catalog-common/alpha';
 import { usePermission } from '@backstage/plugin-permission-react';
+import { ColumnConfig } from '../CatalogTable/columnConfig';
 
 /** @internal */
 export type BaseCatalogPageProps = {
   filters: ReactNode;
   content?: ReactNode;
   pagination?: EntityListPagination;
+  columnsConfig?: ColumnConfig;
 };
 
 function CatalogPageContent(props: BaseCatalogPageProps) {
-  const { filters, content = <CatalogTable />, pagination } = props;
+  const { filters, content, pagination, columnsConfig } = props;
+  const tableContent = content ?? <CatalogTable columnsConfig={columnsConfig} />;
 
   return (
     <EntityListProvider pagination={pagination}>
       <CatalogFilterLayout>
         <CatalogFilterLayout.Filters>{filters}</CatalogFilterLayout.Filters>
-        <CatalogFilterLayout.Content>{content}</CatalogFilterLayout.Content>
+        <CatalogFilterLayout.Content>{tableContent}</CatalogFilterLayout.Content>
       </CatalogFilterLayout>
     </EntityListProvider>
   );
@@ -64,36 +67,6 @@ function CatalogPageContent(props: BaseCatalogPageProps) {
 
 /** @internal */
 export function BaseCatalogPage(props: BaseCatalogPageProps) {
-  const orgName =
-    useApi(configApiRef).getOptionalString('organization.name') ?? 'Backstage';
-  const createComponentLink = useRouteRef(createComponentRouteRef);
-  const { t } = useTranslationRef(catalogTranslationRef);
-  const { allowed } = usePermission({
-    permission: catalogEntityCreatePermission,
-  });
-  const headerActions = (
-    <>
-      {allowed && (
-        <CreateButton
-          title={t('indexPage.createButtonTitle')}
-          to={createComponentLink && createComponentLink()}
-        />
-      )}
-      <SupportButton>{t('indexPage.supportButtonContent')}</SupportButton>
-    </>
-  );
-
-  return (
-    <PageWithHeader title={t('indexPage.title', { orgName })} themeId="home">
-      <Content>
-        <ContentHeader title="">{headerActions}</ContentHeader>
-        <CatalogPageContent {...props} />
-      </Content>
-    </PageWithHeader>
-  );
-}
-
-function NfsBaseCatalogPage(props: BaseCatalogPageProps) {
   const orgName =
     useApi(configApiRef).getOptionalString('organization.name') ?? 'Backstage';
   const createComponentLink = useRouteRef(createComponentRouteRef);
@@ -119,6 +92,7 @@ function NfsBaseCatalogPage(props: BaseCatalogPageProps) {
         }
       />
       <Content>
+<<<<<<< HEAD
         <CatalogPageContent {...props} />
       </Content>
     </>
@@ -141,6 +115,7 @@ export interface DefaultCatalogPageProps {
   filters?: ReactNode;
   initiallySelectedNamespaces?: string[];
   pagination?: EntityListPagination;
+  columnsConfig?: ColumnConfig;
 }
 
 export function DefaultCatalogPage(props: DefaultCatalogPageProps) {
@@ -194,6 +169,7 @@ export function NfsDefaultCatalogPage(props: DefaultCatalogPageProps) {
     ownerPickerMode,
     filters,
     initiallySelectedNamespaces,
+    columnsConfig,
   } = props;
 
   return (
@@ -214,6 +190,7 @@ export function NfsDefaultCatalogPage(props: DefaultCatalogPageProps) {
           actions={actions}
           tableOptions={tableOptions}
           emptyContent={emptyContent}
+          columnsConfig={columnsConfig}
         />
       }
       pagination={pagination}

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -50,6 +50,7 @@ import { defaultCatalogTableColumnsFunc } from './defaultCatalogTableColumnsFunc
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { catalogTranslationRef } from '../../alpha';
 import { FavoriteToggleIcon } from '@backstage/core-components';
+import { applyColumnConfig, ColumnConfig } from './columnConfig';
 
 /**
  * Props for {@link CatalogTable}.
@@ -67,6 +68,11 @@ export interface CatalogTableProps {
    */
   title?: string;
   subtitle?: string;
+  /**
+   * Configuration for customizing which columns are displayed.
+   * Allows including/excluding built-in columns and adding custom columns.
+   */
+  columnsConfig?: ColumnConfig;
 }
 
 const refCompare = (a: Entity, b: Entity) => {
@@ -95,6 +101,7 @@ export const CatalogTable = (props: CatalogTableProps) => {
     tableOptions,
     subtitle,
     emptyContent,
+    columnsConfig,
   } = props;
   const { isStarredEntity, toggleStarredEntity } = useStarredEntities();
   const entityListContext = useEntityList();
@@ -117,11 +124,11 @@ export const CatalogTable = (props: CatalogTableProps) => {
   const isLoading =
     paginationMode === 'none' ? loading && entities.length === 0 : loading;
 
-  const tableColumns = useMemo(
-    () =>
-      typeof columns === 'function' ? columns(entityListContext) : columns,
-    [columns, entityListContext],
-  );
+  const tableColumns = useMemo(() => {
+    const baseColumns =
+      typeof columns === 'function' ? columns(entityListContext) : columns;
+    return applyColumnConfig(baseColumns, columnsConfig);
+  }, [columns, entityListContext, columnsConfig]);
   const { t } = useTranslationRef(catalogTranslationRef);
 
   if (error) {

--- a/plugins/catalog/src/components/CatalogTable/columnConfig.test.ts
+++ b/plugins/catalog/src/components/CatalogTable/columnConfig.test.ts
@@ -145,7 +145,7 @@ describe('createCustomColumn', () => {
       },
     };
 
-    const rendered = column.render!(row, 'asc');
+    const rendered = column.render!(row, 'row');
     expect(rendered).toBe('service');
   });
 
@@ -173,7 +173,7 @@ describe('createCustomColumn', () => {
       },
     };
 
-    const rendered = column.render!(row, 'asc');
+    const rendered = column.render!(row, 'row');
     expect(rendered).toBe('N/A');
   });
 
@@ -218,8 +218,8 @@ describe('createCustomColumn', () => {
       },
     };
 
-    expect(column.render!(componentRow, 'asc')).toBe('service');
-    expect(column.render!(apiRow, 'asc')).toBeNull();
+    expect(column.render!(componentRow, 'row')).toBe('service');
+    expect(column.render!(apiRow, 'row')).toBeNull();
   });
 });
 

--- a/plugins/catalog/src/components/CatalogTable/columnConfig.test.ts
+++ b/plugins/catalog/src/components/CatalogTable/columnConfig.test.ts
@@ -49,7 +49,9 @@ describe('resolveFieldPath', () => {
   };
 
   it('should resolve simple dot notation paths', () => {
-    expect(resolveFieldPath(testEntity, 'metadata.name')).toBe('test-component');
+    expect(resolveFieldPath(testEntity, 'metadata.name')).toBe(
+      'test-component',
+    );
     expect(resolveFieldPath(testEntity, 'spec.type')).toBe('service');
     expect(resolveFieldPath(testEntity, 'kind')).toBe('Component');
   });
@@ -67,16 +69,18 @@ describe('resolveFieldPath', () => {
   });
 
   it('should resolve bracket notation for labels', () => {
-    expect(
-      resolveFieldPath(testEntity, "metadata.labels['cost-center']"),
-    ).toBe('engineering');
+    expect(resolveFieldPath(testEntity, "metadata.labels['cost-center']")).toBe(
+      'engineering',
+    );
     expect(resolveFieldPath(testEntity, "metadata.labels['team']")).toBe(
       'platform',
     );
   });
 
   it('should return undefined for non-existent paths', () => {
-    expect(resolveFieldPath(testEntity, 'metadata.nonexistent')).toBeUndefined();
+    expect(
+      resolveFieldPath(testEntity, 'metadata.nonexistent'),
+    ).toBeUndefined();
     expect(
       resolveFieldPath(testEntity, "metadata.annotations['nonexistent']"),
     ).toBeUndefined();

--- a/plugins/catalog/src/components/CatalogTable/columnConfig.test.ts
+++ b/plugins/catalog/src/components/CatalogTable/columnConfig.test.ts
@@ -1,0 +1,307 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity } from '@backstage/catalog-model';
+import {
+  resolveFieldPath,
+  createCustomColumn,
+  applyColumnConfig,
+} from './columnConfig';
+import { CatalogTableRow } from './types';
+import { TableColumn } from '@backstage/core-components';
+
+describe('resolveFieldPath', () => {
+  const testEntity: Entity = {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Component',
+    metadata: {
+      name: 'test-component',
+      namespace: 'default',
+      description: 'A test component',
+      annotations: {
+        'backstage.io/techdocs-ref': 'dir:.',
+        'security/tier': 'high',
+      },
+      labels: {
+        'cost-center': 'engineering',
+        team: 'platform',
+      },
+      tags: ['typescript', 'react'],
+    },
+    spec: {
+      type: 'service',
+      lifecycle: 'production',
+      owner: 'team-platform',
+    },
+  };
+
+  it('should resolve simple dot notation paths', () => {
+    expect(resolveFieldPath(testEntity, 'metadata.name')).toBe('test-component');
+    expect(resolveFieldPath(testEntity, 'spec.type')).toBe('service');
+    expect(resolveFieldPath(testEntity, 'kind')).toBe('Component');
+  });
+
+  it('should resolve bracket notation for annotations', () => {
+    expect(
+      resolveFieldPath(testEntity, "metadata.annotations['security/tier']"),
+    ).toBe('high');
+    expect(
+      resolveFieldPath(
+        testEntity,
+        "metadata.annotations['backstage.io/techdocs-ref']",
+      ),
+    ).toBe('dir:.');
+  });
+
+  it('should resolve bracket notation for labels', () => {
+    expect(
+      resolveFieldPath(testEntity, "metadata.labels['cost-center']"),
+    ).toBe('engineering');
+    expect(resolveFieldPath(testEntity, "metadata.labels['team']")).toBe(
+      'platform',
+    );
+  });
+
+  it('should return undefined for non-existent paths', () => {
+    expect(resolveFieldPath(testEntity, 'metadata.nonexistent')).toBeUndefined();
+    expect(
+      resolveFieldPath(testEntity, "metadata.annotations['nonexistent']"),
+    ).toBeUndefined();
+  });
+
+  it('should handle arrays', () => {
+    expect(resolveFieldPath(testEntity, 'metadata.tags')).toEqual([
+      'typescript',
+      'react',
+    ]);
+  });
+});
+
+describe('createCustomColumn', () => {
+  it('should create a column with basic properties', () => {
+    const column = createCustomColumn({
+      title: 'Security Tier',
+      field: "metadata.annotations['security/tier']",
+    });
+
+    expect(column.title).toBe('Security Tier');
+    expect(column.sorting).toBe(true);
+  });
+
+  it('should create a column with custom width', () => {
+    const column = createCustomColumn({
+      title: 'Cost Center',
+      field: "metadata.labels['cost-center']",
+      width: 150,
+    });
+
+    expect(column.width).toBe('150px');
+  });
+
+  it('should create a column with sorting disabled', () => {
+    const column = createCustomColumn({
+      title: 'Test',
+      field: 'metadata.name',
+      sortable: false,
+    });
+
+    expect(column.sorting).toBe(false);
+    expect(column.customSort).toBeUndefined();
+  });
+
+  it('should render column value correctly', () => {
+    const column = createCustomColumn({
+      title: 'Type',
+      field: 'spec.type',
+    });
+
+    const testEntity: Entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: { name: 'test' },
+      spec: { type: 'service' },
+    };
+
+    const row: CatalogTableRow = {
+      entity: testEntity,
+      resolved: {
+        name: 'test',
+        entityRef: 'component:default/test',
+        partOfSystemRelations: [],
+        ownedByRelations: [],
+      },
+    };
+
+    const rendered = column.render!(row, 'asc');
+    expect(rendered).toBe('service');
+  });
+
+  it('should render default value when field is empty', () => {
+    const column = createCustomColumn({
+      title: 'Missing',
+      field: 'spec.nonexistent',
+      defaultValue: 'N/A',
+    });
+
+    const testEntity: Entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: { name: 'test' },
+      spec: {},
+    };
+
+    const row: CatalogTableRow = {
+      entity: testEntity,
+      resolved: {
+        name: 'test',
+        entityRef: 'component:default/test',
+        partOfSystemRelations: [],
+        ownedByRelations: [],
+      },
+    };
+
+    const rendered = column.render!(row, 'asc');
+    expect(rendered).toBe('N/A');
+  });
+
+  it('should filter by entity kind', () => {
+    const column = createCustomColumn({
+      title: 'Type',
+      field: 'spec.type',
+      kind: 'Component',
+    });
+
+    const componentEntity: Entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: { name: 'test' },
+      spec: { type: 'service' },
+    };
+
+    const apiEntity: Entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'API',
+      metadata: { name: 'test-api' },
+      spec: { type: 'openapi' },
+    };
+
+    const componentRow: CatalogTableRow = {
+      entity: componentEntity,
+      resolved: {
+        name: 'test',
+        entityRef: 'component:default/test',
+        partOfSystemRelations: [],
+        ownedByRelations: [],
+      },
+    };
+
+    const apiRow: CatalogTableRow = {
+      entity: apiEntity,
+      resolved: {
+        name: 'test-api',
+        entityRef: 'api:default/test-api',
+        partOfSystemRelations: [],
+        ownedByRelations: [],
+      },
+    };
+
+    expect(column.render!(componentRow, 'asc')).toBe('service');
+    expect(column.render!(apiRow, 'asc')).toBeNull();
+  });
+});
+
+describe('applyColumnConfig', () => {
+  const createMockColumn = (
+    field: string,
+    title: string,
+  ): TableColumn<CatalogTableRow> => ({
+    title,
+    field,
+  });
+
+  const baseColumns: TableColumn<CatalogTableRow>[] = [
+    createMockColumn('resolved.entityRef', 'Name'),
+    createMockColumn('resolved.ownedByRelationsTitle', 'Owner'),
+    createMockColumn('entity.spec.type', 'Type'),
+    createMockColumn('entity.spec.lifecycle', 'Lifecycle'),
+    createMockColumn('entity.metadata.description', 'Description'),
+    createMockColumn('entity.metadata.tags', 'Tags'),
+  ];
+
+  it('should return original columns when no config provided', () => {
+    expect(applyColumnConfig(baseColumns, undefined)).toEqual(baseColumns);
+  });
+
+  it('should filter columns by include list', () => {
+    const result = applyColumnConfig(baseColumns, {
+      include: ['name', 'owner', 'type'],
+    });
+
+    expect(result).toHaveLength(3);
+    expect(result.map(c => c.title)).toEqual(['Name', 'Owner', 'Type']);
+  });
+
+  it('should filter columns by exclude list', () => {
+    const result = applyColumnConfig(baseColumns, {
+      exclude: ['tags', 'description'],
+    });
+
+    expect(result).toHaveLength(4);
+    expect(result.map(c => c.title)).toEqual([
+      'Name',
+      'Owner',
+      'Type',
+      'Lifecycle',
+    ]);
+  });
+
+  it('should add custom columns', () => {
+    const result = applyColumnConfig(baseColumns, {
+      custom: [
+        {
+          title: 'Security Tier',
+          field: "metadata.annotations['security/tier']",
+        },
+      ],
+    });
+
+    expect(result).toHaveLength(7);
+    expect(result[result.length - 1].title).toBe('Security Tier');
+  });
+
+  it('should handle case-insensitive column IDs', () => {
+    const result = applyColumnConfig(baseColumns, {
+      include: ['NAME', 'Owner', 'TYPE'],
+    });
+
+    expect(result).toHaveLength(3);
+  });
+
+  it('should combine include and custom columns', () => {
+    const result = applyColumnConfig(baseColumns, {
+      include: ['name', 'owner'],
+      custom: [
+        {
+          title: 'Custom Field',
+          field: 'spec.custom',
+        },
+      ],
+    });
+
+    expect(result).toHaveLength(3);
+    expect(result.map(c => c.title)).toEqual(['Name', 'Owner', 'Custom Field']);
+  });
+});

--- a/plugins/catalog/src/components/CatalogTable/columnConfig.ts
+++ b/plugins/catalog/src/components/CatalogTable/columnConfig.ts
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity } from '@backstage/catalog-model';
+import { TableColumn } from '@backstage/core-components';
+import { CatalogTableRow } from './types';
+
+/**
+ * Configuration for a custom column.
+ * @public
+ */
+export interface CustomColumnConfig {
+  title: string;
+  field: string;
+  width?: number;
+  sortable?: boolean;
+  defaultValue?: string;
+  kind?: string | string[];
+}
+
+/**
+ * Configuration for catalog table columns.
+ * @public
+ */
+export interface ColumnConfig {
+  include?: string[];
+  exclude?: string[];
+  custom?: CustomColumnConfig[];
+}
+
+/**
+ * Built-in column IDs that can be used with include/exclude.
+ * @public
+ */
+export const BUILTIN_COLUMN_IDS = [
+  'name',
+  'owner',
+  'type',
+  'lifecycle',
+  'description',
+  'tags',
+  'namespace',
+  'system',
+  'targets',
+] as const;
+
+export type BuiltinColumnId = (typeof BUILTIN_COLUMN_IDS)[number];
+
+/**
+ * Resolves a field path from an entity.
+ * Supports dot notation and bracket notation for annotations/labels.
+ * Examples:
+ *   - "metadata.name"
+ *   - "metadata.annotations['backstage.io/techdocs-ref']"
+ *   - "spec.type"
+ */
+export function resolveFieldPath(entity: Entity, fieldPath: string): unknown {
+  const parts: string[] = [];
+  let current = '';
+  let inBracket = false;
+
+  for (let i = 0; i < fieldPath.length; i++) {
+    const char = fieldPath[i];
+
+    if (char === '[' && !inBracket) {
+      if (current) {
+        parts.push(current);
+        current = '';
+      }
+      inBracket = true;
+    } else if (char === ']' && inBracket) {
+      // Remove quotes from bracket notation
+      const bracketContent = current.replace(/^['"]|['"]$/g, '');
+      parts.push(bracketContent);
+      current = '';
+      inBracket = false;
+    } else if (char === '.' && !inBracket) {
+      if (current) {
+        parts.push(current);
+        current = '';
+      }
+    } else {
+      current += char;
+    }
+  }
+
+  if (current) {
+    parts.push(current);
+  }
+
+  let value: unknown = entity;
+  for (const part of parts) {
+    if (value === null || value === undefined) {
+      return undefined;
+    }
+    if (typeof value === 'object') {
+      value = (value as Record<string, unknown>)[part];
+    } else {
+      return undefined;
+    }
+  }
+
+  return value;
+}
+
+/**
+ * Creates a custom column from configuration.
+ */
+export function createCustomColumn(
+  config: CustomColumnConfig,
+): TableColumn<CatalogTableRow> {
+  const { title, field, width, sortable = true, defaultValue, kind } = config;
+
+  return {
+    title,
+    field: `entity.${field}`,
+    width: width ? `${width}px` : 'auto',
+    sorting: sortable,
+    render: ({ entity }) => {
+      // Check if kind filter applies
+      if (kind) {
+        const entityKind = entity.kind?.toLowerCase();
+        const allowedKinds = Array.isArray(kind)
+          ? kind.map(k => k.toLowerCase())
+          : [kind.toLowerCase()];
+        if (!allowedKinds.includes(entityKind)) {
+          return null;
+        }
+      }
+
+      const value = resolveFieldPath(entity, field);
+
+      if (value === undefined || value === null || value === '') {
+        return defaultValue ?? '';
+      }
+
+      if (Array.isArray(value)) {
+        return value.join(', ');
+      }
+
+      return String(value);
+    },
+    customSort: sortable
+      ? ({ entity: entity1 }, { entity: entity2 }) => {
+          const value1 = resolveFieldPath(entity1, field);
+          const value2 = resolveFieldPath(entity2, field);
+          const str1 = value1 != null ? String(value1) : '';
+          const str2 = value2 != null ? String(value2) : '';
+          return str1.localeCompare(str2);
+        }
+      : undefined,
+  };
+}
+
+/**
+ * Applies column configuration to filter and extend columns.
+ * @public
+ */
+export function applyColumnConfig(
+  columns: TableColumn<CatalogTableRow>[],
+  config: ColumnConfig | undefined,
+): TableColumn<CatalogTableRow>[] {
+  if (!config) {
+    return columns;
+  }
+
+  let result = [...columns];
+
+  // Apply include filter (whitelist)
+  if (config.include && config.include.length > 0) {
+    const includeSet = new Set(config.include.map(id => id.toLowerCase()));
+    result = result.filter(col => {
+      const colId = getColumnId(col);
+      return colId && includeSet.has(colId.toLowerCase());
+    });
+  }
+
+  // Apply exclude filter (blacklist)
+  if (config.exclude && config.exclude.length > 0) {
+    const excludeSet = new Set(config.exclude.map(id => id.toLowerCase()));
+    result = result.filter(col => {
+      const colId = getColumnId(col);
+      return !colId || !excludeSet.has(colId.toLowerCase());
+    });
+  }
+
+  // Add custom columns
+  if (config.custom && config.custom.length > 0) {
+    const customColumns = config.custom.map(createCustomColumn);
+    result = [...result, ...customColumns];
+  }
+
+  return result;
+}
+
+/**
+ * Extracts the column ID from a TableColumn.
+ * The ID is derived from the field property or title.
+ */
+function getColumnId(column: TableColumn<CatalogTableRow>): string | undefined {
+  if (typeof column.field === 'string') {
+    // Extract the last part of field path for matching
+    // e.g., "entity.spec.type" -> "type"
+    // e.g., "resolved.ownedByRelationsTitle" -> "owner" (special case)
+    const field = column.field;
+
+    if (field.includes('ownedByRelations')) {
+      return 'owner';
+    }
+    if (field.includes('partOfSystemRelation')) {
+      return 'system';
+    }
+    if (field === 'resolved.entityRef' || field.includes('.name')) {
+      return 'name';
+    }
+    if (field.includes('spec.type')) {
+      return 'type';
+    }
+    if (field.includes('spec.lifecycle')) {
+      return 'lifecycle';
+    }
+    if (field.includes('description')) {
+      return 'description';
+    }
+    if (field.includes('tags')) {
+      return 'tags';
+    }
+    if (field.includes('namespace')) {
+      return 'namespace';
+    }
+    if (field.includes('targets') || field.includes('target')) {
+      return 'targets';
+    }
+  }
+
+  // Fallback to title-based matching
+  const title =
+    typeof column.title === 'string'
+      ? column.title.toLowerCase()
+      : undefined;
+
+  if (title) {
+    for (const id of BUILTIN_COLUMN_IDS) {
+      if (title.includes(id)) {
+        return id;
+      }
+    }
+  }
+
+  return undefined;
+}

--- a/plugins/catalog/src/components/CatalogTable/columnConfig.ts
+++ b/plugins/catalog/src/components/CatalogTable/columnConfig.ts
@@ -66,6 +66,7 @@ export type BuiltinColumnId = (typeof BUILTIN_COLUMN_IDS)[number];
  *   - "metadata.name"
  *   - "metadata.annotations['backstage.io/techdocs-ref']"
  *   - "spec.type"
+ * @public
  */
 export function resolveFieldPath(entity: Entity, fieldPath: string): unknown {
   const parts: string[] = [];
@@ -248,9 +249,7 @@ function getColumnId(column: TableColumn<CatalogTableRow>): string | undefined {
 
   // Fallback to title-based matching
   const title =
-    typeof column.title === 'string'
-      ? column.title.toLowerCase()
-      : undefined;
+    typeof column.title === 'string' ? column.title.toLowerCase() : undefined;
 
   if (title) {
     for (const id of BUILTIN_COLUMN_IDS) {

--- a/plugins/catalog/src/components/CatalogTable/columnConfig.ts
+++ b/plugins/catalog/src/components/CatalogTable/columnConfig.ts
@@ -128,7 +128,7 @@ export function createCustomColumn(
   return {
     title,
     field: `entity.${field}`,
-    width: width ? `${width}px` : 'auto',
+    width: width !== undefined ? `${width}px` : 'auto',
     sorting: sortable,
     render: ({ entity }) => {
       // Check if kind filter applies
@@ -158,8 +158,10 @@ export function createCustomColumn(
       ? ({ entity: entity1 }, { entity: entity2 }) => {
           const value1 = resolveFieldPath(entity1, field);
           const value2 = resolveFieldPath(entity2, field);
-          const str1 = value1 != null ? String(value1) : '';
-          const str2 = value2 != null ? String(value2) : '';
+          const str1 =
+            value1 !== null && value1 !== undefined ? String(value1) : '';
+          const str2 =
+            value2 !== null && value2 !== undefined ? String(value2) : '';
           return str1.localeCompare(str2);
         }
       : undefined,
@@ -184,8 +186,10 @@ export function applyColumnConfig(
   if (config.include && config.include.length > 0) {
     const includeSet = new Set(config.include.map(id => id.toLowerCase()));
     result = result.filter(col => {
+      // Always preserve hidden columns (e.g., the title column used for search)
+      if (col.hidden) return true;
       const colId = getColumnId(col);
-      return colId && includeSet.has(colId.toLowerCase());
+      return colId ? includeSet.has(colId.toLowerCase()) : false;
     });
   }
 

--- a/plugins/catalog/src/components/CatalogTable/index.ts
+++ b/plugins/catalog/src/components/CatalogTable/index.ts
@@ -18,3 +18,9 @@ export { CatalogTable } from './CatalogTable';
 export type { CatalogTableProps } from './CatalogTable';
 export type { CatalogTableToolbarClassKey } from './CatalogTableToolbar';
 export type { CatalogTableRow, CatalogTableColumnsFunc } from './types';
+export type { ColumnConfig, CustomColumnConfig } from './columnConfig';
+export {
+  applyColumnConfig,
+  resolveFieldPath,
+  BUILTIN_COLUMN_IDS,
+} from './columnConfig';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### Summary

This PR adds support for customizing catalog table columns via `app-config.yaml` when using the New Frontend System, as requested in #32549.

Platform engineers can now configure which columns appear in the catalog table without code changes. The configuration supports three modes:

**1. Include mode (whitelist)** - Show only specific columns:
```yaml
app:
  extensions:
    - page:catalog:
        config:
          columns:
            include:
              - name
              - owner
              - type
```

**2. Exclude mode (blacklist)** - Hide specific columns:
```yaml
app:
  extensions:
    - page:catalog:
        config:
          columns:
            exclude:
              - namespace
              - tags
              - description
```

**3. Custom columns** - Add columns from entity metadata:
```yaml
app:
  extensions:
    - page:catalog:
        config:
          columns:
            custom:
              - title: "Security Tier"
                field: "metadata.annotations['security/tier']"
                width: 120
                sortable: true
                defaultValue: "Not Set"
              - title: "Cost Center"
                field: "metadata.labels['cost-center']"
                kind:
                  - Component
                  - Resource
```

### Available Built-in Column IDs
`name`, `owner`, `type`, `lifecycle`, `description`, `tags`, `namespace`, `system`, `targets`

### Custom Column Properties
| Property | Type | Required | Description |
|----------|------|----------|-------------|
| `title` | string | Yes | Column header text |
| `field` | string | Yes | Entity field path (supports dot/bracket notation) |
| `width` | number | No | Column width in pixels |
| `sortable` | boolean | No | Enable sorting (default: true) |
| `defaultValue` | string | No | Value when field is empty |
| `kind` | string \| string[] | No | Limit to specific entity kinds |

### Implementation Details

- **Config Schema**: Added to `config.d.ts` with full TypeScript types
- **Column Utilities**: New `columnConfig.ts` with `resolveFieldPath()`, `createCustomColumn()`, and `applyColumnConfig()` functions
- **New Frontend System**: Integrated via `pages.tsx` with Zod validation schema
- **Component Updates**: `CatalogTable` and `BaseCatalogPage` accept `columnsConfig` prop

Fixes #32549

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
