### PR TITLE
docs: fix markdown links in v1.2.0 release notes

### DIFF
--- a/docs/releases/v1.2.0.md
+++ b/docs/releases/v1.2.0.md
@@ -38,7 +38,7 @@ Server-to-server authentication tokens issued from a TokenManager (specifically,
 
 ### Kubernetes
 
-Added support for `oidc` as an auth provider for kubernetes authentication and added an optional `oidcTokenProvider` config value. This will allow users to authenticate to kubernetes clusters using ID tokens obtained from the configured auth provider in their Backstage instance. Contributed by [@dbravovmw](https://github.com/dbravovmw). [#11328](https://github.com/backstage/backstage/pull/11328)
+Added support for `oidc` as an auth provider for kubernetes authentication and added an optional `oidcTokenProvider` config value. This will allow users to authenticate to kubernetes clusters using ID tokens obtained from the configured auth provider in their Backstage instance. Contributed by [@dbravovmw](https://github.com/dbravovmw) in [#11328](https://github.com/backstage/backstage/pull/11328)
 
 ### Misc
 


### PR DESCRIPTION
### Summary
Fixes malformed markdown links in the v1.2.0 release notes.

### Problem
The contributor mention and PR reference were not properly formatted as markdown links:
- `@dbravovmw(https://...)` → `[@dbravovmw](https://...)`
- `#11328(https://...)` → `[#11328](https://...)`

This caused the links to not render correctly on the documentation site.

### Changes
- Fixed contributor link format
- Fixed PR reference link format

<img width="1060" height="313" alt="image" src="https://github.com/user-attachments/assets/a93d98b3-297d-468c-b89e-333801f5d89e" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
