### PR TITLE
docs: fix TODO placeholder link in quickstart-app-plugin tutorial

### DIFF
--- a/docs/tutorials/quickstart-app-plugin.md
+++ b/docs/tutorials/quickstart-app-plugin.md
@@ -304,6 +304,5 @@ return (
 > Break apart ExampleFetchComponent into smaller logical parts contained in
 > their own files. Rename your components to something other than ExampleXxx.
 >
-> You might be really proud of a plugin you develop. Follow this next tutorial
-> for an in-depth look at publishing and including that for the entire Backstage
-> community. [TODO](#).
+> You might be really proud of a plugin you develop. Consider sharing it with
+> the Backstage community by contributing to the [community-plugins repository](https://github.com/backstage/community-plugins).


### PR DESCRIPTION
### Summary
Fixes a broken placeholder link in the [quickstart-app-plugin](https://backstage.io/docs/tutorials/quickstart-app-plugin/#) tutorial.

### Problem
The "Where to go from here" section had a `[TODO](#)` placeholder that was not replaced with an actual link, leaving users with a dead-end reference.
<img width="572" height="180" alt="image" src="https://github.com/user-attachments/assets/f595700e-036e-45c8-bfc1-0635e98fa66e" />


### Solution
Replaced the broken TODO link with a reference to the Backstage community-plugins repository, which is where users can contribute their plugins to the community.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
