### PR TITLE
docs: update React documentation links to react.dev

### DIFF
--- a/docs/architecture-decisions/adr003-avoid-default-exports.md
+++ b/docs/architecture-decisions/adr003-avoid-default-exports.md
@@ -48,7 +48,7 @@ benefits. A few are:
 ## Decision
 
 We will stop using default exports except when absolutely necessary (such as
-[`React.lazy`](https://react.dev/reference/react/lazy) modules).
+[`React.lazy`](https://18.react.dev/reference/react/lazy) modules).
 A workaround exists for those that would prefer to never use `default`:
 
 ```ts

--- a/docs/plugins/integrating-plugin-into-software-catalog.md
+++ b/docs/plugins/integrating-plugin-into-software-catalog.md
@@ -45,7 +45,7 @@ export const MyPluginEntityContent = () => {
 ```
 
 Internally `useEntity` makes use of
-[react `Contexts`](https://react.dev/learn/passing-data-deeply-with-context). The entity context is
+[react `Contexts`](https://18.react.dev/learn/passing-data-deeply-with-context). The entity context is
 provided by the entity page into which your plugin will be embedded.
 
 ### Import your plugin and embed in the entities page
@@ -63,7 +63,7 @@ To add your component to the Entity view, you will need to modify the
 your plugin, you may only care about certain kinds of
 [entities](https://backstage.io/docs/features/software-catalog/descriptor-format),
 each of which has its own
-[element](https://react.dev/learn/rendering-lists) for rendering. This
+element for rendering. This
 functionality is handled by the `EntitySwitch` component:
 
 ```tsx


### PR DESCRIPTION
## Summary

Updates outdated React documentation links from `reactjs.org` to `react.dev` across the Backstage documentation.

## Problem

The old React documentation at `reactjs.org` has been deprecated and now redirects to `react.dev`. Having direct links to the new documentation provides a better user experience by avoiding redirects.

<img width="1238" height="503" alt="image" src="https://github.com/user-attachments/assets/a98af60e-e8da-4f9b-ae63-4dd707bc17f0" />
<img width="1204" height="505" alt="image" src="https://github.com/user-attachments/assets/0ca53c14-5a4a-44cf-a93e-5f51f39b9745" />


## Changes

- **docs/architecture-decisions/adr003-avoid-default-exports.md**: Updated `React.lazy` link
- **docs/plugins/integrating-plugin-into-software-catalog.md**: Updated React Context and rendering elements links

| Old URL | New URL |
|---------|---------|
| `reactjs.org/docs/code-splitting.html#reactlazy` | `react.dev/reference/react/lazy` |
| `reactjs.org/docs/context.html` | `react.dev/learn/passing-data-deeply-with-context` |
| `reactjs.org/docs/rendering-elements.html` | `react.dev/learn/rendering-lists` |


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
