### PR TITLE
docs: fix proxy extension point import path

### DIFF
--- a/docs/plugins/proxying.md
+++ b/docs/plugins/proxying.md
@@ -142,7 +142,7 @@ Example:
 
 ```ts
 import { createBackendModule } from '@backstage/backend-plugin-api';
-import { proxyEndpointsExtensionPoint } from '@backstage/plugin-proxy-node';
+import { proxyEndpointsExtensionPoint } from '@backstage/plugin-proxy-node/alpha';
 
 backend.add(
   createBackendModule({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes the import path for the proxy extension point in the docs. The `@backstage/plugin-proxy-node` package only exports via the `/alpha` subpath.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))