### PR TITLE
frontend-test-utils: add extension snapshot testing

### DIFF
--- a/.changeset/extension-snapshot-testing.md
+++ b/.changeset/extension-snapshot-testing.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-test-utils': patch
+---
+
+Added `snapshot()` method to `ExtensionTester`, which returns a tree-shaped representation of the resolved extension hierarchy. Convenient to use with `toMatchInlineSnapshot()`.

--- a/docs/frontend-system/building-plugins/02-testing.md
+++ b/docs/frontend-system/building-plugins/02-testing.md
@@ -200,8 +200,6 @@ describe('Index page', () => {
 });
 ```
 
-That's all for testing features!
-
 ## Mounting routes
 
 If your component or extension uses `useRouteRef` to generate links to other routes, you need to mount those routes in the test environment. Both `renderInTestApp` and `renderTestApp` support the `mountedRoutes` option for this purpose.
@@ -242,6 +240,10 @@ describe('MyComponent', () => {
   });
 });
 ```
+
+## Extension tree snapshots
+
+The `snapshot()` method on `ExtensionTester` returns a tree-shaped representation of the resolved extension hierarchy, which is convenient to use with Jest's `toMatchInlineSnapshot()` for verifying extension structure in tests.
 
 ## Missing something?
 

--- a/packages/frontend-test-utils/report.api.md
+++ b/packages/frontend-test-utils/report.api.md
@@ -66,6 +66,14 @@ export class ExtensionQuery<UOutput extends ExtensionDataRef> {
   get node(): AppNode;
 }
 
+// @public
+export interface ExtensionSnapshotNode {
+  children?: Record<string, ExtensionSnapshotNode[]>;
+  disabled?: true;
+  id: string;
+  outputs?: string[];
+}
+
 // @public (undocumented)
 export class ExtensionTester<UOutput extends ExtensionDataRef> {
   // (undocumented)
@@ -89,6 +97,7 @@ export class ExtensionTester<UOutput extends ExtensionDataRef> {
   ): ExtensionQuery<NonNullable<T['output']>>;
   // (undocumented)
   reactElement(): JSX.Element;
+  snapshot(): ExtensionSnapshotNode;
 }
 
 // @public

--- a/packages/frontend-test-utils/src/app/index.ts
+++ b/packages/frontend-test-utils/src/app/index.ts
@@ -18,6 +18,7 @@ export {
   createExtensionTester,
   type ExtensionTester,
   type ExtensionQuery,
+  type ExtensionSnapshotNode,
 } from './createExtensionTester';
 
 export { renderInTestApp, type TestAppOptions } from './renderInTestApp';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds support for extension tree snapshot testing through the new `snapshot()` method on `ExtensionTester`. It's useful for verifying the structure of extension hierarchies, catching regressions during refactoring, and documenting complex extension relationships.

The snapshots use a tree-shaped format that mirrors the actual extension hierarchy, with children nested under their parent's `children` field. Empty arrays and default values are omitted to keep snapshots concise and readable.

Example usage:
```tsx
const tester = createExtensionTester(myPage)
  .add(card1)
  .add(card2);

expect(tester.snapshot()).toMatchSnapshot();
```

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message.