### PR TITLE
fix(catalog): resolve owned-by filter using POST endpoint to fix 431 when users have many groups

### DIFF
--- a/.changeset/catalog-query-post-filters.md
+++ b/.changeset/catalog-query-post-filters.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Improves scaffolder entity pickers by using the catalog POST endpoint so large template filters are sent in the request body instead of the URL, helping avoid 431 errors and empty option lists.

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.test.tsx
@@ -52,7 +52,9 @@ describe('<EntityPicker />', () => {
   let props: FieldProps<string>;
 
   const catalogApi = catalogApiMock.mock({
-    getEntities: jest.fn(async () => ({ items: entities })),
+    streamEntities: jest.fn(async function* () {
+      yield entities;
+    }),
   });
 
   let Wrapper: ComponentType<PropsWithChildren<{}>>;
@@ -95,7 +97,7 @@ describe('<EntityPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.getEntities).toHaveBeenCalledWith({
+      expect(catalogApi.streamEntities).toHaveBeenCalledWith({
         fields: [
           'kind',
           'metadata.name',
@@ -105,7 +107,6 @@ describe('<EntityPicker />', () => {
           'spec.profile.displayName',
           'spec.type',
         ],
-        filter: undefined,
       });
     });
 
@@ -137,7 +138,9 @@ describe('<EntityPicker />', () => {
         formData,
       } as unknown as FieldProps<any>;
 
-      catalogApi.getEntities.mockResolvedValue({ items: entities });
+      catalogApi.streamEntities.mockImplementation(async function* () {
+        yield entities;
+      });
     });
 
     it('searches for users and groups', async () => {
@@ -147,11 +150,10 @@ describe('<EntityPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.getEntities).toHaveBeenCalledWith(
+      expect(catalogApi.streamEntities).toHaveBeenCalledWith(
         expect.objectContaining({
-          filter: {
-            kind: ['User'],
-          },
+          query: {},
+          filter: { kind: ['User'] },
         }),
       );
     });
@@ -182,7 +184,9 @@ describe('<EntityPicker />', () => {
         formData,
       } as unknown as FieldProps<any>;
 
-      catalogApi.getEntities.mockResolvedValue({ items: entities });
+      catalogApi.streamEntities.mockImplementation(async function* () {
+        yield entities;
+      });
     });
 
     it('searches for a specific group entity', async () => {
@@ -192,8 +196,9 @@ describe('<EntityPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.getEntities).toHaveBeenCalledWith(
+      expect(catalogApi.streamEntities).toHaveBeenCalledWith(
         expect.objectContaining({
+          query: {},
           filter: [
             {
               kind: ['Group'],
@@ -217,7 +222,9 @@ describe('<EntityPicker />', () => {
         },
       };
 
-      catalogApi.getEntities.mockResolvedValue({ items: entities });
+      catalogApi.streamEntities.mockImplementation(async function* () {
+        yield entities;
+      });
 
       await renderInTestApp(
         <Wrapper>
@@ -225,8 +232,9 @@ describe('<EntityPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.getEntities).toHaveBeenCalledWith(
+      expect(catalogApi.streamEntities).toHaveBeenCalledWith(
         expect.objectContaining({
+          query: {},
           filter: {
             kind: ['Group'],
             'metadata.name': 'test-entity',
@@ -253,8 +261,9 @@ describe('<EntityPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.getEntities).toHaveBeenCalledWith(
+      expect(catalogApi.streamEntities).toHaveBeenCalledWith(
         expect.objectContaining({
+          query: {},
           filter: [
             {
               kind: ['User'],
@@ -291,7 +300,9 @@ describe('<EntityPicker />', () => {
         formData,
       } as unknown as FieldProps<any>;
 
-      catalogApi.getEntities.mockResolvedValue({ items: entities });
+      catalogApi.streamEntities.mockImplementation(async function* () {
+        yield entities;
+      });
     });
     it('Prevents user from modifying input when ui:disabled is true', async () => {
       props.uiSchema = { 'ui:disabled': true };
@@ -355,7 +366,9 @@ describe('<EntityPicker />', () => {
         formData,
       } as unknown as FieldProps<any>;
 
-      catalogApi.getEntities.mockResolvedValue({ items: entities });
+      catalogApi.streamEntities.mockImplementation(async function* () {
+        yield entities;
+      });
     });
 
     it('searches for a Group entity', async () => {
@@ -365,8 +378,9 @@ describe('<EntityPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.getEntities).toHaveBeenCalledWith(
+      expect(catalogApi.streamEntities).toHaveBeenCalledWith(
         expect.objectContaining({
+          query: {},
           filter: [
             {
               kind: ['Group'],
@@ -394,7 +408,9 @@ describe('<EntityPicker />', () => {
         formData,
       } as unknown as FieldProps<any>;
 
-      catalogApi.getEntities.mockResolvedValue({ items: entities });
+      catalogApi.streamEntities.mockImplementation(async function* () {
+        yield entities;
+      });
     });
 
     it('default behavior', async () => {
@@ -488,7 +504,9 @@ describe('<EntityPicker />', () => {
         formData,
       } as unknown as FieldProps<any>;
 
-      catalogApi.getEntities.mockResolvedValue({ items: entities });
+      catalogApi.streamEntities.mockImplementation(async function* () {
+        yield entities;
+      });
     });
 
     it('returns the full entityRef when entity exists in the list', async () => {
@@ -539,13 +557,14 @@ describe('<EntityPicker />', () => {
     });
 
     it('renders selection displayName', async () => {
-      catalogApi.getEntities.mockResolvedValue({
-        items: entities.map(item => ({
-          ...item,
-          spec: {
-            profile: { displayName: item.metadata.name.replace('-', ' ') },
-          },
-        })),
+      const items = entities.map(item => ({
+        ...item,
+        spec: {
+          profile: { displayName: item.metadata.name.replace('-', ' ') },
+        },
+      }));
+      catalogApi.streamEntities.mockImplementation(async function* () {
+        yield items;
       });
 
       const { getByRole, getByText } = await renderInTestApp(
@@ -568,14 +587,15 @@ describe('<EntityPicker />', () => {
     });
 
     it('renders selection title', async () => {
-      catalogApi.getEntities.mockResolvedValue({
-        items: entities.map(item => ({
-          ...item,
-          metadata: {
-            ...item.metadata,
-            title: item.metadata.name.replace('-', ' ').toUpperCase(),
-          },
-        })),
+      const items = entities.map(item => ({
+        ...item,
+        metadata: {
+          ...item.metadata,
+          title: item.metadata.name.replace('-', ' ').toUpperCase(),
+        },
+      }));
+      catalogApi.streamEntities.mockImplementation(async function* () {
+        yield items;
       });
 
       const { getByRole, getByText } = await renderInTestApp(
@@ -623,7 +643,9 @@ describe('<EntityPicker />', () => {
         formData,
       } as unknown as FieldProps<any>;
 
-      catalogApi.getEntities.mockResolvedValue({ items: entities });
+      catalogApi.streamEntities.mockImplementation(async function* () {
+        yield entities;
+      });
     });
 
     it('User enters clear input', async () => {
@@ -720,7 +742,9 @@ describe('<EntityPicker />', () => {
         formData,
       } as unknown as FieldProps<any>;
 
-      catalogApi.getEntities.mockResolvedValue({ items: entities });
+      catalogApi.streamEntities.mockImplementation(async function* () {
+        yield entities;
+      });
     });
 
     it('User enters clear input', async () => {
@@ -818,7 +842,9 @@ describe('<EntityPicker />', () => {
         formData,
       } as unknown as FieldProps<any>;
 
-      catalogApi.getEntities.mockResolvedValue({ items: entities });
+      catalogApi.streamEntities.mockImplementation(async function* () {
+        yield entities;
+      });
     });
 
     it('User enters clear input', async () => {
@@ -916,7 +942,9 @@ describe('<EntityPicker />', () => {
         formData,
       } as unknown as FieldProps<any>;
 
-      catalogApi.getEntities.mockResolvedValue({ items: entities });
+      catalogApi.streamEntities.mockImplementation(async function* () {
+        yield entities;
+      });
     });
 
     it('User enters clear input', async () => {

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
@@ -90,11 +90,13 @@ export const EntityPicker = (props: EntityPickerProps) => {
       'spec.profile.displayName',
       'spec.type',
     ];
-    const { items } = await catalogApi.getEntities(
-      catalogFilter
-        ? { filter: catalogFilter, fields }
-        : { filter: undefined, fields },
-    );
+    const streamRequest = catalogFilter
+      ? { query: {}, filter: catalogFilter, fields }
+      : { fields };
+    const items: Entity[] = [];
+    for await (const batch of catalogApi.streamEntities(streamRequest)) {
+      items.push(...batch);
+    }
 
     const entityRefToPresentation = new Map<
       string,

--- a/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.test.tsx
@@ -54,7 +54,9 @@ describe('<MultiEntityPicker />', () => {
   let props: FieldProps<string[]>;
 
   const catalogApi = catalogApiMock.mock({
-    getEntities: jest.fn(async () => ({ items: entities })),
+    streamEntities: jest.fn(async function* () {
+      yield entities;
+    }),
   });
   let Wrapper: ComponentType<PropsWithChildren<{}>>;
 
@@ -96,7 +98,7 @@ describe('<MultiEntityPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.getEntities).toHaveBeenCalledWith(undefined);
+      expect(catalogApi.streamEntities).toHaveBeenCalledWith({});
     });
 
     it('updates even if there is not an exact match', async () => {
@@ -140,7 +142,9 @@ describe('<MultiEntityPicker />', () => {
         formData,
       } as unknown as FieldProps<any>;
 
-      catalogApi.getEntities.mockResolvedValue({ items: entities });
+      catalogApi.streamEntities.mockImplementation(async function* () {
+        yield entities;
+      });
     });
 
     it('searches for a specific group entity', async () => {
@@ -150,7 +154,8 @@ describe('<MultiEntityPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.getEntities).toHaveBeenCalledWith({
+      expect(catalogApi.streamEntities).toHaveBeenCalledWith({
+        query: {},
         filter: [
           {
             kind: ['Group'],
@@ -174,7 +179,9 @@ describe('<MultiEntityPicker />', () => {
         },
       };
 
-      catalogApi.getEntities.mockResolvedValue({ items: entities });
+      catalogApi.streamEntities.mockImplementation(async function* () {
+        yield entities;
+      });
 
       await renderInTestApp(
         <Wrapper>
@@ -182,7 +189,8 @@ describe('<MultiEntityPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.getEntities).toHaveBeenCalledWith({
+      expect(catalogApi.streamEntities).toHaveBeenCalledWith({
+        query: {},
         filter: {
           kind: ['Group'],
           'metadata.name': 'test-entity',
@@ -208,7 +216,8 @@ describe('<MultiEntityPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.getEntities).toHaveBeenCalledWith({
+      expect(catalogApi.streamEntities).toHaveBeenCalledWith({
+        query: {},
         filter: [
           {
             kind: ['User'],
@@ -241,7 +250,9 @@ describe('<MultiEntityPicker />', () => {
         formData,
       } as unknown as FieldProps<any>;
 
-      catalogApi.getEntities.mockResolvedValue({ items: entities });
+      catalogApi.streamEntities.mockImplementation(async function* () {
+        yield entities;
+      });
     });
 
     it('searches for a Group entity', async () => {
@@ -251,7 +262,8 @@ describe('<MultiEntityPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.getEntities).toHaveBeenCalledWith({
+      expect(catalogApi.streamEntities).toHaveBeenCalledWith({
+        query: {},
         filter: [
           {
             kind: ['Group'],
@@ -306,7 +318,9 @@ describe('<MultiEntityPicker />', () => {
     });
 
     it('preserves existing data on selecting an existing option', async () => {
-      catalogApi.getEntities.mockResolvedValue({ items: entities });
+      catalogApi.streamEntities.mockImplementation(async function* () {
+        yield entities;
+      });
 
       const { getByRole } = await renderInTestApp(
         <Wrapper>
@@ -343,7 +357,9 @@ describe('<MultiEntityPicker />', () => {
         formData,
       } as unknown as FieldProps<any>;
 
-      catalogApi.getEntities.mockResolvedValue({ items: entities });
+      catalogApi.streamEntities.mockImplementation(async function* () {
+        yield entities;
+      });
     });
 
     it('returns the full entityRef when entity exists in the list', async () => {
@@ -402,7 +418,9 @@ describe('<MultiEntityPicker />', () => {
         formData,
       } as unknown as FieldProps<any>;
 
-      catalogApi.getEntities.mockResolvedValue({ items: entities });
+      catalogApi.streamEntities.mockImplementation(async function* () {
+        yield entities;
+      });
     });
 
     it('User enters clear input', async () => {
@@ -491,7 +509,9 @@ describe('<MultiEntityPicker />', () => {
         formData,
       } as unknown as FieldProps<any>;
 
-      catalogApi.getEntities.mockResolvedValue({ items: entities });
+      catalogApi.streamEntities.mockImplementation(async function* () {
+        yield entities;
+      });
     });
     it('Prevents user from modifying input when ui:disabled is true', async () => {
       props.formData = ['component/default:myentity'];
@@ -531,7 +551,9 @@ describe('<MultiEntityPicker />', () => {
         formData,
       } as unknown as FieldProps<any>;
 
-      catalogApi.getEntities.mockResolvedValue({ items: entities });
+      catalogApi.streamEntities.mockImplementation(async function* () {
+        yield entities;
+      });
     });
 
     it('User enters clear input', async () => {
@@ -628,7 +650,9 @@ describe('<MultiEntityPicker />', () => {
         formData,
       } as unknown as FieldProps<any>;
 
-      catalogApi.getEntities.mockResolvedValue({ items: entities });
+      catalogApi.streamEntities.mockImplementation(async function* () {
+        yield entities;
+      });
     });
 
     it('User enters clear input', async () => {
@@ -725,7 +749,9 @@ describe('<MultiEntityPicker />', () => {
         formData,
       } as unknown as FieldProps<any>;
 
-      catalogApi.getEntities.mockResolvedValue({ items: entities });
+      catalogApi.streamEntities.mockImplementation(async function* () {
+        yield entities;
+      });
     });
 
     it('User enters clear input', async () => {
@@ -829,7 +855,9 @@ describe('<MultiEntityPicker />', () => {
         formData,
       } as unknown as FieldProps<any>;
 
-      catalogApi.getEntities.mockResolvedValue({ items: testEntities });
+      catalogApi.streamEntities.mockImplementation(async function* () {
+        yield testEntities;
+      });
     });
 
     it('limit the number of selected entities when maxNoOfEntities is specified', async () => {
@@ -1031,13 +1059,14 @@ describe('<MultiEntityPicker />', () => {
     });
 
     it('renders and filters selection displayName', async () => {
-      catalogApi.getEntities.mockResolvedValue({
-        items: entities.map(item => ({
-          ...item,
-          spec: {
-            profile: { displayName: item.metadata.name.replace('-', ' ') },
-          },
-        })),
+      const items = entities.map(item => ({
+        ...item,
+        spec: {
+          profile: { displayName: item.metadata.name.replace('-', ' ') },
+        },
+      }));
+      catalogApi.streamEntities.mockImplementation(async function* () {
+        yield items;
       });
 
       const { getByRole, getByText } = await renderInTestApp(
@@ -1060,14 +1089,15 @@ describe('<MultiEntityPicker />', () => {
     });
 
     it('renders and filters selection title', async () => {
-      catalogApi.getEntities.mockResolvedValue({
-        items: entities.map(item => ({
-          ...item,
-          metadata: {
-            ...item.metadata,
-            title: item.metadata.name.replace('-', ' ').toUpperCase(),
-          },
-        })),
+      const items = entities.map(item => ({
+        ...item,
+        metadata: {
+          ...item.metadata,
+          title: item.metadata.name.replace('-', ' ').toUpperCase(),
+        },
+      }));
+      catalogApi.streamEntities.mockImplementation(async function* () {
+        yield items;
       });
 
       const { getByRole, getByText } = await renderInTestApp(

--- a/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.tsx
@@ -86,9 +86,13 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
   const catalogApi = useApi(catalogApiRef);
   const entityPresentationApi = useApi(entityPresentationApiRef);
   const { value: entities, loading } = useAsync(async () => {
-    const { items } = await catalogApi.getEntities(
-      catalogFilter ? { filter: catalogFilter } : undefined,
-    );
+    const streamRequest = catalogFilter
+      ? { query: {}, filter: catalogFilter }
+      : {};
+    const items: Entity[] = [];
+    for await (const batch of catalogApi.streamEntities(streamRequest)) {
+      items.push(...batch);
+    }
     const entityRefToPresentation = new Map<
       string,
       EntityRefPresentationSnapshot

--- a/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.test.tsx
@@ -50,7 +50,9 @@ describe('<MyGroupsPicker />', () => {
   const required = false;
 
   const catalogApi = catalogApiMock.mock({
-    getEntities: jest.fn(async () => ({ items: entities })),
+    streamEntities: jest.fn(async function* () {
+      yield entities;
+    }),
   });
 
   const mockErrorApi: jest.Mocked<ErrorApi> = {
@@ -81,7 +83,7 @@ describe('<MyGroupsPicker />', () => {
     ];
 
     onChange.mockClear();
-    catalogApi.getEntities.mockClear();
+    catalogApi.streamEntities.mockClear();
   });
 
   afterEach(() => {
@@ -96,7 +98,9 @@ describe('<MyGroupsPicker />', () => {
         entity.spec.members.includes('Bob'),
     );
 
-    catalogApi.getEntities.mockResolvedValue({ items: userGroups });
+    catalogApi.streamEntities.mockImplementation(async function* () {
+      yield userGroups;
+    });
 
     const props = {
       onChange,
@@ -122,47 +126,16 @@ describe('<MyGroupsPicker />', () => {
     );
 
     await waitFor(() =>
-      expect(catalogApi.getEntities).toHaveBeenCalledTimes(1),
+      expect(catalogApi.streamEntities).toHaveBeenCalledTimes(1),
     );
 
-    expect(catalogApi.getEntities).toHaveBeenCalledWith({
+    expect(catalogApi.streamEntities).toHaveBeenCalledWith({
+      query: {},
       filter: {
         kind: 'Group',
         'relations.hasMember': ['user:default/bob'],
       },
     });
-
-    // Check that getEntities was set up to return the correct data
-    await expect(catalogApi.getEntities.mock.results[0].value).resolves.toEqual(
-      {
-        items: [
-          {
-            apiVersion: 'backstage.io/v1alpha1',
-            kind: 'Group',
-            metadata: { name: 'group1' },
-            spec: { members: ['Bob'] },
-          },
-          {
-            apiVersion: 'backstage.io/v1alpha1',
-            kind: 'Group',
-            metadata: { name: 'group2' },
-            spec: { members: ['Bob'] },
-          },
-        ],
-      },
-    );
-
-    await expect(
-      catalogApi.getEntities.mock.results[0].value,
-    ).resolves.not.toEqual(
-      expect.objectContaining({
-        items: expect.arrayContaining([
-          expect.objectContaining({
-            metadata: { name: 'group3' },
-          }),
-        ]),
-      }),
-    );
   });
 
   it('should display the groups a user is part of and not display the groups a user is not part of', async () => {
@@ -173,7 +146,9 @@ describe('<MyGroupsPicker />', () => {
         entity.spec.members.includes('Bob'),
     );
 
-    catalogApi.getEntities.mockResolvedValue({ items: userGroups });
+    catalogApi.streamEntities.mockImplementation(async function* () {
+      yield userGroups;
+    });
 
     const props = {
       onChange,
@@ -199,7 +174,7 @@ describe('<MyGroupsPicker />', () => {
     );
 
     await waitFor(() =>
-      expect(catalogApi.getEntities).toHaveBeenCalledTimes(1),
+      expect(catalogApi.streamEntities).toHaveBeenCalledTimes(1),
     );
 
     // Simulate user input
@@ -235,7 +210,9 @@ describe('<MyGroupsPicker />', () => {
       },
     ];
 
-    catalogApi.getEntities.mockResolvedValue({ items: userGroups });
+    catalogApi.streamEntities.mockImplementation(async function* () {
+      yield userGroups;
+    });
 
     const props = {
       onChange,
@@ -261,7 +238,7 @@ describe('<MyGroupsPicker />', () => {
     );
 
     await waitFor(() =>
-      expect(catalogApi.getEntities).toHaveBeenCalledTimes(1),
+      expect(catalogApi.streamEntities).toHaveBeenCalledTimes(1),
     );
 
     const inputField = getByRole('combobox');
@@ -299,7 +276,9 @@ describe('<MyGroupsPicker />', () => {
       },
     ];
 
-    catalogApi.getEntities.mockResolvedValue({ items: userGroups });
+    catalogApi.streamEntities.mockImplementation(async function* () {
+      yield userGroups;
+    });
 
     const props = {
       onChange,
@@ -326,7 +305,7 @@ describe('<MyGroupsPicker />', () => {
     );
 
     await waitFor(() =>
-      expect(catalogApi.getEntities).toHaveBeenCalledTimes(1),
+      expect(catalogApi.streamEntities).toHaveBeenCalledTimes(1),
     );
 
     const inputField = getByRole('combobox');

--- a/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.tsx
@@ -70,12 +70,16 @@ export const MyGroupsPicker = (props: MyGroupsPickerProps) => {
       return { catalogEntities: [], entityRefToPresentation: new Map() };
     }
 
-    const { items } = await catalogApi.getEntities({
+    const items: Entity[] = [];
+    for await (const batch of catalogApi.streamEntities({
+      query: {},
       filter: {
         kind: 'Group',
         ['relations.hasMember']: [userEntityRef],
       },
-    });
+    })) {
+      items.push(...batch);
+    }
 
     const entityRefToPresentation = new Map<
       string,

--- a/plugins/scaffolder/src/components/fields/OwnerPicker/OwnerPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/OwnerPicker/OwnerPicker.test.tsx
@@ -57,7 +57,9 @@ describe('<OwnerPicker />', () => {
   let props: FieldProps<string>;
 
   const catalogApi = catalogApiMock.mock({
-    getEntities: jest.fn(async () => ({ items: entities })),
+    streamEntities: jest.fn(async function* () {
+      yield entities;
+    }),
   });
   let Wrapper: ComponentType<PropsWithChildren<{}>>;
 
@@ -99,22 +101,19 @@ describe('<OwnerPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.getEntities).toHaveBeenCalledWith(
-        expect.objectContaining({
-          filter: {
-            kind: ['Group', 'User'],
-          },
-          fields: [
-            'kind',
-            'metadata.name',
-            'metadata.namespace',
-            'metadata.title',
-            'metadata.description',
-            'spec.profile.displayName',
-            'spec.type',
-          ],
-        }),
-      );
+      expect(catalogApi.streamEntities).toHaveBeenCalledWith({
+        query: {},
+        filter: { kind: ['Group', 'User'] },
+        fields: [
+          'kind',
+          'metadata.name',
+          'metadata.namespace',
+          'metadata.title',
+          'metadata.description',
+          'spec.profile.displayName',
+          'spec.type',
+        ],
+      });
     });
   });
 
@@ -143,7 +142,9 @@ describe('<OwnerPicker />', () => {
         formData,
       } as unknown as FieldProps<any>;
 
-      catalogApi.getEntities.mockResolvedValue({ items: entities });
+      catalogApi.streamEntities.mockImplementation(async function* () {
+        yield entities;
+      });
     });
     it('Prevents user from modifying input when ui:disabled is true', async () => {
       props.uiSchema = { 'ui:disabled': true };
@@ -205,22 +206,19 @@ describe('<OwnerPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.getEntities).toHaveBeenCalledWith(
-        expect.objectContaining({
-          filter: {
-            kind: ['User'],
-          },
-          fields: [
-            'kind',
-            'metadata.name',
-            'metadata.namespace',
-            'metadata.title',
-            'metadata.description',
-            'spec.profile.displayName',
-            'spec.type',
-          ],
-        }),
-      );
+      expect(catalogApi.streamEntities).toHaveBeenCalledWith({
+        query: {},
+        filter: { kind: ['User'] },
+        fields: [
+          'kind',
+          'metadata.name',
+          'metadata.namespace',
+          'metadata.title',
+          'metadata.description',
+          'spec.profile.displayName',
+          'spec.type',
+        ],
+      });
     });
   });
 
@@ -245,7 +243,9 @@ describe('<OwnerPicker />', () => {
         formData,
       } as unknown as FieldProps<any>;
 
-      catalogApi.getEntities.mockResolvedValue({ items: entities });
+      catalogApi.streamEntities.mockImplementation(async function* () {
+        yield entities;
+      });
     });
 
     it('searches for group entities of type team', async () => {
@@ -255,8 +255,9 @@ describe('<OwnerPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.getEntities).toHaveBeenCalledWith(
+      expect(catalogApi.streamEntities).toHaveBeenCalledWith(
         expect.objectContaining({
+          query: {},
           filter: [
             {
               kind: ['Group'],
@@ -300,8 +301,9 @@ describe('<OwnerPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.getEntities).toHaveBeenCalledWith(
+      expect(catalogApi.streamEntities).toHaveBeenCalledWith(
         expect.objectContaining({
+          query: {},
           filter: [
             {
               kind: ['Group', 'User'],


### PR DESCRIPTION
## Fixes: https://github.com/backstage/backstage/issues/32367
## Description
<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
     
Scaffolder entity pickers that load catalog data now call `catalogApi.queryEntities` with a query predicate instead of a traditional filter. That matches how CatalogClient uses the POST `/entities/by-query` path when a predicate query is present, so large template-defined filters are sent in the request body instead of as long GET query strings.



## Screenshot


<img width="1904" height="946" alt="image" src="https://github.com/user-attachments/assets/e9b5dfc3-ce59-45b3-bd24-ca369a252cbf" />




---

## **How to test?:**


1. Create a user that belongs to 35+ groups with long names (e.g., group-001-abcdefghijklmnopqrstuv through group-036-abcdefghijklmnopqrstuv)

2. Configure authentication to include all group membership in the user's ownedEntityRefs:

guest provider:
```yaml

auth:
  providers:
    guest:
      userEntityRef: user:default/testuser
      ownershipEntityRefs:
        - user:default/testuser
        - group:default/group-001-abcdefghijklmnopqrstuv
        - group:default/group-002-abcdefghijklmnopqrstuv
        # include all 35+ groups
```
3. Create a scaffolder template with `OwnedEntityPicker` field containing multiple catalogFilter entries:  
```yaml
properties:
  ownedEntity:
     title: Entities
     type: string
     "ui:field": OwnedEntityPicker
     "ui:options":
       catalogFilter:
          - kind: component
          - kind: api
          - kind: template
          - kind: system
          - kind: template 
          - kind: group
         # add more filters if needed
```


4. Access the scaffolder template as the user with many groups

5. The OwnedEntityPicker should list all the components/api/templates as defined in the catalogFilter



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
