### PR TITLE
workflows: fix pr sync trigger setup

### DIFF
--- a/.github/workflows/sync_pull-requests-trigger.yml
+++ b/.github/workflows/sync_pull-requests-trigger.yml
@@ -8,39 +8,11 @@ on:
   issue_comment:
     types: [created]
 
-concurrency:
-  group: sync-pr-trigger-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: true
-
 jobs:
-  # Run directly for pull_request_target since it has secrets access
-  label:
-    if: >
-      github.repository == 'backstage/backstage' &&
-      github.event.sender.type != 'Bot' &&
-      github.event_name == 'pull_request_target'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@df199fb7be9f65074067a9eb93f12bb4c5547cf2 # v2.13.3
-        with:
-          egress-policy: audit
-
-      - name: Backstage PR automation
-        uses: backstage/actions/pr-automation@c0110c14def021f64b4774335b0d55ac705b9318 # v0.7.1
-        with:
-          app-id: ${{ secrets.BACKSTAGE_GOALIE_APPLICATION_ID }}
-          private-key: ${{ secrets.BACKSTAGE_GOALIE_PRIVATE_KEY }}
-          installation-id: ${{ secrets.BACKSTAGE_GOALIE_INSTALLATION_ID }}
-          project-owner: backstage
-          project-number: '14'
-
-  # Dispatch event for other triggers to be processed with secrets access
   trigger:
     if: >
       github.repository == 'backstage/backstage' &&
       github.event.sender.type != 'Bot' &&
-      github.event_name != 'pull_request_target' &&
       (github.event.pull_request || github.event.issue.pull_request)
     runs-on: ubuntu-latest
     steps:
@@ -49,17 +21,19 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Dispatch sync event
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      - name: Save PR context
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          LABEL_ADDED: ${{ github.event.action == 'labeled' && github.event.label.name || '' }}
+          REVIEW_STATE: ${{ github.event.review.state }}
+        run: |
+          mkdir -p ./context
+          echo "$PR_NUMBER" > ./context/pr-number
+          echo "$LABEL_ADDED" > ./context/label-added
+          echo "$REVIEW_STATE" > ./context/review-state
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          script: |
-            await github.rest.repos.createDispatchEvent({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              event_type: 'sync-pull-requests',
-              client_payload: {
-                'pr-number': String(context.payload.pull_request?.number || context.payload.issue?.number),
-                'label-added': context.payload.action === 'labeled' ? context.payload.label?.name : '',
-                'review-state': context.payload.review?.state || '',
-              },
-            });
+          name: pr-context
+          path: context/
+          overwrite: true

--- a/.github/workflows/sync_pull-requests.yml
+++ b/.github/workflows/sync_pull-requests.yml
@@ -1,23 +1,44 @@
 name: Sync Pull Requests
 
 on:
-  repository_dispatch:
-    types: [sync-pull-requests]
-
-concurrency:
-  group: sync-pr-${{ github.event.client_payload.pr-number }}
-  cancel-in-progress: true
+  workflow_run:
+    workflows: ['Sync Pull Requests Trigger']
+    types:
+      - completed
 
 jobs:
   run:
     runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@df199fb7be9f65074067a9eb93f12bb4c5547cf2 # v2.13.3
         with:
           egress-policy: audit
 
+      - name: Download PR context
+        id: download
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        continue-on-error: true
+        with:
+          name: pr-context
+          path: ./context
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Read context
+        if: steps.download.outcome == 'success'
+        id: context
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            core.setOutput('pr-number', fs.readFileSync('./context/pr-number', 'utf8').trim());
+            core.setOutput('label-added', fs.readFileSync('./context/label-added', 'utf8').trim());
+            core.setOutput('review-state', fs.readFileSync('./context/review-state', 'utf8').trim());
+
       - name: Backstage PR automation
+        if: steps.download.outcome == 'success'
         uses: backstage/actions/pr-automation@c0110c14def021f64b4774335b0d55ac705b9318 # v0.7.1
         with:
           app-id: ${{ secrets.BACKSTAGE_GOALIE_APPLICATION_ID }}
@@ -25,6 +46,6 @@ jobs:
           installation-id: ${{ secrets.BACKSTAGE_GOALIE_INSTALLATION_ID }}
           project-owner: backstage
           project-number: '14'
-          pr-number: ${{ github.event.client_payload.pr-number }}
-          label-added: ${{ github.event.client_payload.label-added }}
-          review-state: ${{ github.event.client_payload.review-state }}
+          pr-number: ${{ steps.context.outputs.pr-number }}
+          label-added: ${{ steps.context.outputs.label-added }}
+          review-state: ${{ steps.context.outputs.review-state }}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Wasn't working as intended due to access restrictions, switching to the same structure as the `pr-review-comment` workflow. Got rid of concurrency because it could cancel ongoing runs only to be skipped.
