### PR TITLE
fix(ui): export PasswordField component

### DIFF
--- a/.changeset/ripe-women-follow.md
+++ b/.changeset/ripe-women-follow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+export PasswordField component

--- a/packages/ui/report.api.md
+++ b/packages/ui/report.api.md
@@ -1396,6 +1396,34 @@ export interface PaginationOptions
   initialOffset?: number;
 }
 
+// @public (undocumented)
+export const PasswordField: ForwardRefExoticComponent<
+  PasswordFieldProps & RefAttributes<HTMLDivElement>
+>;
+
+// @public
+export const PasswordFieldDefinition: {
+  readonly classNames: {
+    readonly root: 'bui-PasswordField';
+    readonly inputWrapper: 'bui-PasswordFieldInputWrapper';
+    readonly input: 'bui-PasswordFieldInput';
+    readonly inputIcon: 'bui-PasswordFieldIcon';
+    readonly inputVisibility: 'bui-PasswordFieldVisibility';
+  };
+  readonly dataAttributes: {
+    readonly size: readonly ['small', 'medium'];
+  };
+};
+
+// @public (undocumented)
+export interface PasswordFieldProps
+  extends TextFieldProps_2,
+    Omit<FieldLabelProps, 'htmlFor' | 'id' | 'className'> {
+  icon?: ReactNode;
+  placeholder?: string;
+  size?: 'small' | 'medium' | Partial<Record<Breakpoint, 'small' | 'medium'>>;
+}
+
 // @public
 export const Popover: ForwardRefExoticComponent<
   PopoverProps & RefAttributes<HTMLDivElement>

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -46,6 +46,7 @@ export * from './components/Tabs';
 export * from './components/TagGroup';
 export * from './components/Text';
 export * from './components/TextField';
+export * from './components/PasswordField';
 export * from './components/Tooltip';
 export * from './components/Menu';
 export * from './components/Popover';


### PR DESCRIPTION
Added the missing export for the PasswordField component in the main entry point of the UI package. This ensures the component is properly exposed and available for use by external consumers.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
