### PR TITLE
[BUI] Fix dynamically changing columns crashing the table component

### DIFF
--- a/.changeset/many-ravens-move.md
+++ b/.changeset/many-ravens-move.md
@@ -1,0 +1,7 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed changing columns after first render from crashing. It now renders the table with the new column layout as columns change.
+
+Affected components: Table

--- a/packages/ui/src/components/Table/components/Table.tsx
+++ b/packages/ui/src/components/Table/components/Table.tsx
@@ -176,6 +176,7 @@ export function Table<T extends TableItem>({
           </TableHeader>
           <TableBody
             items={data}
+            dependencies={[visibleColumns]}
             renderEmptyState={
               emptyState ? () => <Flex p="3">{emptyState}</Flex> : undefined
             }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes #32676 so that when the `columnConfig` props for the `Table` component changes, the table is updated and the column layout reflects this. Before this, it crashed the `Table` component. It seems that it's just a dependency issue causing the column headers to render the new set of columns, but the `TableBody` still only knows about the previous set of columns as its internally memoed by the `dependencies` prop.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
