### PR TITLE
refactor(catalog): migrate warnings components from MUI to BUI

### DIFF
--- a/.changeset/wild-emus-write.md
+++ b/.changeset/wild-emus-write.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Migrated `EntityRelationWarning` and `EntityProcessingErrorsPanel` components from Material UI to Backstage UI.

--- a/plugins/catalog/src/components/EntityProcessingErrorsPanel/EntityProcessingErrorsPanel.tsx
+++ b/plugins/catalog/src/components/EntityProcessingErrorsPanel/EntityProcessingErrorsPanel.tsx
@@ -21,7 +21,6 @@ import {
   EntityRefLink,
   useEntity,
 } from '@backstage/plugin-catalog-react';
-import Box from '@material-ui/core/Box';
 import { ResponseErrorPanel } from '@backstage/core-components';
 import {
   CatalogApi,
@@ -32,6 +31,7 @@ import useAsync from 'react-use/esm/useAsync';
 import { SerializedError } from '@backstage/errors';
 import { catalogTranslationRef } from '../../alpha/translation';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import { Box } from '@backstage/ui';
 
 const errorFilter = (i: EntityStatusItem) =>
   i.error &&
@@ -100,7 +100,7 @@ export function EntityProcessingErrorsPanel() {
 
   if (error) {
     return (
-      <Box mb={1}>
+      <Box mb="2">
         <ResponseErrorPanel error={error} />
       </Box>
     );
@@ -113,10 +113,10 @@ export function EntityProcessingErrorsPanel() {
   return (
     <>
       {value.items.map((ancestorError, index) => (
-        <Box key={index} mb={1}>
+        <Box key={index} mb="2">
           {stringifyEntityRef(entity) !==
             stringifyEntityRef(ancestorError.entity) && (
-            <Box p={1}>
+            <Box p="2">
               {t('entityProcessingErrorsDescription')}{' '}
               <EntityRefLink entityRef={ancestorError.entity} />
             </Box>

--- a/plugins/catalog/src/components/EntityRelationWarning/EntityRelationWarning.tsx
+++ b/plugins/catalog/src/components/EntityRelationWarning/EntityRelationWarning.tsx
@@ -20,13 +20,12 @@ import {
   catalogApiRef,
   useEntity,
 } from '@backstage/plugin-catalog-react';
-import Alert from '@material-ui/lab/Alert';
 import useAsync from 'react-use/esm/useAsync';
-import Box from '@material-ui/core/Box';
 import { ResponseErrorPanel } from '@backstage/core-components';
 import { useApi, ApiHolder } from '@backstage/core-plugin-api';
 import { catalogTranslationRef } from '../../alpha/translation';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import { Alert, Box } from '@backstage/ui';
 
 async function getRelationWarnings(entity: Entity, catalogApi: CatalogApi) {
   const entityRefRelations = entity.relations?.map(
@@ -85,7 +84,7 @@ export function EntityRelationWarning() {
 
   if (error) {
     return (
-      <Box mb={1}>
+      <Box mb="2">
         <ResponseErrorPanel error={error} />
       </Box>
     );
@@ -96,10 +95,15 @@ export function EntityRelationWarning() {
   }
 
   return (
-    <>
-      <Alert severity="warning" style={{ whiteSpace: 'pre-line' }}>
-        {t('entityRelationWarningDescription')} {value.join(', ')}
-      </Alert>
-    </>
+    <Alert
+      status="warning"
+      icon
+      style={{ whiteSpace: 'pre-line' }}
+      description={
+        <>
+          {t('entityRelationWarningDescription')} {value.join(', ')}
+        </>
+      }
+    />
   );
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Migrated `EntityRelationWarning` and `EntityProcessingErrorsPanel` components
from Material UI to Backstage UI.

**Before**
<img width="2480" height="1668" alt="image" src="https://github.com/user-attachments/assets/ae7b907d-e45f-46ec-a189-f78ff6a7b72a" />

**After**
<img width="1237" height="823" alt="image" src="https://github.com/user-attachments/assets/5fd36e0f-3bfc-4109-9f9f-220c1d4bdc83" />

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.