### PR TITLE
OWNERS.md: remove waiting-for filter from board links

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -19,7 +19,7 @@ These are the separate project areas of Backstage, each with their own project a
 
 ### Auth
 
-Team: @backstage/auth-maintainers — [Review board](https://github.com/orgs/backstage/projects/14/views/1?filterQuery=no%3Aassignee+label%3Awaiting-for%3Areview+reviewers%3Aauth-maintainers)
+Team: @backstage/auth-maintainers — [Review board](https://github.com/orgs/backstage/projects/14/views/1?filterQuery=no%3Aassignee+reviewers%3Aauth-maintainers)
 
 Scope: The Backstage auth plugin and modules, as well as client-side implementations.
 
@@ -34,7 +34,7 @@ Scope: The Backstage auth plugin and modules, as well as client-side implementat
 
 ### Catalog
 
-Team: @backstage/catalog-maintainers — [Review board](https://github.com/orgs/backstage/projects/14/views/1?filterQuery=no%3Aassignee+label%3Awaiting-for%3Areview+reviewers%3Acatalog-maintainers)
+Team: @backstage/catalog-maintainers — [Review board](https://github.com/orgs/backstage/projects/14/views/1?filterQuery=no%3Aassignee+reviewers%3Acatalog-maintainers)
 
 Scope: The catalog plugin and catalog model
 
@@ -63,7 +63,7 @@ Scope: Tooling and Community Repo Maintainers for the Backstage [Community Plugi
 
 ### Design System
 
-Team: @backstage/design-system-maintainers — [Review board](https://github.com/orgs/backstage/projects/14/views/1?filterQuery=no%3Aassignee+label%3Awaiting-for%3Areview+reviewers%3Adesign-system-maintainers)
+Team: @backstage/design-system-maintainers — [Review board](https://github.com/orgs/backstage/projects/14/views/1?filterQuery=no%3Aassignee+reviewers%3Adesign-system-maintainers)
 
 Scope: The Backstage design system, component library, as well as surrounding tooling such as Storybook.
 
@@ -75,7 +75,7 @@ Scope: The Backstage design system, component library, as well as surrounding to
 
 ### Documentation
 
-Team: @backstage/documentation-maintainers — [Review board](https://github.com/orgs/backstage/projects/14/views/1?filterQuery=no%3Aassignee+label%3Awaiting-for%3Areview+reviewers%3Adocumentation-maintainers)
+Team: @backstage/documentation-maintainers — [Review board](https://github.com/orgs/backstage/projects/14/views/1?filterQuery=no%3Aassignee+reviewers%3Adocumentation-maintainers)
 
 Scope: The Backstage Documentation and Microsite, excluding the plugins listing
 
@@ -87,7 +87,7 @@ Scope: The Backstage Documentation and Microsite, excluding the plugins listing
 
 ### Framework
 
-Team: @backstage/framework-maintainers — [Review board](https://github.com/orgs/backstage/projects/14/views/1?filterQuery=no%3Aassignee+label%3Awaiting-for%3Areview+reviewers%3Aframework-maintainers)
+Team: @backstage/framework-maintainers — [Review board](https://github.com/orgs/backstage/projects/14/views/1?filterQuery=no%3Aassignee+reviewers%3Aframework-maintainers)
 
 Scope: The Backstage core framework, including all revisions of the frontend and backend systems, as well as the App plugin.
 
@@ -114,7 +114,7 @@ Scope: The Backstage [Helm Chart(s)](https://github.com/backstage/charts).
 
 ### Home
 
-Team: @backstage/home-maintainers — [Review board](https://github.com/orgs/backstage/projects/14/views/1?filterQuery=no%3Aassignee+label%3Awaiting-for%3Areview+reviewers%3Ahome-maintainers)
+Team: @backstage/home-maintainers — [Review board](https://github.com/orgs/backstage/projects/14/views/1?filterQuery=no%3Aassignee+reviewers%3Ahome-maintainers)
 
 Scope: The Backstage home page and information architecture
 
@@ -129,7 +129,7 @@ Scope: The Backstage home page and information architecture
 
 ### Kubernetes
 
-Team: @backstage/kubernetes-maintainers — [Review board](https://github.com/orgs/backstage/projects/14/views/1?filterQuery=no%3Aassignee+label%3Awaiting-for%3Areview+reviewers%3Akubernetes-maintainers)
+Team: @backstage/kubernetes-maintainers — [Review board](https://github.com/orgs/backstage/projects/14/views/1?filterQuery=no%3Aassignee+reviewers%3Akubernetes-maintainers)
 
 Scope: The Kubernetes plugin and the base it provides for other plugins to build upon.
 
@@ -139,7 +139,7 @@ Scope: The Kubernetes plugin and the base it provides for other plugins to build
 
 ### Operations
 
-Team: @backstage/operations-maintainers — [Review board](https://github.com/orgs/backstage/projects/14/views/1?filterQuery=no%3Aassignee+label%3Awaiting-for%3Areview+reviewers%3Aoperations-maintainers)
+Team: @backstage/operations-maintainers — [Review board](https://github.com/orgs/backstage/projects/14/views/1?filterQuery=no%3Aassignee+reviewers%3Aoperations-maintainers)
 
 Scope: The management and operation of the main Backstage repository and release process, along with the surrounding tooling.
 
@@ -154,7 +154,7 @@ Scope: The management and operation of the main Backstage repository and release
 
 ### Permission Framework
 
-Team: @backstage/permission-maintainers — [Review board](https://github.com/orgs/backstage/projects/14/views/1?filterQuery=no%3Aassignee+label%3Awaiting-for%3Areview+reviewers%3Apermission-maintainers)
+Team: @backstage/permission-maintainers — [Review board](https://github.com/orgs/backstage/projects/14/views/1?filterQuery=no%3Aassignee+reviewers%3Apermission-maintainers)
 
 Scope: The Permission Framework and plugins integrating with the permission framework
 
@@ -169,7 +169,7 @@ Scope: The Permission Framework and plugins integrating with the permission fram
 
 ### Search
 
-Team: @backstage/search-maintainers — [Review board](https://github.com/orgs/backstage/projects/14/views/1?filterQuery=no%3Aassignee+label%3Awaiting-for%3Areview+reviewers%3Asearch-maintainers)
+Team: @backstage/search-maintainers — [Review board](https://github.com/orgs/backstage/projects/14/views/1?filterQuery=no%3Aassignee+reviewers%3Asearch-maintainers)
 
 Scope: The Backstage Search plugin
 
@@ -181,7 +181,7 @@ Scope: The Backstage Search plugin
 
 ### TechDocs
 
-Team: @backstage/techdocs-maintainers — [Review board](https://github.com/orgs/backstage/projects/14/views/1?filterQuery=no%3Aassignee+label%3Awaiting-for%3Areview+reviewers%3Atechdocs-maintainers)
+Team: @backstage/techdocs-maintainers — [Review board](https://github.com/orgs/backstage/projects/14/views/1?filterQuery=no%3Aassignee+reviewers%3Atechdocs-maintainers)
 
 Scope: The TechDocs plugin and related tooling
 
@@ -195,7 +195,7 @@ Scope: The TechDocs plugin and related tooling
 
 ### Tooling
 
-Team: @backstage/tooling-maintainers — [Review board](https://github.com/orgs/backstage/projects/14/views/1?filterQuery=no%3Aassignee+label%3Awaiting-for%3Areview+reviewers%3Atooling-maintainers)
+Team: @backstage/tooling-maintainers — [Review board](https://github.com/orgs/backstage/projects/14/views/1?filterQuery=no%3Aassignee+reviewers%3Atooling-maintainers)
 
 Scope: All published Backstage CLI tools in the main `backstage` repository that do not belong to other areas, including `@backstage/cli` and `@backstage/repo-tools`.
 
@@ -215,7 +215,7 @@ These incubating project areas have shared ownership with @backstage/maintainers
 
 ### Auditor
 
-Team: @backstage/auditor-maintainers — [Review board](https://github.com/orgs/backstage/projects/14/views/1?filterQuery=no%3Aassignee+label%3Awaiting-for%3Areview+reviewers%3Aauditor-maintainers)
+Team: @backstage/auditor-maintainers — [Review board](https://github.com/orgs/backstage/projects/14/views/1?filterQuery=no%3Aassignee+reviewers%3Aauditor-maintainers)
 
 Scope: The auditor core service, along with auditor usage in the main repository
 
@@ -225,7 +225,7 @@ Scope: The auditor core service, along with auditor usage in the main repository
 
 ### Events
 
-Team: @backstage/events-maintainers — [Review board](https://github.com/orgs/backstage/projects/14/views/1?filterQuery=no%3Aassignee+label%3Awaiting-for%3Areview+reviewers%3Aevents-maintainers)
+Team: @backstage/events-maintainers — [Review board](https://github.com/orgs/backstage/projects/14/views/1?filterQuery=no%3Aassignee+reviewers%3Aevents-maintainers)
 
 Scope: The Events plugin and library, along with events modules in the main repository
 
@@ -235,7 +235,7 @@ Scope: The Events plugin and library, along with events modules in the main repo
 
 ### Notifications
 
-Team: @backstage/notifications-maintainers — [Review board](https://github.com/orgs/backstage/projects/14/views/1?filterQuery=no%3Aassignee+label%3Awaiting-for%3Areview+reviewers%3Anotifications-maintainers)
+Team: @backstage/notifications-maintainers — [Review board](https://github.com/orgs/backstage/projects/14/views/1?filterQuery=no%3Aassignee+reviewers%3Anotifications-maintainers)
 
 Scope: The Notifications and Signals plugins and libraries
 
@@ -245,7 +245,7 @@ Scope: The Notifications and Signals plugins and libraries
 
 ### OpenAPI Tooling
 
-Team: @backstage/openapi-tooling-maintainers — [Review board](https://github.com/orgs/backstage/projects/14/views/1?filterQuery=no%3Aassignee+label%3Awaiting-for%3Areview+reviewers%3Aopenapi-tooling-maintainers)
+Team: @backstage/openapi-tooling-maintainers — [Review board](https://github.com/orgs/backstage/projects/14/views/1?filterQuery=no%3Aassignee+reviewers%3Aopenapi-tooling-maintainers)
 
 Scope: Tooling for frontend and backend schema-first OpenAPI development.
 
@@ -255,7 +255,7 @@ Scope: Tooling for frontend and backend schema-first OpenAPI development.
 
 ### Scaffolder
 
-Team: @backstage/scaffolder-maintainers — [Review board](https://github.com/orgs/backstage/projects/14/views/1?filterQuery=no%3Aassignee+label%3Awaiting-for%3Areview+reviewers%3Ascaffolder-maintainers)
+Team: @backstage/scaffolder-maintainers — [Review board](https://github.com/orgs/backstage/projects/14/views/1?filterQuery=no%3Aassignee+reviewers%3Ascaffolder-maintainers)
 
 Scope: The Scaffolder frontend and backend plugins, and related tooling.
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

As discussed in maintainer sync, figured it wasn't very useful to have the `waiting-for:review` filter