### PR TITLE
Clear legacy auth cookies with explicit domain and switch to host-onl…

### DIFF
--- a/.changeset/little-rooms-repair.md
+++ b/.changeset/little-rooms-repair.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': minor
+---
+
+Issue the backstage-auth cookie as host to avoid cross-subdomain conflicts. Legacy domain-scoped cookies are cleared when re-issuing/clearing the cookie.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This pull request makes it so that the `domain` attribute is not set on backstage cookies.  This prevents auth issues when serving instances of backstage from subdomains.

This fixes https://github.com/backstage/backstage/issues/32093.

Here is the cookie that was generated before these changes:
<img width="282" height="147" alt="cookie_before" src="https://github.com/user-attachments/assets/9f3c1c24-feca-48f8-9293-a438aba74f15" />

And the one after:
<img width="286" height="162" alt="cookie_after" src="https://github.com/user-attachments/assets/b8e010c5-1710-469b-aa92-a599dfa08362" />

I confirmed that after these changes, the cookie with the domain attribute is removed when it was still present in the browser before page load.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
