### PR TITLE
Added theme option to set default border radius for MUI components

### DIFF
--- a/.changeset/sharp-coats-fry.md
+++ b/.changeset/sharp-coats-fry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/theme': minor
+---
+
+Added theme option to set default border radius for MUI components

--- a/docs/golden-path/create-app/customize-theme.md
+++ b/docs/golden-path/create-app/customize-theme.md
@@ -122,6 +122,7 @@ export const myTheme = createUnifiedTheme({
       },
     },
   }),
+  borderRadius: 8,
   defaultPageTheme: 'home',
   fontFamily: 'Comic Sans MS',
   /* below drives the header colors */

--- a/packages/theme/report.api.md
+++ b/packages/theme/report.api.md
@@ -162,6 +162,8 @@ export type BackstageTypography = {
 // @public
 export interface BaseThemeOptionsInput<PaletteOptions> {
   // (undocumented)
+  borderRadius?: number;
+  // (undocumented)
   defaultPageTheme?: string;
   // (undocumented)
   fontFamily?: string;
@@ -183,6 +185,9 @@ export function createBaseThemeOptions<PaletteOptions>(
   options: BaseThemeOptionsInput<PaletteOptions>,
 ): {
   palette: PaletteOptions;
+  shape: {
+    borderRadius: number;
+  };
   typography: BackstageTypography;
   page: PageTheme;
   getPageTheme: ({ themeId }: PageThemeSelector) => PageTheme;
@@ -433,6 +438,8 @@ export interface UnifiedTheme {
 
 // @public
 export interface UnifiedThemeOptions {
+  // (undocumented)
+  borderRadius?: number;
   // (undocumented)
   components?: ThemeOptions['components'];
   // (undocumented)

--- a/packages/theme/src/base/createBaseThemeOptions.ts
+++ b/packages/theme/src/base/createBaseThemeOptions.ts
@@ -17,6 +17,7 @@
 import { BackstageTypography, PageTheme, PageThemeSelector } from './types';
 import { pageTheme as defaultPageThemes } from './pageTheme';
 
+const DEFAULT_BORDER_RADIUS = 4;
 const DEFAULT_HTML_FONT_SIZE = 16;
 const DEFAULT_FONT_FAMILY =
   '"Helvetica Neue", Helvetica, Roboto, Arial, sans-serif';
@@ -69,6 +70,7 @@ export const defaultTypography: BackstageTypography = {
  */
 export interface BaseThemeOptionsInput<PaletteOptions> {
   palette: PaletteOptions;
+  borderRadius?: number;
   defaultPageTheme?: string;
   pageTheme?: Record<string, PageTheme>;
   fontFamily?: string;
@@ -86,6 +88,7 @@ export function createBaseThemeOptions<PaletteOptions>(
 ) {
   const {
     palette,
+    borderRadius = DEFAULT_BORDER_RADIUS,
     htmlFontSize = DEFAULT_HTML_FONT_SIZE,
     fontFamily = DEFAULT_FONT_FAMILY,
     defaultPageTheme = DEFAULT_PAGE_THEME,
@@ -102,6 +105,7 @@ export function createBaseThemeOptions<PaletteOptions>(
 
   return {
     palette,
+    shape: { borderRadius },
     typography: typography ?? defaultTypography,
     page: pageTheme[defaultPageTheme],
     getPageTheme: ({ themeId }: PageThemeSelector) =>

--- a/packages/theme/src/unified/UnifiedTheme.tsx
+++ b/packages/theme/src/unified/UnifiedTheme.tsx
@@ -59,6 +59,7 @@ export class UnifiedThemeHolder implements UnifiedTheme {
  */
 export interface UnifiedThemeOptions {
   palette: PaletteOptionsV4 & PaletteOptionsV5;
+  borderRadius?: number;
   defaultPageTheme?: string;
   pageTheme?: Record<string, PageTheme>;
   fontFamily?: string;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I was missing an option to change the default border radius for MUI components, and I didn't want to override each component individually.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
