### PR TITLE
docs: add examples for filtering Actions Service actions

### DIFF
--- a/docs/backend-system/core-services/actions.md
+++ b/docs/backend-system/core-services/actions.md
@@ -55,7 +55,7 @@ backend:
         - 'catalog.*'
 ```
 
-#### Exclude specific actionspwd
+#### Exclude specific actions
 
 ```yaml
 backend:


### PR DESCRIPTION
This PR adds documentation examples for filtering Actions Service actions.

A new "Filtering actions" section has been added under the Configuration section
to demonstrate how action visibility can be controlled using include and exclude
rules, as suggested in #32718.