### PR TITLE
plugins: move `@backstage/backend-defaults` to devDependencies in backend plugins

### DIFF
--- a/.changeset/remove-backend-defaults-from-plugins.md
+++ b/.changeset/remove-backend-defaults-from-plugins.md
@@ -1,0 +1,10 @@
+---
+'@backstage/plugin-devtools-backend': patch
+'@backstage/plugin-mcp-actions-backend': patch
+'@backstage/plugin-scaffolder-backend': patch
+'@backstage/plugin-search-backend': patch
+'@backstage/plugin-techdocs-backend': patch
+'@backstage/plugin-user-settings-backend': patch
+---
+
+Moved `@backstage/backend-defaults` from `dependencies` to `devDependencies`.

--- a/plugins/devtools-backend/package.json
+++ b/plugins/devtools-backend/package.json
@@ -39,7 +39,6 @@
     "test": "backstage-cli package test"
   },
   "dependencies": {
-    "@backstage/backend-defaults": "workspace:^",
     "@backstage/backend-plugin-api": "workspace:^",
     "@backstage/cli-common": "workspace:^",
     "@backstage/config": "workspace:^",

--- a/plugins/mcp-actions-backend/package.json
+++ b/plugins/mcp-actions-backend/package.json
@@ -34,7 +34,6 @@
     "test": "backstage-cli package test"
   },
   "dependencies": {
-    "@backstage/backend-defaults": "workspace:^",
     "@backstage/backend-plugin-api": "workspace:^",
     "@backstage/catalog-client": "workspace:^",
     "@backstage/errors": "workspace:^",
@@ -47,6 +46,7 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
+    "@backstage/backend-defaults": "workspace:^",
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@types/express": "^4.17.6"

--- a/plugins/scaffolder-backend/package.json
+++ b/plugins/scaffolder-backend/package.json
@@ -65,7 +65,6 @@
     "test": "backstage-cli package test"
   },
   "dependencies": {
-    "@backstage/backend-defaults": "workspace:^",
     "@backstage/backend-openapi-utils": "workspace:^",
     "@backstage/backend-plugin-api": "workspace:^",
     "@backstage/catalog-model": "workspace:^",

--- a/plugins/search-backend/package.json
+++ b/plugins/search-backend/package.json
@@ -56,7 +56,6 @@
     "test": "backstage-cli package test"
   },
   "dependencies": {
-    "@backstage/backend-defaults": "workspace:^",
     "@backstage/backend-openapi-utils": "workspace:^",
     "@backstage/backend-plugin-api": "workspace:^",
     "@backstage/config": "workspace:^",
@@ -74,6 +73,7 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
+    "@backstage/backend-defaults": "workspace:^",
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@backstage/repo-tools": "workspace:^",

--- a/plugins/techdocs-backend/package.json
+++ b/plugins/techdocs-backend/package.json
@@ -61,7 +61,6 @@
     "test": "backstage-cli package test"
   },
   "dependencies": {
-    "@backstage/backend-defaults": "workspace:^",
     "@backstage/backend-plugin-api": "workspace:^",
     "@backstage/catalog-client": "workspace:^",
     "@backstage/catalog-model": "workspace:^",

--- a/plugins/user-settings-backend/package.json
+++ b/plugins/user-settings-backend/package.json
@@ -48,7 +48,6 @@
     "test": "backstage-cli package test"
   },
   "dependencies": {
-    "@backstage/backend-defaults": "workspace:^",
     "@backstage/backend-plugin-api": "workspace:^",
     "@backstage/errors": "workspace:^",
     "@backstage/plugin-auth-node": "workspace:^",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This moves `@backstage/backend-defaults` from `dependencies` to `devDependencies` in all backend plugins that had it as a production dependency. None of these plugins actually import from `@backstage/backend-defaults` in their production source code - it's only used in `dev/index.ts` files (for local dev servers) and in test files.

**Affected plugins:**

| Plugin | Change |
|--------|--------|
| `@backstage/plugin-devtools-backend` | Removed from `dependencies` (already in `devDependencies`) |
| `@backstage/plugin-mcp-actions-backend` | Moved from `dependencies` to `devDependencies` |
| `@backstage/plugin-scaffolder-backend` | Removed from `dependencies` (already in `devDependencies`) |
| `@backstage/plugin-search-backend` | Moved from `dependencies` to `devDependencies` |
| `@backstage/plugin-techdocs-backend` | Removed from `dependencies` (already in `devDependencies`) |
| `@backstage/plugin-user-settings-backend` | Removed from `dependencies` (already in `devDependencies`) |

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
