### PR TITLE
docs: standardize note syntax in testing.md

### DIFF
--- a/docs/plugins/testing.md
+++ b/docs/plugins/testing.md
@@ -371,8 +371,12 @@ functions:
       expect(mangoWrapper.context().store).toBeDefined();
     });
 
-Note: wrapping in the test application **requires** you to do a `find()` or
+:::note Note
+
+wrapping in the test application **requires** you to do a `find()` or
 `dive()` since the wrapped component is now the application.
+
+:::
 
 ## Debugging Jest Tests
 


### PR DESCRIPTION
### Summary

This pull request standardizes the usage of note admonition blocks in `docs/plugins/testing.md` by replacing all instances of `Note` with the consistent `:::note` syntax.

Consistent documentation formatting improves clarity and makes it easier for contributors and users to read and maintain the docs.
<img width="1055" height="216" alt="image" src="https://github.com/user-attachments/assets/d65ae16d-6443-4476-a402-144101775b41" />

<img width="1028" height="112" alt="image" src="https://github.com/user-attachments/assets/29838a8a-60b5-4668-adb4-1866989777ce" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
