### PR TITLE
feat(scaffolder): enable entityRef filtering for EntityPicker, scroll to selected item in dropdown

### DIFF
--- a/.changeset/three-bananas-yell.md
+++ b/.changeset/three-bananas-yell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Enable text filtering of EntityPicker options by entity reference. Scroll selected EntityPicker item into view on dropdown opening.

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.test.tsx
@@ -22,6 +22,7 @@ import {
 } from '@backstage/plugin-catalog-react';
 import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
 import { fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { PropsWithChildren, ComponentType, ReactNode } from 'react';
 import { EntityPicker } from './EntityPicker';
 import { EntityPickerProps } from './schema';
@@ -1109,6 +1110,137 @@ describe('<EntityPicker />', () => {
       expect(queryByText(description.default!)).toBe(null);
       expect(queryByText(description.fromSchema)).toBe(null);
       expect(getByText(description.fromUiSchema)).toBeInTheDocument();
+    });
+  });
+
+  describe('with large number of entities', () => {
+    beforeEach(() => {
+      props = {
+        onChange,
+        schema,
+        required: true,
+        rawErrors,
+        formData,
+        uiSchema: { 'ui:options': {} },
+      } as unknown as FieldProps<any>;
+
+      const manyEntities = Array.from({ length: 100 }, (_, index) => {
+        const entity = makeEntity('Group', 'default', `some-team-${index}`);
+        entity.metadata.title = `Display Name ${index}`;
+        return entity;
+      });
+      manyEntities.push(makeEntity('Component', 'default', 'test-service'));
+
+      catalogApi.getEntities.mockResolvedValue({ items: manyEntities });
+    });
+
+    it('allows text filtering on entity ref kind', async () => {
+      await renderInTestApp(
+        <Wrapper>
+          <EntityPicker {...props} />
+          <div data-testid="outside">Outside</div>
+        </Wrapper>,
+      );
+
+      // Open the Autocomplete dropdown
+      const input = screen.getByRole('textbox');
+      fireEvent.click(input);
+
+      // Select an option from the dropdown
+      fireEvent.change(input, { target: { value: 'component' } });
+
+      const listItems = screen.getAllByRole('option');
+
+      // Expect only the Component entity to be shown
+      expect(listItems).toHaveLength(1);
+      expect(listItems[0]).toHaveTextContent('test-service');
+    });
+
+    it('allows text filtering on metadata name', async () => {
+      await renderInTestApp(
+        <Wrapper>
+          <EntityPicker {...props} />
+          <div data-testid="outside">Outside</div>
+        </Wrapper>,
+      );
+
+      // Open the Autocomplete dropdown
+      const input = screen.getByRole('textbox');
+      fireEvent.click(input);
+
+      // Select an option from the dropdown
+      fireEvent.change(input, { target: { value: 'some-team-57' } });
+
+      const listItems = screen.getAllByRole('option');
+
+      // Expect only the Component entity to be shown
+      expect(listItems).toHaveLength(1);
+      expect(listItems[0]).toHaveTextContent('Display Name 57');
+    });
+
+    it('allows text filtering on whole entity ref', async () => {
+      await renderInTestApp(
+        <Wrapper>
+          <EntityPicker {...props} />
+          <div data-testid="outside">Outside</div>
+        </Wrapper>,
+      );
+
+      // Open the Autocomplete dropdown
+      const input = screen.getByRole('textbox');
+      fireEvent.click(input);
+
+      // Select an option from the dropdown
+      fireEvent.change(input, {
+        target: { value: 'component:default/test-service' },
+      });
+
+      const listItems = screen.getAllByRole('option');
+
+      // Expect only the Component entity to be shown
+      expect(listItems).toHaveLength(1);
+      expect(listItems[0]).toHaveTextContent('test-service');
+    });
+
+    it('allows text filtering on display value', async () => {
+      await renderInTestApp(
+        <Wrapper>
+          <EntityPicker {...props} />
+          <div data-testid="outside">Outside</div>
+        </Wrapper>,
+      );
+
+      // Open the Autocomplete dropdown
+      const input = screen.getByRole('textbox');
+      fireEvent.click(input);
+
+      // Select an option from the dropdown
+      fireEvent.change(input, { target: { value: 'Display Name 57' } });
+
+      const listItems = screen.getAllByRole('option');
+
+      // Expect only the Component entity to be shown
+      expect(listItems).toHaveLength(1);
+      expect(listItems[0]).toHaveTextContent('Display Name 57');
+    });
+
+    it('auto scrolls to selected option', async () => {
+      // Set formData to an entity that is far down the list
+      await renderInTestApp(
+        <Wrapper>
+          <EntityPicker {...props} formData="group:default/some-team-57" />
+          <div data-testid="outside">Outside</div>
+        </Wrapper>,
+      );
+
+      // Open the Autocomplete dropdown
+      const input = screen.getByRole('textbox');
+      await userEvent.click(input);
+
+      // ensure that the option is scrolled into view
+      await expect(
+        screen.findByText('Display Name 57'),
+      ).resolves.toBeInTheDocument();
     });
   });
 });

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.test.tsx
@@ -1173,7 +1173,7 @@ describe('<EntityPicker />', () => {
 
       const listItems = screen.getAllByRole('option');
 
-      // Expect only the Component entity to be shown
+      // Expect only this Group entity to be shown
       expect(listItems).toHaveLength(1);
       expect(listItems[0]).toHaveTextContent('Display Name 57');
     });
@@ -1219,7 +1219,7 @@ describe('<EntityPicker />', () => {
 
       const listItems = screen.getAllByRole('option');
 
-      // Expect only the Component entity to be shown
+      // Expect only this Group entity to be shown
       expect(listItems).toHaveLength(1);
       expect(listItems[0]).toHaveTextContent('Display Name 57');
     });

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
@@ -34,7 +34,8 @@ import Autocomplete, {
   AutocompleteChangeReason,
   createFilterOptions,
 } from '@material-ui/lab/Autocomplete';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
+import { FixedSizeList } from 'react-window';
 import useAsync from 'react-use/esm/useAsync';
 import {
   EntityPickerFilterQueryValue,
@@ -183,6 +184,8 @@ export const EntityPicker = (props: EntityPickerProps) => {
     }
   }, [entities, onChange, selectedEntity, required, allowArbitraryValues]);
 
+  const listRef = useRef<FixedSizeList>(null);
+
   return (
     <ScaffolderField
       rawErrors={rawErrors}
@@ -225,11 +228,29 @@ export const EntityPicker = (props: EntityPickerProps) => {
         )}
         renderOption={option => <EntityDisplayName entityRef={option} />}
         filterOptions={createFilterOptions<Entity>({
-          stringify: option =>
-            entities?.entityRefToPresentation.get(stringifyEntityRef(option))
-              ?.primaryTitle!,
+          stringify: option => {
+            const entityRef = stringifyEntityRef(option);
+            const presentation =
+              entities?.entityRefToPresentation.get(entityRef);
+            return presentation
+              ? `${presentation.primaryTitle}${entityRef}`
+              : '';
+          },
         })}
-        ListboxComponent={VirtualizedListbox}
+        ListboxComponent={params => (
+          <VirtualizedListbox {...params} listRef={listRef} />
+        )}
+        onOpen={() => {
+          // ensure that the list has a chance to render before scrolling to the selected item
+          setTimeout(() => {
+            listRef.current?.scrollToItem(
+              entities?.catalogEntities.findIndex(
+                entity => stringifyEntityRef(entity) === formData,
+              ) ?? 0,
+              'center',
+            );
+          }, 1);
+        }}
       />
     </ScaffolderField>
   );

--- a/plugins/scaffolder/src/components/fields/VirtualizedListbox.tsx
+++ b/plugins/scaffolder/src/components/fields/VirtualizedListbox.tsx
@@ -41,32 +41,37 @@ const OuterElementType = forwardRef<HTMLDivElement, HTMLDivProps>(
   },
 );
 
-export const VirtualizedListbox = forwardRef<HTMLDivElement, HTMLDivProps>(
-  (props, ref) => {
-    const { children, ...other } = props;
-    const itemData = Children.toArray(children);
-    const itemCount = itemData.length;
+type VirtualizedListBoxProps = HTMLDivProps & {
+  listRef?: React.Ref<FixedSizeList>;
+};
+export const VirtualizedListbox = forwardRef<
+  HTMLDivElement,
+  VirtualizedListBoxProps
+>((props, ref) => {
+  const { children, listRef, ...other } = props;
+  const itemData = Children.toArray(children);
+  const itemCount = itemData.length;
 
-    const itemSize = 36;
+  const itemSize = 36;
 
-    const itemsToShow = Math.min(10, itemCount) + 0.5;
-    const height = itemsToShow * itemSize;
+  const itemsToShow = Math.min(10, itemCount) + 0.5;
+  const height = itemsToShow * itemSize;
 
-    return (
-      <div ref={ref}>
-        <OuterElementContext.Provider value={other}>
-          <FixedSizeList
-            height={height}
-            itemData={itemData}
-            itemCount={itemCount}
-            itemSize={itemSize}
-            outerElementType={OuterElementType}
-            width="100%"
-          >
-            {renderRow}
-          </FixedSizeList>
-        </OuterElementContext.Provider>
-      </div>
-    );
-  },
-);
+  return (
+    <div ref={ref}>
+      <OuterElementContext.Provider value={other}>
+        <FixedSizeList
+          ref={listRef}
+          height={height}
+          itemData={itemData}
+          itemCount={itemCount}
+          itemSize={itemSize}
+          outerElementType={OuterElementType}
+          width="100%"
+        >
+          {renderRow}
+        </FixedSizeList>
+      </OuterElementContext.Provider>
+    </div>
+  );
+});


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Minor UX improvements to the `EntityPicker` scaffolder field extension to support usage with entities that primarily specify display names or titles:
* allow for text filtering based on the entity ref
* scroll into view the selected option to easily see the selected display name of an entity when the entity ref is only shown in the input

These should help improve the UX when dealing with display names that may be slightly different than entity reference values. It will help users find the entities they are looking for in dropboxes.

## Demo
 

https://github.com/user-attachments/assets/9e14622d-34df-409c-8bc8-c4350454a548


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
