### PR TITLE
Fix/search api scopes

### DIFF
--- a/.changeset/small-shirts-lose.md
+++ b/.changeset/small-shirts-lose.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-gitlab': patch
+---
+
+Fixed GitLab search API scope parameter from `'blob'` to `'blobs'`, resolving 400 errors in discovery provider.

--- a/plugins/catalog-backend-module-gitlab/src/__testUtils__/handlers.ts
+++ b/plugins/catalog-backend-module-gitlab/src/__testUtils__/handlers.ts
@@ -201,7 +201,13 @@ const httpGroupFindByEncodedPathDynamic = all_groups_response.flatMap(group => [
 const httpSearchFilesInGroupDynamic = all_groups_response.map(group => {
   return rest.get(
     `${apiBaseUrl}/groups/${encodeURIComponent(group.full_path)}/search`,
-    (_, res, ctx) => {
+    (req, res, ctx) => {
+      const scope = req.url.searchParams.get('scope');
+
+      if (scope !== 'blobs') {
+        return res(ctx.status(400), ctx.text('400 Bad Request'));
+      }
+
       const searchResults = projects_with_catalog_info_yaml
         .filter(project =>
           project.path_with_namespace?.startsWith(group.full_path),

--- a/plugins/catalog-backend-module-gitlab/src/lib/client.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/client.test.ts
@@ -280,6 +280,67 @@ describe('GitLabClient', () => {
     });
   });
 
+  describe('listFiles', () => {
+    it('should call group search API with correct scope parameter', async () => {
+      const client = new GitLabClient({
+        config: readGitLabIntegrationConfig(
+          new ConfigReader(mock.config_self_managed),
+        ),
+        logger: mockServices.logger.mock(),
+      });
+
+      const pagedRequestSpy = jest.spyOn(client as any, 'pagedRequest');
+
+      await client.listFiles({
+        group: 'group1',
+        search: 'filename:catalog-info.yaml',
+        page: 1,
+        per_page: 50,
+      });
+
+      expect(pagedRequestSpy).toHaveBeenCalledWith(
+        '/groups/group1/search',
+        expect.objectContaining({
+          group: 'group1',
+          search: 'filename:catalog-info.yaml',
+          scope: 'blobs',
+          page: 1,
+          per_page: 50,
+        }),
+      );
+    });
+
+    it('should return empty items when group is missing', async () => {
+      const client = new GitLabClient({
+        config: readGitLabIntegrationConfig(
+          new ConfigReader(mock.config_self_managed),
+        ),
+        logger: mockServices.logger.mock(),
+      });
+
+      const result = await client.listFiles({
+        search: 'filename:catalog-info.yaml',
+      });
+
+      expect(result.items).toEqual([]);
+    });
+
+    it('should return empty items when search is missing', async () => {
+      const client = new GitLabClient({
+        config: readGitLabIntegrationConfig(
+          new ConfigReader(mock.config_self_managed),
+        ),
+        logger: mockServices.logger.mock(),
+      });
+
+      const result = await client.listFiles({
+        group: 'my-group',
+      });
+
+      expect(result.items).toEqual([]);
+    });
+  });
+
   describe('get gitlab.com users', () => {
     it('gets all users under group', async () => {
       const client = new GitLabClient({

--- a/plugins/catalog-backend-module-gitlab/src/lib/client.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/client.ts
@@ -185,7 +185,7 @@ export class GitLabClient {
         `/groups/${encodeURIComponent(options?.group)}/search`,
         {
           ...options,
-          scope: 'blob',
+          scope: 'blobs',
         },
       );
     }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Hi, after testing this https://github.com/backstage/backstage/pull/31993 in my GitLab instance, I found an error with the **GitlabDiscoveryEntityProvider**:
```bash
catalog error GitlabDiscoveryEntityProvider:development refresh failed, Error: Unexpected response when fetching https://my-gitlab-instance.com/api/v4/groups/my-group/search?group=my-group&search=filename%3Acatalog-info.yaml&page=1&per_page=50&scope=blob. Expected 200 but got 400 - Bad Request Unexpected response when fetching https://my-gitlab-instance.com/api/v4/groups/my-group/search?group=my-group&search=filename%3Acatalog-info.yaml&page=1&per_page=50&scope=blob. Expected 200 but got 400 - Bad Request env="development" target="GitlabDiscoveryEntityProvider:development" class="GitlabDiscoveryEntityProvider" taskId="GitlabDiscoveryEntityProvider:development:refresh" 
```
This is caused by a small typo in the search API scope. It should be `blobs` and not `blob`. 


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
