### PR TITLE
Expose group filter extension on scaffolder page

### DIFF
--- a/packages/app-next/src/App.tsx
+++ b/packages/app-next/src/App.tsx
@@ -49,6 +49,8 @@ import devtoolsPlugin from '@backstage/plugin-devtools/alpha';
 import { unprocessedEntitiesDevToolsContent } from '@backstage/plugin-catalog-unprocessed-entities/alpha';
 import catalogPlugin from '@backstage/plugin-catalog/alpha';
 import InfoIcon from '@material-ui/icons/Info';
+import scaffolderPlugin from '@backstage/plugin-scaffolder/alpha';
+import { TemplateGroupBlueprint } from '@backstage/plugin-scaffolder-react/alpha';
 
 /*
 
@@ -142,6 +144,18 @@ const collectedLegacyPlugins = convertLegacyAppRoot(
   </FlatRoutes>,
 );
 
+const customizedScaffolder = scaffolderPlugin.withOverrides({
+  extensions: [
+    TemplateGroupBlueprint.make({
+      params: {
+        title: 'Recomended',
+        filter: entity =>
+          entity?.metadata?.tags?.includes('recommended') ?? false,
+      },
+    }),
+  ],
+});
+
 const app = createApp({
   features: [
     customizedCatalog,
@@ -156,6 +170,7 @@ const app = createApp({
     customHomePageModule,
     devtoolsPlugin,
     devtoolsPluginUnprocessed,
+    customizedScaffolder,
     ...collectedLegacyPlugins,
   ],
   advanced: {

--- a/plugins/scaffolder-react/src/next/blueprints/TemplateGroupBlueprint.ts
+++ b/plugins/scaffolder-react/src/next/blueprints/TemplateGroupBlueprint.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  createExtensionBlueprint,
+  createExtensionDataRef,
+} from '@backstage/frontend-plugin-api';
+import { TemplateGroupFilter } from '@backstage/plugin-scaffolder-react';
+
+const templateGroupDataRef = createExtensionDataRef<TemplateGroupFilter>().with(
+  {
+    id: 'scaffolder.template-group-filter',
+  },
+);
+
+/**
+ * @alpha
+ * Creates extensions that allow for template grouping within the Scaffolder
+ */
+export const TemplateGroupBlueprint = createExtensionBlueprint({
+  kind: 'scaffolder-template-group-filter',
+  attachTo: { id: 'page:scaffolder', input: 'groups' },
+  dataRefs: {
+    templateGroup: templateGroupDataRef,
+  },
+  output: [templateGroupDataRef],
+  *factory(params: TemplateGroupFilter) {
+    yield templateGroupDataRef(params);
+  },
+});

--- a/plugins/scaffolder-react/src/next/blueprints/index.ts
+++ b/plugins/scaffolder-react/src/next/blueprints/index.ts
@@ -16,4 +16,5 @@
 
 export * from './FormDecoratorBlueprint';
 export * from './FormFieldBlueprint';
+export * from './TemplateGroupBlueprint';
 export * from './types';

--- a/plugins/scaffolder/src/alpha/extensions.tsx
+++ b/plugins/scaffolder/src/alpha/extensions.tsx
@@ -25,7 +25,10 @@ import {
 } from '@backstage/frontend-plugin-api';
 import { rootRouteRef } from '../routes';
 import CreateComponentIcon from '@material-ui/icons/AddCircleOutline';
-import { FormFieldBlueprint } from '@backstage/plugin-scaffolder-react/alpha';
+import {
+  FormFieldBlueprint,
+  TemplateGroupBlueprint,
+} from '@backstage/plugin-scaffolder-react/alpha';
 import { scmIntegrationsApiRef } from '@backstage/integration-react';
 import { scaffolderApiRef } from '@backstage/plugin-scaffolder-react';
 import { ScaffolderClient } from '../api';
@@ -36,9 +39,16 @@ export const scaffolderPage = PageBlueprint.makeWithOverrides({
     formFields: createExtensionInput([
       FormFieldBlueprint.dataRefs.formFieldLoader,
     ]),
+    groups: createExtensionInput([
+      TemplateGroupBlueprint.dataRefs.templateGroup,
+    ]),
   },
   factory(originalFactory, { apis, inputs }) {
     const formFieldsApi = apis.get(formFieldsApiRef);
+
+    const groups = inputs.groups.map(output =>
+      output.get(TemplateGroupBlueprint.dataRefs.templateGroup),
+    );
 
     return originalFactory({
       routeRef: rootRouteRef,
@@ -57,7 +67,10 @@ export const scaffolderPage = PageBlueprint.makeWithOverrides({
         const formFields = [...apiFormFields, ...loadedFormFields];
 
         return import('../components/Router/Router').then(m => (
-          <m.InternalRouter formFields={formFields} />
+          <m.InternalRouter
+            formFields={formFields}
+            groups={groups.length > 0 ? groups : undefined}
+          />
         ));
       },
     });


### PR DESCRIPTION
Updated app-next to use the newly exposed extension so software templates are filter just like on the non new frontend version.

closes #32776 

## Hey, I just made a Pull Request!
<img width="1649" height="960" alt="image" src="https://github.com/user-attachments/assets/3f8bbd9c-683c-43b3-ae97-5d4523bc9696" />

Exposed group via extension so you can set it via NFS. Example from the updated app-next App.tsx:

```
const customizedScaffolder = scaffolderPlugin.withOverrides({
  extensions: [
    TemplateGroupBlueprint.make({
      params: {
        title: 'Recomended',
        filter: entity =>
          entity?.metadata?.tags?.includes('recommended') ?? false,
      },
    }),
  ],
});

const app = createApp({
  features: [
    customizedCatalog,
@@ -156,6 +170,7 @@ const app = createApp({
    customHomePageModule,
    devtoolsPlugin,
    devtoolsPluginUnprocessed,
    customizedScaffolder,
    ...collectedLegacyPlugins,
  ],
  ```

Copied heavily from the FormField extension, so I have some questions and want to learn and make any changes suggested (hence why I made this a draft PR). 

### Questions 
1. Should I prefer making a blueprint like I did (when I copied from FormField or should I do something more like the `plugin.getExtension().override` I see in places like the catalog?

```
const customizedCatalog = catalogPlugin.withOverrides({
  extensions: [
    catalogPlugin.getExtension('entity-content:catalog/overview').override({
      params: {
        icon: <InfoIcon />,
      },
    }),
  ],
});
```

2. Any good examples of how to test something like this? 
3. I don't fully understand the API reports, but I see how to run them and I can add those to a changeset 


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
    - Draft PR, will do when submitting full PR
- [ ] Added or updated documentation
    - This is a good idea, could update these docs to include this option (IDK how you're doing new front end vs old in docs): https://backstage.io/docs/features/software-templates/configuration/#customizing-the-scaffolderpage-with-grouping-and-filtering
- [ ] Tests for new functionality and regression tests for bug fixes
    - Again, looking for suggestions on how to test this
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
    - I did do at least this one 
