### PR TITLE
fix: export `createRateLimitMiddleware` from @backstage/backend-defaults/httpRouter

### DIFF
--- a/.changeset/open-cameras-smoke.md
+++ b/.changeset/open-cameras-smoke.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+`createRateLimitMiddleware` is now exported from `@backstage/backend-defaults/httpRouter`

--- a/packages/backend-defaults/report-httpRouter.api.md
+++ b/packages/backend-defaults/report-httpRouter.api.md
@@ -40,6 +40,12 @@ export function createLifecycleMiddleware(
 ): RequestHandler;
 
 // @public
+export const createRateLimitMiddleware: (options: {
+  pluginId: string;
+  config: RootConfigService;
+}) => RequestHandler;
+
+// @public
 export const httpRouterServiceFactory: ServiceFactory<
   HttpRouterService,
   'plugin',

--- a/packages/backend-defaults/src/entrypoints/httpRouter/http/createRateLimitMiddleware.ts
+++ b/packages/backend-defaults/src/entrypoints/httpRouter/http/createRateLimitMiddleware.ts
@@ -13,15 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { NextFunction, Request, Response } from 'express';
+import { NextFunction, Request, Response, RequestHandler } from 'express';
 import { RateLimitStoreFactory } from '../../../lib/RateLimitStoreFactory.ts';
-import { Config } from '@backstage/config';
+import { RootConfigService } from '@backstage/backend-plugin-api';
+
 import { rateLimitMiddleware } from '../../../lib/rateLimitMiddleware.ts';
 
+/**
+ * @public
+ * Creates a middleware that applies rate limiting to requests based on the provided configuration.
+ */
 export const createRateLimitMiddleware = (options: {
   pluginId: string;
-  config: Config;
-}) => {
+  config: RootConfigService;
+}): RequestHandler => {
   const { pluginId, config } = options;
   const configKey = `backend.rateLimit.plugin.${pluginId}`;
   const enabled = config.has(configKey);

--- a/packages/backend-defaults/src/entrypoints/httpRouter/http/index.ts
+++ b/packages/backend-defaults/src/entrypoints/httpRouter/http/index.ts
@@ -18,3 +18,4 @@ export { createCredentialsBarrier } from './createCredentialsBarrier';
 export { createLifecycleMiddleware } from './createLifecycleMiddleware';
 export type { LifecycleMiddlewareOptions } from './createLifecycleMiddleware';
 export { createCookieAuthRefreshMiddleware } from './createCookieAuthRefreshMiddleware';
+export { createRateLimitMiddleware } from './createRateLimitMiddleware';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When attempting to follow the directions in the [docs to customize the HTTP router](https://backstage.io/docs/backend-system/core-services/http-router/#configuring-the-service), I found that I could not follow them because `createRateLimitMiddleware` was not exported as the code suggested it should be. This patch exports it.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
