### PR TITLE
refactor(ui): remove never-typed ghost props from useDefinition ownProps

### DIFF
--- a/.changeset/grumpy-towns-stick.md
+++ b/.changeset/grumpy-towns-stick.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Cleaned up `useDefinition` `ownProps` types to remove never-typed ghost properties from autocomplete.

--- a/packages/ui/src/hooks/useDefinition/types.ts
+++ b/packages/ui/src/hooks/useDefinition/types.ts
@@ -81,10 +81,19 @@ type ResolvedOwnProps<
   [K in keyof PropDefs & keyof P]: ResolvePropType<P[K], PropDefs[K]>;
 };
 
-type ChildrenProps<Bg extends 'provider' | 'consumer' | undefined> =
-  Bg extends 'provider'
-    ? { childrenWithBgProvider: ReactNode; children?: never }
-    : { children: ReactNode; childrenWithBgProvider?: never };
+type BaseOwnProps<
+  D extends ComponentConfig<any, any>,
+  P extends Record<string, any>,
+> = {
+  classes: Record<keyof D['classNames'], string>;
+} & ResolvedOwnProps<P, D['propDefs']>;
+
+type ResolveBgProps<
+  D extends ComponentConfig<any, any>,
+  TBase,
+> = D['bg'] extends 'provider'
+  ? Omit<TBase, 'children'> & { childrenWithBgProvider: ReactNode }
+  : TBase;
 
 type DataAttributeKeys<PropDefs> = {
   [K in keyof PropDefs]: PropDefs[K] extends { dataAttribute: true }
@@ -122,10 +131,7 @@ export interface UseDefinitionResult<
   D extends ComponentConfig<any, any>,
   P extends Record<string, any>,
 > {
-  ownProps: {
-    classes: Record<keyof D['classNames'], string>;
-  } & ResolvedOwnProps<P, D['propDefs']> &
-    ChildrenProps<D['bg']>;
+  ownProps: ResolveBgProps<D, BaseOwnProps<D, P>>;
 
   // Rest props excludes both propDefs keys AND utility prop keys
   restProps: keyof Omit<P, keyof D['propDefs'] | UtilityKeys<D>> extends never


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Replace the `ChildrenProps` intersection approach with `ResolveBgProps`,
which transforms the base type so that only the relevant children
variant exists in the final type. Provider components get
`childrenWithBgProvider` (with `children` Omit'd), non-providers pass
through unchanged — no more optional `never` properties in autocomplete.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.