### PR TITLE
docs: fix reference to parent inputs in child extension

### DIFF
--- a/docs/frontend-system/architecture/20-extensions.md
+++ b/docs/frontend-system/architecture/20-extensions.md
@@ -399,7 +399,7 @@ const parent = createExtension({
 
 // Create a child extension that attaches to the parent's input
 const child = createExtension({
-  attachTo: page.inputs.children, // Direct reference to the input
+  attachTo: parent.inputs.children, // Direct reference to the input
   output: [coreExtensionData.reactElement], // Outputs are verified against the parent input
   // other options...
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Docsite feedback, afaik this should be parent not page.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
