### PR TITLE
docs: Fix spelling typos in documentation

### DIFF
--- a/docs/backend-system/core-services/http-router.md
+++ b/docs/backend-system/core-services/http-router.md
@@ -89,7 +89,7 @@ backend:
     window: 6s # Time window for rate limiting for single client
     incomingRequestLimit: 100 # Number of requests to accept from one client during time window
     ipAllowList: ['127.0.0.1'] # IPs to bypass rate limiting
-    skipSuccesfulRequests: false # Rate limit successful requests
+    skipSuccessfulRequests: false # Rate limit successful requests
     skipFailedRequests: false # Rate limit failed requests
     plugin:
       # Plugin specific rate limiting

--- a/docs/features/kubernetes/installation.md
+++ b/docs/features/kubernetes/installation.md
@@ -130,7 +130,7 @@ export const kubernetesModuleCustomClusterDiscovery = createBackendModule({
         );
 
         // there's also the ability to get access to some of the default implementations of the extension points where
-        // neccessary:
+        // necessary:
         serviceLocator.addServiceLocator(
           async ({ getDefault, clusterSupplier }) => {
             // get access to the default service locator:

--- a/docs/releases/v1.30.0-changelog.md
+++ b/docs/releases/v1.30.0-changelog.md
@@ -338,7 +338,7 @@ Upgrade Helper: [https://backstage.github.io/upgrade-helper/?to=1.30.0](https://
 - b2d97fd: Fixing loading of additional config files with new `ConfigSources`
 - fbc7819: Use ES2022 in CLI bundler
 - 93095ee: Make sure node-fetch is version 2.7.0 or greater
-- 6d898d8: Switched the `process` polyfill to use `require.resolve` for greater compatability.
+- 6d898d8: Switched the `process` polyfill to use `require.resolve` for greater compatibility.
 - e53074f: Updated default backend plugin to use `RootConfigService` instead of `Config`. This also removes the dependency on `@backstage/config` as it's no longer used.
 - ee2b0e5: The experimental module federation build now has the ability to force the use of development versions of `react` and `react-dom` by setting the `FORCE_REACT_DEVELOPMENT` flag.
 - 239dffc: Remove usage of deprecated functionality from @backstage/config-loader

--- a/docs/releases/v1.30.0-next.4-changelog.md
+++ b/docs/releases/v1.30.0-next.4-changelog.md
@@ -212,7 +212,7 @@ Upgrade Helper: [https://backstage.github.io/upgrade-helper/?to=1.30.0-next.4](h
 
 ### Patch Changes
 
-- 6d898d8: Switched the `process` polyfill to use `require.resolve` for greater compatability.
+- 6d898d8: Switched the `process` polyfill to use `require.resolve` for greater compatibility.
 - 2ced236: Updated dependency `@module-federation/enhanced` to `0.3.1`
 - Updated dependencies
   - @backstage/catalog-model@1.6.0-next.0

--- a/docs/releases/v1.4.0-changelog.md
+++ b/docs/releases/v1.4.0-changelog.md
@@ -793,7 +793,7 @@
 ### Minor Changes
 
 - 8798f8d93f: Introduces a new annotation `pagerduty.com/service-id` that can be used instead of the `pagerduty.com/integration-key` annotation.
-  _Note: If both annotations are specified on a given Entity, then the `pagerduty.com/integration-key` annotation will be prefered_
+  _Note: If both annotations are specified on a given Entity, then the `pagerduty.com/integration-key` annotation will be preferred_
 
   **BREAKING** The `PagerDutyClient.fromConfig` static method now expects a `FetchApi` compatible object and has been refactored to
   accept 2 arguments: config and ClientApiDependencies

--- a/docs/releases/v1.4.0-next.0-changelog.md
+++ b/docs/releases/v1.4.0-next.0-changelog.md
@@ -45,7 +45,7 @@
 ### Minor Changes
 
 - 8798f8d93f: Introduces a new annotation `pagerduty.com/service-id` that can be used instead of the `pagerduty.com/integration-key` annotation.
-  _Note: If both annotations are specified on a given Entity, then the `pagerduty.com/integration-key` annotation will be prefered_
+  _Note: If both annotations are specified on a given Entity, then the `pagerduty.com/integration-key` annotation will be preferred_
 
   **BREAKING** The `PagerDutyClient.fromConfig` static method now expects a `FetchApi` compatible object and has been refactored to
   accept 2 arguments: config and ClientApiDependencies


### PR DESCRIPTION
This PR fixes several spelling typos found in the documentation:
- `neccessary` → `necessary` in kubernetes installation docs
- `skipSuccesfulRequests` → `skipSuccessfulRequests` in http-router docs
- `compatability` → `compatibility` in v1.30.0 changelog
- `prefered` → `preferred` in v1.4.0 changelog

<img width="1553" height="851" alt="image" src="https://github.com/user-attachments/assets/6f729c2d-8768-4f91-80b7-fc03c65f1686" />

<img width="1280" height="329" alt="image" src="https://github.com/user-attachments/assets/329d1cd0-9ab8-43f5-a9af-b31ba0b6ea40" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
