### PR TITLE
docs: fix TechDocs CLI README link path

### DIFF
--- a/docs/features/techdocs/cli.md
+++ b/docs/features/techdocs/cli.md
@@ -271,5 +271,5 @@ upon your cloud storage provider -
 
 You are welcome to contribute to TechDocs CLI to improve it and support new
 features! See the project
-[README](https://github.com/backstage/backstage/blob/main/src/packages/techdocs-cli/README.md)
+[README](https://github.com/backstage/backstage/blob/master/packages/techdocs-cli/README.md)
 for more information.


### PR DESCRIPTION
## Description
Fixed incorrect README link path in TechDocs CLI documentation.

## Changes
- Updated the README link path from `blob/main/src/packages/techdocs-cli/README.md` to `blob/master/packages/techdocs-cli/README.md`

## Reason
The previous link was incorrect and would result in a 404 error:

<img width="1366" height="602" alt="image" src="https://github.com/user-attachments/assets/40d72fb4-10ac-48c4-9d5f-336655f69e58" />

## Impact
- Documentation now correctly links to the TechDocs CLI README
- Users can successfully navigate to the TechDocs CLI project documentation

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
