### PR TITLE
docs: fix broken internal link in well-known-annotations.md

### DIFF
--- a/docs/features/software-catalog/well-known-annotations.md
+++ b/docs/features/software-catalog/well-known-annotations.md
@@ -462,7 +462,7 @@ migrating away from them.
 ### backstage.io/github-actions-id
 
 This annotation was used for a while to enable the GitHub Actions feature. This
-is now instead using the [github.com/project-slug](#github-com-project-slug)
+is now instead using the [github.com/project-slug](#githubcomproject-slug)
 annotation, with the same value format.
 
 ### backstage.io/definition-at-location


### PR DESCRIPTION
# Description

Fixes an internal link in the well-known-annotations documentation.

## Changes

- Fixed the internal link reference from `#github-com-project-slug` to `#githubcomproject-slug` in the `backstage.io/github-actions-id` annotation section

## Issue

The link to the `github.com/project-slug` annotation was using an incorrect anchor ID. Markdown anchor IDs are generated by removing special characters (dots and slashes) from headings, not replacing them with hyphens. The heading `### github.com/project-slug` generates the anchor `#githubcomproject-slug`, not `#github-com-project-slug`.
<img width="944" height="190" alt="image" src="https://github.com/user-attachments/assets/2ab8b439-ac70-4dee-b369-e62e70b79c8a" />

## Impact

This fix ensures that users clicking the link in the deprecated `backstage.io/github-actions-id` section will be correctly navigated to the `github.com/project-slug` annotation section instead of encountering a broken link.
<img width="877" height="209" alt="image" src="https://github.com/user-attachments/assets/e798b5fc-ab42-4591-9e25-ca668d2af44a" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
