### PR TITLE
auth-backend-module-okta-provider: validate that audience is an absolute URL

### DIFF
--- a/.changeset/okta-audience-url-validation.md
+++ b/.changeset/okta-audience-url-validation.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-okta-provider': patch
+---
+
+Added a validation check that rejects `audience` configuration values that are not absolute URLs (i.e. missing `https://` or `http://` prefix).

--- a/plugins/auth-backend-module-okta-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-okta-provider/src/authenticator.ts
@@ -33,6 +33,11 @@ export const oktaAuthenticator = createOAuthAuthenticator({
     const clientId = config.getString('clientId');
     const clientSecret = config.getString('clientSecret');
     const audience = config.getOptionalString('audience') || 'https://okta.com';
+    if (!audience.match(/^https?:\/\//)) {
+      throw new Error(
+        `The provided audience "${audience}" is not a valid URL. It must start with "https://" or "http://".`,
+      );
+    }
     const authServerId = config.getOptionalString('authServerId');
     const idp = config.getOptionalString('idp');
 

--- a/plugins/auth-backend-module-okta-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-okta-provider/src/module.test.ts
@@ -76,4 +76,35 @@ describe('authModuleOktaProvider', () => {
       nonce: decodeURIComponent(nonceCookie.value),
     });
   });
+
+  it('should reject a relative audience URL', async () => {
+    await expect(
+      startTestBackend({
+        features: [
+          import('@backstage/plugin-auth-backend'),
+          authModuleOktaProvider,
+          mockServices.rootConfig.factory({
+            data: {
+              app: {
+                baseUrl: 'http://localhost:3000',
+              },
+              auth: {
+                providers: {
+                  okta: {
+                    development: {
+                      clientId: 'my-client-id',
+                      clientSecret: 'my-client-secret',
+                      audience: 'example.okta.com',
+                    },
+                  },
+                },
+              },
+            },
+          }),
+        ],
+      }),
+    ).rejects.toThrow(
+      'The provided audience "example.okta.com" is not a valid URL. It must start with "https://" or "http://".',
+    );
+  });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds a validation check in the Okta auth provider that ensures the configured `audience` value is an absolute URL (starting with `https://` or `http://`). A common misconfiguration is to provide just `example.okta.com` without the protocol, which leads to confusing errors downstream. This catches that mistake early with a clear error message.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
