### PR TITLE
fix: resolve tab URL duplication with v7_relativeSplatPath

### DIFF
--- a/.changeset/nice-wasps-grin.md
+++ b/.changeset/nice-wasps-grin.md
@@ -1,0 +1,7 @@
+---
+'@backstage/core-components': patch
+'@backstage/plugin-app-visualizer': patch
+'@backstage/plugin-catalog': patch
+---
+
+Fixed tab navigation URL duplication in `RoutedTabs`, `EntityTabs`, and `AppVisualizerPage` caused by the `v7_relativeSplatPath` future flag. Replaced `useRoutes` with `matchRoutes` for direct rendering and added `../` prefix for relative tab links when inside a splat child route.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

fixes https://github.com/backstage/backstage/issues/32805

With `v7_relativeSplatPath` enabled in the New Frontend System, clicking tabs in catalog entity pages, DevTools, Settings, and the App Visualizer caused URL segments to accumulate on each click (e.g., `/devtools/info/config/tasks` instead of `/devtools/tasks`). This happened because relative links inside splat (`*`) child routes resolve from the full matched URL under v7 behavior, rather than from the parent route path.

The fix touches three components. In `EntityTabs` and `AppVisualizerPage` (both NFS-only), `useRoutes` was replaced with `matchRoutes` for direct content rendering, and tab links now use a `../` prefix when inside a splat child route so they navigate up to the parent before resolving the new tab path. In the shared `RoutedTabs` component from `core-components`, the same approach is used but with an additional compatibility layer: `useRoutes` is retained as the primary content renderer for legacy contexts that depend on the nested route context it provides, falling back to `matchRoutes` when `useRoutes` returns null (which happens in the NFS Outlet structure). The `../` prefix is only applied when `useResolvedPath('.')` confirms that v7 splat behavior is active, keeping legacy apps unaffected.

Existing tests for `RoutedTabs` continue to pass unchanged. New regression tests were added to both `RoutedTabs` and `EntityTabs` covering tab selection, link href generation, and multi-tab click-through navigation under `v7_relativeSplatPath` and `v7_startTransition`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
