### PR TITLE
Vendor openBrowser from react-dev-utils

### DIFF
--- a/.changeset/deep-pigs-drive.md
+++ b/.changeset/deep-pigs-drive.md
@@ -2,4 +2,4 @@
 '@backstage/cli-common': patch
 ---
 
-Added `openBrowser`, which opens a URL in the user's browser and reuses an existing Chromium tab on macOS where possible. Install the optional `open` peer dependency to use it; without it `openBrowser` returns `false`.
+Added `openBrowser`, which opens a URL in the user's browser and reuses an existing Chromium tab on macOS where possible. Only the default-browser fallback requires the optional `open` peer dependency; `openBrowser` warns and returns `false` when that path is reached without it.

--- a/.changeset/deep-pigs-drive.md
+++ b/.changeset/deep-pigs-drive.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli-common': patch
+---
+
+Added `openBrowser`, which opens a URL in the user's browser and reuses an existing Chromium tab on macOS where possible. Install the optional `open` peer dependency to use it; without it `openBrowser` returns `false`.

--- a/.changeset/hungry-papers-rescue.md
+++ b/.changeset/hungry-papers-rescue.md
@@ -1,0 +1,7 @@
+---
+'@backstage/cli-module-config': patch
+'@backstage/cli-module-github': patch
+'@techdocs/cli': patch
+---
+
+Removed the dependency on the unmaintained `react-dev-utils` package.

--- a/.changeset/hungry-papers-rescue.md
+++ b/.changeset/hungry-papers-rescue.md
@@ -4,4 +4,4 @@
 '@techdocs/cli': patch
 ---
 
-Removed the dependency on the unmaintained `react-dev-utils` package.
+Removed the dependency on the unmaintained `react-dev-utils` package. Opening the browser now honors the `BROWSER` and `BROWSER_ARGS` environment variables.

--- a/.changeset/lucky-moons-shave.md
+++ b/.changeset/lucky-moons-shave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli-module-build': patch
+---
+
+Switched to the `openBrowser` helper from `@backstage/cli-common`.

--- a/.changeset/lucky-moons-shave.md
+++ b/.changeset/lucky-moons-shave.md
@@ -2,4 +2,4 @@
 '@backstage/cli-module-build': patch
 ---
 
-Switched to the `openBrowser` helper from `@backstage/cli-common`.
+Fixed the `start` command to honor the `BROWSER` and `BROWSER_ARGS` environment variables when opening the browser, and extended macOS tab reuse to Google Chrome Dev and Beta.

--- a/.changeset/tame-ducks-wave.md
+++ b/.changeset/tame-ducks-wave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Removed an unused internal type declaration for the `react-dev-utils/openBrowser` module.

--- a/.github/vale/config/vocabularies/Backstage/accept.txt
+++ b/.github/vale/config/vocabularies/Backstage/accept.txt
@@ -581,7 +581,6 @@ validator
 validators
 Valkey
 varchar
-vendored
 viewport
 virtualized
 vite

--- a/.github/vale/config/vocabularies/Backstage/accept.txt
+++ b/.github/vale/config/vocabularies/Backstage/accept.txt
@@ -581,6 +581,7 @@ validator
 validators
 Valkey
 varchar
+vendored
 viewport
 virtualized
 vite

--- a/NOTICE
+++ b/NOTICE
@@ -5,3 +5,4 @@ Portions of this software were developed by third-party software vendors:
 
 - Tech Radar Plugin (https://opensource.zalando.com/tech-radar/), Copyright (c) 2017 Zalando SE
 - [OpenAPI Generator Templates](./packages/repo-tools/templates), Copyright 2018 OpenAPI-Generator Contributors (https://openapi-generator.tech) Copyright 2018 SmartBear Software
+- [react-dev-utils](https://github.com/facebook/create-react-app/tree/main/packages/react-dev-utils), Copyright (c) 2015-present, Facebook, Inc., licensed under the MIT License

--- a/packages/cli-common/README.md
+++ b/packages/cli-common/README.md
@@ -6,6 +6,8 @@ This package provides config loading functionality used by the backend, and CLI.
 
 Do not install this package directly, it is an internal package used by [@backstage/cli](https://www.npmjs.com/package/@backstage/cli), and [@backstage/create-app](https://www.npmjs.com/package/@backstage/create-app). Depend on either of those instead.
 
+The `openBrowser` export requires the optional `open` peer dependency; packages that use it must declare a dependency on `open` themselves.
+
 ## Documentation
 
 - [Backstage Readme](https://github.com/backstage/backstage/blob/master/README.md)

--- a/packages/cli-common/package.json
+++ b/packages/cli-common/package.json
@@ -54,6 +54,15 @@
   "devDependencies": {
     "@backstage/cli": "workspace:^",
     "@types/cross-spawn": "^6.0.2",
-    "@types/node": "^22.13.14"
+    "@types/node": "^22.13.14",
+    "open": "^10"
+  },
+  "peerDependencies": {
+    "open": "^10"
+  },
+  "peerDependenciesMeta": {
+    "open": {
+      "optional": true
+    }
   }
 }

--- a/packages/cli-common/package.json
+++ b/packages/cli-common/package.json
@@ -55,10 +55,10 @@
     "@backstage/cli": "workspace:^",
     "@types/cross-spawn": "^6.0.2",
     "@types/node": "^22.13.14",
-    "open": "^10"
+    "open": "^10.2.0"
   },
   "peerDependencies": {
-    "open": "^10"
+    "open": "^10.2.0"
   },
   "peerDependenciesMeta": {
     "open": {

--- a/packages/cli-common/report.api.md
+++ b/packages/cli-common/report.api.md
@@ -26,6 +26,9 @@ export function findPaths(searchDir: string): Paths;
 export function isChildPath(base: string, path: string): boolean;
 
 // @public
+export function openBrowser(url: string): boolean;
+
+// @public
 export type OwnPaths = {
   dir: string;
   rootDir: string;

--- a/packages/cli-common/src/vendored/react-dev-utils/loadOpen.ts
+++ b/packages/cli-common/src/vendored/react-dev-utils/loadOpen.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2026 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,21 +15,20 @@
  */
 
 /**
- * Common functionality used by cli, backend, and create-app
- *
- * @packageDocumentation
+ * Access to the optional, ESM-only `open` peer dependency. Isolated in its own
+ * module so tests can jest.mock it, and so the CJS-only `require.resolve` sits
+ * next to the dynamic import it guards.
  */
 
-export { findPaths, findOwnPaths, targetPaths, BACKSTAGE_JSON } from './paths';
-export { isChildPath } from './isChildPath';
-export type { Paths, TargetPaths, OwnPaths, ResolveFunc } from './paths';
-export {
-  run,
-  runOutput,
-  runCheck,
-  type RunChildProcess,
-  type RunOptions,
-  type RunOnOutput,
-} from './run';
-export { ExitCodeError } from './errors';
-export { openBrowser } from './vendored/react-dev-utils/openBrowser';
+export function isOpenInstalled(): boolean {
+  try {
+    require.resolve('open');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function loadOpen() {
+  return import('open');
+}

--- a/packages/cli-common/src/vendored/react-dev-utils/openBrowser.test.ts
+++ b/packages/cli-common/src/vendored/react-dev-utils/openBrowser.test.ts
@@ -58,9 +58,22 @@ describe('openBrowser', () => {
     expect(openBrowser('http://example.com')).toBe(false);
   });
 
-  it('returns false when the open peer dependency is not installed', () => {
+  it('warns and returns false when the fallback needs the missing open peer dependency', () => {
     jest.mocked(isOpenInstalled).mockReturnValue(false);
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
     expect(openBrowser('http://example.com')).toBe(false);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("optional 'open' peer dependency"),
+    );
+    warn.mockRestore();
+  });
+
+  it('reuses a macOS Chromium tab without the open peer dependency', () => {
+    jest.mocked(isOpenInstalled).mockReturnValue(false);
+    setPlatform('darwin');
+    jest.mocked(execFileSync).mockReturnValue('');
+    expect(openBrowser('http://example.com')).toBe(true);
+    expect(openMock).not.toHaveBeenCalled();
   });
 
   it('opens the default browser when BROWSER is unset', async () => {
@@ -103,6 +116,37 @@ describe('openBrowser', () => {
         input: expect.stringContaining('on run argv'),
         stdio: ['pipe', 'ignore', 'ignore'],
       },
+    );
+    expect(openMock).not.toHaveBeenCalled();
+  });
+
+  it('tries Chromium browsers in priority order, including long app names', () => {
+    setPlatform('darwin');
+    // Only Google Chrome Beta is running.
+    jest.mocked(execFileSync).mockImplementation((file, args) => {
+      if (file === 'pgrep' && args?.[1] !== 'Google Chrome Beta') {
+        throw new Error('no such process');
+      }
+      return '';
+    });
+
+    expect(openBrowser('http://example.com')).toBe(true);
+    expect(execFileSync).toHaveBeenNthCalledWith(
+      1,
+      'pgrep',
+      ['-x', 'Google Chrome Canary'],
+      { stdio: 'ignore' },
+    );
+    expect(execFileSync).toHaveBeenNthCalledWith(
+      2,
+      'pgrep',
+      ['-x', 'Google Chrome Dev'],
+      { stdio: 'ignore' },
+    );
+    expect(execFileSync).toHaveBeenLastCalledWith(
+      'osascript',
+      ['-', 'http://example.com', 'Google Chrome Beta'],
+      expect.objectContaining({ stdio: ['pipe', 'ignore', 'ignore'] }),
     );
     expect(openMock).not.toHaveBeenCalled();
   });

--- a/packages/cli-common/src/vendored/react-dev-utils/openBrowser.test.ts
+++ b/packages/cli-common/src/vendored/react-dev-utils/openBrowser.test.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+jest.mock('./loadOpen');
+jest.mock('node:child_process');
+
+import { execFileSync } from 'node:child_process';
+import { openBrowser } from './openBrowser';
+import { isOpenInstalled, loadOpen } from './loadOpen';
+
+const flush = () => new Promise(resolve => setImmediate(resolve));
+
+describe('openBrowser', () => {
+  const originalEnv = process.env;
+  const originalPlatform = process.platform;
+  let openMock: jest.Mock;
+
+  const setPlatform = (platform: string) =>
+    Object.defineProperty(process, 'platform', { value: platform });
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.BROWSER;
+    delete process.env.BROWSER_ARGS;
+    // The AppleScript branch is opt-in per test.
+    setPlatform('linux');
+
+    openMock = jest.fn().mockResolvedValue(undefined);
+    jest.mocked(isOpenInstalled).mockReturnValue(true);
+    jest
+      .mocked(loadOpen)
+      .mockResolvedValue({ default: openMock } as unknown as Awaited<
+        ReturnType<typeof loadOpen>
+      >);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    setPlatform(originalPlatform);
+    jest.clearAllMocks();
+  });
+
+  it('returns false when BROWSER=none', () => {
+    process.env.BROWSER = 'none';
+    expect(openBrowser('http://example.com')).toBe(false);
+  });
+
+  it('returns false when the open peer dependency is not installed', () => {
+    jest.mocked(isOpenInstalled).mockReturnValue(false);
+    expect(openBrowser('http://example.com')).toBe(false);
+  });
+
+  it('opens the default browser when BROWSER is unset', async () => {
+    expect(openBrowser('http://example.com')).toBe(true);
+    await flush();
+    expect(openMock).toHaveBeenCalledWith('http://example.com', {
+      app: undefined,
+      wait: false,
+    });
+  });
+
+  it('passes BROWSER and BROWSER_ARGS as an app name and arguments', async () => {
+    process.env.BROWSER = 'firefox';
+    process.env.BROWSER_ARGS = '--private-window --new-tab';
+    expect(openBrowser('http://example.com')).toBe(true);
+    await flush();
+    expect(openMock).toHaveBeenCalledWith('http://example.com', {
+      app: { name: 'firefox', arguments: ['--private-window', '--new-tab'] },
+      wait: false,
+    });
+  });
+
+  it('reuses a running Chromium tab on macOS without re-encoding the URL', () => {
+    setPlatform('darwin');
+    // pgrep finds nothing until Chrome, then osascript succeeds.
+    jest.mocked(execFileSync).mockImplementation((_file, args) => {
+      if (args?.[0] === '-x' && args[1] !== 'Google Chrome') {
+        throw new Error('no such process');
+      }
+      return '';
+    });
+
+    expect(openBrowser('http://example.com/?to=a%2Fb')).toBe(true);
+    expect(execFileSync).toHaveBeenCalledWith(
+      'osascript',
+      ['-', 'http://example.com/?to=a%2Fb', 'Google Chrome'],
+      // stdin must stay piped; osascript reads an empty script from /dev/null
+      // and exits 0, which would look like success.
+      {
+        input: expect.stringContaining('on run argv'),
+        stdio: ['pipe', 'ignore', 'ignore'],
+      },
+    );
+    expect(openMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli-common/src/vendored/react-dev-utils/openBrowser.ts
+++ b/packages/cli-common/src/vendored/react-dev-utils/openBrowser.ts
@@ -42,11 +42,12 @@
  * - Replaced chalk with Node built-in styleText (node:util)
  * - Inlined AppleScript: openChrome.applescript is embedded as a string and piped to `osascript -` on stdin; no separate .applescript file. The package build only emits JavaScript into dist, so a sibling script file would be missing from the published package.
  * - osascript is invoked via execFileSync with an argument array rather than a shell string. The URL is therefore passed verbatim instead of through encodeURI, which upstream needed for shell quoting but which double-encodes already-escaped query parameters.
- * - Process check on macOS: original uses "ps cax | grep <browser>"; we use "pgrep -x <browser>", which matches the command name exactly rather than by substring, and without spawning a shell.
+ * - Process check on macOS: original uses "ps cax | grep <browser>"; we use "pgrep -x <browser>", which matches the command name exactly rather than by substring, and without spawning a shell. macOS pgrep matches the full executable name even beyond the kernel's 15-character comm limit.
  * - open() options: original used url: true; removed in open v8, deprecated in v7.2
  * - open() app option: original passed [browser, ...args], which open v8+ reads as a list of fallback apps rather than a browser and its arguments; we pass { name, arguments } so BROWSER_ARGS is honoured.
  * - Browser list follows current upstream main, which adds Google Chrome Dev and Google Chrome Beta over the released react-dev-utils 12.0.1.
- * - Make open an optional peer dependency
+ * - Make open an optional peer dependency; only the default-browser fallback path needs it, and openBrowser warns and returns false if that path is reached without it
+ * - The open fallback is loaded on demand, so its browser launch starts only after openBrowser has returned; upstream loaded open at require time and began the spawn before returning
  * - Ported to TypeScript with basic types; same API openBrowser(url: string): boolean.
  *
  * -----------------------------------------------------------------------
@@ -267,15 +268,17 @@ function startBrowserProcess(
   if (typeof resolvedBrowser === 'string' && resolvedBrowser) {
     appOption =
       args.length > 0
-        ? { name: resolvedBrowser, arguments: args as readonly string[] }
+        ? { name: resolvedBrowser, arguments: args }
         : { name: resolvedBrowser };
   }
 
   // Fallback to open (ESM-only; load via dynamic import from CJS build).
-  // It will always open a new tab. The result has to be reported synchronously,
-  // so check up front that the optional peer is installed and let any later
-  // failure go unreported.
+  // It will always open a new tab. The result has to be reported
+  // synchronously, so any later failure goes unreported.
   if (!isOpenInstalled()) {
+    console.warn(
+      "openBrowser requires the optional 'open' peer dependency of @backstage/cli-common to open the default browser",
+    );
     return false;
   }
   loadOpen()
@@ -290,8 +293,10 @@ function startBrowserProcess(
  *
  * Adapted from `react-dev-utils/openBrowser`.
  *
- * Opening a browser requires the optional `open` peer dependency; without it
- * this returns false. A browser is launched asynchronously, so a true result
+ * Only the default-browser fallback requires the optional `open` peer
+ * dependency; that path warns and returns false without it. The macOS
+ * Chromium tab-reuse path works without it. On the fallback path the launch
+ * starts asynchronously after this function has returned, so a true result
  * means it was started, not that it succeeded.
  *
  * @public

--- a/packages/cli-common/src/vendored/react-dev-utils/openBrowser.ts
+++ b/packages/cli-common/src/vendored/react-dev-utils/openBrowser.ts
@@ -1,0 +1,314 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Vendored from Create React App (react-dev-utils/openBrowser.js).
+ * Original: https://github.com/facebook/create-react-app/blob/main/packages/react-dev-utils/openBrowser.js
+ *
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Changes from upstream:
+ * - Replaced chalk with Node built-in styleText (node:util)
+ * - Inlined AppleScript: openChrome.applescript is embedded as a string and piped to `osascript -` on stdin; no separate .applescript file. The package build only emits JavaScript into dist, so a sibling script file would be missing from the published package.
+ * - osascript is invoked via execFileSync with an argument array rather than a shell string. The URL is therefore passed verbatim instead of through encodeURI, which upstream needed for shell quoting but which double-encodes already-escaped query parameters.
+ * - Process check on macOS: original uses "ps cax | grep <browser>"; we use "pgrep -x <browser>", which matches the command name exactly rather than by substring, and without spawning a shell.
+ * - open() options: original used url: true; removed in open v8, deprecated in v7.2
+ * - open() app option: original passed [browser, ...args], which open v8+ reads as a list of fallback apps rather than a browser and its arguments; we pass { name, arguments } so BROWSER_ARGS is honoured.
+ * - Browser list follows current upstream main, which adds Google Chrome Dev and Google Chrome Beta over the released react-dev-utils 12.0.1.
+ * - Make open an optional peer dependency
+ * - Ported to TypeScript with basic types; same API openBrowser(url: string): boolean.
+ *
+ * -----------------------------------------------------------------------
+ */
+
+import { execFileSync } from 'node:child_process';
+import { styleText } from 'node:util';
+import spawn from 'cross-spawn';
+import { isOpenInstalled, loadOpen } from './loadOpen';
+
+// https://github.com/sindresorhus/open#app
+const OSX_CHROME = 'google chrome';
+
+const Actions = {
+  NONE: 0,
+  BROWSER: 1,
+  SCRIPT: 2,
+} as const;
+
+function getBrowserEnv(): {
+  action: (typeof Actions)[keyof typeof Actions];
+  value: string | undefined;
+  args: string[];
+} {
+  // Attempt to honor this environment variable.
+  // It is specific to the operating system.
+  // See https://github.com/sindresorhus/open#app for documentation.
+  const value = process.env.BROWSER;
+  const args = process.env.BROWSER_ARGS
+    ? process.env.BROWSER_ARGS.split(' ')
+    : [];
+  let action: (typeof Actions)[keyof typeof Actions];
+  if (!value) {
+    // Default.
+    action = Actions.BROWSER;
+  } else if (value.toLowerCase().endsWith('.js')) {
+    action = Actions.SCRIPT;
+  } else if (value.toLowerCase() === 'none') {
+    action = Actions.NONE;
+  } else {
+    action = Actions.BROWSER;
+  }
+  return { action, value, args };
+}
+
+// Embedded openChrome.applescript from Create React App (MIT). Original:
+// https://github.com/facebook/create-react-app/blob/main/packages/react-dev-utils/openChrome.applescript
+const OPEN_CHROME_APPLESCRIPT = `(*
+Copyright (c) 2015-present, Facebook, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*)
+
+property targetTab: null
+property targetTabIndex: -1
+property targetWindow: null
+property theProgram: "Google Chrome"
+
+on run argv
+  set theURL to item 1 of argv
+
+  -- Allow requested program to be optional,
+  -- default to Google Chrome
+  if (count of argv) > 1 then
+    set theProgram to item 2 of argv
+  end if
+
+  using terms from application "Google Chrome"
+    tell application theProgram
+
+      if (count every window) = 0 then
+        make new window
+      end if
+
+      -- 1: Looking for tab running debugger
+      -- then, Reload debugging tab if found
+      -- then return
+      set found to my lookupTabWithUrl(theURL)
+      if found then
+        set targetWindow's active tab index to targetTabIndex
+        tell targetTab to reload
+        tell targetWindow to activate
+        set index of targetWindow to 1
+        return
+      end if
+
+      -- 2: Looking for Empty tab
+      -- In case debugging tab was not found
+      -- We try to find an empty tab instead
+      set found to my lookupTabWithUrl("chrome://newtab/")
+      if found then
+        set targetWindow's active tab index to targetTabIndex
+        set URL of targetTab to theURL
+        tell targetWindow to activate
+        return
+      end if
+
+      -- 3: Create new tab
+      -- both debugging and empty tab were not found
+      -- make a new tab with url
+      tell window 1
+        activate
+        make new tab with properties {URL:theURL}
+      end tell
+    end tell
+  end using terms from
+end run
+
+-- Function:
+-- Lookup tab with given url
+-- if found, store tab, index, and window in properties
+-- (properties were declared on top of file)
+on lookupTabWithUrl(lookupUrl)
+  using terms from application "Google Chrome"
+    tell application theProgram
+      -- Find a tab with the given url
+      set found to false
+      set theTabIndex to -1
+      repeat with theWindow in every window
+        set theTabIndex to 0
+        repeat with theTab in every tab of theWindow
+          set theTabIndex to theTabIndex + 1
+          if (theTab's URL as string) contains lookupUrl then
+            -- assign tab, tab index, and window to properties
+            set targetTab to theTab
+            set targetTabIndex to theTabIndex
+            set targetWindow to theWindow
+            set found to true
+            exit repeat
+          end if
+        end repeat
+
+        if found then
+          exit repeat
+        end if
+      end repeat
+    end tell
+  end using terms from
+  return found
+end lookupTabWithUrl
+`;
+
+function executeNodeScript(scriptPath: string, url: string): boolean {
+  const extraArgs = process.argv.slice(2);
+  const child = spawn(process.execPath, [scriptPath, ...extraArgs, url], {
+    stdio: 'inherit',
+  });
+  child.on('close', code => {
+    if (code !== 0) {
+      console.log();
+      console.log(
+        styleText(
+          'red',
+          'The script specified as BROWSER environment variable failed.',
+        ),
+      );
+      console.log(`${styleText('cyan', scriptPath)} exited with code ${code}.`);
+      console.log();
+    }
+  });
+  return true;
+}
+
+function startBrowserProcess(
+  browser: string | undefined,
+  url: string,
+  args: string[],
+): boolean {
+  // If we're on OS X, the user hasn't specifically
+  // requested a different browser, we can try opening
+  // Chrome with AppleScript. This lets us reuse an
+  // existing tab when possible instead of creating a new one.
+  const shouldTryOpenChromiumWithAppleScript =
+    process.platform === 'darwin' &&
+    (typeof browser !== 'string' || browser === OSX_CHROME);
+
+  if (shouldTryOpenChromiumWithAppleScript) {
+    // Will use the first open browser found from list
+    const supportedChromiumBrowsers = [
+      'Google Chrome Canary',
+      'Google Chrome Dev',
+      'Google Chrome Beta',
+      'Google Chrome',
+      'Microsoft Edge',
+      'Brave Browser',
+      'Vivaldi',
+      'Chromium',
+    ];
+
+    for (const chromiumBrowser of supportedChromiumBrowsers) {
+      try {
+        // Try our best to reuse existing tab
+        // on OSX Chromium-based browser with AppleScript.
+        // Original used: ps cax | grep "<browser>".
+        execFileSync('pgrep', ['-x', chromiumBrowser], { stdio: 'ignore' });
+        // `osascript -` reads the script from stdin and still forwards argv.
+        execFileSync('osascript', ['-', url, chromiumBrowser], {
+          input: OPEN_CHROME_APPLESCRIPT,
+          stdio: ['pipe', 'ignore', 'ignore'],
+        });
+        return true;
+      } catch {
+        // Ignore errors.
+      }
+    }
+  }
+
+  // Another special case: on OS X, check if BROWSER has been set to "open".
+  // In this case, instead of passing `open` to `opn` (which won't work),
+  // just ignore it (thus ensuring the intended behavior, i.e. opening the system browser):
+  // https://github.com/facebook/create-react-app/pull/1690#issuecomment-283518768
+  const resolvedBrowser: string | undefined =
+    process.platform === 'darwin' && browser === 'open' ? undefined : browser;
+
+  // If there are arguments, they must be passed as array with the browser
+  let appOption: { name: string; arguments?: readonly string[] } | undefined;
+  if (typeof resolvedBrowser === 'string' && resolvedBrowser) {
+    appOption =
+      args.length > 0
+        ? { name: resolvedBrowser, arguments: args as readonly string[] }
+        : { name: resolvedBrowser };
+  }
+
+  // Fallback to open (ESM-only; load via dynamic import from CJS build).
+  // It will always open a new tab. The result has to be reported synchronously,
+  // so check up front that the optional peer is installed and let any later
+  // failure go unreported.
+  if (!isOpenInstalled()) {
+    return false;
+  }
+  loadOpen()
+    .then(m => m.default(url, { app: appOption, wait: false }).catch(() => {}))
+    .catch(() => {});
+  return true;
+}
+
+/**
+ * Reads the BROWSER environment variable and decides what to do with it.
+ * Returns true if it opened a browser or ran a node.js script, otherwise false.
+ *
+ * Adapted from `react-dev-utils/openBrowser`.
+ *
+ * Opening a browser requires the optional `open` peer dependency; without it
+ * this returns false. A browser is launched asynchronously, so a true result
+ * means it was started, not that it succeeded.
+ *
+ * @public
+ * @param url - The URL to open.
+ * @returns True if it opened a browser or ran a node.js script, otherwise false.
+ */
+export function openBrowser(url: string): boolean {
+  const { action, value, args } = getBrowserEnv();
+  switch (action) {
+    case Actions.NONE:
+      // Special case: BROWSER="none" will prevent opening completely.
+      return false;
+    case Actions.SCRIPT:
+      return executeNodeScript(value!, url);
+    case Actions.BROWSER:
+      return startBrowserProcess(value, url, args);
+    default:
+      throw new Error('Not implemented.');
+  }
+}

--- a/packages/cli-module-auth/src/commands/login.ts
+++ b/packages/cli-module-auth/src/commands/login.ts
@@ -352,7 +352,8 @@ function cryptoRandom(): string {
   return crypto.randomBytes(32).toString('hex');
 }
 
-// The react-dev-utils/openBrowser breaks the login URL by encoding the URL parameters again
+// Kept local for now; the vendored openBrowser in @backstage/cli-common no
+// longer re-encodes the URL, so this can be migrated to it separately.
 export function openInBrowser(url: string): void {
   const handleError = (error: unknown) => {
     const message = error instanceof Error ? error.message : 'Unknown error';

--- a/packages/cli-module-build/package.json
+++ b/packages/cli-module-build/package.json
@@ -76,6 +76,7 @@
     "mini-css-extract-plugin": "^2.4.2",
     "node-stdlib-browser": "^1.3.1",
     "npm-packlist": "^5.0.0",
+    "open": "^10",
     "p-queue": "^6.6.2",
     "portfinder": "^1.0.32",
     "postcss": "^8.1.0",

--- a/packages/cli-module-build/package.json
+++ b/packages/cli-module-build/package.json
@@ -76,7 +76,7 @@
     "mini-css-extract-plugin": "^2.4.2",
     "node-stdlib-browser": "^1.3.1",
     "npm-packlist": "^5.0.0",
-    "open": "^10",
+    "open": "^10.2.0",
     "p-queue": "^6.6.2",
     "portfinder": "^1.0.32",
     "postcss": "^8.1.0",

--- a/packages/cli-module-build/src/lib/bundler/server.ts
+++ b/packages/cli-module-build/src/lib/bundler/server.ts
@@ -18,7 +18,7 @@ import { AppConfig } from '@backstage/config';
 import chalk from 'chalk';
 import fs from 'fs-extra';
 import { resolve as resolvePath } from 'node:path';
-import openBrowser from 'react-dev-utils/openBrowser';
+import { openBrowser } from '@backstage/cli-common';
 import { rspack } from '@rspack/core';
 import { RspackDevServer } from '@rspack/dev-server';
 

--- a/packages/cli-module-build/src/lib/bundler/server.ts
+++ b/packages/cli-module-build/src/lib/bundler/server.ts
@@ -18,11 +18,10 @@ import { AppConfig } from '@backstage/config';
 import chalk from 'chalk';
 import fs from 'fs-extra';
 import { resolve as resolvePath } from 'node:path';
-import { openBrowser } from '@backstage/cli-common';
 import { rspack } from '@rspack/core';
 import { RspackDevServer } from '@rspack/dev-server';
 
-import { targetPaths } from '@backstage/cli-common';
+import { openBrowser, targetPaths } from '@backstage/cli-common';
 
 import { loadCliConfig } from '../config';
 import { createConfig, resolveBaseUrl, resolveEndpoint } from './config';

--- a/packages/cli-module-config/package.json
+++ b/packages/cli-module-config/package.json
@@ -41,7 +41,7 @@
     "@manypkg/get-packages": "^1.1.3",
     "chalk": "^4.0.0",
     "cleye": "^2.6.0",
-    "open": "^10",
+    "open": "^10.2.0",
     "yaml": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/cli-module-config/package.json
+++ b/packages/cli-module-config/package.json
@@ -41,7 +41,7 @@
     "@manypkg/get-packages": "^1.1.3",
     "chalk": "^4.0.0",
     "cleye": "^2.6.0",
-    "react-dev-utils": "^12.0.0-next.60",
+    "open": "^10",
     "yaml": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/cli-module-config/src/commands/docs.ts
+++ b/packages/cli-module-config/src/commands/docs.ts
@@ -18,7 +18,7 @@ import { cli } from 'cleye';
 import { JsonObject } from '@backstage/types';
 import { mergeConfigSchemas } from '@backstage/config-loader';
 import type { JSONSchema7 as JSONSchema } from 'json-schema';
-import openBrowser from 'react-dev-utils/openBrowser';
+import { openBrowser } from '@backstage/cli-common';
 import chalk from 'chalk';
 import { loadCliConfig } from '../lib/config';
 import type { CliCommandContext } from '@backstage/cli-node';

--- a/packages/cli-module-github/package.json
+++ b/packages/cli-module-github/package.json
@@ -41,7 +41,7 @@
     "express": "^4.22.0",
     "fs-extra": "^11.2.0",
     "inquirer": "^8.2.0",
-    "open": "^10",
+    "open": "^10.2.0",
     "yaml": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/cli-module-github/package.json
+++ b/packages/cli-module-github/package.json
@@ -41,7 +41,7 @@
     "express": "^4.22.0",
     "fs-extra": "^11.2.0",
     "inquirer": "^8.2.0",
-    "react-dev-utils": "^12.0.0-next.60",
+    "open": "^10",
     "yaml": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/cli-module-github/src/commands/create-github-app/GithubCreateAppServer.ts
+++ b/packages/cli-module-github/src/commands/create-github-app/GithubCreateAppServer.ts
@@ -15,7 +15,7 @@
  */
 
 import crypto from 'node:crypto';
-import openBrowser from 'react-dev-utils/openBrowser';
+import { openBrowser } from '@backstage/cli-common';
 import { request } from '@octokit/request';
 import express, { Express, Request, Response } from 'express';
 

--- a/packages/cli-module-github/src/commands/create-github-app/index.ts
+++ b/packages/cli-module-github/src/commands/create-github-app/index.ts
@@ -18,11 +18,10 @@ import fs from 'fs-extra';
 import chalk from 'chalk';
 import { stringify as stringifyYaml } from 'yaml';
 import inquirer, { Question, Answers } from 'inquirer';
-import { targetPaths } from '@backstage/cli-common';
+import { openBrowser, targetPaths } from '@backstage/cli-common';
 import { cli } from 'cleye';
 
 import { GithubCreateAppServer } from './GithubCreateAppServer';
-import openBrowser from 'react-dev-utils/openBrowser';
 import type { CliCommandContext } from '@backstage/cli-node';
 
 // This is an experimental command that at this point does not support GitHub Enterprise

--- a/packages/cli/src/types.d.ts
+++ b/packages/cli/src/types.d.ts
@@ -39,10 +39,6 @@ declare module 'react-dev-utils/formatWebpackMessages' {
   };
 }
 
-declare module 'react-dev-utils/openBrowser' {
-  export default function (url: string): boolean;
-}
-
 declare module 'react-dev-utils/ModuleScopePlugin' {
   import webpack = require('webpack');
 

--- a/packages/techdocs-cli/package.json
+++ b/packages/techdocs-cli/package.json
@@ -52,7 +52,7 @@
     "commander": "^14.0.3",
     "fs-extra": "^11.0.0",
     "http-proxy": "^1.18.1",
-    "react-dev-utils": "^12.0.0-next.60",
+    "open": "^10",
     "serve-handler": "^6.1.3",
     "winston": "^3.2.1"
   },

--- a/packages/techdocs-cli/package.json
+++ b/packages/techdocs-cli/package.json
@@ -52,7 +52,7 @@
     "commander": "^14.0.3",
     "fs-extra": "^11.0.0",
     "http-proxy": "^1.18.1",
-    "open": "^10",
+    "open": "^10.2.0",
     "serve-handler": "^6.1.3",
     "winston": "^3.2.1"
   },

--- a/packages/techdocs-cli/src/commands/serve/mkdocs.ts
+++ b/packages/techdocs-cli/src/commands/serve/mkdocs.ts
@@ -15,10 +15,9 @@
  */
 
 import { OptionValues } from 'commander';
-import openBrowser from 'react-dev-utils/openBrowser';
 import { createLogger } from '../../lib/utility';
 import { runMkdocsServer } from '../../lib/mkdocsServer';
-import { RunOnOutput } from '@backstage/cli-common';
+import { openBrowser, RunOnOutput } from '@backstage/cli-common';
 import { getMkdocsYml } from '@backstage/plugin-techdocs-node';
 import fs from 'fs-extra';
 import { checkIfDockerIsOperational } from './utils';

--- a/packages/techdocs-cli/src/commands/serve/serve.ts
+++ b/packages/techdocs-cli/src/commands/serve/serve.ts
@@ -16,8 +16,7 @@
 
 import { OptionValues } from 'commander';
 import path from 'node:path';
-import openBrowser from 'react-dev-utils/openBrowser';
-import { findOwnPaths, RunOnOutput } from '@backstage/cli-common';
+import { findOwnPaths, openBrowser, RunOnOutput } from '@backstage/cli-common';
 import HTTPServer from '../../lib/httpServer';
 import { runMkdocsServer } from '../../lib/mkdocsServer';
 import { createLogger } from '../../lib/utility';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2210,6 +2210,12 @@ __metadata:
     "@types/cross-spawn": "npm:^6.0.2"
     "@types/node": "npm:^22.13.14"
     cross-spawn: "npm:^7.0.3"
+    open: "npm:^10"
+  peerDependencies:
+    open: ^10
+  peerDependenciesMeta:
+    open:
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -2326,6 +2332,7 @@ __metadata:
     mini-css-extract-plugin: "npm:^2.4.2"
     node-stdlib-browser: "npm:^1.3.1"
     npm-packlist: "npm:^5.0.0"
+    open: "npm:^10"
     p-queue: "npm:^6.6.2"
     portfinder: "npm:^1.0.32"
     postcss: "npm:^8.1.0"
@@ -2375,7 +2382,7 @@ __metadata:
     "@types/json-schema": "npm:^7.0.6"
     chalk: "npm:^4.0.0"
     cleye: "npm:^2.6.0"
-    react-dev-utils: "npm:^12.0.0-next.60"
+    open: "npm:^10"
     yaml: "npm:^2.0.0"
   bin:
     cli-module-config: bin/backstage-cli-module-config
@@ -2397,7 +2404,7 @@ __metadata:
     express: "npm:^4.22.0"
     fs-extra: "npm:^11.2.0"
     inquirer: "npm:^8.2.0"
-    react-dev-utils: "npm:^12.0.0-next.60"
+    open: "npm:^10"
     yaml: "npm:^2.0.0"
   bin:
     cli-module-github: bin/backstage-cli-module-github
@@ -18253,7 +18260,7 @@ __metadata:
     fs-extra: "npm:^11.0.0"
     http-proxy: "npm:^1.18.1"
     nodemon: "npm:^3.0.1"
-    react-dev-utils: "npm:^12.0.0-next.60"
+    open: "npm:^10"
     serve-handler: "npm:^6.1.3"
     techdocs-cli-embedded-app: "link:../techdocs-cli-embedded-app"
     winston: "npm:^3.2.1"
@@ -37125,7 +37132,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"open@npm:^10.0.3, open@npm:^10.1.0, open@npm:^10.2.0":
+"open@npm:^10, open@npm:^10.0.3, open@npm:^10.1.0, open@npm:^10.2.0":
   version: 10.2.0
   resolution: "open@npm:10.2.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2210,9 +2210,9 @@ __metadata:
     "@types/cross-spawn": "npm:^6.0.2"
     "@types/node": "npm:^22.13.14"
     cross-spawn: "npm:^7.0.3"
-    open: "npm:^10"
+    open: "npm:^10.2.0"
   peerDependencies:
-    open: ^10
+    open: ^10.2.0
   peerDependenciesMeta:
     open:
       optional: true
@@ -2332,7 +2332,7 @@ __metadata:
     mini-css-extract-plugin: "npm:^2.4.2"
     node-stdlib-browser: "npm:^1.3.1"
     npm-packlist: "npm:^5.0.0"
-    open: "npm:^10"
+    open: "npm:^10.2.0"
     p-queue: "npm:^6.6.2"
     portfinder: "npm:^1.0.32"
     postcss: "npm:^8.1.0"
@@ -2382,7 +2382,7 @@ __metadata:
     "@types/json-schema": "npm:^7.0.6"
     chalk: "npm:^4.0.0"
     cleye: "npm:^2.6.0"
-    open: "npm:^10"
+    open: "npm:^10.2.0"
     yaml: "npm:^2.0.0"
   bin:
     cli-module-config: bin/backstage-cli-module-config
@@ -2404,7 +2404,7 @@ __metadata:
     express: "npm:^4.22.0"
     fs-extra: "npm:^11.2.0"
     inquirer: "npm:^8.2.0"
-    open: "npm:^10"
+    open: "npm:^10.2.0"
     yaml: "npm:^2.0.0"
   bin:
     cli-module-github: bin/backstage-cli-module-github
@@ -18260,7 +18260,7 @@ __metadata:
     fs-extra: "npm:^11.0.0"
     http-proxy: "npm:^1.18.1"
     nodemon: "npm:^3.0.1"
-    open: "npm:^10"
+    open: "npm:^10.2.0"
     serve-handler: "npm:^6.1.3"
     techdocs-cli-embedded-app: "link:../techdocs-cli-embedded-app"
     winston: "npm:^3.2.1"
@@ -37132,7 +37132,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"open@npm:^10, open@npm:^10.0.3, open@npm:^10.1.0, open@npm:^10.2.0":
+"open@npm:^10.0.3, open@npm:^10.1.0, open@npm:^10.2.0":
   version: 10.2.0
   resolution: "open@npm:10.2.0"
   dependencies:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### Context

`react-dev-utils` is a [deprecated](https://github.com/facebook/create-react-app?tab=readme-ov-file#create-react-app--) package that hasn't had an official release in [4 years](https://www.npmjs.com/package/react-dev-utils), and the beta release we're currently using is more than [a year old](https://www.npmjs.com/package/react-dev-utils/v/12.1.0-next.26).

`react-dev-utils` has [24 direct dependencies, and many transitive dependencies](https://npmgraph.js.org/?q=react-dev-utils%4012.0.0-next.60#color=outdated&zoom=h). Many direct/transitive dependencies are outdated.

The techdocs-cli depends on it only to open the browser, which should not need to bring `fork-ts-checker-webpack-plugin` and many other dependencies on our end-users machines.

[Some users are also complaining about the install size of `techdocs-cli`](https://github.com/backstage/backstage/issues/32311#issuecomment-3861212788), this should help a little (but the bulk of it is heavy Cloud SDKs for publishing, a way bigger refactor).

### Proposal

Vendor it in `cli-common`, use in in Techdocs & Backstage CLI.

Upstream is licensed under MIT, so we should be good :) 

### Alternatives

#### Switch to `open-browsers`

I considered switching to [open-browsers](https://www.npmjs.com/package/open-browsers) package, which already redistribute an updated version of the utility.

However, the package has very few weekly downloads and its organization is [pretty much inactive](https://github.com/react-doc), so I suggest we vendor it instead, to avoid any supply chain risks.

> Note: In my org's custom `techdocs-cli`, we are currently using a pinned version of `open-browsers`, but I do think it's the best/safest way forward to vendor it.

#### Drop it altogether

Compared to raw `open`, the utility has features to re-use Chrome tabs on MacOS. This is a nice QoL for techdocs-cli and Backstage CLI, which imo is worth the ~300 LoC to maintain.

### Maintenance burden

Seeing how [little changes were needed upstream](https://github.com/facebook/create-react-app/commits/main/packages/react-dev-utils/openBrowser.js), and that this utility has been working fine for years, we can only hope we won't have much issues.

### 🤔 But Gabriel we still have `react-dev-utils` in `@backstage/cli`

For now, but we could consider vendoring the 3 usages left, or replacing them by alternatives. Some may not be needed after Webpack support removal. 

## Clanker notice

The utility has been ported in TS with AI for this POC, and only lightly reviewed & tested manually.

If we're okay to vendor-it, I'll go more thoroughly. We might also prefer to keep the AppleScript as a file instead of inlined. We may also keep a plain JS version closer to the original. Lmk!

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
