### PR TITLE
docs(catalog): add mention of backstage-openapi backend module to configuration

### DIFF
--- a/docs/features/software-catalog/configuration.md
+++ b/docs/features/software-catalog/configuration.md
@@ -371,12 +371,6 @@ backend.add(eventsModuleCatalogErrors);
 
 The **OpenAPI Catalog Backend Module** registers a JSON Schema placeholder resolver for the `openapi` (and `asyncapi`) placeholder keys. This enables you to use `$openapi` and `$asyncapi` references in your catalog entities, while having all underlying `$ref` pointers resolved and bundled as part of the schema processing.
 
-## Backstage OpenAPI Module
-
-As Backstage increasingly uses OpenAPI to define its core APIs (such as the Catalog and Scaffolder), discovering and interacting with these APIs is essential for integrating external tools.
-
-You can install the **Backstage OpenAPI Module** to easily expose the OpenAPI specifications for your Backstage instance plugins directly into the catalog.
-
 ### Installation
 
 1. Add the package to your backend:
@@ -409,6 +403,28 @@ spec:
     $openapi: ./spec/openapi.yaml # by using $openapi Backstage will now resolve all $ref instances
 ```
 
+## Backstage OpenAPI Module
+
+As Backstage increasingly uses OpenAPI to define its core APIs (such as the Catalog and Scaffolder), discovering and interacting with these APIs is essential for integrating external tools.
+
+You can install the **Backstage OpenAPI Module** to easily expose the OpenAPI specifications for your Backstage instance plugins directly into the catalog.
+
+### Installation
+
+1. Install the module in your backend:
+
+```bash
+yarn --cwd packages/backend add @backstage/plugin-catalog-backend-module-backstage-openapi
+```
+
+2. Register the module in your backend:
+
+```ts title="packages/backend/src/index.ts"
+backend.add(
+  import('@backstage/plugin-catalog-backend-module-backstage-openapi'),
+);
+```
+
 3. Add the configuration to your `app-config.yaml`:
 
 ```yaml title="app-config.yaml"
@@ -418,4 +434,14 @@ catalog:
       plugins:
         - catalog
         - scaffolder
+      # Optional configuration:
+      # definitionFormat controls how generated definitions are serialized.
+      # Supported values: 'json' (default) or 'yaml'.
+      # definitionFormat: json
+      # entityOverrides can be used to override parts of the produced entities.
+      # For example, to add a tag to all generated APIs:
+      # entityOverrides:
+      #   metadata:
+      #     tags:
+      #       - from-openapi
 ```


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds documentation for the backstage-openapi backend module to the catalog configuration guide, including installation, registration, and required configuration steps.

It helps users discover how to ingest OpenAPI definitions directly from Backstage plugins, as requested in #32719.

Fixes #32719

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
