### PR TITLE
docs(catalog): add mention of unprocessed entities plugin and module

### DIFF
--- a/docs/features/software-catalog/index.md
+++ b/docs/features/software-catalog/index.md
@@ -138,7 +138,7 @@ or by [building your own](../../plugins/index.md).
 
 ## Unprocessed Entities
 
-Sometimes entities fail to process correctly. The **Unprocessed Entities** feature helps Backstage admins find and diagnose these entities to understand the state of the Catalog.
+Sometimes entities fail to process correctly. The **Unprocessed Entities** feature helps Backstage admins find and diagnose these entities to understand the state of the catalog.
 
 To use this feature, check out the documentation for the [catalog-unprocessed-entities plugin](https://github.com/backstage/backstage/tree/master/plugins/catalog-unprocessed-entities) and its [backend module](https://github.com/backstage/backstage/tree/master/plugins/catalog-backend-module-unprocessed).
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds a section to the Software Catalog overview documentation mentioning the `catalog-unprocessed-entities` plugin and its backend module.

It helps admins discover tools to diagnose catalog ingestion issues, as requested in #32721.

Fixes #32721

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
