### PR TITLE
docs: use postgres:17-bookworm in database getting-started and remove version key from Compose file

### DIFF
--- a/docs/getting-started/config/database.md
+++ b/docs/getting-started/config/database.md
@@ -211,13 +211,13 @@ You can run Postgres in a Docker container, this is great for local development 
 First we need to pull down the container image, we'll use Postgres 17, check out the [Postgres Version Policy](../../overview/versioning-policy.md#postgresql-releases) to learn which versions are supported.
 
 ```shell
-docker pull postgres:17.0-trixie
+docker pull postgres:17-bookworm
 ```
 
 Then we just need to start up the container.
 
 ```shell
-docker run -d --name postgres --restart=always -p 5432:5432 -e POSTGRES_PASSWORD=<secret> postgres:17.0-trixie
+docker run -d --name postgres --restart=always -p 5432:5432 -e POSTGRES_PASSWORD=<secret> postgres:17-bookworm
 ```
 
 This will run Postgres in the background for you, but remember to start it up again when you reboot your system.
@@ -227,11 +227,9 @@ This will run Postgres in the background for you, but remember to start it up ag
 Another way to run Postgres is to use Docker Compose, here's what that would look like:
 
 ```yaml title="docker-compose.local.yaml"
-version: '4'
-
 services:
   postgres:
-    image: postgres:17.0-trixie
+    image: postgres:17-bookworm
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: <secret>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I updated the database getting-started tutorial for docker compose.

- I changed Postgres image from 17.0-trixie to 17-bookworm since 17.0-trixie is not a published tag and bookworm should be more stable.
- I also removed the top-level "version" key from the compose YAML file since it is obsolete/ignored since Docker Compose V2 that the tutorial assumes; "docker compose" instead of "docker-compose"

#### :heavy_check_mark: 

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
