### PR TITLE
docs: follow up on PR: #32844 ( database docker getting-started )

### DIFF
--- a/docs/getting-started/config/database.md
+++ b/docs/getting-started/config/database.md
@@ -208,16 +208,16 @@ You may not want to install Postgres locally, the following sections outline alt
 
 You can run Postgres in a Docker container, this is great for local development or getting a Backstage POC up and running quickly, here's how:
 
-First we need to pull down the container image, we'll use Postgres 17, check out the [Postgres Version Policy](../../overview/versioning-policy.md#postgresql-releases) to learn which versions are supported.
+First we need to pull down the container image, we'll use Postgres 18, check out the [Postgres Version Policy](../../overview/versioning-policy.md#postgresql-releases) to learn which versions are supported.
 
 ```shell
-docker pull postgres:17-bookworm
+docker pull postgres:18-trixie
 ```
 
 Then we just need to start up the container.
 
 ```shell
-docker run -d --name postgres --restart=always -p 5432:5432 -e POSTGRES_PASSWORD=<secret> postgres:17-bookworm
+docker run -d --name postgres --restart=always -p 5432:5432 -e POSTGRES_PASSWORD=<secret> postgres:18-trixie
 ```
 
 This will run Postgres in the background for you, but remember to start it up again when you reboot your system.
@@ -229,7 +229,7 @@ Another way to run Postgres is to use Docker Compose, here's what that would loo
 ```yaml title="docker-compose.local.yaml"
 services:
   postgres:
-    image: postgres:17-bookworm
+    image: postgres:18-trixie
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: <secret>

--- a/docs/overview/versioning-policy.md
+++ b/docs/overview/versioning-policy.md
@@ -195,4 +195,4 @@ The Backstage project recommends and supports using PostgreSQL for persistent st
 
 The PostgreSQL [versioning policy](https://www.postgresql.org/support/versioning/) is to release a new major version every year with new features which is then supported for 5 years after its initial release.
 
-Our policy mirrors the PostgreSQL versioning policy - we will support the last 5 major versions. We will also test the newest and oldest versions in that range. For example, if the range we support is currently 13 to 17, then we would only test 13 and 17 explicitly.
+Our policy mirrors the PostgreSQL versioning policy - we will support the last 5 major versions. We will also test the newest and oldest versions in that range. For example, if the range we support is currently 14 to 18, then we would only test 14 and 18 explicitly.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

- Updated the postgesql policy example so that it clearly displays what versions we supprt.
- Updated from docker image from postgres:17-bookworm to postgres:18-trixie since we support postgres:18 and trixie is the latest stable version of debian.


#### :heavy_check_mark: 

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
