### PR TITLE
fix(ui): limit Select menu height and enable scrolling

### DIFF
--- a/.changeset/six-adults-arrive.md
+++ b/.changeset/six-adults-arrive.md
@@ -1,0 +1,7 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed an issue where the Select component dropdown would overflow the viewport and flicker when containing many items.
+
+**Affected components:** Select

--- a/packages/ui/src/components/Select/Select.module.css
+++ b/packages/ui/src/components/Select/Select.module.css
@@ -19,6 +19,9 @@
 @layer components {
   .bui-Select,
   .bui-SelectPopover {
+    /* added this to manage popover max-height */
+    --select-popover-max-height: 400px;
+
     &[data-size='small'] {
       --select-item-height: 2rem;
     }
@@ -30,6 +33,12 @@
 
   .bui-SelectPopover {
     min-width: var(--trigger-width);
+    /* Constrain height against both a fixed max and the viewport height */
+    max-height: min(var(--select-popover-max-height), calc(100vh - 2rem));
+    display: flex;
+    flex-direction: column;
+    /* Prevent popover itself from scrolling to avoid double scrollbars */
+    overflow: hidden;
   }
 
   .bui-SelectTrigger {
@@ -116,12 +125,21 @@
     }
   }
 
-  .bui-SelectList:focus-visible {
-    /* Remove default focus-visible outline because React Aria
-     * triggers it on mouse click open of the list for some reason.
-     * On keyboard use, the top item receives the focus style,
-     * so it's not needed anyway. */
-    outline: none;
+  .bui-SelectList {
+    /* Allow list to fill the popover space */
+    flex: 1 1 auto;
+    /* Ensure flex child can shrink below content size to enable scrolling */
+    min-height: 0;
+    /* Enable vertical scrolling for the list items */
+    overflow-y: auto;
+
+    &:focus-visible {
+      /* Remove default focus-visible outline because React Aria
+       * triggers it on mouse click open of the list for some reason.
+       * On keyboard use, the top item receives the focus style,
+       * so it's not needed anyway. */
+      outline: none;
+    }
   }
 
   .bui-SelectItem {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR addresses an overflow issue in the `@backstage/ui` `<Select />` component. By constraining the Popover height and enabling scrolling on the internal ListBox, we prevent the dropdown from expanding beyond the viewport and flickering. The fix uses CSS variables and flexbox to ensure the search field remains visible while the list scrolls.

The attached screen recording demonstrates the dropdown behaviour with 50+ items, showing the 400px height constraint and the functional vertical scrollbar.

https://github.com/user-attachments/assets/7c431742-c116-43af-b418-2ecba6dfe918


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
