### PR TITLE
catalog: move stitch queue concerns into `final_entities`

### DIFF
--- a/.changeset/gentle-tables-march.md
+++ b/.changeset/gentle-tables-march.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Moved stitch queue columns (`next_stitch_at`, `next_stitch_ticket`) from `refresh_state` to `final_entities` table. This change improves semantic alignment since stitching operates on a per-entity-ref basis and the output belongs to `final_entities`. The migration handles existing data and is fully reversible.

--- a/plugins/catalog-backend/migrations/20260215000000_move_stitch_queue.js
+++ b/plugins/catalog-backend/migrations/20260215000000_move_stitch_queue.js
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @ts-check
+
+/**
+ * Moves the stitch queue columns from refresh_state to final_entities.
+ * The stitch queue semantically belongs to final_entities since stitching
+ * operates on a per-entity-ref basis and produces one output entity.
+ *
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function up(knex) {
+  const isSQLite = knex.client.config.client.includes('sqlite');
+
+  // Step 1: Add next_stitch_at column to final_entities
+  await knex.schema.alterTable('final_entities', table => {
+    table
+      .dateTime('next_stitch_at')
+      .nullable()
+      .comment('Timestamp of when entity should be stitched');
+  });
+
+  // Step 1b: Create partial index separately
+  // For SQLite, we use raw SQL to create the partial index to avoid
+  // Knex's table rebuild which can cause issues with FK constraints.
+  // For other databases, we use Knex's API.
+  if (isSQLite) {
+    await knex.raw(`
+      CREATE INDEX final_entities_next_stitch_at_idx
+      ON final_entities (next_stitch_at)
+      WHERE next_stitch_at IS NOT NULL
+    `);
+  } else {
+    await knex.schema.alterTable('final_entities', table => {
+      table.index('next_stitch_at', 'final_entities_next_stitch_at_idx', {
+        predicate: knex.whereNotNull('next_stitch_at'),
+      });
+    });
+  }
+
+  // Step 2: Migrate existing stitch requests from refresh_state to final_entities
+  // using upsert - insert new rows or update existing ones in a single operation.
+  const pendingStitches = await knex
+    .select({
+      entity_id: 'refresh_state.entity_id',
+      entity_ref: 'refresh_state.entity_ref',
+      next_stitch_at: 'refresh_state.next_stitch_at',
+      next_stitch_ticket: 'refresh_state.next_stitch_ticket',
+    })
+    .from('refresh_state')
+    .whereNotNull('refresh_state.next_stitch_at');
+
+  // Process in batches to avoid issues with large datasets
+  for (let i = 0; i < pendingStitches.length; i += 1000) {
+    const batch = pendingStitches.slice(i, i + 1000);
+    await knex('final_entities')
+      .insert(
+        batch.map(row => ({
+          entity_id: row.entity_id,
+          entity_ref: row.entity_ref,
+          hash: '', // Empty hash indicates needs stitching
+          stitch_ticket: row.next_stitch_ticket || '',
+          final_entity: null,
+          last_updated_at: null,
+          next_stitch_at: row.next_stitch_at,
+        })),
+      )
+      .onConflict('entity_ref')
+      .merge(['next_stitch_at', 'stitch_ticket']);
+  }
+
+  // Step 4: Remove next_stitch_at and next_stitch_ticket columns from refresh_state
+  if (isSQLite) {
+    // SQLite 3.35+ supports ALTER TABLE DROP COLUMN natively
+    // Use raw SQL to avoid Knex's table rebuild which can cause issues with FKs
+    await knex.raw('DROP INDEX IF EXISTS refresh_state_next_stitch_at_idx');
+    await knex.raw('ALTER TABLE refresh_state DROP COLUMN next_stitch_at');
+    await knex.raw('ALTER TABLE refresh_state DROP COLUMN next_stitch_ticket');
+  } else {
+    await knex.schema.alterTable('refresh_state', table => {
+      table.dropIndex([], 'refresh_state_next_stitch_at_idx');
+      table.dropColumn('next_stitch_at');
+      table.dropColumn('next_stitch_ticket');
+    });
+  }
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function down(knex) {
+  const isSQLite = knex.client.config.client.includes('sqlite');
+
+  // Step 1: Add back the columns to refresh_state
+  await knex.schema.alterTable('refresh_state', table => {
+    table
+      .dateTime('next_stitch_at')
+      .nullable()
+      .comment('Timestamp of when entity should be stitched');
+    table
+      .string('next_stitch_ticket')
+      .nullable()
+      .comment('Random value distinguishing stitch requests');
+  });
+
+  // Step 1b: Create partial index separately
+  if (isSQLite) {
+    await knex.raw(`
+      CREATE INDEX refresh_state_next_stitch_at_idx
+      ON refresh_state (next_stitch_at)
+      WHERE next_stitch_at IS NOT NULL
+    `);
+  } else {
+    await knex.schema.alterTable('refresh_state', table => {
+      table.index('next_stitch_at', 'refresh_state_next_stitch_at_idx', {
+        predicate: knex.whereNotNull('next_stitch_at'),
+      });
+    });
+  }
+
+  // Step 2: Migrate stitch requests back from final_entities to refresh_state
+  if (isSQLite) {
+    const pendingStitches = await knex
+      .select({
+        entityRef: 'final_entities.entity_ref',
+        nextStitchAt: 'final_entities.next_stitch_at',
+        stitchTicket: 'final_entities.stitch_ticket',
+      })
+      .from('final_entities')
+      .whereNotNull('final_entities.next_stitch_at');
+
+    for (const row of pendingStitches) {
+      await knex('refresh_state')
+        .update({
+          next_stitch_at: row.nextStitchAt,
+          next_stitch_ticket: row.stitchTicket,
+        })
+        .where('entity_ref', row.entityRef);
+    }
+  } else {
+    await knex('refresh_state')
+      .update({
+        next_stitch_at: knex
+          .select('final_entities.next_stitch_at')
+          .from('final_entities')
+          .whereRaw('final_entities.entity_ref = refresh_state.entity_ref')
+          .whereNotNull('final_entities.next_stitch_at'),
+        next_stitch_ticket: knex
+          .select('final_entities.stitch_ticket')
+          .from('final_entities')
+          .whereRaw('final_entities.entity_ref = refresh_state.entity_ref')
+          .whereNotNull('final_entities.next_stitch_at'),
+      })
+      .whereIn(
+        'entity_ref',
+        knex
+          .select('entity_ref')
+          .from('final_entities')
+          .whereNotNull('next_stitch_at'),
+      );
+  }
+
+  // Step 3: Remove next_stitch_at column from final_entities
+  if (isSQLite) {
+    await knex.raw('DROP INDEX IF EXISTS final_entities_next_stitch_at_idx');
+    await knex.schema.alterTable('final_entities', table => {
+      table.dropColumn('next_stitch_at');
+    });
+  } else {
+    await knex.schema.alterTable('final_entities', table => {
+      table.dropIndex([], 'final_entities_next_stitch_at_idx');
+      table.dropColumn('next_stitch_at');
+    });
+  }
+};

--- a/plugins/catalog-backend/report.sql.md
+++ b/plugins/catalog-backend/report.sql.md
@@ -19,11 +19,13 @@
 | `final_entity`    | `text`                     | true     | -          | -       |
 | `hash`            | `character varying`        | false    | 255        | -       |
 | `last_updated_at` | `timestamp with time zone` | true     | -          | -       |
+| `next_stitch_at`  | `timestamp with time zone` | true     | -          | -       |
 | `stitch_ticket`   | `text`                     | false    | -          | -       |
 
 ### Indices
 
 - `final_entities_entity_ref_uniq` (`entity_ref`) unique
+- `final_entities_next_stitch_at_idx` (`next_stitch_at`)
 - `final_entities_pkey` (`entity_id`) unique primary
 
 ## Table `location_update_log`
@@ -76,8 +78,6 @@
 | `errors`             | `text`                     | false    | -          | -       |
 | `last_discovery_at`  | `timestamp with time zone` | false    | -          | -       |
 | `location_key`       | `text`                     | true     | -          | -       |
-| `next_stitch_at`     | `timestamp with time zone` | true     | -          | -       |
-| `next_stitch_ticket` | `character varying`        | true     | 255        | -       |
 | `next_update_at`     | `timestamp with time zone` | false    | -          | -       |
 | `processed_entity`   | `text`                     | true     | -          | -       |
 | `result_hash`        | `text`                     | true     | -          | -       |
@@ -87,7 +87,6 @@
 ### Indices
 
 - `refresh_state_entity_ref_uniq` (`entity_ref`) unique
-- `refresh_state_next_stitch_at_idx` (`next_stitch_at`)
 - `refresh_state_next_update_at_idx` (`next_update_at`)
 - `refresh_state_pkey` (`entity_id`) unique primary
 

--- a/plugins/catalog-backend/src/database/operations/stitcher/getDeferredStitchableEntities.test.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/getDeferredStitchableEntities.test.ts
@@ -16,6 +16,7 @@
 
 import { TestDatabases } from '@backstage/backend-test-utils';
 import { applyDatabaseMigrations } from '../../migrations';
+import { DbFinalEntitiesRow, DbRefreshStateRow } from '../../tables';
 import { getDeferredStitchableEntities } from './getDeferredStitchableEntities';
 
 jest.setTimeout(60_000);
@@ -29,56 +30,79 @@ describe('getDeferredStitchableEntities', () => {
       const knex = await databases.init(databaseId);
       await applyDatabaseMigrations(knex);
 
-      await knex
-        .insert([
-          {
-            entity_id: '1',
-            entity_ref: 'k:ns/no_stitch_time',
-            unprocessed_entity: '{}',
-            processed_entity: '{}',
-            errors: '[]',
-            next_update_at: knex.fn.now(),
-            last_discovery_at: knex.fn.now(),
-            next_stitch_at: null,
-            next_stitch_ticket: null,
-          },
-          {
-            entity_id: '2',
-            entity_ref: 'k:ns/future_stitch_time',
-            unprocessed_entity: '{}',
-            processed_entity: '{}',
-            errors: '[]',
-            next_update_at: knex.fn.now(),
-            last_discovery_at: knex.fn.now(),
-            next_stitch_at: '2037-01-01T00:00:00.000',
-            next_stitch_ticket: 't1',
-          },
-          {
-            entity_id: '3',
-            entity_ref: 'k:ns/past_stitch_time',
-            unprocessed_entity: '{}',
-            processed_entity: '{}',
-            errors: '[]',
-            next_update_at: knex.fn.now(),
-            last_discovery_at: knex.fn.now(),
-            next_stitch_at: '1971-01-01T00:00:00.000',
-            next_stitch_ticket: 't3',
-          },
-          {
-            entity_id: '4',
-            entity_ref: 'k:ns/past_stitch_time_again',
-            unprocessed_entity: '{}',
-            processed_entity: '{}',
-            errors: '[]',
-            next_update_at: knex.fn.now(),
-            last_discovery_at: knex.fn.now(),
-            next_stitch_at: '1972-01-01T00:00:00.000',
-            next_stitch_ticket: 't4',
-          },
-        ])
-        .into('refresh_state');
+      // Insert refresh_state rows (needed for FK constraints)
+      await knex<DbRefreshStateRow>('refresh_state').insert([
+        {
+          entity_id: '1',
+          entity_ref: 'k:ns/no_stitch_time',
+          unprocessed_entity: '{}',
+          processed_entity: '{}',
+          errors: '[]',
+          next_update_at: knex.fn.now(),
+          last_discovery_at: knex.fn.now(),
+        },
+        {
+          entity_id: '2',
+          entity_ref: 'k:ns/future_stitch_time',
+          unprocessed_entity: '{}',
+          processed_entity: '{}',
+          errors: '[]',
+          next_update_at: knex.fn.now(),
+          last_discovery_at: knex.fn.now(),
+        },
+        {
+          entity_id: '3',
+          entity_ref: 'k:ns/past_stitch_time',
+          unprocessed_entity: '{}',
+          processed_entity: '{}',
+          errors: '[]',
+          next_update_at: knex.fn.now(),
+          last_discovery_at: knex.fn.now(),
+        },
+        {
+          entity_id: '4',
+          entity_ref: 'k:ns/past_stitch_time_again',
+          unprocessed_entity: '{}',
+          processed_entity: '{}',
+          errors: '[]',
+          next_update_at: knex.fn.now(),
+          last_discovery_at: knex.fn.now(),
+        },
+      ]);
 
-      const rowsBefore = await knex('refresh_state');
+      // Insert final_entities rows with stitch data
+      await knex<DbFinalEntitiesRow>('final_entities').insert([
+        {
+          entity_id: '1',
+          entity_ref: 'k:ns/no_stitch_time',
+          hash: 'h1',
+          stitch_ticket: '',
+          next_stitch_at: null,
+        },
+        {
+          entity_id: '2',
+          entity_ref: 'k:ns/future_stitch_time',
+          hash: 'h2',
+          stitch_ticket: 't1',
+          next_stitch_at: '2037-01-01T00:00:00.000',
+        },
+        {
+          entity_id: '3',
+          entity_ref: 'k:ns/past_stitch_time',
+          hash: 'h3',
+          stitch_ticket: 't3',
+          next_stitch_at: '1971-01-01T00:00:00.000',
+        },
+        {
+          entity_id: '4',
+          entity_ref: 'k:ns/past_stitch_time_again',
+          hash: 'h4',
+          stitch_ticket: 't4',
+          next_stitch_at: '1972-01-01T00:00:00.000',
+        },
+      ]);
+
+      const rowsBefore = await knex<DbFinalEntitiesRow>('final_entities');
 
       const items = await getDeferredStitchableEntities({
         knex,
@@ -86,7 +110,7 @@ describe('getDeferredStitchableEntities', () => {
         stitchTimeout: { seconds: 2 },
       });
 
-      const rowsAfter = await knex('refresh_state');
+      const rowsAfter = await knex<DbFinalEntitiesRow>('final_entities');
 
       expect(items).toEqual([
         {
@@ -105,8 +129,8 @@ describe('getDeferredStitchableEntities', () => {
       const missRowAfter = rowsAfter.filter(r => r.entity_id === '4')[0]
         .next_stitch_at;
 
-      expect(+new Date(hitRowAfter)).toBeGreaterThan(+new Date(hitRowBefore));
-      expect(+new Date(missRowAfter)).toEqual(+new Date(missRowBefore));
+      expect(+new Date(hitRowAfter!)).toBeGreaterThan(+new Date(hitRowBefore!));
+      expect(+new Date(missRowAfter!)).toEqual(+new Date(missRowBefore!));
     },
   );
 });

--- a/plugins/catalog-backend/src/database/operations/stitcher/getDeferredStitchableEntities.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/getDeferredStitchableEntities.ts
@@ -18,7 +18,7 @@ import { durationToMilliseconds, HumanDuration } from '@backstage/types';
 import { Knex } from 'knex';
 import { DateTime } from 'luxon';
 import { timestampToDateTime } from '../../conversion';
-import { DbRefreshStateRow } from '../../tables';
+import { DbFinalEntitiesRow } from '../../tables';
 
 // TODO(freben): There is no retry counter or similar. If items start
 // perpetually crashing during stitching, they'll just get silently retried over
@@ -31,7 +31,7 @@ import { DbRefreshStateRow } from '../../tables';
  *
  * This assumes that the stitching strategy is set to deferred.
  *
- * They are expected to already have the next_stitch_ticket set (by
+ * They are expected to already have the stitch_ticket set (by
  * markForStitching) so that their tickets can be returned with each item.
  *
  * All returned items have their next_stitch_at updated to be moved forward by
@@ -52,10 +52,10 @@ export async function getDeferredStitchableEntities(options: {
 > {
   const { knex, batchSize, stitchTimeout } = options;
 
-  let itemsQuery = knex<DbRefreshStateRow>('refresh_state').select(
+  let itemsQuery = knex<DbFinalEntitiesRow>('final_entities').select(
     'entity_ref',
     'next_stitch_at',
-    'next_stitch_ticket',
+    'stitch_ticket',
   );
 
   // This avoids duplication of work because of race conditions and is
@@ -67,7 +67,6 @@ export async function getDeferredStitchableEntities(options: {
 
   const items = await itemsQuery
     .whereNotNull('next_stitch_at')
-    .whereNotNull('next_stitch_ticket')
     .where('next_stitch_at', '<=', knex.fn.now())
     .orderBy('next_stitch_at', 'asc')
     .limit(batchSize);
@@ -76,20 +75,20 @@ export async function getDeferredStitchableEntities(options: {
     return [];
   }
 
-  await knex<DbRefreshStateRow>('refresh_state')
+  await knex<DbFinalEntitiesRow>('final_entities')
     .whereIn(
       'entity_ref',
       items.map(i => i.entity_ref),
     )
     // avoid race condition where someone completes a stitch right between these statements
-    .whereNotNull('next_stitch_ticket')
+    .whereNotNull('next_stitch_at')
     .update({
       next_stitch_at: nowPlus(knex, stitchTimeout),
     });
 
   return items.map(i => ({
     entityRef: i.entity_ref,
-    stitchTicket: i.next_stitch_ticket!,
+    stitchTicket: i.stitch_ticket!,
     stitchRequestedAt: timestampToDateTime(i.next_stitch_at!),
   }));
 }

--- a/plugins/catalog-backend/src/database/operations/stitcher/markDeferredStitchCompleted.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/markDeferredStitchCompleted.ts
@@ -15,7 +15,7 @@
  */
 
 import { Knex } from 'knex';
-import { DbRefreshStateRow } from '../../tables';
+import { DbFinalEntitiesRow } from '../../tables';
 
 /**
  * Marks a single entity as having been stitched.
@@ -36,11 +36,13 @@ export async function markDeferredStitchCompleted(option: {
 }): Promise<void> {
   const { knex, entityRef, stitchTicket } = option;
 
-  await knex<DbRefreshStateRow>('refresh_state')
+  await knex<DbFinalEntitiesRow>('final_entities')
     .update({
       next_stitch_at: null,
-      next_stitch_ticket: null,
+      // Intentionally leave stitch_ticket at its old value; we are supposed to
+      // only ever call this function when we had a complete stitch run and the
+      // next one should set this string to a new random value.
     })
     .where('entity_ref', '=', entityRef)
-    .andWhere('next_stitch_ticket', '=', stitchTicket);
+    .andWhere('stitch_ticket', '=', stitchTicket);
 }

--- a/plugins/catalog-backend/src/database/operations/stitcher/markForStitching.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/markForStitching.ts
@@ -77,30 +77,56 @@ export async function markForStitching(options: {
       }, knex);
     }
   } else if (mode === 'deferred') {
-    // It's OK that this is shared across refresh state rows; it just needs to
+    // It's OK that this is shared across final_entities rows; it just needs to
     // be uniquely generated for every new stitch request.
     const ticket = uuid();
 
-    // Update by primary key in deterministic order to avoid deadlocks
+    // Use a single-pass upsert: look up entity info from refresh_state, then
+    // insert into final_entities with ON CONFLICT merge. This handles both
+    // updating existing rows and inserting new ones in a single operation.
     for (const chunk of entityRefs) {
       await retryOnDeadlock(async () => {
-        await knex<DbRefreshStateRow>('refresh_state')
-          .update({
-            next_stitch_at: knex.fn.now(),
-            next_stitch_ticket: ticket,
-          })
+        const refreshStateRows = await knex<DbRefreshStateRow>('refresh_state')
+          .select('entity_id', 'entity_ref')
           .whereIn('entity_ref', chunk);
+
+        if (refreshStateRows.length > 0) {
+          await knex<DbFinalEntitiesRow>('final_entities')
+            .insert(
+              refreshStateRows.map(row => ({
+                entity_id: row.entity_id,
+                entity_ref: row.entity_ref,
+                hash: '',
+                stitch_ticket: ticket,
+                next_stitch_at: knex.fn.now(),
+              })),
+            )
+            .onConflict('entity_id')
+            .merge(['next_stitch_at', 'stitch_ticket']);
+        }
       }, knex);
     }
 
     for (const chunk of entityIds) {
       await retryOnDeadlock(async () => {
-        await knex<DbRefreshStateRow>('refresh_state')
-          .update({
-            next_stitch_at: knex.fn.now(),
-            next_stitch_ticket: ticket,
-          })
+        const refreshStateRows = await knex<DbRefreshStateRow>('refresh_state')
+          .select('entity_id', 'entity_ref')
           .whereIn('entity_id', chunk);
+
+        if (refreshStateRows.length > 0) {
+          await knex<DbFinalEntitiesRow>('final_entities')
+            .insert(
+              refreshStateRows.map(row => ({
+                entity_id: row.entity_id,
+                entity_ref: row.entity_ref,
+                hash: '',
+                stitch_ticket: ticket,
+                next_stitch_at: knex.fn.now(),
+              })),
+            )
+            .onConflict('entity_id')
+            .merge(['next_stitch_at', 'stitch_ticket']);
+        }
       }, knex);
     }
   } else {

--- a/plugins/catalog-backend/src/database/operations/util/deleteOrphanedEntities.test.ts
+++ b/plugins/catalog-backend/src/database/operations/util/deleteOrphanedEntities.test.ts
@@ -100,7 +100,7 @@ describe('deleteOrphanedEntities', () => {
   async function refreshState(knex: Knex) {
     return await knex<DbRefreshStateRow>('refresh_state')
       .orderBy('entity_ref')
-      .select('entity_ref', 'result_hash', 'next_stitch_at');
+      .select('entity_ref', 'result_hash');
   }
 
   async function finalEntities(knex: Knex) {
@@ -114,7 +114,7 @@ describe('deleteOrphanedEntities', () => {
       .select({
         entity_ref: 'refresh_state.entity_ref',
         hash: 'final_entities.hash',
-        next_stitch_at: 'refresh_state.next_stitch_at',
+        next_stitch_at: 'final_entities.next_stitch_at',
       });
   }
 
@@ -178,19 +178,11 @@ describe('deleteOrphanedEntities', () => {
       await insertRelation(knex, 'E7', 'E6');
       await expect(run(knex, { mode: 'immediate' })).resolves.toEqual(5);
       await expect(refreshState(knex)).resolves.toEqual([
-        { entity_ref: 'E1', result_hash: 'original', next_stitch_at: null },
-        {
-          entity_ref: 'E2',
-          result_hash: 'force-stitching',
-          next_stitch_at: null,
-        },
-        {
-          entity_ref: 'E7',
-          result_hash: 'force-stitching',
-          next_stitch_at: null,
-        },
-        { entity_ref: 'E8', result_hash: 'original', next_stitch_at: null },
-        { entity_ref: 'E9', result_hash: 'original', next_stitch_at: null },
+        { entity_ref: 'E1', result_hash: 'original' },
+        { entity_ref: 'E2', result_hash: 'force-stitching' },
+        { entity_ref: 'E7', result_hash: 'force-stitching' },
+        { entity_ref: 'E8', result_hash: 'original' },
+        { entity_ref: 'E9', result_hash: 'original' },
       ]);
       await expect(finalEntities(knex)).resolves.toEqual([
         { entity_ref: 'E1', hash: 'original', next_stitch_at: null },
@@ -276,19 +268,11 @@ describe('deleteOrphanedEntities', () => {
         }),
       ).resolves.toEqual(5);
       await expect(refreshState(knex)).resolves.toEqual([
-        { entity_ref: 'E1', result_hash: 'original', next_stitch_at: null },
-        {
-          entity_ref: 'E2',
-          result_hash: 'original',
-          next_stitch_at: expect.anything(),
-        },
-        {
-          entity_ref: 'E7',
-          result_hash: 'original',
-          next_stitch_at: expect.anything(),
-        },
-        { entity_ref: 'E8', result_hash: 'original', next_stitch_at: null },
-        { entity_ref: 'E9', result_hash: 'original', next_stitch_at: null },
+        { entity_ref: 'E1', result_hash: 'original' },
+        { entity_ref: 'E2', result_hash: 'original' },
+        { entity_ref: 'E7', result_hash: 'original' },
+        { entity_ref: 'E8', result_hash: 'original' },
+        { entity_ref: 'E9', result_hash: 'original' },
       ]);
       await expect(finalEntities(knex)).resolves.toEqual([
         { entity_ref: 'E1', hash: 'original', next_stitch_at: null },

--- a/plugins/catalog-backend/src/database/tables.ts
+++ b/plugins/catalog-backend/src/database/tables.ts
@@ -82,47 +82,6 @@ export type DbRefreshStateRow = {
    */
   next_update_at: string | Date;
   /**
-   * If a stitch has been requested, this is the point in time that that last
-   * happened.
-   *
-   * @remarks
-   *
-   * Each time that a request is made, this timestamp is updated to the current
-   * time, overwriting the previous value if applicable.
-   *
-   * When the stitch loop runs and picks up an entity, this timestamp is not
-   * immediately reset. It's instead moved forward in time by a certain amount,
-   * which means that if the stitcher for some reason fails (eg if the process
-   * crashes or gets shut down), the entity will be picked up again in the
-   * future.
-   *
-   * Only when a stitch run is completed successfully, AND it's found that the
-   * stitch ticket has not changed since the start (which means that no new
-   * request has been made behind our backs), does the timestamp (and the
-   * ticket) get reset.
-   */
-  next_stitch_at?: string | Date | null;
-  /**
-   * If a stitch has been requested, this is the unique ticket that was chosen
-   * to mark the last request.
-   *
-   * @remarks
-   *
-   * Each time that a request is made, a new random ticket is chosen,
-   * overwriting the previous value if applicable.
-   *
-   * When the stitch loop runs and picks up an entity, this column is left
-   * unchanged. This means that if the stitcher for some reason fails (eg if the
-   * process crashes or gets shut down), the entity will be picked up again in
-   * the future.
-   *
-   * Only when a stitch run is completed successfully, AND it's found that the
-   * stitch ticket has not changed since the start (which means that no new
-   * request has been made behind our backs), does the ticket (and the
-   * timestamp) get reset.
-   */
-  next_stitch_ticket?: string | null;
-  /**
    * The last time that this entity was emitted by somebody (the entity provider
    * or a parent entity).
    *
@@ -180,6 +139,26 @@ export type DbFinalEntitiesRow = {
   final_entity?: string;
   last_updated_at?: string | Date;
   entity_ref: string;
+  /**
+   * If a stitch has been requested, this is the point in time when that
+   * request was made.
+   *
+   * @remarks
+   *
+   * Each time that a request is made, this timestamp is updated to the current
+   * time, overwriting the previous value if applicable.
+   *
+   * When the stitch loop runs and picks up an entity, this timestamp is not
+   * immediately reset. It's instead moved forward in time by a certain amount,
+   * which means that if the stitcher for some reason fails (eg if the process
+   * crashes or gets shut down), the entity will be picked up again in the
+   * future.
+   *
+   * Only when a stitch run is completed successfully, AND it's found that the
+   * stitch ticket has not changed since the start (which means that no new
+   * request has been made behind our backs), does the timestamp get reset.
+   */
+  next_stitch_at?: string | Date | null;
 };
 
 export type DbSearchRow = {

--- a/plugins/catalog-backend/src/stitching/progressTracker.ts
+++ b/plugins/catalog-backend/src/stitching/progressTracker.ts
@@ -17,7 +17,7 @@
 import { stringifyError } from '@backstage/errors';
 import { Knex } from 'knex';
 import { DateTime } from 'luxon';
-import { DbRefreshStateRow } from '../database/tables';
+import { DbFinalEntitiesRow } from '../database/tables';
 import { createCounterMetric } from '../util/metrics';
 import { LoggerService } from '@backstage/backend-plugin-api';
 import { MetricsService } from '@backstage/backend-plugin-api/alpha';
@@ -54,7 +54,7 @@ export function progressTracker(
     { description: 'Number of entities currently in the stitching queue' },
   );
   stitchingQueueCount.addCallback(async result => {
-    const total = await knex<DbRefreshStateRow>('refresh_state')
+    const total = await knex<DbFinalEntitiesRow>('final_entities')
       .count({ count: '*' })
       .whereNotNull('next_stitch_at');
     result.observe(Number(total[0].count));


### PR DESCRIPTION
Related to https://github.com/backstage/backstage/issues/32856

Move all stitch queue concerns into the `final_entities` table, which means removing `next_stitch_at` and `next_stitch_ticket` from `refresh_state`.