### PR TITLE
feat(core-components): Migrate CopyTextButton from MUI to BUI

### DIFF
--- a/.changeset/migrate-copytextbutton-mui-to-bui.md
+++ b/.changeset/migrate-copytextbutton-mui-to-bui.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Migrated CopyTextButton component from Material-UI to Backstage UI (BUI). Replaced MUI IconButton and Tooltip with BUI ButtonIcon and TooltipTrigger/Tooltip components. This is an internal refactoring that maintains backward compatibility - the component API remains unchanged.

--- a/packages/core-components/package.json
+++ b/packages/core-components/package.json
@@ -58,6 +58,7 @@
     "@backstage/core-plugin-api": "workspace:^",
     "@backstage/errors": "workspace:^",
     "@backstage/theme": "workspace:^",
+    "@backstage/ui": "workspace:^",
     "@backstage/version-bridge": "workspace:^",
     "@dagrejs/dagre": "^1.1.4",
     "@date-io/core": "^1.3.13",

--- a/packages/core-components/src/components/CopyTextButton/CopyTextButton.test.tsx
+++ b/packages/core-components/src/components/CopyTextButton/CopyTextButton.test.tsx
@@ -50,12 +50,11 @@ const apis = [[errorApiRef, mockErrorApi] as const] as const;
 
 describe('<CopyTextButton />', () => {
   it('renders without exploding', async () => {
-    const { getByTitle, queryByText, getByLabelText } = await renderInTestApp(
+    const { queryByText, getByLabelText } = await renderInTestApp(
       <TestApiProvider apis={apis}>
         <CopyTextButton {...props} />
       </TestApiProvider>,
     );
-    expect(getByTitle('mockTooltip')).toBeInTheDocument();
     expect(queryByText('mockTooltip')).not.toBeInTheDocument();
     expect(getByLabelText('Copy text')).toBeInTheDocument();
   });
@@ -72,7 +71,7 @@ describe('<CopyTextButton />', () => {
         <CopyTextButton {...props} />
       </TestApiProvider>,
     );
-    const button = rendered.getByTitle('mockTooltip');
+    const button = rendered.getByLabelText('Copy text');
     fireEvent.click(button);
     act(() => {
       jest.runAllTimers();

--- a/packages/core-components/src/components/CopyTextButton/CopyTextButton.test.tsx
+++ b/packages/core-components/src/components/CopyTextButton/CopyTextButton.test.tsx
@@ -73,11 +73,12 @@ describe('<CopyTextButton />', () => {
     );
     const button = rendered.getByLabelText('Copy text');
     fireEvent.click(button);
+    expect(copy).toHaveBeenCalledWith('mockText');
+    rendered.getByText('mockTooltip');
     act(() => {
       jest.runAllTimers();
     });
-    expect(copy).toHaveBeenCalledWith('mockText');
-    rendered.getByText('mockTooltip');
+    expect(rendered.queryByText('mockTooltip')).not.toBeInTheDocument();
     jest.useRealTimers();
   });
 

--- a/packages/core-components/src/components/CopyTextButton/CopyTextButton.tsx
+++ b/packages/core-components/src/components/CopyTextButton/CopyTextButton.tsx
@@ -15,8 +15,7 @@
  */
 
 import { errorApiRef, useApi } from '@backstage/core-plugin-api';
-import IconButton from '@material-ui/core/IconButton';
-import Tooltip from '@material-ui/core/Tooltip';
+import { ButtonIcon, Tooltip, TooltipTrigger } from '@backstage/ui';
 import CopyIcon from '@material-ui/icons/FileCopy';
 import { MouseEventHandler, useEffect, useState } from 'react';
 import useCopyToClipboard from 'react-use/esm/useCopyToClipboard';
@@ -103,20 +102,22 @@ export function CopyTextButton(props: CopyTextButtonProps) {
     copyToClipboard(text);
   };
 
+  useEffect(() => {
+    if (open) {
+      const timer = setTimeout(() => setOpen(false), tooltipDelay);
+      return () => clearTimeout(timer);
+    }
+    return undefined;
+  }, [open, tooltipDelay]);
+
   return (
-    <>
-      <Tooltip
-        id="copy-test-tooltip"
-        title={tooltipText}
-        placement="top"
-        leaveDelay={tooltipDelay}
-        onClose={() => setOpen(false)}
-        open={open}
-      >
-        <IconButton onClick={handleCopyClick} aria-label={ariaLabel}>
-          <CopyIcon />
-        </IconButton>
-      </Tooltip>
-    </>
+    <TooltipTrigger isOpen={open} onOpenChange={setOpen}>
+      <ButtonIcon
+        icon={<CopyIcon />}
+        onPress={handleCopyClick}
+        aria-label={ariaLabel}
+      />
+      <Tooltip>{tooltipText}</Tooltip>
+    </TooltipTrigger>
   );
 }

--- a/packages/core-components/src/components/CopyTextButton/CopyTextButton.tsx
+++ b/packages/core-components/src/components/CopyTextButton/CopyTextButton.tsx
@@ -122,7 +122,7 @@ export function CopyTextButton(props: CopyTextButtonProps) {
   }, []);
 
   return (
-    <TooltipTrigger isOpen={open}>
+    <TooltipTrigger isOpen={open} onOpenChange={setOpen}>
       <ButtonIcon
         icon={<CopyIcon />}
         onPress={handleCopyClick}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3618,6 +3618,7 @@ __metadata:
     "@backstage/errors": "workspace:^"
     "@backstage/test-utils": "workspace:^"
     "@backstage/theme": "workspace:^"
+    "@backstage/ui": "workspace:^"
     "@backstage/version-bridge": "workspace:^"
     "@dagrejs/dagre": "npm:^1.1.4"
     "@date-io/core": "npm:^1.3.13"


### PR DESCRIPTION
# Pull Request: Migrate CopyTextButton Component from MUI to BUI

## Description

Migrated the **CopyTextButton** component from Material-UI (MUI) to Backstage UI (BUI) as part of the ongoing MUI to BUI migration effort ([Issue #31467](https://github.com/backstage/backstage/issues/31467)).

### Changes Made

- **Replaced MUI IconButton** → BUI ButtonIcon from `@backstage/ui`
- **Replaced MUI Tooltip** → BUI TooltipTrigger + Tooltip components
- **Updated component logic** to use BUI's tooltip API with `isOpen` and `onOpenChange` props
- **Updated tests** to work with BUI component structure
- **Added @backstage/ui dependency** to core-components package.json
- **Created changeset** for release notes
- **Maintained backward compatibility** - Component API remains unchanged

### Key Implementation Details

**Before (MUI):**
```tsx
<Tooltip
  title={tooltipText}
  placement="top"
  leaveDelay={tooltipDelay}
  onClose={() => setOpen(false)}
  open={open}
>
  <IconButton onClick={handleCopyClick} aria-label={ariaLabel}>
    <CopyIcon />
  </IconButton>
</Tooltip>
```

**After (BUI):**
```tsx
<TooltipTrigger isOpen={open} onOpenChange={setOpen}>
  <ButtonIcon
    icon={<CopyIcon />}
    onPress={handleCopyClick}
    aria-label={ariaLabel}
  />
  <Tooltip>{tooltipText}</Tooltip>
</TooltipTrigger>
```

### Affected Files

- `packages/core-components/src/components/CopyTextButton/CopyTextButton.tsx` - Component implementation
- `packages/core-components/src/components/CopyTextButton/CopyTextButton.test.tsx` - Updated tests
- `packages/core-components/package.json` - Added @backstage/ui dependency
- `.changeset/migrate-copytextbutton-mui-to-bui.md` - Changeset file

## :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All tests updated and passing
- [x] No breaking changes - backward compatible
- [x] Pre-commit hooks passed
- [ ] Screenshots (N/A - Internal refactoring)
- [ ] All commits have a `Signed-off-by` line (will add on merge if needed)

## Testing

- Updated existing tests to work with BUI component structure
- Component maintains same visual feedback:
  - Hover color via BUI ButtonIcon styling
  - Tooltip shown after click with configurable delay
  - Copy to clipboard functionality preserved

## Migration Pattern

This migration follows the same pattern as other MUI to BUI migrations:

1. **Replace component imports** - Swap MUI components for BUI equivalents
2. **Update props/API** - Adapt to BUI component API (e.g., `onPress` instead of `onClick`)
3. **Update styling** - BUI uses CSS modules and design tokens instead of makeStyles
4. **Update tests** - Adjust tests to work with BUI component structure
5. **Add dependencies** - Include @backstage/ui in package.json
6. **Create changeset** - Document the change for release notes

## Related Issue

Contributes to [#31467](https://github.com/backstage/backstage/issues/31467) - MUI to BUI Migration

---

**Component Details:**
- **File:** `packages/core-components/src/components/CopyTextButton/CopyTextButton.tsx`
- **Lines:** 122
- **Complexity:** Low
- **Risk:** Low (internal refactoring with no API changes)
- **Testing:** All tests updated

