### PR TITLE
fix: move onBrokenMarkdownLinks config in docusaurus.config.ts to the…

### DIFF
--- a/microsite/docusaurus.config.ts
+++ b/microsite/docusaurus.config.ts
@@ -86,7 +86,6 @@ const config: Config = {
     repoUrl: 'https://github.com/backstage/backstage',
   },
   onBrokenLinks: 'log',
-  onBrokenMarkdownLinks: 'log',
   future: {
     v4: {
       removeLegacyPostBuildHeadAttribute: true,
@@ -169,6 +168,9 @@ const config: Config = {
       return removeHtmlComments(fileContent);
     },
     format: 'detect',
+    hooks: {
+      onBrokenMarkdownLinks: 'log',
+    },
   },
   plugins: [
     'docusaurus-plugin-sass',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR fixes the following Docusaurus warning during build:

> The `siteConfig.onBrokenMarkdownLinks` config option is deprecated and will be removed in Docusaurus v4. Please migrate and move this option to `siteConfig.markdown.hooks.onBrokenMarkdownLinks` instead.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
