### PR TITLE
ui: fix FullPage changeset to reference PluginHeader

### DIFF
--- a/.changeset/afraid-rats-invent.md
+++ b/.changeset/afraid-rats-invent.md
@@ -2,10 +2,10 @@
 '@backstage/ui': patch
 ---
 
-Added a new `FullPage` component that fills the remaining viewport height below the `Header`.
+Added a new `FullPage` component that fills the remaining viewport height below the `PluginHeader`.
 
 ```tsx
-<Header title="My Plugin" tabs={tabs} />
+<PluginHeader title="My Plugin" tabs={tabs} />
 <FullPage>
   {/* content fills remaining height */}
 </FullPage>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Missed this as part of #32875.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
