### PR TITLE
Add branch field to config schema for Azure catalog provider

### DIFF
--- a/.changeset/thin-parents-hug.md
+++ b/.changeset/thin-parents-hug.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-azure': patch
+---
+
+Added missing `branch` field to the `azureDevOps` provider config schema.

--- a/plugins/catalog-backend-module-azure/config.d.ts
+++ b/plugins/catalog-backend-module-azure/config.d.ts
@@ -45,6 +45,10 @@ export interface Config {
            */
           repository?: string;
           /**
+           * (Optional) The name of a branch to use. If not set, defaults to the default branch of the repository.
+           */
+          branch?: string;
+          /**
            * (Optional) Where to find catalog-info.yaml files. Wildcards are supported.
            * If not set, defaults to /catalog-info.yaml.
            */


### PR DESCRIPTION
## Hey, I just made a Pull Request!

A branch filter was added to the Azure catalog provider in https://github.com/backstage/backstage/pull/16749, but the property was never included in the config schema for the module. This PR just adds that in for completeness.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
