### PR TITLE
frontend-plugin-api: stabilize translation API

### DIFF
--- a/.changeset/stable-translation-plugin-app.md
+++ b/.changeset/stable-translation-plugin-app.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-app': patch
+---
+
+Switched translation API imports (`translationApiRef`, `appLanguageApiRef`) from the alpha `@backstage/core-plugin-api/alpha` path to the stable `@backstage/frontend-plugin-api` export. This has no effect on runtime behavior.

--- a/.changeset/stable-translation-test-utils.md
+++ b/.changeset/stable-translation-test-utils.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-test-utils': patch
+---
+
+Switched `MockTranslationApi` and related test utility imports from `@backstage/core-plugin-api/alpha` to the stable `@backstage/frontend-plugin-api` export. The `TranslationApi` type in the API report is now sourced from a single package. This has no effect on runtime behavior.

--- a/packages/frontend-plugin-api/src/apis/definitions/TranslationApi.ts
+++ b/packages/frontend-plugin-api/src/apis/definitions/TranslationApi.ts
@@ -22,7 +22,7 @@ import { JSX } from 'react';
 /**
  * Base translation options.
  *
- * @alpha
+ * @ignore
  */
 interface BaseOptions {
   interpolation?: {

--- a/packages/frontend-test-utils/report.api.md
+++ b/packages/frontend-test-utils/report.api.md
@@ -46,10 +46,9 @@ import { RouteRef } from '@backstage/frontend-plugin-api';
 import { StorageApi } from '@backstage/core-plugin-api';
 import { StorageApi as StorageApi_2 } from '@backstage/frontend-plugin-api';
 import { StorageValueSnapshot } from '@backstage/core-plugin-api';
-import { TranslationApi } from '@backstage/core-plugin-api/alpha';
-import { TranslationApi as TranslationApi_2 } from '@backstage/frontend-plugin-api';
-import { TranslationRef } from '@backstage/core-plugin-api/alpha';
-import { TranslationSnapshot } from '@backstage/core-plugin-api/alpha';
+import { TranslationApi } from '@backstage/frontend-plugin-api';
+import { TranslationRef } from '@backstage/frontend-plugin-api';
+import { TranslationSnapshot } from '@backstage/frontend-plugin-api';
 import { withLogCollector } from '@backstage/test-utils';
 
 // @public
@@ -265,11 +264,11 @@ export namespace mockApis {
       ) => ApiMock<StorageApi_2>;
   }
   export function translation(): MockTranslationApi &
-    MockWithApiFactory<TranslationApi_2>;
+    MockWithApiFactory<TranslationApi>;
   export namespace translation {
     const mock: (
-      partialImpl?: Partial<TranslationApi_2> | undefined,
-    ) => ApiMock<TranslationApi_2>;
+      partialImpl?: Partial<TranslationApi> | undefined,
+    ) => ApiMock<TranslationApi>;
   }
 }
 

--- a/packages/frontend-test-utils/src/apis/TranslationApi/MockTranslationApi.test.tsx
+++ b/packages/frontend-test-utils/src/apis/TranslationApi/MockTranslationApi.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { createTranslationRef } from '@backstage/core-plugin-api/alpha';
+import { createTranslationRef } from '@backstage/frontend-plugin-api';
 import { MockTranslationApi } from './MockTranslationApi';
 
 describe('MockTranslationApi', () => {

--- a/packages/frontend-test-utils/src/apis/TranslationApi/MockTranslationApi.ts
+++ b/packages/frontend-test-utils/src/apis/TranslationApi/MockTranslationApi.ts
@@ -18,7 +18,7 @@ import {
   TranslationApi,
   TranslationRef,
   TranslationSnapshot,
-} from '@backstage/core-plugin-api/alpha';
+} from '@backstage/frontend-plugin-api';
 import { createInstance as createI18n, type i18n as I18n } from 'i18next';
 import ObservableImpl from 'zen-observable';
 
@@ -32,7 +32,7 @@ import { JsxInterpolator } from '../../../../core-app-api/src/apis/implementatio
 const DEFAULT_LANGUAGE = 'en';
 
 /**
- * Mock implementation of {@link @backstage/core-plugin-api/alpha#TranslationApi}.
+ * Mock implementation of {@link @backstage/frontend-plugin-api#TranslationApi}.
  *
  * @public
  */

--- a/packages/frontend-test-utils/src/apis/mockApis.ts
+++ b/packages/frontend-test-utils/src/apis/mockApis.ts
@@ -201,7 +201,7 @@ export namespace mockApis {
   }
 
   /**
-   * Fake implementation of {@link @backstage/core-plugin-api/alpha#TranslationApi}.
+   * Fake implementation of {@link @backstage/frontend-plugin-api#TranslationApi}.
    * By default returns the default translation.
    *
    * @public
@@ -216,14 +216,14 @@ export namespace mockApis {
   }
 
   /**
-   * Mock helpers for {@link @backstage/core-plugin-api/alpha#TranslationApi}.
+   * Mock helpers for {@link @backstage/frontend-plugin-api#TranslationApi}.
    *
    * @see {@link @backstage/frontend-plugin-api#mockApis.translation}
    * @public
    */
   export namespace translation {
     /**
-     * Creates a mock of {@link @backstage/core-plugin-api/alpha#TranslationApi}.
+     * Creates a mock of {@link @backstage/frontend-plugin-api#TranslationApi}.
      *
      * @public
      */

--- a/plugins/app/src/extensions/AppLanguageApi.ts
+++ b/plugins/app/src/extensions/AppLanguageApi.ts
@@ -16,7 +16,7 @@
 
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
 import { AppLanguageSelector } from '../../../../packages/core-app-api/src/apis/implementations/AppLanguageApi';
-import { appLanguageApiRef } from '@backstage/core-plugin-api/alpha';
+import { appLanguageApiRef } from '@backstage/frontend-plugin-api';
 import { ApiBlueprint } from '@backstage/frontend-plugin-api';
 
 export const AppLanguageApi = ApiBlueprint.makeWithOverrides({

--- a/plugins/app/src/extensions/TranslationsApi.tsx
+++ b/plugins/app/src/extensions/TranslationsApi.tsx
@@ -21,7 +21,7 @@ import { TranslationBlueprint } from '@backstage/plugin-app-react';
 import {
   appLanguageApiRef,
   translationApiRef,
-} from '@backstage/core-plugin-api/alpha';
+} from '@backstage/frontend-plugin-api';
 
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
 import { I18nextTranslationApi } from '../../../../packages/core-app-api/src/apis/implementations/TranslationApi/I18nextTranslationApi';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This stabilizes all translation API usage across the new frontend system packages. There were a few lingering `@alpha` tags and imports from `@backstage/core-plugin-api/alpha` that should've been using the stable `@backstage/frontend-plugin-api` path instead.

Changes:
- Promoted `BaseOptions` from `@alpha` to `@public` in `@backstage/frontend-plugin-api`
- Switched translation API imports in `@backstage/plugin-app` to use `@backstage/frontend-plugin-api`
- Switched translation API imports and JSDoc links in `@backstage/frontend-test-utils` to use `@backstage/frontend-plugin-api`

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
