### PR TITLE
microsite: fix broken office hours links

### DIFF
--- a/docs/overview/roadmap.md
+++ b/docs/overview/roadmap.md
@@ -55,4 +55,4 @@ guidelines to get started.
 
 If you have specific questions about the roadmap, please create an
 [issue](https://github.com/backstage/backstage/issues/new/choose), ping us on
-[Discord](https://discord.gg/backstage-687207715902193673), or [book time](https://info.backstage.spotify.com/office-hours) with the Spotify team.
+[Discord](https://discord.gg/backstage-687207715902193673), or [book time](https://spoti.fi/backstageofficehours) with the Spotify team.

--- a/microsite/blog/2023-06-21-switching-out-sandbox.mdx
+++ b/microsite/blog/2023-06-21-switching-out-sandbox.mdx
@@ -71,4 +71,4 @@ This change comes with the v1.15.0 release of Backstage that was released yester
 
 For more guidance on how to upgrade, check out the documentation for [keeping Backstage updated](https://backstage.io/docs/getting-started/keeping-backstage-updated).
 
-If you have any further questions you can either reach out to us in the [Community Discord](https://discord.gg/backstage-687207715902193673), or in the [office hours](https://info.backstage.spotify.com/office-hours).
+If you have any further questions you can either reach out to us in the [Community Discord](https://discord.gg/backstage-687207715902193673), or in the [office hours](https://spoti.fi/backstageofficehours).

--- a/microsite/blog/2023-09-29-chicago-traiding-company-adopter-spotlight.mdx
+++ b/microsite/blog/2023-09-29-chicago-traiding-company-adopter-spotlight.mdx
@@ -57,4 +57,4 @@ Finally, don't be afraid to step outside the core use cases when it comes to the
 
 Interested in more stories from Backstage adopters? Check out these recent posts from [Stash](https://backstage.io/blog/2023/07/08/stash-adopter-post) and [Expedia Group](https://backstage.io/blog/2023/08/17/expedia-proof-of-value-metrics-2).
 
-Want to learn more about Backstage? Join our weekly [Office Hours](https://info.backstage.spotify.com/office-hours) and bring your burning questions.
+Want to learn more about Backstage? Join our weekly [Office Hours](https://spoti.fi/backstageofficehours) and bring your burning questions.

--- a/microsite/src/pages/home/_home.tsx
+++ b/microsite/src/pages/home/_home.tsx
@@ -84,7 +84,7 @@ const HomePage = () => {
                   label: 'GITHUB',
                 },
                 {
-                  link: 'https://info.backstage.spotify.com/office-hours',
+                  link: 'https://spoti.fi/backstageofficehours',
                   label: 'OFFICE HOURS',
                 },
               ]}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The office hours links across the microsite were pointing to `https://info.backstage.spotify.com/office-hours` which is broken. This updates them to `https://spoti.fi/backstageofficehours`.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
