### PR TITLE
fix: restored vertical spacing between tags in catalog table

### DIFF
--- a/plugins/catalog/src/components/CatalogTable/columns.tsx
+++ b/plugins/catalog/src/components/CatalogTable/columns.tsx
@@ -174,7 +174,7 @@ export const columnFactories = Object.freeze({
                 label={t}
                 size="small"
                 variant="outlined"
-                style={{ marginBottom: '0px' }}
+                style={{ marginBottom: '4px' }}
               />
             ))}
         </>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#### :heavy_check_mark: Checklist
Fixes the issue where tags in the catalog component list had no vertical spacing when they wrapped to multiple lines. Changed from 0px to 4px.
This change only affects the styling of the tags in the catalog table and does not impact any backend logic.

<!--- Please include the following in your Pull Request when applicable: -->
![SWEOpenSource](https://github.com/user-attachments/assets/b19cb678-2560-4981-a425-9878083164f6)


- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
[ :heavy_check_mark:]  Screenshots attached (for UI changes)
(https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
