### PR TITLE
docs: add missing sharing extensions sidebar item

### DIFF
--- a/.patches/pr-32903.txt
+++ b/.patches/pr-32903.txt
@@ -1,0 +1,1 @@
+Add missing sharing extensions sidebar item in frontend system architecture docs

--- a/microsite/sidebars.ts
+++ b/microsite/sidebars.ts
@@ -556,6 +556,7 @@ export default {
                 'frontend-system/architecture/extensions',
                 'frontend-system/architecture/extension-blueprints',
                 'frontend-system/architecture/extension-overrides',
+                'frontend-system/architecture/sharing-extensions',
                 'frontend-system/architecture/references',
                 'frontend-system/architecture/utility-apis',
                 'frontend-system/architecture/routes',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The "Sharing Extensions" architecture doc (`docs/frontend-system/architecture/27-sharing-extensions.md`) exists but was missing from the sidebar in the microsite, so there was no way to navigate to it. This adds it in its expected position between "Extension Overrides" and "References".

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
