### PR TITLE
frontend-plugin-api: fix type compat for older plugins in FrontendFeature

### DIFF
--- a/.changeset/fix-frontend-feature-compat.md
+++ b/.changeset/fix-frontend-feature-compat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': patch
+---
+
+Made the `pluginId` property optional in the `FrontendFeature` type, allowing plugins published against older versions of the framework to be used without type errors.

--- a/.patches/pr-32905.txt
+++ b/.patches/pr-32905.txt
@@ -1,0 +1,1 @@
+Fix type compatibility for older plugins in FrontendFeature type

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -1336,7 +1336,11 @@ export type FetchApi = {
 export const fetchApiRef: ApiRef<FetchApi>;
 
 // @public (undocumented)
-export type FrontendFeature = FrontendPlugin | FrontendModule;
+export type FrontendFeature =
+  | (Omit<FrontendPlugin, 'pluginId'> & {
+      pluginId?: string;
+    })
+  | FrontendModule;
 
 // @public (undocumented)
 export interface FrontendFeatureLoader {

--- a/packages/frontend-plugin-api/src/wiring/types.ts
+++ b/packages/frontend-plugin-api/src/wiring/types.ts
@@ -73,4 +73,6 @@ export type ExtensionFactoryMiddleware = (
 ) => Iterable<ExtensionDataValue<any, any>>;
 
 /** @public  */
-export type FrontendFeature = FrontendPlugin | FrontendModule;
+export type FrontendFeature =
+  | (Omit<FrontendPlugin, 'pluginId'> & { pluginId?: string })
+  | FrontendModule;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes a type compatibility issue where community plugins published against older versions of `@backstage/frontend-plugin-api` (e.g. `^0.13.4`) can't be used in apps on the latest release (`0.14.0`). The `pluginId` property was added as required to `FrontendPlugin`, which means old compiled `.d.ts` files that don't include it fail to satisfy the `FrontendFeature` type used in `createApp({ features: [...] })`.

The fix makes `pluginId` optional in the `FrontendFeature` union type only, keeping it required on `FrontendPlugin` itself so it's always available when accessing plugins through the app tree. The runtime backfill in `resolveAppNodeSpecs` already handles old plugins by copying `id` to `pluginId`.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))