### PR TITLE
[Docs] fix danger note taking the whole section on database configuration

### DIFF
--- a/docs/getting-started/config/database.md
+++ b/docs/getting-started/config/database.md
@@ -106,6 +106,8 @@ When filling these out, you have 2 choices,
 
 If you opt for the second option of replacing the entire string, take care to not commit your `app-config.yaml` to source control. It may contain passwords that you don't want leaked.
 
+:::
+
 ## Passwordless PostgreSQL in the Cloud
 
 If you want to host your PostgreSQL server in the cloud with passwordless authentication, you can use Azure Database for PostgreSQL with Microsoft Entra authentication or Google Cloud SQL for PostgreSQL with Cloud IAM.
@@ -187,8 +189,6 @@ backend:
       password: ${POSTGRES_PASSWORD}
       # highlight-remove-end
 ```
-
-:::
 
 [Start the Backstage app](../index.md#2-run-the-backstage-app):
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

While adding the new database configuration options the "danger" note was taking all the new content. this close the danger note bracket on the right place

| prev | new |
| --- | --- |
|<img width="2072" height="1638" alt="image" src="https://github.com/user-attachments/assets/6f6084da-5605-4796-830e-c30666ae3a00" />| <img width="2040" height="1536" alt="image" src="https://github.com/user-attachments/assets/eecf75a6-1d69-4eae-8cd4-5f63eeb61720" /> |

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
