### PR TITLE
Fix getLocations in ReadWriteSplitCatalogService

### DIFF
--- a/contrib/catalog/read-write-split/workspace/packages/backend/src/catalogService.ts
+++ b/contrib/catalog/read-write-split/workspace/packages/backend/src/catalogService.ts
@@ -142,7 +142,7 @@ export class ReadWriteSplitCatalogService implements CatalogService {
   }
 
   async getLocations(
-    request: object | undefined,
+    request: {} | undefined,
     options: CatalogServiceRequestOptions,
   ): Promise<GetLocationsResponse> {
     return this.#catalogRead.getLocations(


### PR DESCRIPTION
This pull request updates the `getLocations` method signature in the `ReadWriteSplitCatalogService` implementation to align with the expected `#catalogRead.getLocations` parameters.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
