### PR TITLE
fix: default pg connection config:check type

### DIFF
--- a/.changeset/pretty-days-taste.md
+++ b/.changeset/pretty-days-taste.md
@@ -1,0 +1,7 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Fixed `yarn backstage-cli config:check --strict --config app-config.yaml` config validation error by adding
+an optional `default` type discriminator to PostgreSQL connection configuration,
+allowing `config:check` to properly validate `default` connection configurations.

--- a/packages/backend-defaults/config.d.ts
+++ b/packages/backend-defaults/config.d.ts
@@ -634,6 +634,10 @@ export interface Config {
           }
         | {
             /**
+             * The rest config for default, regular connections
+             */
+            type?: 'default';
+            /**
              * Password that belongs to the client User
              * @visibility secret
              */


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Maybe this [PR](https://github.com/backstage/backstage/pull/31855) broke the config check:

```
yarn backstage-cli config:check --strict --config app-config.yaml
```

I'm trying to refine it with this PR.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
