### PR TITLE
Catalog - Deprecated two moved processors

### DIFF
--- a/.changeset/rare-falcons-pump.md
+++ b/.changeset/rare-falcons-pump.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Deprecated two processors as they have been moved to the Community Plugins repo with their own backend modules:
+
+- `AnnotateScmSlugEntityProcessor`: Use `@backstage-community/plugin-catalog-backend-module-annotate-scm-slug` instead
+- `CodeOwnersProcessor`: Use `@backstage-community/plugin-catalog-backend-module-codeowners` instead

--- a/plugins/catalog-backend/report.api.md
+++ b/plugins/catalog-backend/report.api.md
@@ -31,7 +31,7 @@ export class AnnotateLocationEntityProcessor implements CatalogProcessor {
   ): Promise<Entity>;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export class AnnotateScmSlugEntityProcessor implements CatalogProcessor {
   constructor(opts: {
     scmIntegrationRegistry: ScmIntegrationRegistry;
@@ -76,7 +76,7 @@ export const CATALOG_ERRORS_TOPIC = 'experimental.catalog.errors';
 const catalogPlugin: BackendFeature;
 export default catalogPlugin;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export class CodeOwnersProcessor implements CatalogProcessor {
   constructor(options: {
     integrations: ScmIntegrationRegistry;

--- a/plugins/catalog-backend/src/processors/AnnotateScmSlugEntityProcessor.ts
+++ b/plugins/catalog-backend/src/processors/AnnotateScmSlugEntityProcessor.ts
@@ -29,7 +29,10 @@ const GITHUB_ACTIONS_ANNOTATION = 'github.com/project-slug';
 const GITLAB_ACTIONS_ANNOTATION = 'gitlab.com/project-slug';
 const AZURE_ACTIONS_ANNOTATION = 'dev.azure.com/project-repo';
 
-/** @public */
+/**
+ * @public
+ * @deprecated Use `@backstage-community/plugin-catalog-backend-module-annotate-scm-slug` instead, this will be removed in a future release
+ */
 export class AnnotateScmSlugEntityProcessor implements CatalogProcessor {
   private readonly opts: {
     scmIntegrationRegistry: ScmIntegrationRegistry;

--- a/plugins/catalog-backend/src/processors/CodeOwnersProcessor.ts
+++ b/plugins/catalog-backend/src/processors/CodeOwnersProcessor.ts
@@ -28,7 +28,10 @@ import { LoggerService, UrlReaderService } from '@backstage/backend-plugin-api';
 const ALLOWED_KINDS = ['API', 'Component', 'Domain', 'Resource', 'System'];
 const ALLOWED_LOCATION_TYPES = ['url'];
 
-/** @public */
+/**
+ * @public
+ * @deprecated Use `@backstage-community/plugin-catalog-backend-module-codeowners` instead, this will be removed in a future release
+ */
 export class CodeOwnersProcessor implements CatalogProcessor {
   private readonly integrations: ScmIntegrationRegistry;
   private readonly logger: LoggerService;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Deprecated two processors as they have been moved to the Community Plugins repo with their own backend modules:

- `AnnotateScmSlugEntityProcessor`: Use `@backstage-community/plugin-catalog-backend-module-annotate-scm-slug` instead
- `CodeOwnersProcessor`: Use `@backstage-community/plugin-catalog-backend-module-codeowners` instead

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
