### PR TITLE
docs(techdocs): fix incorrect S3 IAM permission (PutObjectAcl)

### DIFF
--- a/docs/features/techdocs/using-cloud-storage.md
+++ b/docs/features/techdocs/using-cloud-storage.md
@@ -207,7 +207,7 @@ If you need to migrate documentation objects from an older-style path
 format including case-sensitive entity metadata, you will need to add some
 additional permissions to be able to perform the migration, including:
 
-- `s3:PutBucketAcl` (for copying files,
+- `s3:PutObjectAcl` (for copying files,
   [more info here](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectAcl.html))
 - `s3:DeleteObject` and `s3:DeleteObjectVersion` (for deleting migrated files,
   [more info here](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html))


### PR DESCRIPTION
#### Summary

Fix incorrect IAM action in the “Configuring AWS S3 Bucket with TechDocs” documentation.

#### What changed

* Replaced `s3:PutBucketAcl` with `s3:PutObjectAcl` in the migration note under the AWS S3 configuration section.

#### Why

The documentation referenced `s3:PutBucketAcl`, but the correct IAM permission for copying or updating object ACLs during migration is `s3:PutObjectAcl`.

Fixes #32925
