### PR TITLE
fix(cli): add config schema validation to repo fix command

### DIFF
--- a/.changeset/fix-config-schema-validation.md
+++ b/.changeset/fix-config-schema-validation.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Added config schema validation to `repo fix` command. When a package contains a `config.d.ts` file, the fixer ensures that `configSchema` in `package.json` references it and that it is included in the `files` array.

--- a/packages/cli/src/modules/maintenance/commands/repo/fix.ts
+++ b/packages/cli/src/modules/maintenance/commands/repo/fix.ts
@@ -31,6 +31,7 @@ import {
 } from 'node:path';
 import { paths } from '../../../../lib/paths';
 import { publishPreflightCheck } from '../../lib/publishing';
+import { fixConfigSchema } from './fixConfigSchema';
 
 const SCRIPT_EXTS = ['.js', '.jsx', '.ts', '.tsx', '.json'];
 
@@ -497,7 +498,11 @@ export async function command(opts: OptionValues): Promise<void> {
   const packages = await readFixablePackages();
   const fixRepositoryField = createRepositoryFieldFixer();
 
-  const fixers: PackageFixer[] = [fixPackageExports, fixSideEffects];
+  const fixers: PackageFixer[] = [
+    fixPackageExports,
+    fixSideEffects,
+    fixConfigSchema,
+  ];
 
   // Fixers that only apply to repos that publish packages
   if (opts.publish) {

--- a/packages/cli/src/modules/maintenance/commands/repo/fixConfigSchema.test.ts
+++ b/packages/cli/src/modules/maintenance/commands/repo/fixConfigSchema.test.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createMockDirectory } from '@backstage/backend-test-utils';
+import { BackstagePackageJson } from '@backstage/cli-node';
+import { fixConfigSchema } from './fixConfigSchema';
+import { FixablePackage } from './fix';
+
+function createFixablePackage(
+  dir: string,
+  packageJson: Partial<BackstagePackageJson>,
+): FixablePackage {
+  return {
+    dir,
+    packageJson: {
+      name: 'test-package',
+      version: '0.0.0',
+      ...packageJson,
+    } as BackstagePackageJson,
+    changed: false,
+  };
+}
+
+describe('fixConfigSchema', () => {
+  const mockDir = createMockDirectory();
+
+  afterEach(() => {
+    mockDir.clear();
+  });
+
+  it('should do nothing if config.d.ts does not exist', () => {
+    mockDir.setContent({
+      'package.json': JSON.stringify({ name: 'test', version: '0.0.0' }),
+    });
+
+    const pkg = createFixablePackage(mockDir.path, {});
+    fixConfigSchema(pkg);
+    expect(pkg.changed).toBe(false);
+  });
+
+  it('should add configSchema and files entry when config.d.ts exists but is not referenced', () => {
+    mockDir.setContent({
+      'config.d.ts': 'export interface Config {}',
+      'package.json': JSON.stringify({ name: 'test', version: '0.0.0' }),
+    });
+
+    const pkg = createFixablePackage(mockDir.path, {});
+    fixConfigSchema(pkg);
+    expect(pkg.changed).toBe(true);
+    expect((pkg.packageJson as any).configSchema).toBe('config.d.ts');
+    expect(pkg.packageJson.files).toContain('config.d.ts');
+  });
+
+  it('should add config.d.ts to files array when configSchema is correct but files is missing it', () => {
+    mockDir.setContent({
+      'config.d.ts': 'export interface Config {}',
+      'package.json': JSON.stringify({
+        name: 'test',
+        version: '0.0.0',
+        configSchema: 'config.d.ts',
+        files: ['dist'],
+      }),
+    });
+
+    const pkg = createFixablePackage(mockDir.path, {
+      configSchema: 'config.d.ts',
+      files: ['dist'],
+    });
+    fixConfigSchema(pkg);
+    expect(pkg.changed).toBe(true);
+    expect(pkg.packageJson.files).toContain('config.d.ts');
+    expect(pkg.packageJson.files).toContain('dist');
+  });
+
+  it('should not mark changed if everything is already correct', () => {
+    mockDir.setContent({
+      'config.d.ts': 'export interface Config {}',
+      'package.json': JSON.stringify({
+        name: 'test',
+        version: '0.0.0',
+        configSchema: 'config.d.ts',
+        files: ['dist', 'config.d.ts'],
+      }),
+    });
+
+    const pkg = createFixablePackage(mockDir.path, {
+      configSchema: 'config.d.ts',
+      files: ['dist', 'config.d.ts'],
+    });
+    fixConfigSchema(pkg);
+    expect(pkg.changed).toBe(false);
+  });
+
+  it('should skip validation when configSchema is an inline object', () => {
+    mockDir.setContent({
+      'config.d.ts': 'export interface Config {}',
+      'package.json': JSON.stringify({
+        name: 'test',
+        version: '0.0.0',
+        configSchema: { type: 'object' },
+      }),
+    });
+
+    const pkg = createFixablePackage(mockDir.path, {
+      configSchema: { type: 'object' } as any,
+    });
+    fixConfigSchema(pkg);
+    expect(pkg.changed).toBe(false);
+  });
+
+  it('should fix configSchema when it points to a wrong path', () => {
+    mockDir.setContent({
+      'config.d.ts': 'export interface Config {}',
+      'package.json': JSON.stringify({
+        name: 'test',
+        version: '0.0.0',
+        configSchema: 'wrong-config.d.ts',
+        files: ['dist'],
+      }),
+    });
+
+    const pkg = createFixablePackage(mockDir.path, {
+      configSchema: 'wrong-config.d.ts',
+      files: ['dist'],
+    });
+    fixConfigSchema(pkg);
+    expect(pkg.changed).toBe(true);
+    expect((pkg.packageJson as any).configSchema).toBe('config.d.ts');
+    expect(pkg.packageJson.files).toContain('config.d.ts');
+  });
+});

--- a/packages/cli/src/modules/maintenance/commands/repo/fixConfigSchema.ts
+++ b/packages/cli/src/modules/maintenance/commands/repo/fixConfigSchema.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { resolve as resolvePath } from 'node:path';
+import fs from 'fs-extra';
+import { FixablePackage } from './fix';
+
+/**
+ * Ensures that packages with a config.d.ts file have the correct
+ * configSchema and files entries in their package.json.
+ *
+ * - If config.d.ts exists, configSchema must reference it.
+ * - If config.d.ts exists, it must be listed in the files array.
+ * - If configSchema references a file, that file must be in the files array.
+ */
+export function fixConfigSchema(pkg: FixablePackage) {
+  const hasConfigDts = fs.pathExistsSync(
+    resolvePath(pkg.dir, 'config.d.ts'),
+  );
+
+  const configSchemaVal = pkg.packageJson.configSchema;
+
+  // If configSchema is an inline object (not a string path), skip validation
+  if (configSchemaVal !== undefined && typeof configSchemaVal === 'object') {
+    return;
+  }
+
+  const configSchemaPath =
+    typeof configSchemaVal === 'string' && configSchemaVal.trim().length > 0
+      ? configSchemaVal
+      : undefined;
+
+  if (!hasConfigDts) {
+    return;
+  }
+
+  // Ensure files array exists
+  if (!Array.isArray(pkg.packageJson.files)) {
+    pkg.packageJson.files = [];
+  }
+
+  const filesArray = pkg.packageJson.files as string[];
+
+  // Fix configSchema to point to config.d.ts
+  if (configSchemaPath !== 'config.d.ts') {
+    (pkg.packageJson as any).configSchema = 'config.d.ts';
+    pkg.changed = true;
+  }
+
+  // Add config.d.ts to the files array if missing
+  if (!filesArray.includes('config.d.ts')) {
+    filesArray.push('config.d.ts');
+    pkg.changed = true;
+  }
+}


### PR DESCRIPTION
## What this PR does

This adds a config schema validation step to the ackstage-cli repo fix command.

When a package contains a config.d.ts file, the fixer ensures that:
- The configSchema property in package.json points to config.d.ts
- The config.d.ts file is included in the iles array

If the configSchema is an inline JSON object (not a file path), validation is skipped since file-level checks don't apply.

This helps prevent common mistakes where plugin authors forget to properly reference their config schema definitions in package.json, which can lead to missing configuration at runtime.

### Changes

- **New**: ixConfigSchema.ts - Fixer function that auto-corrects config schema references
- **New**: ixConfigSchema.test.ts - Unit tests covering all validation scenarios
- **Modified**: ix.ts - Added ixConfigSchema to the list of fixers

### Why epo fix instead of lint

Per feedback from @Rugvip, this is better suited as part of the existing epo fix infrastructure rather than a standalone lint check, since:
- It executes very fast
- It can auto-fix issues rather than just reporting them
- It aligns with the plan to move non-ESLint checks to unified tooling

Fixes #32951

---

- [x] I have read the [Code of Conduct](https://github.com/backstage/backstage/blob/master/CODE_OF_CONDUCT.md)
- [x] I have read the [Contributing](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md) document
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have added a changeset describing my changes