### PR TITLE
Add n8n to plugin directory

### DIFF
--- a/microsite/data/plugins/n8n.yaml
+++ b/microsite/data/plugins/n8n.yaml
@@ -1,0 +1,11 @@
+---
+title: n8n
+author: André Ahlert Junior
+authorUrl: https://github.com/andreahlert
+category: Other
+description: n8n workflow automation — view workflows and execution history on Backstage entity pages.
+documentation: https://github.com/backstage/community-plugins/tree/main/workspaces/n8n/plugins/n8n
+iconUrl: /img/logo-gradient-on-dark.svg
+npmPackageName: '@backstage-community/plugin-n8n'
+addedDate: '2026-02-15'
+status: active


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds the n8n workflow automation plugin to the [Plugin Directory](https://backstage.io/plugins). The plugin lives in [backstage/community-plugins](https://github.com/backstage/community-plugins) (merged in [#7522](https://github.com/backstage/community-plugins/pull/7522)) and is published on npm as \@backstage-community/plugin-n8n\.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a \Signed-off-by\ line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))