### PR TITLE
scaffolder: add back form fields API alpha exports

### DIFF
--- a/.changeset/scaffolder-export-form-fields-api.md
+++ b/.changeset/scaffolder-export-form-fields-api.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Added back the `formFieldsApiRef` and `ScaffolderFormFieldsApi` alpha exports that were unintentionally removed.

--- a/.patches/pr-32969.txt
+++ b/.patches/pr-32969.txt
@@ -1,0 +1,1 @@
+Add back `formFieldsApiRef` and `ScaffolderFormFieldsApi` alpha exports from `@backstage/plugin-scaffolder`

--- a/plugins/scaffolder/report-alpha.api.md
+++ b/plugins/scaffolder/report-alpha.api.md
@@ -480,6 +480,9 @@ export const formDecoratorsApi: OverridableExtensionDefinition<{
 // @alpha (undocumented)
 export const formDecoratorsApiRef: ApiRef<ScaffolderFormDecoratorsApi>;
 
+// @alpha (undocumented)
+export const formFieldsApiRef: ApiRef<ScaffolderFormFieldsApi>;
+
 // @alpha @deprecated
 export type FormProps = Pick<
   FormProps_2,
@@ -497,6 +500,12 @@ export type ScaffolderCustomFieldExplorerClassKey =
 export interface ScaffolderFormDecoratorsApi {
   // (undocumented)
   getFormDecorators(): Promise<ScaffolderFormDecorator[]>;
+}
+
+// @alpha (undocumented)
+export interface ScaffolderFormFieldsApi {
+  // (undocumented)
+  loadFormFields(): Promise<FormField[]>;
 }
 
 // @public (undocumented)

--- a/plugins/scaffolder/src/alpha/formFieldsApi.ts
+++ b/plugins/scaffolder/src/alpha/formFieldsApi.ts
@@ -19,17 +19,18 @@ import {
   createApiRef,
   createExtensionInput,
 } from '@backstage/frontend-plugin-api';
-import { FormFieldBlueprint } from '@backstage/plugin-scaffolder-react/alpha';
+import {
+  FormFieldBlueprint,
+  type FormField,
+} from '@backstage/plugin-scaffolder-react/alpha';
 import { OpaqueFormField } from '@internal/scaffolder';
 
-interface FormField {
-  readonly $$type: '@backstage/scaffolder/FormField';
-}
-
-interface ScaffolderFormFieldsApi {
+/** @alpha */
+export interface ScaffolderFormFieldsApi {
   loadFormFields(): Promise<FormField[]>;
 }
 
+/** @alpha */
 const formFieldsApiRef = createApiRef<ScaffolderFormFieldsApi>({
   id: 'plugin.scaffolder.form-fields-loader',
 });

--- a/plugins/scaffolder/src/alpha/index.ts
+++ b/plugins/scaffolder/src/alpha/index.ts
@@ -24,5 +24,9 @@ export {
 
 export { scaffolderTranslationRef } from '../translation';
 export * from './api';
+export {
+  formFieldsApiRef,
+  type ScaffolderFormFieldsApi,
+} from './formFieldsApi';
 
 export { default } from './plugin';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds back the `formFieldsApiRef` and `ScaffolderFormFieldsApi` alpha exports from `@backstage/plugin-scaffolder/alpha` that were removed as part of the form fields utility API migration in 1.48. We optimistically removed it as it's a fairly internal API, but have gotten reports that it breaks customization and are adding it back as a public API.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))