### PR TITLE
chore: remove applied patch files

### DIFF
--- a/.patches/pr-32903.txt
+++ b/.patches/pr-32903.txt
@@ -1,1 +1,0 @@
-Add missing sharing extensions sidebar item in frontend system architecture docs

--- a/.patches/pr-32905.txt
+++ b/.patches/pr-32905.txt
@@ -1,1 +1,0 @@
-Fix type compatibility for older plugins in FrontendFeature type

--- a/.patches/pr-32950.txt
+++ b/.patches/pr-32950.txt
@@ -1,1 +1,0 @@
-Updated `@microsoft/api-extractor` to `7.57.3`

--- a/.patches/pr-32969.txt
+++ b/.patches/pr-32969.txt
@@ -1,1 +1,0 @@
-Add back `formFieldsApiRef` and `ScaffolderFormFieldsApi` alpha exports from `@backstage/plugin-scaffolder`


### PR DESCRIPTION
Removes the pending patch files now that they've all been applied in https://github.com/backstage/backstage/pull/32974.