### PR TITLE
Add Form Validations To New Adaptors Form

### DIFF
--- a/microsite/src/pages/home/_hubSpotNewAdoptersForm.tsx
+++ b/microsite/src/pages/home/_hubSpotNewAdoptersForm.tsx
@@ -7,13 +7,19 @@ const MIN_NAME_LENGTH = 2;
 const MAX_NAME_LENGTH = 50;
 const NAME_PATTERN = /^[a-zA-Z\s'-]+$/;
 
+const HUBSPOT_SCRIPT_ID = 'hubspot-forms-script';
+let isFormInitialized = false;
+
 export const HubSpotNewAdoptersForm = () => {
   const [isClosed, setClosed] = useState(true);
 
   useEffect(() => {
+    const eventListeners: Array<{ element: HTMLInputElement; handler: EventListener }> = [];
+    
     const initializeForm = () => {
       // @ts-ignore
-      if (window.hbspt) {
+      if (window.hbspt && !isFormInitialized) {
+        isFormInitialized = true;
 
         const getValidationError = (
           value: string,
@@ -94,17 +100,26 @@ export const HubSpotNewAdoptersForm = () => {
           
           const value = input.value.trim();
           
-          clearValidationError(input);
-          
-          if (!value) return true;
+          if (!value) {
+            clearValidationError(input);
+            return true;
+          }
           
           const errorMessage = getValidationError(value, fieldName, requireMinLength);
+          const existingError = input.parentElement?.querySelector(
+            '.hs-error-msgs.custom-validation .hs-error-msg'
+          );
+          const currentErrorText = existingError?.textContent;
           
           if (errorMessage) {
-            showValidationError(input, errorMessage);
+            if (currentErrorText !== errorMessage) {
+              clearValidationError(input);
+              showValidationError(input, errorMessage);
+            }
             return false;
           }
           
+          clearValidationError(input);
           return true;
         };
         
@@ -118,24 +133,20 @@ export const HubSpotNewAdoptersForm = () => {
             const firstNameInput = $form.querySelector('input[name="firstname"]') as HTMLInputElement | null;
             const lastNameInput = $form.querySelector('input[name="lastname"]') as HTMLInputElement | null;
             
-            const createBlurHandler = (
-              input: HTMLInputElement,
-              fieldName: string,
-              requireMinLength: boolean,
-            ) => {
-              return () => {
-                validateName(input, fieldName, requireMinLength);
-              };
-            };
-            
             if (firstNameInput) {
-              const firstNameHandler = createBlurHandler(firstNameInput, 'First name', true);
+              const firstNameHandler = () => {
+                validateName(firstNameInput, 'First name', true);
+              };
               firstNameInput.addEventListener('blur', firstNameHandler);
+              eventListeners.push({ element: firstNameInput, handler: firstNameHandler });
             }
             
             if (lastNameInput) {
-              const lastNameHandler = createBlurHandler(lastNameInput, 'Last name', false);
+              const lastNameHandler = () => {
+                validateName(lastNameInput, 'Last name', false);
+              };
               lastNameInput.addEventListener('blur', lastNameHandler);
+              eventListeners.push({ element: lastNameInput, handler: lastNameHandler });
             }
           },
           onFormSubmit: function($form: HTMLFormElement) {
@@ -171,13 +182,14 @@ export const HubSpotNewAdoptersForm = () => {
       }
     };
     
-    const HUBSPOT_SCRIPT_ID = 'hubspot-forms-script';
+    let script: HTMLScriptElement | null = null;
+    let handleLoad: (() => void) | null = null;
     
     // @ts-ignore
     if (window.hbspt) {
       initializeForm();
     } else {
-      let script = document.getElementById(HUBSPOT_SCRIPT_ID) as HTMLScriptElement | null;
+      script = document.getElementById(HUBSPOT_SCRIPT_ID) as HTMLScriptElement | null;
       
       if (!script) {
         script = document.createElement('script');
@@ -186,16 +198,22 @@ export const HubSpotNewAdoptersForm = () => {
         document.body.appendChild(script);
       }
       
-      const handleLoad = () => {
+      handleLoad = () => {
         initializeForm();
       };
       
       script.addEventListener('load', handleLoad);
-      
-      return () => {
-        script?.removeEventListener('load', handleLoad);
-      };
     }
+    
+    return () => {
+      if (script && handleLoad) {
+        script.removeEventListener('load', handleLoad);
+      }
+      eventListeners.forEach(({ element, handler }) => {
+        element.removeEventListener('blur', handler as EventListener);
+      });
+      isFormInitialized = false;
+    };
   }, []);
 
   return (

--- a/microsite/src/pages/home/_hubSpotNewAdoptersForm.tsx
+++ b/microsite/src/pages/home/_hubSpotNewAdoptersForm.tsx
@@ -51,7 +51,9 @@ export const HubSpotNewAdoptersForm = () => {
           }
           input.classList.remove('custom-invalid');
           
-          if (!value) return true;
+           if (!value) {
+            return !requireMinLength;
+          }
           
           const errorMessage = getValidationError(value, fieldName, requireMinLength);
           

--- a/microsite/src/pages/home/_hubSpotNewAdoptersForm.tsx
+++ b/microsite/src/pages/home/_hubSpotNewAdoptersForm.tsx
@@ -20,6 +20,75 @@ export const HubSpotNewAdoptersForm = () => {
           formId: '9a5aa2af-87f3-4a44-819f-88ee243bb61e',
           target: `.${hubSpotStyles.hubSpotNewAdopterFormContent}`,
           pageId: '79735607665',
+          onFormReady: function($form) {
+            const firstNameInput = $form.querySelector('input[name="firstname"]');
+            const lastNameInput = $form.querySelector('input[name="lastname"]');
+            
+            const validateName = (input, fieldName, requireMinLength = true) => {
+              if (!input) return;
+              
+              input.addEventListener('blur', function() {
+                const value = this.value.trim();
+                const existingError = input.parentElement.querySelector('.hs-error-msgs.custom-validation');
+                if (existingError) {
+                  existingError.remove();
+                }
+                input.classList.remove('custom-invalid');
+                
+                if (!value) return;
+                
+                let errorMessage = '';
+                
+                if (requireMinLength && value.length < 2) {
+                  errorMessage = `${fieldName} must be at least 2 characters`;
+                } else if (value.length > 50) {
+                  errorMessage = `${fieldName} must be less than 50 characters`;
+                } else if (!/^[a-zA-Z\s'-]+$/.test(value)) {
+                  errorMessage = `${fieldName} can only contain letters, spaces, hyphens, and apostrophes`;
+                }
+                
+                if (errorMessage) {
+                  const errorElement = document.createElement('ul');
+                  errorElement.className = 'hs-error-msgs inputs-list custom-validation';
+                  errorElement.setAttribute('role', 'alert');
+                  const errorItem = document.createElement('li');
+                  const errorLabel = document.createElement('label');
+                  errorLabel.className = 'hs-error-msg';
+                  errorLabel.textContent = errorMessage;
+                  errorItem.appendChild(errorLabel);
+                  errorElement.appendChild(errorItem);
+                  input.parentElement.appendChild(errorElement);
+                  input.classList.add('custom-invalid');
+                }
+              });
+            };
+            
+            validateName(firstNameInput, 'First name', true);
+            validateName(lastNameInput, 'Last name', false);
+          },
+          onFormSubmit: function($form) {
+            const firstNameInput = $form.querySelector('input[name="firstname"]');
+            const lastNameInput = $form.querySelector('input[name="lastname"]');
+            
+            let hasErrors = false;
+            
+            [firstNameInput, lastNameInput].forEach(input => {
+              if (!input) return;
+              
+              const value = input.value.trim();
+              const isFirstName = input.name === 'firstname';
+              
+              if (value && (
+                  (isFirstName && value.length < 2) || 
+                  value.length > 50 || 
+                  !/^[a-zA-Z\s'-]+$/.test(value))) {
+                hasErrors = true;
+                input.focus();
+              }
+            });
+            
+            return !hasErrors;
+          },
         });
       }
     });

--- a/microsite/src/pages/home/_hubSpotNewAdoptersForm.tsx
+++ b/microsite/src/pages/home/_hubSpotNewAdoptersForm.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import hubSpotStyles from './hubSpotNewAdoptersForm.module.scss';
 
@@ -26,20 +26,23 @@ declare global {
 
 const MIN_NAME_LENGTH = 2;
 const MAX_NAME_LENGTH = 50;
-const NAME_PATTERN = /^[a-zA-Z\s'-]+$/;
+const NAME_PATTERN = /^[\p{L}\p{M}\s''-]+$/u;
 
 const HUBSPOT_SCRIPT_ID = 'hubspot-forms-script';
-let isFormInitialized = false;
 
 export const HubSpotNewAdoptersForm = () => {
   const [isClosed, setClosed] = useState(true);
+  const isFormInitializedRef = useRef(false);
 
   useEffect(() => {
     const eventListeners: Array<{ element: HTMLInputElement; handler: EventListener }> = [];
     
     const initializeForm = () => {
-      if (window.hbspt && !isFormInitialized) {
-        isFormInitialized = true;
+      const formContainer = document.querySelector(`.${hubSpotStyles.hubSpotNewAdopterFormContent}`);
+      const hasExistingForm = formContainer?.querySelector('form');
+      
+      if (window.hbspt && !isFormInitializedRef.current && !hasExistingForm) {
+        isFormInitializedRef.current = true;
 
         const getValidationError = (
           value: string,
@@ -232,7 +235,7 @@ export const HubSpotNewAdoptersForm = () => {
       eventListeners.forEach(({ element, handler }) => {
         element.removeEventListener('blur', handler as EventListener);
       });
-      isFormInitialized = false;
+      isFormInitializedRef.current = false;
     };
   }, []);
 

--- a/microsite/src/pages/home/_hubSpotNewAdoptersForm.tsx
+++ b/microsite/src/pages/home/_hubSpotNewAdoptersForm.tsx
@@ -11,11 +11,7 @@ export const HubSpotNewAdoptersForm = () => {
   const [isClosed, setClosed] = useState(true);
 
   useEffect(() => {
-    const script = document.createElement('script');
-    script.src = 'https://js.hsforms.net/forms/v2.js';
-    document.body.appendChild(script);
-
-    const handleLoad = () => {
+    const initializeForm = () => {
       // @ts-ignore
       if (window.hbspt) {
 
@@ -36,6 +32,59 @@ export const HubSpotNewAdoptersForm = () => {
           return '';
         };
         
+        const clearValidationError = (input: HTMLInputElement) => {
+          const errorId = `${input.name}-validation-error`;
+          const existingError = input.parentElement?.querySelector('.hs-error-msgs.custom-validation');
+          if (existingError) {
+            existingError.remove();
+          }
+          
+          input.classList.remove('custom-invalid');
+          input.removeAttribute('aria-invalid');
+          
+          const describedBy = input.getAttribute('aria-describedby');
+          if (describedBy) {
+            const tokens = describedBy
+              .split(/\s+/)
+              .filter(token => token && token !== errorId);
+            if (tokens.length > 0) {
+              input.setAttribute('aria-describedby', tokens.join(' '));
+            } else {
+              input.removeAttribute('aria-describedby');
+            }
+          }
+        };
+        
+        const showValidationError = (
+          input: HTMLInputElement,
+          errorMessage: string,
+        ) => {
+          const errorId = `${input.name}-validation-error`;
+          const errorElement = document.createElement('ul');
+          errorElement.className = 'hs-error-msgs inputs-list custom-validation';
+          errorElement.setAttribute('role', 'alert');
+          const errorItem = document.createElement('li');
+          const errorSpan = document.createElement('span');
+          errorSpan.className = 'hs-error-msg';
+          errorSpan.id = errorId;
+          errorSpan.textContent = errorMessage;
+          errorItem.appendChild(errorSpan);
+          errorElement.appendChild(errorItem);
+          input.parentElement?.appendChild(errorElement);
+          
+          input.classList.add('custom-invalid');
+          input.setAttribute('aria-invalid', 'true');
+          
+          const describedBy = input.getAttribute('aria-describedby');
+          const tokens = describedBy
+            ? describedBy.split(/\s+/).filter(token => token)
+            : [];
+          if (!tokens.includes(errorId)) {
+            tokens.push(errorId);
+          }
+          input.setAttribute('aria-describedby', tokens.join(' '));
+        };
+        
         const validateName = (
           input: HTMLInputElement | null,
           fieldName: string,
@@ -45,30 +94,14 @@ export const HubSpotNewAdoptersForm = () => {
           
           const value = input.value.trim();
           
-          const existingError = input.parentElement?.querySelector('.hs-error-msgs.custom-validation');
-          if (existingError) {
-            existingError.remove();
-          }
-          input.classList.remove('custom-invalid');
+          clearValidationError(input);
           
-          if (!value) {
-            return !requireMinLength;
-          }
+          if (!value) return true;
           
           const errorMessage = getValidationError(value, fieldName, requireMinLength);
           
           if (errorMessage) {
-            const errorElement = document.createElement('ul');
-            errorElement.className = 'hs-error-msgs inputs-list custom-validation';
-            errorElement.setAttribute('role', 'alert');
-            const errorItem = document.createElement('li');
-            const errorLabel = document.createElement('label');
-            errorLabel.className = 'hs-error-msg';
-            errorLabel.textContent = errorMessage;
-            errorItem.appendChild(errorLabel);
-            errorElement.appendChild(errorItem);
-            input.parentElement?.appendChild(errorElement);
-            input.classList.add('custom-invalid');
+            showValidationError(input, errorMessage);
             return false;
           }
           
@@ -122,7 +155,6 @@ export const HubSpotNewAdoptersForm = () => {
               const isValid = validateName(input, fieldName, requireMinLength);
               if (!isValid) {
                 hasErrors = true;
-                // Track the first invalid field to focus on it
                 if (!firstInvalidInput) {
                   firstInvalidInput = input;
                 }
@@ -138,15 +170,32 @@ export const HubSpotNewAdoptersForm = () => {
         });
       }
     };
-
-    script.addEventListener('load', handleLoad);
-
-    return () => {
-      script.removeEventListener('load', handleLoad);
-      if (script.parentNode) {
-        script.parentNode.removeChild(script);
+    
+    const HUBSPOT_SCRIPT_ID = 'hubspot-forms-script';
+    
+    // @ts-ignore
+    if (window.hbspt) {
+      initializeForm();
+    } else {
+      let script = document.getElementById(HUBSPOT_SCRIPT_ID) as HTMLScriptElement | null;
+      
+      if (!script) {
+        script = document.createElement('script');
+        script.id = HUBSPOT_SCRIPT_ID;
+        script.src = 'https://js.hsforms.net/forms/v2.js';
+        document.body.appendChild(script);
       }
-    };
+      
+      const handleLoad = () => {
+        initializeForm();
+      };
+      
+      script.addEventListener('load', handleLoad);
+      
+      return () => {
+        script?.removeEventListener('load', handleLoad);
+      };
+    }
   }, []);
 
   return (

--- a/microsite/src/pages/home/_hubSpotNewAdoptersForm.tsx
+++ b/microsite/src/pages/home/_hubSpotNewAdoptersForm.tsx
@@ -3,6 +3,27 @@ import React, { useEffect, useState } from 'react';
 
 import hubSpotStyles from './hubSpotNewAdoptersForm.module.scss';
 
+interface HubSpotFormOptions {
+  portalId: string;
+  formId: string;
+  target: string;
+  pageId: string;
+  onFormReady?: (form: HTMLFormElement) => void;
+  onFormSubmit?: (form: HTMLFormElement) => boolean;
+}
+
+interface HubSpot {
+  forms: {
+    create: (options: HubSpotFormOptions) => void;
+  };
+}
+
+declare global {
+  interface Window {
+    hbspt?: HubSpot;
+  }
+}
+
 const MIN_NAME_LENGTH = 2;
 const MAX_NAME_LENGTH = 50;
 const NAME_PATTERN = /^[a-zA-Z\s'-]+$/;
@@ -17,7 +38,6 @@ export const HubSpotNewAdoptersForm = () => {
     const eventListeners: Array<{ element: HTMLInputElement; handler: EventListener }> = [];
     
     const initializeForm = () => {
-      // @ts-ignore
       if (window.hbspt && !isFormInitialized) {
         isFormInitialized = true;
 
@@ -45,8 +65,10 @@ export const HubSpotNewAdoptersForm = () => {
             existingError.remove();
           }
           
-          input.classList.remove('custom-invalid');
-          input.removeAttribute('aria-invalid');
+          if (input.classList.contains('custom-invalid')) {
+            input.classList.remove('custom-invalid');
+            input.removeAttribute('aria-invalid');
+          }
           
           const describedBy = input.getAttribute('aria-describedby');
           if (describedBy) {
@@ -123,7 +145,6 @@ export const HubSpotNewAdoptersForm = () => {
           return true;
         };
         
-        // @ts-ignore
         window.hbspt.forms.create({
           portalId: '21894833',
           formId: '9a5aa2af-87f3-4a44-819f-88ee243bb61e',
@@ -185,7 +206,6 @@ export const HubSpotNewAdoptersForm = () => {
     let script: HTMLScriptElement | null = null;
     let handleLoad: (() => void) | null = null;
     
-    // @ts-ignore
     if (window.hbspt) {
       initializeForm();
     } else {

--- a/microsite/src/pages/home/_hubSpotNewAdoptersForm.tsx
+++ b/microsite/src/pages/home/_hubSpotNewAdoptersForm.tsx
@@ -3,6 +3,10 @@ import React, { useEffect, useState } from 'react';
 
 import hubSpotStyles from './hubSpotNewAdoptersForm.module.scss';
 
+const MIN_NAME_LENGTH = 2;
+const MAX_NAME_LENGTH = 50;
+const NAME_PATTERN = /^[a-zA-Z\s'-]+$/;
+
 export const HubSpotNewAdoptersForm = () => {
   const [isClosed, setClosed] = useState(true);
 
@@ -14,74 +18,103 @@ export const HubSpotNewAdoptersForm = () => {
     script.addEventListener('load', () => {
       // @ts-ignore
       if (window.hbspt) {
+
+        const getValidationError = (
+          value: string,
+          fieldName: string,
+          requireMinLength: boolean,
+        ): string => {
+          if (requireMinLength && value.length < MIN_NAME_LENGTH) {
+            return `${fieldName} must be at least ${MIN_NAME_LENGTH} characters`;
+          }
+          if (value.length > MAX_NAME_LENGTH) {
+            return `${fieldName} must be less than ${MAX_NAME_LENGTH} characters`;
+          }
+          if (!NAME_PATTERN.test(value)) {
+            return `${fieldName} can only contain letters, spaces, hyphens, and apostrophes`;
+          }
+          return '';
+        };
+        
+        const validateName = (
+          input: HTMLInputElement | null,
+          fieldName: string,
+          requireMinLength: boolean = true,
+        ): boolean => {
+          if (!input) return true;
+          
+          const value = input.value.trim();
+          
+          const existingError = input.parentElement?.querySelector('.hs-error-msgs.custom-validation');
+          if (existingError) {
+            existingError.remove();
+          }
+          input.classList.remove('custom-invalid');
+          
+          if (!value) return true;
+          
+          const errorMessage = getValidationError(value, fieldName, requireMinLength);
+          
+          if (errorMessage) {
+            const errorElement = document.createElement('ul');
+            errorElement.className = 'hs-error-msgs inputs-list custom-validation';
+            errorElement.setAttribute('role', 'alert');
+            const errorItem = document.createElement('li');
+            const errorLabel = document.createElement('label');
+            errorLabel.className = 'hs-error-msg';
+            errorLabel.textContent = errorMessage;
+            errorItem.appendChild(errorLabel);
+            errorElement.appendChild(errorItem);
+            input.parentElement?.appendChild(errorElement);
+            input.classList.add('custom-invalid');
+            return false;
+          }
+          
+          return true;
+        };
+        
         // @ts-ignore
         window.hbspt.forms.create({
           portalId: '21894833',
           formId: '9a5aa2af-87f3-4a44-819f-88ee243bb61e',
           target: `.${hubSpotStyles.hubSpotNewAdopterFormContent}`,
           pageId: '79735607665',
-          onFormReady: function($form) {
-            const firstNameInput = $form.querySelector('input[name="firstname"]');
-            const lastNameInput = $form.querySelector('input[name="lastname"]');
+          onFormReady: function($form: HTMLFormElement) {
+            const firstNameInput = $form.querySelector('input[name="firstname"]') as HTMLInputElement | null;
+            const lastNameInput = $form.querySelector('input[name="lastname"]') as HTMLInputElement | null;
             
-            const validateName = (input, fieldName, requireMinLength = true) => {
+            const handleBlur = (
+              input: HTMLInputElement | null,
+              fieldName: string,
+              requireMinLength: boolean,
+            ) => {
               if (!input) return;
               
-              input.addEventListener('blur', function() {
-                const value = this.value.trim();
-                const existingError = input.parentElement.querySelector('.hs-error-msgs.custom-validation');
-                if (existingError) {
-                  existingError.remove();
-                }
-                input.classList.remove('custom-invalid');
-                
-                if (!value) return;
-                
-                let errorMessage = '';
-                
-                if (requireMinLength && value.length < 2) {
-                  errorMessage = `${fieldName} must be at least 2 characters`;
-                } else if (value.length > 50) {
-                  errorMessage = `${fieldName} must be less than 50 characters`;
-                } else if (!/^[a-zA-Z\s'-]+$/.test(value)) {
-                  errorMessage = `${fieldName} can only contain letters, spaces, hyphens, and apostrophes`;
-                }
-                
-                if (errorMessage) {
-                  const errorElement = document.createElement('ul');
-                  errorElement.className = 'hs-error-msgs inputs-list custom-validation';
-                  errorElement.setAttribute('role', 'alert');
-                  const errorItem = document.createElement('li');
-                  const errorLabel = document.createElement('label');
-                  errorLabel.className = 'hs-error-msg';
-                  errorLabel.textContent = errorMessage;
-                  errorItem.appendChild(errorLabel);
-                  errorElement.appendChild(errorItem);
-                  input.parentElement.appendChild(errorElement);
-                  input.classList.add('custom-invalid');
-                }
-              });
+              const blurHandler = () => {
+                validateName(input, fieldName, requireMinLength);
+              };
+              
+              input.addEventListener('blur', blurHandler);
             };
             
-            validateName(firstNameInput, 'First name', true);
-            validateName(lastNameInput, 'Last name', false);
+            handleBlur(firstNameInput, 'First name', true);
+            handleBlur(lastNameInput, 'Last name', false);
           },
-          onFormSubmit: function($form) {
-            const firstNameInput = $form.querySelector('input[name="firstname"]');
-            const lastNameInput = $form.querySelector('input[name="lastname"]');
+          onFormSubmit: function($form: HTMLFormElement) {
+            const firstNameInput = $form.querySelector('input[name="firstname"]') as HTMLInputElement | null;
+            const lastNameInput = $form.querySelector('input[name="lastname"]') as HTMLInputElement | null;
             
             let hasErrors = false;
             
             [firstNameInput, lastNameInput].forEach(input => {
-              if (!input) return;
+              if (!input || hasErrors) return;
               
-              const value = input.value.trim();
               const isFirstName = input.name === 'firstname';
+              const fieldName = isFirstName ? 'First name' : 'Last name';
+              const requireMinLength = isFirstName;
               
-              if (value && (
-                  (isFirstName && value.length < 2) || 
-                  value.length > 50 || 
-                  !/^[a-zA-Z\s'-]+$/.test(value))) {
+              const isValid = validateName(input, fieldName, requireMinLength);
+              if (!isValid) {
                 hasErrors = true;
                 input.focus();
               }

--- a/microsite/src/pages/home/_hubSpotNewAdoptersForm.tsx
+++ b/microsite/src/pages/home/_hubSpotNewAdoptersForm.tsx
@@ -28,7 +28,7 @@ export const HubSpotNewAdoptersForm = () => {
             return `${fieldName} must be at least ${MIN_NAME_LENGTH} characters`;
           }
           if (value.length > MAX_NAME_LENGTH) {
-            return `${fieldName} must be less than ${MAX_NAME_LENGTH} characters`;
+            return `${fieldName} must be ${MAX_NAME_LENGTH} characters or fewer`;
           }
           if (!NAME_PATTERN.test(value)) {
             return `${fieldName} can only contain letters, spaces, hyphens, and apostrophes`;

--- a/microsite/src/pages/home/_hubSpotNewAdoptersForm.tsx
+++ b/microsite/src/pages/home/_hubSpotNewAdoptersForm.tsx
@@ -15,7 +15,7 @@ export const HubSpotNewAdoptersForm = () => {
     script.src = 'https://js.hsforms.net/forms/v2.js';
     document.body.appendChild(script);
 
-    script.addEventListener('load', () => {
+    const handleLoad = () => {
       // @ts-ignore
       if (window.hbspt) {
 
@@ -51,7 +51,7 @@ export const HubSpotNewAdoptersForm = () => {
           }
           input.classList.remove('custom-invalid');
           
-           if (!value) {
+          if (!value) {
             return !requireMinLength;
           }
           
@@ -85,31 +85,35 @@ export const HubSpotNewAdoptersForm = () => {
             const firstNameInput = $form.querySelector('input[name="firstname"]') as HTMLInputElement | null;
             const lastNameInput = $form.querySelector('input[name="lastname"]') as HTMLInputElement | null;
             
-            const handleBlur = (
-              input: HTMLInputElement | null,
+            const createBlurHandler = (
+              input: HTMLInputElement,
               fieldName: string,
               requireMinLength: boolean,
             ) => {
-              if (!input) return;
-              
-              const blurHandler = () => {
+              return () => {
                 validateName(input, fieldName, requireMinLength);
               };
-              
-              input.addEventListener('blur', blurHandler);
             };
             
-            handleBlur(firstNameInput, 'First name', true);
-            handleBlur(lastNameInput, 'Last name', false);
+            if (firstNameInput) {
+              const firstNameHandler = createBlurHandler(firstNameInput, 'First name', true);
+              firstNameInput.addEventListener('blur', firstNameHandler);
+            }
+            
+            if (lastNameInput) {
+              const lastNameHandler = createBlurHandler(lastNameInput, 'Last name', false);
+              lastNameInput.addEventListener('blur', lastNameHandler);
+            }
           },
           onFormSubmit: function($form: HTMLFormElement) {
             const firstNameInput = $form.querySelector('input[name="firstname"]') as HTMLInputElement | null;
             const lastNameInput = $form.querySelector('input[name="lastname"]') as HTMLInputElement | null;
             
             let hasErrors = false;
+            let firstInvalidInput: HTMLInputElement | null = null;
             
             [firstNameInput, lastNameInput].forEach(input => {
-              if (!input || hasErrors) return;
+              if (!input) return;
               
               const isFirstName = input.name === 'firstname';
               const fieldName = isFirstName ? 'First name' : 'Last name';
@@ -118,15 +122,31 @@ export const HubSpotNewAdoptersForm = () => {
               const isValid = validateName(input, fieldName, requireMinLength);
               if (!isValid) {
                 hasErrors = true;
-                input.focus();
+                // Track the first invalid field to focus on it
+                if (!firstInvalidInput) {
+                  firstInvalidInput = input;
+                }
               }
             });
+            
+            if (firstInvalidInput) {
+              firstInvalidInput.focus();
+            }
             
             return !hasErrors;
           },
         });
       }
-    });
+    };
+
+    script.addEventListener('load', handleLoad);
+
+    return () => {
+      script.removeEventListener('load', handleLoad);
+      if (script.parentNode) {
+        script.parentNode.removeChild(script);
+      }
+    };
   }, []);
 
   return (

--- a/microsite/src/pages/home/_hubSpotNewAdoptersForm.tsx
+++ b/microsite/src/pages/home/_hubSpotNewAdoptersForm.tsx
@@ -35,12 +35,17 @@ export const HubSpotNewAdoptersForm = () => {
   const isFormInitializedRef = useRef(false);
 
   useEffect(() => {
-    const eventListeners: Array<{ element: HTMLInputElement; handler: EventListener }> = [];
-    
+    const eventListeners: Array<{
+      element: HTMLInputElement;
+      handler: EventListener;
+    }> = [];
+
     const initializeForm = () => {
-      const formContainer = document.querySelector(`.${hubSpotStyles.hubSpotNewAdopterFormContent}`);
+      const formContainer = document.querySelector(
+        `.${hubSpotStyles.hubSpotNewAdopterFormContent}`,
+      );
       const hasExistingForm = formContainer?.querySelector('form');
-      
+
       if (window.hbspt && !isFormInitializedRef.current && !hasExistingForm) {
         isFormInitializedRef.current = true;
 
@@ -60,19 +65,21 @@ export const HubSpotNewAdoptersForm = () => {
           }
           return '';
         };
-        
+
         const clearValidationError = (input: HTMLInputElement) => {
           const errorId = `${input.name}-validation-error`;
-          const existingError = input.parentElement?.querySelector('.hs-error-msgs.custom-validation');
+          const existingError = input.parentElement?.querySelector(
+            '.hs-error-msgs.custom-validation',
+          );
           if (existingError) {
             existingError.remove();
           }
-          
+
           if (input.classList.contains('custom-invalid')) {
             input.classList.remove('custom-invalid');
             input.removeAttribute('aria-invalid');
           }
-          
+
           const describedBy = input.getAttribute('aria-describedby');
           if (describedBy) {
             const tokens = describedBy
@@ -85,14 +92,15 @@ export const HubSpotNewAdoptersForm = () => {
             }
           }
         };
-        
+
         const showValidationError = (
           input: HTMLInputElement,
           errorMessage: string,
         ) => {
           const errorId = `${input.name}-validation-error`;
           const errorElement = document.createElement('ul');
-          errorElement.className = 'hs-error-msgs inputs-list custom-validation';
+          errorElement.className =
+            'hs-error-msgs inputs-list custom-validation';
           errorElement.setAttribute('role', 'alert');
           const errorItem = document.createElement('li');
           const errorSpan = document.createElement('span');
@@ -102,10 +110,10 @@ export const HubSpotNewAdoptersForm = () => {
           errorItem.appendChild(errorSpan);
           errorElement.appendChild(errorItem);
           input.parentElement?.appendChild(errorElement);
-          
+
           input.classList.add('custom-invalid');
           input.setAttribute('aria-invalid', 'true');
-          
+
           const describedBy = input.getAttribute('aria-describedby');
           const tokens = describedBy
             ? describedBy.split(/\s+/).filter(token => token)
@@ -115,27 +123,31 @@ export const HubSpotNewAdoptersForm = () => {
           }
           input.setAttribute('aria-describedby', tokens.join(' '));
         };
-        
+
         const validateName = (
           input: HTMLInputElement | null,
           fieldName: string,
           requireMinLength: boolean = true,
         ): boolean => {
           if (!input) return true;
-          
+
           const value = input.value.trim();
-          
+
           if (!value) {
             clearValidationError(input);
             return true;
           }
-          
-          const errorMessage = getValidationError(value, fieldName, requireMinLength);
+
+          const errorMessage = getValidationError(
+            value,
+            fieldName,
+            requireMinLength,
+          );
           const existingError = input.parentElement?.querySelector(
-            '.hs-error-msgs.custom-validation .hs-error-msg'
+            '.hs-error-msgs.custom-validation .hs-error-msg',
           );
           const currentErrorText = existingError?.textContent;
-          
+
           if (errorMessage) {
             if (currentErrorText !== errorMessage) {
               clearValidationError(input);
@@ -143,50 +155,64 @@ export const HubSpotNewAdoptersForm = () => {
             }
             return false;
           }
-          
+
           clearValidationError(input);
           return true;
         };
-        
+
         window.hbspt.forms.create({
           portalId: '21894833',
           formId: '9a5aa2af-87f3-4a44-819f-88ee243bb61e',
           target: `.${hubSpotStyles.hubSpotNewAdopterFormContent}`,
           pageId: '79735607665',
-          onFormReady: function($form: HTMLFormElement) {
-            const firstNameInput = $form.querySelector('input[name="firstname"]') as HTMLInputElement | null;
-            const lastNameInput = $form.querySelector('input[name="lastname"]') as HTMLInputElement | null;
-            
+          onFormReady: function ($form: HTMLFormElement) {
+            const firstNameInput = $form.querySelector(
+              'input[name="firstname"]',
+            ) as HTMLInputElement | null;
+            const lastNameInput = $form.querySelector(
+              'input[name="lastname"]',
+            ) as HTMLInputElement | null;
+
             if (firstNameInput) {
               const firstNameHandler = () => {
                 validateName(firstNameInput, 'First name', true);
               };
               firstNameInput.addEventListener('blur', firstNameHandler);
-              eventListeners.push({ element: firstNameInput, handler: firstNameHandler });
+              eventListeners.push({
+                element: firstNameInput,
+                handler: firstNameHandler,
+              });
             }
-            
+
             if (lastNameInput) {
               const lastNameHandler = () => {
                 validateName(lastNameInput, 'Last name', false);
               };
               lastNameInput.addEventListener('blur', lastNameHandler);
-              eventListeners.push({ element: lastNameInput, handler: lastNameHandler });
+              eventListeners.push({
+                element: lastNameInput,
+                handler: lastNameHandler,
+              });
             }
           },
-          onFormSubmit: function($form: HTMLFormElement) {
-            const firstNameInput = $form.querySelector('input[name="firstname"]') as HTMLInputElement | null;
-            const lastNameInput = $form.querySelector('input[name="lastname"]') as HTMLInputElement | null;
-            
+          onFormSubmit: function ($form: HTMLFormElement) {
+            const firstNameInput = $form.querySelector(
+              'input[name="firstname"]',
+            ) as HTMLInputElement | null;
+            const lastNameInput = $form.querySelector(
+              'input[name="lastname"]',
+            ) as HTMLInputElement | null;
+
             let hasErrors = false;
             let firstInvalidInput: HTMLInputElement | null = null;
-            
+
             [firstNameInput, lastNameInput].forEach(input => {
               if (!input) return;
-              
+
               const isFirstName = input.name === 'firstname';
               const fieldName = isFirstName ? 'First name' : 'Last name';
               const requireMinLength = isFirstName;
-              
+
               const isValid = validateName(input, fieldName, requireMinLength);
               if (!isValid) {
                 hasErrors = true;
@@ -195,39 +221,41 @@ export const HubSpotNewAdoptersForm = () => {
                 }
               }
             });
-            
+
             if (firstInvalidInput) {
               firstInvalidInput.focus();
             }
-            
+
             return !hasErrors;
           },
         });
       }
     };
-    
+
     let script: HTMLScriptElement | null = null;
     let handleLoad: (() => void) | null = null;
-    
+
     if (window.hbspt) {
       initializeForm();
     } else {
-      script = document.getElementById(HUBSPOT_SCRIPT_ID) as HTMLScriptElement | null;
-      
+      script = document.getElementById(
+        HUBSPOT_SCRIPT_ID,
+      ) as HTMLScriptElement | null;
+
       if (!script) {
         script = document.createElement('script');
         script.id = HUBSPOT_SCRIPT_ID;
         script.src = 'https://js.hsforms.net/forms/v2.js';
         document.body.appendChild(script);
       }
-      
+
       handleLoad = () => {
         initializeForm();
       };
-      
+
       script.addEventListener('load', handleLoad);
     }
-    
+
     return () => {
       if (script && handleLoad) {
         script.removeEventListener('load', handleLoad);

--- a/microsite/src/pages/home/hubSpotNewAdoptersForm.module.scss
+++ b/microsite/src/pages/home/hubSpotNewAdoptersForm.module.scss
@@ -43,4 +43,30 @@ $page-header-height: 44px;
   input[class*='hs-button'] {
     color: black;
   }
+  
+  input.custom-invalid {
+    border-color: #dc3545;
+    
+    &:focus {
+      border-color: #dc3545;
+      box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.25);
+    }
+  }
+  
+  .hs-error-msgs.custom-validation {
+    list-style: none;
+    padding: 0;
+    margin: 0.25rem 0 0 0;
+    
+    li {
+      margin: 0;
+    }
+    
+    .hs-error-msg {
+      color: #dc3545;
+      font-size: 0.875rem;
+      display: block;
+      margin-top: 0.25rem;
+    }
+  }
 }

--- a/microsite/src/pages/home/hubSpotNewAdoptersForm.module.scss
+++ b/microsite/src/pages/home/hubSpotNewAdoptersForm.module.scss
@@ -44,7 +44,7 @@ $page-header-height: 44px;
     color: black;
   }
   
-  input.custom-invalid {
+  :global(input.custom-invalid) {
     border-color: #dc3545;
     
     &:focus {
@@ -53,7 +53,7 @@ $page-header-height: 44px;
     }
   }
   
-  .hs-error-msgs.custom-validation {
+  :global(.hs-error-msgs.custom-validation) {
     list-style: none;
     padding: 0;
     margin: 0.25rem 0 0 0;
@@ -62,7 +62,7 @@ $page-header-height: 44px;
       margin: 0;
     }
     
-    .hs-error-msg {
+    :global(.hs-error-msg) {
       color: #dc3545;
       font-size: 0.875rem;
       display: block;

--- a/microsite/src/pages/home/hubSpotNewAdoptersForm.module.scss
+++ b/microsite/src/pages/home/hubSpotNewAdoptersForm.module.scss
@@ -45,11 +45,11 @@ $page-header-height: 44px;
   }
   
   :global(input.custom-invalid) {
-    border-color: #dc3545;
+    border-color: var(--ifm-color-danger);
     
     &:focus {
-      border-color: #dc3545;
-      box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.25);
+      border-color: var(--ifm-color-danger);
+      box-shadow: 0 0 0 0.2rem var(--ifm-color-danger-contrast-background);
     }
   }
   
@@ -63,7 +63,7 @@ $page-header-height: 44px;
     }
     
     :global(.hs-error-msg) {
-      color: #dc3545;
+      color: var(--ifm-color-danger);
       font-size: 0.875rem;
       display: block;
       margin-top: 0.25rem;

--- a/microsite/src/pages/home/hubSpotNewAdoptersForm.module.scss
+++ b/microsite/src/pages/home/hubSpotNewAdoptersForm.module.scss
@@ -43,25 +43,25 @@ $page-header-height: 44px;
   input[class*='hs-button'] {
     color: black;
   }
-  
+
   :global(input.custom-invalid) {
     border-color: var(--ifm-color-danger);
-    
+
     &:focus {
       border-color: var(--ifm-color-danger);
       box-shadow: 0 0 0 0.2rem var(--ifm-color-danger-contrast-background);
     }
   }
-  
+
   :global(.hs-error-msgs.custom-validation) {
     list-style: none;
     padding: 0;
     margin: 0.25rem 0 0 0;
-    
+
     li {
       margin: 0;
     }
-    
+
     :global(.hs-error-msg) {
       color: var(--ifm-color-danger);
       font-size: 0.875rem;


### PR DESCRIPTION
**Before FIX:**

<img width="648" height="804" alt="image" src="https://github.com/user-attachments/assets/6ebf9fbb-75f3-48f3-b41b-a9a0b1ef4cb1" />


**After FIX:**
<img width="549" height="716" alt="image" src="https://github.com/user-attachments/assets/f3976bf2-9b08-4731-9bb0-6a1d035d8dc4" />


## Summary

Improved validation for the new adopters form on the homepage by adding client-side validation for first and last name fields.

## Changes

- Added validation rules for first/last name fields:
  - First name: minimum 2 characters
  - Both fields: maximum 50 characters, letters/spaces/hyphens/apostrophes only
- Implemented real-time validation on field blur
- Added visual feedback with error messages and styling
- Fixed validation state clearing when valid input is entered
- Removed duplicate "required" messages (handled by HubSpot's native validation)