### PR TITLE
run vale directly instead of through the action

### DIFF
--- a/.github/workflows/verify_docs-quality.yml
+++ b/.github/workflows/verify_docs-quality.yml
@@ -24,20 +24,20 @@ jobs:
       - name: Install vale
         run: |
           VALE_VERSION="3.7.1"
-          VALE_REPO="errata-ai/vale"
+          VALE_CHECKSUM="ba4924bf2c5884499f09b02a6eb3318b29df40a3e81701c0804b9b1aefcd9483"
           VALE_DIST_DIR="/tmp/vale-dist"
+          VALE_ARCHIVE="vale_${VALE_VERSION}_Linux_64-bit.tar.gz"
 
           mkdir -p "$VALE_DIST_DIR"
 
-          # Download pinned Vale binary and corresponding checksums file
-          gh release download "v${VALE_VERSION}" --repo "$VALE_REPO" --pattern "vale_${VALE_VERSION}_Linux_64-bit.tar.gz" --dir "$VALE_DIST_DIR"
-          gh release download "v${VALE_VERSION}" --repo "$VALE_REPO" --pattern "vale_${VALE_VERSION}_checksums.txt" --dir "$VALE_DIST_DIR"
+          # Download pinned Vale binary
+          curl -fsSL -H "Authorization: token $GH_TOKEN" "https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/${VALE_ARCHIVE}" -o "$VALE_DIST_DIR/$VALE_ARCHIVE"
 
           # Verify the integrity of the downloaded archive
-          (cd "$VALE_DIST_DIR" && sha256sum --check --ignore-missing "vale_${VALE_VERSION}_checksums.txt")
+          echo "$VALE_CHECKSUM  $VALE_DIST_DIR/$VALE_ARCHIVE" | sha256sum --check
 
           mkdir -p "$HOME/.local/bin"
-          tar -xzf "$VALE_DIST_DIR/vale_${VALE_VERSION}_Linux_64-bit.tar.gz" -C "$HOME/.local/bin" vale
+          tar -xzf "$VALE_DIST_DIR/$VALE_ARCHIVE" -C "$HOME/.local/bin" vale
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           vale --version
         env:

--- a/scripts/check-docs-quality.js
+++ b/scripts/check-docs-quality.js
@@ -36,6 +36,7 @@ const IGNORED_WHEN_LISTING = [
 const IGNORED_WHEN_EXPLICIT = [
   /^ADOPTERS\.md$/,
   /^OWNERS\.md$/,
+  /^.*[/\\]CHANGELOG\.md$/, // generated from changesets anyway - THOSE should have been checked earlier
   /^.*[/\\]knip-report\.md$/,
 ];
 


### PR DESCRIPTION
We keep running into the vale limit of not being able to lint more than 300 files, when making huge PRs or releases.

Well, this is what claude suggested to fix it, since the limit is inherent to the inability for the GitHub API to return more than 300 files with the implementation that the action uses internally.

Is it ... is it too wild?