### PR TITLE
module-federation-common: fix trailing slash in MUI styles shared dependency key

### DIFF
--- a/.changeset/fix-mui-styles-shared-dep.md
+++ b/.changeset/fix-mui-styles-shared-dep.md
@@ -1,0 +1,5 @@
+---
+'@backstage/module-federation-common': patch
+---
+
+Fixed the `@mui/material/styles` shared dependency key by removing a trailing slash that caused module resolution failures with MUI package exports.

--- a/.patches/pr-32996.txt
+++ b/.patches/pr-32996.txt
@@ -1,0 +1,1 @@
+Fixes the `@mui/material/styles` shared dependency key by removing a trailing slash that caused module resolution failures with MUI package exports.

--- a/packages/frontend-dynamic-feature-loader/src/loader.test.tsx
+++ b/packages/frontend-dynamic-feature-loader/src/loader.test.tsx
@@ -165,7 +165,7 @@ describe('dynamicFrontendFeaturesLoader', () => {
       shareConfig: { singleton: true, requiredVersion: '*', eager: true },
     },
     {
-      name: '@mui/material/styles/',
+      name: '@mui/material/styles',
       version: '5.16.14',
       lib: async () => ({ default: {} }),
       shareConfig: { singleton: true, requiredVersion: '*', eager: true },

--- a/packages/module-federation-common/src/defaults.ts
+++ b/packages/module-federation-common/src/defaults.ts
@@ -55,7 +55,7 @@ const defaultSharedDependencies = {
   // MUI v5
   // not setting import: false for MUI packages as this
   // will break once Backstage moves to BUI
-  '@mui/material/styles/': {
+  '@mui/material/styles': {
     host: {},
     remote: {},
   },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes an issue where the `@mui/material/styles/` shared dependency key in the module federation defaults had a trailing slash. MUI's `package.json` exports map only defines `./styles`, not `./styles/`, so when the CLI generates the runtime shared dependencies script, the resulting `import("@mui/material/styles/")` fails with:

```
Package subpath './styles/' is not defined by "exports" in @mui/material/package.json
```

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))