### PR TITLE
Fix capitalization in resource description

### DIFF
--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -1121,7 +1121,7 @@ Describes the following entity kind:
 | `apiVersion` | `backstage.io/v1alpha1` |
 | `kind`       | `Resource`              |
 
-A resource describes the infrastructure a system needs to operate, like BigTable
+A Resource describes the infrastructure a system needs to operate, like BigTable
 databases, Pub/Sub topics, S3 buckets or CDNs. Modelling them together with
 components and systems allows to visualize resource footprint, and create
 tooling around them.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Corrected capitalization of 'A Resource' at the beginning of the sentence (as it is a proper noun)

See https://backstage.io/docs/features/software-catalog/descriptor-format#kind-resource

#### :heavy_check_mark: Checklist

Only a documentation update.

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
