### PR TITLE
techdocs, api-docs: add default entity content groups

### DIFF
--- a/.changeset/entity-content-group-api-docs.md
+++ b/.changeset/entity-content-group-api-docs.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-api-docs': patch
+---
+
+Added default entity content groups for the API docs entity content tabs. The API definition tab defaults to the `documentation` group and the APIs tab defaults to the `development` group.

--- a/.changeset/entity-content-group-techdocs.md
+++ b/.changeset/entity-content-group-techdocs.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Added `documentation` as the default entity content group for the TechDocs entity content tab.

--- a/packages/app/app-config.yaml
+++ b/packages/app/app-config.yaml
@@ -97,22 +97,19 @@ app:
     # - entity-card:azure-devops/readme
 
     # Entity page contents
-    - entity-content:catalog/overview:
-        config:
-          group: overview
+    - entity-content:catalog/overview
     - entity-content:api-docs/definition
     - entity-content:api-docs/apis:
         config:
-          # example associating with a default group
+          # example overriding the default group
           group: documentation
           icon: kind:api
     - entity-content:techdocs:
         config:
-          group: documentation
           icon: techdocs
     - entity-content:kubernetes/kubernetes:
         config:
-          # example disassociating with a default group
+          # example disassociating from the default group
           group: false
     # - entity-content:azure-devops/pipelines
     # - entity-content:azure-devops/pull-requests

--- a/plugins/api-docs/src/alpha.tsx
+++ b/plugins/api-docs/src/alpha.tsx
@@ -174,6 +174,7 @@ const apiDocsDefinitionEntityContent = EntityContentBlueprint.make({
   params: {
     path: '/definition',
     title: 'Definition',
+    group: 'documentation',
     filter: { kind: 'api' },
     loader: async () =>
       import('./components/ApiDefinitionCard').then(m => (
@@ -191,6 +192,7 @@ const apiDocsApisEntityContent = EntityContentBlueprint.make({
   params: {
     path: '/apis',
     title: 'APIs',
+    group: 'development',
     filter: { kind: 'component' },
     loader: async () =>
       import('./components/ApisCards').then(m => (

--- a/plugins/techdocs/src/alpha/index.tsx
+++ b/plugins/techdocs/src/alpha/index.tsx
@@ -223,6 +223,7 @@ const techDocsEntityContent = EntityContentBlueprint.makeWithOverrides({
       {
         path: 'docs',
         title: 'TechDocs',
+        group: 'documentation',
         routeRef: rootCatalogDocsRouteRef,
         loader: () => {
           // Merge addons from the API with old-style direct attachments


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds default entity content group assignments for the techdocs and api-docs plugins, so they automatically associate with the appropriate tab groups in the entity page without needing app-config overrides.

- **techdocs**: defaults to `documentation` group
- **api-docs definition**: defaults to `documentation` group
- **api-docs apis**: defaults to `development` group

Also cleaned up the example app config to remove group overrides that are now redundant.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))