### PR TITLE
core-compat-api: preserve EntityLayout.Group info in entity page conversion

### DIFF
--- a/.changeset/entity-layout-group-component.md
+++ b/.changeset/entity-layout-group-component.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': minor
+---
+
+Added `EntityLayout.Group` compound component that allows grouping `EntityLayout.Route` elements with a title and optional `if` filter.

--- a/.changeset/entity-page-groups-compat.md
+++ b/.changeset/entity-page-groups-compat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-compat-api': patch
+---
+
+Fixed `collectEntityPageContents` to preserve `EntityLayout.Group` information when converting legacy entity pages to the new frontend system. Routes inside groups now correctly receive the `group` parameter in the resulting `EntityContentBlueprint` extensions.

--- a/packages/core-compat-api/src/collectEntityPageContents.test.tsx
+++ b/packages/core-compat-api/src/collectEntityPageContents.test.tsx
@@ -14,8 +14,13 @@
  * limitations under the License.
  */
 
-import { ExtensionAttachToSpec } from '@backstage/frontend-plugin-api';
+import {
+  ExtensionAttachToSpec,
+  ExtensionDefinition,
+} from '@backstage/frontend-plugin-api';
 import { EntityLayout, EntitySwitch, isKind } from '@backstage/plugin-catalog';
+import { EntityContentBlueprint } from '@backstage/plugin-catalog-react/alpha';
+import { createExtensionTester } from '@backstage/frontend-test-utils';
 import { JSX } from 'react';
 import { collectEntityPageContents } from './collectEntityPageContents';
 import {
@@ -87,6 +92,17 @@ function collect(element: JSX.Element) {
     },
   });
   return result;
+}
+
+function collectExtensions(element: JSX.Element) {
+  const extensions = new Array<ExtensionDefinition>();
+
+  collectEntityPageContents(element, {
+    discoverExtension(extension) {
+      extensions.push(extension);
+    },
+  });
+  return extensions;
 }
 
 describe('collectEntityPageContents', () => {
@@ -167,5 +183,94 @@ describe('collectEntityPageContents', () => {
         },
       ]
     `);
+  });
+
+  it('should preserve group information from EntityLayout.Group', () => {
+    const extensions = collectExtensions(
+      <EntityLayout>
+        <EntityLayout.Route path="/" title="Overview">
+          <div>overview content</div>
+        </EntityLayout.Route>
+        <EntityLayout.Group title="CI CD">
+          <EntityLayout.Route path="/builds" title="Builds">
+            <div>builds content</div>
+          </EntityLayout.Route>
+          <EntityLayout.Route path="/deploys" title="Deploys">
+            <div>deploys content</div>
+          </EntityLayout.Route>
+        </EntityLayout.Group>
+        <EntityLayout.Route path="/docs" title="Docs">
+          <div>docs content</div>
+        </EntityLayout.Route>
+      </EntityLayout>,
+    );
+
+    expect(extensions).toHaveLength(4);
+
+    const groupDataRef = EntityContentBlueprint.dataRefs.group;
+
+    expect(createExtensionTester(extensions[1]).get(groupDataRef)).toBe(
+      'ci-cd',
+    );
+    expect(createExtensionTester(extensions[2]).get(groupDataRef)).toBe(
+      'ci-cd',
+    );
+    expect(
+      createExtensionTester(extensions[3]).get(groupDataRef),
+    ).toBeUndefined();
+  });
+
+  it('should merge group filter with route filters', () => {
+    const groupFilter = isKind('component');
+
+    const extensions = collectExtensions(
+      <EntityLayout>
+        <EntityLayout.Group title="My Group" if={groupFilter}>
+          <EntityLayout.Route path="/foo" title="Foo">
+            <div>foo content</div>
+          </EntityLayout.Route>
+        </EntityLayout.Group>
+      </EntityLayout>,
+    );
+
+    expect(extensions).toHaveLength(1);
+
+    const filterFn = createExtensionTester(extensions[0]).get(
+      EntityContentBlueprint.dataRefs.filterFunction,
+    ) as ((entity: any) => boolean) | undefined;
+    expect(filterFn).toBeDefined();
+    expect(filterFn!({ apiVersion: 'v1', kind: 'component' })).toBe(true);
+    expect(filterFn!({ apiVersion: 'v1', kind: 'api' })).toBe(false);
+  });
+
+  it('should thread group through EntitySwitch inside a group', () => {
+    const extensions = collectExtensions(
+      <EntityLayout>
+        <EntityLayout.Group title="Monitoring">
+          <EntitySwitch>
+            <EntitySwitch.Case if={isKind('component')}>
+              <EntityLayout.Route path="/metrics" title="Metrics">
+                <div>metrics content</div>
+              </EntityLayout.Route>
+            </EntitySwitch.Case>
+            <EntitySwitch.Case>
+              <EntityLayout.Route path="/logs" title="Logs">
+                <div>logs content</div>
+              </EntityLayout.Route>
+            </EntitySwitch.Case>
+          </EntitySwitch>
+        </EntityLayout.Group>
+      </EntityLayout>,
+    );
+
+    expect(extensions).toHaveLength(2);
+
+    const groupDataRef = EntityContentBlueprint.dataRefs.group;
+    expect(createExtensionTester(extensions[0]).get(groupDataRef)).toBe(
+      'monitoring',
+    );
+    expect(createExtensionTester(extensions[1]).get(groupDataRef)).toBe(
+      'monitoring',
+    );
   });
 });

--- a/packages/core-compat-api/src/collectEntityPageContents.ts
+++ b/packages/core-compat-api/src/collectEntityPageContents.ts
@@ -29,6 +29,7 @@ import { normalizeRoutePath } from './normalizeRoutePath';
 
 const ENTITY_SWITCH_KEY = 'core.backstage.entitySwitch';
 const ENTITY_ROUTE_KEY = 'plugin.catalog.entityLayoutRoute';
+const ENTITY_GROUP_KEY = 'plugin.catalog.entityLayoutGroup';
 
 // Placeholder to make sure internal types here are consistent
 type Entity = { apiVersion: string; kind: string };
@@ -84,8 +85,23 @@ export function collectEntityPageContents(
   let cardCounter = 1;
   let routeCounter = 1;
 
-  function traverse(element: ReactNode, parentFilter?: EntityFilter) {
+  function traverse(
+    element: ReactNode,
+    parentFilter?: EntityFilter,
+    parentGroup?: string,
+  ) {
     if (!isValidElement(element)) {
+      return;
+    }
+
+    if (getComponentData(element, ENTITY_GROUP_KEY)) {
+      const groupTitle = element.props?.title;
+      const groupIf = element.props?.if;
+      const groupId = groupTitle?.toLowerCase().replace(/\s+/g, '-');
+      const mergedIf = allFilters(parentFilter, groupIf);
+      Children.forEach(element.props?.children, child => {
+        traverse(child, mergedIf, groupId);
+      });
       return;
     }
 
@@ -117,6 +133,7 @@ export function collectEntityPageContents(
                 return originalFactory({
                   path: normalizeRoutePath(pageNode.path),
                   title: pageNode.title,
+                  group: parentGroup,
                   filter: mergedIf && (entity => mergedIf(entity, { apis })),
                   loader: () => Promise.resolve(pageNode.children),
                 });
@@ -135,6 +152,7 @@ export function collectEntityPageContents(
             traverse(
               entityCase.children,
               allFilters(parentFilter, entityCase.if),
+              parentGroup,
             );
           }
         } else {
@@ -144,6 +162,7 @@ export function collectEntityPageContents(
             traverse(
               entityCase.children,
               allFilters(parentFilter, entityCase.if, didNotMatchEarlier),
+              parentGroup,
             );
             previousIf = anyFilters(previousIf, entityCase.if)!;
           }
@@ -155,7 +174,7 @@ export function collectEntityPageContents(
     Children.forEach(
       (element.props as { children?: ReactNode })?.children,
       child => {
-        traverse(child, parentFilter);
+        traverse(child, parentFilter, parentGroup);
       },
     );
   }

--- a/plugins/catalog/src/components/EntityLayout/EntityLayout.tsx
+++ b/plugins/catalog/src/components/EntityLayout/EntityLayout.tsx
@@ -78,11 +78,22 @@ export type EntityLayoutRouteProps = {
   tabProps?: TabProps<ElementType, { component?: ElementType }>;
 };
 
+/** @public */
+export type EntityLayoutGroupProps = {
+  title: string;
+  children: ReactNode;
+  if?: (entity: Entity) => boolean;
+};
+
 const dataKey = 'plugin.catalog.entityLayoutRoute';
+const groupDataKey = 'plugin.catalog.entityLayoutGroup';
 
 const Route: (props: EntityLayoutRouteProps) => null = () => null;
 attachComponentData(Route, dataKey, true);
 attachComponentData(Route, 'core.gatherMountPoints', true); // This causes all mount points that are discovered within this route to use the path of the route itself
+
+const Group: (props: EntityLayoutGroupProps) => null = () => null;
+attachComponentData(Group, groupDataKey, true);
 
 function EntityLayoutTitle(props: {
   title: string;
@@ -439,3 +450,4 @@ export const EntityLayout = (props: EntityLayoutProps) => {
 };
 
 EntityLayout.Route = Route;
+EntityLayout.Group = Group;

--- a/plugins/catalog/src/components/EntityLayout/index.ts
+++ b/plugins/catalog/src/components/EntityLayout/index.ts
@@ -15,4 +15,8 @@
  */
 
 export { EntityLayout } from './EntityLayout';
-export type { EntityLayoutProps, EntityLayoutRouteProps } from './EntityLayout';
+export type {
+  EntityLayoutProps,
+  EntityLayoutRouteProps,
+  EntityLayoutGroupProps,
+} from './EntityLayout';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes an issue where `collectEntityPageContents` would ignore `EntityLayout.Group` elements when converting legacy JSX entity pages to the new frontend system. Routes inside groups were found, but without group info — so each route became its own tab instead of being grouped.

The fix:
- Adds `EntityLayout.Group` as a compound component in `@backstage/plugin-catalog`, with the `plugin.catalog.entityLayoutGroup` component data key
- Updates `collectEntityPageContents` to detect groups, extract the group ID from the title (kebab-cased), merge the group's `if` filter with the parent filter, and pass `group` through to the resulting `EntityContentBlueprint` extensions
- Threads the `parentGroup` through all recursive traverse paths (switch cases, generic children)

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))