### PR TITLE
microsite: add missing status field to plugin directory entry

### DIFF
--- a/microsite/data/plugins/balajisiva-backstage-plugin-template-builder.yaml
+++ b/microsite/data/plugins/balajisiva-backstage-plugin-template-builder.yaml
@@ -8,3 +8,4 @@ documentation: https://github.com/balajisiva/backstage-template-builder#readme
 iconUrl: https://raw.githubusercontent.com/balajisiva/backstage-template-builder/main/plugins/backstage-template-builder/icon.svg
 npmPackageName: '@balajisiva/backstage-plugin-template-builder'
 addedDate: '2026-02-16'
+status: active


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `balajisiva-backstage-plugin-template-builder.yaml` plugin directory entry is missing the required `status` field, which causes the `verify plugin directory` CI step to fail.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))