### PR TITLE
ci: run CI for changes to microsite/data/

### DIFF
--- a/.github/workflows/ci-noop.yml
+++ b/.github/workflows/ci-noop.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths:
       - 'microsite/**'
+      - '!microsite/data/**'
       - 'beps/**'
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,11 @@ name: CI
 on:
   # NOTE: If you change these you must update ci-noop.yml as well
   pull_request:
-    paths-ignore:
-      - 'microsite/**'
-      - 'beps/**'
+    paths:
+      - '**'
+      - '!microsite/**'
+      - 'microsite/data/**'
+      - '!beps/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `paths-ignore` for `microsite/**` was also skipping CI for changes to `microsite/data/plugins/`, which is where the plugin directory YAML files live. This meant the `verify plugin directory` step never ran for the files it was supposed to validate — allowing #33014 to slip through.

This switches from `paths-ignore` to `paths` with negation so that `microsite/data/` changes still trigger CI while other microsite changes (docs, storybook, etc.) remain excluded. Updates `ci-noop.yml` accordingly.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))