### PR TITLE
Fix error forwarding for `actionService` and `mcp-actions-backend`

### DIFF
--- a/.changeset/fix-mcp-error-forwarding.md
+++ b/.changeset/fix-mcp-error-forwarding.md
@@ -1,0 +1,7 @@
+---
+'@backstage/backend-defaults': patch
+'@backstage/backend-test-utils': patch
+'@backstage/plugin-mcp-actions-backend': patch
+---
+
+Fixed error forwarding in the actions registry so that known errors like `InputError` and `NotFoundError` thrown by actions preserve their original status codes and messages instead of being wrapped in `ForwardedError` and coerced to 500.

--- a/packages/backend-defaults/src/alpha/entrypoints/actionsRegistry/DefaultActionsRegistryService.ts
+++ b/packages/backend-defaults/src/alpha/entrypoints/actionsRegistry/DefaultActionsRegistryService.ts
@@ -28,12 +28,7 @@ import {
   ActionsRegistryActionOptions,
   ActionsRegistryService,
 } from '@backstage/backend-plugin-api/alpha';
-import {
-  ForwardedError,
-  InputError,
-  NotAllowedError,
-  NotFoundError,
-} from '@backstage/errors';
+import { InputError, NotAllowedError, NotFoundError } from '@backstage/errors';
 
 export class DefaultActionsRegistryService implements ActionsRegistryService {
   private actions: Map<string, ActionsRegistryActionOptions<any, any>> =
@@ -131,31 +126,24 @@ export class DefaultActionsRegistryService implements ActionsRegistryService {
           );
         }
 
-        try {
-          const result = await action.action({
-            input: input.data,
-            credentials,
-            logger: this.logger,
-          });
+        const result = await action.action({
+          input: input.data,
+          credentials,
+          logger: this.logger,
+        });
 
-          const output = action.schema?.output
-            ? action.schema.output(z).safeParse(result?.output)
-            : ({ success: true, data: result?.output } as const);
+        const output = action.schema?.output
+          ? action.schema.output(z).safeParse(result?.output)
+          : ({ success: true, data: result?.output } as const);
 
-          if (!output.success) {
-            throw new InputError(
-              `Invalid output from action "${req.params.actionId}"`,
-              output.error,
-            );
-          }
-
-          res.json({ output: output.data });
-        } catch (error) {
-          throw new ForwardedError(
-            `Failed execution of action "${req.params.actionId}"`,
-            error,
+        if (!output.success) {
+          throw new InputError(
+            `Invalid output from action "${req.params.actionId}"`,
+            output.error,
           );
         }
+
+        res.json({ output: output.data });
       },
     );
     return router;

--- a/packages/backend-test-utils/src/alpha/services/MockActionsRegistry.ts
+++ b/packages/backend-test-utils/src/alpha/services/MockActionsRegistry.ts
@@ -17,7 +17,7 @@ import {
   BackstageCredentials,
   LoggerService,
 } from '@backstage/backend-plugin-api';
-import { ForwardedError, InputError, NotFoundError } from '@backstage/errors';
+import { InputError, NotFoundError } from '@backstage/errors';
 import { JsonObject, JsonValue } from '@backstage/types';
 import { z, AnyZodObject } from 'zod';
 import zodToJsonSchema from 'zod-to-json-schema';
@@ -126,31 +126,24 @@ export class MockActionsRegistry
       throw new InputError(`Invalid input to action "${opts.id}"`, input.error);
     }
 
-    try {
-      const result = await action.action({
-        input: input.data,
-        credentials: opts.credentials ?? mockCredentials.none(),
-        logger: this.logger,
-      });
+    const result = await action.action({
+      input: input.data,
+      credentials: opts.credentials ?? mockCredentials.none(),
+      logger: this.logger,
+    });
 
-      const output = action.schema?.output
-        ? action.schema.output(z).safeParse(result?.output)
-        : ({ success: true, data: result?.output } as const);
+    const output = action.schema?.output
+      ? action.schema.output(z).safeParse(result?.output)
+      : ({ success: true, data: result?.output } as const);
 
-      if (!output.success) {
-        throw new InputError(
-          `Invalid output from action "${opts.id}"`,
-          output.error,
-        );
-      }
-
-      return { output: output.data };
-    } catch (error) {
-      throw new ForwardedError(
-        `Failed execution of action "${opts.id}"`,
-        error,
+    if (!output.success) {
+      throw new InputError(
+        `Invalid output from action "${opts.id}"`,
+        output.error,
       );
     }
+
+    return { output: output.data };
   }
 
   register<

--- a/plugins/mcp-actions-backend/src/services/handleErrors.test.ts
+++ b/plugins/mcp-actions-backend/src/services/handleErrors.test.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  InputError,
+  NotFoundError,
+  NotAllowedError,
+  ForwardedError,
+  ResponseError,
+} from '@backstage/errors';
+import { handleErrors } from './handleErrors';
+
+describe('handleErrors', () => {
+  it('should return the error description for a known error', async () => {
+    const result = await handleErrors(async () => {
+      throw new InputError('bad input');
+    });
+
+    expect(result).toEqual({
+      content: [{ type: 'text', text: 'InputError: bad input' }],
+      isError: true,
+    });
+  });
+
+  it('should return the error description for a NotFoundError', async () => {
+    const result = await handleErrors(async () => {
+      throw new NotFoundError('entity not found');
+    });
+
+    expect(result).toEqual({
+      content: [{ type: 'text', text: 'NotFoundError: entity not found' }],
+      isError: true,
+    });
+  });
+
+  it('should return the error description for a NotAllowedError', async () => {
+    const result = await handleErrors(async () => {
+      throw new NotAllowedError('forbidden');
+    });
+
+    expect(result).toEqual({
+      content: [{ type: 'text', text: 'NotAllowedError: forbidden' }],
+      isError: true,
+    });
+  });
+
+  it('should rethrow an unknown error', async () => {
+    await expect(
+      handleErrors(async () => {
+        throw new Error('unknown problem');
+      }),
+    ).rejects.toThrow('unknown problem');
+  });
+
+  it('should handle a ForwardedError that inherits the cause name', async () => {
+    const result = await handleErrors(async () => {
+      throw new ForwardedError(
+        'wrapper message',
+        new InputError('original error'),
+      );
+    });
+
+    // ForwardedError inherits name from cause and CustomErrorBase
+    // concatenates the cause message into the full message
+    expect(result).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: 'InputError: wrapper message; caused by InputError: original error',
+        },
+      ],
+      isError: true,
+    });
+  });
+
+  it('should extract the cause from a ResponseError', async () => {
+    const response = {
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      headers: new Headers({ 'content-type': 'application/json' }),
+      text: async () =>
+        JSON.stringify({
+          error: { name: 'InputError', message: 'bad value' },
+          response: { statusCode: 400 },
+        }),
+    };
+
+    const responseError = await ResponseError.fromResponse(response as any);
+
+    const result = await handleErrors(async () => {
+      throw responseError;
+    });
+
+    expect(result).toEqual({
+      content: [{ type: 'text', text: 'InputError: bad value' }],
+      isError: true,
+    });
+  });
+
+  it('should recursively extract through nested ResponseErrors', async () => {
+    const innerResponse = {
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      headers: new Headers({ 'content-type': 'application/json' }),
+      text: async () =>
+        JSON.stringify({
+          error: {
+            name: 'ResponseError',
+            message: 'Request failed with 400 Bad Request',
+            cause: { name: 'InputError', message: 'deeply nested error' },
+          },
+          response: { statusCode: 400 },
+        }),
+    };
+
+    const responseError = await ResponseError.fromResponse(
+      innerResponse as any,
+    );
+
+    const result = await handleErrors(async () => {
+      throw responseError;
+    });
+
+    expect(result).toEqual({
+      content: [{ type: 'text', text: 'InputError: deeply nested error' }],
+      isError: true,
+    });
+  });
+});

--- a/plugins/mcp-actions-backend/src/services/handleErrors.ts
+++ b/plugins/mcp-actions-backend/src/services/handleErrors.ts
@@ -35,14 +35,14 @@ const knownErrors = new Set([
   'ServiceUnavailableError',
 ]);
 
-// Extracts the cause error, if the provided error is `ResponseError` or
-// `ForwardedError` with a cause.
+// Recursively extracts the innermost cause from ResponseError or
+// ForwardedError wrappers to surface the original error.
 function extractCause(err: ErrorLike): ErrorLike {
   if (
     (err.name === 'ResponseError' || err instanceof ForwardedError) &&
     isError(err.cause)
   ) {
-    return err.cause;
+    return extractCause(err.cause);
   }
   return err;
 }


### PR DESCRIPTION
Known errors thrown by actions were wrapped in `ForwardedError`, which coerced 400-level status codes to 500 and buried the original error message. This removes the `ForwardedError` wrapping so errors propagate with their original type and status code. Maybe there's a better fix here?

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
