### PR TITLE
Speed up search-backend router tests

### DIFF
--- a/.changeset/fast-tests-search.md
+++ b/.changeset/fast-tests-search.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend': patch
+---
+
+Sped up router tests by removing the `wrapServer` dependency on `mockttp`.

--- a/plugins/search-backend/src/service/router.test.ts
+++ b/plugins/search-backend/src/service/router.test.ts
@@ -23,8 +23,6 @@ import {
 import express from 'express';
 import request from 'supertest';
 import { createRouter } from './router';
-import { wrapServer } from '@backstage/backend-openapi-utils/testUtils';
-import { Server } from 'node:http';
 import {
   mockCredentials,
   mockErrorHandler,
@@ -42,7 +40,7 @@ const mockPermissionEvaluator: PermissionEvaluator = {
 };
 
 describe('createRouter', () => {
-  let app: express.Express | Server;
+  let app: express.Express;
   let mockSearchEngine: jest.Mocked<SearchEngine>;
 
   const mockBaseUrl = 'http://backstage:9191/api/proxy';
@@ -87,7 +85,7 @@ describe('createRouter', () => {
       auth: mockServices.auth(),
       httpAuth: mockServices.httpAuth(),
     });
-    app = await wrapServer(express().use(router).use(mockErrorHandler()));
+    app = express().use(router).use(mockErrorHandler());
   });
 
   beforeEach(() => {
@@ -259,6 +257,8 @@ describe('createRouter', () => {
     });
 
     describe('search result filtering', () => {
+      let filterApp: express.Express;
+
       beforeAll(async () => {
         const logger = mockServices.logger.mock();
         mockSearchEngine = {
@@ -266,14 +266,10 @@ describe('createRouter', () => {
           setTranslator: jest.fn(),
           query: jest.fn(),
         };
-        const indexBuilder = new IndexBuilder({
-          logger,
-          searchEngine: mockSearchEngine,
-        });
 
         const router = await createRouter({
-          engine: indexBuilder.getSearchEngine(),
-          types: indexBuilder.getDocumentTypes(),
+          engine: mockSearchEngine,
+          types: {},
           config: new ConfigReader({ permissions: { enabled: false } }),
           permissions: mockPermissionEvaluator,
           discovery,
@@ -281,7 +277,7 @@ describe('createRouter', () => {
           auth: mockServices.auth(),
           httpAuth: mockServices.httpAuth(),
         });
-        app = express().use(router);
+        filterApp = express().use(router);
       });
 
       describe('where the search result set includes unsafe results', () => {
@@ -314,7 +310,7 @@ describe('createRouter', () => {
         });
 
         it('removes the unsafe results', async () => {
-          const response = await request(app).get('/query');
+          const response = await request(filterApp).get('/query');
 
           expect(response.status).toEqual(200);
           expect(response.body).toMatchObject({ results: [safeResult] });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Remove the `mockttp`-backed `wrapServer` dependency from the search-backend router tests. This avoids transpiling 918 transitive modules just for OpenAPI spec validation, cutting warm-cache test time roughly in half (~1.5s vs ~3s+).

- Replace `wrapServer(express().use(router))` with plain `express().use(router)` + supertest
- Simplify the nested "search result filtering" `beforeAll` by passing the mock engine directly instead of wrapping it in an `IndexBuilder`
- Scope the filtering sub-tests to their own `filterApp` variable instead of reassigning the outer `app`

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

🤖 Generated with [Claude Code](https://claude.com/claude-code)