### PR TITLE
Added Playwright E2E test for catalog entity creation flow

### DIFF
--- a/packages/app/e2e-tests/CreateEntityFlow.test.ts
+++ b/packages/app/e2e-tests/CreateEntityFlow.test.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from '@playwright/test';
+import { failOnBrowserErrors } from '@backstage/e2e-test-utils';
+
+failOnBrowserErrors();
+
+test('user can register an existing component via catalog import', async ({
+  page,
+}) => {
+  // Stub catalog location creation to keep the flow deterministic.
+  await page.route('**/api/catalog/locations**', async route => {
+    if (route.request().method() !== 'POST') {
+      return route.continue();
+    }
+
+    const requestBody = route.request().postDataJSON() as {
+      target?: string;
+    };
+    const target =
+      requestBody?.target ??
+      'https://github.com/backstage/backstage/blob/master/catalog-info.yaml';
+
+    return route.fulfill({
+      status: 201,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        location: { type: 'url', target },
+        entities: [
+          {
+            kind: 'Component',
+            metadata: {
+              name: 'imported-component-e2e',
+              namespace: 'default',
+            },
+          },
+        ],
+        exists: route.request().url().includes('dryRun=true') ? false : false,
+      }),
+    });
+  });
+
+  await page.goto('/');
+
+  const enterButton = page.getByRole('button', { name: 'Enter' });
+  await expect(enterButton).toBeVisible();
+  await enterButton.click();
+
+  await expect(page).toHaveURL(/\/catalog/);
+
+  await page.goto('/catalog-import');
+
+  await expect(
+    page.getByRole('heading', { name: 'Register an existing component' }),
+  ).toBeVisible();
+
+  const exampleUrl =
+    'https://github.com/backstage/backstage/blob/master/catalog-info.yaml';
+
+  await page.getByLabel('URL').fill(exampleUrl);
+  await page.getByRole('button', { name: 'Analyze' }).click();
+
+  await expect(
+    page.getByText('The following entities will be added to the catalog:'),
+  ).toBeVisible();
+  await expect(page.getByText('imported-component-e2e')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Import' }).click();
+
+  await expect(
+    page.getByText('The following entities have been added to the catalog:'),
+  ).toBeVisible();
+  await expect(page.getByText('imported-component-e2e')).toBeVisible();
+});


### PR DESCRIPTION
Closes #8

### Summary

- Add `CreateEntityFlow.test.ts` Playwright E2E test under `packages/app/e2e-tests`.
- Exercise the “Register existing component” flow via `/catalog-import`, from landing on the app to confirming the imported component.
- Stub `POST /api/catalog/locations` so the flow is deterministic and does not depend on a real catalog backend or external SCM.

### How to run the relevant tests

cd backstage
yarn install
yarn tsc
yarn build:all
yarn e2e-test run
# or: npx playwright test --config=playwright.config.ts

## What changed and why?

- Added a Playwright E2E test (`CreateEntityFlow.test.ts`) that drives the “Register existing component” flow through the catalog import page.
- This protects the core create/register entity journey, which is high-impact for catalog onboarding and a key regression risk.
- The test stubs the catalog location API so it’s deterministic and doesn’t depend on external SCM or a real catalog backend.

## Why is this the right test layer (UI / E2E)?

- The flow spans routing, frontend form validation, internationalized copy, and the interaction with the catalog-import wizard.
- Only a full browser-level test can verify that these pieces work together from the user’s perspective (navigation → form → review → finish).
- Lower-level unit tests already exist for catalog-import internals; this E2E test focuses on the end-to-end behavior.

## What could still break / what’s not covered?

- It relies on a stubbed `/api/catalog/locations` response, so issues in the real backend’s integration with SCM or catalog validation are not covered.
- Variants of the flow (e.g., multiple locations, repositories with no entities, error handling) are not exercised.
- Permission-related failures (`catalogEntityCreatePermission`) or sign-in flows are not tested here.

## What risks or follow-ups remain?

- Future changes to the catalog-import UI copy or layout could make selectors brittle and might require test updates.
- We may want additional E2E tests for:
  - Importing repositories with multiple entity files.
  - Handling error states (invalid URL, missing entities, permission errors).
- If we integrate with upstream Backstage, we might add a changeset for this test-only change.