### PR TITLE
Re-establish postgres connection pool on config changes

### DIFF
--- a/.changeset/pg-config-reconnect.md
+++ b/.changeset/pg-config-reconnect.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+The postgres database connector now automatically reconnects the connection pool when the underlying configuration changes, for example when environment-injected secrets in the configuration change.

--- a/packages/backend-defaults/src/entrypoints/database/connectors/postgres.test.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/postgres.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { mockServices } from '@backstage/backend-test-utils';
 import { Config, ConfigReader } from '@backstage/config';
 import {
   buildPgDatabaseConfig,
@@ -23,11 +24,16 @@ import {
   parsePgConnectionString,
 } from './postgres';
 import { type Knex } from 'knex';
+import waitForExpect from 'wait-for-expect';
 
 jest.mock('@google-cloud/cloud-sql-connector');
 jest.mock('@azure/identity');
 
 describe('postgres', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   const createMockConnection = () => ({
     host: 'acme',
     user: 'foo',
@@ -683,6 +689,120 @@ describe('postgres', () => {
           ),
         ),
       ).rejects.toThrow(/no such file or directory/);
+    });
+
+    it('wraps connection in a factory when subscribe is available', async () => {
+      const knex = jest.fn().mockReturnValue({});
+      const config = createConfig({
+        host: 'acme',
+        user: 'foo',
+        password: 'bar',
+        database: 'foodb',
+      });
+      config.subscribe = () => ({ unsubscribe: () => {} });
+
+      await createPgDatabaseClient(config, {
+        testInjectedKnexFactory: knex as any,
+        subscribe: true,
+      });
+
+      expect(knex).toHaveBeenCalledWith(
+        expect.objectContaining({
+          connection: expect.any(Function),
+        }),
+      );
+    });
+
+    it('does not wrap connection when subscribe is not available', async () => {
+      const knex = jest.fn().mockReturnValue({});
+
+      await createPgDatabaseClient(
+        createConfig({
+          host: 'acme',
+          user: 'foo',
+          password: 'bar',
+          database: 'foodb',
+        }),
+        { testInjectedKnexFactory: knex as any, subscribe: true },
+      );
+
+      expect(knex).toHaveBeenCalledWith(
+        expect.objectContaining({
+          connection: expect.objectContaining({ host: 'acme' }),
+        }),
+      );
+    });
+
+    it('rebuilds connection config on subscribe callback', async () => {
+      const knex = jest.fn().mockReturnValue({});
+      let onChange: (() => void) | undefined;
+      const config = createConfig({
+        host: 'acme',
+        user: 'foo',
+        password: 'bar',
+        database: 'foodb',
+      });
+      config.subscribe = cb => {
+        onChange = cb;
+        return { unsubscribe: () => {} };
+      };
+
+      await createPgDatabaseClient(config, {
+        testInjectedKnexFactory: knex as any,
+        subscribe: true,
+      });
+
+      const connFn = knex.mock.calls[0][0].connection as Function;
+
+      // Before any config change, the factory returns the original config
+      const conn1 = await connFn();
+      expect(conn1).toEqual(
+        expect.objectContaining({ host: 'acme', password: 'bar' }),
+      );
+      expect(conn1.expirationChecker()).toBe(false);
+
+      // Trigger a config change - since ConfigReader is a snapshot,
+      // the rebuilt config is identical so nothing should expire
+      onChange!();
+      await waitForExpect(async () => {
+        const conn = await connFn();
+        expect(conn.expirationChecker()).toBe(false);
+      });
+    });
+
+    it('logs a warning when config rebuild fails', async () => {
+      const knex = jest.fn().mockReturnValue({});
+      const logger = mockServices.logger.mock();
+      let onChange: (() => void) | undefined;
+      const config = createConfig({
+        host: 'acme',
+        user: 'foo',
+        password: 'bar',
+        database: 'foodb',
+      });
+      config.subscribe = cb => {
+        onChange = cb;
+        return { unsubscribe: () => {} };
+      };
+
+      await createPgDatabaseClient(config, {
+        testInjectedKnexFactory: knex as any,
+        logger,
+        subscribe: true,
+      });
+
+      // Break the config so rebuilding will fail
+      (config as any).get = () => {
+        throw new Error('broken config');
+      };
+
+      onChange!();
+      await waitForExpect(() => {
+        expect(logger.warn).toHaveBeenCalledWith(
+          'Failed to rebuild database connection config after config change',
+          expect.objectContaining({ error: expect.any(Error) }),
+        );
+      });
     });
   });
 

--- a/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
@@ -26,8 +26,8 @@ import {
   HumanDuration,
   JsonObject,
 } from '@backstage/types';
-import knexFactory, { Knex } from 'knex';
-import { merge, omit } from 'lodash';
+import defaultKnexFactory, { Knex } from 'knex';
+import { isEqual, merge, omit } from 'lodash';
 import limiterFactory from 'p-limit';
 import { Client } from 'pg';
 import { Connector } from '../types';
@@ -46,13 +46,86 @@ const ddlLimiter = limiterFactory(1);
  */
 export async function createPgDatabaseClient(
   dbConfig: Config,
-  overrides?: Knex.Config,
+  options?: {
+    overrides?: Knex.Config;
+    logger?: LoggerService;
+    testInjectedKnexFactory?: typeof defaultKnexFactory;
+    subscribe?: boolean;
+  },
 ) {
+  const overrides = options?.overrides;
+  const logger = options?.logger;
+  const knexFactory = options?.testInjectedKnexFactory ?? defaultKnexFactory;
+  const subscribe = options?.subscribe ?? false;
   const knexConfig = await buildPgDatabaseConfig(dbConfig, overrides);
+
+  // If the connection is already a function (Azure/CloudSQL), it handles
+  // its own connection lifecycle via expirationChecker, so use it as-is.
+  // For static connections, wrap in a connection factory that responds to
+  // config changes so the pool can reconnect with updated credentials.
+  if (
+    subscribe &&
+    typeof knexConfig.connection !== 'function' &&
+    dbConfig.subscribe
+  ) {
+    const current: { connection: Knex.PgConnectionConfig } = {
+      connection: knexConfig.connection,
+    };
+    const next: { connection?: Knex.PgConnectionConfig } = {
+      connection: undefined,
+    };
+
+    let configReveision = 0;
+    dbConfig.subscribe(() => {
+      configReveision += 1;
+      const startRevision = configReveision;
+      buildPgDatabaseConfig(dbConfig, overrides).then(
+        rebuilt => {
+          if (
+            startRevision === configReveision &&
+            !isEqual(rebuilt.connection, current.connection)
+          ) {
+            logger?.info(
+              'Database config changed, reconnecting connection pool',
+              { connection: rebuilt.connection },
+            );
+            next.connection = rebuilt.connection;
+          }
+        },
+        error => {
+          // Config may be in an intermediate state during hot reload;
+          // keep the previous connection until a valid one arrives
+          logger?.warn(
+            `Failed to rebuild database connection config after config change`,
+            { error },
+          );
+        },
+      );
+    });
+
+    knexConfig.connection = async () => {
+      const expirationChecker = () => {
+        // It's safe to compare by reference, because the change handler above
+        // performs a deep compare and replaces the entire object if there are
+        // differences.
+        const needsReload = next.connection !== undefined;
+        console.log('EXPIRATION CHECKER', needsReload);
+        if (needsReload) {
+          current.connection = next.connection!;
+          next.connection = undefined;
+          return true;
+        }
+        return false;
+      };
+      return typeof current.connection === 'string'
+        ? { connectionString: current.connection, expirationChecker }
+        : { ...current.connection, expirationChecker };
+    };
+  }
+
   const database = knexFactory(knexConfig);
 
   const role = dbConfig.getOptionalString('role');
-
   if (role) {
     database.client.pool.on(
       'createSuccess',
@@ -62,6 +135,7 @@ export async function createPgDatabaseClient(
       },
     );
   }
+
   return database;
 }
 
@@ -105,9 +179,9 @@ export async function buildPgDatabaseConfig(
 
   switch (config.connection.type) {
     case 'azure':
-      return buildAzurePgConfig(mergedConfigReader);
+      return await buildAzurePgConfig(mergedConfigReader);
     case 'cloudsql':
-      return buildCloudSqlConfig(mergedConfigReader);
+      return await buildCloudSqlConfig(mergedConfigReader);
     default:
       throw new Error(`Unknown connection type: ${config.connection.type}`);
   }
@@ -324,12 +398,14 @@ export async function ensurePgDatabaseExists(
   ...databases: Array<string>
 ) {
   const admin = await createPgDatabaseClient(dbConfig, {
-    connection: {
-      database: 'postgres',
-    },
-    pool: {
-      min: 0,
-      acquireTimeoutMillis: 10000,
+    overrides: {
+      connection: {
+        database: 'postgres',
+      },
+      pool: {
+        min: 0,
+        acquireTimeoutMillis: 10000,
+      },
     },
   });
 
@@ -607,7 +683,7 @@ export class PgConnector implements Connector {
 
   async getClient(
     pluginId: string,
-    _deps: {
+    deps: {
       logger: LoggerService;
       lifecycle: LifecycleService;
     },
@@ -640,13 +716,11 @@ export class PgConnector implements Connector {
       }
     }
 
-    const client = createPgDatabaseClient(
-      this.config,
-      mergeDatabaseConfig(
-        pluginDbConfig.knexConfig,
-        pluginDbConfig.databaseClientOverrides,
-      ),
-    );
+    const client = createPgDatabaseClient(this.config, {
+      overrides: pluginDbConfig.databaseClientOverrides,
+      logger: deps.logger,
+      subscribe: true,
+    });
 
     return client;
   }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When database configuration changes at runtime (e.g. during config hot reload), the postgres connection pool now automatically reconnects with the updated configuration.

This works by:
- Subscribing to `Config.subscribe()` for change notifications
- Structurally comparing the connection config on each change
- Using knex's `expirationChecker` on `PgConnectionConfig` to signal that existing pooled connections should be replaced

This only applies to static connection configs (the default path). Azure and CloudSQL connections already manage their own lifecycle via connection functions.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

🤖 Generated with [Claude Code](https://claude.com/claude-code)