### PR TITLE
fix(ui): fix scroll overflow in Menu and Select popovers

### DIFF
--- a/.changeset/khaki-days-arrive.md
+++ b/.changeset/khaki-days-arrive.md
@@ -1,0 +1,7 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed scroll overflow in Menu and Select popover content when constrained by viewport height.
+
+**Affected components:** Menu, Select

--- a/packages/ui/src/components/Menu/Menu.module.css
+++ b/packages/ui/src/components/Menu/Menu.module.css
@@ -58,6 +58,10 @@
 
   .bui-MenuInner {
     border-radius: var(--menu-border-radius);
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    overflow: hidden;
   }
 
   .bui-MenuContent {

--- a/packages/ui/src/components/Select/Select.module.css
+++ b/packages/ui/src/components/Select/Select.module.css
@@ -116,12 +116,17 @@
     }
   }
 
-  .bui-SelectList:focus-visible {
-    /* Remove default focus-visible outline because React Aria
-     * triggers it on mouse click open of the list for some reason.
-     * On keyboard use, the top item receives the focus style,
-     * so it's not needed anyway. */
-    outline: none;
+  .bui-SelectList {
+    overflow: auto;
+    min-height: 0;
+
+    &:focus-visible {
+      /* Remove default focus-visible outline because React Aria
+       * triggers it on mouse click open of the list for some reason.
+       * On keyboard use, the top item receives the focus style,
+       * so it's not needed anyway. */
+      outline: none;
+    }
   }
 
   .bui-SelectItem {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When viewport height constrains the popover, Menu and Select
content now scrolls instead of overflowing the popover boundary.

- Menu: add flex column layout and `overflow: hidden` to
  `.bui-MenuInner` so the scroll chain from popover to content
  is unbroken
- Select: add `overflow: auto` and `min-height: 0` to
  `.bui-SelectList` so the list scrolls when constrained

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.