### PR TITLE
plugin-catalog: fix entity page default content order config name

### DIFF
--- a/.changeset/entity-page-group-aliases-and-ordering-catalog.md
+++ b/.changeset/entity-page-group-aliases-and-ordering-catalog.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog': minor
 ---
 
-Added support for group alias IDs and configurable content ordering on the entity page. Groups can now declare `aliases` so that content targeting an aliased group is included in the group. A new `contentOrder` option (default `title`) controls how content items within each group are sorted, with support for both a page-level default and per-group overrides.
+Added support for group alias IDs and configurable content ordering on the entity page. Groups can now declare `aliases` so that content targeting an aliased group is included in the group. A new `defaultContentOrder` option (default `title`) controls how content items within each group are sorted, with support for both a page-level default and per-group overrides.

--- a/docs/features/software-catalog/catalog-customization.md
+++ b/docs/features/software-catalog/catalog-customization.md
@@ -730,12 +730,12 @@ Notes:
 
 ### Content ordering within groups
 
-By default, content items within each group are sorted alphabetically by title. You can change this with the `contentOrder` option, which supports two modes:
+By default, content items within each group are sorted alphabetically by title. You can change this with the `defaultContentOrder` option, which supports two modes:
 
 - **`title`** (default) — sort alphabetically by the content extension's title (case-insensitive).
 - **`natural`** — preserve the natural extension discovery/registration order.
 
-A page-level `contentOrder` sets the default for all groups, and individual groups can override it:
+A page-level `defaultContentOrder` sets the default for all groups, and individual groups can override it with a per-group `contentOrder`:
 
 ```yaml
 app:
@@ -743,7 +743,7 @@ app:
     - page:catalog/entity:
         config:
           # Default content order for all groups
-          contentOrder: title
+          defaultContentOrder: title
 
           groups:
             - documentation:

--- a/packages/app/app-config.yaml
+++ b/packages/app/app-config.yaml
@@ -49,7 +49,7 @@ app:
         config:
           showNavItemIcons: true
           # default content order for all groups, can be 'title' or 'natural'
-          # contentOrder: title
+          # defaultContentOrder: title
           groups:
             # placing a tab at the beginning
             - overview:

--- a/plugins/catalog/report-alpha.api.md
+++ b/plugins/catalog/report-alpha.api.md
@@ -1097,12 +1097,12 @@ const _default: OverridableFrontendPlugin<
               {
                 title: string;
                 icon?: string | undefined;
-                contentOrder?: 'title' | 'natural' | undefined;
                 aliases?: string[] | undefined;
+                contentOrder?: 'title' | 'natural' | undefined;
               }
             >[]
           | undefined;
-        contentOrder: 'title' | 'natural';
+        defaultContentOrder: 'title' | 'natural';
         showNavItemIcons: boolean;
         path: string | undefined;
         title: string | undefined;
@@ -1114,13 +1114,13 @@ const _default: OverridableFrontendPlugin<
               {
                 title: string;
                 icon?: string | undefined;
-                contentOrder?: 'title' | 'natural' | undefined;
                 aliases?: string[] | undefined;
+                contentOrder?: 'title' | 'natural' | undefined;
               }
             >[]
           | undefined;
+        defaultContentOrder?: 'title' | 'natural' | undefined;
         showNavItemIcons?: boolean | undefined;
-        contentOrder?: 'title' | 'natural' | undefined;
         title?: string | undefined;
         path?: string | undefined;
       };

--- a/plugins/catalog/src/alpha/pages.test.tsx
+++ b/plugins/catalog/src/alpha/pages.test.tsx
@@ -523,7 +523,7 @@ describe('Entity page', () => {
         Object.assign({ namespace: 'catalog' }, catalogEntityPage),
         {
           config: {
-            contentOrder: 'natural',
+            defaultContentOrder: 'natural',
           },
         },
       )
@@ -564,7 +564,7 @@ describe('Entity page', () => {
         Object.assign({ namespace: 'catalog' }, catalogEntityPage),
         {
           config: {
-            contentOrder: 'title',
+            defaultContentOrder: 'title',
             groups: [
               {
                 documentation: {

--- a/plugins/catalog/src/alpha/pages.tsx
+++ b/plugins/catalog/src/alpha/pages.tsx
@@ -115,7 +115,7 @@ export const catalogEntityPage = PageBlueprint.makeWithOverrides({
             ),
           )
           .optional(),
-      contentOrder: z =>
+      defaultContentOrder: z =>
         z.enum(['title', 'natural']).optional().default('title'),
       showNavItemIcons: z => z.boolean().optional().default(false),
     },
@@ -178,7 +178,7 @@ export const catalogEntityPage = PageBlueprint.makeWithOverrides({
                 header={header}
                 contextMenuItems={filteredMenuItems}
                 groupDefinitions={groupDefinitions}
-                defaultContentOrder={config.contentOrder}
+                defaultContentOrder={config.defaultContentOrder}
                 showNavItemIcons={config.showNavItemIcons}
               >
                 {inputs.contents.map(output => (


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes a mistake from #33019 where the top-level config option for the entity page content ordering was named `contentOrder` instead of `defaultContentOrder`. The `contentOrder` name was only supposed to be used for the per-group configurations, while the page-level default should be `defaultContentOrder` to distinguish the two.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))