### PR TITLE
docs: add no-animal-violence Vale package for inclusive language checking

### DIFF
--- a/.github/workflows/verify_docs-quality.yml
+++ b/.github/workflows/verify_docs-quality.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches: [master]
     paths:
+      - '.vale.ini'
       - '.github/workflows/verify_docs-quality.yml'
       - '**.md'
 
@@ -40,6 +41,11 @@ jobs:
           tar -xzf "$VALE_DIST_DIR/$VALE_ARCHIVE" -C "$HOME/.local/bin" vale
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           vale --version
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Sync vale packages
+        run: vale sync
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/.vale.ini
+++ b/.vale.ini
@@ -2,7 +2,7 @@ StylesPath = .github/vale
 
 Vocab = Backstage
 
-Packages = https://github.com/Open-Paws/vale-no-animal-violence/releases/latest/download/NoAnimalViolence.zip
+Packages = https://github.com/Open-Paws/vale-no-animal-violence/releases/download/v0.1.0/NoAnimalViolence.zip
 
 [*.md]
 BasedOnStyles = Vale, NoAnimalViolence


### PR DESCRIPTION
Adds the [no-animal-violence](https://github.com/Open-Paws/vale-no-animal-violence) Vale package to the docs Vale configuration.

The package flags phrases that normalize violence toward animals and suggests clearer, more professional alternatives common in backend and platform engineering docs:

| Phrase | Suggested alternative |
|--------|----------------------|
| "kill two birds with one stone" | "accomplish two things at once" |
| "guinea pig" | "test subject" |
| "cattle vs. pets" | "ephemeral vs. persistent" |
| "canary deployment" | "progressive rollout" |
| "sacred cow" | "unquestioned belief" |
| "scapegoat" | "blame target" |

**Package**: https://github.com/Open-Paws/vale-no-animal-violence (MIT)

**Changes**:
- `.vale.ini` — add `Packages` with the NoAnimalViolence URL (pinned to v0.1.0) and `NoAnimalViolence` to `BasedOnStyles`
- `.github/workflows/verify_docs-quality.yml` — add `vale sync` step to download packages before linting; add `.vale.ini` to path triggers

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))