### PR TITLE
feat(ui/Text): add copy-to-clipboard and disabled features

### DIFF
--- a/.changeset/rude-geese-cover.md
+++ b/.changeset/rude-geese-cover.md
@@ -1,0 +1,6 @@
+---
+'@backstage/ui': minor
+---
+
+Add copy-to-clipboard feature to Text component
+Add disabled prop to Text component

--- a/packages/ui/src/components/Text/Text.module.css
+++ b/packages/ui/src/components/Text/Text.module.css
@@ -107,5 +107,12 @@
   .bui-Text[data-as='em'],
   .bui-Text[data-as='small'] {
     display: inline-block;
-  }
+    }
+    
+    .bui-Text--disabled {
+      color: #aaa !important;
+      opacity: 0.6;
+      pointer-events: none;
+      user-select: none;
+    }
 }

--- a/packages/ui/src/components/Text/Text.stories.tsx
+++ b/packages/ui/src/components/Text/Text.stories.tsx
@@ -175,3 +175,28 @@ export const Playground = meta.story({
     </Flex>
   ),
 });
+
+export const Copyable = meta.story({
+  args: {
+    children: 'This text can be copied!',
+    copyable: true,
+  },
+  render: args => (
+    <Flex gap="4" direction="column">
+      <Text {...args} />
+      {/* <Text {...args} variant="body-large" children="Try copying this large text!" /> */}
+    </Flex>
+  ),
+});
+
+export const Disabled = meta.story({
+  args: {
+    children: 'This text is disabled',
+    disabled: true,
+  },
+  render: args => (
+    <Flex gap="4" direction="column">
+      <Text {...args} />
+    </Flex>
+  ),
+});

--- a/packages/ui/src/components/Text/Text.tsx
+++ b/packages/ui/src/components/Text/Text.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { forwardRef } from 'react';
+import { forwardRef, useState } from 'react';
 import clsx from 'clsx';
 import type { ElementType } from 'react';
 import type { TextProps } from './types';
@@ -27,7 +27,6 @@ function TextComponent<T extends ElementType = 'span'>(
   ref: React.Ref<any>,
 ) {
   const Component = props.as || 'span';
-
   const { classNames, dataAttributes, cleanedProps } = useStyles(
     TextDefinition,
     {
@@ -37,16 +36,50 @@ function TextComponent<T extends ElementType = 'span'>(
       ...props,
     },
   );
+  const { className, truncate, copyable, children, disabled, ...restProps } =
+    cleanedProps;
+  const [copied, setCopied] = useState(false);
 
-  const { className, truncate, ...restProps } = cleanedProps;
+  const handleCopy = () => {
+    if (typeof children === 'string') {
+      window.navigator.clipboard.writeText(children);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    }
+  };
 
   return (
-    <Component
-      ref={ref}
-      className={clsx(classNames.root, styles[classNames.root], className)}
-      {...dataAttributes}
-      {...restProps}
-    />
+    <span style={{ display: 'inline-flex', alignItems: 'center' }}>
+      <Component
+        ref={ref}
+        className={clsx(
+          classNames.root,
+          styles[classNames.root],
+          className,
+          disabled && styles['bui-Text--disabled'],
+        )}
+        {...dataAttributes}
+        {...restProps}
+        aria-disabled={disabled || undefined}
+      >
+        {children}
+      </Component>
+      {copyable && typeof children === 'string' && !disabled && (
+        <button
+          type="button"
+          aria-label="Copy text"
+          onClick={handleCopy}
+          style={{ marginLeft: 4, cursor: 'pointer' }}
+        >
+          📋
+        </button>
+      )}
+      {copied && (
+        <span style={{ marginLeft: 4, color: 'green', fontSize: '0.9em' }}>
+          Copied!
+        </span>
+      )}
+    </span>
   );
 }
 

--- a/packages/ui/src/components/Text/types.ts
+++ b/packages/ui/src/components/Text/types.ts
@@ -47,6 +47,8 @@ export type TextOwnProps = {
     | TextColorStatus
     | Partial<Record<Breakpoint, TextColors | TextColorStatus>>;
   truncate?: boolean;
+  copyable?: boolean;
+  disabled?: boolean;
 };
 
 /** @public */


### PR DESCRIPTION
Adds copy-to-clipboard functionality to the Text component
Introduces a disabled prop for visually non-interactive text
Updates stories and documentation for new Text features

<img width="242" height="82" alt="image" src="https://github.com/user-attachments/assets/2fae6934-3243-4bca-a111-4f6b2bd981a0" />

<img width="272" height="97" alt="image" src="https://github.com/user-attachments/assets/3aaecd33-2494-4ce0-83d3-ebdeeced442f" />


- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
