### PR TITLE
fix(repo-tools): re-add allowExcessArguments for generate-catalog-info

### DIFF
--- a/.changeset/bright-items-see.md
+++ b/.changeset/bright-items-see.md
@@ -1,0 +1,5 @@
+---
+'@backstage/repo-tools': patch
+---
+
+Fixed `generate-catalog-info` command failing with "too many arguments" when invoked by lint-staged via the pre-commit hook.

--- a/packages/repo-tools/src/commands/index.ts
+++ b/packages/repo-tools/src/commands/index.ts
@@ -226,6 +226,7 @@ export function registerCommands(program: Command) {
       'CI run checks that there are no changes to catalog-info.yaml files',
     )
     .description('Create or fix info yaml files for all backstage packages')
+    .allowExcessArguments(true)
     .action(
       lazy(
         () => import('./generate-catalog-info/generate-catalog-info'),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Re-adds `.allowExcessArguments(true)` to the `generate-catalog-info`
command, which was accidentally removed during conflict resolution
in the Commander v14 upgrade (#32583).

lint-staged passes staged file paths as extra arguments when invoking
`generate-catalog-info` via the pre-commit hook. Commander v14 rejects
excess arguments by default, so staging any nested `package.json` now
breaks the pre-commit hook with "too many arguments".

Only `generate-catalog-info` is affected — `type-deps` and `peer-deps`
are not invoked by lint-staged.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.