### PR TITLE
feat: sidebar submenuitem active match on URL hash

### DIFF
--- a/.changeset/rotten-months-wear.md
+++ b/.changeset/rotten-months-wear.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': minor
+---
+
+Adds optional matchHash prop for sidebar sub menu items which allows matching hash in URL when determining active state of menu item

--- a/.github/vale/config/vocabularies/Backstage/accept.txt
+++ b/.github/vale/config/vocabularies/Backstage/accept.txt
@@ -262,6 +262,7 @@ maintainership
 makefile
 Matomo
 matchers
+matchHash
 md
 memcache
 memoization

--- a/packages/core-components/report.api.md
+++ b/packages/core-components/report.api.md
@@ -1217,6 +1217,7 @@ export type SidebarSubmenuItemProps = {
   icon?: IconComponent;
   dropdownItems?: SidebarSubmenuItemDropdownItem[];
   exact?: boolean;
+  matchHash?: boolean;
   initialShowDropdown?: boolean;
 };
 

--- a/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
+++ b/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
@@ -137,7 +137,7 @@ export type SidebarSubmenuItemDropdownItem = {
  * to: Path to navigate to when item is clicked
  * icon: Icon displayed on the left of text content
  * dropdownItems: Optional array of dropdown items displayed when submenu item is clicked.
- * exact: Match query string in URL when testing for "active" menu item
+ * exact: Match query parameters in URL exactly (otherwise subset match is used)
  * matchHash: Match hash in URL (e.g. 'toolbox#my-tool') when testing for "active" menu item
  *
  * @public

--- a/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
+++ b/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
@@ -137,6 +137,8 @@ export type SidebarSubmenuItemDropdownItem = {
  * to: Path to navigate to when item is clicked
  * icon: Icon displayed on the left of text content
  * dropdownItems: Optional array of dropdown items displayed when submenu item is clicked.
+ * exact: Match query string in URL when testing for "active" menu item
+ * matchHash: Match hash in URL (e.g. 'toolbox#my-tool') when testing for "active" menu item
  *
  * @public
  */
@@ -147,6 +149,7 @@ export type SidebarSubmenuItemProps = {
   icon?: IconComponent;
   dropdownItems?: SidebarSubmenuItemDropdownItem[];
   exact?: boolean;
+  matchHash?: boolean;
   initialShowDropdown?: boolean;
 };
 
@@ -156,7 +159,15 @@ export type SidebarSubmenuItemProps = {
  * @public
  */
 export const SidebarSubmenuItem = (props: SidebarSubmenuItemProps) => {
-  const { title, subtitle, to, icon: Icon, dropdownItems, exact } = props;
+  const {
+    title,
+    subtitle,
+    to,
+    icon: Icon,
+    dropdownItems,
+    exact,
+    matchHash,
+  } = props;
   const classes = useStyles();
   const { setIsHoveredOn } = useContext(SidebarItemWithSubmenuContext);
   const closeSubmenu = () => {
@@ -164,7 +175,7 @@ export const SidebarSubmenuItem = (props: SidebarSubmenuItemProps) => {
   };
   const toLocation = useResolvedPath(to ?? '');
   const currentLocation = useLocation();
-  let isActive = isLocationMatch(currentLocation, toLocation, exact);
+  let isActive = isLocationMatch(currentLocation, toLocation, exact, matchHash);
 
   const [showDropDown, setShowDropDown] = useState(
     props.initialShowDropdown ?? false,
@@ -175,7 +186,12 @@ export const SidebarSubmenuItem = (props: SidebarSubmenuItemProps) => {
   if (dropdownItems !== undefined) {
     dropdownItems.some(item => {
       const resolvedPath = resolvePath(item.to);
-      isActive = isLocationMatch(currentLocation, resolvedPath, exact);
+      isActive = isLocationMatch(
+        currentLocation,
+        resolvedPath,
+        exact,
+        matchHash,
+      );
       return isActive;
     });
     return (

--- a/packages/core-components/src/layout/Sidebar/utils.test.ts
+++ b/packages/core-components/src/layout/Sidebar/utils.test.ts
@@ -121,4 +121,56 @@ describe('isLocationMatching', () => {
       expect(isLocationMatch(currentLocation, toLocation, true)).toBe(true);
     });
   });
+
+  describe('hash matching', () => {
+    it('return true when hash does not match, but hashMatch is not enabled', async () => {
+      currentLocation = {
+        pathname: '/toolbox',
+        search: '?x=foo&y=bar',
+        state: null,
+        hash: '#my-tool',
+        key: '',
+      };
+      toLocation = {
+        pathname: '/toolbox',
+        search: '?x=foo',
+        hash: '#other-tool',
+      };
+      expect(isLocationMatch(currentLocation, toLocation, false, false)).toBe(
+        true,
+      );
+    });
+
+    it('return false when hash does not match, and hashMatch is enabled', async () => {
+      currentLocation = {
+        pathname: '/toolbox',
+        search: '?x=foo&y=bar',
+        state: null,
+        hash: '#my-tool',
+        key: '',
+      };
+      toLocation = {
+        pathname: '/toolbox',
+        search: '?x=foo',
+        hash: '#other-tool',
+      };
+      expect(isLocationMatch(currentLocation, toLocation, false, true)).toBe(
+        false,
+      );
+    });
+
+    it('return true when hash does match, and hashMatch is enabled', async () => {
+      currentLocation = {
+        pathname: '/toolbox',
+        search: '?x=foo&y=bar',
+        state: null,
+        hash: '#my-tool',
+        key: '',
+      };
+      toLocation = { pathname: '/toolbox', search: '?x=foo', hash: '#my-tool' };
+      expect(isLocationMatch(currentLocation, toLocation, false, true)).toBe(
+        true,
+      );
+    });
+  });
 });

--- a/packages/core-components/src/layout/Sidebar/utils.test.ts
+++ b/packages/core-components/src/layout/Sidebar/utils.test.ts
@@ -123,7 +123,7 @@ describe('isLocationMatching', () => {
   });
 
   describe('hash matching', () => {
-    it('return true when hash does not match, but hashMatch is not enabled', async () => {
+    it('return true when hash does not match, but matchHash is not enabled', async () => {
       currentLocation = {
         pathname: '/toolbox',
         search: '?x=foo&y=bar',
@@ -141,7 +141,7 @@ describe('isLocationMatching', () => {
       );
     });
 
-    it('return false when hash does not match, and hashMatch is enabled', async () => {
+    it('return false when hash does not match, and matchHash is enabled', async () => {
       currentLocation = {
         pathname: '/toolbox',
         search: '?x=foo&y=bar',
@@ -159,7 +159,7 @@ describe('isLocationMatching', () => {
       );
     });
 
-    it('return true when hash does match, and hashMatch is enabled', async () => {
+    it('return true when hash does match, and matchHash is enabled', async () => {
       currentLocation = {
         pathname: '/toolbox',
         search: '?x=foo&y=bar',

--- a/packages/core-components/src/layout/Sidebar/utils.ts
+++ b/packages/core-components/src/layout/Sidebar/utils.ts
@@ -22,6 +22,7 @@ export function isLocationMatch(
   currentLocation: Location,
   toLocation: Path,
   exact: boolean = false,
+  matchHash: boolean = false,
 ) {
   const toDecodedSearch = new URLSearchParams(toLocation.search).toString();
   const toQueryParameters = qs.parse(toDecodedSearch);
@@ -32,10 +33,12 @@ export function isLocationMatch(
   const currentQueryParameters = qs.parse(currentDecodedSearch);
 
   const queryStringMatcher = exact ? isEqual : isMatch;
+  const hashMatch = matchHash ? toLocation.hash === currentLocation.hash : true;
 
   const matching =
     isEqual(toLocation.pathname, currentLocation.pathname) &&
-    queryStringMatcher(currentQueryParameters, toQueryParameters);
+    queryStringMatcher(currentQueryParameters, toQueryParameters) &&
+    hashMatch;
 
   return matching;
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Sidebar sub menu items do not currently have the ability to match on hash in the URL. This means that different items can all be in "active" state if the base path matches, even if the hash does not.

For example, when you use the [Toolbox plugin](https://github.com/drodil/backstage-plugin-toolbox), you may want sub menu items that point to:
`/toolbox`
`/toolbox#my-tool`
`/toolbox#some-other-tool`

However, if you click on any of the items to visit the tool, you will notice that all the sub menu items are active.

Steps to reproduce issue:

1. Install backstage [as per basic instructions](https://backstage.io/docs/getting-started/#creating-and-running-a-backstage-application):
2. Install the toolbox plugin [as per instructions](https://github.com/drodil/backstage-plugin-toolbox/blob/main/docs/index.md#installation).
3. Modify the sidebar to add a submenu, as per example:
```tsx
<SidebarItem icon={CardTravel} to="toolbox" text="Toolbox">
          <SidebarSubmenu title="Toolbox">
            <SidebarSubmenuItem
              title="All Tools"
              to="toolbox"
            />
            <SidebarSubmenuItem
              title="Entity Validator"
              to="toolbox#entity-validator"
            />
            <SidebarSubmenuItem
              title="CSV to JSON"
              to="toolbox#csv-to-json-convert"
            />
          </SidebarSubmenu>
        </SidebarItem>
```
4. Visit any of the menu items
5. Observe all sub menu items are active:
<img width="741" height="461" alt="image" src="https://github.com/user-attachments/assets/6227b614-d31c-42df-a21f-bda2d272d654" />

To fix:

With this change, set `matchHash` on each item to ensure that the hash is checked when determining active state:

```tsx
<SidebarItem icon={CardTravel} to="toolbox" text="Toolbox">
          <SidebarSubmenu title="Toolbox">
            <SidebarSubmenuItem
              title="All Tools"
              to="toolbox"
              matchHash
            />
            <SidebarSubmenuItem
              title="Entity Validator"
              to="toolbox#entity-validator"
              matchHash
            />
            <SidebarSubmenuItem
              title="CSV to JSON"
              to="toolbox#csv-to-json-convert"
              matchHash
            />
          </SidebarSubmenu>
        </SidebarItem>
``` 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
