### PR TITLE
docs(adrs): add Decision Guardian section for enforcing ADRs on pull requests

### DIFF
--- a/docs/architecture-decisions/index.md
+++ b/docs/architecture-decisions/index.md
@@ -35,3 +35,85 @@ Records should be stored under the `architecture-decisions` directory.
 
 If an ADR supersedes an older ADR then the status of the older ADR is changed to
 "superseded by ADR-XXXX", and links to the new ADR.
+
+# Enforcing ADRs on Pull Requests
+
+To help teams remember architectural constraints when modifying affected code,
+you can surface relevant ADRs automatically during pull request reviews using
+[Decision Guardian](https://github.com/DecispherHQ/decision-guardian).
+
+## GitHub Actions Workflow
+
+Create `.github/workflows/check-adrs.yml`:
+
+```yaml
+name: Check ADRs
+
+on:
+  pull_request:
+
+# contents: read is required for actions/checkout.
+# pull-requests: write is required to post decision comments.
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check-adrs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Pin to a specific commit SHA in production workflows to protect
+      # against supply-chain compromise. Find the latest SHA at:
+      # https://github.com/DecispherHQ/decision-guardian/releases
+      - uses: DecispherHQ/decision-guardian@v1  # replace with @<commit-sha> for production
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          decision_file: '.decispher/decisions.md'
+          fail_on_critical: true
+```
+
+> **Note for public repositories:** Pull requests from forks receive a
+> read-only `GITHUB_TOKEN`, which cannot post PR comments. If your repository
+> accepts fork contributions, use `pull_request_target` instead of
+> `pull_request` as the trigger. Decision Guardian only reads the decision file
+> from your base branch and calls the GitHub API — it does not execute code
+> from the PR branch — so `pull_request_target` is safe for this use case.
+> Review [GitHub's security hardening guidance](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections)
+> before adopting `pull_request_target` in other workflows.
+
+## Checking Locally Before Pushing
+
+```bash
+npx decision-guardian check .decispher/decisions.md --staged --fail-on-critical
+```
+
+## Decision File Format
+
+Create `.decispher/decisions.md` to map file globs to your ADRs:
+
+```markdown
+<!-- DECISION-AUTH-001 -->
+## Decision: Authentication Flow
+
+**Status**: Active
+**Date**: 2024-01-15
+**Severity**: Critical
+
+**Files**:
+- `src/auth/**/*.ts`
+- `src/plugins/auth-backend/**`
+
+### Context
+
+See [ADR-0XXX](./adrXXX-your-decision.md) before modifying auth flows.
+
+Changes to authentication can affect all plugins. Coordinate with the
+security team and run the full auth integration test suite before merging.
+
+---
+```
+
+> **Tip:** Replace `adrXXX-your-decision.md` with the actual filename of the
+> relevant ADR in this directory (e.g. `adr015-authentication-strategy.md`).


### PR DESCRIPTION

## Hey, I just made a Pull Request!

Added a new **"Enforcing ADRs on Pull Requests"** section to the ADR overview page.

ADRs are only useful if developers are reminded of them when touching relevant code. This section documents how to use [Decision Guardian](https://github.com/DecispherHQ/decision-guardian) — a GitHub Action + CLI — to automatically surface ADRs as PR comments when a pull request touches files covered by a decision.

The addition covers:
- GitHub Action setup for automatic PR enforcement
- CLI usage for local checks before pushing
- Example `.decispher/decisions.md` file linking back to Backstage ADR docs

No code changes — documentation only.

#### :heavy_check_mark: Checklist
- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
