### PR TITLE
fix(scaffolder-backend-module-gitlab): update to support v43

### DIFF
--- a/plugins/scaffolder-backend-module-gitlab/package.json
+++ b/plugins/scaffolder-backend-module-gitlab/package.json
@@ -50,6 +50,7 @@
     "@backstage/errors": "workspace:^",
     "@backstage/integration": "workspace:^",
     "@backstage/plugin-scaffolder-node": "workspace:^",
+    "@gitbeaker/core": "^43.8.0",
     "@gitbeaker/requester-utils": "^43.8.0",
     "@gitbeaker/rest": "^43.8.0",
     "luxon": "^3.0.0",

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabGroupAccessAction.examples.test.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabGroupAccessAction.examples.test.ts
@@ -73,16 +73,12 @@ describe('gitlab:group:access examples', () => {
     });
 
     expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledTimes(2);
-    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(
-      123,
-      456,
-      30,
-    );
-    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(
-      123,
-      789,
-      30,
-    );
+    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(123, 30, {
+      userId: 456,
+    });
+    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(123, 30, {
+      userId: 789,
+    });
 
     expect(mockContext.output).toHaveBeenCalledWith('userIds', [456, 789]);
     expect(mockContext.output).toHaveBeenCalledWith('path', 123);
@@ -99,8 +95,8 @@ describe('gitlab:group:access examples', () => {
 
     expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(
       'group1',
-      456,
       30,
+      { userId: 456 },
     );
 
     expect(mockContext.output).toHaveBeenCalledWith('userIds', [456]);

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabGroupAccessAction.test.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabGroupAccessAction.test.ts
@@ -88,11 +88,9 @@ describe('gitlab:group:access', () => {
       },
     });
 
-    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(
-      123,
-      456,
-      30,
-    );
+    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(123, 30, {
+      userId: 456,
+    });
 
     expect(mockContext.output).toHaveBeenCalledWith('userIds', [456]);
     expect(mockContext.output).toHaveBeenCalledWith('path', 123);
@@ -113,21 +111,15 @@ describe('gitlab:group:access', () => {
     });
 
     expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledTimes(3);
-    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(
-      123,
-      456,
-      30,
-    );
-    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(
-      123,
-      789,
-      30,
-    );
-    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(
-      123,
-      101,
-      30,
-    );
+    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(123, 30, {
+      userId: 456,
+    });
+    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(123, 30, {
+      userId: 789,
+    });
+    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(123, 30, {
+      userId: 101,
+    });
 
     expect(mockContext.output).toHaveBeenCalledWith('userIds', [456, 789, 101]);
     expect(mockContext.output).toHaveBeenCalledWith('path', 123);
@@ -147,11 +139,9 @@ describe('gitlab:group:access', () => {
       },
     });
 
-    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(
-      123,
-      456,
-      30,
-    );
+    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(123, 30, {
+      userId: 456,
+    });
     expect(mockGitlabClient.GroupMembers.remove).not.toHaveBeenCalled();
   });
 
@@ -211,11 +201,9 @@ describe('gitlab:group:access', () => {
       },
     });
 
-    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(
-      123,
-      456,
-      30,
-    );
+    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(123, 30, {
+      userId: 456,
+    });
     expect(mockContext.output).toHaveBeenCalledWith('accessLevel', 30);
   });
 
@@ -314,11 +302,9 @@ describe('gitlab:group:access', () => {
       },
     });
 
-    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(
-      123,
-      456,
-      10,
-    );
+    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(123, 10, {
+      userId: 456,
+    });
   });
 
   it('should add users as Maintainer (accessLevel 40)', async () => {
@@ -334,11 +320,9 @@ describe('gitlab:group:access', () => {
       },
     });
 
-    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(
-      123,
-      456,
-      40,
-    );
+    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(123, 40, {
+      userId: 456,
+    });
   });
 
   it('should add users as Owner (accessLevel 50)', async () => {
@@ -354,11 +338,9 @@ describe('gitlab:group:access', () => {
       },
     });
 
-    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(
-      123,
-      456,
-      50,
-    );
+    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(123, 50, {
+      userId: 456,
+    });
   });
 
   it('should accept string accessLevel "developer"', async () => {
@@ -374,11 +356,9 @@ describe('gitlab:group:access', () => {
       },
     });
 
-    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(
-      123,
-      456,
-      30,
-    );
+    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(123, 30, {
+      userId: 456,
+    });
     expect(mockContext.output).toHaveBeenCalledWith('accessLevel', 30);
   });
 
@@ -395,11 +375,9 @@ describe('gitlab:group:access', () => {
       },
     });
 
-    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(
-      123,
-      456,
-      40,
-    );
+    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(123, 40, {
+      userId: 456,
+    });
     expect(mockContext.output).toHaveBeenCalledWith('accessLevel', 40);
   });
 
@@ -435,11 +413,9 @@ describe('gitlab:group:access', () => {
       },
     });
 
-    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(
-      123,
-      456,
-      30,
-    );
+    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(123, 30, {
+      userId: 456,
+    });
     expect(mockGitlabClient.GroupMembers.edit).toHaveBeenCalledWith(
       123,
       456,
@@ -585,16 +561,12 @@ describe('gitlab:group:access', () => {
     });
 
     expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledTimes(2);
-    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(
-      123,
-      456,
-      30,
-    );
-    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(
-      123,
-      789,
-      30,
-    );
+    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(123, 30, {
+      userId: 456,
+    });
+    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(123, 30, {
+      userId: 789,
+    });
 
     expect(mockGitlabClient.Groups.share).toHaveBeenCalledTimes(2);
     expect(mockGitlabClient.Groups.share).toHaveBeenCalledWith(

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabGroupAccessAction.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabGroupAccessAction.ts
@@ -17,8 +17,11 @@
 import { InputError } from '@backstage/errors';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
+import { AccessLevel } from '@gitbeaker/core';
 import { getClient, parseRepoHost } from '../util';
 import { examples } from './gitlabGroupAccessAction.examples';
+
+type NonAdminAccessLevel = Exclude<AccessLevel, AccessLevel.ADMIN>;
 
 const accessLevelMapping: Record<string, number> = {
   no_access: 0,
@@ -154,8 +157,7 @@ export const createGitlabGroupAccessAction = (options: {
         );
       }
 
-      const accessLevel =
-        action === 'add' ? resolveAccessLevel(rawAccessLevel) : 0;
+      const accessLevel = resolveAccessLevel(rawAccessLevel);
 
       if (ctx.isDryRun) {
         if (userIds.length > 0) {
@@ -187,11 +189,19 @@ export const createGitlabGroupAccessAction = (options: {
           fn: async () => {
             if (action === 'add') {
               try {
-                await api.GroupMembers.add(path, userId, accessLevel);
+                await api.GroupMembers.add(
+                  path,
+                  accessLevel as NonAdminAccessLevel,
+                  { userId },
+                );
               } catch (error: any) {
                 // If member already exists, try to edit instead
                 if (error.cause?.response?.status === 409) {
-                  await api.GroupMembers.edit(path, userId, accessLevel);
+                  await api.GroupMembers.edit(
+                    path,
+                    userId,
+                    accessLevel as NonAdminAccessLevel,
+                  );
                   return;
                 }
                 throw error;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6881,6 +6881,7 @@ __metadata:
     "@backstage/integration": "workspace:^"
     "@backstage/plugin-scaffolder-node": "workspace:^"
     "@backstage/plugin-scaffolder-node-test-utils": "workspace:^"
+    "@gitbeaker/core": "npm:^43.8.0"
     "@gitbeaker/requester-utils": "npm:^43.8.0"
     "@gitbeaker/rest": "npm:^43.8.0"
     luxon: "npm:^3.0.0"


### PR DESCRIPTION
`@gitbeaker/core v43` changed `ResourceMembers.add` signature to accept `accessLevel` as the second arg and `userId` in an options object.

Using the same changeset as #32528 