### PR TITLE
Fix GroupMembers.add call signature for @gitbeaker/rest v43

### DIFF
--- a/.changeset/fix-gitlab-group-access-add-signature.md
+++ b/.changeset/fix-gitlab-group-access-add-signature.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gitlab': patch
+---
+
+Fixed `gitlab:group:access` action to use the correct `GroupMembers.add` call signature for `@gitbeaker/rest` v43, passing `userId` via the options object instead of as a positional argument.

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabGroupAccessAction.test.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabGroupAccessAction.test.ts
@@ -88,11 +88,9 @@ describe('gitlab:group:access', () => {
       },
     });
 
-    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(
-      123,
-      456,
-      30,
-    );
+    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(123, 30, {
+      userId: 456,
+    });
 
     expect(mockContext.output).toHaveBeenCalledWith('userIds', [456]);
     expect(mockContext.output).toHaveBeenCalledWith('path', 123);
@@ -113,21 +111,15 @@ describe('gitlab:group:access', () => {
     });
 
     expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledTimes(3);
-    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(
-      123,
-      456,
-      30,
-    );
-    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(
-      123,
-      789,
-      30,
-    );
-    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(
-      123,
-      101,
-      30,
-    );
+    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(123, 30, {
+      userId: 456,
+    });
+    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(123, 30, {
+      userId: 789,
+    });
+    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(123, 30, {
+      userId: 101,
+    });
 
     expect(mockContext.output).toHaveBeenCalledWith('userIds', [456, 789, 101]);
     expect(mockContext.output).toHaveBeenCalledWith('path', 123);
@@ -147,11 +139,9 @@ describe('gitlab:group:access', () => {
       },
     });
 
-    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(
-      123,
-      456,
-      30,
-    );
+    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(123, 30, {
+      userId: 456,
+    });
     expect(mockGitlabClient.GroupMembers.remove).not.toHaveBeenCalled();
   });
 
@@ -211,11 +201,9 @@ describe('gitlab:group:access', () => {
       },
     });
 
-    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(
-      123,
-      456,
-      30,
-    );
+    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(123, 30, {
+      userId: 456,
+    });
     expect(mockContext.output).toHaveBeenCalledWith('accessLevel', 30);
   });
 
@@ -314,11 +302,9 @@ describe('gitlab:group:access', () => {
       },
     });
 
-    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(
-      123,
-      456,
-      10,
-    );
+    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(123, 10, {
+      userId: 456,
+    });
   });
 
   it('should add users as Maintainer (accessLevel 40)', async () => {
@@ -334,11 +320,9 @@ describe('gitlab:group:access', () => {
       },
     });
 
-    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(
-      123,
-      456,
-      40,
-    );
+    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(123, 40, {
+      userId: 456,
+    });
   });
 
   it('should add users as Owner (accessLevel 50)', async () => {
@@ -354,11 +338,9 @@ describe('gitlab:group:access', () => {
       },
     });
 
-    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(
-      123,
-      456,
-      50,
-    );
+    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(123, 50, {
+      userId: 456,
+    });
   });
 
   it('should accept string accessLevel "developer"', async () => {
@@ -374,11 +356,9 @@ describe('gitlab:group:access', () => {
       },
     });
 
-    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(
-      123,
-      456,
-      30,
-    );
+    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(123, 30, {
+      userId: 456,
+    });
     expect(mockContext.output).toHaveBeenCalledWith('accessLevel', 30);
   });
 
@@ -395,11 +375,9 @@ describe('gitlab:group:access', () => {
       },
     });
 
-    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(
-      123,
-      456,
-      40,
-    );
+    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(123, 40, {
+      userId: 456,
+    });
     expect(mockContext.output).toHaveBeenCalledWith('accessLevel', 40);
   });
 
@@ -435,11 +413,9 @@ describe('gitlab:group:access', () => {
       },
     });
 
-    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(
-      123,
-      456,
-      30,
-    );
+    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(123, 30, {
+      userId: 456,
+    });
     expect(mockGitlabClient.GroupMembers.edit).toHaveBeenCalledWith(
       123,
       456,
@@ -585,16 +561,12 @@ describe('gitlab:group:access', () => {
     });
 
     expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledTimes(2);
-    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(
-      123,
-      456,
-      30,
-    );
-    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(
-      123,
-      789,
-      30,
-    );
+    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(123, 30, {
+      userId: 456,
+    });
+    expect(mockGitlabClient.GroupMembers.add).toHaveBeenCalledWith(123, 30, {
+      userId: 789,
+    });
 
     expect(mockGitlabClient.Groups.share).toHaveBeenCalledTimes(2);
     expect(mockGitlabClient.Groups.share).toHaveBeenCalledWith(

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabGroupAccessAction.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabGroupAccessAction.ts
@@ -187,7 +187,7 @@ export const createGitlabGroupAccessAction = (options: {
           fn: async () => {
             if (action === 'add') {
               try {
-                await api.GroupMembers.add(path, userId, accessLevel);
+                await api.GroupMembers.add(path, accessLevel, { userId });
               } catch (error: any) {
                 // If member already exists, try to edit instead
                 if (error.cause?.response?.status === 409) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `GroupMembers.add` method in `@gitbeaker/rest` v43 changed its signature from `add(resourceId, userId, accessLevel)` to `add(resourceId, accessLevel, options?)`, where `userId` is now passed via the options object. The old call at `gitlabGroupAccessAction.ts:190` was passing `accessLevel` (a number) in the third position where the type system now expects `AddMemberOptions & Sudo & ShowExpanded<false>`, causing `TS2345`.

The fix updates the call to `add(path, accessLevel, { userId })` to match the v43 API. The `GroupMembers.edit` call was already correct since its signature still takes `userId` as a positional argument.

The existing `ProjectMembers.add` call in `gitlab.ts` was already using the correct v43 signature (`add(projectId, 50, { userId })`), confirming this is the right pattern.

**Verified:**
- `yarn tsc` passes clean (0 errors)
- All 28 tests in `gitlabGroupAccessAction.test.ts` pass
- No lockfile seed update needed (gitbeaker is not in the create-app seed)

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Made with [Cursor](https://cursor.com)