### PR TITLE
chore: add design-system-maintainers as code owners for .storybook and docs-ui

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,8 +12,10 @@ yarn.lock                                         @backstage/maintainers @backst
 /.github                                          @backstage/operations-maintainers
 /.github/vale                                     @backstage/maintainers @backstage/documentation-maintainers
 /.patches                                         @backstage/operations-maintainers
+/.storybook                                       @backstage/design-system-maintainers
 /beps/0001-notifications-system                   @backstage/maintainers @backstage/notifications-maintainers
 /docs                                             @backstage/maintainers @backstage/documentation-maintainers
+/docs-ui                                          @backstage/design-system-maintainers
 /docs/assets/search                               @backstage/search-maintainers
 /docs/auth                                        @backstage/auth-maintainers
 /docs/backend-system                              @backstage/framework-maintainers


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add `@backstage/design-system-maintainers` as code owners for `/.storybook` and `/docs-ui`. These directories were previously only covered by the catch-all rule, requiring review from `@backstage/maintainers`. Since they fall under the Design System project area scope (per `OWNERS.md`), they should be owned by the design system team.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))