### PR TITLE
bui(ui): improve Select trigger bg and focus ring

### DIFF
--- a/.changeset/odd-ears-grab.md
+++ b/.changeset/odd-ears-grab.md
@@ -1,0 +1,7 @@
+---
+'@backstage/ui': patch
+---
+
+The `Select` trigger now automatically adapts its background colour based on the parent background context.
+
+**Affected components:** Select

--- a/packages/ui/src/components/Select/Select.module.css
+++ b/packages/ui/src/components/Select/Select.module.css
@@ -35,8 +35,26 @@
   .bui-SelectTrigger {
     box-sizing: border-box;
     border-radius: var(--bui-radius-3);
-    border: 1px solid var(--bui-border-2);
+    border: none;
+    outline: none;
     background-color: var(--bui-bg-neutral-1);
+    transition: box-shadow 0.2s ease-in-out;
+
+    &[data-on-bg='neutral-1'] {
+      background-color: var(--bui-bg-neutral-2);
+    }
+
+    &[data-on-bg='neutral-2'] {
+      background-color: var(--bui-bg-neutral-3);
+    }
+
+    &[data-on-bg='neutral-3'] {
+      background-color: var(--bui-bg-neutral-4);
+    }
+
+    .bui-Select[data-focused] & {
+      box-shadow: inset 0 0 0 1px var(--bui-ring);
+    }
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -73,12 +91,7 @@
     }
 
     .bui-Select[data-invalid] & {
-      border-color: var(--bui-fg-danger);
-
-      &:focus-visible,
-      &:hover {
-        outline: 1px solid var(--bui-fg-danger);
-      }
+      box-shadow: inset 0 0 0 1px var(--bui-border-danger);
     }
 
     &[disabled] {
@@ -119,6 +132,8 @@
   .bui-SelectList {
     overflow: auto;
     min-height: 0;
+    padding-block: var(--bui-space-1);
+    padding-inline: var(--bui-space-1);
 
     &:focus-visible {
       /* Remove default focus-visible outline because React Aria
@@ -132,7 +147,6 @@
   .bui-SelectItem {
     box-sizing: border-box;
     position: relative;
-    width: var(--anchor-width);
     display: grid;
     grid-template-areas: 'icon text';
     grid-template-columns: 1rem 1fr;
@@ -147,20 +161,10 @@
     font-size: var(--bui-font-size-3);
     gap: var(--bui-space-2);
     outline: none;
+    border-radius: var(--bui-radius-2);
 
-    &[data-focus-visible] {
-      outline: 2px solid var(--bui-ring);
-      outline-offset: 2px;
-    }
-
-    &[data-focused]::before {
-      content: '';
-      position: absolute;
-      inset-block: 0;
-      inset-inline: var(--bui-space-1);
-      border-radius: var(--bui-radius-2);
-      background: var(--bui-bg-neutral-2);
-      z-index: -1;
+    &[data-focused] {
+      background-color: var(--bui-bg-neutral-2);
     }
 
     &[data-disabled] {

--- a/packages/ui/src/components/Select/Select.stories.tsx
+++ b/packages/ui/src/components/Select/Select.stories.tsx
@@ -17,6 +17,8 @@
 import preview from '../../../../../.storybook/preview';
 import { Select } from './Select';
 import { Flex } from '../Flex';
+import { Box } from '../Box';
+import { Text } from '../Text';
 import { Form } from 'react-aria-components';
 import { RiCloudLine } from '@remixicon/react';
 
@@ -389,6 +391,41 @@ export const WithLongNamesAndPadding = meta.story({
       </div>
     ),
   ],
+});
+
+export const AutoBg = meta.story({
+  render: () => (
+    <Flex direction="column" gap="4">
+      <div style={{ maxWidth: '600px' }}>
+        Select automatically detects its parent bg context and increments the
+        neutral level by 1. No prop is needed — it's fully automatic.
+      </div>
+      <Box bg="neutral" p="4">
+        <Text>Neutral 1 container</Text>
+        <Flex mt="2" style={{ maxWidth: '300px' }}>
+          <Select options={fontOptions} aria-label="Font family" />
+        </Flex>
+      </Box>
+      <Box bg="neutral">
+        <Box bg="neutral" p="4">
+          <Text>Neutral 2 container</Text>
+          <Flex mt="2" style={{ maxWidth: '300px' }}>
+            <Select options={fontOptions} aria-label="Font family" />
+          </Flex>
+        </Box>
+      </Box>
+      <Box bg="neutral">
+        <Box bg="neutral">
+          <Box bg="neutral" p="4">
+            <Text>Neutral 3 container</Text>
+            <Flex mt="2" style={{ maxWidth: '300px' }}>
+              <Select options={fontOptions} aria-label="Font family" />
+            </Flex>
+          </Box>
+        </Box>
+      </Box>
+    </Flex>
+  ),
 });
 
 export const WithAccessibilityProps = meta.story({

--- a/packages/ui/src/components/Select/SelectTrigger.tsx
+++ b/packages/ui/src/components/Select/SelectTrigger.tsx
@@ -25,11 +25,14 @@ interface SelectTriggerProps {
 }
 
 export function SelectTrigger(props: SelectTriggerProps) {
-  const { ownProps } = useDefinition(SelectTriggerDefinition, props);
+  const { ownProps, dataAttributes } = useDefinition(
+    SelectTriggerDefinition,
+    props,
+  );
   const { classes, icon } = ownProps;
 
   return (
-    <Button className={classes.root}>
+    <Button className={classes.root} {...dataAttributes}>
       {icon}
       <SelectValue className={classes.value} />
       <div className={classes.chevron}>

--- a/packages/ui/src/components/Select/definition.ts
+++ b/packages/ui/src/components/Select/definition.ts
@@ -59,6 +59,7 @@ export const SelectTriggerDefinition = defineComponent<SelectTriggerOwnProps>()(
       chevron: 'bui-SelectTriggerChevron',
       value: 'bui-SelectValue',
     },
+    bg: 'consumer',
     propDefs: {
       icon: {},
     },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Improves the `Select` component trigger styling to align with the `SearchField` component patterns.

| Before | After |
|--------|--------|
| <img width="668" height="176" alt="CleanShot 2026-03-03 at 18 04 13@2x" src="https://github.com/user-attachments/assets/542689bd-d4a1-4626-8ab7-7ad48f44f5ec" /> | <img width="672" height="180" alt="CleanShot 2026-03-03 at 18 03 53@2x" src="https://github.com/user-attachments/assets/74e21260-74a8-44ee-ac6d-feb2c6cdcaf4" /> | 

### Adapt to different background

<img width="1026" height="662" alt="CleanShot 2026-03-03 at 18 05 45@2x" src="https://github.com/user-attachments/assets/0ee758ef-3099-4529-85dd-0d4dbff8b3d0" />

**Changes:**
- The trigger background now automatically adapts to its parent background context (neutral-1 → neutral-2, etc.) using the `bg: 'consumer'` mechanism
- Replaced the static border with an inset `box-shadow` focus ring that animates in/out, consistent with `SearchField`
- Invalid state now also uses an inset `box-shadow` instead of `border-color`
- Added an `AutoBg` story demonstrating the background context behaviour

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Made with [Cursor](https://cursor.com)